### PR TITLE
state commands with remote state backends

### DIFF
--- a/command/state_meta.go
+++ b/command/state_meta.go
@@ -11,30 +11,32 @@ import (
 )
 
 // StateMeta is the meta struct that should be embedded in state subcommands.
-type StateMeta struct{}
+type StateMeta struct {
+	Meta
+}
 
 // State returns the state for this meta. This gets the appropriate state from
 // the backend, but changes the way that backups are done. This configures
 // backups to be timestamped rather than just the original state path plus a
 // backup path.
-func (c *StateMeta) State(m *Meta) (state.State, error) {
+func (c *StateMeta) State() (state.State, error) {
 	var realState state.State
-	backupPath := m.backupPath
-	stateOutPath := m.statePath
+	backupPath := c.backupPath
+	stateOutPath := c.statePath
 
 	// use the specified state
-	if m.statePath != "" {
+	if c.statePath != "" {
 		realState = &state.LocalState{
-			Path: m.statePath,
+			Path: c.statePath,
 		}
 	} else {
 		// Load the backend
-		b, err := m.Backend(nil)
+		b, err := c.Backend(nil)
 		if err != nil {
 			return nil, err
 		}
 
-		env := m.Workspace()
+		env := c.Workspace()
 		// Get the state
 		s, err := b.State(env)
 		if err != nil {
@@ -42,7 +44,7 @@ func (c *StateMeta) State(m *Meta) (state.State, error) {
 		}
 
 		// Get a local backend
-		localRaw, err := m.Backend(&BackendOpts{ForceLocal: true})
+		localRaw, err := c.Backend(&BackendOpts{ForceLocal: true})
 		if err != nil {
 			// This should never fail
 			panic(err)

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -40,7 +40,7 @@ func (c *StateMvCommand) Run(args []string) int {
 	stateFrom, err := c.State()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
-		return cli.RunResultHelp
+		return 1
 	}
 
 	if err := stateFrom.RefreshState(); err != nil {
@@ -64,7 +64,7 @@ func (c *StateMvCommand) Run(args []string) int {
 		stateTo, err = c.State()
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
-			return cli.RunResultHelp
+			return 1
 		}
 
 		if err := stateTo.RefreshState(); err != nil {

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -183,28 +183,30 @@ func (c *StateMvCommand) addableResult(results []*terraform.StateFilterResult) i
 
 func (c *StateMvCommand) Help() string {
 	helpText := `
-Usage: terraform state mv [options] ADDRESS ADDRESS
+Usage: terraform state mv [options] SOURCE DESTINATION
 
-  Move an item in the state to another location or to a completely different
-  state file.
+ This command will move an item matched by the address given to the
+ destination address. This command can also move to a destination address
+ in a completely different state file.
 
-  This command is useful for module refactors (moving items into a module),
-  configuration refactors (moving items to a completely different or new
-  state file), or generally renaming of resources.
+ This can be used for simple resource renaming, moving items to and from
+ a module, moving entire modules, and more. And because this command can also
+ move data to a completely new state, it can also be used for refactoring
+ one configuration into multiple separately managed Terraform configurations.
 
-  This command creates a timestamped backup of the state on every invocation.
-  This can't be disabled. Due to the destructive nature of this command,
-  the backup is ensured by Terraform for safety reasons.
+ This command will output a backup copy of the state prior to saving any
+ changes. The backup cannot be disabled. Due to the destructive nature
+ of this command, backups are required.
 
-  If you're moving from one state file to a different state file, a backup
-  will be created for each state file.
+ If you're moving an item to a different state file, a backup will be created
+ for each state file.
 
 Options:
 
   -backup=PATH        Path where Terraform should write the backup for the original
                       state. This can't be disabled. If not set, Terraform
                       will write it to the same path as the statefile with
-                      a backup extension.
+                      a ".backup" extension.
 
   -backup-out=PATH    Path where Terraform should write the backup for the destination
                       state. This can't be disabled. If not set, Terraform
@@ -213,13 +215,12 @@ Options:
                       to be specified if -state-out is set to a different path
                       than -state.
 
-  -state=PATH         Path to a Terraform state file to use to look
-                      up Terraform-managed resources. By default it will
-                      use the state "terraform.tfstate" if it exists.
+  -state=PATH         Path to the source state file. Defaults to the configured
+                      backend, or "terraform.tfstate"
 
-  -state-out=PATH     Path to the destination state file to move the item
-                      to. This defaults to the same statefile. This will
-                      overwrite the destination state file.
+  -state-out=PATH     Path to the destination state file to write to. If this
+                      isn't specified, the source state file will be used. This
+                      can be a new or existing path.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -24,7 +24,7 @@ func (c *StateMvCommand) Run(args []string) int {
 	var meta1, meta2 Meta
 	cmdFlags := c.Meta.flagSet("state mv")
 	cmdFlags.StringVar(&meta1.backupPath, "backup", "-", "backup")
-	cmdFlags.StringVar(&meta1.statePath, "state", DefaultStateFilename, "path")
+	cmdFlags.StringVar(&meta1.statePath, "state", "", "path")
 	cmdFlags.StringVar(&meta2.backupPath, "backup-out", "-", "backup")
 	cmdFlags.StringVar(&meta2.statePath, "state-out", "", "path")
 	if err := cmdFlags.Parse(args); err != nil {

--- a/command/state_mv_test.go
+++ b/command/state_mv_test.go
@@ -47,9 +47,11 @@ func TestStateMv(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateMvCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 
@@ -133,9 +135,11 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 	p := testProvider()
 	ui = new(cli.MockUi)
 	c := &StateMvCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 
@@ -194,9 +198,11 @@ func TestStateMv_backupExplicit(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateMvCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 
@@ -244,9 +250,11 @@ func TestStateMv_stateOutNew(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateMvCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 
@@ -316,9 +324,11 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateMvCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 
@@ -357,9 +367,11 @@ func TestStateMv_noState(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateMvCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 
@@ -418,9 +430,11 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateMvCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 
@@ -596,9 +610,11 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateMvCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 
@@ -677,9 +693,11 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateMvCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 

--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -21,7 +21,7 @@ func (c *StateRmCommand) Run(args []string) int {
 
 	cmdFlags := c.Meta.flagSet("state show")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "-", "backup")
-	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
+	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	if err := cmdFlags.Parse(args); err != nil {
 		return cli.RunResultHelp
 	}

--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -9,7 +9,6 @@ import (
 
 // StateRmCommand is a Command implementation that shows a single resource.
 type StateRmCommand struct {
-	Meta
 	StateMeta
 }
 
@@ -20,8 +19,8 @@ func (c *StateRmCommand) Run(args []string) int {
 	}
 
 	cmdFlags := c.Meta.flagSet("state show")
-	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "-", "backup")
-	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
+	cmdFlags.StringVar(&c.backupPath, "backup", "-", "backup")
+	cmdFlags.StringVar(&c.statePath, "state", "", "path")
 	if err := cmdFlags.Parse(args); err != nil {
 		return cli.RunResultHelp
 	}
@@ -32,7 +31,7 @@ func (c *StateRmCommand) Run(args []string) int {
 		return 1
 	}
 
-	state, err := c.StateMeta.State(&c.Meta)
+	state, err := c.State()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 		return cli.RunResultHelp

--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -34,7 +34,7 @@ func (c *StateRmCommand) Run(args []string) int {
 	state, err := c.State()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
-		return cli.RunResultHelp
+		return 1
 	}
 	if err := state.RefreshState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))

--- a/command/state_rm_test.go
+++ b/command/state_rm_test.go
@@ -47,9 +47,11 @@ func TestStateRm(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateRmCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 
@@ -109,9 +111,11 @@ func TestStateRmNoArgs(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateRmCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 
@@ -169,9 +173,11 @@ func TestStateRm_backupExplicit(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateRmCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 
@@ -198,9 +204,11 @@ func TestStateRm_noState(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &StateRmCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			},
 		},
 	}
 

--- a/command/state_test.go
+++ b/command/state_test.go
@@ -28,7 +28,7 @@ func TestStateDefaultBackupExtension(t *testing.T) {
 	tmp, cwd := testCwd(t)
 	defer testFixCwd(t, tmp, cwd)
 
-	s, err := (&StateMeta{}).State(&Meta{})
+	s, err := (&StateMeta{}).State()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/commands.go
+++ b/commands.go
@@ -276,13 +276,17 @@ func init() {
 
 		"state rm": func() (cli.Command, error) {
 			return &command.StateRmCommand{
-				Meta: meta,
+				StateMeta: command.StateMeta{
+					Meta: meta,
+				},
 			}, nil
 		},
 
 		"state mv": func() (cli.Command, error) {
 			return &command.StateMvCommand{
-				Meta: meta,
+				StateMeta: command.StateMeta{
+					Meta: meta,
+				},
 			}, nil
 		},
 

--- a/website/docs/commands/state/mv.html.md
+++ b/website/docs/commands/state/mv.html.md
@@ -40,19 +40,22 @@ in [resource addressing format](/docs/commands/state/addressing.html).
 
 The command-line flags are all optional. The list of available flags are:
 
-* `-backup=path` - Path to a backup file Defaults to the state path plus
-                   a timestamp with the ".backup" extension.
+* `-backup=path` - Path where Terraform should write the backup for the
+  original state. This can't be disabled. If not set, Terraform will write it
+  to the same path as the statefile with a ".backup" extension.
 
-* `-backup-out=path` - Path to the backup file for the output state.
-                       This is only necessary if `-state-out` is specified.
+* `-backup-out=path` - Path where Terraform should write the backup for the
+  destination state. This can't be disabled. If not set, Terraform will write
+  it to the same path as the destination state file with a backup extension.
+  This only needs to be specified if -state-out is set to a different path than
+  -state.
 
-* `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
-  Ignored when [remote state](/docs/state/remote.html) is used.
+* `-state=path` - Path to the source state file to read from. Defaults to the
+  configured backend, or "terraform.tfstate".
 
-* `-state-out=path` - Path to the state file to write to. If this isn't specified
-                      the state specified by `-state` will be used. This can be
-                      a new or existing path. Ignored when
-                      [remote state](/docs/state/remote.html) is used.
+* `-state-out=path` - Path to the destination state file to write to. If this
+  isn't specified the source state file will be used. This can be a new or
+  existing path.
 
 ## Example: Rename a Resource
 

--- a/website/docs/commands/state/rm.html.md
+++ b/website/docs/commands/state/rm.html.md
@@ -17,7 +17,7 @@ and more.
 
 Usage: `terraform state rm [options] ADDRESS...`
 
-The command will remove all the items matched by the addresses given.
+Remove one or more items from the Terraform state.
 
 Items removed from the Terraform state are _not physically destroyed_.
 Items removed from the Terraform state are only no longer managed by
@@ -43,10 +43,13 @@ in [resource addressing format](/docs/commands/state/addressing.html).
 
 The command-line flags are all optional. The list of available flags are:
 
-* `-backup=path` - Path to a backup file Defaults to the state path plus
-                   a timestamp with the ".backup" extension.
+* `-backup=path` - Path where Terraform should write the backup state. This
+  can't be disabled. If not set, Terraform will write it to the same path as
+  the statefile with a backup extension.
 
-* `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
+* `-state=path` - Path to a Terraform state file to use to look up
+  Terraform-managed resources. By default it will use the configured backend,
+  or the default "terraform.tfstate" if it exists.
 
 ## Example: Remove a Resource
 


### PR DESCRIPTION
Some state commands worked with the backend configuration (push, pull, list, show), while others ignored it (mv, rm), leading to confusing behavior when trying to refactor state files. The website docs were also incorrectly updated, and did not match the behavior of the command, making the overall usage of the state commands confusing and possibly dangerous. 

This makes the `rm` and `mv` commands also work with a configured backend, reflecting the behavior of the other state commands, and the logical expectations of users. 

The one piece missing here is that there is no single command to move resources or modules from a local state file to a remote state, or between remote states. There are a number of ways we could introduce the behavior, a special identifier for `-state-out` like `@backend` for example, but complex refactoring probably warrants pulling the state into local files anyway, and not all possible options need to be supported. We can put off handing remote targets and workspaces for future refactoring.

Fixes #10481