### PR TITLE
Allow terraform-bundle to include custom plugins

### DIFF
--- a/tools/terraform-bundle/README.md
+++ b/tools/terraform-bundle/README.md
@@ -54,10 +54,10 @@ providers {
   # the bundle archive.
   google = ["~> 1.0", "~> 2.0"]
 
-  #Include a custom plugin to the bundle. Will search for the plugin in the 
-	#plugins directory, and package it with the bundle archive. Plugin must have
-	#a name of the form: terraform-provider-*, and must be build with the operating
-	#system and architecture that terraform enterprise is running, e.g. linux and amd64
+  # Include a custom plugin to the bundle. Will search for the plugin in the 
+	# plugins directory, and package it with the bundle archive. Plugin must have
+	# a name of the form: terraform-provider-*, and must be build with the operating
+	# system and architecture that terraform enterprise is running, e.g. linux and amd64
 	customplugin = ["0.1"]
 }
 
@@ -109,7 +109,7 @@ bundles contain the same core Terraform version.
 To include custom plugins in the bundle file, create a local directory "./plugins"
 and put all the plugins you want to include there. Optionally, you can use the 
 `-plugin-dir` flag to specify a location where to find the plugins. To be recognized
-as a valid plugin, the file must have a name of the form: "terraform-provider-*". In 
+as a valid plugin, the file must have a name of the form: "terraform-provider-*-v*". In 
 addition, ensure that the plugin is build using the same operating system and 
 architecture used for terraform enterprise. Typically this will be linux and amd64.
 

--- a/tools/terraform-bundle/README.md
+++ b/tools/terraform-bundle/README.md
@@ -55,10 +55,10 @@ providers {
   google = ["~> 1.0", "~> 2.0"]
 
   # Include a custom plugin to the bundle. Will search for the plugin in the 
-	# plugins directory, and package it with the bundle archive. Plugin must have
-	# a name of the form: terraform-provider-*, and must be build with the operating
-	# system and architecture that terraform enterprise is running, e.g. linux and amd64
-	customplugin = ["0.1"]
+  # plugins directory, and package it with the bundle archive. Plugin must have
+  # a name of the form: terraform-provider-*, and must be build with the operating
+  # system and architecture that terraform enterprise is running, e.g. linux and amd64
+  customplugin = ["0.1"]
 }
 
 ```

--- a/tools/terraform-bundle/README.md
+++ b/tools/terraform-bundle/README.md
@@ -53,6 +53,12 @@ providers {
   # two expressions match different versions then _both_ are included in
   # the bundle archive.
   google = ["~> 1.0", "~> 2.0"]
+
+  #Include a custom plugin to the bundle. Will search for the plugin in the 
+	#plugins directory, and package it with the bundle archive. Plugin must have
+	#a name of the form: terraform-provider-*, and must be build with the operating
+	#system and architecture that terraform enterprise is running, e.g. linux and amd64
+	customplugin = ["0.1"]
 }
 
 ```
@@ -100,6 +106,13 @@ this composite version number so that bundle archives can be easily
 distinguished from official release archives and from each other when multiple
 bundles contain the same core Terraform version.
 
+To include custom plugins in the bundle file, create a local directory "./plugins"
+and put all the plugins you want to include there. Optionally, you can use the 
+`-plugin-dir` flag to specify a location where to find the plugins. To be recognized
+as a valid plugin, the file must have a name of the form: "terraform-provider-*". In 
+addition, ensure that the plugin is build using the same operating system and 
+architecture used for terraform enterprise. Typically this will be linux and amd64.
+
 ## Provider Resolution Behavior
 
 Terraform's provider resolution behavior is such that if a given constraint
@@ -111,13 +124,6 @@ that version constraints within Terraform configurations do not exclude all
 of the versions available from the bundle. If a suitable version cannot be
 found in the bundle, Terraform _will_ attempt to satisfy that dependency by
 automatic installation from the official repository.
-
-To disable automatic installation altogether -- and thus cause a hard failure
-if no local plugins match -- the `-plugin-dir` option can be passed to
-`terraform init`, giving the directory into which the bundle was extracted.
-The presence of this option overrides all of the normal automatic discovery
-and installation behavior, and thus forces the use of only the plugins that
-can be found in the directory indicated.
 
 The downloaded provider archives are verified using the same signature check
 that is used for auto-installed plugins, using Hashicorp's release key. At

--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -2,14 +2,14 @@ package main
 
 import (
 	"archive/zip"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
-
-	"flag"
 
 	"io"
 
@@ -23,10 +23,66 @@ type PackageCommand struct {
 	ui cli.Ui
 }
 
+// shameless stackoverflow copy + pasta https://stackoverflow.com/questions/21060945/simple-way-to-copy-a-file-in-golang
+func CopyFile(src, dst string) (err error) {
+	sfi, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	if !sfi.Mode().IsRegular() {
+		// cannot copy non-regular files (e.g., directories,
+		// symlinks, devices, etc.)
+		return fmt.Errorf("CopyFile: non-regular source file %s (%q)", sfi.Name(), sfi.Mode().String())
+	}
+	dfi, err := os.Stat(dst)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return
+		}
+	} else {
+		if !(dfi.Mode().IsRegular()) {
+			return fmt.Errorf("CopyFile: non-regular destination file %s (%q)", dfi.Name(), dfi.Mode().String())
+		}
+		if os.SameFile(sfi, dfi) {
+			return
+		}
+	}
+	if err = os.Link(src, dst); err == nil {
+		return
+	}
+	err = copyFileContents(src, dst)
+	return
+}
+
+// see above
+func copyFileContents(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	defer func() {
+		cerr := out.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+	if _, err = io.Copy(out, in); err != nil {
+		return
+	}
+	err = out.Sync()
+	return
+}
+
 func (c *PackageCommand) Run(args []string) int {
 	flags := flag.NewFlagSet("package", flag.ExitOnError)
 	osPtr := flags.String("os", "", "Target operating system")
 	archPtr := flags.String("arch", "", "Target CPU architecture")
+	pluginDirPtr := flags.String("plugin-dir", "", "Path to custom plugins directory")
 	err := flags.Parse(args)
 	if err != nil {
 		c.ui.Error(err.Error())
@@ -35,11 +91,15 @@ func (c *PackageCommand) Run(args []string) int {
 
 	osName := runtime.GOOS
 	archName := runtime.GOARCH
+	pluginDir := "./plugins"
 	if *osPtr != "" {
 		osName = *osPtr
 	}
 	if *archPtr != "" {
 		archName = *archPtr
+	}
+	if *pluginDirPtr != "" {
+		pluginDir = *pluginDirPtr
 	}
 
 	if flags.NArg() != 1 {
@@ -70,6 +130,7 @@ func (c *PackageCommand) Run(args []string) int {
 
 	coreZipURL := c.coreURL(config.Terraform.Version, osName, archName)
 	err = getter.Get(workDir, coreZipURL)
+
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("Failed to fetch core package from %s: %s", coreZipURL, err))
 	}
@@ -103,8 +164,42 @@ func (c *PackageCommand) Run(args []string) int {
 				name, constraint))
 			_, err := installer.Get(name, constraint.MustParse())
 			if err != nil {
-				c.ui.Error(fmt.Sprintf("- Failed to resolve %s provider %s: %s", name, constraint, err))
-				return 1
+				c.ui.Output(fmt.Sprintf("- Could not locate plugin in public registry Checking if %q provider (%s) is a custom plugin in: %s",
+					name, constraint, pluginDir))
+
+				//check if it is in the custom providers folder. if so then copy it to the workDir,
+				// otherwise throw error
+				plugins, err := ioutil.ReadDir(pluginDir)
+				if err != nil {
+					//there is no plugin directory so we are screwed
+					c.ui.Error(fmt.Sprintf("- Failed to resolve %s provider %s: %s", name, constraint, err))
+					return 1
+				}
+
+				var found = false
+				for _, file := range plugins {
+					var parts = strings.Split(file.Name(), "-")
+
+					//not a valid plugin name
+					if len(parts) < 2 {
+						c.ui.Output(fmt.Sprintf("- Skipping invalid file: %s", file.Name()))
+						break
+					}
+
+					var pluginName = parts[2]
+					c.ui.Output(fmt.Sprintf("- Found plugin: %s", file.Name()))
+					if pluginName == name {
+						found = true
+						CopyFile(pluginDir+"/"+file.Name(), workDir+"/"+file.Name()) //copy plugin to workDir
+						break
+					}
+				}
+
+				if !found {
+					//plugin folder exists but we can't find it
+					c.ui.Error(fmt.Sprintf("- Failed to find %s provider %s in plugins folder", name, constraint))
+					return 1
+				}
 			}
 		}
 	}
@@ -202,11 +297,13 @@ current working directory containing a Terraform binary along with zero or
 more provider plugin binaries.
 
 Options:
-  -os=name    Target operating system the archive will be built for. Defaults
-              to that of the system where the command is being run.
+  -os=name    		Target operating system the archive will be built for. Defaults
+              		to that of the system where the command is being run.
 
-  -arch=name  Target CPU architecture the archive will be built for. Defaults
-              to that of the system where the command is being run.
+  -arch=name  		Target CPU architecture the archive will be built for. Defaults
+					to that of the system where the command is being run.
+					  
+  -plugin-dir=path 	The path to the custom plugins directory. Defaults to "./plugins".
 
 The resulting zip file can be used to more easily install Terraform and
 a fixed set of providers together on a server, so that Terraform's provider
@@ -233,7 +330,13 @@ not a normal Terraform configuration file. The file format looks like this:
     # Each item in these lists allows a distinct version to be added. If the
 	# two expressions match different versions then _both_ are included in
 	# the bundle archive.
-    google = ["~> 1.0", "~> 2.0"]
+	google = ["~> 1.0", "~> 2.0"]
+	
+	#Include a custom plugin to the bundle. Will search for the plugin in the 
+	#plugins directory, and package it with the bundle archive. Plugin must have
+	#a name of the form: terraform-provider-*, and must be build with the operating
+	#system and architecture that terraform enterprise is running, e.g. linux and amd64
+	customplugin = ["0.1"]
   }
 
 `


### PR DESCRIPTION
This commit allows for terraform-bundle to be able to package custom private plugins and addresses support ticket #7214. Now, terraform-bundle will attempt to look for a plugin on the public registry, and if that fails, it will look in a local plugins directory. If the plugin can be found in the local folder, that plugin will be included in the bundle. By default the local plugins directory is "./plugins", but this can be changed by setting the -plugins-dir argument. Ex: 

my test.hcl file with a custom plugin that does not exist on the public registry
```
providers {
  # Include the newest "aws" provider version in the 1.0 series.
  aws = ["~> 1.0"]

  # Include both the newest 1.0 and 2.0 versions of the "google" provider.
  # Each item in these lists allows a distinct version to be added. If the
  # two expressions match different versions then _both_ are included in
  # the bundle archive.
  google = ["~> 1.0"]

 mycustomplugin = ["0.1"] # lives at ./my-plugins/terraform-provider-mycustomplugin
}
```

use case
```
$ terraform-bundle -os=linux -arch=amd64 -plugin-dir=./my-plugins test.hcl
```