### PR TITLE
Support 'customer supplied encryption keys' in the GCS backend

### DIFF
--- a/backend/remote-state/gcs/backend.go
+++ b/backend/remote-state/gcs/backend.go
@@ -3,6 +3,7 @@ package gcs
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -29,6 +30,8 @@ type gcsBackend struct {
 	bucketName       string
 	prefix           string
 	defaultStateFile string
+
+	encryptionKey []byte
 
 	projectID string
 	region    string
@@ -62,6 +65,13 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Google Cloud JSON Account Key",
+				Default:     "",
+			},
+
+			"encryption_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A 32 byte base64 encoded 'customer supplied encryption key' used to encrypt all state.",
 				Default:     "",
 			},
 
@@ -153,6 +163,30 @@ func (b *gcsBackend) configure(ctx context.Context) error {
 	}
 
 	b.storageClient = client
+
+	key := data.Get("encryption_key").(string)
+	if key == "" {
+		key = os.Getenv("GOOGLE_ENCRYPTION_KEY")
+	}
+
+	if key != "" {
+		kc, _, err := pathorcontents.Read(key)
+		if err != nil {
+			return fmt.Errorf("Error loading encryption key: %s", err)
+		}
+
+		// The GCS client expects a customer supplied encryption key to be
+		// passed in as a 32 byte long byte slice. The byte slice is base64
+		// encoded before being passed to the API. We take a base64 encoded key
+		// to remain consistent with the GCS docs.
+		// https://cloud.google.com/storage/docs/encryption#customer-supplied
+		// https://github.com/GoogleCloudPlatform/google-cloud-go/blob/def681/storage/storage.go#L1181
+		k, err := base64.StdEncoding.DecodeString(kc)
+		if err != nil {
+			return fmt.Errorf("Error decoding encryption key: %s", err)
+		}
+		b.encryptionKey = k
+	}
 
 	return nil
 }

--- a/backend/remote-state/gcs/backend_state.go
+++ b/backend/remote-state/gcs/backend_state.go
@@ -79,6 +79,7 @@ func (b *gcsBackend) client(name string) (*remoteClient, error) {
 		bucketName:     b.bucketName,
 		stateFilePath:  b.stateFile(name),
 		lockFilePath:   b.lockFile(name),
+		encryptionKey:  b.encryptionKey,
 	}, nil
 }
 

--- a/backend/remote-state/gcs/client.go
+++ b/backend/remote-state/gcs/client.go
@@ -22,6 +22,7 @@ type remoteClient struct {
 	bucketName     string
 	stateFilePath  string
 	lockFilePath   string
+	encryptionKey  []byte
 }
 
 func (c *remoteClient) Get() (payload *remote.Payload, err error) {
@@ -152,7 +153,11 @@ func (c *remoteClient) lockInfo() (*state.LockInfo, error) {
 }
 
 func (c *remoteClient) stateFile() *storage.ObjectHandle {
-	return c.storageClient.Bucket(c.bucketName).Object(c.stateFilePath)
+	h := c.storageClient.Bucket(c.bucketName).Object(c.stateFilePath)
+	if len(c.encryptionKey) > 0 {
+		return h.Key(c.encryptionKey)
+	}
+	return h
 }
 
 func (c *remoteClient) stateFileURL() string {

--- a/website/docs/backends/types/gcs.html.md
+++ b/website/docs/backends/types/gcs.html.md
@@ -59,3 +59,4 @@ The following configuration options are supported:
     Since buckets have globally unique names, the project ID is not required to access the bucket during normal operation.
  *  `region` / `GOOGLE_REGION` - (Optional) The region in which a new bucket is created.
     For more information, see [Bucket Locations](https://cloud.google.com/storage/docs/bucket-locations).
+ *  `encryption_key` / `GOOGLE_ENCRYPTION_KEY` - (Optional) A 32 byte base64 encoded 'customer supplied encryption key' used to encrypt all state. For more information see [Customer Supplied Encryption Keys](https://cloud.google.com/storage/docs/encryption#customer-supplied).


### PR DESCRIPTION
Currently all files in GCS are transparently encrypted at rest using Google's keys, and IAM/ACL can be used to restrict access to GCS buckets. Allowing state files in GCS to be encrypted with a custom key provides an additional layer of defense around sensitive Terraform state.

Objects created with a customer supplied encryption key can only be read when the key used for creation is passed in with the read request. See https://github.com/hashicorp/terraform/issues/16836 for further details.