### PR TITLE
Use pooled http client for fetching providers

### DIFF
--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -33,7 +33,7 @@ const protocolVersionHeader = "x-terraform-protocol-version"
 
 var releaseHost = "https://releases.hashicorp.com"
 
-var httpClient = cleanhttp.DefaultClient()
+var httpClient = cleanhttp.DefaultPooledClient()
 
 // An Installer maintains a local cache of plugins by downloading plugins
 // from an online repository.


### PR DESCRIPTION
While the TLS handshakes are a fairly small overhead compared to
downloading the providers, clients in some situation are failing to
complete the TLS handshake in a timely manner. It's unclear if this is
because of heavily constrained clients are stalling while doing the
major crypto operations, or the edge servers are throttling repeated
requests from the same IPs.

This should allow reusing the open TLS connection to the release edge
servers during init.