### PR TITLE
Override expected subject of a certificate for WinRM

### DIFF
--- a/communicator/winrm/provisioner.go
+++ b/communicator/winrm/provisioner.go
@@ -31,16 +31,17 @@ const (
 // only keys we look at. If a KeyFile is given, that is used instead
 // of a password.
 type connectionInfo struct {
-	User       string
-	Password   string
-	Host       string
-	Port       int
-	HTTPS      bool
-	Insecure   bool
-	CACert     string `mapstructure:"cacert"`
-	Timeout    string
-	ScriptPath string        `mapstructure:"script_path"`
-	TimeoutVal time.Duration `mapstructure:"-"`
+	User          string
+	Password      string
+	Host          string
+	Port          int
+	HTTPS         bool
+	Insecure      bool
+	TLSServerName string `mapstructure:"tls_server_name"`
+	CACert        string `mapstructure:"cacert"`
+	Timeout       string
+	ScriptPath    string        `mapstructure:"script_path"`
+	TimeoutVal    time.Duration `mapstructure:"-"`
 }
 
 // parseConnectionInfo is used to convert the ConnInfo of the InstanceState into

--- a/communicator/winrm/provisioner_test.go
+++ b/communicator/winrm/provisioner_test.go
@@ -75,14 +75,15 @@ GnSud83VUo9G9w==
 	r := &terraform.InstanceState{
 		Ephemeral: terraform.EphemeralState{
 			ConnInfo: map[string]string{
-				"type":     "winrm",
-				"user":     "Administrator",
-				"password": "supersecret",
-				"host":     "127.0.0.1",
-				"port":     "5985",
-				"https":    "true",
-				"timeout":  "30s",
-				"cacert":   caCert,
+				"type":            "winrm",
+				"user":            "Administrator",
+				"password":        "supersecret",
+				"host":            "127.0.0.1",
+				"port":            "5985",
+				"https":           "true",
+				"timeout":         "30s",
+				"cacert":          caCert,
+				"tls_server_name": "cn",
 			},
 		},
 	}
@@ -115,6 +116,9 @@ GnSud83VUo9G9w==
 	}
 	if conf.CACert != caCert {
 		t.Fatalf("expected: %v: got: %v", caCert, conf.CACert)
+	}
+	if conf.TLSServerName != "cn" {
+		t.Fatalf("expected: %v: got %v", "cn", conf.TLSServerName)
 	}
 }
 

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -152,9 +152,10 @@ func (n *EvalValidateProvisioner) validateConnConfig(connConfig *ResourceConfig)
 		BastionPrivateKey interface{} `mapstructure:"bastion_private_key"`
 
 		// For type=winrm only (enforced in winrm communicator)
-		HTTPS    interface{} `mapstructure:"https"`
-		Insecure interface{} `mapstructure:"insecure"`
-		CACert   interface{} `mapstructure:"cacert"`
+		HTTPS         interface{} `mapstructure:"https"`
+		Insecure      interface{} `mapstructure:"insecure"`
+		TLSServerName interface{} `mapstructure:"tls_server_name"`
+		CACert        interface{} `mapstructure:"cacert"`
 	}
 
 	var metadata mapstructure.Metadata

--- a/website/docs/provisioners/connection.html.markdown
+++ b/website/docs/provisioners/connection.html.markdown
@@ -87,6 +87,9 @@ provisioner "file" {
 
 * `insecure` - Set to `true` to not validate the HTTPS certificate chain.
 
+* `tls_server_name` - Set to override the server name that is used when verifying the
+  server certificate.
+
 * `cacert` - The CA certificate to validate against.
 
 <a id="bastion"></a>


### PR DESCRIPTION
Sometimes the hostname and IP of a resource is not known ahead of
time. This makes it hard to generate a valid certificate before a VM
has been created. Overriding the expected subject of a certificate
overcomes this.

Full use case - end-to-end secure deployment of an instance:
 * Generate a self-signed certificate via terraform.
 * Supply certificate securely to VM at creation-time via user_data
 * winrm provisioner configured with ca_cert set to generated cert.
   and tls_server_name set to cert subject.
 * Provisioner connects securely.