### PR TITLE
make //subdir notation work for registry modules

### DIFF
--- a/config/module/get.go
+++ b/config/module/get.go
@@ -87,8 +87,8 @@ var detectors = []getter.Detector{
 	new(getter.GitHubDetector),
 	new(getter.BitBucketDetector),
 	new(getter.S3Detector),
-	new(localDetector),
 	new(registryDetector),
+	new(localDetector),
 }
 
 // these prefixes can't be registry IDs

--- a/config/module/get.go
+++ b/config/module/get.go
@@ -92,8 +92,8 @@ var detectors = []getter.Detector{
 }
 
 // these prefixes can't be registry IDs
-// "http", "./", "/", "getter::"
-var skipRegistry = regexp.MustCompile(`^(http|\./|/|[A-Za-z0-9]+::)`).MatchString
+// "http", "../", "./", "/", "getter::", etc
+var skipRegistry = regexp.MustCompile(`^(http|[.]{1,2}/|/|[A-Za-z0-9]+::)`).MatchString
 
 // registryDetector implements getter.Detector to detect Terraform Registry modules.
 // If a path looks like a registry module identifier, attempt to locate it in

--- a/config/module/test-fixtures/discover-registry-local/exists-in-registry/identifier/provider/main.tf
+++ b/config/module/test-fixtures/discover-registry-local/exists-in-registry/identifier/provider/main.tf
@@ -1,0 +1,3 @@
+output "local" {
+	value = "test"
+}

--- a/config/module/test-fixtures/discover-registry-local/main.tf
+++ b/config/module/test-fixtures/discover-registry-local/main.tf
@@ -1,0 +1,3 @@
+module "provider" {
+	source = "exists-in-registry/identifier/provider"
+}

--- a/config/module/test-fixtures/registry-subdir/main.tf
+++ b/config/module/test-fixtures/registry-subdir/main.tf
@@ -1,0 +1,4 @@
+module "foo" {
+	// the mock test registry will redirect this to the local tar file
+    source = "registry/local/sub//baz"
+}

--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -241,14 +241,9 @@ func (t *Tree) Load(s getter.Storage, mode GetMode) error {
 		// For example, the registry always adds a subdir of `//*`,
 		// indicating that we need to strip off the first component from the
 		// tar archive, though we may not yet know what it is called.
-		//
-		// TODO: This can cause us to lose the previously detected subdir. It
-		// was never an issue before, since none of the supported detectors
-		// previously had this behavior, but we may want to add this ability to
-		// registry modules.
-		source, subDir2 := getter.SourceDirSubdir(source)
-		if subDir2 != "" {
-			subDir = subDir2
+		source, detectedSubDir := getter.SourceDirSubdir(source)
+		if detectedSubDir != "" {
+			subDir = filepath.Join(detectedSubDir, subDir)
 		}
 
 		log.Printf("[TRACE] getting module source %q", source)

--- a/config/module/tree_test.go
+++ b/config/module/tree_test.go
@@ -705,3 +705,8 @@ root
   foo (path: foo)
     bar (path: foo, bar)
 `
+
+const treeLoadRegistrySubdirStr = `
+root
+  foo (path: foo)
+`


### PR DESCRIPTION
This makes the subdir notation work for registry modules.

It also instates the correct search order for registry modules, preventing local folders from possibly loading when a registry module is desired, and allowing us to surface any registry errors rather than only leaving warnings in the logs. 