### PR TITLE
alicloud/provider: Add oss bucket examples

### DIFF
--- a/examples/alicloud-oss-bucket-cors/main.tf
+++ b/examples/alicloud-oss-bucket-cors/main.tf
@@ -1,0 +1,24 @@
+provider "alicloud" {
+  alias = "us-prod"
+  region = "us-west-1"
+}
+
+resource "alicloud_oss_bucket" "bucket-cors" {
+  provider = "alicloud.us-prod"
+
+  bucket = "${var.name}"
+  acl = "${var.acl}"
+
+  cors_rule ={
+    allowed_origins=["${var.allow-origins-star}"]
+    allowed_methods="${split(",",var.allow-methods-put)}"
+    allowed_headers=["${var.allowed_headers}"]
+  }
+  cors_rule ={
+    allowed_origins=["${var.allow-origins-aliyun}"]
+    allowed_methods=["${split(",",var.allow-methods-get)}"]
+    allowed_headers=["${var.allowed_headers}"]
+    expose_headers=["${var.expose_headers}"]
+    max_age_seconds="${var.max_age_seconds}"
+  }
+}

--- a/examples/alicloud-oss-bucket-cors/outputs.tf
+++ b/examples/alicloud-oss-bucket-cors/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket-cors" {
+  value = "${alicloud_oss_bucket.bucket-cors.id}"
+}
+
+output "bucket-cors-rule" {
+  value = "${alicloud_oss_bucket.bucket-cors.cors_rule}"
+}

--- a/examples/alicloud-oss-bucket-cors/variables.tf
+++ b/examples/alicloud-oss-bucket-cors/variables.tf
@@ -1,0 +1,35 @@
+variable "name" {
+  default = "bucket-us-20170509"
+}
+
+variable "acl" {
+  default = "public-read"
+}
+
+variable "allow-origins-star" {
+  default = "*"
+}
+
+variable "allow-origins-aliyun" {
+  default = "http://www.aliyun.com, http://*.aliyun.com"
+}
+
+variable "allow-methods-get" {
+  default = "GET"
+}
+
+variable "allow-methods-put" {
+  default = "PUT,GET"
+}
+
+variable "allowed_headers" {
+  default = "authorization"
+}
+
+variable "expose_headers" {
+  default = "x-oss-test, x-oss-test1"
+}
+
+variable "max_age_seconds" {
+  default = 100
+}

--- a/examples/alicloud-oss-bucket/main.tf
+++ b/examples/alicloud-oss-bucket/main.tf
@@ -1,0 +1,52 @@
+provider "alicloud" {
+  alias = "bj-prod"
+  region = "cn-beijing"
+}
+
+resource "alicloud_oss_bucket" "bucket-new" {
+  provider = "alicloud.bj-prod"
+
+  bucket = "${var.bucket-new}"
+  acl = "${var.acl-bj}"
+}
+
+
+resource "alicloud_oss_bucket" "bucket-attr" {
+  provider = "alicloud.bj-prod"
+
+  bucket = "${var.bucket-attr}"
+
+  website = {
+    index_document = "${var.index-doc}"
+    error_document = "${var.error-doc}"
+  }
+
+  logging {
+    target_bucket = "${alicloud_oss_bucket.bucket-new.id}"
+    target_prefix = "${var.target-prefix}"
+  }
+
+  lifecycle_rule {
+    id = "${var.rule-days}"
+    prefix = "${var.rule-prefix}/${var.role-days}"
+    enabled = true
+
+    expiration {
+      days = "${var.rule-days}"
+    }
+  }
+  lifecycle_rule {
+    id = "${var.role-date}"
+    prefix = "${var.rule-prefix}/${var.role-date}"
+    enabled = true
+
+    expiration {
+      date = "${var.rule-date}"
+    }
+  }
+
+  referer_config {
+    allow_empty = "${var.allow-empty}"
+    referers = ["${var.referers}"]
+  }
+}

--- a/examples/alicloud-oss-bucket/outputs.tf
+++ b/examples/alicloud-oss-bucket/outputs.tf
@@ -1,0 +1,23 @@
+output "bucket-new" {
+  value = "${alicloud_oss_bucket.bucket-new.id}"
+}
+
+output "bucket-attr" {
+  value = "${alicloud_oss_bucket.bucket-attr.id}"
+}
+
+output "bucket-attr-website" {
+  value = "${alicloud_oss_bucket.bucket-attr.website}"
+}
+
+output "bucket-attr-logging" {
+  value = "${alicloud_oss_bucket.bucket-attr.logging}"
+}
+
+output "bucket-attr-lifecycle" {
+  value = "${alicloud_oss_bucket.bucket-attr.lifecycle}"
+}
+
+output "bucket-attr-referers" {
+  value = "${alicloud_oss_bucket.bucket-attr.referer_config}"
+}

--- a/examples/alicloud-oss-bucket/variables.tf
+++ b/examples/alicloud-oss-bucket/variables.tf
@@ -1,0 +1,51 @@
+variable "bucket-new" {
+  default = "bucket-20170509-1"
+}
+
+variable "bucket-attr"{
+  default = "bucket-20170509-2"
+}
+
+variable "acl-bj" {
+  default = "public-read"
+}
+
+variable "index-doc" {
+  default = "index.html"
+}
+
+variable "error-doc" {
+  default = "error.html"
+}
+
+variable "target-prefix" {
+  default = "log/"
+}
+
+variable "role-days" {
+  default = "expirationByDays"
+}
+
+variable "rule-days" {
+  default = 365
+}
+
+variable "role-date" {
+  default = "expirationByDate"
+}
+
+variable "rule-date" {
+  default = "2018-01-01"
+}
+
+variable "rule-prefix" {
+  default = "path"
+}
+
+variable "allow-empty" {
+  default = true
+}
+
+variable "referers" {
+  default = "http://www.aliyun.com, https://www.aliyun.com, http://?.aliyun.com"
+}


### PR DESCRIPTION
The PR has a dependency on terraform-providers/terraform-provider-alicloud#10. It adds two examples that create an oss bucket and set configuration for oss bucket.