### PR TITLE
cmd/state_rm: log removed item count

### DIFF
--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -52,6 +52,8 @@ func (c *StateRmCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Ui.Output(fmt.Sprintf("%d items removed.", len(args)))
+
 	if err := state.WriteState(stateReal); err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateRmPersist, err))
 		return 1


### PR DESCRIPTION
This change adds a line with item count:
```
$ terraform state rm aws_launch_configuration.mylc1 aws_launch_configuration.mylc2
2 items removed.
Item removal successful.
```

I feel we can also log "Writing the new state...", which happens right after removal.

Fixes #16109 