### PR TITLE
remove old warning care create_before_destroy

### DIFF
--- a/website/docs/configuration/resources.html.md
+++ b/website/docs/configuration/resources.html.md
@@ -71,11 +71,6 @@ There are **meta-parameters** available to all resources:
     example, this can be used to create an new DNS record before removing an old
     record.
 
-        ~> Resources that utilize the `create_before_destroy` key can only
-        depend on other resources that also include `create_before_destroy`.
-        Referencing a resource that does not include `create_before_destroy`
-        will result in a dependency graph cycle.
-
   - `prevent_destroy` (bool) - This flag provides extra protection against the
     destruction of a given resource. When this is set to `true`, any plan that
     includes a destroy of this resource will return an error message.


### PR DESCRIPTION
Create-before-destroy dependencies are automatically ordered correctly
by terraform. Remove the old notice about requiring all dependencies to
have the same setting for create_before_destroy.