### PR TITLE
clean up remote.Cmd api

### DIFF
--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -680,17 +680,10 @@ func (p *provisioner) runCommand(o terraform.UIOutput, comm communicator.Communi
 
 	outR, outW := io.Pipe()
 	errR, errW := io.Pipe()
-	outDoneCh := make(chan struct{})
-	errDoneCh := make(chan struct{})
-	go p.copyOutput(o, outR, outDoneCh)
-	go p.copyOutput(o, errR, errDoneCh)
-	go func() {
-		// Wait for output to clean up
-		outW.Close()
-		errW.Close()
-		<-outDoneCh
-		<-errDoneCh
-	}()
+	go p.copyOutput(o, outR)
+	go p.copyOutput(o, errR)
+	defer outW.Close()
+	defer errW.Close()
 
 	cmd := &remote.Cmd{
 		Command: command,
@@ -703,20 +696,17 @@ func (p *provisioner) runCommand(o terraform.UIOutput, comm communicator.Communi
 		return fmt.Errorf("Error executing command %q: %v", cmd.Command, err)
 	}
 
-	cmd.Wait()
-	if cmd.Err() != nil {
-		return cmd.Err()
-	}
-
-	if cmd.ExitStatus() != 0 {
-		return fmt.Errorf("Command %q exited with non-zero exit status: %d", cmd.Command, cmd.ExitStatus())
+	if err := cmd.Wait(); err != nil {
+		if rc, ok := err.(remote.ExitError); ok {
+			return fmt.Errorf("Command %q exited with non-zero exit status: %d", cmd.Command, rc)
+		}
+		return err
 	}
 
 	return nil
 }
 
-func (p *provisioner) copyOutput(o terraform.UIOutput, r io.Reader, doneCh chan<- struct{}) {
-	defer close(doneCh)
+func (p *provisioner) copyOutput(o terraform.UIOutput, r io.Reader) {
 	lr := linereader.New(r)
 	for line := range lr.Ch {
 		o.Output(line)

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -697,9 +697,6 @@ func (p *provisioner) runCommand(o terraform.UIOutput, comm communicator.Communi
 	}
 
 	if err := cmd.Wait(); err != nil {
-		if rc, ok := err.(remote.ExitError); ok {
-			return fmt.Errorf("Command %q exited with non-zero exit status: %d", cmd.Command, rc)
-		}
 		return err
 	}
 

--- a/builtin/provisioners/habitat/resource_provisioner.go
+++ b/builtin/provisioners/habitat/resource_provisioner.go
@@ -756,9 +756,6 @@ func (p *provisioner) runCommand(o terraform.UIOutput, comm communicator.Communi
 	}
 
 	if err := cmd.Wait(); err != nil {
-		if rc, ok := err.(remote.ExitError); ok {
-			return fmt.Errorf("Command %q exited with non-zero exit status: %d", cmd.Command, rc)
-		}
 		return err
 	}
 

--- a/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -196,14 +196,12 @@ func runScripts(
 		if err := comm.Start(cmd); err != nil {
 			return fmt.Errorf("Error starting script: %v", err)
 		}
-		cmd.Wait()
 
-		if err := cmd.Err(); err != nil {
+		if err := cmd.Wait(); err != nil {
+			if rc, ok := err.(remote.ExitError); ok {
+				return fmt.Errorf("Script exited with non-zero exit status: %d", rc)
+			}
 			return fmt.Errorf("Remote command exited with error: %s", err)
-		}
-
-		if cmd.ExitStatus() != 0 {
-			err = fmt.Errorf("Script exited with non-zero exit status: %d", cmd.ExitStatus())
 		}
 
 		// Upload a blank follow up file in the same path to prevent residual

--- a/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -198,10 +198,7 @@ func runScripts(
 		}
 
 		if err := cmd.Wait(); err != nil {
-			if rc, ok := err.(remote.ExitError); ok {
-				return fmt.Errorf("Script exited with non-zero exit status: %d", rc)
-			}
-			return fmt.Errorf("Remote command exited with error: %s", err)
+			return err
 		}
 
 		// Upload a blank follow up file in the same path to prevent residual

--- a/builtin/provisioners/salt-masterless/resource_provisioner.go
+++ b/builtin/provisioners/salt-masterless/resource_provisioner.go
@@ -161,9 +161,6 @@ func applyFn(ctx context.Context) error {
 		}
 
 		if err := cmd.Wait(); err != nil {
-			if rc, ok := err.(remote.ExitError); ok {
-				return fmt.Errorf("Curl exited with non-zero exit status: %d", rc)
-			}
 			return err
 		}
 
@@ -186,9 +183,6 @@ func applyFn(ctx context.Context) error {
 		}
 
 		if err := cmd.Wait(); err != nil {
-			if rc, ok := err.(remote.ExitError); ok {
-				return fmt.Errorf("install_salt.sh exited with non-zero exit status: %d", rc)
-			}
 			return err
 		}
 	}
@@ -273,9 +267,6 @@ func applyFn(ctx context.Context) error {
 	}
 
 	if err := cmd.Wait(); err != nil {
-		if rc, ok := err.(remote.ExitError); ok {
-			return fmt.Errorf("Script exited with non-zero exit status: %d", rc)
-		}
 		return err
 	}
 	return nil
@@ -340,9 +331,6 @@ func (p *provisioner) moveFile(o terraform.UIOutput, comm communicator.Communica
 		return fmt.Errorf("Unable to move %s to %s: %s", src, dst, err)
 	}
 	if err := cmd.Wait(); err != nil {
-		if rc, ok := err.(remote.ExitError); ok {
-			return fmt.Errorf("Unable to move %s to %s: exit status: %d", src, dst, rc)
-		}
 		return err
 	}
 	return nil
@@ -358,9 +346,6 @@ func (p *provisioner) createDir(o terraform.UIOutput, comm communicator.Communic
 	}
 
 	if err := cmd.Wait(); err != nil {
-		if _, ok := err.(remote.ExitError); ok {
-			return fmt.Errorf("Non-zero exit status.")
-		}
 		return err
 	}
 	return nil
@@ -375,9 +360,6 @@ func (p *provisioner) removeDir(o terraform.UIOutput, comm communicator.Communic
 		return err
 	}
 	if err := cmd.Wait(); err != nil {
-		if _, ok := err.(remote.ExitError); ok {
-			return fmt.Errorf("Non-zero exit status.")
-		}
 		return err
 	}
 	return nil

--- a/communicator/remote/command.go
+++ b/communicator/remote/command.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"fmt"
 	"io"
 	"sync"
 )
@@ -59,23 +60,28 @@ func (c *Cmd) SetExitStatus(status int, err error) {
 	close(c.exitCh)
 }
 
-// Err returns any communicator related error.
-func (c *Cmd) Err() error {
-	c.Lock()
-	defer c.Unlock()
-
-	return c.err
-}
-
-// ExitStatus returns the exit status of the remote command
-func (c *Cmd) ExitStatus() int {
-	c.Lock()
-	defer c.Unlock()
-
-	return c.exitStatus
-}
-
 // Wait waits for the remote command to complete.
-func (c *Cmd) Wait() {
+// Wait may return an error from the communicator, or an ExitError if the
+// process exits with a non-zero exit status.
+func (c *Cmd) Wait() error {
 	<-c.exitCh
+
+	c.Lock()
+	defer c.Unlock()
+
+	if c.err != nil {
+		return c.err
+	}
+
+	if c.exitStatus != 0 {
+		return ExitError(c.exitStatus)
+	}
+
+	return nil
+}
+
+type ExitError int
+
+func (e ExitError) Error() string {
+	return fmt.Sprintf("exit status: %d", e)
 }

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -359,11 +359,11 @@ func (c *Communicator) UploadScript(path string, input io.Reader) error {
 			"Error chmodding script file to 0777 in remote "+
 				"machine: %s", err)
 	}
-	cmd.Wait()
-	if cmd.ExitStatus() != 0 {
+
+	if err := cmd.Wait(); err != nil {
 		return fmt.Errorf(
 			"Error chmodding script file to 0777 in remote "+
-				"machine %d: %s %s", cmd.ExitStatus(), stdout.String(), stderr.String())
+				"machine %v: %s %s", err, stdout.String(), stderr.String())
 	}
 
 	return nil

--- a/communicator/ssh/communicator_test.go
+++ b/communicator/ssh/communicator_test.go
@@ -219,12 +219,9 @@ func TestLostConnection(t *testing.T) {
 		c.Disconnect()
 	}()
 
-	cmd.Wait()
-	if cmd.Err() == nil {
+	err = cmd.Wait()
+	if err == nil {
 		t.Fatal("expected communicator error")
-	}
-	if cmd.ExitStatus() != 0 {
-		t.Fatal("command should not have returned an exit status")
 	}
 }
 


### PR DESCRIPTION
This reduces the surface area for the `remote.Cmd` API, as mentioned in #17596.

Combine the `ExitStatus` and `Err` values from `remote.Cmd` into an error
returned by `Wait`, better matching the behavior of the `os/exec` package.

Non-zero exit codes are returned from Wait as a `remote.ExitError`.
Communicator related errors are returned directly.

Clean up all the error handling in the provisioners using a
communicator. Also remove the extra copyOutput synchronization that was
copied from package to package.