### PR TITLE
config: source code ranges for InterpolatedVariable

### DIFF
--- a/config/interpolate.go
+++ b/config/interpolate.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform/tfdiags"
+
 	"github.com/hashicorp/hil/ast"
 )
 
@@ -14,6 +16,21 @@ import (
 // variables can come from: user variables, resources, etc.
 type InterpolatedVariable interface {
 	FullKey() string
+	SourceRange() tfdiags.SourceRange
+}
+
+// varRange can be embedded into an InterpolatedVariable implementation to
+// implement the SourceRange method.
+type varRange struct {
+	rng tfdiags.SourceRange
+}
+
+func (r varRange) SourceRange() tfdiags.SourceRange {
+	return r.rng
+}
+
+func makeVarRange(rng tfdiags.SourceRange) varRange {
+	return varRange{rng}
 }
 
 // CountVariable is a variable for referencing information about
@@ -21,6 +38,7 @@ type InterpolatedVariable interface {
 type CountVariable struct {
 	Type CountValueType
 	key  string
+	varRange
 }
 
 // CountValueType is the type of the count variable that is referenced.
@@ -37,6 +55,7 @@ type ModuleVariable struct {
 	Name  string
 	Field string
 	key   string
+	varRange
 }
 
 // A PathVariable is a variable that references path information about the
@@ -44,6 +63,7 @@ type ModuleVariable struct {
 type PathVariable struct {
 	Type PathValueType
 	key  string
+	varRange
 }
 
 type PathValueType byte
@@ -67,6 +87,7 @@ type ResourceVariable struct {
 	Index int  // Index for multi-variable: aws_instance.foo.1.id == 1
 
 	key string
+	varRange
 }
 
 // SelfVariable is a variable that is referencing the same resource
@@ -75,6 +96,7 @@ type SelfVariable struct {
 	Field string
 
 	key string
+	varRange
 }
 
 // SimpleVariable is an unprefixed variable, which can show up when users have
@@ -82,6 +104,7 @@ type SelfVariable struct {
 // internally. The template_file resource is an example of this.
 type SimpleVariable struct {
 	Key string
+	varRange
 }
 
 // TerraformVariable is a "terraform."-prefixed variable used to access
@@ -89,6 +112,7 @@ type SimpleVariable struct {
 type TerraformVariable struct {
 	Field string
 	key   string
+	varRange
 }
 
 // A UserVariable is a variable that is referencing a user variable
@@ -99,12 +123,14 @@ type UserVariable struct {
 	Elem string
 
 	key string
+	varRange
 }
 
 // A LocalVariable is a variable that references a local value defined within
 // the current module, via a "locals" block. This looks like "${local.foo}".
 type LocalVariable struct {
 	Name string
+	varRange
 }
 
 func NewInterpolatedVariable(v string) (InterpolatedVariable, error) {
@@ -284,7 +310,7 @@ func (v *SelfVariable) GoString() string {
 }
 
 func NewSimpleVariable(key string) (*SimpleVariable, error) {
-	return &SimpleVariable{key}, nil
+	return &SimpleVariable{Key: key}, nil
 }
 
 func (v *SimpleVariable) FullKey() string {


### PR DESCRIPTION
Having a reference to the originating source range will allow us to generate decent error messages if certain references can't be resolved at interpolation time.

This is not yet populated or used. It will never be populated nor used by the current HCL/HIL-based interpolation path, but will be used by the experimental HCL2-based interpolation path to give it the necessary info to produce diagnostics.