### PR TITLE
Remove attribute value from ConflictsWith validation message (leaks sensitive data)

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1270,9 +1270,9 @@ func (m schemaMap) validateConflictingAttributes(
 	}
 
 	for _, conflicting_key := range schema.ConflictsWith {
-		if value, ok := c.Get(conflicting_key); ok {
+		if _, ok := c.Get(conflicting_key); ok {
 			return fmt.Errorf(
-				"%q: conflicts with %s (%#v)", k, conflicting_key, value)
+				"%q: conflicts with %s", k, conflicting_key)
 		}
 	}
 

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -4790,7 +4790,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 
 			Err: true,
 			Errors: []error{
-				fmt.Errorf("\"blacklist\": conflicts with whitelist (\"white-val\")"),
+				fmt.Errorf("\"blacklist\": conflicts with whitelist"),
 			},
 		},
 
@@ -4834,7 +4834,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 
 			Err: true,
 			Errors: []error{
-				fmt.Errorf(`"optional_att": conflicts with required_att ("required-val")`),
+				fmt.Errorf(`"optional_att": conflicts with required_att`),
 			},
 		},
 
@@ -4861,8 +4861,8 @@ func TestSchemaMap_Validate(t *testing.T) {
 
 			Err: true,
 			Errors: []error{
-				fmt.Errorf(`"foo_att": conflicts with bar_att ("bar-val")`),
-				fmt.Errorf(`"bar_att": conflicts with foo_att ("foo-val")`),
+				fmt.Errorf(`"foo_att": conflicts with bar_att`),
+				fmt.Errorf(`"bar_att": conflicts with foo_att`),
 			},
 		},
 


### PR DESCRIPTION
The error message displayed when a validating conflicting schema attributes includes the value of the conflicting attribute, regardless of whether or not it is marked as Sensitive. This can leak sensitive data.  
Since the attribute value is not really relevant to the purpose of the error message, this PR removes the value from the error message. 

(See also discussion at https://github.com/terraform-providers/terraform-provider-local/pull/9)