### PR TITLE
Change URL Endpoint for Chef Provider to omnitruck

### DIFF
--- a/builtin/provisioners/chef/linux_provisioner.go
+++ b/builtin/provisioners/chef/linux_provisioner.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	chmod      = "find %s -maxdepth 1 -type f -exec /bin/chmod %d {} +"
-	installURL = "https://www.chef.io/chef/install.sh"
+	installURL = "https://omnitruck-direct.chef.io/chef/install.sh"
 )
 
 func (p *provisioner) linuxInstallChefClient(o terraform.UIOutput, comm communicator.Communicator) error {

--- a/builtin/provisioners/chef/linux_provisioner.go
+++ b/builtin/provisioners/chef/linux_provisioner.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	chmod      = "find %s -maxdepth 1 -type f -exec /bin/chmod %d {} +"
-	installURL = "https://omnitruck.chef.io/chef/install.sh"
+	installURL = "https://omnitruck-direct.chef.io/chef/install.sh"
 )
 
 func (p *provisioner) linuxInstallChefClient(o terraform.UIOutput, comm communicator.Communicator) error {

--- a/builtin/provisioners/chef/linux_provisioner.go
+++ b/builtin/provisioners/chef/linux_provisioner.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	chmod      = "find %s -maxdepth 1 -type f -exec /bin/chmod %d {} +"
-	installURL = "https://omnitruck-direct.chef.io/chef/install.sh"
+	installURL = "https://omnitruck.chef.io/chef/install.sh"
 )
 
 func (p *provisioner) linuxInstallChefClient(o terraform.UIOutput, comm communicator.Communicator) error {

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -25,7 +25,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"sudo curl -LO https://www.chef.io/chef/install.sh": true,
+				"sudo curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
 				"sudo bash ./install.sh -v \"\"":                    true,
 				"sudo rm -f install.sh":                             true,
 			},
@@ -43,7 +43,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"curl -LO https://www.chef.io/chef/install.sh": true,
+				"curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
 				"bash ./install.sh -v \"\"":                    true,
 				"rm -f install.sh":                             true,
 			},
@@ -61,7 +61,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"http_proxy='http://proxy.local' curl -LO https://www.chef.io/chef/install.sh": true,
+				"http_proxy='http://proxy.local' curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
 				"http_proxy='http://proxy.local' bash ./install.sh -v \"\"":                    true,
 				"http_proxy='http://proxy.local' rm -f install.sh":                             true,
 			},
@@ -79,7 +79,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"https_proxy='https://proxy.local' curl -LO https://www.chef.io/chef/install.sh": true,
+				"https_proxy='https://proxy.local' curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
 				"https_proxy='https://proxy.local' bash ./install.sh -v \"\"":                    true,
 				"https_proxy='https://proxy.local' rm -f install.sh":                             true,
 			},
@@ -99,7 +99,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
-					"curl -LO https://www.chef.io/chef/install.sh": true,
+					"curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
 				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
 					"bash ./install.sh -v \"\"": true,
 				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
@@ -119,7 +119,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"curl -LO https://www.chef.io/chef/install.sh": true,
+				"curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
 				"bash ./install.sh -v \"11.18.6\"":             true,
 				"rm -f install.sh":                             true,
 			},

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -25,7 +25,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"sudo curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
+				"sudo curl -LO https://omnitruck.chef.io/chef/install.sh": true,
 				"sudo bash ./install.sh -v \"\"":                                 true,
 				"sudo rm -f install.sh":                                          true,
 			},
@@ -43,7 +43,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
+				"curl -LO https://omnitruck.chef.io/chef/install.sh": true,
 				"bash ./install.sh -v \"\"":                                 true,
 				"rm -f install.sh":                                          true,
 			},
@@ -61,7 +61,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"http_proxy='http://proxy.local' curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
+				"http_proxy='http://proxy.local' curl -LO https://omnitruck.chef.io/chef/install.sh": true,
 				"http_proxy='http://proxy.local' bash ./install.sh -v \"\"":                                 true,
 				"http_proxy='http://proxy.local' rm -f install.sh":                                          true,
 			},
@@ -79,7 +79,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"https_proxy='https://proxy.local' curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
+				"https_proxy='https://proxy.local' curl -LO https://omnitruck.chef.io/chef/install.sh": true,
 				"https_proxy='https://proxy.local' bash ./install.sh -v \"\"":                                 true,
 				"https_proxy='https://proxy.local' rm -f install.sh":                                          true,
 			},

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -99,7 +99,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
-					"curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
+					"curl -LO https://omnitruck.chef.io/chef/install.sh": true,
 				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
 					"bash ./install.sh -v \"\"": true,
 				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
@@ -119,9 +119,9 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
-				"bash ./install.sh -v \"11.18.6\"":                          true,
-				"rm -f install.sh":                                          true,
+				"curl -LO https://omnitruck.chef.io/chef/install.sh": true,
+				"bash ./install.sh -v \"11.18.6\"":                   true,
+				"rm -f install.sh":                                   true,
 			},
 		},
 	}

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -26,8 +26,8 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"sudo curl -LO https://omnitruck.chef.io/chef/install.sh": true,
-				"sudo bash ./install.sh -v \"\"":                                 true,
-				"sudo rm -f install.sh":                                          true,
+				"sudo bash ./install.sh -v \"\"":                          true,
+				"sudo rm -f install.sh":                                   true,
 			},
 		},
 
@@ -44,8 +44,8 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"curl -LO https://omnitruck.chef.io/chef/install.sh": true,
-				"bash ./install.sh -v \"\"":                                 true,
-				"rm -f install.sh":                                          true,
+				"bash ./install.sh -v \"\"":                          true,
+				"rm -f install.sh":                                   true,
 			},
 		},
 
@@ -62,8 +62,8 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"http_proxy='http://proxy.local' curl -LO https://omnitruck.chef.io/chef/install.sh": true,
-				"http_proxy='http://proxy.local' bash ./install.sh -v \"\"":                                 true,
-				"http_proxy='http://proxy.local' rm -f install.sh":                                          true,
+				"http_proxy='http://proxy.local' bash ./install.sh -v \"\"":                          true,
+				"http_proxy='http://proxy.local' rm -f install.sh":                                   true,
 			},
 		},
 
@@ -80,8 +80,8 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"https_proxy='https://proxy.local' curl -LO https://omnitruck.chef.io/chef/install.sh": true,
-				"https_proxy='https://proxy.local' bash ./install.sh -v \"\"":                                 true,
-				"https_proxy='https://proxy.local' rm -f install.sh":                                          true,
+				"https_proxy='https://proxy.local' bash ./install.sh -v \"\"":                          true,
+				"https_proxy='https://proxy.local' rm -f install.sh":                                   true,
 			},
 		},
 

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -26,8 +26,8 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"sudo curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
-				"sudo bash ./install.sh -v \"\"":                    true,
-				"sudo rm -f install.sh":                             true,
+				"sudo bash ./install.sh -v \"\"":                                 true,
+				"sudo rm -f install.sh":                                          true,
 			},
 		},
 
@@ -44,8 +44,8 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
-				"bash ./install.sh -v \"\"":                    true,
-				"rm -f install.sh":                             true,
+				"bash ./install.sh -v \"\"":                                 true,
+				"rm -f install.sh":                                          true,
 			},
 		},
 
@@ -62,8 +62,8 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"http_proxy='http://proxy.local' curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
-				"http_proxy='http://proxy.local' bash ./install.sh -v \"\"":                    true,
-				"http_proxy='http://proxy.local' rm -f install.sh":                             true,
+				"http_proxy='http://proxy.local' bash ./install.sh -v \"\"":                                 true,
+				"http_proxy='http://proxy.local' rm -f install.sh":                                          true,
 			},
 		},
 
@@ -80,8 +80,8 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"https_proxy='https://proxy.local' curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
-				"https_proxy='https://proxy.local' bash ./install.sh -v \"\"":                    true,
-				"https_proxy='https://proxy.local' rm -f install.sh":                             true,
+				"https_proxy='https://proxy.local' bash ./install.sh -v \"\"":                                 true,
+				"https_proxy='https://proxy.local' rm -f install.sh":                                          true,
 			},
 		},
 
@@ -120,8 +120,8 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
-				"bash ./install.sh -v \"11.18.6\"":             true,
-				"rm -f install.sh":                             true,
+				"bash ./install.sh -v \"11.18.6\"":                          true,
+				"rm -f install.sh":                                          true,
 			},
 		},
 	}

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -25,9 +25,9 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"sudo curl -LO https://omnitruck.chef.io/chef/install.sh": true,
-				"sudo bash ./install.sh -v \"\"":                          true,
-				"sudo rm -f install.sh":                                   true,
+				"sudo curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
+				"sudo bash ./install.sh -v \"\"":                                 true,
+				"sudo rm -f install.sh":                                          true,
 			},
 		},
 
@@ -43,9 +43,9 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"curl -LO https://omnitruck.chef.io/chef/install.sh": true,
-				"bash ./install.sh -v \"\"":                          true,
-				"rm -f install.sh":                                   true,
+				"curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
+				"bash ./install.sh -v \"\"":                                 true,
+				"rm -f install.sh":                                          true,
 			},
 		},
 
@@ -61,9 +61,9 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"http_proxy='http://proxy.local' curl -LO https://omnitruck.chef.io/chef/install.sh": true,
-				"http_proxy='http://proxy.local' bash ./install.sh -v \"\"":                          true,
-				"http_proxy='http://proxy.local' rm -f install.sh":                                   true,
+				"http_proxy='http://proxy.local' curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
+				"http_proxy='http://proxy.local' bash ./install.sh -v \"\"":                                 true,
+				"http_proxy='http://proxy.local' rm -f install.sh":                                          true,
 			},
 		},
 
@@ -79,9 +79,9 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"https_proxy='https://proxy.local' curl -LO https://omnitruck.chef.io/chef/install.sh": true,
-				"https_proxy='https://proxy.local' bash ./install.sh -v \"\"":                          true,
-				"https_proxy='https://proxy.local' rm -f install.sh":                                   true,
+				"https_proxy='https://proxy.local' curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
+				"https_proxy='https://proxy.local' bash ./install.sh -v \"\"":                                 true,
+				"https_proxy='https://proxy.local' rm -f install.sh":                                          true,
 			},
 		},
 
@@ -99,7 +99,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 			Commands: map[string]bool{
 				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
-					"curl -LO https://omnitruck.chef.io/chef/install.sh": true,
+					"curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
 				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
 					"bash ./install.sh -v \"\"": true,
 				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
@@ -119,9 +119,9 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"curl -LO https://omnitruck.chef.io/chef/install.sh": true,
-				"bash ./install.sh -v \"11.18.6\"":                   true,
-				"rm -f install.sh":                                   true,
+				"curl -LO https://omnitruck-direct.chef.io/chef/install.sh": true,
+				"bash ./install.sh -v \"11.18.6\"":                          true,
+				"rm -f install.sh":                                          true,
 			},
 		},
 	}


### PR DESCRIPTION
The default Chef Provider endpoint has SSL issues preventing chef installs.
switch to the URL install endpoint used by knife: https://docs.chef.io/install_omnibus.html

Not sure which branch this should go to so if you need another request let me know.