### PR TITLE
init -from-module

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/posener/complete"
 
-	"github.com/hashicorp/go-getter"
-
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/config"
@@ -131,7 +129,8 @@ func (c *InitCommand) Run(args []string) int {
 		)))
 		header = true
 
-		if err := c.copyConfigFromModule(path, src, pwd); err != nil {
+		s := module.NewStorage("", c.Services, c.Credentials)
+		if err := s.GetModule(path, src); err != nil {
 			c.Ui.Error(fmt.Sprintf("Error copying source module: %s", err))
 			return 1
 		}
@@ -270,19 +269,6 @@ func (c *InitCommand) Run(args []string) int {
 	}
 
 	return 0
-}
-
-func (c *InitCommand) copyConfigFromModule(dst, src, pwd string) error {
-	// errors from this function will be prefixed with "Error copying source module: "
-	// when returned to the user.
-	var err error
-
-	src, err = getter.Detect(src, pwd, getter.Detectors)
-	if err != nil {
-		return fmt.Errorf("invalid module source: %s", err)
-	}
-
-	return module.GetCopy(dst, src)
 }
 
 // Load the complete module tree, and fetch any missing providers.

--- a/config/module/storage_test.go
+++ b/config/module/storage_test.go
@@ -1,0 +1,49 @@
+package module
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetModule(t *testing.T) {
+	server := mockRegistry()
+	defer server.Close()
+	disco := testDisco(server)
+
+	td, err := ioutil.TempDir("", "tf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(td)
+	storage := NewStorage(td, disco, nil)
+
+	// this module exists in a test fixture, and is known by the mockRegistry
+	// relative to our cwd.
+	err = storage.GetModule(filepath.Join(td, "foo"), "registry/local/sub")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// list everything to make sure nothing else got unpacked in here
+	ls, err := ioutil.ReadDir(td)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var names []string
+	for _, info := range ls {
+		names = append(names, info.Name())
+	}
+
+	if !(len(names) == 1 && names[0] == "foo") {
+		t.Fatalf("expected only directory 'foo', found entries %q", names)
+	}
+
+	_, err = os.Stat(filepath.Join(td, "foo", "main.tf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}


### PR DESCRIPTION
Add GetModule for the cli to initialize from a regisry module source.

Storage.GetModule fetches a module using the same detection and
discovery as used by the normal module loading. The final copy is still
done by module.GetCopy to remove vcs files.