### PR TITLE
make sure ResourceData timeouts are always set

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -492,6 +492,12 @@ func (r *Resource) Data(s *terraform.InstanceState) *ResourceData {
 		panic(err)
 	}
 
+	// load the Resource timeouts
+	result.timeouts = r.Timeouts
+	if result.timeouts == nil {
+		result.timeouts = &ResourceTimeout{}
+	}
+
 	// Set the schema version to latest by default
 	result.meta = map[string]interface{}{
 		"schema_version": strconv.Itoa(r.SchemaVersion),

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -366,6 +366,13 @@ func (d *ResourceData) State() *terraform.InstanceState {
 func (d *ResourceData) Timeout(key string) time.Duration {
 	key = strings.ToLower(key)
 
+	// System default of 20 minutes
+	defaultTimeout := 20 * time.Minute
+
+	if d.timeouts == nil {
+		return defaultTimeout
+	}
+
 	var timeout *time.Duration
 	switch key {
 	case TimeoutCreate:
@@ -386,8 +393,7 @@ func (d *ResourceData) Timeout(key string) time.Duration {
 		return *d.timeouts.Default
 	}
 
-	// Return system default of 20 minutes
-	return 20 * time.Minute
+	return defaultTimeout
 }
 
 func (d *ResourceData) init() {

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -1366,6 +1366,11 @@ func TestResourceDataTimeout(t *testing.T) {
 			Rd:       &ResourceData{timeouts: timeoutForValues(10, 3, 0, 0, 13)},
 			Expected: expectedTimeoutForValues(10, 3, 13, 13, 13),
 		},
+		{
+			Name:     "Resource has no config",
+			Rd:       &ResourceData{},
+			Expected: expectedTimeoutForValues(0, 0, 0, 0, 0),
+		},
 	}
 
 	keys := timeoutKeys()
@@ -1398,7 +1403,7 @@ func TestResourceDataTimeout(t *testing.T) {
 				// confirm values
 				if ex != nil {
 					if got != *ex {
-						t.Fatalf("Timeout %s case (%d) expected (%#v), got (%#v)", k, i, *ex, got)
+						t.Fatalf("Timeout %s case (%d) expected (%s), got (%s)", k, i, *ex, got)
 					}
 				}
 			}

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -1318,3 +1318,39 @@ func TestResourceData_blank(t *testing.T) {
 		t.Fatalf("bad: %#v", v)
 	}
 }
+
+func TestResourceData_timeouts(t *testing.T) {
+	one := 1 * time.Second
+	two := 2 * time.Second
+	three := 3 * time.Second
+	four := 4 * time.Second
+	five := 5 * time.Second
+
+	timeouts := &ResourceTimeout{
+		Create:  &one,
+		Read:    &two,
+		Update:  &three,
+		Delete:  &four,
+		Default: &five,
+	}
+
+	r := &Resource{
+		SchemaVersion: 2,
+		Schema: map[string]*Schema{
+			"foo": &Schema{
+				Type:     TypeInt,
+				Optional: true,
+			},
+		},
+		Timeouts: timeouts,
+	}
+
+	data := r.Data(nil)
+	if data.Id() != "" {
+		t.Fatalf("err: %s", data.Id())
+	}
+
+	if !reflect.DeepEqual(timeouts, data.timeouts) {
+		t.Fatalf("incorrect ResourceData timeouts: %#v\n", *data.timeouts)
+	}
+}


### PR DESCRIPTION
Return the global default timeout if the ResourceData timeouts are nil.

Set the timeouts from the Resource when calling Resource.Data, so that
the provider-configured values are always available.

Fixes #17672