### PR TITLE
[provisioner-habitat] Detect if hab user exists

### DIFF
--- a/builtin/provisioners/habitat/resource_provisioner.go
+++ b/builtin/provisioners/habitat/resource_provisioner.go
@@ -587,7 +587,8 @@ func (p *provisioner) startHabSystemd(o terraform.UIOutput, comm communicator.Co
 }
 
 func (p *provisioner) createHabUser(o terraform.UIOutput, comm communicator.Communicator) error {
-	// Create the hab user
+	addUser := false
+	// Install busybox to get us the user tools we need
 	command := fmt.Sprintf("env HAB_NONINTERACTIVE=true hab install core/busybox")
 	if p.UseSudo {
 		command = fmt.Sprintf("sudo %s", command)
@@ -596,11 +597,25 @@ func (p *provisioner) createHabUser(o terraform.UIOutput, comm communicator.Comm
 		return err
 	}
 
-	command = fmt.Sprintf("hab pkg exec core/busybox adduser -D -g \"\" hab")
+	// Check for existing hab user
+	command = fmt.Sprintf("hab pkg exec core/busybox id hab")
 	if p.UseSudo {
 		command = fmt.Sprintf("sudo %s", command)
 	}
-	return p.runCommand(o, comm, command)
+	if err := p.runCommand(o, comm, command); err != nil {
+		o.Output("No existing hab user detected, creating...")
+		addUser = true
+	}
+
+	if addUser {
+		command = fmt.Sprintf("hab pkg exec core/busybox adduser -D -g \"\" hab")
+		if p.UseSudo {
+			command = fmt.Sprintf("sudo %s", command)
+		}
+		return p.runCommand(o, comm, command)
+	}
+
+	return nil
 }
 
 func (p *provisioner) startHabService(o terraform.UIOutput, comm communicator.Communicator, service Service) error {


### PR DESCRIPTION
Currently the provisioner will fail if the `hab` user already exists on
the target system.

This adds a check to see if we need to create the user before trying to
add it.

Fixes #17159

Signed-off-by: Nolan Davidson <ndavidson@chef.io>