### PR TITLE
Fix default values in salt masterless provisioner

### DIFF
--- a/builtin/provisioners/salt-masterless/resource_provisioner.go
+++ b/builtin/provisioners/salt-masterless/resource_provisioner.go
@@ -92,9 +92,10 @@ func Provisioner() terraform.ResourceProvisioner {
 				Default:  "state.highstate",
 			},
 			"minion_config_file": &schema.Schema{
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateSaltFile,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ValidateFunc:  validateSaltFile,
+				ConflictsWith: []string{"remote_state_tree", "remote_pillar_roots"},
 			},
 			"cmd_args": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/provisioners/salt-masterless/resource_provisioner.go
+++ b/builtin/provisioners/salt-masterless/resource_provisioner.go
@@ -400,10 +400,11 @@ func decodeConfig(d *schema.ResourceData) (*provisioner, error) {
 	// build the command line args to pass onto salt
 	var cmdArgs bytes.Buffer
 
-	if p.CustomState != "" {
+	if p.CustomState != "state.highstate" {
 		cmdArgs.WriteString(" state.sls ")
-		cmdArgs.WriteString(p.CustomState)
 	}
+
+	cmdArgs.WriteString(p.CustomState)
 
 	if p.MinionConfig == "" {
 		// pass --file-root and --pillar-root if no minion_config_file is supplied

--- a/builtin/provisioners/salt-masterless/resource_provisioner_test.go
+++ b/builtin/provisioners/salt-masterless/resource_provisioner_test.go
@@ -76,6 +76,32 @@ func TestResourceProvider_Validate_LocalStateTree_doesnt_exist(t *testing.T) {
 	}
 }
 
+func TestResourceProvider_Validate_LocalStateTree_empty_value(t *testing.T) {
+	c := testConfig(t, map[string]interface{}{
+		"local_state_tree": "",
+	})
+	warn, errs := Provisioner().Validate(c)
+	if len(warn) > 0 {
+		t.Fatalf("Warnings: %v", warn)
+	}
+	if len(errs) == 0 {
+		t.Fatalf("Should have errors")
+	}
+}
+
+func TestResourceProvider_Validate_LocalPillarRoot_empty_value(t *testing.T) {
+	c := testConfig(t, map[string]interface{}{
+		"local_pillar_roots": "",
+	})
+	warn, errs := Provisioner().Validate(c)
+	if len(warn) > 0 {
+		t.Fatalf("Warnings: %v", warn)
+	}
+	if len(errs) == 0 {
+		t.Fatalf("Should have errors")
+	}
+}
+
 func TestResourceProvisioner_Validate_invalid(t *testing.T) {
 	dir, err := ioutil.TempDir("", "_terraform_saltmasterless_test")
 	if err != nil {


### PR DESCRIPTION
## Overview

I'm still working with saltstack provider and I found a problem with default values.
Provider does not set remote_state_tree and remote_pillar_roots correctly and does not copy salt state into the correct directory.

Moving /tmp/salt/pillar to **no directory here**

In this pull request, i'm tryn' to use build-in mechanism into schema definition.

### Expected Behavior
```
aws_instance.saltstack (salt-masterless): Removing directory: /srv/salt
aws_instance.saltstack (salt-masterless): Moving /tmp/salt/states to /srv/salt
aws_instance.saltstack (salt-masterless): Uploading local pillar roots: ../salt/pillar/
aws_instance.saltstack (salt-masterless): Creating directory: /tmp/salt/pillar
aws_instance.saltstack (salt-masterless): Removing directory: /srv/pillar
aws_instance.saltstack (salt-masterless): Moving /tmp/salt/pillar to /srv/pillar
```
### Actual Behavior
```
aws_instance.saltstack (salt-masterless): Moving /tmp/salt/states to
aws_instance.saltstack (salt-masterless): Uploading local pillar roots: ../salt/pillar
aws_instance.saltstack (salt-masterless): Creating directory: /tmp/salt/pillar
aws_instance.saltstack (salt-masterless): Removing directory:
aws_instance.saltstack (salt-masterless): Moving /tmp/salt/pillar to
```

## Test result
```bash
go test -timeout=60s -parallel=4 github.com/hashicorp/terraform/builtin/provisioners/salt-masterless
ok  	github.com/hashicorp/terraform/builtin/provisioners/salt-masterless	0.024s
```