### PR TITLE
Fully enable shutdown for plan and refresh in the local backend

### DIFF
--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -151,14 +151,6 @@ func (b *Local) opApply(
 		_, applyErr = tfCtx.Apply()
 		// we always want the state, even if apply failed
 		applyState = tfCtx.State()
-
-		/*
-			// Record any shadow errors for later
-			if err := ctx.ShadowError(); err != nil {
-				shadowErr = multierror.Append(shadowErr, multierror.Prefix(
-					err, "apply operation:"))
-			}
-		*/
 	}()
 
 	// Wait for the apply to finish or for us to be interrupted so

--- a/command/apply.go
+++ b/command/apply.go
@@ -171,6 +171,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	// Perform the operation
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	defer ctxCancel()
+
 	op, err := b.Operation(ctx, opReq)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error starting operation: %s", err))
@@ -182,11 +183,6 @@ func (c *ApplyCommand) Run(args []string) int {
 	case <-c.ShutdownCh:
 		// Cancel our context so we can start gracefully exiting
 		ctxCancel()
-
-		// notify tests that the command context was canceled
-		if testShutdownHook != nil {
-			testShutdownHook()
-		}
 
 		// Notify the user
 		c.Ui.Output(outputInterrupt)

--- a/command/meta.go
+++ b/command/meta.go
@@ -641,7 +641,3 @@ func isAutoVarFile(path string) bool {
 	return strings.HasSuffix(path, ".auto.tfvars") ||
 		strings.HasSuffix(path, ".auto.tfvars.json")
 }
-
-// testShutdownHook is used by tests to verify that a command context has been
-// canceled
-var testShutdownHook func()

--- a/command/plan.go
+++ b/command/plan.go
@@ -118,11 +118,6 @@ func (c *PlanCommand) Run(args []string) int {
 		// Cancel our context so we can start gracefully exiting
 		ctxCancel()
 
-		// notify tests that the command context was canceled
-		if testShutdownHook != nil {
-			testShutdownHook()
-		}
-
 		// Notify the user
 		c.Ui.Output(outputInterrupt)
 

--- a/terraform/resource_provider_mock.go
+++ b/terraform/resource_provider_mock.go
@@ -196,13 +196,14 @@ func (p *MockResourceProvider) Diff(
 	info *InstanceInfo,
 	state *InstanceState,
 	desired *ResourceConfig) (*InstanceDiff, error) {
-	p.Lock()
-	defer p.Unlock()
 
+	p.Lock()
 	p.DiffCalled = true
 	p.DiffInfo = info
 	p.DiffState = state
 	p.DiffDesired = desired
+	p.Unlock()
+
 	if p.DiffFn != nil {
 		return p.DiffFn(info, state, desired)
 	}


### PR DESCRIPTION
The backends need to specifically watch for and handle context cancellation because the context received for the operation is disjoint from the context used in the RunningOperation. This was only implemented in the apply operation, so the other operations couldn't be fully cancelled. 