### PR TITLE
only split the prefix string once from the s3 key

### DIFF
--- a/backend/remote-state/s3/backend_state.go
+++ b/backend/remote-state/s3/backend_state.go
@@ -53,7 +53,7 @@ func (b *Backend) keyEnv(key string) string {
 		}
 	}
 
-	parts := strings.SplitAfter(key, b.workspaceKeyPrefix)
+	parts := strings.SplitAfterN(key, b.workspaceKeyPrefix, 2)
 
 	if len(parts) < 2 {
 		return ""


### PR DESCRIPTION
Ensure that the prefix is only split off a single time when the
workspace_key_prefix is a substring of the workspace or key name.

Fixes #17083 