### PR TITLE
helper: Allow logs isolation per acceptance test

### DIFF
--- a/helper/logging/logging.go
+++ b/helper/logging/logging.go
@@ -18,7 +18,7 @@ const (
 	EnvLogFile = "TF_LOG_PATH" // Set to a file
 )
 
-var validLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
+var ValidLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
 
 // LogOutput determines where we should send logs (if anywhere) and the log level.
 func LogOutput() (logOutput io.Writer, err error) {
@@ -40,7 +40,7 @@ func LogOutput() (logOutput io.Writer, err error) {
 
 	// This was the default since the beginning
 	logOutput = &logutils.LevelFilter{
-		Levels:   validLevels,
+		Levels:   ValidLevels,
 		MinLevel: logutils.LogLevel(logLevel),
 		Writer:   logOutput,
 	}
@@ -77,7 +77,7 @@ func LogLevel() string {
 		logLevel = strings.ToUpper(envLevel)
 	} else {
 		log.Printf("[WARN] Invalid log level: %q. Defaulting to level: TRACE. Valid levels are: %+v",
-			envLevel, validLevels)
+			envLevel, ValidLevels)
 	}
 
 	return logLevel
@@ -90,7 +90,7 @@ func IsDebugOrHigher() bool {
 }
 
 func isValidLogLevel(level string) bool {
-	for _, l := range validLevels {
+	for _, l := range ValidLevels {
 		if strings.ToUpper(level) == string(l) {
 			return true
 		}

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -627,6 +627,10 @@ func (t *mockT) Skip(args ...interface{}) {
 	t.f = true
 }
 
+func (t *mockT) Name() string {
+	return "MockedName"
+}
+
 func (t *mockT) failed() bool {
 	return t.f
 }


### PR DESCRIPTION
## Why

We run nightly acceptance tests for and collect debug logs produced during the whole run. As we run tests in parallel for some providers (e.g. AWS), the **logs get written to the file in parallel too** which isn't very helpful for debugging, especially when you're trying to isolate a problem related to a single test and track down a chain of HTTP requests/responses and you have to skip unrelated messages just b/c another test happens to run at the same time.

This also means we only need to download a single ~0.5M file for the test that is actually failing instead of downloading debug log for the whole run (~650M in case of AWS).

## How

This patch allows us to use a new ENV variable:

```
TF_LOG_PATH_MASK=/log/location/tf-test-%s.log
```

I have considered the option of using templating (`/log/location/test-{{.TestName}}.log`)  instead of sprintf which would be _safer_ (we'd know if interpolation failed), but I treat this as initial version we can iterate on and potentially break the convention as it's only used during test runs, not by users, so we don't need to be worried as much about deprecation etc.

## Example

```
ls -lh ./*.log
-rw-r--r--  1 radeksimko  staff   592K Oct 14 16:49 tf-test-TestAccAWSBatchComputeEnvironment_createEc2.log
-rw-r--r--  1 radeksimko  staff   593K Oct 14 16:50 tf-test-TestAccAWSBatchComputeEnvironment_createEc2WithTags.log
-rw-r--r--  1 radeksimko  staff   392K Oct 14 16:58 tf-test-TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources.log
-rw-r--r--  1 radeksimko  staff   597K Oct 14 16:51 tf-test-TestAccAWSBatchComputeEnvironment_createSpot.log
-rw-r--r--  1 radeksimko  staff   396K Oct 14 17:00 tf-test-TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage.log
-rw-r--r--  1 radeksimko  staff   591K Oct 14 16:52 tf-test-TestAccAWSBatchComputeEnvironment_createUnmanaged.log
-rw-r--r--  1 radeksimko  staff   594K Oct 14 16:59 tf-test-TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources.log
-rw-r--r--  1 radeksimko  staff   964K Oct 14 16:58 tf-test-TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName.log
-rw-r--r--  1 radeksimko  staff   961K Oct 14 16:56 tf-test-TestAccAWSBatchComputeEnvironment_updateInstanceType.log
-rw-r--r--  1 radeksimko  staff   941K Oct 14 16:54 tf-test-TestAccAWSBatchComputeEnvironment_updateMaxvCpus.log
-rw-r--r--  1 radeksimko  staff   112K Oct 14 17:01 tf-test-TestAccAWSBatchJobDefinition_basic.log
-rw-r--r--  1 radeksimko  staff   199K Oct 14 17:01 tf-test-TestAccAWSBatchJobDefinition_updateForcesNewResource.log
-rw-r--r--  1 radeksimko  staff   560K Oct 14 17:03 tf-test-TestAccAWSBatchJobQueue_basic.log
-rw-r--r--  1 radeksimko  staff   882K Oct 14 17:05 tf-test-TestAccAWSBatchJobQueue_update.log
```

## Future

I reckon we might have more advanced/formalised tracing and logging which would allow the _user_ to send logs **with more context** somewhere they can process them more efficiently and easily in the future. This is IMO much bigger project and this patch isn't supposed to address that.