### PR TITLE
Provide example for terraform taint documentation

### DIFF
--- a/website/docs/commands/taint.html.markdown
+++ b/website/docs/commands/taint.html.markdown
@@ -66,6 +66,15 @@ The command-line flags are all optional. The list of available flags are:
   `-state` path will be used. Ignored when
   [remote state](/docs/state/remote.html) is used.
 
+## Example: Tainting a Single Resource
+
+This example will taint a single resource:
+
+```
+$ terraform taint aws_security_group.allow_all
+The resource aws_security_group.allow_all in the module root has been marked as tainted!
+```
+
 ## Example: Tainting a Resource within a Module
 
 This example will only taint a resource within a module:

--- a/website/docs/commands/taint.html.markdown
+++ b/website/docs/commands/taint.html.markdown
@@ -65,3 +65,12 @@ The command-line flags are all optional. The list of available flags are:
 * `-state-out=path` - Path to write updated state file. By default, the
   `-state` path will be used. Ignored when
   [remote state](/docs/state/remote.html) is used.
+
+## Example: Tainting a Resource within a Module
+
+This example will only taint a resource within a module:
+
+```
+$ terraform taint -module=couchbase aws_instance.cb_node.9
+The resource aws_instance.couchbase.11 in the module root.couchbase has been marked as tainted!
+```


### PR DESCRIPTION
Provides an example (with similar formatting as
https://www.terraform.io/docs/commands/state/list.html#example-filtering-by-module)
for tainting resources within a module.