### PR TITLE
Updates deprecated MAINTAINER in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # scripts/docker-release/Dockerfile-release.
 
 FROM golang:alpine
-MAINTAINER "HashiCorp Terraform Team <terraform@hashicorp.com>"
+LABEL maintainer="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
 RUN apk add --update git bash openssh
 


### PR DESCRIPTION
The `MAINTAINER` command has been [deprecated](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated) from the `Dockerfile` syntax.

This PR moves the content into the `maintainer` label instead.