### PR TITLE
ResourceConfig.get: Check for negative slice indexes.

### DIFF
--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -346,7 +346,7 @@ func (c *ResourceConfig) get(
 				if err != nil {
 					return nil, false
 				}
-				if i >= int64(cv.Len()) {
+				if int(i) < 0 || int(i) >= cv.Len() {
 					return nil, false
 				}
 				current = cv.Index(int(i)).Interface()

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -158,6 +158,14 @@ func TestResourceConfigGet(t *testing.T) {
 			Value: nil,
 		},
 
+		{
+			Config: map[string]interface{}{
+				"foo": []interface{}{1, 2, 5},
+			},
+			Key:   "foo.-1",
+			Value: nil,
+		},
+
 		// get from map
 		{
 			Config: map[string]interface{}{


### PR DESCRIPTION
The bounds checking in `ResourceConfig.get()` was insufficient: it detected when the index was greater than or equal to `cv.Len()` but not when the index was less than zero. If the user provided an (invalid)
configuration that referenced `"foo.-1.bar"`, the provider would panic, which is never a good thing to do.