### PR TITLE
Add an option to skip the region check

### DIFF
--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -136,6 +136,13 @@ func New() backend.Backend {
 				Default:     false,
 			},
 
+			"skip_region_validation": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Skip static validation of region name.",
+				Default:     false,
+			},
+
 			"skip_requesting_account_id": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -243,6 +250,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		Token:                   data.Get("token").(string),
 		SkipCredsValidation:     data.Get("skip_credentials_validation").(bool),
 		SkipGetEC2Platforms:     data.Get("skip_get_ec2_platforms").(bool),
+		SkipRegionValidation:    data.Get("skip_region_validation").(bool),
 		SkipRequestingAccountId: data.Get("skip_requesting_account_id").(bool),
 		SkipMetadataApiCheck:    data.Get("skip_metadata_api_check").(bool),
 	}

--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -110,10 +110,11 @@ The following configuration options or environment variables are supported:
  * `assume_role_policy` - (Optional) The permissions applied when assuming a role.
  * `external_id` - (Optional) The external ID to use when assuming the role.
  * `session_name` - (Optional) The session name to use when assuming the role.
- * `workspace_key_prefix` - (Optional) The prefix applied to the state path 
+ * `workspace_key_prefix` - (Optional) The prefix applied to the state path
    inside the bucket. This is only relevant when using a non-default workspace.
    This defaults to "env:"
  * `skip_credentials_validation` - (Optional) Skip the credentials validation via the STS API.
  * `skip_get_ec2_platforms` - (Optional) Skip getting the supported EC2 platforms.
+ * `skip_region_validation` - (Optional) Skip validation of provided region name.
  * `skip_requesting_account_id` - (Optional) Skip requesting the account ID.
  * `skip_metadata_api_check` - (Optional) Skip the AWS Metadata API check.


### PR DESCRIPTION
Without the possibility to skip this check, it’s not possible to use a custom region with an S3 compatible solution.