### PR TITLE
configs: Disable deprecation warning for quoted keywords/references

### DIFF
--- a/configs/compat_shim.go
+++ b/configs/compat_shim.go
@@ -59,21 +59,28 @@ func shimTraversalInString(expr hcl.Expression, wantKeyword bool) (hcl.Expressio
 	)
 	diags = append(diags, tDiags...)
 
-	if wantKeyword {
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagWarning,
-			Summary:  "Quoted keywords are deprecated",
-			Detail:   "In this context, keywords are expected literally rather than in quotes. Previous versions of Terraform required quotes, but that usage is now deprecated. Remove the quotes surrounding this keyword to silence this warning.",
-			Subject:  &srcRange,
-		})
-	} else {
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagWarning,
-			Summary:  "Quoted references are deprecated",
-			Detail:   "In this context, references are expected literally rather than in quotes. Previous versions of Terraform required quotes, but that usage is now deprecated. Remove the quotes surrounding this reference to silence this warning.",
-			Subject:  &srcRange,
-		})
-	}
+	// For initial release our deprecation warnings are disabled to allow
+	// a period where modules can be compatible with both old and new
+	// conventions.
+	// FIXME: Re-enable these deprecation warnings in a release prior to
+	// Terraform 0.13 and then remove the shims altogether for 0.13.
+	/*
+		if wantKeyword {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Quoted keywords are deprecated",
+				Detail:   "In this context, keywords are expected literally rather than in quotes. Previous versions of Terraform required quotes, but that usage is now deprecated. Remove the quotes surrounding this keyword to silence this warning.",
+				Subject:  &srcRange,
+			})
+		} else {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Quoted references are deprecated",
+				Detail:   "In this context, references are expected literally rather than in quotes. Previous versions of Terraform required quotes, but that usage is now deprecated. Remove the quotes surrounding this reference to silence this warning.",
+				Subject:  &srcRange,
+			})
+		}
+	*/
 
 	return &hclsyntax.ScopeTraversalExpr{
 		Traversal: traversal,

--- a/configs/parser_config_test.go
+++ b/configs/parser_config_test.go
@@ -100,11 +100,6 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 			"Invalid variable type hint",
 		},
 		{
-			"valid-files/variable-type-quoted.tf",
-			hcl.DiagWarning,
-			"Quoted keywords are deprecated",
-		},
-		{
 			"invalid-files/unexpected-attr.tf",
 			hcl.DiagError,
 			"Unsupported attribute",
@@ -120,16 +115,6 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 			"Unsuitable value type",
 		},
 		{
-			"valid-files/resources-dependson-quoted.tf",
-			hcl.DiagWarning,
-			"Quoted references are deprecated",
-		},
-		{
-			"valid-files/resources-ignorechanges-quoted.tf",
-			hcl.DiagWarning,
-			"Quoted references are deprecated",
-		},
-		{
 			"valid-files/resources-ignorechanges-all-legacy.tf",
 			hcl.DiagWarning,
 			"Deprecated ignore_changes wildcard",
@@ -138,16 +123,6 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 			"valid-files/resources-ignorechanges-all-legacy.tf.json",
 			hcl.DiagWarning,
 			"Deprecated ignore_changes wildcard",
-		},
-		{
-			"valid-files/resources-provisioner-when-quoted.tf",
-			hcl.DiagWarning,
-			"Quoted keywords are deprecated",
-		},
-		{
-			"valid-files/resources-provisioner-onfailure-quoted.tf",
-			hcl.DiagWarning,
-			"Quoted keywords are deprecated",
 		},
 	}
 


### PR DESCRIPTION
This relates to the new form for references, like this:

```hcl
  depends_on = [aws_instance.foo]
```

...which in the current version of the language must put the reference in quotes:

```hcl
  depends_on = ["aws_instance.foo"]
```

The new config loader (not yet in use) has always allowed both of these forms, but before this change the latter form would generate a warning. This applies to `depends_on` and `ignore_changes` in resources, `type` in variables, and `when` and `on_failure` in provisioners. The test assertions about the warnings themselves are removed, but other remaining tests (not visible in the diff here) still parse these to test for their validity.

Although we do still consider this usage deprecated for 0.12, we'll defer actually generating warnings for them until a later minor release so that module authors can retain their quoted identifiers for a period after 0.12 release for backward-compatibility with Terraform 0.11.

The intent here is to allow a migration period where modules can be written in a way that is compatible with both the old and new loaders so that users with lots of modules and lots of workspaces can migrate them gradually.

The warning messages are retained commented-out here just to remind us that we want to re-enable them at some point before 0.13 and to make it easier to do so.
