### PR TITLE
WIP: interpolate funcs: support format in timestamp and addtime

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -1504,7 +1504,16 @@ func interpolationFuncTimestamp() ast.Function {
 		ArgTypes:   []ast.Type{},
 		ReturnType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {
-			return time.Now().UTC().Format(time.RFC3339), nil
+
+			format := time.RFC3339
+			if len(args) > 0 {
+				f, ok := args[0].(string)
+				if !ok {
+					return nil, fmt.Errorf("argument %d represents a time layout, so it must be a string", 2)
+				}
+				format = f
+			}
+			return time.Now().UTC().Format(format), nil
 		},
 	}
 }
@@ -1518,7 +1527,26 @@ func interpolationFuncTimeAdd() ast.Function {
 		ReturnType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {
 
-			ts, err := time.Parse(time.RFC3339, args[0].(string))
+			inputFormat := time.RFC3339
+			outputFormat := time.RFC3339
+
+			if len(args) > 2 {
+				f, ok := args[2].(string)
+				if !ok {
+					return nil, fmt.Errorf("argument %d represents a time layout, so it must be a string", 3)
+				}
+				outputFormat = f
+			}
+
+			if len(args) > 3 {
+				f, ok := args[3].(string)
+				if !ok {
+					return nil, fmt.Errorf("argument %d represents a time layout, so it must be a string", 4)
+				}
+				outputFormat = f
+			}
+
+			ts, err := time.Parse(inputFormat, args[0].(string))
 			if err != nil {
 				return nil, err
 			}
@@ -1527,7 +1555,7 @@ func interpolationFuncTimeAdd() ast.Function {
 				return nil, err
 			}
 
-			return ts.Add(duration).Format(time.RFC3339), nil
+			return ts.Add(duration).Format(outputFormat), nil
 		},
 	}
 }

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -402,12 +402,15 @@ The supported built-in functions are:
 
   * `substr(string, offset, length)` - Extracts a substring from the input string. A negative offset is interpreted as being equivalent to a positive offset measured backwards from the end of the string. A length of `-1` is interpreted as meaning "until the end of the string".
 
-  * `timestamp()` - Returns a UTC timestamp string in RFC 3339 format. This string will change with every
+  * `timestamp(format)` - Returns a UTC timestamp string in `format`. This string will change with every
    invocation of the function, so in order to prevent diffs on every plan & apply, it must be used with the
    [`ignore_changes`](/docs/configuration/resources.html#ignore-changes) lifecycle attribute.
+   The format syntax is the same as Go's time layout as documented in [go time pkg](https://golang.org/pkg/time/#pkg-constants).
+    A default `format` of `RFC 3339` is used if not provided.
 
-  * `timeadd(time, duration)` - Returns a UTC timestamp string corresponding to adding a given `duration` to `time` in RFC 3339 format.      
+  * `timeadd(time, duration, format, timeFormat)` - Returns a UTC timestamp string corresponding to adding a given `duration` to `time` in `format`.
     For example, `timeadd("2017-11-22T00:00:00Z", "10m")` produces a value `"2017-11-22T00:10:00Z"`. 
+    A default `format` and `timeFormat` of `RFC 3339` is used when not provided.
     
   * `title(string)` - Returns a copy of the string with the first characters of all the words capitalized.
 


### PR DESCRIPTION
Hello!

Add optional format arguments to timestamp and addtime interopolate
functions.

Fixes #16146

Related #12395 - no longer need to use md5 and instead use a time
formated that is allowed in snapshot names.


This is a backwards compatible change and once I get an initial review, I will add tests.

Cheers