### PR TITLE
Get the enviroment from the environment variable

### DIFF
--- a/backend/remote-state/azure/backend.go
+++ b/backend/remote-state/azure/backend.go
@@ -39,7 +39,7 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The Azure cloud environment.",
-				Default:     schame.EnvDefaultFunc("ARM_ENVIRONMENT", ""),
+				DefaultFunc: schema.EnvDefaultFunc("ARM_ENVIRONMENT", ""),
 			},
 
 			"access_key": {

--- a/backend/remote-state/azure/backend.go
+++ b/backend/remote-state/azure/backend.go
@@ -39,7 +39,7 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The Azure cloud environment.",
-				Default:     "",
+				Default:     schame.EnvDefaultFunc("ARM_ENVIRONMENT", ""),
 			},
 
 			"access_key": {


### PR DESCRIPTION
It looks like the ARM_ENVIRONMENT was ignored. According to the documentation, this variable can be set instead of manually setting it in the resource.

