### PR TITLE
Uses current working directory to name the binary

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -54,7 +54,7 @@ gox \
     -arch="${XC_ARCH}" \
     -osarch="${XC_EXCLUDE_OSARCH}" \
     -ldflags "${LD_FLAGS}" \
-    -output "pkg/{{.OS}}_{{.Arch}}/terraform" \
+    -output "pkg/{{.OS}}_{{.Arch}}/${PWD##*/}" \
     .
 
 # Move all the compiled things to the $GOPATH/bin


### PR DESCRIPTION
I was struggling to figure out how to build terraform plugins cross-platform. Doing it for terraform itself is quite easy, and I realized eventually that the terraform `build.sh` script just needed a small tweak to work with plugins also.

This patch allows `build.sh` to be used with terraform plugins to easily create cross-platform packages, using the same method as the terraform Makefile:

```
mkdir scripts
curl https://raw.githubusercontent.com/hashicorp/terraform/master/scripts/build.sh -o scripts/build.sh
TF_RELEASE=1 sh -c "scripts/build.sh"  # make bin
```