### PR TITLE
plugin: Display version + source when initializing plugins

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -75,6 +75,7 @@ func (c *InitCommand) Run(args []string) int {
 			Dir: c.pluginDir(),
 			PluginProtocolVersion: plugin.Handshake.ProtocolVersion,
 			SkipVerify:            !flagVerifyPlugins,
+			Ui:                    c.Ui,
 		}
 	}
 
@@ -310,8 +311,12 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 
 	var errs error
 	if c.getPlugins {
+		if len(missing) > 0 {
+			c.Ui.Output(fmt.Sprintf(" - Checking for available provider plugins on %s...",
+				discovery.GetReleaseHost()))
+		}
+
 		for provider, reqd := range missing {
-			c.Ui.Output(fmt.Sprintf("- Downloading plugin for provider %q...", provider))
 			_, err := c.providerInstaller.Get(provider, reqd.Versions)
 
 			if err != nil {

--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -16,6 +16,7 @@ import (
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	getter "github.com/hashicorp/go-getter"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/mitchellh/cli"
 )
 
 // Releases are located by parsing the html listing from releases.hashicorp.com.
@@ -58,6 +59,8 @@ type ProviderInstaller struct {
 
 	// Skip checksum and signature verification
 	SkipVerify bool
+
+	Ui cli.Ui // Ui for output
 }
 
 // Get is part of an implementation of type Installer, and attempts to download
@@ -116,6 +119,7 @@ func (i *ProviderInstaller) Get(provider string, req Constraints) (PluginMeta, e
 
 		log.Printf("[DEBUG] fetching provider info for %s version %s", provider, v)
 		if checkPlugin(url, i.PluginProtocolVersion) {
+			i.Ui.Info(fmt.Sprintf("- Downloading plugin for provider %q (%s)...", provider, v.String()))
 			log.Printf("[DEBUG] getting provider %q version %q at %s", provider, v, url)
 			err := getter.Get(i.Dir, url)
 			if err != nil {
@@ -421,4 +425,8 @@ func getFile(url string) ([]byte, error) {
 		return data, err
 	}
 	return data, nil
+}
+
+func GetReleaseHost() string {
+	return releaseHost
 }

--- a/plugin/discovery/get_test.go
+++ b/plugin/discovery/get_test.go
@@ -13,6 +13,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/mitchellh/cli"
 )
 
 const testProviderFile = "test provider binary"
@@ -149,6 +151,7 @@ func TestProviderInstallerGet(t *testing.T) {
 		Dir: tmpDir,
 		PluginProtocolVersion: 5,
 		SkipVerify:            true,
+		Ui:                    cli.NewMockUi(),
 	}
 	_, err = i.Get("test", AllVersions)
 	if err != ErrorNoVersionCompatible {
@@ -159,6 +162,7 @@ func TestProviderInstallerGet(t *testing.T) {
 		Dir: tmpDir,
 		PluginProtocolVersion: 3,
 		SkipVerify:            true,
+		Ui:                    cli.NewMockUi(),
 	}
 
 	{
@@ -230,6 +234,7 @@ func TestProviderInstallerPurgeUnused(t *testing.T) {
 		Dir: tmpDir,
 		PluginProtocolVersion: 3,
 		SkipVerify:            true,
+		Ui:                    cli.NewMockUi(),
 	}
 	purged, err := i.PurgeUnused(map[string]PluginMeta{
 		"test": PluginMeta{


### PR DESCRIPTION
In the spirit of transparency and improving UX I think we should be printing out chosen version & source for each plugin being downloaded.

## Why

1. When there's firewall in the way the user might not immediately realize what exactly is going on behind the scenes and what hostname/port should be whitelisted.
2. We display a single message ("Downloading") which is half-right as we might not end up downloading anything if discovery fails - e.g. no satisfiable version found.
3. ~The discovery phase actually takes some significant portion of the total time and splitting it can make the user feel it's "faster" because there's more feedback.~ (avoiding two lines to keep output short and brief)

## Before

```
Initializing provider plugins...
- Downloading plugin for provider "google"...
- Downloading plugin for provider "aws"...
- Downloading plugin for provider "cloudflare"...
```

## After

```
Initializing provider plugins...
Checking available provider plugins at https://releases.hashicorp.com...
- Downloading plugin for provider "google" (0.1.2)...
- Downloading plugin for provider "aws" (0.1.4)...
- Downloading plugin for provider "cloudflare" (0.1.0)...

```