### PR TITLE
Fix destroy-time handling of outputs and local values

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -7641,6 +7641,8 @@ func TestContext2Apply_destroyProvisionerWithLocals(t *testing.T) {
 	}
 }
 
+// this also tests a local value in the config referencing a resource that
+// wasn't in the state during destroy.
 func TestContext2Apply_destroyProvisionerWithMultipleLocals(t *testing.T) {
 	m := testModule(t, "apply-provisioner-destroy-multiple-locals")
 	p := testProvider("aws")

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -2590,24 +2590,14 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 			&ModuleState{
 				Path: rootModulePath,
 				Resources: map[string]*ResourceState{
-					"aws_instance.b": &ResourceState{
-						Type: "aws_instance",
-						Primary: &InstanceState{
-							ID: "b",
-						},
-					},
+					"aws_instance.b": resourceState("aws_instance", "b"),
 				},
 			},
 
 			&ModuleState{
 				Path: []string{"root", "child"},
 				Resources: map[string]*ResourceState{
-					"aws_instance.a": &ResourceState{
-						Type: "aws_instance",
-						Primary: &InstanceState{
-							ID: "a",
-						},
-					},
+					"aws_instance.a": resourceState("aws_instance", "a"),
 				},
 				Outputs: map[string]*OutputState{
 					"a_output": &OutputState{

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -375,6 +375,9 @@ func resourceState(resourceType, resourceID string) *ResourceState {
 		Type: resourceType,
 		Primary: &InstanceState{
 			ID: resourceID,
+			Attributes: map[string]string{
+				"id": resourceID,
+			},
 		},
 	}
 }

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -126,6 +126,11 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 			&DestroyValueReferenceTransformer{},
 		),
 
+		GraphTransformIf(
+			func() bool { return b.Destroy },
+			&DestroyOutputTransformer{},
+		),
+
 		// Add the node to fix the state count boundaries
 		&CountBoundaryTransformer{},
 

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -119,7 +119,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// Connect references so ordering is correct
 		&ReferenceTransformer{},
 
-		// Reverse the edges to outputs and locals, so that
+		// Reverse the edges from outputs and locals, so that
 		// interpolations don't fail during destroy.
 		GraphTransformIf(
 			func() bool { return b.Destroy },

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -119,16 +119,19 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// Connect references so ordering is correct
 		&ReferenceTransformer{},
 
+		// Handle destroy time transformations for output and local values.
 		// Reverse the edges from outputs and locals, so that
 		// interpolations don't fail during destroy.
+		// Create a destroy node for outputs to remove them from the state.
+		// Prune unreferenced values, which may have interpolations that can't
+		// be resolved.
 		GraphTransformIf(
 			func() bool { return b.Destroy },
-			&DestroyValueReferenceTransformer{},
-		),
-
-		GraphTransformIf(
-			func() bool { return b.Destroy },
-			&DestroyOutputTransformer{},
+			GraphTransformMulti(
+				&DestroyValueReferenceTransformer{},
+				&DestroyOutputTransformer{},
+				&PruneUnusedValuesTransformer{},
+			),
 		),
 
 		// Add the node to fix the state count boundaries

--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -518,6 +518,16 @@ func (i *Interpolater) computeResourceVariable(
 		return &v, err
 	}
 
+	// special case for the "id" field which is usually also an attribute
+	if v.Field == "id" && r.Primary.ID != "" {
+		// This is usually pulled from the attributes, but is sometimes missing
+		// during destroy. We can return the ID field in this case.
+		// FIXME: there should only be one ID to rule them all.
+		log.Printf("[WARN] resource %s missing 'id' attribute", v.ResourceId())
+		v, err := hil.InterfaceToVariable(r.Primary.ID)
+		return &v, err
+	}
+
 	// computed list or map attribute
 	_, isList = r.Primary.Attributes[v.Field+".#"]
 	_, isMap = r.Primary.Attributes[v.Field+".%"]
@@ -653,6 +663,11 @@ func (i *Interpolater) computeResourceMultiVariable(
 		if singleAttr, ok := r.Primary.Attributes[v.Field]; ok {
 			values = append(values, singleAttr)
 			continue
+		}
+
+		if v.Field == "id" && r.Primary.ID != "" {
+			log.Printf("[WARN] resource %s missing 'id' attribute", v.ResourceId())
+			values = append(values, r.Primary.ID)
 		}
 
 		// computed list or map attribute

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -129,6 +129,40 @@ func TestInterpolater_localVal(t *testing.T) {
 	})
 }
 
+func TestInterpolater_missingID(t *testing.T) {
+	lock := new(sync.RWMutex)
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: rootModulePath,
+				Resources: map[string]*ResourceState{
+					"aws_instance.web": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	i := &Interpolater{
+		Module:    testModule(t, "interpolate-resource-variable"),
+		State:     state,
+		StateLock: lock,
+	}
+
+	scope := &InterpolationScope{
+		Path: rootModulePath,
+	}
+
+	testInterpolate(t, i, scope, "aws_instance.web.id", ast.Variable{
+		Value: "bar",
+		Type:  ast.TypeString,
+	})
+}
+
 func TestInterpolater_pathCwd(t *testing.T) {
 	i := &Interpolater{}
 	scope := &InterpolationScope{}
@@ -314,8 +348,8 @@ func TestInterpolater_resourceVariableMissingDuringInput(t *testing.T) {
 			&ModuleState{
 				Path:      rootModulePath,
 				Resources: map[string]*ResourceState{
-				// No resources at all yet, because we're still dealing
-				// with input and so the resources haven't been created.
+					// No resources at all yet, because we're still dealing
+					// with input and so the resources haven't been created.
 				},
 			},
 		},

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -348,8 +348,8 @@ func TestInterpolater_resourceVariableMissingDuringInput(t *testing.T) {
 			&ModuleState{
 				Path:      rootModulePath,
 				Resources: map[string]*ResourceState{
-					// No resources at all yet, because we're still dealing
-					// with input and so the resources haven't been created.
+				// No resources at all yet, because we're still dealing
+				// with input and so the resources haven't been created.
 				},
 			},
 		},

--- a/terraform/node_local.go
+++ b/terraform/node_local.go
@@ -59,38 +59,8 @@ func (n *NodeLocal) References() []string {
 
 // GraphNodeEvalable
 func (n *NodeLocal) EvalTree() EvalNode {
-	return &EvalSequence{
-		Nodes: []EvalNode{
-			&EvalOpFilter{
-				Ops: []walkOperation{
-					walkInput,
-					walkValidate,
-					walkRefresh,
-					walkPlan,
-					walkApply,
-				},
-				Node: &EvalSequence{
-					Nodes: []EvalNode{
-						&EvalLocal{
-							Name:  n.Config.Name,
-							Value: n.Config.RawConfig,
-						},
-					},
-				},
-			},
-			&EvalOpFilter{
-				Ops: []walkOperation{
-					walkPlanDestroy,
-					walkDestroy,
-				},
-				Node: &EvalSequence{
-					Nodes: []EvalNode{
-						&EvalDeleteLocal{
-							Name: n.Config.Name,
-						},
-					},
-				},
-			},
-		},
+	return &EvalLocal{
+		Name:  n.Config.Name,
+		Value: n.Config.RawConfig,
 	}
 }

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -122,6 +122,12 @@ func (n *NodeDestroyableOutput) RemoveIfNotTargeted() bool {
 	return true
 }
 
+// This will keep the destroy node in the graph if its corresponding output
+// node is also in the destroy graph.
+func (n *NodeDestroyableOutput) TargetDownstream(targetedDeps, untargetedDeps *dag.Set) bool {
+	return true
+}
+
 // GraphNodeReferencer
 func (n *NodeDestroyableOutput) References() []string {
 	var result []string

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -83,17 +83,11 @@ func (n *NodeApplyableOutput) EvalTree() EvalNode {
 				},
 			},
 			&EvalOpFilter{
-				Ops: []walkOperation{walkRefresh, walkPlan, walkApply, walkValidate},
+				Ops: []walkOperation{walkRefresh, walkPlan, walkApply, walkValidate, walkDestroy, walkPlanDestroy},
 				Node: &EvalWriteOutput{
 					Name:      n.Config.Name,
 					Sensitive: n.Config.Sensitive,
 					Value:     n.Config.RawConfig,
-				},
-			},
-			&EvalOpFilter{
-				Ops: []walkOperation{walkDestroy, walkPlanDestroy},
-				Node: &EvalDeleteOutput{
-					Name: n.Config.Name,
 				},
 			},
 		},

--- a/terraform/test-fixtures/apply-provisioner-destroy-locals/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy-locals/main.tf
@@ -1,0 +1,14 @@
+locals {
+  value = "local"
+}
+
+resource "aws_instance" "foo" {
+    provisioner "shell" {
+        command  = "${local.value}"
+        when = "create"
+    }
+    provisioner "shell" {
+        command  = "${local.value}"
+        when = "destroy"
+    }
+}

--- a/terraform/test-fixtures/apply-provisioner-destroy-multiple-locals/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy-multiple-locals/main.tf
@@ -1,0 +1,24 @@
+locals {
+  value = "local"
+  foo_id = "${aws_instance.foo.id}"
+
+  // baz is not in the state during destroy, but this is a valid config that
+  // should not fail.
+  baz_id = "${aws_instance.baz.id}"
+}
+
+resource "aws_instance" "baz" {}
+
+resource "aws_instance" "foo" {
+    provisioner "shell" {
+        command  = "${local.value}"
+        when = "destroy"
+    }
+}
+
+resource "aws_instance" "bar" {
+    provisioner "shell" {
+        command  = "${local.foo_id}"
+        when = "destroy"
+    }
+}

--- a/terraform/test-fixtures/apply-provisioner-destroy-outputs/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy-outputs/main.tf
@@ -1,0 +1,19 @@
+module "mod" {
+  source = "./mod"
+}
+
+locals {
+  value = "${module.mod.value}"
+}
+
+resource "aws_instance" "foo" {
+    provisioner "shell" {
+        command  = "${local.value}"
+        when = "destroy"
+    }
+}
+
+module "mod2" {
+  source = "./mod2"
+  value = "${module.mod.value}"
+}

--- a/terraform/test-fixtures/apply-provisioner-destroy-outputs/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy-outputs/main.tf
@@ -17,3 +17,7 @@ module "mod2" {
   source = "./mod2"
   value = "${module.mod.value}"
 }
+
+output "value" {
+  value = "${local.value}"
+}

--- a/terraform/test-fixtures/apply-provisioner-destroy-outputs/mod/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy-outputs/mod/main.tf
@@ -1,0 +1,5 @@
+output "value" {
+  value = "${aws_instance.baz.id}"
+}
+
+resource "aws_instance" "baz" {}

--- a/terraform/test-fixtures/apply-provisioner-destroy-outputs/mod2/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy-outputs/mod2/main.tf
@@ -1,0 +1,10 @@
+variable "value" {
+}
+
+resource "aws_instance" "bar" {
+    provisioner "shell" {
+        command  = "${var.value}"
+        when = "destroy"
+    }
+}
+

--- a/terraform/transform_reference.go
+++ b/terraform/transform_reference.go
@@ -96,6 +96,11 @@ func (t *DestroyValueReferenceTransformer) Transform(g *Graph) error {
 		// reverse any outgoing edges so that the value is evaluated first.
 		for _, e := range g.EdgesFrom(v) {
 			target := e.Target()
+			switch target.(type) {
+			case *NodeApplyableOutput, *NodeLocal:
+				// don't reverse other values
+				continue
+			}
 			log.Printf("[TRACE] output dep: %s", dag.VertexName(target))
 
 			g.RemoveEdge(e)

--- a/terraform/transform_reference.go
+++ b/terraform/transform_reference.go
@@ -112,6 +112,30 @@ func (t *DestroyValueReferenceTransformer) Transform(g *Graph) error {
 	return nil
 }
 
+// PruneUnusedValuesTransformer is s GraphTransformer that removes local and
+// output values which are not referenced in the graph. Since outputs and
+// locals always need to be evaluated, if they reference a resource that is not
+// available in the state the interpolation could fail.
+type PruneUnusedValuesTransformer struct{}
+
+func (t *PruneUnusedValuesTransformer) Transform(g *Graph) error {
+	vs := g.Vertices()
+	for _, v := range vs {
+		switch v.(type) {
+		case *NodeApplyableOutput, *NodeLocal:
+			// OK
+		default:
+			continue
+		}
+
+		if len(g.EdgesTo(v)) == 0 {
+			g.Remove(v)
+		}
+	}
+
+	return nil
+}
+
 // ReferenceMap is a structure that can be used to efficiently check
 // for references on a graph.
 type ReferenceMap struct {

--- a/terraform/transform_reference.go
+++ b/terraform/transform_reference.go
@@ -96,11 +96,12 @@ func (t *DestroyValueReferenceTransformer) Transform(g *Graph) error {
 		// reverse any outgoing edges so that the value is evaluated first.
 		for _, e := range g.EdgesFrom(v) {
 			target := e.Target()
-			switch target.(type) {
-			case *NodeApplyableOutput, *NodeLocal:
-				// don't reverse other values
+
+			// only destroy nodes will be evaluated in reverse
+			if _, ok := target.(GraphNodeDestroyer); !ok {
 				continue
 			}
+
 			log.Printf("[TRACE] output dep: %s", dag.VertexName(target))
 
 			g.RemoveEdge(e)


### PR DESCRIPTION
Because destroy time provisioners are not evaluated until the destroy operation, and outputs and locals are "dynamic" in the sense that they can be evaluated on demand, we always need to evaluate them, even during destroy.

Since the destroy-time local and output nodes are no longer a
"destroy" operation, the order of evaluation need to be reversed. Take
the existing `DestroyValueReferenceTransformer` and change it to reverse
the outgoing edges, rather than in incoming edges. This makes it so that
any dependencies of a local or output node are destroyed after
evaluation.

Previously, outputs were removed during destroy from the same
"Applyable" node type that evaluates them. Now that we need to possibly
both evaluate and remove outputs during an apply, we add a new node -
`NodeDestroyableOutput`.

This new node is added to the graph by the `DestroyOutputTransformer`,
which makes the new destroy node depend on all descendants of the output
node.  This ensures that the output remains in the state as long as
everything which may interpolate the output still exists

Also, since outputs and local nodes are always evaluated, interpolation can fail
if they reference a resource form the configuration that isn't in the state. The new `PruneUnusedValuesTransformer` removes unused value nodes from the graph.

Throughout this PR, a number of unrelated tests went through failure, due to the attempted interpolation of "id" attributes which weren't in the state. Add a failsafe in the interpolation function to fallback on the `ID` field when the attribute no longer exists. We should plan in the future to only have a single location for a resource ID.

Fixes #17158, #17181, #16907, #16420, #14450, probably others