### PR TITLE
Updating links to TFE docs

### DIFF
--- a/website/docs/registry/private.html.md
+++ b/website/docs/registry/private.html.md
@@ -45,10 +45,8 @@ newer.
 
 ## Coming Soon
 
-Terraform Enterprise is currently in beta and does not allow open signups.
-
 Terraform Enterprise will be publicly available for self service signup
-by the end of 2017. In the mean time, if you're interested in private
+soon. In the mean time, if you're interested in private
 registries and being part of the beta, please contact us at
 [hello@hashicorp.com](mailto:hello@hashicorp.com).
 

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -617,12 +617,12 @@
 
       <hr>
 
-      <li<%= sidebar_current("docs-enterprise-home") %>>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise (classic)</a>
+      <li<%= sidebar_current("docs-enterprise2-home") %>>
+        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-home") %>>
-        <a class="back" href="/docs/enterprise-beta/index.html">Terraform Enterprise (beta)</a>
+      <li<%= sidebar_current("docs-enterprise-home") %>>
+        <a class="back" href="/docs/enterprise-legacy/index.html">Terraform Enterprise (legacy)</a>
       </li>
 
     </ul>

--- a/website/layouts/guides.erb
+++ b/website/layouts/guides.erb
@@ -5,15 +5,15 @@
         <a href="/intro/getting-started/install.html">Getting Started</a>
       </li>
 
-      <li<%= sidebar_current("recommended-practices") %>><a href="/docs/enterprise-beta/guides/recommended-practices/index.html">Terraform Recommended Practices</a>
+      <li<%= sidebar_current("recommended-practices") %>><a href="/docs/enterprise/guides/recommended-practices/index.html">Terraform Recommended Practices</a>
         <ul class="nav">
-          <li<%= sidebar_current("recommended-practices-1") %>><a href="/docs/enterprise-beta/guides/recommended-practices/part1.html">Part 1: Workflow Overview</a></li>
-          <li<%= sidebar_current("recommended-practices-2") %>><a href="/docs/enterprise-beta/guides/recommended-practices/part2.html">Part 2: Evaluating Current Practices</a></li>
-          <li<%= sidebar_current("recommended-practices-3-0") %>><a href="/docs/enterprise-beta/guides/recommended-practices/part3.html">Part 3: Evolving Your Practices</a></li>
-          <li<%= sidebar_current("recommended-practices-3-1") %>><a href="/docs/enterprise-beta/guides/recommended-practices/part3.1.html">Part 3.1: From Manual to Semi-Automated</a></li>
-          <li<%= sidebar_current("recommended-practices-3-2") %>><a href="/docs/enterprise-beta/guides/recommended-practices/part3.2.html">Part 3.2: From Semi-Automated to Infrastructure as Code</a></li>
-          <li<%= sidebar_current("recommended-practices-3-3") %>><a href="/docs/enterprise-beta/guides/recommended-practices/part3.3.html">Part 3.3: From Infrastructure as Code to Collaborative IaC</a></li>
-          <li<%= sidebar_current("recommended-practices-3-4") %>><a href="/docs/enterprise-beta/guides/recommended-practices/part3.4.html">Part 3.4: Advanced Improvements</a></li>
+          <li<%= sidebar_current("recommended-practices-1") %>><a href="/docs/enterprise/guides/recommended-practices/part1.html">Part 1: Workflow Overview</a></li>
+          <li<%= sidebar_current("recommended-practices-2") %>><a href="/docs/enterprise/guides/recommended-practices/part2.html">Part 2: Evaluating Current Practices</a></li>
+          <li<%= sidebar_current("recommended-practices-3-0") %>><a href="/docs/enterprise/guides/recommended-practices/part3.html">Part 3: Evolving Your Practices</a></li>
+          <li<%= sidebar_current("recommended-practices-3-1") %>><a href="/docs/enterprise/guides/recommended-practices/part3.1.html">Part 3.1: From Manual to Semi-Automated</a></li>
+          <li<%= sidebar_current("recommended-practices-3-2") %>><a href="/docs/enterprise/guides/recommended-practices/part3.2.html">Part 3.2: From Semi-Automated to Infrastructure as Code</a></li>
+          <li<%= sidebar_current("recommended-practices-3-3") %>><a href="/docs/enterprise/guides/recommended-practices/part3.3.html">Part 3.3: From Infrastructure as Code to Collaborative IaC</a></li>
+          <li<%= sidebar_current("recommended-practices-3-4") %>><a href="/docs/enterprise/guides/recommended-practices/part3.4.html">Part 3.4: Advanced Improvements</a></li>
         </ul>
       </li>
 


### PR DESCRIPTION
This updates links on the menu with a few changes
- renames `classic` to `legacy`
- updates the links from `enterprise` to `enterprise-legacy`
- updates the links from `enterprise-beta` to `enterprise`