### PR TITLE
Update our documentation to push "Getting Started" better

### DIFF
--- a/website/docs/plugins/basics.html.md
+++ b/website/docs/plugins/basics.html.md
@@ -10,8 +10,8 @@ description: |-
 
 ~> **Advanced topic!** Plugin development is a highly advanced
 topic in Terraform, and is not required knowledge for day-to-day usage.
-If you don't plan on writing any plugins, we recommend not reading
-this section of the documentation. For general use of Terraform, please see our
+If you don't plan on writing any plugins, this section of the documentation is 
+not necessary to read. For general use of Terraform, please see our
 [Intro to Terraform](/intro/index.html) and [Getting
 Started](/intro/getting-started/install.html) guides.
 

--- a/website/docs/plugins/basics.html.md
+++ b/website/docs/plugins/basics.html.md
@@ -8,14 +8,16 @@ description: |-
 
 # Plugin Basics
 
-This page documents the basics of how the plugin system in Terraform
-works, and how to setup a basic development environment for plugin development
-if you're writing a Terraform plugin.
-
 ~> **Advanced topic!** Plugin development is a highly advanced
 topic in Terraform, and is not required knowledge for day-to-day usage.
 If you don't plan on writing any plugins, we recommend not reading
-this section of the documentation.
+this section of the documentation. For general use of Terraform, please see our
+[Intro to Terraform](/intro/index.html) and [Getting
+Started](/intro/getting-started/install.html) guides.
+
+This page documents the basics of how the plugin system in Terraform
+works, and how to setup a basic development environment for plugin development
+if you're writing a Terraform plugin.
 
 ## How it Works
 

--- a/website/docs/plugins/provider.html.md
+++ b/website/docs/plugins/provider.html.md
@@ -10,8 +10,8 @@ description: |-
 
 ~> **Advanced topic!** Plugin development is a highly advanced
 topic in Terraform, and is not required knowledge for day-to-day usage.
-If you don't plan on writing any plugins, we recommend not reading
-this section of the documentation. For general use of Terraform, please see our
+If you don't plan on writing any plugins, this section of the documentation is 
+not necessary to read. For general use of Terraform, please see our
 [Intro to Terraform](/intro/index.html) and [Getting
 Started](/intro/getting-started/install.html) guides.
 

--- a/website/docs/plugins/provider.html.md
+++ b/website/docs/plugins/provider.html.md
@@ -8,6 +8,13 @@ description: |-
 
 # Provider Plugins
 
+~> **Advanced topic!** Plugin development is a highly advanced
+topic in Terraform, and is not required knowledge for day-to-day usage.
+If you don't plan on writing any plugins, we recommend not reading
+this section of the documentation. For general use of Terraform, please see our
+[Intro to Terraform](/intro/index.html) and [Getting
+Started](/intro/getting-started/install.html) guides.
+
 A provider in Terraform is responsible for the lifecycle of a resource:
 create, read, update, delete. An example of a provider is AWS, which
 can manage resources of type `aws_instance`, `aws_eip`, `aws_elb`, etc.
@@ -21,11 +28,6 @@ The primary reasons to care about provider plugins are:
 
   * You want to write a completely new provider for custom, internal
     systems such as a private inventory management system.
-
-~> **Advanced topic!** Plugin development is a highly advanced
-topic in Terraform, and is not required knowledge for day-to-day usage.
-If you don't plan on writing any plugins, we recommend not reading
-this section of the documentation.
 
 If you're interested in provider development, then read on. The remainder
 of this page will assume you're familiar with

--- a/website/intro/getting-started/build.html.md
+++ b/website/intro/getting-started/build.html.md
@@ -121,8 +121,13 @@ an existing configuration from version control -- is `terraform init`, which
 initializes various local settings and data that will be used by subsequent
 commands.
 
-In particular, this command will install the plugins for the providers in
-use within the configuration, which in this case is just the `aws` provider:
+Terraform uses a plugin based architecture to support the numerous infrastructure 
+and service providers available. As of Terraform version 0.10.0, each "Provider" is it's 
+own encapsulated binary distributed separately from Terraform itself. The
+`terraform init` command will automatically download and install any Provider
+binary for the providers in use within the configuration, which in this case is 
+just the `aws` provider:
+
 
 ```
 $ terraform init

--- a/website/intro/getting-started/install.html.markdown
+++ b/website/intro/getting-started/install.html.markdown
@@ -57,6 +57,17 @@ If you get an error that `terraform` could not be found, your `PATH` environment
 variable was not set up properly. Please go back and ensure that your `PATH`
 variable contains the directory where Terraform was installed.
 
+## Installing Terraform Providers
+
+Terraform uses a plugin based architecture to support the numerous infrastructure 
+and service providers. As of Terraform version 0.10.0, each "Provider" is it's 
+own encapsulated binary distributed separately from Terraform itself. The core 
+Terraform binary downloaded and installed above will automatically download and 
+install any Provider binary needed for you, so you don't have to find and install 
+them yourself. A list of currently supported Providers can be found on 
+[our Providers page](/docs/providers/index.html).
+
+
 ## Next Steps
 
 Time to [build infrastructure](/intro/getting-started/build.html) using a

--- a/website/intro/getting-started/install.html.markdown
+++ b/website/intro/getting-started/install.html.markdown
@@ -57,9 +57,6 @@ If you get an error that `terraform` could not be found, your `PATH` environment
 variable was not set up properly. Please go back and ensure that your `PATH`
 variable contains the directory where Terraform was installed.
 
-~> **Note:** Terraform Providers are seperate binaries and are installed 
-automatically by Terraform based on your configuraiton files. 
-
 ## Next Steps
 
 Time to [build infrastructure](/intro/getting-started/build.html) using a

--- a/website/intro/getting-started/install.html.markdown
+++ b/website/intro/getting-started/install.html.markdown
@@ -57,17 +57,6 @@ If you get an error that `terraform` could not be found, your `PATH` environment
 variable was not set up properly. Please go back and ensure that your `PATH`
 variable contains the directory where Terraform was installed.
 
-## Installing Terraform Providers
-
-Terraform uses a plugin based architecture to support the numerous infrastructure 
-and service providers available. As of Terraform version 0.10.0, each "Provider" is it's 
-own encapsulated binary distributed separately from Terraform itself. The core 
-Terraform binary downloaded and installed above will automatically download and 
-install any Provider binary needed for you, so you don't have to find and install 
-them yourself. A list of currently supported Providers can be found on 
-[our Providers page](/docs/providers/index.html).
-
-
 ## Next Steps
 
 Time to [build infrastructure](/intro/getting-started/build.html) using a

--- a/website/intro/getting-started/install.html.markdown
+++ b/website/intro/getting-started/install.html.markdown
@@ -60,7 +60,7 @@ variable contains the directory where Terraform was installed.
 ## Installing Terraform Providers
 
 Terraform uses a plugin based architecture to support the numerous infrastructure 
-and service providers. As of Terraform version 0.10.0, each "Provider" is it's 
+and service providers available. As of Terraform version 0.10.0, each "Provider" is it's 
 own encapsulated binary distributed separately from Terraform itself. The core 
 Terraform binary downloaded and installed above will automatically download and 
 install any Provider binary needed for you, so you don't have to find and install 

--- a/website/intro/getting-started/install.html.markdown
+++ b/website/intro/getting-started/install.html.markdown
@@ -57,6 +57,9 @@ If you get an error that `terraform` could not be found, your `PATH` environment
 variable was not set up properly. Please go back and ensure that your `PATH`
 variable contains the directory where Terraform was installed.
 
+~> **Note:** Terraform Providers are seperate binaries and are installed 
+automatically by Terraform based on your configuraiton files. 
+
 ## Next Steps
 
 Time to [build infrastructure](/intro/getting-started/build.html) using a

--- a/website/layouts/guides.erb
+++ b/website/layouts/guides.erb
@@ -1,6 +1,9 @@
 <% wrap_layout :inner do %>
   <% content_for :sidebar do %>
     <ul class="nav docs-sidenav">
+      <li<%= sidebar_current("guides-getting-started") %>>
+        <a href="/intro/getting-started/install.html">Getting Started</a>
+      </li>
       <li<%= sidebar_current("guides-writing-custom-terraform-providers") %>>
         <a href="/guides/writing-custom-terraform-providers.html">Writing Custom Providers</a>
       </li>


### PR DESCRIPTION
Continuing https://github.com/hashicorp/terraform/pull/15865 by trying to surface our "Getting Started" guide better. 

- Adds link to "Getting Started" on our "Guides" layout
- Moves the `Advanced Topic!` notice higher on 2 plugin pages
- Adds `Installing Terraform Providers` section on "Installing" page of Getting Started