### PR TITLE
finish removing vet from the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TEST?=./...
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
-default: test vet
+default: test
 
 tools:
 	go get -u github.com/kardianos/govendor
@@ -30,7 +30,6 @@ plugin-dev: generate
 # we run this one package at a time here because running the entire suite in
 # one command creates memory usage issues when running in Travis-CI.
 test: fmtcheck generate
-	go test -i $(TEST) || exit 1
 	go list $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=60s -parallel=4
 
 # testacc runs acceptance tests


### PR DESCRIPTION
The test target will already cover vet, since it's run as part of the
test command now.

Also remove the `go test -i` since it's no longer needed with the new
build cache.