### PR TITLE
Remove overly verbose DEBUG log

### DIFF
--- a/plugin/discovery/find.go
+++ b/plugin/discovery/find.go
@@ -59,7 +59,6 @@ func findPluginPaths(kind string, dirs []string) []string {
 			fullName := item.Name()
 
 			if !strings.HasPrefix(fullName, prefix) {
-				log.Printf("[DEBUG] skipping %q, not a %s", fullName, kind)
 				continue
 			}
 


### PR DESCRIPTION
This is causing Terraform to spit out basically all filenames in the CWD, which isn't great from sensitivity/security point of view and I it causes the debug log to be just unnecessarily verbose while bringing low value (IMO).

I'm open to downgrading the level to `TRACE` though, if removal seems too brutal.