### PR TITLE
normalize missing provider names

### DIFF
--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -193,6 +193,11 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 		}
 
 		p := pv.ProvidedBy()
+		// this may be the resolved provider from the state, so we need to get
+		// the base provider name.
+		parts := strings.SplitAfter(p, "provider.")
+		p = parts[len(parts)-1]
+
 		key := ResolveProviderName(p, nil)
 		provider := m[key]
 
@@ -203,9 +208,11 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 
 		// we don't implicitly create aliased providers
 		if strings.Contains(p, ".") {
-			log.Println("[DEBUG] not adding missing provider alias", p)
+			log.Println("[DEBUG] not adding missing provider alias:", p)
 			continue
 		}
+
+		log.Println("[DEBUG] adding missing provider:", p)
 
 		// create the misisng top-level provider
 		provider = t.Concrete(&NodeAbstractProvider{


### PR DESCRIPTION
The provider name coming from ProvidedBy may be resolved if it only
exists in the state. Make sure to strip the module and provider
prefixes for the provider name when adding missing providers.