### PR TITLE
Drop untestable error in localexec tests

### DIFF
--- a/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -64,7 +64,8 @@ func TestResourceProvider_stop(t *testing.T) {
 		defer close(doneCh)
 		// The functionality of p.Apply is tested in TestResourceProvider_Apply.
 		// Because p.Apply is called in a goroutine, trying to t.Fatal() on its
-		// result would be ignored.
+		// result would be ignored or would cause a panic if the parent goroutine
+		// has already completed.
 		_ = p.Apply(output, nil, c)
 	}()
 

--- a/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -58,26 +58,35 @@ func TestResourceProvider_stop(t *testing.T) {
 	output := new(terraform.MockUIOutput)
 	p := Provisioner()
 
-	var err error
 	doneCh := make(chan struct{})
+	startTime := time.Now()
 	go func() {
 		defer close(doneCh)
-		err = p.Apply(output, nil, c)
+		// The functionality of p.Apply is tested in TestResourceProvider_Apply.
+		// Because p.Apply is called in a goroutine, trying to t.Fatal() on its
+		// result would be ignored.
+		_ = p.Apply(output, nil, c)
 	}()
 
+	mustExceed := (50 * time.Millisecond)
 	select {
 	case <-doneCh:
-		t.Fatal("should not finish quickly")
-	case <-time.After(50 * time.Millisecond):
+		t.Fatalf("expected to finish sometime after %s finished in %s", mustExceed, time.Since(startTime))
+	case <-time.After(mustExceed):
+		t.Logf("correctly took longer than %s", mustExceed)
 	}
 
 	// Stop it
+	stopTime := time.Now()
 	p.Stop()
 
+	maxTempl := "expected to finish under %s, finished in %s"
+	finishWithin := (2 * time.Second)
 	select {
 	case <-doneCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("should finish")
+		t.Logf(maxTempl, finishWithin, time.Since(stopTime))
+	case <-time.After(finishWithin):
+		t.Fatalf(maxTempl, finishWithin, time.Since(stopTime))
 	}
 }
 


### PR DESCRIPTION
TestResourceProvider_stop() is testing the ability to stop a Provisioner, while TestResourceProvider_Apply() is testing Apply().

TestResourceProvider_stop() uses a goroutine, which means that any function with *testing.T as its receiver within that goroutine will silently fail.

This PR changes the test to accept that an error that occurs within the goroutine is lost. It also adds some verbosity to the logs to explain what is happening.