### PR TITLE
minor race issue in mockResourceProvider

### DIFF
--- a/terraform/resource_provider_mock.go
+++ b/terraform/resource_provider_mock.go
@@ -196,13 +196,13 @@ func (p *MockResourceProvider) Diff(
 	info *InstanceInfo,
 	state *InstanceState,
 	desired *ResourceConfig) (*InstanceDiff, error) {
-
 	p.Lock()
+	defer p.Unlock()
+
 	p.DiffCalled = true
 	p.DiffInfo = info
 	p.DiffState = state
 	p.DiffDesired = desired
-	p.Unlock()
 
 	if p.DiffFn != nil {
 		return p.DiffFn(info, state, desired)


### PR DESCRIPTION
The interrupt tests for providers no longer check for the condition
during the diff operation. defer the lock so other test's DiffFns don't
need to be as carefull locking themselves.