### PR TITLE
  This change will fix the dobule lock issue when we use data.terrafo…

### DIFF
--- a/backend/remote-state/gcs/backend_state.go
+++ b/backend/remote-state/gcs/backend_state.go
@@ -97,8 +97,6 @@ func (b *gcsBackend) State(name string) (state.State, error) {
 		return nil, err
 	}
 
-	fmt.Println("XXXXXXXXYYYYYY", st.State())
-
 	// If we have no state, we have to create an empty state
 	if v := st.State(); v == nil {
 

--- a/backend/remote-state/gcs/backend_state.go
+++ b/backend/remote-state/gcs/backend_state.go
@@ -91,50 +91,55 @@ func (b *gcsBackend) State(name string) (state.State, error) {
 	}
 
 	st := &remote.State{Client: c}
-	lockInfo := state.NewLockInfo()
-	lockInfo.Operation = "init"
-	lockID, err := st.Lock(lockInfo)
-	if err != nil {
-		return nil, err
-	}
-
-	// Local helper function so we can call it multiple places
-	unlock := func(baseErr error) error {
-		if err := st.Unlock(lockID); err != nil {
-			const unlockErrMsg = `%v
-Additionally, unlocking the state file on Google Cloud Storage failed:
-
-  Error message: %q
-  Lock ID (gen): %v
-  Lock file URL: %v
-
-You may have to force-unlock this state in order to use it again.
-The GCloud backend acquires a lock during initialization to ensure
-the initial state file is created.`
-			return fmt.Errorf(unlockErrMsg, baseErr, err.Error(), lockID, c.lockFileURL())
-		}
-
-		return baseErr
-	}
 
 	// Grab the value
 	if err := st.RefreshState(); err != nil {
-		return nil, unlock(err)
+		return nil, err
 	}
+
+	fmt.Println("XXXXXXXXYYYYYY", st.State())
 
 	// If we have no state, we have to create an empty state
 	if v := st.State(); v == nil {
+
+		lockInfo := state.NewLockInfo()
+		lockInfo.Operation = "init"
+		lockID, err := st.Lock(lockInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		// Local helper function so we can call it multiple places
+		unlock := func(baseErr error) error {
+			if err := st.Unlock(lockID); err != nil {
+				const unlockErrMsg = `%v
+				Additionally, unlocking the state file on Google Cloud Storage failed:
+
+				Error message: %q
+				Lock ID (gen): %v
+				Lock file URL: %v
+
+				You may have to force-unlock this state in order to use it again.
+				The GCloud backend acquires a lock during initialization to ensure
+				the initial state file is created.`
+				return fmt.Errorf(unlockErrMsg, baseErr, err.Error(), lockID, c.lockFileURL())
+			}
+
+			return baseErr
+		}
+
 		if err := st.WriteState(terraform.NewState()); err != nil {
 			return nil, unlock(err)
 		}
 		if err := st.PersistState(); err != nil {
 			return nil, unlock(err)
 		}
-	}
 
-	// Unlock, the state should now be initialized
-	if err := unlock(nil); err != nil {
-		return nil, err
+		// Unlock, the state should now be initialized
+		if err := unlock(nil); err != nil {
+			return nil, err
+		}
+
 	}
 
 	return st, nil


### PR DESCRIPTION
Fixes #16741

There is a reproduceable double lock bug as far as I see. It exists in terraform 0.11 that introduced gcs with lock. You can reproduce the issue using the following setup.

Adding terraform_remote_state is causing a double lock that always fails.
Remove the terraform_remote_state section and all goes fine.

```terraform
provider "google" {
  credentials = "service-account.json"
  project     = "my-project"
  region      = "europe-west1"
}

terraform {
  backend "gcs" {
    credentials = "service-account.json"
    project     = "my-project"
    bucket      = "my-bucket"
    path        = "test.tfstate"
  }
}

data "terraform_remote_state" "k8s" {
  backend = "gcs"

  config {
    credentials = "service-account.json"
    project     = "my-project"
    bucket      = "my-bucket"
    path        = "test.tfstate"
  }

}
```

This change just moved the lock into a section that will run only if state does not exists. This seems in line with what I seem in implementation of s3 remote state.
