### PR TITLE
vendor: github.com/hashicorp/go-version

### DIFF
--- a/vendor/github.com/hashicorp/go-version/version.go
+++ b/vendor/github.com/hashicorp/go-version/version.go
@@ -15,8 +15,8 @@ var versionRegexp *regexp.Regexp
 // The raw regular expression string used for testing the validity
 // of a version.
 const VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
-	`(-?([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
-	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(-?([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
+	`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 	`?`
 
 // Version represents a single version.
@@ -166,24 +166,42 @@ func comparePart(preSelf string, preOther string) int {
 		return 0
 	}
 
+	var selfInt int64
+	selfNumeric := true
+	selfInt, err := strconv.ParseInt(preSelf, 10, 64)
+	if err != nil {
+		selfNumeric = false
+	}
+
+	var otherInt int64
+	otherNumeric := true
+	otherInt, err = strconv.ParseInt(preOther, 10, 64)
+	if err != nil {
+		otherNumeric = false
+	}
+
 	// if a part is empty, we use the other to decide
 	if preSelf == "" {
-		_, notIsNumeric := strconv.ParseInt(preOther, 10, 64)
-		if notIsNumeric == nil {
+		if otherNumeric {
 			return -1
 		}
 		return 1
 	}
 
 	if preOther == "" {
-		_, notIsNumeric := strconv.ParseInt(preSelf, 10, 64)
-		if notIsNumeric == nil {
+		if selfNumeric {
 			return 1
 		}
 		return -1
 	}
 
-	if preSelf > preOther {
+	if selfNumeric && !otherNumeric {
+		return -1
+	} else if !selfNumeric && otherNumeric {
+		return 1
+	} else if !selfNumeric && !otherNumeric && preSelf > preOther {
+		return 1
+	} else if selfInt > otherInt {
 		return 1
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1521,10 +1521,10 @@
 			"revision": "36289988d83ca270bc07c234c36f364b0dd9c9a7"
 		},
 		{
-			"checksumSHA1": "EcZfls6vcqjasWV/nBlu+C+EFmc=",
+			"checksumSHA1": "9w1ZtxhdB/J0qqNPJQNNI/ZTwwE=",
 			"path": "github.com/hashicorp/go-version",
-			"revision": "e96d3840402619007766590ecea8dd7af1292276",
-			"revisionTime": "2016-10-31T18:26:05Z"
+			"revision": "4fe82ae3040f80a03d04d2cccb5606a626b8e1ee",
+			"revisionTime": "2017-11-29T15:08:20Z"
 		},
 		{
 			"checksumSHA1": "o3XZZdOnSnwQSpYw215QV75ZDeI=",


### PR DESCRIPTION
We required updated version of `go-version`, because we have deployment of mariadb that has `~` in version name: https://github.com/hashicorp/go-version/commit/43575a7136563760458ce6756b50ac0ab7245adb