### PR TITLE
don't add missing provider aliases to the graph

### DIFF
--- a/terraform/test-fixtures/import-provider-alias/main.tf
+++ b/terraform/test-fixtures/import-provider-alias/main.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  foo = "bar"
+  alias = "alias"
+}

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -19,6 +19,10 @@ func TransformProviders(providers []string, concrete ConcreteProviderNodeFunc, m
 			Providers: providers,
 			Concrete:  concrete,
 		},
+		// Attach configuration to each provider instance
+		&AttachProviderConfigTransformer{
+			Module: mod,
+		},
 		// Add any remaining missing providers
 		&MissingProviderTransformer{
 			Providers: providers,
@@ -30,10 +34,6 @@ func TransformProviders(providers []string, concrete ConcreteProviderNodeFunc, m
 		&DisableProviderTransformer{},
 		// Connect provider to their parent provider nodes
 		&ParentProviderTransformer{},
-		// Attach configuration to each provider instance
-		&AttachProviderConfigTransformer{
-			Module: mod,
-		},
 	)
 }
 
@@ -109,6 +109,7 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 				break
 			}
 
+			log.Printf("[DEBUG] resource %s using provider %s", dag.VertexName(pv), key)
 			pv.SetProvider(key)
 			g.Connect(dag.BasicEdge(v, target))
 		}
@@ -193,6 +194,12 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 
 		// we already have it
 		if provider != nil {
+			continue
+		}
+
+		// we don't implicitly create aliased providers
+		if strings.Contains(p, ".") {
+			log.Println("[DEBUG] not adding missing provider alias", p)
 			continue
 		}
 


### PR DESCRIPTION
A missing provider alias should not be implicitly added to the graph.

Run the AttachaProviderConfigTransformer immediately after adding the
providers, since the ProviderConfigTransformer should have just added
these nodes.