### PR TITLE
Document changes to terraform import behavior (v0.10.0-beta1 onward) as a backwards incompatibility in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
   this was not true. After upgrading, be sure to look carefully at the set of changes proposed by `terraform plan` when using `-target`
   to ensure that the target is being interpreted as expected. Note that the `-target` argument is offered for exceptional circumstances
   only and is not intended for routine use.
+* The `import` command requires that imported resources be specified in the configuration file. Previously, users were encouraged to
+  import a resource and _then_ write the configuration block for it. This creates the risk that users could import a resource and
+  subsequently create no configuration for it, which results in Terraform deleting the resource. ([#11835](https://github.com/hashicorp/terraform/issues/11835))
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,8 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
   only and is not intended for routine use.
 * The `import` command requires that imported resources be specified in the configuration file. Previously, users were encouraged to
   import a resource and _then_ write the configuration block for it. This creates the risk that users could import a resource and
-  subsequently create no configuration for it, which results in Terraform deleting the resource. ([#11835](https://github.com/hashicorp/terraform/issues/11835))
+  subsequently create no configuration for it, which results in Terraform deleting the resource. If the imported resource is not
+  present in the configuration file, the `import` command will fail.
 
 IMPROVEMENTS:
 


### PR DESCRIPTION
It came as a surprise to my team when migrating to Terraform v0.10.0-rc1 that our `terraform import` commands would fail, even though we had read the changelog and noticed no potentially breaking changes related to import commands. (Specifically, we were calling `terraform import` with a template that only contained a provider block.) For the benefit of others who may be in the same situation, I thought this might be worth calling out explicitly in the changelogs, with a link to the issue ([#11835](https://github.com/hashicorp/terraform/issues/11835)) that provides the reasoning behind the change.

Documentation is based on the notes in PR [#14561](https://github.com/hashicorp/terraform/pull/14561), and the commit message which changed import behavior, [9a398a779383795f8bb79548aea98efa9e5e4df9](https://github.com/hashicorp/terraform/commit/9a398a779383795f8bb79548aea98efa9e5e4df9).