### PR TITLE
Actively disallow reserved field names in schema

### DIFF
--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -17,6 +17,20 @@ type hclConfigurable struct {
 	Root *ast.File
 }
 
+var ReservedResourceFields = []string{
+	"connection",
+	"count",
+	"depends_on",
+	"lifecycle",
+	"provider",
+	"provisioner",
+}
+
+var ReservedProviderFields = []string{
+	"alias",
+	"version",
+}
+
 func (t *hclConfigurable) Config() (*Config, error) {
 	validKeys := map[string]struct{}{
 		"atlas":     struct{}{},

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -89,6 +90,13 @@ func (p *Provider) InternalValidate() error {
 		validationErrors = multierror.Append(validationErrors, err)
 	}
 
+	// Provider-specific checks
+	for k, _ := range sm {
+		if isReservedProviderFieldName(k) {
+			return fmt.Errorf("%s is a reserved field name for a provider", k)
+		}
+	}
+
 	for k, r := range p.ResourcesMap {
 		if err := r.InternalValidate(nil, true); err != nil {
 			validationErrors = multierror.Append(validationErrors, fmt.Errorf("resource %s: %s", k, err))
@@ -102,6 +110,15 @@ func (p *Provider) InternalValidate() error {
 	}
 
 	return validationErrors
+}
+
+func isReservedProviderFieldName(name string) bool {
+	for _, reservedName := range config.ReservedProviderFields {
+		if name == reservedName {
+			return true
+		}
+	}
+	return false
 }
 
 // Meta returns the metadata associated with this provider that was

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -394,7 +395,23 @@ func (r *Resource) InternalValidate(topSchemaMap schemaMap, writable bool) error
 		}
 	}
 
+	// Resource-specific checks
+	for k, _ := range tsm {
+		if isReservedResourceFieldName(k) {
+			return fmt.Errorf("%s is a reserved field name for a resource", k)
+		}
+	}
+
 	return schemaMap(r.Schema).InternalValidate(tsm)
+}
+
+func isReservedResourceFieldName(name string) bool {
+	for _, reservedName := range config.ReservedResourceFields {
+		if name == reservedName {
+			return true
+		}
+	}
+	return false
 }
 
 // Data returns a ResourceData struct for this Resource. Each return value


### PR DESCRIPTION
Previously providers/resources could specify reserved field names, they'd be just caught by schema code and deleted prior to execution of CRUD, so any such field would be ignored anyway.

Nonetheless I think we should be more upfront about this and fail the provider `InternalValidate` test if any schema contains reserved name.