### PR TITLE
[WIP] introducing transparent ssh bastions

### DIFF
--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/terraform"
@@ -64,6 +65,140 @@ func TestProvisioner_connInfo(t *testing.T) {
 	if conf.BastionPrivateKey != "someprivatekeycontents" {
 		t.Fatalf("bad: %v", conf)
 	}
+}
+
+func TestProvisioner_connInfo_bastionList(t *testing.T) {
+	r := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: map[string]string{
+				"type":        "ssh",
+				"user":        "root",
+				"password":    "supersecret",
+				"private_key": "someprivatekeycontents",
+				"host":        "127.0.0.1",
+				"port":        "22",
+				"timeout":     "30s",
+
+				"bastion_host": "127.0.1.1,127.0.1.2",
+			},
+		},
+	}
+
+	conf, err := parseConnectionInfo(r)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if conf.User != "root" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.Password != "supersecret" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.PrivateKey != "someprivatekeycontents" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.Host != "127.0.0.1" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.Port != 22 {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.Timeout != "30s" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.ScriptPath != DefaultScriptPath {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionHost != "127.0.1.1,127.0.1.2" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionPort != 22 {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionPortList != "22,22" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionUser != "root,root" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionPassword != "supersecret,supersecret" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionPrivateKey != "someprivatekeycontents,someprivatekeycontents" {
+		t.Fatalf("bad: %v", conf)
+	}
+}
+
+func TestProvisioner_connInfo_transparentBastion(t *testing.T) {
+	r := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: map[string]string{
+				"type":        "ssh",
+				"user":        "root",
+				"password":    "supersecret",
+				"private_key": "someprivatekeycontents",
+				"host":        "127.0.0.1",
+				"port":        "22",
+				"timeout":     "30s",
+
+				"bastion_host": "127.0.1.1",
+			},
+		},
+	}
+	os.Setenv("TRANSPARENT_BASTIONHOST", "127.0.1.2")
+	os.Setenv("TRANSPARENT_BASTIONUSER", "wheel")
+	os.Setenv("TRANSPARENT_BASTIONPASSWORD", "extremesecret")
+	os.Setenv("TRANSPARENT_BASTIONPRIVATEKEY", "anotherprivatekeycontents")
+
+	conf, err := parseConnectionInfo(r)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if conf.User != "root" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.Password != "supersecret" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.PrivateKey != "someprivatekeycontents" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.Host != "127.0.0.1" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.Port != 22 {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.Timeout != "30s" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.ScriptPath != DefaultScriptPath {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionHost != "127.0.1.2,127.0.1.1" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionPort != 22 {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionPortList != "22,22" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionUser != "wheel,root" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionPassword != "extremesecret,supersecret" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.BastionPrivateKey != "anotherprivatekeycontents,someprivatekeycontents" {
+		t.Fatalf("bad: %v", conf)
+	}
+	os.Unsetenv("TRANSPARENT_BASTIONHOST")
+	os.Unsetenv("TRANSPARENT_BASTIONUSER")
+	os.Unsetenv("TRANSPARENT_BASTIONPASSWORD")
+	os.Unsetenv("TRANSPARENT_BASTIONPRIVATEKEY")
 }
 
 func TestProvisioner_connInfoIpv6(t *testing.T) {

--- a/website/docs/provisioners/connection.html.markdown
+++ b/website/docs/provisioners/connection.html.markdown
@@ -111,3 +111,58 @@ The `ssh` connection also supports the following fields to facilitate connnectio
   host. These can be loaded from a file on disk using the [`file()`
   interpolation function](/docs/configuration/interpolation.html#file_path_).
   Defaults to the value of the `private_key` field.
+
+### Using more than one Bastion Host with SSH
+
+All of the fields described above can be used as a comma separated list. Except for the bastion_port which needs to remain a single value.
+
+Missing values are filled with the default values accordingly.
+
+#### Example usage
+
+```hcl
+# Using two Bastion hosts
+provisioner "remote-exec" {
+  inline = [
+    "echo Connected through two Bastion hosts"
+  ]
+
+  connection {
+    user             = "root"
+    password         = "${var.root_password}"
+    bastion_host     = "bastionhost1,bastionhost2"
+    # bastionhost1 will be connected using user 'wheel' and 'wheelsecret'
+    # bastionhost2 will default to 'root' and '${var.root_password}'
+    bastion_user     = "wheel"
+    bastion_password = "wheelsecret"
+  }
+}
+```
+
+### Using a transparent Bastion Host with SSH
+
+Similar to the list of Bastion Hosts introduced above you can use environment variables to add additional Bastion Hosts.
+
+The Bastion Hosts added in this way will be used first for all `ssh` connections. Inline Bastion Host definitions will be chained to the global ones accordingly.
+
+These variable names can be used in accordance with the inline fields:
+
+* `TRANSPARENT_BASTIONHOST` - Setting this enables the use of the transparent
+  bastion hosts.
+
+* `TRANSPARENT_BASTIONPORT` - The port to use connect to the transparent bastion   host. In this case a comma separated list can be used as opposed to the
+  `bastion_port` inline field.
+
+* `TRANSPARENT_BASTIONUSER` - The user name to use connect to the transparent
+  bastion host.
+
+* `TRANSPARENT_BASTIONPASSWORD` - The password to use connect to the transparent
+  bastion host.
+
+* `TRANSPARENT_BASTIONPRIVATEKEY` - The private key to use connect to the
+  transparent bastion host. You cannot use Terraform's interpolation syntax
+  inside the environment variables, therefore you have to put the key here.
+  For example you can use this this bash syntax:
+  _TRANSPARENT_BASTIONPRIVATEKEY=$(< ~/.ssh/keyfile)_
+
+The default values are assigned as described above. Every missing value is filled with the corresponding field inside the `connection` block of your `ssh` resource.


### PR DESCRIPTION
This PR is related to https://github.com/hashicorp/terraform/issues/14523.
It is a very simple change just providing the possibility to specify more than one bastion host inside a remote-exec configuration block. This can be combined with environment variables TRANSPARENT_BASTION... to also add a bastion host at runtime.
There is no change in the configuration structure, just turning the string variables into a csv string and looping over it.
Pls. check the connection.html.markdown page for an example.
I am not sure if this fits therefore I flagged it WIP. Putting an update in the issue above asking for review.