### PR TITLE
provisioner/salt-masterless: fix crash processing connection config

### DIFF
--- a/builtin/provisioners/salt-masterless/resource_provisioner.go
+++ b/builtin/provisioners/salt-masterless/resource_provisioner.go
@@ -116,6 +116,7 @@ func applyFn(ctx context.Context) error {
 
 	o := ctx.Value(schema.ProvOutputKey).(terraform.UIOutput)
 	d := ctx.Value(schema.ProvConfigDataKey).(*schema.ResourceData)
+	connState := ctx.Value(schema.ProvRawStateKey).(*terraform.InstanceState)
 
 	p, err := decodeConfig(d)
 	if err != nil {
@@ -123,7 +124,7 @@ func applyFn(ctx context.Context) error {
 	}
 
 	// Get a new communicator
-	comm, err := communicator.New(d.State())
+	comm, err := communicator.New(connState)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The code here was previously assuming that d.State() was equivalent to the `schema.ProvRawStateKey` due to them both being of type `InstanceState`, but that is in fact not true since a state object contains some transient information that is _not_ part of the persisted state, including the connection information we need here.

Calling `ResourceData.State()` constructs a _new_ state based on its stored values, so the constructed object is lacking this transient information. We need to use the specific state object provided by the caller in order to get access to the transient connection configuration.

Unfortunately there is no automated test coverage for this because we have no good story for testing provisioners that use `communicator`. While such tests could potentially be written, we'd like to get this in somewhat quickly to unblock a release, rather than delaying to design and implement some sort of mocking system for this.

This fixes #15867.