### PR TITLE
Documenting implicit behavior of string types to boolean and decimal.

### DIFF
--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -57,7 +57,7 @@ These are the parameters that can be set:
 - `type` (optional) - If set this defines the type of the variable. Valid values
   are `string`, `list`, and `map`. If this field is omitted, the variable type
   will be inferred based on the `default`. If no `default` is provided, the type
-  is assumed to be `string`.
+  is assumed to be `string`. Terraform will make an implicit conversation of any values to `boolean` or `decimal` types if the consumer expects that.
 
 - `default` (optional) - This sets a default value for the variable. If no
   default is provided, the variable is considered required and Terraform will


### PR DESCRIPTION
Updating documentation per #6254 .

**Reasoning for documentation update:**
Unclear documentation on how variables such as "0" or "true" would be handled when something such as `count` would expect a specific type (integer in this case)

**Relevant Terraform version:**
Current version

