### PR TITLE
helper/schema: If a list field contains maps with computed entries, then mark the list as computed

### DIFF
--- a/helper/schema/field_reader.go
+++ b/helper/schema/field_reader.go
@@ -217,8 +217,8 @@ func readListField(
 	}
 
 	return FieldReadResult{
-		Value:  result,
-		Exists: true,
+		Value:    result,
+		Exists:   true,
 		Computed: computed,
 	}, nil
 }

--- a/helper/schema/field_reader.go
+++ b/helper/schema/field_reader.go
@@ -195,6 +195,7 @@ func readListField(
 
 	// Go through each count, and get the item value out of it
 	result := make([]interface{}, countResult.Value.(int))
+	computed := false
 	for i, _ := range result {
 		is := strconv.FormatInt(int64(i), 10)
 		addrPadded[len(addrPadded)-1] = is
@@ -208,6 +209,9 @@ func readListField(
 			// Schema.
 			rawResult.Value = nil
 		}
+		if rawResult.Computed {
+			computed = true
+		}
 
 		result[i] = rawResult.Value
 	}
@@ -215,6 +219,7 @@ func readListField(
 	return FieldReadResult{
 		Value:  result,
 		Exists: true,
+		Computed: computed,
 	}, nil
 }
 

--- a/helper/schema/field_reader_diff_test.go
+++ b/helper/schema/field_reader_diff_test.go
@@ -410,6 +410,26 @@ func TestDiffFieldReader(t *testing.T) {
 						New: "42",
 					},
 
+					"listMap.#": &terraform.ResourceAttrDiff{
+						Old: "0",
+						New: "1",
+					},
+
+					"listMap.0.%": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "2",
+					},
+
+					"listMap.0.foo": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "bar",
+					},
+
+					"listMap.0.bar": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "baz",
+					},
+
 					"map.foo": &terraform.ResourceAttrDiff{
 						Old: "",
 						New: "bar",

--- a/helper/schema/field_reader_map_test.go
+++ b/helper/schema/field_reader_map_test.go
@@ -28,6 +28,11 @@ func TestMapFieldReader(t *testing.T) {
 				"listInt.0": "21",
 				"listInt.1": "42",
 
+				"listMap.#":     "1",
+				"listMap.0.%":   "2",
+				"listMap.0.foo": "bar",
+				"listMap.0.bar": "baz",
+
 				"map.%":   "2",
 				"map.foo": "bar",
 				"map.bar": "baz",

--- a/helper/schema/field_reader_test.go
+++ b/helper/schema/field_reader_test.go
@@ -320,6 +320,20 @@ func testFieldReader(t *testing.T, f func(map[string]*Schema) FieldReader) {
 			},
 			false,
 		},
+		"listMap": {
+			[]string{"listMap"},
+			FieldReadResult{
+				Value: []interface{}{
+					map[string]interface{}{
+						"foo": "bar",
+						"bar": "baz",
+					},
+				},
+				Exists:   true,
+				Computed: false,
+			},
+			false,
+		},
 
 		"listInt": {
 			[]string{"listInt"},
@@ -445,7 +459,7 @@ func testFieldReader(t *testing.T, f func(map[string]*Schema) FieldReader) {
 			out.Value = s.List()
 		}
 		if !reflect.DeepEqual(tc.Result, out) {
-			t.Fatalf("%s: bad: %#v", name, out)
+			t.Fatalf("%s: expected: %#v, got: %#v", name, tc.Result, out)
 		}
 	}
 }


### PR DESCRIPTION
Prior to this change, I noticed that:
1. if a list field contains computed string elements, then the list is marked as computed.   
2. if a map field contains computed elements, then the map is marked as computed.
3. if a list field contains maps, which contain computed elements, then the list is NOT marked as computed (this seemed incorrect)

This change corrects 3, such that the list will be marked as computed.


In particular, this fixes a problem for fields of type `schema.TypeSet`, whose elements are of type `schema.TypeMap`, whose elements are computed.  Note that `readSet` actually reads the field as a list first.

For example, consider the following schema...

```go
	"maps": &schema.Schema{
		Type:        schema.TypeSet,
		Set:         mapHash,
		MinItems:    0,

		Elem: &schema.Schema{
			Type:        schema.TypeMap,
			MinItems:    1,
			MaxItems:    1,
			Elem: &schema.Schema{
				Type:        schema.TypeString,
			},
		},
		Optional: true,
	},
```

Note that the `mapHash` function determines the unique ID of an item (a map) so that a proper set can be built.

Without this change, during `terraform plan`, the `mapHash` function will be passed `nil` for computed maps (since field_reader.ReadField returns null for maps with computed entries).
A proper hash for `nil` cannot be accurately determined.  You could theoretically always return the same value, but that breaks downstream logic that assumes each element will have a unique hash.

With this change, since the list is marked as computed, `mapHash` is not invoked for each element during `terraform plan`

This is causing Pryz/terraform-provider-ldap#6.  To reproduce the issue, take a look at that issue.

I tried to get creative and fix `terraform-provider-ldap` by handling `nil` by always returning the same value, or by returning unique values for each invocation, but could never get both plan and apply to work.

So, I started looking into terraform itself, and was able to solve the issue with this change.
