### PR TITLE
Allow module variable interpolation to fail during Input

### DIFF
--- a/terraform/eval_interpolate.go
+++ b/terraform/eval_interpolate.go
@@ -1,6 +1,10 @@
 package terraform
 
-import "github.com/hashicorp/terraform/config"
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/config"
+)
 
 // EvalInterpolate is an EvalNode implementation that takes a raw
 // configuration and interpolates it.
@@ -14,6 +18,31 @@ func (n *EvalInterpolate) Eval(ctx EvalContext) (interface{}, error) {
 	rc, err := ctx.Interpolate(n.Config, n.Resource)
 	if err != nil {
 		return nil, err
+	}
+
+	if n.Output != nil {
+		*n.Output = rc
+	}
+
+	return nil, nil
+}
+
+// EvalTryInterpolate is an EvalNode implementation that takes a raw
+// configuration and interpolates it, but only logs a warning on an
+// interpolation error, and stops further Eval steps.
+// This is used during Input where a value may not be known before Refresh, but
+// we don't want to block Input.
+type EvalTryInterpolate struct {
+	Config   *config.RawConfig
+	Resource *Resource
+	Output   **ResourceConfig
+}
+
+func (n *EvalTryInterpolate) Eval(ctx EvalContext) (interface{}, error) {
+	rc, err := ctx.Interpolate(n.Config, n.Resource)
+	if err != nil {
+		log.Printf("[WARN] Interpolation %q failed: %s", n.Config.Key, err)
+		return nil, EvalEarlyExitError{}
 	}
 
 	if n.Output != nil {

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -1,6 +1,8 @@
 package terraform
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // EvalReadState is an EvalNode implementation that reads the
 // primary InstanceState for a specific resource out of the state.

--- a/terraform/graph_builder_input.go
+++ b/terraform/graph_builder_input.go
@@ -10,6 +10,9 @@ import (
 // and is based on the PlanGraphBuilder. The PlanGraphBuilder passed in will be
 // modified and should not be used for any other operations.
 func InputGraphBuilder(p *PlanGraphBuilder) GraphBuilder {
+	// convert this to an InputPlan
+	p.Input = true
+
 	// We're going to customize the concrete functions
 	p.CustomConcrete = true
 

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -40,6 +40,9 @@ type PlanGraphBuilder struct {
 	// Validate will do structural validation of the graph.
 	Validate bool
 
+	// Input represents that this builder is for an Input operation.
+	Input bool
+
 	// CustomConcrete can be set to customize the node types created
 	// for various parts of the plan. This is useful in order to customize
 	// the plan behavior.
@@ -107,7 +110,10 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		),
 
 		// Add module variables
-		&ModuleVariableTransformer{Module: b.Module},
+		&ModuleVariableTransformer{
+			Module: b.Module,
+			Input:  b.Input,
+		},
 
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.

--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -15,6 +15,9 @@ type NodeApplyableModuleVariable struct {
 	Value     *config.RawConfig // Value is the value that is set
 
 	Module *module.Tree // Antiquated, want to remove
+
+	// Input is set if this graph was created for the Input operation.
+	Input bool
 }
 
 func (n *NodeApplyableModuleVariable) Name() string {
@@ -92,12 +95,24 @@ func (n *NodeApplyableModuleVariable) EvalTree() EvalNode {
 	// within the variables mapping.
 	var config *ResourceConfig
 	variables := make(map[string]interface{})
+
+	var interpolate EvalNode
+
+	if n.Input {
+		interpolate = &EvalTryInterpolate{
+			Config: n.Value,
+			Output: &config,
+		}
+	} else {
+		interpolate = &EvalInterpolate{
+			Config: n.Value,
+			Output: &config,
+		}
+	}
+
 	return &EvalSequence{
 		Nodes: []EvalNode{
-			&EvalInterpolate{
-				Config: n.Value,
-				Output: &config,
-			},
+			interpolate,
 
 			&EvalVariableBlock{
 				Config:         &config,

--- a/terraform/test-fixtures/input-module-data-vars/child/main.tf
+++ b/terraform/test-fixtures/input-module-data-vars/child/main.tf
@@ -1,0 +1,5 @@
+variable "in" {}
+
+output "out" {
+	value = "${var.in}"
+}

--- a/terraform/test-fixtures/input-module-data-vars/main.tf
+++ b/terraform/test-fixtures/input-module-data-vars/main.tf
@@ -1,0 +1,8 @@
+data "null_data_source" "bar" {
+  foo = ["a", "b"]
+}
+
+module "child" {
+  source = "./child"
+  in = "${data.null_data_source.bar.foo[1]}"
+}

--- a/terraform/transform_module_variable.go
+++ b/terraform/transform_module_variable.go
@@ -17,6 +17,7 @@ type ModuleVariableTransformer struct {
 	Module *module.Tree
 
 	DisablePrune bool // True if pruning unreferenced should be disabled
+	Input        bool // True if this is from an Input operation.
 }
 
 func (t *ModuleVariableTransformer) Transform(g *Graph) error {
@@ -99,6 +100,7 @@ func (t *ModuleVariableTransformer) transformSingle(g *Graph, parent, m *module.
 			Config:    v,
 			Value:     value,
 			Module:    t.Module,
+			Input:     t.Input,
 		}
 
 		if !t.DisablePrune {


### PR DESCRIPTION
It may not be possible to interpolate module variables during the Input phase. The common instance of this is when a module variable references a data source which needs to be refreshed to resolve. The usual workaround is to either disable input, or target specific resources to exclude the variable from the graph.

This fix allows interpolation of module variables to fail silently, only logging the warnings during Input, allowing terraform to continue on to the Refresh phase. If the variable is still not valid by that point it will be caught during Plan.

Fixes #10460 