### PR TITLE
"HCL2"-based validate command

### DIFF
--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -120,7 +120,10 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 						continue
 					}
 					if b.CLI != nil {
-						b.CLI.Warn(format.Diagnostic(diag, b.Colorize(), 72))
+						// FIXME: We don't have access to the source code cache
+						// in here, so we can't produce source code snippets
+						// from this codepath.
+						b.CLI.Warn(format.Diagnostic(diag, nil, b.Colorize(), 72))
 					} else {
 						desc := diag.Description()
 						log.Printf("[WARN] backend/local: %s", desc.Summary)

--- a/command/format/diagnostic.go
+++ b/command/format/diagnostic.go
@@ -1,9 +1,14 @@
 package format
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
+	"strings"
 
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcled"
+	"github.com/hashicorp/hcl2/hclparse"
 	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/mitchellh/colorstring"
 	wordwrap "github.com/mitchellh/go-wordwrap"
@@ -16,7 +21,7 @@ import (
 // at all. Although the long-form text parts of the message are wrapped,
 // not all aspects of the message are guaranteed to fit within the specified
 // terminal width.
-func Diagnostic(diag tfdiags.Diagnostic, color *colorstring.Colorize, width int) string {
+func Diagnostic(diag tfdiags.Diagnostic, sources map[string][]byte, color *colorstring.Colorize, width int) string {
 	if diag == nil {
 		// No good reason to pass a nil diagnostic in here...
 		return ""
@@ -41,17 +46,74 @@ func Diagnostic(diag tfdiags.Diagnostic, color *colorstring.Colorize, width int)
 	// We don't wrap the summary, since we expect it to be terse, and since
 	// this is where we put the text of a native Go error it may not always
 	// be pure text that lends itself well to word-wrapping.
-	if sourceRefs.Subject != nil {
-		fmt.Fprintf(&buf, color.Color("[bold]%s[reset] at %s\n\n"), desc.Summary, sourceRefs.Subject.StartString())
-	} else {
-		fmt.Fprintf(&buf, color.Color("[bold]%s[reset]\n\n"), desc.Summary)
-	}
+	fmt.Fprintf(&buf, color.Color("[bold]%s[reset]\n\n"), desc.Summary)
 
-	// TODO: also print out the relevant snippet of config source with the
-	// relevant section highlighted, so the user doesn't need to manually
-	// correlate back to config. Before we can do this, the HCL2 parser
-	// needs to be more deeply integrated so that we can use it to obtain
-	// the parsed source code and AST.
+	if sourceRefs.Subject != nil {
+		// We'll borrow HCL's range implementation here, because it has some
+		// handy features to help us produce a nice source code snippet.
+		highlightRange := sourceRefs.Subject.ToHCL()
+		snippetRange := highlightRange
+		if sourceRefs.Context != nil {
+			snippetRange = sourceRefs.Context.ToHCL()
+		}
+		// Make sure the snippet includes the highlight. This should be true
+		// for any reasonable diagnostic, but we'll make sure.
+		snippetRange = hcl.RangeOver(snippetRange, highlightRange)
+
+		// We can't illustrate an empty range, so we'll turn such ranges into
+		// single-character ranges, which might not be totally valid (may point
+		// off the end of a line, or off the end of the file) but are good
+		// enough for the bounds checks we do below.
+		if snippetRange.Empty() {
+			snippetRange.End.Byte++
+			snippetRange.End.Column++
+		}
+		if highlightRange.Empty() {
+			highlightRange.End.Byte++
+			highlightRange.End.Column++
+		}
+
+		var src []byte
+		if sources != nil {
+			src = sources[snippetRange.Filename]
+		}
+		if src == nil {
+			// This should generally not happen, as long as sources are always
+			// loaded through the main loader. We may load things in other
+			// ways in weird cases, so we'll tolerate it at the expense of
+			// a not-so-helpful error message.
+			fmt.Fprintf(&buf, "  on %s line %d:\n  (source code not available)\n\n", highlightRange.Filename, highlightRange.Start.Line)
+		} else {
+			contextStr := sourceCodeContextStr(src, highlightRange)
+			if contextStr != "" {
+				contextStr = ", in " + contextStr
+			}
+			fmt.Fprintf(&buf, "  on %s line %d%s:\n", highlightRange.Filename, highlightRange.Start.Line, contextStr)
+
+			sc := hcl.NewRangeScanner(src, highlightRange.Filename, bufio.ScanLines)
+			for sc.Scan() {
+				lineRange := sc.Range()
+				if !lineRange.Overlaps(snippetRange) {
+					continue
+				}
+				beforeRange, highlightedRange, afterRange := lineRange.PartitionAround(highlightRange)
+				if highlightedRange.Empty() {
+					fmt.Fprintf(&buf, "%4d: %s\n", lineRange.Start.Line, sc.Bytes())
+				} else {
+					before := beforeRange.SliceBytes(src)
+					highlighted := highlightedRange.SliceBytes(src)
+					after := afterRange.SliceBytes(src)
+					fmt.Fprintf(
+						&buf, color.Color("%4d: %s[underline]%s[reset]%s\n"),
+						lineRange.Start.Line,
+						before, highlighted, after,
+					)
+				}
+			}
+
+			buf.WriteByte('\n')
+		}
+	}
 
 	if desc.Detail != "" {
 		detail := desc.Detail
@@ -62,4 +124,34 @@ func Diagnostic(diag tfdiags.Diagnostic, color *colorstring.Colorize, width int)
 	}
 
 	return buf.String()
+}
+
+// sourceCodeContextStr attempts to find a user-friendly description of
+// the location of the given range in the given source code.
+//
+// An empty string is returned if no suitable description is available, e.g.
+// because the source is invalid, or because the offset is not inside any sort
+// of identifiable container.
+func sourceCodeContextStr(src []byte, rng hcl.Range) string {
+	filename := rng.Filename
+	offset := rng.Start.Byte
+
+	// We need to re-parse here to get a *hcl.File we can interrogate. This
+	// is not awesome since we presumably already parsed the file earlier too,
+	// but this re-parsing is architecturally simpler than retaining all of
+	// the hcl.File objects and we only do this in the case of an error anyway
+	// so the overhead here is not a big problem.
+	parser := hclparse.NewParser()
+	var file *hcl.File
+	var diags hcl.Diagnostics
+	if strings.HasSuffix(filename, ".json") {
+		file, diags = parser.ParseJSON(src, filename)
+	} else {
+		file, diags = parser.ParseHCL(src, filename)
+	}
+	if diags.HasErrors() {
+		return ""
+	}
+
+	return hcled.ContextString(file, offset)
 }

--- a/command/hook_module_install.go
+++ b/command/hook_module_install.go
@@ -1,0 +1,33 @@
+package command
+
+import (
+	"fmt"
+
+	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/mitchellh/cli"
+)
+
+type uiModuleInstallHooks struct {
+	configload.InstallHooksImpl
+	Ui             cli.Ui
+	ShowLocalPaths bool
+}
+
+var _ configload.InstallHooks = uiModuleInstallHooks{}
+
+func (h uiModuleInstallHooks) Download(modulePath, packageAddr string, v *version.Version) {
+	if v != nil {
+		h.Ui.Info(fmt.Sprintf("Downloading %s %s for %s...", packageAddr, v, modulePath))
+	} else {
+		h.Ui.Info(fmt.Sprintf("Downloading %s for %s...", packageAddr, modulePath))
+	}
+}
+
+func (h uiModuleInstallHooks) Install(modulePath string, v *version.Version, localDir string) {
+	if h.ShowLocalPaths {
+		h.Ui.Info(fmt.Sprintf("- %s in %s", modulePath, localDir))
+	} else {
+		h.Ui.Info(fmt.Sprintf("- %s", modulePath))
+	}
+}

--- a/command/meta.go
+++ b/command/meta.go
@@ -547,7 +547,7 @@ func (m *Meta) showDiagnostics(vals ...interface{}) {
 		// For now, we don't have easy access to the writer that
 		// ui.Error (etc) are writing to and thus can't interrogate
 		// to see if it's a terminal and what size it is.
-		msg := format.Diagnostic(diag, m.Colorize(), 78)
+		msg := format.Diagnostic(diag, nil, m.Colorize(), 78)
 		switch diag.Severity() {
 		case tfdiags.Error:
 			m.Ui.Error(msg)

--- a/command/meta.go
+++ b/command/meta.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform/command/format"
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
+	"github.com/hashicorp/terraform/configs/configload"
 	"github.com/hashicorp/terraform/helper/experiment"
 	"github.com/hashicorp/terraform/helper/variables"
 	"github.com/hashicorp/terraform/helper/wrappedstreams"
@@ -102,6 +103,11 @@ type Meta struct {
 	//----------------------------------------------------------
 	// Private: do not set these
 	//----------------------------------------------------------
+
+	// configLoader is a shared configuration loader that is used by
+	// LoadConfig and other commands that access configuration files.
+	// It is initialized on first use.
+	configLoader *configload.Loader
 
 	// backendState is the currently active backend state
 	backendState *terraform.BackendState
@@ -547,7 +553,7 @@ func (m *Meta) showDiagnostics(vals ...interface{}) {
 		// For now, we don't have easy access to the writer that
 		// ui.Error (etc) are writing to and thus can't interrogate
 		// to see if it's a terminal and what size it is.
-		msg := format.Diagnostic(diag, nil, m.Colorize(), 78)
+		msg := format.Diagnostic(diag, m.configSources(), m.Colorize(), 78)
 		switch diag.Severity() {
 		case tfdiags.Error:
 			m.Ui.Error(msg)

--- a/command/meta_config.go
+++ b/command/meta_config.go
@@ -1,0 +1,194 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// normalizePath normalizes a given path so that it is, if possible, relative
+// to the current working directory. This is primarily used to prepare
+// paths used to load configuration, because we want to prefer recording
+// relative paths in source code references within the configuration.
+func (m *Meta) normalizePath(path string) string {
+	var err error
+
+	// First we will make it absolute so that we have a consistent place
+	// to start.
+	path, err = filepath.Abs(path)
+	if err != nil {
+		// We'll just accept what we were given, then.
+		return path
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil || !filepath.IsAbs(cwd) {
+		return path
+	}
+
+	ret, err := filepath.Rel(cwd, path)
+	if err != nil {
+		return path
+	}
+
+	return ret
+}
+
+// loadConfig reads a configuration from the given directory, which should
+// contain a root module and have already have any required descendent modules
+// installed.
+func (m *Meta) loadConfig(rootDir string) (*configs.Config, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	rootDir = m.normalizePath(rootDir)
+
+	loader, err := m.initConfigLoader()
+	if err != nil {
+		diags = diags.Append(err)
+		return nil, diags
+	}
+
+	config, hclDiags := loader.LoadConfig(rootDir)
+	diags = diags.Append(hclDiags)
+	return config, diags
+}
+
+// loadSingleModule reads configuration from the given directory and returns
+// a description of that module only, without attempting to assemble a module
+// tree for referenced child modules.
+//
+// Most callers should use loadConfig. This method exists to support early
+// initialization use-cases where the root module must be inspected in order
+// to determine what else needs to be installed before the full configuration
+// can be used.
+func (m *Meta) loadSingleModule(dir string) (*configs.Module, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	dir = m.normalizePath(dir)
+
+	loader, err := m.initConfigLoader()
+	if err != nil {
+		diags = diags.Append(err)
+		return nil, diags
+	}
+
+	module, hclDiags := loader.Parser().LoadConfigDir(dir)
+	diags = diags.Append(hclDiags)
+	return module, diags
+}
+
+// installModules reads a root module from the given directory and attempts
+// recursively install all of its descendent modules.
+//
+// The given hooks object will be notified of installation progress, which
+// can then be relayed to the end-user. The moduleUiInstallHooks type in
+// this package has a reasonable implementation for displaying notifications
+// via a provided cli.Ui.
+func (m *Meta) installModules(rootDir string, upgrade bool, hooks configload.InstallHooks) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	rootDir = m.normalizePath(rootDir)
+
+	err := os.MkdirAll(m.modulesDir(), os.ModePerm)
+	if err != nil {
+		diags = diags.Append(fmt.Errorf("failed to create local modules directory: %s", err))
+		return diags
+	}
+
+	loader, err := m.initConfigLoader()
+	if err != nil {
+		diags = diags.Append(err)
+		return diags
+	}
+
+	hclDiags := loader.InstallModules(rootDir, upgrade, hooks)
+	diags = diags.Append(hclDiags)
+	return diags
+}
+
+// initDirFromModule initializes the given directory (which should be
+// pre-verified as empty by the caller) by copying the source code from the
+// given module address.
+//
+// Internally this runs similar steps to installModules.
+// The given hooks object will be notified of installation progress, which
+// can then be relayed to the end-user. The moduleUiInstallHooks type in
+// this package has a reasonable implementation for displaying notifications
+// via a provided cli.Ui.
+func (m *Meta) initDirFromModule(targetDir string, addr string, hooks configload.InstallHooks) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	targetDir = m.normalizePath(targetDir)
+
+	loader, err := m.initConfigLoader()
+	if err != nil {
+		diags = diags.Append(err)
+		return diags
+	}
+
+	hclDiags := loader.InitDirFromModule(targetDir, addr, hooks)
+	diags = diags.Append(hclDiags)
+	return diags
+}
+
+// loadVarsFile reads a file from the given path and interprets it as a
+// "vars file", returning the contained values as a map.
+//
+// The file is read using the parser associated with the receiver's
+// configuration loader, which means that the file's contents will be added
+// to the source cache that is used for config snippets in diagnostic messages.
+func (m *Meta) loadVarsFile(filename string) (map[string]cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	loader, err := m.initConfigLoader()
+	if err != nil {
+		diags = diags.Append(err)
+		return nil, diags
+	}
+
+	parser := loader.Parser()
+	ret, hclDiags := parser.LoadValuesFile(filename)
+	diags = diags.Append(hclDiags)
+	return ret, diags
+}
+
+// configSources returns the source cache from the receiver's config loader,
+// which the caller must not modify.
+//
+// If a config loader has not yet been instantiated then no files could have
+// been loaded already, so this method returns a nil map in that case.
+func (m *Meta) configSources() map[string][]byte {
+	if m.configLoader == nil {
+		return nil
+	}
+
+	return m.configLoader.Sources()
+}
+
+func (m *Meta) modulesDir() string {
+	return filepath.Join(m.DataDir(), "modules")
+}
+
+// initConfigLoader initializes the shared configuration loader if it isn't
+// already initialized.
+//
+// If the loader cannot be created for some reason then an error is returned
+// and no loader is created. Subsequent calls will presumably see the same
+// error. Loader initialization errors will tend to prevent any further use
+// of most Terraform features, so callers should report any error and safely
+// terminate.
+func (m *Meta) initConfigLoader() (*configload.Loader, error) {
+	if m.configLoader == nil {
+		loader, err := configload.NewLoader(&configload.Config{
+			ModulesDir: m.modulesDir(),
+			Services:   m.Services,
+			Creds:      m.Credentials,
+		})
+		if err != nil {
+			return nil, err
+		}
+		m.configLoader = loader
+	}
+	return m.configLoader, nil
+}

--- a/command/meta_new.go
+++ b/command/meta_new.go
@@ -31,7 +31,8 @@ func (m *Meta) Input() bool {
 	return true
 }
 
-// Module loads the module tree for the given root path.
+// Module loads the module tree for the given root path using the legacy
+// configuration loader.
 //
 // It expects the modules to already be downloaded. This will never
 // download any modules.
@@ -65,8 +66,11 @@ func (m *Meta) Module(path string) (*module.Tree, tfdiags.Diagnostics) {
 	return mod, diags
 }
 
-// Config loads the root config for the path specified. Path may be a directory
-// or file. The absence of configuration is not an error and returns a nil Config.
+// Config loads the root config for the path specified, using the legacy
+// configuration loader.
+//
+// Path may be a directory or file. The absence of configuration is not an
+// error and returns a nil Config.
 func (m *Meta) Config(path string) (*config.Config, error) {
 	// If no explicit path was given then it is okay for there to be
 	// no backend configuration found.

--- a/command/test-fixtures/validate-invalid/main.tf
+++ b/command/test-fixtures/validate-invalid/main.tf
@@ -1,8 +1,8 @@
-resource "test_instance" "foo" {
+resorce "test_instance" "foo" { # Intentional typo to test error reporting
     ami = "bar"
 
     network_interface {
       device_index = 0
-      description = "Main network interface ${var.this_is_an_error}"
+      description = "Main network interface"
     }
 }

--- a/command/test-fixtures/validate-invalid/multiple_modules/main.tf
+++ b/command/test-fixtures/validate-invalid/multiple_modules/main.tf
@@ -1,5 +1,7 @@
 module "multi_module" {
+  source = "./foo"
 }
 
 module "multi_module" {
+  source = "./foo"
 }

--- a/main.go
+++ b/main.go
@@ -134,7 +134,10 @@ func wrappedMain() int {
 				Disable: true, // Disable color to be conservative until we know better
 				Reset:   true,
 			}
-			Ui.Error(format.Diagnostic(diag, earlyColor, 78))
+			// We don't currently have access to the source code cache for
+			// the parser used to load the CLI config, so we can't show
+			// source code snippets in early diagnostics.
+			Ui.Error(format.Diagnostic(diag, nil, earlyColor, 78))
 		}
 		if diags.HasErrors() {
 			Ui.Error("As a result of the above problems, Terraform may not behave as intended.\n\n")


### PR DESCRIPTION
> **Note:** The target of this PR is the `v0.12-dev` branch, because this change is not shippable in isolation.

This is the first of many more changes required to fully integrate the "HCL2" implementation of HCL into Terraform. As a mostly-isolated starting point this changes the `terraform validate` command to use the new parser.

As proposed in #15895, this reduces slightly the scope of the `terraform validate` command to just "safe" static validation, which will eventually include checking configuration values against provider validation rules but will not do any "dynamic" validation that requires per-run context, state, etc.

This changeset anticipates (but does not yet implement) a `terraform plan -validate-only` mode that does a slightly-deeper validation with the full context of a particular run, including a set of variables, the current state, etc. The distinction between these two commands is:

* `terraform validate` asks "is this configuration valid, regardless of what context it's applied in?", and is a good check for a text editor integration to run automatically on save, since it requires no credentials or other contextual information.
* `terraform plan -validate-only` asks "is this proposed _change_ valid?", and does all the same checks as `terraform validate` but also ensures that we have appropriate values for all variables. This might be a good command to run in order to smoke-test a pull request to the configuration of a real environment, for example.

Currently the distinction feels unclear because all operation context is local anyway, but it will become more significant in future when we implement backend-stored per-workspace variables and a backend that is able to run `terraform plan` remotely, both of which will require network requests to the backend in order to do full validation of a proposed change, as opposed to validation of just the configuration. `terraform validate` promises to _always_ be local-only.

---

This set of changes was originally written in order to allow a first pass of batch-validating a set of "real-world" Terraform modules to pick some low-hanging parser bugs. (And it did! In hashicorp/hcl2#15, hashicorp/hcl2#16, hashicorp/hcl2#17, hashicorp/hcl2#18, hashicorp/hcl2#19, and hashicorp/hcl2#21.)

As a consequence of that goal, this patch also includes some extra functionality beyond just a port of the existing `terraform validate` command:

* Some support code is added to `command` to allow us to convenient load configurations via a centralized loader. which then allows us to populate the source code cache we'll use for source code snippets in diagnostics.

* The diagnostics printer is now able to print out source code snippets for errors that are able to generate them:

![Screenshot of a terminal showing a Terraform error message with a copy of the line of source code where the error appears](https://user-images.githubusercontent.com/20180/37184195-e00c1918-22ee-11e8-967c-fedd65055ad1.png)

* The `validate` command has a JSON output mode. In future we will probably extend other commands with similar output, when Terraform's workflow is more stable and we're more confident that we won't need to break the format, but at least for _this_ command the result format is unlikely to significantly change, because it's just a list of errors and warnings. This output format is hopefully useful for integrating "validate on save" functionality in text editor extensions.

```json
{
  "valid": false,
  "error_count": 1,
  "warning_count": 0,
  "diagnostics": [
    {
      "severity": "error",
      "summary": "Unsupported block type",
      "detail": "Blocks of type \"vaariable\" are not expected here. Did you mean \"variable\"?",
      "range": {
        "filename": "variables.tf",
        "start": {
          "line": 1,
          "column": 1,
          "byte": 0
        },
        "end": {
          "line": 1,
          "column": 10,
          "byte": 9
        }
      }
    }
  ]
}
```

* The temporary validation test harness also included some incomplete `terraform init` updates in order to install modules to validate, which are not included here. However this changeset _does_ include a `configload.InstallHooks` implementation that can print installation progress to the UI. That's included here mainly just to keep it safe for later, when we make the more-complete `terraform init` updates.

This changeset temporarily breaks the "deep" validation done by walking the graph, instead just doing syntax validation. The validation of resource configurations against schema, etc, will be added back later once Terraform Core has been updated to work with the new configuration structures.
