### PR TITLE
terraform+dag: Set lower log levels

### DIFF
--- a/dag/walk.go
+++ b/dag/walk.go
@@ -166,7 +166,7 @@ func (w *Walker) Update(g *AcyclicGraph) {
 		w.wait.Add(1)
 
 		// Add to our own set so we know about it already
-		log.Printf("[DEBUG] dag/walk: added new vertex: %q", VertexName(v))
+		log.Printf("[TRACE] dag/walk: added new vertex: %q", VertexName(v))
 		w.vertices.Add(raw)
 
 		// Initialize the vertex info
@@ -198,7 +198,7 @@ func (w *Walker) Update(g *AcyclicGraph) {
 		// Delete it out of the map
 		delete(w.vertexMap, v)
 
-		log.Printf("[DEBUG] dag/walk: removed vertex: %q", VertexName(v))
+		log.Printf("[TRACE] dag/walk: removed vertex: %q", VertexName(v))
 		w.vertices.Delete(raw)
 	}
 
@@ -229,7 +229,7 @@ func (w *Walker) Update(g *AcyclicGraph) {
 		changedDeps.Add(waiter)
 
 		log.Printf(
-			"[DEBUG] dag/walk: added edge: %q waiting on %q",
+			"[TRACE] dag/walk: added edge: %q waiting on %q",
 			VertexName(waiter), VertexName(dep))
 		w.edges.Add(raw)
 	}
@@ -253,7 +253,7 @@ func (w *Walker) Update(g *AcyclicGraph) {
 		changedDeps.Add(waiter)
 
 		log.Printf(
-			"[DEBUG] dag/walk: removed edge: %q waiting on %q",
+			"[TRACE] dag/walk: removed edge: %q waiting on %q",
 			VertexName(waiter), VertexName(dep))
 		w.edges.Delete(raw)
 	}
@@ -296,7 +296,7 @@ func (w *Walker) Update(g *AcyclicGraph) {
 		info.depsCancelCh = cancelCh
 
 		log.Printf(
-			"[DEBUG] dag/walk: dependencies changed for %q, sending new deps",
+			"[TRACE] dag/walk: dependencies changed for %q, sending new deps",
 			VertexName(v))
 
 		// Start the waiter
@@ -383,10 +383,10 @@ func (w *Walker) walkVertex(v Vertex, info *walkerVertex) {
 	// Run our callback or note that our upstream failed
 	var err error
 	if depsSuccess {
-		log.Printf("[DEBUG] dag/walk: walking %q", VertexName(v))
+		log.Printf("[TRACE] dag/walk: walking %q", VertexName(v))
 		err = w.Callback(v)
 	} else {
-		log.Printf("[DEBUG] dag/walk: upstream errored, not walking %q", VertexName(v))
+		log.Printf("[TRACE] dag/walk: upstream errored, not walking %q", VertexName(v))
 		err = errWalkUpstream
 	}
 
@@ -423,7 +423,7 @@ func (w *Walker) waitDeps(
 				return
 
 			case <-time.After(time.Second * 5):
-				log.Printf("[DEBUG] dag/walk: vertex %q, waiting for: %q",
+				log.Printf("[TRACE] dag/walk: vertex %q, waiting for: %q",
 					VertexName(v), VertexName(dep))
 			}
 		}

--- a/terraform/eval.go
+++ b/terraform/eval.go
@@ -49,11 +49,11 @@ func EvalRaw(n EvalNode, ctx EvalContext) (interface{}, error) {
 		path = strings.Join(ctx.Path(), ".")
 	}
 
-	log.Printf("[DEBUG] %s: eval: %T", path, n)
+	log.Printf("[TRACE] %s: eval: %T", path, n)
 	output, err := n.Eval(ctx)
 	if err != nil {
 		if _, ok := err.(EvalEarlyExitError); ok {
-			log.Printf("[DEBUG] %s: eval: %T, err: %s", path, n, err)
+			log.Printf("[TRACE] %s: eval: %T, err: %s", path, n, err)
 		} else {
 			log.Printf("[ERROR] %s: eval: %T, err: %s", path, n, err)
 		}

--- a/terraform/graph.go
+++ b/terraform/graph.go
@@ -70,7 +70,7 @@ func (g *Graph) walk(walker GraphWalker) error {
 	// Walk the graph.
 	var walkFn dag.WalkFunc
 	walkFn = func(v dag.Vertex) (rerr error) {
-		log.Printf("[DEBUG] vertex '%s.%s': walking", path, dag.VertexName(v))
+		log.Printf("[TRACE] vertex '%s.%s': walking", path, dag.VertexName(v))
 		g.DebugVisitInfo(v, g.debugName)
 
 		// If we have a panic wrap GraphWalker and a panic occurs, recover
@@ -118,7 +118,7 @@ func (g *Graph) walk(walker GraphWalker) error {
 
 			// Allow the walker to change our tree if needed. Eval,
 			// then callback with the output.
-			log.Printf("[DEBUG] vertex '%s.%s': evaluating", path, dag.VertexName(v))
+			log.Printf("[TRACE] vertex '%s.%s': evaluating", path, dag.VertexName(v))
 
 			g.DebugVertexInfo(v, fmt.Sprintf("evaluating %T(%s)", v, path))
 
@@ -132,7 +132,7 @@ func (g *Graph) walk(walker GraphWalker) error {
 		// If the node is dynamically expanded, then expand it
 		if ev, ok := v.(GraphNodeDynamicExpandable); ok {
 			log.Printf(
-				"[DEBUG] vertex '%s.%s': expanding/walking dynamic subgraph",
+				"[TRACE] vertex '%s.%s': expanding/walking dynamic subgraph",
 				path,
 				dag.VertexName(v))
 
@@ -154,7 +154,7 @@ func (g *Graph) walk(walker GraphWalker) error {
 		// If the node has a subgraph, then walk the subgraph
 		if sn, ok := v.(GraphNodeSubgraph); ok {
 			log.Printf(
-				"[DEBUG] vertex '%s.%s': walking subgraph",
+				"[TRACE] vertex '%s.%s': walking subgraph",
 				path,
 				dag.VertexName(v))
 


### PR DESCRIPTION
I know we don't have a good way to filter by levels atm anyway, but it can be helpful even with simple `grep/awk`-based filtering.

I bumped into these messages messages when "decoding" big crash log and I'd love to have the ability to filter these out more easily - ideally in one step, rather than many.