### PR TITLE
website: fix a wrong anchor

### DIFF
--- a/website/docs/registry/api.html.md
+++ b/website/docs/registry/api.html.md
@@ -61,7 +61,7 @@ These endpoints list modules according to some criteria.
 
 ### Query Parameters
 
-- `offset`, `limit` `(int: <optional>)` - See [Pagination](#Pagination) for details.
+- `offset`, `limit` `(int: <optional>)` - See [Pagination](#pagination) for details.
 - `provider` `(string: <optional>)` - Limits modules to a specific provider.
 - `verified` `(bool: <optional>)` - If `true`, limits results to only verified
   modules. Any other value including none returns all modules _including_
@@ -127,7 +127,7 @@ This endpoint allows searching modules.
 - `q` `(string: <required>)` - The search string. Search syntax understood
   depends on registry implementation. The public registry supports basic keyword
   or phrase searches.
-- `offset`, `limit` `(int: <optional>)` - See [Pagination](#Pagination) for details.
+- `offset`, `limit` `(int: <optional>)` - See [Pagination](#pagination) for details.
 - `provider` `(string: <optional>)` - Limits results to a specific provider.
 - `namespace` `(string: <optional>)` - Limits results to a specific namespace.
 - `verified` `(bool: <optional>)` - If `true`, limits results to only verified
@@ -345,7 +345,7 @@ This endpoint returns the latest version of each provider for a module.
 
 ### Query Parameters
 
-- `offset`, `limit` `(int: <optional>)` - See [Pagination](#Pagination) for details.
+- `offset`, `limit` `(int: <optional>)` - See [Pagination](#pagination) for details.
 
 ### Sample Request
 


### PR DESCRIPTION
In [Registry HTTP API document](https://www.terraform.io/docs/registry/api.html), 
all links for [Pagination](https://www.terraform.io/docs/registry/api.html#pagination) is to `#Pagination` not `#pagination`. Therefore, it is move to top of the page instead the Pagination section.