### PR TITLE
config/module: allow registry download sources to be relative paths

### DIFF
--- a/config/module/get_test.go
+++ b/config/module/get_test.go
@@ -49,6 +49,10 @@ var testMods = map[string][]testMod{
 		location: "file:///registry/exists",
 		version:  "0.2.0",
 	}},
+	"relative/foo/bar": {{ // There is an exception for the "relative/" prefix in the test registry server
+		location: "/relative-path",
+		version:  "0.2.0",
+	}},
 	"test-versions/name/provider": {
 		{version: "2.2.0"},
 		{version: "2.1.1"},
@@ -103,7 +107,7 @@ func mockRegHandler() http.Handler {
 		mod := versions[0]
 
 		location := mod.location
-		if !strings.HasPrefix(location, "file:///") {
+		if !strings.HasPrefix(matches[0], "relative/") && !strings.HasPrefix(location, "file:///") {
 			// we can't use filepath.Abs because it will clean `//`
 			wd, _ := os.Getwd()
 			location = fmt.Sprintf("file://%s/%s", wd, location)

--- a/config/module/registry_test.go
+++ b/config/module/registry_test.go
@@ -93,7 +93,30 @@ func TestRegistryAuth(t *testing.T) {
 	}
 
 }
+func TestLookupModuleLocationRelative(t *testing.T) {
+	server := mockRegistry()
+	defer server.Close()
 
+	regDisco := testDisco(server)
+	storage := testStorage(t, regDisco)
+
+	src := "relative/foo/bar"
+	mod, err := regsrc.ParseModuleSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := storage.lookupModuleLocation(mod, "0.2.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := server.URL + "/relative-path"
+	if got != want {
+		t.Errorf("wrong location %s; want %s", got, want)
+	}
+
+}
 func TestAccLookupModuleVersions(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip()


### PR DESCRIPTION
It's not always easy or convenient for a web application to determine its own absolute URL to return, so here we pragmatically allow the download source string from a registry to be a path relative to the download endpoint.

Since `X-Terraform-Get` is a `go-getter` string, not all valid values are valid URLs and so we sniff for certain relative-path-looking prefixes in order to decide whether to apply the relative lookup transform.