### PR TITLE
Configure service host credentials using the CLI Config file

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 	"os/signal"
 
@@ -361,9 +362,11 @@ func credentialsSource(config *Config) auth.CredentialsSource {
 	}
 
 	for helperType, helperConfig := range config.CredentialsHelpers {
+		log.Printf("[DEBUG] Searching for credentials helper named %q", helperType)
 		available := pluginDiscovery.FindPlugins("credentials", globalPluginDirs())
 		available = available.WithName(helperType)
 		if available.Count() == 0 {
+			log.Printf("[ERROR] Unable to find credentials helper %q; ignoring", helperType)
 			break
 		}
 

--- a/config.go
+++ b/config.go
@@ -27,6 +27,15 @@ type Config struct {
 	// If set, enables local caching of plugins in this directory to
 	// avoid repeatedly re-downloading over the Internet.
 	PluginCacheDir string `hcl:"plugin_cache_dir"`
+
+	Credentials        map[string]map[string]interface{}   `hcl:"credentials"`
+	CredentialsHelpers map[string]*ConfigCredentialsHelper `hcl:"credentials_helper"`
+}
+
+// ConfigCredentialsHelper is the structure of the "credentials_helper"
+// nested block within the CLI configuration.
+type ConfigCredentialsHelper struct {
+	Args []string `hcl:"args"`
 }
 
 // BuiltinConfig is the built-in defaults for the configuration. These

--- a/config.go
+++ b/config.go
@@ -147,5 +147,28 @@ func (c1 *Config) Merge(c2 *Config) *Config {
 		result.PluginCacheDir = c2.PluginCacheDir
 	}
 
+	if (len(c1.Credentials) + len(c2.Credentials)) > 0 {
+		result.Credentials = make(map[string]map[string]interface{})
+		for host, creds := range c1.Credentials {
+			result.Credentials[host] = creds
+		}
+		for host, creds := range c2.Credentials {
+			// We just clobber an entry from the other file right now. Will
+			// improve on this later using the more-robust merging behavior
+			// built in to HCL2.
+			result.Credentials[host] = creds
+		}
+	}
+
+	if (len(c1.CredentialsHelpers) + len(c2.CredentialsHelpers)) > 0 {
+		result.CredentialsHelpers = make(map[string]*ConfigCredentialsHelper)
+		for name, helper := range c1.CredentialsHelpers {
+			result.CredentialsHelpers[name] = helper
+		}
+		for name, helper := range c2.CredentialsHelpers {
+			result.CredentialsHelpers[name] = helper
+		}
+	}
+
 	return &result
 }

--- a/config_test.go
+++ b/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // This is the directory where our test fixtures are.
@@ -49,6 +51,34 @@ func TestLoadConfig_env(t *testing.T) {
 
 	if !reflect.DeepEqual(c, expected) {
 		t.Fatalf("bad: %#v", c)
+	}
+}
+
+func TestLoadConfig_credentials(t *testing.T) {
+	got, err := LoadConfig(filepath.Join(fixtureDir, "credentials"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &Config{
+		Credentials: map[string]map[string]interface{}{
+			"example.com": map[string]interface{}{
+				"token": "foo the bar baz",
+			},
+			"example.net": map[string]interface{}{
+				"username": "foo",
+				"password": "baz",
+			},
+		},
+		CredentialsHelpers: map[string]*ConfigCredentialsHelper{
+			"foo": &ConfigCredentialsHelper{
+				Args: []string{"bar", "baz"},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("wrong result\ngot:  %swant: %s", spew.Sdump(got), spew.Sdump(want))
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -92,6 +92,14 @@ func TestConfig_Merge(t *testing.T) {
 			"local":  "local",
 			"remote": "bad",
 		},
+		Credentials: map[string]map[string]interface{}{
+			"foo": {
+				"bar": "baz",
+			},
+		},
+		CredentialsHelpers: map[string]*ConfigCredentialsHelper{
+			"buz": {},
+		},
 	}
 
 	c2 := &Config{
@@ -101,6 +109,14 @@ func TestConfig_Merge(t *testing.T) {
 		},
 		Provisioners: map[string]string{
 			"remote": "remote",
+		},
+		Credentials: map[string]map[string]interface{}{
+			"fee": {
+				"bur": "bez",
+			},
+		},
+		CredentialsHelpers: map[string]*ConfigCredentialsHelper{
+			"biz": {},
 		},
 	}
 
@@ -113,6 +129,18 @@ func TestConfig_Merge(t *testing.T) {
 		Provisioners: map[string]string{
 			"local":  "local",
 			"remote": "remote",
+		},
+		Credentials: map[string]map[string]interface{}{
+			"foo": {
+				"bar": "baz",
+			},
+			"fee": {
+				"bur": "bez",
+			},
+		},
+		CredentialsHelpers: map[string]*ConfigCredentialsHelper{
+			"buz": {},
+			"biz": {},
 		},
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -13,7 +13,7 @@ import (
 const fixtureDir = "./test-fixtures"
 
 func TestLoadConfig(t *testing.T) {
-	c, err := LoadConfig(filepath.Join(fixtureDir, "config"))
+	c, err := loadConfigFile(filepath.Join(fixtureDir, "config"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -34,7 +34,7 @@ func TestLoadConfig_env(t *testing.T) {
 	defer os.Unsetenv("TFTEST")
 	os.Setenv("TFTEST", "hello")
 
-	c, err := LoadConfig(filepath.Join(fixtureDir, "config-env"))
+	c, err := loadConfigFile(filepath.Join(fixtureDir, "config-env"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -55,7 +55,7 @@ func TestLoadConfig_env(t *testing.T) {
 }
 
 func TestLoadConfig_credentials(t *testing.T) {
-	got, err := LoadConfig(filepath.Join(fixtureDir, "credentials"))
+	got, err := loadConfigFile(filepath.Join(fixtureDir, "credentials"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test-fixtures/credentials
+++ b/test-fixtures/credentials
@@ -1,0 +1,17 @@
+
+credentials "example.com" {
+  token = "foo the bar baz"
+}
+
+credentials "example.net" {
+  # Username and password are not currently supported, but we want to tolerate
+  # unknown keys in case future versions add new keys when both old and new
+  # versions of Terraform are installed on a system, sharing the same
+  # CLI config.
+  username = "foo"
+  password = "baz"
+}
+
+credentials_helper "foo" {
+  args = ["bar", "baz"]
+}


### PR DESCRIPTION
In #16368 we added some new packages for dealing with discovery and authentication for so-called "service hosts", where Terraform-native services such as the module registry are served.

This follow-up set of changes makes it possible to configure the authentication credentials within the CLI config file, using new blocks `credentials` and `credentials_helper`.

In addition, we also allow multiple CLI config files by looking for files matching `~/.terraform.d/*.tfrc` and `~/.terraform.d/*.tfrc.json` (or the usual equivalent on Windows) so that it's possible to keep credentials in a separate file from other settings, and possibly to spread credentials blocks across multiple separate files for easier management.

Along the way here I also took the opportunity to do some light restructuring of the config-loading code, since it was becoming quite noisy embedded inside the `main` function. It's now using our new diagnostics abstraction to report errors, with the intent that when we later update the CLI config loader to use the HCL2 API we can pass through the richer error and warning information it is able to produce. For now, it just allows us to return potentially multiple errors if e.g. multiple files contain syntax errors.
