### PR TITLE
backend/local: Remove unused const DefaultDataDir.

### DIFF
--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -23,7 +23,6 @@ const (
 	DefaultWorkspaceDir    = "terraform.tfstate.d"
 	DefaultWorkspaceFile   = "environment"
 	DefaultStateFilename   = "terraform.tfstate"
-	DefaultDataDir         = ".terraform"
 	DefaultBackupExtension = ".backup"
 )
 


### PR DESCRIPTION
> Not to be confused with the const of the same name in the `command` package.

Hi, I'm familiarizing myself with the Terraform codebase, so here's a trivial cleanup fix :)

Best regards,
—octo