### PR TITLE
provisioner/salt-masterless: add "_file" suffix to "minion_config"

### DIFF
--- a/builtin/provisioners/salt-masterless/resource_provisioner.go
+++ b/builtin/provisioners/salt-masterless/resource_provisioner.go
@@ -86,7 +86,7 @@ func Provisioner() terraform.ResourceProvisioner {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"minion_config": &schema.Schema{
+			"minion_config_file": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -360,13 +360,13 @@ func validateFn(c *terraform.ResourceConfig) (ws []string, es []error) {
 	}
 
 	var minionConfig string
-	minionConfigTmp, ok := c.Get("minion_config")
+	minionConfigTmp, ok := c.Get("minion_config_file")
 	if !ok {
 		minionConfig = ""
 	} else {
 		minionConfig = minionConfigTmp.(string)
 	}
-	err = validateFileConfig(minionConfig, "minion_config", false)
+	err = validateFileConfig(minionConfig, "minion_config_file", false)
 	if err != nil {
 		es = append(es, err)
 	}
@@ -389,7 +389,7 @@ func validateFn(c *terraform.ResourceConfig) (ws []string, es []error) {
 
 	if minionConfig != "" && (remoteStateTree != "" || remotePillarRoots != "") {
 		es = append(es,
-			errors.New("remote_state_tree and remote_pillar_roots only apply when minion_config is not used"))
+			errors.New("remote_state_tree and remote_pillar_roots only apply when minion_config_file is not used"))
 	}
 
 	if len(es) > 0 {
@@ -405,7 +405,7 @@ func decodeConfig(d *schema.ResourceData) (*provisioner, error) {
 		LogLevel:          d.Get("log_level").(string),
 		SaltCallArgs:      d.Get("salt_call_args").(string),
 		CmdArgs:           d.Get("cmd_args").(string),
-		MinionConfig:      d.Get("minion_config").(string),
+		MinionConfig:      d.Get("minion_config_file").(string),
 		CustomState:       d.Get("custom_state").(string),
 		DisableSudo:       d.Get("disable_sudo").(bool),
 		BootstrapArgs:     d.Get("bootstrap_args").(string),
@@ -428,7 +428,7 @@ func decodeConfig(d *schema.ResourceData) (*provisioner, error) {
 	}
 
 	if p.MinionConfig == "" {
-		// pass --file-root and --pillar-root if no minion_config is supplied
+		// pass --file-root and --pillar-root if no minion_config_file is supplied
 		if p.RemoteStateTree != "" {
 			cmdArgs.WriteString(" --file-root=")
 			cmdArgs.WriteString(p.RemoteStateTree)

--- a/builtin/provisioners/salt-masterless/resource_provisioner_test.go
+++ b/builtin/provisioners/salt-masterless/resource_provisioner_test.go
@@ -150,8 +150,8 @@ func TestProvisionerPrepare_MinionConfig(t *testing.T) {
 	defer os.RemoveAll(dir) // clean up
 
 	c := testConfig(t, map[string]interface{}{
-		"local_state_tree": dir,
-		"minion_config":    "i/dont/exist",
+		"local_state_tree":   dir,
+		"minion_config_file": "i/dont/exist",
 	})
 
 	warns, errs := Provisioner().Validate(c)
@@ -171,8 +171,8 @@ func TestProvisionerPrepare_MinionConfig(t *testing.T) {
 	defer os.Remove(tf.Name())
 
 	c = testConfig(t, map[string]interface{}{
-		"local_state_tree": dir,
-		"minion_config":    tf.Name(),
+		"local_state_tree":   dir,
+		"minion_config_file": tf.Name(),
 	})
 
 	warns, errs = Provisioner().Validate(c)
@@ -192,9 +192,9 @@ func TestProvisionerPrepare_MinionConfig_RemoteStateTree(t *testing.T) {
 	}
 
 	c := testConfig(t, map[string]interface{}{
-		"local_state_tree":  dir,
-		"minion_config":     "i/dont/exist",
-		"remote_state_tree": "i/dont/exist/remote_state_tree",
+		"local_state_tree":   dir,
+		"minion_config_file": "i/dont/exist",
+		"remote_state_tree":  "i/dont/exist/remote_state_tree",
 	})
 
 	warns, errs := Provisioner().Validate(c)
@@ -214,7 +214,7 @@ func TestProvisionerPrepare_MinionConfig_RemotePillarRoots(t *testing.T) {
 
 	c := testConfig(t, map[string]interface{}{
 		"local_state_tree":    dir,
-		"minion_config":       "i/dont/exist",
+		"minion_config_file":  "i/dont/exist",
 		"remote_pillar_roots": "i/dont/exist/remote_pillar_roots",
 	})
 
@@ -235,7 +235,7 @@ func TestProvisionerPrepare_LocalPillarRoots(t *testing.T) {
 
 	c := testConfig(t, map[string]interface{}{
 		"local_state_tree":   dir,
-		"minion_config":      "i/dont/exist",
+		"minion_config_file": "i/dont/exist",
 		"local_pillar_roots": "i/dont/exist/local_pillar_roots",
 	})
 

--- a/website/docs/provisioners/salt-masterless.html.md
+++ b/website/docs/provisioners/salt-masterless.html.md
@@ -64,7 +64,7 @@ Optional:
 -   `custom_state` (string) - A state to be run instead of `state.highstate`.
     Defaults to `state.highstate` if unspecified.
 
--   `minion_config` (string) - The path to your local [minion config
+-   `minion_config_file` (string) - The path to your local [minion config
     file](http://docs.saltstack.com/ref/configuration/minion.html). This will be
     uploaded to the `/etc/salt` on the remote. This option overrides the
     `remote_state_tree` or `remote_pillar_roots` options.


### PR DESCRIPTION
In #15870 we got good feedback that it'd be more useful to have the various filename-accepting arguments on this provisioner instead accept strings that represent the contents of such files, so that they can be generated from elsewhere in the Terraform config.

This change does not achieve that, but it does make room for doing this later by renaming `minion_config` to `minion_config_file` so that we can later add a `minion_config` option alongside that takes the file content, and deprecate `minion_config_file`.

Ideally we'd just implement the requested change immediately, but unfortunately the release schedule doesn't have time for this so this is a pragmatic change to allow us to make the full requested change at a later date without backward incompatibilities.

This change is safe because the salt-masterless provisioner has not yet been included in a release at the time of this commit.