### PR TITLE
Add StateLocker interface to backend operations

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/hashicorp/terraform/command/clistate"
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
@@ -134,6 +135,10 @@ type Operation struct {
 	// If LockState is true, the Operation must Lock any
 	// state.Lockers for its duration, and Unlock when complete.
 	LockState bool
+
+	// StateLocker is used to lock the state while providing UI feedback to the
+	// user. This will be supplied by the Backend itself.
+	StateLocker clistate.Locker
 
 	// The duration to retry obtaining a State lock.
 	StateLockTimeout time.Duration

--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/command/clistate"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
@@ -260,11 +261,23 @@ func (b *Local) Operation(ctx context.Context, op *backend.Operation) (*backend.
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	runningOp.Cancel = cancel
 
+	if op.LockState {
+		op.StateLocker = clistate.NewLocker(stopCtx, op.StateLockTimeout, b.CLI, b.Colorize())
+	} else {
+		op.StateLocker = clistate.NewNoopLocker()
+	}
+
 	// Do it
 	go func() {
 		defer done()
 		defer stop()
 		defer cancel()
+
+		// the state was locked during context creation, unlock the state when
+		// the operation completes
+		defer func() {
+			runningOp.Err = op.StateLocker.Unlock(runningOp.Err)
+		}()
 
 		defer b.opLock.Unlock()
 		f(stopCtx, cancelCtx, op, runningOp)

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/backend"
-	"github.com/hashicorp/terraform/command/clistate"
 	"github.com/hashicorp/terraform/command/format"
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/state"
@@ -53,25 +52,6 @@ func (b *Local) opApply(
 	if err != nil {
 		runningOp.Err = err
 		return
-	}
-
-	if op.LockState {
-		lockCtx, cancel := context.WithTimeout(stopCtx, op.StateLockTimeout)
-		defer cancel()
-
-		lockInfo := state.NewLockInfo()
-		lockInfo.Operation = op.Type.String()
-		lockID, err := clistate.Lock(lockCtx, opState, lockInfo, b.CLI, b.Colorize())
-		if err != nil {
-			runningOp.Err = errwrap.Wrapf("Error locking state: {{err}}", err)
-			return
-		}
-
-		defer func() {
-			if err := clistate.Unlock(opState, lockID, b.CLI, b.Colorize()); err != nil {
-				runningOp.Err = multierror.Append(runningOp.Err, err)
-			}
-		}()
 	}
 
 	// Setup the state

--- a/backend/local/backend_refresh.go
+++ b/backend/local/backend_refresh.go
@@ -8,11 +8,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/backend"
-	"github.com/hashicorp/terraform/command/clistate"
 	"github.com/hashicorp/terraform/config/module"
-	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -51,25 +48,6 @@ func (b *Local) opRefresh(
 	if err != nil {
 		runningOp.Err = err
 		return
-	}
-
-	if op.LockState {
-		lockCtx, cancel := context.WithTimeout(stopCtx, op.StateLockTimeout)
-		defer cancel()
-
-		lockInfo := state.NewLockInfo()
-		lockInfo.Operation = op.Type.String()
-		lockID, err := clistate.Lock(lockCtx, opState, lockInfo, b.CLI, b.Colorize())
-		if err != nil {
-			runningOp.Err = errwrap.Wrapf("Error locking state: {{err}}", err)
-			return
-		}
-
-		defer func() {
-			if err := clistate.Unlock(opState, lockID, b.CLI, b.Colorize()); err != nil {
-				runningOp.Err = multierror.Append(runningOp.Err, err)
-			}
-		}()
 	}
 
 	// Set our state

--- a/command/clistate/state.go
+++ b/command/clistate/state.go
@@ -50,9 +50,15 @@ that no one else is holding a lock.
 `
 )
 
-// Locker allows for more convenient locking, by creating the timeout context
-// and LockInfo for the caller, while storing any related data required for
-// Unlock.
+// Locker allows for more convenient usage of the lower-level state.Locker
+// implementations.
+// The state.Locker API requires passing in a state.LockInfo struct. Locker
+// implementations are expected to create the required LockInfo struct when
+// Lock is called, populate the Operation field with the "reason" string
+// provided, and pass that on to the underlying state.Locker.
+// Locker implementations are also expected to store any state required to call
+// Unlock, which is at a minimum the LockID string returned by the
+// state.Locker.
 type Locker interface {
 	// Lock the provided state, storing the reason string in the LockInfo.
 	Lock(s state.State, reason string) error
@@ -73,9 +79,9 @@ type locker struct {
 }
 
 // Create a new Locker.
-// The provided context will be used for lock cancellation, and combined with
-// the timeout duration. Lock progress will be be reported to the user through
-// the provided UI.
+// This Locker uses state.LockWithContext to retry the lock until the provided
+// timeout is reached, or the context is canceled. Lock progress will be be
+// reported to the user through the provided UI.
 func NewLocker(
 	ctx context.Context,
 	timeout time.Duration,

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -586,15 +586,11 @@ func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, error) {
 		lockCtx, cancel := context.WithTimeout(context.Background(), m.stateLockTimeout)
 		defer cancel()
 
-		// Lock the state if we can
-		lockInfo := state.NewLockInfo()
-		lockInfo.Operation = "backend from plan"
-
-		lockID, err := clistate.Lock(lockCtx, realMgr, lockInfo, m.Ui, m.Colorize())
+		unlock, err := clistate.Lock(lockCtx, realMgr, "backend from plan", "", m.Ui, m.Colorize())
 		if err != nil {
 			return nil, fmt.Errorf("Error locking state: %s", err)
 		}
-		defer clistate.Unlock(realMgr, lockID, m.Ui, m.Colorize())
+		defer unlock(nil)
 	}
 
 	if err := realMgr.RefreshState(); err != nil {
@@ -967,15 +963,11 @@ func (m *Meta) backend_C_r_s(
 		lockCtx, cancel := context.WithTimeout(context.Background(), m.stateLockTimeout)
 		defer cancel()
 
-		// Lock the state if we can
-		lockInfo := state.NewLockInfo()
-		lockInfo.Operation = "backend from config"
-
-		lockID, err := clistate.Lock(lockCtx, sMgr, lockInfo, m.Ui, m.Colorize())
+		unlock, err := clistate.Lock(lockCtx, sMgr, "backend from config", "", m.Ui, m.Colorize())
 		if err != nil {
 			return nil, fmt.Errorf("Error locking state: %s", err)
 		}
-		defer clistate.Unlock(sMgr, lockID, m.Ui, m.Colorize())
+		defer unlock(nil)
 	}
 
 	// Store the metadata in our saved state location
@@ -1050,15 +1042,11 @@ func (m *Meta) backend_C_r_S_changed(
 		lockCtx, cancel := context.WithTimeout(context.Background(), m.stateLockTimeout)
 		defer cancel()
 
-		// Lock the state if we can
-		lockInfo := state.NewLockInfo()
-		lockInfo.Operation = "backend from config"
-
-		lockID, err := clistate.Lock(lockCtx, sMgr, lockInfo, m.Ui, m.Colorize())
+		unlock, err := clistate.Lock(lockCtx, sMgr, "backend from config", "", m.Ui, m.Colorize())
 		if err != nil {
 			return nil, fmt.Errorf("Error locking state: %s", err)
 		}
-		defer clistate.Unlock(sMgr, lockID, m.Ui, m.Colorize())
+		defer unlock(nil)
 	}
 
 	// Update the backend state
@@ -1193,15 +1181,11 @@ func (m *Meta) backend_C_R_S_unchanged(
 		lockCtx, cancel := context.WithTimeout(context.Background(), m.stateLockTimeout)
 		defer cancel()
 
-		// Lock the state if we can
-		lockInfo := state.NewLockInfo()
-		lockInfo.Operation = "backend from config"
-
-		lockID, err := clistate.Lock(lockCtx, sMgr, lockInfo, m.Ui, m.Colorize())
+		unlock, err := clistate.Lock(lockCtx, sMgr, "backend from config", "", m.Ui, m.Colorize())
 		if err != nil {
 			return nil, fmt.Errorf("Error locking state: %s", err)
 		}
-		defer clistate.Unlock(sMgr, lockID, m.Ui, m.Colorize())
+		defer unlock(nil)
 	}
 
 	// Unset the remote state

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -583,14 +583,11 @@ func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, error) {
 	}
 
 	if m.stateLock {
-		lockCtx, cancel := context.WithTimeout(context.Background(), m.stateLockTimeout)
-		defer cancel()
-
-		unlock, err := clistate.Lock(lockCtx, realMgr, "backend from plan", "", m.Ui, m.Colorize())
-		if err != nil {
+		stateLocker := clistate.NewLocker(context.Background(), m.stateLockTimeout, m.Ui, m.Colorize())
+		if err := stateLocker.Lock(realMgr, "backend from plan"); err != nil {
 			return nil, fmt.Errorf("Error locking state: %s", err)
 		}
-		defer unlock(nil)
+		defer stateLocker.Unlock(nil)
 	}
 
 	if err := realMgr.RefreshState(); err != nil {
@@ -960,14 +957,11 @@ func (m *Meta) backend_C_r_s(
 	}
 
 	if m.stateLock {
-		lockCtx, cancel := context.WithTimeout(context.Background(), m.stateLockTimeout)
-		defer cancel()
-
-		unlock, err := clistate.Lock(lockCtx, sMgr, "backend from config", "", m.Ui, m.Colorize())
-		if err != nil {
+		stateLocker := clistate.NewLocker(context.Background(), m.stateLockTimeout, m.Ui, m.Colorize())
+		if err := stateLocker.Lock(sMgr, "backend from plan"); err != nil {
 			return nil, fmt.Errorf("Error locking state: %s", err)
 		}
-		defer unlock(nil)
+		defer stateLocker.Unlock(nil)
 	}
 
 	// Store the metadata in our saved state location
@@ -1039,14 +1033,11 @@ func (m *Meta) backend_C_r_S_changed(
 	}
 
 	if m.stateLock {
-		lockCtx, cancel := context.WithTimeout(context.Background(), m.stateLockTimeout)
-		defer cancel()
-
-		unlock, err := clistate.Lock(lockCtx, sMgr, "backend from config", "", m.Ui, m.Colorize())
-		if err != nil {
+		stateLocker := clistate.NewLocker(context.Background(), m.stateLockTimeout, m.Ui, m.Colorize())
+		if err := stateLocker.Lock(sMgr, "backend from plan"); err != nil {
 			return nil, fmt.Errorf("Error locking state: %s", err)
 		}
-		defer unlock(nil)
+		defer stateLocker.Unlock(nil)
 	}
 
 	// Update the backend state
@@ -1178,14 +1169,11 @@ func (m *Meta) backend_C_R_S_unchanged(
 	}
 
 	if m.stateLock {
-		lockCtx, cancel := context.WithTimeout(context.Background(), m.stateLockTimeout)
-		defer cancel()
-
-		unlock, err := clistate.Lock(lockCtx, sMgr, "backend from config", "", m.Ui, m.Colorize())
-		if err != nil {
+		stateLocker := clistate.NewLocker(context.Background(), m.stateLockTimeout, m.Ui, m.Colorize())
+		if err := stateLocker.Lock(sMgr, "backend from plan"); err != nil {
 			return nil, fmt.Errorf("Error locking state: %s", err)
 		}
-		defer unlock(nil)
+		defer stateLocker.Unlock(nil)
 	}
 
 	// Unset the remote state

--- a/command/meta_backend_migrate.go
+++ b/command/meta_backend_migrate.go
@@ -236,25 +236,17 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 		lockCtx, cancel := context.WithTimeout(context.Background(), m.stateLockTimeout)
 		defer cancel()
 
-		lockInfoOne := state.NewLockInfo()
-		lockInfoOne.Operation = "migration"
-		lockInfoOne.Info = "source state"
-
-		lockIDOne, err := clistate.Lock(lockCtx, stateOne, lockInfoOne, m.Ui, m.Colorize())
+		unlockOne, err := clistate.Lock(lockCtx, stateOne, "migration", "source state", m.Ui, m.Colorize())
 		if err != nil {
 			return fmt.Errorf("Error locking source state: %s", err)
 		}
-		defer clistate.Unlock(stateOne, lockIDOne, m.Ui, m.Colorize())
+		defer unlockOne(nil)
 
-		lockInfoTwo := state.NewLockInfo()
-		lockInfoTwo.Operation = "migration"
-		lockInfoTwo.Info = "destination state"
-
-		lockIDTwo, err := clistate.Lock(lockCtx, stateTwo, lockInfoTwo, m.Ui, m.Colorize())
+		unlockTwo, err := clistate.Lock(lockCtx, stateTwo, "migration", "destination state", m.Ui, m.Colorize())
 		if err != nil {
 			return fmt.Errorf("Error locking destination state: %s", err)
 		}
-		defer clistate.Unlock(stateTwo, lockIDTwo, m.Ui, m.Colorize())
+		defer unlockTwo(nil)
 
 		// We now own a lock, so double check that we have the version
 		// corresponding to the lock.

--- a/command/taint.go
+++ b/command/taint.go
@@ -83,16 +83,12 @@ func (c *TaintCommand) Run(args []string) int {
 	}
 
 	if c.stateLock {
-		lockCtx, cancel := context.WithTimeout(context.Background(), c.stateLockTimeout)
-		defer cancel()
-
-		unlock, err := clistate.Lock(lockCtx, st, "taint", "", c.Ui, c.Colorize())
-		if err != nil {
+		stateLocker := clistate.NewLocker(context.Background(), c.stateLockTimeout, c.Ui, c.Colorize())
+		if err := stateLocker.Lock(st, "taint"); err != nil {
 			c.Ui.Error(fmt.Sprintf("Error locking state: %s", err))
 			return 1
 		}
-
-		defer unlock(nil)
+		defer stateLocker.Unlock(nil)
 	}
 
 	// Get the actual state structure

--- a/command/taint.go
+++ b/command/taint.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/command/clistate"
-	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -87,15 +86,13 @@ func (c *TaintCommand) Run(args []string) int {
 		lockCtx, cancel := context.WithTimeout(context.Background(), c.stateLockTimeout)
 		defer cancel()
 
-		lockInfo := state.NewLockInfo()
-		lockInfo.Operation = "taint"
-		lockID, err := clistate.Lock(lockCtx, st, lockInfo, c.Ui, c.Colorize())
+		unlock, err := clistate.Lock(lockCtx, st, "taint", "", c.Ui, c.Colorize())
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error locking state: %s", err))
 			return 1
 		}
 
-		defer clistate.Unlock(st, lockID, c.Ui, c.Colorize())
+		defer unlock(nil)
 	}
 
 	// Get the actual state structure

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/command/clistate"
-	"github.com/hashicorp/terraform/state"
 )
 
 // UntaintCommand is a cli.Command implementation that manually untaints
@@ -75,15 +74,12 @@ func (c *UntaintCommand) Run(args []string) int {
 		lockCtx, cancel := context.WithTimeout(context.Background(), c.stateLockTimeout)
 		defer cancel()
 
-		lockInfo := state.NewLockInfo()
-		lockInfo.Operation = "untaint"
-		lockID, err := clistate.Lock(lockCtx, st, lockInfo, c.Ui, c.Colorize())
+		unlock, err := clistate.Lock(lockCtx, st, "untaint", "", c.Ui, c.Colorize())
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error locking state: %s", err))
 			return 1
 		}
-
-		defer clistate.Unlock(st, lockID, c.Ui, c.Colorize())
+		defer unlock(nil)
 	}
 
 	// Get the actual state structure

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -71,15 +71,12 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	if c.stateLock {
-		lockCtx, cancel := context.WithTimeout(context.Background(), c.stateLockTimeout)
-		defer cancel()
-
-		unlock, err := clistate.Lock(lockCtx, st, "untaint", "", c.Ui, c.Colorize())
-		if err != nil {
+		stateLocker := clistate.NewLocker(context.Background(), c.stateLockTimeout, c.Ui, c.Colorize())
+		if err := stateLocker.Lock(st, "untaint"); err != nil {
 			c.Ui.Error(fmt.Sprintf("Error locking state: %s", err))
 			return 1
 		}
-		defer unlock(nil)
+		defer stateLocker.Unlock(nil)
 	}
 
 	// Get the actual state structure

--- a/command/workspace_delete.go
+++ b/command/workspace_delete.go
@@ -96,6 +96,17 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
+	var stateLocker clistate.Locker
+	if c.stateLock {
+		stateLocker = clistate.NewLocker(context.Background(), c.stateLockTimeout, c.Ui, c.Colorize())
+		if err := stateLocker.Lock(sMgr, "workspace_delete"); err != nil {
+			c.Ui.Error(fmt.Sprintf("Error locking state: %s", err))
+			return 1
+		}
+	} else {
+		stateLocker = clistate.NewNoopLocker()
+	}
+
 	if err := sMgr.RefreshState(); err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -108,28 +119,16 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Honor the lock request, for consistency and one final safety check.
-	if c.stateLock {
-		lockCtx, cancel := context.WithTimeout(context.Background(), c.stateLockTimeout)
-		defer cancel()
-
-		unlock, err := clistate.Lock(lockCtx, sMgr, "workspace delete", "", c.Ui, c.Colorize())
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error locking state: %s", err))
-			return 1
-		}
-
-		// We need to release the lock just before deleting the state, in case
-		// the backend can't remove the resource while holding the lock. This
-		// is currently true for Windows local files.
-		//
-		// TODO: While there is little safety in locking while deleting the
-		// state, it might be nice to be able to coordinate processes around
-		// state deletion, i.e. in a CI environment. Adding Delete() as a
-		// required method of States would allow the removal of the resource to
-		// be delegated from the Backend to the State itself.
-		unlock(nil)
-	}
+	// We need to release the lock just before deleting the state, in case
+	// the backend can't remove the resource while holding the lock. This
+	// is currently true for Windows local files.
+	//
+	// TODO: While there is little safety in locking while deleting the
+	// state, it might be nice to be able to coordinate processes around
+	// state deletion, i.e. in a CI environment. Adding Delete() as a
+	// required method of States would allow the removal of the resource to
+	// be delegated from the Backend to the State itself.
+	stateLocker.Unlock(nil)
 
 	err = b.DeleteState(delEnv)
 	if err != nil {

--- a/command/workspace_new.go
+++ b/command/workspace_new.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/command/clistate"
-	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
@@ -118,15 +117,12 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		lockCtx, cancel := context.WithTimeout(context.Background(), c.stateLockTimeout)
 		defer cancel()
 
-		// Lock the state if we can
-		lockInfo := state.NewLockInfo()
-		lockInfo.Operation = "workspace new"
-		lockID, err := clistate.Lock(lockCtx, sMgr, lockInfo, c.Ui, c.Colorize())
+		unlock, err := clistate.Lock(lockCtx, sMgr, "workspace_new", "", c.Ui, c.Colorize())
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error locking state: %s", err))
 			return 1
 		}
-		defer clistate.Unlock(sMgr, lockID, c.Ui, c.Colorize())
+		defer unlock(nil)
 	}
 
 	// read the existing state file

--- a/command/workspace_new.go
+++ b/command/workspace_new.go
@@ -114,15 +114,12 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	}
 
 	if c.stateLock {
-		lockCtx, cancel := context.WithTimeout(context.Background(), c.stateLockTimeout)
-		defer cancel()
-
-		unlock, err := clistate.Lock(lockCtx, sMgr, "workspace_new", "", c.Ui, c.Colorize())
-		if err != nil {
+		stateLocker := clistate.NewLocker(context.Background(), c.stateLockTimeout, c.Ui, c.Colorize())
+		if err := stateLocker.Lock(sMgr, "workspace_delete"); err != nil {
 			c.Ui.Error(fmt.Sprintf("Error locking state: %s", err))
 			return 1
 		}
-		defer unlock(nil)
+		defer stateLocker.Unlock(nil)
 	}
 
 	// read the existing state file


### PR DESCRIPTION
The additional UI code to report the status of obtaining a lock to the user broke the state locking order by having the state refreshed without a lock when creating the initial context. While the lock was still honored for the duration of the actual operations being applied, the command could be starting with a stale version of the state. Most of the time this is not a major issue, since the refresh phase would update the state again, but strict CAS operations used by the Consul backend (and other operations strictly comparing the state.Serial) would fail writing the new state. 

Fixes #17407

We start by simplifying the use of `clistate.Lock` by creating a `clistate.Locker` interface, which stores the context of locking a state, to allow unlock to be called without knowledge of how the state was locked. This allows the backend code to bring the needed UI methods to the point where the state is locked, and still unlock the state from an outer scope.

That new Locker is then added to the `backend.Operation`, so the lowest level function scopes of the backend code can lock the state before it's read, while still allowing the different operations to unlock the state when they complete.
