### PR TITLE
Check for nil config in node_resource_refresh

### DIFF
--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -213,10 +213,16 @@ func (n *NodeRefreshableManagedResourceInstance) evalTreeManagedResourceNoState(
 	// Determine the dependencies for the state.
 	stateDeps := n.StateReferences()
 
+	// n.Config can be nil if the config and state don't match
+	var raw *config.RawConfig
+	if n.Config != nil {
+		raw = n.Config.RawConfig.Copy()
+	}
+
 	return &EvalSequence{
 		Nodes: []EvalNode{
 			&EvalInterpolate{
-				Config:   n.Config.RawConfig.Copy(),
+				Config:   raw,
 				Resource: resource,
 				Output:   &resourceConfig,
 			},


### PR DESCRIPTION
While not normally possible, manual manipulation of the state and config
can cause us to end up with a nil config in
evalTreeManagedResourceNoState.

Regardless of how it got here, we can't ever assume the Config field is
not nil, and EvalInterpolate happily accepts a nil RawConfig

Fixes #17509