### PR TITLE
Fix providers categories descriptions in documentation

### DIFF
--- a/website/docs/providers/type/community-index.html.markdown
+++ b/website/docs/providers/type/community-index.html.markdown
@@ -3,7 +3,7 @@ layout: "docs"
 page_title: "Community Providers"
 sidebar_current: "docs-providers-community"
 description: |-
-  Category for database vendors.
+  Category for community-built providers.
 ---
 
 # Community Providers

--- a/website/docs/providers/type/infra-index.html.markdown
+++ b/website/docs/providers/type/infra-index.html.markdown
@@ -3,7 +3,7 @@ layout: "docs"
 page_title: "Infrastructure Software Providers"
 sidebar_current: "docs-providers-infra"
 description: |-
-  Category for standard cloud vendors.
+  Category for infrastructure management vendors.
 ---
 
 # Infrastructure Software Providers

--- a/website/docs/providers/type/misc-index.html.markdown
+++ b/website/docs/providers/type/misc-index.html.markdown
@@ -3,7 +3,7 @@ layout: "docs"
 page_title: "Misc Providers"
 sidebar_current: "docs-providers-misc"
 description: |-
-  Category for database vendors.
+  Category for miscellaneous vendors.
 ---
 
 # Miscellaneous Providers

--- a/website/docs/providers/type/network-index.html.markdown
+++ b/website/docs/providers/type/network-index.html.markdown
@@ -3,7 +3,7 @@ layout: "docs"
 page_title: "Network Providers"
 sidebar_current: "docs-providers-network"
 description: |-
-  Category for netowrk vendors.
+  Category for network vendors.
 ---
 
 # Network Providers


### PR DESCRIPTION
I noticed some pages of the Terraform website have wrong descriptions in their meta headers...