### PR TITLE
Strip flags from internal_plugin args (fixes TF_CLI_ARGS usage)

### DIFF
--- a/command/internal_plugin.go
+++ b/command/internal_plugin.go
@@ -33,7 +33,24 @@ func BuildPluginCommandString(pluginType, pluginName string) (string, error) {
 	return strings.Join(parts, TFSPACE), nil
 }
 
+// Internal plugins do not support any CLI args, but we do receive flags that
+// main.go:mergeEnvArgs has merged in from EnvCLI. Instead of making main.go
+// aware of this exception, we strip all flags from our args. Flags are easily
+// identified by the '-' prefix, ensured by the cli package used.
+func StripArgFlags(args []string) []string {
+	argsNoFlags := []string{}
+	for i := range args {
+		if !strings.HasPrefix(args[i], "-") {
+			argsNoFlags = append(argsNoFlags, args[i])
+		}
+	}
+	return argsNoFlags
+}
+
 func (c *InternalPluginCommand) Run(args []string) int {
+	// strip flags from args, only use subcommands.
+	args = StripArgFlags(args)
+
 	if len(args) != 2 {
 		log.Printf("Wrong number of args; expected: terraform internal-plugin pluginType pluginName")
 		return 1

--- a/command/internal_plugin_test.go
+++ b/command/internal_plugin_test.go
@@ -42,3 +42,12 @@ func TestInternalPlugin_BuildPluginCommandString(t *testing.T) {
 		t.Errorf("Expected command to end with %s; got:\n%s\n", expected, actual)
 	}
 }
+
+func TestInternalPlugin_StripArgFlags(t *testing.T) {
+	actual := StripArgFlags([]string{"provisioner", "remote-exec", "-var-file=my_vars.tfvars", "-flag"})
+	expected := []string{"provisioner", "remote-exec"}
+	// Must be same length and order.
+	if len(actual) != len(expected) || expected[0] != actual[0] || actual[1] != actual[1] {
+		t.Fatalf("Expected args to be exactly '%s', got '%s'", expected, actual)
+	}
+}


### PR DESCRIPTION
This fixes #14847, #17094 

Hi,

This PR fixes the internal plugins breaking over the amount of `args` received. Though it might be a bit naïve.

My first approach was to add an exception to `mergeEnvArgs`, to simply skip the merge if the command was `internal-plugin`. Something something, separation of concerns, so I decided to let the internal plugin command handle this. I think the cli package guarantees that all command options/flags are prefixed with a dash, making it easy and reliable to filter these.

I added a unit test for the newly added function. I couldn't find any test that actually called the `Run` function, but I might have overlooked something. 