### PR TITLE
config: validate terraform block for unknown keys

### DIFF
--- a/config/config_terraform.go
+++ b/config/config_terraform.go
@@ -13,11 +13,19 @@ import (
 type Terraform struct {
 	RequiredVersion string   `hcl:"required_version"` // Required Terraform version (constraint)
 	Backend         *Backend // See Backend struct docs
+
+	unknownKeys []string
 }
 
 // Validate performs the validation for just the Terraform configuration.
 func (t *Terraform) Validate() []error {
 	var errs []error
+
+	// Error on any unknown key configuration.
+	if len(t.unknownKeys) > 0 {
+		errs = append(errs, fmt.Errorf(
+			"terraform: unknown configurations: %s", strings.Join(t.unknownKeys, ", ")))
+	}
 
 	if raw := t.RequiredVersion; raw != "" {
 		// Check that the value has no interpolations

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -225,6 +225,12 @@ func TestConfigValidate_table(t *testing.T) {
 			true,
 			"does not exist",
 		},
+		{
+			"unknown configurations in terraform block",
+			"validate-terraform-block",
+			true,
+			"unknown configurations: version, configx",
+		},
 	}
 
 	for i, tc := range cases {

--- a/config/test-fixtures/validate-terraform-block/main.tf
+++ b/config/test-fixtures/validate-terraform-block/main.tf
@@ -1,0 +1,8 @@
+terraform {
+    version = "xyz"
+    required_version = "1.0"
+    backend "foo" {
+        key = "bar"
+    }
+    configx = "100"
+}


### PR DESCRIPTION
Records unknownKeys from terraform block during loading of terraform HCL
and errors out the unknown keys during validation.

fixes #16755 