### PR TITLE
e2e test for `init -from-module`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ install:
 # See: https://github.com/golang/go/issues/12933
 - bash scripts/gogetcookie.sh
 - go get github.com/kardianos/govendor
+
+before_script:
+- git config --global url.https://github.com/.insteadOf ssh://git@github.com/
+
 script:
 - make vendor-status
 - make test


### PR DESCRIPTION
Pull down the hashicorp/vault/aws module into the current directory with
init.