### PR TITLE
backend/gcs: Create the bucket if it does not exists

### DIFF
--- a/backend/remote-state/gcs/backend_test.go
+++ b/backend/remote-state/gcs/backend_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/state/remote"
 )
@@ -186,20 +185,9 @@ func setupBackend(t *testing.T, bucket, prefix, key string) backend.Backend {
 	be := b.(*gcsBackend)
 
 	// create the bucket if it doesn't exist
-	bkt := be.storageClient.Bucket(bucket)
-	_, err := bkt.Attrs(be.storageContext)
+	err := createBucketIfNotExist(be)
 	if err != nil {
-		if err != storage.ErrBucketNotExist {
-			t.Fatal(err)
-		}
-
-		attrs := &storage.BucketAttrs{
-			Location: be.region,
-		}
-		err := bkt.Create(be.storageContext, be.projectID, attrs)
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Fatal(err)
 	}
 
 	return b


### PR DESCRIPTION
When running `terraform init` on a new project if bucket does not exists we get error.

```
* writing "gs://my-new-bucket-name/terraform/state/default.tflock" failed: googleapi: Error 404: Not Found, notFound
* storage: object doesn't exist
```

As far as I can read the document, if I provide `project`, `init` should try to create the bucket if it does not exists.

https://www.terraform.io/docs/backends/types/gcs.html

My guess is that behavior was changed during recent refactoring which added lock to gcs.

This PR will bring back the behaviour.
