### PR TITLE
Add optional locking support to the http state backend

### DIFF
--- a/state/remote/http.go
+++ b/state/remote/http.go
@@ -35,9 +35,9 @@ func httpFactory(conf map[string]string) (Client, error) {
 	}
 
 	var lockURL *url.URL
-	lockAddress, ok := conf["lock_address"]
-	if ok {
-		lockURL, err := url.Parse(lockAddress)
+	if lockAddress, ok := conf["lock_address"]; ok {
+		var err error
+		lockURL, err = url.Parse(lockAddress)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse lockAddress URL: %s", err)
 		}
@@ -53,9 +53,9 @@ func httpFactory(conf map[string]string) (Client, error) {
 	}
 
 	var unlockURL *url.URL
-	unlockAddress, ok := conf["unlock_address"]
-	if ok {
-		unlockURL, err := url.Parse(unlockAddress)
+	if unlockAddress, ok := conf["unlock_address"]; ok {
+		var err error
+		unlockURL, err = url.Parse(unlockAddress)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse unlockAddress URL: %s", err)
 		}
@@ -97,9 +97,11 @@ func httpFactory(conf map[string]string) (Client, error) {
 		UnlockURL:    unlockURL,
 		UnlockMethod: unlockMethod,
 
-		Client:   client,
 		Username: conf["username"],
 		Password: conf["password"],
+
+		// accessible only for testing use
+		Client: client,
 	}
 
 	return ret, nil
@@ -185,7 +187,7 @@ func (c *HTTPClient) Lock(info *state.LockInfo) (string, error) {
 		return "", fmt.Errorf("HTTP remote state endpoint requires auth")
 	case http.StatusForbidden:
 		return "", fmt.Errorf("HTTP remote state endpoint invalid auth")
-	case http.StatusConflict:
+	case http.StatusConflict, http.StatusLocked:
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {

--- a/state/remote/http.go
+++ b/state/remote/http.go
@@ -22,16 +22,16 @@ func httpFactory(conf map[string]string) (Client, error) {
 		return nil, fmt.Errorf("missing 'address' configuration")
 	}
 
-	storeURL, err := url.Parse(address)
+	updateURL, err := url.Parse(address)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse address URL: %s", err)
 	}
-	if storeURL.Scheme != "http" && storeURL.Scheme != "https" {
+	if updateURL.Scheme != "http" && updateURL.Scheme != "https" {
 		return nil, fmt.Errorf("address must be HTTP or HTTPS")
 	}
-	storeMethod, ok := conf["store_method"]
+	updateMethod, ok := conf["update_method"]
 	if !ok {
-		storeMethod = "POST"
+		updateMethod = "POST"
 	}
 
 	var lockURL *url.URL
@@ -89,8 +89,8 @@ func httpFactory(conf map[string]string) (Client, error) {
 	}
 
 	ret := &HTTPClient{
-		URL:         storeURL,
-		StoreMethod: storeMethod,
+		URL:          updateURL,
+		UpdateMethod: updateMethod,
 
 		LockURL:      lockURL,
 		LockMethod:   lockMethod,
@@ -109,9 +109,9 @@ func httpFactory(conf map[string]string) (Client, error) {
 
 // HTTPClient is a remote client that stores data in Consul or HTTP REST.
 type HTTPClient struct {
-	// Store & Retrieve
-	URL         *url.URL
-	StoreMethod string
+	// Update & Retrieve
+	URL          *url.URL
+	UpdateMethod string
 
 	// Locking
 	LockURL      *url.URL
@@ -302,8 +302,8 @@ func (c *HTTPClient) Put(data []byte) error {
 	*/
 
 	var method string = "POST"
-	if c.StoreMethod != "" {
-		method = c.StoreMethod
+	if c.UpdateMethod != "" {
+		method = c.UpdateMethod
 	}
 	resp, err := c.httpRequest(method, &base, &data, "upload state")
 	if err != nil {

--- a/state/remote/http_test.go
+++ b/state/remote/http_test.go
@@ -27,14 +27,14 @@ func TestHTTPClient(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Test basic get/store
+	// Test basic get/update
 	client := &HTTPClient{URL: url, Client: cleanhttp.DefaultClient()}
 	testClient(t, client)
 
-	// Test locking and alternative StoreMethod
+	// Test locking and alternative UpdateMethod
 	a := &HTTPClient{
 		URL:          url,
-		StoreMethod:  "PUT",
+		UpdateMethod: "PUT",
 		LockURL:      url,
 		LockMethod:   "LOCK",
 		UnlockURL:    url,
@@ -43,7 +43,7 @@ func TestHTTPClient(t *testing.T) {
 	}
 	b := &HTTPClient{
 		URL:          url,
-		StoreMethod:  "PUT",
+		UpdateMethod: "PUT",
 		LockURL:      url,
 		LockMethod:   "LOCK",
 		UnlockURL:    url,
@@ -79,8 +79,8 @@ func TestHTTPClientFactory(t *testing.T) {
 	if client.URL.String() != conf["address"] {
 		t.Fatalf("Expected address \"%s\", got \"%s\"", conf["address"], client.URL.String())
 	}
-	if client.StoreMethod != "POST" {
-		t.Fatalf("Expected store_method \"%s\", got \"%s\"", "POST", client.StoreMethod)
+	if client.UpdateMethod != "POST" {
+		t.Fatalf("Expected update_method \"%s\", got \"%s\"", "POST", client.UpdateMethod)
 	}
 	if client.LockURL != nil || client.LockMethod != "LOCK" {
 		t.Fatal("Unexpected lock_address or lock_method")
@@ -95,7 +95,7 @@ func TestHTTPClientFactory(t *testing.T) {
 	// custom
 	conf = map[string]string{
 		"address":        "http://127.0.0.1:8888/foo",
-		"store_method":   "BLAH",
+		"update_method":  "BLAH",
 		"lock_address":   "http://127.0.0.1:8888/bar",
 		"lock_method":    "BLIP",
 		"unlock_address": "http://127.0.0.1:8888/baz",
@@ -106,10 +106,10 @@ func TestHTTPClientFactory(t *testing.T) {
 	c, err = httpFactory(conf)
 	client, _ = c.(*HTTPClient)
 	if client == nil || err != nil {
-		t.Fatal("Unexpected failure, store_method")
+		t.Fatal("Unexpected failure, update_method")
 	}
-	if client.StoreMethod != "BLAH" {
-		t.Fatalf("Expected store_method \"%s\", got \"%s\"", "BLAH", client.StoreMethod)
+	if client.UpdateMethod != "BLAH" {
+		t.Fatalf("Expected update_method \"%s\", got \"%s\"", "BLAH", client.UpdateMethod)
 	}
 	if client.LockURL.String() != conf["lock_address"] || client.LockMethod != "BLIP" {
 		t.Fatalf("Unexpected lock_address \"%s\" vs \"%s\" or lock_method \"%s\" vs \"%s\"", client.LockURL.String(),

--- a/website/docs/backends/types/http.html.md
+++ b/website/docs/backends/types/http.html.md
@@ -12,19 +12,20 @@ description: |-
 
 Stores the state using a simple [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) client.
 
-State will be fetched via GET, updated via POST, and purged with DELETE.
+State will be fetched via GET, updated via POST, and purged with DELETE. The method used for updating is configurable.
 
-If locking is enabled a lock POST request will be made by appending `/lock` to the configured address with the lock info in the
-body as json. The endpiont should return a 409 Conflict with the holding lock info when it's already taken, 200 OK for success.
-Any other status will be considered an error. Unlocking works simillarly, appending `/unlock` and adding the `ID` of the lock
-being freed as a query parameter. An `ID` query parameter will also be added when sending state updates.
+When locking support is enabled it will use LOCK and UNLOCK requests providing the lock info in the body. The endpoint should
+return a 423: Locked or 409: Conflict with the holding lock info when it's already taken, 200: OK for success. Any other status
+will be considered an error. The ID of the holding lock info will be added as a query parameter to state updates requests.
 
 ## Example Usage
 
 ```hcl
 terraform {
   backend "http" {
-    address = "http://myrest.api.com"
+    address = "http://myrest.api.com/foo"
+    lock_address = "http://myrest.api.com/foo"
+    unlock_address = "http://myrest.api.com/foo"
   }
 }
 ```
@@ -45,9 +46,17 @@ data "terraform_remote_state" "foo" {
 The following configuration options are supported:
 
  * `address` - (Required) The address of the REST endpoint
+ * `update_method` - (Optional) HTTP method to use when updating state.
+   Defaults to `POST`.
+ * `lock_address` - (Optional) The address of the lock REST endpoint.
+   Defaults to disabled.
+ * `lock_method` - (Optional) The HTTP method to use when locking.
+   Defaults to `LOCK`.
+ * `unlock_address` - (Optional) The address of the unlock REST endpoint.
+   Defaults to disabled.
+ * `unlock_method` - (Optional) The HTTP method to use when unlocking.
+   Defaults to `UNLOCK`.
  * `username` - (Optional) The username for HTTP basic authentication
  * `password` - (Optional) The password for HTTP basic authentication
  * `skip_cert_verification` - (Optional) Whether to skip TLS verification.
-   Defaults to `false`.
- * `supports_locking` - (Optional) Whether to enable locking related calls
    Defaults to `false`.

--- a/website/docs/backends/types/http.html.md
+++ b/website/docs/backends/types/http.html.md
@@ -8,11 +8,16 @@ description: |-
 
 # http
 
-**Kind: Standard (with no locking)**
+**Kind: Standard (with optional locking)**
 
 Stores the state using a simple [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) client.
 
 State will be fetched via GET, updated via POST, and purged with DELETE.
+
+If locking is enabled a lock POST request will be made by appending `/lock` to the configured address with the lock info in the
+body as json. The endpiont should return a 409 Conflict with the holding lock info when it's already taken, 200 OK for success.
+Any other status will be considered an error. Unlocking works simillarly, appending `/unlock` and adding the `ID` of the lock
+being freed as a query parameter. An `ID` query parameter will also be added when sending state updates.
 
 ## Example Usage
 
@@ -43,4 +48,6 @@ The following configuration options are supported:
  * `username` - (Optional) The username for HTTP basic authentication
  * `password` - (Optional) The password for HTTP basic authentication
  * `skip_cert_verification` - (Optional) Whether to skip TLS verification.
+   Defaults to `false`.
+ * `supports_locking` - (Optional) Whether to enable locking related calls
    Defaults to `false`.


### PR DESCRIPTION
This PR adds the ability to enable `supports_locking` for the http backend in a fully backwards compatible manner. 

### Configuration

```
terraform {
    backend "http" {
        address          = "http://localhost:8888/"
        supports_locking = "true"
    }
}
```

### Calls

Once enabled additional REST calls will be made:

* Lock: `<address>/lock` - body will contain the json marshaled `LockInfo`
* Unlock: `<address>/unlock?ID=<lock_id>` - body will be empty
* State Put: `<address>?ID=<lock_id>` - no other changes.

### Example Server

The following implements quick-n-dirty handling of the state storage and locking functionality. It would be useless in a real situation since it doesn't actually persist data, but hopefully serves to further illustrate the behavior. 

```python
#!/usr/bin/env python

from tornado.escape import json_decode
from tornado.ioloop import IOLoop
from tornado.options import parse_command_line
from tornado.web import Application, RequestHandler
from logging import getLogger


class JsonHandler(RequestHandler):

    def prepare(self):
        self.data = json_decode(self.request.body) if self.request.body else {}


class TerraformLockHandler(JsonHandler):
    log = getLogger('TerraformLockHandler')

    lock = {}

    def post(self, op):
        self.log.info('post: op=%s, data=%s', op, self.data)
        if op == 'unlock':
            lock_id = self.get_argument('ID')
            self.log.info('post: lock_id=%s', lock_id)
            expected = TerraformLockHandler.lock.get('ID', 'unlocked')
            if lock_id != expected:
                self.log.warn('post: unexpected lock_id %s, expected %s',
                              lock_id, expected)
                self.set_status(400)
                return
            self.log.info('post: un-locking')
            TerraformLockHandler.lock = {}
        else:
            if TerraformLockHandler.lock:
                self.log.warn('post: already locked, lock=%s',
                              TerraformLockHandler.lock)
                self.set_status(409)
            else:
                self.log.info('post: locking')
                TerraformLockHandler.lock = self.data
        self.write(TerraformLockHandler.lock)


class TerraformStateHandler(JsonHandler):
    log = getLogger('TerraformStateHandler')

    state = ''

    def get(self):
        self.log.info('get: state=***')
        self.write(TerraformStateHandler.state)

    def post(self):
        lock_id = self.get_argument('ID')
        self.log.info('post: lock_id=%s, data=%s', lock_id, self.data)
        expected = TerraformLockHandler.lock.get('ID', 'unlocked')
        if lock_id != expected:
            self.log.warn('post: unexpected lock_id %s, expected %s', lock_id,
                          expected)
            self.set_status(400)
            return
        TerraformStateHandler.state = self.data
        self.write(TerraformStateHandler.state)


if __name__ == '__main__':
    parse_command_line()
    app = Application([
        (r'/(?P<op>lock|unlock)', TerraformLockHandler),
        (r'/', TerraformStateHandler),
    ], debug=True)
    app.listen(8888, address='127.0.0.1')
    IOLoop.current().start()
```
