### PR TITLE
round time to millisecond precision

### DIFF
--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -246,7 +246,7 @@ func (h *UiHook) PostApply(
 
 	colorized := h.Colorize.Color(fmt.Sprintf(
 		"[reset][bold]%s: %s after %s%s[reset]",
-		addr, msg, time.Now().Round(time.Second).Sub(state.Start), stateIdSuffix))
+		addr, msg, time.Now().Round(time.Millisecond).Sub(state.Start), stateIdSuffix))
 
 	h.ui.Output(colorized)
 

--- a/command/hook_ui_test.go
+++ b/command/hook_ui_test.go
@@ -174,7 +174,7 @@ func TestUiHookPostApply_emptyState(t *testing.T) {
 		t.Fatalf("Expected hook to continue, given: %#v", action)
 	}
 
-	expectedRegexp := "^data.google_compute_zones.available: Destruction complete after -?[a-z0-9.]+\n$"
+	expectedRegexp := "^data.google_compute_zones.available: Destruction complete after -?[µa-z0-9.]+\n$"
 	output := ui.OutputWriter.String()
 	if matched, _ := regexp.MatchString(expectedRegexp, output); !matched {
 		t.Fatalf("Output didn't match regexp.\nExpected: %q\nGiven: %q", expectedRegexp, output)


### PR DESCRIPTION
Hello!

We would like to gather some performance data during our terraform runs. To get some meaningfull measurements, it would be great to get the creation/modification/deletion times with a higher precision than seconds. This PR reports the elapsed time with millisecond precision, which would be very helpful for our usecases. Would be great to get your ideas on this!

Cheers,
Christian