### PR TITLE
Fix scrub mistake

### DIFF
--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -173,7 +173,7 @@ func (c *PackageCommand) Run(args []string) int {
 
 			if len(foundPlugins) > 0 {
 				plugin := foundPlugins.Newest()
-				CopyFile(plugin.Path, workDir+"/terraform-provider-"+plugin.Name+"-v"+plugin.Version.MustParse().String()) //put into temp dir
+				CopyFile(plugin.Path, workDir+"/terraform-provider-"+plugin.Name+"_v"+plugin.Version.MustParse().String()) //put into temp dir
 			} else { //attempt to get from the public registry if not found locally
 				c.ui.Output(fmt.Sprintf("- Checking for provider plugin on %s...",
 					discovery.GetReleaseHost()))


### PR DESCRIPTION
Fixed a bug in which an example custom provider would be saved as "terraform-provider-custom-v0.0.1" instead of "terraform-provider-custom_v0.0.1". Not an issue when running the bundle on TFE, but is annoying when trying to run a terraform bundle locally.