### PR TITLE
helper/schema: Force field names to be alphanum lowercase + underscores

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -661,12 +662,23 @@ func (m schemaMap) InternalValidate(topSchemaMap schemaMap) error {
 		if v.ValidateFunc != nil {
 			switch v.Type {
 			case TypeList, TypeSet:
-				return fmt.Errorf("ValidateFunc is not yet supported on lists or sets.")
+				return fmt.Errorf("%s: ValidateFunc is not yet supported on lists or sets.", k)
+			}
+		}
+
+		if v.Deprecated == "" && v.Removed == "" {
+			if !isValidFieldName(k) {
+				return fmt.Errorf("%s: Field name may only contain lowercase alphanumeric characters & underscores.", k)
 			}
 		}
 	}
 
 	return nil
+}
+
+func isValidFieldName(name string) bool {
+	re := regexp.MustCompile("^[a-z0-9_]+$")
+	return re.MatchString(name)
 }
 
 func (m schemaMap) diff(

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3353,6 +3353,48 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			},
 			true,
 		},
+
+		"invalid field name format #1": {
+			map[string]*Schema{
+				"with space": &Schema{
+					Type:     TypeString,
+					Optional: true,
+				},
+			},
+			true,
+		},
+
+		"invalid field name format #2": {
+			map[string]*Schema{
+				"WithCapitals": &Schema{
+					Type:     TypeString,
+					Optional: true,
+				},
+			},
+			true,
+		},
+
+		"invalid field name format of a Deprecated field": {
+			map[string]*Schema{
+				"WithCapitals": &Schema{
+					Type:       TypeString,
+					Optional:   true,
+					Deprecated: "Use with_underscores instead",
+				},
+			},
+			false,
+		},
+
+		"invalid field name format of a Removed field": {
+			map[string]*Schema{
+				"WithCapitals": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Removed:  "Use with_underscores instead",
+				},
+			},
+			false,
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
This may look controversial, but it will actually hit a very small percentage of our official providers (4 fields across all providers in total).

Excluding deprecated & removed fields from the validation should allow us to phase out the fields with invalid names.

```sh
$ ls | xargs -I{} sh -c "cd {}; pwd; make test TESTARGS='-run=TestProvider'"
```
```
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-alicloud
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-alicloud github.com/terraform-providers/terraform-provider-alicloud/alicloud
?   	github.com/terraform-providers/terraform-provider-alicloud	[no test files]
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	0.014s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-archive
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-archive github.com/terraform-providers/terraform-provider-archive/archive
?   	github.com/terraform-providers/terraform-provider-archive	[no test files]
ok  	github.com/terraform-providers/terraform-provider-archive/archive	0.012s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-arukas
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-arukas github.com/terraform-providers/terraform-provider-arukas/arukas
?   	github.com/terraform-providers/terraform-provider-arukas	[no test files]
ok  	github.com/terraform-providers/terraform-provider-arukas/arukas	0.013s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-atlas
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-atlas github.com/terraform-providers/terraform-provider-atlas/atlas
?   	github.com/terraform-providers/terraform-provider-atlas	[no test files]
ok  	github.com/terraform-providers/terraform-provider-atlas/atlas	0.020s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-aws
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-aws github.com/terraform-providers/terraform-provider-aws/aws
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
--- FAIL: TestProvider (0.03s)
	provider_test.go:37: err: 1 error(s) occurred:

		* resource aws_elastictranscoder_preset: resolution:: Field name may only contain lowercase alphanumeric characters & underscores.
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	0.053s
make: *** [test] Error 1
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-azure
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-azure github.com/terraform-providers/terraform-provider-azure/azure
?   	github.com/terraform-providers/terraform-provider-azure	[no test files]
ok  	github.com/terraform-providers/terraform-provider-azure/azure	0.015s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-azurerm
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-azurerm github.com/terraform-providers/terraform-provider-azurerm/azurerm
?   	github.com/terraform-providers/terraform-provider-azurerm	[no test files]
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	0.024s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-bitbucket
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-bitbucket github.com/terraform-providers/terraform-provider-bitbucket/bitbucket
?   	github.com/terraform-providers/terraform-provider-bitbucket	[no test files]
ok  	github.com/terraform-providers/terraform-provider-bitbucket/bitbucket	0.012s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-chef
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-chef github.com/terraform-providers/terraform-provider-chef/chef
?   	github.com/terraform-providers/terraform-provider-chef	[no test files]
ok  	github.com/terraform-providers/terraform-provider-chef/chef	0.018s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-circonus
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-circonus github.com/terraform-providers/terraform-provider-circonus/circonus
?   	github.com/terraform-providers/terraform-provider-circonus	[no test files]
ok  	github.com/terraform-providers/terraform-provider-circonus/circonus	0.018s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-clc
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-clc github.com/terraform-providers/terraform-provider-clc/clc
?   	github.com/terraform-providers/terraform-provider-clc	[no test files]
ok  	github.com/terraform-providers/terraform-provider-clc/clc	0.017s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-cloudflare
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-cloudflare github.com/terraform-providers/terraform-provider-cloudflare/cloudflare
?   	github.com/terraform-providers/terraform-provider-cloudflare	[no test files]
ok  	github.com/terraform-providers/terraform-provider-cloudflare/cloudflare	0.019s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-cloudstack
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-cloudstack github.com/terraform-providers/terraform-provider-cloudstack/cloudstack
?   	github.com/terraform-providers/terraform-provider-cloudstack	[no test files]
ok  	github.com/terraform-providers/terraform-provider-cloudstack/cloudstack	0.019s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-cobbler
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-cobbler github.com/terraform-providers/terraform-provider-cobbler/cobbler
?   	github.com/terraform-providers/terraform-provider-cobbler	[no test files]
ok  	github.com/terraform-providers/terraform-provider-cobbler/cobbler	0.016s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-consul
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-consul github.com/terraform-providers/terraform-provider-consul/consul
?   	github.com/terraform-providers/terraform-provider-consul	[no test files]
ok  	github.com/terraform-providers/terraform-provider-consul/consul	0.012s [no tests to run]
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-datadog
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-datadog github.com/terraform-providers/terraform-provider-datadog/datadog
?   	github.com/terraform-providers/terraform-provider-datadog	[no test files]
ok  	github.com/terraform-providers/terraform-provider-datadog/datadog	0.016s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-digitalocean
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-digitalocean github.com/terraform-providers/terraform-provider-digitalocean/digitalocean
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	0.016s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-dme
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-dme github.com/terraform-providers/terraform-provider-dme/dme
?   	github.com/terraform-providers/terraform-provider-dme	[no test files]
--- FAIL: TestProvider (0.00s)
	provider_test.go:24: err: 1 error(s) occurred:

		* resource dme_record: hardLink: Field name may only contain lowercase alphanumeric characters & underscores.
FAIL
FAIL	github.com/terraform-providers/terraform-provider-dme/dme	0.022s
make: *** [test] Error 1
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-dns
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-dns github.com/terraform-providers/terraform-provider-dns/dns
?   	github.com/terraform-providers/terraform-provider-dns	[no test files]
ok  	github.com/terraform-providers/terraform-provider-dns/dns	0.025s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-dnsimple
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-dnsimple github.com/terraform-providers/terraform-provider-dnsimple/dnsimple
?   	github.com/terraform-providers/terraform-provider-dnsimple	[no test files]
ok  	github.com/terraform-providers/terraform-provider-dnsimple/dnsimple	0.012s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-docker
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-docker github.com/terraform-providers/terraform-provider-docker/docker
?   	github.com/terraform-providers/terraform-provider-docker	[no test files]
ok  	github.com/terraform-providers/terraform-provider-docker/docker	0.024s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-dyn
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-dyn github.com/terraform-providers/terraform-provider-dyn/dyn
?   	github.com/terraform-providers/terraform-provider-dyn	[no test files]
ok  	github.com/terraform-providers/terraform-provider-dyn/dyn	0.014s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-external
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-external github.com/terraform-providers/terraform-provider-external/external github.com/terraform-providers/terraform-provider-external/external/test-programs/tf-acc-external-data-source
?   	github.com/terraform-providers/terraform-provider-external	[no test files]
ok  	github.com/terraform-providers/terraform-provider-external/external	0.015s
?   	github.com/terraform-providers/terraform-provider-external/external/test-programs/tf-acc-external-data-source	[no test files]
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-fastly
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-fastly github.com/terraform-providers/terraform-provider-fastly/fastly
?   	github.com/terraform-providers/terraform-provider-fastly	[no test files]
ok  	github.com/terraform-providers/terraform-provider-fastly/fastly	0.016s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-github
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-github github.com/terraform-providers/terraform-provider-github/github
?   	github.com/terraform-providers/terraform-provider-github	[no test files]
ok  	github.com/terraform-providers/terraform-provider-github/github	0.033s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-gitlab
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-gitlab github.com/terraform-providers/terraform-provider-gitlab/gitlab
?   	github.com/terraform-providers/terraform-provider-gitlab	[no test files]
ok  	github.com/terraform-providers/terraform-provider-gitlab/gitlab	0.019s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-google
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-google github.com/terraform-providers/terraform-provider-google/google
?   	github.com/terraform-providers/terraform-provider-google	[no test files]
ok  	github.com/terraform-providers/terraform-provider-google/google	0.021s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-grafana
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-grafana github.com/terraform-providers/terraform-provider-grafana/grafana
?   	github.com/terraform-providers/terraform-provider-grafana	[no test files]
ok  	github.com/terraform-providers/terraform-provider-grafana/grafana	0.015s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-heroku
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-heroku github.com/terraform-providers/terraform-provider-heroku/heroku
?   	github.com/terraform-providers/terraform-provider-heroku	[no test files]
ok  	github.com/terraform-providers/terraform-provider-heroku/heroku	0.018s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-http
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-http github.com/terraform-providers/terraform-provider-http/http
?   	github.com/terraform-providers/terraform-provider-http	[no test files]
ok  	github.com/terraform-providers/terraform-provider-http/http	0.012s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-icinga2
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-icinga2 github.com/terraform-providers/terraform-provider-icinga2/icinga2
?   	github.com/terraform-providers/terraform-provider-icinga2	[no test files]
ok  	github.com/terraform-providers/terraform-provider-icinga2/icinga2	0.016s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-ignition
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-ignition github.com/terraform-providers/terraform-provider-ignition/ignition
?   	github.com/terraform-providers/terraform-provider-ignition	[no test files]
ok  	github.com/terraform-providers/terraform-provider-ignition/ignition	0.018s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-influxdb
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-influxdb github.com/terraform-providers/terraform-provider-influxdb/influxdb
?   	github.com/terraform-providers/terraform-provider-influxdb	[no test files]
ok  	github.com/terraform-providers/terraform-provider-influxdb/influxdb	0.012s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-kubernetes
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-kubernetes github.com/terraform-providers/terraform-provider-kubernetes/kubernetes
?   	github.com/terraform-providers/terraform-provider-kubernetes	[no test files]
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	0.080s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-librato
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-librato github.com/terraform-providers/terraform-provider-librato/librato
?   	github.com/terraform-providers/terraform-provider-librato	[no test files]
ok  	github.com/terraform-providers/terraform-provider-librato/librato	0.018s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-local
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-local github.com/terraform-providers/terraform-provider-local/local
?   	github.com/terraform-providers/terraform-provider-local	[no test files]
ok  	github.com/terraform-providers/terraform-provider-local/local	0.015s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-logentries
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-logentries github.com/terraform-providers/terraform-provider-logentries/logentries github.com/terraform-providers/terraform-provider-logentries/logentries/expect
?   	github.com/terraform-providers/terraform-provider-logentries	[no test files]
ok  	github.com/terraform-providers/terraform-provider-logentries/logentries	0.016s
?   	github.com/terraform-providers/terraform-provider-logentries/logentries/expect	[no test files]
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-mailgun
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-mailgun github.com/terraform-providers/terraform-provider-mailgun/mailgun
?   	github.com/terraform-providers/terraform-provider-mailgun	[no test files]
ok  	github.com/terraform-providers/terraform-provider-mailgun/mailgun	0.014s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-mysql
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-mysql github.com/terraform-providers/terraform-provider-mysql/mysql
?   	github.com/terraform-providers/terraform-provider-mysql	[no test files]
ok  	github.com/terraform-providers/terraform-provider-mysql/mysql	0.016s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-newrelic
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-newrelic github.com/terraform-providers/terraform-provider-newrelic/newrelic
?   	github.com/terraform-providers/terraform-provider-newrelic	[no test files]
ok  	github.com/terraform-providers/terraform-provider-newrelic/newrelic	0.018s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-nomad
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-nomad github.com/terraform-providers/terraform-provider-nomad/nomad
?   	github.com/terraform-providers/terraform-provider-nomad	[no test files]
ok  	github.com/terraform-providers/terraform-provider-nomad/nomad	0.016s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-ns1
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-ns1 github.com/terraform-providers/terraform-provider-ns1/ns1
?   	github.com/terraform-providers/terraform-provider-ns1	[no test files]
ok  	github.com/terraform-providers/terraform-provider-ns1/ns1	0.025s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-null
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-null github.com/terraform-providers/terraform-provider-null/null
?   	github.com/terraform-providers/terraform-provider-null	[no test files]
ok  	github.com/terraform-providers/terraform-provider-null/null	0.015s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-oneandone
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-oneandone github.com/terraform-providers/terraform-provider-oneandone/oneandone
?   	github.com/terraform-providers/terraform-provider-oneandone	[no test files]
ok  	github.com/terraform-providers/terraform-provider-oneandone/oneandone	0.014s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-opc
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-opc github.com/terraform-providers/terraform-provider-opc/opc
?   	github.com/terraform-providers/terraform-provider-opc	[no test files]
ok  	github.com/terraform-providers/terraform-provider-opc/opc	0.017s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-openstack
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-openstack github.com/terraform-providers/terraform-provider-openstack/openstack
?   	github.com/terraform-providers/terraform-provider-openstack	[no test files]
ok  	github.com/terraform-providers/terraform-provider-openstack/openstack	0.021s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-opsgenie
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-opsgenie github.com/terraform-providers/terraform-provider-opsgenie/opsgenie
?   	github.com/terraform-providers/terraform-provider-opsgenie	[no test files]
ok  	github.com/terraform-providers/terraform-provider-opsgenie/opsgenie	0.020s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-ovh
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-ovh github.com/terraform-providers/terraform-provider-ovh/ovh
?   	github.com/terraform-providers/terraform-provider-ovh	[no test files]
--- FAIL: TestProvider (0.00s)
	provider_test.go:29: err: 1 error(s) occurred:

		* data source ovh_publiccloud_region: datacenterLocation: Field name may only contain lowercase alphanumeric characters & underscores.
FAIL
FAIL	github.com/terraform-providers/terraform-provider-ovh/ovh	0.019s
make: *** [test] Error 1
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-packet
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-packet github.com/terraform-providers/terraform-provider-packet/packet
?   	github.com/terraform-providers/terraform-provider-packet	[no test files]
ok  	github.com/terraform-providers/terraform-provider-packet/packet	0.020s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-pagerduty
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-pagerduty github.com/terraform-providers/terraform-provider-pagerduty/pagerduty
?   	github.com/terraform-providers/terraform-provider-pagerduty	[no test files]
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	0.015s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-postgresql
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-postgresql github.com/terraform-providers/terraform-provider-postgresql/postgresql
?   	github.com/terraform-providers/terraform-provider-postgresql	[no test files]
ok  	github.com/terraform-providers/terraform-provider-postgresql/postgresql	0.016s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-powerdns
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-powerdns github.com/terraform-providers/terraform-provider-powerdns/powerdns
?   	github.com/terraform-providers/terraform-provider-powerdns	[no test files]
ok  	github.com/terraform-providers/terraform-provider-powerdns/powerdns	0.013s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-profitbricks
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-profitbricks github.com/terraform-providers/terraform-provider-profitbricks/profitbricks
?   	github.com/terraform-providers/terraform-provider-profitbricks	[no test files]
ok  	github.com/terraform-providers/terraform-provider-profitbricks/profitbricks	0.016s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-rabbitmq
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-rabbitmq github.com/terraform-providers/terraform-provider-rabbitmq/rabbitmq
?   	github.com/terraform-providers/terraform-provider-rabbitmq	[no test files]
ok  	github.com/terraform-providers/terraform-provider-rabbitmq/rabbitmq	0.015s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-rancher
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-rancher github.com/terraform-providers/terraform-provider-rancher/rancher
?   	github.com/terraform-providers/terraform-provider-rancher	[no test files]
ok  	github.com/terraform-providers/terraform-provider-rancher/rancher	0.025s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-random
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-random github.com/terraform-providers/terraform-provider-random/random
?   	github.com/terraform-providers/terraform-provider-random	[no test files]
ok  	github.com/terraform-providers/terraform-provider-random/random	0.012s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-rundeck
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-rundeck github.com/terraform-providers/terraform-provider-rundeck/rundeck
?   	github.com/terraform-providers/terraform-provider-rundeck	[no test files]
ok  	github.com/terraform-providers/terraform-provider-rundeck/rundeck	0.017s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-scaleway
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-scaleway github.com/terraform-providers/terraform-provider-scaleway/scaleway
?   	github.com/terraform-providers/terraform-provider-scaleway	[no test files]
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway	0.013s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-softlayer
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-softlayer github.com/terraform-providers/terraform-provider-softlayer/softlayer
?   	github.com/terraform-providers/terraform-provider-softlayer	[no test files]
ok  	github.com/terraform-providers/terraform-provider-softlayer/softlayer	0.021s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-spotinst
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-spotinst github.com/terraform-providers/terraform-provider-spotinst/spotinst
?   	github.com/terraform-providers/terraform-provider-spotinst	[no test files]
ok  	github.com/terraform-providers/terraform-provider-spotinst/spotinst	0.018s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-statuscake
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-statuscake github.com/terraform-providers/terraform-provider-statuscake/statuscake
?   	github.com/terraform-providers/terraform-provider-statuscake	[no test files]
ok  	github.com/terraform-providers/terraform-provider-statuscake/statuscake	0.012s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-template
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-template github.com/terraform-providers/terraform-provider-template/template
?   	github.com/terraform-providers/terraform-provider-template	[no test files]
ok  	github.com/terraform-providers/terraform-provider-template/template	0.021s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-terraform
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-terraform github.com/terraform-providers/terraform-provider-terraform/terraform
?   	github.com/terraform-providers/terraform-provider-terraform	[no test files]
ok  	github.com/terraform-providers/terraform-provider-terraform/terraform	0.040s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-tls
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-tls github.com/terraform-providers/terraform-provider-tls/tls
?   	github.com/terraform-providers/terraform-provider-tls	[no test files]
ok  	github.com/terraform-providers/terraform-provider-tls/tls	0.017s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-triton
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-triton github.com/terraform-providers/terraform-provider-triton/triton
?   	github.com/terraform-providers/terraform-provider-triton	[no test files]
ok  	github.com/terraform-providers/terraform-provider-triton/triton	0.012s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-ultradns
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-ultradns github.com/terraform-providers/terraform-provider-ultradns/ultradns
?   	github.com/terraform-providers/terraform-provider-ultradns	[no test files]
ok  	github.com/terraform-providers/terraform-provider-ultradns/ultradns	0.018s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-vault
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-vault github.com/terraform-providers/terraform-provider-vault/vault
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
ok  	github.com/terraform-providers/terraform-provider-vault/vault	0.016s
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-vcd
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-vcd github.com/terraform-providers/terraform-provider-vcd/vcd
?   	github.com/terraform-providers/terraform-provider-vcd	[no test files]
--- FAIL: TestProvider (0.00s)
	provider_test.go:23: err: 1 error(s) occurred:

		* maxRetryTimeout: Field name may only contain lowercase alphanumeric characters & underscores.
FAIL
FAIL	github.com/terraform-providers/terraform-provider-vcd/vcd	0.012s
make: *** [test] Error 1
/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-vsphere
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -run=TestProvider -timeout=30s -parallel=4
go test -run=TestProvider -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-vsphere github.com/terraform-providers/terraform-provider-vsphere/vsphere
?   	github.com/terraform-providers/terraform-provider-vsphere	[no test files]
ok  	github.com/terraform-providers/terraform-provider-vsphere/vsphere	0.020s
```