### PR TITLE
Add support for user configured state object names in swift containers

### DIFF
--- a/backend/remote-state/swift/backend.go
+++ b/backend/remote-state/swift/backend.go
@@ -237,6 +237,13 @@ func New() backend.Backend {
 				Description: "Lock state access",
 				Default:     true,
 			},
+
+			"state_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["state_name"],
+				Default:     "tfstate.tf",
+			},
 		},
 	}
 
@@ -308,6 +315,8 @@ func init() {
 		"archive_container": "Swift container to archive state to.",
 
 		"expire_after": "Archive object expiry duration.",
+
+		"state_name": "Name of state object in container",
 	}
 }
 
@@ -321,6 +330,7 @@ type Backend struct {
 	expireSecs       int
 	container        string
 	lock             bool
+	stateName        string
 }
 
 func (b *Backend) configure(ctx context.Context) error {
@@ -363,6 +373,9 @@ func (b *Backend) configure(ctx context.Context) error {
 	if err := config.LoadAndValidate(); err != nil {
 		return err
 	}
+
+	// Assign state name
+	b.stateName = data.Get("state_name").(string)
 
 	// Assign Container
 	b.container = data.Get("container").(string)

--- a/backend/remote-state/swift/backend_state.go
+++ b/backend/remote-state/swift/backend_state.go
@@ -189,9 +189,9 @@ func (b *Backend) StateMgr(name string) (state.State, error) {
 
 func (b *Backend) objectName(name string) string {
 	if name != backend.DefaultStateName {
-		name = fmt.Sprintf("%s%s/%s", objectEnvPrefix, name, TFSTATE_NAME)
+		name = fmt.Sprintf("%s%s/%s", objectEnvPrefix, name, b.stateName)
 	} else {
-		name = TFSTATE_NAME
+		name = b.stateName
 	}
 
 	return name

--- a/backend/remote-state/swift/client.go
+++ b/backend/remote-state/swift/client.go
@@ -19,8 +19,6 @@ import (
 )
 
 const (
-	TFSTATE_NAME = "tfstate.tf"
-
 	consistencyTimeout = 15
 
 	// Suffix that will be appended to state file paths

--- a/website/docs/backends/types/swift.html.md
+++ b/website/docs/backends/types/swift.html.md
@@ -26,8 +26,6 @@ terraform {
 ```
 This will create a container called `terraform-state` and an object within that container called `tfstate.tf`. It will enable versioning using the `terraform-state-archive` container to contain the older version.
 
--> Note: Currently, the object name is statically defined as 'tfstate.tf'. Therefore Swift [pseudo-folders](https://docs.openstack.org/user-guide/cli-swift-pseudo-hierarchical-folders-directories.html) are not currently supported.
-
 For the access credentials we recommend using a
 [partial configuration](/docs/backends/config.html).
 
@@ -52,6 +50,9 @@ The following configuration options are supported:
 
  * `container` - (Required) The name of the container to create for storing
    the Terraform state file.
+
+ * `state_name` - (Optional) The name of the state file in the container.
+   Defaults to `tfstate.tf`.
 
  * `path` - (Optional) DEPRECATED: Use `container` instead.
    The name of the container to create in order to store the state file.


### PR DESCRIPTION
Currently in the swift backend, the object state name is hardcoded to "tfstate.tf". This PR makes that configurable via a "state_name" option. The option is optional and  defaults to "tfstate.tf". This puts the backend more in line with the S3 backend and will allow users to have one container with multiple states.

I'm not 100% happy with the option name. I'd prefer to use "key" or something similar, but the backend already uses that internally for the Openstack key and I didn't want to have the option and internal struct members named differently. Any suggestions?

I, of course still need to update the documentation and test it a bit more, so this is very much a WIP.

