### PR TITLE
communicator/ssh: add what error details we can for the user

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -467,7 +467,7 @@ func (c *Communicator) scpSession(scpCommand string, f func(io.Writer, *bufio.Re
 		if exitErr, ok := err.(*ssh.ExitError); ok {
 			// Otherwise, we have an ExitErorr, meaning we can just read
 			// the exit status
-			log.Printf("non-zero exit status: %d", exitErr.ExitStatus())
+			log.Printf(exitErr.String())
 
 			// If we exited with status 127, it means SCP isn't available.
 			// Return a more descriptive error for that.


### PR DESCRIPTION
I've been running into some EOF errors with the file provisioner (my fault -- deleting files that it's trying to scp), but debugging this was a lot harder than I expected. This change adds some more information that helps describe what's going on. 

`ssh.WaitMsg` / `ssh.ExitError` have a [`Signal()` method](https://godoc.org/golang.org/x/crypto/ssh#Waitmsg), but it doesn't work (on openssl installs). Otherwise, I'd suggest adding that too: 

```go
if exitErr.Signal() != "" {
    msg += fmt.Sprintf(", signal=%s", exitErr.Signal())
}
```

Related Issues: 
- https://github.com/golang/go/issues/4115
- https://github.com/golang/go/issues/16597