### PR TITLE
Fix init help text for upgrade

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -505,7 +505,7 @@ Options:
   -reconfigure         Reconfigure the backend, ignoring any saved
                        configuration.
 
-  -upgrade=false       If installing modules (-get) or plugins (-get-plugins),
+  -upgrade=true        If installing modules (-get) or plugins (-get-plugins),
                        ignore previously-downloaded objects and install the
                        latest version allowed within configured constraints.
 


### PR DESCRIPTION
`-upgrade=true` will upgrade plugins to the latest allowable version, `-upgrade=false` doesn't seem to. My apologies if I've misunderstood something here and am suggesting the wrong change.