### PR TITLE
Don't evaluate locals during destroy

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -8809,3 +8809,50 @@ module.child:
 		t.Fatalf("wrong final state\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
+
+func TestContext2Apply_destroyWithLocals(t *testing.T) {
+	m := testModule(t, "apply-destroy-with-locals")
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		ProviderResolver: ResourceProviderResolverFixed(
+			map[string]ResourceProviderFactory{
+				"aws": testProviderFuncFixed(testProvider("aws")),
+			},
+		),
+		State: &State{
+			Modules: []*ModuleState{
+				&ModuleState{
+					Path: rootModulePath,
+					Outputs: map[string]*OutputState{
+						"name": &OutputState{
+							Type:  "string",
+							Value: "test-bar",
+						},
+					},
+					Resources: map[string]*ResourceState{
+						"aws_instance.foo": &ResourceState{
+							Type: "aws_instance",
+							Primary: &InstanceState{
+								ID: "foo",
+							},
+						},
+					},
+				},
+			},
+		},
+		Destroy: true,
+	})
+
+	state, err := ctx.Apply()
+	if err != nil {
+		t.Fatalf("error during apply: %s", err)
+	}
+
+	got := strings.TrimSpace(state.String())
+	want := strings.TrimSpace(`
+	TODO
+`)
+	if got != want {
+		t.Fatalf("wrong final state\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}

--- a/terraform/eval_local.go
+++ b/terraform/eval_local.go
@@ -56,3 +56,31 @@ func (n *EvalLocal) Eval(ctx EvalContext) (interface{}, error) {
 
 	return nil, nil
 }
+
+// EvalDeleteLocal is an EvalNode implementation that deletes a Local value
+// from the state. Locals aren't persisted, but we don't need to evaluate them
+// during destroy.
+type EvalDeleteLocal struct {
+	Name string
+}
+
+func (n *EvalDeleteLocal) Eval(ctx EvalContext) (interface{}, error) {
+	state, lock := ctx.State()
+	if state == nil {
+		return nil, nil
+	}
+
+	// Get a write lock so we can access this instance
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Look for the module state. If we don't have one, create it.
+	mod := state.ModuleByPath(ctx.Path())
+	if mod == nil {
+		return nil, nil
+	}
+
+	delete(mod.Locals, n.Name)
+
+	return nil, nil
+}

--- a/terraform/node_local.go
+++ b/terraform/node_local.go
@@ -59,20 +59,36 @@ func (n *NodeLocal) References() []string {
 
 // GraphNodeEvalable
 func (n *NodeLocal) EvalTree() EvalNode {
-	return &EvalOpFilter{
-		Ops: []walkOperation{
-			walkInput,
-			walkValidate,
-			walkRefresh,
-			walkPlan,
-			walkApply,
-			walkDestroy,
-		},
-		Node: &EvalSequence{
-			Nodes: []EvalNode{
-				&EvalLocal{
-					Name:  n.Config.Name,
-					Value: n.Config.RawConfig,
+	return &EvalSequence{
+		Nodes: []EvalNode{
+			&EvalOpFilter{
+				Ops: []walkOperation{
+					walkInput,
+					walkValidate,
+					walkRefresh,
+					walkPlan,
+					walkApply,
+				},
+				Node: &EvalSequence{
+					Nodes: []EvalNode{
+						&EvalLocal{
+							Name:  n.Config.Name,
+							Value: n.Config.RawConfig,
+						},
+					},
+				},
+			},
+			&EvalOpFilter{
+				Ops: []walkOperation{
+					walkPlanDestroy,
+					walkDestroy,
+				},
+				Node: &EvalSequence{
+					Nodes: []EvalNode{
+						&EvalDeleteLocal{
+							Name: n.Config.Name,
+						},
+					},
 				},
 			},
 		},

--- a/terraform/test-fixtures/apply-destroy-with-locals/main.tf
+++ b/terraform/test-fixtures/apply-destroy-with-locals/main.tf
@@ -1,0 +1,8 @@
+locals {
+  name = "test-${aws_instance.foo.id}"
+}
+resource "aws_instance" "foo" {}
+
+output "name" {
+  value = "${local.name}"
+}

--- a/terraform/test-fixtures/provider-with-locals/main.tf
+++ b/terraform/test-fixtures/provider-with-locals/main.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+	alias = "${local.foo}"
+}
+
+locals {
+	foo = "bar"
+}
+
+resource "aws_instance" "foo" {
+    value = "${local.foo}"
+}


### PR DESCRIPTION
Locals don't need to be evaluated during destroy.  Rather than simply
skipping them, remove them from the state as they are encountered. Even
though they are not persisted in the state, it keeps the state up to
date as the destroy happens, and we reduce the chance of other
inconstancies later on.

Fixes #16190