### PR TITLE
terraform: use hashicorp/go-uuid for lineage generation

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -16,10 +16,10 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/config"
 	"github.com/mitchellh/copystructure"
-	"github.com/satori/go.uuid"
 
 	tfversion "github.com/hashicorp/terraform/version"
 )
@@ -706,7 +706,11 @@ func (s *State) EnsureHasLineage() {
 
 func (s *State) ensureHasLineage() {
 	if s.Lineage == "" {
-		s.Lineage = uuid.NewV4().String()
+		lineage, err := uuid.GenerateUUID()
+		if err != nil {
+			panic(fmt.Errorf("Failed to generate lineage: %v", err))
+		}
+		s.Lineage = lineage
 		log.Printf("[DEBUG] New state was assigned lineage %q\n", s.Lineage)
 	} else {
 		log.Printf("[TRACE] Preserving existing state lineage %q\n", s.Lineage)


### PR DESCRIPTION
There was an upstream change to this vendored lib which introduced a breaking change. To get ahead of this, and to match all other uses of UUID's within HashiCorp tooling, just swap this out for our own `go-uuid` lib. Luckily we already have this vendored as well 💃 .

The panic is a bit ugly, but it appears to be very common in this code path so I just went with it. Failing to generate a UUID for lineage is a major problem, so it seems fitting that this might cause a crash.