### PR TITLE
Ensure consistency of details and tallies in plan and apply

### DIFF
--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -108,19 +108,15 @@ func (b *Local) opApply(
 					"There is no undo. Only 'yes' will be accepted to confirm."
 				query = "Do you really want to destroy?"
 			} else {
-				desc = "Terraform will apply the changes described above.\n" +
+				desc = "Terraform will perform the actions described above.\n" +
 					"Only 'yes' will be accepted to approve."
-				query = "Do you want to apply these changes?"
+				query = "Do you want to perform these actions?"
 			}
 
 			if !trivialPlan {
 				// Display the plan of what we are going to apply/destroy.
-				if op.Destroy {
-					op.UIOut.Output("\n" + strings.TrimSpace(approveDestroyPlanHeader) + "\n")
-				} else {
-					op.UIOut.Output("\n" + strings.TrimSpace(approvePlanHeader) + "\n")
-				}
-				op.UIOut.Output(dispPlan.Format(b.Colorize()))
+				b.renderPlan(dispPlan)
+				b.CLI.Output("")
 			}
 
 			v, err := op.UIIn.Input(&terraform.InputOpts{
@@ -336,18 +332,4 @@ const earlyStateWriteErrorFmt = `Error saving current state: %s
 Terraform encountered an error attempting to save the state before canceling
 the current operation. Once the operation is complete another attempt will be
 made to save the final state.
-`
-
-const approvePlanHeader = `
-The Terraform execution plan has been generated and is shown below.
-Resources are shown in alphabetical order for quick scanning. Green resources
-will be created (or destroyed and then created if an existing resource
-exists), yellow resources are being changed in-place, and red resources
-will be destroyed. Cyan entries are data sources to be read.
-`
-
-const approveDestroyPlanHeader = `
-The Terraform destroy plan has been generated and is shown below.
-Resources are shown in alphabetical order for quick scanning.
-Resources shown in red will be destroyed.
 `

--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -133,7 +133,8 @@ func (b *Local) opPlan(
 
 	// Perform some output tasks if we have a CLI to output to.
 	if b.CLI != nil {
-		if plan.Diff.Empty() {
+		dispPlan := format.NewPlan(plan)
+		if dispPlan.Empty() {
 			b.CLI.Output(b.Colorize().Color(strings.TrimSpace(planNoChanges)))
 			return
 		}
@@ -146,18 +147,14 @@ func (b *Local) opPlan(
 				path))
 		}
 
-		b.CLI.Output(format.Plan(&format.PlanOpts{
-			Plan:        plan,
-			Color:       b.Colorize(),
-			ModuleDepth: -1,
-		}))
+		b.CLI.Output(dispPlan.Format(b.Colorize()))
 
+		stats := dispPlan.Stats()
 		b.CLI.Output(b.Colorize().Color(fmt.Sprintf(
 			"[reset][bold]Plan:[reset] "+
 				"%d to add, %d to change, %d to destroy.",
-			countHook.ToAdd+countHook.ToRemoveAndAdd,
-			countHook.ToChange,
-			countHook.ToRemove+countHook.ToRemoveAndAdd)))
+			stats.ToAdd, stats.ToChange, stats.ToDestroy,
+		)))
 	}
 }
 

--- a/command/format/plan_test.go
+++ b/command/format/plan_test.go
@@ -1,14 +1,452 @@
 package format
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/colorstring"
 )
 
-// Test that a root level data source gets a special plan output on create
+var disabledColorize = &colorstring.Colorize{
+	Colors:  colorstring.DefaultColors,
+	Disable: true,
+}
+
+func TestNewPlan(t *testing.T) {
+	tests := map[string]struct {
+		Input *terraform.Plan
+		Want  *Plan
+	}{
+		"nil input": {
+			Input: nil,
+			Want: &Plan{
+				Resources: nil,
+			},
+		},
+		"nil diff": {
+			Input: &terraform.Plan{},
+			Want: &Plan{
+				Resources: nil,
+			},
+		},
+		"empty diff": {
+			Input: &terraform.Plan{
+				Diff: &terraform.Diff{
+					Modules: []*terraform.ModuleDiff{
+						{
+							Path:      []string{"root"},
+							Resources: map[string]*terraform.InstanceDiff{},
+						},
+					},
+				},
+			},
+			Want: &Plan{
+				Resources: nil,
+			},
+		},
+		"create managed resource": {
+			Input: &terraform.Plan{
+				Diff: &terraform.Diff{
+					Modules: []*terraform.ModuleDiff{
+						{
+							Path: []string{"root"},
+							Resources: map[string]*terraform.InstanceDiff{
+								"test_resource.foo": {
+									Attributes: map[string]*terraform.ResourceAttrDiff{
+										"id": {
+											NewComputed: true,
+											RequiresNew: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: &Plan{
+				Resources: []*InstanceDiff{
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo"),
+						Action: terraform.DiffCreate,
+						Attributes: []*AttributeDiff{
+							{
+								Path:        "id",
+								Action:      terraform.DiffCreate,
+								NewComputed: true,
+								ForcesNew:   true,
+							},
+						},
+					},
+				},
+			},
+		},
+		"create managed resource in child module": {
+			Input: &terraform.Plan{
+				Diff: &terraform.Diff{
+					Modules: []*terraform.ModuleDiff{
+						{
+							Path: []string{"root"},
+							Resources: map[string]*terraform.InstanceDiff{
+								"test_resource.foo": {
+									Attributes: map[string]*terraform.ResourceAttrDiff{
+										"id": {
+											NewComputed: true,
+											RequiresNew: true,
+										},
+									},
+								},
+							},
+						},
+						{
+							Path: []string{"root", "foo"},
+							Resources: map[string]*terraform.InstanceDiff{
+								"test_resource.foo": {
+									Attributes: map[string]*terraform.ResourceAttrDiff{
+										"id": {
+											NewComputed: true,
+											RequiresNew: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: &Plan{
+				Resources: []*InstanceDiff{
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo"),
+						Action: terraform.DiffCreate,
+						Attributes: []*AttributeDiff{
+							{
+								Path:        "id",
+								Action:      terraform.DiffCreate,
+								NewComputed: true,
+								ForcesNew:   true,
+							},
+						},
+					},
+					{
+						Addr:   mustParseResourceAddress("module.foo.test_resource.foo"),
+						Action: terraform.DiffCreate,
+						Attributes: []*AttributeDiff{
+							{
+								Path:        "id",
+								Action:      terraform.DiffCreate,
+								NewComputed: true,
+								ForcesNew:   true,
+							},
+						},
+					},
+				},
+			},
+		},
+		"create data resource": {
+			Input: &terraform.Plan{
+				Diff: &terraform.Diff{
+					Modules: []*terraform.ModuleDiff{
+						{
+							Path: []string{"root"},
+							Resources: map[string]*terraform.InstanceDiff{
+								"data.test_data_source.foo": {
+									Attributes: map[string]*terraform.ResourceAttrDiff{
+										"id": {
+											NewComputed: true,
+											RequiresNew: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: &Plan{
+				Resources: []*InstanceDiff{
+					{
+						Addr:   mustParseResourceAddress("data.test_data_source.foo"),
+						Action: terraform.DiffRefresh,
+						Attributes: []*AttributeDiff{
+							{
+								Path:        "id",
+								Action:      terraform.DiffUpdate,
+								NewComputed: true,
+								ForcesNew:   true,
+							},
+						},
+					},
+				},
+			},
+		},
+		"destroy managed resource": {
+			Input: &terraform.Plan{
+				Diff: &terraform.Diff{
+					Modules: []*terraform.ModuleDiff{
+						{
+							Path: []string{"root"},
+							Resources: map[string]*terraform.InstanceDiff{
+								"test_resource.foo": {
+									Destroy: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: &Plan{
+				Resources: []*InstanceDiff{
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo"),
+						Action: terraform.DiffDestroy,
+					},
+				},
+			},
+		},
+		"destroy data resource": {
+			Input: &terraform.Plan{
+				Diff: &terraform.Diff{
+					Modules: []*terraform.ModuleDiff{
+						{
+							Path: []string{"root"},
+							Resources: map[string]*terraform.InstanceDiff{
+								"data.test_data_source.foo": {
+									Destroy: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: &Plan{
+				// Data source destroys are not shown
+				Resources: nil,
+			},
+		},
+		"destroy many instances of a resource": {
+			Input: &terraform.Plan{
+				Diff: &terraform.Diff{
+					Modules: []*terraform.ModuleDiff{
+						{
+							Path: []string{"root"},
+							Resources: map[string]*terraform.InstanceDiff{
+								"test_resource.foo.0": {
+									Destroy: true,
+								},
+								"test_resource.foo.1": {
+									Destroy: true,
+								},
+								"test_resource.foo.10": {
+									Destroy: true,
+								},
+								"test_resource.foo.2": {
+									Destroy: true,
+								},
+								"test_resource.foo.3": {
+									Destroy: true,
+								},
+								"test_resource.foo.4": {
+									Destroy: true,
+								},
+								"test_resource.foo.5": {
+									Destroy: true,
+								},
+								"test_resource.foo.6": {
+									Destroy: true,
+								},
+								"test_resource.foo.7": {
+									Destroy: true,
+								},
+								"test_resource.foo.8": {
+									Destroy: true,
+								},
+								"test_resource.foo.9": {
+									Destroy: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: &Plan{
+				Resources: []*InstanceDiff{
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo[0]"),
+						Action: terraform.DiffDestroy,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo[1]"),
+						Action: terraform.DiffDestroy,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo[2]"),
+						Action: terraform.DiffDestroy,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo[3]"),
+						Action: terraform.DiffDestroy,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo[4]"),
+						Action: terraform.DiffDestroy,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo[5]"),
+						Action: terraform.DiffDestroy,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo[6]"),
+						Action: terraform.DiffDestroy,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo[7]"),
+						Action: terraform.DiffDestroy,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo[8]"),
+						Action: terraform.DiffDestroy,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo[9]"),
+						Action: terraform.DiffDestroy,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo[10]"),
+						Action: terraform.DiffDestroy,
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := NewPlan(test.Input)
+			if !reflect.DeepEqual(got, test.Want) {
+				t.Errorf(
+					"wrong result\ninput: %sgot: %swant:%s",
+					spew.Sdump(test.Input),
+					spew.Sdump(got),
+					spew.Sdump(test.Want),
+				)
+			}
+		})
+	}
+}
+
+func TestPlanStats(t *testing.T) {
+	tests := map[string]struct {
+		Input *Plan
+		Want  PlanStats
+	}{
+		"empty": {
+			&Plan{},
+			PlanStats{},
+		},
+		"destroy": {
+			&Plan{
+				Resources: []*InstanceDiff{
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo"),
+						Action: terraform.DiffDestroy,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.bar"),
+						Action: terraform.DiffDestroy,
+					},
+				},
+			},
+			PlanStats{
+				ToDestroy: 2,
+			},
+		},
+		"create": {
+			&Plan{
+				Resources: []*InstanceDiff{
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo"),
+						Action: terraform.DiffCreate,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.bar"),
+						Action: terraform.DiffCreate,
+					},
+				},
+			},
+			PlanStats{
+				ToAdd: 2,
+			},
+		},
+		"update": {
+			&Plan{
+				Resources: []*InstanceDiff{
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo"),
+						Action: terraform.DiffUpdate,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.bar"),
+						Action: terraform.DiffUpdate,
+					},
+				},
+			},
+			PlanStats{
+				ToChange: 2,
+			},
+		},
+		"data source refresh": {
+			&Plan{
+				Resources: []*InstanceDiff{
+					{
+						Addr:   mustParseResourceAddress("data.test.foo"),
+						Action: terraform.DiffRefresh,
+					},
+				},
+			},
+			PlanStats{
+			// data resource refreshes are not counted in our stats
+			},
+		},
+		"replace": {
+			&Plan{
+				Resources: []*InstanceDiff{
+					{
+						Addr:   mustParseResourceAddress("test_resource.foo"),
+						Action: terraform.DiffDestroyCreate,
+					},
+					{
+						Addr:   mustParseResourceAddress("test_resource.bar"),
+						Action: terraform.DiffDestroyCreate,
+					},
+				},
+			},
+			PlanStats{
+				ToDestroy: 2,
+				ToAdd:     2,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := test.Input.Stats()
+			if !reflect.DeepEqual(got, test.Want) {
+				t.Errorf(
+					"wrong result\ninput: %sgot: %swant:%s",
+					spew.Sdump(test.Input),
+					spew.Sdump(got),
+					spew.Sdump(test.Want),
+				)
+			}
+		})
+	}
+}
+
+// Test that deposed instances are marked as such
 func TestPlan_destroyDeposed(t *testing.T) {
 	plan := &terraform.Plan{
 		Diff: &terraform.Diff{
@@ -24,16 +462,8 @@ func TestPlan_destroyDeposed(t *testing.T) {
 			},
 		},
 	}
-	opts := &PlanOpts{
-		Plan: plan,
-		Color: &colorstring.Colorize{
-			Colors:  colorstring.DefaultColors,
-			Disable: true,
-		},
-		ModuleDepth: 1,
-	}
-
-	actual := Plan(opts)
+	dispPlan := NewPlan(plan)
+	actual := dispPlan.Format(disabledColorize)
 
 	expected := strings.TrimSpace(`
 - aws_instance.foo (deposed)
@@ -64,16 +494,8 @@ func TestPlan_displayInterpolations(t *testing.T) {
 			},
 		},
 	}
-	opts := &PlanOpts{
-		Plan: plan,
-		Color: &colorstring.Colorize{
-			Colors:  colorstring.DefaultColors,
-			Disable: true,
-		},
-		ModuleDepth: 1,
-	}
-
-	out := Plan(opts)
+	dispPlan := NewPlan(plan)
+	out := dispPlan.Format(disabledColorize)
 	lines := strings.Split(out, "\n")
 	if len(lines) != 2 {
 		t.Fatal("expected 2 lines of output, got:\n", out)
@@ -108,16 +530,8 @@ func TestPlan_rootDataSource(t *testing.T) {
 			},
 		},
 	}
-	opts := &PlanOpts{
-		Plan: plan,
-		Color: &colorstring.Colorize{
-			Colors:  colorstring.DefaultColors,
-			Disable: true,
-		},
-		ModuleDepth: 1,
-	}
-
-	actual := Plan(opts)
+	dispPlan := NewPlan(plan)
+	actual := dispPlan.Format(disabledColorize)
 
 	expected := strings.TrimSpace(`
  <= data.type.name
@@ -149,16 +563,8 @@ func TestPlan_nestedDataSource(t *testing.T) {
 			},
 		},
 	}
-	opts := &PlanOpts{
-		Plan: plan,
-		Color: &colorstring.Colorize{
-			Colors:  colorstring.DefaultColors,
-			Disable: true,
-		},
-		ModuleDepth: 2,
-	}
-
-	actual := Plan(opts)
+	dispPlan := NewPlan(plan)
+	actual := dispPlan.Format(disabledColorize)
 
 	expected := strings.TrimSpace(`
  <= module.nested.data.type.name
@@ -167,4 +573,12 @@ func TestPlan_nestedDataSource(t *testing.T) {
 	if actual != expected {
 		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, actual)
 	}
+}
+
+func mustParseResourceAddress(s string) *terraform.ResourceAddress {
+	addr, err := terraform.ParseResourceAddress(s)
+	if err != nil {
+		panic(err)
+	}
+	return addr
 }

--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -65,6 +65,7 @@ func (h *UiHook) PreApply(
 	}
 
 	id := n.HumanId()
+	addr := n.ResourceAddress()
 
 	op := uiResourceModify
 	if d.Destroy {
@@ -142,7 +143,7 @@ func (h *UiHook) PreApply(
 
 	h.ui.Output(h.Colorize.Color(fmt.Sprintf(
 		"[reset][bold]%s: %s%s[reset]%s",
-		id,
+		addr,
 		operation,
 		stateIdSuffix,
 		attrString)))
@@ -210,6 +211,7 @@ func (h *UiHook) PostApply(
 	applyerr error) (terraform.HookAction, error) {
 
 	id := n.HumanId()
+	addr := n.ResourceAddress()
 
 	h.l.Lock()
 	state := h.resources[id]
@@ -244,7 +246,7 @@ func (h *UiHook) PostApply(
 
 	colorized := h.Colorize.Color(fmt.Sprintf(
 		"[reset][bold]%s: %s after %s%s[reset]",
-		id, msg, time.Now().Round(time.Second).Sub(state.Start), stateIdSuffix))
+		addr, msg, time.Now().Round(time.Second).Sub(state.Start), stateIdSuffix))
 
 	h.ui.Output(colorized)
 
@@ -260,10 +262,10 @@ func (h *UiHook) PreDiff(
 func (h *UiHook) PreProvision(
 	n *terraform.InstanceInfo,
 	provId string) (terraform.HookAction, error) {
-	id := n.HumanId()
+	addr := n.ResourceAddress()
 	h.ui.Output(h.Colorize.Color(fmt.Sprintf(
 		"[reset][bold]%s: Provisioning with '%s'...[reset]",
-		id, provId)))
+		addr, provId)))
 	return terraform.HookActionContinue, nil
 }
 
@@ -271,11 +273,11 @@ func (h *UiHook) ProvisionOutput(
 	n *terraform.InstanceInfo,
 	provId string,
 	msg string) {
-	id := n.HumanId()
+	addr := n.ResourceAddress()
 	var buf bytes.Buffer
 	buf.WriteString(h.Colorize.Color("[reset]"))
 
-	prefix := fmt.Sprintf("%s (%s): ", id, provId)
+	prefix := fmt.Sprintf("%s (%s): ", addr, provId)
 	s := bufio.NewScanner(strings.NewReader(msg))
 	s.Split(scanLines)
 	for s.Scan() {
@@ -293,7 +295,7 @@ func (h *UiHook) PreRefresh(
 	s *terraform.InstanceState) (terraform.HookAction, error) {
 	h.once.Do(h.init)
 
-	id := n.HumanId()
+	addr := n.ResourceAddress()
 
 	var stateIdSuffix string
 	// Data resources refresh before they have ids, whereas managed
@@ -304,7 +306,7 @@ func (h *UiHook) PreRefresh(
 
 	h.ui.Output(h.Colorize.Color(fmt.Sprintf(
 		"[reset][bold]%s: Refreshing state...%s",
-		id, stateIdSuffix)))
+		addr, stateIdSuffix)))
 	return terraform.HookActionContinue, nil
 }
 
@@ -313,9 +315,10 @@ func (h *UiHook) PreImportState(
 	id string) (terraform.HookAction, error) {
 	h.once.Do(h.init)
 
+	addr := n.ResourceAddress()
 	h.ui.Output(h.Colorize.Color(fmt.Sprintf(
 		"[reset][bold]%s: Importing from ID %q...",
-		n.HumanId(), id)))
+		addr, id)))
 	return terraform.HookActionContinue, nil
 }
 
@@ -324,9 +327,9 @@ func (h *UiHook) PostImportState(
 	s []*terraform.InstanceState) (terraform.HookAction, error) {
 	h.once.Do(h.init)
 
-	id := n.HumanId()
+	addr := n.ResourceAddress()
 	h.ui.Output(h.Colorize.Color(fmt.Sprintf(
-		"[reset][bold][green]%s: Import complete!", id)))
+		"[reset][bold][green]%s: Import complete!", addr)))
 	for _, s := range s {
 		h.ui.Output(h.Colorize.Color(fmt.Sprintf(
 			"[reset][green]  Imported %s (ID: %s)",

--- a/command/show.go
+++ b/command/show.go
@@ -110,11 +110,8 @@ func (c *ShowCommand) Run(args []string) int {
 	}
 
 	if plan != nil {
-		c.Ui.Output(format.Plan(&format.PlanOpts{
-			Plan:        plan,
-			Color:       c.Colorize(),
-			ModuleDepth: moduleDepth,
-		}))
+		dispPlan := format.NewPlan(plan)
+		c.Ui.Output(dispPlan.Format(c.Colorize()))
 		return 0
 	}
 

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -1519,6 +1519,7 @@ func TestContext2Apply_destroyData(t *testing.T) {
 			},
 		},
 	}
+	hook := &testHook{}
 	ctx := testContext2(t, &ContextOpts{
 		Module: m,
 		ProviderResolver: ResourceProviderResolverFixed(
@@ -1528,6 +1529,7 @@ func TestContext2Apply_destroyData(t *testing.T) {
 		),
 		State:   state,
 		Destroy: true,
+		Hooks:   []Hook{hook},
 	})
 
 	if p, err := ctx.Plan(); err != nil {
@@ -1547,6 +1549,15 @@ func TestContext2Apply_destroyData(t *testing.T) {
 
 	if got := len(newState.Modules[0].Resources); got != 0 {
 		t.Fatalf("state has %d resources after destroy; want 0", got)
+	}
+
+	wantHookCalls := []*testHookCall{
+		{"PreDiff", "data.null_data_source.testing"},
+		{"PostDiff", "data.null_data_source.testing"},
+		{"PostStateUpdate", ""},
+	}
+	if !reflect.DeepEqual(hook.Calls, wantHookCalls) {
+		t.Errorf("wrong hook calls\ngot: %swant: %s", spew.Sdump(hook.Calls), spew.Sdump(wantHookCalls))
 	}
 }
 

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -23,6 +23,12 @@ const (
 	DiffUpdate
 	DiffDestroy
 	DiffDestroyCreate
+
+	// DiffRefresh is only used in the UI for displaying diffs.
+	// Managed resource reads never appear in plan, and when data source
+	// reads appear they are represented as DiffCreate in core before
+	// transforming to DiffRefresh in the UI layer.
+	DiffRefresh // TODO: Actually use DiffRefresh in core too, for less confusion
 )
 
 // multiVal matches the index key to a flatmapped set, list or map

--- a/terraform/hook_test.go
+++ b/terraform/hook_test.go
@@ -7,3 +7,89 @@ import (
 func TestNilHook_impl(t *testing.T) {
 	var _ Hook = new(NilHook)
 }
+
+// testHook is a Hook implementation that logs the calls it receives.
+// It is intended for testing that core code is emitting the correct hooks
+// for a given situation.
+type testHook struct {
+	Calls []*testHookCall
+}
+
+// testHookCall represents a single call in testHook.
+// This hook just logs string names to make it easy to write "want" expressions
+// in tests that can DeepEqual against the real calls.
+type testHookCall struct {
+	Action     string
+	InstanceID string
+}
+
+func (h *testHook) PreApply(i *InstanceInfo, s *InstanceState, d *InstanceDiff) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PreApply", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) PostApply(i *InstanceInfo, s *InstanceState, err error) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PostApply", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) PreDiff(i *InstanceInfo, s *InstanceState) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PreDiff", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) PostDiff(i *InstanceInfo, d *InstanceDiff) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PostDiff", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) PreProvisionResource(i *InstanceInfo, s *InstanceState) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PreProvisionResource", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) PostProvisionResource(i *InstanceInfo, s *InstanceState) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PostProvisionResource", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) PreProvision(i *InstanceInfo, n string) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PreProvision", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) PostProvision(i *InstanceInfo, n string, err error) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PostProvision", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) ProvisionOutput(i *InstanceInfo, n string, m string) {
+	h.Calls = append(h.Calls, &testHookCall{"ProvisionOutput", i.ResourceAddress().String()})
+}
+
+func (h *testHook) PreRefresh(i *InstanceInfo, s *InstanceState) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PreRefresh", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) PostRefresh(i *InstanceInfo, s *InstanceState) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PostRefresh", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) PreImportState(i *InstanceInfo, n string) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PreImportState", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) PostImportState(i *InstanceInfo, ss []*InstanceState) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PostImportState", i.ResourceAddress().String()})
+	return HookActionContinue, nil
+}
+
+func (h *testHook) PostStateUpdate(s *State) (HookAction, error) {
+	h.Calls = append(h.Calls, &testHookCall{"PostStateUpdate", ""})
+	return HookActionContinue, nil
+}
+
+var _ Hook = new(testHook)

--- a/terraform/resource_address.go
+++ b/terraform/resource_address.go
@@ -362,40 +362,41 @@ func (addr *ResourceAddress) Less(other *ResourceAddress) bool {
 
 	switch {
 
-	case len(addr.Path) < len(other.Path):
-		return true
+	case len(addr.Path) != len(other.Path):
+		return len(addr.Path) < len(other.Path)
 
 	case !reflect.DeepEqual(addr.Path, other.Path):
 		// If the two paths are the same length but don't match, we'll just
 		// cheat and compare the string forms since it's easier than
-		// comparing all of the path segments in turn.
+		// comparing all of the path segments in turn, and lexicographic
+		// comparison is correct for the module path portion.
 		addrStr := addr.String()
 		otherStr := other.String()
 		return addrStr < otherStr
 
-	case addr.Mode == config.DataResourceMode && other.Mode != config.DataResourceMode:
-		return true
+	case addr.Mode != other.Mode:
+		return addr.Mode == config.DataResourceMode
 
-	case addr.Type < other.Type:
-		return true
+	case addr.Type != other.Type:
+		return addr.Type < other.Type
 
-	case addr.Name < other.Name:
-		return true
+	case addr.Name != other.Name:
+		return addr.Name < other.Name
 
-	case addr.Index < other.Index:
+	case addr.Index != other.Index:
 		// Since "Index" is -1 for an un-indexed address, this also conveniently
 		// sorts unindexed addresses before indexed ones, should they both
 		// appear for some reason.
-		return true
+		return addr.Index < other.Index
 
-	case other.InstanceTypeSet && !addr.InstanceTypeSet:
-		return true
+	case addr.InstanceTypeSet != other.InstanceTypeSet:
+		return !addr.InstanceTypeSet
 
-	case addr.InstanceType < other.InstanceType:
+	case addr.InstanceType != other.InstanceType:
 		// InstanceType is actually an enum, so this is just an arbitrary
 		// sort based on the enum numeric values, and thus not particularly
 		// meaningful.
-		return true
+		return addr.InstanceType < other.InstanceType
 
 	default:
 		return false

--- a/terraform/resource_address_test.go
+++ b/terraform/resource_address_test.go
@@ -1235,6 +1235,11 @@ func TestResourceAddressLess(t *testing.T) {
 		},
 		{
 			"module.baz.foo.bar",
+			"zzz.bar", // would sort after "module" in lexicographical sort
+			false,
+		},
+		{
+			"module.baz.foo.bar",
 			"module.baz.foo.bar",
 			false,
 		},
@@ -1242,6 +1247,11 @@ func TestResourceAddressLess(t *testing.T) {
 			"module.baz.foo.bar",
 			"module.boz.foo.bar",
 			true,
+		},
+		{
+			"module.boz.foo.bar",
+			"module.baz.foo.bar",
+			false,
 		},
 		{
 			"a.b",
@@ -1254,9 +1264,19 @@ func TestResourceAddressLess(t *testing.T) {
 			true,
 		},
 		{
+			"c.b",
+			"b.c",
+			false,
+		},
+		{
 			"a.b[9]",
 			"a.b[10]",
 			true,
+		},
+		{
+			"b.b[9]",
+			"a.b[10]",
+			false,
 		},
 		{
 			"a.b",


### PR DESCRIPTION
As reported in #14048, we currently have a number of inconsistencies between the following:

* The detailed plan output for normal updates vs. destroying.
* The plan detail vs. the tally of resources to be created, updated and destroyed.
* The count of resources to destroy during plan and the count of resources destroyed during apply.

The root cause of these inconsistencies is that we have some leaky abstractions around the handling of data sources: internally we include data sources in the diff and act on them during apply to either refresh them or remove them from state (depending on what sort of apply we're doing), but in the user-facing model we think of data sources as being "read" in an apply and not appearing _at all_ in destroy.

The goal of this PR, then, is to ensure that this abstraction stops leaking by cleaning up some places where it's not honored properly and refactoring so that these results are being computed in a more centralized place where it's less likely for future changes to cause consistency regressions.

Along the way it also adjusts some other weirdness in the plan and apply output, as a result of the refactoring.

This fixes #14048.