### PR TITLE
configs: Various utilities needed for handling HCL2-based configuration

### DIFF
--- a/config/configschema/coerce_value.go
+++ b/config/configschema/coerce_value.go
@@ -1,0 +1,241 @@
+package configschema
+
+import (
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+// CoerceValue attempts to force the given value to conform to the type
+// implied by the receiever, while also applying the same validation and
+// transformation rules that would be applied by the decoder specification
+// returned by method DecoderSpec.
+//
+// This is useful in situations where a configuration must be derived from
+// an already-decoded value. It is always better to decode directly from
+// configuration where possible since then source location information is
+// still available to produce diagnostics, but in special situations this
+// function allows a compatible result to be obtained even if the
+// configuration objects are not available.
+//
+// If the given value cannot be converted to conform to the receiving schema
+// then an error is returned describing one of possibly many problems. This
+// error may be a cty.PathError indicating a position within the nested
+// data structure where the problem applies.
+func (b *Block) CoerceValue(in cty.Value) (cty.Value, error) {
+	var path cty.Path
+	return b.coerceValue(in, path)
+}
+
+func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
+	switch {
+	case in.IsNull():
+		return cty.NullVal(b.ImpliedType()), nil
+	case !in.IsKnown():
+		return cty.UnknownVal(b.ImpliedType()), nil
+	}
+
+	ty := in.Type()
+	if !ty.IsObjectType() {
+		return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("an object is required")
+	}
+
+	for name := range ty.AttributeTypes() {
+		if _, defined := b.Attributes[name]; defined {
+			continue
+		}
+		if _, defined := b.BlockTypes[name]; defined {
+			continue
+		}
+		return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("unexpected attribute %q", name)
+	}
+
+	attrs := make(map[string]cty.Value)
+
+	for name, attrS := range b.Attributes {
+		var val cty.Value
+		switch {
+		case ty.HasAttribute(name):
+			val = in.GetAttr(name)
+		case attrS.Computed:
+			val = cty.UnknownVal(attrS.Type)
+		case attrS.Optional:
+			val = cty.NullVal(attrS.Type)
+		default:
+			return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("attribute %q is required", name)
+		}
+
+		val, err := attrS.coerceValue(val, append(path, cty.GetAttrStep{Name: name}))
+		if err != nil {
+			return cty.UnknownVal(b.ImpliedType()), err
+		}
+
+		attrs[name] = val
+	}
+	for typeName, blockS := range b.BlockTypes {
+		switch blockS.Nesting {
+
+		case NestingSingle:
+			switch {
+			case ty.HasAttribute(typeName):
+				var err error
+				val := in.GetAttr(typeName)
+				attrs[typeName], err = blockS.coerceValue(val, append(path, cty.GetAttrStep{Name: typeName}))
+				if err != nil {
+					return cty.UnknownVal(b.ImpliedType()), err
+				}
+			case blockS.MinItems != 1 && blockS.MaxItems != 1:
+				attrs[typeName] = cty.NullVal(blockS.ImpliedType())
+			default:
+				// We use the word "attribute" here because we're talking about
+				// the cty sense of that word rather than the HCL sense.
+				return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("attribute %q is required", typeName)
+			}
+
+		case NestingList:
+			switch {
+			case ty.HasAttribute(typeName):
+				coll := in.GetAttr(typeName)
+
+				switch {
+				case coll.IsNull():
+					attrs[typeName] = cty.NullVal(cty.List(b.ImpliedType()))
+					continue
+				case !coll.IsKnown():
+					attrs[typeName] = cty.UnknownVal(cty.List(b.ImpliedType()))
+					continue
+				}
+
+				if !coll.CanIterateElements() {
+					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("attribute %q must be a list", typeName)
+				}
+				l := coll.LengthInt()
+				if l < blockS.MinItems {
+					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("insufficient items for attribute %q; must have at least %d", typeName, blockS.MinItems)
+				}
+				if l > blockS.MaxItems && blockS.MaxItems > 0 {
+					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("too many items for attribute %q; must have at least %d", typeName, blockS.MinItems)
+				}
+				if l == 0 {
+					attrs[typeName] = cty.ListValEmpty(b.ImpliedType())
+					continue
+				}
+				elems := make([]cty.Value, 0, l)
+				for it := in.ElementIterator(); it.Next(); {
+					var err error
+					_, val := it.Element()
+					val, err = blockS.coerceValue(val, append(path, cty.GetAttrStep{Name: typeName}))
+					if err != nil {
+						return cty.UnknownVal(b.ImpliedType()), err
+					}
+					elems = append(elems, val)
+				}
+				attrs[typeName] = cty.ListVal(elems)
+			case blockS.MinItems == 0:
+				attrs[typeName] = cty.ListValEmpty(blockS.ImpliedType())
+			default:
+				return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("attribute %q is required", typeName)
+			}
+
+		case NestingSet:
+			switch {
+			case ty.HasAttribute(typeName):
+				coll := in.GetAttr(typeName)
+
+				switch {
+				case coll.IsNull():
+					attrs[typeName] = cty.NullVal(cty.Set(b.ImpliedType()))
+					continue
+				case !coll.IsKnown():
+					attrs[typeName] = cty.UnknownVal(cty.Set(b.ImpliedType()))
+					continue
+				}
+
+				if !coll.CanIterateElements() {
+					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("attribute %q must be a set", typeName)
+				}
+				l := coll.LengthInt()
+				if l < blockS.MinItems {
+					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("insufficient items for attribute %q; must have at least %d", typeName, blockS.MinItems)
+				}
+				if l > blockS.MaxItems && blockS.MaxItems > 0 {
+					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("too many items for attribute %q; must have at least %d", typeName, blockS.MinItems)
+				}
+				if l == 0 {
+					attrs[typeName] = cty.SetValEmpty(b.ImpliedType())
+					continue
+				}
+				elems := make([]cty.Value, 0, l)
+				for it := in.ElementIterator(); it.Next(); {
+					var err error
+					_, val := it.Element()
+					val, err = blockS.coerceValue(val, append(path, cty.GetAttrStep{Name: typeName}))
+					if err != nil {
+						return cty.UnknownVal(b.ImpliedType()), err
+					}
+					elems = append(elems, val)
+				}
+				attrs[typeName] = cty.SetVal(elems)
+			case blockS.MinItems == 0:
+				attrs[typeName] = cty.SetValEmpty(blockS.ImpliedType())
+			default:
+				return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("attribute %q is required", typeName)
+			}
+
+		case NestingMap:
+			switch {
+			case ty.HasAttribute(typeName):
+				coll := in.GetAttr(typeName)
+
+				switch {
+				case coll.IsNull():
+					attrs[typeName] = cty.NullVal(cty.Map(b.ImpliedType()))
+					continue
+				case !coll.IsKnown():
+					attrs[typeName] = cty.UnknownVal(cty.Map(b.ImpliedType()))
+					continue
+				}
+
+				if !coll.CanIterateElements() {
+					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("attribute %q must be a map", typeName)
+				}
+				l := coll.LengthInt()
+				if l == 0 {
+					attrs[typeName] = cty.MapValEmpty(b.ImpliedType())
+					continue
+				}
+				elems := make(map[string]cty.Value)
+				for it := in.ElementIterator(); it.Next(); {
+					var err error
+					key, val := it.Element()
+					if key.Type() != cty.String || key.IsNull() || !key.IsKnown() {
+						return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("attribute %q must be a map", typeName)
+					}
+					val, err = blockS.coerceValue(val, append(path, cty.GetAttrStep{Name: typeName}))
+					if err != nil {
+						return cty.UnknownVal(b.ImpliedType()), err
+					}
+					elems[key.AsString()] = val
+				}
+				attrs[typeName] = cty.MapVal(elems)
+			default:
+				attrs[typeName] = cty.MapValEmpty(blockS.ImpliedType())
+			}
+
+		default:
+			// should never happen because above is exhaustive
+			panic(fmt.Errorf("unsupported nesting mode %#v", blockS.Nesting))
+		}
+	}
+
+	return cty.ObjectVal(attrs), nil
+}
+
+func (a *Attribute) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
+	val, err := convert.Convert(in, a.Type)
+	if err != nil {
+		return cty.UnknownVal(a.Type), path.NewError(err)
+	}
+	return val, nil
+}

--- a/config/configschema/coerce_value_test.go
+++ b/config/configschema/coerce_value_test.go
@@ -1,0 +1,233 @@
+package configschema
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestCoerceValue(t *testing.T) {
+	tests := map[string]struct {
+		Schema    *Block
+		Input     cty.Value
+		WantValue cty.Value
+		WantErr   string
+	}{
+		"empty schema and value": {
+			&Block{},
+			cty.EmptyObjectVal,
+			cty.EmptyObjectVal,
+			``,
+		},
+		"attribute present": {
+			&Block{
+				Attributes: map[string]*Attribute{
+					"foo": {
+						Type:     cty.String,
+						Optional: true,
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.True,
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("true"),
+			}),
+			``,
+		},
+		"single block present": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"foo": {
+						Block:   Block{},
+						Nesting: NestingSingle,
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.EmptyObjectVal,
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.EmptyObjectVal,
+			}),
+			``,
+		},
+		"single block wrong type": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"foo": {
+						Block:   Block{},
+						Nesting: NestingSingle,
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.True,
+			}),
+			cty.DynamicVal,
+			`an object is required`,
+		},
+		"missing optional attribute": {
+			&Block{
+				Attributes: map[string]*Attribute{
+					"foo": {
+						Type:     cty.String,
+						Optional: true,
+					},
+				},
+			},
+			cty.EmptyObjectVal,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(cty.String),
+			}),
+			``,
+		},
+		"missing optional single block": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"foo": {
+						Block:   Block{},
+						Nesting: NestingSingle,
+					},
+				},
+			},
+			cty.EmptyObjectVal,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(cty.EmptyObject),
+			}),
+			``,
+		},
+		"missing optional list block": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"foo": {
+						Block:   Block{},
+						Nesting: NestingList,
+					},
+				},
+			},
+			cty.EmptyObjectVal,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListValEmpty(cty.EmptyObject),
+			}),
+			``,
+		},
+		"missing optional set block": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"foo": {
+						Block:   Block{},
+						Nesting: NestingSet,
+					},
+				},
+			},
+			cty.EmptyObjectVal,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetValEmpty(cty.EmptyObject),
+			}),
+			``,
+		},
+		"missing optional map block": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"foo": {
+						Block:   Block{},
+						Nesting: NestingMap,
+					},
+				},
+			},
+			cty.EmptyObjectVal,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.MapValEmpty(cty.EmptyObject),
+			}),
+			``,
+		},
+		"missing required attribute": {
+			&Block{
+				Attributes: map[string]*Attribute{
+					"foo": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+			},
+			cty.EmptyObjectVal,
+			cty.DynamicVal,
+			`attribute "foo" is required`,
+		},
+		"missing required single block": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"foo": {
+						Block:    Block{},
+						Nesting:  NestingSingle,
+						MinItems: 1,
+						MaxItems: 1,
+					},
+				},
+			},
+			cty.EmptyObjectVal,
+			cty.DynamicVal,
+			`attribute "foo" is required`,
+		},
+		"missing required list block": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"foo": {
+						Block:    Block{},
+						Nesting:  NestingList,
+						MinItems: 1,
+					},
+				},
+			},
+			cty.EmptyObjectVal,
+			cty.DynamicVal,
+			`attribute "foo" is required`,
+		},
+		"missing required set block": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"foo": {
+						Block:    Block{},
+						Nesting:  NestingList,
+						MinItems: 1,
+					},
+				},
+			},
+			cty.EmptyObjectVal,
+			cty.DynamicVal,
+			`attribute "foo" is required`,
+		},
+		"extraneous attribute": {
+			&Block{},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("bar"),
+			}),
+			cty.DynamicVal,
+			`unexpected attribute "foo"`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotValue, gotErrObj := test.Schema.CoerceValue(test.Input)
+
+			if gotErrObj == nil {
+				if test.WantErr != "" {
+					t.Fatalf("coersion succeeded; want error: %q", test.WantErr)
+				}
+			} else {
+				gotErr := gotErrObj.Error()
+				if gotErr != test.WantErr {
+					t.Fatalf("wrong error\ngot:  %s\nwant: %s", gotErr, test.WantErr)
+				}
+				return
+			}
+
+			if !gotValue.RawEquals(test.WantValue) {
+				t.Errorf("wrong result\ninput: %#v\ngot:   %#v\nwant:  %#v", test.Input, gotValue, test.WantValue)
+			}
+		})
+	}
+}

--- a/config/configschema/schema.go
+++ b/config/configschema/schema.go
@@ -28,6 +28,12 @@ type Attribute struct {
 	// Type is a type specification that the attribute's value must conform to.
 	Type cty.Type
 
+	// Description is an English-language description of the purpose and
+	// usage of the attribute. A description should be concise and use only
+	// one or two sentences, leaving full definition to longer-form
+	// documentation defined elsewhere.
+	Description string
+
 	// Required, if set to true, specifies that an omitted or null value is
 	// not permitted.
 	Required bool

--- a/configs/configload/loader.go
+++ b/configs/configload/loader.go
@@ -90,3 +90,10 @@ func (l *Loader) Parser() *configs.Parser {
 func (l *Loader) Sources() map[string][]byte {
 	return l.parser.Sources()
 }
+
+// IsConfigDir returns true if and only if the given directory contains at
+// least one Terraform configuration file. This is a wrapper around calling
+// the same method name on the loader's parser.
+func (l *Loader) IsConfigDir(path string) bool {
+	return l.parser.IsConfigDir(path)
+}

--- a/configs/module_merge.go
+++ b/configs/module_merge.go
@@ -28,7 +28,7 @@ func (p *Provider) merge(op *Provider) hcl.Diagnostics {
 		p.Version = op.Version
 	}
 
-	p.Config = mergeBodies(p.Config, op.Config)
+	p.Config = MergeBodies(p.Config, op.Config)
 
 	return diags
 }
@@ -172,7 +172,7 @@ func (mc *ModuleCall) merge(omc *ModuleCall) hcl.Diagnostics {
 		mc.Version = omc.Version
 	}
 
-	mc.Config = mergeBodies(mc.Config, omc.Config)
+	mc.Config = MergeBodies(mc.Config, omc.Config)
 
 	// We don't allow depends_on to be overridden because that is likely to
 	// cause confusing misbehavior.
@@ -218,7 +218,7 @@ func (r *ManagedResource) merge(or *ManagedResource) hcl.Diagnostics {
 		r.Provisioners = or.Provisioners
 	}
 
-	r.Config = mergeBodies(r.Config, or.Config)
+	r.Config = MergeBodies(r.Config, or.Config)
 
 	// We don't allow depends_on to be overridden because that is likely to
 	// cause confusing misbehavior.
@@ -247,7 +247,7 @@ func (r *DataResource) merge(or *DataResource) hcl.Diagnostics {
 		r.ProviderConfigRef = or.ProviderConfigRef
 	}
 
-	r.Config = mergeBodies(r.Config, or.Config)
+	r.Config = MergeBodies(r.Config, or.Config)
 
 	// We don't allow depends_on to be overridden because that is likely to
 	// cause confusing misbehavior.

--- a/configs/module_merge_body.go
+++ b/configs/module_merge_body.go
@@ -4,7 +4,15 @@ import (
 	"github.com/hashicorp/hcl2/hcl"
 )
 
-func mergeBodies(base, override hcl.Body) hcl.Body {
+// MergeBodies creates a new HCL body that contains a combination of the
+// given base and override bodies. Attributes and blocks defined in the
+// override body take precedence over those of the same name defined in
+// the base body.
+//
+// If any block of a particular type appears in "override" then it will
+// replace _all_ of the blocks of the same type in "base" in the new
+// body.
+func MergeBodies(base, override hcl.Body) hcl.Body {
 	return mergeBody{
 		Base:     base,
 		Override: override,
@@ -55,7 +63,7 @@ func (b mergeBody) PartialContent(schema *hcl.BodySchema) (*hcl.BodyContent, hcl
 
 	content := b.prepareContent(baseContent, overrideContent)
 
-	remain := mergeBodies(baseRemain, overrideRemain)
+	remain := MergeBodies(baseRemain, overrideRemain)
 
 	return content, remain, diags
 }

--- a/configs/synth_body.go
+++ b/configs/synth_body.go
@@ -1,0 +1,118 @@
+package configs
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// SynthBody produces a synthetic hcl.Body that behaves as if it had attributes
+// corresponding to the elements given in the values map.
+//
+// This is useful in situations where, for example, values provided on the
+// command line can override values given in configuration, using MergeBodies.
+//
+// The given filename is used in case any diagnostics are returned. Since
+// the created body is synthetic, it is likely that this will not be a "real"
+// filename. For example, if from a command line argument it could be
+// a representation of that argument's name, such as "-var=...".
+func SynthBody(filename string, values map[string]cty.Value) hcl.Body {
+	return synthBody{
+		Filename: filename,
+		Values:   values,
+	}
+}
+
+type synthBody struct {
+	Filename string
+	Values   map[string]cty.Value
+}
+
+func (b synthBody) Content(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Diagnostics) {
+	content, remain, diags := b.PartialContent(schema)
+	remainS := remain.(synthBody)
+	for name := range remainS.Values {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unsupported attribute",
+			Detail:   fmt.Sprintf("An attribute named %q is not expected here.", name),
+			Subject:  b.synthRange().Ptr(),
+		})
+	}
+	return content, diags
+}
+
+func (b synthBody) PartialContent(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Body, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	content := &hcl.BodyContent{
+		Attributes:       make(hcl.Attributes),
+		MissingItemRange: b.synthRange(),
+	}
+
+	remainValues := make(map[string]cty.Value)
+	for attrName, val := range b.Values {
+		remainValues[attrName] = val
+	}
+
+	for _, attrS := range schema.Attributes {
+		delete(remainValues, attrS.Name)
+		val, defined := b.Values[attrS.Name]
+		if !defined {
+			if attrS.Required {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Missing required attribute",
+					Detail:   fmt.Sprintf("The attribute %q is required, but no definition was found.", attrS.Name),
+					Subject:  b.synthRange().Ptr(),
+				})
+			}
+			continue
+		}
+		content.Attributes[attrS.Name] = b.synthAttribute(attrS.Name, val)
+	}
+
+	// We just ignore blocks altogether, because this body type never has
+	// nested blocks.
+
+	remain := synthBody{
+		Filename: b.Filename,
+		Values:   remainValues,
+	}
+
+	return content, remain, diags
+}
+
+func (b synthBody) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
+	ret := make(hcl.Attributes)
+	for name, val := range b.Values {
+		ret[name] = b.synthAttribute(name, val)
+	}
+	return ret, nil
+}
+
+func (b synthBody) MissingItemRange() hcl.Range {
+	return b.synthRange()
+}
+
+func (b synthBody) synthAttribute(name string, val cty.Value) *hcl.Attribute {
+	rng := b.synthRange()
+	return &hcl.Attribute{
+		Name: name,
+		Expr: &hclsyntax.LiteralValueExpr{
+			Val:      val,
+			SrcRange: rng,
+		},
+		NameRange: rng,
+		Range:     rng,
+	}
+}
+
+func (b synthBody) synthRange() hcl.Range {
+	return hcl.Range{
+		Filename: b.Filename,
+		Start:    hcl.Pos{Line: 1, Column: 1},
+		End:      hcl.Pos{Line: 1, Column: 1},
+	}
+}

--- a/configs/synth_body_test.go
+++ b/configs/synth_body_test.go
@@ -1,0 +1,65 @@
+package configs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestSynthBodyContent(t *testing.T) {
+	tests := map[string]struct {
+		Values    map[string]cty.Value
+		Schema    *hcl.BodySchema
+		DiagCount int
+	}{
+		"empty": {
+			Values:    map[string]cty.Value{},
+			Schema:    &hcl.BodySchema{},
+			DiagCount: 0,
+		},
+		"missing required attribute": {
+			Values: map[string]cty.Value{},
+			Schema: &hcl.BodySchema{
+				Attributes: []hcl.AttributeSchema{
+					{
+						Name:     "nonexist",
+						Required: true,
+					},
+				},
+			},
+			DiagCount: 1, // missing required attribute
+		},
+		"missing optional attribute": {
+			Values: map[string]cty.Value{},
+			Schema: &hcl.BodySchema{
+				Attributes: []hcl.AttributeSchema{
+					{
+						Name: "nonexist",
+					},
+				},
+			},
+			DiagCount: 0,
+		},
+		"extraneous attribute": {
+			Values: map[string]cty.Value{
+				"foo": cty.StringVal("unwanted"),
+			},
+			Schema:    &hcl.BodySchema{},
+			DiagCount: 1, // unsupported attribute
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			body := SynthBody("synth", test.Values)
+			_, diags := body.Content(test.Schema)
+			if got, want := len(diags), test.DiagCount; got != want {
+				t.Errorf("wrong number of diagnostics %d; want %d", got, want)
+				for _, diag := range diags {
+					t.Logf("- %s", diag)
+				}
+			}
+		})
+	}
+}

--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -59,11 +59,12 @@ func (m schemaMap) CoreConfigSchema() *configschema.Block {
 // whose elem is a whole resource.
 func (s *Schema) coreConfigSchemaAttribute() *configschema.Attribute {
 	return &configschema.Attribute{
-		Type:      s.coreConfigSchemaType(),
-		Optional:  s.Optional,
-		Required:  s.Required,
-		Computed:  s.Computed,
-		Sensitive: s.Sensitive,
+		Type:        s.coreConfigSchemaType(),
+		Optional:    s.Optional,
+		Required:    s.Required,
+		Computed:    s.Computed,
+		Sensitive:   s.Sensitive,
+		Description: s.Description,
 	}
 }
 

--- a/helper/schema/core_schema_test.go
+++ b/helper/schema/core_schema_test.go
@@ -23,8 +23,9 @@ func TestSchemaMapCoreConfigSchema(t *testing.T) {
 		"primitives": {
 			map[string]*Schema{
 				"int": {
-					Type:     TypeInt,
-					Required: true,
+					Type:        TypeInt,
+					Required:    true,
+					Description: "foo bar baz",
 				},
 				"float": {
 					Type:     TypeFloat,
@@ -43,8 +44,9 @@ func TestSchemaMapCoreConfigSchema(t *testing.T) {
 			&configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"int": {
-						Type:     cty.Number,
-						Required: true,
+						Type:        cty.Number,
+						Required:    true,
+						Description: "foo bar baz",
 					},
 					"float": {
 						Type:     cty.Number,


### PR DESCRIPTION
This PR has four commits that are actually pretty orthogonal to one another but are all in the area of configuration-handling and so are presented together just in the interests of reducing paperwork. It is probably easiest to review each of the included commits separately rather than as a single diff.

These changes were all made in the course of implementing the new HCL2-powered handling of backends which will follow in a subsequent PR.
