### PR TITLE
docs: no interpolations in `lifecycle` attribute (#3116)

### DIFF
--- a/website/docs/configuration/resources.html.md
+++ b/website/docs/configuration/resources.html.md
@@ -92,6 +92,8 @@ There are **meta-parameters** available to all resources:
         which will match all attribute names. Using a partial string together
         with a wildcard (e.g. `"rout*"`) is **not** supported.
 
+  -> **Note**: Interpolations are **not** supported in `lifecycle` yet (see [issue #3116](https://github.com/hashicorp/terraform/issues/3116)).
+
 ### Timeouts
 
 Individual Resources may provide a `timeouts` block to enable users to configure the

--- a/website/docs/configuration/resources.html.md
+++ b/website/docs/configuration/resources.html.md
@@ -92,7 +92,7 @@ There are **meta-parameters** available to all resources:
         which will match all attribute names. Using a partial string together
         with a wildcard (e.g. `"rout*"`) is **not** supported.
 
-  -> **Note**: Interpolations are **not** supported in `lifecycle` yet (see [issue #3116](https://github.com/hashicorp/terraform/issues/3116)).
+  -> Interpolations are not currently supported in the `lifecycle` configuration block (see [issue #3116](https://github.com/hashicorp/terraform/issues/3116))
 
 ### Timeouts
 


### PR DESCRIPTION
I like to see in documentation what's non-expected behaviour and where to follow for updates.

#3116