### PR TITLE
helper/acctest: Fix RandIntRange function

### DIFF
--- a/helper/acctest/random.go
+++ b/helper/acctest/random.go
@@ -37,7 +37,7 @@ func RandIntRange(min int, max int) int {
 	source := rand.New(rand.NewSource(time.Now().UnixNano()))
 	rangeMax := max - min
 
-	return int(source.Int31n(int32(rangeMax)))
+	return int(source.Int31n(int32(rangeMax))) + min
 }
 
 // RandString generates a random alphanumeric string of the length specified


### PR DESCRIPTION
RandIntRange should return integers within the range of min...max, not within the range of 0...(max - min).

I ran into this while working on https://github.com/terraform-providers/terraform-provider-aws/pull/2861. As far as I can tell all other uses within at least the AWS provider are not affected by this bug because any random integer is acceptable in those resources, however for the linked PR, it must be within a specific range.