### PR TITLE
backend/manta: Manta Backend was not dealing with a ResourceNotFound

### DIFF
--- a/backend/remote-state/manta/client.go
+++ b/backend/remote-state/manta/client.go
@@ -106,7 +106,7 @@ func (c *RemoteClient) Lock(info *state.LockInfo) (string, error) {
 	lockErr := &state.LockError{}
 	lockInfo, err := c.getLockInfo()
 	if err != nil {
-		if tritonErrors.IsResourceNotFound(err) {
+		if !tritonErrors.IsResourceNotFound(err) {
 			lockErr.Err = fmt.Errorf("failed to retrieve lock info: %s", err)
 			return "", lockErr
 		}


### PR DESCRIPTION
Fixes: #17314

We now deal correctly with the creation of the state file - we were
not dealing well with a ResourceNotFound error

Now that this has been changed around, we try and create the statefile
and if there is an error, we look for an existing statefile - previously
this was not the order of operations

https://asciinema.org/a/o9UGr3jgV36SFeuKvAybducaF

```
terraform [manta-backend] % acctests backend/remote-state/manta 2>~/tf.log
=== RUN   TestBackend_impl
--- PASS: TestBackend_impl (0.00s)
=== RUN   TestBackend
--- PASS: TestBackend (26.78s)
=== RUN   TestBackendLocked
--- PASS: TestBackendLocked (14.09s)
=== RUN   TestRemoteClient_impl
--- PASS: TestRemoteClient_impl (0.00s)
=== RUN   TestRemoteClient
--- PASS: TestRemoteClient (3.14s)
=== RUN   TestRemoteClientLocks
--- PASS: TestRemoteClientLocks (6.60s)
PASS
ok  	github.com/hashicorp/terraform/backend/remote-state/manta
```