### PR TITLE
filter null output values from state

### DIFF
--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -118,7 +118,9 @@ func dataSourceRemoteStateRead(d *schema.ResourceData, meta interface{}) error {
 		log.Println("[DEBUG] empty remote state")
 	} else {
 		for key, val := range remoteState.RootModule().Outputs {
-			outputMap[key] = val.Value
+			if val.Value != nil {
+				outputMap[key] = val.Value
+			}
 		}
 	}
 

--- a/builtin/providers/terraform/data_source_state_test.go
+++ b/builtin/providers/terraform/data_source_state_test.go
@@ -63,6 +63,20 @@ func TestState_complexOutputs(t *testing.T) {
 	})
 }
 
+// outputs should never have a null value, but don't crash if we ever encounter
+// them.
+func TestState_nullOutputs(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccState_nullOutputs,
+			},
+		},
+	})
+}
+
 func TestEmptyState_defaults(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -139,6 +153,15 @@ resource "terraform_remote_state" "foo" {
 
 	config {
 		path = "./test-fixtures/complex_outputs.tfstate"
+	}
+}`
+
+const testAccState_nullOutputs = `
+resource "terraform_remote_state" "foo" {
+	backend = "local"
+
+	config {
+		path = "./test-fixtures/null_outputs.tfstate"
 	}
 }`
 

--- a/builtin/providers/terraform/test-fixtures/null_outputs.tfstate
+++ b/builtin/providers/terraform/test-fixtures/null_outputs.tfstate
@@ -1,0 +1,24 @@
+{
+    "version": 3,
+    "terraform_version": "0.7.0",
+    "serial": 3,
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {
+                "map": {
+                    "sensitive": false,
+                    "type": "map",
+                    "value": null
+                },
+                "list": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": null
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
While null values should not normally appear in a state file, we should
filter the values rather than crash.