### PR TITLE
remove extra slash from registry urls

### DIFF
--- a/config/module/get.go
+++ b/config/module/get.go
@@ -79,7 +79,7 @@ func getStorage(s getter.Storage, key string, src string, mode GetMode) (string,
 }
 
 const (
-	registryAPI   = "https://registry.terraform.io/v1/modules/"
+	registryAPI   = "https://registry.terraform.io/v1/modules"
 	xTerraformGet = "X-Terraform-Get"
 )
 

--- a/config/module/get_test.go
+++ b/config/module/get_test.go
@@ -102,7 +102,7 @@ func TestDetectRegistry(t *testing.T) {
 	defer server.Close()
 
 	detector := registryDetector{
-		api:    server.URL + "/v1/modules/",
+		api:    server.URL + "/v1/modules",
 		client: server.Client(),
 	}
 
@@ -181,7 +181,7 @@ func TestDetectors(t *testing.T) {
 	}
 
 	regDetector := &registryDetector{
-		api:    server.URL + "/v1/modules/",
+		api:    server.URL + "/v1/modules",
 		client: server.Client(),
 	}
 
@@ -280,7 +280,7 @@ func TestRegistryGitHubArchive(t *testing.T) {
 	defer server.Close()
 
 	regDetector := &registryDetector{
-		api:    server.URL + "/v1/modules/",
+		api:    server.URL + "/v1/modules",
 		client: server.Client(),
 	}
 
@@ -310,6 +310,18 @@ func TestRegistryGitHubArchive(t *testing.T) {
 
 	if err := tree.Load(storage, GetModeNone); err != nil {
 		t.Fatalf("err: %s", err)
+	}
+
+	// stop the registry server, and make sure that we don't need to call out again
+	server.Close()
+	tree = NewTree("", testConfig(t, "registry-tar-subdir"))
+
+	if err := tree.Load(storage, GetModeGet); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !tree.Loaded() {
+		t.Fatal("should be loaded")
 	}
 
 	actual := strings.TrimSpace(tree.String())


### PR DESCRIPTION
A refactor introduced an extra `/` in the download url, which causes an
extra redirect during discovery.

Improve a registry test to verify that detection doesn't require the
registry after the modules have been fetched.