### PR TITLE
validation: Add ValidateRFC3339TimeString

### DIFF
--- a/helper/validation/validation.go
+++ b/helper/validation/validation.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
@@ -206,6 +207,15 @@ func ValidateListUniqueStrings(v interface{}, k string) (ws []string, errors []e
 // supplied string is a valid regular expression.
 func ValidateRegexp(v interface{}, k string) (ws []string, errors []error) {
 	if _, err := regexp.Compile(v.(string)); err != nil {
+		errors = append(errors, fmt.Errorf("%q: %s", k, err))
+	}
+	return
+}
+
+// ValidateRFC3339TimeString is a ValidateFunc that ensures a string parses
+// as time.RFC3339 format
+func ValidateRFC3339TimeString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := time.Parse(time.RFC3339, v.(string)); err != nil {
 		errors = append(errors, fmt.Errorf("%q: %s", k, err))
 	}
 	return

--- a/helper/validation/validation.go
+++ b/helper/validation/validation.go
@@ -216,7 +216,7 @@ func ValidateRegexp(v interface{}, k string) (ws []string, errors []error) {
 // as time.RFC3339 format
 func ValidateRFC3339TimeString(v interface{}, k string) (ws []string, errors []error) {
 	if _, err := time.Parse(time.RFC3339, v.(string)); err != nil {
-		errors = append(errors, fmt.Errorf("%q: %s", k, err))
+		errors = append(errors, fmt.Errorf("%q: invalid RFC3339 timestamp", k))
 	}
 	return
 }

--- a/helper/validation/validation_test.go
+++ b/helper/validation/validation_test.go
@@ -144,6 +144,58 @@ func TestValidationRegexp(t *testing.T) {
 	})
 }
 
+func TestValidateRFC3339TimeString(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "2018-03-01T00:00:00Z",
+			f:   ValidateRFC3339TimeString,
+		},
+		{
+			val: "2018-03-01T00:00:00-05:00",
+			f:   ValidateRFC3339TimeString,
+		},
+		{
+			val: "2018-03-01T00:00:00+05:00",
+			f:   ValidateRFC3339TimeString,
+		},
+		{
+			val:         "03/01/2018",
+			f:           ValidateRFC3339TimeString,
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`cannot parse "1/2018" as "2006"`)),
+		},
+		{
+			val:         "03-01-2018",
+			f:           ValidateRFC3339TimeString,
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`cannot parse "1-2018" as "2006"`)),
+		},
+		{
+			val:         "2018-03-01",
+			f:           ValidateRFC3339TimeString,
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`cannot parse "" as "T"`)),
+		},
+		{
+			val:         "2018-03-01T",
+			f:           ValidateRFC3339TimeString,
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`cannot parse "" as "15"`)),
+		},
+		{
+			val:         "2018-03-01T00:00:00",
+			f:           ValidateRFC3339TimeString,
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`cannot parse "" as "Z07:00"`)),
+		},
+		{
+			val:         "2018-03-01T00:00:00Z05:00",
+			f:           ValidateRFC3339TimeString,
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`extra text: 05:00`)),
+		},
+		{
+			val:         "2018-03-01T00:00:00Z-05:00",
+			f:           ValidateRFC3339TimeString,
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`extra text: -05:00`)),
+		},
+	})
+}
+
 func TestValidateJsonString(t *testing.T) {
 	type testCases struct {
 		Value    string

--- a/helper/validation/validation_test.go
+++ b/helper/validation/validation_test.go
@@ -161,37 +161,37 @@ func TestValidateRFC3339TimeString(t *testing.T) {
 		{
 			val:         "03/01/2018",
 			f:           ValidateRFC3339TimeString,
-			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`cannot parse "1/2018" as "2006"`)),
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`invalid RFC3339 timestamp`)),
 		},
 		{
 			val:         "03-01-2018",
 			f:           ValidateRFC3339TimeString,
-			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`cannot parse "1-2018" as "2006"`)),
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`invalid RFC3339 timestamp`)),
 		},
 		{
 			val:         "2018-03-01",
 			f:           ValidateRFC3339TimeString,
-			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`cannot parse "" as "T"`)),
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`invalid RFC3339 timestamp`)),
 		},
 		{
 			val:         "2018-03-01T",
 			f:           ValidateRFC3339TimeString,
-			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`cannot parse "" as "15"`)),
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`invalid RFC3339 timestamp`)),
 		},
 		{
 			val:         "2018-03-01T00:00:00",
 			f:           ValidateRFC3339TimeString,
-			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`cannot parse "" as "Z07:00"`)),
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`invalid RFC3339 timestamp`)),
 		},
 		{
 			val:         "2018-03-01T00:00:00Z05:00",
 			f:           ValidateRFC3339TimeString,
-			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`extra text: 05:00`)),
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`invalid RFC3339 timestamp`)),
 		},
 		{
 			val:         "2018-03-01T00:00:00Z-05:00",
 			f:           ValidateRFC3339TimeString,
-			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`extra text: -05:00`)),
+			expectedErr: regexp.MustCompile(regexp.QuoteMeta(`invalid RFC3339 timestamp`)),
 		},
 	})
 }


### PR DESCRIPTION
Helper function so providers can easily ensure an attribute parses as `time.RFC3339`. We could also introduce a `func TimeString(format string) schema.SchemaValidateFunc`. Let me know if you think that would be better or if we should have both. 😄 