### PR TITLE
Documentation: Add version specifier information to provider version docs and clarify pessimistic specifier

### DIFF
--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -110,6 +110,16 @@ This special argument applies to _all_ providers.
 view the specified version constraints for all providers used in the
 current configuration.
 
+The `version` attribute value may either be a single explicit version or
+a version constraint expression. Constraint expressions use the following
+syntax to specify a _range_ of versions that are acceptable:
+
+* `>= 1.2.0`: version 1.2.0 or newer
+* `<= 1.2.0`: version 1.2.0 or older
+* `~> 1.2.0`: any non-beta version between 1.2.0 (inclusive) and 1.3.0 (exclusive), e.g. `1.2.X`
+* `~> 1.2`: any non-beta version between 1.2.0 (inclusive) and 2.0.0 (exclusive), e.g. `1.X.Y`
+* `>= 1.0.0, <= 2.0.0`: any version between 1.0.0 and 2.0.0 inclusive
+
 When `terraform init` is re-run with providers already installed, it will
 use an already-installed provider that meets the constraints in preference
 to downloading a new version. To upgrade to the latest acceptable version

--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -116,8 +116,8 @@ syntax to specify a _range_ of versions that are acceptable:
 
 * `>= 1.2.0`: version 1.2.0 or newer
 * `<= 1.2.0`: version 1.2.0 or older
-* `~> 1.2.0`: any non-beta version between 1.2.0 (inclusive) and 1.3.0 (exclusive), e.g. `1.2.X`
-* `~> 1.2`: any non-beta version between 1.2.0 (inclusive) and 2.0.0 (exclusive), e.g. `1.X.Y`
+* `~> 1.2.0`: any non-beta version `>= 1.2.0` and `< 1.3.0`, e.g. `1.2.X`
+* `~> 1.2`: any non-beta version `>= 1.2.0` and `< 2.0.0`, e.g. `1.X.Y`
 * `>= 1.0.0, <= 2.0.0`: any version between 1.0.0 and 2.0.0 inclusive
 
 When `terraform init` is re-run with providers already installed, it will

--- a/website/docs/modules/usage.html.markdown
+++ b/website/docs/modules/usage.html.markdown
@@ -93,7 +93,8 @@ syntax to specify a _range_ of versions that are acceptable:
 
 * `>= 1.2.0`: version 1.2.0 or newer
 * `<= 1.2.0`: version 1.2.0 or older
-* `~> 1.2`: any non-beta patch release within the `1.2` range
+* `~> 1.2.0`: any non-beta version between 1.2.0 (inclusive) and 1.3.0 (exclusive), e.g. `1.2.X`
+* `~> 1.2`: any non-beta version between 1.2.0 (inclusive) and 2.0.0 (exclusive), e.g. `1.X.Y`
 * `>= 1.0.0, <= 2.0.0`: any version between 1.0.0 and 2.0.0 inclusive
 
 When depending on third-party modules, references to specific versions are

--- a/website/docs/modules/usage.html.markdown
+++ b/website/docs/modules/usage.html.markdown
@@ -93,8 +93,8 @@ syntax to specify a _range_ of versions that are acceptable:
 
 * `>= 1.2.0`: version 1.2.0 or newer
 * `<= 1.2.0`: version 1.2.0 or older
-* `~> 1.2.0`: any non-beta version between 1.2.0 (inclusive) and 1.3.0 (exclusive), e.g. `1.2.X`
-* `~> 1.2`: any non-beta version between 1.2.0 (inclusive) and 2.0.0 (exclusive), e.g. `1.X.Y`
+* `~> 1.2.0`: any non-beta version `>= 1.2.0` and `< 1.3.0`, e.g. `1.2.X`
+* `~> 1.2`: any non-beta version `>= 1.2.0` and `< 2.0.0`, e.g. `1.X.Y`
 * `>= 1.0.0, <= 2.0.0`: any version between 1.0.0 and 2.0.0 inclusive
 
 When depending on third-party modules, references to specific versions are


### PR DESCRIPTION
Simple update to duplicate the documentation for now. It could also be specified in one configuration page and linked in both places. 😄 