### PR TITLE
Add 'transpose' interpolation function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -112,6 +112,7 @@ func Funcs() map[string]ast.Function {
 		"substr":       interpolationFuncSubstr(),
 		"timestamp":    interpolationFuncTimestamp(),
 		"title":        interpolationFuncTitle(),
+		"transpose":    interpolationFuncTranspose(),
 		"trimspace":    interpolationFuncTrimSpace(),
 		"upper":        interpolationFuncUpper(),
 		"urlencode":    interpolationFuncURLEncode(),
@@ -1544,6 +1545,53 @@ func interpolationFuncURLEncode() ast.Function {
 		Callback: func(args []interface{}) (interface{}, error) {
 			s := args[0].(string)
 			return url.QueryEscape(s), nil
+		},
+	}
+}
+
+// interpolationFuncTranspose implements the "transpose" function
+// that converts a map (string,list) to a map (string,list) where
+// the unique values of the original lists become the keys of the
+// new map and the keys of the original map become values for the
+// corresponding new keys.
+func interpolationFuncTranspose() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeMap},
+		ReturnType: ast.TypeMap,
+		Callback: func(args []interface{}) (interface{}, error) {
+
+			inputMap := args[0].(map[string]ast.Variable)
+			outputMap := make(map[string]ast.Variable)
+			tmpMap := make(map[string][]string)
+
+			for inKey, inVal := range inputMap {
+				if inVal.Type != ast.TypeList {
+					return nil, fmt.Errorf("transpose requires a map of lists of strings")
+				}
+				values := inVal.Value.([]ast.Variable)
+				for _, listVal := range values {
+					if listVal.Type != ast.TypeString {
+						return nil, fmt.Errorf("transpose requires the given map values to be lists of strings")
+					}
+					outKey := listVal.Value.(string)
+					if _, ok := tmpMap[outKey]; !ok {
+						tmpMap[outKey] = make([]string, 0)
+					}
+					outVal := tmpMap[outKey]
+					outVal = append(outVal, inKey)
+					sort.Strings(outVal)
+					tmpMap[outKey] = outVal
+				}
+			}
+
+			for outKey, outVal := range tmpMap {
+				values := make([]ast.Variable, 0)
+				for _, v := range outVal {
+					values = append(values, ast.Variable{Type: ast.TypeString, Value: v})
+				}
+				outputMap[outKey] = ast.Variable{Type: ast.TypeList, Value: values}
+			}
+			return outputMap, nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2615,6 +2615,82 @@ func TestInterpolateFuncURLEncode(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncTranspose(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Vars: map[string]ast.Variable{
+			"var.map": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"key1": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							{Type: ast.TypeString, Value: "a"},
+							{Type: ast.TypeString, Value: "b"},
+						},
+					},
+					"key2": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							{Type: ast.TypeString, Value: "a"},
+							{Type: ast.TypeString, Value: "b"},
+							{Type: ast.TypeString, Value: "c"},
+						},
+					},
+					"key3": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							{Type: ast.TypeString, Value: "c"},
+						},
+					},
+					"key4": ast.Variable{
+						Type:  ast.TypeList,
+						Value: []ast.Variable{},
+					},
+				}},
+			"var.badmap": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"key1": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							{Type: ast.TypeList, Value: []ast.Variable{}},
+							{Type: ast.TypeList, Value: []ast.Variable{}},
+						},
+					},
+				}},
+			"var.worsemap": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"key1": ast.Variable{
+						Type:  ast.TypeString,
+						Value: "not-a-list",
+					},
+				}},
+		},
+		Cases: []testFunctionCase{
+			{
+				`${transpose(var.map)}`,
+				map[string]interface{}{
+					"a": []interface{}{"key1", "key2"},
+					"b": []interface{}{"key1", "key2"},
+					"c": []interface{}{"key2", "key3"},
+				},
+				false,
+			},
+			{
+				`${transpose(var.badmap)}`,
+				nil,
+				true,
+			},
+			{
+				`${transpose(var.worsemap)}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncAbs(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -392,6 +392,8 @@ The supported built-in functions are:
 
   * `title(string)` - Returns a copy of the string with the first characters of all the words capitalized.
 
+  * `transpose(map)` - Swaps the keys and list values in a map of lists of strings. For example, transpose(map("a", list("1", "2"), "b", list("2", "3")) produces a value equivalent to map("1", list("a"), "2", list("a", "b"), "3", list("b")).
+
   * `trimspace(string)` - Returns a copy of the string with all leading and trailing white spaces removed.
 
   * `upper(string)` - Returns a copy of the string with all Unicode letters mapped to their upper case.


### PR DESCRIPTION
The motivation for this new function comes from a desire to declare AWS IAM users/groups (and other similar constructs) in the following manner:
```
variable "users" {
  default = {
    "jon.snow"        = [ "Leaders", "Fighters" ]
    "tyrion.lanister" = [ "Strategists" ]
    "cersei.lanister" = [ "Leaders" ]
    "arya.stark"      = [ "Fighters" ]
    "oberyn.martell"  = [ "Fighters" ]
  }
}
```

Each user could be created with existing functions:
```
resource "aws_iam_user" "user" {
  count = "${length(keys(var.users))}"
  name  = "${element(keys(var.users), count.index)}"
}
```

However, due to how group membership works with IAM, a user cannot be directly associated with a list of `aws_iam_group` resources. Instead, an `aws_iam_group` has to be created alongside a `aws_iam_group_membership` as follows:
```
resource "aws_iam_group" "leaders-group" {
  name = "Leaders"
  path = "/"
}

resource "aws_iam_group_membership" "leaders-group-membership" {
  name  = "leaders-membership"
  users = [...] // ???
}
```

The challenge is in collecting all the users that should be in the "Leaders" group in a list than can be provided in the `aws_iam_group_membership.users` attribute.

I suppose others smarter than me have figured out a way to combine the existing functions to do this, but I have not been able to arrive at something that I feel comfortable with.

A `transpose(map)` function will take the map above, and transpose the unique set of values as keys, and the keys as values in a new map:

```
{
  "Leaders"     = [ "jon.snow", "cersei.lanister" ]
  "Strategists" = [ "tyrion.lanister" ]
  "Fighters"    = [ "jon.snow", "arya.stark", "oberyn.martell" ]
}
```

A complete working example:

```
variable "users" {
  default = {
    "jon.snow"        = [ "Leaders", "Fighters" ]
    "tyrion.lanister" = [ "Strategists" ]
    "cersei.lanister" = [ "Leaders" ]
    "arya.stark"      = [ "Fighters" ]
    "oberyn.martell"  = [ "Fighters" ]
  }
}

locals {
  groups = "${transpose(var.users)}"
}

resource "aws_iam_user" "user" {
  count = "${length(keys(var.users))}"
  name  = "${element(keys(var.users), count.index)}"
}

resource "aws_iam_group" "group" {
  count = "${length(keys(local.groups))}"
  name  = "${element(keys(local.groups), count.index)}"
  path  = "/"
}

resource "aws_iam_group_membership" "group-membership" {
  depends_on = [ "aws_iam_user.user", "aws_iam_group.group" ]
  count      = "${length(keys(local.groups))}"
  name       = "${element(keys(local.groups), count.index)}-membership"
  group      = "${element(keys(local.groups), count.index)}"
  users      = "${local.groups["${element(keys(local.groups), count.index)}"]}"
}
```
