### PR TITLE
[Update] Stringer replaces fmt with strconv

### DIFF
--- a/backend/local/counthookaction_string.go
+++ b/backend/local/counthookaction_string.go
@@ -2,7 +2,7 @@
 
 package local
 
-import "fmt"
+import "strconv"
 
 const _countHookAction_name = "countHookActionAddcountHookActionChangecountHookActionRemove"
 
@@ -10,7 +10,7 @@ var _countHookAction_index = [...]uint8{0, 18, 39, 60}
 
 func (i countHookAction) String() string {
 	if i >= countHookAction(len(_countHookAction_index)-1) {
-		return fmt.Sprintf("countHookAction(%d)", i)
+		return "countHookAction(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _countHookAction_name[_countHookAction_index[i]:_countHookAction_index[i+1]]
 }

--- a/backend/operationtype_string.go
+++ b/backend/operationtype_string.go
@@ -2,7 +2,7 @@
 
 package backend
 
-import "fmt"
+import "strconv"
 
 const _OperationType_name = "OperationTypeInvalidOperationTypeRefreshOperationTypePlanOperationTypeApply"
 
@@ -10,7 +10,7 @@ var _OperationType_index = [...]uint8{0, 20, 40, 57, 75}
 
 func (i OperationType) String() string {
 	if i >= OperationType(len(_OperationType_index)-1) {
-		return fmt.Sprintf("OperationType(%d)", i)
+		return "OperationType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _OperationType_name[_OperationType_index[i]:_OperationType_index[i+1]]
 }

--- a/config/configschema/nestingmode_string.go
+++ b/config/configschema/nestingmode_string.go
@@ -2,7 +2,7 @@
 
 package configschema
 
-import "fmt"
+import "strconv"
 
 const _NestingMode_name = "nestingModeInvalidNestingSingleNestingListNestingSetNestingMap"
 
@@ -10,7 +10,7 @@ var _NestingMode_index = [...]uint8{0, 18, 31, 42, 52, 62}
 
 func (i NestingMode) String() string {
 	if i < 0 || i >= NestingMode(len(_NestingMode_index)-1) {
-		return fmt.Sprintf("NestingMode(%d)", i)
+		return "NestingMode(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _NestingMode_name[_NestingMode_index[i]:_NestingMode_index[i+1]]
 }

--- a/config/resource_mode_string.go
+++ b/config/resource_mode_string.go
@@ -2,7 +2,7 @@
 
 package config
 
-import "fmt"
+import "strconv"
 
 const _ResourceMode_name = "ManagedResourceModeDataResourceMode"
 
@@ -10,7 +10,7 @@ var _ResourceMode_index = [...]uint8{0, 19, 35}
 
 func (i ResourceMode) String() string {
 	if i < 0 || i >= ResourceMode(len(_ResourceMode_index)-1) {
-		return fmt.Sprintf("ResourceMode(%d)", i)
+		return "ResourceMode(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _ResourceMode_name[_ResourceMode_index[i]:_ResourceMode_index[i+1]]
 }

--- a/helper/schema/getsource_string.go
+++ b/helper/schema/getsource_string.go
@@ -2,7 +2,7 @@
 
 package schema
 
-import "fmt"
+import "strconv"
 
 const (
 	_getSource_name_0 = "getSourceStategetSourceConfig"
@@ -13,8 +13,6 @@ const (
 
 var (
 	_getSource_index_0 = [...]uint8{0, 14, 29}
-	_getSource_index_1 = [...]uint8{0, 13}
-	_getSource_index_2 = [...]uint8{0, 12}
 	_getSource_index_3 = [...]uint8{0, 18, 32}
 )
 
@@ -31,6 +29,6 @@ func (i getSource) String() string {
 		i -= 15
 		return _getSource_name_3[_getSource_index_3[i]:_getSource_index_3[i+1]]
 	default:
-		return fmt.Sprintf("getSource(%d)", i)
+		return "getSource(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 }

--- a/helper/schema/valuetype_string.go
+++ b/helper/schema/valuetype_string.go
@@ -2,7 +2,7 @@
 
 package schema
 
-import "fmt"
+import "strconv"
 
 const _ValueType_name = "TypeInvalidTypeBoolTypeIntTypeFloatTypeStringTypeListTypeMapTypeSettypeObject"
 
@@ -10,7 +10,7 @@ var _ValueType_index = [...]uint8{0, 11, 19, 26, 35, 45, 53, 60, 67, 77}
 
 func (i ValueType) String() string {
 	if i < 0 || i >= ValueType(len(_ValueType_index)-1) {
-		return fmt.Sprintf("ValueType(%d)", i)
+		return "ValueType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _ValueType_name[_ValueType_index[i]:_ValueType_index[i+1]]
 }

--- a/terraform/graphtype_string.go
+++ b/terraform/graphtype_string.go
@@ -2,7 +2,7 @@
 
 package terraform
 
-import "fmt"
+import "strconv"
 
 const _GraphType_name = "GraphTypeInvalidGraphTypeLegacyGraphTypeRefreshGraphTypePlanGraphTypePlanDestroyGraphTypeApplyGraphTypeInputGraphTypeValidate"
 
@@ -10,7 +10,7 @@ var _GraphType_index = [...]uint8{0, 16, 31, 47, 60, 80, 94, 108, 125}
 
 func (i GraphType) String() string {
 	if i >= GraphType(len(_GraphType_index)-1) {
-		return fmt.Sprintf("GraphType(%d)", i)
+		return "GraphType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _GraphType_name[_GraphType_index[i]:_GraphType_index[i+1]]
 }

--- a/terraform/instancetype_string.go
+++ b/terraform/instancetype_string.go
@@ -2,7 +2,7 @@
 
 package terraform
 
-import "fmt"
+import "strconv"
 
 const _InstanceType_name = "TypeInvalidTypePrimaryTypeTaintedTypeDeposed"
 
@@ -10,7 +10,7 @@ var _InstanceType_index = [...]uint8{0, 11, 22, 33, 44}
 
 func (i InstanceType) String() string {
 	if i < 0 || i >= InstanceType(len(_InstanceType_index)-1) {
-		return fmt.Sprintf("InstanceType(%d)", i)
+		return "InstanceType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _InstanceType_name[_InstanceType_index[i]:_InstanceType_index[i+1]]
 }

--- a/terraform/walkoperation_string.go
+++ b/terraform/walkoperation_string.go
@@ -2,7 +2,7 @@
 
 package terraform
 
-import "fmt"
+import "strconv"
 
 const _walkOperation_name = "walkInvalidwalkInputwalkApplywalkPlanwalkPlanDestroywalkRefreshwalkValidatewalkDestroywalkImport"
 
@@ -10,7 +10,7 @@ var _walkOperation_index = [...]uint8{0, 11, 20, 29, 37, 52, 63, 75, 86, 96}
 
 func (i walkOperation) String() string {
 	if i >= walkOperation(len(_walkOperation_index)-1) {
-		return fmt.Sprintf("walkOperation(%d)", i)
+		return "walkOperation(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _walkOperation_name[_walkOperation_index[i]:_walkOperation_index[i+1]]
 }

--- a/tfdiags/severity_string.go
+++ b/tfdiags/severity_string.go
@@ -2,16 +2,11 @@
 
 package tfdiags
 
-import "fmt"
+import "strconv"
 
 const (
 	_Severity_name_0 = "Error"
 	_Severity_name_1 = "Warning"
-)
-
-var (
-	_Severity_index_0 = [...]uint8{0, 5}
-	_Severity_index_1 = [...]uint8{0, 7}
 )
 
 func (i Severity) String() string {
@@ -21,6 +16,6 @@ func (i Severity) String() string {
 	case i == 87:
 		return _Severity_name_1
 	default:
-		return fmt.Sprintf("Severity(%d)", i)
+		return "Severity(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 }


### PR DESCRIPTION
**Context:** When setting up a new development environment the latest version of `stringer` is installed. This commit 26 days ago  (https://github.com/golang/tools/commit/bd4635fd25596cdd56c1fb399c53b351d1a81f2d) introduces functionality that changes generated files to use `strconv` instead of `fmt`.

After performing a `go get` and `make` or `make dev`, the changes in this pull request are made before any development occurs. This PR brings the auto-generated files up to date.

**Caveats:** If we don't want to do this, then we'll need to "pin" a version of stringer.