### PR TITLE
docs: Clarify the use of private github repos with TFE

### DIFF
--- a/website/docs/modules/sources.html.markdown
+++ b/website/docs/modules/sources.html.markdown
@@ -97,17 +97,19 @@ You can use the same parameters to GitHub repositories as you can generic Git re
 
 ### Private GitHub Repos
 
-If you need Terraform to be able to fetch modules from private GitHub repos on a remote machine (like Terraform Enterprise or a CI server), you'll need to provide Terraform with credentials that can be used to authenticate as a user with read access to the private repo.
+If you need Terraform to fetch modules from private GitHub repos, you must provide Terraform with credentials to authenticate as a user with read access to those repos.
 
-First, create a [machine user](https://developer.github.com/guides/managing-deploy-keys/#machine-users) on GitHub with read access to the private repo in question, then embed this user's credentials into the `source` parameter:
+- If you run Terraform only on your local machine, you can specify the module source as an SSH URI (like `git@github.com:hashicorp/example.git`) and Terraform will use your default SSH key to authenticate.
+- If you use Terraform Enterprise, you can use SSH URIs. You'll need to add an SSH private key to your organization and assign it to any workspace that fetches modules from private repos. [See the Terraform Enterprise docs about SSH keys for cloning modules.](/docs/enterprise/workspaces/ssh-keys.html)
+- If you need to run Terraform on a remote machine like a CI worker, you either need to write an SSH key to disk and set the `GIT_SSH_COMMAND` environment variable appropriately during the worker's provisioning process, or create a [GitHub machine user](https://developer.github.com/guides/managing-deploy-keys/#machine-users) with read access to the repos in question and embed its credentials into the modules' `source` parameters:
 
-```hcl
-module "private-infra" {
-  source = "git::https://MACHINE-USER:MACHINE-PASS@github.com/org/privatemodules//modules/foo"
-}
-```
+    ```hcl
+    module "private-infra" {
+      source = "git::https://MACHINE-USER:MACHINE-PASS@github.com/org/privatemodules//modules/foo"
+    }
+    ```
 
-**Note:** Terraform does not yet support interpolations in the `source` field, so the machine username and password will have to be embedded directly into the `source` string. You can track [GH-1439](https://github.com/hashicorp/terraform/issues/1439) to learn when this limitation is addressed.
+    Note that Terraform does not support interpolations in the `source` parameter of a module, so you must hardcode the machine username and password if using this method.
 
 ## Bitbucket
 


### PR DESCRIPTION
The current version of TFE can use centrally-managed SSH keys to access modules from git repos, which is better than embedded machine user credentials for most use cases. 

Also, as I understand it, any other CI-like systems can use the same mechanism TFE uses for accessing private Git-sourced modules, with the `GIT_SSH_COMMAND` env var, which might be preferable depending on your worker provisioning process. 