### PR TITLE
helper/resource: Fail tests with no error that have ExpectError set

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -488,6 +488,15 @@ func Test(t TestT, c TestCase) {
 			}
 		}
 
+		// If we expected an error, but did not get one, fail
+		if err == nil && step.ExpectError != nil {
+			errored = true
+			t.Error(fmt.Sprintf(
+				"Step %d, no error received, but expected a match to:\n\n%s\n\n",
+				i, step.ExpectError))
+			break
+		}
+
 		// If there was an error, exit
 		if err != nil {
 			// Perhaps we expected an error? Check if it matches


### PR DESCRIPTION
Looks like while we were checking errors correctly when ExpectError was
set, we weren't checking for the *absence* of an error, which is should
be checked as well (no error is still not the error we are looking for).

Added a few more tests for ExpectError as well.