### PR TITLE
vendor: update zclconf/go-cty

### DIFF
--- a/vendor/github.com/zclconf/go-cty/cty/types_to_register.go
+++ b/vendor/github.com/zclconf/go-cty/cty/types_to_register.go
@@ -2,7 +2,9 @@ package cty
 
 import (
 	"encoding/gob"
+	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/zclconf/go-cty/cty/set"
 )
@@ -45,6 +47,11 @@ func init() {
 	// Register these with gob here, rather than in gob.go, to ensure
 	// that this will always happen after we build the above.
 	for _, tv := range InternalTypesToRegister {
-		gob.Register(tv)
+		typeName := fmt.Sprintf("%T", tv)
+		if strings.HasPrefix(typeName, "cty.") {
+			gob.RegisterName(fmt.Sprintf("github.com/zclconf/go-cty/%s", typeName), tv)
+		} else {
+			gob.Register(tv)
+		}
 	}
 }

--- a/vendor/github.com/zclconf/go-cty/cty/value_ops.go
+++ b/vendor/github.com/zclconf/go-cty/cty/value_ops.go
@@ -737,6 +737,30 @@ func (val Value) HasIndex(key Value) Value {
 	}
 }
 
+// HasElement returns True if the receiver (which must be of a set type)
+// has the given value as an element, or False if it does not.
+//
+// The result will be UnknownVal(Bool) if either the set or the
+// given value are unknown.
+//
+// This method will panic if the receiver is not a set, or if it is a null set.
+func (val Value) HasElement(elem Value) Value {
+	ty := val.Type()
+
+	if !ty.IsSetType() {
+		panic("not a set type")
+	}
+	if !val.IsKnown() || !elem.IsKnown() {
+		return UnknownVal(Bool)
+	}
+	if val.IsNull() {
+		panic("can't call HasElement on a nil value")
+	}
+
+	s := val.v.(set.Set)
+	return BoolVal(s.Has(elem.v))
+}
+
 // Length returns the length of the receiver, which must be a collection type
 // or tuple type, as a number value. If the receiver is not a compatible type
 // then this method will panic.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2132,46 +2132,46 @@
 			"revisionTime": "2016-10-29T10:40:18Z"
 		},
 		{
-			"checksumSHA1": "R9ayYqxeUsPcIbs6KXCVwDIdf6M=",
+			"checksumSHA1": "TudZOVOvOvR5zw7EFbvD3eZpmLI=",
 			"path": "github.com/zclconf/go-cty/cty",
-			"revision": "8bf222d6d03b7b336d013978f3acbfd877da428f",
-			"revisionTime": "2017-10-13T21:58:09Z"
+			"revision": "709e4033eeb037dc543dbc2048065dfb814ce316",
+			"revisionTime": "2018-01-06T05:58:34Z"
 		},
 		{
 			"checksumSHA1": "IjvfMUZ9S1L1NM0haXwMfKzkyvM=",
 			"path": "github.com/zclconf/go-cty/cty/convert",
-			"revision": "8bf222d6d03b7b336d013978f3acbfd877da428f",
-			"revisionTime": "2017-10-13T21:58:09Z"
+			"revision": "709e4033eeb037dc543dbc2048065dfb814ce316",
+			"revisionTime": "2018-01-06T05:58:34Z"
 		},
 		{
 			"checksumSHA1": "TU21yqpRZdbEbH8pp4I5YsQa00E=",
 			"path": "github.com/zclconf/go-cty/cty/function",
-			"revision": "8bf222d6d03b7b336d013978f3acbfd877da428f",
-			"revisionTime": "2017-10-13T21:58:09Z"
+			"revision": "709e4033eeb037dc543dbc2048065dfb814ce316",
+			"revisionTime": "2018-01-06T05:58:34Z"
 		},
 		{
 			"checksumSHA1": "Ke4kpRBTSophcLSCrusR8XxSC0Y=",
 			"path": "github.com/zclconf/go-cty/cty/function/stdlib",
-			"revision": "8bf222d6d03b7b336d013978f3acbfd877da428f",
-			"revisionTime": "2017-10-13T21:58:09Z"
+			"revision": "709e4033eeb037dc543dbc2048065dfb814ce316",
+			"revisionTime": "2018-01-06T05:58:34Z"
 		},
 		{
 			"checksumSHA1": "tmCzwfNXOEB1sSO7TKVzilb2vjA=",
 			"path": "github.com/zclconf/go-cty/cty/gocty",
-			"revision": "8bf222d6d03b7b336d013978f3acbfd877da428f",
-			"revisionTime": "2017-10-13T21:58:09Z"
+			"revision": "709e4033eeb037dc543dbc2048065dfb814ce316",
+			"revisionTime": "2018-01-06T05:58:34Z"
 		},
 		{
 			"checksumSHA1": "1ApmO+Q33+Oem/3f6BU6sztJWNc=",
 			"path": "github.com/zclconf/go-cty/cty/json",
-			"revision": "8bf222d6d03b7b336d013978f3acbfd877da428f",
-			"revisionTime": "2017-10-13T21:58:09Z"
+			"revision": "709e4033eeb037dc543dbc2048065dfb814ce316",
+			"revisionTime": "2018-01-06T05:58:34Z"
 		},
 		{
 			"checksumSHA1": "gH4rRyzIQknMIXAJfpvC04KTsME=",
 			"path": "github.com/zclconf/go-cty/cty/set",
-			"revision": "8bf222d6d03b7b336d013978f3acbfd877da428f",
-			"revisionTime": "2017-10-13T21:58:09Z"
+			"revision": "709e4033eeb037dc543dbc2048065dfb814ce316",
+			"revisionTime": "2018-01-06T05:58:34Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",


### PR DESCRIPTION
Update `go-cty` to enable decode a gob encoded response from provider even if the provider uses vendored version of `go-cty`.

Refs: https://github.com/hashicorp/terraform/issues/16423#issuecomment-355560949
Refs: https://github.com/zclconf/go-cty/commit/14e23b14828dd12cc7ae0956813c7e91a196e68f

```
[terraform@master]$ govendor fetch github.com/zclconf/go-cty/...
```