### PR TITLE
Miscellaneous diagnostic printing improvements

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -205,7 +205,7 @@ func (c *ApplyCommand) Run(args []string) int {
 		}
 	case <-op.Done():
 		if err := op.Err; err != nil {
-			c.Ui.Error(err.Error())
+			c.showDiagnostics(err)
 			return 1
 		}
 	}

--- a/command/plan.go
+++ b/command/plan.go
@@ -113,7 +113,7 @@ func (c *PlanCommand) Run(args []string) int {
 	// Wait for the operation to complete
 	<-op.Done()
 	if err := op.Err; err != nil {
-		c.Ui.Error(err.Error())
+		c.showDiagnostics(err)
 		return 1
 	}
 

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -84,7 +84,7 @@ func (c *RefreshCommand) Run(args []string) int {
 	// Wait for the operation to complete
 	<-op.Done()
 	if err := op.Err; err != nil {
-		c.Ui.Error(err.Error())
+		c.showDiagnostics(err)
 		return 1
 	}
 

--- a/tfdiags/diagnostics.go
+++ b/tfdiags/diagnostics.go
@@ -148,12 +148,21 @@ func (dae diagnosticsAsError) Error() string {
 		// there are no diagnostics in the list.
 		return "no errors"
 	case len(diags) == 1:
-		return diags[0].Description().Summary
+		desc := diags[0].Description()
+		if desc.Detail == "" {
+			return desc.Summary
+		}
+		return fmt.Sprintf("%s: %s", desc.Summary, desc.Detail)
 	default:
 		var ret bytes.Buffer
 		fmt.Fprintf(&ret, "%d problems:\n", len(diags))
 		for _, diag := range dae.Diagnostics {
-			fmt.Fprintf(&ret, "\n- %s", diag.Description().Summary)
+			desc := diag.Description()
+			if desc.Detail == "" {
+				fmt.Fprintf(&ret, "\n- %s", desc.Summary)
+			} else {
+				fmt.Fprintf(&ret, "\n- %s: %s", desc.Summary, desc.Detail)
+			}
 		}
 		return ret.String()
 	}


### PR DESCRIPTION
```
    command: use c.showDiagnostics for backend operation errors
    
    This allows richer diagnostics produced by some subsystems to be displayed
    in full-fidelity to the user.
```

```
    tfdiags: show descriptions in diagnosticsAsError
    
    Previously we were showing only the summaries when converting to a string
    error, but HCL generates summaries that indicate only the _type_ of error,
    expecting that the detail will give the details, and so we need to show
    both in order to produce a useful error message.
```
