### PR TITLE
added .bash_login and .profile which are also valid bash profile files.

### DIFF
--- a/vendor/github.com/posener/complete/cmd/install/install.go
+++ b/vendor/github.com/posener/complete/cmd/install/install.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-
-	"github.com/hashicorp/go-multierror"
 )
 
 type installer interface {
@@ -19,7 +17,7 @@ type installer interface {
 func Install(cmd string) error {
 	is := installers()
 	if len(is) == 0 {
-		return errors.New("Did not found any shells to install")
+		return errors.New("Did not find any shells to install")
 	}
 	bin, err := getBinaryPath()
 	if err != nil {
@@ -41,7 +39,7 @@ func Install(cmd string) error {
 func Uninstall(cmd string) error {
 	is := installers()
 	if len(is) == 0 {
-		return errors.New("Did not found any shells to uninstall")
+		return errors.New("Did not find any shells to uninstall")
 	}
 	bin, err := getBinaryPath()
 	if err != nil {
@@ -59,7 +57,7 @@ func Uninstall(cmd string) error {
 }
 
 func installers() (i []installer) {
-	for _, rc := range [...]string{".bashrc", ".bash_profile"} {
+	for _, rc := range [...]string{".bashrc", ".bash_profile", ".bash_login", ".profile"} {
 		if f := rcFile(rc); f != "" {
 			i = append(i, bash{f})
 			break


### PR DESCRIPTION
Fixes the issue where if .profile is used and not any of the other files the -install-autocomplete fails with :
Error executing CLI: Did not found any shells to install

excerpt from bash man page

    When bash is invoked as an interactive login shell, or as a non-interactive shell with the --login option, it first reads and executes commands from the file /etc/profile, if that file exists. After reading that file, it looks for ~/.bash_profile, ~/.bash_login, and ~/.profile, in that order, and reads and executes commands from the first one that exists and is readable. The --noprofile option may be used when the shell is started to inhibit this behavior.

    When an interactive shell that is not a login shell is started, bash reads and executes commands from /etc/bash.bashrc and ~/.bashrc, if these files exist. This may be inhibited by using the --norc option. The --rcfile file option will force bash to read and execute commands from file instead of /etc/bash.bashrc and ~/.bashrc.