### PR TITLE
 don't ignore partial containers in diffs

### DIFF
--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -396,11 +396,6 @@ type ResourceAttrDiff struct {
 	Type        DiffAttrType
 }
 
-// Modified returns the inequality of Old and New for this attr
-func (d *ResourceAttrDiff) Modified() bool {
-	return d.Old != d.New
-}
-
 // Empty returns true if the diff for this attr is neutral
 func (d *ResourceAttrDiff) Empty() bool {
 	return d.Old == d.New && !d.NewComputed && !d.NewRemoved

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1675,7 +1675,10 @@ aws_instance.foo:
 const testTFPlanDiffIgnoreChangesWithFlatmaps = `
 UPDATE: aws_instance.foo
   lst.#:   "1" => "2"
+  lst.0:   "j" => "j"
   lst.1:   "" => "k"
+  set.#:   "1" => "1"
+  set.0.a: "1" => "1"
   set.0.b: "" => "2"
   type:    "" => "aws_instance"
 `


### PR DESCRIPTION
Revert the changes from #16780, but improve the diff behavior to match the intent of that PR.

Containers (maps, lists, sets) in an InstanceDiff need to be handled in
their entirety.  Unchanged values cannot be filtered out from diffs, as
providers expect attribute containers to be complete.

If a value in ignore_changes maps to a single key in an attribute
container, and there are other changes present, that ignored value must
be included in the diff as well. If there are no other changes outside of the ignored values, then all of the attributes can be removed from the diff.

Fixes #17117