### PR TITLE
command: Implement the "data-dir" flag.

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -71,6 +71,11 @@ type Meta struct {
 	// into the given directory.
 	PluginCacheDir string
 
+	// OverrideDataDir, if non-empty, overrides the return value of the
+	// DataDir method for situations where the local .terraform/ directory
+	// is not suitable, e.g. because of a read-only filesystem.
+	OverrideDataDir string
+
 	//----------------------------------------------------------
 	// Protected: commands can set these
 	//----------------------------------------------------------
@@ -202,14 +207,12 @@ func (m *Meta) Colorize() *colorstring.Colorize {
 }
 
 // DataDir returns the directory where local data will be stored.
-// Defaults to DefaultsDataDir in the current working directory.
+// Defaults to DefaultDataDir in the current working directory.
 func (m *Meta) DataDir() string {
-	dataDir := DefaultDataDir
-	if m.dataDir != "" {
-		dataDir = m.dataDir
+	if m.OverrideDataDir != "" {
+		return m.OverrideDataDir
 	}
-
-	return dataDir
+	return DefaultDataDir
 }
 
 const (

--- a/commands.go
+++ b/commands.go
@@ -49,6 +49,8 @@ func initCommands(config *Config) {
 		services.ForceHostServices(host, hostConfig.Services)
 	}
 
+	dataDir := os.Getenv("TF_DATA_DIR")
+
 	meta := command.Meta{
 		Color:            true,
 		GlobalPluginDirs: globalPluginDirs(),
@@ -60,6 +62,7 @@ func initCommands(config *Config) {
 
 		RunningInAutomation: inAutomation,
 		PluginCacheDir:      config.PluginCacheDir,
+		OverrideDataDir:     dataDir,
 	}
 
 	// The command list is included in the terraform -help

--- a/website/docs/configuration/environment-variables.html.md
+++ b/website/docs/configuration/environment-variables.html.md
@@ -88,6 +88,23 @@ The value of the flag is parsed as if you typed it directly to the shell.
 Double and single quotes are allowed to capture strings and arguments will
 be separated by spaces otherwise.
 
+## TF_DATA_DIR
+
+`TF_DATA_DIR` changes the location where Terraform keeps its
+per-working-directory data, such as the current remote backend configuration.
+
+By default this data is written into a `.terraform` subdirectory of the
+current directory, but the path given in `TF_DATA_DIR` will be used instead
+if non-empty.
+
+In most cases it should not be necessary to set this variable, but it may
+be useful to do so if e.g. the working directory is not writable.
+
+The data directory is used to retain data that must persist from one command
+to the next, so it's important to have this variable set consistently throughout
+all of the Terraform workflow commands (starting with `terraform init`) or else
+Terraform may be unable to find providers, modules, and other artifacts.
+
 ## TF_SKIP_REMOTE_TESTS
 
 This can be set prior to running the unit tests to opt-out of any tests


### PR DESCRIPTION
This flag allows to set the Meta.dataDir field, which was not previously possible.

For context: we'd like to be able to run Terraform from a read-only directory. This option allows us to direct all write access to a writable directory elsewhere.

While there, I simplified `"command".Meta.DataDir()`.