### PR TITLE
Fix panic with substr interpolation function by invalid offset

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -1577,7 +1577,7 @@ func interpolationFuncSubstr() ast.Function {
 				return nil, fmt.Errorf("length should be a non-negative integer")
 			}
 
-			if offset > len(str) {
+			if offset > len(str) || offset < 0 {
 				return nil, fmt.Errorf("offset cannot be larger than the length of the string")
 			}
 

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2568,6 +2568,11 @@ func TestInterpolateFuncSubstr(t *testing.T) {
 				nil,
 				true,
 			},
+			{
+				`${substr("foo", -4, -1)}`,
+				nil,
+				true,
+			},
 
 			// invalid length
 			{


### PR DESCRIPTION
Fixes #17041

## before

```
[terraform@check-substr-offset x]$ go test -v ./config -run TestInterpolateFuncSubstr
=== RUN   TestInterpolateFuncSubstr
=== RUN   TestInterpolateFuncSubstr/${substr("foobar",_0,_0)}
=== RUN   TestInterpolateFuncSubstr/${substr("foobar",_0,_-1)}
=== RUN   TestInterpolateFuncSubstr/${substr("foobar",_0,_3)}
=== RUN   TestInterpolateFuncSubstr/${substr("foobar",_3,_3)}
=== RUN   TestInterpolateFuncSubstr/${substr("foobar",_-3,_3)}
=== RUN   TestInterpolateFuncSubstr/${substr("",_0,_0)}
=== RUN   TestInterpolateFuncSubstr/${substr("",_1,_0)}
=== RUN   TestInterpolateFuncSubstr/${substr("foo",_-4,_-1)}
panic: runtime error: slice bounds out of range [recovered]
        panic: runtime error: slice bounds out of range

goroutine 36 [running]:
testing.tRunner.func1(0xc4202a00f0)
        /usr/local/Cellar/go/1.9/libexec/src/testing/testing.go:711 +0x2d2
panic(0x173dac0, 0x1c85bc0)
        /usr/local/Cellar/go/1.9/libexec/src/runtime/panic.go:491 +0x283
github.com/hashicorp/terraform/config.interpolationFuncSubstr.func1(0xc42026a780, 0x3, 0x3, 0xc42026a780, 0x3, 0x3, 0x8)
        /Users/minamijoyo/src/github.com/hashicorp/terraform/config/interpolate_funcs.go:1588 +0x294
github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil.(*evalCall).Eval(0xc4202700c0, 0x1c33600, 0xc4202643b0, 0xc4201c32d0, 0x0, 0x0, 0xc4201c3540, 0xc4201c32d0, 0xc42012bbf0)
        /Users/minamijoyo/src/github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil/eval.go:283 +0x33d
github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil.(*evalVisitor).visit(0xc4201c32c0, 0x1c35940, 0xc420268230, 0x3, 0xc42026a710)
        /Users/minamijoyo/src/github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil/eval.go:215 +0x10d
github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil.(*evalVisitor).(github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil.visit)-fm(0x1c35940, 0xc420268230, 0x1c35940, 0xc420268370)
        /Users/minamijoyo/src/github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil/eval.go:175 +0x3e
github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil/ast.(*Call).Accept(0xc420268230, 0xc420264410, 0x1012a18, 0x10)
        /Users/minamijoyo/src/github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil/ast/call.go:20 +0xf3
github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil/ast.(*Output).Accept(0xc4201c31c0, 0xc420264410, 0xc4201c32c0, 0x1eacbc0)
        /Users/minamijoyo/src/github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil/ast/output.go:20 +0x76
github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil.(*evalVisitor).Visit(0xc4201c32c0, 0x1c35a40, 0xc4201c31c0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/minamijoyo/src/github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil/eval.go:175 +0xaa
github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil.internalEval(0x1c35a40, 0xc4201c31c0, 0xc420266280, 0x1736b60, 0xc42026a570, 0xc420281400, 0xc420281400, 0x0)
        /Users/minamijoyo/src/github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil/eval.go:153 +0x7f4
github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil.Eval(0x1c35a40, 0xc4201c31c0, 0xc420266280, 0xc4201c31c0, 0x0, 0x0, 0xc420160480, 0xc42026c490)
        /Users/minamijoyo/src/github.com/hashicorp/terraform/vendor/github.com/hashicorp/hil/eval.go:52 +0x49
github.com/hashicorp/terraform/config.testFunction.func1(0xc4202a00f0)
        /Users/minamijoyo/src/github.com/hashicorp/terraform/config/interpolate_funcs_test.go:2481 +0x10f
testing.tRunner(0xc4202a00f0, 0xc42026a4b0)
        /usr/local/Cellar/go/1.9/libexec/src/testing/testing.go:746 +0xd0
created by testing.(*T).Run
        /usr/local/Cellar/go/1.9/libexec/src/testing/testing.go:789 +0x2de
exit status 2
FAIL    github.com/hashicorp/terraform/config   0.334s

```

## after

```
[terraform@check-substr-offset x]$ go test -v ./config -run TestInterpolateFuncSubstr
=== RUN   TestInterpolateFuncSubstr
=== RUN   TestInterpolateFuncSubstr/${substr("foobar",_0,_0)}
=== RUN   TestInterpolateFuncSubstr/${substr("foobar",_0,_-1)}
=== RUN   TestInterpolateFuncSubstr/${substr("foobar",_0,_3)}
=== RUN   TestInterpolateFuncSubstr/${substr("foobar",_3,_3)}
=== RUN   TestInterpolateFuncSubstr/${substr("foobar",_-3,_3)}
=== RUN   TestInterpolateFuncSubstr/${substr("",_0,_0)}
=== RUN   TestInterpolateFuncSubstr/${substr("",_1,_0)}
=== RUN   TestInterpolateFuncSubstr/${substr("foo",_-4,_-1)}
=== RUN   TestInterpolateFuncSubstr/${substr("",_0,_1)}
=== RUN   TestInterpolateFuncSubstr/${substr("",_0,_-2)}
--- PASS: TestInterpolateFuncSubstr (0.00s)
    --- PASS: TestInterpolateFuncSubstr/${substr("foobar",_0,_0)} (0.00s)
    --- PASS: TestInterpolateFuncSubstr/${substr("foobar",_0,_-1)} (0.00s)
    --- PASS: TestInterpolateFuncSubstr/${substr("foobar",_0,_3)} (0.00s)
    --- PASS: TestInterpolateFuncSubstr/${substr("foobar",_3,_3)} (0.00s)
    --- PASS: TestInterpolateFuncSubstr/${substr("foobar",_-3,_3)} (0.00s)
    --- PASS: TestInterpolateFuncSubstr/${substr("",_0,_0)} (0.00s)
    --- PASS: TestInterpolateFuncSubstr/${substr("",_1,_0)} (0.00s)
    --- PASS: TestInterpolateFuncSubstr/${substr("foo",_-4,_-1)} (0.00s)
    --- PASS: TestInterpolateFuncSubstr/${substr("",_0,_1)} (0.00s)
    --- PASS: TestInterpolateFuncSubstr/${substr("",_0,_-2)} (0.00s)
PASS
ok      github.com/hashicorp/terraform/config   0.041s
```