### PR TITLE
detect scaled in resources when evaluating *s

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -820,7 +820,13 @@ func (i *Interpolater) resourceCountMax(
 	// use "cr.Count()" but that doesn't work if the count is interpolated
 	// and we can't guarantee that so we instead depend on the state.
 	max := -1
-	for k, _ := range ms.Resources {
+	for k, s := range ms.Resources {
+		// This resource may have been just removed, in which case the Primary
+		// may be nil, or just empty.
+		if s == nil || s.Primary == nil || len(s.Primary.Attributes) == 0 {
+			continue
+		}
+
 		// Get the index number for this resource
 		index := ""
 		if k == id {

--- a/terraform/test-fixtures/apply-resource-scale-in/main.tf
+++ b/terraform/test-fixtures/apply-resource-scale-in/main.tf
@@ -1,0 +1,13 @@
+variable "count" {}
+
+resource "aws_instance" "one" {
+  count = "${var.count}"
+}
+
+locals {
+  "one_id" = "${element(concat(aws_instance.one.*.id, list("")), 0)}"
+}
+
+resource "aws_instance" "two" {
+  val = "${local.one_id}"
+}


### PR DESCRIPTION
If an existing resources is scaled back to 0, locals and outputs will
still have a multi-variable reference to evaluate, which should return
an empty list. Due to how the resource is removed, the resource will
still exist in the state but with no primary instance, which needs to be
ignored in the instance count.

Fixes #17425