### PR TITLE
[provisioner-habitat] Fix package channel honoring and documentation

### DIFF
--- a/website/docs/provisioners/habitat.html.markdown
+++ b/website/docs/provisioners/habitat.html.markdown
@@ -70,9 +70,9 @@ There are 2 configuration levels, `supervisor` and `service`.  Configuration pla
 
 ```hcl
 bind {
-  Alias = "backend"
-  Service = "nginx"
-  Group = "default"
+  alias = "backend"
+  service = "nginx"
+  group = "default"
 }
 ```
 * `topology (string)` - (Optional) Topology to start service in. Possible values `standalone` or `leader`.  (Defaults to `standalone`)


### PR DESCRIPTION
**This PR:**

* Fixes https://github.com/hashicorp/terraform/issues/17334 - On installation the channel and builder URL were not passed properly. This is no longer the case
* Updates the binding documentation as the example listed generates a slew of errors

Signed-off-by: Rob Campbell <rcampbell@chef.io>