### PR TITLE
Fix race in writing state during hard cancelation

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -145,14 +145,22 @@ type Operation struct {
 
 // RunningOperation is the result of starting an operation.
 type RunningOperation struct {
-	// Context should be used to track Done and Err for errors.
-	//
 	// For implementers of a backend, this context should not wrap the
 	// passed in context. Otherwise, canceling the parent context will
 	// immediately mark this context as "done" but those aren't the semantics
 	// we want: we want this context to be done only when the operation itself
 	// is fully done.
 	context.Context
+
+	// Stop requests the operation to complete early, by calling Stop on all
+	// the plugins. If the process needs to terminate immediately, call Cancel.
+	Stop context.CancelFunc
+
+	// Cancel is the context.CancelFunc associated with the embedded context,
+	// and can be called to terminate the operation early.
+	// Once Cancel is called, the operation should return as soon as possible
+	// to avoid running operations during process exit.
+	Cancel context.CancelFunc
 
 	// Err is the error of the operation. This is populated after
 	// the operation has completed.

--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -271,6 +272,53 @@ func (b *Local) Operation(ctx context.Context, op *backend.Operation) (*backend.
 
 	// Return
 	return runningOp, nil
+}
+
+// opWait wats for the operation to complete, and a stop signal or a
+// cancelation signal.
+func (b *Local) opWait(
+	doneCh <-chan struct{},
+	stopCtx context.Context,
+	cancelCtx context.Context,
+	tfCtx *terraform.Context,
+	opState state.State) (canceled bool) {
+	// Wait for the operation to finish or for us to be interrupted so
+	// we can handle it properly.
+	select {
+	case <-stopCtx.Done():
+		if b.CLI != nil {
+			b.CLI.Output("stopping operation...")
+		}
+
+		// try to force a PersistState just in case the process is terminated
+		// before we can complete.
+		if err := opState.PersistState(); err != nil {
+			// We can't error out from here, but warn the user if there was an error.
+			// If this isn't transient, we will catch it again below, and
+			// attempt to save the state another way.
+			if b.CLI != nil {
+				b.CLI.Error(fmt.Sprintf(earlyStateWriteErrorFmt, err))
+			}
+		}
+
+		// Stop execution
+		go tfCtx.Stop()
+
+		select {
+		case <-cancelCtx.Done():
+			log.Println("[WARN] running operation canceled")
+			// if the operation was canceled, we need to return immediately
+			canceled = true
+		case <-doneCh:
+		}
+	case <-cancelCtx.Done():
+		// this should not be called without first attempting to stop the
+		// operation
+		log.Println("[ERROR] running operation canceled without Stop")
+		canceled = true
+	case <-doneCh:
+	}
+	return
 }
 
 // Colorize returns the Colorize structure that can be used for colorizing

--- a/backend/local/backend_refresh.go
+++ b/backend/local/backend_refresh.go
@@ -91,28 +91,8 @@ func (b *Local) opRefresh(
 		log.Printf("[INFO] backend/local: refresh calling Refresh")
 	}()
 
-	select {
-	case <-stopCtx.Done():
-		if b.CLI != nil {
-			b.CLI.Output("stopping refresh operation...")
-		}
-
-		// Stop execution
-		go tfCtx.Stop()
-
-		select {
-		case <-cancelCtx.Done():
-			log.Println("[WARN] running operation canceled")
-			// if the operation was canceled, we need to return immediately
-			return
-		case <-doneCh:
-		}
-	case <-cancelCtx.Done():
-		// this should not be called without first attempting to stop the
-		// operation
-		log.Println("[ERROR] running operation canceled without Stop")
+	if b.opWait(doneCh, stopCtx, cancelCtx, tfCtx, opState) {
 		return
-	case <-doneCh:
 	}
 
 	// write the resulting state to the running op

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -824,12 +824,11 @@ func TestApply_refresh(t *testing.T) {
 }
 
 func TestApply_shutdown(t *testing.T) {
-	cancelled := false
-	stopped := make(chan struct{})
+	cancelled := make(chan struct{})
+	shutdownCh := make(chan struct{})
 
 	statePath := testTempFile(t)
 	p := testProvider()
-	shutdownCh := make(chan struct{})
 
 	ui := new(cli.MockUi)
 	c := &ApplyCommand{
@@ -841,8 +840,7 @@ func TestApply_shutdown(t *testing.T) {
 	}
 
 	p.StopFn = func() error {
-		close(stopped)
-		cancelled = true
+		close(cancelled)
 		return nil
 	}
 
@@ -858,15 +856,26 @@ func TestApply_shutdown(t *testing.T) {
 			},
 		}, nil
 	}
+
+	var once sync.Once
 	p.ApplyFn = func(
 		*terraform.InstanceInfo,
 		*terraform.InstanceState,
 		*terraform.InstanceDiff) (*terraform.InstanceState, error) {
+
 		// only cancel once
-		if !cancelled {
+		once.Do(func() {
 			shutdownCh <- struct{}{}
-			<-stopped
-		}
+		})
+
+		// Because of the internal lock in the MockProvider, we can't
+		// coordiante directly with the calling of Stop, and making the
+		// MockProvider concurrent is disruptive to a lot of existing tests.
+		// Wait here a moment to help make sure the main goroutine gets to the
+		// Stop call before we exit, or the plan may finish before it can be
+		// canceled.
+		time.Sleep(200 * time.Millisecond)
+
 		return &terraform.InstanceState{
 			ID: "foo",
 			Attributes: map[string]string{
@@ -888,7 +897,9 @@ func TestApply_shutdown(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if !cancelled {
+	select {
+	case <-cancelled:
+	default:
 		t.Fatal("command not cancelled")
 	}
 

--- a/command/plan.go
+++ b/command/plan.go
@@ -1,10 +1,8 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/config"
@@ -108,43 +106,9 @@ func (c *PlanCommand) Run(args []string) int {
 	opReq.Type = backend.OperationTypePlan
 
 	// Perform the operation
-	op, err := b.Operation(context.Background(), opReq)
+	op, err := c.RunOperation(b, opReq)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error starting operation: %s", err))
-		return 1
-	}
-
-	select {
-	case <-c.ShutdownCh:
-		// Cancel our context so we can start gracefully exiting
-		op.Stop()
-
-		// Notify the user
-		c.Ui.Output(outputInterrupt)
-
-		// Still get the result, since there is still one
-		select {
-		case <-c.ShutdownCh:
-			c.Ui.Error(
-				"Two interrupts received. Exiting immediately")
-
-			// cancel the operation completely
-			op.Cancel()
-
-			// the operation should return asap
-			// but timeout just in case
-			select {
-			case <-op.Done():
-			case <-time.After(5 * time.Second):
-			}
-
-			return 1
-		case <-op.Done():
-		}
-	case <-op.Done():
-		if err := op.Err; err != nil {
-			diags = diags.Append(err)
-		}
+		diags = diags.Append(err)
 	}
 
 	c.showDiagnostics(diags)

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -835,8 +835,8 @@ func TestPlan_detailedExitcode_emptyDiff(t *testing.T) {
 
 func TestPlan_shutdown(t *testing.T) {
 	cancelled := make(chan struct{})
-
 	shutdownCh := make(chan struct{})
+
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &PlanCommand{
@@ -880,8 +880,10 @@ func TestPlan_shutdown(t *testing.T) {
 		}, nil
 	}
 
-	if code := c.Run([]string{testFixturePath("apply-shutdown")}); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	if code := c.Run([]string{testFixturePath("apply-shutdown")}); code != 1 {
+		// FIXME: we should be able to avoid the error during evaluation
+		// the early exit isn't caught before the interpolation is evaluated
+		t.Fatal(ui.OutputWriter.String())
 	}
 
 	select {

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -1,10 +1,8 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/config"
@@ -76,47 +74,9 @@ func (c *RefreshCommand) Run(args []string) int {
 	opReq.Type = backend.OperationTypeRefresh
 	opReq.Module = mod
 
-	// Perform the operation
-	op, err := b.Operation(context.Background(), opReq)
+	op, err := c.RunOperation(b, opReq)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error starting operation: %s", err))
-		return 1
-	}
-
-	// Wait for the operation to complete or an interrupt to occur
-	select {
-	case <-c.ShutdownCh:
-		// gracefully stop the operation
-		op.Stop()
-
-		// Notify the user
-		c.Ui.Output(outputInterrupt)
-
-		// Still get the result, since there is still one
-		select {
-		case <-c.ShutdownCh:
-			c.Ui.Error(
-				"Two interrupts received. Exiting immediately. Note that data\n" +
-					"loss may have occurred.")
-
-			// cancel the operation completely
-			op.Cancel()
-
-			// the operation should return asap
-			// but timeout just in case
-			select {
-			case <-op.Done():
-			case <-time.After(5 * time.Second):
-			}
-
-			return 1
-
-		case <-op.Done():
-		}
-	case <-op.Done():
-		if err := op.Err; err != nil {
-			diags = diags.Append(err)
-		}
+		diags = diags.Append(err)
 	}
 
 	c.showDiagnostics(diags)


### PR DESCRIPTION
If the user wishes to interrupt the running operation, only the first
interrupt was communicated to the operation by canceling the provided
context. A second interrupt would start the shutdown process, but not
communicate this to the running operation. This order of events could
cause partial writes of state.

What would happen is that once the command returns, the plugin system
would stop the provider processes. Once the provider processes dies, all
pending Eval operations would return return with an error, and quickly
cause the operation to complete. Since the backend code didn't know that
the process was shutting down imminently, it would continue by
attempting to write out the last known state. Under the right
conditions, the process would exit part way through the writing of the
state file.

Add Stop and Cancel CancelFuncs to the RunningOperation, to allow it to
easily differentiate between the two signals. The backend will then be
able to detect a shutdown and abort more gracefully.

In order to ensure that the backend is not in the process of writing the
state out, the command will always attempt to wait for the process to
complete after cancellation.

fixes #17282