### PR TITLE
Interpolation functions rsaencrypt and rsadecrypt

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -4,12 +4,16 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/md5"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -103,6 +107,8 @@ func Funcs() map[string]ast.Function {
 		"pow":          interpolationFuncPow(),
 		"uuid":         interpolationFuncUUID(),
 		"replace":      interpolationFuncReplace(),
+		"rsadecrypt":   interpolationFuncRsaDecrypt(),
+		"rsaencrypt":   interpolationFuncRsaEncrypt(),
 		"sha1":         interpolationFuncSha1(),
 		"sha256":       interpolationFuncSha256(),
 		"sha512":       interpolationFuncSha512(),
@@ -1654,6 +1660,77 @@ func interpolationFuncAbs() ast.Function {
 		ReturnType: ast.TypeFloat,
 		Callback: func(args []interface{}) (interface{}, error) {
 			return math.Abs(args[0].(float64)), nil
+		},
+	}
+}
+
+// interpolationFuncRsaDecrypt implements the "rsadecrypt" function that does
+// RSA decryption.
+func interpolationFuncRsaDecrypt() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString, ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			s := args[0].(string)
+			key := args[1].(string)
+
+			b, err := base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				b = []byte(s)
+			}
+
+			block, _ := pem.Decode([]byte(key))
+			if block == nil {
+				return "", fmt.Errorf("Failed to read key %q: no key found", key)
+			}
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				return "", fmt.Errorf(
+					"Failed to read key %q: password protected keys are\n"+
+						"not supported. Please decrypt the key prior to use.", key)
+			}
+
+			x509Key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+			if err != nil {
+				return "", err
+			}
+
+			out, err := rsa.DecryptPKCS1v15(nil, x509Key, b)
+			if err != nil {
+				return "", err
+			}
+
+			return string(out), nil
+		},
+	}
+}
+
+// interpolationFuncReplace implements the "rsaencrypt" function that does
+// RSA encryption.
+func interpolationFuncRsaEncrypt() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString, ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			s := args[0].(string)
+			key := args[1].(string)
+
+			block, _ := pem.Decode([]byte(key))
+			if block == nil {
+				return "", fmt.Errorf("Failed to read key %q: no key found", key)
+			}
+
+			x509Key, err := x509.ParsePKIXPublicKey(block.Bytes)
+			if err != nil {
+				return "", err
+			}
+
+			random := rand.Reader
+			out, err := rsa.EncryptPKCS1v15(random, x509Key.(*rsa.PublicKey), []byte(s))
+			if err != nil {
+				return "", err
+			}
+
+			return string(out), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2780,3 +2780,255 @@ func TestInterpolateFuncAbs(t *testing.T) {
 		},
 	})
 }
+
+func TestInterpolateFuncRsaDecrypt(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Vars: map[string]ast.Variable{
+			"var.cipher_base64": ast.Variable{
+				Type:  ast.TypeString,
+				Value: "eczGaDhXDbOFRZGhjx2etVzWbRqWDlmq0bvNt284JHVbwCgObiuyX9uV0LSAMY707IEgMkExJqXmsB4OWKxvB7epRB9G/3+F+pcrQpODlDuL9oDUAsa65zEpYF0Wbn7Oh7nrMQncyUPpyr9WUlALl0gRWytOA23S+y5joa4M34KFpawFgoqTu/2EEH4Xl1zo+0fy73fEto+nfkUY+meuyGZ1nUx/+DljP7ZqxHBFSlLODmtuTMdswUbHbXbWneW51D7Jm7xB8nSdiA2JQNK5+Sg5x8aNfgvFTt/m2w2+qpsyFa5Wjeu6fZmXSl840CA07aXbk9vN4I81WmJyblD/ZA==",
+			},
+			"var.private_key": ast.Variable{
+				Type: ast.TypeString,
+				Value: `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAgUElV5mwqkloIrM8ZNZ72gSCcnSJt7+/Usa5G+D15YQUAdf9
+c1zEekTfHgDP+04nw/uFNFaE5v1RbHaPxhZYVg5ZErNCa/hzn+x10xzcepeS3KPV
+Xcxae4MR0BEegvqZqJzN9loXsNL/c3H/B+2Gle3hTxjlWFb3F5qLgR+4Mf4ruhER
+1v6eHQa/nchi03MBpT4UeJ7MrL92hTJYLdpSyCqmr8yjxkKJDVC2uRrr+sTSxfh7
+r6v24u/vp/QTmBIAlNPgadVAZw17iNNb7vjV7Gwl/5gHXonCUKURaV++dBNLrHIZ
+pqcAM8wHRph8mD1EfL9hsz77pHewxolBATV+7QIDAQABAoIBAC1rK+kFW3vrAYm3
++8/fQnQQw5nec4o6+crng6JVQXLeH32qXShNf8kLLG/Jj0vaYcTPPDZw9JCKkTMQ
+0mKj9XR/5DLbBMsV6eNXXuvJJ3x4iKW5eD9WkLD4FKlNarBRyO7j8sfPTqXW7uat
+NxWdFH7YsSRvNh/9pyQHLWA5OituidMrYbc3EUx8B1GPNyJ9W8Q8znNYLfwYOjU4
+Wv1SLE6qGQQH9Q0WzA2WUf8jklCYyMYTIywAjGb8kbAJlKhmj2t2Igjmqtwt1PYc
+pGlqbtQBDUiWXt5S4YX/1maIQ/49yeNUajjpbJiH3DbhJbHwFTzP3pZ9P9GHOzlG
+kYR+wSECgYEAw/Xida8kSv8n86V3qSY/I+fYQ5V+jDtXIE+JhRnS8xzbOzz3v0WS
+Oo5H+o4nJx5eL3Ghb3Gcm0Jn46dHrxinHbm+3RjXv/X6tlbxIYjRSQfHOTSMCTvd
+qcliF5vC6RCLXuc7R+IWR1Ky6eDEZGtrvt3DyeYABsp9fRUFR/6NluUCgYEAqNsw
+1aSl7WJa27F0DoJdlU9LWerpXcazlJcIdOz/S9QDmSK3RDQTdqfTxRmrxiYI9LEs
+mkOkvzlnnOBMpnZ3ZOU5qIRfprecRIi37KDAOHWGnlC0EWGgl46YLb7/jXiWf0AG
+Y+DfJJNd9i6TbIDWu8254/erAS6bKMhW/3q7f2kCgYAZ7Id/BiKJAWRpqTRBXlvw
+BhXoKvjI2HjYP21z/EyZ+PFPzur/lNaZhIUlMnUfibbwE9pFggQzzf8scM7c7Sf+
+mLoVSdoQ/Rujz7CqvQzi2nKSsM7t0curUIb3lJWee5/UeEaxZcmIufoNUrzohAWH
+BJOIPDM4ssUTLRq7wYM9uQKBgHCBau5OP8gE6mjKuXsZXWUoahpFLKwwwmJUp2vQ
+pOFPJ/6WZOlqkTVT6QPAcPUbTohKrF80hsZqZyDdSfT3peFx4ZLocBrS56m6NmHR
+UYHMvJ8rQm76T1fryHVidz85g3zRmfBeWg8yqT5oFg4LYgfLsPm1gRjOhs8LfPvI
+OLlRAoGBAIZ5Uv4Z3s8O7WKXXUe/lq6j7vfiVkR1NW/Z/WLKXZpnmvJ7FgxN4e56
+RXT7GwNQHIY8eDjDnsHxzrxd+raOxOZeKcMHj3XyjCX3NHfTscnsBPAGYpY/Wxzh
+T8UYnFu6RzkixElTf2rseEav7rkdKkI3LAeIZy7B0HulKKsmqVQ7
+-----END RSA PRIVATE KEY-----
+`,
+			},
+			"var.wrong_private_key": ast.Variable{
+				Type: ast.TypeString,
+				Value: `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAlrCgnEVgmNKCq7KPc+zUU5IrxPu1ClMNJS7RTsTPEkbwe5SB
+p+6V6WtCbD/X/lDRRGbOENChh1Phulb7lViqgrdpHydgsrKoS5ah3DfSIxLFLE00
+9Yo4TCYwgw6+s59j16ZAFVinaQ9l6Kmrb2ll136hMrz8QKh+qw+onOLd38WFgm+W
+ZtUqSXf2LANzfzzy4OWFNyFqKaCAolSkPdTS9Nz+svtScvp002DQp8OdP1AgPO+l
+o5N3M38Fftapwg0pCtJ5Zq0NRWIXEonXiTEMA6zy3gEZVOmDxoIFUWnmrqlMJLFy
+5S6LDrHSdqJhCxDK6WRZj43X9j8spktk3eGhMwIDAQABAoIBAAem8ID/BOi9x+Tw
+LFi2rhGQWqimH4tmrEQ3HGnjlKBY+d1MrUjZ1MMFr1nP5CgF8pqGnfA8p/c3Sz8r
+K5tp5T6+EZiDZ2WrrOApxg5ox0MAsQKO6SGO40z6o3wEQ6rbbTaGOrraxaWQIpyu
+AQanU4Sd6ZGqByVBaS1GnklZO+shCHqw73b7g1cpLEmFzcYnKHYHlUUIsstMe8E1
+BaCY0CH7JbWBjcbiTnBVwIRZuu+EjGiQuhTilYL2OWqoMVg1WU0L2IFpR8lkf/2W
+SBx5J6xhwbBGASOpM+qidiN580GdPzGhWYSqKGroHEzBm6xPSmV1tadNA26WFG4p
+pthLiAECgYEA5BsPRpNYJAQLu5B0N7mj9eEp0HABVEgL/MpwiImjaKdAwp78HM64
+IuPvJxs7r+xESiIz4JyjR8zrQjYOCKJsARYkmNlEuAz0SkHabCw1BdEBwUhjUGVB
+efoERK6GxfAoNqmSDwsOvHFOtsmDIlbHmg7G2rUxNVpeou415BSB0B8CgYEAqR4J
+YHKk2Ibr9rU+rBU33TcdTGw0aAkFNAVeqM9j0haWuFXmV3RArgoy09lH+2Ha6z/g
+fTX2xSDAWV7QUlLOlBRIhurPAo2jO2yCrGHPZcWiugstrR2hTTInigaSnCmK3i7F
+6sYmL3S7K01IcVNxSlWvGijtClT92Cl2WUCTfG0CgYAiEjyk4QtQTd5mxLvnOu5X
+oqs5PBGmwiAwQRiv/EcRMbJFn7Oupd3xMDSflbzDmTnWDOfMy/jDl8MoH6TW+1PA
+kcsjnYhbKWwvz0hN0giVdtOZSDO1ZXpzOrn6fEsbM7T9/TQY1SD9WrtUKCNTNL0Z
+sM1ZC6lu+7GZCpW4HKwLJwKBgQCRT0yxQXBg1/UxwuO5ynV4rx2Oh76z0WRWIXMH
+S0MyxdP1SWGkrS/SGtM3cg/GcHtA/V6vV0nUcWK0p6IJyjrTw2XZ/zGluPuTWJYi
+9dvVT26Vunshrz7kbH7KuwEICy3V4IyQQHeY+QzFlR70uMS0IVFWAepCoWqHbIDT
+CYhwNQKBgGPcLXmjpGtkZvggl0aZr9LsvCTckllSCFSI861kivL/rijdNoCHGxZv
+dfDkLTLcz9Gk41rD9Gxn/3sqodnTAc3Z2PxFnzg1Q/u3+x6YAgBwI/g/jE2xutGW
+H7CurtMwALQ/n/6LUKFmjRZjqbKX9SO2QSaC3grd6sY9Tu+bZjLe
+-----END RSA PRIVATE KEY-----
+`,
+			},
+		},
+		Cases: []testFunctionCase{
+			// Raw cipher decrypts correctly
+			{
+				`${rsadecrypt(base64decode(var.cipher_base64), var.private_key)}`,
+				"message",
+				false,
+			},
+			// Base-64 encoded cipher decrypts correctly
+			{
+				`${rsadecrypt(var.cipher_base64, var.private_key)}`,
+				"message",
+				false,
+			},
+			// Wrong key
+			{
+				`${rsadecrypt(var.cipher_base64, var.wrong_private_key)}`,
+				nil,
+				true,
+			},
+			// Bad key
+			{
+				`${rsadecrypt(var.cipher_base64, "bad key")}`,
+				nil,
+				true,
+			},
+			// Empty key
+			{
+				`${rsadecrypt(var.cipher_base64, "")}`,
+				nil,
+				true,
+			},
+			// Bad cipher
+			{
+				`${rsadecrypt("bad cipher", var.private_key)}`,
+				nil,
+				true,
+			},
+			// Empty cipher
+			{
+				`${rsadecrypt("", var.private_key)}`,
+				nil,
+				true,
+			},
+			// Too many arguments
+			{
+				`${rsadecrypt("", "", "")}`,
+				nil,
+				true,
+			},
+			// One argument
+			{
+				`${rsadecrypt("")}`,
+				nil,
+				true,
+			},
+			// No arguments
+			{
+				`${rsadecrypt()}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
+func TestInterpolateFuncRsaEncrypt(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Vars: map[string]ast.Variable{
+			"var.public_key": ast.Variable{
+				Type: ast.TypeString,
+				Value: `
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgUElV5mwqkloIrM8ZNZ7
+2gSCcnSJt7+/Usa5G+D15YQUAdf9c1zEekTfHgDP+04nw/uFNFaE5v1RbHaPxhZY
+Vg5ZErNCa/hzn+x10xzcepeS3KPVXcxae4MR0BEegvqZqJzN9loXsNL/c3H/B+2G
+le3hTxjlWFb3F5qLgR+4Mf4ruhER1v6eHQa/nchi03MBpT4UeJ7MrL92hTJYLdpS
+yCqmr8yjxkKJDVC2uRrr+sTSxfh7r6v24u/vp/QTmBIAlNPgadVAZw17iNNb7vjV
+7Gwl/5gHXonCUKURaV++dBNLrHIZpqcAM8wHRph8mD1EfL9hsz77pHewxolBATV+
+7QIDAQAB
+-----END PUBLIC KEY-----
+`,
+			},
+			"var.private_key": ast.Variable{
+				Type: ast.TypeString,
+				Value: `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAgUElV5mwqkloIrM8ZNZ72gSCcnSJt7+/Usa5G+D15YQUAdf9
+c1zEekTfHgDP+04nw/uFNFaE5v1RbHaPxhZYVg5ZErNCa/hzn+x10xzcepeS3KPV
+Xcxae4MR0BEegvqZqJzN9loXsNL/c3H/B+2Gle3hTxjlWFb3F5qLgR+4Mf4ruhER
+1v6eHQa/nchi03MBpT4UeJ7MrL92hTJYLdpSyCqmr8yjxkKJDVC2uRrr+sTSxfh7
+r6v24u/vp/QTmBIAlNPgadVAZw17iNNb7vjV7Gwl/5gHXonCUKURaV++dBNLrHIZ
+pqcAM8wHRph8mD1EfL9hsz77pHewxolBATV+7QIDAQABAoIBAC1rK+kFW3vrAYm3
++8/fQnQQw5nec4o6+crng6JVQXLeH32qXShNf8kLLG/Jj0vaYcTPPDZw9JCKkTMQ
+0mKj9XR/5DLbBMsV6eNXXuvJJ3x4iKW5eD9WkLD4FKlNarBRyO7j8sfPTqXW7uat
+NxWdFH7YsSRvNh/9pyQHLWA5OituidMrYbc3EUx8B1GPNyJ9W8Q8znNYLfwYOjU4
+Wv1SLE6qGQQH9Q0WzA2WUf8jklCYyMYTIywAjGb8kbAJlKhmj2t2Igjmqtwt1PYc
+pGlqbtQBDUiWXt5S4YX/1maIQ/49yeNUajjpbJiH3DbhJbHwFTzP3pZ9P9GHOzlG
+kYR+wSECgYEAw/Xida8kSv8n86V3qSY/I+fYQ5V+jDtXIE+JhRnS8xzbOzz3v0WS
+Oo5H+o4nJx5eL3Ghb3Gcm0Jn46dHrxinHbm+3RjXv/X6tlbxIYjRSQfHOTSMCTvd
+qcliF5vC6RCLXuc7R+IWR1Ky6eDEZGtrvt3DyeYABsp9fRUFR/6NluUCgYEAqNsw
+1aSl7WJa27F0DoJdlU9LWerpXcazlJcIdOz/S9QDmSK3RDQTdqfTxRmrxiYI9LEs
+mkOkvzlnnOBMpnZ3ZOU5qIRfprecRIi37KDAOHWGnlC0EWGgl46YLb7/jXiWf0AG
+Y+DfJJNd9i6TbIDWu8254/erAS6bKMhW/3q7f2kCgYAZ7Id/BiKJAWRpqTRBXlvw
+BhXoKvjI2HjYP21z/EyZ+PFPzur/lNaZhIUlMnUfibbwE9pFggQzzf8scM7c7Sf+
+mLoVSdoQ/Rujz7CqvQzi2nKSsM7t0curUIb3lJWee5/UeEaxZcmIufoNUrzohAWH
+BJOIPDM4ssUTLRq7wYM9uQKBgHCBau5OP8gE6mjKuXsZXWUoahpFLKwwwmJUp2vQ
+pOFPJ/6WZOlqkTVT6QPAcPUbTohKrF80hsZqZyDdSfT3peFx4ZLocBrS56m6NmHR
+UYHMvJ8rQm76T1fryHVidz85g3zRmfBeWg8yqT5oFg4LYgfLsPm1gRjOhs8LfPvI
+OLlRAoGBAIZ5Uv4Z3s8O7WKXXUe/lq6j7vfiVkR1NW/Z/WLKXZpnmvJ7FgxN4e56
+RXT7GwNQHIY8eDjDnsHxzrxd+raOxOZeKcMHj3XyjCX3NHfTscnsBPAGYpY/Wxzh
+T8UYnFu6RzkixElTf2rseEav7rkdKkI3LAeIZy7B0HulKKsmqVQ7
+-----END RSA PRIVATE KEY-----
+`,
+			},
+		},
+		Cases: []testFunctionCase{
+			// Valid value decrypts correctly
+			{
+				`${rsadecrypt(rsaencrypt("message", var.public_key), var.private_key)}`,
+				"message",
+				false,
+			},
+			// Subsequent encryption of the same value is different
+			{
+				`${rsaencrypt("message", var.public_key) != rsaencrypt("message", var.public_key)}`,
+				"true",
+				false,
+			},
+			// Bad key
+			{
+				`${rsaencrypt("message", "bad key")}`,
+				nil,
+				true,
+			},
+			// Empty key
+			{
+				`${rsaencrypt("message", "")}`,
+				nil,
+				true,
+			},
+			// Empty message
+			{
+				`${rsadecrypt(rsaencrypt("", var.public_key), var.private_key)}`,
+				"",
+				false,
+			},
+			// Max-length message
+			{
+				`${rsadecrypt(rsaencrypt("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz12345678901", var.public_key), var.private_key)}`,
+				"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz12345678901",
+				false,
+			},
+			// Too-long message
+			{
+				`${rsaencrypt("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz123456789012", var.public_key)}`,
+				nil,
+				true,
+			},
+			// Too many arguments
+			{
+				`${rsaencrypt("", "", "")}`,
+				nil,
+				true,
+			},
+			// One argument
+			{
+				`${rsaencrypt("")}`,
+				nil,
+				true,
+			},
+			// No arguments
+			{
+				`${rsaencrypt()}`,
+				nil,
+				true,
+			},
+		},
+	})
+}

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2854,17 +2854,17 @@ H7CurtMwALQ/n/6LUKFmjRZjqbKX9SO2QSaC3grd6sY9Tu+bZjLe
 			},
 		},
 		Cases: []testFunctionCase{
-			// Raw cipher decrypts correctly
-			{
-				`${rsadecrypt(base64decode(var.cipher_base64), var.private_key)}`,
-				"message",
-				false,
-			},
 			// Base-64 encoded cipher decrypts correctly
 			{
 				`${rsadecrypt(var.cipher_base64, var.private_key)}`,
 				"message",
 				false,
+			},
+			// Raw cipher
+			{
+				`${rsadecrypt(base64decode(var.cipher_base64), var.private_key)}`,
+				nil,
+				true,
 			},
 			// Wrong key
 			{
@@ -2890,6 +2890,12 @@ H7CurtMwALQ/n/6LUKFmjRZjqbKX9SO2QSaC3grd6sY9Tu+bZjLe
 				nil,
 				true,
 			},
+			// Bad base64-encoded cipher
+			{
+				`${rsadecrypt(base64encode("bad cipher"), var.private_key)}`,
+				nil,
+				true,
+			},
 			// Empty cipher
 			{
 				`${rsadecrypt("", var.private_key)}`,
@@ -2911,121 +2917,6 @@ H7CurtMwALQ/n/6LUKFmjRZjqbKX9SO2QSaC3grd6sY9Tu+bZjLe
 			// No arguments
 			{
 				`${rsadecrypt()}`,
-				nil,
-				true,
-			},
-		},
-	})
-}
-
-func TestInterpolateFuncRsaEncrypt(t *testing.T) {
-	testFunction(t, testFunctionConfig{
-		Vars: map[string]ast.Variable{
-			"var.public_key": ast.Variable{
-				Type: ast.TypeString,
-				Value: `
------BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgUElV5mwqkloIrM8ZNZ7
-2gSCcnSJt7+/Usa5G+D15YQUAdf9c1zEekTfHgDP+04nw/uFNFaE5v1RbHaPxhZY
-Vg5ZErNCa/hzn+x10xzcepeS3KPVXcxae4MR0BEegvqZqJzN9loXsNL/c3H/B+2G
-le3hTxjlWFb3F5qLgR+4Mf4ruhER1v6eHQa/nchi03MBpT4UeJ7MrL92hTJYLdpS
-yCqmr8yjxkKJDVC2uRrr+sTSxfh7r6v24u/vp/QTmBIAlNPgadVAZw17iNNb7vjV
-7Gwl/5gHXonCUKURaV++dBNLrHIZpqcAM8wHRph8mD1EfL9hsz77pHewxolBATV+
-7QIDAQAB
------END PUBLIC KEY-----
-`,
-			},
-			"var.private_key": ast.Variable{
-				Type: ast.TypeString,
-				Value: `
------BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAgUElV5mwqkloIrM8ZNZ72gSCcnSJt7+/Usa5G+D15YQUAdf9
-c1zEekTfHgDP+04nw/uFNFaE5v1RbHaPxhZYVg5ZErNCa/hzn+x10xzcepeS3KPV
-Xcxae4MR0BEegvqZqJzN9loXsNL/c3H/B+2Gle3hTxjlWFb3F5qLgR+4Mf4ruhER
-1v6eHQa/nchi03MBpT4UeJ7MrL92hTJYLdpSyCqmr8yjxkKJDVC2uRrr+sTSxfh7
-r6v24u/vp/QTmBIAlNPgadVAZw17iNNb7vjV7Gwl/5gHXonCUKURaV++dBNLrHIZ
-pqcAM8wHRph8mD1EfL9hsz77pHewxolBATV+7QIDAQABAoIBAC1rK+kFW3vrAYm3
-+8/fQnQQw5nec4o6+crng6JVQXLeH32qXShNf8kLLG/Jj0vaYcTPPDZw9JCKkTMQ
-0mKj9XR/5DLbBMsV6eNXXuvJJ3x4iKW5eD9WkLD4FKlNarBRyO7j8sfPTqXW7uat
-NxWdFH7YsSRvNh/9pyQHLWA5OituidMrYbc3EUx8B1GPNyJ9W8Q8znNYLfwYOjU4
-Wv1SLE6qGQQH9Q0WzA2WUf8jklCYyMYTIywAjGb8kbAJlKhmj2t2Igjmqtwt1PYc
-pGlqbtQBDUiWXt5S4YX/1maIQ/49yeNUajjpbJiH3DbhJbHwFTzP3pZ9P9GHOzlG
-kYR+wSECgYEAw/Xida8kSv8n86V3qSY/I+fYQ5V+jDtXIE+JhRnS8xzbOzz3v0WS
-Oo5H+o4nJx5eL3Ghb3Gcm0Jn46dHrxinHbm+3RjXv/X6tlbxIYjRSQfHOTSMCTvd
-qcliF5vC6RCLXuc7R+IWR1Ky6eDEZGtrvt3DyeYABsp9fRUFR/6NluUCgYEAqNsw
-1aSl7WJa27F0DoJdlU9LWerpXcazlJcIdOz/S9QDmSK3RDQTdqfTxRmrxiYI9LEs
-mkOkvzlnnOBMpnZ3ZOU5qIRfprecRIi37KDAOHWGnlC0EWGgl46YLb7/jXiWf0AG
-Y+DfJJNd9i6TbIDWu8254/erAS6bKMhW/3q7f2kCgYAZ7Id/BiKJAWRpqTRBXlvw
-BhXoKvjI2HjYP21z/EyZ+PFPzur/lNaZhIUlMnUfibbwE9pFggQzzf8scM7c7Sf+
-mLoVSdoQ/Rujz7CqvQzi2nKSsM7t0curUIb3lJWee5/UeEaxZcmIufoNUrzohAWH
-BJOIPDM4ssUTLRq7wYM9uQKBgHCBau5OP8gE6mjKuXsZXWUoahpFLKwwwmJUp2vQ
-pOFPJ/6WZOlqkTVT6QPAcPUbTohKrF80hsZqZyDdSfT3peFx4ZLocBrS56m6NmHR
-UYHMvJ8rQm76T1fryHVidz85g3zRmfBeWg8yqT5oFg4LYgfLsPm1gRjOhs8LfPvI
-OLlRAoGBAIZ5Uv4Z3s8O7WKXXUe/lq6j7vfiVkR1NW/Z/WLKXZpnmvJ7FgxN4e56
-RXT7GwNQHIY8eDjDnsHxzrxd+raOxOZeKcMHj3XyjCX3NHfTscnsBPAGYpY/Wxzh
-T8UYnFu6RzkixElTf2rseEav7rkdKkI3LAeIZy7B0HulKKsmqVQ7
------END RSA PRIVATE KEY-----
-`,
-			},
-		},
-		Cases: []testFunctionCase{
-			// Valid value decrypts correctly
-			{
-				`${rsadecrypt(rsaencrypt("message", var.public_key), var.private_key)}`,
-				"message",
-				false,
-			},
-			// Subsequent encryption of the same value is different
-			{
-				`${rsaencrypt("message", var.public_key) != rsaencrypt("message", var.public_key)}`,
-				"true",
-				false,
-			},
-			// Bad key
-			{
-				`${rsaencrypt("message", "bad key")}`,
-				nil,
-				true,
-			},
-			// Empty key
-			{
-				`${rsaencrypt("message", "")}`,
-				nil,
-				true,
-			},
-			// Empty message
-			{
-				`${rsadecrypt(rsaencrypt("", var.public_key), var.private_key)}`,
-				"",
-				false,
-			},
-			// Max-length message
-			{
-				`${rsadecrypt(rsaencrypt("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz12345678901", var.public_key), var.private_key)}`,
-				"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz12345678901",
-				false,
-			},
-			// Too-long message
-			{
-				`${rsaencrypt("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz123456789012", var.public_key)}`,
-				nil,
-				true,
-			},
-			// Too many arguments
-			{
-				`${rsaencrypt("", "", "")}`,
-				nil,
-				true,
-			},
-			// One argument
-			{
-				`${rsaencrypt("")}`,
-				nil,
-				true,
-			},
-			// No arguments
-			{
-				`${rsaencrypt()}`,
 				nil,
 				true,
 			},

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -355,13 +355,9 @@ The supported built-in functions are:
       `n` is the index or name of the subcapture. If using a regular expression,
       the syntax conforms to the [re2 regular expression syntax](https://github.com/google/re2/wiki/Syntax).
 
-  * `rsadecrypt(string, key)` - Decrypts `string` using RSA PKCS #1 v1.5.
-    The `string` may be base64-encoded or the raw cipher text. `key` must be an
+  * `rsadecrypt(string, key)` - Decrypts `string` using RSA. The padding scheme
+    PKCS #1 v1.5 is used. The `string` must be base64-encoded. `key` must be an
     RSA private key in PEM format. You may use `file()` to load it from a file.
-
-  * `rsaencrypt(string, key)` - Encrypts `string` using RSA PKCS #1 v1.5.
-    `key` must be an RSA public key in PEM format. You may use `file()` to load
-    it from a file.
 
   * `sha1(string)` - Returns a (conventional) hexadecimal representation of the
     SHA-1 hash of the given string.

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -355,6 +355,14 @@ The supported built-in functions are:
       `n` is the index or name of the subcapture. If using a regular expression,
       the syntax conforms to the [re2 regular expression syntax](https://github.com/google/re2/wiki/Syntax).
 
+  * `rsadecrypt(string, key)` - Decrypts `string` using RSA PKCS #1 v1.5.
+    The `string` may be base64-encoded or the raw cipher text. `key` must be an
+    RSA private key in PEM format. You may use `file()` to load it from a file.
+
+  * `rsaencrypt(string, key)` - Encrypts `string` using RSA PKCS #1 v1.5.
+    `key` must be an RSA public key in PEM format. You may use `file()` to load
+    it from a file.
+
   * `sha1(string)` - Returns a (conventional) hexadecimal representation of the
     SHA-1 hash of the given string.
     Example: `"${sha1("${aws_vpc.default.tags.customer}-s3-bucket")}"`


### PR DESCRIPTION
This is the second half of the puzzle which was previously https://github.com/hashicorp/terraform/pull/5675.

This addresses issue https://github.com/hashicorp/terraform/issues/3148 which was moved to https://github.com/terraform-providers/terraform-provider-aws/issues/30.

The first half is https://github.com/terraform-providers/terraform-provider-aws/pull/2219 which enables you to get (Windows) password data from an instance.  This data is encrypted, and we don't want the decrypted password (or private key) to end up in the state file.

So to get around this, I added interpolation functions to allow decryption of this password data when setting the password in the connection section.  Since that section is not stored in the state file, we're ok.

So, for example, once both of these PR's are merged, you can do this:

```hcl
resource "aws_instance" "foo" {
  ...

  connection {
    ...

    password = "${rsadecrypt(self.password_data, file("/path/to/private_key.pem"))}"
  }
}
```

Or:

```hcl
resource "null_resource" "foo" {
  ...

  connection {
    ...

    password = "${rsadecrypt(data.aws_instance.foo.password_data, file("/path/to/private_key.pem"))}"
  }
}
```

Technically, we only need `rsadecrypt` to enable this feature, but I also added a matching `rsaencrypt` function while I was at it.

This PR is ready to merge, containing updated docs and working unit tests.