### PR TITLE
plugin/discovery: trim off .exe suffix when parsing filenames

### DIFF
--- a/plugin/discovery/find.go
+++ b/plugin/discovery/find.go
@@ -129,6 +129,12 @@ func ResolvePluginPaths(paths []string) PluginMetaSet {
 			continue
 		}
 
+		// Trim the .exe suffix used on Windows before we start wrangling
+		// the remainder of the path.
+		if strings.HasSuffix(baseName, ".exe") {
+			baseName = baseName[:len(baseName)-4]
+		}
+
 		parts := strings.SplitN(baseName, "_v", 2)
 		name := parts[0]
 		version := VersionZero

--- a/plugin/discovery/find_test.go
+++ b/plugin/discovery/find_test.go
@@ -19,7 +19,7 @@ func TestFindPluginPaths(t *testing.T) {
 	)
 	want := []string{
 		filepath.Join("test-fixtures", "current-style-plugins", "mockos_mockarch", "terraform-foo-bar_v0.0.1"),
-		filepath.Join("test-fixtures", "current-style-plugins", "mockos_mockarch", "terraform-foo-bar_v1.0.0"),
+		filepath.Join("test-fixtures", "current-style-plugins", "mockos_mockarch", "terraform-foo-bar_v1.0.0.exe"),
 		// un-versioned plugins are still picked up, even in current-style paths
 		filepath.Join("test-fixtures", "current-style-plugins", "mockos_mockarch", "terraform-foo-missing-version"),
 		filepath.Join("test-fixtures", "legacy-style-plugins", "terraform-foo-bar"),
@@ -59,6 +59,9 @@ func TestResolvePluginPaths(t *testing.T) {
 		"/example/terraform-foo-bar",
 		"/example/mockos_mockarch/terraform-foo-bar_vbananas",
 		"/example/mockos_mockarch/terraform-foo-bar_v",
+		"/example/mockos_mockarch/terraform-foo-windowsthing1_v1.0.0.exe",
+		"/example/mockos_mockarch/terraform-foo-windowsthing2_v1.0.0_x4.exe",
+		"/example/mockos_mockarch/terraform-foo-windowsthing3.exe",
 		"/example2/mockos_mockarch/terraform-foo-bar_v0.0.1",
 	})
 
@@ -102,6 +105,21 @@ func TestResolvePluginPaths(t *testing.T) {
 			Name:    "bar",
 			Version: "",
 			Path:    "/example/mockos_mockarch/terraform-foo-bar_v",
+		},
+		{
+			Name:    "windowsthing1",
+			Version: "1.0.0",
+			Path:    "/example/mockos_mockarch/terraform-foo-windowsthing1_v1.0.0.exe",
+		},
+		{
+			Name:    "windowsthing2",
+			Version: "1.0.0",
+			Path:    "/example/mockos_mockarch/terraform-foo-windowsthing2_v1.0.0_x4.exe",
+		},
+		{
+			Name:    "windowsthing3",
+			Version: "0.0.0",
+			Path:    "/example/mockos_mockarch/terraform-foo-windowsthing3.exe",
 		},
 	}
 


### PR DESCRIPTION
On Windows systems the plugin binaries use a `.exe` suffix, which we were misparsing as part of either the "v" or "x" parts of the filename.

This fixes #15578.