### PR TITLE
helper/schema: Add TestResourceDataStateRaw

### DIFF
--- a/helper/schema/testing.go
+++ b/helper/schema/testing.go
@@ -10,6 +10,13 @@ import (
 // TestResourceDataRaw creates a ResourceData from a raw configuration map.
 func TestResourceDataRaw(
 	t *testing.T, schema map[string]*Schema, raw map[string]interface{}) *ResourceData {
+	return TestResourceDataStateRaw(t, schema, nil, raw)
+}
+
+// TestResourceDataStateRaw creates a ResourceData from an instance state map
+// and a raw configuration map.
+func TestResourceDataStateRaw(t *testing.T, schema map[string]*Schema,
+	state map[string]string, raw map[string]interface{}) *ResourceData {
 	t.Helper()
 
 	c, err := config.NewRawConfig(raw)
@@ -23,7 +30,13 @@ func TestResourceDataRaw(
 		t.Fatalf("err: %s", err)
 	}
 
-	result, err := sm.Data(nil, diff)
+	var instanceState *terraform.InstanceState = nil
+	if state != nil {
+		instanceState = &terraform.InstanceState{
+			Attributes: state,
+		}
+	}
+	result, err := sm.Data(instanceState, diff)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
This lets us write provider tests that generate `ResourceData` objects with different settings at config/instance levels.

This is needed for https://github.com/terraform-providers/terraform-provider-aws/pull/2353.