### PR TITLE
update etcd documentation links

### DIFF
--- a/website/docs/backends/types/etcd.html.md
+++ b/website/docs/backends/types/etcd.html.md
@@ -10,7 +10,7 @@ description: |-
 
 **Kind: Standard (with no locking)**
 
-Stores the state in [etcd](https://coreos.com/etcd/) at a given path.
+Stores the state in [etcd 2.x](https://coreos.com/etcd/docs/latest/v2/README.html) at a given path.
 
 ## Example Configuration
 

--- a/website/layouts/backend-types.erb
+++ b/website/layouts/backend-types.erb
@@ -35,6 +35,9 @@
           <li<%= sidebar_current("docs-backends-types-standard-etcd") %>>
             <a href="/docs/backends/types/etcd.html">etcd</a>
           </li>
+          <li<%= sidebar_current("docs-backends-types-standard-etcdv3") %>>
+            <a href="/docs/backends/types/etcdv3.html">etcd</a>
+          </li>
           <li<%= sidebar_current("docs-backends-types-standard-gcs") %>>
             <a href="/docs/backends/types/gcs.html">gcs</a>
           </li>


### PR DESCRIPTION
Add missing link to ectdv3.

Update etcd v2 link to the current v2 README, which highlights the pending
deprecation.

fixes #17299