### PR TITLE
Fix typo in Getting Started documentation

### DIFF
--- a/website/intro/getting-started/variables.html.md
+++ b/website/intro/getting-started/variables.html.md
@@ -93,7 +93,7 @@ specify a file. These files are the same syntax as Terraform
 configuration files. And like Terraform configuration files, these files
 can also be JSON.
 
-We don't recommend saving usernames and password to version control, But you
+We don't recommend saving usernames and password to version control, but you
 can create a local secret variables file and use `-var-file` to load it.
 
 You can use multiple `-var-file` arguments in a single command, with some


### PR DESCRIPTION
This PR fixes a typo in the `Input Variables`
section of the `Getting Started` documentation.