### PR TITLE
command: Always validate config as part of loading it

### DIFF
--- a/command/console.go
+++ b/command/console.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/wrappedstreams"
 	"github.com/hashicorp/terraform/repl"
+	"github.com/hashicorp/terraform/tfdiags"
 
 	"github.com/mitchellh/cli"
 )
@@ -38,10 +39,12 @@ func (c *ConsoleCommand) Run(args []string) int {
 		return 1
 	}
 
+	var diags tfdiags.Diagnostics
+
 	// Load the module
-	mod, err := c.Module(configPath)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+	mod, diags := c.Module(configPath)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 

--- a/command/providers.go
+++ b/command/providers.go
@@ -39,9 +39,9 @@ func (c *ProvidersCommand) Run(args []string) int {
 	}
 
 	// Load the config
-	root, err := c.Module(configPath)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+	root, diags := c.Module(configPath)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 	if root == nil {
@@ -50,14 +50,6 @@ func (c *ProvidersCommand) Run(args []string) int {
 				"This command requires configuration to run.",
 			configPath))
 		return 1
-	}
-
-	// Validate the config (to ensure the version constraints are valid)
-	if diags := root.Validate(); len(diags) != 0 {
-		c.showDiagnostics(diags)
-		if diags.HasErrors() {
-			return 1
-		}
 	}
 
 	// Load the backend
@@ -90,6 +82,11 @@ func (c *ProvidersCommand) Run(args []string) int {
 	providersCommandPopulateTreeNode(printRoot, depTree)
 
 	c.Ui.Output(printRoot.String())
+
+	c.showDiagnostics(diags)
+	if diags.HasErrors() {
+		return 1
+	}
 
 	return 0
 }

--- a/command/push.go
+++ b/command/push.go
@@ -89,9 +89,9 @@ func (c *PushCommand) Run(args []string) int {
 	}
 
 	// Load the module
-	mod, err := c.Module(configPath)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+	mod, diags := c.Module(configPath)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 	if mod == nil {
@@ -347,6 +347,12 @@ func (c *PushCommand) Run(args []string) int {
 	c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
 		"[reset][bold][green]Configuration %q uploaded! (v%d)",
 		name, vsn)))
+
+	c.showDiagnostics(diags)
+	if diags.HasErrors() {
+		return 1
+	}
+
 	return 0
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	hcl2 "github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hil/ast"
 	"github.com/hashicorp/terraform/helper/hilmapstructure"
 	"github.com/hashicorp/terraform/plugin/discovery"
@@ -415,10 +416,17 @@ func (c *Config) Validate() tfdiags.Diagnostics {
 		if p.Version != "" {
 			_, err := discovery.ConstraintStr(p.Version).Parse()
 			if err != nil {
-				diags = diags.Append(fmt.Errorf(
-					"provider.%s: invalid version constraint %q: %s",
-					name, p.Version, err,
-				))
+				diags = diags.Append(&hcl2.Diagnostic{
+					Severity: hcl2.DiagError,
+					Summary:  "Invalid provider version constraint",
+					Detail: fmt.Sprintf(
+						"The value %q given for provider.%s is not a valid version constraint.",
+						p.Version, name,
+					),
+					// TODO: include a "Subject" source reference in here,
+					// once the config loader is able to retain source
+					// location information.
+				})
 			}
 		}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -217,7 +217,7 @@ func TestConfigValidate_table(t *testing.T) {
 			"provider with invalid version constraint",
 			"provider-version-invalid",
 			true,
-			"invalid version constraint",
+			"not a valid version constraint",
 		},
 		{
 			"invalid provider name in module block",


### PR DESCRIPTION
Previously we required callers to separately call `.Validate` on the root module to determine if there were any value errors, but we did that inconsistently and would thus see crashes in some cases where later code would try to use invalid configuration as if it were valid.

Now we run `.Validate` automatically after config loading, returning the resulting diagnostics. Since we return a `tfdiags.Diagnostics` here, it's possible to return both warnings and errors.

We return the loaded module even if it's invalid, so callers are free to ignore returned errors and try to work with the config anyway, though they will need to be defensive against invalid configuration themselves in that case.

As a result of this, all of the commands that load configuration now need to use diagnostic printing to signal errors. For the moment this just allows us to return potentially-multiple config errors/warnings in full fidelity, but also sets us up for later when more subsystems are able to produce rich diagnostics so we can show them all together. (There are still lots of directly-printed errors here. Over time we should inspect these and see if turning them into diagnostics would be beneficial, so that we can mix both warnings and errors in those cases too.)

Finally, this commit also removes some stale, commented-out code for the "legacy" (pre-0.8) graph implementation, which has not been available for some time.

This fixes #15742.