### PR TITLE
helper/validation: Add StringMatch

### DIFF
--- a/helper/validation/validation.go
+++ b/helper/validation/validation.go
@@ -107,9 +107,8 @@ func StringLenBetween(min, max int) schema.SchemaValidateFunc {
 }
 
 // StringMatch returns a SchemaValidateFunc which tests if the provided value
-// matches a given regexp, which must compile or else the function will panic.
-// Optionally an error message can be provided to return something friendlier
-// than "must match some globby regexp".
+// matches a given regexp. Optionally an error message can be provided to
+// return something friendlier than "must match some globby regexp".
 func StringMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) ([]string, []error) {
 		v, ok := i.(string)

--- a/helper/validation/validation.go
+++ b/helper/validation/validation.go
@@ -106,6 +106,28 @@ func StringLenBetween(min, max int) schema.SchemaValidateFunc {
 	}
 }
 
+// StringMatch returns a SchemaValidateFunc which tests if the provided value
+// matches a given regexp, which must compile or else the function will panic.
+// Optionally an error message can be provided to return something friendlier
+// than "must match some globby regexp".
+func StringMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		v, ok := i.(string)
+		if !ok {
+			return nil, []error{fmt.Errorf("expected type of %s to be string", k)}
+		}
+
+		if ok := r.MatchString(v); !ok {
+			if message != "" {
+				return nil, []error{fmt.Errorf("invalid value for %s (%s)", k, message)}
+
+			}
+			return nil, []error{fmt.Errorf("expected value of %s to match regular expression %q", k, r)}
+		}
+		return nil, nil
+	}
+}
+
 // NoZeroValues is a SchemaValidateFunc which tests if the provided value is
 // not a zero value. It's useful in situations where you want to catch
 // explicit zero values on things like required fields during validation.

--- a/helper/validation/validation_test.go
+++ b/helper/validation/validation_test.go
@@ -111,6 +111,25 @@ func TestValidationStringInSlice(t *testing.T) {
 	})
 }
 
+func TestValidationStringMatch(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "foobar",
+			f:   StringMatch(regexp.MustCompile(".*foo.*"), ""),
+		},
+		{
+			val:         "bar",
+			f:           StringMatch(regexp.MustCompile(".*foo.*"), ""),
+			expectedErr: regexp.MustCompile("expected value of [\\w]+ to match regular expression " + regexp.QuoteMeta(`".*foo.*"`)),
+		},
+		{
+			val:         "bar",
+			f:           StringMatch(regexp.MustCompile(".*foo.*"), "value must contain foo"),
+			expectedErr: regexp.MustCompile("invalid value for [\\w]+ \\(value must contain foo\\)"),
+		},
+	})
+}
+
 func TestValidationRegexp(t *testing.T) {
 	runTestCases(t, []testCase{
 		{


### PR DESCRIPTION
`StringMatch` returns a validation function that can be used to match a
string against a regular expression. This can be used for simple
substring validations or more complex validation scenarios. Optionally,
an error message can be returned so that the user is returned a better
error message other than that their field did not match a regular
expression that they might not be able to understand.