### PR TITLE
Deprecate the environment key in favour of workspace in remote state

### DIFF
--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -43,6 +43,13 @@ func dataSourceRemoteState() *schema.Resource {
 			},
 
 			"environment": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Default:    backend.DefaultStateName,
+				Deprecated: "Terraform environments are now called workspaces. Please use the workspace key instead.",
+			},
+
+			"workspace": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  backend.DefaultStateName,
@@ -84,9 +91,13 @@ func dataSourceRemoteStateRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error initializing backend: %s", err)
 	}
 
-	// Get the state
-	env := d.Get("environment").(string)
-	state, err := b.State(env)
+	// environment is deprecated in favour of workspace.
+	// If both keys are set workspace should win.
+	name := d.Get("environment").(string)
+	if ws, ok := d.GetOk("workspace"); ok {
+		name = ws.(string)
+	}
+	state, err := b.State(name)
 	if err != nil {
 		return fmt.Errorf("error loading the remote state: %s", err)
 	}

--- a/website/docs/providers/terraform/d/remote_state.html.md
+++ b/website/docs/providers/terraform/d/remote_state.html.md
@@ -31,7 +31,7 @@ resource "aws_instance" "foo" {
 The following arguments are supported:
 
 * `backend` - (Required) The remote backend to use.
-* `environment` - (Optional) The Terraform environment to use.
+* `workspace` - (Optional) The Terraform workspace to use.
 * `config` - (Optional) The configuration of the remote backend.
 * `defaults` - (Optional) default value for outputs in case state file is empty or it does not have the output.
  * Remote state config docs can be found [here](/docs/backends/types/terraform-enterprise.html)


### PR DESCRIPTION
This should close out the existing PRs for this change in the soon to be defunct terraform-provider-terraform repo:
* https://github.com/terraform-providers/terraform-provider-terraform/pull/16
* https://github.com/terraform-providers/terraform-provider-terraform/pull/9