### PR TITLE
Make "terraform init" work with the new config loader

### DIFF
--- a/backend/atlas/backend.go
+++ b/backend/atlas/backend.go
@@ -1,14 +1,17 @@
 package atlas
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"os"
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/config/configschema"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/state/remote"
@@ -16,6 +19,9 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/colorstring"
 )
+
+const EnvVarToken = "ATLAS_TOKEN"
+const EnvVarAddress = "ATLAS_ADDRESS"
 
 // Backend is an implementation of EnhancedBackend that performs all operations
 // in Atlas. State must currently also be stored in Atlas, although it is worth
@@ -45,20 +51,114 @@ type Backend struct {
 	opLock sync.Mutex
 }
 
-func (b *Backend) Input(
-	ui terraform.UIInput, c *terraform.ResourceConfig) (*terraform.ResourceConfig, error) {
-	b.once.Do(b.init)
-	return b.schema.Input(ui, c)
+func (b *Backend) ConfigSchema() *configschema.Block {
+	return &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"name": {
+				Type:        cty.String,
+				Required:    true,
+				Description: "Full name of the environment in Terraform Enterprise, such as 'myorg/myenv'",
+			},
+			"access_token": {
+				Type:        cty.String,
+				Optional:    true,
+				Description: "Access token to use to access Terraform Enterprise; the ATLAS_TOKEN environment variable is used if this argument is not set",
+			},
+			"address": {
+				Type:        cty.String,
+				Optional:    true,
+				Description: "Base URL for your Terraform Enterprise installation; the ATLAS_ADDRESS environment variable is used if this argument is not set, finally falling back to a default of 'https://atlas.hashicorp.com/' if neither are set.",
+			},
+		},
+	}
 }
 
-func (b *Backend) Validate(c *terraform.ResourceConfig) ([]string, []error) {
-	b.once.Do(b.init)
-	return b.schema.Validate(c)
+func (b *Backend) ValidateConfig(obj cty.Value) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	name := obj.GetAttr("name").AsString()
+	if ct := strings.Count(name, "/"); ct != 1 {
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Invalid workspace selector",
+			`The "name" argument must be an organization name and a workspace name separated by a slash, such as "acme/network-production".`,
+			cty.Path{cty.GetAttrStep{Name: "name"}},
+		))
+	}
+
+	if v := obj.GetAttr("address"); !v.IsNull() {
+		addr := v.AsString()
+		_, err := url.Parse(addr)
+		if err != nil {
+			diags = diags.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Invalid Terraform Enterprise URL",
+				fmt.Sprintf(`The "address" argument must be a valid URL: %s.`, err),
+				cty.Path{cty.GetAttrStep{Name: "address"}},
+			))
+		}
+	}
+
+	return diags
 }
 
-func (b *Backend) Configure(c *terraform.ResourceConfig) error {
-	b.once.Do(b.init)
-	return b.schema.Configure(c)
+func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	client := &stateClient{
+		// This is optionally set during Atlas Terraform runs.
+		RunId: os.Getenv("ATLAS_RUN_ID"),
+	}
+
+	name := obj.GetAttr("name").AsString() // assumed valid due to ValidateConfig method
+	slashIdx := strings.Index(name, "/")
+	client.User = name[:slashIdx]
+	client.Name = name[slashIdx+1:]
+
+	if v := obj.GetAttr("access_token"); !v.IsNull() {
+		client.AccessToken = v.AsString()
+	} else {
+		client.AccessToken = os.Getenv(EnvVarToken)
+		if client.AccessToken == "" {
+			diags = diags.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Missing Terraform Enterprise access token",
+				`The "access_token" argument must be set unless the ATLAS_TOKEN environment variable is set to provide the authentication token for Terraform Enterprise.`,
+				cty.Path{cty.GetAttrStep{Name: "access_token"}},
+			))
+		}
+	}
+
+	if v := obj.GetAttr("address"); !v.IsNull() {
+		addr := v.AsString()
+		addrURL, err := url.Parse(addr)
+		if err != nil {
+			// We already validated the URL in ValidateConfig, so this shouldn't happen
+			panic(err)
+		}
+		client.Server = addr
+		client.ServerURL = addrURL
+	} else {
+		addr := os.Getenv(EnvVarAddress)
+		if addr == "" {
+			addr = defaultAtlasServer
+		}
+		addrURL, err := url.Parse(addr)
+		if err != nil {
+			diags = diags.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Invalid Terraform Enterprise URL",
+				fmt.Sprintf(`The ATLAS_ADDRESS environment variable must contain a valid URL: %s.`, err),
+				cty.Path{cty.GetAttrStep{Name: "address"}},
+			))
+		}
+		client.Server = addr
+		client.ServerURL = addrURL
+	}
+
+	b.stateClient = client
+
+	return diags
 }
 
 func (b *Backend) States() ([]string, error) {
@@ -89,75 +189,4 @@ func (b *Backend) Colorize() *colorstring.Colorize {
 		Colors:  colorstring.DefaultColors,
 		Disable: true,
 	}
-}
-
-func (b *Backend) init() {
-	b.schema = &schema.Backend{
-		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: schemaDescriptions["name"],
-			},
-
-			"access_token": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: schemaDescriptions["access_token"],
-				DefaultFunc: schema.EnvDefaultFunc("ATLAS_TOKEN", nil),
-			},
-
-			"address": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: schemaDescriptions["address"],
-				DefaultFunc: schema.EnvDefaultFunc("ATLAS_ADDRESS", defaultAtlasServer),
-			},
-		},
-
-		ConfigureFunc: b.schemaConfigure,
-	}
-}
-
-func (b *Backend) schemaConfigure(ctx context.Context) error {
-	d := schema.FromContextBackendConfig(ctx)
-
-	// Parse the address
-	addr := d.Get("address").(string)
-	addrUrl, err := url.Parse(addr)
-	if err != nil {
-		return fmt.Errorf("Error parsing 'address': %s", err)
-	}
-
-	// Parse the org/env
-	name := d.Get("name").(string)
-	parts := strings.Split(name, "/")
-	if len(parts) != 2 {
-		return fmt.Errorf("malformed name '%s', expected format '<org>/<name>'", name)
-	}
-	org := parts[0]
-	env := parts[1]
-
-	// Setup the client
-	b.stateClient = &stateClient{
-		Server:      addr,
-		ServerURL:   addrUrl,
-		AccessToken: d.Get("access_token").(string),
-		User:        org,
-		Name:        env,
-
-		// This is optionally set during Atlas Terraform runs.
-		RunId: os.Getenv("ATLAS_RUN_ID"),
-	}
-
-	return nil
-}
-
-var schemaDescriptions = map[string]string{
-	"name": "Full name of the environment in Atlas, such as 'hashicorp/myenv'",
-	"access_token": "Access token to use to access Atlas. If ATLAS_TOKEN is set then\n" +
-		"this will override any saved value for this.",
-	"address": "Address to your Atlas installation. This defaults to the publicly\n" +
-		"hosted version at 'https://atlas.hashicorp.com/'. This address\n" +
-		"should contain the full HTTP scheme to use.",
 }

--- a/backend/atlas/state_client_test.go
+++ b/backend/atlas/state_client_test.go
@@ -13,14 +13,23 @@ import (
 	"testing"
 	"time"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/state/remote"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func testStateClient(t *testing.T, c map[string]interface{}) remote.Client {
-	b := backend.TestBackendConfig(t, &Backend{}, c)
+func testStateClient(t *testing.T, c map[string]string) remote.Client {
+	vals := make(map[string]cty.Value)
+	for k, s := range c {
+		vals[k] = cty.StringVal(s)
+	}
+	synthBody := configs.SynthBody("<test>", vals)
+
+	b := backend.TestBackendConfig(t, &Backend{}, synthBody)
 	raw, err := b.State(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -42,7 +51,7 @@ func TestStateClient(t *testing.T) {
 		t.Skipf("skipping, ATLAS_TOKEN must be set")
 	}
 
-	client := testStateClient(t, map[string]interface{}{
+	client := testStateClient(t, map[string]string{
 		"access_token": token,
 		"name":         "hashicorp/test-remote-state",
 	})
@@ -53,7 +62,7 @@ func TestStateClient(t *testing.T) {
 func TestStateClient_noRetryOnBadCerts(t *testing.T) {
 	acctest.RemoteTestPrecheck(t)
 
-	client := testStateClient(t, map[string]interface{}{
+	client := testStateClient(t, map[string]string{
 		"access_token": "NOT_REQUIRED",
 		"name":         "hashicorp/test-remote-state",
 	})
@@ -99,7 +108,7 @@ func TestStateClient_ReportedConflictEqualStates(t *testing.T) {
 	srv := fakeAtlas.Server()
 	defer srv.Close()
 
-	client := testStateClient(t, map[string]interface{}{
+	client := testStateClient(t, map[string]string{
 		"access_token": "sometoken",
 		"name":         "someuser/some-test-remote-state",
 		"address":      srv.URL,
@@ -124,7 +133,7 @@ func TestStateClient_NoConflict(t *testing.T) {
 	srv := fakeAtlas.Server()
 	defer srv.Close()
 
-	client := testStateClient(t, map[string]interface{}{
+	client := testStateClient(t, map[string]string{
 		"access_token": "sometoken",
 		"name":         "someuser/some-test-remote-state",
 		"address":      srv.URL,
@@ -152,7 +161,7 @@ func TestStateClient_LegitimateConflict(t *testing.T) {
 	srv := fakeAtlas.Server()
 	defer srv.Close()
 
-	client := testStateClient(t, map[string]interface{}{
+	client := testStateClient(t, map[string]string{
 		"access_token": "sometoken",
 		"name":         "someuser/some-test-remote-state",
 		"address":      srv.URL,
@@ -191,7 +200,7 @@ func TestStateClient_UnresolvableConflict(t *testing.T) {
 	srv := fakeAtlas.Server()
 	defer srv.Close()
 
-	client := testStateClient(t, map[string]interface{}{
+	client := testStateClient(t, map[string]string{
 		"access_token": "sometoken",
 		"name":         "someuser/some-test-remote-state",
 		"address":      srv.URL,

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -9,10 +9,16 @@ import (
 	"errors"
 	"time"
 
+	"github.com/hashicorp/terraform/configs"
+
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/command/clistate"
-	"github.com/hashicorp/terraform/config/module"
+	"github.com/hashicorp/terraform/config/configschema"
+	"github.com/hashicorp/terraform/configs/configload"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // This is the name of the default, initial state that every backend
@@ -26,11 +32,45 @@ var ErrNamedStatesNotSupported = errors.New("named states not supported")
 
 // Backend is the minimal interface that must be implemented to enable Terraform.
 type Backend interface {
-	// Ask for input and configure the backend. Similar to
-	// terraform.ResourceProvider.
-	Input(terraform.UIInput, *terraform.ResourceConfig) (*terraform.ResourceConfig, error)
-	Validate(*terraform.ResourceConfig) ([]string, []error)
-	Configure(*terraform.ResourceConfig) error
+	// ConfigSchema returns a description of the expected configuration
+	// structure for the receiving backend.
+	//
+	// This method does not have any side-effects for the backend and can
+	// be safely used before configuring.
+	ConfigSchema() *configschema.Block
+
+	// ValidateConfig checks the validity of the values in the given
+	// configuration, assuming that its structure has already been validated
+	// per the schema returned by ConfigSchema.
+	//
+	// This method does not have any side-effects for the backend and can
+	// be safely used before configuring. It also does not consult any
+	// external data such as environment variables, disk files, etc. Validation
+	// that requires such external data should be deferred until the
+	// Configure call.
+	//
+	// If error diagnostics are returned then the configuration is not valid
+	// and must not subsequently be passed to the Configure method.
+	//
+	// This method may return configuration-contextual diagnostics such
+	// as tfdiags.AttributeValue, and so the caller should provide the
+	// necessary context via the diags.InConfigBody method before returning
+	// diagnostics to the user.
+	ValidateConfig(cty.Value) tfdiags.Diagnostics
+
+	// Configure uses the provided configuration to set configuration fields
+	// within the backend.
+	//
+	// The given configuration is assumed to have already been validated
+	// against the schema returned by ConfigSchema and passed validation
+	// via ValidateConfig.
+	//
+	// This method may be called only once per backend instance, and must be
+	// called before all other methods except where otherwise stated.
+	//
+	// If error diagnostics are returned, the internal state of the instance
+	// is undefined and no other methods may be called.
+	Configure(cty.Value) tfdiags.Diagnostics
 
 	// State returns the current state for this environment. This state may
 	// not be loaded locally: the proper APIs should be called on state.State
@@ -81,7 +121,7 @@ type Enhanced interface {
 type Local interface {
 	// Context returns a runnable terraform Context. The operation parameter
 	// doesn't need a Type set but it needs other options set such as Module.
-	Context(*Operation) (*terraform.Context, state.State, error)
+	Context(*Operation) (*terraform.Context, state.State, tfdiags.Diagnostics)
 }
 
 // An operation represents an operation for Terraform to execute.
@@ -113,8 +153,13 @@ type Operation struct {
 	PlanOutPath    string // PlanOutPath is the path to save the plan
 	PlanOutBackend *terraform.BackendState
 
-	// Module settings specify the root module to use for operations.
-	Module *module.Tree
+	// ConfigDir is the path to the directory containing the configuration's
+	// root module.
+	ConfigDir string
+
+	// ConfigLoader is a configuration loader that can be used to load
+	// configuration from ConfigDir.
+	ConfigLoader *configload.Loader
 
 	// Plan is a plan that was passed as an argument. This is valid for
 	// plan and apply arguments but may not work for all backends.
@@ -148,6 +193,22 @@ type Operation struct {
 	Workspace string
 }
 
+// HasConfig returns true if and only if the operation has a ConfigDir value
+// that refers to a directory containing at least one Terraform configuration
+// file.
+func (o *Operation) HasConfig() bool {
+	return o.ConfigLoader.IsConfigDir(o.ConfigDir)
+}
+
+// Config loads the configuration that the operation applies to, using the
+// ConfigDir and ConfigLoader fields within the receiving operation.
+func (o *Operation) Config() (*configs.Config, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	config, hclDiags := o.ConfigLoader.LoadConfig(o.ConfigDir)
+	diags = diags.Append(hclDiags)
+	return config, diags
+}
+
 // RunningOperation is the result of starting an operation.
 type RunningOperation struct {
 	// For implementers of a backend, this context should not wrap the
@@ -167,9 +228,9 @@ type RunningOperation struct {
 	// to avoid running operations during process exit.
 	Cancel context.CancelFunc
 
-	// Err is the error of the operation. This is populated after
-	// the operation has completed.
-	Err error
+	// Result is the exit status of the operation, populated only after the
+	// operation has completed.
+	Result OperationResult
 
 	// PlanEmpty is populated after a Plan operation completes without error
 	// to note whether a plan is empty or has changes.
@@ -180,3 +241,16 @@ type RunningOperation struct {
 	// after the operation completes to avoid read/write races.
 	State *terraform.State
 }
+
+// OperationResult describes the result status of an operation.
+type OperationResult int
+
+const (
+	// OperationSuccess indicates that the operation completed as expected.
+	OperationSuccess OperationResult = 0
+
+	// OperationFailure indicates that the operation encountered some sort
+	// of error, and thus may have been only partially performed or not
+	// performed at all.
+	OperationFailure OperationResult = 1
+)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -254,3 +254,7 @@ const (
 	// performed at all.
 	OperationFailure OperationResult = 1
 )
+
+func (r OperationResult) ExitStatus() int {
+	return int(r)
+}

--- a/backend/cli.go
+++ b/backend/cli.go
@@ -48,6 +48,10 @@ type CLIOpts struct {
 	CLI      cli.Ui
 	CLIColor *colorstring.Colorize
 
+	// ShowDiagnostics is a function that will format and print diagnostic
+	// messages to the UI.
+	ShowDiagnostics func(vals ...interface{})
+
 	// StatePath is the local path where state is read from.
 	//
 	// StateOutPath is the local path where the state will be written.

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -6,15 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/command/format"
-	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 func (b *Local) opApply(
@@ -24,17 +22,18 @@ func (b *Local) opApply(
 	runningOp *backend.RunningOperation) {
 	log.Printf("[INFO] backend/local: starting Apply operation")
 
-	// If we have a nil module at this point, then set it to an empty tree
-	// to avoid any potential crashes.
-	if op.Plan == nil && op.Module == nil && !op.Destroy {
-		runningOp.Err = fmt.Errorf(strings.TrimSpace(applyErrNoConfig))
-		return
-	}
+	var diags tfdiags.Diagnostics
 
 	// If we have a nil module at this point, then set it to an empty tree
 	// to avoid any potential crashes.
-	if op.Module == nil {
-		op.Module = module.NewEmptyTree()
+	if op.Plan == nil && !op.Destroy && !op.HasConfig() {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"No configuration files",
+			"Apply requires configuration to be present. Applying without a configuration would mark everything for destruction, which is normally not what is desired. If you would like to destroy everything, run 'terraform destroy' instead.",
+		))
+		b.ReportResult(runningOp, diags)
+		return
 	}
 
 	// Setup our count hook that keeps track of resource changes
@@ -50,7 +49,8 @@ func (b *Local) opApply(
 	// Get our context
 	tfCtx, opState, err := b.context(op)
 	if err != nil {
-		runningOp.Err = err
+		diags = diags.Append(err)
+		b.ReportResult(runningOp, diags)
 		return
 	}
 
@@ -64,7 +64,9 @@ func (b *Local) opApply(
 			log.Printf("[INFO] backend/local: apply calling Refresh")
 			_, err := tfCtx.Refresh()
 			if err != nil {
-				runningOp.Err = errwrap.Wrapf("Error refreshing state: {{err}}", err)
+				diags = diags.Append(err)
+				runningOp.Result = backend.OperationFailure
+				b.ShowDiagnostics(diags)
 				return
 			}
 		}
@@ -73,7 +75,8 @@ func (b *Local) opApply(
 		log.Printf("[INFO] backend/local: apply calling Plan")
 		plan, err := tfCtx.Plan()
 		if err != nil {
-			runningOp.Err = errwrap.Wrapf("Error running plan: {{err}}", err)
+			diags = diags.Append(err)
+			b.ReportResult(runningOp, diags)
 			return
 		}
 
@@ -106,15 +109,17 @@ func (b *Local) opApply(
 				Description: desc,
 			})
 			if err != nil {
-				runningOp.Err = errwrap.Wrapf("Error asking for approval: {{err}}", err)
+				diags = diags.Append(errwrap.Wrapf("Error asking for approval: {{err}}", err))
+				b.ReportResult(runningOp, diags)
 				return
 			}
 			if v != "yes" {
 				if op.Destroy {
-					runningOp.Err = errors.New("Destroy cancelled.")
+					b.CLI.Info("Destroy cancelled.")
 				} else {
-					runningOp.Err = errors.New("Apply cancelled.")
+					b.CLI.Info("Apply cancelled.")
 				}
+				runningOp.Result = backend.OperationFailure
 				return
 			}
 		}
@@ -143,25 +148,30 @@ func (b *Local) opApply(
 
 	// Persist the state
 	if err := opState.WriteState(applyState); err != nil {
-		runningOp.Err = b.backupStateForError(applyState, err)
+		diags = diags.Append(b.backupStateForError(applyState, err))
+		b.ReportResult(runningOp, diags)
 		return
 	}
 	if err := opState.PersistState(); err != nil {
-		runningOp.Err = b.backupStateForError(applyState, err)
+		diags = diags.Append(b.backupStateForError(applyState, err))
+		b.ReportResult(runningOp, diags)
 		return
 	}
 
 	if applyErr != nil {
-		runningOp.Err = fmt.Errorf(
-			"Error applying plan:\n\n"+
-				"%s\n\n"+
-				"Terraform does not automatically rollback in the face of errors.\n"+
-				"Instead, your Terraform state file has been partially updated with\n"+
-				"any resources that successfully completed. Please address the error\n"+
-				"above and apply again to incrementally change your infrastructure.",
-			multierror.Flatten(applyErr))
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			applyErr.Error(),
+			"Terraform does not automatically rollback in the face of errors. Instead, your Terraform state file has been partially updated with any resources that successfully completed. Please address the error above and apply again to incrementally change your infrastructure.",
+		))
+		b.ReportResult(runningOp, diags)
 		return
 	}
+
+	// If we've accumulated any warnings along the way then we'll show them
+	// here just before we show the summary and next steps. If we encountered
+	// errors then we would've returned early at some other point above.
+	b.ShowDiagnostics(diags)
 
 	// If we have a UI, output the results
 	if b.CLI != nil {
@@ -228,15 +238,6 @@ func (b *Local) backupStateForError(applyState *terraform.State, err error) erro
 
 	return errors.New(stateWriteBackedUpError)
 }
-
-const applyErrNoConfig = `
-No configuration files found!
-
-Apply requires configuration to be present. Applying without a configuration
-would mark everything for destruction, which is normally not what is desired.
-If you would like to destroy everything, please run 'terraform destroy' instead
-which does not require any configuration files.
-`
 
 const stateWriteBackedUpError = `Failed to persist state to backend.
 

--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -3,10 +3,8 @@ package local
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/hashicorp/terraform/command/clistate"
-	"github.com/hashicorp/terraform/command/format"
 
 	"github.com/hashicorp/terraform/tfdiags"
 
@@ -17,7 +15,7 @@ import (
 )
 
 // backend.Local implementation.
-func (b *Local) Context(op *backend.Operation) (*terraform.Context, state.State, error) {
+func (b *Local) Context(op *backend.Operation) (*terraform.Context, state.State, tfdiags.Diagnostics) {
 	// Make sure the type is invalid. We use this as a way to know not
 	// to ask for input/validate.
 	op.Type = backend.OperationTypeInvalid
@@ -31,19 +29,24 @@ func (b *Local) Context(op *backend.Operation) (*terraform.Context, state.State,
 	return b.context(op)
 }
 
-func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State, error) {
+func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
 	// Get the state.
 	s, err := b.State(op.Workspace)
 	if err != nil {
-		return nil, nil, errwrap.Wrapf("Error loading state: {{err}}", err)
+		diags = diags.Append(errwrap.Wrapf("Error loading state: {{err}}", err))
+		return nil, nil, diags
 	}
 
 	if err := op.StateLocker.Lock(s, op.Type.String()); err != nil {
-		return nil, nil, errwrap.Wrapf("Error locking state: {{err}}", err)
+		diags = diags.Append(errwrap.Wrapf("Error locking state: {{err}}", err))
+		return nil, nil, diags
 	}
 
 	if err := s.RefreshState(); err != nil {
-		return nil, nil, errwrap.Wrapf("Error loading state: {{err}}", err)
+		diags = diags.Append(errwrap.Wrapf("Error loading state: {{err}}", err))
+		return nil, nil, diags
 	}
 
 	// Initialize our context options
@@ -54,12 +57,17 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 
 	// Copy set options from the operation
 	opts.Destroy = op.Destroy
-	opts.Module = op.Module
 	opts.Targets = op.Targets
 	opts.UIInput = op.UIIn
 	if op.Variables != nil {
 		opts.Variables = op.Variables
 	}
+
+	// FIXME: Configuration is temporarily stubbed out here to artificially
+	// create a stopping point in our work to switch to the new config loader.
+	// This means no backend-provided Terraform operations will actually work.
+	// This will be addressed in a subsequent commit.
+	opts.Module = nil
 
 	// Load our state
 	// By the time we get here, the backend creation code in "command" took
@@ -81,11 +89,13 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 		b.pluginInitRequired(rpe)
 		// we wrote the full UI error here, so return a generic error for flow
 		// control in the command.
-		return nil, nil, errors.New("error satisfying plugin requirements")
+		diags = diags.Append(errors.New("Can't satisfy plugin requirements"))
+		return nil, nil, diags
 	}
 
 	if err != nil {
-		return nil, nil, err
+		diags = diags.Append(err)
+		return nil, nil, diags
 	}
 
 	// If we have an operation, then we automatically do the input/validate
@@ -98,45 +108,19 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 			mode |= terraform.InputModeVarUnset
 
 			if err := tfCtx.Input(mode); err != nil {
-				return nil, nil, errwrap.Wrapf("Error asking for user input: {{err}}", err)
+				diags = diags.Append(errwrap.Wrapf("Error asking for user input: {{err}}", err))
+				return nil, nil, diags
 			}
 		}
 
 		// If validation is enabled, validate
 		if b.OpValidation {
-			diags := tfCtx.Validate()
-			if len(diags) > 0 {
-				if diags.HasErrors() {
-					// If there are warnings _and_ errors then we'll take this
-					// path and return them all together in this error.
-					return nil, nil, diags.Err()
-				}
-
-				// For now we can't propagate warnings any further without
-				// printing them directly to the UI, so we'll need to
-				// format them here ourselves.
-				for _, diag := range diags {
-					if diag.Severity() != tfdiags.Warning {
-						continue
-					}
-					if b.CLI != nil {
-						// FIXME: We don't have access to the source code cache
-						// in here, so we can't produce source code snippets
-						// from this codepath.
-						b.CLI.Warn(format.Diagnostic(diag, nil, b.Colorize(), 72))
-					} else {
-						desc := diag.Description()
-						log.Printf("[WARN] backend/local: %s", desc.Summary)
-					}
-				}
-
-				// Make a newline before continuing
-				b.CLI.Output("")
-			}
+			validateDiags := tfCtx.Validate()
+			diags = diags.Append(validateDiags)
 		}
 	}
 
-	return tfCtx, s, nil
+	return tfCtx, s, diags
 }
 
 const validateWarnHeader = `

--- a/backend/local/backend_refresh.go
+++ b/backend/local/backend_refresh.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/backend"
-	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 func (b *Local) opRefresh(
@@ -18,6 +18,9 @@ func (b *Local) opRefresh(
 	cancelCtx context.Context,
 	op *backend.Operation,
 	runningOp *backend.RunningOperation) {
+
+	var diags tfdiags.Diagnostics
+
 	// Check if our state exists if we're performing a refresh operation. We
 	// only do this if we're managing state with this backend.
 	if b.Backend == nil {
@@ -27,26 +30,22 @@ func (b *Local) opRefresh(
 			}
 
 			if err != nil {
-				runningOp.Err = fmt.Errorf(
-					"There was an error reading the Terraform state that is needed\n"+
-						"for refreshing. The path and error are shown below.\n\n"+
-						"Path: %s\n\nError: %s",
-					b.StatePath, err)
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Cannot read state file",
+					fmt.Sprintf("Failed to read %s: %s", b.StatePath, err),
+				))
+				b.ReportResult(runningOp, diags)
 				return
 			}
 		}
 	}
 
-	// If we have no config module given to use, create an empty tree to
-	// avoid crashes when Terraform.Context is initialized.
-	if op.Module == nil {
-		op.Module = module.NewEmptyTree()
-	}
-
 	// Get our context
-	tfCtx, opState, err := b.context(op)
-	if err != nil {
-		runningOp.Err = err
+	tfCtx, opState, contextDiags := b.context(op)
+	diags = diags.Append(contextDiags)
+	if contextDiags.HasErrors() {
+		b.ReportResult(runningOp, diags)
 		return
 	}
 
@@ -76,17 +75,20 @@ func (b *Local) opRefresh(
 	// write the resulting state to the running op
 	runningOp.State = newState
 	if refreshErr != nil {
-		runningOp.Err = errwrap.Wrapf("Error refreshing state: {{err}}", refreshErr)
+		diags = diags.Append(refreshErr)
+		b.ReportResult(runningOp, diags)
 		return
 	}
 
 	// Write and persist the state
 	if err := opState.WriteState(newState); err != nil {
-		runningOp.Err = errwrap.Wrapf("Error writing state: {{err}}", err)
+		diags = diags.Append(errwrap.Wrapf("Failed to write state: {{err}}", err))
+		b.ReportResult(runningOp, diags)
 		return
 	}
 	if err := opState.PersistState(); err != nil {
-		runningOp.Err = errwrap.Wrapf("Error saving state: {{err}}", err)
+		diags = diags.Append(errwrap.Wrapf("Failed to save state: {{err}}", err))
+		b.ReportResult(runningOp, diags)
 		return
 	}
 }

--- a/backend/local/cli.go
+++ b/backend/local/cli.go
@@ -8,6 +8,7 @@ import (
 func (b *Local) CLIInit(opts *backend.CLIOpts) error {
 	b.CLI = opts.CLI
 	b.CLIColor = opts.CLIColor
+	b.ShowDiagnostics = opts.ShowDiagnostics
 	b.ContextOpts = opts.ContextOpts
 	b.OpInput = opts.Input
 	b.OpValidation = opts.Validation

--- a/backend/local/testing.go
+++ b/backend/local/testing.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // TestLocal returns a configured Local struct with temporary paths and
@@ -17,13 +18,26 @@ import (
 // No operations will be called on the returned value, so you can still set
 // public fields without any locks.
 func TestLocal(t *testing.T) (*Local, func()) {
+	t.Helper()
+
 	tempDir := testTempDir(t)
-	local := &Local{
+	var local *Local
+	local = &Local{
 		StatePath:         filepath.Join(tempDir, "state.tfstate"),
 		StateOutPath:      filepath.Join(tempDir, "state.tfstate"),
 		StateBackupPath:   filepath.Join(tempDir, "state.tfstate.bak"),
 		StateWorkspaceDir: filepath.Join(tempDir, "state.tfstate.d"),
 		ContextOpts:       &terraform.ContextOpts{},
+		ShowDiagnostics: func(vals ...interface{}) {
+			var diags tfdiags.Diagnostics
+			diags = diags.Append(vals...)
+			for _, diag := range diags {
+				t.Log(diag.Description().Summary)
+				if local.CLI != nil {
+					local.CLI.Error(diag.Description().Summary)
+				}
+			}
+		},
 	}
 	cleanup := func() {
 		if err := os.RemoveAll(tempDir); err != nil {

--- a/backend/nil.go
+++ b/backend/nil.go
@@ -1,8 +1,10 @@
 package backend
 
 import (
+	"github.com/hashicorp/terraform/config/configschema"
 	"github.com/hashicorp/terraform/state"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Nil is a no-op implementation of Backend.
@@ -11,17 +13,15 @@ import (
 // backend interface for testing.
 type Nil struct{}
 
-func (Nil) Input(
-	ui terraform.UIInput,
-	c *terraform.ResourceConfig) (*terraform.ResourceConfig, error) {
-	return c, nil
+func (Nil) ConfigSchema() *configschema.Block {
+	return &configschema.Block{}
 }
 
-func (Nil) Validate(*terraform.ResourceConfig) ([]string, []error) {
-	return nil, nil
+func (Nil) ValidateConfig(cty.Value) tfdiags.Diagnostics {
+	return nil
 }
 
-func (Nil) Configure(*terraform.ResourceConfig) error {
+func (Nil) Configure(cty.Value) tfdiags.Diagnostics {
 	return nil
 }
 

--- a/backend/remote-state/artifactory/client_test.go
+++ b/backend/remote-state/artifactory/client_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/state/remote"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestArtifactoryClient_impl(t *testing.T) {
@@ -15,18 +17,18 @@ func TestArtifactoryFactory(t *testing.T) {
 	// This test just instantiates the client. Shouldn't make any actual
 	// requests nor incur any costs.
 
-	config := make(map[string]interface{})
-	config["url"] = "http://artifactory.local:8081/artifactory"
-	config["repo"] = "terraform-repo"
-	config["subpath"] = "myproject"
+	config := make(map[string]cty.Value)
+	config["url"] = cty.StringVal("http://artifactory.local:8081/artifactory")
+	config["repo"] = cty.StringVal("terraform-repo")
+	config["subpath"] = cty.StringVal("myproject")
 
 	// For this test we'll provide the credentials as config. The
 	// acceptance tests implicitly test passing credentials as
 	// environment variables.
-	config["username"] = "test"
-	config["password"] = "testpass"
+	config["username"] = cty.StringVal("test")
+	config["password"] = cty.StringVal("testpass")
 
-	b := backend.TestBackendConfig(t, New(), config)
+	b := backend.TestBackendConfig(t, New(), configs.SynthBody("synth", config))
 
 	state, err := b.State(backend.DefaultStateName)
 	if err != nil {

--- a/backend/remote-state/azure/backend_test.go
+++ b/backend/remote-state/azure/backend_test.go
@@ -40,7 +40,7 @@ func TestBackendConfig(t *testing.T) {
 		"access_key": "QUNDRVNTX0tFWQ0K",
 	}
 
-	b := backend.TestBackendConfig(t, New(), config).(*Backend)
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
 
 	if b.containerName != "tfcontainer" {
 		t.Fatalf("Incorrect bucketName was populated")
@@ -57,12 +57,12 @@ func TestBackend(t *testing.T) {
 	res := setupResources(t, keyName)
 	defer destroyResources(t, res.resourceGroupName)
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.containerName,
 		"key":                  keyName,
 		"access_key":           res.accessKey,
-	}).(*Backend)
+	})).(*Backend)
 
 	backend.TestBackendStates(t, b)
 }
@@ -74,19 +74,19 @@ func TestBackendLocked(t *testing.T) {
 	res := setupResources(t, keyName)
 	defer destroyResources(t, res.resourceGroupName)
 
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.containerName,
 		"key":                  keyName,
 		"access_key":           res.accessKey,
-	}).(*Backend)
+	})).(*Backend)
 
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.containerName,
 		"key":                  keyName,
 		"access_key":           res.accessKey,
-	}).(*Backend)
+	})).(*Backend)
 
 	backend.TestBackendStateLocks(t, b1, b2)
 	backend.TestBackendStateForceUnlock(t, b1, b2)

--- a/backend/remote-state/azure/client_test.go
+++ b/backend/remote-state/azure/client_test.go
@@ -21,12 +21,12 @@ func TestRemoteClient(t *testing.T) {
 	res := setupResources(t, keyName)
 	defer destroyResources(t, res.resourceGroupName)
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.containerName,
 		"key":                  keyName,
 		"access_key":           res.accessKey,
-	}).(*Backend)
+	})).(*Backend)
 
 	state, err := b.State(backend.DefaultStateName)
 	if err != nil {
@@ -43,19 +43,19 @@ func TestRemoteClientLocks(t *testing.T) {
 	res := setupResources(t, keyName)
 	defer destroyResources(t, res.resourceGroupName)
 
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.containerName,
 		"key":                  keyName,
 		"access_key":           res.accessKey,
-	}).(*Backend)
+	})).(*Backend)
 
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.containerName,
 		"key":                  keyName,
 		"access_key":           res.accessKey,
-	}).(*Backend)
+	})).(*Backend)
 
 	s1, err := b1.State(backend.DefaultStateName)
 	if err != nil {

--- a/backend/remote-state/backend.go
+++ b/backend/remote-state/backend.go
@@ -10,7 +10,8 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/state/remote"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Backend implements backend.Backend for remote state backends.
@@ -30,7 +31,8 @@ type Backend struct {
 	client remote.Client
 }
 
-func (b *Backend) Configure(rc *terraform.ResourceConfig) error {
+func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
+
 	// Set our configureFunc manually
 	b.Backend.ConfigureFunc = func(ctx context.Context) error {
 		c, err := b.ConfigureFunc(ctx)
@@ -43,8 +45,7 @@ func (b *Backend) Configure(rc *terraform.ResourceConfig) error {
 		return nil
 	}
 
-	// Run the normal configuration
-	return b.Backend.Configure(rc)
+	return b.Backend.Configure(obj)
 }
 
 func (b *Backend) States() ([]string, error) {

--- a/backend/remote-state/consul/backend_test.go
+++ b/backend/remote-state/consul/backend_test.go
@@ -52,15 +52,15 @@ func TestBackend(t *testing.T) {
 	path := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
 	// Get the backend. We need two to test locking.
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path,
-	})
+	}))
 
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path,
-	})
+	}))
 
 	// Test
 	backend.TestBackendStates(t, b1)
@@ -71,17 +71,17 @@ func TestBackend_lockDisabled(t *testing.T) {
 	path := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
 	// Get the backend. We need two to test locking.
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path,
 		"lock":    false,
-	})
+	}))
 
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path + "different", // Diff so locking test would fail if it was locking
 		"lock":    false,
-	})
+	}))
 
 	// Test
 	backend.TestBackendStates(t, b1)
@@ -90,11 +90,11 @@ func TestBackend_lockDisabled(t *testing.T) {
 
 func TestBackend_gzip(t *testing.T) {
 	// Get the backend
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    fmt.Sprintf("tf-unit/%s", time.Now().String()),
 		"gzip":    true,
-	})
+	}))
 
 	// Test
 	backend.TestBackendStates(t, b)

--- a/backend/remote-state/consul/client_test.go
+++ b/backend/remote-state/consul/client_test.go
@@ -20,10 +20,10 @@ func TestRemoteClient_impl(t *testing.T) {
 
 func TestRemoteClient(t *testing.T) {
 	// Get the backend
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    fmt.Sprintf("tf-unit/%s", time.Now().String()),
-	})
+	}))
 
 	// Grab the client
 	state, err := b.State(backend.DefaultStateName)
@@ -40,10 +40,10 @@ func TestRemoteClient_gzipUpgrade(t *testing.T) {
 	statePath := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
 	// Get the backend
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    statePath,
-	})
+	}))
 
 	// Grab the client
 	state, err := b.State(backend.DefaultStateName)
@@ -55,11 +55,11 @@ func TestRemoteClient_gzipUpgrade(t *testing.T) {
 	remote.TestClient(t, state.(*remote.State).Client)
 
 	// create a new backend with gzip
-	b = backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b = backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    statePath,
 		"gzip":    true,
-	})
+	}))
 
 	// Grab the client
 	state, err = b.State(backend.DefaultStateName)
@@ -75,18 +75,18 @@ func TestConsul_stateLock(t *testing.T) {
 	path := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
 	// create 2 instances to get 2 remote.Clients
-	sA, err := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	sA, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path,
-	}).State(backend.DefaultStateName)
+	})).State(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	sB, err := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	sB, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path,
-	}).State(backend.DefaultStateName)
+	})).State(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,10 +96,10 @@ func TestConsul_stateLock(t *testing.T) {
 
 func TestConsul_destroyLock(t *testing.T) {
 	// Get the backend
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    fmt.Sprintf("tf-unit/%s", time.Now().String()),
-	})
+	}))
 
 	// Grab the client
 	s, err := b.State(backend.DefaultStateName)
@@ -135,18 +135,18 @@ func TestConsul_lostLock(t *testing.T) {
 	path := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
 	// create 2 instances to get 2 remote.Clients
-	sA, err := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	sA, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path,
-	}).State(backend.DefaultStateName)
+	})).State(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	sB, err := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	sB, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path + "-not-used",
-	}).State(backend.DefaultStateName)
+	})).State(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,10 +190,10 @@ func TestConsul_lostLockConnection(t *testing.T) {
 
 	path := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path,
-	})
+	}))
 
 	s, err := b.State(backend.DefaultStateName)
 	if err != nil {

--- a/backend/remote-state/etcdv2/client_test.go
+++ b/backend/remote-state/etcdv2/client_test.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/state/remote"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestEtcdClient_impl(t *testing.T) {
@@ -21,19 +23,19 @@ func TestEtcdClient(t *testing.T) {
 	}
 
 	// Get the backend
-	config := map[string]interface{}{
-		"endpoints": endpoint,
-		"path":      fmt.Sprintf("tf-unit/%s", time.Now().String()),
+	config := map[string]cty.Value{
+		"endpoints": cty.StringVal(endpoint),
+		"path":      cty.StringVal(fmt.Sprintf("tf-unit/%s", time.Now().String())),
 	}
 
 	if username := os.Getenv("ETCD_USERNAME"); username != "" {
-		config["username"] = username
+		config["username"] = cty.StringVal(username)
 	}
 	if password := os.Getenv("ETCD_PASSWORD"); password != "" {
-		config["password"] = password
+		config["password"] = cty.StringVal(password)
 	}
 
-	b := backend.TestBackendConfig(t, New(), config)
+	b := backend.TestBackendConfig(t, New(), configs.SynthBody("synth", config))
 	state, err := b.State(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("Error for valid config: %s", err)

--- a/backend/remote-state/etcdv3/backend_test.go
+++ b/backend/remote-state/etcdv3/backend_test.go
@@ -55,15 +55,15 @@ func TestBackend(t *testing.T) {
 	prefix := fmt.Sprintf("%s/%s/", keyPrefix, time.Now().Format(time.RFC3339))
 
 	// Get the backend. We need two to test locking.
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"endpoints": etcdv3Endpoints,
 		"prefix":    prefix,
-	})
+	}))
 
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"endpoints": etcdv3Endpoints,
 		"prefix":    prefix,
-	})
+	}))
 
 	// Test
 	backend.TestBackendStates(t, b1)
@@ -78,17 +78,17 @@ func TestBackend_lockDisabled(t *testing.T) {
 	prefix := fmt.Sprintf("%s/%s/", keyPrefix, time.Now().Format(time.RFC3339))
 
 	// Get the backend. We need two to test locking.
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"endpoints": etcdv3Endpoints,
 		"prefix":    prefix,
 		"lock":      false,
-	})
+	}))
 
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"endpoints": etcdv3Endpoints,
 		"prefix":    prefix + "/" + "different", // Diff so locking test would fail if it was locking
 		"lock":      false,
-	})
+	}))
 
 	// Test
 	backend.TestBackendStateLocks(t, b1, b2)

--- a/backend/remote-state/etcdv3/client_test.go
+++ b/backend/remote-state/etcdv3/client_test.go
@@ -22,10 +22,10 @@ func TestRemoteClient(t *testing.T) {
 	prefix := fmt.Sprintf("%s/%s/", keyPrefix, time.Now().Format(time.RFC3339))
 
 	// Get the backend
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"endpoints": etcdv3Endpoints,
 		"prefix":    prefix,
-	})
+	}))
 
 	// Grab the client
 	state, err := b.State(backend.DefaultStateName)
@@ -44,18 +44,18 @@ func TestEtcdv3_stateLock(t *testing.T) {
 	prefix := fmt.Sprintf("%s/%s/", keyPrefix, time.Now().Format(time.RFC3339))
 
 	// Get the backend
-	s1, err := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	s1, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"endpoints": etcdv3Endpoints,
 		"prefix":    prefix,
-	}).State(backend.DefaultStateName)
+	})).State(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	s2, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"endpoints": etcdv3Endpoints,
 		"prefix":    prefix,
-	}).State(backend.DefaultStateName)
+	})).State(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,10 +70,10 @@ func TestEtcdv3_destroyLock(t *testing.T) {
 	prefix := fmt.Sprintf("%s/%s/", keyPrefix, time.Now().Format(time.RFC3339))
 
 	// Get the backend
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"endpoints": etcdv3Endpoints,
 		"prefix":    prefix,
-	})
+	}))
 
 	// Grab the client
 	s, err := b.State(backend.DefaultStateName)

--- a/backend/remote-state/gcs/backend_test.go
+++ b/backend/remote-state/gcs/backend_test.go
@@ -187,7 +187,7 @@ func setupBackend(t *testing.T, bucket, prefix, key string) backend.Backend {
 		"encryption_key": key,
 	}
 
-	b := backend.TestBackendConfig(t, New(), config)
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config))
 	be := b.(*gcsBackend)
 
 	// create the bucket if it doesn't exist

--- a/backend/remote-state/http/backend_test.go
+++ b/backend/remote-state/http/backend_test.go
@@ -3,6 +3,9 @@ package http
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/configs"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/backend"
 )
 
@@ -13,16 +16,16 @@ func TestBackend_impl(t *testing.T) {
 func TestHTTPClientFactory(t *testing.T) {
 	// defaults
 
-	conf := map[string]interface{}{
-		"address": "http://127.0.0.1:8888/foo",
+	conf := map[string]cty.Value{
+		"address": cty.StringVal("http://127.0.0.1:8888/foo"),
 	}
-	b := backend.TestBackendConfig(t, New(), conf).(*Backend)
+	b := backend.TestBackendConfig(t, New(), configs.SynthBody("synth", conf)).(*Backend)
 	client := b.client
 
 	if client == nil {
 		t.Fatal("Unexpected failure, address")
 	}
-	if client.URL.String() != conf["address"] {
+	if client.URL.String() != "http://127.0.0.1:8888/foo" {
 		t.Fatalf("Expected address \"%s\", got \"%s\"", conf["address"], client.URL.String())
 	}
 	if client.UpdateMethod != "POST" {
@@ -39,18 +42,18 @@ func TestHTTPClientFactory(t *testing.T) {
 	}
 
 	// custom
-	conf = map[string]interface{}{
-		"address":        "http://127.0.0.1:8888/foo",
-		"update_method":  "BLAH",
-		"lock_address":   "http://127.0.0.1:8888/bar",
-		"lock_method":    "BLIP",
-		"unlock_address": "http://127.0.0.1:8888/baz",
-		"unlock_method":  "BLOOP",
-		"username":       "user",
-		"password":       "pass",
+	conf = map[string]cty.Value{
+		"address":        cty.StringVal("http://127.0.0.1:8888/foo"),
+		"update_method":  cty.StringVal("BLAH"),
+		"lock_address":   cty.StringVal("http://127.0.0.1:8888/bar"),
+		"lock_method":    cty.StringVal("BLIP"),
+		"unlock_address": cty.StringVal("http://127.0.0.1:8888/baz"),
+		"unlock_method":  cty.StringVal("BLOOP"),
+		"username":       cty.StringVal("user"),
+		"password":       cty.StringVal("pass"),
 	}
 
-	b = backend.TestBackendConfig(t, New(), conf).(*Backend)
+	b = backend.TestBackendConfig(t, New(), configs.SynthBody("synth", conf)).(*Backend)
 	client = b.client
 
 	if client == nil {
@@ -59,13 +62,13 @@ func TestHTTPClientFactory(t *testing.T) {
 	if client.UpdateMethod != "BLAH" {
 		t.Fatalf("Expected update_method \"%s\", got \"%s\"", "BLAH", client.UpdateMethod)
 	}
-	if client.LockURL.String() != conf["lock_address"] || client.LockMethod != "BLIP" {
+	if client.LockURL.String() != conf["lock_address"].AsString() || client.LockMethod != "BLIP" {
 		t.Fatalf("Unexpected lock_address \"%s\" vs \"%s\" or lock_method \"%s\" vs \"%s\"", client.LockURL.String(),
-			conf["lock_address"], client.LockMethod, conf["lock_method"])
+			conf["lock_address"].AsString(), client.LockMethod, conf["lock_method"])
 	}
-	if client.UnlockURL.String() != conf["unlock_address"] || client.UnlockMethod != "BLOOP" {
+	if client.UnlockURL.String() != conf["unlock_address"].AsString() || client.UnlockMethod != "BLOOP" {
 		t.Fatalf("Unexpected unlock_address \"%s\" vs \"%s\" or unlock_method \"%s\" vs \"%s\"", client.UnlockURL.String(),
-			conf["unlock_address"], client.UnlockMethod, conf["unlock_method"])
+			conf["unlock_address"].AsString(), client.UnlockMethod, conf["unlock_method"])
 	}
 	if client.Username != "user" || client.Password != "pass" {
 		t.Fatalf("Unexpected username \"%s\" vs \"%s\" or password \"%s\" vs \"%s\"", client.Username, conf["username"],

--- a/backend/remote-state/inmem/backend_test.go
+++ b/backend/remote-state/inmem/backend_test.go
@@ -3,6 +3,7 @@ package inmem
 import (
 	"testing"
 
+	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/state/remote"
 	"github.com/hashicorp/terraform/terraform"
@@ -20,7 +21,7 @@ func TestBackendConfig(t *testing.T) {
 		"lock_id": testID,
 	}
 
-	b := backend.TestBackendConfig(t, New(), config).(*Backend)
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
 
 	s, err := b.State(backend.DefaultStateName)
 	if err != nil {
@@ -39,14 +40,14 @@ func TestBackendConfig(t *testing.T) {
 
 func TestBackend(t *testing.T) {
 	defer Reset()
-	b := backend.TestBackendConfig(t, New(), nil).(*Backend)
+	b := backend.TestBackendConfig(t, New(), hcl.EmptyBody()).(*Backend)
 	backend.TestBackendStates(t, b)
 }
 
 func TestBackendLocked(t *testing.T) {
 	defer Reset()
-	b1 := backend.TestBackendConfig(t, New(), nil).(*Backend)
-	b2 := backend.TestBackendConfig(t, New(), nil).(*Backend)
+	b1 := backend.TestBackendConfig(t, New(), hcl.EmptyBody()).(*Backend)
+	b2 := backend.TestBackendConfig(t, New(), hcl.EmptyBody()).(*Backend)
 
 	backend.TestBackendStateLocks(t, b1, b2)
 }
@@ -54,7 +55,7 @@ func TestBackendLocked(t *testing.T) {
 // use the this backen to test the remote.State implementation
 func TestRemoteState(t *testing.T) {
 	defer Reset()
-	b := backend.TestBackendConfig(t, New(), nil)
+	b := backend.TestBackendConfig(t, New(), hcl.EmptyBody())
 
 	workspace := "workspace"
 

--- a/backend/remote-state/inmem/client_test.go
+++ b/backend/remote-state/inmem/client_test.go
@@ -3,6 +3,7 @@ package inmem
 import (
 	"testing"
 
+	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/state/remote"
 )
@@ -14,7 +15,7 @@ func TestRemoteClient_impl(t *testing.T) {
 
 func TestRemoteClient(t *testing.T) {
 	defer Reset()
-	b := backend.TestBackendConfig(t, New(), nil)
+	b := backend.TestBackendConfig(t, New(), hcl.EmptyBody())
 
 	s, err := b.State(backend.DefaultStateName)
 	if err != nil {
@@ -26,7 +27,7 @@ func TestRemoteClient(t *testing.T) {
 
 func TestInmemLocks(t *testing.T) {
 	defer Reset()
-	s, err := backend.TestBackendConfig(t, New(), nil).State(backend.DefaultStateName)
+	s, err := backend.TestBackendConfig(t, New(), hcl.EmptyBody()).State(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/remote-state/manta/backend_test.go
+++ b/backend/remote-state/manta/backend_test.go
@@ -30,10 +30,10 @@ func TestBackend(t *testing.T) {
 	directory := fmt.Sprintf("terraform-remote-manta-test-%x", time.Now().Unix())
 	keyName := "testState"
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"path":       directory,
 		"objectName": keyName,
-	}).(*Backend)
+	})).(*Backend)
 
 	createMantaFolder(t, b.storageClient, directory)
 	defer deleteMantaFolder(t, b.storageClient, directory)
@@ -47,15 +47,15 @@ func TestBackendLocked(t *testing.T) {
 	directory := fmt.Sprintf("terraform-remote-manta-test-%x", time.Now().Unix())
 	keyName := "testState"
 
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"path":       directory,
 		"objectName": keyName,
-	}).(*Backend)
+	})).(*Backend)
 
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"path":       directory,
 		"objectName": keyName,
-	}).(*Backend)
+	})).(*Backend)
 
 	createMantaFolder(t, b1.storageClient, directory)
 	defer deleteMantaFolder(t, b1.storageClient, directory)

--- a/backend/remote-state/manta/client_test.go
+++ b/backend/remote-state/manta/client_test.go
@@ -20,10 +20,10 @@ func TestRemoteClient(t *testing.T) {
 	directory := fmt.Sprintf("terraform-remote-manta-test-%x", time.Now().Unix())
 	keyName := "testState"
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"path":       directory,
 		"objectName": keyName,
-	}).(*Backend)
+	})).(*Backend)
 
 	createMantaFolder(t, b.storageClient, directory)
 	defer deleteMantaFolder(t, b.storageClient, directory)
@@ -41,15 +41,15 @@ func TestRemoteClientLocks(t *testing.T) {
 	directory := fmt.Sprintf("terraform-remote-manta-test-%x", time.Now().Unix())
 	keyName := "testState"
 
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"path":       directory,
 		"objectName": keyName,
-	}).(*Backend)
+	})).(*Backend)
 
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"path":       directory,
 		"objectName": keyName,
-	}).(*Backend)
+	})).(*Backend)
 
 	createMantaFolder(t, b1.storageClient, directory)
 	defer deleteMantaFolder(t, b1.storageClient, directory)

--- a/backend/remote-state/s3/backend_test.go
+++ b/backend/remote-state/s3/backend_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform/backend"
-	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/config/hcl2shim"
 	"github.com/hashicorp/terraform/state/remote"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -42,7 +42,7 @@ func TestBackendConfig(t *testing.T) {
 		"dynamodb_table": "dynamoTable",
 	}
 
-	b := backend.TestBackendConfig(t, New(), config).(*Backend)
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
 
 	if *b.s3Client.Config.Region != "us-west-1" {
 		t.Fatalf("Incorrect region was populated")
@@ -68,22 +68,16 @@ func TestBackendConfig(t *testing.T) {
 
 func TestBackendConfig_invalidKey(t *testing.T) {
 	testACC(t)
-	cfg := map[string]interface{}{
+	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{
 		"region":         "us-west-1",
 		"bucket":         "tf-test",
 		"key":            "/leading-slash",
 		"encrypt":        true,
 		"dynamodb_table": "dynamoTable",
-	}
+	})
 
-	rawCfg, err := config.NewRawConfig(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resCfg := terraform.NewResourceConfig(rawCfg)
-
-	_, errs := New().Validate(resCfg)
-	if len(errs) != 1 {
+	diags := New().ValidateConfig(cfg)
+	if !diags.HasErrors() {
 		t.Fatal("expected config validation error")
 	}
 }
@@ -94,11 +88,11 @@ func TestBackend(t *testing.T) {
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
 	keyName := "testState"
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":  bucketName,
 		"key":     keyName,
 		"encrypt": true,
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b.s3Client, bucketName)
 	defer deleteS3Bucket(t, b.s3Client, bucketName)
@@ -112,19 +106,19 @@ func TestBackendLocked(t *testing.T) {
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
 	keyName := "test/state"
 
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":         bucketName,
 		"key":            keyName,
 		"encrypt":        true,
 		"dynamodb_table": bucketName,
-	}).(*Backend)
+	})).(*Backend)
 
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":         bucketName,
 		"key":            keyName,
 		"encrypt":        true,
 		"dynamodb_table": bucketName,
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b1.s3Client, bucketName)
 	defer deleteS3Bucket(t, b1.s3Client, bucketName)
@@ -141,11 +135,11 @@ func TestBackendExtraPaths(t *testing.T) {
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
 	keyName := "test/state/tfstate"
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":  bucketName,
 		"key":     keyName,
 		"encrypt": true,
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b.s3Client, bucketName)
 	defer deleteS3Bucket(t, b.s3Client, bucketName)
@@ -256,11 +250,11 @@ func TestBackendPrefixInWorkspace(t *testing.T) {
 	testACC(t)
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket": bucketName,
 		"key":    "test-env.tfstate",
 		"workspace_key_prefix": "env",
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b.s3Client, bucketName)
 	defer deleteS3Bucket(t, b.s3Client, bucketName)
@@ -284,33 +278,33 @@ func TestKeyEnv(t *testing.T) {
 	keyName := "some/paths/tfstate"
 
 	bucket0Name := fmt.Sprintf("terraform-remote-s3-test-%x-0", time.Now().Unix())
-	b0 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b0 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":               bucket0Name,
 		"key":                  keyName,
 		"encrypt":              true,
 		"workspace_key_prefix": "",
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b0.s3Client, bucket0Name)
 	defer deleteS3Bucket(t, b0.s3Client, bucket0Name)
 
 	bucket1Name := fmt.Sprintf("terraform-remote-s3-test-%x-1", time.Now().Unix())
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":               bucket1Name,
 		"key":                  keyName,
 		"encrypt":              true,
 		"workspace_key_prefix": "project/env:",
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b1.s3Client, bucket1Name)
 	defer deleteS3Bucket(t, b1.s3Client, bucket1Name)
 
 	bucket2Name := fmt.Sprintf("terraform-remote-s3-test-%x-2", time.Now().Unix())
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":  bucket2Name,
 		"key":     keyName,
 		"encrypt": true,
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b2.s3Client, bucket2Name)
 	defer deleteS3Bucket(t, b2.s3Client, bucket2Name)

--- a/backend/remote-state/s3/client_test.go
+++ b/backend/remote-state/s3/client_test.go
@@ -24,11 +24,11 @@ func TestRemoteClient(t *testing.T) {
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
 	keyName := "testState"
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":  bucketName,
 		"key":     keyName,
 		"encrypt": true,
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b.s3Client, bucketName)
 	defer deleteS3Bucket(t, b.s3Client, bucketName)
@@ -46,19 +46,19 @@ func TestRemoteClientLocks(t *testing.T) {
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
 	keyName := "testState"
 
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":         bucketName,
 		"key":            keyName,
 		"encrypt":        true,
 		"dynamodb_table": bucketName,
-	}).(*Backend)
+	})).(*Backend)
 
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":         bucketName,
 		"key":            keyName,
 		"encrypt":        true,
 		"dynamodb_table": bucketName,
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b1.s3Client, bucketName)
 	defer deleteS3Bucket(t, b1.s3Client, bucketName)
@@ -84,19 +84,19 @@ func TestForceUnlock(t *testing.T) {
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-force-%x", time.Now().Unix())
 	keyName := "testState"
 
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":         bucketName,
 		"key":            keyName,
 		"encrypt":        true,
 		"dynamodb_table": bucketName,
-	}).(*Backend)
+	})).(*Backend)
 
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":         bucketName,
 		"key":            keyName,
 		"encrypt":        true,
 		"dynamodb_table": bucketName,
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b1.s3Client, bucketName)
 	defer deleteS3Bucket(t, b1.s3Client, bucketName)
@@ -161,11 +161,11 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
 	keyName := "testState"
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":         bucketName,
 		"key":            keyName,
 		"dynamodb_table": bucketName,
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b.s3Client, bucketName)
 	defer deleteS3Bucket(t, b.s3Client, bucketName)
@@ -209,11 +209,11 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
 	keyName := "testState"
 
-	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket":         bucketName,
 		"key":            keyName,
 		"dynamodb_table": bucketName,
-	}).(*Backend)
+	})).(*Backend)
 
 	createS3Bucket(t, b1.s3Client, bucketName)
 	defer deleteS3Bucket(t, b1.s3Client, bucketName)
@@ -240,10 +240,10 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 
 	// Use b2 without a dynamodb_table to bypass the lock table to write the state directly.
 	// client2 will write the "incorrect" state, simulating s3 eventually consistency delays
-	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"bucket": bucketName,
 		"key":    keyName,
-	}).(*Backend)
+	})).(*Backend)
 	s2, err := b2.State(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)

--- a/backend/remote-state/swift/backend_test.go
+++ b/backend/remote-state/swift/backend_test.go
@@ -46,7 +46,7 @@ func TestBackendConfig(t *testing.T) {
 		"container":         "test-tfstate",
 	}
 
-	b := backend.TestBackendConfig(t, New(), config).(*Backend)
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
 
 	if b.container != "test-tfstate" {
 		t.Fatal("Incorrect path was provided.")
@@ -61,9 +61,9 @@ func TestBackend(t *testing.T) {
 
 	container := fmt.Sprintf("terraform-state-swift-test-%x", time.Now().Unix())
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"container": container,
-	}).(*Backend)
+	})).(*Backend)
 
 	defer deleteSwiftContainer(t, b.client, container)
 
@@ -75,9 +75,9 @@ func TestBackendPath(t *testing.T) {
 
 	path := fmt.Sprintf("terraform-state-swift-test-%x", time.Now().Unix())
 	t.Logf("[DEBUG] Generating backend config")
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"path": path,
-	}).(*Backend)
+	})).(*Backend)
 	t.Logf("[DEBUG] Backend configured")
 
 	defer deleteSwiftContainer(t, b.client, path)
@@ -131,10 +131,10 @@ func TestBackendArchive(t *testing.T) {
 	container := fmt.Sprintf("terraform-state-swift-test-%x", time.Now().Unix())
 	archiveContainer := fmt.Sprintf("%s_archive", container)
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"archive_container": archiveContainer,
 		"container":         container,
-	}).(*Backend)
+	})).(*Backend)
 
 	defer deleteSwiftContainer(t, b.client, container)
 	defer deleteSwiftContainer(t, b.client, archiveContainer)

--- a/backend/remote-state/swift/client_test.go
+++ b/backend/remote-state/swift/client_test.go
@@ -18,9 +18,9 @@ func TestRemoteClient(t *testing.T) {
 
 	container := fmt.Sprintf("terraform-state-swift-test-%x", time.Now().Unix())
 
-	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"container": container,
-	}).(*Backend)
+	})).(*Backend)
 
 	state, err := b.State(backend.DefaultStateName)
 	if err != nil {

--- a/command/apply.go
+++ b/command/apply.go
@@ -7,12 +7,13 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/terraform/configs"
+
 	"github.com/hashicorp/terraform/tfdiags"
 
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/config"
-	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -118,66 +119,74 @@ func (c *ApplyCommand) Run(args []string) int {
 
 	var diags tfdiags.Diagnostics
 
-	// Load the module if we don't have one yet (not running from plan)
-	var mod *module.Tree
+	var backendConfig *configs.Backend
 	if plan == nil {
-		var modDiags tfdiags.Diagnostics
-		mod, modDiags = c.Module(configPath)
-		diags = diags.Append(modDiags)
-		if modDiags.HasErrors() {
+		var configDiags tfdiags.Diagnostics
+		backendConfig, configDiags = c.loadBackendConfig(configPath)
+		diags = diags.Append(configDiags)
+		if configDiags.HasErrors() {
 			c.showDiagnostics(diags)
 			return 1
 		}
 	}
 
-	var conf *config.Config
-	if mod != nil {
-		conf = mod.Config()
-	}
-
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{
-		Config: conf,
+	b, beDiags := c.Backend(&BackendOpts{
+		Config: backendConfig,
 		Plan:   plan,
 	})
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	diags = diags.Append(beDiags)
+	if beDiags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
+
+	// Before we delegate to the backend, we'll print any warning diagnostics
+	// we've accumulated here, since the backend will start fresh with its own
+	// diagnostics.
+	c.showDiagnostics(diags)
+	diags = nil
 
 	// Build the operation
 	opReq := c.Operation()
 	opReq.Destroy = c.Destroy
-	opReq.Module = mod
+	opReq.ConfigDir = configPath
 	opReq.Plan = plan
 	opReq.PlanRefresh = refresh
 	opReq.Type = backend.OperationTypeApply
 	opReq.AutoApprove = autoApprove
 	opReq.DestroyForce = destroyForce
-
-	op, err := c.RunOperation(b, opReq)
+	opReq.ConfigLoader, err = c.initConfigLoader()
 	if err != nil {
-		diags = diags.Append(err)
-	}
-
-	c.showDiagnostics(diags)
-	if diags.HasErrors() {
+		c.showDiagnostics(err)
 		return 1
 	}
 
-	if !c.Destroy {
-		// Get the right module that we used. If we ran a plan, then use
-		// that module.
-		if plan != nil {
-			mod = plan.Module
-		}
-
-		if outputs := outputsAsString(op.State, terraform.RootModulePath, mod.Config().Outputs, true); outputs != "" {
-			c.Ui.Output(c.Colorize().Color(outputs))
-		}
+	op, err := c.RunOperation(b, opReq)
+	if err != nil {
+		c.showDiagnostics(err)
+		return 1
+	}
+	if op.Result != backend.OperationSuccess {
+		return op.Result.ExitStatus()
 	}
 
-	return 0
+	if !c.Destroy {
+		// TODO: Print outputs, once this is updated to use new config types.
+		/*
+			// Get the right module that we used. If we ran a plan, then use
+			// that module.
+			if plan != nil {
+				mod = plan.Module
+			}
+
+			if outputs := outputsAsString(op.State, terraform.RootModulePath, mod.Config().Outputs, true); outputs != "" {
+				c.Ui.Output(c.Colorize().Color(outputs))
+			}
+		*/
+	}
+
+	return op.Result.ExitStatus()
 }
 
 func (c *ApplyCommand) Help() string {

--- a/command/autocomplete.go
+++ b/command/autocomplete.go
@@ -49,15 +49,15 @@ func (m *Meta) completePredictWorkspaceName() complete.Predictor {
 			return nil
 		}
 
-		cfg, err := m.Config(configPath)
-		if err != nil {
+		backendConfig, diags := m.loadBackendConfig(configPath)
+		if diags.HasErrors() {
 			return nil
 		}
 
-		b, err := m.Backend(&BackendOpts{
-			Config: cfg,
+		b, diags := m.Backend(&BackendOpts{
+			Config: backendConfig,
 		})
-		if err != nil {
+		if diags.HasErrors() {
 			return nil
 		}
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -548,9 +548,9 @@ func testBackendState(t *testing.T, s *terraform.State, c int) (*terraform.State
 
 	state := terraform.NewState()
 	state.Backend = &terraform.BackendState{
-		Type:   "http",
-		Config: map[string]interface{}{"address": srv.URL},
-		Hash:   2529831861221416334,
+		Type:      "http",
+		ConfigRaw: json.RawMessage(fmt.Sprintf(`{"address":%q}`, srv.URL)),
+		Hash:      2529831861221416334,
 	}
 
 	return state, srv

--- a/command/init.go
+++ b/command/init.go
@@ -7,16 +7,19 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/posener/complete"
-
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform/backend"
+	backendinit "github.com/hashicorp/terraform/backend/init"
 	"github.com/hashicorp/terraform/config"
-	"github.com/hashicorp/terraform/config/module"
-	"github.com/hashicorp/terraform/helper/variables"
+	"github.com/hashicorp/terraform/config/configschema"
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/posener/complete"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // InitCommand is a Command implementation that takes a Terraform
@@ -37,9 +40,9 @@ type InitCommand struct {
 func (c *InitCommand) Run(args []string) int {
 	var flagFromModule string
 	var flagBackend, flagGet, flagUpgrade bool
-	var flagConfigExtra map[string]interface{}
 	var flagPluginPath FlagStringSlice
 	var flagVerifyPlugins bool
+	flagConfigExtra := newRawFlags("-backend-config")
 
 	args, err := c.Meta.process(args, false)
 	if err != nil {
@@ -47,7 +50,7 @@ func (c *InitCommand) Run(args []string) int {
 	}
 	cmdFlags := c.flagSet("init")
 	cmdFlags.BoolVar(&flagBackend, "backend", true, "")
-	cmdFlags.Var((*variables.FlagAny)(&flagConfigExtra), "backend-config", "")
+	cmdFlags.Var(flagConfigExtra, "backend-config", "")
 	cmdFlags.StringVar(&flagFromModule, "from-module", "", "copy the source of the given module into the directory before init")
 	cmdFlags.BoolVar(&flagGet, "get", true, "")
 	cmdFlags.BoolVar(&c.getPlugins, "get-plugins", true, "")
@@ -63,6 +66,8 @@ func (c *InitCommand) Run(args []string) int {
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
 	}
+
+	var diags tfdiags.Diagnostics
 
 	if len(flagPluginPath) > 0 {
 		c.pluginPath = flagPluginPath
@@ -129,9 +134,15 @@ func (c *InitCommand) Run(args []string) int {
 		)))
 		header = true
 
-		s := module.NewStorage("", c.Services, c.Credentials)
-		if err := s.GetModule(path, src); err != nil {
-			c.Ui.Error(fmt.Sprintf("Error copying source module: %s", err))
+		hooks := uiModuleInstallHooks{
+			Ui:             c.Ui,
+			ShowLocalPaths: false, // since they are in a weird location for init
+		}
+
+		initDiags := c.initDirFromModule(path, src, hooks)
+		diags = diags.Append(initDiags)
+		if initDiags.HasErrors() {
+			c.showDiagnostics(diags)
 			return 1
 		}
 	}
@@ -139,8 +150,7 @@ func (c *InitCommand) Run(args []string) int {
 	// If our directory is empty, then we're done. We can't get or setup
 	// the backend with an empty directory.
 	if empty, err := config.IsEmptyDir(path); err != nil {
-		c.Ui.Error(fmt.Sprintf(
-			"Error checking configuration: %s", err))
+		diags = diags.Append(fmt.Errorf("Error checking configuration: %s", err))
 		return 1
 	} else if empty {
 		c.Ui.Output(c.Colorize().Color(strings.TrimSpace(outputInitEmpty)))
@@ -152,32 +162,34 @@ func (c *InitCommand) Run(args []string) int {
 	// If we're performing a get or loading the backend, then we perform
 	// some extra tasks.
 	if flagGet || flagBackend {
-		conf, err := c.Config(path)
-		if err != nil {
+		config, confDiags := c.loadSingleModule(path)
+		diags = diags.Append(confDiags)
+		if confDiags.HasErrors() {
 			// Since this may be the user's first ever interaction with Terraform,
 			// we'll provide some additional context in this case.
 			c.Ui.Error(strings.TrimSpace(errInitConfigError))
-			c.showDiagnostics(err)
+			c.showDiagnostics(diags)
 			return 1
 		}
 
 		// If we requested downloading modules and have modules in the config
-		if flagGet && len(conf.Modules) > 0 {
+		if flagGet && len(config.ModuleCalls) > 0 {
 			header = true
 
-			getMode := module.GetModeGet
 			if flagUpgrade {
-				getMode = module.GetModeUpdate
-				c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
-					"[reset][bold]Upgrading modules...")))
+				c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[reset][bold]Upgrading modules...")))
 			} else {
-				c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
-					"[reset][bold]Initializing modules...")))
+				c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[reset][bold]Initializing modules...")))
 			}
 
-			if err := getModules(&c.Meta, path, getMode); err != nil {
-				c.Ui.Error(fmt.Sprintf(
-					"Error downloading modules: %s", err))
+			hooks := uiModuleInstallHooks{
+				Ui:             c.Ui,
+				ShowLocalPaths: true,
+			}
+			instDiags := c.installModules(path, flagUpgrade, hooks)
+			diags = diags.Append(instDiags)
+			if instDiags.HasErrors() {
+				c.showDiagnostics(diags)
 				return 1
 			}
 		}
@@ -187,21 +199,52 @@ func (c *InitCommand) Run(args []string) int {
 		if flagBackend {
 			header = true
 
+			var backendSchema *configschema.Block
+
 			// Only output that we're initializing a backend if we have
 			// something in the config. We can be UNSETTING a backend as well
 			// in which case we choose not to show this.
-			if conf.Terraform != nil && conf.Terraform.Backend != nil {
-				c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
-					"\n[reset][bold]Initializing the backend...")))
+			if config.Backend != nil {
+				c.Ui.Output(c.Colorize().Color(fmt.Sprintf("\n[reset][bold]Initializing the backend...")))
+
+				backendType := config.Backend.Type
+				bf := backendinit.Backend(backendType)
+				if bf == nil {
+					diags = diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Unsupported backend type",
+						Detail:   fmt.Sprintf("There is no backend type named %q.", backendType),
+						Subject:  &config.Backend.TypeRange,
+					})
+					c.showDiagnostics()
+					return 1
+				}
+
+				b := bf()
+				backendSchema = b.ConfigSchema()
+			}
+
+			var backendConfigOverride hcl.Body
+			if backendSchema != nil {
+				var overrideDiags tfdiags.Diagnostics
+				backendConfigOverride, overrideDiags = c.backendConfigOverrideBody(flagConfigExtra, backendSchema)
+				diags = diags.Append(overrideDiags)
+				if overrideDiags.HasErrors() {
+					c.showDiagnostics()
+					return 1
+				}
 			}
 
 			opts := &BackendOpts{
-				Config:      conf,
-				ConfigExtra: flagConfigExtra,
-				Init:        true,
+				Config:         config.Backend,
+				ConfigOverride: backendConfigOverride,
+				Init:           true,
 			}
-			if back, err = c.Backend(opts); err != nil {
-				c.Ui.Error(err.Error())
+			var backDiags tfdiags.Diagnostics
+			back, backDiags = c.Backend(opts)
+			diags = diags.Append(backDiags)
+			if backDiags.HasErrors() {
+				c.showDiagnostics(diags)
 				return 1
 			}
 		}
@@ -212,8 +255,9 @@ func (c *InitCommand) Run(args []string) int {
 		// instantiate one. This might fail if it wasn't already initalized
 		// by a previous run, so we must still expect that "back" may be nil
 		// in code that follows.
-		back, err = c.Backend(nil)
-		if err != nil {
+		var backDiags tfdiags.Diagnostics
+		back, backDiags = c.Backend(nil)
+		if backDiags.HasErrors() {
 			// This is fine. We'll proceed with no backend, then.
 			back = nil
 		}
@@ -268,6 +312,75 @@ func (c *InitCommand) Run(args []string) int {
 	}
 
 	return 0
+}
+
+// backendConfigOverrideBody interprets the raw values of -backend-config
+// arguments into a hcl Body that should override the backend settings given
+// in the configuration.
+//
+// If the result is nil then no override needs to be provided.
+//
+// If the returned diagnostics contains errors then the returned body may be
+// incomplete or invalid.
+func (c *InitCommand) backendConfigOverrideBody(flags rawFlags, schema *configschema.Block) (hcl.Body, tfdiags.Diagnostics) {
+	items := flags.AllItems()
+	if len(items) == 0 {
+		return nil, nil
+	}
+
+	var ret hcl.Body
+	var diags tfdiags.Diagnostics
+	synthVals := make(map[string]cty.Value)
+
+	mergeBody := func(newBody hcl.Body) {
+		if ret == nil {
+			ret = newBody
+		} else {
+			ret = configs.MergeBodies(ret, newBody)
+		}
+	}
+	flushVals := func() {
+		if len(synthVals) == 0 {
+			return
+		}
+		newBody := configs.SynthBody("-backend-config=...", synthVals)
+		mergeBody(newBody)
+		synthVals = make(map[string]cty.Value)
+	}
+
+	for _, item := range items {
+		eq := strings.Index(item.Value, "=")
+
+		if eq == -1 {
+			// The value is interpreted as a filename.
+			newBody, fileDiags := c.loadHCLFile(item.Value)
+			diags = diags.Append(fileDiags)
+			flushVals() // deal with any accumulated individual values first
+			mergeBody(newBody)
+		} else {
+			name := item.Value[:eq]
+			rawValue := item.Value[eq+1:]
+			attrS := schema.Attributes[name]
+			if attrS == nil {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid backend configuration argument",
+					fmt.Sprintf("The backend configuration argument %q given on the command line is not expected for the selected backend type.", name),
+				))
+				continue
+			}
+			value, valueDiags := configValueFromCLI(item.String(), rawValue, attrS.Type)
+			diags = diags.Append(valueDiags)
+			if valueDiags.HasErrors() {
+				continue
+			}
+			synthVals[name] = value
+		}
+	}
+
+	flushVals()
+
+	return ret, diags
 }
 
 // Load the complete module tree, and fetch any missing providers.

--- a/command/init.go
+++ b/command/init.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform/backend"
 	backendinit "github.com/hashicorp/terraform/backend/init"
@@ -145,6 +144,8 @@ func (c *InitCommand) Run(args []string) int {
 			c.showDiagnostics(diags)
 			return 1
 		}
+
+		c.Ui.Output("")
 	}
 
 	// If our directory is empty, then we're done. We can't get or setup
@@ -290,10 +291,10 @@ func (c *InitCommand) Run(args []string) int {
 	}
 
 	// Now that we have loaded all modules, check the module tree for missing providers.
-	err = c.getProviders(path, state, flagUpgrade)
-	if err != nil {
-		// this function provides its own output
-		log.Printf("[ERROR] %s", err)
+	providerDiags := c.getProviders(path, state, flagUpgrade)
+	diags = diags.Append(providerDiags)
+	if providerDiags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 
@@ -302,6 +303,11 @@ func (c *InitCommand) Run(args []string) int {
 	if header {
 		c.Ui.Output("")
 	}
+
+	// If we accumulated any warnings along the way that weren't accompanied
+	// by errors then we'll output them here so that the success message is
+	// still the final thing shown.
+	c.showDiagnostics(diags)
 
 	c.Ui.Output(c.Colorize().Color(strings.TrimSpace(outputInitSuccess)))
 	if !c.RunningInAutomation {
@@ -385,24 +391,25 @@ func (c *InitCommand) backendConfigOverrideBody(flags rawFlags, schema *configsc
 
 // Load the complete module tree, and fetch any missing providers.
 // This method outputs its own Ui.
-func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade bool) error {
-	mod, diags := c.Module(path)
+func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade bool) tfdiags.Diagnostics {
+	config, diags := c.loadConfig(path)
 	if diags.HasErrors() {
-		c.showDiagnostics(diags)
-		return diags.Err()
+		return diags
 	}
 
 	if err := terraform.CheckStateVersion(state); err != nil {
 		diags = diags.Append(err)
-		c.showDiagnostics(diags)
-		return err
+		return diags
 	}
 
-	if err := terraform.CheckRequiredVersion(mod); err != nil {
-		diags = diags.Append(err)
-		c.showDiagnostics(diags)
-		return err
-	}
+	// FIXME: Restore this once terraform.CheckRequiredVersion is updated to
+	// work with a configs.Config instead of a legacy module.Tree.
+	/*
+		if err := terraform.CheckRequiredVersion(mod); err != nil {
+			diags = diags.Append(err)
+			return diags
+		}
+	*/
 
 	var available discovery.PluginMetaSet
 	if upgrade {
@@ -413,7 +420,7 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 		available = c.providerPluginSet()
 	}
 
-	requirements := terraform.ModuleTreeDependencies(mod, state).AllPluginRequirements()
+	requirements := terraform.ConfigTreeDependencies(config, state).AllPluginRequirements()
 	if len(requirements) == 0 {
 		// nothing to initialize
 		return nil
@@ -425,7 +432,6 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 
 	missing := c.missingPlugins(available, requirements)
 
-	var errs error
 	if c.getPlugins {
 		if len(missing) > 0 {
 			c.Ui.Output(fmt.Sprintf("- Checking for available provider plugins on %s...",
@@ -462,12 +468,12 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 					c.Ui.Error(fmt.Sprintf(errProviderInstallError, provider, err.Error(), DefaultPluginVendorDir))
 				}
 
-				errs = multierror.Append(errs, err)
+				diags = diags.Append(err)
 			}
 		}
 
-		if errs != nil {
-			return errs
+		if diags.HasErrors() {
+			return diags
 		}
 	} else if len(missing) > 0 {
 		// we have missing providers, but aren't going to try and download them
@@ -478,11 +484,11 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 			} else {
 				lines = append(lines, fmt.Sprintf("* %s (%s)\n", provider, reqd.Versions))
 			}
-			errs = multierror.Append(errs, fmt.Errorf("missing provider %q", provider))
+			diags = diags.Append(fmt.Errorf("missing provider %q", provider))
 		}
 		sort.Strings(lines)
 		c.Ui.Error(fmt.Sprintf(errMissingProvidersNoInstall, strings.Join(lines, ""), DefaultPluginVendorDir))
-		return errs
+		return diags
 	}
 
 	// With all the providers downloaded, we'll generate our lock file
@@ -498,8 +504,8 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 	for name, meta := range chosen {
 		digest, err := meta.SHA256()
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("failed to read provider plugin %s: %s", meta.Path, err))
-			return err
+			diags = diags.Append(fmt.Errorf("Failed to read provider plugin %s: %s", meta.Path, err))
+			return diags
 		}
 		digests[name] = digest
 		if c.ignorePluginChecksum {
@@ -508,8 +514,8 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 	}
 	err := c.providerPluginsLock().Write(digests)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("failed to save provider manifest: %s", err))
-		return err
+		diags = diags.Append(fmt.Errorf("failed to save provider manifest: %s", err))
+		return diags
 	}
 
 	{
@@ -557,7 +563,7 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 		}
 	}
 
-	return nil
+	return diags
 }
 
 func (c *InitCommand) AutocompleteArgs() complete.Predictor {

--- a/command/meta.go
+++ b/command/meta.go
@@ -266,6 +266,15 @@ func (m *Meta) StdinPiped() bool {
 	return fi.Mode()&os.ModeNamedPipe != 0
 }
 
+// RunOperation executes the given operation on the given backend, blocking
+// until that operation completes or is inteerrupted, and then returns
+// the RunningOperation object representing the completed or
+// aborted operation that is, despite the name, no longer running.
+//
+// An error is returned if the operation either fails to start or is cancelled.
+// If the operation runs to completion then no error is returned even if the
+// operation itself is unsuccessful. Use the "Result" field of the
+// returned operation object to recognize operation-level failure.
 func (m *Meta) RunOperation(b backend.Enhanced, opReq *backend.Operation) (*backend.RunningOperation, error) {
 	op, err := b.Operation(context.Background(), opReq)
 	if err != nil {
@@ -305,10 +314,6 @@ func (m *Meta) RunOperation(b backend.Enhanced, opReq *backend.Operation) (*back
 		}
 	case <-op.Done():
 		// operation completed normally
-	}
-
-	if op.Err != nil {
-		return op, op.Err
 	}
 
 	return op, nil

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/command/clistate"
 	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/mapstructure"
@@ -27,9 +28,9 @@ import (
 
 // BackendOpts are the options used to initialize a backend.Backend.
 type BackendOpts struct {
-	// Module is the root module from which we will extract the terraform and
-	// backend configuration.
-	Config *config.Config
+	// Config is a representation of the backend configuration block given in
+	// the root module, or nil if no such block is present.
+	Config *configs.Backend
 
 	// ConfigFile is a path to a file that contains configuration that
 	// is merged directly into the backend configuration when loaded

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -5,25 +5,26 @@ package command
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"path/filepath"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/hcl"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcldec"
 	"github.com/hashicorp/terraform/backend"
+	backendinit "github.com/hashicorp/terraform/backend/init"
+	backendlocal "github.com/hashicorp/terraform/backend/local"
 	"github.com/hashicorp/terraform/command/clistate"
-	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/mitchellh/mapstructure"
-
-	backendinit "github.com/hashicorp/terraform/backend/init"
-	backendlocal "github.com/hashicorp/terraform/backend/local"
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 // BackendOpts are the options used to initialize a backend.Backend.
@@ -32,14 +33,10 @@ type BackendOpts struct {
 	// the root module, or nil if no such block is present.
 	Config *configs.Backend
 
-	// ConfigFile is a path to a file that contains configuration that
-	// is merged directly into the backend configuration when loaded
-	// from a file.
-	ConfigFile string
-
-	// ConfigExtra is extra configuration to merge into the backend
-	// configuration after the extra file above.
-	ConfigExtra map[string]interface{}
+	// ConfigOverride is an hcl.Body that, if non-nil, will be used with
+	// configs.MergeBodies to override the type-specific backend configuration
+	// arguments in Config.
+	ConfigOverride hcl.Body
 
 	// Plan is a plan that is being used. If this is set, the backend
 	// configuration and output configuration will come from this plan.
@@ -69,7 +66,9 @@ type BackendOpts struct {
 // and is unsafe to create multiple backends used at once. This function
 // can be called multiple times with each backend being "live" (usable)
 // one at a time.
-func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, error) {
+func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
 	// If no opts are set, then initialize
 	if opts == nil {
 		opts = &BackendOpts{}
@@ -79,17 +78,20 @@ func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, error) {
 	// local operation.
 	var b backend.Backend
 	if !opts.ForceLocal {
-		var err error
-
 		// If we have a plan then, we get the the backend from there. Otherwise,
 		// the backend comes from the configuration.
 		if opts.Plan != nil {
-			b, err = m.backendFromPlan(opts)
+			var backendDiags tfdiags.Diagnostics
+			b, backendDiags = m.backendFromPlan(opts)
+			diags = diags.Append(backendDiags)
 		} else {
-			b, err = m.backendFromConfig(opts)
+			var backendDiags tfdiags.Diagnostics
+			b, backendDiags = m.backendFromConfig(opts)
+			diags = diags.Append(backendDiags)
 		}
-		if err != nil {
-			return nil, err
+
+		if diags.HasErrors() {
+			return nil, diags
 		}
 
 		log.Printf("[INFO] command: backend initialized: %T", b)
@@ -99,6 +101,7 @@ func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, error) {
 	cliOpts := &backend.CLIOpts{
 		CLI:                 m.Ui,
 		CLIColor:            m.Colorize(),
+		ShowDiagnostics:     m.showDiagnostics,
 		StatePath:           m.statePath,
 		StateOutPath:        m.stateOutPath,
 		StateBackupPath:     m.backupPath,
@@ -115,10 +118,12 @@ func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, error) {
 	// If the backend supports CLI initialization, do it.
 	if cli, ok := b.(backend.CLI); ok {
 		if err := cli.CLIInit(cliOpts); err != nil {
-			return nil, fmt.Errorf(
+			diags = diags.Append(fmt.Errorf(
 				"Error initializing backend %T: %s\n\n"+
-					"This is a bug, please report it to the backend developer",
-				b, err)
+					"This is a bug; please report it to the backend developer",
+				b, err,
+			))
+			return nil, diags
 		}
 	}
 
@@ -178,17 +183,19 @@ func (m *Meta) Operation() *backend.Operation {
 }
 
 // backendConfig returns the local configuration for the backend
-func (m *Meta) backendConfig(opts *BackendOpts) (*config.Backend, error) {
+func (m *Meta) backendConfig(opts *BackendOpts) (*configs.Backend, int, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
 	if opts.Config == nil {
 		// check if the config was missing, or just not required
-		conf, err := m.Config(".")
+		conf, err := m.loadBackendConfig(".")
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		if conf == nil {
 			log.Println("[INFO] command: no config, returning nil")
-			return nil, nil
+			return nil, 0, nil
 		}
 
 		log.Println("[WARN] BackendOpts.Config not set, but config found")
@@ -197,81 +204,37 @@ func (m *Meta) backendConfig(opts *BackendOpts) (*config.Backend, error) {
 
 	c := opts.Config
 
-	// If there is no Terraform configuration block, no backend config
-	if c.Terraform == nil {
-		log.Println("[INFO] command: empty terraform config, returning nil")
-		return nil, nil
+	if c == nil {
+		log.Println("[INFO] command: no explicit backend config")
+		return nil, 0, nil
 	}
 
-	// Get the configuration for the backend itself.
-	backend := c.Terraform.Backend
-	if backend == nil {
-		log.Println("[INFO] command: empty backend config, returning nil")
-		return nil, nil
+	bf := backendinit.Backend(c.Type)
+	if bf == nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid backend type",
+			Detail:   fmt.Sprintf("There is no backend type named %q.", c.Type),
+			Subject:  &c.TypeRange,
+		})
+		return nil, 0, diags
+	}
+	b := bf()
+
+	configSchema := b.ConfigSchema()
+	configBody := c.Config
+	configHash := c.Hash(configSchema)
+
+	// If we have an override configuration body then we must apply it now.
+	if opts.ConfigOverride != nil {
+		configBody = configs.MergeBodies(configBody, opts.ConfigOverride)
 	}
 
-	// If we have a config file set, load that and merge.
-	if opts.ConfigFile != "" {
-		log.Printf(
-			"[DEBUG] command: loading extra backend config from: %s",
-			opts.ConfigFile)
-		rc, err := m.backendConfigFile(opts.ConfigFile)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"Error loading extra configuration file for backend: %s", err)
-		}
-
-		// Merge in the configuration
-		backend.RawConfig = backend.RawConfig.Merge(rc)
-	}
-
-	// If we have extra config values, merge that
-	if len(opts.ConfigExtra) > 0 {
-		log.Printf(
-			"[DEBUG] command: adding extra backend config from CLI")
-		rc, err := config.NewRawConfig(opts.ConfigExtra)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"Error adding extra configuration file for backend: %s", err)
-		}
-
-		// Merge in the configuration
-		backend.RawConfig = backend.RawConfig.Merge(rc)
-	}
-
-	// Validate the backend early. We have to do this before the normal
-	// config validation pass since backend loading happens earlier.
-	if errs := backend.Validate(); len(errs) > 0 {
-		return nil, multierror.Append(nil, errs...)
-	}
-
-	// Return the configuration which may or may not be set
-	return backend, nil
-}
-
-// backendConfigFile loads the extra configuration to merge with the
-// backend configuration from an extra file if specified by
-// BackendOpts.ConfigFile.
-func (m *Meta) backendConfigFile(path string) (*config.RawConfig, error) {
-	// Read the file
-	d, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	// Parse it
-	hclRoot, err := hcl.Parse(string(d))
-	if err != nil {
-		return nil, err
-	}
-
-	// Decode it
-	var c map[string]interface{}
-	if err := hcl.DecodeObject(&c, hclRoot); err != nil {
-		return nil, err
-	}
-
-	return config.NewRawConfig(c)
+	// We'll shallow-copy configs.Backend here so that we can replace the
+	// body without affecting others that hold this reference.
+	configCopy := *c
+	c.Config = configBody
+	return &configCopy, configHash, diags
 }
 
 // backendFromConfig returns the initialized (not configured) backend
@@ -283,21 +246,11 @@ func (m *Meta) backendConfigFile(path string) (*config.RawConfig, error) {
 //
 // This function may query the user for input unless input is disabled, in
 // which case this function will error.
-func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, error) {
+func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Diagnostics) {
 	// Get the local backend configuration.
-	c, err := m.backendConfig(opts)
-	if err != nil {
-		return nil, fmt.Errorf("Error loading backend config: %s", err)
-	}
-
-	// cHash defaults to zero unless c is set
-	var cHash uint64
-	if c != nil {
-		// We need to rehash to get the value since we may have merged the
-		// config with an extra ConfigFile. We don't do this when merging
-		// because we do want the ORIGINAL value on c so that we store
-		// that to not detect drift. This is covered in tests.
-		cHash = c.Rehash()
+	c, cHash, diags := m.backendConfig(opts)
+	if diags.HasErrors() {
+		return nil, diags
 	}
 
 	// Get the path to where we store a local cache of backend configuration
@@ -306,7 +259,8 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, error) {
 	statePath := filepath.Join(m.DataDir(), DefaultStateFilename)
 	sMgr := &state.LocalState{Path: statePath}
 	if err := sMgr.RefreshState(); err != nil {
-		return nil, fmt.Errorf("Error loading state: %s", err)
+		diags = diags.Append(fmt.Errorf("Failed to load state: %s", err))
+		return nil, diags
 	}
 
 	// Load the state, it must be non-nil for the tests below but can be empty
@@ -347,10 +301,11 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, error) {
 				"Unsetting the previously set backend %q",
 				s.Backend.Type)
 			m.backendInitRequired(initReason)
-			return nil, errBackendInitRequired
+			diags = diags.Append(errBackendInitRequired)
+			return nil, diags
 		}
 
-		return m.backend_c_r_S(c, sMgr, true)
+		return m.backend_c_r_S(c, cHash, sMgr, true)
 
 	// We have a legacy remote state configuration but no new backend config
 	case c == nil && !s.Remote.Empty() && s.Backend.Empty():
@@ -368,10 +323,11 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, error) {
 				"Unsetting the previously set backend %q",
 				s.Backend.Type)
 			m.backendInitRequired(initReason)
-			return nil, errBackendInitRequired
+			diags = diags.Append(errBackendInitRequired)
+			return nil, diags
 		}
 
-		return m.backend_c_R_S(c, sMgr)
+		return m.backend_c_R_S(c, cHash, sMgr)
 
 	// Configuring a backend for the first time.
 	case c != nil && s.Remote.Empty() && s.Backend.Empty():
@@ -380,24 +336,20 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, error) {
 				"Initial configuration of the requested backend %q",
 				c.Type)
 			m.backendInitRequired(initReason)
-			return nil, errBackendInitRequired
+			diags = diags.Append(errBackendInitRequired)
+			return nil, diags
 		}
 
-		return m.backend_C_r_s(c, sMgr)
+		return m.backend_C_r_s(c, cHash, sMgr)
 
 	// Potentially changing a backend configuration
 	case c != nil && s.Remote.Empty() && !s.Backend.Empty():
 		// If our configuration is the same, then we're just initializing
 		// a previously configured remote backend.
 		if !s.Backend.Empty() {
-			hash := s.Backend.Hash
-			// on init we need an updated hash containing any extra options
-			// that were added after merging.
-			if opts.Init {
-				hash = s.Backend.Rehash()
-			}
-			if hash == cHash {
-				return m.backend_C_r_S_unchanged(c, sMgr)
+			storedHash := s.Backend.Hash
+			if storedHash == cHash {
+				return m.backend_C_r_S_unchanged(c, cHash, sMgr)
 			}
 		}
 
@@ -406,13 +358,14 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, error) {
 				"Backend configuration changed for %q",
 				c.Type)
 			m.backendInitRequired(initReason)
-			return nil, errBackendInitRequired
+			diags = diags.Append(errBackendInitRequired)
+			return nil, diags
 		}
 
 		log.Printf(
 			"[WARN] command: backend config change! saved: %d, new: %d",
 			s.Backend.Hash, cHash)
-		return m.backend_C_r_S_changed(c, sMgr, true)
+		return m.backend_C_r_S_changed(c, cHash, sMgr, true)
 
 	// Configuring a backend for the first time while having legacy
 	// remote state. This is very possible if a Terraform user configures
@@ -423,7 +376,8 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, error) {
 				"Initial configuration for backend %q",
 				c.Type)
 			m.backendInitRequired(initReason)
-			return nil, errBackendInitRequired
+			diags = diags.Append(errBackendInitRequired)
+			return nil, diags
 		}
 
 		return m.backend_C_R_s(c, sMgr)
@@ -433,17 +387,15 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, error) {
 	case c != nil && !s.Remote.Empty() && !s.Backend.Empty():
 		// If the hashes are the same, we have a legacy remote state with
 		// an unchanged stored backend state.
-		hash := s.Backend.Hash
-		if opts.Init {
-			hash = s.Backend.Rehash()
-		}
-		if hash == cHash {
+		storedHash := s.Backend.Hash
+		if storedHash == cHash {
 			if !opts.Init {
 				initReason := fmt.Sprintf(
 					"Legacy remote state found with configured backend %q",
 					c.Type)
 				m.backendInitRequired(initReason)
-				return nil, errBackendInitRequired
+				diags = diags.Append(errBackendInitRequired)
+				return nil, diags
 			}
 
 			return m.backend_C_R_S_unchanged(c, sMgr, true)
@@ -454,7 +406,8 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, error) {
 				"Reconfiguring the backend %q",
 				c.Type)
 			m.backendInitRequired(initReason)
-			return nil, errBackendInitRequired
+			diags = diags.Append(errBackendInitRequired)
+			return nil, diags
 		}
 
 		// We have change in all three
@@ -463,29 +416,33 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, error) {
 		// This should be impossible since all state possibilties are
 		// tested above, but we need a default case anyways and we should
 		// protect against the scenario where a case is somehow removed.
-		return nil, fmt.Errorf(
+		diags = diags.Append(fmt.Errorf(
 			"Unhandled backend configuration state. This is a bug. Please\n"+
 				"report this error with the following information.\n\n"+
 				"Config Nil: %v\n"+
 				"Saved Backend Empty: %v\n"+
 				"Legacy Remote Empty: %v\n",
-			c == nil, s.Backend.Empty(), s.Remote.Empty())
+			c == nil, s.Backend.Empty(), s.Remote.Empty(),
+		))
+		return nil, diags
 	}
 }
 
 // backendFromPlan loads the backend from a given plan file.
-func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, error) {
-	// Precondition check
+func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, tfdiags.Diagnostics) {
 	if opts.Plan == nil {
 		panic("plan should not be nil")
 	}
 
+	var diags tfdiags.Diagnostics
+
 	// We currently don't allow "-state" to be specified.
 	if m.statePath != "" {
-		return nil, fmt.Errorf(
+		diags = diags.Append(fmt.Errorf(
 			"State path cannot be specified with a plan file. The plan itself contains\n" +
 				"the state to use. If you wish to change that, please create a new plan\n" +
-				"and specify the state path when creating the plan.")
+				"and specify the state path when creating the plan.",
+		))
 	}
 
 	planBackend := opts.Plan.Backend
@@ -501,30 +458,10 @@ func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, error) {
 	if !local {
 		// We currently don't allow "-state-out" to be specified.
 		if m.stateOutPath != "" {
-			return nil, fmt.Errorf(strings.TrimSpace(errBackendPlanStateFlag))
+			diags = diags.Append(fmt.Errorf(strings.TrimSpace(errBackendPlanStateFlag)))
+			return nil, diags
 		}
 	}
-
-	/*
-		// Determine the path where we'd be writing state
-		path := DefaultStateFilename
-		if !planState.Remote.Empty() || !planBackend.Empty() {
-			path = filepath.Join(m.DataDir(), DefaultStateFilename)
-		}
-
-		// If the path exists, then we need to verify we're writing the same
-		// state lineage. If the path doesn't exist that's okay.
-		_, err := os.Stat(path)
-		if err != nil && !os.IsNotExist(err) {
-			return nil, fmt.Errorf("Error checking state destination: %s", err)
-		}
-		if err == nil {
-			// The file exists, we need to read it and compare
-			if err := m.backendFromPlan_compareStates(state, path); err != nil {
-				return nil, err
-			}
-		}
-	*/
 
 	// If we have a stateOutPath, we must also specify it as the
 	// input path so we can check it properly. We restore it after this
@@ -534,14 +471,15 @@ func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, error) {
 	defer func() { m.statePath = original }()
 
 	var b backend.Backend
-	var err error
 	switch {
 	// No remote state at all, all local
 	case planState.Remote.Empty() && planBackend.Empty():
 		log.Printf("[INFO] command: initializing local backend from plan (not set)")
 
 		// Get the local backend
-		b, err = m.Backend(&BackendOpts{ForceLocal: true})
+		var backendDiags tfdiags.Diagnostics
+		b, backendDiags = m.Backend(&BackendOpts{ForceLocal: true})
+		diags = diags.Append(backendDiags)
 
 	// New backend configuration set
 	case planState.Remote.Empty() && !planBackend.Empty():
@@ -549,7 +487,9 @@ func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, error) {
 			"[INFO] command: initializing backend from plan: %s",
 			planBackend.Type)
 
-		b, err = m.backendInitFromSaved(planBackend)
+		var backendDiags tfdiags.Diagnostics
+		b, backendDiags = m.backendInitFromSaved(planBackend)
+		diags = diags.Append(backendDiags)
 
 	// Legacy remote state set
 	case !planState.Remote.Empty() && planBackend.Empty():
@@ -563,16 +503,19 @@ func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, error) {
 		inmem.WriteState(planState)
 
 		// Get the backend through the normal means of legacy state
-		b, err = m.backend_c_R_s(nil, inmem)
+		var moreDiags tfdiags.Diagnostics
+		b, moreDiags = m.backend_c_R_s(nil, inmem)
+		diags = diags.Append(moreDiags)
 
 	// Both set, this can't happen in a plan.
 	case !planState.Remote.Empty() && !planBackend.Empty():
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendPlanBoth))
+		diags = diags.Append(fmt.Errorf(strings.TrimSpace(errBackendPlanBoth)))
+		return nil, diags
 	}
 
 	// If we had an error, return that
-	if err != nil {
-		return nil, err
+	if diags.HasErrors() {
+		return nil, diags
 	}
 
 	env := m.Workspace()
@@ -580,31 +523,36 @@ func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, error) {
 	// Get the state so we can determine the effect of using this plan
 	realMgr, err := b.State(env)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading state: %s", err)
+		diags = diags.Append(fmt.Errorf("Error reading state: %s", err))
+		return nil, diags
 	}
 
 	if m.stateLock {
 		stateLocker := clistate.NewLocker(context.Background(), m.stateLockTimeout, m.Ui, m.Colorize())
 		if err := stateLocker.Lock(realMgr, "backend from plan"); err != nil {
-			return nil, fmt.Errorf("Error locking state: %s", err)
+			diags = diags.Append(fmt.Errorf("Error locking state: %s", err))
+			return nil, diags
 		}
 		defer stateLocker.Unlock(nil)
 	}
 
 	if err := realMgr.RefreshState(); err != nil {
-		return nil, fmt.Errorf("Error reading state: %s", err)
+		diags = diags.Append(fmt.Errorf("Error reading state: %s", err))
+		return nil, diags
 	}
 	real := realMgr.State()
 	if real != nil {
 		// If they're not the same lineage, don't allow this
 		if !real.SameLineage(planState) {
-			return nil, fmt.Errorf(strings.TrimSpace(errBackendPlanLineageDiff))
+			diags = diags.Append(fmt.Errorf(strings.TrimSpace(errBackendPlanLineageDiff)))
+			return nil, diags
 		}
 
 		// Compare ages
 		comp, err := real.CompareAges(planState)
 		if err != nil {
-			return nil, fmt.Errorf("Error comparing state ages for safety: %s", err)
+			diags = diags.Append(fmt.Errorf("Error comparing state ages for safety: %s", err))
+			return nil, diags
 		}
 		switch comp {
 		case terraform.StateAgeEqual:
@@ -617,15 +565,16 @@ func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, error) {
 			// If we have an older serial it is a problem but if we have a
 			// differing serial but are still identical, just let it through.
 			if real.Equal(planState) {
-				log.Printf(
-					"[WARN] command: state in plan has older serial, but Equal is true")
+				log.Printf("[WARN] command: state in plan has older serial, but Equal is true")
 				break
 			}
 
 			// The real state is newer, this is not allowed.
-			return nil, fmt.Errorf(
+			diags = diags.Append(fmt.Errorf(
 				strings.TrimSpace(errBackendPlanOlder),
-				planState.Serial, real.Serial)
+				planState.Serial, real.Serial,
+			))
+			return nil, diags
 		}
 	}
 
@@ -638,13 +587,15 @@ func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, error) {
 
 	// realMgr locked above
 	if err := realMgr.WriteState(newState); err != nil {
-		return nil, fmt.Errorf("Error writing state: %s", err)
+		diags = diags.Append(fmt.Errorf("Error writing state: %s", err))
+		return nil, diags
 	}
 	if err := realMgr.PersistState(); err != nil {
-		return nil, fmt.Errorf("Error writing state: %s", err)
+		diags = diags.Append(fmt.Errorf("Error writing state: %s", err))
+		return nil, diags
 	}
 
-	return b, nil
+	return b, diags
 }
 
 //-------------------------------------------------------------------
@@ -665,8 +616,7 @@ func (m *Meta) backendFromPlan(opts *BackendOpts) (backend.Backend, error) {
 //-------------------------------------------------------------------
 
 // Unconfiguring a backend (moving from backend => local).
-func (m *Meta) backend_c_r_S(
-	c *config.Backend, sMgr state.State, output bool) (backend.Backend, error) {
+func (m *Meta) backend_c_r_S(c *configs.Backend, cHash int, sMgr state.State, output bool) (backend.Backend, tfdiags.Diagnostics) {
 	s := sMgr.State()
 
 	// Get the backend type for output
@@ -675,36 +625,39 @@ func (m *Meta) backend_c_r_S(
 	m.Ui.Output(fmt.Sprintf(strings.TrimSpace(outputBackendMigrateLocal), s.Backend.Type))
 
 	// Grab a purely local backend to get the local state if it exists
-	localB, err := m.Backend(&BackendOpts{ForceLocal: true})
-	if err != nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendLocalRead), err)
+	localB, diags := m.Backend(&BackendOpts{ForceLocal: true})
+	if diags.HasErrors() {
+		return nil, diags
 	}
 
 	// Initialize the configured backend
-	b, err := m.backend_C_r_S_unchanged(c, sMgr)
-	if err != nil {
-		return nil, fmt.Errorf(
-			strings.TrimSpace(errBackendSavedUnsetConfig), s.Backend.Type, err)
+	b, moreDiags := m.backend_C_r_S_unchanged(c, cHash, sMgr)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		return nil, diags
 	}
 
 	// Perform the migration
-	err = m.backendMigrateState(&backendMigrateOpts{
+	err := m.backendMigrateState(&backendMigrateOpts{
 		OneType: s.Backend.Type,
 		TwoType: "local",
 		One:     b,
 		Two:     localB,
 	})
 	if err != nil {
-		return nil, err
+		diags = diags.Append(err)
+		return nil, diags
 	}
 
 	// Remove the stored metadata
 	s.Backend = nil
 	if err := sMgr.WriteState(s); err != nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendClearSaved), err)
+		diags = diags.Append(fmt.Errorf(strings.TrimSpace(errBackendClearSaved), err))
+		return nil, diags
 	}
 	if err := sMgr.PersistState(); err != nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendClearSaved), err)
+		diags = diags.Append(fmt.Errorf(strings.TrimSpace(errBackendClearSaved), err))
+		return nil, diags
 	}
 
 	if output {
@@ -714,208 +667,64 @@ func (m *Meta) backend_c_r_S(
 	}
 
 	// Return no backend
-	return nil, nil
+	return nil, diags
 }
 
 // Legacy remote state
-func (m *Meta) backend_c_R_s(
-	c *config.Backend, sMgr state.State) (backend.Backend, error) {
-	s := sMgr.State()
+func (m *Meta) backend_c_R_s(c *configs.Backend, sMgr state.State) (backend.Backend, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 
-	// Warn the user
-	m.Ui.Warn(strings.TrimSpace(warnBackendLegacy) + "\n")
+	m.Ui.Error(strings.TrimSpace(errBackendLegacy) + "\n")
 
-	// We need to convert the config to map[string]interface{} since that
-	// is what the backends expect.
-	var configMap map[string]interface{}
-	if err := mapstructure.Decode(s.Remote.Config, &configMap); err != nil {
-		return nil, fmt.Errorf("Error configuring remote state: %s", err)
-	}
-
-	// Create the config
-	rawC, err := config.NewRawConfig(configMap)
-	if err != nil {
-		return nil, fmt.Errorf("Error configuring remote state: %s", err)
-	}
-	config := terraform.NewResourceConfig(rawC)
-
-	// Get the backend
-	f := backendinit.Backend(s.Remote.Type)
-	if f == nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendLegacyUnknown), s.Remote.Type)
-	}
-	b := f()
-
-	// Configure
-	if err := b.Configure(config); err != nil {
-		return nil, fmt.Errorf(errBackendLegacyConfig, err)
-	}
-
-	return b, nil
+	diags = diags.Append(fmt.Errorf("Cannot initialize legacy remote state"))
+	return nil, diags
 }
 
 // Unsetting backend, saved backend, legacy remote state
-func (m *Meta) backend_c_R_S(
-	c *config.Backend, sMgr state.State) (backend.Backend, error) {
-	// Notify the user
-	m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-		"[reset]%s\n\n",
-		strings.TrimSpace(outputBackendUnsetWithLegacy))))
+func (m *Meta) backend_c_R_S(c *configs.Backend, cHash int, sMgr state.State) (backend.Backend, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 
-	// Get the backend type for later
-	backendType := sMgr.State().Backend.Type
+	m.Ui.Error(strings.TrimSpace(errBackendLegacy) + "\n")
 
-	// First, perform the configured => local tranasition
-	if _, err := m.backend_c_r_S(c, sMgr, false); err != nil {
-		return nil, err
-	}
-
-	// Grab a purely local backend
-	localB, err := m.Backend(&BackendOpts{ForceLocal: true})
-	if err != nil {
-		return nil, fmt.Errorf(errBackendLocalRead, err)
-	}
-
-	// Grab the state
-	s := sMgr.State()
-
-	m.Ui.Output(strings.TrimSpace(outputBackendMigrateLegacy))
-	// Initialize the legacy backend
-	oldB, err := m.backendInitFromLegacy(s.Remote)
-	if err != nil {
-		return nil, err
-	}
-
-	// Perform the migration
-	err = m.backendMigrateState(&backendMigrateOpts{
-		OneType: s.Remote.Type,
-		TwoType: "local",
-		One:     oldB,
-		Two:     localB,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Unset the remote state
-	s = sMgr.State()
-	if s == nil {
-		s = terraform.NewState()
-	}
-	s.Remote = nil
-	if err := sMgr.WriteState(s); err != nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendClearLegacy), err)
-	}
-	if err := sMgr.PersistState(); err != nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendClearLegacy), err)
-	}
-
-	m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-		"[reset][green]\n\n"+
-			strings.TrimSpace(successBackendUnset), backendType)))
-
-	return nil, nil
+	diags = diags.Append(fmt.Errorf("Cannot initialize legacy remote state"))
+	return nil, diags
 }
 
 // Configuring a backend for the first time with legacy remote state.
-func (m *Meta) backend_C_R_s(
-	c *config.Backend, sMgr state.State) (backend.Backend, error) {
-	// Notify the user
-	m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-		"[reset]%s\n\n",
-		strings.TrimSpace(outputBackendConfigureWithLegacy))))
+func (m *Meta) backend_C_R_s(c *configs.Backend, sMgr state.State) (backend.Backend, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 
-	// First, configure the new backend
-	b, err := m.backendInitFromConfig(c)
-	if err != nil {
-		return nil, err
-	}
+	m.Ui.Error(strings.TrimSpace(errBackendLegacy) + "\n")
 
-	// Next, save the new configuration. This will not overwrite our
-	// legacy remote state. We'll handle that after.
-	s := sMgr.State()
-	if s == nil {
-		s = terraform.NewState()
-	}
-	s.Backend = &terraform.BackendState{
-		Type:   c.Type,
-		Config: c.RawConfig.Raw,
-		Hash:   c.Hash,
-	}
-	if err := sMgr.WriteState(s); err != nil {
-		return nil, fmt.Errorf(errBackendWriteSaved, err)
-	}
-	if err := sMgr.PersistState(); err != nil {
-		return nil, fmt.Errorf(errBackendWriteSaved, err)
-	}
-
-	// I don't know how this is possible but if we don't have remote
-	// state config anymore somehow, just return the backend. This
-	// shouldn't be possible, though.
-	if s.Remote.Empty() {
-		return b, nil
-	}
-
-	m.Ui.Output(strings.TrimSpace(outputBackendMigrateLegacy))
-	// Initialize the legacy backend
-	oldB, err := m.backendInitFromLegacy(s.Remote)
-	if err != nil {
-		return nil, err
-	}
-
-	// Perform the migration
-	err = m.backendMigrateState(&backendMigrateOpts{
-		OneType: s.Remote.Type,
-		TwoType: c.Type,
-		One:     oldB,
-		Two:     b,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Unset the remote state
-	s = sMgr.State()
-	if s == nil {
-		s = terraform.NewState()
-	}
-	s.Remote = nil
-	if err := sMgr.WriteState(s); err != nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendClearLegacy), err)
-	}
-	if err := sMgr.PersistState(); err != nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendClearLegacy), err)
-	}
-
-	m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-		"[reset][green]\n"+strings.TrimSpace(successBackendSet), s.Backend.Type)))
-
-	return b, nil
+	diags = diags.Append(fmt.Errorf("Cannot initialize legacy remote state"))
+	return nil, diags
 }
 
 // Configuring a backend for the first time.
-func (m *Meta) backend_C_r_s(
-	c *config.Backend, sMgr state.State) (backend.Backend, error) {
+func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr state.State) (backend.Backend, tfdiags.Diagnostics) {
 	// Get the backend
-	b, err := m.backendInitFromConfig(c)
-	if err != nil {
-		return nil, err
+	b, configVal, diags := m.backendInitFromConfig(c)
+	if diags.HasErrors() {
+		return nil, diags
 	}
 
 	// Grab a purely local backend to get the local state if it exists
-	localB, err := m.Backend(&BackendOpts{ForceLocal: true})
-	if err != nil {
-		return nil, fmt.Errorf(errBackendLocalRead, err)
+	localB, localBDiags := m.Backend(&BackendOpts{ForceLocal: true})
+	if localBDiags.HasErrors() {
+		diags = diags.Append(localBDiags)
+		return nil, diags
 	}
 
 	env := m.Workspace()
 
 	localState, err := localB.State(env)
 	if err != nil {
-		return nil, fmt.Errorf(errBackendLocalRead, err)
+		diags = diags.Append(fmt.Errorf(errBackendLocalRead, err))
+		return nil, diags
 	}
 	if err := localState.RefreshState(); err != nil {
-		return nil, fmt.Errorf(errBackendLocalRead, err)
+		diags = diags.Append(fmt.Errorf(errBackendLocalRead, err))
+		return nil, diags
 	}
 
 	// If the local state is not empty, we need to potentially do a
@@ -930,7 +739,8 @@ func (m *Meta) backend_C_r_s(
 			Two:     b,
 		})
 		if err != nil {
-			return nil, err
+			diags = diags.Append(err)
+			return nil, diags
 		}
 
 		// we usually remove the local state after migration to prevent
@@ -949,10 +759,12 @@ func (m *Meta) backend_C_r_s(
 		if erase {
 			// We always delete the local state, unless that was our new state too.
 			if err := localState.WriteState(nil); err != nil {
-				return nil, fmt.Errorf(errBackendMigrateLocalDelete, err)
+				diags = diags.Append(fmt.Errorf(errBackendMigrateLocalDelete, err))
+				return nil, diags
 			}
 			if err := localState.PersistState(); err != nil {
-				return nil, fmt.Errorf(errBackendMigrateLocalDelete, err)
+				diags = diags.Append(fmt.Errorf(errBackendMigrateLocalDelete, err))
+				return nil, diags
 			}
 		}
 	}
@@ -960,9 +772,16 @@ func (m *Meta) backend_C_r_s(
 	if m.stateLock {
 		stateLocker := clistate.NewLocker(context.Background(), m.stateLockTimeout, m.Ui, m.Colorize())
 		if err := stateLocker.Lock(sMgr, "backend from plan"); err != nil {
-			return nil, fmt.Errorf("Error locking state: %s", err)
+			diags = diags.Append(fmt.Errorf("Error locking state: %s", err))
+			return nil, diags
 		}
 		defer stateLocker.Unlock(nil)
+	}
+
+	configJSON, err := ctyjson.Marshal(configVal, b.ConfigSchema().ImpliedType())
+	if err != nil {
+		diags = diags.Append(fmt.Errorf("Can't serialize backend configuration as JSON: %s", err))
+		return nil, diags
 	}
 
 	// Store the metadata in our saved state location
@@ -971,28 +790,29 @@ func (m *Meta) backend_C_r_s(
 		s = terraform.NewState()
 	}
 	s.Backend = &terraform.BackendState{
-		Type:   c.Type,
-		Config: c.RawConfig.Raw,
-		Hash:   c.Hash,
+		Type:      c.Type,
+		ConfigRaw: json.RawMessage(configJSON),
+		Hash:      cHash,
 	}
 
 	if err := sMgr.WriteState(s); err != nil {
-		return nil, fmt.Errorf(errBackendWriteSaved, err)
+		diags = diags.Append(fmt.Errorf(errBackendWriteSaved, err))
+		return nil, diags
 	}
 	if err := sMgr.PersistState(); err != nil {
-		return nil, fmt.Errorf(errBackendWriteSaved, err)
+		diags = diags.Append(fmt.Errorf(errBackendWriteSaved, err))
+		return nil, diags
 	}
 
 	m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
 		"[reset][green]\n"+strings.TrimSpace(successBackendSet), s.Backend.Type)))
 
 	// Return the backend
-	return b, nil
+	return b, diags
 }
 
 // Changing a previously saved backend.
-func (m *Meta) backend_C_r_S_changed(
-	c *config.Backend, sMgr state.State, output bool) (backend.Backend, error) {
+func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr state.State, output bool) (backend.Backend, tfdiags.Diagnostics) {
 	if output {
 		// Notify the user
 		m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
@@ -1004,10 +824,9 @@ func (m *Meta) backend_C_r_S_changed(
 	s := sMgr.State()
 
 	// Get the backend
-	b, err := m.backendInitFromConfig(c)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"Error initializing new backend: %s", err)
+	b, configVal, diags := m.backendInitFromConfig(c)
+	if diags.HasErrors() {
+		return nil, diags
 	}
 
 	// no need to confuse the user if the backend types are the same
@@ -1016,29 +835,37 @@ func (m *Meta) backend_C_r_S_changed(
 	}
 
 	// Grab the existing backend
-	oldB, err := m.backend_C_r_S_unchanged(c, sMgr)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"Error loading previously configured backend: %s", err)
+	oldB, oldBDiags := m.backend_C_r_S_unchanged(c, cHash, sMgr)
+	diags = diags.Append(oldBDiags)
+	if oldBDiags.HasErrors() {
+		return nil, diags
 	}
 
 	// Perform the migration
-	err = m.backendMigrateState(&backendMigrateOpts{
+	err := m.backendMigrateState(&backendMigrateOpts{
 		OneType: s.Backend.Type,
 		TwoType: c.Type,
 		One:     oldB,
 		Two:     b,
 	})
 	if err != nil {
-		return nil, err
+		diags = diags.Append(err)
+		return nil, diags
 	}
 
 	if m.stateLock {
 		stateLocker := clistate.NewLocker(context.Background(), m.stateLockTimeout, m.Ui, m.Colorize())
 		if err := stateLocker.Lock(sMgr, "backend from plan"); err != nil {
-			return nil, fmt.Errorf("Error locking state: %s", err)
+			diags = diags.Append(fmt.Errorf("Error locking state: %s", err))
+			return nil, diags
 		}
 		defer stateLocker.Unlock(nil)
+	}
+
+	configJSON, err := ctyjson.Marshal(configVal, b.ConfigSchema().ImpliedType())
+	if err != nil {
+		diags = diags.Append(fmt.Errorf("Can't serialize backend configuration as JSON: %s", err))
+		return nil, diags
 	}
 
 	// Update the backend state
@@ -1047,16 +874,18 @@ func (m *Meta) backend_C_r_S_changed(
 		s = terraform.NewState()
 	}
 	s.Backend = &terraform.BackendState{
-		Type:   c.Type,
-		Config: c.RawConfig.Raw,
-		Hash:   c.Hash,
+		Type:      c.Type,
+		ConfigRaw: json.RawMessage(configJSON),
+		Hash:      cHash,
 	}
 
 	if err := sMgr.WriteState(s); err != nil {
-		return nil, fmt.Errorf(errBackendWriteSaved, err)
+		diags = diags.Append(fmt.Errorf(errBackendWriteSaved, err))
+		return nil, diags
 	}
 	if err := sMgr.PersistState(); err != nil {
-		return nil, fmt.Errorf(errBackendWriteSaved, err)
+		diags = diags.Append(fmt.Errorf(errBackendWriteSaved, err))
+		return nil, diags
 	}
 
 	if output {
@@ -1064,245 +893,155 @@ func (m *Meta) backend_C_r_S_changed(
 			"[reset][green]\n"+strings.TrimSpace(successBackendSet), s.Backend.Type)))
 	}
 
-	return b, nil
+	return b, diags
 }
 
 // Initiailizing an unchanged saved backend
-func (m *Meta) backend_C_r_S_unchanged(
-	c *config.Backend, sMgr state.State) (backend.Backend, error) {
+func (m *Meta) backend_C_r_S_unchanged(c *configs.Backend, cHash int, sMgr state.State) (backend.Backend, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
 	s := sMgr.State()
 
 	// it's possible for a backend to be unchanged, and the config itself to
 	// have changed by moving a parameter from the config to `-backend-config`
 	// In this case we only need to update the Hash.
-	if c != nil && s.Backend.Hash != c.Hash {
-		s.Backend.Hash = c.Hash
+	if c != nil && s.Backend.Hash != cHash {
+		s.Backend.Hash = cHash
 		if err := sMgr.WriteState(s); err != nil {
-			return nil, fmt.Errorf(errBackendWriteSaved, err)
+			diags = diags.Append(err)
+			return nil, diags
 		}
 	}
-
-	// Create the config. We do this from the backend state since this
-	// has the complete configuration data whereas the config itself
-	// may require input.
-	rawC, err := config.NewRawConfig(s.Backend.Config)
-	if err != nil {
-		return nil, fmt.Errorf("Error configuring backend: %s", err)
-	}
-	config := terraform.NewResourceConfig(rawC)
 
 	// Get the backend
 	f := backendinit.Backend(s.Backend.Type)
 	if f == nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendSavedUnknown), s.Backend.Type)
+		diags = diags.Append(fmt.Errorf(strings.TrimSpace(errBackendSavedUnknown), s.Backend.Type))
+		return nil, diags
 	}
 	b := f()
 
-	// Configure
-	if err := b.Configure(config); err != nil {
-		return nil, fmt.Errorf(errBackendSavedConfig, s.Backend.Type, err)
+	// The configuration saved in the working directory state file is used
+	// in this case, since it will contain any additional values that
+	// were provided via -backend-config arguments on terraform init.
+	schema := b.ConfigSchema()
+	configVal, err := s.Backend.Config(schema)
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to decode current backend config",
+			fmt.Sprintf("The backend configuration created by the most recent run of \"terraform init\" could not be decoded: %s. The configuration may have been initialized by an earlier version that used an incompatible configuration structure. Run \"terraform init -reconfigure\" to force re-initialization of the backend.", err),
+		))
+		return nil, diags
 	}
 
-	return b, nil
+	// Validate the config and then configure the backend
+	validDiags := b.ValidateConfig(configVal)
+	diags = diags.Append(validDiags)
+	if validDiags.HasErrors() {
+		return nil, diags
+	}
+	configDiags := b.Configure(configVal)
+	diags = diags.Append(configDiags)
+	if configDiags.HasErrors() {
+		return nil, diags
+	}
+
+	return b, diags
 }
 
 // Initiailizing a changed saved backend with legacy remote state.
-func (m *Meta) backend_C_R_S_changed(
-	c *config.Backend, sMgr state.State) (backend.Backend, error) {
-	// Notify the user
-	m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-		"[reset]%s\n\n",
-		strings.TrimSpace(outputBackendSavedWithLegacyChanged))))
+func (m *Meta) backend_C_R_S_changed(c *configs.Backend, sMgr state.State) (backend.Backend, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 
-	// Reconfigure the backend first
-	if _, err := m.backend_C_r_S_changed(c, sMgr, false); err != nil {
-		return nil, err
-	}
+	m.Ui.Error(strings.TrimSpace(errBackendLegacy) + "\n")
 
-	// Handle the case where we have all set but unchanged
-	b, err := m.backend_C_R_S_unchanged(c, sMgr, false)
-	if err != nil {
-		return nil, err
-	}
-
-	// Output success message
-	m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-		"[reset][green]\n\n"+
-			strings.TrimSpace(successBackendReconfigureWithLegacy), c.Type)))
-
-	return b, nil
+	diags = diags.Append(fmt.Errorf("Cannot initialize legacy remote state"))
+	return nil, diags
 }
 
 // Initiailizing an unchanged saved backend with legacy remote state.
-func (m *Meta) backend_C_R_S_unchanged(
-	c *config.Backend, sMgr state.State, output bool) (backend.Backend, error) {
-	if output {
-		// Notify the user
-		m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-			"[reset]%s\n\n",
-			strings.TrimSpace(outputBackendSavedWithLegacy))))
-	}
+func (m *Meta) backend_C_R_S_unchanged(c *configs.Backend, sMgr state.State, output bool) (backend.Backend, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 
-	// Load the backend from the state
-	s := sMgr.State()
-	b, err := m.backendInitFromSaved(s.Backend)
-	if err != nil {
-		return nil, err
-	}
+	m.Ui.Error(strings.TrimSpace(errBackendLegacy) + "\n")
 
-	m.Ui.Output(strings.TrimSpace(outputBackendMigrateLegacy))
-
-	// Initialize the legacy backend
-	oldB, err := m.backendInitFromLegacy(s.Remote)
-	if err != nil {
-		return nil, err
-	}
-
-	// Perform the migration
-	err = m.backendMigrateState(&backendMigrateOpts{
-		OneType: s.Remote.Type,
-		TwoType: s.Backend.Type,
-		One:     oldB,
-		Two:     b,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if m.stateLock {
-		stateLocker := clistate.NewLocker(context.Background(), m.stateLockTimeout, m.Ui, m.Colorize())
-		if err := stateLocker.Lock(sMgr, "backend from plan"); err != nil {
-			return nil, fmt.Errorf("Error locking state: %s", err)
-		}
-		defer stateLocker.Unlock(nil)
-	}
-
-	// Unset the remote state
-	s = sMgr.State()
-	if s == nil {
-		s = terraform.NewState()
-	}
-	s.Remote = nil
-
-	if err := sMgr.WriteState(s); err != nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendClearLegacy), err)
-	}
-	if err := sMgr.PersistState(); err != nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendClearLegacy), err)
-	}
-
-	if output {
-		m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-			"[reset][green]\n\n"+
-				strings.TrimSpace(successBackendLegacyUnset), s.Backend.Type)))
-	}
-
-	return b, nil
+	diags = diags.Append(fmt.Errorf("Cannot initialize legacy remote state"))
+	return nil, diags
 }
 
 //-------------------------------------------------------------------
 // Reusable helper functions for backend management
 //-------------------------------------------------------------------
 
-func (m *Meta) backendInitFromConfig(c *config.Backend) (backend.Backend, error) {
-	// Create the config.
-	config := terraform.NewResourceConfig(c.RawConfig)
+func (m *Meta) backendInitFromConfig(c *configs.Backend) (backend.Backend, cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 
 	// Get the backend
 	f := backendinit.Backend(c.Type)
 	if f == nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendNewUnknown), c.Type)
+		diags = diags.Append(fmt.Errorf(strings.TrimSpace(errBackendNewUnknown), c.Type))
+		return nil, cty.NilVal, diags
 	}
 	b := f()
 
+	schema := b.ConfigSchema()
+	decSpec := schema.DecoderSpec()
+	configVal, hclDiags := hcldec.Decode(c.Config, decSpec, nil)
+	diags = diags.Append(hclDiags)
+	if hclDiags.HasErrors() {
+		return nil, cty.NilVal, diags
+	}
+
 	// TODO: test
-	// Ask for input if we have input enabled
 	if m.Input() {
 		var err error
-		config, err = b.Input(m.UIInput(), config)
+		configVal, err = m.inputForSchema(configVal, schema)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"Error asking for input to configure the backend %q: %s",
-				c.Type, err)
+			diags = diags.Append(fmt.Errorf("Error asking for input to configure backend %q: %s", c.Type, err))
 		}
 	}
 
-	// Validate
-	warns, errs := b.Validate(config)
-	for _, warning := range warns {
-		// We just write warnings directly to the UI. This isn't great
-		// since we're a bit deep here to be pushing stuff out into the
-		// UI, but sufficient to let us print out deprecation warnings
-		// and the like.
-		m.Ui.Warn(warning)
-	}
-	if len(errs) > 0 {
-		return nil, fmt.Errorf(
-			"Error configuring the backend %q: %s",
-			c.Type, multierror.Append(nil, errs...))
+	validateDiags := b.ValidateConfig(configVal)
+	diags = diags.Append(validateDiags.InConfigBody(c.Config))
+	if validateDiags.HasErrors() {
+		return nil, cty.NilVal, diags
 	}
 
-	// Configure
-	if err := b.Configure(config); err != nil {
-		return nil, fmt.Errorf(errBackendNewConfig, c.Type, err)
-	}
+	configureDiags := b.Configure(configVal)
+	diags = diags.Append(configureDiags.InConfigBody(c.Config))
 
-	return b, nil
+	return b, configVal, diags
 }
 
-func (m *Meta) backendInitFromLegacy(s *terraform.RemoteState) (backend.Backend, error) {
-	// We need to convert the config to map[string]interface{} since that
-	// is what the backends expect.
-	var configMap map[string]interface{}
-	if err := mapstructure.Decode(s.Config, &configMap); err != nil {
-		return nil, fmt.Errorf("Error configuring remote state: %s", err)
-	}
-
-	// Create the config
-	rawC, err := config.NewRawConfig(configMap)
-	if err != nil {
-		return nil, fmt.Errorf("Error configuring remote state: %s", err)
-	}
-	config := terraform.NewResourceConfig(rawC)
+func (m *Meta) backendInitFromSaved(s *terraform.BackendState) (backend.Backend, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 
 	// Get the backend
 	f := backendinit.Backend(s.Type)
 	if f == nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendLegacyUnknown), s.Type)
+		diags = diags.Append(fmt.Errorf(strings.TrimSpace(errBackendSavedUnknown), s.Type))
+		return nil, diags
 	}
 	b := f()
 
-	// Configure
-	if err := b.Configure(config); err != nil {
-		return nil, fmt.Errorf(errBackendLegacyConfig, err)
-	}
-
-	return b, nil
-}
-
-func (m *Meta) backendInitFromSaved(s *terraform.BackendState) (backend.Backend, error) {
-	// Create the config. We do this from the backend state since this
-	// has the complete configuration data whereas the config itself
-	// may require input.
-	rawC, err := config.NewRawConfig(s.Config)
+	schema := b.ConfigSchema()
+	configVal, err := s.Config(schema)
 	if err != nil {
-		return nil, fmt.Errorf("Error configuring backend: %s", err)
-	}
-	config := terraform.NewResourceConfig(rawC)
-
-	// Get the backend
-	f := backendinit.Backend(s.Type)
-	if f == nil {
-		return nil, fmt.Errorf(strings.TrimSpace(errBackendSavedUnknown), s.Type)
-	}
-	b := f()
-
-	// Configure
-	if err := b.Configure(config); err != nil {
-		return nil, fmt.Errorf(errBackendSavedConfig, s.Type, err)
+		diags = diags.Append(errwrap.Wrapf("saved backend configuration is invalid: {{err}}", err))
+		return nil, diags
 	}
 
-	return b, nil
+	validateDiags := b.ValidateConfig(configVal)
+	diags = diags.Append(validateDiags)
+	if validateDiags.HasErrors() {
+		return nil, diags
+	}
+
+	configureDiags := b.Configure(configVal)
+	diags = diags.Append(configureDiags)
+
+	return b, diags
 }
 
 func (m *Meta) backendInitRequired(reason string) {
@@ -1603,14 +1342,11 @@ Successfully configured the backend %q! Terraform will automatically
 use this backend unless the backend configuration changes.
 `
 
-const warnBackendLegacy = `
-Deprecation warning: This environment is configured to use legacy remote state.
-Remote state changed significantly in Terraform 0.9. Please update your remote
-state configuration to use the new 'backend' settings. For now, Terraform
-will continue to use your existing settings. Legacy remote state support
-will be removed in Terraform 0.11.
+const errBackendLegacy = `
+This working directory is configured to use the legacy remote state features
+from Terraform 0.8 or earlier. Remote state changed significantly in Terraform
+0.9 and the automatic upgrade mechanism has now been removed.
 
-You can find a guide for upgrading here:
-
-https://www.terraform.io/docs/backends/legacy-0-8.html
+To upgrade, please first use Terraform v0.11 to complete the upgrade steps:
+    https://www.terraform.io/docs/backends/legacy-0-8.html
 `

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/configs"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/backend"
 	backendinit "github.com/hashicorp/terraform/backend/init"
 	backendlocal "github.com/hashicorp/terraform/backend/local"
@@ -28,9 +31,9 @@ func TestMetaBackend_emptyDir(t *testing.T) {
 
 	// Get the backend
 	m := testMetaBackend(t, nil)
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Write some state
@@ -98,9 +101,9 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 
 	// Get the backend
 	m := testMetaBackend(t, nil)
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -171,9 +174,9 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 	m.statePath = statePath
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -230,9 +233,9 @@ func TestMetaBackend_emptyLegacyRemote(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -297,9 +300,9 @@ func TestMetaBackend_configureNew(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -366,9 +369,9 @@ func TestMetaBackend_configureNewWithState(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -444,9 +447,9 @@ func TestMetaBackend_configureNewWithoutCopy(t *testing.T) {
 	m.input = false
 
 	// init the backend
-	_, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	_, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Verify the state is where we expect
@@ -493,9 +496,9 @@ func TestMetaBackend_configureNewWithStateNoMigrate(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -537,9 +540,9 @@ func TestMetaBackend_configureNewWithStateExisting(t *testing.T) {
 	m.forceInitCopy = true
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -611,9 +614,9 @@ func TestMetaBackend_configureNewWithStateExistingNoMigrate(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -685,9 +688,9 @@ func TestMetaBackend_configureNewLegacy(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -779,9 +782,9 @@ func TestMetaBackend_configureNewLegacyCopy(t *testing.T) {
 	m.forceInitCopy = true
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -872,9 +875,9 @@ func TestMetaBackend_configuredUnchanged(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -919,9 +922,9 @@ func TestMetaBackend_configuredChange(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1007,9 +1010,9 @@ func TestMetaBackend_reconfigureChange(t *testing.T) {
 	m.reconfigure = true
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1051,9 +1054,9 @@ func TestMetaBackend_configuredChangeCopy(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1106,9 +1109,9 @@ func TestMetaBackend_configuredChangeCopy_singleState(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1162,9 +1165,9 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleDefault(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1218,9 +1221,9 @@ func TestMetaBackend_configuredChangeCopy_multiToSingle(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1290,9 +1293,9 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleCurrentEnv(t *testing.T) 
 	}
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1347,9 +1350,9 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check resulting states
@@ -1437,9 +1440,9 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1521,9 +1524,9 @@ func TestMetaBackend_configuredUnsetCopy(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1600,9 +1603,9 @@ func TestMetaBackend_configuredUnchangedLegacy(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1701,9 +1704,9 @@ func TestMetaBackend_configuredUnchangedLegacyCopy(t *testing.T) {
 	m.forceInitCopy = true
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1804,9 +1807,9 @@ func TestMetaBackend_configuredChangedLegacy(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -1904,9 +1907,9 @@ func TestMetaBackend_configuredChangedLegacyCopyBackend(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -2007,9 +2010,9 @@ func TestMetaBackend_configuredChangedLegacyCopyLegacy(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -2110,9 +2113,9 @@ func TestMetaBackend_configuredChangedLegacyCopyBoth(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -2213,9 +2216,9 @@ func TestMetaBackend_configuredUnsetWithLegacyNoCopy(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -2303,9 +2306,9 @@ func TestMetaBackend_configuredUnsetWithLegacyCopyBackend(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -2401,9 +2404,9 @@ func TestMetaBackend_configuredUnsetWithLegacyCopyLegacy(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -2499,9 +2502,9 @@ func TestMetaBackend_configuredUnsetWithLegacyCopyBoth(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Init: true})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -2600,9 +2603,9 @@ func TestMetaBackend_planLocal(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Plan: plan})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Plan: plan})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -2697,9 +2700,9 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 	m.stateOutPath = statePath
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Plan: plan})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Plan: plan})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -2783,9 +2786,9 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Plan: plan})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Plan: plan})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -2876,12 +2879,12 @@ func TestMetaBackend_planLocalMismatchLineage(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	_, err := m.Backend(&BackendOpts{Plan: plan})
-	if err == nil {
+	_, diags := m.Backend(&BackendOpts{Plan: plan})
+	if !diags.HasErrors() {
 		t.Fatal("should have error")
 	}
-	if !strings.Contains(err.Error(), "lineage") {
-		t.Fatalf("bad: %s", err)
+	if !strings.Contains(diags[0].Description().Summary, "lineage") {
+		t.Fatalf("wrong diagnostic message %q; want something containing \"lineage\"", diags[0].Description().Summary)
 	}
 
 	// Verify our local state didn't change
@@ -2928,12 +2931,12 @@ func TestMetaBackend_planLocalNewer(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	_, err := m.Backend(&BackendOpts{Plan: plan})
-	if err == nil {
+	_, diags := m.Backend(&BackendOpts{Plan: plan})
+	if !diags.HasErrors() {
 		t.Fatal("should have error")
 	}
-	if !strings.Contains(err.Error(), "older") {
-		t.Fatalf("bad: %s", err)
+	if !strings.Contains(diags[0].Description().Summary, "older") {
+		t.Fatalf("wrong diagnostic message %q; want something containing \"older\"", diags[0].Description().Summary)
 	}
 
 	// Verify our local state didn't change
@@ -2983,9 +2986,9 @@ func TestMetaBackend_planBackendEmptyDir(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Plan: plan})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Plan: plan})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -3085,9 +3088,9 @@ func TestMetaBackend_planBackendMatch(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Plan: plan})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	b, diags := m.Backend(&BackendOpts{Plan: plan})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -3190,12 +3193,12 @@ func TestMetaBackend_planBackendMismatchLineage(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	_, err := m.Backend(&BackendOpts{Plan: plan})
-	if err == nil {
+	_, diags := m.Backend(&BackendOpts{Plan: plan})
+	if !diags.HasErrors() {
 		t.Fatal("should have error")
 	}
-	if !strings.Contains(err.Error(), "lineage") {
-		t.Fatalf("bad: %s", err)
+	if !strings.Contains(diags[0].Description().Summary, "lineage") {
+		t.Fatalf("wrong diagnostic message %q; want something containing \"lineage\"", diags[0].Description().Summary)
 	}
 
 	// Verify our local state didn't change
@@ -3248,9 +3251,9 @@ func TestMetaBackend_planLegacy(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, err := m.Backend(&BackendOpts{Plan: plan})
-	if err != nil {
-		t.Fatalf("err: %s", err)
+	b, diags := m.Backend(&BackendOpts{Plan: plan})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
@@ -3329,44 +3332,38 @@ func TestMetaBackend_configureWithExtra(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
-	extras := map[string]interface{}{"path": "hello"}
+	extras := map[string]cty.Value{"path": cty.StringVal("hello")}
 	m := testMetaBackend(t, nil)
 	opts := &BackendOpts{
-		ConfigExtra: extras,
-		Init:        true,
+		ConfigOverride: configs.SynthBody("synth", extras),
+		Init:           true,
 	}
 
-	backendCfg, err := m.backendConfig(opts)
+	_, cHash, err := m.backendConfig(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// init the backend
-	_, err = m.Backend(&BackendOpts{
-		ConfigExtra: extras,
-		Init:        true,
+	_, diags := m.Backend(&BackendOpts{
+		ConfigOverride: configs.SynthBody("synth", extras),
+		Init:           true,
 	})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// Check the state
 	s := testStateRead(t, filepath.Join(DefaultDataDir, backendlocal.DefaultStateFilename))
-	if s.Backend.Hash != backendCfg.Hash {
+	if s.Backend.Hash != cHash {
 		t.Fatal("mismatched state and config backend hashes")
-	}
-	if s.Backend.Rehash() == s.Backend.Hash {
-		t.Fatal("saved hash should not match actual hash")
-	}
-	if s.Backend.Rehash() != backendCfg.Rehash() {
-		t.Fatal("mismatched state and config re-hashes")
 	}
 
 	// init the backend again with the same options
 	m = testMetaBackend(t, nil)
 	_, err = m.Backend(&BackendOpts{
-		ConfigExtra: extras,
-		Init:        true,
+		ConfigOverride: configs.SynthBody("synth", extras),
+		Init:           true,
 	})
 	if err != nil {
 		t.Fatalf("bad: %s", err)
@@ -3374,7 +3371,7 @@ func TestMetaBackend_configureWithExtra(t *testing.T) {
 
 	// Check the state
 	s = testStateRead(t, filepath.Join(DefaultDataDir, backendlocal.DefaultStateFilename))
-	if s.Backend.Hash != backendCfg.Hash {
+	if s.Backend.Hash != cHash {
 		t.Fatal("mismatched state and config backend hashes")
 	}
 }
@@ -3410,11 +3407,9 @@ func TestMetaBackend_localDoesNotDeleteLocal(t *testing.T) {
 	m := testMetaBackend(t, nil)
 	m.forceInitCopy = true
 	// init the backend
-	_, err = m.Backend(&BackendOpts{
-		Init: true,
-	})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	_, diags := m.Backend(&BackendOpts{Init: true})
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// check that we can read the state
@@ -3452,15 +3447,15 @@ func TestMetaBackend_configToExtra(t *testing.T) {
 	}
 
 	// init the backend again with the  options
-	extras := map[string]interface{}{"path": "hello"}
+	extras := map[string]cty.Value{"path": cty.StringVal("hello")}
 	m = testMetaBackend(t, nil)
 	m.forceInitCopy = true
-	_, err = m.Backend(&BackendOpts{
-		ConfigExtra: extras,
-		Init:        true,
+	_, diags := m.Backend(&BackendOpts{
+		ConfigOverride: configs.SynthBody("synth", extras),
+		Init:           true,
 	})
-	if err != nil {
-		t.Fatalf("bad: %s", err)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	s = testStateRead(t, filepath.Join(DefaultDataDir, backendlocal.DefaultStateFilename))

--- a/command/meta_config.go
+++ b/command/meta_config.go
@@ -4,11 +4,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/terraform/config/configschema"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // normalizePath normalizes a given path so that it is, if possible, relative
@@ -80,6 +87,23 @@ func (m *Meta) loadSingleModule(dir string) (*configs.Module, tfdiags.Diagnostic
 	return module, diags
 }
 
+// dirIsConfigPath checks if the given path is a directory that contains at
+// least one Terraform configuration file (.tf or .tf.json), returning true
+// if so.
+//
+// In the unlikely event that the underlying config loader cannot be initalized,
+// this function optimistically returns true, assuming that the caller will
+// then do some other operation that requires the config loader and get an
+// error at that point.
+func (m *Meta) dirIsConfigPath(dir string) bool {
+	loader, err := m.initConfigLoader()
+	if err != nil {
+		return true
+	}
+
+	return loader.IsConfigDir(dir)
+}
+
 // loadBackendConfig reads configuration from the given directory and returns
 // the backend configuration defined by that module, if any. Nil is returned
 // if the specified module does not have an explicit backend configuration.
@@ -97,6 +121,41 @@ func (m *Meta) loadSingleModule(dir string) (*configs.Module, tfdiags.Diagnostic
 func (m *Meta) loadBackendConfig(rootDir string) (*configs.Backend, tfdiags.Diagnostics) {
 	mod, diags := m.loadSingleModule(rootDir)
 	return mod.Backend, diags
+}
+
+// loadValuesFile loads a file that defines a single map of key/value pairs.
+// This is the format used for "tfvars" files.
+func (m *Meta) loadValuesFile(filename string) (map[string]cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	filename = m.normalizePath(filename)
+
+	loader, err := m.initConfigLoader()
+	if err != nil {
+		diags = diags.Append(err)
+		return nil, diags
+	}
+
+	vals, hclDiags := loader.Parser().LoadValuesFile(filename)
+	diags = diags.Append(hclDiags)
+	return vals, diags
+}
+
+// loadHCLFile reads an arbitrary HCL file and returns the unprocessed body
+// representing its toplevel. Most callers should use one of the more
+// specialized "load..." methods to get a higher-level representation.
+func (m *Meta) loadHCLFile(filename string) (hcl.Body, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	filename = m.normalizePath(filename)
+
+	loader, err := m.initConfigLoader()
+	if err != nil {
+		diags = diags.Append(err)
+		return nil, diags
+	}
+
+	body, hclDiags := loader.Parser().LoadHCLFile(filename)
+	diags = diags.Append(hclDiags)
+	return body, diags
 }
 
 // installModules reads a root module from the given directory and attempts
@@ -172,6 +231,67 @@ func (m *Meta) loadVarsFile(filename string) (map[string]cty.Value, tfdiags.Diag
 	return ret, diags
 }
 
+// inputForSchema uses interactive prompts to try to populate any
+// not-yet-populated required attributes in the given object value to
+// comply with the given schema.
+//
+// An error will be returned if input is disabled for this meta or if
+// values cannot be obtained for some other operational reason. Errors are
+// not returned for invalid input since the input loop itself will report
+// that interactively.
+//
+// It is not guaranteed that the result will be valid, since certain attribute
+// types and nested blocks are not supported for input.
+//
+// The given value must conform to the given schema. If not, this method will
+// panic.
+func (m *Meta) inputForSchema(given cty.Value, schema *configschema.Block) (cty.Value, error) {
+	if given.IsNull() || !given.IsKnown() {
+		// This is not reasonable input, but we'll tolerate it anyway and
+		// just pass it through for the caller to handle downstream.
+		return given, nil
+	}
+
+	givenVals := given.AsValueMap()
+	retVals := make(map[string]cty.Value, len(givenVals))
+	names := make([]string, 0, len(schema.Attributes))
+	for name, attrS := range schema.Attributes {
+		retVals[name] = givenVals[name]
+		if givenVal := givenVals[name]; attrS.Required && givenVal.IsNull() && attrS.Type.IsPrimitiveType() {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+
+	input := m.UIInput()
+	for _, name := range names {
+		attrS := schema.Attributes[name]
+
+		for {
+			strVal, err := input.Input(&terraform.InputOpts{
+				Id:          name,
+				Query:       name,
+				Description: attrS.Description,
+			})
+			if err != nil {
+				return cty.UnknownVal(schema.ImpliedType()), fmt.Errorf("%s: %s", name, err)
+			}
+
+			val := cty.StringVal(strVal)
+			val, err = convert.Convert(val, attrS.Type)
+			if err != nil {
+				m.showDiagnostics(fmt.Errorf("Invalid value: %s", err))
+				continue
+			}
+
+			retVals[name] = val
+			break
+		}
+	}
+
+	return cty.ObjectVal(retVals), nil
+}
+
 // configSources returns the source cache from the receiver's config loader,
 // which the caller must not modify.
 //
@@ -210,4 +330,88 @@ func (m *Meta) initConfigLoader() (*configload.Loader, error) {
 		m.configLoader = loader
 	}
 	return m.configLoader, nil
+}
+
+// configValueFromCLI parses a configuration value that was provided in a
+// context in the CLI where only strings can be provided, such as on the
+// command line or in an environment variable, and returns the resulting
+// value.
+func configValueFromCLI(synthFilename, rawValue string, wantType cty.Type) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	switch {
+	case wantType.IsPrimitiveType():
+		// Primitive types are handled as conversions from string.
+		val := cty.StringVal(rawValue)
+		var err error
+		val, err = convert.Convert(val, wantType)
+		if err != nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid backend configuration value",
+				fmt.Sprintf("Invalid backend configuration argument %s: %s", synthFilename, err),
+			))
+			val = cty.DynamicVal // just so we return something valid-ish
+		}
+		return val, diags
+	default:
+		// Non-primitives are parsed as HCL expressions
+		src := []byte(rawValue)
+		expr, hclDiags := hclsyntax.ParseExpression(src, synthFilename, hcl.Pos{Line: 1, Column: 1})
+		diags = diags.Append(hclDiags)
+		if hclDiags.HasErrors() {
+			return cty.DynamicVal, diags
+		}
+		val, hclDiags := expr.Value(nil)
+		diags = diags.Append(hclDiags)
+		if hclDiags.HasErrors() {
+			val = cty.DynamicVal
+		}
+		return val, diags
+	}
+}
+
+// rawFlags is a flag.Value implementation that just appends raw flag
+// names and values to a slice.
+type rawFlags struct {
+	flagName string
+	items    *[]rawFlag
+}
+
+func newRawFlags(flagName string) rawFlags {
+	return rawFlags{
+		flagName: flagName,
+	}
+}
+
+func (f rawFlags) AllItems() []rawFlag {
+	return *f.items
+}
+
+func (f rawFlags) Alias(flagName string) rawFlags {
+	return rawFlags{
+		flagName: flagName,
+		items:    f.items,
+	}
+}
+
+func (f rawFlags) String() string {
+	return ""
+}
+
+func (f rawFlags) Set(str string) error {
+	*f.items = append(*f.items, rawFlag{
+		Name:  f.flagName,
+		Value: str,
+	})
+	return nil
+}
+
+type rawFlag struct {
+	Name  string
+	Value string
+}
+
+func (f rawFlag) String() string {
+	return fmt.Sprintf("%s=%q", f.Name, f.Value)
 }

--- a/command/meta_config.go
+++ b/command/meta_config.go
@@ -80,6 +80,25 @@ func (m *Meta) loadSingleModule(dir string) (*configs.Module, tfdiags.Diagnostic
 	return module, diags
 }
 
+// loadBackendConfig reads configuration from the given directory and returns
+// the backend configuration defined by that module, if any. Nil is returned
+// if the specified module does not have an explicit backend configuration.
+//
+// This is a convenience method for command code that will delegate to the
+// configured backend to do most of its work, since in that case it is the
+// backend that will do the full configuration load.
+//
+// Although this method returns only the backend configuration, at present it
+// actually loads and validates the entire configuration first. Therefore errors
+// returned may be about other aspects of the configuration. This behavior may
+// change in future, so callers must not rely on it. (That is, they must expect
+// that a call to loadSingleModule or loadConfig could fail on the same
+// directory even if loadBackendConfig succeeded.)
+func (m *Meta) loadBackendConfig(rootDir string) (*configs.Backend, tfdiags.Diagnostics) {
+	mod, diags := m.loadSingleModule(rootDir)
+	return mod.Backend, diags
+}
+
 // installModules reads a root module from the given directory and attempts
 // recursively install all of its descendent modules.
 //

--- a/command/output.go
+++ b/command/output.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // OutputCommand is a Command implementation that reads an output
@@ -46,10 +48,13 @@ func (c *OutputCommand) Run(args []string) int {
 		name = args[0]
 	}
 
+	var diags tfdiags.Diagnostics
+
 	// Load the backend
-	b, err := c.Backend(nil)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	b, backendDiags := c.Backend(nil)
+	diags = diags.Append(backendDiags)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 

--- a/command/plan.go
+++ b/command/plan.go
@@ -5,8 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/backend"
-	"github.com/hashicorp/terraform/config"
-	"github.com/hashicorp/terraform/config/module"
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
@@ -70,57 +69,61 @@ func (c *PlanCommand) Run(args []string) int {
 
 	var diags tfdiags.Diagnostics
 
-	// Load the module if we don't have one yet (not running from plan)
-	var mod *module.Tree
+	var backendConfig *configs.Backend
 	if plan == nil {
-		var modDiags tfdiags.Diagnostics
-		mod, modDiags = c.Module(configPath)
-		diags = diags.Append(modDiags)
-		if modDiags.HasErrors() {
+		var configDiags tfdiags.Diagnostics
+		backendConfig, configDiags = c.loadBackendConfig(configPath)
+		diags = diags.Append(configDiags)
+		if configDiags.HasErrors() {
 			c.showDiagnostics(diags)
 			return 1
 		}
 	}
 
-	var conf *config.Config
-	if mod != nil {
-		conf = mod.Config()
-	}
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{
-		Config: conf,
+	b, backendDiags := c.Backend(&BackendOpts{
+		Config: backendConfig,
 		Plan:   plan,
 	})
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	diags = diags.Append(backendDiags)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
+
+	// Emit any diagnostics we've accumulated before we delegate to the
+	// backend, since the backend will handle its own diagnostics internally.
+	c.showDiagnostics(diags)
+	diags = nil
 
 	// Build the operation
 	opReq := c.Operation()
 	opReq.Destroy = destroy
-	opReq.Module = mod
+	opReq.ConfigDir = configPath
 	opReq.Plan = plan
 	opReq.PlanRefresh = refresh
 	opReq.PlanOutPath = outPath
 	opReq.Type = backend.OperationTypePlan
+	opReq.ConfigLoader, err = c.initConfigLoader()
+	if err != nil {
+		c.showDiagnostics(err)
+		return 1
+	}
 
 	// Perform the operation
 	op, err := c.RunOperation(b, opReq)
 	if err != nil {
-		diags = diags.Append(err)
-	}
-
-	c.showDiagnostics(diags)
-	if diags.HasErrors() {
+		c.showDiagnostics(err)
 		return 1
 	}
 
+	if op.Result != backend.OperationSuccess {
+		return op.Result.ExitStatus()
+	}
 	if detailed && !op.PlanEmpty {
 		return 2
 	}
-
-	return 0
+	return op.Result.ExitStatus()
 }
 
 func (c *PlanCommand) Help() string {

--- a/command/providers.go
+++ b/command/providers.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/hashicorp/terraform/moduledeps"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/xlab/treeprint"
 )
@@ -69,11 +70,8 @@ func (c *ProvidersCommand) Run(args []string) int {
 		return 1
 	}
 
-	// FIXME: Restore this once the "terraform" package is updated to deal
-	// with HCL2 config types.
-	//s := state.State()
-	//depTree := terraform.ModuleTreeDependencies(config, s)
-	var depTree *moduledeps.Module
+	s := state.State()
+	depTree := terraform.ConfigTreeDependencies(config, s)
 	depTree.SortDescendents()
 
 	printRoot := treeprint.New()

--- a/command/show.go
+++ b/command/show.go
@@ -71,9 +71,9 @@ func (c *ShowCommand) Run(args []string) int {
 		}
 	} else {
 		// Load the backend
-		b, err := c.Backend(nil)
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+		b, backendDiags := c.Backend(nil)
+		if backendDiags.HasErrors() {
+			c.showDiagnostics(backendDiags)
 			return 1
 		}
 

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -30,9 +30,9 @@ func (c *StateListCommand) Run(args []string) int {
 	args = cmdFlags.Args()
 
 	// Load the backend
-	b, err := c.Backend(nil)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	b, backendDiags := c.Backend(nil)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(backendDiags)
 		return 1
 	}
 

--- a/command/state_meta.go
+++ b/command/state_meta.go
@@ -31,9 +31,9 @@ func (c *StateMeta) State() (state.State, error) {
 		}
 	} else {
 		// Load the backend
-		b, err := c.Backend(nil)
-		if err != nil {
-			return nil, err
+		b, backendDiags := c.Backend(nil)
+		if backendDiags.HasErrors() {
+			return nil, backendDiags.Err()
 		}
 
 		env := c.Workspace()
@@ -44,10 +44,10 @@ func (c *StateMeta) State() (state.State, error) {
 		}
 
 		// Get a local backend
-		localRaw, err := c.Backend(&BackendOpts{ForceLocal: true})
-		if err != nil {
+		localRaw, backendDiags := c.Backend(&BackendOpts{ForceLocal: true})
+		if backendDiags.HasErrors() {
 			// This should never fail
-			panic(err)
+			panic(backendDiags.Err())
 		}
 		localB := localRaw.(*backendlocal.Local)
 		_, stateOutPath, _ = localB.StatePaths(env)

--- a/command/state_pull.go
+++ b/command/state_pull.go
@@ -28,9 +28,9 @@ func (c *StatePullCommand) Run(args []string) int {
 	args = cmdFlags.Args()
 
 	// Load the backend
-	b, err := c.Backend(nil)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	b, backendDiags := c.Backend(nil)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(backendDiags)
 		return 1
 	}
 

--- a/command/state_push.go
+++ b/command/state_push.go
@@ -63,9 +63,9 @@ func (c *StatePushCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, err := c.Backend(nil)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	b, backendDiags := c.Backend(nil)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(backendDiags)
 		return 1
 	}
 

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -30,9 +30,9 @@ func (c *StateShowCommand) Run(args []string) int {
 	args = cmdFlags.Args()
 
 	// Load the backend
-	b, err := c.Backend(nil)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	b, backendDiags := c.Backend(nil)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(backendDiags)
 		return 1
 	}
 

--- a/command/taint.go
+++ b/command/taint.go
@@ -64,9 +64,9 @@ func (c *TaintCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, err := c.Backend(nil)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	b, backendDiags := c.Backend(nil)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(backendDiags)
 		return 1
 	}
 

--- a/command/unlock.go
+++ b/command/unlock.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/mitchellh/cli"
 )
 
@@ -46,18 +47,22 @@ func (c *UnlockCommand) Run(args []string) int {
 		return 1
 	}
 
-	conf, err := c.Config(configPath)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+	var diags tfdiags.Diagnostics
+
+	backendConfig, backendDiags := c.loadBackendConfig(configPath)
+	diags = diags.Append(backendDiags)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{
-		Config: conf,
+	b, backendDiags := c.Backend(&BackendOpts{
+		Config: backendConfig,
 	})
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	diags = diags.Append(backendDiags)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -52,9 +52,9 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, err := c.Backend(nil)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	b, backendDiags := c.Backend(nil)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(backendDiags)
 		return 1
 	}
 

--- a/command/workspace_delete.go
+++ b/command/workspace_delete.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/command/clistate"
+	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 )
@@ -49,19 +50,22 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	cfg, err := c.Config(configPath)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+	var diags tfdiags.Diagnostics
+
+	backendConfig, backendDiags := c.loadBackendConfig(configPath)
+	diags = diags.Append(backendDiags)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{
-		Config: cfg,
+	b, backendDiags := c.Backend(&BackendOpts{
+		Config: backendConfig,
 	})
-
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	diags = diags.Append(backendDiags)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -2,9 +2,9 @@ package command
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/posener/complete"
 )
 
@@ -34,19 +34,22 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 		return 1
 	}
 
-	cfg, err := c.Config(configPath)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+	var diags tfdiags.Diagnostics
+
+	backendConfig, backendDiags := c.loadBackendConfig(configPath)
+	diags = diags.Append(backendDiags)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{
-		Config: cfg,
+	b, backendDiags := c.Backend(&BackendOpts{
+		Config: backendConfig,
 	})
-
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	diags = diags.Append(backendDiags)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 

--- a/command/workspace_new.go
+++ b/command/workspace_new.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/command/clistate"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 )
@@ -59,18 +60,22 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		return 1
 	}
 
-	conf, err := c.Config(configPath)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+	var diags tfdiags.Diagnostics
+
+	backendConfig, backendDiags := c.loadBackendConfig(configPath)
+	diags = diags.Append(backendDiags)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
 	}
 
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{
-		Config: conf,
+	b, backendDiags := c.Backend(&BackendOpts{
+		Config: backendConfig,
 	})
-
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+	diags = diags.Append(backendDiags)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 

--- a/config/configschema/none_required.go
+++ b/config/configschema/none_required.go
@@ -1,0 +1,38 @@
+package configschema
+
+// NoneRequired returns a deep copy of the receiver with any required
+// attributes translated to optional.
+func (b *Block) NoneRequired() *Block {
+	ret := &Block{}
+
+	if b.Attributes != nil {
+		ret.Attributes = make(map[string]*Attribute, len(b.Attributes))
+	}
+	for name, attrS := range b.Attributes {
+		ret.Attributes[name] = attrS.forceOptional()
+	}
+
+	if b.BlockTypes != nil {
+		ret.BlockTypes = make(map[string]*NestedBlock, len(b.BlockTypes))
+	}
+	for name, blockS := range b.BlockTypes {
+		ret.BlockTypes[name] = blockS.noneRequired()
+	}
+
+	return ret
+}
+
+func (b *NestedBlock) noneRequired() *NestedBlock {
+	ret := *b
+	ret.Block = *(ret.Block.NoneRequired())
+	ret.MinItems = 0
+	ret.MaxItems = 0
+	return &ret
+}
+
+func (a *Attribute) forceOptional() *Attribute {
+	ret := *a
+	ret.Optional = true
+	ret.Required = false
+	return &ret
+}

--- a/configs/backend.go
+++ b/configs/backend.go
@@ -2,6 +2,9 @@ package configs
 
 import (
 	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcldec"
+	"github.com/hashicorp/terraform/config/configschema"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Backend represents a "backend" block inside a "terraform" block in a module
@@ -21,4 +24,32 @@ func decodeBackendBlock(block *hcl.Block) (*Backend, hcl.Diagnostics) {
 		Config:    block.Body,
 		DeclRange: block.DefRange,
 	}, nil
+}
+
+// Hash produces a hash value for the reciever that covers the type and the
+// portions of the config that conform to the given schema.
+//
+// If the config does not conform to the schema then the result is not
+// meaningful for comparison since it will be based on an incomplete result.
+//
+// As an exception, required attributes in the schema are treated as optional
+// for the purpose of hashing, so that an incomplete configuration can still
+// be hashed. Other errors, such as extraneous attributes, have no such special
+// case.
+func (b *Backend) Hash(schema *configschema.Block) int {
+	// Don't fail if required attributes are not set. Instead, we'll just
+	// hash them as nulls.
+	schema = schema.NoneRequired()
+	spec := schema.DecoderSpec()
+	val, _ := hcldec.Decode(b.Config, spec, nil)
+	if val == cty.NilVal {
+		val = cty.UnknownVal(schema.ImpliedType())
+	}
+
+	toHash := cty.TupleVal([]cty.Value{
+		cty.StringVal(b.Type),
+		val,
+	})
+
+	return toHash.Hash()
 }

--- a/configs/config.go
+++ b/configs/config.go
@@ -113,3 +113,21 @@ func (c *Config) AllModules() []*Config {
 	})
 	return ret
 }
+
+// Descendent returns the descendent config that has the given path beneath
+// the receiver, or nil if there is no such module.
+//
+// The path traverses the static module tree, prior to any expansion to handle
+// count and for_each arguments.
+//
+// An empty path will just return the receiver, and is therefore pointless.
+func (c *Config) Descendent(path []string) *Config {
+	current := c
+	for _, name := range path {
+		current = current.Children[name]
+		if current == nil {
+			return nil
+		}
+	}
+	return current
+}

--- a/configs/configload/testing.go
+++ b/configs/configload/testing.go
@@ -1,0 +1,101 @@
+package configload
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/tfdiags"
+)
+
+// NewLoaderForTests is a variant of NewLoader that is intended to be more
+// convenient for unit tests.
+//
+// The loader's modules directory is a separate temporary directory created
+// for each call. Along with the created loader, this function returns a
+// cleanup function that should be called before the test completes in order
+// to remove that temporary directory.
+//
+// In the case of any errors, t.Fatal (or similar) will be called to halt
+// execution of the test, so the calling test does not need to handle errors
+// itself.
+func NewLoaderForTests(t *testing.T) (*Loader, func()) {
+	t.Helper()
+
+	modulesDir, err := ioutil.TempDir("", "tf-configs")
+	if err != nil {
+		t.Fatalf("failed to create temporary modules dir: %s", err)
+		return nil, func() {}
+	}
+
+	cleanup := func() {
+		os.RemoveAll(modulesDir)
+	}
+
+	loader, err := NewLoader(&Config{
+		ModulesDir: modulesDir,
+	})
+	if err != nil {
+		cleanup()
+		t.Fatalf("failed to create config loader: %s", err)
+		return nil, func() {}
+	}
+
+	return loader, cleanup
+}
+
+// LoadConfigForTests is a convenience wrapper around NewLoaderForTests,
+// Loader.InstallModules and Loader.LoadConfig that allows a test configuration
+// to be loaded in a single step.
+//
+// If module installation fails, t.Fatal (or similar) is called to halt
+// execution of the test, under the assumption that installation failures are
+// not expected. If installation failures _are_ expected then use
+// NewLoaderForTests and work with the loader object directly. If module
+// installation succeeds but generates warnings, these warnings are discarded.
+//
+// If installation succeeds but errors are detected during loading then a
+// possibly-incomplete config is returned along with error diagnostics. The
+// test run is not aborted in this case, so that the caller can make assertions
+// against the returned diagnostics.
+//
+// As with NewLoaderForTests, a cleanup function is returned which must be
+// called before the test completes in order to remove the temporary
+// modules directory.
+func LoadConfigForTests(t *testing.T, rootDir string) (*configs.Config, *Loader, func(), tfdiags.Diagnostics) {
+	t.Helper()
+
+	var diags tfdiags.Diagnostics
+
+	loader, cleanup := NewLoaderForTests(t)
+	hclDiags := loader.InstallModules(rootDir, true, InstallHooksImpl{})
+	if diags.HasErrors() {
+		cleanup()
+		diags = diags.Append(hclDiags)
+		t.Fatal(diags.Err())
+		return nil, nil, cleanup, diags
+	}
+
+	config, hclDiags := loader.LoadConfig(rootDir)
+	diags = diags.Append(hclDiags)
+	return config, loader, cleanup, diags
+}
+
+// MustLoadConfigForTests is a variant of LoadConfigForTests which calls
+// t.Fatal (or similar) if there are any errors during loading, and thus
+// does not return diagnostics at all.
+//
+// This is useful for concisely writing tests that don't expect errors at
+// all. For tests that expect errors and need to assert against them, use
+// LoadConfigForTests instead.
+func MustLoadConfigForTests(t *testing.T, rootDir string) (*configs.Config, *Loader, func()) {
+	t.Helper()
+
+	config, loader, cleanup, diags := LoadConfigForTests(t, rootDir)
+	if diags.HasErrors() {
+		cleanup()
+		t.Fatal(diags.Err())
+	}
+	return config, loader, cleanup
+}

--- a/helper/schema/backend.go
+++ b/helper/schema/backend.go
@@ -3,6 +3,11 @@ package schema
 import (
 	"context"
 
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/config/configschema"
+	"github.com/hashicorp/terraform/config/hcl2shim"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -38,41 +43,50 @@ func FromContextBackendConfig(ctx context.Context) *ResourceData {
 	return ctx.Value(backendConfigKey).(*ResourceData)
 }
 
-func (b *Backend) Input(
-	input terraform.UIInput,
-	c *terraform.ResourceConfig) (*terraform.ResourceConfig, error) {
-	if b == nil {
-		return c, nil
-	}
-
-	return schemaMap(b.Schema).Input(input, c)
+func (b *Backend) ConfigSchema() *configschema.Block {
+	// This is an alias of CoreConfigSchema just to implement the
+	// backend.Backend interface.
+	return b.CoreConfigSchema()
 }
 
-func (b *Backend) Validate(c *terraform.ResourceConfig) ([]string, []error) {
-	if b == nil {
-		return nil, nil
-	}
-
-	return schemaMap(b.Schema).Validate(c)
-}
-
-func (b *Backend) Configure(c *terraform.ResourceConfig) error {
+func (b *Backend) ValidateConfig(obj cty.Value) tfdiags.Diagnostics {
 	if b == nil {
 		return nil
 	}
 
+	var diags tfdiags.Diagnostics
+	shimRC := b.shimConfig(obj)
+	warns, errs := schemaMap(b.Schema).Validate(shimRC)
+	for _, warn := range warns {
+		diags = diags.Append(tfdiags.SimpleWarning(warn))
+	}
+	for _, err := range errs {
+		diags = diags.Append(err)
+	}
+	return diags
+}
+
+func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
+	if b == nil {
+		return nil
+	}
+
+	var diags tfdiags.Diagnostics
 	sm := schemaMap(b.Schema)
+	shimRC := b.shimConfig(obj)
 
 	// Get a ResourceData for this configuration. To do this, we actually
 	// generate an intermediary "diff" although that is never exposed.
-	diff, err := sm.Diff(nil, c, nil, nil)
+	diff, err := sm.Diff(nil, shimRC, nil, nil)
 	if err != nil {
-		return err
+		diags = diags.Append(err)
+		return diags
 	}
 
 	data, err := sm.Data(nil, diff)
 	if err != nil {
-		return err
+		diags = diags.Append(err)
+		return diags
 	}
 	b.config = data
 
@@ -80,11 +94,24 @@ func (b *Backend) Configure(c *terraform.ResourceConfig) error {
 		err = b.ConfigureFunc(context.WithValue(
 			context.Background(), backendConfigKey, data))
 		if err != nil {
-			return err
+			diags = diags.Append(err)
+			return diags
 		}
 	}
 
-	return nil
+	return diags
+}
+
+// shimConfig turns a new-style cty.Value configuration (which must be of
+// an object type) into a minimal old-style *terraform.ResourceConfig object
+// that should be populated enough to appease the not-yet-updated functionality
+// in this package. This should be removed once everything is updated.
+func (b *Backend) shimConfig(obj cty.Value) *terraform.ResourceConfig {
+	shimMap := hcl2shim.ConfigValueFromHCL2(obj).(map[string]interface{})
+	return &terraform.ResourceConfig{
+		Config: shimMap,
+		Raw:    shimMap,
+	}
 }
 
 // Config returns the configuration. This is available after Configure is

--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -154,3 +154,9 @@ func (s *Schema) coreConfigSchemaType() cty.Type {
 func (r *Resource) CoreConfigSchema() *configschema.Block {
 	return schemaMap(r.Schema).CoreConfigSchema()
 }
+
+// CoreConfigSchema is a convenient shortcut for calling CoreConfigSchema
+// on the backends's schema.
+func (r *Backend) CoreConfigSchema() *configschema.Block {
+	return schemaMap(r.Schema).CoreConfigSchema()
+}

--- a/plugin/discovery/version_set.go
+++ b/plugin/discovery/version_set.go
@@ -36,6 +36,11 @@ type Constraints struct {
 	raw version.Constraints
 }
 
+// NewConstraints creates a Constraints based on a version.Constraints.
+func NewConstraints(c version.Constraints) Constraints {
+	return Constraints{c}
+}
+
 // AllVersions is a Constraints containing all versions
 var AllVersions Constraints
 

--- a/terraform/module_dependencies.go
+++ b/terraform/module_dependencies.go
@@ -1,11 +1,206 @@
 package terraform
 
 import (
+	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/moduledeps"
 	"github.com/hashicorp/terraform/plugin/discovery"
 )
+
+// ConfigTreeDependencies returns the dependencies of the tree of modules
+// described by the given configuration and state.
+//
+// Both configuration and state are required because there can be resources
+// implied by instances in the state that no longer exist in config.
+func ConfigTreeDependencies(root *configs.Config, state *State) *moduledeps.Module {
+	// First we walk the configuration tree to build the overall structure
+	// and capture the explicit/implicit/inherited provider dependencies.
+	deps := configTreeConfigDependencies(root, nil)
+
+	// Next we walk over the resources in the state to catch any additional
+	// dependencies created by existing resources that are no longer in config.
+	// Most things we find in state will already be present in 'deps', but
+	// we're interested in the rare thing that isn't.
+	configTreeMergeStateDependencies(deps, state)
+
+	return deps
+}
+
+func configTreeConfigDependencies(root *configs.Config, inheritProviders map[string]*configs.Provider) *moduledeps.Module {
+	if root == nil {
+		// If no config is provided, we'll make a synthetic root.
+		// This isn't necessarily correct if we're called with a nil that
+		// *isn't* at the root, but in practice that can never happen.
+		return &moduledeps.Module{
+			Name: "root",
+		}
+	}
+
+	name := "root"
+	if len(root.Path) != 0 {
+		name = root.Path[len(root.Path)-1]
+	}
+
+	ret := &moduledeps.Module{
+		Name: name,
+	}
+
+	module := root.Module
+
+	// Provider dependencies
+	{
+		providers := make(moduledeps.Providers)
+
+		// The main way to declare a provider dependency is explicitly inside
+		// the "terraform" block, which allows declaring a requirement without
+		// also creating a configuration.
+		for fullName, constraints := range module.ProviderRequirements {
+			inst := moduledeps.ProviderInstance(fullName)
+
+			// The handling here is a bit fiddly because the moduledeps package
+			// was designed around the legacy (pre-0.12) configuration model
+			// and hasn't yet been revised to handle the new model. As a result,
+			// we need to do some translation here.
+			// FIXME: Eventually we should adjust the underlying model so we
+			// can also retain the source location of each constraint, for
+			// more informative output from the "terraform providers" command.
+			var rawConstraints version.Constraints
+			for _, constraint := range constraints {
+				rawConstraints = append(rawConstraints, constraint.Required...)
+			}
+			discoConstraints := discovery.NewConstraints(rawConstraints)
+
+			providers[inst] = moduledeps.ProviderDependency{
+				Constraints: discoConstraints,
+				Reason:      moduledeps.ProviderDependencyExplicit,
+			}
+		}
+
+		// Provider configurations can also include version constraints,
+		// allowing for more terse declaration in situations where both a
+		// configuration and a constraint are defined in the same module.
+		for fullName, pCfg := range module.ProviderConfigs {
+			inst := moduledeps.ProviderInstance(fullName)
+			discoConstraints := discovery.AllVersions
+			if pCfg.Version.Required != nil {
+				discoConstraints = discovery.NewConstraints(pCfg.Version.Required)
+			}
+			if existing, exists := providers[inst]; exists {
+				existing.Constraints = existing.Constraints.Append(discoConstraints)
+			} else {
+				providers[inst] = moduledeps.ProviderDependency{
+					Constraints: discoConstraints,
+					Reason:      moduledeps.ProviderDependencyExplicit,
+				}
+			}
+		}
+
+		// Each resource in the configuration creates an *implicit* provider
+		// dependency, though we'll only record it if there isn't already
+		// an explicit dependency on the same provider.
+		for _, rc := range module.ManagedResources {
+			fullName := rc.ProviderConfigKey()
+			inst := moduledeps.ProviderInstance(fullName)
+			if _, exists := providers[inst]; exists {
+				// Explicit dependency already present
+				continue
+			}
+
+			reason := moduledeps.ProviderDependencyImplicit
+			if _, inherited := inheritProviders[fullName]; inherited {
+				reason = moduledeps.ProviderDependencyInherited
+			}
+
+			providers[inst] = moduledeps.ProviderDependency{
+				Constraints: discovery.AllVersions,
+				Reason:      reason,
+			}
+		}
+		for _, rc := range module.DataResources {
+			fullName := rc.ProviderConfigKey()
+			inst := moduledeps.ProviderInstance(fullName)
+			if _, exists := providers[inst]; exists {
+				// Explicit dependency already present
+				continue
+			}
+
+			reason := moduledeps.ProviderDependencyImplicit
+			if _, inherited := inheritProviders[fullName]; inherited {
+				reason = moduledeps.ProviderDependencyInherited
+			}
+
+			providers[inst] = moduledeps.ProviderDependency{
+				Constraints: discovery.AllVersions,
+				Reason:      reason,
+			}
+		}
+
+		ret.Providers = providers
+	}
+
+	childInherit := make(map[string]*configs.Provider)
+	for k, v := range inheritProviders {
+		childInherit[k] = v
+	}
+	for k, v := range module.ProviderConfigs {
+		childInherit[k] = v
+	}
+	for _, c := range root.Children {
+		ret.Children = append(ret.Children, configTreeConfigDependencies(c, childInherit))
+	}
+
+	return ret
+}
+
+func configTreeMergeStateDependencies(root *moduledeps.Module, state *State) {
+	if state == nil {
+		return
+	}
+
+	findModule := func(path []string) *moduledeps.Module {
+		module := root
+		for _, name := range path[1:] { // skip initial "root"
+			var next *moduledeps.Module
+			for _, cm := range module.Children {
+				if cm.Name == name {
+					next = cm
+					break
+				}
+			}
+
+			if next == nil {
+				// If we didn't find a next node, we'll need to make one
+				next = &moduledeps.Module{
+					Name: name,
+				}
+				module.Children = append(module.Children, next)
+			}
+
+			module = next
+		}
+		return module
+	}
+
+	for _, ms := range state.Modules {
+		module := findModule(ms.Path)
+
+		for _, is := range ms.Resources {
+			fullName := config.ResourceProviderFullName(is.Type, is.Provider)
+			inst := moduledeps.ProviderInstance(fullName)
+			if _, exists := module.Providers[inst]; !exists {
+				if module.Providers == nil {
+					module.Providers = make(moduledeps.Providers)
+				}
+				module.Providers[inst] = moduledeps.ProviderDependency{
+					Constraints: discovery.AllVersions,
+					Reason:      moduledeps.ProviderDependencyFromState,
+				}
+			}
+		}
+	}
+}
 
 // ModuleTreeDependencies returns the dependencies of the tree of modules
 // described by the given configuration tree and state.
@@ -106,50 +301,9 @@ func moduleTreeConfigDependencies(root *module.Tree, inheritProviders map[string
 }
 
 func moduleTreeMergeStateDependencies(root *moduledeps.Module, state *State) {
-	if state == nil {
-		return
-	}
-
-	findModule := func(path []string) *moduledeps.Module {
-		module := root
-		for _, name := range path[1:] { // skip initial "root"
-			var next *moduledeps.Module
-			for _, cm := range module.Children {
-				if cm.Name == name {
-					next = cm
-					break
-				}
-			}
-
-			if next == nil {
-				// If we didn't find a next node, we'll need to make one
-				next = &moduledeps.Module{
-					Name: name,
-				}
-				module.Children = append(module.Children, next)
-			}
-
-			module = next
-		}
-		return module
-	}
-
-	for _, ms := range state.Modules {
-		module := findModule(ms.Path)
-
-		for _, is := range ms.Resources {
-			fullName := config.ResourceProviderFullName(is.Type, is.Provider)
-			inst := moduledeps.ProviderInstance(fullName)
-			if _, exists := module.Providers[inst]; !exists {
-				if module.Providers == nil {
-					module.Providers = make(moduledeps.Providers)
-				}
-				module.Providers[inst] = moduledeps.ProviderDependency{
-					Constraints: discovery.AllVersions,
-					Reason:      moduledeps.ProviderDependencyFromState,
-				}
-			}
-		}
-	}
-
+	// This is really just the same logic as configTreeMergeStateDependencies
+	// but we retain this old name just to keep the symmetry until we've
+	// removed all of these "moduleTree..." versions that use the legacy
+	// configuration structs.
+	configTreeMergeStateDependencies(root, state)
 }


### PR DESCRIPTION
This sequence of commits allows the new config loader, and thus HCL2 syntax, to work up until the point where control transfers into the `terraform` package, in `terraform.Context`.

In order to create an artificial milestone and thus avoid this changeset growing even larger, the `b.context` method in the local backend temporarily sets the `Module` field to `nil`, thus making the backend-powered commands `plan`, `apply` and `refresh` panic with a nil pointer dereference.

However, this PR does get us to the point where `terraform init` uses the new loader, along the way altering the `backend` interfaces slightly to use new HCL2-oriented data types and to expose the backend configuration schemas.

Since all of the interesting Terraform operations panic immediately, the tests do not run successfully as of this PR. This changeset just includes changes to make them _compile_, under the expectation that we'll find and fix other regressions later once the core `terraform` package is retrofitted with the new config types and HCL2 interpreter.

A lot of the diff on this PR is mechanical updates for the various interface changes. Here are some more interesting elements to look out for in the diff:

* The backend interface now uses a `ConfigSchema`, `ValidateConfig`, `Configure` workflow for initialization, where the latter two take already-decoded configuration values. This uses the contextual diagnostics feature added in an earlier commit to allow us to still include useful source location information in errors even though the functions here don't have access to the configuration AST.
* `Input` is no longer a part of the backend interface and is instead implemented in the `command` package using the schema, in the `inputForSchema` method. A similar approach will be used for provider configuration input in a later commit.
* The `-backend-config` argument to `terraform init` is implemented slightly deeper than before so that we can properly retain source location information for the configuration values, possibly reporting locations in a given external configuration file.
* The backend configuration retained in the backend state file (`.terraform/terraform.tfstate`) is now kept in memory as a raw `[]byte`, marshalling and unmarshalling as necessary using the backend configuration schema. This is necessary because `encoding/json` is only able to use static type information and thus can't "see" the dynamically-built backend configuration schema.
* Some of the backends are now directly using `configschema` types to represent their schemas, rather than `helper/schema.Backend`. This is in anticipation of `helper/schema` later being extracted out of this repository to become a separate plugin SDK, though for the moment the remote state backends are still using it since that reduces the size of this already-noisy diff.
* Since the types used in the new config loader are intentionally treated as immutable after loading, the `Rehash` approach used for hash computation is replaced with a functional-style method that just returns a hash result, which the caller then copies into the backend state when needed. Because HCL2 requires schema in order to decode the contents of a config block, computing the config hash now requires the backend's configuration schema to properly interpret the content.
* The interface for backend operations is adjusted slightly to clarify its relationship with the `command` package: a backend operation now takes a configuration _directory_ and _loader_ rather than an already-loaded configuration, which thus allows for a future situation where the source code must be uploaded elsewhere to run an operation remotely, and backends are now responsible for printing out any error messages they want to produce, now returning an exit status rather than an `error` as before. The latter allows the operation implementation to choose where in the output to place diagnostic messages, and again is partially in anticipation of future work to run operations remotely where error messages can then be returned in-band as part of other log output.

Since this is just a resting point as part of a larger change, parts of this will almost certainly be revised further as the work continues. For now though, the code here is able to run the current generation of our public registry smoke test which just installs and validates syntax for verified modules in Terraform Registry:

```
GoogleCloudPlatform	GoogleCloudPlatform/lb-http/google	ERROR	Attribute redefined
GoogleCloudPlatform	GoogleCloudPlatform/nat-gateway/google	ERROR	Missing key/value separator
hashicorp	hashicorp/vault/google	ERROR	Failed to download module
hashicorp	hashicorp/vault/aws	ERROR	Failed to download module
coreos	coreos/kubernetes/azurerm	ERROR	Module has no versions
coreos	coreos/kubernetes/aws	ERROR	Module has no versions
hashicorp	hashicorp/nomad/google	ERROR	Failed to download module
terraform-aws-modules	terraform-aws-modules/security-group/aws	ERROR	Invalid default value for variable
terraform-aws-modules	terraform-aws-modules/security-group/aws	ERROR	Invalid default value for variable
```

(This set of errors replicates our initial results from the more hacky smoke test, and are all captured elsewhere.)
