### PR TITLE
[feature] Add option to skip PurgeUnused call -purge-unused=true|false

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -27,6 +27,9 @@ type InitCommand struct {
 	// getPlugins is for the -get-plugins flag
 	getPlugins bool
 
+	// flagPurgeUnusedPlugins is for the -purge-unused flag
+	flagPurgeUnusedPlugins bool
+
 	// providerInstaller is used to download and install providers that
 	// aren't found locally. This uses a discovery.ProviderInstaller instance
 	// by default, but it can be overridden here as a way to mock fetching
@@ -58,6 +61,7 @@ func (c *InitCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&flagUpgrade, "upgrade", false, "")
 	cmdFlags.Var(&flagPluginPath, "plugin-dir", "plugin directory")
 	cmdFlags.BoolVar(&flagVerifyPlugins, "verify-plugins", true, "verify plugins")
+	cmdFlags.BoolVar(&c.flagPurgeUnusedPlugins, "purge-unused", true, "purge not used auto-installed plugins")
 
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
@@ -404,7 +408,7 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 		return err
 	}
 
-	{
+	if c.flagPurgeUnusedPlugins {
 		// Purge any auto-installed plugins that aren't being used.
 		purged, err := c.providerInstaller.PurgeUnused(chosen)
 		if err != nil {
@@ -517,6 +521,8 @@ Options:
 
   -verify-plugins=true Verify the authenticity and integrity of automatically
                        downloaded plugins.
+
+  -purge-unused=true   Purge any auto-installed plugins that aren't being used.
 `
 	return strings.TrimSpace(helpText)
 }


### PR DESCRIPTION
The `PurgeUnused` should be optional if we don't want all previosuly downloaded plugins to be purged.

The default value should be kept as `true` to keep everything safe and backward compatible but if someone don't want their precious plugins to be purged, keep it.

For example sometimes I'm working from a location with very-very slow internet and the `aws` provider download time takes around 30min which is unacceptable. But sometimes I'm switching between branches and if a specific branch does not use the aws plugin, it'll be removed on init.