### PR TITLE
provider/aws: Support SMS in SNS Topic Subscription protocols

### DIFF
--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/validators.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/validators.go
@@ -745,7 +745,7 @@ func validateSQSFifoQueueName(v interface{}, k string) (errors []error) {
 
 func validateSNSSubscriptionProtocol(v interface{}, k string) (ws []string, errors []error) {
 	value := strings.ToLower(v.(string))
-	forbidden := []string{"email", "sms"}
+	forbidden := []string{"email"}
 	for _, f := range forbidden {
 		if strings.Contains(value, f) {
 			errors = append(


### PR DESCRIPTION
Since June 2016 SMS recipients no longer need to opt-in to SNS. See also

https://aws.amazon.com/blogs/aws/new-worldwide-delivery-of-amazon-sns-messages-via-sms/

We also need another PR to update documentation (https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html).