### PR TITLE
scripts: helper for launching Terraform in the dlv debugger

### DIFF
--- a/scripts/debug-terraform
+++ b/scripts/debug-terraform
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# This is a helper script to launch Terraform inside the "dlv" debugger,
+# configured to await a remote debugging connection on port 2345. You can
+# then connect to it using the following command, or its equivalent in your
+# debugging frontend of choice:
+#    dlv connect 127.0.0.1:2345
+#
+# This tool does not install dlv. To install it, see its instructions:
+#    https://github.com/derekparker/delve/tree/master/Documentation/installation
+#
+# For more convenient use, you may wish to put this script in your PATH:
+#    ln -s ../src/github.com/hashicorp/terraform/scripts/debug-terraform $GOPATH/bin/debug-terraform
+#
+# Note that when running this script the Terraform binary is NOT in $GOPATH/bin,
+# so any providers installed there won't be found unless Terraform searches
+# there for some _other_ reason.
+
+set -eu
+
+# Make sure we're debugging the process where the code is actually running.
+# (This also, as a side effect, causes raw logs to go directly to stderr,
+# and panics to be expressed directly, since we lose the log/panic wrapper.)
+export TF_FORK=0
+
+echo "Launching Terraform in a headless debug session"
+echo "Connect to it using: dlv connect 127.0.0.1:2345"
+echo "(Terraform takes a long time to build and launch in this mode; some logs will appear below)"
+echo "---------------------------"
+
+exec dlv debug github.com/hashicorp/terraform --headless --listen :2345 --log -- "$@"


### PR DESCRIPTION
This launches Terraform inside a headless dlv configured to accept a remote debugging process. It's configured this way so it can be easily used from a debugger GUI integrated into an IDE/editor, but it can also be used from the CLI by running the command it prints.

Using a remote debugger here is useful even when debugging with the CLI, since it keeps Terraform's verbose and colorful output from interfering with the debugger UI.