### PR TITLE
Allow overriding host-based discovery in CLI config

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -39,6 +39,15 @@ func initCommands(config *Config) {
 	credsSrc := credentialsSource(config)
 	services := disco.NewDisco()
 	services.SetCredentialsSource(credsSrc)
+	for userHost, hostConfig := range config.Hosts {
+		host, err := svchost.ForComparison(userHost)
+		if err != nil {
+			// We expect the config was already validated by the time we get
+			// here, so we'll just ignore invalid hostnames.
+			continue
+		}
+		services.ForceHostServices(host, hostConfig.Services)
+	}
 
 	meta := command.Meta{
 		Color:            true,

--- a/svchost/disco/disco.go
+++ b/svchost/disco/disco.go
@@ -58,6 +58,33 @@ func (d *Disco) SetCredentialsSource(src auth.CredentialsSource) {
 	d.credsSrc = src
 }
 
+// ForceHostServices provides a pre-defined set of services for a given
+// host, which prevents the receiver from attempting network-based discovery
+// for the given host. Instead, the given services map will be returned
+// verbatim.
+//
+// When providing "forced" services, any relative URLs are resolved against
+// the initial discovery URL that would have been used for network-based
+// discovery, yielding the same results as if the given map were published
+// at the host's default discovery URL, though using absolute URLs is strongly
+// recommended to make the configured behavior more explicit.
+func (d *Disco) ForceHostServices(host svchost.Hostname, services map[string]interface{}) {
+	if d.hostCache == nil {
+		d.hostCache = map[svchost.Hostname]Host{}
+	}
+	if services == nil {
+		services = map[string]interface{}{}
+	}
+	d.hostCache[host] = Host{
+		discoURL: &url.URL{
+			Scheme: "https",
+			Host:   string(host),
+			Path:   discoPath,
+		},
+		services: services,
+	}
+}
+
 // Discover runs the discovery protocol against the given hostname (which must
 // already have been validated and prepared with svchost.ForComparison) and
 // returns an object describing the services available at that host.

--- a/test-fixtures/hosts
+++ b/test-fixtures/hosts
@@ -1,0 +1,6 @@
+
+host "example.com" {
+  services = {
+    "modules.v1" = "https://example.com/",
+  }
+}


### PR DESCRIPTION
For situations where the default network-based discovery is inappropriate or inconvenient, this allows users to provide a hard-coded discovery document for a particular hostname in the CLI config.

This is a new config block, rather than combined with the existing `credentials` block, because credentials should ideally live in separate files from other config so that they can be managed more carefully. However, this new `host` block _is_ designed to have room for additional host-specific configuration _other than_ credentials in future, which might include TLS certificate overrides or other such things used during the discovery step.

The main use-case imagined for this is when running Terraform in automation. In that case, if Terraform is always running against the same hosts it may be desired to statically configure the locations to avoid constantly re-fetching the same discovery documents on each run. It also allows for a particularly-sophisticated automation system that provides its _own_ services to override with different internal addresses when it runs Terraform, leaving the normal network-based discovery with addresses appropriate for Terraform used outside of automation, for development.
