### PR TITLE
Warn about potential errors when output interpolation expressions use a counted resource like a singleton

### DIFF
--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -2,12 +2,13 @@ package local
 
 import (
 	"errors"
-	"fmt"
 	"log"
-	"strings"
+
+	"github.com/hashicorp/terraform/command/format"
+
+	"github.com/hashicorp/terraform/tfdiags"
 
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
@@ -91,27 +92,31 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 
 		// If validation is enabled, validate
 		if b.OpValidation {
-			// We ignore warnings here on purpose. We expect users to be listening
-			// to the terraform.Hook called after a validation.
-			ws, es := tfCtx.Validate()
-			if len(ws) > 0 {
-				// Log just in case the CLI isn't enabled
-				log.Printf("[WARN] backend/local: %d warnings: %v", len(ws), ws)
-
-				// If we have a CLI, output the warnings
-				if b.CLI != nil {
-					b.CLI.Warn(strings.TrimSpace(validateWarnHeader) + "\n")
-					for _, w := range ws {
-						b.CLI.Warn(fmt.Sprintf("  * %s", w))
-					}
-
-					// Make a newline before continuing
-					b.CLI.Output("")
+			diags := tfCtx.Validate()
+			if len(diags) > 0 {
+				if diags.HasErrors() {
+					// If there are warnings _and_ errors then we'll take this
+					// path and return them all together in this error.
+					return nil, nil, diags.Err()
 				}
-			}
 
-			if len(es) > 0 {
-				return nil, nil, multierror.Append(nil, es...)
+				// For now we can't propagate warnings any further without
+				// printing them directly to the UI, so we'll need to
+				// format them here ourselves.
+				for _, diag := range diags {
+					if diag.Severity() != tfdiags.Warning {
+						continue
+					}
+					if b.CLI != nil {
+						b.CLI.Warn(format.Diagnostic(diag, b.Colorize(), 72))
+					} else {
+						desc := diag.Description()
+						log.Printf("[WARN] backend/local: %s", desc.Summary)
+					}
+				}
+
+				// Make a newline before continuing
+				b.CLI.Output("")
 			}
 		}
 	}

--- a/command/init.go
+++ b/command/init.go
@@ -280,7 +280,8 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 		return err
 	}
 
-	if err := mod.Validate(); err != nil {
+	if diags := mod.Validate(); diags.HasErrors() {
+		err := diags.Err()
 		c.Ui.Error(fmt.Sprintf("Error getting plugins: %s", err))
 		return err
 	}

--- a/command/providers.go
+++ b/command/providers.go
@@ -53,10 +53,11 @@ func (c *ProvidersCommand) Run(args []string) int {
 	}
 
 	// Validate the config (to ensure the version constraints are valid)
-	err = root.Validate()
-	if err != nil {
-		c.Ui.Error(err.Error())
-		return 1
+	if diags := root.Validate(); len(diags) != 0 {
+		c.showDiagnostics(diags)
+		if diags.HasErrors() {
+			return 1
+		}
 	}
 
 	// Load the backend

--- a/command/validate.go
+++ b/command/validate.go
@@ -100,10 +100,11 @@ func (c *ValidateCommand) validate(dir string, checkVars bool) int {
 		c.showDiagnostics(err)
 		return 1
 	}
-	err = cfg.Validate()
-	if err != nil {
-		c.showDiagnostics(err)
-		return 1
+	if diags := cfg.Validate(); len(diags) != 0 {
+		c.showDiagnostics(diags)
+		if diags.HasErrors() {
+			return 1
+		}
 	}
 
 	if checkVars {
@@ -122,7 +123,7 @@ func (c *ValidateCommand) validate(dir string, checkVars bool) int {
 			return 1
 		}
 
-		if !validateContext(tfCtx, c.Ui) {
+		if !c.validateContext(tfCtx) {
 			return 1
 		}
 	}

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -74,7 +74,7 @@ func TestValidateFailingCommandMissingVariable(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("Should have failed: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
-	if !strings.HasSuffix(strings.TrimSpace(ui.ErrorWriter.String()), "config: unknown variable referenced: 'description'. define it with 'variable' blocks") {
+	if !strings.HasSuffix(strings.TrimSpace(ui.ErrorWriter.String()), "config: unknown variable referenced: 'description'; define it with a 'variable' block") {
 		t.Fatalf("Should have failed: %d\n\n'%s'", code, ui.ErrorWriter.String())
 	}
 }
@@ -84,7 +84,7 @@ func TestSameProviderMutipleTimesShouldFail(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("Should have failed: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
-	if !strings.HasSuffix(strings.TrimSpace(ui.ErrorWriter.String()), "provider.aws: declared multiple times, you can only declare a provider once") {
+	if !strings.HasSuffix(strings.TrimSpace(ui.ErrorWriter.String()), "provider.aws: multiple configurations present; only one configuration is allowed per provider") {
 		t.Fatalf("Should have failed: %d\n\n'%s'", code, ui.ErrorWriter.String())
 	}
 }
@@ -94,7 +94,7 @@ func TestSameModuleMultipleTimesShouldFail(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("Should have failed: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
-	if !strings.HasSuffix(strings.TrimSpace(ui.ErrorWriter.String()), "multi_module: module repeated multiple times") {
+	if !strings.HasSuffix(strings.TrimSpace(ui.ErrorWriter.String()), "module \"multi_module\": module repeated multiple times") {
 		t.Fatalf("Should have failed: %d\n\n'%s'", code, ui.ErrorWriter.String())
 	}
 }
@@ -114,7 +114,7 @@ func TestOutputWithoutValueShouldFail(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("Should have failed: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
-	if !strings.HasSuffix(strings.TrimSpace(ui.ErrorWriter.String()), "output is missing required 'value' key") {
+	if !strings.HasSuffix(strings.TrimSpace(ui.ErrorWriter.String()), "output \"myvalue\": missing required 'value' argument") {
 		t.Fatalf("Should have failed: %d\n\n'%s'", code, ui.ErrorWriter.String())
 	}
 }
@@ -125,7 +125,7 @@ func TestModuleWithIncorrectNameShouldFail(t *testing.T) {
 		t.Fatalf("Should have failed: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 
-	if !strings.Contains(ui.ErrorWriter.String(), "module name can only contain letters, numbers, dashes, and underscores") {
+	if !strings.Contains(ui.ErrorWriter.String(), "module name must be a letter or underscore followed by only letters, numbers, dashes, and underscores") {
 		t.Fatalf("Should have failed: %d\n\n'%s'", code, ui.ErrorWriter.String())
 	}
 	if !strings.Contains(ui.ErrorWriter.String(), "module source cannot contain interpolations") {
@@ -142,7 +142,7 @@ func TestWronglyUsedInterpolationShouldFail(t *testing.T) {
 	if !strings.Contains(ui.ErrorWriter.String(), "depends on value cannot contain interpolations") {
 		t.Fatalf("Should have failed: %d\n\n'%s'", code, ui.ErrorWriter.String())
 	}
-	if !strings.Contains(ui.ErrorWriter.String(), "Variable 'vairable_with_interpolation': cannot contain interpolations") {
+	if !strings.Contains(ui.ErrorWriter.String(), "variable \"vairable_with_interpolation\": default may not contain interpolations") {
 		t.Fatalf("Should have failed: %d\n\n'%s'", code, ui.ErrorWriter.String())
 	}
 }

--- a/config/module/tree_test.go
+++ b/config/module/tree_test.go
@@ -404,15 +404,15 @@ func TestTreeValidate_table(t *testing.T) {
 				t.Fatalf("err: %s", err)
 			}
 
-			err := tree.Validate()
-			if (err != nil) != (tc.Err != "") {
-				t.Fatalf("err: %s", err)
+			diags := tree.Validate()
+			if (diags.HasErrors()) != (tc.Err != "") {
+				t.Fatalf("err: %s", diags.Err())
 			}
-			if err == nil {
+			if len(diags) == 0 {
 				return
 			}
-			if !strings.Contains(err.Error(), tc.Err) {
-				t.Fatalf("err should contain %q: %s", tc.Err, err)
+			if !strings.Contains(diags.Err().Error(), tc.Err) {
+				t.Fatalf("err should contain %q: %s", tc.Err, diags.Err().Error())
 			}
 		})
 	}
@@ -519,13 +519,13 @@ func TestTreeValidate_requiredChildVar(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	err := tree.Validate()
-	if err == nil {
+	diags := tree.Validate()
+	if !diags.HasErrors() {
 		t.Fatal("should error")
 	}
 
 	// ensure both variables are mentioned in the output
-	errMsg := err.Error()
+	errMsg := diags.Err().Error()
 	for _, v := range []string{"feature", "memory"} {
 		if !strings.Contains(errMsg, v) {
 			t.Fatalf("no mention of missing variable %q", v)

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -7966,12 +7966,9 @@ func TestContext2Apply_vars(t *testing.T) {
 		},
 	})
 
-	w, e := ctx.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %s", e)
+	diags := ctx.Validate()
+	if len(diags) != 0 {
+		t.Fatalf("bad: %#v", diags)
 	}
 
 	if _, err := ctx.Plan(); err != nil {
@@ -8009,12 +8006,9 @@ func TestContext2Apply_varsEnv(t *testing.T) {
 		),
 	})
 
-	w, e := ctx.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %s", e)
+	diags := ctx.Validate()
+	if len(diags) != 0 {
+		t.Fatalf("bad: %#v", diags)
 	}
 
 	if _, err := ctx.Plan(); err != nil {

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -3499,12 +3499,9 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 		State: s,
 	})
 
-	w, e := ctx.Validate()
-	if len(w) > 0 {
-		t.Fatalf("warnings generated on validate: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("errors generated on validate: %#v", e)
+	diags := ctx.Validate()
+	if len(diags) != 0 {
+		t.Fatalf("bad: %#v", diags)
 	}
 
 	_, err := ctx.Refresh()
@@ -3582,12 +3579,9 @@ output "out" {
 	})
 
 	// if this ever fails to pass validate, add a resource to reference in the config
-	w, e := ctx.Validate()
-	if len(w) > 0 {
-		t.Fatalf("warnings generated on validate: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("errors generated on validate: %v", e)
+	diags := ctx.Validate()
+	if len(diags) != 0 {
+		t.Fatalf("bad: %#v", diags)
 	}
 
 	_, err := ctx.Refresh()
@@ -3630,12 +3624,9 @@ resource "aws_instance" "foo" {
 	})
 
 	// if this ever fails to pass validate, add a resource to reference in the config
-	w, e := ctx.Validate()
-	if len(w) > 0 {
-		t.Fatalf("warnings generated on validate: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("errors generated on validate: %v", e)
+	diags := ctx.Validate()
+	if len(diags) != 0 {
+		t.Fatalf("bad: %#v", diags)
 	}
 
 	_, err := ctx.Refresh()

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -1042,12 +1042,9 @@ func TestContext2Validate(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if len(diags) != 0 {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -18,12 +18,9 @@ func TestContext2Validate_badCount(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -39,12 +36,9 @@ func TestContext2Validate_badVar(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -63,12 +57,9 @@ func TestContext2Validate_varMapOverrideOld(t *testing.T) {
 		},
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -78,12 +69,9 @@ func TestContext2Validate_varNoDefaultExplicitType(t *testing.T) {
 		Module: m,
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -112,14 +100,9 @@ func TestContext2Validate_computedVar(t *testing.T) {
 		return fmt.Errorf("Configure should not be called for provider")
 	}
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		for _, err := range e {
-			t.Errorf("bad: %s", err)
-		}
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -138,12 +121,9 @@ func TestContext2Validate_countComputed(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -159,12 +139,9 @@ func TestContext2Validate_countNegative(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -180,12 +157,9 @@ func TestContext2Validate_countVariable(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -201,12 +175,9 @@ func TestContext2Validate_countVariableNoDefault(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) != 1 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -224,12 +195,9 @@ func TestContext2Validate_cycle(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("expected no warns, got: %#v", w)
-	}
-	if len(e) != 1 {
-		t.Fatalf("expected 1 err, got: %s", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 */
@@ -246,12 +214,9 @@ func TestContext2Validate_moduleBadOutput(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -267,12 +232,9 @@ func TestContext2Validate_moduleGood(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -290,12 +252,9 @@ func TestContext2Validate_moduleBadResource(t *testing.T) {
 
 	p.ValidateResourceReturnErrors = []error{fmt.Errorf("bad")}
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -311,13 +270,9 @@ func TestContext2Validate_moduleDepsShouldNotCycle(t *testing.T) {
 		),
 	})
 
-	w, e := ctx.Validate()
-
-	if len(w) > 0 {
-		t.Fatalf("expected no warnings, got: %s", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("expected no errors, got: %s", e)
+	diags := ctx.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -360,12 +315,9 @@ func TestContext2Validate_moduleProviderInheritOrphan(t *testing.T) {
 		return nil, nil
 	}
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -388,12 +340,9 @@ func TestContext2Validate_moduleProviderVar(t *testing.T) {
 		return nil, c.CheckSet([]string{"foo"})
 	}
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -413,12 +362,9 @@ func TestContext2Validate_moduleProviderInheritUnused(t *testing.T) {
 		return nil, c.CheckSet([]string{"foo"})
 	}
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -455,12 +401,9 @@ func TestContext2Validate_orphans(t *testing.T) {
 		return nil, c.CheckSet([]string{"foo"})
 	}
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -478,15 +421,12 @@ func TestContext2Validate_providerConfig_bad(t *testing.T) {
 
 	p.ValidateReturnErrors = []error{fmt.Errorf("bad")}
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
+	diags := c.Validate()
+	if len(diags) != 1 {
+		t.Fatalf("wrong number of diagnostics %d; want %d", len(diags), 1)
 	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %s", e)
-	}
-	if !strings.Contains(fmt.Sprintf("%s", e), "bad") {
-		t.Fatalf("bad: %s", e)
+	if !strings.Contains(diags.Err().Error(), "bad") {
+		t.Fatalf("bad: %s", diags.Err().Error())
 	}
 }
 
@@ -504,12 +444,9 @@ func TestContext2Validate_providerConfig_badEmpty(t *testing.T) {
 
 	p.ValidateReturnErrors = []error{fmt.Errorf("bad")}
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -525,12 +462,9 @@ func TestContext2Validate_providerConfig_good(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -552,12 +486,9 @@ func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 
 	pr.ValidateReturnErrors = []error{fmt.Errorf("bad")}
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -583,12 +514,9 @@ func TestContext2Validate_provisionerConfig_good(t *testing.T) {
 		},
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -604,12 +532,9 @@ func TestContext2Validate_requiredVar(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -627,12 +552,9 @@ func TestContext2Validate_resourceConfig_bad(t *testing.T) {
 
 	p.ValidateResourceReturnErrors = []error{fmt.Errorf("bad")}
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -648,12 +570,9 @@ func TestContext2Validate_resourceConfig_good(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -669,12 +588,9 @@ func TestContext2Validate_resourceNameSymbol(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -690,12 +606,9 @@ func TestContext2Validate_selfRef(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %s", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -711,12 +624,9 @@ func TestContext2Validate_selfRefMulti(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -732,12 +642,9 @@ func TestContext2Validate_selfRefMultiAll(t *testing.T) {
 		),
 	})
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) == 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -775,12 +682,9 @@ func TestContext2Validate_tainted(t *testing.T) {
 		return nil, c.CheckSet([]string{"foo"})
 	}
 
-	w, e := c.Validate()
-	if len(w) > 0 {
-		t.Fatalf("bad: %#v", w)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %#v", e)
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -815,16 +719,9 @@ func TestContext2Validate_targetedDestroy(t *testing.T) {
 		Destroy: true,
 	})
 
-	w, e := ctx.Validate()
-	if len(w) > 0 {
-		warnStr := ""
-		for _, v := range w {
-			warnStr = warnStr + " " + v
-		}
-		t.Fatalf("bad: %s", warnStr)
-	}
-	if len(e) > 0 {
-		t.Fatalf("bad: %s", e)
+	diags := ctx.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -875,12 +772,9 @@ func TestContext2Validate_interpolateVar(t *testing.T) {
 		UIInput: input,
 	})
 
-	w, e := ctx.Validate()
-	if w != nil {
-		t.Log("warnings:", w)
-	}
-	if e != nil {
-		t.Fatal("err:", e)
+	diags := ctx.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -904,12 +798,9 @@ func TestContext2Validate_interpolateComputedModuleVarDef(t *testing.T) {
 		UIInput: input,
 	})
 
-	w, e := ctx.Validate()
-	if w != nil {
-		t.Log("warnings:", w)
-	}
-	if e != nil {
-		t.Fatal("err:", e)
+	diags := ctx.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 
@@ -932,12 +823,9 @@ func TestContext2Validate_interpolateMap(t *testing.T) {
 		UIInput: input,
 	})
 
-	w, e := ctx.Validate()
-	if w != nil {
-		t.Log("warnings:", w)
-	}
-	if e != nil {
-		t.Fatal("err:", e)
+	diags := ctx.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("bad: %#v", diags)
 	}
 }
 


### PR DESCRIPTION
When `count` is set to anything other than `1` on a resource it is necessary to access attributes of the resource via the splat syntax to get a list of all of the results.

This has always been an error, but due to the earlier bug that errors were swallowed for outputs there are some existing configs that have erroneous outputs that now fail in 0.11.0. While in some cases this problem is immediately obvious due to Terraform failing to even plan, it's problematic when the dynamic value of the count _happens to be_ `1` on the first plan after an upgrade, but then later becomes some other value in a subsequent change: now something that used to work doesn't anymore, and you've already updated your state to 0.11.0 and so downgrading isn't an option.

This change is intended as _part_ of the fix for #16726: it emits a warning when an output references a resource with `count` using the singleton form, _even if_ the current _dynamic_ value of `count` is `1`. Omitting the `count` altogether or specifying the _literal_ value `1` (as opposed to an expression that evaluates to `1`) allows this usage without the warning. This means that Terraform will give an early warning about the problematic usage so that it can be corrected immediately, rather than becoming a surprising gotcha after it's already too late to downgrade again.

---

Unfortunately Terraform has never needed to produce warnings at this stage in validation before, so we had no mechanism available to do so. Thus a big part of this PR is a reorganization of the validation code to use our new "diagnostics" abstraction. This was originally intended to come as part of integrating the new config language parser, but we're expediting this change in order to allow for this warning.
