### PR TITLE
some consul lock improvements

### DIFF
--- a/backend/remote-state/consul/backend.go
+++ b/backend/remote-state/consul/backend.go
@@ -120,11 +120,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	config := consulapi.DefaultConfig()
 
 	// replace the default Transport Dialer to reduce the KeepAlive
-
-	config.Transport.DialContext = (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 17 * time.Second,
-	}).DialContext
+	config.Transport.DialContext = dialContext
 
 	if v, ok := data.GetOk("access_token"); ok && v.(string) != "" {
 		config.Token = v.(string)
@@ -175,3 +171,10 @@ func (b *Backend) configure(ctx context.Context) error {
 	b.client = client
 	return nil
 }
+
+// dialContext is the DialContext function for the consul client transport.
+// This is stored in a package var to inject a different dialer for tests.
+var dialContext = (&net.Dialer{
+	Timeout:   30 * time.Second,
+	KeepAlive: 17 * time.Second,
+}).DialContext

--- a/backend/remote-state/consul/backend.go
+++ b/backend/remote-state/consul/backend.go
@@ -2,7 +2,9 @@ package consul
 
 import (
 	"context"
+	"net"
 	"strings"
+	"time"
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform/backend"
@@ -100,6 +102,7 @@ type Backend struct {
 	*schema.Backend
 
 	// The fields below are set from configure
+	client     *consulapi.Client
 	configData *schema.ResourceData
 	lock       bool
 }
@@ -111,16 +114,18 @@ func (b *Backend) configure(ctx context.Context) error {
 	// Store the lock information
 	b.lock = b.configData.Get("lock").(bool)
 
-	// Initialize a client to test config
-	_, err := b.clientRaw()
-	return err
-}
-
-func (b *Backend) clientRaw() (*consulapi.Client, error) {
 	data := b.configData
 
 	// Configure the client
 	config := consulapi.DefaultConfig()
+
+	// replace the default Transport Dialer to reduce the KeepAlive
+
+	config.Transport.DialContext = (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 17 * time.Second,
+	}).DialContext
+
 	if v, ok := data.GetOk("access_token"); ok && v.(string) != "" {
 		config.Token = v.(string)
 	}
@@ -162,5 +167,11 @@ func (b *Backend) clientRaw() (*consulapi.Client, error) {
 		}
 	}
 
-	return consulapi.NewClient(config)
+	client, err := consulapi.NewClient(config)
+	if err != nil {
+		return err
+	}
+
+	b.client = client
+	return nil
 }

--- a/backend/remote-state/consul/backend_state.go
+++ b/backend/remote-state/consul/backend_state.go
@@ -85,6 +85,11 @@ func (b *Backend) State(name string) (state.State, error) {
 		stateMgr = &state.LockDisabled{Inner: stateMgr}
 	}
 
+	// the default state always exists
+	if name == backend.DefaultStateName {
+		return stateMgr, nil
+	}
+
 	// Grab a lock, we use this to write an empty state if one doesn't
 	// exist already. We have to write an empty state as a sentinel value
 	// so States() knows it exists.

--- a/backend/remote-state/consul/client.go
+++ b/backend/remote-state/consul/client.go
@@ -32,6 +32,8 @@ const (
 	lockReacquireInterval = 2 * time.Second
 )
 
+var lostLockErr = errors.New("consul lock was lost")
+
 // RemoteClient is a remote client that stores data in Consul.
 type RemoteClient struct {
 	Client *consulapi.Client
@@ -409,7 +411,7 @@ func (c *RemoteClient) unlock(id string) error {
 
 	select {
 	case <-c.lockCh:
-		return errors.New("consul lock was lost")
+		return lostLockErr
 	default:
 	}
 

--- a/backend/remote-state/consul/client.go
+++ b/backend/remote-state/consul/client.go
@@ -228,6 +228,9 @@ func (c *RemoteClient) lock() (string, error) {
 		return "", err
 	}
 
+	// store the session ID for correlation with consul logs
+	c.info.Info = "consul session: " + lockSession
+
 	opts := &consulapi.LockOptions{
 		Key:     c.Path + lockSuffix,
 		Session: lockSession,

--- a/backend/remote-state/consul/client_test.go
+++ b/backend/remote-state/consul/client_test.go
@@ -176,6 +176,7 @@ func TestConsul_lostLock(t *testing.T) {
 	reLocked := make(chan struct{})
 	testLockHook = func() {
 		close(reLocked)
+		testLockHook = nil
 	}
 
 	// now we use the second client to break the lock


### PR DESCRIPTION
- Only initialize a single consul client in the backend, which will help with connection pooling.
- Lower the TCP KeepAlive duration. The default of 30s coincides with common network timeouts, and may be racing to keep the connection open.
- Add a test showing that the lock can be lost on certain patterns of network errors. This test will fail once the consul client is updated.

While simply lowering the KeepAlive duration may be enough to superficially fix #16098, an updated consul client should complete that issue. 