### PR TITLE
main: don't print the CLI config into the logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,7 +141,6 @@ func wrappedMain() int {
 			// We continue to run anyway, since Terraform has reasonable defaults.
 		}
 	}
-	log.Printf("[DEBUG] CLI config is %#v", config)
 
 	// In tests, Commands may already be set to provide mock commands
 	if Commands == nil {


### PR DESCRIPTION
Now that we're expecting "credentials" blocks in the config (with auth tokens for private module registries, etc) we should not print out the config contents into the log, or else people will probably end up accidentally disclosing their credentials when sharing debug output with us, or will be reluctant to share debug output.
