### PR TITLE
Make the `index` interpolation function return -1 when no item is found.

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -374,8 +374,7 @@ func interpolationFuncContains() ast.Function {
 		ArgTypes:   []ast.Type{ast.TypeList, ast.TypeString},
 		ReturnType: ast.TypeBool,
 		Callback: func(args []interface{}) (interface{}, error) {
-			_, err := interpolationFuncIndex().Callback(args)
-			if err != nil {
+			if rv, _ := interpolationFuncIndex().Callback(args); rv.(int) < 0 {
 				return false, nil
 			}
 			return true, nil
@@ -708,7 +707,7 @@ func interpolationFuncIndex() ast.Function {
 					return index, nil
 				}
 			}
-			return nil, fmt.Errorf("Could not find '%s' in '%s'", needle, haystack)
+			return -1, nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -1335,8 +1335,8 @@ func TestInterpolateFuncIndex(t *testing.T) {
 
 			{
 				`${index(var.list1, "foo")}`,
-				nil,
-				true,
+				"-1",
+				false,
 			},
 
 			{

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -272,8 +272,9 @@ The supported built-in functions are:
       indented string to be placed after some sort of already-indented preamble.
       Example: `"    \"items\": ${ indent(4, "[\n    \"item1\"\n]") },"`
 
-  * `index(list, elem)` - Finds the index of a given element in a list.
-      This function only works on flat lists.
+  * `index(list, elem)` - Returns the **index** of the first element found
+      in the given list, otherwise -1 is returned. This function only works
+      on flat lists.
       Example: `index(aws_instance.foo.*.tags.Name, "foo-test")`
 
   * `join(delim, list)` - Joins the list with the delimiter for a resultant string.


### PR DESCRIPTION
This commit changes the default behaviour of the `index` interpolation function
so that it would no longer interrupt Terraform execution with an error should no
item be found in the list.

Returning -1 (so a negative index) would allow for the `index` function to be
used as part of boolean conditions which are available for quite some time now.

This idea is more conceptually related to JavaScript `findIndex()` rather than
Python's `index()` where the latter would raise an exception when no item could
be found, whereas the former simply returns -1, which is a clear indication that
an item could not be found since array indices can only be a zero or
non-negative number.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>