### PR TITLE
Move towards consistently specifying the type of a Map in a nested *Schema elemnt

### DIFF
--- a/helper/schema/field_reader.go
+++ b/helper/schema/field_reader.go
@@ -126,6 +126,8 @@ func addrToSchema(addr []string, schemaMap map[string]*Schema) []*Schema {
 				switch v := current.Elem.(type) {
 				case ValueType:
 					current = &Schema{Type: v}
+				case *Schema:
+					current, _ = current.Elem.(*Schema)
 				default:
 					// maps default to string values. This is all we can have
 					// if this is nested in another list or map.
@@ -249,11 +251,10 @@ func readObjectField(
 }
 
 // convert map values to the proper primitive type based on schema.Elem
-func mapValuesToPrimitive(m map[string]interface{}, schema *Schema) error {
-
-	elemType := TypeString
-	if et, ok := schema.Elem.(ValueType); ok {
-		elemType = et
+func mapValuesToPrimitive(k string, m map[string]interface{}, schema *Schema) error {
+	elemType, err := getValueType(k, schema)
+	if err != nil {
+		return err
 	}
 
 	switch elemType {

--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -206,7 +206,7 @@ func (r *ConfigFieldReader) readMap(k string, schema *Schema) (FieldReadResult, 
 		panic(fmt.Sprintf("unknown type: %#v", mraw))
 	}
 
-	err := mapValuesToPrimitive(result, schema)
+	err := mapValuesToPrimitive(k, result, schema)
 	if err != nil {
 		return FieldReadResult{}, nil
 	}

--- a/helper/schema/field_reader_config_test.go
+++ b/helper/schema/field_reader_config_test.go
@@ -39,6 +39,10 @@ func TestConfigFieldReader(t *testing.T) {
 					"one": "1",
 					"two": "2",
 				},
+				"mapIntNestedSchema": map[string]interface{}{
+					"one": "1",
+					"two": "2",
+				},
 				"mapFloat": map[string]interface{}{
 					"oneDotTwo": "1.2",
 				},

--- a/helper/schema/field_reader_diff.go
+++ b/helper/schema/field_reader_diff.go
@@ -122,7 +122,8 @@ func (r *DiffFieldReader) readMap(
 		result[k] = v.New
 	}
 
-	err = mapValuesToPrimitive(result, schema)
+	key := address[len(address)-1]
+	err = mapValuesToPrimitive(key, result, schema)
 	if err != nil {
 		return FieldReadResult{}, nil
 	}

--- a/helper/schema/field_reader_diff_test.go
+++ b/helper/schema/field_reader_diff_test.go
@@ -433,6 +433,19 @@ func TestDiffFieldReader(t *testing.T) {
 						New: "2",
 					},
 
+					"mapIntNestedSchema.%": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "2",
+					},
+					"mapIntNestedSchema.one": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "1",
+					},
+					"mapIntNestedSchema.two": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "2",
+					},
+
 					"mapFloat.%": &terraform.ResourceAttrDiff{
 						Old: "",
 						New: "1",

--- a/helper/schema/field_reader_map.go
+++ b/helper/schema/field_reader_map.go
@@ -61,7 +61,7 @@ func (r *MapFieldReader) readMap(k string, schema *Schema) (FieldReadResult, err
 		return true
 	})
 
-	err := mapValuesToPrimitive(result, schema)
+	err := mapValuesToPrimitive(k, result, schema)
 	if err != nil {
 		return FieldReadResult{}, nil
 	}

--- a/helper/schema/field_reader_map_test.go
+++ b/helper/schema/field_reader_map_test.go
@@ -46,6 +46,10 @@ func TestMapFieldReader(t *testing.T) {
 				"mapInt.one": "1",
 				"mapInt.two": "2",
 
+				"mapIntNestedSchema.%":   "2",
+				"mapIntNestedSchema.one": "1",
+				"mapIntNestedSchema.two": "2",
+
 				"mapFloat.%":         "1",
 				"mapFloat.oneDotTwo": "1.2",
 

--- a/helper/schema/field_reader_test.go
+++ b/helper/schema/field_reader_test.go
@@ -215,6 +215,13 @@ func testFieldReader(t *testing.T, f func(map[string]*Schema) FieldReader) {
 			Type: TypeMap,
 			Elem: TypeInt,
 		},
+
+		// This is used to verify that the type of a Map can be specified using the
+		// same syntax as for lists (as a nested *Schema passed to Elem)
+		"mapIntNestedSchema": &Schema{
+			Type: TypeMap,
+			Elem: &Schema{Type: TypeInt},
+		},
 		"mapFloat": &Schema{
 			Type: TypeMap,
 			Elem: TypeFloat,
@@ -349,6 +356,19 @@ func testFieldReader(t *testing.T, f func(map[string]*Schema) FieldReader) {
 
 		"mapInt": {
 			[]string{"mapInt"},
+			FieldReadResult{
+				Value: map[string]interface{}{
+					"one": 1,
+					"two": 2,
+				},
+				Exists:   true,
+				Computed: false,
+			},
+			false,
+		},
+
+		"mapIntNestedSchema": {
+			[]string{"mapIntNestedSchema"},
 			FieldReadResult{
 				Value: map[string]interface{}{
 					"one": 1,

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1461,13 +1461,10 @@ func getValueType(k string, schema *Schema) (ValueType, error) {
 		return vt, nil
 	}
 
+	// If a Schema is provided to a Map, we use the Type of that schema
+	// as the type for each element in the Map.
 	if s, ok := schema.Elem.(*Schema); ok {
-		if s.Elem == nil {
-			return TypeString, nil
-		}
-		if vt, ok := s.Elem.(ValueType); ok {
-			return vt, nil
-		}
+		return s.Type, nil
 	}
 
 	if _, ok := schema.Elem.(*Resource); ok {

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -4481,6 +4481,42 @@ func TestSchemaMap_Validate(t *testing.T) {
 			},
 		},
 
+		"Map with type specified as value type": {
+			Schema: map[string]*Schema{
+				"user_data": &Schema{
+					Type:     TypeMap,
+					Optional: true,
+					Elem:     TypeBool,
+				},
+			},
+
+			Config: map[string]interface{}{
+				"user_data": map[string]interface{}{
+					"foo": "not_a_bool",
+				},
+			},
+
+			Err: true,
+		},
+
+		"Map with type specified as nested Schema": {
+			Schema: map[string]*Schema{
+				"user_data": &Schema{
+					Type:     TypeMap,
+					Optional: true,
+					Elem:     &Schema{Type: TypeBool},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"user_data": map[string]interface{}{
+					"foo": "not_a_bool",
+				},
+			},
+
+			Err: true,
+		},
+
 		"Bad map: just a slice": {
 			Schema: map[string]*Schema{
 				"user_data": &Schema{


### PR DESCRIPTION
When specifying the type of a Map in a provider schema, we have two options which are (today) inconsistently applied - although Option 1 is more commonly used.

**Option 1: Provide a ValueType directly to the Elem**
```
"field": &schema.Schema{
    Type:         schema.TypeMap,
    Elem:         schema.TypeString,
}
```

**Option 2: Specify the Type using a nested Schema**
```
"field": &schema.Schema{
    Type:         schema.TypeMap,
    Elem:         &schema.Schema{Type:schema.TypeString},
}
```

Different parts of the helper/schema codebase make different assumptions about which approach will be used which can cause panics. I would like to move towards consistent use of one or the other.

Option 2 is my preferred approach, as it:

* Is consistent with how lists of scalar types are declared (big win!)
* Simplifies possible types for Elem (only *Schema or *Resource)
* Will make it easier if we ever want Maps of complex elements (e.g. a Map of Lists)

My plan is:

1. Merge this PR, which will allow resources to be read/written if a schema uses the notation in Option 2.
2. Wait for major providers (AWS/Google) to vendor this change
3. Update these providers to consistently use Option 2 syntax
4. Update InternalValidate to validate the type of Elem for Maps and Lists
5. Remove the code which supports Option 1

Alternative:

The alternative is to continue to support the existing Option 1 syntax and audit and fix anywhere that we expect Elem to be a *Schema or a *Resource. I'm equally happy with this, although I think it creates an unexpected difference in the way Maps and Lists are specified.

