### PR TITLE
Describing Module Encapsulation

### DIFF
--- a/website/docs/modules/usage.html.markdown
+++ b/website/docs/modules/usage.html.markdown
@@ -84,7 +84,7 @@ Additionally, because these map directly to variables, module configuration can 
 
 ## Outputs
 
-Modules can also specify their own [outputs](/docs/configuration/outputs.html). These outputs can be referenced in other places in your configuration, for example:
+Modules encapsulate their resources. A resource in one module cannot directly depend on resources or attributes in other modules, unless those are exported through [outputs](/docs/configuration/outputs.html). These outputs can be referenced in other places in your configuration, for example:
 
 ```hcl
 resource "aws_instance" "client" {


### PR DESCRIPTION
Terraform modules encapsulate their resources, and dependencies can only
be expressed through outputs, which wasn't clear to me in the existing
documentation. I'm hoping a small change will make that more explicit.

e.g. https://stackoverflow.com/questions/45849165/do-you-need-an-output-to-express-a-dependency-on-a-resource-in-a-terraform-mod/45876522#45876522

Happy to revise if the core team thinks there's a better way to describe this.