### PR TITLE
Clean up regsrc module

### DIFF
--- a/config/module/storage.go
+++ b/config/module/storage.go
@@ -343,7 +343,9 @@ func (s Storage) findRegistryModule(mSource, constraint string) (moduleRecord, e
 			return rec, err
 		}
 
-		s.output(fmt.Sprintf("  Found version %s of %s on %s", rec.Version, mod.Module(), mod.RawHost.Display()))
+		// we've already validated this by now
+		host, _ := mod.SvcHost()
+		s.output(fmt.Sprintf("  Found version %s of %s on %s", rec.Version, mod.Module(), host.ForDisplay()))
 
 	}
 	return rec, nil

--- a/registry/regsrc/friendly_host.go
+++ b/registry/regsrc/friendly_host.go
@@ -128,7 +128,3 @@ func (h *FriendlyHost) Equal(other *FriendlyHost) bool {
 
 	return h.Normalized() == other.Normalized()
 }
-
-func (h *FriendlyHost) SvcHost() (svchost.Hostname, error) {
-	return svchost.ForComparison(h.Raw)
-}

--- a/registry/regsrc/friendly_host.go
+++ b/registry/regsrc/friendly_host.go
@@ -126,5 +126,15 @@ func (h *FriendlyHost) Equal(other *FriendlyHost) bool {
 		return false
 	}
 
-	return h.Normalized() == other.Normalized()
+	otherHost, err := svchost.ForComparison(other.Raw)
+	if err != nil {
+		return false
+	}
+
+	host, err := svchost.ForComparison(h.Raw)
+	if err != nil {
+		return false
+	}
+
+	return otherHost == host
 }

--- a/registry/regsrc/friendly_host_test.go
+++ b/registry/regsrc/friendly_host_test.go
@@ -59,7 +59,7 @@ func TestFriendlyHost(t *testing.T) {
 			source:      "xn--s-fka0wmm0zea7g8b.xn--o-8ta85a3b1dwcda1k.io",
 			wantHost:    "xn--s-fka0wmm0zea7g8b.xn--o-8ta85a3b1dwcda1k.io",
 			wantDisplay: "ʎɹʇsıƃǝɹ.ɯɹoɟɐɹɹǝʇ.io",
-			wantNorm:    "xn--s-fka0wmm0zea7g8b.xn--o-8ta85a3b1dwcda1k.io",
+			wantNorm:    InvalidHostString,
 			wantValid:   false,
 		},
 		{
@@ -109,13 +109,9 @@ func TestFriendlyHost(t *testing.T) {
 				}
 
 				// Also verify that host compares equal with all the variants.
-				if !gotHost.Equal(&FriendlyHost{Raw: tt.wantDisplay}) {
-					t.Fatalf("Equal() should be true for %s and %s", tt.wantHost, tt.wantValid)
+				if gotHost.Valid() && !gotHost.Equal(&FriendlyHost{Raw: tt.wantDisplay}) {
+					t.Fatalf("Equal() should be true for %s and %s", tt.wantHost, tt.wantDisplay)
 				}
-				if !gotHost.Equal(&FriendlyHost{Raw: tt.wantNorm}) {
-					t.Fatalf("Equal() should be true for %s and %s", tt.wantHost, tt.wantNorm)
-				}
-
 			})
 		}
 	}

--- a/registry/regsrc/friendly_host_test.go
+++ b/registry/regsrc/friendly_host_test.go
@@ -95,20 +95,14 @@ func TestFriendlyHost(t *testing.T) {
 				if v := gotHost.String(); v != tt.wantHost {
 					t.Fatalf("String() = %v, want %v", v, tt.wantHost)
 				}
-				if v := gotHost.Valid(); v != tt.wantValid {
-					t.Fatalf("Valid() = %v, want %v", v, tt.wantValid)
-				}
-
-				// FIXME: should we allow punycode as input
-				if !tt.wantValid {
-					return
-				}
-
 				if v := gotHost.Display(); v != tt.wantDisplay {
 					t.Fatalf("Display() = %v, want %v", v, tt.wantDisplay)
 				}
 				if v := gotHost.Normalized(); v != tt.wantNorm {
 					t.Fatalf("Normalized() = %v, want %v", v, tt.wantNorm)
+				}
+				if v := gotHost.Valid(); v != tt.wantValid {
+					t.Fatalf("Valid() = %v, want %v", v, tt.wantValid)
 				}
 				if gotRest != strings.TrimLeft(sfx, "/") {
 					t.Fatalf("ParseFriendlyHost() rest = %v, want %v", gotRest, strings.TrimLeft(sfx, "/"))
@@ -116,15 +110,11 @@ func TestFriendlyHost(t *testing.T) {
 
 				// Also verify that host compares equal with all the variants.
 				if !gotHost.Equal(&FriendlyHost{Raw: tt.wantDisplay}) {
-					t.Fatalf("Equal() should be true for %s and %t", tt.wantHost, tt.wantValid)
+					t.Fatalf("Equal() should be true for %s and %s", tt.wantHost, tt.wantValid)
 				}
-
-				// FIXME: Do we need to accept normalized input?
-				//if !gotHost.Equal(&FriendlyHost{Raw: tt.wantNorm}) {
-				//    fmt.Println(gotHost.Normalized(), tt.wantNorm)
-				//    fmt.Println("     ", (&FriendlyHost{Raw: tt.wantNorm}).Normalized())
-				//    t.Fatalf("Equal() should be true for %s and %s", tt.wantHost, tt.wantNorm)
-				//}
+				if !gotHost.Equal(&FriendlyHost{Raw: tt.wantNorm}) {
+					t.Fatalf("Equal() should be true for %s and %s", tt.wantHost, tt.wantNorm)
+				}
 
 			})
 		}

--- a/registry/regsrc/friendly_host_test.go
+++ b/registry/regsrc/friendly_host_test.go
@@ -116,3 +116,26 @@ func TestFriendlyHost(t *testing.T) {
 		}
 	}
 }
+
+func TestInvalidHostEquals(t *testing.T) {
+	invalid := NewFriendlyHost("NOT_A_HOST_NAME")
+	valid := PublicRegistryHost
+
+	// invalid hosts are not comparable
+	if invalid.Equal(invalid) {
+		t.Fatal("invalid host names are not comparable")
+	}
+
+	if valid.Equal(invalid) {
+		t.Fatalf("%q is not equal to %q", valid, invalid)
+	}
+
+	puny := NewFriendlyHost("xn--s-fka0wmm0zea7g8b.xn--o-8ta85a3b1dwcda1k.io")
+	display := NewFriendlyHost("ʎɹʇsıƃǝɹ.ɯɹoɟɐɹɹǝʇ.io")
+
+	// The pre-normalized host is not a valid source, and therefore not
+	// comparable to the display version.
+	if display.Equal(puny) {
+		t.Fatalf("invalid host %q should not be comparable", puny)
+	}
+}

--- a/registry/regsrc/module.go
+++ b/registry/regsrc/module.go
@@ -184,3 +184,9 @@ func (m *Module) formatWithPrefix(hostPrefix string, preserveCase bool) string {
 	}
 	return str
 }
+
+// Module returns just the registry ID of the module, without a hostname or
+// suffix.
+func (m *Module) Module() string {
+	return fmt.Sprintf("%s/%s/%s", m.RawNamespace, m.RawName, m.RawProvider)
+}

--- a/registry/regsrc/module.go
+++ b/registry/regsrc/module.go
@@ -40,6 +40,13 @@ var (
 	// ProviderRe is a regular expression defining the format allowed for
 	// provider fields in module registry implementations.
 	ProviderRe = regexp.MustCompile("^" + providerSubRe + "$")
+
+	// these hostnames are not allowed as registry sources, because they are
+	// already special case module sources in terraform.
+	disallowed = map[string]bool{
+		"github.com":    true,
+		"bitbucket.org": true,
+	}
 )
 
 // Module describes a Terraform Registry Module source.
@@ -60,7 +67,7 @@ type Module struct {
 
 // NewModule construct a new module source from separate parts. Pass empty
 // string if host or submodule are not needed.
-func NewModule(host, namespace, name, provider, submodule string) *Module {
+func NewModule(host, namespace, name, provider, submodule string) (*Module, error) {
 	m := &Module{
 		RawNamespace: namespace,
 		RawName:      name,
@@ -68,9 +75,16 @@ func NewModule(host, namespace, name, provider, submodule string) *Module {
 		RawSubmodule: submodule,
 	}
 	if host != "" {
-		m.RawHost = NewFriendlyHost(host)
+		h := NewFriendlyHost(host)
+		if h != nil {
+			fmt.Println("HOST:", h)
+			if !h.Valid() || disallowed[h.Display()] {
+				return nil, ErrInvalidModuleSource
+			}
+		}
+		m.RawHost = h
 	}
-	return m
+	return m, nil
 }
 
 // ParseModuleSource attempts to parse source as a Terraform registry module
@@ -85,8 +99,10 @@ func NewModule(host, namespace, name, provider, submodule string) *Module {
 func ParseModuleSource(source string) (*Module, error) {
 	// See if there is a friendly host prefix.
 	host, rest := ParseFriendlyHost(source)
-	if host != nil && !host.Valid() {
-		return nil, ErrInvalidModuleSource
+	if host != nil {
+		if !host.Valid() || disallowed[host.Display()] {
+			return nil, ErrInvalidModuleSource
+		}
 	}
 
 	matches := moduleSourceRe.FindStringSubmatch(rest)

--- a/registry/regsrc/module.go
+++ b/registry/regsrc/module.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/hashicorp/terraform/svchost"
 )
 
 var (
@@ -189,4 +191,15 @@ func (m *Module) formatWithPrefix(hostPrefix string, preserveCase bool) string {
 // suffix.
 func (m *Module) Module() string {
 	return fmt.Sprintf("%s/%s/%s", m.RawNamespace, m.RawName, m.RawProvider)
+}
+
+// SvcHost returns the svchost.Hostname for this module. Since FriendlyHost may
+// contain an invalid hostname, this also returns an error indicating if it
+// could be converted to a svchost.Hostname. If no host is specified, the
+// default PublicRegistryHost is returned.
+func (m *Module) SvcHost() (svchost.Hostname, error) {
+	if m.RawHost == nil {
+		return svchost.ForComparison(PublicRegistryHost.Raw)
+	}
+	return svchost.ForComparison(m.RawHost.Raw)
 }

--- a/registry/regsrc/module_test.go
+++ b/registry/regsrc/module_test.go
@@ -96,6 +96,16 @@ func TestModule(t *testing.T) {
 			source:  "foo.com/var/baz?otherthing",
 			wantErr: true,
 		},
+		{
+			name:    "disallow github",
+			source:  "github.com/HashiCorp/Consul/aws",
+			wantErr: true,
+		},
+		{
+			name:    "disallow bitbucket",
+			source:  "bitbucket.org/HashiCorp/Consul/aws",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/registry/regsrc/module_test.go
+++ b/registry/regsrc/module_test.go
@@ -96,16 +96,6 @@ func TestModule(t *testing.T) {
 			source:  "foo.com/var/baz?otherthing",
 			wantErr: true,
 		},
-		{
-			name:    "disallow github",
-			source:  "github.com/HashiCorp/Consul/aws",
-			wantErr: true,
-		},
-		{
-			name:    "disallow bitbucket",
-			source:  "bitbucket.org/HashiCorp/Consul/aws",
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Some basic cleanup to do before refactoring the config/module source. 

The registry's requirements for FriendlyHost are slightly different that those of terraform itself. Rather than try and unify the concepts of FriendlyHost and svchost.Hostname, I'm going to leave the FriendlyHost api as-is, and add `SvcHost` method to return a svchost.Hostname. The only test checks now omitted or changes from the original set are where a punycode source was allowed even though it was not valid. 