### PR TITLE
helper/resource: allow truncating prefix of PrefixedUniqueId

### DIFF
--- a/helper/resource/id_test.go
+++ b/helper/resource/id_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -65,4 +66,29 @@ func TestUniqueId(t *testing.T) {
 		t.Fatalf("Timestamp part should update at least once a millisecond %s %s",
 			id1, id2)
 	}
+}
+
+func TestPrefixedUniqueId(t *testing.T) {
+	const prefix = "terraform-"
+	const suffixLength = 26
+
+	var id string
+	var maxLength, totalLength int
+
+	// truncate the prefix
+	maxLength = 4
+
+	id = PrefixedUniqueIdLimit(prefix, maxLength)
+
+	totalLength = maxLength + suffixLength
+
+	if len(id) != totalLength {
+		t.Fatalf("ID not truncated to %d characters %s", totalLength, id)
+	}
+
+	matched, err := regexp.MatchString(fmt.Sprintf("^terr[[:digit:]]{%d}$", suffixLength), id)
+	if !matched {
+		t.Fatalf("ID prefix not correctly truncated %s %v", id, err)
+	}
+
 }


### PR DESCRIPTION
Add an optional `max_length` parameter to `PrefixedUniqueId`; when
present, this parameter truncates the `prefix` parameter before
constructing the unique ID string.  This provides a potential solution
to the problem described in
terraform-providers/terraform-provider-aws#625; since AWS enforces a
variety of length limits on resource names, it's not too hard when using
the `name_prefix` resource parameter to generate invalid names (which
cannot be discovered until the plan is applied).  The `max_length`
parameter offers provider maintainers the option of capturing the length
limits and truncating them rather than generating invalid names.