### PR TITLE
docs/salt-masterless: remove grains_file

### DIFF
--- a/website/docs/provisioners/salt-masterless.html.md
+++ b/website/docs/provisioners/salt-masterless.html.md
@@ -69,9 +69,6 @@ Optional:
     uploaded to the `/etc/salt` on the remote. This option overrides the
     `remote_state_tree` or `remote_pillar_roots` options.
 
--   `grains_file` (string) - The path to your local [grains file](https://docs.saltstack.com/en/latest/topics/grains). This will be
-    uploaded to `/etc/salt/grains` on the remote.
-
 -   `skip_bootstrap` (boolean) - By default the salt provisioner runs [salt
     bootstrap](https://github.com/saltstack/salt-bootstrap) to install salt. Set
     this to true to skip this step.


### PR DESCRIPTION
**Reasoning for docs update**: grains_file is currently not implemented
**Relevant terraform version**: current