### PR TITLE
timeadd interpolation function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -112,6 +112,7 @@ func Funcs() map[string]ast.Function {
 		"split":        interpolationFuncSplit(),
 		"substr":       interpolationFuncSubstr(),
 		"timestamp":    interpolationFuncTimestamp(),
+		"timeadd":      interpolationFuncTimeAdd(),
 		"title":        interpolationFuncTitle(),
 		"transpose":    interpolationFuncTranspose(),
 		"trimspace":    interpolationFuncTrimSpace(),
@@ -1500,6 +1501,29 @@ func interpolationFuncTimestamp() ast.Function {
 		ReturnType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {
 			return time.Now().UTC().Format(time.RFC3339), nil
+		},
+	}
+}
+
+func interpolationFuncTimeAdd() ast.Function {
+	return ast.Function{
+		ArgTypes: []ast.Type{
+			ast.TypeString, // input timestamp string in RFC3339 format
+			ast.TypeString, // duration to add to input timestamp that should be parsable by time.ParseDuration
+		},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+
+			ts, err := time.Parse(time.RFC3339, args[0].(string))
+			if err != nil {
+				return nil, err
+			}
+			duration, err := time.ParseDuration(args[1].(string))
+			if err != nil {
+				return nil, err
+			}
+
+			return ts.Add(duration).Format(time.RFC3339), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2426,6 +2426,38 @@ func TestInterpolateFuncTimestamp(t *testing.T) {
 	}
 }
 
+func TestInterpolateFuncTimeAdd(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${timeadd("2017-11-22T00:00:00Z", "1s")}`,
+				"2017-11-22T00:00:01Z",
+				false,
+			},
+			{
+				`${timeadd("2017-11-22T00:00:00Z", "10m1s")}`,
+				"2017-11-22T00:10:01Z",
+				false,
+			},
+			{ // also support subtraction
+				`${timeadd("2017-11-22T00:00:00Z", "-1h")}`,
+				"2017-11-21T23:00:00Z",
+				false,
+			},
+			{ // Invalid format timestamp
+				`${timeadd("2017-11-22", "-1h")}`,
+				nil,
+				true,
+			},
+			{ // Invalid format duration (day is not supported by ParseDuration)
+				`${timeadd("2017-11-22T00:00:00Z", "1d")}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
 type testFunctionConfig struct {
 	Cases []testFunctionCase
 	Vars  map[string]ast.Variable

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -395,6 +395,9 @@ The supported built-in functions are:
    invocation of the function, so in order to prevent diffs on every plan & apply, it must be used with the
    [`ignore_changes`](/docs/configuration/resources.html#ignore-changes) lifecycle attribute.
 
+  * `timeadd(time, duration)` - Returns a UTC timestamp string corresponding to adding a given `duration` to `time` in RFC 3339 format.      
+    For example, `timeadd("2017-11-22T00:00:00Z", "10m")` produces a value `"2017-11-22T00:10:00Z"`. 
+    
   * `title(string)` - Returns a copy of the string with the first characters of all the words capitalized.
 
   * `transpose(map)` - Swaps the keys and list values in a map of lists of strings. For example, transpose(map("a", list("1", "2"), "b", list("2", "3")) produces a value equivalent to map("1", list("a"), "2", list("a", "b"), "3", list("b")).


### PR DESCRIPTION
Added a interpolation function `timeadd(time, duration)`.

There is no way to designate relative time to the field [expiration_time](https://www.terraform.io/docs/providers/google/r/sql_database_instance.html#expiration_time) of google_sql_database_instance.

In our case, we want to allow access from the host which executes terraform only while  provisioning steps (e.g. grant users' privileges, create tables) and deny any access after that because it can be access via [CloudSQL proxy](https://cloud.google.com/sql/docs/mysql/sql-proxy?hl=en).

With this function, we can specify expiration time e.g. after 1 hour as follows:
```
ip_configuration {
      require_ssl = true

      authorized_networks {
        expiration_time = "${timeadd(timestamp(), "1h")}"
        name            = "provisioner"
        value           = "${var.provisioner_global_ip}"
      }
}
```