### PR TITLE
command:init Allow TF_PLUGIN_DIR for plugin directory

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -67,6 +67,11 @@ func (c *InitCommand) Run(args []string) int {
 	if len(flagPluginPath) > 0 {
 		c.pluginPath = flagPluginPath
 		c.getPlugins = false
+		log.Print("[DEBUG] Using `-plugin-dir` for plugin directories")
+	} else if v := os.Getenv(ProviderPluginDir); v != "" {
+		c.pluginPath = []string{v}
+		c.getPlugins = false
+		log.Printf("[DEBUG] Using `%s` for plugin directory", ProviderPluginDir)
 	}
 
 	// set getProvider if we don't have a test version already

--- a/command/meta.go
+++ b/command/meta.go
@@ -230,6 +230,7 @@ func (m *Meta) StdinPiped() bool {
 
 const (
 	ProviderSkipVerifyEnvVar = "TF_SKIP_PROVIDER_VERIFY"
+	ProviderPluginDir        = "TF_PLUGIN_DIR"
 )
 
 // contextOpts returns the options to use to initialize a Terraform

--- a/website/docs/commands/init.html.markdown
+++ b/website/docs/commands/init.html.markdown
@@ -133,7 +133,10 @@ The automatic plugin installation behavior can be overridden by extracting
 the desired providers into a local directory and using the additional option
 `-plugin-dir=PATH`. When this option is specified, _only_ the given directory
 is consulted, which prevents Terraform from making requests to the plugin
-repository or looking for plugins in other local directories.
+repository or looking for plugins in other local directories. The `TF_PLUGIN_DIR`
+environment variable can also be used to specify the plugin directory, and follows
+the same constraints as using the argument flag(s). Argument flag(s) take precedence
+over the environment variable as well.
 
 Custom plugins can be used along with automatically installed plugins by
 placing them in `terraform.d/plugins/OS_ARCH/` inside the directory being


### PR DESCRIPTION
Allows the user to use the `TF_PLUGIN_DIR` to specify the plugin directory,
for Terraform plugins. While the argument flag can be used multiple times
for multiple directories, the environment variable limits users to only
using a single directory, however it's very beneficial for an automated
setup.

```
$ make test TEST=./command TESTARGS="-v -run=TestInit_pluginDirEnvVar"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/08/14 14:35:22 Generated command/internal_plugin_list.go
go test -i ./command || exit 1
echo ./command | \
        xargs -t -n4 go test -v -run=TestInit_pluginDirEnvVar -timeout=60s -parallel=4
go test -v -run=TestInit_pluginDirEnvVar -timeout=60s -parallel=4 ./command
=== RUN   TestInit_pluginDirEnvVar
--- PASS: TestInit_pluginDirEnvVar (0.00s)
PASS
ok      github.com/hashicorp/terraform/command  0.009s
```