### PR TITLE
command: show a special error message when importing in an empty dir

### DIFF
--- a/command/test-fixtures/empty/README
+++ b/command/test-fixtures/empty/README
@@ -1,0 +1,2 @@
+This directory is intentionally empty, for testing any specialized error
+messages that deal with empty configuration directories.


### PR DESCRIPTION
If users run `terraform import` in a directory with no Terraform configuration files, it's likely that they've made a mistake either by being in the wrong directory or forgetting to use the `-config` option on the command line.

To help users find their mistake in this case, we'll now produce a specialized error message for this situation:

    Error: No Terraform configuration files

    The directory /home/user/example does not contain any Terraform
    configuration files (.tf or .tf.json). To specify a different
    configuration directory, use the -config="..." command line option.

While here, this also converts some of the other existing messages to diagnostics so that we can show any configuration warnings along with the error message, and move towards the new standard error presentation.

This was motivated by #16691.
