### PR TITLE
fix race in MockResourceProvider

### DIFF
--- a/terraform/resource_provider_mock.go
+++ b/terraform/resource_provider_mock.go
@@ -94,6 +94,8 @@ func (p *MockResourceProvider) Close() error {
 
 func (p *MockResourceProvider) Input(
 	input UIInput, c *ResourceConfig) (*ResourceConfig, error) {
+	p.Lock()
+	defer p.Unlock()
 	p.InputCalled = true
 	p.InputInput = input
 	p.InputConfig = c


### PR DESCRIPTION
Input can be called concurrently from multiple nodes in the graph.