### PR TITLE
add gcs to the backends that support workspaces in the documentation

### DIFF
--- a/website/docs/backends/types/gcs.html.md
+++ b/website/docs/backends/types/gcs.html.md
@@ -53,7 +53,7 @@ The following configuration options are supported:
  *  `credentials` / `GOOGLE_CREDENTIALS` - (Optional) Local path to Google Cloud Platform account credentials in JSON format.
     If unset, [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials) are used.
     The provided credentials need to have the `devstorage.read_write` scope and `WRITER` permissions on the bucket.
- *  `prefix` - (Optional) GCS prefix inside the bucket. Named states are stored in an object called `<prefix>/<name>.tfstate`.
+ *  `prefix` - (Optional) GCS prefix inside the bucket. Named states for workspaces are stored in an object called `<prefix>/<name>.tfstate`.
  *  `path` - (Deprecated) GCS path to the state file of the default state. For backwards compatibility only, use `prefix` instead.
  *  `project` / `GOOGLE_PROJECT` - (Optional) The project ID to which the bucket belongs. This is only used when creating a new bucket during initialization.
     Since buckets have globally unique names, the project ID is not required to access the bucket during normal operation.

--- a/website/docs/state/workspaces.html.md
+++ b/website/docs/state/workspaces.html.md
@@ -21,8 +21,9 @@ Multiple workspaces are currently supported by the following backends:
 
  * [AzureRM](/docs/backends/types/azurerm.html)
  * [Consul](/docs/backends/types/consul.html)
- * [S3](/docs/backends/types/s3.html)
+ * [GCS](/docs/backends/types/gcs.html)
  * [Manta](/docs/backends/types/manta.html)
+ * [S3](/docs/backends/types/s3.html)
 
 In the 0.9 line of Terraform releases, this concept was known as "environment".
 It was renamed in 0.10 based on feedback about confusion caused by the


### PR DESCRIPTION
Also add the term "workspaces" to the `prefix` documentation.

Fixes #16911