### PR TITLE
fix(validate): add variables support

### DIFF
--- a/command/test-fixtures/validate-valid/with-tfvars-file/main.tf
+++ b/command/test-fixtures/validate-valid/with-tfvars-file/main.tf
@@ -1,0 +1,4 @@
+variable "var_without_default" {
+  type = "string"
+}
+

--- a/command/test-fixtures/validate-valid/with-tfvars-file/terraform.tfvars
+++ b/command/test-fixtures/validate-valid/with-tfvars-file/terraform.tfvars
@@ -1,0 +1,1 @@
+var_without_default = "foo"

--- a/command/validate.go
+++ b/command/validate.go
@@ -17,7 +17,7 @@ type ValidateCommand struct {
 const defaultPath = "."
 
 func (c *ValidateCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, false)
+	args, err := c.Meta.process(args, true)
 	if err != nil {
 		return 1
 	}


### PR DESCRIPTION
Enable variables support in meta-parameters processing in validate command.

Fixes #15733, #15894