### PR TITLE
Halt on provisioner errors

### DIFF
--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
-	"time"
 
 	"github.com/hashicorp/terraform/communicator"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -50,6 +48,9 @@ func applyFn(ctx context.Context) error {
 		return err
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, comm.Timeout())
+	defer cancel()
+
 	// Get the source
 	src, deleteSource, err := getSrc(data)
 	if err != nil {
@@ -61,21 +62,11 @@ func applyFn(ctx context.Context) error {
 
 	// Begin the file copy
 	dst := data.Get("destination").(string)
-	resultCh := make(chan error, 1)
-	go func() {
-		resultCh <- copyFiles(comm, src, dst)
-	}()
 
-	// Allow the file copy to complete unless there is an interrupt.
-	// If there is an interrupt we make no attempt to cleanly close
-	// the connection currently. We just abruptly exit. Because Terraform
-	// taints the resource, this is fine.
-	select {
-	case err := <-resultCh:
+	if err := copyFiles(ctx, comm, src, dst); err != nil {
 		return err
-	case <-ctx.Done():
-		return fmt.Errorf("file transfer interrupted")
 	}
+	return nil
 }
 
 func validateFn(c *terraform.ResourceConfig) (ws []string, es []error) {
@@ -107,9 +98,9 @@ func getSrc(data *schema.ResourceData) (string, bool, error) {
 }
 
 // copyFiles is used to copy the files from a source to a destination
-func copyFiles(comm communicator.Communicator, src, dst string) error {
+func copyFiles(ctx context.Context, comm communicator.Communicator, src, dst string) error {
 	// Wait and retry until we establish the connection
-	err := retryFunc(comm.Timeout(), func() error {
+	err := communicator.Retry(ctx, func() error {
 		err := comm.Connect(nil)
 		return err
 	})
@@ -143,22 +134,4 @@ func copyFiles(comm communicator.Communicator, src, dst string) error {
 		return fmt.Errorf("Upload failed: %v", err)
 	}
 	return err
-}
-
-// retryFunc is used to retry a function for a given duration
-func retryFunc(timeout time.Duration, f func() error) error {
-	finish := time.After(timeout)
-	for {
-		err := f()
-		if err == nil {
-			return nil
-		}
-		log.Printf("Retryable error: %v", err)
-
-		select {
-		case <-finish:
-			return err
-		case <-time.After(3 * time.Second):
-		}
-	}
 }

--- a/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -169,9 +169,9 @@ func runScripts(
 
 	// Wait and retry until we establish the connection
 	err := communicator.Retry(ctx, func() error {
-		err := comm.Connect(o)
-		return err
+		return comm.Connect(o)
 	})
+
 	if err != nil {
 		return err
 	}

--- a/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -2,12 +2,8 @@ package remoteexec
 
 import (
 	"bytes"
-	"context"
-	"errors"
 	"io"
-	"net"
 	"testing"
-	"time"
 
 	"strings"
 
@@ -207,64 +203,6 @@ func TestResourceProvider_CollectScripts_scriptsEmpty(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "Error parsing") {
 		t.Fatalf("Expected parsing error, got: %s", err)
-	}
-}
-
-func TestRetryFunc(t *testing.T) {
-	origMax := maxBackoffDelay
-	maxBackoffDelay = time.Second
-	origStart := initialBackoffDelay
-	initialBackoffDelay = 10 * time.Millisecond
-
-	defer func() {
-		maxBackoffDelay = origMax
-		initialBackoffDelay = origStart
-	}()
-
-	// succeed on the third try
-	errs := []error{io.EOF, &net.OpError{Err: errors.New("ERROR")}, nil}
-	count := 0
-
-	err := retryFunc(context.Background(), time.Second, func() error {
-		if count >= len(errs) {
-			return errors.New("failed to stop after nil error")
-		}
-
-		err := errs[count]
-		count++
-
-		return err
-	})
-
-	if count != 3 {
-		t.Fatal("retry func should have been called 3 times")
-	}
-
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestRetryFuncBackoff(t *testing.T) {
-	origMax := maxBackoffDelay
-	maxBackoffDelay = time.Second
-	origStart := initialBackoffDelay
-	initialBackoffDelay = 100 * time.Millisecond
-
-	defer func() {
-		maxBackoffDelay = origMax
-		initialBackoffDelay = origStart
-	}()
-
-	count := 0
-
-	retryFunc(context.Background(), time.Second, func() error {
-		count++
-		return io.EOF
-	})
-
-	if count > 4 {
-		t.Fatalf("retry func failed to backoff. called %d times", count)
 	}
 }
 

--- a/communicator/communicator.go
+++ b/communicator/communicator.go
@@ -1,8 +1,11 @@
 package communicator
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"log"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/terraform/communicator/remote"
@@ -50,4 +53,94 @@ func New(s *terraform.InstanceState) (Communicator, error) {
 	default:
 		return nil, fmt.Errorf("connection type '%s' not supported", connType)
 	}
+}
+
+// maxBackoffDealy is the maximum delay between retry attempts
+var maxBackoffDelay = 10 * time.Second
+var initialBackoffDelay = time.Second
+
+type Fatal interface {
+	FatalError() error
+}
+
+func Retry(ctx context.Context, f func() error) error {
+	// container for atomic error value
+	type errWrap struct {
+		E error
+	}
+
+	// Try the function in a goroutine
+	var errVal atomic.Value
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+
+		delay := time.Duration(0)
+		for {
+			// If our context ended, we want to exit right away.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(delay):
+			}
+
+			// Try the function call
+			err := f()
+
+			// return if we have no error, or a FatalError
+			done := false
+			switch e := err.(type) {
+			case nil:
+				done = true
+			case Fatal:
+				err = e.FatalError()
+				done = true
+			}
+
+			errVal.Store(&errWrap{err})
+
+			if done {
+				return
+			}
+
+			log.Printf("[WARN] retryable error: %v", err)
+
+			delay *= 2
+
+			if delay == 0 {
+				delay = initialBackoffDelay
+			}
+
+			if delay > maxBackoffDelay {
+				delay = maxBackoffDelay
+			}
+
+			log.Printf("[INFO] sleeping for %s", delay)
+		}
+	}()
+
+	// Wait for completion
+	select {
+	case <-ctx.Done():
+	case <-doneCh:
+	}
+
+	var lastErr error
+	// Check if we got an error executing
+	if ev, ok := errVal.Load().(errWrap); ok {
+		lastErr = ev.E
+	}
+
+	// Check if we have a context error to check if we're interrupted or timeout
+	switch ctx.Err() {
+	case context.Canceled:
+		return fmt.Errorf("interrupted - last error: %v", lastErr)
+	case context.DeadlineExceeded:
+		return fmt.Errorf("timeout - last error: %v", lastErr)
+	}
+
+	if lastErr != nil {
+		return lastErr
+	}
+	return nil
 }

--- a/communicator/communicator.go
+++ b/communicator/communicator.go
@@ -55,14 +55,17 @@ func New(s *terraform.InstanceState) (Communicator, error) {
 	}
 }
 
-// maxBackoffDealy is the maximum delay between retry attempts
-var maxBackoffDelay = 10 * time.Second
+// maxBackoffDelay is the maximum delay between retry attempts
+var maxBackoffDelay = 20 * time.Second
 var initialBackoffDelay = time.Second
 
+// Fatal is an interface that error values can return to halt Retry
 type Fatal interface {
 	FatalError() error
 }
 
+// Retry retries the function f until it returns a nil error, a Fatal error, or
+// the context expires.
 func Retry(ctx context.Context, f func() error) error {
 	// container for atomic error value
 	type errWrap struct {
@@ -97,7 +100,7 @@ func Retry(ctx context.Context, f func() error) error {
 				done = true
 			}
 
-			errVal.Store(&errWrap{err})
+			errVal.Store(errWrap{err})
 
 			if done {
 				return

--- a/communicator/communicator_test.go
+++ b/communicator/communicator_test.go
@@ -1,7 +1,12 @@
 package communicator
 
 import (
+	"context"
+	"errors"
+	"io"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -26,5 +31,68 @@ func TestCommunicator_new(t *testing.T) {
 	r.Ephemeral.ConnInfo["type"] = "winrm"
 	if _, err := New(r); err != nil {
 		t.Fatalf("err: %v", err)
+	}
+}
+func TestRetryFunc(t *testing.T) {
+	origMax := maxBackoffDelay
+	maxBackoffDelay = time.Second
+	origStart := initialBackoffDelay
+	initialBackoffDelay = 10 * time.Millisecond
+
+	defer func() {
+		maxBackoffDelay = origMax
+		initialBackoffDelay = origStart
+	}()
+
+	// succeed on the third try
+	errs := []error{io.EOF, &net.OpError{Err: errors.New("ERROR")}, nil}
+	count := 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := Retry(ctx, func() error {
+		if count >= len(errs) {
+			return errors.New("failed to stop after nil error")
+		}
+
+		err := errs[count]
+		count++
+
+		return err
+	})
+
+	if count != 3 {
+		t.Fatal("retry func should have been called 3 times")
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRetryFuncBackoff(t *testing.T) {
+	origMax := maxBackoffDelay
+	maxBackoffDelay = time.Second
+	origStart := initialBackoffDelay
+	initialBackoffDelay = 100 * time.Millisecond
+
+	defer func() {
+		maxBackoffDelay = origMax
+		initialBackoffDelay = origStart
+	}()
+
+	count := 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	Retry(ctx, func() error {
+		count++
+		return io.EOF
+	})
+
+	if count > 4 {
+		t.Fatalf("retry func failed to backoff. called %d times", count)
 	}
 }


### PR DESCRIPTION
Previously, provisioners would always retry on error, even when they are not recoverable, e.g. invalid credentials, file not found, etc. They then need to be interrupted, or wait for the timeout which defaults to 5min. The remote-exec retryFunc was also not returning the stored error when it was finally interrupted.

First, this moves all the retryFunc implementations to the communicator package, using the most complete (remote-exec) version as the template. This new implementation also checks of the error implements the communicator.Fatal interface, as a signal to stop retrying. While in practice "retry-able" errors are more likely the exception, signaling off fatal errors is less likely to cause regressions in the providers, since not tagging an error as fatal will only continue the existing behavior. 

The ssh communicator can now tag the handshake errors as fatal, since retrying will not ever fix the situation.

We also can remote the retry logic around the remote command portion of remote-exec, since errors related to locating, uploading, and executing scripts are not likely to ever resolve themselves.