### PR TITLE
Upgrade to Go 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ dist: trusty
 sudo: false
 language: go
 go:
-- 1.8.3
-- 1.9rc1
+- 1.9
 
 # add TF_CONSUL_TEST=1 to run consul tests
 # they were causing timouts in travis

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TEST?=$$(go list ./... | grep -v '/terraform/vendor/' | grep -v '/builtin/bins/')
+TEST?=./...
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 default: test vet
@@ -27,10 +27,11 @@ plugin-dev: generate
 	mv $(GOPATH)/bin/$(PLUGIN) $(GOPATH)/bin/terraform-$(PLUGIN)
 
 # test runs the unit tests
+# we run this one package at a time here because running the entire suite in
+# one command creates memory usage issues when running in Travis-CI.
 test: fmtcheck generate
 	go test -i $(TEST) || exit 1
-	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=60s -parallel=4
+	go list $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=60s -parallel=4
 
 # testacc runs acceptance tests
 testacc: fmtcheck generate
@@ -64,8 +65,8 @@ cover:
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.
 vet:
-	@echo 'go vet $$(go list ./... | grep -v /terraform/vendor/)'
-	@go vet $$(go list ./... | grep -v /terraform/vendor/) ; if [ $$? -eq 1 ]; then \
+	@echo 'go vet ./...'
+	@go vet ./... ; if [ $$? -eq 1 ]; then \
 		echo ""; \
 		echo "Vet found suspicious constructs. Please check the reported constructs"; \
 		echo "and fix them if necessary before submitting the code for review."; \
@@ -78,7 +79,7 @@ generate:
 	@which stringer > /dev/null; if [ $$? -ne 0 ]; then \
 	  go get -u golang.org/x/tools/cmd/stringer; \
 	fi
-	go generate $$(go list ./... | grep -v /terraform/vendor/)
+	go generate ./...
 	@go fmt command/internal_plugin_list.go > /dev/null
 
 fmt:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All documentation is available on the [Terraform website](http://www.terraform.i
 Developing Terraform
 --------------------
 
-If you wish to work on Terraform itself or any of its built-in providers, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.8+ is *required*). Alternatively, you can use the Vagrantfile in the root of this repo to stand up a virtual machine with the appropriate dev tooling already set up for you.
+If you wish to work on Terraform itself or any of its built-in providers, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.9+ is *required*). Alternatively, you can use the Vagrantfile in the root of this repo to stand up a virtual machine with the appropriate dev tooling already set up for you.
 
 This repository contains only Terraform core, which includes the command line interface and the main graph engine. Providers are implemented as plugins that each have their own repository in [the `terraform-providers` organization](https://github.com/terraform-providers) on GitHub. Instructions for developing each provider are in the associated README file. For more information, see [the provider development overview](https://www.terraform.io/docs/plugins/provider.html).
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 # Software version variables
-GOVERSION = "1.8.3"
+GOVERSION = "1.9"
 UBUNTUVERSION = "16.04"
 
 # CPU and RAM can be adjusted depending on your system

--- a/backend/testing.go
+++ b/backend/testing.go
@@ -13,6 +13,8 @@ import (
 // TestBackendConfig validates and configures the backend with the
 // given configuration.
 func TestBackendConfig(t *testing.T, b Backend, c map[string]interface{}) Backend {
+	t.Helper()
+
 	// Get the proper config structure
 	rc, err := config.NewRawConfig(c)
 	if err != nil {
@@ -45,6 +47,8 @@ func TestBackendConfig(t *testing.T, b Backend, c map[string]interface{}) Backen
 // If you want to test locking, two backends must be given. If b2 is nil,
 // then state lockign won't be tested.
 func TestBackend(t *testing.T, b1, b2 Backend) {
+	t.Helper()
+
 	testBackendStates(t, b1)
 
 	if b2 != nil {
@@ -53,6 +57,8 @@ func TestBackend(t *testing.T, b1, b2 Backend) {
 }
 
 func testBackendStates(t *testing.T, b Backend) {
+	t.Helper()
+
 	states, err := b.States()
 	if err == ErrNamedStatesNotSupported {
 		t.Logf("TestBackend: named states not supported in %T, skipping", b)
@@ -231,6 +237,8 @@ func testBackendStates(t *testing.T, b Backend) {
 }
 
 func testBackendStateLock(t *testing.T, b1, b2 Backend) {
+	t.Helper()
+
 	// Get the default state for each
 	b1StateMgr, err := b1.State(DefaultStateName)
 	if err != nil {

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -54,6 +54,8 @@ func TestMain(m *testing.M) {
 }
 
 func tempDir(t *testing.T) string {
+	t.Helper()
+
 	dir, err := ioutil.TempDir("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -99,6 +101,8 @@ func metaOverridesForProviderAndProvisioner(p terraform.ResourceProvider, pr ter
 }
 
 func testModule(t *testing.T, name string) *module.Tree {
+	t.Helper()
+
 	mod, err := module.NewTreeModule("", filepath.Join(fixtureDir, name))
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -114,6 +118,8 @@ func testModule(t *testing.T, name string) *module.Tree {
 
 // testPlan returns a non-nil noop plan.
 func testPlan(t *testing.T) *terraform.Plan {
+	t.Helper()
+
 	state := terraform.NewState()
 	state.RootModule().Outputs["foo"] = &terraform.OutputState{
 		Type:  "string",
@@ -127,6 +133,8 @@ func testPlan(t *testing.T) *terraform.Plan {
 }
 
 func testPlanFile(t *testing.T, plan *terraform.Plan) string {
+	t.Helper()
+
 	path := testTempFile(t)
 
 	f, err := os.Create(path)
@@ -143,6 +151,8 @@ func testPlanFile(t *testing.T, plan *terraform.Plan) string {
 }
 
 func testReadPlan(t *testing.T, path string) *terraform.Plan {
+	t.Helper()
+
 	f, err := os.Open(path)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -180,6 +190,8 @@ func testState() *terraform.State {
 }
 
 func testStateFile(t *testing.T, s *terraform.State) string {
+	t.Helper()
+
 	path := testTempFile(t)
 
 	f, err := os.Create(path)
@@ -198,6 +210,8 @@ func testStateFile(t *testing.T, s *terraform.State) string {
 // testStateFileDefault writes the state out to the default statefile
 // in the cwd. Use `testCwd` to change into a temp cwd.
 func testStateFileDefault(t *testing.T, s *terraform.State) string {
+	t.Helper()
+
 	f, err := os.Create(DefaultStateFilename)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -214,6 +228,8 @@ func testStateFileDefault(t *testing.T, s *terraform.State) string {
 // testStateFileRemote writes the state out to the remote statefile
 // in the cwd. Use `testCwd` to change into a temp cwd.
 func testStateFileRemote(t *testing.T, s *terraform.State) string {
+	t.Helper()
+
 	path := filepath.Join(DefaultDataDir, DefaultStateFilename)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatalf("err: %s", err)
@@ -234,6 +250,8 @@ func testStateFileRemote(t *testing.T, s *terraform.State) string {
 
 // testStateRead reads the state from a file
 func testStateRead(t *testing.T, path string) *terraform.State {
+	t.Helper()
+
 	f, err := os.Open(path)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -251,6 +269,8 @@ func testStateRead(t *testing.T, path string) *terraform.State {
 // testStateOutput tests that the state at the given path contains
 // the expected state string.
 func testStateOutput(t *testing.T, path string, expected string) {
+	t.Helper()
+
 	newState := testStateRead(t, path)
 	actual := strings.TrimSpace(newState.String())
 	expected = strings.TrimSpace(expected)
@@ -277,10 +297,14 @@ func testProvider() *terraform.MockResourceProvider {
 }
 
 func testTempFile(t *testing.T) string {
+	t.Helper()
+
 	return filepath.Join(testTempDir(t), "state.tfstate")
 }
 
 func testTempDir(t *testing.T) string {
+	t.Helper()
+
 	d, err := ioutil.TempDir("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -292,6 +316,8 @@ func testTempDir(t *testing.T) string {
 // testRename renames the path to new and returns a function to defer to
 // revert the rename.
 func testRename(t *testing.T, base, path, new string) func() {
+	t.Helper()
+
 	if base != "" {
 		path = filepath.Join(base, path)
 		new = filepath.Join(base, new)
@@ -310,6 +336,8 @@ func testRename(t *testing.T, base, path, new string) func() {
 // testChdir changes the directory and returns a function to defer to
 // revert the old cwd.
 func testChdir(t *testing.T, new string) func() {
+	t.Helper()
+
 	old, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -328,6 +356,8 @@ func testChdir(t *testing.T, new string) func() {
 // testCwd is used to change the current working directory
 // into a test directory that should be remoted after
 func testCwd(t *testing.T) (string, string) {
+	t.Helper()
+
 	tmp, err := ioutil.TempDir("", "tf")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -347,6 +377,8 @@ func testCwd(t *testing.T) (string, string) {
 
 // testFixCwd is used to as a defer to testDir
 func testFixCwd(t *testing.T, tmp, cwd string) {
+	t.Helper()
+
 	if err := os.Chdir(cwd); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -362,6 +394,8 @@ func testFixCwd(t *testing.T, tmp, cwd string) {
 // The returned function should be deferred to properly clean up and restore
 // the original stdin.
 func testStdinPipe(t *testing.T, src io.Reader) func() {
+	t.Helper()
+
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -390,6 +424,8 @@ func testStdinPipe(t *testing.T, src io.Reader) func() {
 // not useful since the commands are configured to write to a cli.Ui, not
 // Stdout directly. Commands like `console` though use the raw stdout.
 func testStdoutCapture(t *testing.T, dst io.Writer) func() {
+	t.Helper()
+
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -424,6 +460,8 @@ func testStdoutCapture(t *testing.T, dst io.Writer) func() {
 // in order to interactive prompts. The returned function must be called
 // in a defer to clean up.
 func testInteractiveInput(t *testing.T, answers []string) func() {
+	t.Helper()
+
 	// Disable test mode so input is called
 	test = false
 
@@ -443,6 +481,8 @@ func testInteractiveInput(t *testing.T, answers []string) func() {
 // for calls to Input when the right question is asked. The key is the
 // question "Id" that is used.
 func testInputMap(t *testing.T, answers map[string]string) func() {
+	t.Helper()
+
 	// Disable test mode so input is called
 	test = false
 
@@ -465,6 +505,8 @@ func testInputMap(t *testing.T, answers map[string]string) func() {
 // backend. This returns the complete state that can be saved. Use
 // `testStateFileRemote` to write the returned state.
 func testBackendState(t *testing.T, s *terraform.State, c int) (*terraform.State, *httptest.Server) {
+	t.Helper()
+
 	var b64md5 string
 	buf := bytes.NewBuffer(nil)
 
@@ -507,6 +549,8 @@ func testBackendState(t *testing.T, s *terraform.State, c int) (*terraform.State
 // testRemoteState is used to make a test HTTP server to return a given
 // state file that can be used for testing legacy remote state.
 func testRemoteState(t *testing.T, s *terraform.State, c int) (*terraform.RemoteState, *httptest.Server) {
+	t.Helper()
+
 	var b64md5 string
 	buf := bytes.NewBuffer(nil)
 

--- a/command/e2etest/main_test.go
+++ b/command/e2etest/main_test.go
@@ -51,6 +51,8 @@ func canAccessNetwork() bool {
 }
 
 func skipIfCannotAccessNetwork(t *testing.T) {
+	t.Helper()
+
 	if !canAccessNetwork() {
 		t.Skip("network access not allowed; use TF_ACC=1 to enable")
 	}

--- a/config/testing.go
+++ b/config/testing.go
@@ -6,6 +6,8 @@ import (
 
 // TestRawConfig is used to create a RawConfig for testing.
 func TestRawConfig(t *testing.T, c map[string]interface{}) *RawConfig {
+	t.Helper()
+
 	cfg, err := NewRawConfig(c)
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/helper/schema/testing.go
+++ b/helper/schema/testing.go
@@ -10,6 +10,8 @@ import (
 // TestResourceDataRaw creates a ResourceData from a raw configuration map.
 func TestResourceDataRaw(
 	t *testing.T, schema map[string]*Schema, raw map[string]interface{}) *ResourceData {
+	t.Helper()
+
 	c, err := config.NewRawConfig(raw)
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/state/testing.go
+++ b/state/testing.go
@@ -11,6 +11,8 @@ import (
 // that the given implementation is pre-loaded with the TestStateInitial
 // state.
 func TestState(t *testing.T, s State) {
+	t.Helper()
+
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -48,6 +48,8 @@ func TestMain(m *testing.M) {
 }
 
 func tempDir(t *testing.T) string {
+	t.Helper()
+
 	dir, err := ioutil.TempDir("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -63,6 +65,8 @@ func tempDir(t *testing.T) string {
 // a function to defer to reset the old value.
 // the old value that should be set via a defer.
 func tempEnv(t *testing.T, k string, v string) func() {
+	t.Helper()
+
 	old, oldOk := os.LookupEnv(k)
 	os.Setenv(k, v)
 	return func() {
@@ -75,6 +79,8 @@ func tempEnv(t *testing.T, k string, v string) func() {
 }
 
 func testConfig(t *testing.T, name string) *config.Config {
+	t.Helper()
+
 	c, err := config.LoadFile(filepath.Join(fixtureDir, name, "main.tf"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -84,6 +90,8 @@ func testConfig(t *testing.T, name string) *config.Config {
 }
 
 func testModule(t *testing.T, name string) *module.Tree {
+	t.Helper()
+
 	mod, err := module.NewTreeModule("", filepath.Join(fixtureDir, name))
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -100,6 +108,8 @@ func testModule(t *testing.T, name string) *module.Tree {
 // testModuleInline takes a map of path -> config strings and yields a config
 // structure with those files loaded from disk
 func testModuleInline(t *testing.T, config map[string]string) *module.Tree {
+	t.Helper()
+
 	cfgPath, err := ioutil.TempDir("", "tf-test")
 	if err != nil {
 		t.Errorf("Error creating temporary directory for config: %s", err)
@@ -146,6 +156,8 @@ func testModuleInline(t *testing.T, config map[string]string) *module.Tree {
 }
 
 func testStringMatch(t *testing.T, s fmt.Stringer, expected string) {
+	t.Helper()
+
 	actual := strings.TrimSpace(s.String())
 	expected = strings.TrimSpace(expected)
 	if actual != expected {


### PR DESCRIPTION
Using Go 1.9 allows us to:

* Simplify our Makefile by exploiting the fact that `./...` no longer includes `vendor/` packages by default
* Make use of the new `t.Helper()` function in our test helpers so that we get better source code references when they fail.
