### PR TITLE
more module storage updates

### DIFF
--- a/config/module/get.go
+++ b/config/module/get.go
@@ -64,18 +64,6 @@ func GetCopy(dst, src string) error {
 	return copyDir(dst, tmpDir)
 }
 
-func getStorage(s getter.Storage, key string, src string, mode GetMode) (string, bool, error) {
-	// Get the module with the level specified if we were told to.
-	if mode > GetModeNone {
-		if err := s.Get(key, src, mode == GetModeUpdate); err != nil {
-			return "", false, err
-		}
-	}
-
-	// Get the directory where the module is.
-	return s.Dir(key)
-}
-
 const (
 	registryAPI   = "https://registry.terraform.io/v1/modules"
 	xTerraformGet = "X-Terraform-Get"

--- a/config/module/storage.go
+++ b/config/module/storage.go
@@ -44,7 +44,7 @@ type moduleRecord struct {
 	Root string
 }
 
-// moduleStorgae implements methods to record and fetch metadata about the
+// moduleStorage implements methods to record and fetch metadata about the
 // modules that have been fetched and stored locally. The getter.Storgae
 // abstraction doesn't provide the information needed to know which versions of
 // a module have been stored, or their location.
@@ -162,4 +162,19 @@ func (m moduleStorage) recordModuleRoot(dir, root string) error {
 	}
 
 	return m.recordModule(rec)
+}
+
+func (m moduleStorage) getStorage(key string, src string, mode GetMode) (string, bool, error) {
+	// Get the module with the level specified if we were told to.
+	if mode > GetModeNone {
+		log.Printf("[DEBUG] fetching %q with key %q", src, key)
+		if err := m.Storage.Get(key, src, mode == GetModeUpdate); err != nil {
+			return "", false, err
+		}
+	}
+
+	// Get the directory where the module is.
+	dir, found, err := m.Storage.Dir(key)
+	log.Printf("[DEBUG] found %q in %q: %t", src, dir, found)
+	return dir, found, err
 }

--- a/config/module/storage.go
+++ b/config/module/storage.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 )
 
+const manifestName = "modules.json"
+
 // moduleManifest is the serialization structure used to record the stored
 // module's metadata.
 type moduleManifest struct {
@@ -39,21 +41,19 @@ type moduleRecord struct {
 	Root string
 }
 
-// Return the path to the manifest in parent of the storage directory dir.
-func moduleManifestPath(dir string) string {
-	const filename = "modules.json"
-	// Get the parent directory.
-	// The current FolderStorage implementation needed to be able to create
-	// this directory, so we can be reasonably certain we can use it.
-	parent := filepath.Dir(filepath.Clean(dir))
-	return filepath.Join(parent, filename)
+// moduleStorgae implements methods to record and fetch metadata about the
+// modules that have been fetched and stored locally. The getter.Storgae
+// abstraction doesn't provide the information needed to know which versions of
+// a module have been stored, or their location.
+type moduleStorage struct {
+	storageDir string
 }
 
 // loadManifest returns the moduleManifest file from the parent directory.
-func loadManifest(dir string) (moduleManifest, error) {
+func (m moduleStorage) loadManifest() (moduleManifest, error) {
 	manifest := moduleManifest{}
 
-	manifestPath := moduleManifestPath(dir)
+	manifestPath := filepath.Join(m.storageDir, manifestName)
 	data, err := ioutil.ReadFile(manifestPath)
 	if err != nil && !os.IsNotExist(err) {
 		return manifest, err
@@ -73,50 +73,50 @@ func loadManifest(dir string) (moduleManifest, error) {
 // root directory. The storage method loads the entire file and rewrites it
 // each time. This is only done a few times during init, so efficiency is
 // not a concern.
-func recordModule(dir string, m moduleRecord) error {
-	manifest, err := loadManifest(dir)
+func (m moduleStorage) recordModule(rec moduleRecord) error {
+	manifest, err := m.loadManifest()
 	if err != nil {
 		// if there was a problem with the file, we will attempt to write a new
 		// one. Any non-data related error should surface there.
-		log.Printf("[WARN] error reading module manifest from %q: %s", dir, err)
+		log.Printf("[WARN] error reading module manifest: %s", err)
 	}
 
 	// do nothing if we already have the exact module
 	for i, stored := range manifest.Modules {
-		if m == stored {
+		if rec == stored {
 			return nil
 		}
 
 		// they are not equal, but if the storage path is the same we need to
-		// remove this record to be replaced.
-		if m.Dir == stored.Dir {
+		// remove this rec to be replaced.
+		if rec.Dir == stored.Dir {
 			manifest.Modules[i] = manifest.Modules[len(manifest.Modules)-1]
 			manifest.Modules = manifest.Modules[:len(manifest.Modules)-1]
 			break
 		}
 	}
 
-	manifest.Modules = append(manifest.Modules, m)
+	manifest.Modules = append(manifest.Modules, rec)
 
 	js, err := json.Marshal(manifest)
 	if err != nil {
 		panic(err)
 	}
 
-	manifestPath := moduleManifestPath(dir)
+	manifestPath := filepath.Join(m.storageDir, manifestName)
 	return ioutil.WriteFile(manifestPath, js, 0644)
 }
 
 // return only the root directory of the module stored in dir.
-func getModuleRoot(dir string) (string, error) {
-	manifest, err := loadManifest(dir)
+func (m moduleStorage) getModuleRoot(dir string) (string, error) {
+	manifest, err := m.loadManifest()
 	if err != nil {
 		return "", err
 	}
 
-	for _, m := range manifest.Modules {
-		if m.Dir == dir {
-			return m.Root, nil
+	for _, mod := range manifest.Modules {
+		if mod.Dir == dir {
+			return mod.Root, nil
 		}
 	}
 	return "", nil
@@ -124,11 +124,11 @@ func getModuleRoot(dir string) (string, error) {
 
 // record only the Root directory for the module stored at dir.
 // TODO: remove this compatibility function to store the full moduleRecord.
-func recordModuleRoot(dir, root string) error {
-	m := moduleRecord{
+func (m moduleStorage) recordModuleRoot(dir, root string) error {
+	rec := moduleRecord{
 		Dir:  dir,
 		Root: root,
 	}
 
-	return recordModule(dir, m)
+	return m.recordModule(rec)
 }

--- a/config/module/test-fixtures/conficting-submodule-names/a/c/main.tf
+++ b/config/module/test-fixtures/conficting-submodule-names/a/c/main.tf
@@ -1,0 +1,1 @@
+resource "test_instance" "a-c" {}

--- a/config/module/test-fixtures/conficting-submodule-names/a/main.tf
+++ b/config/module/test-fixtures/conficting-submodule-names/a/main.tf
@@ -1,0 +1,3 @@
+module "c" {
+  source = "./c"
+}

--- a/config/module/test-fixtures/conficting-submodule-names/b/c/main.tf
+++ b/config/module/test-fixtures/conficting-submodule-names/b/c/main.tf
@@ -1,0 +1,1 @@
+resource "test_instance" "b-c" {}

--- a/config/module/test-fixtures/conficting-submodule-names/b/main.tf
+++ b/config/module/test-fixtures/conficting-submodule-names/b/main.tf
@@ -1,0 +1,3 @@
+module "c" {
+  source = "./c"
+}

--- a/config/module/test-fixtures/conficting-submodule-names/main.tf
+++ b/config/module/test-fixtures/conficting-submodule-names/main.tf
@@ -1,0 +1,7 @@
+module "a" {
+  source = "./a"
+}
+
+module "b" {
+  source = "./b"
+}

--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -248,7 +248,7 @@ func (t *Tree) Load(storage getter.Storage, mode GetMode) error {
 
 		log.Printf("[TRACE] getting module source %q", source)
 
-		dir, ok, err := getStorage(s, key, source, mode)
+		dir, ok, err := s.getStorage(key, source, mode)
 		if err != nil {
 			return err
 		}

--- a/config/module/tree_test.go
+++ b/config/module/tree_test.go
@@ -271,15 +271,17 @@ func TestTree_recordManifest(t *testing.T) {
 	}
 	defer os.RemoveAll(td)
 
+	storage := moduleStorage{storageDir: td}
+
 	dir := filepath.Join(td, "0131bf0fef686e090b16bdbab4910ddf")
 
 	subDir := "subDirName"
 
 	// record and read the subdir path
-	if err := recordModuleRoot(dir, subDir); err != nil {
+	if err := storage.recordModuleRoot(dir, subDir); err != nil {
 		t.Fatal(err)
 	}
-	actual, err := getModuleRoot(dir)
+	actual, err := storage.getModuleRoot(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,10 +292,10 @@ func TestTree_recordManifest(t *testing.T) {
 
 	// overwrite the path, and nmake sure we get the new one
 	subDir = "newSubDir"
-	if err := recordModuleRoot(dir, subDir); err != nil {
+	if err := storage.recordModuleRoot(dir, subDir); err != nil {
 		t.Fatal(err)
 	}
-	actual, err = getModuleRoot(dir)
+	actual, err = storage.getModuleRoot(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,21 +305,21 @@ func TestTree_recordManifest(t *testing.T) {
 	}
 
 	// create a fake entry
-	if err := ioutil.WriteFile(moduleManifestPath(dir), []byte("BAD DATA"), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(td, manifestName), []byte("BAD DATA"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	// this should fail because there aare now 2 entries
-	actual, err = getModuleRoot(dir)
+	actual, err = storage.getModuleRoot(dir)
 	if err == nil {
 		t.Fatal("expected multiple subdir entries")
 	}
 
 	// writing the subdir entry should remove the incorrect value
-	if err := recordModuleRoot(dir, subDir); err != nil {
+	if err := storage.recordModuleRoot(dir, subDir); err != nil {
 		t.Fatal(err)
 	}
-	actual, err = getModuleRoot(dir)
+	actual, err = storage.getModuleRoot(dir)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is another attempt to get just enough access to the module storage layer without completely ripping out the getter.Storage interface. While that interface may need to go away, it's too intrusive a change at the moment.

The module manifest needs to be read before we have loaded any modules, so the directory being used for the local storage needs to be known by the module.Tree somehow. This uses a couple assertions and a touch of reflection to get the FolderStorage directory, and manage the module manifest.