### PR TITLE
Output warnings flag

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -862,3 +862,33 @@ func TestConfigModuleProviders(t *testing.T) {
 		t.Fatalf("exptected providers %#v, got providers %#v", expected, got)
 	}
 }
+
+func TestValidateOutputErrorWarnings(t *testing.T) {
+	// TODO: remove this in 0.12
+	c := testConfig(t, "output-warnings")
+	if err := c.Validate(); err != nil {
+		t.Fatal("config should have no warnings or errors")
+	}
+
+	// Now run the same config with output warnings on
+	flagWarnOutputErrors = true
+	defer func() {
+		flagWarnOutputErrors = false
+	}()
+
+	c = testConfig(t, "output-warnings")
+
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatal("config should not have errors:", diags)
+	}
+	if len(diags) != 2 {
+		t.Fatalf("should have 2 warnings, got %d:\n%s", len(diags), diags)
+	}
+
+	// this fixture has no explicit count, and should have no warning
+	c = testConfig(t, "output-no-warnings")
+	if err := c.Validate(); err != nil {
+		t.Fatal("config should have no warnings or errors")
+	}
+}

--- a/config/test-fixtures/output-no-warnings/main.tf
+++ b/config/test-fixtures/output-no-warnings/main.tf
@@ -1,0 +1,6 @@
+resource "test_instance" "foo" {
+}
+
+output "foo_id" {
+  value = "${test_instance.foo.id}"
+}

--- a/config/test-fixtures/output-warnings/main.tf
+++ b/config/test-fixtures/output-warnings/main.tf
@@ -1,0 +1,24 @@
+locals {
+  "count" = 1
+}
+
+resource "test_instance" "foo" {
+  count = "${local.count}"
+}
+
+output "foo_id" {
+  value = "${test_instance.foo.id}"
+}
+
+variable "condition" {
+  default = "true"
+}
+
+resource "test_instance" "bar" {
+  count = "${var.condition ? 1 : 0}"
+}
+
+
+output "bar_id" {
+  value = "${test_instance.bar.id}"
+}

--- a/terraform/eval_output.go
+++ b/terraform/eval_output.go
@@ -68,9 +68,9 @@ func (n *EvalWriteOutput) Eval(ctx EvalContext) (interface{}, error) {
 
 	// handling the interpolation error
 	if err != nil {
-		if n.ContinueOnErr {
+		if n.ContinueOnErr || flagWarnOutputErrors {
 			log.Printf("[ERROR] Output interpolation %q failed: %s", n.Name, err)
-			// if we're continueing, make sure the output is included, and
+			// if we're continuing, make sure the output is included, and
 			// marked as unknown
 			mod.Outputs[n.Name] = &OutputState{
 				Type:  "string",

--- a/terraform/features.go
+++ b/terraform/features.go
@@ -1,3 +1,7 @@
 package terraform
 
+import "os"
+
 // This file holds feature flags for the next release
+
+var flagWarnOutputErrors = os.Getenv("TF_WARN_OUTPUT_ERRORS") != ""


### PR DESCRIPTION
This adds an opt out env variable `TF_WARN_OUTPUT_ERRORS` which will make output errors non fatal during interpolation. The flag will also cause config validation to insert warnings about suspected sources of output errors du to variable count values. 

