### PR TITLE
Add `intsum` interpolation function 

### DIFF
--- a/command/format/plan_test.go
+++ b/command/format/plan_test.go
@@ -408,7 +408,7 @@ func TestPlanStats(t *testing.T) {
 				},
 			},
 			PlanStats{
-				// data resource refreshes are not counted in our stats
+			// data resource refreshes are not counted in our stats
 			},
 		},
 		"replace": {

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -115,6 +115,7 @@ func Funcs() map[string]ast.Function {
 		"sort":         interpolationFuncSort(),
 		"split":        interpolationFuncSplit(),
 		"substr":       interpolationFuncSubstr(),
+		"sum":          interpolationFuncSum(),
 		"timestamp":    interpolationFuncTimestamp(),
 		"timeadd":      interpolationFuncTimeAdd(),
 		"title":        interpolationFuncTitle(),
@@ -1722,6 +1723,36 @@ func interpolationFuncRsaDecrypt() ast.Function {
 			}
 
 			return string(out), nil
+		},
+	}
+}
+
+/**
+ * Computes the sum of a list of floats or ints.
+ */
+func interpolationFuncSum() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeList},
+		ReturnType: ast.TypeInt,
+		Variadic:   false,
+		Callback: func(args []interface{}) (interface{}, error) {
+			subject := args[0]
+
+			switch typedSubject := subject.(type) {
+			case []ast.Variable:
+				theSum := 0
+				for _, item := range typedSubject {
+					switch item.Type {
+					case ast.TypeInt:
+						theSum += item.Value.(int)
+					default:
+						return 0, fmt.Errorf("list argument to sum() must consist only of integer elements")
+					}
+				}
+				return theSum, nil
+			}
+
+			return 0, fmt.Errorf("arguments to sum() must be a list")
 		},
 	}
 }

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -1748,7 +1748,7 @@ func interpolationFuncIntSum() ast.Function {
 					case ast.TypeFloat:
 						theSum += int(item.Value.(float64))
 					case ast.TypeString:
-						val, err := strconv.ParseInt(item.Value.(string), 10, 8)
+						val, err := strconv.ParseInt(item.Value.(string), 0, 0)
 						if err != nil {
 							return 0, fmt.Errorf("list item to sum() not parsed as integer: %v", item.Value)
 						}

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -91,6 +91,7 @@ func Funcs() map[string]ast.Function {
 		"formatlist":   interpolationFuncFormatList(),
 		"indent":       interpolationFuncIndent(),
 		"index":        interpolationFuncIndex(),
+		"intsum":       interpolationFuncIntSum(),
 		"join":         interpolationFuncJoin(),
 		"jsonencode":   interpolationFuncJSONEncode(),
 		"length":       interpolationFuncLength(),
@@ -115,7 +116,6 @@ func Funcs() map[string]ast.Function {
 		"sort":         interpolationFuncSort(),
 		"split":        interpolationFuncSplit(),
 		"substr":       interpolationFuncSubstr(),
-		"sum":          interpolationFuncSum(),
 		"timestamp":    interpolationFuncTimestamp(),
 		"timeadd":      interpolationFuncTimeAdd(),
 		"title":        interpolationFuncTitle(),
@@ -1728,9 +1728,9 @@ func interpolationFuncRsaDecrypt() ast.Function {
 }
 
 /**
- * Computes the sum of a list of floats or ints.
+ * Computes the sum of a list of floats or ints as an integer sum
  */
-func interpolationFuncSum() ast.Function {
+func interpolationFuncIntSum() ast.Function {
 	return ast.Function{
 		ArgTypes:   []ast.Type{ast.TypeList},
 		ReturnType: ast.TypeInt,
@@ -1745,8 +1745,16 @@ func interpolationFuncSum() ast.Function {
 					switch item.Type {
 					case ast.TypeInt:
 						theSum += item.Value.(int)
+					case ast.TypeFloat:
+						theSum += int(item.Value.(float64))
+					case ast.TypeString:
+						val, err := strconv.ParseInt(item.Value.(string), 10, 8)
+						if err != nil {
+							return 0, fmt.Errorf("list item to sum() not parsed as integer: %v", item.Value)
+						}
+						theSum += int(val)
 					default:
-						return 0, fmt.Errorf("list argument to sum() must consist only of integer elements")
+						return 0, fmt.Errorf("list item to sum() must consist only of integer, float or parseable string elements, Found: %d, %v", item.Type, item.Value)
 					}
 				}
 				return theSum, nil

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -307,6 +307,18 @@ func TestInterpolateFuncIntSum(t *testing.T) {
 				"3",
 				false,
 			},
+
+			{
+				`${intsum( var.mixedlist )}`,
+				"3",
+				false,
+			},
+
+			{
+				`${intsum( var.floatstringlist )}`,
+				"3",
+				false,
+			},
 		},
 		Vars: map[string]ast.Variable{
 			"var.list": {
@@ -319,6 +331,32 @@ func TestInterpolateFuncIntSum(t *testing.T) {
 					{
 						Type:  ast.TypeInt,
 						Value: 2,
+					},
+				},
+			},
+			"var.mixedlist": {
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					{
+						Type:  ast.TypeString,
+						Value: "1",
+					},
+					{
+						Type:  ast.TypeInt,
+						Value: 2,
+					},
+				},
+			},
+			"var.floatstringlist": {
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					{
+						Type:  ast.TypeFloat,
+						Value: 1.0,
+					},
+					{
+						Type:  ast.TypeString,
+						Value: "2",
 					},
 				},
 			},

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -269,6 +269,63 @@ func TestInterpolateFuncMax(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncSum(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${sum()}`,
+				nil,
+				true,
+			},
+
+			{
+				`${sum("")}`,
+				nil,
+				true,
+			},
+
+			{
+				`${sum( list( -1.0 ) )}`,
+				nil,
+				true,
+			},
+
+			{
+				`${sum( list( 1.0 ) )}`,
+				nil,
+				true,
+			},
+
+			{
+				`${sum( list( 0, 1, 2, 1.0 ) )}`,
+				nil,
+				true,
+			},
+
+			{
+				`${sum( var.list )}`,
+				"3",
+				false,
+			},
+		},
+		Vars: map[string]ast.Variable{
+			"var.list": {
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					{
+						Type:  ast.TypeInt,
+						Value: 1,
+					},
+					{
+						Type:  ast.TypeInt,
+						Value: 2,
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncMin(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -269,41 +269,41 @@ func TestInterpolateFuncMax(t *testing.T) {
 	})
 }
 
-func TestInterpolateFuncSum(t *testing.T) {
+func TestInterpolateFuncIntSum(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{
 			{
-				`${sum()}`,
+				`${intsum()}`,
 				nil,
 				true,
 			},
 
 			{
-				`${sum("")}`,
+				`${intsum("")}`,
 				nil,
 				true,
 			},
 
 			{
-				`${sum( list( -1.0 ) )}`,
+				`${intsum( list( -1.0 ) )}`,
 				nil,
 				true,
 			},
 
 			{
-				`${sum( list( 1.0 ) )}`,
+				`${intsum( list( 1.0 ) )}`,
 				nil,
 				true,
 			},
 
 			{
-				`${sum( list( 0, 1, 2, 1.0 ) )}`,
+				`${intsum( list( 0, 1, 2, 1.0 ) )}`,
 				nil,
 				true,
 			},
 
 			{
-				`${sum( var.list )}`,
+				`${intsum( var.list )}`,
 				"3",
 				false,
 			},

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -348,8 +348,8 @@ func TestInterpolater_resourceVariableMissingDuringInput(t *testing.T) {
 			&ModuleState{
 				Path:      rootModulePath,
 				Resources: map[string]*ResourceState{
-					// No resources at all yet, because we're still dealing
-					// with input and so the resources haven't been created.
+				// No resources at all yet, because we're still dealing
+				// with input and so the resources haven't been created.
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds an `intsum` function to compute a sum of list elements which are integers or convertible to integers.

Floats are truncated to ints in the standard Go fashion and strings which are convertible by `strconv.ParseInt(val, 0, 0)` are included.

Addresses #17239 