### PR TITLE
Renaming the Azure Provider

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ does.
 To try any example, clone this repository and run the following commands
 from within the example's directory:
 
-```
+```shell
 $ terraform init
 $ terraform apply
 ```

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -352,14 +352,10 @@
             <a href="/docs/providers/azurerm/index.html">Microsoft Azure</a>
           </li>
 
-          <li<%= sidebar_current("docs-providers-azurerm") %>>
-            <a href="/docs/providers/azure/index.html">Microsoft Azure (Legacy ASM)</a>
-          </li>
-
           <li<%= sidebar_current("docs-providers-mysql") %>>
             <a href="/docs/providers/mysql/index.html">MySQL</a>
           </li>
-          
+
           <li<%= sidebar_current("docs-providers-newrelic") %>>
             <a href="/docs/providers/newrelic/index.html">New Relic</a>
           </li>

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -216,6 +216,10 @@
             <a href="/docs/providers/aws/index.html">AWS</a>
           </li>
 
+          <li<%= sidebar_current("docs-providers-azurerm") %>>
+            <a href="/docs/providers/azurerm/index.html">Azure</a>
+          </li>
+
           <li<%= sidebar_current("docs-providers-bitbucket") %>>
             <a href="/docs/providers/bitbucket/index.html">Bitbucket</a>
           </li>
@@ -346,10 +350,6 @@
 
           <li<%= sidebar_current("docs-providers-mailgun") %>>
             <a href="/docs/providers/mailgun/index.html">Mailgun</a>
-          </li>
-
-          <li<%= sidebar_current("docs-providers-azurerm") %>>
-            <a href="/docs/providers/azurerm/index.html">Microsoft Azure</a>
           </li>
 
           <li<%= sidebar_current("docs-providers-mysql") %>>


### PR DESCRIPTION
Don't merge this for the moment - I need to make similar changes in the Provider documentation.

- Renaming `Microsoft Azure` -> `Azure` at Microsoft's request, also bumping it up the sidebar
- Removing the legacy Azure (V1 / old portal) Provider from the Sidebar
- Adding a missing hint to the code block