### PR TITLE
fix improper remote-exec timeout and communicator error handling

### DIFF
--- a/communicator/communicator_mock.go
+++ b/communicator/communicator_mock.go
@@ -42,11 +42,13 @@ func (c *MockCommunicator) ScriptPath() string {
 
 // Start implementation of communicator.Communicator interface
 func (c *MockCommunicator) Start(r *remote.Cmd) error {
+	r.Init()
+
 	if !c.Commands[r.Command] {
 		return fmt.Errorf("Command not found!")
 	}
 
-	r.SetExited(0)
+	r.SetExitStatus(0, nil)
 
 	return nil
 }

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -131,6 +131,8 @@ func (c *Communicator) ScriptPath() string {
 
 // Start implementation of communicator.Communicator interface
 func (c *Communicator) Start(rc *remote.Cmd) error {
+	rc.Init()
+
 	err := c.Connect(nil)
 	if err != nil {
 		return err
@@ -168,7 +170,8 @@ func runCommand(shell *winrm.Shell, cmd *winrm.Command, rc *remote.Cmd) {
 
 	cmd.Wait()
 	wg.Wait()
-	rc.SetExited(cmd.ExitCode())
+
+	rc.SetExitStatus(cmd.ExitCode(), nil)
 }
 
 // Upload implementation of communicator.Communicator interface

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -4482,7 +4482,7 @@ func TestContext2Apply_provisionerFail_createBeforeDestroy(t *testing.T) {
 	actual := strings.TrimSpace(state.String())
 	expected := strings.TrimSpace(testTerraformApplyProvisionerFailCreateBeforeDestroyStr)
 	if actual != expected {
-		t.Fatalf("bad: \n%s", actual)
+		t.Fatalf("expected:\n%s\n:got\n%s", expected, actual)
 	}
 }
 

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -227,11 +227,8 @@ func (n *EvalApplyProvisioners) Eval(ctx EvalContext) (interface{}, error) {
 			state.Tainted = true
 		}
 
-		if n.Error != nil {
-			*n.Error = multierror.Append(*n.Error, err)
-		} else {
-			return nil, err
-		}
+		*n.Error = multierror.Append(*n.Error, err)
+		return nil, err
 	}
 
 	{

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -636,11 +636,12 @@ const testTerraformApplyProvisionerFailCreateNoIdStr = `
 `
 
 const testTerraformApplyProvisionerFailCreateBeforeDestroyStr = `
-aws_instance.bar: (1 deposed)
-  ID = bar
+aws_instance.bar: (tainted) (1 deposed)
+  ID = foo
   provider = provider.aws
-  require_new = abc
-  Deposed ID 1 = foo (tainted)
+  require_new = xyz
+  type = aws_instance
+  Deposed ID 1 = bar
 `
 
 const testTerraformApplyProvisionerResourceRefStr = `

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1983,16 +1983,20 @@
 			"revisionTime": "2016-06-08T18:30:07Z"
 		},
 		{
-			"checksumSHA1": "8z5kCCFRsBkhXic9jxxeIV3bBn8=",
+			"checksumSHA1": "dVQEUn5TxdIAXczK7rh6qUrq44Q=",
 			"path": "github.com/masterzen/winrm",
-			"revision": "a2df6b1315e6fd5885eb15c67ed259e85854125f",
-			"revisionTime": "2017-08-14T13:39:27Z"
+			"revision": "7e40f93ae939004a1ef3bd5ff5c88c756ee762bb",
+			"revisionTime": "2018-02-24T16:03:50Z",
+			"version": "master",
+			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "XFSXma+KmkhkIPsh4dTd/eyja5s=",
 			"path": "github.com/masterzen/winrm/soap",
-			"revision": "a2df6b1315e6fd5885eb15c67ed259e85854125f",
-			"revisionTime": "2017-08-14T13:39:27Z"
+			"revision": "7e40f93ae939004a1ef3bd5ff5c88c756ee762bb",
+			"revisionTime": "2018-02-24T16:03:50Z",
+			"version": "master",
+			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "rCffFCN6TpDAN3Jylyo8RFzhQ9E=",


### PR DESCRIPTION
The remote.Cmd struct could not convey any transport related error to
the caller, meaning that interrupted commands would show that they
succeeded.

Change Cmd.SetExited to accept an exit status, as well as an error to
store for the caller.  Make the status and error fields internal,
require serialized access through the getter methods.

Users of remote.Cmd should not check both Cmd.Err() and Cmd.ExitStatus()
until after Wait() returns.

Require communicators to call Cmd.Init before executing the command.
This will indicate incorrect usage of the remote.Cmd by causing a panic
in SetExitStatus.

The timeout for the remote command was taken from the wrong config
field, and the connection timeout was being used which is 5 min. Any
remote command taking more than 5 min would be terminated by
disconnecting the communicator. Remove the timeout from the context, and
rely on the global timeout provided by terraform.

There was no way to get the error from the communicator previously, so
the broken connection was silently ignored and the provisioner returned
successfully. Now we can use the new cmd.Err() method to retrieve any
errors encountered during execution.