### PR TITLE
Assorted e2etest updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
 script:
 - make vendor-status
 - make test
+- make e2etest
 - make vet
 - GOOS=windows go build
 branches:

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ testacc: fmtcheck generate
 	fi
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
+# e2etest runs the end-to-end tests against a generated Terraform binary
+# The TF_ACC here allows network access, but does not require any special
+# credentials since the e2etests use local-only providers such as "null".
+e2etest: generate
+	TF_ACC=1 go test -v ./command/e2etest
+
 test-compile: fmtcheck generate
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \
@@ -96,4 +102,4 @@ vendor-status:
 # under parallel conditions.
 .NOTPARALLEL:
 
-.PHONY: bin cover default dev fmt fmtcheck generate plugin-dev quickdev test-compile test testacc testrace tools vendor-status vet
+.PHONY: bin cover default dev e2etest fmt fmtcheck generate plugin-dev quickdev test-compile test testacc testrace tools vendor-status vet

--- a/command/e2etest/automation_test.go
+++ b/command/e2etest/automation_test.go
@@ -1,0 +1,237 @@
+package e2etest
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform/e2e"
+)
+
+// The tests in this file run through different scenarios recommended in our
+// "Running Terraform in Automation" guide:
+//     https://www.terraform.io/guides/running-terraform-in-automation.html
+
+// TestPlanApplyInAutomation runs through the "main case" of init, plan, apply
+// using the specific command line options suggested in the guide.
+func TestPlanApplyInAutomation(t *testing.T) {
+	t.Parallel()
+
+	// This test reaches out to releases.hashicorp.com to download the
+	// template and null providers, so it can only run if network access is
+	// allowed.
+	skipIfCannotAccessNetwork(t)
+
+	fixturePath := filepath.Join("test-fixtures", "full-workflow-null")
+	tf := e2e.NewBinary(terraformBin, fixturePath)
+	defer tf.Close()
+
+	// We advertise that _any_ non-empty value works, so we'll test something
+	// unconventional here.
+	tf.AddEnv("TF_IN_AUTOMATION=yes-please")
+
+	//// INIT
+	stdout, stderr, err := tf.Run("init", "-input=false")
+	if err != nil {
+		t.Fatalf("unexpected init error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	// Make sure we actually downloaded the plugins, rather than picking up
+	// copies that might be already installed globally on the system.
+	if !strings.Contains(stdout, "- Downloading plugin for provider \"template\"") {
+		t.Errorf("template provider download message is missing from init output:\n%s", stdout)
+		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
+	}
+	if !strings.Contains(stdout, "- Downloading plugin for provider \"null\"") {
+		t.Errorf("null provider download message is missing from init output:\n%s", stdout)
+		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
+	}
+
+	//// PLAN
+	stdout, stderr, err = tf.Run("plan", "-out=tfplan", "-input=false")
+	if err != nil {
+		t.Fatalf("unexpected plan error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	if !strings.Contains(stdout, "1 to add, 0 to change, 0 to destroy") {
+		t.Errorf("incorrect plan tally; want 1 to add:\n%s", stdout)
+	}
+
+	// Because we're running with TF_IN_AUTOMATION set, we should not see
+	// any mention of the plan file in the output.
+	if strings.Contains(stdout, "tfplan") {
+		t.Errorf("unwanted mention of \"tfplan\" file in plan output\n%s", stdout)
+	}
+
+	plan, err := tf.Plan("tfplan")
+	if err != nil {
+		t.Fatalf("failed to read plan file: %s", err)
+	}
+
+	stateResources := plan.State.RootModule().Resources
+	diffResources := plan.Diff.RootModule().Resources
+
+	if len(stateResources) != 1 || stateResources["data.template_file.test"] == nil {
+		t.Errorf("incorrect state in plan; want just data.template_file.test to have been rendered, but have:\n%s", spew.Sdump(stateResources))
+	}
+	if len(diffResources) != 1 || diffResources["null_resource.test"] == nil {
+		t.Errorf("incorrect diff in plan; want just null_resource.test to have been rendered, but have:\n%s", spew.Sdump(diffResources))
+	}
+
+	//// APPLY
+	stdout, stderr, err = tf.Run("apply", "-input=false", "tfplan")
+	if err != nil {
+		t.Fatalf("unexpected apply error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	if !strings.Contains(stdout, "Resources: 1 added, 0 changed, 0 destroyed") {
+		t.Errorf("incorrect apply tally; want 1 added:\n%s", stdout)
+	}
+
+	state, err := tf.LocalState()
+	if err != nil {
+		t.Fatalf("failed to read state file: %s", err)
+	}
+
+	stateResources = state.RootModule().Resources
+	var gotResources []string
+	for n := range stateResources {
+		gotResources = append(gotResources, n)
+	}
+	sort.Strings(gotResources)
+
+	wantResources := []string{
+		"data.template_file.test",
+		"null_resource.test",
+	}
+
+	if !reflect.DeepEqual(gotResources, wantResources) {
+		t.Errorf("wrong resources in state\ngot: %#v\nwant: %#v", gotResources, wantResources)
+	}
+}
+
+// TestAutoApplyInAutomation tests the scenario where the caller skips creating
+// an explicit plan and instead forces automatic application of changes.
+func TestAutoApplyInAutomation(t *testing.T) {
+	t.Parallel()
+
+	// This test reaches out to releases.hashicorp.com to download the
+	// template and null providers, so it can only run if network access is
+	// allowed.
+	skipIfCannotAccessNetwork(t)
+
+	fixturePath := filepath.Join("test-fixtures", "full-workflow-null")
+	tf := e2e.NewBinary(terraformBin, fixturePath)
+	defer tf.Close()
+
+	// We advertise that _any_ non-empty value works, so we'll test something
+	// unconventional here.
+	tf.AddEnv("TF_IN_AUTOMATION=very-much-so")
+
+	//// INIT
+	stdout, stderr, err := tf.Run("init", "-input=false")
+	if err != nil {
+		t.Fatalf("unexpected init error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	// Make sure we actually downloaded the plugins, rather than picking up
+	// copies that might be already installed globally on the system.
+	if !strings.Contains(stdout, "- Downloading plugin for provider \"template\"") {
+		t.Errorf("template provider download message is missing from init output:\n%s", stdout)
+		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
+	}
+	if !strings.Contains(stdout, "- Downloading plugin for provider \"null\"") {
+		t.Errorf("null provider download message is missing from init output:\n%s", stdout)
+		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
+	}
+
+	//// APPLY
+	stdout, stderr, err = tf.Run("apply", "-input=false", "-auto-approve=true")
+	if err != nil {
+		t.Fatalf("unexpected apply error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	if !strings.Contains(stdout, "Resources: 1 added, 0 changed, 0 destroyed") {
+		t.Errorf("incorrect apply tally; want 1 added:\n%s", stdout)
+	}
+
+	state, err := tf.LocalState()
+	if err != nil {
+		t.Fatalf("failed to read state file: %s", err)
+	}
+
+	stateResources := state.RootModule().Resources
+	var gotResources []string
+	for n := range stateResources {
+		gotResources = append(gotResources, n)
+	}
+	sort.Strings(gotResources)
+
+	wantResources := []string{
+		"data.template_file.test",
+		"null_resource.test",
+	}
+
+	if !reflect.DeepEqual(gotResources, wantResources) {
+		t.Errorf("wrong resources in state\ngot: %#v\nwant: %#v", gotResources, wantResources)
+	}
+}
+
+// TestPlanOnlyInAutomation tests the scenario of creating a "throwaway" plan,
+// which we recommend as a way to verify a pull request.
+func TestPlanOnlyInAutomation(t *testing.T) {
+	t.Parallel()
+
+	// This test reaches out to releases.hashicorp.com to download the
+	// template and null providers, so it can only run if network access is
+	// allowed.
+	skipIfCannotAccessNetwork(t)
+
+	fixturePath := filepath.Join("test-fixtures", "full-workflow-null")
+	tf := e2e.NewBinary(terraformBin, fixturePath)
+	defer tf.Close()
+
+	// We advertise that _any_ non-empty value works, so we'll test something
+	// unconventional here.
+	tf.AddEnv("TF_IN_AUTOMATION=verily")
+
+	//// INIT
+	stdout, stderr, err := tf.Run("init", "-input=false")
+	if err != nil {
+		t.Fatalf("unexpected init error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	// Make sure we actually downloaded the plugins, rather than picking up
+	// copies that might be already installed globally on the system.
+	if !strings.Contains(stdout, "- Downloading plugin for provider \"template\"") {
+		t.Errorf("template provider download message is missing from init output:\n%s", stdout)
+		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
+	}
+	if !strings.Contains(stdout, "- Downloading plugin for provider \"null\"") {
+		t.Errorf("null provider download message is missing from init output:\n%s", stdout)
+		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
+	}
+
+	//// PLAN
+	stdout, stderr, err = tf.Run("plan", "-input=false")
+	if err != nil {
+		t.Fatalf("unexpected plan error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	if !strings.Contains(stdout, "1 to add, 0 to change, 0 to destroy") {
+		t.Errorf("incorrect plan tally; want 1 to add:\n%s", stdout)
+	}
+
+	// Because we're running with TF_IN_AUTOMATION set, we should not see
+	// any mention of the the "terraform apply" command in the output.
+	if strings.Contains(stdout, "terraform apply") {
+		t.Errorf("unwanted mention of \"terraform apply\" in plan output\n%s", stdout)
+	}
+
+	if tf.FileExists("tfplan") {
+		t.Error("plan file was created, but was not expected")
+	}
+}

--- a/command/e2etest/primary_test.go
+++ b/command/e2etest/primary_test.go
@@ -57,6 +57,13 @@ func TestPrimarySeparatePlan(t *testing.T) {
 		t.Errorf("incorrect plan tally; want 1 to add:\n%s", stdout)
 	}
 
+	if !strings.Contains(stdout, "This plan was saved to: tfplan") {
+		t.Errorf("missing \"This plan was saved to...\" message in plan output\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "terraform apply \"tfplan\"") {
+		t.Errorf("missing next-step instruction in plan output\n%s", stdout)
+	}
+
 	plan, err := tf.Plan("tfplan")
 	if err != nil {
 		t.Fatalf("failed to read plan file: %s", err)

--- a/command/e2etest/primary_test.go
+++ b/command/e2etest/primary_test.go
@@ -109,8 +109,8 @@ func TestPrimarySeparatePlan(t *testing.T) {
 		t.Fatalf("unexpected destroy error: %s\nstderr:\n%s", err, stderr)
 	}
 
-	if !strings.Contains(stdout, "Resources: 2 destroyed") {
-		t.Errorf("incorrect destroy tally; want 2 destroyed:\n%s", stdout)
+	if !strings.Contains(stdout, "Resources: 1 destroyed") {
+		t.Errorf("incorrect destroy tally; want 1 destroyed:\n%s", stdout)
 	}
 
 	state, err = tf.LocalState()

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -17,6 +17,7 @@ import (
 type binary struct {
 	binPath string
 	workDir string
+	env     []string
 }
 
 // NewBinary prepares a temporary directory containing the files from the
@@ -93,6 +94,12 @@ func NewBinary(binaryPath, workingDir string) *binary {
 	}
 }
 
+// AddEnv appends an entry to the environment variable table passed to any
+// commands subsequently run.
+func (b *binary) AddEnv(entry string) {
+	b.env = append(b.env, entry)
+}
+
 // Cmd returns an exec.Cmd pre-configured to run the generated Terraform
 // binary with the given arguments in the temporary working directory.
 //
@@ -107,6 +114,8 @@ func (b *binary) Cmd(args ...string) *exec.Cmd {
 	// our tests run. (This does, of course, mean we can't actually do
 	// end-to-end testing of our Checkpoint interactions.)
 	cmd.Env = append(cmd.Env, "CHECKPOINT_DISABLE=1")
+
+	cmd.Env = append(cmd.Env, b.env...)
 
 	return cmd
 }


### PR DESCRIPTION
This PR cover three main changes to the end-to-end tests:

* The pre-existing TestPrimarySeparatePlan test is updated to expect that a data source won't be tallied as a destroy action on apply, since that is now the case.
* Three new tests mimic the workflow suggested by [Running Terraform in Automation](https://www.terraform.io/guides/running-terraform-in-automation.html).
* The tests are run in Travis-CI, so we can catch regressions sooner. (Unlike most "acceptance tests", this is safe because these tests only access network resources that don't require special credentials.)
