### PR TITLE
helper/schema: Fail schema validation if Elem is not of a valid type

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -647,6 +647,15 @@ func (m schemaMap) InternalValidate(topSchemaMap schemaMap) error {
 			return fmt.Errorf("%s: ConflictsWith cannot be set with Required", k)
 		}
 
+		if v.Elem != nil {
+			switch v.Elem.(type) {
+			case *Resource:
+			case *Schema:
+			default:
+				return fmt.Errorf("%s: Elem must be a *Resource or a *Schema", k)
+			}
+		}
+
 		if len(v.ConflictsWith) > 0 {
 			for _, key := range v.ConflictsWith {
 				parts := strings.Split(key, ".")

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3713,6 +3713,17 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			},
 			false,
 		},
+
+		"elem field is of wrong type": {
+			map[string]*Schema{
+				"invalid_elem": &Schema{
+					Type:     TypeMap,
+					Optional: true,
+					Elem:     TypeString,
+				},
+			},
+			true,
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
In several places in the helper/schema package, Terraform assumes that the Elem field is either a *Resource or a *Schema, and panics if this is not the case.

The best example of this is in the CoreConfigSchema() function in helper/schema/core_schema.go

This doesn't normally appear to be a problem, but I've managed to tickle it while working on some other changes.

This PR introduces an explicit test for the type of the Elem field as part of the InternalValidate function, which is used to validate the provider schema in unit tests. Schema's which fail this test are definitely invalid.

Unfortunately this will cause this test to begin (correctly) failing for some providers. I have PRs ready to go for AWS and Google, and will keep an eye on others.