### PR TITLE
core: interpolate the count config during the apply walk

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -231,7 +231,10 @@ func (r *Resource) Count() (int, error) {
 
 	v, err := strconv.ParseInt(count, 0, 0)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf(
+			"cannot parse %q as an integer",
+			count,
+		)
 	}
 
 	return int(v), nil

--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -124,6 +124,24 @@ func (n *NodeApplyableResource) evalTreeDataResource(
 				Then: EvalNoop{},
 			},
 
+			// Normally we interpolate count as a preparation step before
+			// a DynamicExpand, but an apply graph has pre-expanded nodes
+			// and so the count would otherwise never be interpolated.
+			//
+			// This is redundant when there are multiple instances created
+			// from the same config (count > 1) but harmless since the
+			// underlying structures have mutexes to make this concurrency-safe.
+			//
+			// In most cases this isn't actually needed because we dealt with
+			// all of the counts during the plan walk, but we do it here
+			// for completeness because other code assumes that the
+			// final count is always available during interpolation.
+			//
+			// Here we are just populating the interpolated value in-place
+			// inside this RawConfig object, like we would in
+			// NodeAbstractCountResource.
+			&EvalInterpolate{Config: n.Config.RawCount},
+
 			// We need to re-interpolate the config here, rather than
 			// just using the diff's values directly, because we've
 			// potentially learned more variable values during the
@@ -235,6 +253,25 @@ func (n *NodeApplyableResource) evalTreeManagedResource(
 					Name: stateId,
 				},
 			},
+
+			// Normally we interpolate count as a preparation step before
+			// a DynamicExpand, but an apply graph has pre-expanded nodes
+			// and so the count would otherwise never be interpolated.
+			//
+			// This is redundant when there are multiple instances created
+			// from the same config (count > 1) but harmless since the
+			// underlying structures have mutexes to make this concurrency-safe.
+			//
+			// In most cases this isn't actually needed because we dealt with
+			// all of the counts during the plan walk, but we need to do this
+			// in order to support interpolation of resource counts from
+			// apply-time-interpolated expressions, such as those in
+			// "provisioner" blocks.
+			//
+			// Here we are just populating the interpolated value in-place
+			// inside this RawConfig object, like we would in
+			// NodeAbstractCountResource.
+			&EvalInterpolate{Config: n.Config.RawCount},
 
 			&EvalInterpolate{
 				Config:   n.Config.RawConfig.Copy(),

--- a/terraform/test-fixtures/apply-provisioner-interp-count/provisioner-interp-count.tf
+++ b/terraform/test-fixtures/apply-provisioner-interp-count/provisioner-interp-count.tf
@@ -1,0 +1,17 @@
+variable "count" {
+  default = 3
+}
+
+resource "aws_instance" "a" {
+  count = "${var.count}"
+}
+
+resource "aws_instance" "b" {
+  provisioner "local-exec" {
+    # Since we're in a provisioner block here, this interpolation is
+    # resolved during the apply walk and so the resource count must
+    # be interpolated during that walk, even though apply walk doesn't
+    # do DynamicExpand.
+    command = "echo ${aws_instance.a.count}"
+  }
+}


### PR DESCRIPTION
Previously we would interpolate the count config (`ResourceConfig.RawCount`) only while preparing to dynamic-expand aggregate resource nodes. This is problematic because we do not dynamic-expand any resource nodes during the apply walk, and so previously the count value was not available for interpolation during apply and would result in an error.
    
Now we interpolate `RawCount` once for each resource we visit during the apply walk -- even though that redundantly interpolates the same config multiple times when `count` > 1 -- to ensure that it's available by the time we interpolate any remaining expressions in the config and any expressions within `connection` and `provisioner` blocks.
    
This error was masked by us sharing a single `RawConfig` instance between the plan and apply walks when `terraform apply` is run with no explicit plan file argument, but was exposed by the workflow where the plan is written first to disk since in that case the interpolation result from during the plan phase is not present in the deflated plan object. For this reason, the new context test serializes the plan into an in-memory buffer and reloads it in order to simulate the effect of the two-step workflow.

This fixes #16840.
