### PR TITLE
Support NTLM for WinRM communicators.

### DIFF
--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -214,9 +214,12 @@ func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
 		},
 		Https:                 c.connInfo.HTTPS,
 		Insecure:              c.connInfo.Insecure,
-		TransportDecorator:    c.client.TransportDecorator,
 		OperationTimeout:      c.Timeout(),
 		MaxOperationsPerShell: 15, // lowest common denominator
+	}
+	
+	if c.connInfo.NTLM == true {
+		config.TransportDecorator = func() winrm.Transporter { return &winrm.ClientNTLM{} }
 	}
 
 	if c.connInfo.CACert != "" {

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -62,6 +62,9 @@ func (c *Communicator) Connect(o terraform.UIOutput) error {
 
 	params := winrm.DefaultParameters
 	params.Timeout = formatDuration(c.Timeout())
+	if c.connInfo.NTLM == true {
+		params.TransportDecorator = func() winrm.Transporter { return &winrm.ClientNTLM{} }
+	}
 
 	client, err := winrm.NewClientWithParameters(
 		c.endpoint, c.connInfo.User, c.connInfo.Password, params)
@@ -78,6 +81,7 @@ func (c *Communicator) Connect(o terraform.UIOutput) error {
 				"  Password: %t\n"+
 				"  HTTPS: %t\n"+
 				"  Insecure: %t\n"+
+				"  NTLM: %t\n"+
 				"  CACert: %t",
 			c.connInfo.Host,
 			c.connInfo.Port,
@@ -85,6 +89,7 @@ func (c *Communicator) Connect(o terraform.UIOutput) error {
 			c.connInfo.Password != "",
 			c.connInfo.HTTPS,
 			c.connInfo.Insecure,
+			c.connInfo.NTLM,
 			c.connInfo.CACert != "",
 		))
 	}
@@ -209,6 +214,7 @@ func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
 		},
 		Https:                 c.connInfo.HTTPS,
 		Insecure:              c.connInfo.Insecure,
+		TransportDecorator:    c.client.TransportDecorator,
 		OperationTimeout:      c.Timeout(),
 		MaxOperationsPerShell: 15, // lowest common denominator
 	}

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -217,7 +217,7 @@ func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
 		OperationTimeout:      c.Timeout(),
 		MaxOperationsPerShell: 15, // lowest common denominator
 	}
-	
+
 	if c.connInfo.NTLM == true {
 		config.TransportDecorator = func() winrm.Transporter { return &winrm.ClientNTLM{} }
 	}

--- a/communicator/winrm/communicator_test.go
+++ b/communicator/winrm/communicator_test.go
@@ -155,6 +155,40 @@ func TestScriptPath(t *testing.T) {
 	}
 }
 
+func TestTransportDecorator(t *testing.T) {
+	wrm := newMockWinRMServer(t)
+	defer wrm.Close()
+
+	r := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: map[string]string{
+				"type":     "winrm",
+				"user":     "user",
+				"password": "pass",
+				"host":     wrm.Host,
+				"port":     strconv.Itoa(wrm.Port),
+				"use_ntlm": "true",
+				"timeout":  "30s",
+			},
+		},
+	}
+
+	c, err := New(r)
+	if err != nil {
+		t.Fatalf("error creating communicator: %s", err)
+	}
+
+	err = c.Connect(nil)
+	if err != nil {
+		t.Fatalf("error connecting communicator: %s", err)
+	}
+	defer c.Disconnect()
+
+	if c.client.TransportDecorator == nil {
+		t.Fatal("bad TransportDecorator: got nil")
+	}
+}
+
 func TestScriptPath_randSeed(t *testing.T) {
 	// Pre GH-4186 fix, this value was the deterministic start the pseudorandom
 	// chain of unseeded math/rand values for Int31().

--- a/communicator/winrm/provisioner.go
+++ b/communicator/winrm/provisioner.go
@@ -37,6 +37,7 @@ type connectionInfo struct {
 	Port       int
 	HTTPS      bool
 	Insecure   bool
+	NTLM       bool   `mapstructure:"use_ntlm"`
 	CACert     string `mapstructure:"cacert"`
 	Timeout    string
 	ScriptPath string        `mapstructure:"script_path"`

--- a/communicator/winrm/provisioner_test.go
+++ b/communicator/winrm/provisioner_test.go
@@ -16,6 +16,7 @@ func TestProvisioner_connInfo(t *testing.T) {
 				"host":     "127.0.0.1",
 				"port":     "5985",
 				"https":    "true",
+				"use_ntlm": "true",
 				"timeout":  "30s",
 			},
 		},
@@ -39,6 +40,9 @@ func TestProvisioner_connInfo(t *testing.T) {
 		t.Fatalf("expected: %v: got: %v", 5985, conf)
 	}
 	if conf.HTTPS != true {
+		t.Fatalf("expected: %v: got: %v", true, conf)
+	}
+	if conf.NTLM != true {
 		t.Fatalf("expected: %v: got: %v", true, conf)
 	}
 	if conf.Timeout != "30s" {

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -157,6 +157,7 @@ func (n *EvalValidateProvisioner) validateConnConfig(connConfig *ResourceConfig)
 		// For type=winrm only (enforced in winrm communicator)
 		HTTPS    interface{} `mapstructure:"https"`
 		Insecure interface{} `mapstructure:"insecure"`
+		NTLM     interface{} `mapstructure:"use_ntlm"`
 		CACert   interface{} `mapstructure:"cacert"`
 	}
 

--- a/website/docs/provisioners/connection.html.markdown
+++ b/website/docs/provisioners/connection.html.markdown
@@ -92,6 +92,8 @@ provisioner "file" {
 
 * `insecure` - Set to `true` to not validate the HTTPS certificate chain.
 
+* `use_ntlm` - Set to `true` to use NTLM authentication, rather than default (basic authentication), removing the requirement for basic authentication to be enabled within the target guest. Further reading for remote connection authentication can be found [here](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx).
+
 * `cacert` - The CA certificate to validate against.
 
 <a id="bastion"></a>


### PR DESCRIPTION
Some customers prohibit *any* basic or digest authentication methods over WinRM.

This is a simple patch to add NTLM (kerberos) support for WinRM connections, modeled after packer's support for the same.

When testing functionality, I ran the following on the host to disable all insecure auth:

```
winrm set winrm/config/client/auth '@{Basic="false"}'
winrm set winrm/config/client/auth '@{Digest="false"}'
winrm set winrm/config/service/auth '@{Basic="false"}'
```

Then, I tested it with the unpatched Terraform to verify that it locked me out.  (It did)
Finally, I tested it with the patched Terraform to verify that it let me in.  (It did)