### PR TITLE
Close providers

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -2401,6 +2401,32 @@ func TestContext2Plan_hook(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_closeProvider(t *testing.T) {
+	// this fixture only has an aliased provider located in the module, to make
+	// sure that the provier name contains a path more complex than
+	// "provider.aws".
+	m := testModule(t, "plan-close-module-provider")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		ProviderResolver: ResourceProviderResolverFixed(
+			map[string]ResourceProviderFactory{
+				"aws": testProviderFuncFixed(p),
+			},
+		),
+	})
+
+	_, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !p.CloseCalled {
+		t.Fatal("provider not closed")
+	}
+}
+
 func TestContext2Plan_orphan(t *testing.T) {
 	m := testModule(t, "plan-orphan")
 	p := testProvider("aws")

--- a/terraform/eval_provider_test.go
+++ b/terraform/eval_provider_test.go
@@ -90,7 +90,8 @@ func TestEvalInitProvider(t *testing.T) {
 }
 
 func TestEvalCloseProvider(t *testing.T) {
-	n := &EvalCloseProvider{Name: "foo"}
+	providerName := ResolveProviderName("foo", nil)
+	n := &EvalCloseProvider{Name: providerName}
 	provider := &MockResourceProvider{}
 	ctx := &MockEvalContext{CloseProviderProvider: provider}
 	if _, err := n.Eval(ctx); err != nil {
@@ -100,7 +101,7 @@ func TestEvalCloseProvider(t *testing.T) {
 	if !ctx.CloseProviderCalled {
 		t.Fatal("should be called")
 	}
-	if ctx.CloseProviderName != "foo" {
+	if ctx.CloseProviderName != providerName {
 		t.Fatalf("bad: %#v", ctx.CloseProviderName)
 	}
 }

--- a/terraform/test-fixtures/plan-close-module-provider/main.tf
+++ b/terraform/test-fixtures/plan-close-module-provider/main.tf
@@ -1,0 +1,3 @@
+module "mod" {
+  source = "./mod"
+}

--- a/terraform/test-fixtures/plan-close-module-provider/mod/main.tf
+++ b/terraform/test-fixtures/plan-close-module-provider/mod/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  alias = "mod"
+}
+
+resource "aws_instance" "bar" {
+  provider = "aws.mod"
+}

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -138,13 +138,13 @@ func (t *CloseProviderTransformer) Transform(g *Graph) error {
 		p := v.(GraphNodeProvider)
 
 		// get the close provider of this type if we alread created it
-		closer := cpm[p.ProviderName()]
+		closer := cpm[p.Name()]
 
 		if closer == nil {
 			// create a closer for this provider type
-			closer = &graphNodeCloseProvider{ProviderNameValue: p.ProviderName()}
+			closer = &graphNodeCloseProvider{ProviderNameValue: p.Name()}
 			g.Add(closer)
-			cpm[p.ProviderName()] = closer
+			cpm[p.Name()] = closer
 		}
 
 		// Close node depends on the provider itself
@@ -336,7 +336,7 @@ type graphNodeCloseProvider struct {
 }
 
 func (n *graphNodeCloseProvider) Name() string {
-	return fmt.Sprintf("provider.%s (close)", n.ProviderNameValue)
+	return n.ProviderNameValue + " (close)"
 }
 
 // GraphNodeEvalable impl.


### PR DESCRIPTION
`CloseProviderTransformer` wasn't using the full provider when creating
the graph node, so the `Close` wasn't actually being called on the
provider.


fixes #17023