### PR TITLE
Allow mixing and matching of password and key auth for bastions/target hosts

### DIFF
--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -108,9 +108,12 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 		}
 		if connInfo.BastionPassword == "" {
 			connInfo.BastionPassword = connInfo.Password
-		}
-		if connInfo.BastionPrivateKey == "" {
-			connInfo.BastionPrivateKey = connInfo.PrivateKey
+
+			// Only default the privateKey for the bastion connection if the password is unset
+			// This is to support the case where the bastion uses user/pass auth and the target host is key based
+			if connInfo.BastionPrivateKey == "" {
+				connInfo.BastionPrivateKey = connInfo.PrivateKey
+			}
 		}
 		if connInfo.BastionPort == 0 {
 			connInfo.BastionPort = connInfo.Port


### PR DESCRIPTION
The way that Terraform currently works, if you use a key for the target host, you can't configure password auth for the bastion host because if the `bastion_private_key` is unset, it is defaulted to the `private_key` from the target host config. The ssh connection then tries to use that key to connect to the bastion, which fails.

This changes Terraform's behavior to default the `bastion_private_key` to the `private_key` only if the `bastion_password` is also being defaulted. If the `bastion_password` is explicitly set, then terraform will not default the `bastion_private_key` to the target hosts `private key`.