### PR TITLE
[WIP] command: Add description auto-population for fmt

### DIFF
--- a/command/fmt.go
+++ b/command/fmt.go
@@ -25,18 +25,16 @@ const (
 // and outputs with leading comment data.
 //
 // The intended behaviour of this filter is to use it to take data from the
-// first contiguous block of text from a leading comment for a variable or
-// output, and either pre-populate, or update the description of an already
-// existing description field with the new data.
+// first paragraph of text from a leading comment for a variable or output, and
+// either pre-populate, or update the description of an already existing
+// description field with the new data.
 type populateFilter struct{}
 
 // Filter implements HCL's printer.Filter for populateFilter.
 func (f *populateFilter) Filter(n *ast.File) error {
 	for _, obj := range n.Node.(*ast.ObjectList).Items {
 		if obj.LeadComment != nil && obj.Keys[0].Token.Type == token.IDENT && (obj.Keys[0].Token.Text == "variable" || obj.Keys[0].Token.Text == "output") {
-			// Insert the first line of the lead comment into the description. The
-			// "first line" in this context means the first contiguous block before a
-			// blank in the comments (the "basic" description).
+			// Insert the first paragraph of the lead comment into the description.
 			var lines []string
 			for _, l := range obj.LeadComment.List {
 				// Split on line breaks and iterate on that. This may seem frivolous,
@@ -191,8 +189,8 @@ Options:
 
   -diff=false      Display diffs of formatting changes
   
-	-populate=false  Auto-populate variable and output descriptions with first
-	                 contiguous block of leading comment data
+  -populate=false  Auto-populate variable and output descriptions with first
+                   paragraph of leading comment data
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/fmt.go
+++ b/command/fmt.go
@@ -5,16 +5,113 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/fmtcmd"
+	"github.com/hashicorp/hcl/hcl/printer"
+	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/mitchellh/cli"
 )
 
 const (
 	stdinArg      = "-"
 	fileExtension = "tf"
+	infinity      = 1 << 30
 )
+
+// populateFilter is a filter that auto-populates the descriptions of variables
+// and outputs with leading comment data.
+//
+// The intended behaviour of this filter is to use it to take data from the
+// first contiguous block of text from a leading comment for a variable or
+// output, and either pre-populate, or update the description of an already
+// existing description field with the new data.
+type populateFilter struct{}
+
+// Filter implements HCL's printer.Filter for populateFilter.
+func (f *populateFilter) Filter(n *ast.File) error {
+	for _, obj := range n.Node.(*ast.ObjectList).Items {
+		if obj.LeadComment != nil && obj.Keys[0].Token.Type == token.IDENT && (obj.Keys[0].Token.Text == "variable" || obj.Keys[0].Token.Text == "output") {
+			// Insert the first line of the lead comment into the description. The
+			// "first line" in this context means the first contiguous block before a
+			// blank in the comments (the "basic" description).
+			var lines []string
+			for _, l := range obj.LeadComment.List {
+				// Split on line breaks and iterate on that. This may seem frivolous,
+				// but in slash-star comment forms, the entire comment block is treated
+				// as a single comment, hence this needs to be split here to avoid
+				// attempting to insert the entire comment, along with any prefixing
+				// comment markers.
+				for _, s := range strings.Split(l.Text, "\n") {
+					r := regexp.MustCompile("^\\s*(?:[/*]+|#+)")
+					s = r.ReplaceAllLiteralString(s, "")
+					s = strings.TrimSpace(s)
+					if s == "" {
+						// Comment line composed of entirely whitespace, end of description,
+						// unless this there has been no text data added yet (line could have
+						// been a heading rule/divider).
+						if len(lines) < 1 {
+							continue
+						}
+						// We are done parsing the first block - we need to break out of
+						// both loops.
+						goto done
+					}
+					lines = append(lines, s)
+				}
+			}
+		done:
+			newVal := fmt.Sprintf("\"%s\"", strings.Join(lines, " "))
+			if newVal == "" {
+				// No string, abort (possibly just an empty lead comment)
+				return nil
+			}
+
+			// Determine if there is already a description object first. If there is,
+			// we just update the data.
+			for _, item := range obj.Val.(*ast.ObjectType).List.Items {
+				if item.Keys[0].Token.Type == token.IDENT && item.Keys[0].Token.Text == "description" {
+					// Update description with new text.
+					item.Val.(*ast.LiteralType).Token.Text = newVal
+					// Update the LineComment, if it exists, with the new position - the
+					// position is the start + len(newVal)+1.
+					if item.LineComment != nil {
+						item.LineComment.List[0].Start.Column = item.Val.(*ast.LiteralType).Token.Pos.Column + len(newVal) + 1
+					}
+					// Done
+					return nil
+				}
+			}
+
+			// If there is no description, we add one. Not just that, we add it at
+			// the beginning of the object, with no position (save the Assignment
+			// item, which needs a position to be rendered - this is given infinity).
+			// This renders it as the first item with a blank line after it, which
+			// ultimately looks nicer.
+			desc := &ast.ObjectItem{
+				Keys: []*ast.ObjectKey{
+					&ast.ObjectKey{
+						Token: token.Token{
+							Type: token.IDENT,
+							Text: "description",
+						},
+					},
+				},
+				Assign: token.Pos{Line: infinity},
+				Val: &ast.LiteralType{
+					Token: token.Token{
+						Type: token.STRING,
+						Text: newVal,
+					},
+				},
+			}
+			obj.Val.(*ast.ObjectType).List.Items = append([]*ast.ObjectItem{desc}, obj.Val.(*ast.ObjectType).List.Items...)
+		}
+	}
+	return nil
+}
 
 // FmtCommand is a Command implementation that rewrites Terraform config
 // files to a canonical format and style.
@@ -34,10 +131,13 @@ func (c *FmtCommand) Run(args []string) int {
 		return 1
 	}
 
+	var populate bool
+
 	cmdFlags := flag.NewFlagSet("fmt", flag.ContinueOnError)
 	cmdFlags.BoolVar(&c.opts.List, "list", true, "list")
 	cmdFlags.BoolVar(&c.opts.Write, "write", true, "write")
 	cmdFlags.BoolVar(&c.opts.Diff, "diff", false, "diff")
+	cmdFlags.BoolVar(&populate, "populate", false, "populate")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 
 	if err := cmdFlags.Parse(args); err != nil {
@@ -62,6 +162,9 @@ func (c *FmtCommand) Run(args []string) int {
 	}
 
 	output := &cli.UiWriter{Ui: c.Ui}
+	if populate {
+		c.opts.Filters = []printer.Filter{&populateFilter{}}
+	}
 	err = fmtcmd.Run(dirs, []string{fileExtension}, c.input, output, c.opts)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error running fmt: %s", err))
@@ -87,6 +190,9 @@ Options:
   -write=true      Write result to source file instead of STDOUT (always false if using STDIN)
 
   -diff=false      Display diffs of formatting changes
+  
+	-populate=false  Auto-populate variable and output descriptions with first
+	                 contiguous block of leading comment data
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/fmt_test.go
+++ b/command/fmt_test.go
@@ -179,6 +179,290 @@ func TestFmt_nonDefaultOptions(t *testing.T) {
 	}
 }
 
+func TestFmtPopulate(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Input    string
+		Expected string
+	}{
+		{
+			Name: "basic single-line double slash with extra detail",
+			Input: `
+// Foo.
+//
+// Bar.
+variable "foo" {
+  default = "bar"
+}
+			`,
+			Expected: `
+// Foo.
+//
+// Bar.
+variable "foo" {
+  description = "Foo."
+
+  default = "bar"
+}
+			`,
+		},
+		{
+			Name: "double slash, multi-line first block",
+			Input: `
+// Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+// tempor incididunt ut labore et dolore magna aliqua.
+//
+// Bar.
+variable "foo" {
+  default = "bar"
+}
+			`,
+			Expected: `
+// Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+// tempor incididunt ut labore et dolore magna aliqua.
+//
+// Bar.
+variable "foo" {
+  description = "Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+
+  default = "bar"
+}
+			`,
+		},
+		{
+			Name: "slashes, fancy bordered comment",
+			Input: `
+///////////////////////////////////////////////////////////////////////////////
+// Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+// tempor incididunt ut labore et dolore magna aliqua.
+//
+// Bar.
+///////////////////////////////////////////////////////////////////////////////
+variable "foo" {
+  default = "bar"
+}
+			`,
+			Expected: `
+///////////////////////////////////////////////////////////////////////////////
+// Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+// tempor incididunt ut labore et dolore magna aliqua.
+//
+// Bar.
+///////////////////////////////////////////////////////////////////////////////
+variable "foo" {
+  description = "Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+
+  default = "bar"
+}
+			`,
+		},
+		{
+			Name: "basic single-line hash with extra detail",
+			Input: `
+# Foo.
+#
+# Bar.
+variable "foo" {
+  default = "bar"
+}
+			`,
+			Expected: `
+# Foo.
+#
+# Bar.
+variable "foo" {
+  description = "Foo."
+
+  default = "bar"
+}
+			`,
+		},
+		{
+			Name: "hash, multi-line first block",
+			Input: `
+# Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+# tempor incididunt ut labore et dolore magna aliqua.
+#
+# Bar.
+variable "foo" {
+  default = "bar"
+}
+			`,
+			Expected: `
+# Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+# tempor incididunt ut labore et dolore magna aliqua.
+#
+# Bar.
+variable "foo" {
+  description = "Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+
+  default = "bar"
+}
+			`,
+		},
+		{
+			Name: "slashes, fancy bordered comment",
+			Input: `
+###############################################################################
+# Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+# tempor incididunt ut labore et dolore magna aliqua.
+#
+# Bar.
+###############################################################################
+variable "foo" {
+  default = "bar"
+}
+			`,
+			Expected: `
+###############################################################################
+# Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+# tempor incididunt ut labore et dolore magna aliqua.
+#
+# Bar.
+###############################################################################
+variable "foo" {
+  description = "Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+
+  default = "bar"
+}
+			`,
+		},
+		{
+			Name: "basic single-line slash-star with extra detail",
+			Input: `
+/*
+ * Foo.
+ *
+ * Bar.
+ */
+variable "foo" {
+  default = "bar"
+}
+			`,
+			Expected: `
+/*
+ * Foo.
+ *
+ * Bar.
+ */
+variable "foo" {
+  description = "Foo."
+
+  default = "bar"
+}
+			`,
+		},
+		{
+			Name: "slash-star, multi-line",
+			Input: `
+/*
+ * Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+ * tempor incididunt ut labore et dolore magna aliqua.
+ *
+ * Bar.
+ */
+variable "foo" {
+  default = "bar"
+}
+			`,
+			Expected: `
+/*
+ * Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+ * tempor incididunt ut labore et dolore magna aliqua.
+ *
+ * Bar.
+ */
+variable "foo" {
+  description = "Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+
+  default = "bar"
+}
+			`,
+		},
+		{
+			Name: "slash-star, fancy bordered comment",
+			Input: `
+/*****************************************************************************
+ * Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+ * tempor incididunt ut labore et dolore magna aliqua.
+ *
+ * Bar.
+ *****************************************************************************/
+variable "foo" {
+  default = "bar"
+}
+			`,
+			Expected: `
+/*****************************************************************************
+ * Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+ * tempor incididunt ut labore et dolore magna aliqua.
+ *
+ * Bar.
+ *****************************************************************************/
+variable "foo" {
+  description = "Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+
+  default = "bar"
+}
+			`,
+		},
+		{
+			Name: "slash-star, with no prefix (legit slash-star use)",
+			Input: `
+/*
+Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua.
+
+Bar.
+ */
+variable "foo" {
+  default = "bar"
+}
+			`,
+			Expected: `
+/*
+Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua.
+
+Bar.
+ */
+variable "foo" {
+  description = "Foo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+
+  default = "bar"
+}
+			`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			input := new(bytes.Buffer)
+			input.WriteString(strings.TrimSpace(tc.Input))
+
+			ui := new(cli.MockUi)
+			c := &FmtCommand{
+				Meta: Meta{
+					testingOverrides: metaOverridesForProvider(testProvider()),
+					Ui:               ui,
+				},
+				input: input,
+			}
+
+			args := []string{"-populate=true", "-"}
+			if code := c.Run(args); code != 0 {
+				t.Fatalf("wrong exit code. errors: \n%s", ui.ErrorWriter.String())
+			}
+
+			expected := []byte(strings.TrimSpace(tc.Expected) + "\n")
+			actual := ui.OutputWriter.Bytes()
+
+			if !bytes.Equal(expected, actual) {
+				t.Fatalf("expected:\n%sgot:\n%s", expected, actual)
+			}
+		})
+	}
+}
+
 var fmtFixture = struct {
 	filename      string
 	input, golden []byte

--- a/command/fmt_test.go
+++ b/command/fmt_test.go
@@ -433,6 +433,28 @@ variable "foo" {
 }
 			`,
 		},
+		{
+			Name: "basic single-line double slash, updating output",
+			Input: `
+// Foo.
+//
+// Bar.
+output "foo" {
+  value = "bar"
+}
+			`,
+			Expected: `
+
+// Foo.
+//
+// Bar.
+output "foo" {
+  description = "Foo."
+
+  value = "bar"
+}
+			`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {

--- a/command/fmt_test.go
+++ b/command/fmt_test.go
@@ -455,6 +455,27 @@ output "foo" {
 }
 			`,
 		},
+		{
+			Name: "existing description, update and preserve position",
+			Input: `
+// Foo.
+//
+// Bar.
+variable "foo" {
+  default     = "bar"
+  description = "Change me!" // LineComment
+}
+			`,
+			Expected: `
+// Foo.
+//
+// Bar.
+variable "foo" {
+  default     = "bar"
+  description = "Foo." // LineComment
+}
+			`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {

--- a/command/hcl_printer.go
+++ b/command/hcl_printer.go
@@ -27,7 +27,7 @@ func encodeHCL(i interface{}) ([]byte, error) {
 	fakeAssignment := append([]byte("X = "), hcl...)
 
 	// use the real hcl parser to verify our output, and format it canonically
-	hcl, err = printer.Format(fakeAssignment)
+	hcl, err = printer.Format(fakeAssignment, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/hashicorp/hcl/decoder.go
+++ b/vendor/github.com/hashicorp/hcl/decoder.go
@@ -89,7 +89,7 @@ func (d *decoder) decode(name string, node ast.Node, result reflect.Value) error
 	switch k.Kind() {
 	case reflect.Bool:
 		return d.decodeBool(name, node, result)
-	case reflect.Float64:
+	case reflect.Float32, reflect.Float64:
 		return d.decodeFloat(name, node, result)
 	case reflect.Int, reflect.Int32, reflect.Int64:
 		return d.decodeInt(name, node, result)
@@ -143,7 +143,7 @@ func (d *decoder) decodeFloat(name string, node ast.Node, result reflect.Value) 
 				return err
 			}
 
-			result.Set(reflect.ValueOf(v))
+			result.Set(reflect.ValueOf(v).Convert(result.Type()))
 			return nil
 		}
 	}

--- a/vendor/github.com/hashicorp/hcl/hcl/printer/printer.go
+++ b/vendor/github.com/hashicorp/hcl/hcl/printer/printer.go
@@ -14,6 +14,18 @@ var DefaultConfig = Config{
 	SpacesWidth: 2,
 }
 
+// Filter is an interface that allows external programs to alter HCL in-line as
+// it's being parsed for printing. This allows specific examples such as adding
+// or altering fields based on context-specific needs.
+type Filter interface {
+	// Filter should modify the supplied ast.File inline, returning an error if
+	// for some reason the process fails. This fails the formatter as well.
+	//
+	// Care should be taken to supply the filters in the order they are intended
+	// to be applied when passing them to the slice in Format.
+	Filter(*ast.File) error
+}
+
 // A Config node controls the output of Fprint.
 type Config struct {
 	SpacesWidth int // if set, it will use spaces instead of tabs for alignment
@@ -48,11 +60,18 @@ func Fprint(output io.Writer, node ast.Node) error {
 	return DefaultConfig.Fprint(output, node)
 }
 
-// Format formats src HCL and returns the result.
-func Format(src []byte) ([]byte, error) {
+// Format formats src HCL and returns the result. External programs can supply
+// a list of filters to directly alter the formatted output as well.
+func Format(src []byte, filters []Filter) ([]byte, error) {
 	node, err := parser.Parse(src)
 	if err != nil {
 		return nil, err
+	}
+
+	for _, f := range filters {
+		if err := f.Filter(node); err != nil {
+			return nil, err
+		}
 	}
 
 	var buf bytes.Buffer

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1288,70 +1288,70 @@
 			"revisionTime": "2016-08-13T22:13:03Z"
 		},
 		{
-			"checksumSHA1": "o3XZZdOnSnwQSpYw215QV75ZDeI=",
+			"checksumSHA1": "7JBkp3EZoc0MSbiyWfzVhO4RYoY=",
 			"path": "github.com/hashicorp/hcl",
-			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
-			"revisionTime": "2017-05-04T19:02:34Z"
+			"revision": "d0affcb7f5e2e948ca0b55c2850434e776a09159",
+			"revisionTime": "2017-07-30T02:37:52Z"
 		},
 		{
 			"checksumSHA1": "XQmjDva9JCGGkIecOgwtBEMCJhU=",
 			"path": "github.com/hashicorp/hcl/hcl/ast",
-			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
-			"revisionTime": "2017-05-04T19:02:34Z"
+			"revision": "d0affcb7f5e2e948ca0b55c2850434e776a09159",
+			"revisionTime": "2017-07-30T02:37:52Z"
 		},
 		{
-			"checksumSHA1": "DaQmLi48oUAwctWcX6A6DNN61UY=",
+			"checksumSHA1": "fvdXff6ugRJfHiL71wFHkh7Hunw=",
 			"path": "github.com/hashicorp/hcl/hcl/fmtcmd",
-			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
-			"revisionTime": "2017-05-04T19:02:34Z"
+			"revision": "d0affcb7f5e2e948ca0b55c2850434e776a09159",
+			"revisionTime": "2017-07-30T02:37:52Z"
 		},
 		{
 			"checksumSHA1": "teokXoyRXEJ0vZHOWBD11l5YFNI=",
 			"path": "github.com/hashicorp/hcl/hcl/parser",
-			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
-			"revisionTime": "2017-05-04T19:02:34Z"
+			"revision": "d0affcb7f5e2e948ca0b55c2850434e776a09159",
+			"revisionTime": "2017-07-30T02:37:52Z"
 		},
 		{
-			"checksumSHA1": "WR1BjzDKgv6uE+3ShcDTYz0Gl6A=",
+			"checksumSHA1": "0OpvZEYnTJghlII8633t0gbDxms=",
 			"path": "github.com/hashicorp/hcl/hcl/printer",
-			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
-			"revisionTime": "2017-05-04T19:02:34Z"
+			"revision": "d0affcb7f5e2e948ca0b55c2850434e776a09159",
+			"revisionTime": "2017-07-30T02:37:52Z"
 		},
 		{
 			"checksumSHA1": "z6wdP4mRw4GVjShkNHDaOWkbxS0=",
 			"path": "github.com/hashicorp/hcl/hcl/scanner",
-			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
-			"revisionTime": "2017-05-04T19:02:34Z"
+			"revision": "d0affcb7f5e2e948ca0b55c2850434e776a09159",
+			"revisionTime": "2017-07-30T02:37:52Z"
 		},
 		{
 			"checksumSHA1": "oS3SCN9Wd6D8/LG0Yx1fu84a7gI=",
 			"path": "github.com/hashicorp/hcl/hcl/strconv",
-			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
-			"revisionTime": "2017-05-04T19:02:34Z"
+			"revision": "d0affcb7f5e2e948ca0b55c2850434e776a09159",
+			"revisionTime": "2017-07-30T02:37:52Z"
 		},
 		{
 			"checksumSHA1": "c6yprzj06ASwCo18TtbbNNBHljA=",
 			"path": "github.com/hashicorp/hcl/hcl/token",
-			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
-			"revisionTime": "2017-05-04T19:02:34Z"
+			"revision": "d0affcb7f5e2e948ca0b55c2850434e776a09159",
+			"revisionTime": "2017-07-30T02:37:52Z"
 		},
 		{
 			"checksumSHA1": "PwlfXt7mFS8UYzWxOK5DOq0yxS0=",
 			"path": "github.com/hashicorp/hcl/json/parser",
-			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
-			"revisionTime": "2017-05-04T19:02:34Z"
+			"revision": "d0affcb7f5e2e948ca0b55c2850434e776a09159",
+			"revisionTime": "2017-07-30T02:37:52Z"
 		},
 		{
 			"checksumSHA1": "YdvFsNOMSWMLnY6fcliWQa0O5Fw=",
 			"path": "github.com/hashicorp/hcl/json/scanner",
-			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
-			"revisionTime": "2017-05-04T19:02:34Z"
+			"revision": "d0affcb7f5e2e948ca0b55c2850434e776a09159",
+			"revisionTime": "2017-07-30T02:37:52Z"
 		},
 		{
 			"checksumSHA1": "fNlXQCQEnb+B3k5UDL/r15xtSJY=",
 			"path": "github.com/hashicorp/hcl/json/token",
-			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
-			"revisionTime": "2017-05-04T19:02:34Z"
+			"revision": "d0affcb7f5e2e948ca0b55c2850434e776a09159",
+			"revisionTime": "2017-07-30T02:37:52Z"
 		},
 		{
 			"checksumSHA1": "M09yxoBoCEtG7EcHR8aEWLzMMJc=",


### PR DESCRIPTION
Ref: #15670. This is a complete example of the proposal, and is WIP right now but feel free to reply with feedback!

Personal checklist:

- [ ] Add full-file test and fix top-of-file comment insertion issues
- [ ] Ensure strings are properly escaped (example: double quotes)
- [ ] Wrap long descriptions with heredocs

-----

This commit adds support for the addition of description population to
fmt. This basically means that when the option is supplied, Terraform
can auto-populate the description fields in variables and outputs,
deriving data from leading comments instead.

Given this example:

```hcl
// The AWS region to deploy to.
//
// Note that one can put extra detail in another paragraph to provide
// more context in the code or other documentation tools and this text
// will not be added to the description.
variable "aws_region" {
  type    = "string"
  default = "ca-central-1"
}
```

Terraform will update the code to look like:

```hcl
// The AWS region to deploy to.
//
// Note that one can put extra detail in another paragraph to provide
// more context in the code or other documentation tools and this text
// will not be added to the description.
variable "aws_region" {
  description = "The AWS region to deploy to."
      
  type    = "string"
  default = "ca-central-1"
}
```

Note that as mentioned above, only the first paragraph of text is
copied. This is to keep the description field terse, saving any extra
context for just the code, or other documentation tools that work off of
parsing comments (like [segmentio/terraform-docs](https://github.com/segmentio/terraform-docs)).

This helps enforce some best practices in Terraform code (in this case,
ensuring that description fields are populated). Also, with the addition
of the filters feature in HCL and this update to Terraform, this also
helps pave the way for future enhancements to fmt (or maybe branching
off to something like terraform lint) that can carry out further
machine-mandated style enforcement.