### PR TITLE
Resource aws_instance does not have attr private_ip_address

### DIFF
--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -46,7 +46,7 @@ return list elements by index: `${var.subnets[idx]}`.
 
 #### Attributes of your own resource
 
-The syntax is `self.ATTRIBUTE`. For example `${self.private_ip_address}`
+The syntax is `self.ATTRIBUTE`. For example `${self.private_ip}`
 will interpolate that resource's private IP address.
 
 -> **Note**: The `self.ATTRIBUTE` syntax is only allowed and valid within

--- a/website/docs/provisioners/index.html.markdown
+++ b/website/docs/provisioners/index.html.markdown
@@ -19,7 +19,7 @@ resource "aws_instance" "web" {
   # ...
 
   provisioner "local-exec" {
-    command = "echo ${self.private_ip_address} > file.txt"
+    command = "echo ${self.private_ip} > file.txt"
   }
 }
 ```
@@ -114,7 +114,7 @@ resource "aws_instance" "web" {
   # ...
 
   provisioner "local-exec" {
-    command    = "echo ${self.private_ip_address} > file.txt"
+    command    = "echo ${self.private_ip} > file.txt"
     on_failure = "continue"
   }
 }


### PR DESCRIPTION
Hello,

This is just a small fix in docs examples where the attribute used doesn't match the resource attributes.

It generates messages like this: 

``` 
Resource 'aws_instance.instances.0' does not have attribute 'private_ip_address' for variable 'aws_instance.server.0.private_ip_address'
```

- Reasoning for docs update: `consistency`
- Relevant Terraform version: `0.8.1`

Best,
Gabriel