### PR TITLE
website: remove an unnecessary parameter for API

### DIFF
--- a/website/docs/registry/api.html.md
+++ b/website/docs/registry/api.html.md
@@ -663,9 +663,6 @@ download endpoint (above) for the latest version.
 - `provider` `(string: <required>)` - The name of the provider.
   This is required and is specified as part of the URL path.
 
-- `version` `(string: <required>)` - The version of the module.
-  This is required and is specified as part of the URL path.
-
 ### Sample Request
 
 ```text


### PR DESCRIPTION
In [Download the Latest Version of a Module](https://www.terraform.io/docs/registry/api.html#download-the-latest-version-of-a-module) API document for registry, `version` parameter isn't needed for that API.
