### PR TITLE
helper/schema: Prevent crash on removal of computed field in CustomizeDiff

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -427,6 +427,13 @@ func (m schemaMap) Diff(
 		}
 	}
 
+	// Remove any nil diffs just to keep things clean
+	for k, v := range result.Attributes {
+		if v == nil {
+			delete(result.Attributes, k)
+		}
+	}
+
 	// If this is a non-destroy diff, call any custom diff logic that has been
 	// defined.
 	if !result.DestroyTainted && customizeDiff != nil {
@@ -519,13 +526,6 @@ func (m schemaMap) Diff(
 
 		// And set the diff!
 		result = result2
-	}
-
-	// Remove any nil diffs just to keep things clean
-	for k, v := range result.Attributes {
-		if v == nil {
-			delete(result.Attributes, k)
-		}
 	}
 
 	// Go through and detect all of the ComputedWhens now that we've


### PR DESCRIPTION
We already perform the cleanup in here:

https://github.com/hashicorp/terraform/blob/1ba8691f35e7584087a83e26deaf82f0e4d3dada/helper/schema/schema.go#L524-L529

however `CustomizeDiff` was called _before_ this cleanup and therefore any `Get()`, `GetOk()` etc. may have caused a crash.

## Before fix

```
=== RUN   TestSchemaMap_Diff/80-optional,_computed,_empty_string_should_not_crash_in_CustomizeDiff
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x21 pc=0x169bc8b]

goroutine 258 [running]:
testing.tRunner.func1(0xc420476c30)
	/usr/local/Cellar/go/1.9.3/libexec/src/testing/testing.go:711 +0x2d2
panic(0x18360e0, 0x1e1b3f0)
	/usr/local/Cellar/go/1.9.3/libexec/src/runtime/panic.go:491 +0x283
github.com/hashicorp/terraform/helper/schema.(*DiffFieldReader).readSet(0xc42045daa0, 0xc4200ff1a0, 0x1, 0x1, 0xc420477a40, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/helper/schema/field_reader_diff.go:183 +0x1bb
github.com/hashicorp/terraform/helper/schema.(*DiffFieldReader).ReadField(0xc42045daa0, 0xc4200ff1a0, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/helper/schema/field_reader_diff.go:73 +0x76e
github.com/hashicorp/terraform/helper/schema.(*MultiLevelFieldReader).ReadFieldMerge(0xc420449900, 0xc4200ff1a0, 0x1, 0x1, 0x1911a3e, 0x7, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/helper/schema/field_reader_multi.go:45 +0x260
github.com/hashicorp/terraform/helper/schema.(*ResourceDiff).get(0xc420461d80, 0xc4200ff1a0, 0x1, 0x1, 0x1911a3e, 0x7, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/helper/schema/resource_diff.go:406 +0xe3
github.com/hashicorp/terraform/helper/schema.(*ResourceDiff).GetOk(0xc420461d80, 0x1916afb, 0xd, 0xc420449900, 0xc4204498e0, 0xc4200ff190)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/helper/schema/resource_diff.go:338 +0xa6
github.com/hashicorp/terraform/helper/schema.TestSchemaMap_Diff.func39(0xc420461d80, 0x0, 0x0, 0xc420449480, 0xc420461d80)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/helper/schema/schema_test.go:3177 +0x44
github.com/hashicorp/terraform/helper/schema.schemaMap.Diff(0xc4202a3890, 0xc420011e50, 0xc42045d5f0, 0x1942df0, 0x0, 0x0, 0xc420020000, 0x1b02dc0, 0x1b02e00)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/helper/schema/schema.go:435 +0xb62
github.com/hashicorp/terraform/helper/schema.TestSchemaMap_Diff.func40(0xc420476c30)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/helper/schema/schema_test.go:3211 +0x130
testing.tRunner(0xc420476c30, 0xc420040650)
	/usr/local/Cellar/go/1.9.3/libexec/src/testing/testing.go:746 +0xd0
created by testing.(*T).Run
	/usr/local/Cellar/go/1.9.3/libexec/src/testing/testing.go:789 +0x2de
exit status 2
```

----

This is currently a blocker for https://github.com/terraform-providers/terraform-provider-aws/pull/3194