### PR TITLE
graph should not panic with no config

### DIFF
--- a/command/graph.go
+++ b/command/graph.go
@@ -88,6 +88,12 @@ func (c *GraphCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Building a graph may require config module to be present, even if it's
+	// empty.
+	if mod == nil && plan == nil {
+		mod = module.NewEmptyTree()
+	}
+
 	// Build the operation
 	opReq := c.Operation()
 	opReq.Module = mod

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -81,6 +81,28 @@ func TestGraph_noArgs(t *testing.T) {
 	}
 }
 
+func TestGraph_noConfig(t *testing.T) {
+	td := tempDir(t)
+	os.MkdirAll(td, 0755)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	ui := new(cli.MockUi)
+	c := &GraphCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			Ui:               ui,
+		},
+	}
+
+	// Running the graph command without a config should not panic,
+	// but this may be an error at some point in the future.
+	args := []string{"-type", "apply"}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+}
+
 func TestGraph_plan(t *testing.T) {
 	tmp, cwd := testCwd(t)
 	defer testFixCwd(t, tmp, cwd)


### PR DESCRIPTION
The backends replace a nil module tree with an empty one before building
the graph, so the graph command needs to do the same.

Fixes #15564