### PR TITLE
unlock state in console, import, graph, and push

### DIFF
--- a/command/console.go
+++ b/command/console.go
@@ -81,6 +81,13 @@ func (c *ConsoleCommand) Run(args []string) int {
 		return 1
 	}
 
+	defer func() {
+		err := opReq.StateLocker.Unlock(nil)
+		if err != nil {
+			c.Ui.Error(err.Error())
+		}
+	}()
+
 	// Setup the UI so we can output directly to stdout
 	ui := &cli.BasicUi{
 		Writer:      wrappedstreams.Stdout(),

--- a/command/graph.go
+++ b/command/graph.go
@@ -112,6 +112,13 @@ func (c *GraphCommand) Run(args []string) int {
 		return 1
 	}
 
+	defer func() {
+		err := opReq.StateLocker.Unlock(nil)
+		if err != nil {
+			c.Ui.Error(err.Error())
+		}
+	}()
+
 	// Determine the graph type
 	graphType := terraform.GraphTypePlan
 	if plan != nil {

--- a/command/import.go
+++ b/command/import.go
@@ -184,6 +184,13 @@ func (c *ImportCommand) Run(args []string) int {
 		return 1
 	}
 
+	defer func() {
+		err := opReq.StateLocker.Unlock(nil)
+		if err != nil {
+			c.Ui.Error(err.Error())
+		}
+	}()
+
 	// Perform the import. Note that as you can see it is possible for this
 	// API to import more than one resource at once. For now, we only allow
 	// one while we stabilize this feature.

--- a/command/import_test.go
+++ b/command/import_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -175,9 +176,15 @@ func TestImport_remoteState(t *testing.T) {
 		"test_instance.foo",
 		"bar",
 	}
+
 	if code := c.Run(args); code != 0 {
 		fmt.Println(ui.OutputWriter)
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// verify that the local state was unlocked after import
+	if _, err := os.Stat(filepath.Join(td, fmt.Sprintf(".%s.lock.info", statePath))); !os.IsNotExist(err) {
+		t.Fatal("state left locked after import")
 	}
 
 	// Verify that we were called

--- a/command/push.go
+++ b/command/push.go
@@ -146,6 +146,13 @@ func (c *PushCommand) Run(args []string) int {
 		return 1
 	}
 
+	defer func() {
+		err := opReq.StateLocker.Unlock(nil)
+		if err != nil {
+			c.Ui.Error(err.Error())
+		}
+	}()
+
 	// Get the configuration
 	config := ctx.Module().Config()
 	if name == "" {


### PR DESCRIPTION
The state locking improvements for the regular commands had the side
effect of locking the state in the console, import, graph and push
commands. Those commands had been updated to get a state via the
Backend.Context method, which now locks the state whenever possible.

Add Unlock calls to all commands that call Context directly.

Fixes #17624