### PR TITLE
Flag output variable naming conventions

### DIFF
--- a/website/docs/configuration/outputs.html.md
+++ b/website/docs/configuration/outputs.html.md
@@ -49,7 +49,8 @@ output "addresses" {
 The `output` block configures a single output variable. Multiple
 output variables can be configured with multiple output blocks.
 The `NAME` given to the output block is the name used to reference
-the output variable.
+the output variable. It must conform to Terraform variable naming
+conventions if it is to be used as an input to other modules.
 
 Within the block (the `{ }`) is configuration for the output.
 These are the parameters that can be set:

--- a/website/intro/getting-started/outputs.html.md
+++ b/website/intro/getting-started/outputs.html.md
@@ -35,7 +35,9 @@ output "ip" {
 }
 ```
 
-This defines an output variable named "ip". The `value` field
+This defines an output variable named "ip". The name of the variable
+must conform to Terraform variable naming conventions if it is
+to be used as an input to other modules. The `value` field
 specifies what the value will be, and almost always contains
 one or more interpolations, since the output data is typically
 dynamic. In this case, we're outputting the


### PR DESCRIPTION
Reason: Make explicitly clear that output variable names must conform to variable naming conventions if they are to be used as input to other modules.

Terraform Version: `0.11.3`

- update the documentation regarding output naming