### PR TITLE
Allow non-AWS S3 backends

### DIFF
--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -112,6 +112,34 @@ func New() backend.Backend {
 				Default:     "",
 			},
 
+			"skip_credentials_validation": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Skip the credentials validation via STS API.",
+				Default:     false,
+			},
+
+			"skip_get_ec2_platforms": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Skip getting the supported EC2 platforms.",
+				Default:     false,
+			},
+
+			"skip_requesting_account_id": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Skip requesting the account ID.",
+				Default:     false,
+			},
+
+			"skip_metadata_api_check": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Skip the AWS Metadata API check.",
+				Default:     false,
+			},
+
 			"role_arn": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -192,17 +220,21 @@ func (b *Backend) configure(ctx context.Context) error {
 	}
 
 	cfg := &terraformAWS.Config{
-		AccessKey:             data.Get("access_key").(string),
-		AssumeRoleARN:         data.Get("role_arn").(string),
-		AssumeRoleExternalID:  data.Get("external_id").(string),
-		AssumeRolePolicy:      data.Get("assume_role_policy").(string),
-		AssumeRoleSessionName: data.Get("session_name").(string),
-		CredsFilename:         data.Get("shared_credentials_file").(string),
-		Profile:               data.Get("profile").(string),
-		Region:                data.Get("region").(string),
-		S3Endpoint:            data.Get("endpoint").(string),
-		SecretKey:             data.Get("secret_key").(string),
-		Token:                 data.Get("token").(string),
+		AccessKey:               data.Get("access_key").(string),
+		AssumeRoleARN:           data.Get("role_arn").(string),
+		AssumeRoleExternalID:    data.Get("external_id").(string),
+		AssumeRolePolicy:        data.Get("assume_role_policy").(string),
+		AssumeRoleSessionName:   data.Get("session_name").(string),
+		CredsFilename:           data.Get("shared_credentials_file").(string),
+		Profile:                 data.Get("profile").(string),
+		Region:                  data.Get("region").(string),
+		S3Endpoint:              data.Get("endpoint").(string),
+		SecretKey:               data.Get("secret_key").(string),
+		Token:                   data.Get("token").(string),
+		SkipCredsValidation:     data.Get("skip_credentials_validation").(bool),
+		SkipGetEC2Platforms:     data.Get("skip_get_ec2_platforms").(bool),
+		SkipRequestingAccountId: data.Get("skip_requesting_account_id").(bool),
+		SkipMetadataApiCheck:    data.Get("skip_metadata_api_check").(bool),
 	}
 
 	client, err := cfg.Client()

--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -111,3 +111,7 @@ The following configuration options or environment variables are supported:
  * `workspace_key_prefix` - (Optional) The prefix applied to the state path 
    inside the bucket. This is only relevant when using a non-default workspace.
    This defaults to "env:"
+ * `skip_credentials_validation` - (Optional) Skip the credentials validation via the STS API.
+ * `skip_get_ec2_platforms` - (Optional) Skip getting the supported EC2 platforms.
+ * `skip_requesting_account_id` - (Optional) Skip requesting the account ID.
+ * `skip_metadata_api_check` - (Optional) Skip the AWS Metadata API check.


### PR DESCRIPTION
This commit makes sts, metadata and other AWS related API calls optional, thus the backend initialization will not send non-AWS API tokens to AWS APIs.

This fixes #12377