### PR TITLE
remove more unneeded partial outputs

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -2969,6 +2969,28 @@ STATE:
 	}
 }
 
+// ensure that outputs missing references due to targetting are removed from
+// the graph.
+func TestContext2Plan_outputContainsTargetedResource(t *testing.T) {
+	m := testModule(t, "plan-untargeted-resource-output")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		ProviderResolver: ResourceProviderResolverFixed(
+			map[string]ResourceProviderFactory{
+				"aws": testProviderFuncFixed(p),
+			},
+		),
+		Targets: []string{"module.mod.aws_instance.a"},
+	})
+
+	_, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 // https://github.com/hashicorp/terraform/issues/4515
 func TestContext2Plan_targetedOverTen(t *testing.T) {
 	m := testModule(t, "plan-targeted-over-ten")

--- a/terraform/test-fixtures/plan-untargeted-resource-output/main.tf
+++ b/terraform/test-fixtures/plan-untargeted-resource-output/main.tf
@@ -1,0 +1,8 @@
+module "mod" {
+  source = "./mod"
+}
+
+
+resource "aws_instance" "c" {
+  name = "${module.mod.output}"
+}

--- a/terraform/test-fixtures/plan-untargeted-resource-output/mod/main.tf
+++ b/terraform/test-fixtures/plan-untargeted-resource-output/mod/main.tf
@@ -1,0 +1,15 @@
+locals {
+  "one" = 1
+}
+
+resource "aws_instance" "a" {
+  count = "${local.one}"
+}
+
+resource "aws_instance" "b" {
+  count = "${local.one}"
+}
+
+output "output" {
+  value = "${join("", coalescelist(aws_instance.a.*.id, aws_instance.b.*.id))}"
+}

--- a/terraform/transform_targets.go
+++ b/terraform/transform_targets.go
@@ -217,6 +217,12 @@ func filterPartialOutputs(v interface{}, targetedNodes *dag.Set, g *Graph) bool 
 		if _, ok := d.(*NodeCountBoundary); ok {
 			continue
 		}
+
+		if !targetedNodes.Include(d) {
+			// this one is going to be removed, so it doesn't count
+			continue
+		}
+
 		// as soon as we see a real dependency, we mark this as
 		// non-removable
 		return true


### PR DESCRIPTION
filterPartialOutputs was not taking into account that some dependent
resources might yet be removed from the graph. Check that they are not
in the targeted set before declaring that the output remain.

fixes #17462 