### PR TITLE
Load plugins from plugin_path file if it exists

### DIFF
--- a/command/validate.go
+++ b/command/validate.go
@@ -46,6 +46,12 @@ func (c *ValidateCommand) Run(args []string) int {
 			"Unable to locate directory %v\n", err.Error()))
 	}
 
+	// Check for user-supplied plugin path
+	if c.pluginPath, err = c.loadPluginPath(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
+		return 1
+	}
+
 	rtnCode := c.validate(dir, checkVars)
 
 	return rtnCode


### PR DESCRIPTION
Noticed this was missing from the validate command, which was causing some of our validate calls to incorrectly fail.

Fixes #15916