### PR TITLE
update missing alias message

### DIFF
--- a/config/module/validate_provider_alias.go
+++ b/config/module/validate_provider_alias.go
@@ -67,7 +67,7 @@ func (t *Tree) validateProviderAlias() error {
 
 			// We didn't find the alias, error!
 			err = multierror.Append(err, fmt.Errorf(
-				"module %s: provider alias must be defined by the module or a parent: %s",
+				"module %s: provider alias must be defined by the module: %s",
 				strings.Join(pv.Path, "."), k))
 		}
 	}


### PR DESCRIPTION
Update the old error message for a missing provider alias, as we no
longer automatically inherit providers.