### PR TITLE
plugin docs

### DIFF
--- a/website/docs/commands/init.html.markdown
+++ b/website/docs/commands/init.html.markdown
@@ -135,12 +135,11 @@ the desired providers into a local directory and using the additional option
 is consulted, which prevents Terraform from making requests to the plugin
 repository or looking for plugins in other local directories.
 
-In case you only want to override specific providers and have Terraform
-download all other providers from the plugin repository, you can place those
-specific provider plugins in a `terraform.d/plugins/os_arch/` directory inside
-the working directory (e.g. `terraform.d/plugins/darwin_amd64/` on Mac OS X).
-Upon `init` Terraform will then use all providers found in this directory and
-download all missing providers from the plugin repository.
+Custom plugins can be used along with automatically installed plugins by
+placing them in `terraform.d/plugins/OS_ARCH/` inside the directory being
+initialized. Plugins found here will take precedence if they meet the required
+constraints in the configuration. The `init` command will continue to
+automatically download other plugins as needed.
 
 When plugins are automatically downloaded and installed, by default the
 contents are verified against an official HashiCorp release signature to

--- a/website/guides/running-terraform-in-automation.html.md
+++ b/website/guides/running-terraform-in-automation.html.md
@@ -282,6 +282,11 @@ use of newer plugin versions that have not yet been installed into the
 local plugin directory. Which approach is more appropriate will depend on
 unique constraints within each organization.
 
+Plugins can also be provided along with the configuration by creating a
+`terraform.d/plugins/OS_ARCH` directory, which will be searched before
+automatically downloading additional plugins. The `-get-plugins=false` flag can
+be used to prevent Terraform from automatically downloading additional plugins. 
+
 ## Terraform Enterprise
 
 As an alternative to home-grown automation solutions, Hashicorp offers


### PR DESCRIPTION
Update the recent addition to the init docs to better match the style of the rest of that section.

Add mention of the `terraform.d/plugins` directory in the "running in automation" doc.