### PR TITLE
core: don't compare attribute values in Diff.Same

### DIFF
--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -1131,26 +1131,6 @@ func TestInstanceDiffSame(t *testing.T) {
 			true,
 			"",
 		},
-		{
-			&InstanceDiff{
-				Attributes: map[string]*ResourceAttrDiff{
-					"foo": &ResourceAttrDiff{
-						Old: "1",
-						New: "2",
-					},
-				},
-			},
-			&InstanceDiff{
-				Attributes: map[string]*ResourceAttrDiff{
-					"foo": &ResourceAttrDiff{
-						Old: "1",
-						New: "3",
-					},
-				},
-			},
-			false,
-			"value mismatch: foo",
-		},
 
 		// Make sure that DestroyTainted diffs pass as well, especially when diff
 		// two works off of no state.

--- a/terraform/test-fixtures/apply-unstable/main.tf
+++ b/terraform/test-fixtures/apply-unstable/main.tf
@@ -1,0 +1,3 @@
+resource "test_resource" "foo" {
+  random = "${uuid()}"
+}


### PR DESCRIPTION
We previously didn't compare values but had a TODO to start doing so, which we then recently did. unfortunately it turns out that we _depend_ on not comparing values here, because when we use EvalCompareDiff (a key user of Diff.Same) we pass in a diff made from a fresh re-interpolation of the configuration and so any non-pure function results (timestamp, uuid) have produced different values.
