### PR TITLE
Fix crash in consul backend

### DIFF
--- a/backend/remote-state/consul/backend.go
+++ b/backend/remote-state/consul/backend.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"context"
-	"net/http"
 	"strings"
 
 	consulapi "github.com/hashicorp/consul/api"
@@ -149,7 +148,7 @@ func (b *Backend) clientRaw() (*consulapi.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	config.HttpClient.Transport.(*http.Transport).TLSClientConfig = cc
+	config.Transport.TLSClientConfig = cc
 
 	if v, ok := data.GetOk("http_auth"); ok && v.(string) != "" {
 		auth := v.(string)


### PR DESCRIPTION
A TLS config was being assigned to a Transport in a nil http.Client. The
Transport is built in the consul config by default, but the http.Client
is not built until later in NewClient.

No new tests, because the existing tests were sufficient to catch this. 
This was introduced in #15405, but there were no ACC tests run.

Fixes #15972 

