### PR TITLE
Improve performance of dev builds by ~20%...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
 - make test
 - make e2etest
 - make vet
-- GOOS=windows go build
+- GOGC=off GOOS=windows go build
 branches:
   only:
   - master

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ bin: fmtcheck generate
 # dev creates binaries for testing Terraform locally. These are put
 # into ./bin/ as well as $GOPATH/bin
 dev: fmtcheck generate
-	@TF_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
+	@env GOGC=off TF_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
 quickdev: generate
-	@TF_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
+	@env GOGC=off TF_DEV=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
 # Shorthand for building and installing just one plugin for local testing.
 # Run as (for example): make plugin-dev PLUGIN=provider-aws

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ plugin-dev: generate
 # we run this one package at a time here because running the entire suite in
 # one command creates memory usage issues when running in Travis-CI.
 test: fmtcheck generate
-	go test -i $(TEST) || exit 1
-	go list $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=60s -parallel=4
+	GOGC=off go test -i $(TEST) || exit 1
+	GOGC=off go list $(TEST) | env GOGC=off xargs -t -n4 go test $(TESTARGS) -timeout=60s -parallel=4
 
 # testacc runs acceptance tests
 testacc: fmtcheck generate

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ testacc: fmtcheck generate
 # The TF_ACC here allows network access, but does not require any special
 # credentials since the e2etests use local-only providers such as "null".
 e2etest: generate
-	TF_ACC=1 go test -v ./command/e2etest
+	GOGC=off TF_ACC=1 go test -v ./command/e2etest
 
 test-compile: fmtcheck generate
 	@if [ "$(TEST)" = "./..." ]; then \
@@ -72,7 +72,7 @@ cover:
 # any common errors.
 vet:
 	@echo 'go vet ./...'
-	@go vet ./... ; if [ $$? -eq 1 ]; then \
+	@GOGC=off go vet ./... ; if [ $$? -eq 1 ]; then \
 		echo ""; \
 		echo "Vet found suspicious constructs. Please check the reported constructs"; \
 		echo "and fix them if necessary before submitting the code for review."; \
@@ -85,8 +85,8 @@ generate:
 	@which stringer > /dev/null; if [ $$? -ne 0 ]; then \
 	  go get -u golang.org/x/tools/cmd/stringer; \
 	fi
-	go generate ./...
-	@go fmt command/internal_plugin_list.go > /dev/null
+	GOGC=off go generate ./...
+	@GOGC=off go fmt command/internal_plugin_list.go > /dev/null
 
 fmt:
 	gofmt -w $(GOFMT_FILES)
@@ -95,7 +95,7 @@ fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
 vendor-status:
-	@govendor status
+	@GOGC=off govendor status
 
 # disallow any parallelism (-j) for Make. This is necessary since some
 # commands during the build process create temporary files that collide


### PR DESCRIPTION
At the expense of ~150MB of RAM improve the performance of compiling Terraform by ~20%.  Before this change the peak memory consumption appears to be `link` coming in at ~1.2GB of RAM.  With this change both `compile` and `link` take ~1.3GB of RAM.  The extra 100MB of RAM is justifiable given the improvements to build times.  With the new parallel compiler in Go 1.9 the improvement to wall clock time is not as significant, but the user time and power consumption on laptops should go down as a result of this change, too (see the first commit for userland CPU time, vs wall clock times reported below).

```
$ gmake dev
Total time                              : 0:55.36s
```

Time with patch:

```
$ gmake dev
Total time                              : 0:46.73s
```

This PR only makes this change for the `dev` and `quickdev` targets.