### PR TITLE
Added more use-cases to normalize_json tests

### DIFF
--- a/helper/structure/normalize_json_test.go
+++ b/helper/structure/normalize_json_test.go
@@ -29,6 +29,40 @@ func TestNormalizeJsonString_valid(t *testing.T) {
 	if actual != expected {
 		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", actual, expected)
 	}
+
+	// Well formatted but not valid,
+	// missing closing square bracket.
+	invalidJson := `{
+   "abc": {
+      "def": 123,
+      "xyz": [
+         {
+            "a": "1"
+         }
+      }
+   }
+}`
+	actual, err = NormalizeJsonString(invalidJson)
+	if err == nil {
+		t.Fatalf("Expected to throw an error while parsing JSON, but got: %s", err)
+	}
+
+	// We expect the invalid JSON to be shown back to us again.
+	if actual != invalidJson {
+		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", actual, invalidJson)
+	}
+
+	// Verify that it leaves strings alone
+	testString := "2016-07-28t04:07:02z\nsomething else"
+	expected = "2016-07-28t04:07:02z\nsomething else"
+	actual, err = NormalizeJsonString(testString)
+	if err == nil {
+		t.Fatalf("Expected to throw an error while parsing JSON, but got: %s", err)
+	}
+
+	if actual != expected {
+		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", actual, expected)
+	}
 }
 
 func TestNormalizeJsonString_invalid(t *testing.T) {


### PR DESCRIPTION
In https://github.com/terraform-providers/terraform-provider-aws/pull/2935,
we have been cleaning code duplication by benefiting from the
"NormalizeJsonString" present in the "structure" helper.

It appears that tests in the AWS provider are covering more use-cases,
which are added in this work.