### PR TITLE
command/format: restore "(forces new resource)" caption

### DIFF
--- a/command/format/plan.go
+++ b/command/format/plan.go
@@ -311,7 +311,7 @@ func formatPlanInstanceDiff(buf *bytes.Buffer, r *InstanceDiff, keyLen int, colo
 
 		updateMsg := ""
 		switch {
-		case attr.ForcesNew && r.Action == terraform.DiffDestroy:
+		case attr.ForcesNew && r.Action == terraform.DiffDestroyCreate:
 			updateMsg = colorizer.Color(" [red](forces new resource)")
 		case attr.Sensitive && oldValues:
 			updateMsg = colorizer.Color(" [yellow](attribute changed)")


### PR DESCRIPTION
In 3ea1592 the plan rendering was refactored to add an extra indirection of producing a display-oriented plan object first and then rendering from that object.

There was a logic error while adapting the existing plan rendering code to use the new display-oriented object: the core `InstanceDiff` object sets the `Destroy` flag (a boolean) for both `DiffDestroy` and `DiffDestroyCreate`, and so this code previously checked `r.Destroy` to recognize the "destroy-create" case. This was incorrectly adapted to a check for the display action being `DiffDestroy`, when it should actually have been `DiffDestroyCreate`.

The effect of this bug was to cause the "(forces new resource)" annotations to not be displayed on attributes, though the resource-level information still correctly reflected that a new resource was required.

This fix restores the attribute-level annotations, which closes #16035.
