### PR TITLE
docs/getting-started: Replace underscores in aws_s3_bucket name in dependencies example

### DIFF
--- a/website/intro/getting-started/dependencies.html.md
+++ b/website/intro/getting-started/dependencies.html.md
@@ -156,7 +156,7 @@ resource "aws_s3_bucket" "example" {
   # NOTE: S3 bucket names must be unique across _all_ AWS accounts, so
   # this name must be changed before applying this example to avoid naming
   # conflicts.
-  bucket = "terraform_getting_started_guide"
+  bucket = "terraform-getting-started-guide"
   acl    = "private"
 }
 


### PR DESCRIPTION
Underscores are no longer allowed as of March 1, 2018. Reference: https://github.com/hashicorp/terraform-website/issues/180