### PR TITLE
website: fix typo in getting started guide

### DIFF
--- a/website/intro/getting-started/outputs.html.md
+++ b/website/intro/getting-started/outputs.html.md
@@ -79,4 +79,4 @@ and bootstrap resources using provisioners.
 
 Next, we're going to take a look at
 [how to use modules](/intro/getting-started/modules.html), a useful
-abstraction to organization and reuse Terraform configurations.
+abstraction to organize and reuse Terraform configurations.


### PR DESCRIPTION
It's just a fix for a small typo.