### PR TITLE
Replace `~` by `$HOME` in documentation of TF_PLUGIN_CACHE_DIR

### DIFF
--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -249,7 +249,7 @@ variable can be used to enable caching or to override an existing cache
 directory within a particular shell session:
 
 ```bash
-export TF_PLUGIN_CACHE_DIR="~/.terraform.d/plugin-cache"
+export TF_PLUGIN_CACHE_DIR="$HOME/.terraform.d/plugin-cache"
 ```
 
 When a plugin cache directory is enabled, the `terraform init` command will


### PR DESCRIPTION
With terraform 0.10.7, the `~` character is not resolved causing the creation of `~/.terraform.d/plugin-cache` directories in each directory where `terraform init` is run.

Using `export TF_PLUGIN_CACHE_DIR="$HOME/.terraform.d/plugin-cache"` works fine.