### PR TITLE
helper/schema: Clear existing map/set/list contents before overwriting

### DIFF
--- a/helper/schema/field_writer_map_test.go
+++ b/helper/schema/field_writer_map_test.go
@@ -261,3 +261,278 @@ func TestMapFieldWriter(t *testing.T) {
 		}
 	}
 }
+
+func TestMapFieldWriterCleanSet(t *testing.T) {
+	schema := map[string]*Schema{
+		"setDeep": &Schema{
+			Type: TypeSet,
+			Elem: &Resource{
+				Schema: map[string]*Schema{
+					"index": &Schema{Type: TypeInt},
+					"value": &Schema{Type: TypeString},
+				},
+			},
+			Set: func(a interface{}) int {
+				return a.(map[string]interface{})["index"].(int)
+			},
+		},
+	}
+
+	values := []struct {
+		Addr  []string
+		Value interface{}
+		Out   map[string]string
+	}{
+		{
+			[]string{"setDeep"},
+			[]interface{}{
+				map[string]interface{}{
+					"index": 10,
+					"value": "foo",
+				},
+				map[string]interface{}{
+					"index": 50,
+					"value": "bar",
+				},
+			},
+			map[string]string{
+				"setDeep.#":        "2",
+				"setDeep.10.index": "10",
+				"setDeep.10.value": "foo",
+				"setDeep.50.index": "50",
+				"setDeep.50.value": "bar",
+			},
+		},
+		{
+			[]string{"setDeep"},
+			[]interface{}{
+				map[string]interface{}{
+					"index": 20,
+					"value": "baz",
+				},
+				map[string]interface{}{
+					"index": 60,
+					"value": "qux",
+				},
+			},
+			map[string]string{
+				"setDeep.#":        "2",
+				"setDeep.20.index": "20",
+				"setDeep.20.value": "baz",
+				"setDeep.60.index": "60",
+				"setDeep.60.value": "qux",
+			},
+		},
+		{
+			[]string{"setDeep"},
+			[]interface{}{
+				map[string]interface{}{
+					"index": 30,
+					"value": "one",
+				},
+				map[string]interface{}{
+					"index": 70,
+					"value": "two",
+				},
+			},
+			map[string]string{
+				"setDeep.#":        "2",
+				"setDeep.30.index": "30",
+				"setDeep.30.value": "one",
+				"setDeep.70.index": "70",
+				"setDeep.70.value": "two",
+			},
+		},
+	}
+
+	w := &MapFieldWriter{Schema: schema}
+
+	for n, tc := range values {
+		err := w.WriteField(tc.Addr, tc.Value)
+		if err != nil {
+			t.Fatalf("%d: err: %s", n, err)
+		}
+
+		actual := w.Map()
+		if !reflect.DeepEqual(actual, tc.Out) {
+			t.Fatalf("%d: bad: %#v", n, actual)
+		}
+	}
+}
+
+func TestMapFieldWriterCleanList(t *testing.T) {
+	schema := map[string]*Schema{
+		"listDeep": &Schema{
+			Type: TypeList,
+			Elem: &Resource{
+				Schema: map[string]*Schema{
+					"thing1": &Schema{Type: TypeString},
+					"thing2": &Schema{Type: TypeString},
+				},
+			},
+		},
+	}
+
+	values := []struct {
+		Addr  []string
+		Value interface{}
+		Out   map[string]string
+	}{
+		{
+			// Base list
+			[]string{"listDeep"},
+			[]interface{}{
+				map[string]interface{}{
+					"thing1": "a",
+					"thing2": "b",
+				},
+				map[string]interface{}{
+					"thing1": "c",
+					"thing2": "d",
+				},
+				map[string]interface{}{
+					"thing1": "e",
+					"thing2": "f",
+				},
+				map[string]interface{}{
+					"thing1": "g",
+					"thing2": "h",
+				},
+			},
+			map[string]string{
+				"listDeep.#":        "4",
+				"listDeep.0.thing1": "a",
+				"listDeep.0.thing2": "b",
+				"listDeep.1.thing1": "c",
+				"listDeep.1.thing2": "d",
+				"listDeep.2.thing1": "e",
+				"listDeep.2.thing2": "f",
+				"listDeep.3.thing1": "g",
+				"listDeep.3.thing2": "h",
+			},
+		},
+		{
+			// Remove an element
+			[]string{"listDeep"},
+			[]interface{}{
+				map[string]interface{}{
+					"thing1": "a",
+					"thing2": "b",
+				},
+				map[string]interface{}{
+					"thing1": "c",
+					"thing2": "d",
+				},
+				map[string]interface{}{
+					"thing1": "e",
+					"thing2": "f",
+				},
+			},
+			map[string]string{
+				"listDeep.#":        "3",
+				"listDeep.0.thing1": "a",
+				"listDeep.0.thing2": "b",
+				"listDeep.1.thing1": "c",
+				"listDeep.1.thing2": "d",
+				"listDeep.2.thing1": "e",
+				"listDeep.2.thing2": "f",
+			},
+		},
+		{
+			// Rewrite with missing keys. This should normally not be necessary, as
+			// hopefully the writers are writing zero values as necessary, but for
+			// brevity we want to make sure that what exists in the writer is exactly
+			// what the last write looked like coming from the provider.
+			[]string{"listDeep"},
+			[]interface{}{
+				map[string]interface{}{
+					"thing1": "a",
+				},
+				map[string]interface{}{
+					"thing1": "c",
+				},
+				map[string]interface{}{
+					"thing1": "e",
+				},
+			},
+			map[string]string{
+				"listDeep.#":        "3",
+				"listDeep.0.thing1": "a",
+				"listDeep.1.thing1": "c",
+				"listDeep.2.thing1": "e",
+			},
+		},
+	}
+
+	w := &MapFieldWriter{Schema: schema}
+
+	for n, tc := range values {
+		err := w.WriteField(tc.Addr, tc.Value)
+		if err != nil {
+			t.Fatalf("%d: err: %s", n, err)
+		}
+
+		actual := w.Map()
+		if !reflect.DeepEqual(actual, tc.Out) {
+			t.Fatalf("%d: bad: %#v", n, actual)
+		}
+	}
+}
+
+func TestMapFieldWriterCleanMap(t *testing.T) {
+	schema := map[string]*Schema{
+		"map": &Schema{
+			Type: TypeMap,
+		},
+	}
+
+	values := []struct {
+		Value interface{}
+		Out   map[string]string
+	}{
+		{
+			// Base map
+			map[string]interface{}{
+				"thing1": "a",
+				"thing2": "b",
+				"thing3": "c",
+				"thing4": "d",
+			},
+			map[string]string{
+				"map.%":      "4",
+				"map.thing1": "a",
+				"map.thing2": "b",
+				"map.thing3": "c",
+				"map.thing4": "d",
+			},
+		},
+		{
+			// Base map
+			map[string]interface{}{
+				"thing1": "a",
+				"thing2": "b",
+				"thing4": "d",
+			},
+			map[string]string{
+				"map.%":      "3",
+				"map.thing1": "a",
+				"map.thing2": "b",
+				"map.thing4": "d",
+			},
+		},
+	}
+
+	w := &MapFieldWriter{Schema: schema}
+
+	for n, tc := range values {
+		err := w.WriteField([]string{"map"}, tc.Value)
+		if err != nil {
+			t.Fatalf("%d: err: %s", n, err)
+		}
+
+		actual := w.Map()
+		if !reflect.DeepEqual(actual, tc.Out) {
+			t.Fatalf("%d: bad: %#v", n, actual)
+		}
+	}
+}


### PR DESCRIPTION
There are situations where one may need to write to a set, list, or map
more than once per single TF operation (apply/refresh/etc). In these
cases, further writes using `Set` (example: `d.Set("some_set", newSet)`)
currently create unstable results in the set writer (the name of the
writer layer that holds the data set by these calls) because old keys
are not being cleared out first.

This bug is most visible when using sets. Example: First write to set
writes elements that have been hashed at 10 and 20, and the second write
writes elements that have been hashed at 30 and 40. While the set
length has been correctly set at 2, since a set is basically a map (as
is the entire map writer) and map results are non-deterministic, reads
to this set will now deliver unstable results in a random but
predictable fashion as the map results are delivered to the caller
non-deterministic - sometimes you may correctly get 30 and 40,
but sometimes you may get 10 and 20, or even 10 and 30, etc.

This problem propagates to state which is even more damaging as unstable
results are set to state where they become part of the permanent data
set going forward.

The problem also applies to lists and maps. This is probably more of an
issue with maps as a map can contain any key/value combination and hence
there is no predictable pattern where keys would be overwritten with
default or zero values. This is contrary to complex lists, which has
this problem as well, but since lists are deterministic and the length
of a list properly gets updated during the overwrite, the problem is
masked by the fact that a read will only read to the boundary of the
list, skipping any bad data that may still be available due past the
list boundary.

This update clears the child contents of any set, list, or map before
beginning a new write to address this issue. Tests are included for all
three data types.