### PR TITLE
website: One more round of 0.11 upgrade guide edits

### DIFF
--- a/website/upgrade-guides/0-11.html.markdown
+++ b/website/upgrade-guides/0-11.html.markdown
@@ -172,7 +172,7 @@ all of the module's resources can be successfully refreshed and destroyed.
 A common configuration is where two child modules have different configurations
 for the same provider, like this:
 
-```
+```hcl
 # root.tf
 
 module "network-use1" {
@@ -186,7 +186,7 @@ module "network-usw2" {
 }
 ```
 
-```
+```hcl
 # network/network.tf
 
 variable "region" {
@@ -212,7 +212,7 @@ This can be addressed by moving the `provider` blocks into the root module
 as _additional configurations_, and then passing them down to the child
 modules as _default configurations_ via the explicit `providers` map:
 
-```
+```hcl
 # root.tf
 
 provider "aws" {
@@ -242,7 +242,7 @@ module "network-usw2" {
 }
 ```
 
-```
+```hcl
 # network/network.tf
 
 # Empty provider block signals that we expect a default (unaliased) "aws"

--- a/website/upgrade-guides/0-11.html.markdown
+++ b/website/upgrade-guides/0-11.html.markdown
@@ -282,3 +282,32 @@ Terraform 0.11 will require adjusting the configuration to avoid the error.
 
 **Action:** If any existing output value expressions contain errors, change these
 expressions to fix the error.
+
+### Referencing Attributes from Resources with `count = 0`
+
+A common pattern for conditional resources is to conditionally set count
+to either `0` or `1` depending on the result of a boolean expression:
+
+```hcl
+resource "aws_instance" "example" {
+  count = "${var.create_instance ? 1 : 0}"
+
+  # ...
+}
+```
+
+When using this pattern, it's required to use a special idiom to access
+attributes of this resource to account for the case where no resource is
+created at all:
+
+```hcl
+output "instance_id" {
+  value = "${element(concat(aws_instance.example.*.id, list("")), 0)}"
+}
+```
+
+Accessing `aws_instance.example.id` directly is an error when `count = 0`.
+This is true for all situations where interpolation expressions are allowed,
+but previously _appeared_ to work for outputs due to the suppression of the
+error. Existing outputs that access non-existent resources must be updated to
+use the idiom above after upgrading to 0.11.0.


### PR DESCRIPTION
* Add some previously-missing `hcl` syntax highlighting annotations to existing code blocks
* Talk specifically about outputs referencing resources where `count = 0`, since that seems to be a common error based on 0.11.0-rc1 testing/feedback.
