### PR TITLE
Handle refresh errors.

### DIFF
--- a/backend/local/backend_refresh.go
+++ b/backend/local/backend_refresh.go
@@ -86,8 +86,8 @@ func (b *Local) opRefresh(
 	doneCh := make(chan struct{})
 	go func() {
 		defer close(doneCh)
-		newState, err = tfCtx.Refresh()
-		log.Printf("[INFO] backend/local: plan calling Plan")
+		newState, refreshErr = tfCtx.Refresh()
+		log.Printf("[INFO] backend/local: refresh calling Refresh")
 	}()
 
 	select {


### PR DESCRIPTION
The condition in line 109 could never evaluate to true because the error returned from tfCtx.Refresh() was assigned to a different variable.

This is a follow-up to #16833.