### PR TITLE
websites/workspaces: Add Manta to the list of workspace backends

### DIFF
--- a/website/docs/state/workspaces.html.md
+++ b/website/docs/state/workspaces.html.md
@@ -22,6 +22,7 @@ Multiple workspaces are currently supported by the following backends:
  * [AzureRM](/docs/backends/types/azurerm.html)
  * [Consul](/docs/backends/types/consul.html)
  * [S3](/docs/backends/types/s3.html)
+ * [Manta](/docs/backends/types/manta.html)
 
 In the 0.9 line of Terraform releases, this concept was known as "environment".
 It was renamed in 0.10 based on feedback about confusion caused by the


### PR DESCRIPTION
As Manta backend has now been merged, this should have been done in the same PR - apologises for that

//cc @jbardin 