### PR TITLE
accessing count directly in an output should is OK

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -849,7 +849,7 @@ func (c *Config) Validate() tfdiags.Diagnostics {
 					// a count might dynamically be set to something
 					// other than 1 and thus splat syntax is still needed
 					// to be safe.
-					if r.RawCount != nil && r.RawCount.Raw != nil && r.RawCount.Raw["count"] != "1" {
+					if r.RawCount != nil && r.RawCount.Raw != nil && r.RawCount.Raw["count"] != "1" && rv.Field != "count" {
 						diags = diags.Append(tfdiags.SimpleWarning(fmt.Sprintf(
 							"output %q: must use splat syntax to access %s attribute %q, because it has \"count\" set; use %s.*.%s to obtain a list of the attributes across all instances",
 							o.Name,

--- a/config/test-fixtures/output-no-warnings/main.tf
+++ b/config/test-fixtures/output-no-warnings/main.tf
@@ -4,3 +4,11 @@ resource "test_instance" "foo" {
 output "foo_id" {
   value = "${test_instance.foo.id}"
 }
+
+resource "test_instance" "bar" {
+  count = 3
+}
+
+output "bar_count" {
+  value = "${test_instance.bar.count}"
+}


### PR DESCRIPTION
There should be no warning when accessing a resource's count value
directly in an output.

Fixes #16864