### PR TITLE
 ignore errors interpolating RawCount during apply

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -9472,5 +9472,72 @@ func TestContext2Apply_providersFromState(t *testing.T) {
 
 		})
 	}
+}
 
+func TestContext2Apply_plannedInterpolatedCount(t *testing.T) {
+	m := testModule(t, "apply-interpolated-count")
+
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+
+	providerResolver := ResourceProviderResolverFixed(
+		map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	)
+
+	s := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: rootModulePath,
+				Resources: map[string]*ResourceState{
+					"aws_instance.test": {
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "foo",
+						},
+						Provider: "provider.aws",
+					},
+				},
+			},
+		},
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Module:           m,
+		ProviderResolver: providerResolver,
+		State:            s,
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("plan failed: %s", err)
+	}
+
+	// We'll marshal and unmarshal the plan here, to ensure that we have
+	// a clean new context as would be created if we separately ran
+	// terraform plan -out=tfplan && terraform apply tfplan
+	var planBuf bytes.Buffer
+	err = WritePlan(plan, &planBuf)
+	if err != nil {
+		t.Fatalf("failed to write plan: %s", err)
+	}
+	plan, err = ReadPlan(&planBuf)
+	if err != nil {
+		t.Fatalf("failed to read plan: %s", err)
+	}
+
+	ctx, err = plan.Context(&ContextOpts{
+		ProviderResolver: providerResolver,
+	})
+	if err != nil {
+		t.Fatalf("failed to create context for plan: %s", err)
+	}
+
+	// Applying the plan should now succeed
+	_, err = ctx.Apply()
+	if err != nil {
+		t.Fatalf("apply failed: %s", err)
+	}
 }

--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -140,7 +140,10 @@ func (n *NodeApplyableResource) evalTreeDataResource(
 			// Here we are just populating the interpolated value in-place
 			// inside this RawConfig object, like we would in
 			// NodeAbstractCountResource.
-			&EvalInterpolate{Config: n.Config.RawCount},
+			&EvalInterpolate{
+				Config:        n.Config.RawCount,
+				ContinueOnErr: true,
+			},
 
 			// We need to re-interpolate the config here, rather than
 			// just using the diff's values directly, because we've
@@ -271,7 +274,10 @@ func (n *NodeApplyableResource) evalTreeManagedResource(
 			// Here we are just populating the interpolated value in-place
 			// inside this RawConfig object, like we would in
 			// NodeAbstractCountResource.
-			&EvalInterpolate{Config: n.Config.RawCount},
+			&EvalInterpolate{
+				Config:        n.Config.RawCount,
+				ContinueOnErr: true,
+			},
 
 			&EvalInterpolate{
 				Config:   n.Config.RawConfig.Copy(),

--- a/terraform/test-fixtures/apply-interpolated-count/main.tf
+++ b/terraform/test-fixtures/apply-interpolated-count/main.tf
@@ -1,0 +1,11 @@
+variable "instance_count" {
+  default = 1
+}
+
+resource "aws_instance" "test" {
+  count = "${var.instance_count}"
+}
+
+resource "aws_instance" "dependent" {
+  count = "${aws_instance.test.count}"
+}


### PR DESCRIPTION
If a count field references another count field which is interpolated
but is attached to a resource already in the state, the result of that
first interpolation will be lost when a plan is serialized. This is
because the result of the first interpolation is stored directly in the
module config, in an unexported config field.

This is not a general fix for the above situation, which would require
refactoring how counts are handles throughout the config. Ignoring the
error works, becuase in most cases the count will be properly
handled during the resource's interpolation. This is a stop-gap solution 
to the improved config handling that is in development.

Fixes #17368