### PR TITLE
CLI autocomplete

### DIFF
--- a/command/autocomplete.go
+++ b/command/autocomplete.go
@@ -15,3 +15,19 @@ var completePredictBoolean = complete.PredictSet("true", "false")
 // We don't currently have a real predictor for module sources, but
 // we'll probably add one later.
 var completePredictModuleSource = complete.PredictAnything
+
+type completePredictSequence []complete.Predictor
+
+func (s completePredictSequence) Predict(a complete.Args) []string {
+	// Only one level of command is stripped off the prefix of a.Completed
+	// here, so nested subcommands like "workspace new" will need to provide
+	// dummy entries (e.g. complete.PredictNothing) as placeholders for
+	// all but the first subcommand. For example, "workspace new" needs
+	// one placeholder for the argument "new".
+	idx := len(a.Completed)
+	if idx >= len(s) {
+		return nil
+	}
+
+	return s[idx].Predict(a)
+}

--- a/command/autocomplete.go
+++ b/command/autocomplete.go
@@ -1,0 +1,17 @@
+package command
+
+import (
+	"github.com/posener/complete"
+)
+
+// This file contains some re-usable predictors for auto-complete. The
+// command-specific autocomplete configurations live within each command's
+// own source file, as AutocompleteArgs and AutocompleteFlags methods on each
+// Command implementation.
+
+// For completing the value of boolean flags like -foo false
+var completePredictBoolean = complete.PredictSet("true", "false")
+
+// We don't currently have a real predictor for module sources, but
+// we'll probably add one later.
+var completePredictModuleSource = complete.PredictAnything

--- a/command/autocomplete_test.go
+++ b/command/autocomplete_test.go
@@ -1,0 +1,60 @@
+package command
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+)
+
+func TestMetaCompletePredictWorkspaceName(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	os.MkdirAll(td, 0755)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	// make sure a vars file doesn't interfere
+	err := ioutil.WriteFile(DefaultVarsFilename, nil, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ui := new(cli.MockUi)
+	meta := &Meta{Ui: ui}
+
+	predictor := meta.completePredictWorkspaceName()
+
+	t.Run("no prefix", func(t *testing.T) {
+		got := predictor.Predict(complete.Args{
+			Last: "",
+		})
+		want := []string{"default"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("prefix that matches", func(t *testing.T) {
+		got := predictor.Predict(complete.Args{
+			Last: "def",
+		})
+		want := []string{"default"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("prefix that doesn't match", func(t *testing.T) {
+		got := predictor.Predict(complete.Args{
+			Last: "x",
+		})
+		want := []string{}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+}

--- a/command/init.go
+++ b/command/init.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/posener/complete"
+
 	"github.com/hashicorp/go-getter"
 
 	multierror "github.com/hashicorp/go-multierror"
@@ -450,6 +452,29 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 	}
 
 	return nil
+}
+
+func (c *InitCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictDirs("")
+}
+
+func (c *InitCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-backend":        completePredictBoolean,
+		"-backend-config": complete.PredictFiles("*.tfvars"), // can also be key=value, but we can't "predict" that
+		"-force-copy":     complete.PredictNothing,
+		"-from-module":    completePredictModuleSource,
+		"-get":            completePredictBoolean,
+		"-get-plugins":    completePredictBoolean,
+		"-input":          completePredictBoolean,
+		"-lock":           completePredictBoolean,
+		"-lock-timeout":   complete.PredictAnything,
+		"-no-color":       complete.PredictNothing,
+		"-plugin-dir":     complete.PredictDirs(""),
+		"-reconfigure":    complete.PredictNothing,
+		"-upgrade":        completePredictBoolean,
+		"-verify-plugins": completePredictBoolean,
+	}
 }
 
 func (c *InitCommand) Help() string {

--- a/command/workspace_delete.go
+++ b/command/workspace_delete.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/command/clistate"
 	"github.com/hashicorp/terraform/state"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
 )
 
 type WorkspaceDeleteCommand struct {
@@ -156,6 +157,21 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 
 	return 0
 }
+
+func (c *WorkspaceDeleteCommand) AutocompleteArgs() complete.Predictor {
+	return completePredictSequence{
+		complete.PredictNothing, // the "select" subcommand itself (already matched)
+		c.completePredictWorkspaceName(),
+		complete.PredictDirs(""),
+	}
+}
+
+func (c *WorkspaceDeleteCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-force": complete.PredictNothing,
+	}
+}
+
 func (c *WorkspaceDeleteCommand) Help() string {
 	helpText := `
 Usage: terraform workspace delete [OPTIONS] NAME [DIR]

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+
+	"github.com/posener/complete"
 )
 
 type WorkspaceListCommand struct {
@@ -73,6 +75,14 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	}
 
 	return 0
+}
+
+func (c *WorkspaceListCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictDirs("")
+}
+
+func (c *WorkspaceListCommand) AutocompleteFlags() complete.Flags {
+	return nil
 }
 
 func (c *WorkspaceListCommand) Help() string {

--- a/command/workspace_new.go
+++ b/command/workspace_new.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
 )
 
 type WorkspaceNewCommand struct {
@@ -154,6 +155,20 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	}
 
 	return 0
+}
+
+func (c *WorkspaceNewCommand) AutocompleteArgs() complete.Predictor {
+	return completePredictSequence{
+		complete.PredictNothing, // the "new" subcommand itself (already matched)
+		complete.PredictAnything,
+		complete.PredictDirs(""),
+	}
+}
+
+func (c *WorkspaceNewCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-state": complete.PredictFiles("*.tfstate"),
+	}
 }
 
 func (c *WorkspaceNewCommand) Help() string {

--- a/command/workspace_select.go
+++ b/command/workspace_select.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
 )
 
 type WorkspaceSelectCommand struct {
@@ -101,6 +102,18 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	)
 
 	return 0
+}
+
+func (c *WorkspaceSelectCommand) AutocompleteArgs() complete.Predictor {
+	return completePredictSequence{
+		complete.PredictNothing, // the "select" subcommand itself (already matched)
+		c.completePredictWorkspaceName(),
+		complete.PredictDirs(""),
+	}
+}
+
+func (c *WorkspaceSelectCommand) AutocompleteFlags() complete.Flags {
+	return nil
 }
 
 func (c *WorkspaceSelectCommand) Help() string {

--- a/command/workspace_show.go
+++ b/command/workspace_show.go
@@ -2,6 +2,8 @@ package command
 
 import (
 	"strings"
+
+	"github.com/posener/complete"
 )
 
 type WorkspaceShowCommand struct {
@@ -24,6 +26,14 @@ func (c *WorkspaceShowCommand) Run(args []string) int {
 	c.Ui.Output(workspace)
 
 	return 0
+}
+
+func (c *WorkspaceShowCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *WorkspaceShowCommand) AutocompleteFlags() complete.Flags {
+	return nil
 }
 
 func (c *WorkspaceShowCommand) Help() string {

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -134,6 +135,7 @@ func wrappedMain() int {
 	defer plugin.CleanupClients()
 
 	// Get the command line args.
+	binName := filepath.Base(os.Args[0])
 	args := os.Args[1:]
 
 	// Build the CLI so far, we do this so we can query the subcommand.
@@ -175,10 +177,15 @@ func wrappedMain() int {
 	// Rebuild the CLI with any modified args.
 	log.Printf("[INFO] CLI command args: %#v", args)
 	cliRunner = &cli.CLI{
+		Name:       binName,
 		Args:       args,
 		Commands:   Commands,
 		HelpFunc:   helpFunc,
 		HelpWriter: os.Stdout,
+
+		Autocomplete:          true,
+		AutocompleteInstall:   "install-autocomplete",
+		AutocompleteUninstall: "uninstall-autocomplete",
 	}
 
 	// Pass in the overriding plugin paths from config

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1723,10 +1723,10 @@
 			"revisionTime": "2017-01-23T01:43:24Z"
 		},
 		{
-			"checksumSHA1": "KXrCoifaKi3Wy4zbCfXTtM/FO48=",
+			"checksumSHA1": "UIqCj7qI0hhIMpAhS9YYqs2jD48=",
 			"path": "github.com/mitchellh/cli",
-			"revision": "b633c78680fa6fb27ac81694f38c28f79602ebd9",
-			"revisionTime": "2017-08-14T15:07:37Z"
+			"revision": "65fcae5817c8600da98ada9d7edf26dd1a84837b",
+			"revisionTime": "2017-09-08T18:10:43Z"
 		},
 		{
 			"checksumSHA1": "ttEN1Aupb7xpPMkQLqb3tzLFdXs=",

--- a/website/docs/commands/index.html.markdown
+++ b/website/docs/commands/index.html.markdown
@@ -73,6 +73,31 @@ Usage: terraform graph [options] PATH
   to read this format.
 ```
 
+## Shell Tab-completion
+
+If you use either `bash` or `zsh` as your command shell, Terraform can provide
+tab-completion support for all command names and (at this time) _some_ command
+arguments.
+
+To add the necessary commands to your shell profile, run the following command:
+
+```bash
+terraform -install-autocomplete
+```
+
+After installation, it is necessary to restart your shell or to re-read its
+profile script before completion will be activated.
+
+To uninstall the completion hook, assuming that it has not been modified
+manually in the shell profile, run the following command:
+
+```bash
+terraform -uninstall-autocomplete
+```
+
+Currently not all of Terraform's subcommands have full tab-completion support
+for all arguments. We plan to improve tab-completion coverage over time.
+
 ## Upgrade and Security Bulletin Checks
 
 The Terraform CLI commands interact with the HashiCorp service


### PR DESCRIPTION
This set of changes enables tab-completion for `bash` and `zsh` users, building on the mechanisms provided by the `cli` package, which in turn delegates to [the `complete` package](https://godoc.org/github.com/posener/complete).

By turning on autocomplete, we get autocomplete of the sub-command names themselves for free.

We then need to augment each command object with some additional methods to define the expected options and arguments. This changeset does this for `terraform init` and for the `terraform workspace ...` family of commands. We can build out comprehensive support across all the commands over time in separate PRs.
