### PR TITLE
helper: Fall back to TF_LOG_PATH instead of os.Stderr

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -372,6 +372,15 @@ func LogOutput(t TestT) (logOutput io.Writer, err error) {
 	}
 
 	logOutput = os.Stderr
+
+	if logPath := os.Getenv(logging.EnvLogFile); logPath != "" {
+		var err error
+		logOutput, err = os.OpenFile(logPath, syscall.O_CREAT|syscall.O_RDWR|syscall.O_APPEND, 0666)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if logPathMask := os.Getenv(EnvLogPathMask); logPathMask != "" {
 		logPath := fmt.Sprintf(logPathMask, t.Name())
 		var err error


### PR DESCRIPTION
This only affects tests, but basically https://github.com/hashicorp/terraform/pull/16356 introduced `TF_LOG_PATH_MASK` and unintentionally made it _the only way_ to send debug logs to a file.