### PR TITLE
Fix swallowed err in acctest package

### DIFF
--- a/helper/acctest/random.go
+++ b/helper/acctest/random.go
@@ -60,6 +60,9 @@ func RandStringFromCharSet(strlen int, charSet string) string {
 // returned in OpenSSH format, and the private key is PEM encoded.
 func RandSSHKeyPair(comment string) (string, string, error) {
 	privateKey, privateKeyPEM, err := genPrivateKey()
+	if err != nil {
+		return "", "", err
+	}
 
 	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
 	if err != nil {


### PR DESCRIPTION
I found a swallowed error in the acctest package where an SSH private key was being generated.