### PR TITLE
Fix the naming scheme for terraform provider

### DIFF
--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -210,7 +210,7 @@ host operating system:
 `terraform init` will search this directory for additional plugins during
 plugin initialization.
 
-The naming scheme for provider plugins is `terraform-provider-NAME-vX.Y.Z`,
+The naming scheme for provider plugins is `terraform-provider-NAME_vX.Y.Z`,
 and Terraform uses the name to understand the name and version of a particular
 provider binary. Third-party plugins will often be distributed with an
 appropriate filename already set in the distribution archive so that it can


### PR DESCRIPTION
I tried to follow `terraform-provider-NAME-vX.Y.Z` pattern with terraform 0.10.7 and it was unable to locate the provider.
I checked the filenames of standard providers and concluded that the proper name is `terraform-provider-NAME_vX.Y.Z`
I also see that the fixed schema worked fine, terraform successfully executed `init` command.
The fix is general and does not attribute to a particular version