### PR TITLE
check state version during init

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -180,7 +180,6 @@ func (c *InitCommand) Run(args []string) int {
 					"Error downloading modules: %s", err))
 				return 1
 			}
-
 		}
 
 		// If we're requesting backend configuration or looking for required
@@ -278,6 +277,12 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 	if diags.HasErrors() {
 		c.showDiagnostics(diags)
 		return diags.Err()
+	}
+
+	if err := terraform.CheckStateVersion(state); err != nil {
+		diags = diags.Append(err)
+		c.showDiagnostics(diags)
+		return err
 	}
 
 	if err := terraform.CheckRequiredVersion(mod); err != nil {

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -145,13 +145,8 @@ func NewContext(opts *ContextOpts) (*Context, error) {
 
 	// If our state is from the future, then error. Callers can avoid
 	// this error by explicitly setting `StateFutureAllowed`.
-	if !opts.StateFutureAllowed && state.FromFutureTerraform() {
-		return nil, fmt.Errorf(
-			"Terraform doesn't allow running any operations against a state\n"+
-				"that was written by a future Terraform version. The state is\n"+
-				"reporting it is written by Terraform '%s'.\n\n"+
-				"Please run at least that version of Terraform to continue.",
-			state.TFVersion)
+	if err := CheckStateVersion(state); err != nil && !opts.StateFutureAllowed {
+		return nil, err
 	}
 
 	// Explicitly reset our state version to our current version so that

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -2174,6 +2174,19 @@ func (s moduleStateSort) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
+// StateCompatible returns an error if the state is not compatible with the
+// current version of terraform.
+func CheckStateVersion(state *State) error {
+	if state == nil {
+		return nil
+	}
+
+	if state.FromFutureTerraform() {
+		return fmt.Errorf(stateInvalidTerraformVersionErr, state.TFVersion)
+	}
+	return nil
+}
+
 const stateValidateErrMultiModule = `
 Multiple modules with the same path: %s
 
@@ -2181,4 +2194,12 @@ This means that there are multiple entries in the "modules" field
 in your state file that point to the same module. This will cause Terraform
 to behave in unexpected and error prone ways and is invalid. Please back up
 and modify your state file manually to resolve this.
+`
+
+const stateInvalidTerraformVersionErr = `
+Terraform doesn't allow running any operations against a state
+that was written by a future Terraform version. The state is
+reporting it is written by Terraform '%s'
+
+Please run at least that version of Terraform to continue.
 `


### PR DESCRIPTION
The init command needs to parse the state to resolve providers, but
changes to the state format can cause that to fail with difficult to
understand errors. Check the terraform version during init and provide
the same error that would be returned by plan or apply.

Fixes #16910