### PR TITLE
config: improve interpolation function test output

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2400,21 +2400,23 @@ type testFunctionCase struct {
 }
 
 func testFunction(t *testing.T, config testFunctionConfig) {
-	for i, tc := range config.Cases {
-		ast, err := hil.Parse(tc.Input)
-		if err != nil {
-			t.Fatalf("Case #%d: input: %#v\nerr: %v", i, tc.Input, err)
-		}
+	t.Helper()
+	for _, tc := range config.Cases {
+		t.Run(tc.Input, func(t *testing.T) {
+			ast, err := hil.Parse(tc.Input)
+			if err != nil {
+				t.Fatalf("unexpected parse error: %s", err)
+			}
 
-		result, err := hil.Eval(ast, langEvalConfig(config.Vars))
-		if err != nil != tc.Error {
-			t.Fatalf("Case #%d:\ninput: %#v\nerr: %v", i, tc.Input, err)
-		}
+			result, err := hil.Eval(ast, langEvalConfig(config.Vars))
+			if err != nil != tc.Error {
+				t.Fatalf("unexpected eval error: %s", err)
+			}
 
-		if !reflect.DeepEqual(result.Value, tc.Result) {
-			t.Fatalf("%d: bad output for input: %s\n\nOutput: %#v\nExpected: %#v",
-				i, tc.Input, result.Value, tc.Result)
-		}
+			if !reflect.DeepEqual(result.Value, tc.Result) {
+				t.Errorf("wrong result\ngiven: %s\ngot:   %#v\nwant:  %#v", tc.Input, result.Value, tc.Result)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
These tests were written before subtest support was available. By running them as subtests we can get better output in the event of an error, or in verbose mode.

I made these changes while trying to repro a bug report. I wasn't able to reproduce it, but I think these changes still make interpolation function test debugging simpler, so figured I might as well submit the change anyway.
