### PR TITLE
Updating the AzureRM Backend Documentation

### DIFF
--- a/website/docs/backends/types/azurerm.html.md
+++ b/website/docs/backends/types/azurerm.html.md
@@ -6,7 +6,7 @@ description: |-
   Terraform can store state remotely in Azure Storage.
 ---
 
-# azurerm
+# azurerm (formerly azure)
 
 **Kind: Standard (with state locking)**
 

--- a/website/docs/backends/types/azurerm.html.md
+++ b/website/docs/backends/types/azurerm.html.md
@@ -3,7 +3,8 @@ layout: "backend-types"
 page_title: "Backend Type: azurerm"
 sidebar_current: "docs-backends-types-standard-azurerm"
 description: |-
-  Terraform can store state remotely in Azure Storage.
+  Terraform can store state remotely in Azure Blob Storage.
+
 ---
 
 # azurerm (formerly azure)

--- a/website/layouts/backend-types.erb
+++ b/website/layouts/backend-types.erb
@@ -27,7 +27,7 @@
             <a href="/docs/backends/types/artifactory.html">artifactory</a>
           </li>
           <li<%= sidebar_current("docs-backends-types-standard-azurerm") %>>
-            <a href="/docs/backends/types/azurerm.html">azure</a>
+            <a href="/docs/backends/types/azurerm.html">azurerm (_formerly `azure`_)</a>
           </li>
           <li<%= sidebar_current("docs-backends-types-standard-consul") %>>
             <a href="/docs/backends/types/consul.html">consul</a>


### PR DESCRIPTION
- Updating the sidebar to reference `azurerm`
- Including the former name of the Backend in the titles
- Clarifying that we're storing in Blob Storage