### PR TITLE
core: more explanation when a provider block cannot be found

### DIFF
--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -102,8 +102,9 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 
 			if target == nil {
 				err = multierror.Append(err, fmt.Errorf(
-					"%s: provider %s couldn't be found",
-					dag.VertexName(v), p))
+					"%s: configuration for %s is not present; a provider configuration block is required for all operations",
+					dag.VertexName(v), p,
+				))
 				break
 			}
 


### PR DESCRIPTION
Our new resource-to-provider matching is stricter about explicitly matching aliases when config is present (no longer automatically inherited) and with locating providers to destroy removed resources.

With this in mind, this is an attempt to expand slightly on this error message now that users are more likely to see it.

In future it would be nice to do some explicit validation of this a bit closer to the UI, so we can have room for more explanatory text, but this additional messaging is intended to help users understand why they might be seeing this message after removing a provider configuration block from configuration, whether directly or as a side-effect of removing a module.

Here's how it looks with actual values interpolated:

```
* module.child.aws_instance.foo: configuration for provider.aws.moo is not present; a provider configuration block is required for all operations
```
