### PR TITLE
Use io.SeekStart instead of deprecated os.SEEK_SET

### DIFF
--- a/state/local.go
+++ b/state/local.go
@@ -83,7 +83,7 @@ func (s *LocalState) WriteState(state *terraform.State) error {
 		s.state.Serial = s.readState.Serial
 	}
 
-	if _, err := s.stateFileOut.Seek(0, os.SEEK_SET); err != nil {
+	if _, err := s.stateFileOut.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
 	if err := s.stateFileOut.Truncate(0); err != nil {
@@ -144,7 +144,7 @@ func (s *LocalState) RefreshState() error {
 		}
 
 		// we have a state file, make sure we're at the start
-		s.stateFileOut.Seek(0, os.SEEK_SET)
+		s.stateFileOut.Seek(0, io.SeekStart)
 		reader = s.stateFileOut
 	}
 

--- a/state/local_lock_unix.go
+++ b/state/local_lock_unix.go
@@ -3,7 +3,7 @@
 package state
 
 import (
-	"os"
+	"io"
 	"syscall"
 )
 
@@ -12,7 +12,7 @@ import (
 func (s *LocalState) lock() error {
 	flock := &syscall.Flock_t{
 		Type:   syscall.F_RDLCK | syscall.F_WRLCK,
-		Whence: int16(os.SEEK_SET),
+		Whence: int16(io.SeekStart),
 		Start:  0,
 		Len:    0,
 	}
@@ -24,7 +24,7 @@ func (s *LocalState) lock() error {
 func (s *LocalState) unlock() error {
 	flock := &syscall.Flock_t{
 		Type:   syscall.F_UNLCK,
-		Whence: int16(os.SEEK_SET),
+		Whence: int16(io.SeekStart),
 		Start:  0,
 		Len:    0,
 	}


### PR DESCRIPTION
This patch replaces the deprecated os.SEEK_SET with the instead recommended io.SeekStart.

https://github.com/golang/go/blob/39852bf4cce6927e01d0136c7843f65a801738cb/src/os/file.go#L81