### PR TITLE
update init output

### DIFF
--- a/command/get_test.go
+++ b/command/get_test.go
@@ -30,7 +30,7 @@ func TestGet(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `Module "foo"`) {
+	if !strings.Contains(output, "module.foo") {
 		t.Fatalf("doesn't look like get: %s", output)
 	}
 	if strings.Contains(output, "(update)") {
@@ -78,7 +78,7 @@ func TestGet_noArgs(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `Module "foo"`) {
+	if !strings.Contains(output, "module.foo") {
 		t.Fatalf("doesn't look like get: %s", output)
 	}
 	if strings.Contains(output, "(update)") {

--- a/command/get_test.go
+++ b/command/get_test.go
@@ -30,7 +30,7 @@ func TestGet(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "Get: file://") {
+	if !strings.Contains(output, `Module "foo"`) {
 		t.Fatalf("doesn't look like get: %s", output)
 	}
 	if strings.Contains(output, "(update)") {
@@ -78,7 +78,7 @@ func TestGet_noArgs(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "Get: file://") {
+	if !strings.Contains(output, `Module "foo"`) {
 		t.Fatalf("doesn't look like get: %s", output)
 	}
 	if strings.Contains(output, "(update)") {
@@ -108,10 +108,7 @@ func TestGet_update(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "Get: file://") {
-		t.Fatalf("doesn't look like get: %s", output)
-	}
-	if !strings.Contains(output, "(update)") {
+	if !strings.Contains(output, `Updating source "./foo"`) {
 		t.Fatalf("doesn't look like get: %s", output)
 	}
 }

--- a/command/init.go
+++ b/command/init.go
@@ -172,7 +172,7 @@ func (c *InitCommand) Run(args []string) int {
 					"[reset][bold]Upgrading modules...")))
 			} else {
 				c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
-					"[reset][bold]Downloading modules...")))
+					"[reset][bold]Initializing modules...")))
 			}
 
 			if err := getModules(&c.Meta, path, getMode); err != nil {

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -170,7 +170,7 @@ func TestInit_get(t *testing.T) {
 
 	// Check output
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "Get: file://") {
+	if !strings.Contains(output, "Getting source") {
 		t.Fatalf("doesn't look like get: %s", output)
 	}
 }
@@ -203,7 +203,7 @@ func TestInit_getUpgradeModules(t *testing.T) {
 
 	// Check output
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "(update)") {
+	if !strings.Contains(output, "Updating source") {
 		t.Fatalf("doesn't look like get upgrade: %s", output)
 	}
 }

--- a/config/module/registry.go
+++ b/config/module/registry.go
@@ -123,6 +123,12 @@ func (s *Storage) lookupModuleVersions(module *regsrc.Module) (*response.ModuleV
 		return nil, err
 	}
 
+	for _, mod := range versions.Modules {
+		for _, v := range mod.Versions {
+			log.Printf("[DEBUG] found available version %q for %s", v.Version, mod.Source)
+		}
+	}
+
 	return &versions, nil
 }
 

--- a/config/module/storage.go
+++ b/config/module/storage.go
@@ -343,7 +343,7 @@ func (s Storage) findRegistryModule(mSource, constraint string) (moduleRecord, e
 			return rec, err
 		}
 
-		s.output(fmt.Sprintf("  Found version %q of %s on %s", rec.Version, mod.Module(), mod.RawHost.Display()))
+		s.output(fmt.Sprintf("  Found version %s of %s on %s", rec.Version, mod.Module(), mod.RawHost.Display()))
 
 	}
 	return rec, nil

--- a/config/module/storage.go
+++ b/config/module/storage.go
@@ -160,6 +160,7 @@ func (s Storage) moduleVersions(source string) ([]moduleRecord, error) {
 
 	for _, m := range manifest.Modules {
 		if m.Source == source && m.Version != "" {
+			log.Printf("[DEBUG] found local version %q for module %s", m.Version, m.Source)
 			matching = append(matching, m)
 		}
 	}
@@ -207,18 +208,19 @@ func (s Storage) recordModuleRoot(dir, root string) error {
 	return s.recordModule(rec)
 }
 
+func (s Storage) output(msg string) {
+	if s.Ui == nil || s.Mode == GetModeNone {
+		return
+	}
+	s.Ui.Output(msg)
+}
+
 func (s Storage) getStorage(key string, src string) (string, bool, error) {
 	storage := &getter.FolderStorage{
 		StorageDir: s.StorageDir,
 	}
 
-	if s.Ui != nil {
-		update := ""
-		if s.Mode == GetModeUpdate {
-			update = " (update)"
-		}
-		s.Ui.Output(fmt.Sprintf("Get: %s%s", src, update))
-	}
+	log.Printf("[DEBUG] fetching module from %s", src)
 
 	// Get the module with the level specified if we were told to.
 	if s.Mode > GetModeNone {
@@ -307,6 +309,7 @@ func (s Storage) findRegistryModule(mSource, constraint string) (moduleRecord, e
 	if err != nil {
 		log.Printf("[INFO] no matching version for %q<%s>, %s", mod.Module(), constraint, err)
 	}
+	log.Printf("[DEBUG] matched %q version %s for %s", mod, match.Version, constraint)
 
 	rec.Dir = match.Dir
 	rec.Version = match.Version
@@ -339,6 +342,9 @@ func (s Storage) findRegistryModule(mSource, constraint string) (moduleRecord, e
 		if err != nil {
 			return rec, err
 		}
+
+		s.output(fmt.Sprintf("  Found version %q of %s on %s", rec.Version, mod.Module(), mod.RawHost.Display()))
+
 	}
 	return rec, nil
 }

--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -216,7 +215,7 @@ func (t *Tree) getChildren(s *Storage) (map[string]*Tree, error) {
 
 		// add the module path to help indicate where modules with relative
 		// paths are being loaded from
-		s.output(fmt.Sprintf("- Module %q", path.Join(modPath...)))
+		s.output(fmt.Sprintf("- module.%s", strings.Join(modPath, ".")))
 
 		// Lookup the local location of the module.
 		// dir is the local directory where the module is stored

--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -365,6 +365,10 @@ func (t *Tree) inheritProviderConfigs(stack []*Tree) {
 		c.inheritProviderConfigs(stack)
 	}
 
+	if len(stack) == 1 {
+		return
+	}
+
 	providers := make(map[string]*config.ProviderConfig)
 	missingProviders := make(map[string]bool)
 
@@ -377,55 +381,6 @@ func (t *Tree) inheritProviderConfigs(stack []*Tree) {
 		if _, ok := providers[p]; !(ok || strings.Contains(p, ".")) {
 			missingProviders[p] = true
 		}
-	}
-
-	// Search for implicit provider configs
-	// This adds an empty config is no inherited config is found, so that
-	// there is always a provider config present.
-	// This is done in the root module as well, just to set the providers.
-	for missing := range missingProviders {
-		// first create an empty provider config
-		pc := &config.ProviderConfig{
-			Name: missing,
-		}
-
-		// walk up the stack looking for matching providers
-		for i := len(stack) - 2; i >= 0; i-- {
-			pt := stack[i]
-			var parentProvider *config.ProviderConfig
-			for _, p := range pt.config.ProviderConfigs {
-				if p.FullName() == missing {
-					parentProvider = p
-					break
-				}
-			}
-
-			if parentProvider == nil {
-				continue
-			}
-
-			pc.Path = pt.Path()
-			pc.Path = append([]string{RootName}, pt.path...)
-			pc.RawConfig = parentProvider.RawConfig
-			pc.Inherited = true
-			log.Printf("[TRACE] provider %q inheriting config from %q",
-				strings.Join(append(t.Path(), pc.FullName()), "."),
-				strings.Join(append(pt.Path(), parentProvider.FullName()), "."),
-			)
-			break
-		}
-
-		// always set a provider config
-		if pc.RawConfig == nil {
-			pc.RawConfig, _ = config.NewRawConfig(map[string]interface{}{})
-		}
-
-		t.config.ProviderConfigs = append(t.config.ProviderConfigs, pc)
-	}
-
-	// After allowing the empty implicit configs to be created in root, there's nothing left to inherit
-	if len(stack) == 1 {
-		return
 	}
 
 	// get our parent's module config block

--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -291,7 +291,13 @@ func (t *Tree) getChildren(s *Storage) (map[string]*Tree, error) {
 			subDir = filepath.Join(detectedSubDir, subDir)
 		}
 
-		output := fmt.Sprintf("  Getting source %q", m.Source)
+		output := ""
+		switch s.Mode {
+		case GetModeUpdate:
+			output = fmt.Sprintf("  Updating source %q", m.Source)
+		default:
+			output = fmt.Sprintf("  Getting source %q", m.Source)
+		}
 		s.output(output)
 
 		dir, ok, err := s.getStorage(key, source)
@@ -371,6 +377,50 @@ func (t *Tree) inheritProviderConfigs(stack []*Tree) {
 		if _, ok := providers[p]; !(ok || strings.Contains(p, ".")) {
 			missingProviders[p] = true
 		}
+	}
+
+	// Search for implicit provider configs
+	// This adds an empty config is no inherited config is found, so that
+	// there is always a provider config present.
+	// This is done in the root module as well, just to set the providers.
+	for missing := range missingProviders {
+		// first create an empty provider config
+		pc := &config.ProviderConfig{
+			Name: missing,
+		}
+
+		// walk up the stack looking for matching providers
+		for i := len(stack) - 2; i >= 0; i-- {
+			pt := stack[i]
+			var parentProvider *config.ProviderConfig
+			for _, p := range pt.config.ProviderConfigs {
+				if p.FullName() == missing {
+					parentProvider = p
+					break
+				}
+			}
+
+			if parentProvider == nil {
+				continue
+			}
+
+			pc.Path = pt.Path()
+			pc.Path = append([]string{RootName}, pt.path...)
+			pc.RawConfig = parentProvider.RawConfig
+			pc.Inherited = true
+			log.Printf("[TRACE] provider %q inheriting config from %q",
+				strings.Join(append(t.Path(), pc.FullName()), "."),
+				strings.Join(append(pt.Path(), parentProvider.FullName()), "."),
+			)
+			break
+		}
+
+		// always set a provider config
+		if pc.RawConfig == nil {
+			pc.RawConfig, _ = config.NewRawConfig(map[string]interface{}{})
+		}
+
+		t.config.ProviderConfigs = append(t.config.ProviderConfigs, pc)
 	}
 
 	// After allowing the empty implicit configs to be created in root, there's nothing left to inherit


### PR DESCRIPTION
Make the output for init nice. We can refine this as we go, but this better matches the provider output, and hides the ugly go-getter urls.

Change "Downloading" to 'Initializing" to match the provider loading
dialog.

List each module being loaded.

If a regisry module is being downloaded, list the registry host, and the
version discovered.

Show the source string from the config that is being fetched, rather
than the go-getter url. The full source can be found in the logs for
debugging.

Add much more extensive logging