### PR TITLE
Link to more useful docs for setting up a backend

### DIFF
--- a/command/push.go
+++ b/command/push.go
@@ -123,7 +123,7 @@ func (c *PushCommand) Run(args []string) int {
 				"for you, remote state must be used and configured. Remote \n" +
 				"state via any backend is accepted, not just Atlas. To configure\n" +
 				"a backend, please see the documentation at the URL below:\n\n" +
-				"https://www.terraform.io/docs/state/remote.html")
+				"https://www.terraform.io/docs/backends/config.html")
 		return 1
 	}
 


### PR DESCRIPTION
When running `terraform push` with a local backend, we explain that a remote backend is required and give a link to relevant docs.

[The current linked documentation](https://www.terraform.io/docs/state/remote.html) explains what remote state is and why you'd want it, but doesn't explain how to configure a remote backend.

This commit changes the link to [the more detailed backend config page](https://www.terraform.io/docs/backends/config.html), which makes it clearer what the next steps are.