### PR TITLE
Usage line for force-unlock is wrong.

### DIFF
--- a/website/docs/commands/force-unlock.html.markdown
+++ b/website/docs/commands/force-unlock.html.markdown
@@ -17,7 +17,7 @@ process.
 
 ## Usage
 
-Usage: terraform force-unlock [DIR]
+Usage: terraform force-unlock LOCK_ID [DIR]
 
 Manually unlock the state for the defined configuration.
 


### PR DESCRIPTION
non-optional argument `LOCK_ID`  was omitted from documentation.