### PR TITLE
[WIP] Create InputGraphBuilder

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -258,11 +258,11 @@ func (c *Context) Graph(typ GraphType, opts *ContextGraphOpts) (*Graph, error) {
 	case GraphTypeInput:
 		return (&InputGraphBuilder{
 			Module:    c.module,
-			State:     c.state,
 			Providers: c.components.ResourceProviders(),
 			Targets:   c.targets,
 			Validate:  opts.Validate,
 		}).Build(RootModulePath)
+
 	case GraphTypeValidate:
 		// The validate graph is just a slightly modified plan graph
 		fallthrough

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -256,8 +256,13 @@ func (c *Context) Graph(typ GraphType, opts *ContextGraphOpts) (*Graph, error) {
 		}).Build(RootModulePath)
 
 	case GraphTypeInput:
-		// The input graph is just a slightly modified plan graph
-		fallthrough
+		return (&InputGraphBuilder{
+			Module:    c.module,
+			State:     c.state,
+			Providers: c.components.ResourceProviders(),
+			Targets:   c.targets,
+			Validate:  opts.Validate,
+		}).Build(RootModulePath)
 	case GraphTypeValidate:
 		// The validate graph is just a slightly modified plan graph
 		fallthrough
@@ -273,10 +278,7 @@ func (c *Context) Graph(typ GraphType, opts *ContextGraphOpts) (*Graph, error) {
 
 		// Some special cases for other graph types shared with plan currently
 		var b GraphBuilder = p
-		switch typ {
-		case GraphTypeInput:
-			b = InputGraphBuilder(p)
-		case GraphTypeValidate:
+		if typ == GraphTypeValidate {
 			// We need to set the provisioners so those can be validated
 			p.Provisioners = c.components.ResourceProvisioners()
 

--- a/terraform/graph_builder_input.go
+++ b/terraform/graph_builder_input.go
@@ -1,27 +1,148 @@
 package terraform
 
 import (
+	"sync"
+
+	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/dag"
 )
 
-// InputGraphBuilder creates the graph for the input operation.
-//
-// Unlike other graph builders, this is a function since it currently modifies
-// and is based on the PlanGraphBuilder. The PlanGraphBuilder passed in will be
-// modified and should not be used for any other operations.
-func InputGraphBuilder(p *PlanGraphBuilder) GraphBuilder {
+// InputGraphBuilder implements GraphBuilder and is responsible for building
+// a graph for input.
+type InputGraphBuilder struct {
+	// Module is the root module for the graph to build.
+	Module *module.Tree
+
+	// State is the current state
+	State *State
+
+	// Providers is the list of providers supported.
+	Providers []string
+
+	// Provisioners is the list of provisioners supported.
+	Provisioners []string
+
+	// Targets are resources to target
+	Targets []string
+
+	// DisableReduce, if true, will not reduce the graph. Great for testing.
+	DisableReduce bool
+
+	// Validate will do structural validation of the graph.
+	Validate bool
+
+	// CustomConcrete can be set to customize the node types created
+	// for various parts of the plan. This is useful in order to customize
+	// the plan behavior.
+	CustomConcrete         bool
+	ConcreteProvider       ConcreteProviderNodeFunc
+	ConcreteResource       ConcreteResourceNodeFunc
+	ConcreteResourceOrphan ConcreteResourceNodeFunc
+
+	once sync.Once
+}
+
+// See GraphBuilder
+func (b *InputGraphBuilder) Build(path []string) (*Graph, error) {
+	return (&BasicGraphBuilder{
+		Steps:    b.Steps(),
+		Validate: b.Validate,
+		Name:     "InputGraphBuilder",
+	}).Build(path)
+}
+
+// See GraphBuilder
+func (b *InputGraphBuilder) Steps() []GraphTransformer {
+	b.once.Do(b.init)
+
+	steps := []GraphTransformer{
+		// Creates all the resources represented in the config
+		&ConfigTransformer{
+			Concrete: b.ConcreteResource,
+			Module:   b.Module,
+		},
+
+		// Add the outputs
+		&OutputTransformer{Module: b.Module},
+
+		// Add orphan resources
+		&OrphanResourceTransformer{
+			Concrete: b.ConcreteResourceOrphan,
+			State:    b.State,
+			Module:   b.Module,
+		},
+
+		// Attach the configuration to any resources
+		&AttachResourceConfigTransformer{Module: b.Module},
+
+		// Attach the state
+		&AttachStateTransformer{State: b.State},
+
+		// Add root variables
+		&RootVariableTransformer{Module: b.Module},
+
+		// Create all the providers
+		&MissingProviderTransformer{Providers: b.Providers, Concrete: b.ConcreteProvider},
+		&ProviderTransformer{},
+		&DisableProviderTransformer{},
+		&ParentProviderTransformer{},
+		&AttachProviderConfigTransformer{Module: b.Module},
+
+		// Provisioner-related transformations. Only add these if requested.
+		GraphTransformIf(
+			func() bool { return b.Provisioners != nil },
+			GraphTransformMulti(
+				&MissingProvisionerTransformer{Provisioners: b.Provisioners},
+				&ProvisionerTransformer{},
+			),
+		),
+
+		// Add module variables
+		&ModuleVariableTransformer{Module: b.Module},
+
+		// Connect so that the references are ready for targeting. We'll
+		// have to connect again later for providers and so on.
+		&ReferenceTransformer{},
+
+		// Add the node to fix the state count boundaries
+		&CountBoundaryTransformer{},
+
+		// Target
+		&TargetsTransformer{
+			Targets: b.Targets,
+
+			// Resource nodes from config have not yet been expanded for
+			// "count", so we must apply targeting without indices. Exact
+			// targeting will be dealt with later when these resources
+			// DynamicExpand.
+			IgnoreIndices: true,
+		},
+
+		// Close opened plugin connections
+		&CloseProviderTransformer{},
+		&CloseProvisionerTransformer{},
+
+		// Single root
+		&RootTransformer{},
+	}
+
+	if !b.DisableReduce {
+		// Perform the transitive reduction to make our graph a bit
+		// more sane if possible (it usually is possible).
+		steps = append(steps, &TransitiveReductionTransformer{})
+	}
+
+	return steps
+}
+
+func (b *InputGraphBuilder) init() {
 	// We're going to customize the concrete functions
-	p.CustomConcrete = true
+	b.CustomConcrete = true
 
 	// Set the provider to the normal provider. This will ask for input.
-	p.ConcreteProvider = func(a *NodeAbstractProvider) dag.Vertex {
+	b.ConcreteProvider = func(a *NodeAbstractProvider) dag.Vertex {
 		return &NodeApplyableProvider{
 			NodeAbstractProvider: a,
 		}
 	}
-
-	// We purposely don't set any more concrete fields since the remainder
-	// should be no-ops.
-
-	return p
 }


### PR DESCRIPTION
Don't handle module variables at all during the Input operation. Because Input happens before Refresh, module variable interpolation can fail when referencing values that aren't yet in the state, but are expected after Refresh. 

This creates a new `InputGraphBuilder`, which strips out all the unneeded pieces transformations inherited form the `PlanGraphBuilder`, most importantly the `ModuleVariableTransformer`.  This also removes the state entirely from the Input phase. Because Input happens before Refresh, but possibly depended on the state that will be refreshed, it is simpler to reason about if we don't allow the Input phase to depend on the state at all.

