### PR TITLE
helper/resource: require explicit usage of NonRetryableError and RetryableError

### DIFF
--- a/helper/resource/wait.go
+++ b/helper/resource/wait.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"fmt"
 	"sync"
 	"time"
 )
@@ -69,16 +70,26 @@ type RetryError struct {
 // given error.
 func RetryableError(err error) *RetryError {
 	if err == nil {
-		return nil
+		return &RetryError{
+			Err: fmt.Errorf("empty retryable error received. " +
+				"This is a bug with the Terraform provider and should be " +
+				"reported as a GitHub issue in the provider repository."),
+			Retryable: false,
+		}
 	}
 	return &RetryError{Err: err, Retryable: true}
 }
 
-// NonRetryableError is a helper to create a RetryError that's _not)_ retryable
+// NonRetryableError is a helper to create a RetryError that's _not_ retryable
 // from a given error.
 func NonRetryableError(err error) *RetryError {
 	if err == nil {
-		return nil
+		return &RetryError{
+			Err: fmt.Errorf("empty non-retryable error received. " +
+				"This is a bug with the Terraform provider and should be " +
+				"reported as a GitHub issue in the provider repository."),
+			Retryable: false,
+		}
 	}
 	return &RetryError{Err: err, Retryable: false}
 }


### PR DESCRIPTION
It is currently possible to introduce subtle bugs or crashes when using `resource.RetryableError` and `resource.NonRetryableError` and allowing a `nil` error input. This PR proposes behavior that requires providers to be explicit with their usage of these errors, otherwise returns a bug reporting message to the operator.

For example (https://github.com/terraform-providers/terraform-provider-aws/blob/4c0387645f982ddcd51b3ffe2cc8992c06fb9c2c/aws/resource_aws_elastic_beanstalk_application.go#L105):

```go
	var app *elasticbeanstalk.ApplicationDescription
	err := resource.Retry(30*time.Second, func() *resource.RetryError {
		var err error
		app, err = getBeanstalkApplication(d.Id(), conn)
		if err != nil {
			return resource.NonRetryableError(err)
		}

		if app == nil {
			if d.IsNewResource() {
				return resource.RetryableError(fmt.Errorf("Elastic Beanstalk Application %q not found", d.Id()))
			}
			// err is nil here
			return resource.NonRetryableError(err)
		}
		return nil
	})
	if err != nil {
		return err
	}
	// app can be nil here, so this can crash Terraform
	d.Set("name", app.ApplicationName)
```

Another example (https://github.com/terraform-providers/terraform-provider-alicloud/blob/927a8e82386e0b32718aa5eef254255fdc36b070/alicloud/resource_alicloud_disk_attachment.go#L112):

```go
	return resource.Retry(5*time.Minute, func() *resource.RetryError {
		err := conn.DetachDisk(instanceID, diskID)
		if err != nil {
			if IsExceptedError(err, DiskIncorrectStatus) || IsExceptedError(err, InstanceLockedForSecurity) ||
				IsExceptedError(err, DiskInvalidOperation) {
				return resource.RetryableError(fmt.Errorf("Detach Disk timeout and got an error: %#v", err))
			}
		}

		disks, _, descErr := conn.DescribeDisks(&ecs.DescribeDisksArgs{
			RegionId: getRegion(d, meta),
			DiskIds:  []string{diskID},
		})

		if descErr != nil {
			log.Printf("[ERROR] Disk %s is not detached.", diskID)
			// err can be nil here
			return resource.NonRetryableError(err)
		}

		for _, disk := range disks {
			if disk.Status != ecs.DiskStatusAvailable {
				return resource.RetryableError(fmt.Errorf("Detach Disk timeout and got an error: %#v", err))
			}
		}
		return nil
	})
```
