### PR TITLE
config: allow local value interpolations in count

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -557,6 +557,7 @@ func (c *Config) Validate() error {
 			case *ResourceVariable:
 			case *TerraformVariable:
 			case *UserVariable:
+			case *LocalVariable:
 
 			default:
 				errs = append(errs, fmt.Errorf(

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -312,6 +312,13 @@ func TestConfigValidate_countUserVar(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_countLocalValue(t *testing.T) {
+	c := testConfig(t, "validate-local-value-count")
+	if err := c.Validate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestConfigValidate_countVar(t *testing.T) {
 	c := testConfig(t, "validate-count-var")
 	if err := c.Validate(); err != nil {

--- a/config/test-fixtures/validate-local-value-count/main.tf
+++ b/config/test-fixtures/validate-local-value-count/main.tf
@@ -1,0 +1,8 @@
+
+locals {
+  count = 3
+}
+
+resource "null_resource" "foo" {
+  count = "${local.count}"
+}

--- a/terraform/test-fixtures/plan-local-value-count/main.tf
+++ b/terraform/test-fixtures/plan-local-value-count/main.tf
@@ -1,0 +1,8 @@
+
+locals {
+  count = 3
+}
+
+resource "test_resource" "foo" {
+  count = "${local.count}"
+}


### PR DESCRIPTION
There is some additional, early validation on the `count` meta-argument that verifies that only suitable variable types are used, and adding local values to this whitelist was missed in the initial implementation.

This fixes #15987.