### PR TITLE
Fix go format using go1.10

### DIFF
--- a/command/format/plan_test.go
+++ b/command/format/plan_test.go
@@ -408,7 +408,7 @@ func TestPlanStats(t *testing.T) {
 				},
 			},
 			PlanStats{
-			// data resource refreshes are not counted in our stats
+				// data resource refreshes are not counted in our stats
 			},
 		},
 		"replace": {

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -348,8 +348,8 @@ func TestInterpolater_resourceVariableMissingDuringInput(t *testing.T) {
 			&ModuleState{
 				Path:      rootModulePath,
 				Resources: map[string]*ResourceState{
-				// No resources at all yet, because we're still dealing
-				// with input and so the resources haven't been created.
+					// No resources at all yet, because we're still dealing
+					// with input and so the resources haven't been created.
 				},
 			},
 		},


### PR DESCRIPTION
After upgrading to go version go1.10 linux/amd64 to build was broken due to formatting. This patch is just the result of running make fmt.