### PR TITLE
Change -force to -auto-approve when destroying

### DIFF
--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -99,7 +99,7 @@ func (b *Local) opApply(
 		dispPlan := format.NewPlan(plan)
 		trivialPlan := dispPlan.Empty()
 		hasUI := op.UIOut != nil && op.UIIn != nil
-		mustConfirm := hasUI && ((op.Destroy && !op.DestroyForce) || (!op.Destroy && !op.AutoApprove && !trivialPlan))
+		mustConfirm := hasUI && ((op.Destroy && (!op.DestroyForce && !op.AutoApprove)) || (!op.Destroy && !op.AutoApprove && !trivialPlan))
 		if mustConfirm {
 			var desc, query string
 			if op.Destroy {

--- a/command/apply.go
+++ b/command/apply.go
@@ -40,13 +40,11 @@ func (c *ApplyCommand) Run(args []string) int {
 	}
 
 	cmdFlags := c.Meta.flagSet(cmdName)
+	cmdFlags.BoolVar(&autoApprove, "auto-approve", false, "skip interactive approval of plan before applying")
 	if c.Destroy {
-		cmdFlags.BoolVar(&destroyForce, "force", false, "force")
+		cmdFlags.BoolVar(&destroyForce, "force", false, "deprecated: same as auto-approve")
 	}
 	cmdFlags.BoolVar(&refresh, "refresh", true, "refresh")
-	if !c.Destroy {
-		cmdFlags.BoolVar(&autoApprove, "auto-approve", false, "skip interactive approval of plan before applying")
-	}
 	cmdFlags.IntVar(
 		&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
@@ -250,8 +248,6 @@ Options:
 
   -lock-timeout=0s       Duration to retry a state lock.
 
-  -auto-approve          Skip interactive approval of plan before applying.
-
   -input=true            Ask for input for variables if not directly set.
 
   -no-color              If specified, output won't contain any color.
@@ -297,7 +293,9 @@ Options:
                          modifying. Defaults to the "-state-out" path with
                          ".backup" extension. Set to "-" to disable backup.
 
-  -force                 Don't ask for input for destroy confirmation.
+  -auto-approve          Skip interactive approval before destroying.
+
+  -force                 Deprecated: same as auto-approve.
 
   -lock=true             Lock the state file when locking is supported.
 

--- a/command/apply_destroy_test.go
+++ b/command/apply_destroy_test.go
@@ -40,7 +40,7 @@ func TestApply_destroy(t *testing.T) {
 
 	// Run the apply command pointing to our existing state
 	args := []string{
-		"-force",
+		"-auto-approve",
 		"-state", statePath,
 		testFixturePath("apply"),
 	}
@@ -130,7 +130,7 @@ func TestApply_destroyLockedState(t *testing.T) {
 
 	// Run the apply command pointing to our existing state
 	args := []string{
-		"-force",
+		"-auto-approve",
 		"-state", statePath,
 		testFixturePath("apply"),
 	}
@@ -206,7 +206,7 @@ func TestApply_destroyTargeted(t *testing.T) {
 
 	// Run the apply command pointing to our existing state
 	args := []string{
-		"-force",
+		"-auto-approve",
 		"-target", "test_instance.foo",
 		"-state", statePath,
 		testFixturePath("apply-destroy-targeted"),

--- a/command/e2etest/primary_test.go
+++ b/command/e2etest/primary_test.go
@@ -111,7 +111,7 @@ func TestPrimarySeparatePlan(t *testing.T) {
 	}
 
 	//// DESTROY
-	stdout, stderr, err = tf.Run("destroy", "-force")
+	stdout, stderr, err = tf.Run("destroy", "-auto-approve")
 	if err != nil {
 		t.Fatalf("unexpected destroy error: %s\nstderr:\n%s", err, stderr)
 	}

--- a/website/docs/commands/destroy.html.markdown
+++ b/website/docs/commands/destroy.html.markdown
@@ -22,7 +22,7 @@ This command accepts all the arguments and flags that the [apply
 command](/docs/commands/apply.html) accepts, with the exception of a plan file
 argument.
 
-If `-force` is set, then the destroy confirmation will not be shown.
+If `-auto-approve` is set, then the destroy confirmation will not be shown.
 
 The `-target` flag, instead of affecting "dependencies" will instead also
 destroy any resources that _depend on_ the target(s) specified.


### PR DESCRIPTION
Since an early version of Terraform, the `destroy` command has always had the `-force` flag to allow an auto approval of the interactive prompt. 0.11 introduced `-auto-approve` as default to `false` when using the `apply` command.

People often use wrappers when automating commands in Terraform, and the inconsistency between `apply` and `destroy` means that additional logic must be added to the wrappers to do similar functions. Both commands are more or less able to run with similar syntax, and I could not find a reason for the inconsistency between the two commands despite the functionality being the same.

This commit updates the command in `apply` to use the `-force` flag making working with the Terraform CLI a more consistent experience.

I searched PRs and issues and could not find any context on why this was implemented the way that it was, or if there was a specific reason why the differences exist between `apply` and `destroy`. I also appreciate this is a breaking change.