### PR TITLE
Fix crash when using consul backend

### DIFF
--- a/backend/remote-state/consul/backend.go
+++ b/backend/remote-state/consul/backend.go
@@ -134,21 +134,15 @@ func (b *Backend) clientRaw() (*consulapi.Client, error) {
 		config.Datacenter = v.(string)
 	}
 
-	tlsConfig := &consulapi.TLSConfig{}
 	if v, ok := data.GetOk("ca_file"); ok && v.(string) != "" {
-		tlsConfig.CAFile = v.(string)
+		config.TLSConfig.CAFile = v.(string)
 	}
 	if v, ok := data.GetOk("cert_file"); ok && v.(string) != "" {
-		tlsConfig.CertFile = v.(string)
+		config.TLSConfig.CertFile = v.(string)
 	}
 	if v, ok := data.GetOk("key_file"); ok && v.(string) != "" {
-		tlsConfig.KeyFile = v.(string)
+		config.TLSConfig.KeyFile = v.(string)
 	}
-	cc, err := consulapi.SetupTLSConfig(tlsConfig)
-	if err != nil {
-		return nil, err
-	}
-	config.Transport.TLSClientConfig = cc
 
 	if v, ok := data.GetOk("http_auth"); ok && v.(string) != "" {
 		auth := v.(string)


### PR DESCRIPTION
Fixes #15972

Crash happens because `config.HttpClient` was not set in `consulapi.DefaultConfig()`, so instead of setting it directly, setting `config.TLSConfig` passing to `consul.NewClient` will do its work.