### PR TITLE
config: parse description field for outputs

### DIFF
--- a/config/config_string.go
+++ b/config/config_string.go
@@ -143,6 +143,10 @@ func outputsStr(os []*Output) string {
 				result += fmt.Sprintf("    %s: %s\n", kind, str)
 			}
 		}
+
+		if o.Description != "" {
+			result += fmt.Sprintf("  description\n    %s\n", o.Description)
+		}
 	}
 
 	return strings.TrimSpace(result)

--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -499,6 +499,7 @@ func loadOutputsHcl(list *ast.ObjectList) ([]*Output, error) {
 
 		// Delete special keys
 		delete(config, "depends_on")
+		delete(config, "description")
 
 		rawConfig, err := NewRawConfig(config)
 		if err != nil {
@@ -520,10 +521,23 @@ func loadOutputsHcl(list *ast.ObjectList) ([]*Output, error) {
 			}
 		}
 
+		// If we have a description field, then filter that
+		var description string
+		if o := listVal.Filter("description"); len(o.Items) > 0 {
+			err := hcl.DecodeObject(&description, o.Items[0].Val)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Error reading description for output %q: %s",
+					n,
+					err)
+			}
+		}
+
 		result = append(result, &Output{
-			Name:      n,
-			RawConfig: rawConfig,
-			DependsOn: dependsOn,
+			Name:        n,
+			RawConfig:   rawConfig,
+			DependsOn:   dependsOn,
+			Description: description,
 		})
 	}
 

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -1058,6 +1058,11 @@ aws_instance.test (x1)
 `
 
 const basicOutputsStr = `
+web_id
+  vars
+    resource: aws_instance.web.id
+  description
+    The ID
 web_ip
   vars
     resource: aws_instance.web.private_ip

--- a/config/test-fixtures/basic.tf
+++ b/config/test-fixtures/basic.tf
@@ -85,6 +85,11 @@ output "web_ip" {
     value = "${aws_instance.web.private_ip}"
 }
 
+output "web_id" {
+    description = "The ID"
+    value = "${aws_instance.web.id}"
+}
+
 atlas {
     name = "mitchellh/foo"
 }

--- a/config/test-fixtures/basic.tf.json
+++ b/config/test-fixtures/basic.tf.json
@@ -88,6 +88,10 @@
     },
 
     "output": {
+        "web_id": {
+            "description": "The ID",
+            "value": "${aws_instance.web.id}"
+        },
         "web_ip": {
             "value": "${aws_instance.web.private_ip}"
         }


### PR DESCRIPTION
We added the description field in 0.9 but we never parsed it because we
didn't have a use for it. As we prepare to use this field, let's start
parsing it out