### PR TITLE
config: when copying a HCL2 RawConfig, don't corrupt it

### DIFF
--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -111,6 +111,10 @@ func (r *RawConfig) Copy() *RawConfig {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
+	if r.Body != nil {
+		return NewRawConfigHCL2(r.Body)
+	}
+
 	newRaw := make(map[string]interface{})
 	for k, v := range r.Raw {
 		newRaw[k] = v

--- a/config/raw_config_test.go
+++ b/config/raw_config_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	hcl2 "github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hil/ast"
 )
 
@@ -432,6 +433,18 @@ func TestRawConfigCopy(t *testing.T) {
 		if rc2.Value() != "qux" {
 			t.Fatalf("bad: %#v", rc2.Value())
 		}
+	}
+}
+
+func TestRawConfigCopyHCL2(t *testing.T) {
+	rc := NewRawConfigHCL2(hcl2.EmptyBody())
+	rc2 := rc.Copy()
+
+	if rc.Body == nil {
+		t.Errorf("RawConfig copy has a nil Body")
+	}
+	if rc2.Raw != nil {
+		t.Errorf("RawConfig copy got a non-nil Raw")
 	}
 }
 


### PR DESCRIPTION
Previously we were demoting HCL2 `RawConfig`s into empty old-school `RawConfig`s on copy.
