### PR TITLE
remove extra backend migration prompts

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -476,7 +476,8 @@ func (m *Meta) confirm(opts *terraform.InputOpts) (bool, error) {
 	if !m.Input() {
 		return false, errors.New("input is disabled")
 	}
-	for {
+
+	for i := 0; i < 2; i++ {
 		v, err := m.UIInput().Input(opts)
 		if err != nil {
 			return false, fmt.Errorf(
@@ -490,6 +491,7 @@ func (m *Meta) confirm(opts *terraform.InputOpts) (bool, error) {
 			return true, nil
 		}
 	}
+	return false, nil
 }
 
 // showDiagnostics displays error and warning messages in the UI.

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -1023,7 +1023,10 @@ func (m *Meta) backend_C_r_S_changed(
 			"Error initializing new backend: %s", err)
 	}
 
-	m.Ui.Output(strings.TrimSpace(fmt.Sprintf(outputBackendMigrateChange, s.Backend.Type, c.Type)))
+	// no need to confuse the user if the backend types are the same
+	if s.Backend.Type != c.Type {
+		m.Ui.Output(strings.TrimSpace(fmt.Sprintf(outputBackendMigrateChange, s.Backend.Type, c.Type)))
+	}
 
 	// Grab the existing backend
 	oldB, err := m.backend_C_r_S_unchanged(c, sMgr)
@@ -1552,7 +1555,7 @@ Current Serial: %[2]d
 `
 
 const outputBackendMigrateChange = `
-Terraform detected a backend configuration change from %q to %q.
+Terraform detected that the backend type changed from %q to %q.
 `
 
 const outputBackendMigrateLegacy = `
@@ -1576,9 +1579,7 @@ const outputBackendReconfigure = `
 [reset][bold]Backend configuration changed![reset]
 
 Terraform has detected that the configuration specified for the backend
-has changed. Terraform will now reconfigure for this backend. If you didn't
-intend to reconfigure your backend please undo any changes to the "backend"
-section in your Terraform configuration.
+has changed. Terraform will now check for existing state in the backends.
 `
 
 const outputBackendSavedWithLegacy = `

--- a/command/meta_backend_migrate.go
+++ b/command/meta_backend_migrate.go
@@ -337,10 +337,8 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 
 func (m *Meta) backendMigrateEmptyConfirm(one, two state.State, opts *backendMigrateOpts) (bool, error) {
 	inputOpts := &terraform.InputOpts{
-		Id: "backend-migrate-copy-to-empty",
-		Query: fmt.Sprintf(
-			"Do you want to copy state from %q to %q?",
-			opts.OneType, opts.TwoType),
+		Id:    "backend-migrate-copy-to-empty",
+		Query: "Do you want to copy existing state to the new backend?",
 		Description: fmt.Sprintf(
 			strings.TrimSpace(inputBackendMigrateEmpty),
 			opts.OneType, opts.TwoType),
@@ -385,10 +383,8 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 
 	// Ask for confirmation
 	inputOpts := &terraform.InputOpts{
-		Id: "backend-migrate-to-backend",
-		Query: fmt.Sprintf(
-			"Do you want to copy state from %q to %q?",
-			opts.OneType, opts.TwoType),
+		Id:    "backend-migrate-to-backend",
+		Query: "Do you want to copy existing state to the new backend?",
 		Description: fmt.Sprintf(
 			strings.TrimSpace(inputBackendMigrateNonEmpty),
 			opts.OneType, opts.TwoType, onePath, twoPath),
@@ -410,7 +406,8 @@ type backendMigrateOpts struct {
 }
 
 const errMigrateLoadStates = `
-Error inspecting state in %q: %s
+Error inspecting states in the %q backend:
+    %s
 
 Prior to changing backends, Terraform inspects the source and destination
 states to determine what kind of migration steps need to be taken, if any.
@@ -419,9 +416,10 @@ destination remain unmodified. Please resolve the above error and try again.
 `
 
 const errMigrateSingleLoadDefault = `
-Error loading state from %q: %s
+Error loading state:
+    %[2]s
 
-Terraform failed to load the default state from %[1]q.
+Terraform failed to load the default state from the %[1]q backend.
 State migration cannot occur unless the state can be loaded. Backend
 modification and state migration has been aborted. The state in both the
 source and the destination remain unmodified. Please resolve the
@@ -429,9 +427,9 @@ above error and try again.
 `
 
 const errMigrateMulti = `
-Error migrating the workspace %q from %q to %q:
-
-%s
+Error migrating the workspace %q from the previous %q backend to the newly
+configured %q backend:
+    %s
 
 Terraform copies workspaces in alphabetical order. Any workspaces
 alphabetically earlier than this one have been copied. Any workspaces
@@ -443,41 +441,45 @@ This will attempt to copy (with permission) all workspaces again.
 `
 
 const errBackendStateCopy = `
-Error copying state from %q to %q: %s
+Error copying state from the previous %q backend to the newly configured %q backend:
+    %s
 
-The state in %[1]q remains intact and unmodified. Please resolve the
-error above and try again.
+The state in the previous backend remains intact and unmodified. Please resolve
+the error above and try again.
 `
 
 const inputBackendMigrateEmpty = `
-Pre-existing state was found in %q while migrating to %q. No existing
-state was found in %[2]q. Do you want to copy the state from %[1]q to
-%[2]q? Enter "yes" to copy and "no" to start with an empty state.
+Pre-existing state was found while migrating the previous %q backend to the
+newly configured %q backend. No existing state was found in the newly
+configured %[2]q backend. Do you want to copy this state to the new %[2]q
+backend? Enter "yes" to copy and "no" to start with an empty state.
 `
 
 const inputBackendMigrateNonEmpty = `
-Pre-existing state was found in %q while migrating to %q. An existing
-non-empty state exists in %[2]q. The two states have been saved to temporary
-files that will be removed after responding to this query.
+Pre-existing state was found while migrating the previous %q backend to the
+newly configured %q backend. An existing non-empty state already exists in
+the new backend. The two states have been saved to temporary files that will be
+removed after responding to this query.
 
-One (%[1]q): %[3]s
-Two (%[2]q): %[4]s
+Previous (type %[1]q): %[3]s
+New      (type %[2]q): %[4]s
 
-Do you want to copy the state from %[1]q to %[2]q? Enter "yes" to copy
-and "no" to start with the existing state in %[2]q.
+Do you want to overwrite the state in the new backend with the previous state?
+Enter "yes" to copy and "no" to start with the existing state in the newly
+configured %[2]q backend.
 `
 
 const inputBackendMigrateMultiToSingle = `
-The existing backend %[1]q supports workspaces and you currently are
-using more than one. The target backend %[2]q doesn't support workspaces.
-If you continue, Terraform will offer to copy your current workspace
-%[3]q to the default workspace in the target. Your existing workspaces
-in the source backend won't be modified. If you want to switch workspaces,
-back them up, or cancel altogether, answer "no" and Terraform will abort.
+The existing %[1]q backend supports workspaces and you currently are
+using more than one. The newly configured %[2]q backend doesn't support
+workspaces. If you continue, Terraform will copy your current workspace %[3]q
+to the default workspace in the target backend. Your existing workspaces in the
+source backend won't be modified. If you want to switch workspaces, back them
+up, or cancel altogether, answer "no" and Terraform will abort.
 `
 
 const inputBackendMigrateMultiToMulti = `
-Both the existing backend %[1]q and the target backend %[2]q support
+Both the existing %[1]q backend and the newly configured %[2]q backend support
 workspaces. When migrating between backends, Terraform will copy all
 workspaces (with the same names). THIS WILL OVERWRITE any conflicting
 states in the destination.

--- a/command/meta_backend_migrate.go
+++ b/command/meta_backend_migrate.go
@@ -346,22 +346,7 @@ func (m *Meta) backendMigrateEmptyConfirm(one, two state.State, opts *backendMig
 			opts.OneType, opts.TwoType),
 	}
 
-	// Confirm with the user that the copy should occur
-	for {
-		v, err := m.UIInput().Input(inputOpts)
-		if err != nil {
-			return false, fmt.Errorf(
-				"Error asking for state copy action: %s", err)
-		}
-
-		switch strings.ToLower(v) {
-		case "no":
-			return false, nil
-
-		case "yes":
-			return true, nil
-		}
-	}
+	return m.confirm(inputOpts)
 }
 
 func (m *Meta) backendMigrateNonEmptyConfirm(
@@ -410,21 +395,7 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 	}
 
 	// Confirm with the user that the copy should occur
-	for {
-		v, err := m.UIInput().Input(inputOpts)
-		if err != nil {
-			return false, fmt.Errorf(
-				"Error asking for state copy action: %s", err)
-		}
-
-		switch strings.ToLower(v) {
-		case "no":
-			return false, nil
-
-		case "yes":
-			return true, nil
-		}
-	}
+	return m.confirm(inputOpts)
 }
 
 type backendMigrateOpts struct {

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -1898,7 +1898,7 @@ func TestMetaBackend_configuredChangedLegacyCopyBackend(t *testing.T) {
 	defer testChdir(t, td)()
 
 	// Ask input
-	defer testInteractiveInput(t, []string{"yes", "yes", "no"})()
+	defer testInteractiveInput(t, []string{"yes", "no"})()
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -2297,7 +2297,7 @@ func TestMetaBackend_configuredUnsetWithLegacyCopyBackend(t *testing.T) {
 	defer testChdir(t, td)()
 
 	// Ask input
-	defer testInteractiveInput(t, []string{"yes", "yes", "no"})()
+	defer testInteractiveInput(t, []string{"yes", "no"})()
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)


### PR DESCRIPTION
The duplicate prompts can be confusing when the user confirms that a
migration should happen and we immediately prompt a second time for the
same thing with slightly different wording. The extra hand-holding that
this provides for legacy remote states is less critical now, since it's
been 2 major release cycles since those were removed.

Only check for input twice in the meta.confirm method. This prevents an
errant newline from aborting the run while allowing Terraform to exit if
there is no input available. We don't just check for a tty, since we
still rely on being able to pipe input in for testing.

Remove the redundant confirmation loops in the migration code, and only
use the confirm method.

fixes #16922
