### PR TITLE
-plugin-dir short-circuits discovery of internal plugins

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -306,7 +306,6 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 	))
 
 	missing := c.missingPlugins(available, requirements)
-	internal := c.internalProviders()
 
 	var errs error
 	if c.getPlugins {
@@ -316,12 +315,6 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 		}
 
 		for provider, reqd := range missing {
-			if _, isInternal := internal[provider]; isInternal {
-				// Ignore internal providers; they are not eligible for
-				// installation.
-				continue
-			}
-
 			_, err := c.providerInstaller.Get(provider, reqd.Versions)
 
 			if err != nil {
@@ -379,7 +372,10 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 	// again. If anything changes, other commands that use providers will
 	// fail with an error instructing the user to re-run this command.
 	available = c.providerPluginSet() // re-discover to see newly-installed plugins
-	chosen := choosePlugins(available, internal, requirements)
+
+	// internal providers were already filtered out, since we don't need to get them.
+	chosen := choosePlugins(available, nil, requirements)
+
 	digests := map[string][]byte{}
 	for name, meta := range chosen {
 		digest, err := meta.SHA256()

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -1063,3 +1063,27 @@ func TestInit_pluginDirProvidersDoesNotGet(t *testing.T) {
 		t.Fatalf("bad: \n%s", ui.OutputWriter)
 	}
 }
+
+// Verify that plugin-dir doesn't prevent discovery of internal providers
+func TestInit_pluginWithInternal(t *testing.T) {
+	td := tempDir(t)
+	copy.CopyDir(testFixturePath("init-internal"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	ui := new(cli.MockUi)
+	m := Meta{
+		testingOverrides: metaOverridesForProvider(testProvider()),
+		Ui:               ui,
+	}
+
+	c := &InitCommand{
+		Meta: m,
+	}
+
+	args := []string{"-plugin-dir", "./"}
+	//args := []string{}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("error: %s", ui.ErrorWriter)
+	}
+}

--- a/command/internal_plugin.go
+++ b/command/internal_plugin.go
@@ -45,16 +45,6 @@ func (c *InternalPluginCommand) Run(args []string) int {
 	log.SetPrefix(fmt.Sprintf("%s-%s (internal) ", pluginName, pluginType))
 
 	switch pluginType {
-	case "provider":
-		pluginFunc, found := InternalProviders[pluginName]
-		if !found {
-			log.Printf("[ERROR] Could not load provider: %s", pluginName)
-			return 1
-		}
-		log.Printf("[INFO] Starting provider plugin %s", pluginName)
-		plugin.Serve(&plugin.ServeOpts{
-			ProviderFunc: pluginFunc,
-		})
 	case "provisioner":
 		pluginFunc, found := InternalProvisioners[pluginName]
 		if !found {

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -14,8 +14,6 @@ import (
 	"github.com/hashicorp/terraform/plugin"
 )
 
-var InternalProviders = map[string]plugin.ProviderFunc{}
-
 var InternalProvisioners = map[string]plugin.ProvisionerFunc{
 	"chef":            chefprovisioner.Provisioner,
 	"file":            fileprovisioner.Provisioner,

--- a/command/internal_plugin_test.go
+++ b/command/internal_plugin_test.go
@@ -2,15 +2,26 @@ package command
 
 import "testing"
 
-// providers are all external for now
-//func TestInternalPlugin_InternalProviders(t *testing.T) {
-//    // Note this is a randomish sample and does not check for all plugins
-//    for _, name := range []string{"atlas", "consul", "docker", "template"} {
-//        if _, ok := InternalProviders[name]; !ok {
-//            t.Errorf("Expected to find %s in InternalProviders", name)
-//        }
-//    }
-//}
+func TestInternalPlugin_InternalProviders(t *testing.T) {
+	m := new(Meta)
+	providers := m.internalProviders()
+	// terraform is the only provider moved back to internal
+	for _, name := range []string{"terraform"} {
+		pf, ok := providers[name]
+		if !ok {
+			t.Errorf("Expected to find %s in InternalProviders", name)
+		}
+
+		provider, err := pf()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if provider == nil {
+			t.Fatal("provider factory returned a nil provider")
+		}
+	}
+}
 
 func TestInternalPlugin_InternalProvisioners(t *testing.T) {
 	for _, name := range []string{"chef", "file", "local-exec", "remote-exec", "salt-masterless"} {

--- a/command/plugins.go
+++ b/command/plugins.go
@@ -272,13 +272,16 @@ func (m *Meta) internalProviders() map[string]terraform.ResourceProviderFactory 
 func (m *Meta) missingPlugins(avail discovery.PluginMetaSet, reqd discovery.PluginRequirements) discovery.PluginRequirements {
 	missing := make(discovery.PluginRequirements)
 
-	for n, r := range reqd {
-		log.Printf("[DEBUG] plugin requirements: %q=%q", n, r.Versions)
-	}
-
 	candidates := avail.ConstrainVersions(reqd)
+	internal := m.internalProviders()
 
 	for name, versionSet := range reqd {
+		// internal providers can't be missing
+		if _, ok := internal[name]; ok {
+			continue
+		}
+
+		log.Printf("[DEBUG] plugin requirements: %q=%q", name, versionSet.Versions)
 		if metas := candidates[name]; metas.Count() == 0 {
 			missing[name] = versionSet
 		}

--- a/command/test-fixtures/init-internal/main.tf
+++ b/command/test-fixtures/init-internal/main.tf
@@ -1,0 +1,1 @@
+provider "terraform" {}


### PR DESCRIPTION
Internal plugins were always listed in the set of missing plugins, and filtered out while trying to fetch the plugins. If missing plugins were not going to be downloaded at all because of the `-plugin-dir` flag, then the internal plugins still being populated in the missing set would raise an error.

Filter internal plugins out in `missingPlugins`, so we don't attempt to locate them at all.

Fixes #16994