### PR TITLE
helper/resource: Add TestStep.SkipFunc

### DIFF
--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -389,6 +389,46 @@ func TestTest_preCheck(t *testing.T) {
 	}
 }
 
+func TestTest_skipFunc(t *testing.T) {
+	preCheckCalled := false
+	skipped := false
+
+	mp := testProvider()
+	mp.ApplyReturn = &terraform.InstanceState{
+		ID: "foo",
+	}
+
+	checkStepFn := func(*terraform.State) error {
+		return fmt.Errorf("error")
+	}
+
+	mt := new(mockT)
+	Test(mt, TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"test": mp,
+		},
+		PreCheck: func() { preCheckCalled = true },
+		Steps: []TestStep{
+			{
+				Config:   testConfigStr,
+				Check:    checkStepFn,
+				SkipFunc: func() (bool, error) { skipped = true; return true, nil },
+			},
+		},
+	})
+
+	if mt.failed() {
+		t.Fatal("Expected check to be skipped")
+	}
+
+	if !preCheckCalled {
+		t.Fatal("precheck should be called")
+	}
+	if !skipped {
+		t.Fatal("SkipFunc should be called")
+	}
+}
+
 func TestTest_stepError(t *testing.T) {
 	mp := testProvider()
 	mp.ApplyReturn = &terraform.InstanceState{


### PR DESCRIPTION
I'd like to use this in the Kubernetes provider acceptance tests. There's a handful of tests which I want to run in most environments (hence not skip the whole test) without having to duplicate the whole test for each platform, just because one check has to be different.

By environments I mean minikube, GKE, custom-built K8S cluster etc. in this context - they should be the same, but there are some tiny differences which cause tests to fail.

Example: https://github.com/terraform-providers/terraform-provider-kubernetes/commit/c5bfdfda06eb9f5b6515b16c56d036fea8b1a515#diff-54c9acee9539dfc51361bc5424f74420R50