### PR TITLE
Add `/downloads` to the outdated version message

### DIFF
--- a/command/version.go
+++ b/command/version.go
@@ -65,7 +65,7 @@ func (c *VersionCommand) Run(args []string) int {
 		if info.Outdated {
 			c.Ui.Output(fmt.Sprintf(
 				"Your version of Terraform is out of date! The latest version\n"+
-					"is %s. You can update by downloading from www.terraform.io",
+					"is %s. You can update by downloading from www.terraform.io/downloads.html",
 				info.Latest))
 		}
 	}


### PR DESCRIPTION
I thought it would be more helpful if the message pointed directly to the downloads page.

I can take the PR a step further and try to calculate the download path based on the os type or  link directly to the releases page i.e `https://releases.hashicorp.com/terraform/0.10.5/`

It would be nice to be able to wget in the terminal right after running `terraform version`