### PR TITLE
Fixes #16226 - two changes to the Provisioners sidebar on the website

### DIFF
--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -497,6 +497,10 @@
             <a href="/docs/provisioners/remote-exec.html">remote-exec</a>
           </li>
 
+          <li<%= sidebar_current("docs-provisioners-salt-masterless") %>>
+            <a href="/docs/provisioners/salt-masterless.html">salt-masterless</a>
+          </li>
+
           <li<%= sidebar_current("docs-provisioners-null-resource") %>>
             <a href="/docs/provisioners/null_resource.html">null_resource</a>
           </li>

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -493,16 +493,16 @@
             <a href="/docs/provisioners/local-exec.html">local-exec</a>
           </li>
 
+          <li<%= sidebar_current("docs-provisioners-null-resource") %>>
+            <a href="/docs/provisioners/null_resource.html">null_resource</a>
+          </li>
+
           <li<%= sidebar_current("docs-provisioners-remote") %>>
             <a href="/docs/provisioners/remote-exec.html">remote-exec</a>
           </li>
 
           <li<%= sidebar_current("docs-provisioners-salt-masterless") %>>
             <a href="/docs/provisioners/salt-masterless.html">salt-masterless</a>
-          </li>
-
-          <li<%= sidebar_current("docs-provisioners-null-resource") %>>
-            <a href="/docs/provisioners/null_resource.html">null_resource</a>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
Adding salt-masterless to the sidebar, and also rearranging null_resource -- everything else in Provisioners (and everything in Providers) is sorted alphabetically, don't think null_resource needs to be an exception.