### PR TITLE
Remove duplicated help messages from `workspace --help`

### DIFF
--- a/command/workspace_command.go
+++ b/command/workspace_command.go
@@ -35,14 +35,6 @@ Usage: terraform workspace
 
   Create, change and delete Terraform workspaces.
 
-
-Subcommands:
-
-    show      Show the current workspace name.
-    list      List workspaces.
-    select    Select a workspace.
-    new       Create a new workspace.
-    delete    Delete an existing workspace.
 `
 	return strings.TrimSpace(helpText)
 }


### PR DESCRIPTION
Fixes #17165 

## before

```
$ terraform workspace --help
Usage: terraform workspace

  Create, change and delete Terraform workspaces.


Subcommands:

    show      Show the current workspace name.
    list      List workspaces.
    select    Select a workspace.
    new       Create a new workspace.
    delete    Delete an existing workspace.

Subcommands:
    delete    Delete a workspace
    list      List Workspaces
    new       Create a new workspace
    select    Select a workspace
    show      Show the name of the current workspace

```

## after

```
$ terraform workspace --help
Usage: terraform workspace

  Create, change and delete Terraform workspaces.

Subcommands:
    delete    Delete a workspace
    list      List Workspaces
    new       Create a new workspace
    select    Select a workspace
    show      Show the name of the current workspace
```