### PR TITLE
Improve the test to show a failure when using locals in a provider

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -8872,6 +8872,15 @@ func TestContext2Apply_destroyWithLocals(t *testing.T) {
 func TestContext2Apply_providerWithLocals(t *testing.T) {
 	m := testModule(t, "provider-with-locals")
 	p := testProvider("aws")
+
+	providerRegion := ""
+	// this should not be overridden during destroy
+	p.ConfigureFn = func(c *ResourceConfig) error {
+		if r, ok := c.Get("region"); ok {
+			providerRegion = r.(string)
+		}
+		return nil
+	}
 	p.DiffFn = testDiffFn
 	p.ApplyFn = testApplyFn
 	ctx := testContext2(t, &ContextOpts{
@@ -8914,5 +8923,13 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 
 	if state.HasResources() {
 		t.Fatal("expected no state, got:", state)
+	}
+
+	// Destroy won't work because the local value is removed before the
+	// provider.  Once this is fixed this test will start to fail, and we
+	// can remove the invalid interpolation string;
+	// if providerRegion != "bar" {
+	if providerRegion != "${local.foo}" {
+		t.Fatalf("expected region %q, got: %q", "bar", providerRegion)
 	}
 }

--- a/terraform/test-fixtures/provider-with-locals/main.tf
+++ b/terraform/test-fixtures/provider-with-locals/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-	alias = "${local.foo}"
+	region = "${local.foo}"
 }
 
 locals {

--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -187,7 +187,12 @@ provider "aws" {
 
 An exception to this is the special `version` attribute that applies to all `provider` blocks for specifying [provider versions](#provider-versions); interpolation is not supported for provider versions since provider compatibility is a property of the configuration rather than something dynamic, and provider plugin installation happens too early for variables to be resolvable in this context.
 
--> **NOTE:** Because providers are one of the first things loaded when Terraform parses the graph, it is not possible to use the output from modules or resources as inputs to the provider. At this time, only [variables](/docs/configuration/variables.html) and [data sources](/docs/configuration/data-sources.html), including [remote state](/docs/providers/terraform/d/remote_state.html) may be used in an interpolation inside a provider stanza.
+-> **NOTE:** Because providers are one of the first things loaded when Terraform parses the graph, it is not possible to
+use the output from modules or resources as inputs to the provider. At this time, only
+[variables](/docs/configuration/variables.html) and [data sources](/docs/configuration/data-sources.html), including
+[remote state](/docs/providers/terraform/d/remote_state.html) may be used in an interpolation inside a provider stanza.
+[Local values](/docs/configuration/locals.html) can also be used, but currently may fail when running `terraform destroy`.
+
 
 ## Third-party Plugins
 


### PR DESCRIPTION
Make sure this fails during destroy

Add a note in the documentation that local values may fail during
destroy. This should only be temporary until we update the graph to properly transform output and locals for destruction.