### PR TITLE
Adds "build_auth_token" option to Habitat Provisioner

### DIFF
--- a/website/docs/provisioners/habitat.html.markdown
+++ b/website/docs/provisioners/habitat.html.markdown
@@ -60,6 +60,7 @@ There are 2 configuration levels, `supervisor` and `service`.  Configuration pla
 * `events (string)` - (Optional) Name of the service group running a Habitat EventSrv to forward Supervisor and service event data to. (Defaults to none)
 * `override_name (string)` - (Optional) The name of the Supervisor (Defaults to `default`)
 * `organization (string)` - (Optional) The organization that the Supervisor and it's subsequent services are part of. (Defaults to `default`)
+* `builder_auth_token (string)` - (Optional) The builder authorization token when using a private origin. (Defaults to none)
 
 ### Service Arguments
 * `name (string)` - (Required) The Habitat package identifier of the service to run. (ie `core/haproxy` or `core/redis/3.2.4/20171002182640`)


### PR DESCRIPTION
**Context:** Per @bixu's comment (https://github.com/hashicorp/terraform/pull/16280#issuecomment-350208983) on the original Habitat Provisioner PR, @nsdavidson and I moved forward with adding the ability to use private Habitat origins that require `HAB_AUTH_TOKEN`.

**This PR:** 
* Adds the `build_auth_token` option in terraform and necessary functionality through which a user's `HAB_AUTH_TOKEN` can be passed.
* Updates the docs