### PR TITLE
Fix panic when running `init` in a dir containing only overrides

### DIFF
--- a/config/loader.go
+++ b/config/loader.go
@@ -80,7 +80,7 @@ func LoadDir(root string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(files) == 0 {
+	if len(files) == 0 && len(overrides) == 0 {
 		return nil, &ErrNoConfigsFound{Dir: root}
 	}
 
@@ -111,6 +111,9 @@ func LoadDir(root string) (*Config, error) {
 		} else {
 			result = c
 		}
+	}
+	if len(files) == 0 {
+		result = &Config{}
 	}
 
 	// Load all the overrides, and merge them into the config

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -1022,6 +1022,22 @@ func TestLoad_jsonAttributes(t *testing.T) {
 	}
 }
 
+func TestLoad_onlyOverride(t *testing.T) {
+	c, err := LoadDir(filepath.Join(fixtureDir, "dir-only-override"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c == nil {
+		t.Fatal("config should not be nil")
+	}
+
+	actual := variablesStr(c.Variables)
+	if actual != strings.TrimSpace(dirOnlyOverrideVariablesStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 const jsonAttributeStr = `
 cloudstack_firewall.test (x1)
   ipaddress
@@ -1226,6 +1242,12 @@ foo
 const dirOverrideVarsVariablesStr = `
 foo
   baz
+  bar
+`
+
+const dirOnlyOverrideVariablesStr = `
+foo
+  bar
   bar
 `
 

--- a/config/test-fixtures/dir-only-override/main_override.tf
+++ b/config/test-fixtures/dir-only-override/main_override.tf
@@ -1,0 +1,4 @@
+variable "foo" {
+    default = "bar"
+    description = "bar"
+}


### PR DESCRIPTION
- Steps to reproduce:
  - mkdir tf-test && cd tf-test
  - touch empty_override.tf
  - terraform init
  - Verify command panics