### PR TITLE
Fix log level `WARNING` to `WARN`

### DIFF
--- a/backend/remote-state/s3/client.go
+++ b/backend/remote-state/s3/client.go
@@ -71,9 +71,9 @@ func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 
 		// verify that this state is what we expect
 		if expected, err := c.getMD5(); err != nil {
-			log.Printf("[WARNING] failed to fetch state md5: %s", err)
+			log.Printf("[WARN] failed to fetch state md5: %s", err)
 		} else if len(expected) > 0 && !bytes.Equal(expected, digest) {
-			log.Printf("[WARNING] state md5 mismatch: expected '%x', got '%x'", expected, digest)
+			log.Printf("[WARN] state md5 mismatch: expected '%x', got '%x'", expected, digest)
 
 			if testChecksumHook != nil {
 				testChecksumHook()
@@ -312,7 +312,7 @@ func (c *RemoteClient) putMD5(sum []byte) error {
 	}
 	_, err := c.dynClient.PutItem(putParams)
 	if err != nil {
-		log.Printf("[WARNING] failed to record state serial in dynamodb: %s", err)
+		log.Printf("[WARN] failed to record state serial in dynamodb: %s", err)
 	}
 
 	return nil

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -436,7 +436,7 @@ func (p *provisioner) deployConfigFiles(o terraform.UIOutput, comm communicator.
 	// Check if the run_list was also in the attributes and if so log a warning
 	// that it will be overwritten with the value of the run_list argument.
 	if _, found := fb["run_list"]; found {
-		log.Printf("[WARNING] Found a 'run_list' specified in the configured attributes! " +
+		log.Printf("[WARN] Found a 'run_list' specified in the configured attributes! " +
 			"This value will be overwritten by the value of the `run_list` argument!")
 	}
 

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -190,7 +190,7 @@ func (m *Meta) backendConfig(opts *BackendOpts) (*config.Backend, error) {
 			return nil, nil
 		}
 
-		log.Println("[WARNING] BackendOpts.Config not set, but config found")
+		log.Println("[WARN] BackendOpts.Config not set, but config found")
 		opts.Config = conf
 	}
 

--- a/command/plugins_lock.go
+++ b/command/plugins_lock.go
@@ -45,7 +45,7 @@ func (pf *pluginSHA256LockFile) Read() map[string][]byte {
 	err = json.Unmarshal(buf, &strDigests)
 	if err != nil {
 		// This should never happen unless the user directly edits the file.
-		log.Printf("[WARNING] Plugin lock file %s failed to parse as JSON: %s", pf.Filename, err)
+		log.Printf("[WARN] Plugin lock file %s failed to parse as JSON: %s", pf.Filename, err)
 		return digests
 	}
 
@@ -56,7 +56,7 @@ func (pf *pluginSHA256LockFile) Read() map[string][]byte {
 			digests[name] = digest
 		} else {
 			// This should never happen unless the user directly edits the file.
-			log.Printf("[WARNING] Plugin lock file %s has invalid digest for %q", pf.Filename, name)
+			log.Printf("[WARN] Plugin lock file %s has invalid digest for %q", pf.Filename, name)
 		}
 	}
 

--- a/plugin/discovery/find.go
+++ b/plugin/discovery/find.go
@@ -95,7 +95,7 @@ func findPluginPaths(kind string, dirs []string) []string {
 				continue
 			}
 
-			log.Printf("[WARNING] found legacy %s %q", kind, fullName)
+			log.Printf("[WARN] found legacy %s %q", kind, fullName)
 
 			ret = append(ret, filepath.Clean(absPath))
 		}

--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -369,7 +369,7 @@ func checkPlugin(url string, pluginProtocolVersion uint) bool {
 	if proto == "" {
 		// The header isn't present, but we don't make this error fatal since
 		// the latest version will probably work.
-		log.Printf("[WARNING] missing %s from: %s", protocolVersionHeader, url)
+		log.Printf("[WARN] missing %s from: %s", protocolVersionHeader, url)
 		return true
 	}
 

--- a/registry/client.go
+++ b/registry/client.go
@@ -140,7 +140,7 @@ func (c *Client) addRequestCreds(host svchost.Hostname, req *http.Request) {
 
 	creds, err := c.creds.ForHost(host)
 	if err != nil {
-		log.Printf("[WARNING] Failed to get credentials for %s: %s (ignoring)", host, err)
+		log.Printf("[WARN] Failed to get credentials for %s: %s (ignoring)", host, err)
 		return
 	}
 

--- a/svchost/disco/disco.go
+++ b/svchost/disco/disco.go
@@ -158,7 +158,7 @@ func (d *Disco) discover(host svchost.Hostname) Host {
 				creds.PrepareRequest(req) // alters req to include credentials
 			}
 		} else {
-			log.Printf("[WARNING] Failed to get credentials for %s: %s (ignoring)", host, err)
+			log.Printf("[WARN] Failed to get credentials for %s: %s (ignoring)", host, err)
 		}
 	}
 
@@ -170,11 +170,11 @@ func (d *Disco) discover(host svchost.Hostname) Host {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Printf("[WARNING] Failed to request discovery document: %s", err)
+		log.Printf("[WARN] Failed to request discovery document: %s", err)
 		return ret // empty
 	}
 	if resp.StatusCode != 200 {
-		log.Printf("[WARNING] Failed to request discovery document: %s", resp.Status)
+		log.Printf("[WARN] Failed to request discovery document: %s", resp.Status)
 		return ret // empty
 	}
 
@@ -185,7 +185,7 @@ func (d *Disco) discover(host svchost.Hostname) Host {
 	contentType := resp.Header.Get("Content-Type")
 	mediaType, _, err := mime.ParseMediaType(contentType)
 	if err != nil {
-		log.Printf("[WARNING] Discovery URL has malformed Content-Type %q", contentType)
+		log.Printf("[WARN] Discovery URL has malformed Content-Type %q", contentType)
 		return ret // empty
 	}
 	if mediaType != "application/json" {
@@ -197,7 +197,7 @@ func (d *Disco) discover(host svchost.Hostname) Host {
 	if resp.ContentLength > maxDiscoDocBytes {
 		// Size limit here is not a contractual requirement and so we may
 		// adjust it over time if we find a different limit is warranted.
-		log.Printf("[WARNING] Discovery doc response is too large (got %d bytes; limit %d)", resp.ContentLength, maxDiscoDocBytes)
+		log.Printf("[WARN] Discovery doc response is too large (got %d bytes; limit %d)", resp.ContentLength, maxDiscoDocBytes)
 		return ret // empty
 	}
 
@@ -208,14 +208,14 @@ func (d *Disco) discover(host svchost.Hostname) Host {
 
 	servicesBytes, err := ioutil.ReadAll(lr)
 	if err != nil {
-		log.Printf("[WARNING] Error reading discovery document body: %s", err)
+		log.Printf("[WARN] Error reading discovery document body: %s", err)
 		return ret // empty
 	}
 
 	var services map[string]interface{}
 	err = json.Unmarshal(servicesBytes, &services)
 	if err != nil {
-		log.Printf("[WARNING] Failed to decode discovery document as a JSON object: %s", err)
+		log.Printf("[WARN] Failed to decode discovery document as a JSON object: %s", err)
 		return ret // empty
 	}
 

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -117,7 +117,7 @@ func (p *Plan) contextOpts(base *ContextOpts) (*ContextOpts, error) {
 		// the state, there is little chance that these aren't actually equal.
 		// Log the error condition for reference, but continue with the state
 		// we have.
-		log.Println("[WARNING] Plan state and ContextOpts state are not equal")
+		log.Println("[WARN] Plan state and ContextOpts state are not equal")
 	}
 
 	thisVersion := version.String()


### PR DESCRIPTION
Fixes #17103
The valid levels of logging are `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`.
However, there are some code using `[WARNING]` (not `[WARN]`).

I fixed all loggig code using `WARNING` to `WARN` except for `vendor/` dir.