### PR TITLE
provider/alicloud: change all instance types to generation three and remove io_optimized

### DIFF
--- a/examples/alicloud-build-lnmp/main.tf
+++ b/examples/alicloud-build-lnmp/main.tf
@@ -3,10 +3,10 @@ provider "alicloud" {
   region = "${var.region}"
 }
 
-data "alicloud_instance_types" "1c2g" {
+data "alicloud_instance_types" "2c4g" {
 	cpu_core_count = 2
 	memory_size = 4
-	instance_type_family = "ecs.n1"
+	instance_type_family = "ecs.n4"
 }
 
 data "alicloud_images" "centos" {
@@ -15,7 +15,7 @@ data "alicloud_images" "centos" {
 }
 
 data "alicloud_zones" "default" {
-	"available_instance_type"= "${data.alicloud_instance_types.1c2g.instance_types.0.id}"
+	"available_instance_type"= "${data.alicloud_instance_types.2c4g.instance_types.0.id}"
 	"available_disk_category"= "${var.disk_category}"
 }
 
@@ -62,9 +62,8 @@ resource "alicloud_instance" "webserver" {
 
 	# series II
 	instance_charge_type = "PostPaid"
-	instance_type = "${data.alicloud_instance_types.1c2g.instance_types.0.id}"
+	instance_type = "${data.alicloud_instance_types.2c4g.instance_types.0.id}"
 	internet_max_bandwidth_out = 0
-	io_optimized = "${var.io_optimized}"
 
 	system_disk_category = "${var.disk_category}"
 	image_id = "${data.alicloud_images.centos.images.0.id}"

--- a/examples/alicloud-build-lnmp/variables.tf
+++ b/examples/alicloud-build-lnmp/variables.tf
@@ -7,9 +7,7 @@ variable "vpc_cidr" {
 variable "vswitch_cidr" {
   default = "10.1.1.0/24"
 }
-variable "io_optimized" {
-  default = "optimized"
-}
+
 variable "ecs_password" {
   default = "Test1234567*"
 }

--- a/examples/alicloud-ecs-image/main.tf
+++ b/examples/alicloud-ecs-image/main.tf
@@ -62,8 +62,6 @@ resource "alicloud_instance" "instance" {
   internet_charge_type = "${var.internet_charge_type}"
   internet_max_bandwidth_out = "${var.internet_max_bandwidth_out}"
 
-  io_optimized = "${var.io_optimized}"
-
   password = "${var.ecs_password}"
 
   allocate_public_ip = "${var.allocate_public_ip}"
@@ -83,6 +81,5 @@ resource "alicloud_disk_attachment" "instance-attachment" {
   count = "${var.count}"
   disk_id = "${element(alicloud_disk.disk.*.id, count.index)}"
   instance_id = "${element(alicloud_instance.instance.*.id, count.index)}"
-  device_name = "${var.device_name}"
 }
 

--- a/examples/alicloud-ecs-image/variables.tf
+++ b/examples/alicloud-ecs-image/variables.tf
@@ -26,13 +26,13 @@ variable "short_name" {
   default = "hi"
 }
 variable "ecs_type" {
-  default = "ecs.n1.small"
+  default = "ecs.n4.small"
 }
 variable "ecs_password" {
   default = "Test12345"
 }
 variable "availability_zones" {
-  default = "cn-beijing-b"
+  default = "cn-beijing-a"
 }
 variable "allocate_public_ip" {
   default = true
@@ -43,15 +43,9 @@ variable "internet_charge_type" {
 variable "internet_max_bandwidth_out" {
   default = 5
 }
-variable "io_optimized" {
-  default = "optimized"
-}
 variable "disk_category" {
   default = "cloud_ssd"
 }
 variable "disk_size" {
   default = "40"
-}
-variable "device_name" {
-  default = "/dev/xvdb"
 }

--- a/examples/alicloud-ecs-nat/main.tf
+++ b/examples/alicloud-ecs-nat/main.tf
@@ -24,7 +24,6 @@ resource "alicloud_instance" "nat" {
   security_groups = ["${alicloud_security_group.group.id}"]
   vswitch_id = "${alicloud_vswitch.main.id}"
   instance_name = "nat"
-  io_optimized = "optimized"
   system_disk_category = "cloud_efficiency"
   password= "${var.instance_pwd}"
 
@@ -52,7 +51,6 @@ resource "alicloud_instance" "worker" {
   security_groups = ["${alicloud_security_group.group.id}"]
   vswitch_id = "${alicloud_vswitch.main.id}"
   instance_name = "worker"
-  io_optimized = "optimized"
   system_disk_category = "cloud_efficiency"
   password= "${var.instance_pwd}"
 

--- a/examples/alicloud-ecs-nat/variables.tf
+++ b/examples/alicloud-ecs-nat/variables.tf
@@ -7,7 +7,7 @@ variable "vswitch_cidr" {
 }
 
 variable "zone" {
-  default = "cn-beijing-c"
+  default = "cn-beijing-d"
 }
 
 variable "image" {
@@ -15,11 +15,11 @@ variable "image" {
 }
 
 variable "instance_nat_type" {
-  default = "ecs.n1.small"
+  default = "ecs.n4.small"
 }
 
 variable "instance_worker_type" {
-  default = "ecs.s2.large"
+  default = "ecs.n4.large"
 }
 
 variable "instance_pwd" {

--- a/examples/alicloud-ecs-slb/main.tf
+++ b/examples/alicloud-ecs-slb/main.tf
@@ -45,7 +45,6 @@ resource "alicloud_instance" "instance" {
   security_groups = ["${alicloud_security_group.group.*.id}"]
   internet_charge_type = "${var.internet_charge_type}"
   internet_max_bandwidth_out = "${var.internet_max_bandwidth_out}"
-  io_optimized = "${var.io_optimized}"
   password = "${var.ecs_password}"
   allocate_public_ip = "${var.allocate_public_ip}"
   availability_zone = ""

--- a/examples/alicloud-ecs-slb/variables.tf
+++ b/examples/alicloud-ecs-slb/variables.tf
@@ -18,7 +18,7 @@ variable "short_name" {
   default = "hi"
 }
 variable "ecs_type" {
-  default = "ecs.n1.small"
+  default = "ecs.n4.small"
 }
 variable "ecs_password" {
   default = "Test12345"
@@ -43,10 +43,6 @@ variable "slb_internet_charge_type" {
 }
 variable "internet_max_bandwidth_out" {
   default = 5
-}
-
-variable "io_optimized" {
-  default = "optimized"
 }
 
 variable "slb_name" {

--- a/examples/alicloud-ecs-special-sg/main.tf
+++ b/examples/alicloud-ecs-special-sg/main.tf
@@ -8,21 +8,19 @@ resource "alicloud_instance" "instance" {
   instance_name = "website-${format(var.count_format, count.index+1)}"
   host_name = "website-${format(var.count_format, count.index+1)}"
   image_id = "centos7u2_64_40G_cloudinit_20160728.raw"
-  instance_type = "ecs.s2.large"
+  instance_type = "ecs.n4.small"
   count = "6"
-  availability_zone = "cn-beijing-b"
+  availability_zone = "cn-beijing-a"
   security_groups = "${var.security_groups}"
 
   internet_charge_type = "PayByBandwidth"
-
-  io_optimized = "none"
 
   password = "${var.ecs_password}"
 
   allocate_public_ip = "false"
 
   instance_charge_type = "PostPaid"
-  system_disk_category = "cloud"
+  system_disk_category = "cloud_ssd"
 
 
   tags {

--- a/examples/alicloud-ecs-userdata/main.tf
+++ b/examples/alicloud-ecs-userdata/main.tf
@@ -32,9 +32,8 @@ resource "alicloud_instance" "website" {
   vswitch_id = "${alicloud_vswitch.vsw.id}"
   image_id = "${var.image}"
 
-  # series II
+  # series III
   instance_type = "${var.ecs_type}"
-  io_optimized = "optimized"
   system_disk_category = "cloud_efficiency"
 
   internet_charge_type = "PayByTraffic"

--- a/examples/alicloud-ecs-userdata/variables.tf
+++ b/examples/alicloud-ecs-userdata/variables.tf
@@ -7,7 +7,7 @@ variable "vswitch_cidr" {
 }
 
 variable "zone" {
-  default = "cn-beijing-b"
+  default = "cn-beijing-a"
 }
 
 variable "password" {
@@ -19,5 +19,5 @@ variable "image" {
 }
 
 variable "ecs_type" {
-  default = "ecs.n1.medium"
+  default = "ecs.n4.large"
 }

--- a/examples/alicloud-ecs-vpc-cluster/variables.tf
+++ b/examples/alicloud-ecs-vpc-cluster/variables.tf
@@ -22,7 +22,7 @@ variable "edge_count_format" {
   default = "%02d"
 }
 variable "edge_ecs_type" {
-  default = "ecs.n1.small"
+  default = "ecs.n4.small"
 }
 
 variable "worker_count" {
@@ -32,7 +32,7 @@ variable "worker_count_format" {
   default = "%03d"
 }
 variable "worker_ecs_type" {
-  default = "ecs.n1.small"
+  default = "ecs.n4.small"
 }
 
 variable "short_name" {
@@ -47,7 +47,7 @@ variable "region" {
 }
 
 variable "availability_zones" {
-  default = "cn-beijing-c"
+  default = "cn-beijing-d"
 }
 
 variable "datacenter" {

--- a/examples/alicloud-ecs-vpc/main.tf
+++ b/examples/alicloud-ecs-vpc/main.tf
@@ -18,8 +18,6 @@ resource "alicloud_instance" "instance" {
   internet_charge_type = "${var.internet_charge_type}"
   internet_max_bandwidth_out = "${var.internet_max_bandwidth_out}"
 
-  io_optimized = "${var.io_optimized}"
-
   allocate_public_ip = "${var.allocate_public_ip}"
 
   password = "${var.ecs_password}"
@@ -39,7 +37,6 @@ resource "alicloud_disk_attachment" "instance-attachment" {
   count = "${var.count}"
   disk_id = "${element(alicloud_disk.disk.*.id, count.index)}"
   instance_id = "${element(alicloud_instance.instance.*.id, count.index)}"
-  device_name = "${var.device_name}"
 }
 
 

--- a/examples/alicloud-ecs-vpc/variables.tf
+++ b/examples/alicloud-ecs-vpc/variables.tf
@@ -45,10 +45,6 @@ variable "internet_max_bandwidth_out" {
   default = 5
 }
 
-variable "io_optimized" {
-  default = "optimized"
-}
-
 variable "allocate_public_ip" {
   default = true
 }
@@ -58,9 +54,6 @@ variable "disk_category" {
 }
 variable "disk_size" {
   default = "40"
-}
-variable "device_name" {
-  default = "/dev/xvdb"
 }
 
 variable "vswitch_id" {

--- a/examples/alicloud-ecs-zone-type/main.tf
+++ b/examples/alicloud-ecs-zone-type/main.tf
@@ -1,7 +1,7 @@
 data "alicloud_instance_types" "1c2g" {
 	cpu_core_count = 1
 	memory_size = 2
-	instance_type_family = "ecs.n1"
+	instance_type_family = "ecs.n4"
 }
 
 data "alicloud_zones" "default" {
@@ -58,8 +58,6 @@ resource "alicloud_instance" "instance" {
 
   internet_charge_type = "${var.internet_charge_type}"
   internet_max_bandwidth_out = "${var.internet_max_bandwidth_out}"
-
-  io_optimized = "${var.io_optimized}"
 
   password = "${var.ecs_password}"
 

--- a/examples/alicloud-ecs-zone-type/variables.tf
+++ b/examples/alicloud-ecs-zone-type/variables.tf
@@ -30,6 +30,3 @@ variable "internet_charge_type" {
 variable "internet_max_bandwidth_out" {
   default = 5
 }
-variable "io_optimized" {
-  default = "optimized"
-}

--- a/examples/alicloud-ecs/main.tf
+++ b/examples/alicloud-ecs/main.tf
@@ -1,5 +1,5 @@
 data "alicloud_instance_types" "instance_type" {
-  instance_type_family = "ecs.n1"
+  instance_type_family = "ecs.n4"
   cpu_core_count = "1"
   memory_size = "2"
 }
@@ -55,8 +55,6 @@ resource "alicloud_instance" "instance" {
 
   allocate_public_ip = "${var.allocate_public_ip}"
 
-  io_optimized = "${var.io_optimized}"
-
   instance_charge_type = "PostPaid"
   system_disk_category = "cloud_efficiency"
 
@@ -72,5 +70,4 @@ resource "alicloud_disk_attachment" "instance-attachment" {
   count = "${var.count}"
   disk_id = "${element(alicloud_disk.disk.*.id, count.index)}"
   instance_id = "${element(alicloud_instance.instance.*.id, count.index)}"
-  device_name = "${var.device_name}"
 }

--- a/examples/alicloud-ecs/variables.tf
+++ b/examples/alicloud-ecs/variables.tf
@@ -37,18 +37,11 @@ variable "internet_max_bandwidth_out" {
   default = 5
 }
 
-variable "io_optimized" {
-  default = "optimized"
-}
-
 variable "disk_category" {
   default = "cloud_efficiency"
 }
 variable "disk_size" {
   default = "40"
-}
-variable "device_name" {
-  default = "/dev/xvdb"
 }
 
 variable "nic_type" {

--- a/examples/alicloud-ess-scaling/main.tf
+++ b/examples/alicloud-ess-scaling/main.tf
@@ -33,6 +33,5 @@ resource "alicloud_ess_scaling_configuration" "config" {
 
   image_id = "${data.alicloud_images.ecs_image.images.0.id}"
   instance_type = "${var.ecs_instance_type}"
-  io_optimized = "optimized"
   security_group_id = "${alicloud_security_group.sg.id}"
 }

--- a/examples/alicloud-ess-scaling/variables.tf
+++ b/examples/alicloud-ess-scaling/variables.tf
@@ -20,5 +20,5 @@ variable "removal_policies" {
 }
 
 variable "ecs_instance_type" {
-  default = "ecs.s2.large"
+  default = "ecs.n4.large"
 }

--- a/examples/alicloud-ess-schedule/main.tf
+++ b/examples/alicloud-ess-schedule/main.tf
@@ -33,7 +33,6 @@ resource "alicloud_ess_scaling_configuration" "config" {
 
   image_id = "${data.alicloud_images.ecs_image.images.0.id}"
   instance_type = "${var.ecs_instance_type}"
-  io_optimized = "optimized"
   security_group_id = "${alicloud_security_group.sg.id}"
 }
 
@@ -47,5 +46,5 @@ resource "alicloud_ess_scaling_rule" "rule" {
 resource "alicloud_ess_schedule" "run" {
   scheduled_action = "${alicloud_ess_scaling_rule.rule.ari}"
   launch_time = "${var.schedule_launch_time}"
-  scheduled_task_name = "tf-run"
+  scheduled_task_name = "tf-run-foo"
 }

--- a/examples/alicloud-ess-schedule/variables.tf
+++ b/examples/alicloud-ess-schedule/variables.tf
@@ -20,7 +20,7 @@ variable "removal_policies" {
 }
 
 variable "ecs_instance_type" {
-  default = "ecs.s2.large"
+  default = "ecs.n4.large"
 }
 
 variable "rule_adjust_size" {
@@ -28,5 +28,5 @@ variable "rule_adjust_size" {
 }
 
 variable "schedule_launch_time" {
-  default = "2017-04-01T01:59Z"
+  default = "2017-07-07T04:22Z"
 }

--- a/examples/alicloud-vpc-route-entry/main.tf
+++ b/examples/alicloud-vpc-route-entry/main.tf
@@ -37,7 +37,7 @@ resource "alicloud_security_group_rule" "ssh-in" {
 resource "alicloud_security_group_rule" "http-in" {
   type = "ingress"
   ip_protocol = "tcp"
-  nic_type = "internet"
+  nic_type = "intranet"
   policy = "accept"
   port_range = "80/80"
   priority = 1
@@ -48,7 +48,7 @@ resource "alicloud_security_group_rule" "http-in" {
 resource "alicloud_security_group_rule" "https-in" {
   type = "ingress"
   ip_protocol = "tcp"
-  nic_type = "internet"
+  nic_type = "intranet"
   policy = "accept"
   port_range = "443/443"
   priority = 1
@@ -69,7 +69,6 @@ resource "alicloud_instance" "snat" {
 	instance_type = "${var.instance_type}"
 	internet_charge_type = "${var.internet_charge_type}"
 	internet_max_bandwidth_out = 5
-	io_optimized = "${var.io_optimized}"
 
 	system_disk_category = "cloud_efficiency"
 	image_id = "${var.image_id}"

--- a/examples/alicloud-vpc-route-entry/variables.tf
+++ b/examples/alicloud-vpc-route-entry/variables.tf
@@ -6,7 +6,7 @@ variable "vswitch_cidr" {
   default = "10.1.1.0/24"
 }
 variable "zone_id" {
-  default = "cn-beijing-c"
+  default = "cn-beijing-d"
 }
 variable "entry_cidr" {
   default = "172.11.1.1/32"
@@ -15,14 +15,11 @@ variable "rule_policy" {
   default = "accept"
 }
 variable "instance_type" {
-  default = "ecs.n1.small"
+  default = "ecs.n4.small"
 }
 variable "image_id" {
   default = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
 }
 variable "internet_charge_type" {
   default = "PayByTraffic"
-}
-variable "io_optimized" {
-  default = "optimized"
 }

--- a/examples/alicloud-vpc-snat/main.tf
+++ b/examples/alicloud-vpc-snat/main.tf
@@ -5,7 +5,7 @@ provider "alicloud" {
 data "alicloud_instance_types" "1c2g" {
 	cpu_core_count = 1
 	memory_size = 2
-	instance_type_family = "ecs.n1"
+	instance_type_family = "ecs.n4"
 }
 
 data "alicloud_zones" "default" {
@@ -75,11 +75,10 @@ resource "alicloud_instance" "default" {
 
 	vswitch_id = "${alicloud_vswitch.default.id}"
 
-	# series II
+	# series III
 	instance_charge_type = "PostPaid"
 	instance_type = "${var.instance_type}"
 	internet_max_bandwidth_out = 0
-	io_optimized = "${var.io_optimized}"
 
 	system_disk_category = "cloud_efficiency"
 	image_id = "${var.image_id}"

--- a/examples/alicloud-vpc-snat/variables.tf
+++ b/examples/alicloud-vpc-snat/variables.tf
@@ -9,13 +9,10 @@ variable "rule_policy" {
   default = "accept"
 }
 variable "instance_type" {
-  default = "ecs.n1.small"
+  default = "ecs.n4.small"
 }
 variable "image_id" {
   default = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
-}
-variable "io_optimized" {
-  default = "optimized"
 }
 variable "disk_category"{
   default = "cloud_efficiency"


### PR DESCRIPTION
The PR has a dependency on [terraform-providers/terraform-provider-alicloud#11](https://github.com/terraform-providers/terraform-provider-alicloud/pull/11), and it mainly change all instance types to generation three and remove the deprecated parameter 'io_optimized' for all related examples.