### PR TITLE
Support for path style S3 bucket address

### DIFF
--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -150,6 +150,13 @@ func New() backend.Backend {
 				Default:     false,
 			},
 
+			"s3_force_path_style": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Force path style S3 bucket address.",
+				Default:     false,
+			},
+
 			"role_arn": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -245,6 +252,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		SkipGetEC2Platforms:     data.Get("skip_get_ec2_platforms").(bool),
 		SkipRequestingAccountId: data.Get("skip_requesting_account_id").(bool),
 		SkipMetadataApiCheck:    data.Get("skip_metadata_api_check").(bool),
+		S3ForcePathStyle:        data.Get("s3_force_path_style").(bool),
 	}
 
 	client, err := cfg.Client()


### PR DESCRIPTION
Added flag to allow s3 bucket address to be created with bucket name in path i.e. http(s)://s3.amazonaws.com/<bucket>/<object>. This style of addressing is required by non-AWS S3 distributions such as Minio.