### PR TITLE
specify a logger for go-plugin

### DIFF
--- a/plugin/client.go
+++ b/plugin/client.go
@@ -1,8 +1,10 @@
 package plugin
 
 import (
+	"os"
 	"os/exec"
 
+	hclog "github.com/hashicorp/go-hclog"
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/terraform/plugin/discovery"
 )
@@ -10,11 +12,18 @@ import (
 // ClientConfig returns a configuration object that can be used to instantiate
 // a client for the plugin described by the given metadata.
 func ClientConfig(m discovery.PluginMeta) *plugin.ClientConfig {
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:   "plugin",
+		Level:  hclog.Trace,
+		Output: os.Stderr,
+	})
+
 	return &plugin.ClientConfig{
 		Cmd:             exec.Command(m.Path),
 		HandshakeConfig: Handshake,
 		Managed:         true,
 		Plugins:         PluginMap,
+		Logger:          logger,
 	}
 }
 


### PR DESCRIPTION
The go-plugin package now uses hclog. The default Logger has a level set
to Info, but all plugin output is relayed via Debug. Create a new named
logger for plugins with the level set to Trace so that all output comes
through.