### PR TITLE
Fix reported GCS state lock ID

### DIFF
--- a/backend/local/backend_test.go
+++ b/backend/local/backend_test.go
@@ -23,7 +23,8 @@ func TestLocal_impl(t *testing.T) {
 func TestLocal_backend(t *testing.T) {
 	defer testTmpDir(t)()
 	b := &Local{}
-	backend.TestBackend(t, b, b)
+	backend.TestBackendStates(t, b)
+	backend.TestBackendStateLocks(t, b, b)
 }
 
 func checkState(t *testing.T, path, expected string) {

--- a/backend/remote-state/azure/backend_test.go
+++ b/backend/remote-state/azure/backend_test.go
@@ -64,7 +64,7 @@ func TestBackend(t *testing.T) {
 		"access_key":           res.accessKey,
 	}).(*Backend)
 
-	backend.TestBackend(t, b, nil)
+	backend.TestBackendStates(t, b)
 }
 
 func TestBackendLocked(t *testing.T) {
@@ -88,7 +88,8 @@ func TestBackendLocked(t *testing.T) {
 		"access_key":           res.accessKey,
 	}).(*Backend)
 
-	backend.TestBackend(t, b1, b2)
+	backend.TestBackendStateLocks(t, b1, b2)
+	backend.TestBackendStateForceUnlock(t, b1, b2)
 }
 
 type testResources struct {

--- a/backend/remote-state/consul/backend_test.go
+++ b/backend/remote-state/consul/backend_test.go
@@ -63,7 +63,8 @@ func TestBackend(t *testing.T) {
 	})
 
 	// Test
-	backend.TestBackend(t, b1, b2)
+	backend.TestBackendStates(t, b1)
+	backend.TestBackendStateLocks(t, b1, b2)
 }
 
 func TestBackend_lockDisabled(t *testing.T) {
@@ -83,7 +84,8 @@ func TestBackend_lockDisabled(t *testing.T) {
 	})
 
 	// Test
-	backend.TestBackend(t, b1, b2)
+	backend.TestBackendStates(t, b1)
+	backend.TestBackendStateLocks(t, b1, b2)
 }
 
 func TestBackend_gzip(t *testing.T) {
@@ -95,5 +97,5 @@ func TestBackend_gzip(t *testing.T) {
 	})
 
 	// Test
-	backend.TestBackend(t, b, nil)
+	backend.TestBackendStates(t, b)
 }

--- a/backend/remote-state/etcdv3/backend_test.go
+++ b/backend/remote-state/etcdv3/backend_test.go
@@ -66,7 +66,9 @@ func TestBackend(t *testing.T) {
 	})
 
 	// Test
-	backend.TestBackend(t, b1, b2)
+	backend.TestBackendStates(t, b1)
+	backend.TestBackendStateLocks(t, b1, b2)
+	backend.TestBackendStateForceUnlock(t, b1, b2)
 }
 
 func TestBackend_lockDisabled(t *testing.T) {
@@ -89,5 +91,5 @@ func TestBackend_lockDisabled(t *testing.T) {
 	})
 
 	// Test
-	backend.TestBackend(t, b1, b2)
+	backend.TestBackendStateLocks(t, b1, b2)
 }

--- a/backend/remote-state/gcs/backend_test.go
+++ b/backend/remote-state/gcs/backend_test.go
@@ -136,8 +136,11 @@ func TestBackend(t *testing.T) {
 
 	be1 := setupBackend(t, bucket, noPrefix, noEncryptionKey)
 
-	backend.TestBackend(t, be0, be1)
+	backend.TestBackendStates(t, be0)
+	backend.TestBackendStateLocks(t, be0, be1)
+	backend.TestBackendStateForceUnlock(t, be0, be1)
 }
+
 func TestBackendWithPrefix(t *testing.T) {
 	t.Parallel()
 
@@ -149,7 +152,8 @@ func TestBackendWithPrefix(t *testing.T) {
 
 	be1 := setupBackend(t, bucket, prefix+"/", noEncryptionKey)
 
-	backend.TestBackend(t, be0, be1)
+	backend.TestBackendStates(t, be0)
+	backend.TestBackendStateLocks(t, be0, be1)
 }
 func TestBackendWithEncryption(t *testing.T) {
 	t.Parallel()
@@ -161,7 +165,8 @@ func TestBackendWithEncryption(t *testing.T) {
 
 	be1 := setupBackend(t, bucket, noPrefix, encryptionKey)
 
-	backend.TestBackend(t, be0, be1)
+	backend.TestBackendStates(t, be0)
+	backend.TestBackendStateLocks(t, be0, be1)
 }
 
 // setupBackend returns a new GCS backend.

--- a/backend/remote-state/inmem/backend_test.go
+++ b/backend/remote-state/inmem/backend_test.go
@@ -40,7 +40,7 @@ func TestBackendConfig(t *testing.T) {
 func TestBackend(t *testing.T) {
 	defer Reset()
 	b := backend.TestBackendConfig(t, New(), nil).(*Backend)
-	backend.TestBackend(t, b, nil)
+	backend.TestBackendStates(t, b)
 }
 
 func TestBackendLocked(t *testing.T) {
@@ -48,7 +48,7 @@ func TestBackendLocked(t *testing.T) {
 	b1 := backend.TestBackendConfig(t, New(), nil).(*Backend)
 	b2 := backend.TestBackendConfig(t, New(), nil).(*Backend)
 
-	backend.TestBackend(t, b1, b2)
+	backend.TestBackendStateLocks(t, b1, b2)
 }
 
 // use the this backen to test the remote.State implementation

--- a/backend/remote-state/manta/backend_test.go
+++ b/backend/remote-state/manta/backend_test.go
@@ -38,7 +38,7 @@ func TestBackend(t *testing.T) {
 	createMantaFolder(t, b.storageClient, directory)
 	defer deleteMantaFolder(t, b.storageClient, directory)
 
-	backend.TestBackend(t, b, nil)
+	backend.TestBackendStates(t, b)
 }
 
 func TestBackendLocked(t *testing.T) {
@@ -60,7 +60,8 @@ func TestBackendLocked(t *testing.T) {
 	createMantaFolder(t, b1.storageClient, directory)
 	defer deleteMantaFolder(t, b1.storageClient, directory)
 
-	backend.TestBackend(t, b1, b2)
+	backend.TestBackendStateLocks(t, b1, b2)
+	backend.TestBackendStateForceUnlock(t, b1, b2)
 }
 
 func createMantaFolder(t *testing.T, mantaClient *storage.StorageClient, directoryName string) {

--- a/backend/remote-state/s3/backend_test.go
+++ b/backend/remote-state/s3/backend_test.go
@@ -103,7 +103,7 @@ func TestBackend(t *testing.T) {
 	createS3Bucket(t, b.s3Client, bucketName)
 	defer deleteS3Bucket(t, b.s3Client, bucketName)
 
-	backend.TestBackend(t, b, nil)
+	backend.TestBackendStates(t, b)
 }
 
 func TestBackendLocked(t *testing.T) {
@@ -131,7 +131,8 @@ func TestBackendLocked(t *testing.T) {
 	createDynamoDBTable(t, b1.dynClient, bucketName)
 	defer deleteDynamoDBTable(t, b1.dynClient, bucketName)
 
-	backend.TestBackend(t, b1, b2)
+	backend.TestBackendStateLocks(t, b1, b2)
+	backend.TestBackendStateForceUnlock(t, b1, b2)
 }
 
 // add some extra junk in S3 to try and confuse the env listing.
@@ -334,9 +335,9 @@ func TestKeyEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	backend.TestBackend(t, b0, nil)
-	backend.TestBackend(t, b1, nil)
-	backend.TestBackend(t, b2, nil)
+	backend.TestBackendStates(t, b0)
+	backend.TestBackendStates(t, b1)
+	backend.TestBackendStates(t, b2)
 }
 
 func testGetWorkspaceForKey(b *Backend, key string, expected string) error {

--- a/backend/remote-state/swift/backend_test.go
+++ b/backend/remote-state/swift/backend_test.go
@@ -67,7 +67,7 @@ func TestBackend(t *testing.T) {
 
 	defer deleteSwiftContainer(t, b.client, container)
 
-	backend.TestBackend(t, b, nil)
+	backend.TestBackendStates(t, b)
 }
 
 func TestBackendPath(t *testing.T) {


### PR DESCRIPTION
The GCS backend uses the object generation as the state ID, but since it's not known until the object is written, it can't be written into the object itself.

Make sure that when we retrieve the lock info, the dummy ID is replaced with the generation ID.

This includes a new backend test helper that unlocks the state by the reported ID, which is the failing test case for this GCS issue. The test helpers were also refactored slightly, and the existing backend test updated to call the new functions. 

fixes #17328