### PR TITLE
Add space after bracket

### DIFF
--- a/vendor/github.com/hashicorp/go-hclog/int.go
+++ b/vendor/github.com/hashicorp/go-hclog/int.go
@@ -17,8 +17,8 @@ var (
 	_levelToBracket = map[Level]string{
 		Debug: "[DEBUG]",
 		Trace: "[TRACE]",
-		Info:  "[INFO ]",
-		Warn:  "[WARN ]",
+		Info:  "[INFO] ",
+		Warn:  "[WARN] ",
 		Error: "[ERROR]",
 	}
 )


### PR DESCRIPTION
I understand the desire to have things aligned vertically, but adding the space inside the bracket makes grepping challenging. I moved the space outside the bracket, which will give the same behavior, but also look less weird (in my humble opinion).