### PR TITLE
load legacy plugin paths

### DIFF
--- a/command/plugins.go
+++ b/command/plugins.go
@@ -172,6 +172,12 @@ func (m *Meta) pluginDirs(includeAutoInstalled bool) []string {
 // the defined search paths.
 func (m *Meta) providerPluginSet() discovery.PluginMetaSet {
 	plugins := discovery.FindPlugins("provider", m.pluginDirs(true))
+
+	// Add providers defined in the legacy .terraformrc,
+	if m.PluginOverrides != nil {
+		plugins = plugins.OverridePaths(m.PluginOverrides.Providers)
+	}
+
 	plugins, _ = plugins.ValidateVersions()
 
 	for p := range plugins {
@@ -198,6 +204,12 @@ func (m *Meta) providerPluginAutoInstalledSet() discovery.PluginMetaSet {
 // in all locations *except* the auto-install directory.
 func (m *Meta) providerPluginManuallyInstalledSet() discovery.PluginMetaSet {
 	plugins := discovery.FindPlugins("provider", m.pluginDirs(false))
+
+	// Add providers defined in the legacy .terraformrc,
+	if m.PluginOverrides != nil {
+		plugins = plugins.OverridePaths(m.PluginOverrides.Providers)
+	}
+
 	plugins, _ = plugins.ValidateVersions()
 
 	for p := range plugins {

--- a/command/test-fixtures/init-legacy-rc/main.tf
+++ b/command/test-fixtures/init-legacy-rc/main.tf
@@ -1,0 +1,1 @@
+provider "legacy" {}

--- a/plugins.go
+++ b/plugins.go
@@ -21,6 +21,7 @@ func globalPluginDirs() []string {
 		log.Printf("[ERROR] Error finding global config directory: %s", err)
 	} else {
 		machineDir := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
+		ret = append(ret, filepath.Join(dir, "plugins"))
 		ret = append(ret, filepath.Join(dir, "plugins", machineDir))
 	}
 

--- a/plugins.go
+++ b/plugins.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"path/filepath"
+	"runtime"
 )
 
 // globalPluginDirs returns directories that should be searched for
@@ -18,7 +20,8 @@ func globalPluginDirs() []string {
 	if err != nil {
 		log.Printf("[ERROR] Error finding global config directory: %s", err)
 	} else {
-		ret = append(ret, filepath.Join(dir, "plugins"))
+		machineDir := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
+		ret = append(ret, filepath.Join(dir, "plugins", machineDir))
 	}
 
 	return ret


### PR DESCRIPTION
Add the OS_ARCH directory to `~/.terraform.d/plugins` because Discovery  no longer searches for subdirectories.

Add the override paths from `Meta.PluginOverrides` for discovery.

Fixes #15705