### PR TITLE
extend disco timeout

### DIFF
--- a/svchost/disco/disco.go
+++ b/svchost/disco/disco.go
@@ -25,9 +25,9 @@ import (
 
 const (
 	discoPath        = "/.well-known/terraform.json"
-	maxRedirects     = 3               // arbitrary-but-small number to prevent runaway redirect loops
-	discoTimeout     = 4 * time.Second // arbitrary-but-small time limit to prevent UI "hangs" during discovery
-	maxDiscoDocBytes = 1 * 1024 * 1024 // 1MB - to prevent abusive services from using loads of our memory
+	maxRedirects     = 3                // arbitrary-but-small number to prevent runaway redirect loops
+	discoTimeout     = 11 * time.Second // arbitrary-but-small time limit to prevent UI "hangs" during discovery
+	maxDiscoDocBytes = 1 * 1024 * 1024  // 1MB - to prevent abusive services from using loads of our memory
 )
 
 var userAgent = fmt.Sprintf("Terraform/%s (service discovery)", version.String())


### PR DESCRIPTION
Extend the discovery timeout from 4 seconds to 11 seconds. This gives a
little more time for a slow host to response. The duration of 11s
keeps the delay reasonable, and puts it just after the default TLS
handshake timeout of 10s for easier differentiation of the error cases.

Related to #16751