### PR TITLE
Restore ability for an empty string to be considered unset in a computed value

### DIFF
--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -445,7 +445,7 @@ func (d *ResourceData) init() {
 }
 
 func (d *ResourceData) diffChange(
-	k string) (interface{}, interface{}, bool, bool) {
+	k string) (interface{}, interface{}, bool, bool, bool) {
 	// Get the change between the state and the config.
 	o, n := d.getChange(k, getSourceState, getSourceConfig|getSourceExact)
 	if !o.Exists {
@@ -456,7 +456,7 @@ func (d *ResourceData) diffChange(
 	}
 
 	// Return the old, new, and whether there is a change
-	return o.Value, n.Value, !reflect.DeepEqual(o.Value, n.Value), n.Computed
+	return o.Value, n.Value, !reflect.DeepEqual(o.Value, n.Value), n.Computed, false
 }
 
 func (d *ResourceData) getChange(

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -236,8 +236,8 @@ func (d *ResourceDiff) clear(key string) error {
 
 // diffChange helps to implement resourceDiffer and derives its change values
 // from ResourceDiff's own change data, in addition to existing diff, config, and state.
-func (d *ResourceDiff) diffChange(key string) (interface{}, interface{}, bool, bool) {
-	old, new := d.getChange(key)
+func (d *ResourceDiff) diffChange(key string) (interface{}, interface{}, bool, bool, bool) {
+	old, new, customized := d.getChange(key)
 
 	if !old.Exists {
 		old.Value = nil
@@ -246,7 +246,7 @@ func (d *ResourceDiff) diffChange(key string) (interface{}, interface{}, bool, b
 		new.Value = nil
 	}
 
-	return old.Value, new.Value, !reflect.DeepEqual(old.Value, new.Value), new.Computed
+	return old.Value, new.Value, !reflect.DeepEqual(old.Value, new.Value), new.Computed, customized
 }
 
 // SetNew is used to set a new diff value for the mentioned key. The value must
@@ -327,7 +327,7 @@ func (d *ResourceDiff) Get(key string) interface{} {
 // results from the exact levels for the new diff, then from state and diff as
 // per normal.
 func (d *ResourceDiff) GetChange(key string) (interface{}, interface{}) {
-	old, new := d.getChange(key)
+	old, new, _ := d.getChange(key)
 	return old.Value, new.Value
 }
 
@@ -387,18 +387,17 @@ func (d *ResourceDiff) Id() string {
 // This implementation differs from ResourceData's in the way that we first get
 // results from the exact levels for the new diff, then from state and diff as
 // per normal.
-func (d *ResourceDiff) getChange(key string) (getResult, getResult) {
+func (d *ResourceDiff) getChange(key string) (getResult, getResult, bool) {
 	old := d.get(strings.Split(key, "."), "state")
 	var new getResult
 	for p := range d.updatedKeys {
 		if childAddrOf(key, p) {
 			new = d.getExact(strings.Split(key, "."), "newDiff")
-			goto done
+			return old, new, true
 		}
 	}
 	new = d.get(strings.Split(key, "."), "newDiff")
-done:
-	return old, new
+	return old, new, false
 }
 
 // get performs the appropriate multi-level reader logic for ResourceDiff,

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -337,6 +337,12 @@ func (s *Schema) finalizeDiff(
 		return d
 	}
 
+	if s.Computed && d.NewComputed && d.Old != "" && d.New == "" {
+		// old case where we pretended that a NewComputed value of "" on a
+		// Computed field was unset
+		return nil
+	}
+
 	if s.Computed && !d.NewComputed {
 		if d.Old != "" && d.New == "" {
 			// This is a computed value with an old value set already,

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -337,6 +337,11 @@ func (s *Schema) finalizeDiff(d *terraform.ResourceAttrDiff, customized bool) *t
 	}
 
 	if s.Computed {
+		// FIXME: This is where the customized bool from getChange finally
+		//        comes into play.  It allows the previously incorrect behavior
+		//        of an empty string being used as "unset" when the value is
+		//        computed. This should be removed once we can properly
+		//        represent an unset/nil value from the configuration.
 		if !customized {
 			if d.Old != "" && d.New == "" {
 				// This is a computed value with an old value set already,

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3113,6 +3113,8 @@ func TestSchemaMap_Diff(t *testing.T) {
 
 		// A lot of resources currently depended on using the empty string as a
 		// nil/unset value.
+		// FIXME: We want this to eventually produce a diff, since there
+		// technically is a new value in the config.
 		{
 			Name: "optional, computed, empty string",
 			Schema: map[string]*Schema{

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3110,6 +3110,36 @@ func TestSchemaMap_Diff(t *testing.T) {
 
 			Err: true,
 		},
+
+		// A lot of resources currently depended on using the empty string as a
+		// nil/unset value.
+		{
+			Name: "optional, computed, empty string",
+			Schema: map[string]*Schema{
+				"attr": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"attr": "bar",
+				},
+			},
+
+			// this does necessarily depend on an interpolated value, but this
+			// is often how it comes about in a configuration, otherwise the
+			// value would be unset.
+			Config: map[string]interface{}{
+				"attr": "${var.foo}",
+			},
+
+			ConfigVariables: map[string]ast.Variable{
+				"var.foo": interfaceToVariableSwallowError(""),
+			},
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Add a test case for this situation where a resource was using an empty string to indicate an unset computed value. This may have been too common in providers, so we need to evaluate reverting that behavior. 

Reverts one of the changes from 6a4f7b0 (#14887), which broke empty strings
being seen as unset for computed values (this breaks a number of newer tests).

Referencing https://github.com/terraform-providers/terraform-provider-aws/issues/2348