### PR TITLE
Fixing the Azure Remote State Backend Documentation

### DIFF
--- a/website/docs/backends/types/azure.html.md
+++ b/website/docs/backends/types/azure.html.md
@@ -49,6 +49,7 @@ The following configuration options are supported:
  * `key` - (Required) The key where to place/look for state file inside the container
  * `access_key` / `ARM_ACCESS_KEY` - (Required) Storage account access key
  * `lease_id` / `ARM_LEASE_ID` - (Optional) If set, will be used when writing to storage blob.
+ * `resource_group_name` - (Optional) The name of the resource group for the storage account. Required if `access_key` isn't specified.
  * `environment` / `ARM_ENVIRONMENT` - (Optional) The cloud environment to use. Supported values are:
    * `public` (default)
    * `usgovernment`


### PR DESCRIPTION
Adding the `resource_group_name` back in which was chopped off in #8936.

Fixes #15610