### PR TITLE
Add warning to mismatched plan state

### DIFF
--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -49,6 +49,10 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 	}
 
 	// Load our state
+	// By the time we get here, the backend creation code in "command" took
+	// care of making s.State() return a state compatible with our plan,
+	// if any, so we can safely pass this value in both the plan context
+	// and new context cases below.
 	opts.State = s.State()
 
 	// Build the context


### PR DESCRIPTION
Forward-port the plan state check from the 0.9 series.
0.10 has improved the serial handling for the state, so this adds relevant
comments and some more test coverage for the case of an incrementing
serial during apply.

Supersedes #15421 