### PR TITLE
cli: Opt-in local cache directory for plugins

### DIFF
--- a/command/e2etest/init_test.go
+++ b/command/e2etest/init_test.go
@@ -1,7 +1,11 @@
 package e2etest
 
 import (
+	"bytes"
+	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -44,4 +48,56 @@ func TestInitProviders(t *testing.T) {
 		t.Errorf("provider pinning recommendation is missing from output:\n%s", stdout)
 	}
 
+}
+
+func TestInitProviders_pluginCache(t *testing.T) {
+	t.Parallel()
+
+	// This test reaches out to releases.hashicorp.com to access plugin
+	// metadata, and download the null plugin, though the template plugin
+	// should come from local cache.
+	skipIfCannotAccessNetwork(t)
+
+	fixturePath := filepath.Join("test-fixtures", "plugin-cache")
+	tf := e2e.NewBinary(terraformBin, fixturePath)
+	defer tf.Close()
+
+	// Our fixture dir has a generic os_arch dir, which we need to customize
+	// to the actual OS/arch where this test is running in order to get the
+	// desired result.
+	fixtMachineDir := tf.Path("cache/os_arch")
+	wantMachineDir := tf.Path("cache", fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH))
+	os.Rename(fixtMachineDir, wantMachineDir)
+
+	cmd := tf.Cmd("init")
+	cmd.Env = append(cmd.Env, "TF_PLUGIN_CACHE_DIR=./cache")
+	cmd.Stdin = nil
+	cmd.Stderr = &bytes.Buffer{}
+
+	err := cmd.Run()
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	stderr := cmd.Stderr.(*bytes.Buffer).String()
+	if stderr != "" {
+		t.Errorf("unexpected stderr output:\n%s", stderr)
+	}
+
+	path := fmt.Sprintf(".terraform/plugins/%s_%s/terraform-provider-template_v0.1.0_x4", runtime.GOOS, runtime.GOARCH)
+	content, err := tf.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read installed plugin from %s: %s", path, err)
+	}
+	if strings.TrimSpace(string(content)) != "this is not a real plugin" {
+		t.Errorf("template plugin was not installed from local cache")
+	}
+
+	if !tf.FileExists(fmt.Sprintf(".terraform/plugins/%s_%s/terraform-provider-null_v0.1.0_x4", runtime.GOOS, runtime.GOARCH)) {
+		t.Errorf("null plugin was not installed")
+	}
+
+	if !tf.FileExists(fmt.Sprintf("cache/%s_%s/terraform-provider-null_v0.1.0_x4", runtime.GOOS, runtime.GOARCH)) {
+		t.Errorf("null plugin is not in cache after install")
+	}
 }

--- a/command/e2etest/test-fixtures/plugin-cache/cache/os_arch/terraform-provider-template_v0.1.0_x4
+++ b/command/e2etest/test-fixtures/plugin-cache/cache/os_arch/terraform-provider-template_v0.1.0_x4
@@ -1,0 +1,1 @@
+this is not a real plugin

--- a/command/e2etest/test-fixtures/plugin-cache/main.tf
+++ b/command/e2etest/test-fixtures/plugin-cache/main.tf
@@ -1,0 +1,7 @@
+provider "template" {
+  version = "0.1.0"
+}
+
+provider "null" {
+  version = "0.1.0"
+}

--- a/command/init.go
+++ b/command/init.go
@@ -71,10 +71,11 @@ func (c *InitCommand) Run(args []string) int {
 		c.getPlugins = false
 	}
 
-	// set getProvider if we don't have a test version already
+	// set providerInstaller if we don't have a test version already
 	if c.providerInstaller == nil {
 		c.providerInstaller = &discovery.ProviderInstaller{
-			Dir: c.pluginDir(),
+			Dir:   c.pluginDir(),
+			Cache: c.pluginCache(),
 			PluginProtocolVersion: plugin.Handshake.ProtocolVersion,
 			SkipVerify:            !flagVerifyPlugins,
 			Ui:                    c.Ui,

--- a/command/meta.go
+++ b/command/meta.go
@@ -55,6 +55,10 @@ type Meta struct {
 	// the specific commands being run.
 	RunningInAutomation bool
 
+	// PluginCacheDir, if non-empty, enables caching of downloaded plugins
+	// into the given directory.
+	PluginCacheDir string
+
 	//----------------------------------------------------------
 	// Protected: commands can set these
 	//----------------------------------------------------------

--- a/command/plugins.go
+++ b/command/plugins.go
@@ -168,6 +168,17 @@ func (m *Meta) pluginDirs(includeAutoInstalled bool) []string {
 	return dirs
 }
 
+func (m *Meta) pluginCache() discovery.PluginCache {
+	dir := m.PluginCacheDir
+	if dir == "" {
+		return nil // cache disabled
+	}
+
+	dir = filepath.Join(dir, pluginMachineName)
+
+	return discovery.NewLocalPluginCache(dir)
+}
+
 // providerPluginSet returns the set of valid providers that were discovered in
 // the defined search paths.
 func (m *Meta) providerPluginSet() discovery.PluginMetaSet {

--- a/commands.go
+++ b/commands.go
@@ -38,6 +38,7 @@ func initCommands(config *Config) {
 		Ui:               Ui,
 
 		RunningInAutomation: inAutomation,
+		PluginCacheDir:      config.PluginCacheDir,
 	}
 
 	// The command list is included in the terraform -help

--- a/commands.go
+++ b/commands.go
@@ -25,15 +25,7 @@ const (
 	OutputPrefix = "o:"
 )
 
-func init() {
-	Ui = &cli.PrefixedUi{
-		AskPrefix:    OutputPrefix,
-		OutputPrefix: OutputPrefix,
-		InfoPrefix:   OutputPrefix,
-		ErrorPrefix:  ErrorPrefix,
-		Ui:           &cli.BasicUi{Writer: os.Stdout},
-	}
-
+func initCommands(config *Config) {
 	var inAutomation bool
 	if v := os.Getenv(runningInAutomationEnvName); v != "" {
 		inAutomation = true

--- a/main.go
+++ b/main.go
@@ -138,6 +138,13 @@ func wrappedMain() int {
 		config = *config.Merge(usrcfg)
 	}
 
+	if envConfig := EnvConfig(); envConfig != nil {
+		// envConfig takes precedence
+		config = *envConfig.Merge(&config)
+	}
+
+	log.Printf("[DEBUG] CLI Config is %#v", config)
+
 	// In tests, Commands may already be set to provide mock commands
 	if Commands == nil {
 		initCommands(&config)

--- a/main.go
+++ b/main.go
@@ -96,6 +96,16 @@ func realMain() int {
 	return wrappedMain()
 }
 
+func init() {
+	Ui = &cli.PrefixedUi{
+		AskPrefix:    OutputPrefix,
+		OutputPrefix: OutputPrefix,
+		InfoPrefix:   OutputPrefix,
+		ErrorPrefix:  ErrorPrefix,
+		Ui:           &cli.BasicUi{Writer: os.Stdout},
+	}
+}
+
 func wrappedMain() int {
 	// We always need to close the DebugInfo before we exit.
 	defer terraform.CloseDebugInfo()
@@ -126,6 +136,11 @@ func wrappedMain() int {
 		}
 
 		config = *config.Merge(usrcfg)
+	}
+
+	// In tests, Commands may already be set to provide mock commands
+	if Commands == nil {
+		initCommands(&config)
 	}
 
 	// Run checkpoint

--- a/main_test.go
+++ b/main_test.go
@@ -18,9 +18,12 @@ func TestMain_cliArgsFromEnv(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	// Setup test command and restore that
+	Commands = make(map[string]cli.CommandFactory)
+	defer func() {
+		Commands = nil
+	}()
 	testCommandName := "unit-test-cli-args"
 	testCommand := &testCommandCLI{}
-	defer func() { delete(Commands, testCommandName) }()
 	Commands[testCommandName] = func() (cli.Command, error) {
 		return testCommand, nil
 	}
@@ -150,6 +153,12 @@ func TestMain_cliArgsFromEnvAdvanced(t *testing.T) {
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 
+	// Setup test command and restore that
+	Commands = make(map[string]cli.CommandFactory)
+	defer func() {
+		Commands = nil
+	}()
+
 	cases := []struct {
 		Name     string
 		Command  string
@@ -230,7 +239,7 @@ func TestMain_cliArgsFromEnvAdvanced(t *testing.T) {
 			testCommand.Args = nil
 			exit := wrappedMain()
 			if (exit != 0) != tc.Err {
-				t.Fatalf("bad: %d", exit)
+				t.Fatalf("unexpected exit status %d; want 0", exit)
 			}
 			if tc.Err {
 				return

--- a/plugin/discovery/find.go
+++ b/plugin/discovery/find.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -70,6 +71,12 @@ func findPluginPaths(kind string, dirs []string) []string {
 					continue
 				}
 
+				// Check that the file we found is usable
+				if !pathIsFile(absPath) {
+					log.Printf("[ERROR] ignoring non-file %s", absPath)
+					continue
+				}
+
 				log.Printf("[DEBUG] found %s %q", kind, fullName)
 				ret = append(ret, filepath.Clean(absPath))
 				continue
@@ -82,6 +89,12 @@ func findPluginPaths(kind string, dirs []string) []string {
 				continue
 			}
 
+			// Check that the file we found is usable
+			if !pathIsFile(absPath) {
+				log.Printf("[ERROR] ignoring non-file %s", absPath)
+				continue
+			}
+
 			log.Printf("[WARNING] found legacy %s %q", kind, fullName)
 
 			ret = append(ret, filepath.Clean(absPath))
@@ -89,6 +102,17 @@ func findPluginPaths(kind string, dirs []string) []string {
 	}
 
 	return ret
+}
+
+// Returns true if and only if the given path refers to a file or a symlink
+// to a file.
+func pathIsFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	return !info.IsDir()
 }
 
 // ResolvePluginPaths takes a list of paths to plugin executables (as returned

--- a/plugin/discovery/get_cache.go
+++ b/plugin/discovery/get_cache.go
@@ -1,0 +1,48 @@
+package discovery
+
+// PluginCache is an interface implemented by objects that are able to maintain
+// a cache of plugins.
+type PluginCache interface {
+	// CachedPluginPath returns a path where the requested plugin is already
+	// cached, or an empty string if the requested plugin is not yet cached.
+	CachedPluginPath(kind string, name string, version Version) string
+
+	// InstallDir returns the directory that new plugins should be installed into
+	// in order to populate the cache. This directory should be used as the
+	// first argument to getter.Get when downloading plugins with go-getter.
+	//
+	// After installing into this directory, use CachedPluginPath to obtain the
+	// path where the plugin was installed.
+	InstallDir() string
+}
+
+// NewLocalPluginCache returns a PluginCache that caches plugins in a
+// given local directory.
+func NewLocalPluginCache(dir string) PluginCache {
+	return &pluginCache{
+		Dir: dir,
+	}
+}
+
+type pluginCache struct {
+	Dir string
+}
+
+func (c *pluginCache) CachedPluginPath(kind string, name string, version Version) string {
+	allPlugins := FindPlugins(kind, []string{c.Dir})
+	plugins := allPlugins.WithName(name).WithVersion(version)
+
+	if plugins.Count() == 0 {
+		// nothing cached
+		return ""
+	}
+
+	// There should generally be only one plugin here; if there's more than
+	// one match for some reason then we'll just choose one arbitrarily.
+	plugin := plugins.Newest()
+	return plugin.Path
+}
+
+func (c *pluginCache) InstallDir() string {
+	return c.Dir
+}

--- a/plugin/discovery/get_cache_test.go
+++ b/plugin/discovery/get_cache_test.go
@@ -1,0 +1,29 @@
+package discovery
+
+import (
+	"testing"
+)
+
+func TestLocalPluginCache(t *testing.T) {
+	cache := NewLocalPluginCache("test-fixtures/plugin-cache")
+
+	foo1Path := cache.CachedPluginPath("provider", "foo", VersionStr("v0.0.1").MustParse())
+	if foo1Path == "" {
+		t.Errorf("foo v0.0.1 not found; should have been found")
+	}
+
+	foo2Path := cache.CachedPluginPath("provider", "foo", VersionStr("v0.0.2").MustParse())
+	if foo2Path != "" {
+		t.Errorf("foo v0.0.2 found at %s; should not have been found", foo2Path)
+	}
+
+	baz1Path := cache.CachedPluginPath("provider", "baz", VersionStr("v0.0.1").MustParse())
+	if baz1Path != "" {
+		t.Errorf("baz v0.0.1 found at %s; should not have been found", baz1Path)
+	}
+
+	baz2Path := cache.CachedPluginPath("provider", "baz", VersionStr("v0.0.2").MustParse())
+	if baz1Path != "" {
+		t.Errorf("baz v0.0.2 found at %s; should not have been found", baz2Path)
+	}
+}

--- a/website/docs/commands/cli-config.html.markdown
+++ b/website/docs/commands/cli-config.html.markdown
@@ -1,0 +1,77 @@
+---
+layout: "docs"
+page_title: "CLI Configuration"
+sidebar_current: "docs-commands-cli-config"
+description: |-
+  The general behavior of the Terraform CLI can be customized using the CLI
+  configuration file.
+---
+
+# CLI Configuration File
+
+The CLI configuration file allows customization of some behaviors of the
+Terraform CLI in general. This is separate from
+[your infrastructure configuration](/docs/configuration/index.html), and
+provides per-user customization that applies regardless of which working
+directory Terraform is being applied to.
+
+For example, the CLI configuration file can be used to activate a shared
+plugin cache directory that allows provider plugins to be shared between
+different working directories, as described in more detail below.
+
+The configuration is placed in a single file whose location depends on the
+host operating system:
+
+* On Windows, the file must be named named `terraform.rc` and placed
+  in the relevant user's "Application Data" directory. The physical location
+  of this directory depends on your Windows version and system configuration;
+  use `$env:APPDATA` in PowerShell to find its location on your system.
+* On all other systems, the file must be named `.terraformrc` (note
+  the leading period) and placed directly in the home directory
+  of the relevant user.
+
+On Windows, beware of Windows Explorer's default behavior of hiding filename
+extensions. Terraform will not recognize a file named `terraform.rc.txt` as a
+CLI configuration file, even though Windows Explorer may _display_ its name
+as just `terraform.rc`. Use `dir` from PowerShell or Command Prompt to
+confirm the filename.
+
+## Configuration File Syntax
+
+The configuration file uses the same _HCL_ syntax as `.tf` files, but with
+different attributes and blocks. The following example illustrates the
+general syntax; see the following section for information on the meaning
+of each of these settings:
+
+```hcl
+plugin_cache_dir   = "$HOME/.terraform.d/plugin-cache"
+disable_checkpoint = true
+```
+
+## Available Settings
+
+The following settings can be set in the CLI configuration file:
+
+* `disable_checkpoint` - when set to `true`, disables
+  [upgrade and security bulletin checks](/docs/commands/index.html#upgrade-and-security-bulletin-checks)
+  that require reaching out to HashiCorp-provided network services.
+
+* `disable_checkpoint_signature` - when set to `true`, allows the upgrade and
+  security bulletin checks described above but disables the use of an anonymous
+  id used to de-duplicate warning messages.
+
+* `plugin_cache_dir` - enables
+  [plugin caching](/docs/configuration/providers.html#provider-plugin-cache)
+  and specifies, as a string, the location of the plugin cache directory.
+
+## Deprecated Settings
+
+The following settings are supported for backward compatibility but are no
+longer recommended for use:
+
+* `providers` - a configuration block that allows specifying the locations of
+  specific plugins for each named provider. This mechanism is deprecated
+  because it is unable to specify a version number for each plugin, and thus
+  it does not co-operate with the plugin versioning mechansim. Instead,
+  place the plugin executable files in
+  [the third-party plugins directory](/docs/configuration/providers.html#third-party-plugins).

--- a/website/docs/commands/index.html.markdown
+++ b/website/docs/commands/index.html.markdown
@@ -116,13 +116,10 @@ optional and can be disabled.
 Checkpoint itself can be entirely disabled for all HashiCorp products by
 setting the environment variable `CHECKPOINT_DISABLE` to any non-empty value.
 
-Alternatively, settings in Terraform's global configuration file can be used
-to disable checkpoint features. On Unix systems this file is named
-`.terraformrc` and is placed within the home directory of the user running
-Terraform. On Windows, this file is named `terraform.rc` and is and is placed
-in the current user's _Application Data_ folder.
-
-The following checkpoint-related settings are supported in this file:
+Alternatively, settings in
+[the CLI configuration file](/docs/commands/cli-config.html) can be used to
+disable checkpoint features. The following checkpoint-related settings are
+supported in this file:
 
 * `disable_checkpoint` - set to `true` to disable checkpoint calls
   entirely. This is similar to the `CHECKPOINT_DISABLE` environment variable

--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -188,3 +188,24 @@ provider "aws" {
 An exception to this is the special `version` attribute that applies to all `provider` blocks for specifying [provider versions](#provider-versions); interpolation is not supported for provider versions since provider compatibility is a property of the configuration rather than something dynamic, and provider plugin installation happens too early for variables to be resolvable in this context.
 
 -> **NOTE:** Because providers are one of the first things loaded when Terraform parses the graph, it is not possible to use the output from modules or resources as inputs to the provider. At this time, only [variables](/docs/configuration/variables.html) and [data sources](/docs/configuration/data-sources.html), including [remote state](/docs/providers/terraform/d/remote_state.html) may be used in an interpolation inside a provider stanza.
+
+## Third-party Plugins
+
+At present Terraform can automatically install only the providers distributed
+by HashiCorp. Third-party providers can be manually installed by placing
+their plugin executables in one of the following locations depending on the
+host operating system:
+
+* On Windows, in the sub-path `terraform.d/plugins` beneath your user's
+  "Application Data" directory.
+* On all other systems, in the sub-path `.terraform.d/plugins` in your
+  user's home directory.
+
+`terraform init` will search this directory for additional plugins during
+plugin initialization.
+
+The naming scheme for provider plugins is `terraform-provider-NAME-vX.Y.Z`,
+and Terraform uses the name to understand the name and version of a particular
+provider binary. Third-party plugins will often be distributed with an
+appropriate filename already set in the distribution archive so that it can
+be extracted directly into the plugin directory described above.

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -148,6 +148,10 @@
           <li<%= sidebar_current("docs-commands-workspace") %>>
             <a href="/docs/commands/workspace/index.html">workspace</a>
           </li>
+
+          <li<%= sidebar_current("docs-commands-cli-config") %>>
+            <a href="/docs/commands/cli-config.html">CLI Config File</a>
+          </li>
         </ul>
       </li>
 


### PR DESCRIPTION
To avoid surprising users by creating a global plugin directory they don't know about, we elected to auto-install plugins into the local `.terraform` directory to keep things contained.

However, an implication of this decision is that by default a fresh set of plugins must be downloaded for each distinct working directory. This is bothersome for those on metered or slow Internet connections.

As a compromise, here we add an _opt-in_ mechanism to treat a local directory as a read-through cache of plugins. When the cache directory is enabled, Terraform will still fetch metadata from releases.hashicorp.com (to learn if new versions are available), but once a particular version is selected the local cache will be consulted first to avoid re-downloading the plugin distribution zip file.

After opting in, it's the user's responsibility to manage this cache directory: Terraform will only add new files to it, and never clean up existing files. Since it is just a cache, it doesn't matter if the user "over-prunes" it since plugins can be re-downloaded automatically when they are next needed.

The cache directory is maintained separately from the auto-install directory to avoid it interfering with our mechanisms to detect when a newer plugin version is available. Unlike the local plugin search directories, which can prevent Terraform for looking for newer versions altogether, the cache directory is consulted only after a specific version of a plugin has been selected, and only for that specific version.

If installing a plugin from cache, Terraform will try to create either a hardlink or a symlink to the cache directory to minimize local disk usage when many configurations require the same plugin. If this can't be done (or if we're on Windows) the file is instead just copied into place.

The cache directory is enabled either from a setting in the `terraformrc` file (`plugin_cache_dir`) or from the `TF_PLUGIN_CACHE_DIR` environment variable, with the latter taking precedence.

---

This change does _not_ attempt to solve for the use-case where Terraform can't access the releases server _at all_. This mechanism is intended for those who wish to use the auto-install feature but wish to reduce the amount of data transfer required.

The existing `-plugin-dir` mechanism is intended to enable working offline, and in a future change we may allow it to be set via `terraformrc` too, so it's easier to "set and forget". That is, however, outside the scope of this change.
