### PR TITLE
the trailing slash check caused a nil dereference

### DIFF
--- a/registry/client.go
+++ b/registry/client.go
@@ -67,6 +67,9 @@ func NewClient(services *disco.Disco, creds auth.CredentialsSource, client *http
 // Discover qeuries the host, and returns the url for the registry.
 func (c *Client) Discover(host svchost.Hostname) *url.URL {
 	service := c.services.DiscoverServiceURL(host, serviceID)
+	if service == nil {
+		return nil
+	}
 	if !strings.HasSuffix(service.Path, "/") {
 		service.Path += "/"
 	}

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -55,6 +55,23 @@ func TestLookupModuleVersions(t *testing.T) {
 	}
 }
 
+func TestInvalidRegistry(t *testing.T) {
+	server := test.Registry()
+	defer server.Close()
+
+	client := NewClient(test.Disco(server), nil, nil)
+
+	src := "non-existent.localhost.localdomain/test-versions/name/provider"
+	modsrc, err := regsrc.ParseModuleSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.Versions(modsrc); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestRegistryAuth(t *testing.T) {
 	server := test.Registry()
 	defer server.Close()


### PR DESCRIPTION
The disco package doesn't return errors, and a nil value indicates that
the input isn't valid. Always check for nil.

Fixes #17119 