### PR TITLE
Issue template: comment out the instruction portions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,43 +1,71 @@
+<!--
 Hi there,
 
 Thank you for opening an issue. Please note that we try to keep the Terraform issue tracker reserved for bug reports and feature requests. For general usage questions, please see: https://www.terraform.io/community.html.
 
 If your issue relates to a specific Terraform provider, please open it in the provider's own repository. The index of providers is at https://github.com/terraform-providers .
+-->
 
 ### Terraform Version
-Run `terraform -v` to show the version. If you are not running the latest version of Terraform, please try upgrading because your issue may have already been fixed.
+<!---
+Run `terraform -v` to show the version, and paste the result between the ``` marks below.
+
+If you are not running the latest version of Terraform, please try upgrading because your issue may have already been fixed.
+-->
+
+```
+...
+```
 
 ### Terraform Configuration Files
+<!--
+Paste the relevant parts of your Terraform configuration between the ``` marks below.
+
+For large Terraform configs, please use a service like Dropbox and share a link to the ZIP file. For security, you can also encrypt the files using our GPG public key.
+-->
+
 ```hcl
-# Copy-paste your Terraform configurations here.
-#
-# For large Terraform configs, please use a service like Dropbox and
-# share a link to the ZIP file. For security, you can also encrypt the
-# files using our GPG public key.
+...
 ```
 
 ### Debug Output
+<!--
 Full debug output can be obtained by running Terraform with the environment variable `TF_LOG=trace`. Please create a GitHub Gist containing the debug output. Please do _not_ paste the debug output in the issue, since debug output is long.
 
 Debug output may contain sensitive information. Please review it before posting publicly, and if you are concerned feel free to encrypt the files using the HashiCorp security public key.
+-->
 
 ### Crash Output
+<!--
 If the console output indicates that Terraform crashed, please share a link to a GitHub Gist containing the output of the `crash.log` file.
+-->
 
 ### Expected Behavior
+<!--
 What should have happened?
+-->
 
 ### Actual Behavior
+<!--
 What actually happened?
+-->
 
 ### Steps to Reproduce
+<!--
 Please list the full steps required to reproduce the issue, for example:
 1. `terraform init`
 2. `terraform apply`
+-->
 
 ### Important Factoids
+<!--
 Are there anything atypical about your situation that we should know? For example: is Terraform running in a wrapper script or in a CI system? Are you passing any unusual command line options or environment variables to opt-in to non-default behavior?
+-->
 
 ### References
+<!--
 Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example:
+
 - #6017
+
+-->


### PR DESCRIPTION
By wrapping the instruction portions in comments we can get a cleaner rendering of the issue if a user posts it without removing the instructions first.

The content is otherwise the same as before.