### PR TITLE
Interesting fact, a factoid is not a fact.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -57,7 +57,7 @@ Please list the full steps required to reproduce the issue, for example:
 2. `terraform apply`
 -->
 
-### Important Factoids
+### Important Facts
 <!--
 Are there anything atypical about your situation that we should know? For example: is Terraform running in a wrapper script or in a CI system? Are you passing any unusual command line options or environment variables to opt-in to non-default behavior?
 -->


### PR DESCRIPTION
>**factoid** |ˈfaktɔɪd|
>_noun_
>an item of unreliable information that is reported and repeated so often that it becomes accepted as fact: _he addresses the facts and factoids which have buttressed the film's legend._

I know this is pure nitpicking, but this is one of my pet peeves, factoids are not reliables and not necessarily true.