### PR TITLE
provisioners/chef: Update linux provisioner to support AIX

### DIFF
--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -173,6 +173,42 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 		Commands map[string]bool
 		Uploads  map[string]string
 	}{
+		"AIX": {
+			Config: map[string]interface{}{
+				"ohai_hints": []interface{}{"test-fixtures/ohaihint.json"},
+				"os_type":    "aix",
+				"node_name":  "nodename1",
+				"run_list":   []interface{}{"cookbook::recipe"},
+				"secret_key": "SECRET-KEY",
+				"server_url": "https://chef.local",
+				"user_name":  "bob",
+				"user_key":   "USER-KEY",
+			},
+
+			Commands: map[string]bool{
+				"sudo mkdir -p " + linuxConfDir:                                             true,
+				"sudo chmod 777 " + linuxConfDir:                                            true,
+				"sudo " + fmt.Sprintf(chmodAix, linuxConfDir, 666):                          true,
+				"sudo mkdir -p " + path.Join(linuxConfDir, "ohai/hints"):                    true,
+				"sudo chmod 777 " + path.Join(linuxConfDir, "ohai/hints"):                   true,
+				"sudo " + fmt.Sprintf(chmodAix, path.Join(linuxConfDir, "ohai/hints"), 666): true,
+				"sudo chmod 755 " + path.Join(linuxConfDir, "ohai/hints"):                   true,
+				"sudo " + fmt.Sprintf(chmodAix, path.Join(linuxConfDir, "ohai/hints"), 600): true,
+				"sudo chown -R root:system " + path.Join(linuxConfDir, "ohai/hints"):        true,
+				"sudo chmod 755 " + linuxConfDir:                                            true,
+				"sudo " + fmt.Sprintf(chmodAix, linuxConfDir, 600):                          true,
+				"sudo chown -R root:system " + linuxConfDir:                                 true,
+			},
+
+			Uploads: map[string]string{
+				linuxConfDir + "/client.rb":                 defaultLinuxClientConf,
+				linuxConfDir + "/encrypted_data_bag_secret": "SECRET-KEY",
+				linuxConfDir + "/first-boot.json":           `{"run_list":["cookbook::recipe"]}`,
+				linuxConfDir + "/ohai/hints/ohaihint.json":  "OHAI-HINT-FILE",
+				linuxConfDir + "/bob.pem":                   "USER-KEY",
+			},
+		},
+
 		"Sudo": {
 			Config: map[string]interface{}{
 				"ohai_hints": []interface{}{"test-fixtures/ohaihint.json"},
@@ -185,18 +221,18 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"sudo mkdir -p " + linuxConfDir:                                          true,
-				"sudo chmod 777 " + linuxConfDir:                                         true,
-				"sudo " + fmt.Sprintf(chmod, linuxConfDir, 666):                          true,
-				"sudo mkdir -p " + path.Join(linuxConfDir, "ohai/hints"):                 true,
-				"sudo chmod 777 " + path.Join(linuxConfDir, "ohai/hints"):                true,
-				"sudo " + fmt.Sprintf(chmod, path.Join(linuxConfDir, "ohai/hints"), 666): true,
-				"sudo chmod 755 " + path.Join(linuxConfDir, "ohai/hints"):                true,
-				"sudo " + fmt.Sprintf(chmod, path.Join(linuxConfDir, "ohai/hints"), 600): true,
-				"sudo chown -R root:root " + path.Join(linuxConfDir, "ohai/hints"):       true,
-				"sudo chmod 755 " + linuxConfDir:                                         true,
-				"sudo " + fmt.Sprintf(chmod, linuxConfDir, 600):                          true,
-				"sudo chown -R root:root " + linuxConfDir:                                true,
+				"sudo mkdir -p " + linuxConfDir:                                               true,
+				"sudo chmod 777 " + linuxConfDir:                                              true,
+				"sudo " + fmt.Sprintf(chmodLinux, linuxConfDir, 666):                          true,
+				"sudo mkdir -p " + path.Join(linuxConfDir, "ohai/hints"):                      true,
+				"sudo chmod 777 " + path.Join(linuxConfDir, "ohai/hints"):                     true,
+				"sudo " + fmt.Sprintf(chmodLinux, path.Join(linuxConfDir, "ohai/hints"), 666): true,
+				"sudo chmod 755 " + path.Join(linuxConfDir, "ohai/hints"):                     true,
+				"sudo " + fmt.Sprintf(chmodLinux, path.Join(linuxConfDir, "ohai/hints"), 600): true,
+				"sudo chown -R root:root " + path.Join(linuxConfDir, "ohai/hints"):            true,
+				"sudo chmod 755 " + linuxConfDir:                                              true,
+				"sudo " + fmt.Sprintf(chmodLinux, linuxConfDir, 600):                          true,
+				"sudo chown -R root:root " + linuxConfDir:                                     true,
 			},
 
 			Uploads: map[string]string{

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -284,7 +284,7 @@ func applyFn(ctx context.Context) error {
 
 	// Set some values based on the targeted OS
 	switch p.OSType {
-	case "linux":
+	case "linux", "aix":
 		p.cleanupUserKeyCmd = fmt.Sprintf("rm -f %s", path.Join(linuxConfDir, p.UserName+".pem"))
 		p.createConfigFiles = p.linuxCreateConfigFiles
 		p.installChefClient = p.linuxInstallChefClient


### PR DESCRIPTION
Resolves Issue #15707 which prevents the find command from running on vm resources that have AIX as it's operating system. The `find` command on this operating system does not support the `-maxdepth` flag so I modified the command used in the linux provisioner using `-path` and `-prune` which yields the same result: returning a list of only the files located in the top level of the etc chef configuration directory. 

Once that was resolved a new issue was discovered using this provisioner on AIX when setting the ownership of the linux config and ohai hints directories. In AIX, the `root` user does not exist in a `root` group. Instead the group name is called `system`. Now the group used for owning the chef files is set based on the `os_type`. 

Both fixes were tested in our on premises data center using the openstack provider with the AIX 7.1 and RedHat 7.3 operating systems. 

I would **love** to get any feedback I can on this to make it better. Not only is this my first contribution to terraform, this is my first exposure to Go, so if there are things that can be improved, please tell me. 