### PR TITLE
backend/manta: Add support for manta backend tiered path structure

### DIFF
--- a/backend/remote-state/manta/client.go
+++ b/backend/remote-state/manta/client.go
@@ -141,6 +141,7 @@ func (c *RemoteClient) Lock(info *state.LockInfo) (string, error) {
 		ContentLength: uint64(contentLength),
 		ObjectPath:    path.Join(mantaDefaultRootStore, c.directoryName, lockFileName),
 		ObjectReader:  bytes.NewReader(data),
+		ForceInsert:   true,
 	}
 
 	log.Printf("[DEBUG] Creating manta state lock: %#v", params)


### PR DESCRIPTION
This was already added to triton-go and is now making its way to
the manta backend

```
% acctests backend/remote-state/manta
=== RUN   TestBackend_impl
--- PASS: TestBackend_impl (0.00s)
=== RUN   TestBackend
--- PASS: TestBackend (27.36s)
=== RUN   TestBackendLocked
--- PASS: TestBackendLocked (16.24s)
=== RUN   TestRemoteClient_impl
--- PASS: TestRemoteClient_impl (0.00s)
=== RUN   TestRemoteClient
--- PASS: TestRemoteClient (3.40s)
=== RUN   TestRemoteClientLocks
--- PASS: TestRemoteClientLocks (7.17s)
PASS
ok  	github.com/hashicorp/terraform/backend/remote-state/manta
```