### PR TITLE
Colorize output from the `terraform output` command

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -103,10 +103,10 @@ func (c *OutputCommand) Run(args []string) int {
 				return 1
 			}
 
-			c.Ui.Output(string(jsonOutputs))
+			c.Ui.Output(c.Colorize().Color(string(jsonOutputs)))
 			return 0
 		} else {
-			c.Ui.Output(outputsAsString(state, modPath, nil, false))
+			c.Ui.Output(c.Colorize().Color(outputsAsString(state, modPath, nil, false)))
 			return 0
 		}
 	}
@@ -127,17 +127,17 @@ func (c *OutputCommand) Run(args []string) int {
 			return 1
 		}
 
-		c.Ui.Output(string(jsonOutputs))
+		c.Ui.Output(c.Colorize().Color(string(jsonOutputs)))
 	} else {
 		switch output := v.Value.(type) {
 		case string:
-			c.Ui.Output(output)
+			c.Ui.Output(c.Colorize().Color(output))
 			return 0
 		case []interface{}:
-			c.Ui.Output(formatListOutput("", "", output))
+			c.Ui.Output(c.Colorize().Color(formatListOutput("", "", output)))
 			return 0
 		case map[string]interface{}:
-			c.Ui.Output(formatMapOutput("", "", output))
+			c.Ui.Output(c.Colorize().Color(formatMapOutput("", "", output)))
 			return 0
 		default:
 			c.Ui.Error(fmt.Sprintf("Unknown output type: %T", v.Type))


### PR DESCRIPTION
 ## Terraform version

```
Terraform v0.11.2
```

## What I did 

- Changed output.go to have colorized outputs when called from command line `terraform output`
- Resolves issue #17453 