### PR TITLE
Adding `azurerm` to the list of supported backends

### DIFF
--- a/website/docs/state/workspaces.html.md
+++ b/website/docs/state/workspaces.html.md
@@ -19,6 +19,7 @@ found on [the _purpose_ page](/docs/state/purpose.html).
 
 Multiple workspaces are currently supported by the following backends:
 
+ * [AzureRM](/docs/backends/types/azurerm.html)
  * [Consul](/docs/backends/types/consul.html)
  * [S3](/docs/backends/types/s3.html)
 

--- a/website/layouts/backend-types.erb
+++ b/website/layouts/backend-types.erb
@@ -27,7 +27,7 @@
             <a href="/docs/backends/types/artifactory.html">artifactory</a>
           </li>
           <li<%= sidebar_current("docs-backends-types-standard-azurerm") %>>
-            <a href="/docs/backends/types/azurerm.html">azurerm (_formerly `azure`_)</a>
+            <a href="/docs/backends/types/azurerm.html">azurerm</a>
           </li>
           <li<%= sidebar_current("docs-backends-types-standard-consul") %>>
             <a href="/docs/backends/types/consul.html">consul</a>


### PR DESCRIPTION
Also cleans up an issue where the sidebar didn't render as originally intended:

<img width="293" alt="screen shot 2017-11-02 at 12 49 59" src="https://user-images.githubusercontent.com/666005/32324641-5fd0cb02-bfcc-11e7-968c-b30d932b5dca.png">

Fixes #16530