### PR TITLE
improve the Module Source documentation

### DIFF
--- a/website/docs/modules/sources.html.markdown
+++ b/website/docs/modules/sources.html.markdown
@@ -14,19 +14,19 @@ Terraform manages modules for you: it downloads them, organizes them on disk, ch
 
 Terraform supports the following sources:
 
-  * Local file paths
+  * [Local file paths](#local-file-paths)
 
-  * [Terraform Registry](/docs/registry/index.html)
+  * [Terraform Registry](#terraform-registry)
 
-  * GitHub
+  * [GitHub](#github)
 
-  * Bitbucket
+  * [Bitbucket](#bitbucket)
 
-  * Generic Git, Mercurial repositories
+  * Generic [Git](#generic-git-repository), [Mercurial](#generic-mercurial-repository) repositories
 
-  * HTTP URLs
+  * [HTTP URLs](#http-urls)
 
-  * S3 buckets
+  * [S3 buckets](#s3-bucket)
 
 Each is documented further below.
 
@@ -93,7 +93,7 @@ module "consul" {
 
 GitHub source URLs require that Git is installed on your system and that you have access to the repository.
 
-You can use the same parameters to GitHub repositories as you can generic Git repositories (such as tags or branches). See the documentation for generic Git repositories for more information.
+You can use the same parameters to GitHub repositories as you can generic Git repositories (such as tags or branches). See [the documentation for generic Git repositories](#parameters) for more information.
 
 ### Private GitHub Repos
 
@@ -134,7 +134,7 @@ module "consul" {
 Bitbucket URLs will require that Git or Mercurial is installed on your system, depending on the type of repository.
 
 ## Private Bitbucket Repos
-Private bitbucket repositories must be specified similar to the Generic Git Respository section below.
+Private bitbucket repositories must be specified similar to the [Generic Git Repository](#generic-git-repository) section below.
 
 ```hcl
 module "consul" {
@@ -176,6 +176,10 @@ module "ami" {
 
 If you do not specify the type of `source` then Terraform will attempt to use the closest match, for example assuming `https://hashicorp.com/consul.git` is a HTTP URL.
 
+Terraform will cache the module locally by default `terraform get` is run, so successive updates to master or a specified branch will not be factored into future plans. Run `terraform get -update=true` to get the latest version of the branch. This is handy in development, but potentially bothersome in production if you don't have control of the repository.
+
+### Parameters
+
 The URLs for Git repositories support the following query parameters:
 
   * `ref` - The ref to checkout. This can be a branch, tag, commit, etc.
@@ -185,8 +189,6 @@ module "consul" {
   source = "git::https://hashicorp.com/consul.git?ref=master"
 }
 ```
-
-Terraform will cache the module locally by default `terraform get` is run, so successive updates to master or a specified branch will not be factored into future plans. Run `terraform get -update=true` to get the latest version of the branch. This is handy in development, but potentially bothersome in production if you don't have control of the repository.
 
 ## Generic Mercurial Repository
 
@@ -223,7 +225,7 @@ Terraform then looks for the resulting module URL in the following order:
 <meta name="terraform-get" content="github.com/hashicorp/example" />
 ```
 
-### S3 Bucket
+## S3 Bucket
 
 Terraform can also store modules in an S3 bucket. To access the bucket
 you must have appropriate AWS credentials in your configuration or

--- a/website/docs/modules/sources.html.markdown
+++ b/website/docs/modules/sources.html.markdown
@@ -61,7 +61,7 @@ The above example would use the
 from the public registry.
 
 You can learn more about the registry at the
-[Terraform Registry documentation section](/docs/registry/index.html).
+[Terraform Registry documentation](/docs/registry/modules/use.html#using-modules).
 
 ## GitHub
 

--- a/website/docs/registry/index.html.md
+++ b/website/docs/registry/index.html.md
@@ -15,17 +15,7 @@ Terraform is written, and find pre-made modules for infrastructure components
 you require.
 
 The Terraform Registry is integrated directly into Terraform to make
-consuming modules easy. The following example shows how easy it is to
-build a fully functional [Consul](https://www.consul.io) cluster using the
-[Consul module for AWS](https://registry.terraform.io/modules/hashicorp/consul/aws).
-
-```hcl
-module "consul" {
-	source = "hashicorp/consul/aws"
-}
-```
-
-~> **Note:** Module registry integration was added in Terraform v0.10.6, and full versioning support in v0.11.0.
+consuming modules easy. See [the usage information](/docs/registry/modules/use.html#using-modules).
 
 You can also publish your own modules on the Terraform Registry. You may
 use the [public registry](https://registry.terraform.io) for public modules.

--- a/website/docs/registry/modules/use.html.md
+++ b/website/docs/registry/modules/use.html.md
@@ -31,9 +31,10 @@ it easy to reference any module in the registry. The syntax for referencing
 a registry module is `namespace/name/provider`. For example:
 `hashicorp/consul/aws`.
 
+~> **Note:** Module registry integration was added in Terraform v0.10.6, and full versioning support in v0.11.0.
+
 When viewing a module on the registry on a tablet or desktop, usage instructions
-are shown on the right side. The screenshot below shows where to find these.
-You can copy and paste this to get started with any module. Some modules may
+are shown on the right side. You can copy and paste this to get started with any module. Some modules may
 have required inputs you must set before being able to use the module.
 
 ```hcl
@@ -47,12 +48,12 @@ module "consul" {
 
 Each module in the registry is versioned. These versions syntactically must
 follow [semantic versioning](http://semver.org/). In addition to pure syntax,
-we encourge all modules to follow the full guidelines of semantic versioning.
+we encourage all modules to follow the full guidelines of semantic versioning.
 
-Terraform since version 0.11 will resolve any provided 
-[module version constraints](/docs/modules/usage.html#module-versions) and 
+Terraform since version 0.11 will resolve any provided
+[module version constraints](/docs/modules/usage.html#module-versions) and
 using them is highly recommended to avoid pulling in breaking changes.
 
-Terraform from version 10.6 through to 0.11 had partial support for the registry 
+Terraform from version 10.6 through to 0.11 had partial support for the registry
 protocol, however will not honor version constraints and always download the
 latest version.


### PR DESCRIPTION
* Adds cross-links within the Module Source page, which should help with navigation.
* Information about how to use modules from the Registry was scattered across a few places, and only fully documented in a somewhat buried page. This pull request removes the other examples, to point to that canonical place.
* Some spelling fixes.

Thanks!