### PR TITLE
Make plan command cancellable 

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -24,9 +24,6 @@ type ApplyCommand struct {
 	// If true, then this apply command will become the "destroy"
 	// command. It is just like apply but only processes a destroy.
 	Destroy bool
-
-	// When this channel is closed, the apply will be cancelled.
-	ShutdownCh <-chan struct{}
 }
 
 func (c *ApplyCommand) Run(args []string) int {

--- a/command/apply.go
+++ b/command/apply.go
@@ -183,6 +183,11 @@ func (c *ApplyCommand) Run(args []string) int {
 		// Cancel our context so we can start gracefully exiting
 		ctxCancel()
 
+		// notify tests that the command context was canceled
+		if testShutdownHook != nil {
+			testShutdownHook()
+		}
+
 		// Notify the user
 		c.Ui.Output(outputInterrupt)
 

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -837,9 +837,8 @@ func TestApply_shutdown(t *testing.T) {
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			ShutdownCh:       shutdownCh,
 		},
-
-		ShutdownCh: shutdownCh,
 	}
 
 	p.DiffFn = func(

--- a/command/console.go
+++ b/command/console.go
@@ -17,9 +17,6 @@ import (
 // configuration and actually builds or changes infrastructure.
 type ConsoleCommand struct {
 	Meta
-
-	// When this channel is closed, the apply will be cancelled.
-	ShutdownCh <-chan struct{}
 }
 
 func (c *ConsoleCommand) Run(args []string) int {

--- a/command/meta.go
+++ b/command/meta.go
@@ -641,3 +641,7 @@ func isAutoVarFile(path string) bool {
 	return strings.HasSuffix(path, ".auto.tfvars") ||
 		strings.HasSuffix(path, ".auto.tfvars.json")
 }
+
+// testShutdownHook is used by tests to verify that a command context has been
+// canceled
+var testShutdownHook func()

--- a/command/meta.go
+++ b/command/meta.go
@@ -76,6 +76,9 @@ type Meta struct {
 	// is not suitable, e.g. because of a read-only filesystem.
 	OverrideDataDir string
 
+	// When this channel is closed, the command will be cancelled.
+	ShutdownCh <-chan struct{}
+
 	//----------------------------------------------------------
 	// Protected: commands can set these
 	//----------------------------------------------------------

--- a/command/plan.go
+++ b/command/plan.go
@@ -117,6 +117,12 @@ func (c *PlanCommand) Run(args []string) int {
 	case <-c.ShutdownCh:
 		// Cancel our context so we can start gracefully exiting
 		ctxCancel()
+
+		// notify tests that the command context was canceled
+		if testShutdownHook != nil {
+			testShutdownHook()
+		}
+
 		// Notify the user
 		c.Ui.Output(outputInterrupt)
 

--- a/command/plan.go
+++ b/command/plan.go
@@ -104,17 +104,35 @@ func (c *PlanCommand) Run(args []string) int {
 	opReq.Type = backend.OperationTypePlan
 
 	// Perform the operation
-	op, err := b.Operation(context.Background(), opReq)
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+
+	op, err := b.Operation(ctx, opReq)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error starting operation: %s", err))
 		return 1
 	}
 
-	// Wait for the operation to complete
-	<-op.Done()
-	if err := op.Err; err != nil {
-		c.showDiagnostics(err)
-		return 1
+	select {
+	case <-c.ShutdownCh:
+		// Cancel our context so we can start gracefully exiting
+		ctxCancel()
+		// Notify the user
+		c.Ui.Output(outputInterrupt)
+
+		// Still get the result, since there is still one
+		select {
+		case <-c.ShutdownCh:
+			c.Ui.Error(
+				"Two interrupts received. Exiting immediately")
+			return 1
+		case <-op.Done():
+		}
+	case <-op.Done():
+		if err := op.Err; err != nil {
+			c.showDiagnostics(err)
+			return 1
+		}
 	}
 
 	/*

--- a/commands.go
+++ b/commands.go
@@ -63,6 +63,8 @@ func initCommands(config *Config) {
 		RunningInAutomation: inAutomation,
 		PluginCacheDir:      config.PluginCacheDir,
 		OverrideDataDir:     dataDir,
+
+		ShutdownCh: makeShutdownCh(),
 	}
 
 	// The command list is included in the terraform -help
@@ -80,23 +82,20 @@ func initCommands(config *Config) {
 	Commands = map[string]cli.CommandFactory{
 		"apply": func() (cli.Command, error) {
 			return &command.ApplyCommand{
-				Meta:       meta,
-				ShutdownCh: makeShutdownCh(),
+				Meta: meta,
 			}, nil
 		},
 
 		"console": func() (cli.Command, error) {
 			return &command.ConsoleCommand{
-				Meta:       meta,
-				ShutdownCh: makeShutdownCh(),
+				Meta: meta,
 			}, nil
 		},
 
 		"destroy": func() (cli.Command, error) {
 			return &command.ApplyCommand{
-				Meta:       meta,
-				Destroy:    true,
-				ShutdownCh: makeShutdownCh(),
+				Meta:    meta,
+				Destroy: true,
 			}, nil
 		},
 


### PR DESCRIPTION
This adds cancellation support to the plan command. While plans are usually fairly uneventful, it can be useful to be able to cancel the plan during operation.

We also fix up the apply test to make it not rely on a sleep for verification. 

Also fixes #16652 which demonstrated the lack of cancellation waiting for a lock during plan.