### PR TITLE
website: Fix broken/old link in Commands/Workspace

### DIFF
--- a/website/layouts/commands-workspace.erb
+++ b/website/layouts/commands-workspace.erb
@@ -7,7 +7,7 @@
         </li>
 
         <li<%= sidebar_current("docs-workspace-index") %>>
-          <a href="/docs/commands/env/index.html">workspace Command</a>
+          <a href="/docs/commands/workspace/index.html">Workspace Command</a>
         </li>
 
         <li<%= sidebar_current("docs-workspace-sub") %>>


### PR DESCRIPTION
I think this is a remnant from when we moved from env->workspace. The sidebar renders fine but the actual `workspace` link is a 404