### PR TITLE
Docs: Fix broken links and a broken example

### DIFF
--- a/website/docs/plugins/provider.html.md
+++ b/website/docs/plugins/provider.html.md
@@ -240,7 +240,7 @@ which cover all available settings.
 
 We recommend viewing schemas of existing or similar providers to learn
 best practices. A good starting place is the
-[core Terraform providers](https://github.com/hashicorp/terraform/tree/master/builtin/providers).
+[core Terraform providers](https://github.com/terraform-providers).
 
 ## Resource Data
 

--- a/website/guides/writing-custom-terraform-providers.html.md
+++ b/website/guides/writing-custom-terraform-providers.html.md
@@ -40,7 +40,7 @@ This post assumes familiarity with Golang and basic programming concepts.
 
 As a reminder, all of Terraform's core providers are open source. When stuck or
 looking for examples, please feel free to reference
-[the open source providers](https://github.com/hashicorp/terraform/tree/master/builtin/providers) for help.
+[the open source providers](https://github.com/terraform-providers) for help.
 
 ## The Provider Schema
 

--- a/website/intro/examples/consul.html.markdown
+++ b/website/intro/examples/consul.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Consul Example
 
-[**Example Source Code**](https://github.com/hashicorp/terraform/tree/master/examples/consul)
+[**Example Source Code**](https://github.com/terraform-providers/terraform-provider-consul/tree/master/examples/kv)
 
 [Consul](https://www.consul.io) is a tool for service discovery, configuration
 and orchestration. The Key/Value store it provides is often used to store

--- a/website/intro/examples/count.markdown
+++ b/website/intro/examples/count.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Count Example
 
-[**Example Source Code**](https://github.com/hashicorp/terraform/tree/master/examples/aws-count)
+[**Example Source Code**](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/count)
 
 The `count` parameter on resources can simplify configurations
 and let you scale resources by simply incrementing a number.

--- a/website/intro/examples/index.html.markdown
+++ b/website/intro/examples/index.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Example Configurations
 
-These examples are designed to help you understand some
+The examples in this section illustrate some
 of the ways Terraform can be used.
 
 All examples are ready to run as-is. Terraform will
@@ -31,23 +31,21 @@ uses it isn't required.
 
 ## Examples
 
-All of the examples are in the
-["examples" directory within the Terraform source code](https://github.com/hashicorp/terraform/tree/master/examples). Each example (as well as the examples
-directory) has a README explaining the goal of the example.
+Our examples are distributed across several repos. [This README file in the Terraform repo has links to all of them.](https://github.com/hashicorp/terraform/tree/master/examples)
 
 To use these examples, Terraform must first be installed on your machine.
 You can install Terraform from the [downloads page](/downloads.html).
-Once installed, you can use two steps to view and run the examples.
+Once installed, you can download, view, and run the examples.
 
-To try these examples, first clone them with git as usual:
+To use an example, clone the repository that contains it and navigate to its directory. For example, to try the AWS two-tier architecture example:
 
 ```
-git clone https://github.com/hashicorp/terraform/examples/aws-two-tier
-cd aws-two-tier
+git clone https://github.com/terraform-providers/terraform-provider-aws.git
+cd terraform-provider-aws/examples/two-tier
 ```
 
-You can then use your own editor to read and browse the configurations.
-To try out the example, initialize and then apply:
+You can then use your preferred code editor to browse and read the configurations.
+To try out an example, run Terraform's init and apply commands while in the example's directory:
 
 ```
 $ terraform init


### PR DESCRIPTION
These links were casualties of the core/provider split. There was also
an example that suggested cloning a subdirectory of a git repo.