### PR TITLE
Default protocol for atlas address to https if not specified

### DIFF
--- a/backend/atlas/backend.go
+++ b/backend/atlas/backend.go
@@ -124,6 +124,12 @@ func (b *Backend) schemaConfigure(ctx context.Context) error {
 
 	// Parse the address
 	addr := d.Get("address").(string)
+
+	// check the address has a prototocol, if not default to https
+	if !strings.HasPrefix("https://", addr) || !strings.HasPrefix("http://", addr) {
+		addr = fmt.Sprintf("https://%s", addr)
+	}
+
 	addrUrl, err := url.Parse(addr)
 	if err != nil {
 		return fmt.Errorf("Error parsing 'address': %s", err)
@@ -159,5 +165,5 @@ var schemaDescriptions = map[string]string{
 		"this will override any saved value for this.",
 	"address": "Address to your Atlas installation. This defaults to the publicly\n" +
 		"hosted version at 'https://atlas.hashicorp.com/'. This address\n" +
-		"should contain the full HTTP scheme to use.",
+		"will default the HTTP scheme to 'https://' if the scheme is not explicitly specified.",
 }

--- a/backend/atlas/backend_test.go
+++ b/backend/atlas/backend_test.go
@@ -1,6 +1,7 @@
 package atlas
 
 import (
+	"log"
 	"os"
 	"testing"
 
@@ -27,6 +28,24 @@ func TestConfigure_envAddr(t *testing.T) {
 	}
 
 	if b.stateClient.Server != "http://foo.com" {
+		t.Fatalf("bad: %#v", b.stateClient)
+	}
+}
+
+func TestConfigure_envAddrWithNoProtocolDefaults_https(t *testing.T) {
+	defer os.Setenv("ATLAS_ADDRESS", os.Getenv("ATLAS_ADDRESS"))
+	os.Setenv("ATLAS_ADDRESS", "foo.com")
+
+	b := &Backend{}
+	err := b.Configure(terraform.NewResourceConfig(config.TestRawConfig(t, map[string]interface{}{
+		"name": "foo/bar",
+	})))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if b.stateClient.Server != "https://foo.com" {
+		log.Println(b.stateClient.Server)
 		t.Fatalf("bad: %#v", b.stateClient)
 	}
 }


### PR DESCRIPTION
When specifying an atlas address either by env var or config block and a HTTP scheme is not specified, default the scheme for the TFE backend to HTTPS.

i.e.
A value specified as:
`atlas.hashicorp.com`

would be re-written to:
`https://atlas.hashicorp.com`

Values of:
`http://atlas.hashicorp.com` or 
`https://atlas.hashicorp.com`
would not be re-written and would be left as configured

Signed-off-by: nicholasjackson <jackson.nic@gmail.com>