### PR TITLE
Document that plugin_cache_dir must already exist

### DIFF
--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -240,6 +240,9 @@ For example:
 plugin_cache_dir = "$HOME/.terraform.d/plugin-cache"
 ```
 
+This directory must already exist before Terraform will cache plugins;
+Terraform will not create the directory itself.
+
 Please note that on Windows it is necessary to use forward slash separators
 (`/`) rather than the conventional backslash (`\`) since the configuration
 file parser considers a backslash to begin an escape sequence.


### PR DESCRIPTION
It was noted in #16401 that if the `plugin_cache_dir` doesn't exist, Terraform will still cache plugins to the filesystem, but it won't hardlink them and the `plugin_cache_dir` won't get created. Terraform could create the directory automatically, but I'm not sure which part of the code is the best place to do that, so it would at least be nice to document this behavior until code to create the directory is implemented 😄