### PR TITLE
docs: Add local values usage example

### DIFF
--- a/website/docs/configuration/locals.html.md
+++ b/website/docs/configuration/locals.html.md
@@ -35,6 +35,12 @@ locals {
   default_name_prefix = "${var.project_name}-web"
   name_prefix         = "${var.name_prefix != "" ? var.name_prefix : local.default_name_prefix}"
 }
+
+# Using a local value
+resource "aws_s3_bucket" "files" {
+  bucket = "${local.name_prefix}-files"
+  # ...
+}
 ```
 
 ## Description


### PR DESCRIPTION
Adds an example of using local values in a resource. There is one example in the block above, but it's nested in a ternary.