### PR TITLE
helper/schema: Opt-in panic on invalid ResourceData.Set

### DIFF
--- a/builtin/providers/test/resource.go
+++ b/builtin/providers/test/resource.go
@@ -49,7 +49,6 @@ func testResource() *schema.Resource {
 			"computed_read_only": {
 				Type:     schema.TypeString,
 				Computed: true,
-				ForceNew: true,
 			},
 			"computed_from_required": {
 				Type:     schema.TypeString,

--- a/builtin/providers/test/resource_gh12183.go
+++ b/builtin/providers/test/resource_gh12183.go
@@ -47,7 +47,7 @@ func testResourceGH12183() *schema.Resource {
 
 func testResourceCreate_gh12183(d *schema.ResourceData, meta interface{}) error {
 	d.SetId("testId")
-	return testResourceRead(d, meta)
+	return testResourceRead_gh12183(d, meta)
 }
 
 func testResourceRead_gh12183(d *schema.ResourceData, meta interface{}) error {

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -35,6 +35,8 @@ type ResourceData struct {
 	partialMap  map[string]struct{}
 	once        sync.Once
 	isNew       bool
+
+	panicOnError bool
 }
 
 // getResult is the internal structure that is generated when a Get
@@ -184,7 +186,11 @@ func (d *ResourceData) Set(key string, value interface{}) error {
 		}
 	}
 
-	return d.setWriter.WriteField(strings.Split(key, "."), value)
+	err := d.setWriter.WriteField(strings.Split(key, "."), value)
+	if err != nil && d.panicOnError {
+		panic(err)
+	}
+	return err
 }
 
 // SetPartial adds the key to the final state output while

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"fmt"
 	"math"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -2054,6 +2055,10 @@ func TestResourceDataSet(t *testing.T) {
 			GetValue: "",
 		},
 	}
+
+	oldEnv := os.Getenv(PanicOnErr)
+	os.Setenv(PanicOnErr, "")
+	defer os.Setenv(PanicOnErr, oldEnv)
 
 	for i, tc := range cases {
 		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff)


### PR DESCRIPTION
We have seen a number of bugs in the past involving `Set("field_name", invalid data)` in the past. These are really hard to discover without explicit error checks.

It is not desired to add error checks to each `Set()` as it would make the CRUD unnecessarily verbose. Making `panic` default seems a bit too aggressive as it would affect user's experience negatively (crash).

This is a compromise which allows us to be strict where we can afford to be strict - e.g. when running acceptance tests for providers and keep the existing behaviour as is for users (i.e. avoid crashes at runtime).

I don't think it's necessary to document this - we can just make `TF_SCHEMA_PANIC_ON_ERROR=1` default in `make testacc` of all providers.