### PR TITLE
Fix panic with invalid module providers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -390,7 +390,7 @@ func (c *Config) Validate() error {
 
 	// Check that providers aren't declared multiple times and that their
 	// version constraints, where present, are syntactically valid.
-	providerSet := make(map[string]struct{})
+	providerSet := make(map[string]bool)
 	for _, p := range c.ProviderConfigs {
 		name := p.FullName()
 		if _, ok := providerSet[name]; ok {
@@ -410,7 +410,7 @@ func (c *Config) Validate() error {
 			}
 		}
 
-		providerSet[name] = struct{}{}
+		providerSet[name] = true
 	}
 
 	// Check that all references to modules are valid
@@ -500,6 +500,15 @@ func (c *Config) Validate() error {
 				"%s: can't initialize configuration: %s",
 				m.Id(), err))
 		}
+
+		// check that all named providers actually exist
+		for _, p := range m.Providers {
+			if !providerSet[p] {
+				errs = append(errs, fmt.Errorf(
+					"provider %q named in module %q does not exist", p, m.Name))
+			}
+		}
+
 	}
 	dupped = nil
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -219,6 +219,12 @@ func TestConfigValidate_table(t *testing.T) {
 			true,
 			"invalid version constraint",
 		},
+		{
+			"invalid provider name in module block",
+			"validate-missing-provider",
+			true,
+			"does not exist",
+		},
 	}
 
 	for i, tc := range cases {

--- a/config/test-fixtures/validate-missing-provider/main.tf
+++ b/config/test-fixtures/validate-missing-provider/main.tf
@@ -1,0 +1,10 @@
+provider "test" {
+    alias = "bar"
+}
+
+module "mod" {
+    source = "./mod"
+    providers = {
+        "test" = "test.foo"
+    }
+}

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -530,7 +530,8 @@ func (t *ProviderConfigTransformer) addProxyProvider(g *Graph, m *module.Tree, p
 	parentProvider := t.providers[fullParentName]
 
 	if parentProvider == nil {
-		panic(fmt.Sprintf("missing provider %s in module %s", parentProviderName, m.Name()))
+		log.Printf("[ERROR] missing provider %s in module %s", parentProviderName, m.Name())
+		return false
 	}
 
 	v := &graphNodeProxyProvider{


### PR DESCRIPTION
Missed validation when a module names a provider that doesn't exist. Catch the error in validation, and remove the panic.

This will also be caught during graph transformation in the next iteration of the provider handling code.

