### PR TITLE
Don't ForceLocal for the import backend

### DIFF
--- a/command/import.go
+++ b/command/import.go
@@ -123,15 +123,18 @@ func (c *ImportCommand) Run(args []string) int {
 
 	// Load the backend
 	b, err := c.Backend(&BackendOpts{
-		Config:     mod.Config(),
-		ForceLocal: true,
+		Config: mod.Config(),
 	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
 		return 1
 	}
 
-	// We require a local backend
+	// We require a backend.Local to build a context.
+	// This isn't necessarily a "local.Local" backend, which provides local
+	// operations, however that is the only current implementation. A
+	// "local.Local" backend also doesn't necessarily provide local state, as
+	// that may be delegated to a "remotestate.Backend".
 	local, ok := b.(backend.Local)
 	if !ok {
 		c.Ui.Error(ErrUnsupportedLocalOp)

--- a/command/import.go
+++ b/command/import.go
@@ -235,11 +235,12 @@ Options:
                       specifying aliases, such as "aws.eu". Defaults to the
                       normal provider prefix of the resource being imported.
 
-  -state=path         Path to read and save state (unless state-out
-                      is specified). Defaults to "terraform.tfstate".
+  -state=PATH         Path to the source state file. Defaults to the configured
+                      backend, or "terraform.tfstate"
 
-  -state-out=path     Path to write updated state file. By default, the
-                      "-state" path will be used.
+  -state-out=PATH     Path to the destination state file to write to. If this
+                      isn't specified, the source state file will be used. This
+                      can be a new or existing path.
 
   -var 'foo=bar'      Set a variable in the Terraform configuration. This
                       flag can be set multiple times. This is only useful

--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -87,9 +87,8 @@ Options:
                       will write it to the same path as the statefile with
                       a backup extension.
 
-  -state=statefile    Path to a Terraform state file to use to look
-                      up Terraform-managed resources. By default it will
-                      use the state "terraform.tfstate" if it exists.
+  -state=PATH         Path to the source state file. Defaults to the configured
+                      backend, or "terraform.tfstate"
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/test-fixtures/import-provider-remote-state/main.tf
+++ b/command/test-fixtures/import-provider-remote-state/main.tf
@@ -1,0 +1,12 @@
+terraform {
+	backend "local" {
+		path = "imported.tfstate"
+	}
+}
+
+provider "test" {
+    foo = "bar"
+}
+
+resource "test_instance" "foo" {
+}

--- a/website/docs/commands/import.html.md
+++ b/website/docs/commands/import.html.md
@@ -53,12 +53,12 @@ The command-line flags are all optional. The list of available flags are:
   provider based on the prefix of the resource being imported. You usually
   don't need to specify this.
 
-* `-state=path` - The path to read and save state files (unless state-out is
-  specified). Ignored when [remote state](/docs/state/remote.html) is used.
+* `-state=path` - Path to the source state file to read from. Defaults to the
+  configured backend, or "terraform.tfstate".
 
-* `-state-out=path` - Path to write the final state file. By default, this is
-  the state path. Ignored when [remote state](/docs/state/remote.html) is
-  used.
+* `-state-out=path` - Path to the destination state file to write to. If this
+  isn't specified the source state file will be used. This can be a new or
+  existing path.
 
 * `-var 'foo=bar'` - Set a variable in the Terraform configuration. This flag
   can be set multiple times. Variable values are interpreted as


### PR DESCRIPTION
While the `local.Local` backend is the only implementation of
`backend.Local`, creating the backend with `ForceLocal` bypasses the
`backend.Backend` in the `local.Local` causing a local state to be
implicitly created rather than using the configured state backend.

Add a test that imports into a configured backend (using the "local"
backend as a remote state proxy). This further confirms the confusing
nature of ForceLocal, as the backend _is_ local, but not from the
viewpoint of meta.Backend.

Fixes #15735

TODO: It's becoming clear there needs to be some helpers for test fixture initialization in the command package. 