### PR TITLE
fix grammar in description

### DIFF
--- a/website/docs/providers/type/cloud-index.html.markdown
+++ b/website/docs/providers/type/cloud-index.html.markdown
@@ -8,8 +8,8 @@ description: |-
 
 #Cloud Providers
 
-This group include cloud providers offering a range of services including IaaS,
-SaaS, and PaaS offerings.  This group of cloud providers include some smaller
+This group includes cloud providers offering a range of services including IaaS,
+SaaS, and PaaS offerings. This group of cloud providers includes some smaller
 scale clouds or ones with more specialized offerings. The Terraform provider
 and associated resources for these clouds are primarily supported by the cloud
 vendor in close collaboration with HashiCorp, and are tested by HashiCorp.


### PR DESCRIPTION
Simple update to grammar on Cloud index description. It is __not__ critical and can be released with a future version of the website.