### PR TITLE
[WIP] Add a diff option to a plan command

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -110,6 +110,7 @@ type Operation struct {
 	PlanId         string
 	PlanRefresh    bool   // PlanRefresh will do a refresh before a plan
 	PlanOutPath    string // PlanOutPath is the path to save the plan
+	PlanDiffPath   string // PlanDiffPath is the path to save the plan diff
 	PlanOutBackend *terraform.BackendState
 
 	// Module settings specify the root module to use for operations.

--- a/command/plan.go
+++ b/command/plan.go
@@ -19,6 +19,7 @@ type PlanCommand struct {
 func (c *PlanCommand) Run(args []string) int {
 	var destroy, refresh, detailed bool
 	var outPath string
+	var diffPath string
 	var moduleDepth int
 
 	args, err := c.Meta.process(args, true)
@@ -31,6 +32,7 @@ func (c *PlanCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&refresh, "refresh", true, "refresh")
 	c.addModuleDepthFlag(cmdFlags, &moduleDepth)
 	cmdFlags.StringVar(&outPath, "out", "", "path")
+	cmdFlags.StringVar(&diffPath, "diff", "", "path")
 	cmdFlags.IntVar(
 		&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
@@ -103,6 +105,7 @@ func (c *PlanCommand) Run(args []string) int {
 	opReq.Plan = plan
 	opReq.PlanRefresh = refresh
 	opReq.PlanOutPath = outPath
+	opReq.PlanDiffPath = diffPath
 	opReq.Type = backend.OperationTypePlan
 
 	// Perform the operation
@@ -147,6 +150,8 @@ Options:
                       0 - Succeeded, diff is empty (no changes)
                       1 - Errored
                       2 - Succeeded, there is a diff
+
+  -diff=path          Write a plan diff file to the given path.
 
   -input=true         Ask for input for variables if not directly set.
 

--- a/website/docs/commands/plan.html.markdown
+++ b/website/docs/commands/plan.html.markdown
@@ -46,6 +46,8 @@ The command-line flags are all optional. The list of available flags are:
   * 1 = Error
   * 2 = Succeeded with non-empty diff (changes present)
 
+* `-diff=path` - The path to save the generated plan diff file.
+
 * `-input=true` - Ask for input for variables if not directly set.
 
 * `-lock=true` - Lock the state file when locking is supported.


### PR DESCRIPTION
Hi, Could I append diff option to `plan` command?
I want to use this file to analyze the diff.

generated example is below:

```
{
  "Modules": [
    {
      "Path": [
        "root"
      ],
      "Resources": {
        "aws_security_group.sample": {
          "Attributes": {
            "revoke_rules_on_delete": {
              "Old": "",
              "New": "true",
              "NewComputed": false,
              "NewRemoved": false,
              "NewExtra": null,
              "RequiresNew": false,
              "Sensitive": false,
              "Type": 0
            },
            "tags.%": {
              "Old": "0",
              "New": "1",
              "NewComputed": false,
              "NewRemoved": false,
              "NewExtra": null,
              "RequiresNew": false,
              "Sensitive": false,
              "Type": 0
            },
            "tags.Name": {
              "Old": "",
              "New": "sample",
              "NewComputed": false,
              "NewRemoved": false,
              "NewExtra": null,
              "RequiresNew": false,
              "Sensitive": false,
              "Type": 0
            }
          },
          "Destroy": false,
          "DestroyDeposed": false,
          "DestroyTainted": false,
          "Meta": null
        }
      },
      "Destroy": false
    }
  ]
}
```

test result

```
$ go test -v -run='TestLocal_plan*' -timeout=60s -parallel=4 github.com/hashicorp/terraform/backend/local
=== RUN   TestLocal_planBasic
--- PASS: TestLocal_planBasic (0.00s)
=== RUN   TestLocal_planInAutomation
--- PASS: TestLocal_planInAutomation (0.00s)
=== RUN   TestLocal_planNoConfig
--- PASS: TestLocal_planNoConfig (0.00s)
=== RUN   TestLocal_planRefreshFalse
--- PASS: TestLocal_planRefreshFalse (0.00s)
=== RUN   TestLocal_planDestroy
--- PASS: TestLocal_planDestroy (0.00s)
=== RUN   TestLocal_planOutPathNoChange
--- PASS: TestLocal_planOutPathNoChange (0.00s)
=== RUN   TestLocal_planDiff
--- PASS: TestLocal_planDiff (0.00s)
=== RUN   TestLocal_planScaleOutNoDupeCount
--- PASS: TestLocal_planScaleOutNoDupeCount (0.01s)
PASS
ok    github.com/hashicorp/terraform/backend/local  0.047s
```
