### PR TITLE
Output duration in UiHook after successful operation completion.

### DIFF
--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -243,8 +243,8 @@ func (h *UiHook) PostApply(
 	}
 
 	colorized := h.Colorize.Color(fmt.Sprintf(
-		"[reset][bold]%s: %s%s[reset]",
-		id, msg, stateIdSuffix))
+		"[reset][bold]%s: %s after %s%s[reset]",
+		id, msg, time.Now().Round(time.Second).Sub(state.Start), stateIdSuffix))
 
 	h.ui.Output(colorized)
 

--- a/command/hook_ui_test.go
+++ b/command/hook_ui_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -186,10 +187,10 @@ func TestUiHookPostApply_emptyState(t *testing.T) {
 		t.Fatalf("Expected hook to continue, given: %#v", action)
 	}
 
-	expectedOutput := "data.google_compute_zones.available: Destruction complete\n"
+	expectedRegexp := "^data.google_compute_zones.available: Destruction complete after -?[a-z0-9.]+\n$"
 	output := ui.OutputWriter.String()
-	if output != expectedOutput {
-		t.Fatalf("Output didn't match.\nExpected: %q\nGiven: %q", expectedOutput, output)
+	if matched, _ := regexp.MatchString(expectedRegexp, output); !matched {
+		t.Fatalf("Output didn't match regexp.\nExpected: %q\nGiven: %q", expectedRegexp, output)
 	}
 
 	expectedErrOutput := ""


### PR DESCRIPTION
Output sample: `data.google_compute_zones.available: Destruction complete after 46.197682ms`

(For operations longer than a second, it will be truncated to the second; using the same timestamp rendering as the still-in-process updates.)