### PR TITLE
Keep permissions when copying file for Linux

### DIFF
--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -36,6 +36,7 @@ func CopyFile(src, dst string) (err error) {
 	}
 	dfi, err := os.Stat(dst)
 	if err != nil {
+		os.Chmod(dst, sfi.Mode())
 		if !os.IsNotExist(err) {
 			return
 		}

--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -36,7 +36,6 @@ func CopyFile(src, dst string) (err error) {
 	}
 	dfi, err := os.Stat(dst)
 	if err != nil {
-		os.Chmod(dst, sfi.Mode())
 		if !os.IsNotExist(err) {
 			return
 		}
@@ -52,6 +51,7 @@ func CopyFile(src, dst string) (err error) {
 		return
 	}
 	err = copyFileContents(src, dst)
+	os.Chmod(dst, sfi.Mode())
 	return
 }
 


### PR DESCRIPTION
Permissions were lost when building on linux. This fixes that bug..