### PR TITLE
alicloud/provider: Add new examples of oss bucket object

### DIFF
--- a/examples/alicloud-oss-bucket-object/main.tf
+++ b/examples/alicloud-oss-bucket-object/main.tf
@@ -1,0 +1,16 @@
+provider "alicloud" {
+  alias = "bj-prod"
+  region = "cn-beijing"
+}
+
+resource "alicloud_oss_bucket" "bucket-new" {
+  bucket = "${var.bucket-new}"
+  acl = "${var.acl}"
+}
+
+
+resource "alicloud_oss_bucket_object" "content" {
+  bucket = "${alicloud_oss_bucket.bucket-new.bucket}"
+  key = "${var.object-key}"
+  content = "${var.object-content}"
+}

--- a/examples/alicloud-oss-bucket-object/outputs.tf
+++ b/examples/alicloud-oss-bucket-object/outputs.tf
@@ -1,0 +1,8 @@
+output "bucket-new" {
+  value = "${alicloud_oss_bucket.bucket-new.id}"
+}
+
+output "content" {
+  value = "${alicloud_oss_bucket_object.content.id}"
+}
+

--- a/examples/alicloud-oss-bucket-object/variables.tf
+++ b/examples/alicloud-oss-bucket-object/variables.tf
@@ -1,0 +1,15 @@
+variable "bucket-new" {
+  default = "bucket-20170522-2"
+}
+
+variable "acl" {
+  default = "public-read"
+}
+
+variable "object-key"{
+  default = "object-content-key"
+}
+
+variable "object-content" {
+  default = "This is my object content in May 22, 2017"
+}


### PR DESCRIPTION
The PR has two dependencies on terraform-providers/terraform-provider-alicloud#10 and and terraform-providers/terraform-provider-alicloud#14. It adds an example that manage oss bucket and object.