### PR TITLE
cmd/import|refresh: take the resource config into account

### DIFF
--- a/backend/local/testing.go
+++ b/backend/local/testing.go
@@ -34,7 +34,8 @@ func TestLocalProvider(t *testing.T, b *Local, name string) *terraform.MockResou
 	p.DiffReturn = &terraform.InstanceDiff{}
 	p.RefreshFn = func(
 		info *terraform.InstanceInfo,
-		s *terraform.InstanceState) (*terraform.InstanceState, error) {
+		s *terraform.InstanceState,
+		c *terraform.ResourceConfig) (*terraform.InstanceState, error) {
 		return s, nil
 	}
 	p.ResourcesReturn = []terraform.ResourceType{

--- a/command/import.go
+++ b/command/import.go
@@ -184,6 +184,8 @@ func (c *ImportCommand) Run(args []string) int {
 		return 1
 	}
 
+	config := terraform.NewResourceConfig(rc.RawConfig)
+
 	// Perform the import. Note that as you can see it is possible for this
 	// API to import more than one resource at once. For now, we only allow
 	// one while we stabilize this feature.
@@ -192,6 +194,7 @@ func (c *ImportCommand) Run(args []string) int {
 			&terraform.ImportTarget{
 				Addr:     args[0],
 				ID:       args[1],
+				Config:   config,
 				Provider: c.Meta.provider,
 			},
 		},

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -299,13 +299,14 @@ func (p *Provider) Diff(
 // Refresh implementation of terraform.ResourceProvider interface.
 func (p *Provider) Refresh(
 	info *terraform.InstanceInfo,
-	s *terraform.InstanceState) (*terraform.InstanceState, error) {
+	s *terraform.InstanceState,
+	c *terraform.ResourceConfig) (*terraform.InstanceState, error) {
 	r, ok := p.ResourcesMap[info.Type]
 	if !ok {
 		return nil, fmt.Errorf("unknown resource type: %s", info.Type)
 	}
 
-	return r.Refresh(s, p.meta)
+	return r.Refresh(s, c, p.meta)
 }
 
 // Resources implementation of terraform.ResourceProvider interface.

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -306,6 +306,7 @@ func (r *Resource) ReadDataApply(
 // Refresh refreshes the state of the resource.
 func (r *Resource) Refresh(
 	s *terraform.InstanceState,
+	c *terraform.ResourceConfig,
 	meta interface{}) (*terraform.InstanceState, error) {
 	// If the ID is already somehow blank, it doesn't exist
 	if s.ID == "" {
@@ -347,6 +348,7 @@ func (r *Resource) Refresh(
 	}
 
 	data, err := schemaMap(r.Schema).Data(s, nil)
+	data.config = c
 	data.timeouts = &rt
 	if err != nil {
 		return s, err

--- a/plugin/resource_provider.go
+++ b/plugin/resource_provider.go
@@ -213,11 +213,13 @@ func (p *ResourceProvider) ValidateDataSource(
 
 func (p *ResourceProvider) Refresh(
 	info *terraform.InstanceInfo,
-	s *terraform.InstanceState) (*terraform.InstanceState, error) {
+	s *terraform.InstanceState,
+	c *terraform.ResourceConfig) (*terraform.InstanceState, error) {
 	var resp ResourceProviderRefreshResponse
 	args := &ResourceProviderRefreshArgs{
-		Info:  info,
-		State: s,
+		Info:   info,
+		State:  s,
+		Config: c,
 	}
 
 	err := p.Client.Call("Plugin.Refresh", args, &resp)
@@ -376,8 +378,9 @@ type ResourceProviderDiffResponse struct {
 }
 
 type ResourceProviderRefreshArgs struct {
-	Info  *terraform.InstanceInfo
-	State *terraform.InstanceState
+	Info   *terraform.InstanceInfo
+	State  *terraform.InstanceState
+	Config *terraform.ResourceConfig
 }
 
 type ResourceProviderRefreshResponse struct {
@@ -546,7 +549,7 @@ func (s *ResourceProviderServer) Diff(
 func (s *ResourceProviderServer) Refresh(
 	args *ResourceProviderRefreshArgs,
 	result *ResourceProviderRefreshResponse) error {
-	newState, err := s.Provider.Refresh(args.Info, args.State)
+	newState, err := s.Provider.Refresh(args.Info, args.State, args.Config)
 	*result = ResourceProviderRefreshResponse{
 		State: newState,
 		Error: plugin.NewBasicError(err),

--- a/terraform/context_import.go
+++ b/terraform/context_import.go
@@ -24,6 +24,9 @@ type ImportTarget struct {
 	// ID is the ID of the resource to import. This is resource-specific.
 	ID string
 
+	// Config is the resource config of the resource to import.
+	Config *ResourceConfig
+
 	// Provider string
 	Provider string
 }

--- a/terraform/eval_refresh.go
+++ b/terraform/eval_refresh.go
@@ -8,9 +8,10 @@ import (
 // EvalRefresh is an EvalNode implementation that does a refresh for
 // a resource.
 type EvalRefresh struct {
+	Info     *InstanceInfo
+	Config   *ResourceConfig
 	Provider *ResourceProvider
 	State    **InstanceState
-	Info     *InstanceInfo
 	Output   **InstanceState
 }
 
@@ -34,7 +35,7 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	// Refresh!
-	state, err = provider.Refresh(n.Info, state)
+	state, err = provider.Refresh(n.Info, state, n.Config)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %s", n.Info.Id, err.Error())
 	}

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -147,6 +147,8 @@ func (n *NodeRefreshableManagedResourceInstance) evalTreeManagedResource() EvalN
 		return &EvalReturnError{Error: &err}
 	}
 
+	config := NewResourceConfig(n.Config.RawConfig)
+
 	return &EvalSequence{
 		Nodes: []EvalNode{
 			&EvalGetProvider{
@@ -159,6 +161,7 @@ func (n *NodeRefreshableManagedResourceInstance) evalTreeManagedResource() EvalN
 			},
 			&EvalRefresh{
 				Info:     info,
+				Config:   config,
 				Provider: &provider,
 				State:    &state,
 				Output:   &state,

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -118,7 +118,10 @@ type ResourceProvider interface {
 
 	// Refresh refreshes a resource and updates all of its attributes
 	// with the latest information.
-	Refresh(*InstanceInfo, *InstanceState) (*InstanceState, error)
+	Refresh(
+		*InstanceInfo,
+		*InstanceState,
+		*ResourceConfig) (*InstanceState, error)
 
 	/*********************************************************************
 	* Functions related to importing

--- a/terraform/resource_provider_mock.go
+++ b/terraform/resource_provider_mock.go
@@ -45,7 +45,7 @@ type MockResourceProvider struct {
 	RefreshCalled                  bool
 	RefreshInfo                    *InstanceInfo
 	RefreshState                   *InstanceState
-	RefreshFn                      func(*InstanceInfo, *InstanceState) (*InstanceState, error)
+	RefreshFn                      func(*InstanceInfo, *InstanceState, *ResourceConfig) (*InstanceState, error)
 	RefreshReturn                  *InstanceState
 	RefreshReturnError             error
 	ResourcesCalled                bool
@@ -213,7 +213,8 @@ func (p *MockResourceProvider) Diff(
 
 func (p *MockResourceProvider) Refresh(
 	info *InstanceInfo,
-	s *InstanceState) (*InstanceState, error) {
+	s *InstanceState,
+	c *ResourceConfig) (*InstanceState, error) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -222,7 +223,7 @@ func (p *MockResourceProvider) Refresh(
 	p.RefreshState = s
 
 	if p.RefreshFn != nil {
-		return p.RefreshFn(info, s)
+		return p.RefreshFn(info, s, c)
 	}
 
 	return p.RefreshReturn.DeepCopy(), p.RefreshReturnError

--- a/terraform/transform_deposed.go
+++ b/terraform/transform_deposed.go
@@ -76,6 +76,7 @@ func (n *graphNodeDeposedResource) SetProvider(p string) {
 
 // GraphNodeEvalable impl.
 func (n *graphNodeDeposedResource) EvalTree() EvalNode {
+	var config *ResourceConfig
 	var provider ResourceProvider
 	var state *InstanceState
 
@@ -101,6 +102,7 @@ func (n *graphNodeDeposedResource) EvalTree() EvalNode {
 				},
 				&EvalRefresh{
 					Info:     info,
+					Config:   config,
 					Provider: &provider,
 					State:    &state,
 					Output:   &state,


### PR DESCRIPTION
Some resources use `d.GetOk()` in their `Read()` function to determine if a value should be set to the state (only update/set the value when the user configured the value).

Without passing the resource config these resources will not be imported or refreshed properly.