### PR TITLE
lang: new package for the runtime parts of the config language

### DIFF
--- a/addrs/count_attr.go
+++ b/addrs/count_attr.go
@@ -6,3 +6,7 @@ type CountAttr struct {
 	referenceable
 	Name string
 }
+
+func (ca CountAttr) String() string {
+	return "count." + ca.Name
+}

--- a/addrs/input_variable.go
+++ b/addrs/input_variable.go
@@ -5,3 +5,7 @@ type InputVariable struct {
 	referenceable
 	Name string
 }
+
+func (v InputVariable) String() string {
+	return "var." + v.Name
+}

--- a/addrs/instance_key.go
+++ b/addrs/instance_key.go
@@ -17,6 +17,7 @@ import (
 // InstanceKey.
 type InstanceKey interface {
 	instanceKeySigil()
+	String() string
 }
 
 // ParseInstanceKey returns the instance key corresponding to the given value,
@@ -51,9 +52,19 @@ type IntKey int
 func (k IntKey) instanceKeySigil() {
 }
 
+func (k IntKey) String() string {
+	return fmt.Sprintf("[%d]", int(k))
+}
+
 // StringKey is the InstanceKey representation representing string indices, as
 // used when the "for_each" argument is specified with a map or object type.
 type StringKey string
 
 func (k StringKey) instanceKeySigil() {
+}
+
+func (k StringKey) String() string {
+	// FIXME: This isn't _quite_ right because Go's quoted string syntax is
+	// slightly different than HCL's, but we'll accept it for now.
+	return fmt.Sprintf("[%q]", string(k))
 }

--- a/addrs/local_value.go
+++ b/addrs/local_value.go
@@ -5,3 +5,7 @@ type LocalValue struct {
 	referenceable
 	Name string
 }
+
+func (v LocalValue) String() string {
+	return "local." + v.Name
+}

--- a/addrs/module_call.go
+++ b/addrs/module_call.go
@@ -1,5 +1,9 @@
 package addrs
 
+import (
+	"fmt"
+)
+
 // ModuleCall is the address of a call from the current module to a child
 // module.
 //
@@ -8,6 +12,10 @@ package addrs
 type ModuleCall struct {
 	referenceable
 	Name string
+}
+
+func (c ModuleCall) String() string {
+	return "module." + c.Name
 }
 
 // Instance returns the address of an instance of the receiver identified by
@@ -28,6 +36,13 @@ type ModuleCallInstance struct {
 	Key  InstanceKey
 }
 
+func (c ModuleCallInstance) String() string {
+	if c.Key == NoKey {
+		return c.Call.String()
+	}
+	return fmt.Sprintf("module.%s%s", c.Call.Name, c.Key)
+}
+
 // Output returns the address of an output of the receiver identified by its
 // name.
 func (c ModuleCallInstance) Output(name string) ModuleCallOutput {
@@ -43,4 +58,8 @@ type ModuleCallOutput struct {
 	referenceable
 	Call ModuleCallInstance
 	Name string
+}
+
+func (co ModuleCallOutput) String() string {
+	return fmt.Sprintf("%s.%s", co.Call.String(), co.Name)
 }

--- a/addrs/path_attr.go
+++ b/addrs/path_attr.go
@@ -6,3 +6,7 @@ type PathAttr struct {
 	referenceable
 	Name string
 }
+
+func (pa PathAttr) String() string {
+	return "path." + pa.Name
+}

--- a/addrs/referenceable.go
+++ b/addrs/referenceable.go
@@ -3,7 +3,14 @@ package addrs
 // Referenceable is an interface implemented by all address types that can
 // appear as references in configuration language expressions.
 type Referenceable interface {
+	// All implementations of this interface must be covered by the type switch
+	// in lang.Scope.buildEvalContext.
 	referenceableSigil()
+
+	// String produces a string representation of the address that could be
+	// parsed as a HCL traversal and passed to ParseRef to produce an identical
+	// result.
+	String() string
 }
 
 type referenceable struct {

--- a/addrs/resource.go
+++ b/addrs/resource.go
@@ -1,5 +1,9 @@
 package addrs
 
+import (
+	"fmt"
+)
+
 // Resource is an address for a resource block within configuration, which
 // contains potentially-multiple resource instances if that configuration
 // block uses "count" or "for_each".
@@ -8,6 +12,17 @@ type Resource struct {
 	Mode ResourceMode
 	Type string
 	Name string
+}
+
+func (r Resource) String() string {
+	switch r.Mode {
+	case ManagedResourceMode:
+		return fmt.Sprintf("%s.%s", r.Type, r.Name)
+	case DataResourceMode:
+		return fmt.Sprintf("data.%s.%s", r.Type, r.Name)
+	default:
+		panic(fmt.Errorf("resource address with invalid mode %s", r.Mode))
+	}
 }
 
 // Instance produces the address for a specific instance of the receiver
@@ -35,6 +50,13 @@ type ResourceInstance struct {
 	referenceable
 	Resource Resource
 	Key      InstanceKey
+}
+
+func (r ResourceInstance) String() string {
+	if r.Key == NoKey {
+		return r.Resource.String()
+	}
+	return r.Resource.String() + r.Key.String()
 }
 
 // Absolute returns an AbsResourceInstance from the receiver and the given module

--- a/addrs/self.go
+++ b/addrs/self.go
@@ -8,3 +8,7 @@ type selfT int
 
 func (s selfT) referenceableSigil() {
 }
+
+func (s selfT) String() string {
+	return "self"
+}

--- a/addrs/terraform_attr.go
+++ b/addrs/terraform_attr.go
@@ -6,3 +6,7 @@ type TerraformAttr struct {
 	referenceable
 	Name string
 }
+
+func (ta TerraformAttr) String() string {
+	return "terraform." + ta.Name
+}

--- a/lang/data.go
+++ b/lang/data.go
@@ -1,0 +1,32 @@
+package lang
+
+import (
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Data is an interface whose implementations can provide cty.Value
+// representations of objects identified by referenceable addresses from
+// the addrs package.
+//
+// This interface will grow each time a new type of reference is added, and so
+// implementations outside of the Terraform codebases are not advised.
+//
+// Each method returns a suitable value and optionally some diagnostics. If the
+// returned diagnostics contains errors then the type of the returned value is
+// used to construct an unknown value of the same type which is then used in
+// place of the requested object so that type checking can still proceed. In
+// cases where it's not possible to even determine a suitable result type,
+// cty.DynamicVal is returned along with errors describing the problem.
+type Data interface {
+	GetCountAttr(addrs.CountAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetResourceInstance(addrs.ResourceInstance, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetLocalValue(addrs.LocalValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetModuleInstance(addrs.ModuleCallInstance, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetModuleInstanceOutput(addrs.ModuleCallOutput, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetPathAttr(addrs.PathAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetSelf(tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetTerraformAttr(addrs.TerraformAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetInputVariable(addrs.InputVariable, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+}

--- a/lang/data_test.go
+++ b/lang/data_test.go
@@ -1,0 +1,58 @@
+package lang
+
+import (
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type dataForTests struct {
+	CountAttrs        map[string]cty.Value
+	ResourceInstances map[string]cty.Value
+	LocalValues       map[string]cty.Value
+	Modules           map[string]cty.Value
+	PathAttrs         map[string]cty.Value
+	Self              cty.Value
+	TerraformAttrs    map[string]cty.Value
+	InputVariables    map[string]cty.Value
+}
+
+var _ Data = &dataForTests{}
+
+func (d *dataForTests) GetCountAttr(addr addrs.CountAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.CountAttrs[addr.Name], nil
+}
+
+func (d *dataForTests) GetResourceInstance(addr addrs.ResourceInstance, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.ResourceInstances[addr.String()], nil
+}
+
+func (d *dataForTests) GetInputVariable(addr addrs.InputVariable, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.InputVariables[addr.Name], nil
+}
+
+func (d *dataForTests) GetLocalValue(addr addrs.LocalValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.LocalValues[addr.Name], nil
+}
+
+func (d *dataForTests) GetModuleInstance(addr addrs.ModuleCallInstance, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.Modules[addr.String()], nil
+}
+
+func (d *dataForTests) GetModuleInstanceOutput(addr addrs.ModuleCallOutput, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// This will panic if the module object does not have the requested attribute
+	obj := d.Modules[addr.Call.String()]
+	return obj.GetAttr(addr.Name), nil
+}
+
+func (d *dataForTests) GetPathAttr(addr addrs.PathAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.PathAttrs[addr.Name], nil
+}
+
+func (d *dataForTests) GetSelf(rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.Self, nil
+}
+
+func (d *dataForTests) GetTerraformAttr(addr addrs.TerraformAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.TerraformAttrs[addr.Name], nil
+}

--- a/lang/doc.go
+++ b/lang/doc.go
@@ -1,0 +1,5 @@
+// Package lang deals with the runtime aspects of Terraform's configuration
+// language, with concerns such as expression evaluation. It is closely related
+// to sibling package "configs", which is responsible for configuration
+// parsing and static validation.
+package lang

--- a/lang/eval.go
+++ b/lang/eval.go
@@ -1,0 +1,360 @@
+package lang
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform/addrs"
+
+	"github.com/hashicorp/hcl2/ext/dynblock"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcldec"
+	"github.com/hashicorp/terraform/config/configschema"
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+// ExpandBlock expands any "dynamic" blocks present in the given body. The
+// result is a body with those blocks expanded, ready to be evaluated with
+// EvalBlock.
+//
+// If the returned diagnostics contains errors then the result may be
+// incomplete or invalid.
+func (s *Scope) ExpandBlock(body hcl.Body, schema *configschema.Block) (hcl.Body, tfdiags.Diagnostics) {
+	spec := schema.DecoderSpec()
+
+	traversals := dynblock.ForEachVariablesHCLDec(body, spec)
+	refs, diags := References(traversals)
+
+	ctx, ctxDiags := s.EvalContext(refs)
+	diags = diags.Append(ctxDiags)
+
+	return dynblock.Expand(body, ctx), diags
+}
+
+// EvalBlock evaluates the given body using the given block schema and returns
+// a cty object value representing its contents. The type of the result conforms
+// to the implied type of the given schema.
+//
+// This function does not automatically expand "dynamic" blocks within the
+// body. If that is desired, first call the ExpandBlock method to obtain
+// an expanded body to pass to this method.
+//
+// If the returned diagnostics contains errors then the result may be
+// incomplete or invalid.
+func (s *Scope) EvalBlock(body hcl.Body, schema *configschema.Block) (cty.Value, tfdiags.Diagnostics) {
+	spec := schema.DecoderSpec()
+
+	traversals := hcldec.Variables(body, spec)
+	refs, diags := References(traversals)
+
+	ctx, ctxDiags := s.EvalContext(refs)
+	diags = diags.Append(ctxDiags)
+
+	val, evalDiags := hcldec.Decode(body, spec, ctx)
+	diags = diags.Append(evalDiags)
+
+	return val, diags
+}
+
+// EvalExpr evaluates a single expression in the receiving context and returns
+// the resulting value. The value will be converted to the given type before
+// it is returned if possible, or else an error diagnostic will be produced
+// describing the conversion error.
+//
+// Pass an expected type of cty.DynamicPseudoType to skip automatic conversion
+// and just obtain the returned value directly.
+//
+// If the returned diagnostics contains errors then the result may be
+// incomplete, but will always be of the requested type.
+func (s *Scope) EvalExpr(expr hcl.Expression, wantType cty.Type) (cty.Value, tfdiags.Diagnostics) {
+	refs, diags := ReferencesInExpr(expr)
+
+	ctx, ctxDiags := s.EvalContext(refs)
+	diags = diags.Append(ctxDiags)
+
+	val, evalDiags := expr.Value(ctx)
+	diags = diags.Append(evalDiags)
+
+	var convErr error
+	val, convErr = convert.Convert(val, wantType)
+	if convErr != nil {
+		val = cty.UnknownVal(wantType)
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Incorrect value type",
+			Detail:   fmt.Sprintf("Invalid expression value: %s.", tfdiags.FormatError(convErr)),
+			Subject:  expr.Range().Ptr(),
+		})
+	}
+
+	return val, diags
+}
+
+// EvalContext constructs a HCL expression evaluation context whose variable
+// scope contains sufficient values to satisfy the given set of references.
+//
+// Most callers should prefer to use the evaluation helper methods that
+// this type offers, but this is here for less common situations where the
+// caller will handle the evaluation calls itself.
+func (s *Scope) EvalContext(refs []*addrs.Reference) (*hcl.EvalContext, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	vals := make(map[string]cty.Value)
+	funcs := s.Functions()
+	ctx := &hcl.EvalContext{
+		Variables: vals,
+		Functions: funcs,
+	}
+
+	if len(refs) == 0 {
+		// Easy path for common case where there are no references at all.
+		return ctx, diags
+	}
+
+	// The reference set we are given has not been de-duped, and so there can
+	// be redundant requests in it for two reasons:
+	//  - The same item is referenced multiple times
+	//  - Both an item and that item's container are separately referenced.
+	// We will still visit every reference here and ask our data source for
+	// it, since that allows us to gather a full set of any errors and
+	// warnings, but once we've gathered all the data we'll then skip anything
+	// that's redundant in the process of populating our values map.
+	dataResources := map[string]map[string]map[addrs.InstanceKey]cty.Value{}
+	managedResources := map[string]map[string]map[addrs.InstanceKey]cty.Value{}
+	wholeModules := map[string]map[addrs.InstanceKey]cty.Value{}
+	moduleOutputs := map[string]map[addrs.InstanceKey]map[string]cty.Value{}
+	inputVariables := map[string]cty.Value{}
+	localValues := map[string]cty.Value{}
+	pathAttrs := map[string]cty.Value{}
+	terraformAttrs := map[string]cty.Value{}
+	countAttrs := map[string]cty.Value{}
+	var self cty.Value
+
+	for _, ref := range refs {
+		rng := ref.SourceRange
+
+		if ref.Subject == addrs.Self {
+			val, valDiags := normalizeRefValue(s.Data.GetSelf(ref.SourceRange))
+			diags = diags.Append(valDiags)
+			self = val
+			continue
+		}
+
+		// This type switch must cover all of the "Referenceable" implementations
+		// in package addrs.
+		switch subj := ref.Subject.(type) {
+
+		case addrs.ResourceInstance:
+			var into map[string]map[string]map[addrs.InstanceKey]cty.Value
+			switch subj.Resource.Mode {
+			case addrs.ManagedResourceMode:
+				into = managedResources
+			case addrs.DataResourceMode:
+				into = dataResources
+			default:
+				panic(fmt.Errorf("unsupported ResourceMode %s", subj.Resource.Mode))
+			}
+
+			val, valDiags := normalizeRefValue(s.Data.GetResourceInstance(subj, rng))
+			diags = diags.Append(valDiags)
+
+			r := subj.Resource
+			if into[r.Type] == nil {
+				into[r.Type] = make(map[string]map[addrs.InstanceKey]cty.Value)
+			}
+			if into[r.Type][r.Name] == nil {
+				into[r.Type][r.Name] = make(map[addrs.InstanceKey]cty.Value)
+			}
+			into[r.Type][r.Name][subj.Key] = val
+
+		case addrs.ModuleCallInstance:
+			val, valDiags := normalizeRefValue(s.Data.GetModuleInstance(subj, rng))
+			diags = diags.Append(valDiags)
+
+			if wholeModules[subj.Call.Name] == nil {
+				wholeModules[subj.Call.Name] = make(map[addrs.InstanceKey]cty.Value)
+			}
+			wholeModules[subj.Call.Name][subj.Key] = val
+
+		case addrs.ModuleCallOutput:
+			val, valDiags := normalizeRefValue(s.Data.GetModuleInstanceOutput(subj, rng))
+			diags = diags.Append(valDiags)
+
+			callName := subj.Call.Call.Name
+			callKey := subj.Call.Key
+			if moduleOutputs[callName] == nil {
+				moduleOutputs[callName] = make(map[addrs.InstanceKey]map[string]cty.Value)
+			}
+			if moduleOutputs[callName][callKey] == nil {
+				moduleOutputs[callName][callKey] = make(map[string]cty.Value)
+			}
+			moduleOutputs[callName][callKey][subj.Name] = val
+
+		case addrs.InputVariable:
+			val, valDiags := normalizeRefValue(s.Data.GetInputVariable(subj, rng))
+			diags = diags.Append(valDiags)
+			inputVariables[subj.Name] = val
+
+		case addrs.LocalValue:
+			val, valDiags := normalizeRefValue(s.Data.GetLocalValue(subj, rng))
+			diags = diags.Append(valDiags)
+			localValues[subj.Name] = val
+
+		case addrs.PathAttr:
+			val, valDiags := normalizeRefValue(s.Data.GetPathAttr(subj, rng))
+			diags = diags.Append(valDiags)
+			pathAttrs[subj.Name] = val
+
+		case addrs.TerraformAttr:
+			val, valDiags := normalizeRefValue(s.Data.GetTerraformAttr(subj, rng))
+			diags = diags.Append(valDiags)
+			terraformAttrs[subj.Name] = val
+
+		case addrs.CountAttr:
+			val, valDiags := normalizeRefValue(s.Data.GetCountAttr(subj, rng))
+			diags = diags.Append(valDiags)
+			countAttrs[subj.Name] = val
+
+		default:
+			// Should never happen
+			panic(fmt.Errorf("Scope.buildEvalContext cannot handle address type %T", ref.Subject))
+		}
+	}
+
+	for k, v := range buildResourceObjects(managedResources) {
+		vals[k] = v
+	}
+	vals["data"] = cty.ObjectVal(buildResourceObjects(dataResources))
+	vals["module"] = cty.ObjectVal(buildModuleObjects(wholeModules, moduleOutputs))
+	vals["var"] = cty.ObjectVal(inputVariables)
+	vals["local"] = cty.ObjectVal(localValues)
+	vals["path"] = cty.ObjectVal(pathAttrs)
+	vals["terraform"] = cty.ObjectVal(terraformAttrs)
+	vals["count"] = cty.ObjectVal(countAttrs)
+	if self != cty.NilVal {
+		vals["self"] = self
+	}
+
+	return ctx, diags
+}
+
+func buildResourceObjects(resources map[string]map[string]map[addrs.InstanceKey]cty.Value) map[string]cty.Value {
+	vals := make(map[string]cty.Value)
+	for typeName, names := range resources {
+		nameVals := make(map[string]cty.Value)
+		for name, keys := range names {
+			nameVals[name] = buildInstanceObjects(keys)
+		}
+		vals[typeName] = cty.ObjectVal(nameVals)
+	}
+	return vals
+}
+
+func buildModuleObjects(wholeModules map[string]map[addrs.InstanceKey]cty.Value, moduleOutputs map[string]map[addrs.InstanceKey]map[string]cty.Value) map[string]cty.Value {
+	vals := make(map[string]cty.Value)
+
+	for name, keys := range wholeModules {
+		vals[name] = buildInstanceObjects(keys)
+	}
+
+	for name, keys := range moduleOutputs {
+		if _, exists := wholeModules[name]; exists {
+			// If we also have a whole module value for this name then we'll
+			// skip this since the individual outputs are embedded in that result.
+			continue
+		}
+
+		// The shape of this collection isn't compatible with buildInstanceObjects,
+		// but rather than replicating most of the buildInstanceObjects logic
+		// here we'll instead first transform the structure to be what that
+		// function expects and then use it. This is a little wasteful, but
+		// we do not expect this these maps to be large and so the extra work
+		// here should not hurt too much.
+		flattened := make(map[addrs.InstanceKey]cty.Value, len(keys))
+		for k, vals := range keys {
+			flattened[k] = cty.ObjectVal(vals)
+		}
+		vals[name] = buildInstanceObjects(flattened)
+	}
+
+	return vals
+}
+
+func buildInstanceObjects(keys map[addrs.InstanceKey]cty.Value) cty.Value {
+	if val, exists := keys[addrs.NoKey]; exists {
+		// If present, a "no key" value supersedes all other values,
+		// since they should be embedded inside it.
+		return val
+	}
+
+	// If we only have individual values then we need to construct
+	// either a list or a map, depending on what sort of keys we
+	// have.
+	haveInt := false
+	haveString := false
+	maxInt := 0
+
+	for k := range keys {
+		switch tk := k.(type) {
+		case addrs.IntKey:
+			haveInt = true
+			if int(tk) > maxInt {
+				maxInt = int(tk)
+			}
+		case addrs.StringKey:
+			haveString = true
+		}
+	}
+
+	// We should either have ints or strings and not both, but
+	// if we have both then we'll prefer strings and let the
+	// language interpreter try to convert the int keys into
+	// strings in a map.
+	switch {
+	case haveString:
+		vals := make(map[string]cty.Value)
+		for k, v := range keys {
+			switch tk := k.(type) {
+			case addrs.StringKey:
+				vals[string(tk)] = v
+			case addrs.IntKey:
+				sk := strconv.Itoa(int(tk))
+				vals[sk] = v
+			}
+		}
+		return cty.ObjectVal(vals)
+	case haveInt:
+		// We'll make a tuple that is long enough for our maximum
+		// index value. It doesn't matter if we end up shorter than
+		// the number of instances because if length(...) were
+		// being evaluated we would've got a NoKey reference and
+		// thus not ended up in this codepath at all.
+		vals := make([]cty.Value, maxInt+1)
+		for i := range vals {
+			if v, exists := keys[addrs.IntKey(i)]; exists {
+				vals[i] = v
+			} else {
+				// Just a placeholder, since nothing will access this anyway
+				vals[i] = cty.DynamicVal
+			}
+		}
+		return cty.TupleVal(vals)
+	default:
+		// Should never happen because there are no other key types.
+		log.Printf("[ERROR] strange makeInstanceObjects call with no supported key types")
+		return cty.EmptyObjectVal
+	}
+}
+
+func normalizeRefValue(val cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
+	if diags.HasErrors() {
+		// If there are errors then we will force an unknown result so that
+		// we can still evaluate and catch type errors but we'll avoid
+		// producing redundant re-statements of the same errors we've already
+		// dealt with here.
+		return cty.UnknownVal(val.Type()), diags
+	}
+	return val, diags
+}

--- a/lang/eval_test.go
+++ b/lang/eval_test.go
@@ -1,0 +1,524 @@
+package lang
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform/config/configschema"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+func TestScopeEvalContext(t *testing.T) {
+	data := &dataForTests{
+		CountAttrs: map[string]cty.Value{
+			"index": cty.NumberIntVal(0),
+		},
+		ResourceInstances: map[string]cty.Value{
+			"null_resource.foo": cty.ObjectVal(map[string]cty.Value{
+				"attr": cty.StringVal("bar"),
+			}),
+			"data.null_data_source.foo": cty.ObjectVal(map[string]cty.Value{
+				"attr": cty.StringVal("bar"),
+			}),
+			"null_resource.multi": cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"attr": cty.StringVal("multi0"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"attr": cty.StringVal("multi1"),
+				}),
+			}),
+			"null_resource.multi[1]": cty.ObjectVal(map[string]cty.Value{
+				"attr": cty.StringVal("multi1"),
+			}),
+		},
+		LocalValues: map[string]cty.Value{
+			"foo": cty.StringVal("bar"),
+		},
+		Modules: map[string]cty.Value{
+			"module.foo": cty.ObjectVal(map[string]cty.Value{
+				"output0": cty.StringVal("bar0"),
+				"output1": cty.StringVal("bar1"),
+			}),
+		},
+		PathAttrs: map[string]cty.Value{
+			"module": cty.StringVal("foo/bar"),
+		},
+		Self: cty.ObjectVal(map[string]cty.Value{
+			"is_self": cty.True,
+		}),
+		TerraformAttrs: map[string]cty.Value{
+			"workspace": cty.StringVal("default"),
+		},
+		InputVariables: map[string]cty.Value{
+			"baz": cty.StringVal("boop"),
+		},
+	}
+
+	tests := []struct {
+		Expr string
+		Want map[string]cty.Value
+	}{
+		{
+			`12`,
+			map[string]cty.Value{},
+		},
+		{
+			`count.index`,
+			map[string]cty.Value{
+				"count": cty.ObjectVal(map[string]cty.Value{
+					"index": cty.NumberIntVal(0),
+				}),
+			},
+		},
+		{
+			`local.foo`,
+			map[string]cty.Value{
+				"local": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("bar"),
+				}),
+			},
+		},
+		{
+			`null_resource.foo`,
+			map[string]cty.Value{
+				"null_resource": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("bar"),
+					}),
+				}),
+			},
+		},
+		{
+			`null_resource.foo.attr`,
+			map[string]cty.Value{
+				"null_resource": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("bar"),
+					}),
+				}),
+			},
+		},
+		{
+			`null_resource.multi`,
+			map[string]cty.Value{
+				"null_resource": cty.ObjectVal(map[string]cty.Value{
+					"multi": cty.TupleVal([]cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("multi0"),
+						}),
+						cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("multi1"),
+						}),
+					}),
+				}),
+			},
+		},
+		{
+			`null_resource.multi[1]`,
+			map[string]cty.Value{
+				"null_resource": cty.ObjectVal(map[string]cty.Value{
+					"multi": cty.TupleVal([]cty.Value{
+						cty.DynamicVal,
+						cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("multi1"),
+						}),
+					}),
+				}),
+			},
+		},
+		{
+			`foo(null_resource.multi, null_resource.multi[1])`,
+			map[string]cty.Value{
+				"null_resource": cty.ObjectVal(map[string]cty.Value{
+					"multi": cty.TupleVal([]cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("multi0"),
+						}),
+						cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("multi1"),
+						}),
+					}),
+				}),
+			},
+		},
+		{
+			`data.null_data_source.foo`,
+			map[string]cty.Value{
+				"data": cty.ObjectVal(map[string]cty.Value{
+					"null_data_source": cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("bar"),
+						}),
+					}),
+				}),
+			},
+		},
+		{
+			`module.foo`,
+			map[string]cty.Value{
+				"module": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.ObjectVal(map[string]cty.Value{
+						"output0": cty.StringVal("bar0"),
+						"output1": cty.StringVal("bar1"),
+					}),
+				}),
+			},
+		},
+		{
+			`module.foo.output1`,
+			map[string]cty.Value{
+				"module": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.ObjectVal(map[string]cty.Value{
+						"output1": cty.StringVal("bar1"),
+					}),
+				}),
+			},
+		},
+		{
+			`path.module`,
+			map[string]cty.Value{
+				"path": cty.ObjectVal(map[string]cty.Value{
+					"module": cty.StringVal("foo/bar"),
+				}),
+			},
+		},
+		{
+			`self.baz`,
+			map[string]cty.Value{
+				"self": cty.ObjectVal(map[string]cty.Value{
+					"is_self": cty.True,
+				}),
+			},
+		},
+		{
+			`terraform.workspace`,
+			map[string]cty.Value{
+				"terraform": cty.ObjectVal(map[string]cty.Value{
+					"workspace": cty.StringVal("default"),
+				}),
+			},
+		},
+		{
+			`var.baz`,
+			map[string]cty.Value{
+				"var": cty.ObjectVal(map[string]cty.Value{
+					"baz": cty.StringVal("boop"),
+				}),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Expr, func(t *testing.T) {
+			expr, parseDiags := hclsyntax.ParseExpression([]byte(test.Expr), "", hcl.Pos{Line: 1, Column: 1})
+			if len(parseDiags) != 0 {
+				t.Errorf("unexpected diagnostics during parse")
+				for _, diag := range parseDiags {
+					t.Errorf("- %s", diag)
+				}
+				return
+			}
+
+			refs, refsDiags := ReferencesInExpr(expr)
+			if refsDiags.HasErrors() {
+				t.Fatal(refsDiags.Err())
+			}
+
+			scope := &Scope{
+				Data: data,
+			}
+			ctx, ctxDiags := scope.EvalContext(refs)
+			if ctxDiags.HasErrors() {
+				t.Fatal(ctxDiags.Err())
+			}
+
+			// For easier test assertions we'll just remove any top-level
+			// empty objects from our variables map.
+			for k, v := range ctx.Variables {
+				if v.RawEquals(cty.EmptyObjectVal) {
+					delete(ctx.Variables, k)
+				}
+			}
+
+			gotVal := cty.ObjectVal(ctx.Variables)
+			wantVal := cty.ObjectVal(test.Want)
+
+			if !gotVal.RawEquals(wantVal) {
+				// We'll JSON-ize our values here just so it's easier to
+				// read them in the assertion output.
+				gotJSON := formattedJSONValue(gotVal)
+				wantJSON := formattedJSONValue(wantVal)
+
+				t.Errorf(
+					"wrong result\nexpr: %s\ngot:  %s\nwant: %s",
+					test.Expr, gotJSON, wantJSON,
+				)
+			}
+		})
+	}
+}
+
+func TestScopeExpandEvalBlock(t *testing.T) {
+	schema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"foo": {
+				Type: cty.String,
+			},
+		},
+		BlockTypes: map[string]*configschema.NestedBlock{
+			"bar": {
+				Nesting: configschema.NestingMap,
+				Block: configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"baz": {
+							Type: cty.String,
+						},
+					},
+				},
+			},
+		},
+	}
+	data := &dataForTests{
+		LocalValues: map[string]cty.Value{
+			"greeting": cty.StringVal("howdy"),
+			"list": cty.ListVal([]cty.Value{
+				cty.StringVal("elem0"),
+				cty.StringVal("elem1"),
+			}),
+			"map": cty.MapVal(map[string]cty.Value{
+				"key1": cty.StringVal("val1"),
+				"key2": cty.StringVal("val2"),
+			}),
+		},
+	}
+
+	tests := map[string]struct {
+		Config string
+		Want   cty.Value
+	}{
+		"empty": {
+			`
+			`,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(cty.String),
+				"bar": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+					"baz": cty.String,
+				})),
+			}),
+		},
+		"literal attribute": {
+			`
+			foo = "hello"
+			`,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("hello"),
+				"bar": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+					"baz": cty.String,
+				})),
+			}),
+		},
+		"variable attribute": {
+			`
+			foo = local.greeting
+			`,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("howdy"),
+				"bar": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+					"baz": cty.String,
+				})),
+			}),
+		},
+		"one static block": {
+			`
+			bar "static" {}
+			`,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(cty.String),
+				"bar": cty.MapVal(map[string]cty.Value{
+					"static": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+		},
+		"two static blocks": {
+			`
+			bar "static0" {
+				baz = 0
+			}
+			bar "static1" {
+				baz = 1
+			}
+			`,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(cty.String),
+				"bar": cty.MapVal(map[string]cty.Value{
+					"static0": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("0"),
+					}),
+					"static1": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("1"),
+					}),
+				}),
+			}),
+		},
+		"dynamic blocks from list": {
+			`
+			dynamic "bar" {
+				for_each = local.list
+				labels = [bar.value]
+				content {
+					baz = bar.key
+				}
+			}
+			`,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(cty.String),
+				"bar": cty.MapVal(map[string]cty.Value{
+					"elem0": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("0"),
+					}),
+					"elem1": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("1"),
+					}),
+				}),
+			}),
+		},
+		"dynamic blocks from map": {
+			`
+			dynamic "bar" {
+				for_each = local.map
+				labels = [bar.key]
+				content {
+					baz = bar.value
+				}
+			}
+			`,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(cty.String),
+				"bar": cty.MapVal(map[string]cty.Value{
+					"key1": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("val1"),
+					}),
+					"key2": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("val2"),
+					}),
+				}),
+			}),
+		},
+		"everything at once": {
+			`
+			foo = "whoop"
+			bar "static0" {
+				baz = "s0"
+			}
+			dynamic "bar" {
+				for_each = local.list
+				labels = [bar.value]
+				content {
+					baz = bar.key
+				}
+			}
+			bar "static1" {
+				baz = "s1"
+			}
+			dynamic "bar" {
+				for_each = local.map
+				labels = [bar.key]
+				content {
+					baz = bar.value
+				}
+			}
+			bar "static2" {
+				baz = "s2"
+			}
+			`,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("whoop"),
+				"bar": cty.MapVal(map[string]cty.Value{
+					"key1": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("val1"),
+					}),
+					"key2": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("val2"),
+					}),
+					"elem0": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("0"),
+					}),
+					"elem1": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("1"),
+					}),
+					"static0": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("s0"),
+					}),
+					"static1": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("s1"),
+					}),
+					"static2": cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.StringVal("s2"),
+					}),
+				}),
+			}),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			file, parseDiags := hclsyntax.ParseConfig([]byte(test.Config), "", hcl.Pos{Line: 1, Column: 1})
+			if len(parseDiags) != 0 {
+				t.Errorf("unexpected diagnostics during parse")
+				for _, diag := range parseDiags {
+					t.Errorf("- %s", diag)
+				}
+				return
+			}
+
+			body := file.Body
+			scope := &Scope{
+				Data: data,
+			}
+
+			body, expandDiags := scope.ExpandBlock(body, schema)
+			if expandDiags.HasErrors() {
+				t.Fatal(expandDiags.Err())
+			}
+
+			got, valDiags := scope.EvalBlock(body, schema)
+			if valDiags.HasErrors() {
+				t.Fatal(valDiags.Err())
+			}
+
+			if !got.RawEquals(test.Want) {
+				// We'll JSON-ize our values here just so it's easier to
+				// read them in the assertion output.
+				gotJSON := formattedJSONValue(got)
+				wantJSON := formattedJSONValue(test.Want)
+
+				t.Errorf(
+					"wrong result\nconfig: %s\ngot:   %s\nwant:  %s",
+					test.Config, gotJSON, wantJSON,
+				)
+			}
+
+		})
+	}
+
+}
+
+func formattedJSONValue(val cty.Value) string {
+	val = cty.UnknownAsNull(val) // since JSON can't represent unknowns
+	j, err := ctyjson.Marshal(val, val.Type())
+	if err != nil {
+		panic(err)
+	}
+	var buf bytes.Buffer
+	json.Indent(&buf, j, "", "  ")
+	return buf.String()
+}

--- a/lang/functions.go
+++ b/lang/functions.go
@@ -1,0 +1,108 @@
+package lang
+
+import (
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+var impureFunctions = []string{
+	"timestamp",
+	"uuid",
+}
+
+// Functions returns the set of functions that should be used to when evaluating
+// expressions in the receiving scope.
+func (s *Scope) Functions() map[string]function.Function {
+	s.funcsLock.Lock()
+	if s.funcs == nil {
+		s.funcs = map[string]function.Function{
+			"abs":          stdlib.AbsoluteFunc,
+			"basename":     unimplFunc, // TODO
+			"base64decode": unimplFunc, // TODO
+			"base64encode": unimplFunc, // TODO
+			"base64gzip":   unimplFunc, // TODO
+			"base64sha256": unimplFunc, // TODO
+			"base64sha512": unimplFunc, // TODO
+			"bcrypt":       unimplFunc, // TODO
+			"ceil":         unimplFunc, // TODO
+			"chomp":        unimplFunc, // TODO
+			"cidrhost":     unimplFunc, // TODO
+			"cidrnetmask":  unimplFunc, // TODO
+			"cidrsubnet":   unimplFunc, // TODO
+			"coalesce":     stdlib.CoalesceFunc,
+			"coalescelist": unimplFunc, // TODO
+			"compact":      unimplFunc, // TODO
+			"concat":       stdlib.ConcatFunc,
+			"contains":     unimplFunc, // TODO
+			"csvdecode":    stdlib.CSVDecodeFunc,
+			"dirname":      unimplFunc, // TODO
+			"distinct":     unimplFunc, // TODO
+			"element":      unimplFunc, // TODO
+			"chunklist":    unimplFunc, // TODO
+			"file":         unimplFunc, // TODO
+			"matchkeys":    unimplFunc, // TODO
+			"flatten":      unimplFunc, // TODO
+			"floor":        unimplFunc, // TODO
+			"format":       stdlib.FormatFunc,
+			"formatlist":   stdlib.FormatListFunc,
+			"indent":       unimplFunc, // TODO
+			"index":        unimplFunc, // TODO
+			"join":         unimplFunc, // TODO
+			"jsondecode":   stdlib.JSONDecodeFunc,
+			"jsonencode":   stdlib.JSONEncodeFunc,
+			"length":       unimplFunc, // TODO
+			"list":         unimplFunc, // TODO
+			"log":          unimplFunc, // TODO
+			"lower":        stdlib.LowerFunc,
+			"map":          unimplFunc, // TODO
+			"max":          stdlib.MaxFunc,
+			"md5":          unimplFunc, // TODO
+			"merge":        unimplFunc, // TODO
+			"min":          stdlib.MinFunc,
+			"pathexpand":   unimplFunc, // TODO
+			"pow":          unimplFunc, // TODO
+			"replace":      unimplFunc, // TODO
+			"rsadecrypt":   unimplFunc, // TODO
+			"sha1":         unimplFunc, // TODO
+			"sha256":       unimplFunc, // TODO
+			"sha512":       unimplFunc, // TODO
+			"signum":       unimplFunc, // TODO
+			"slice":        unimplFunc, // TODO
+			"sort":         unimplFunc, // TODO
+			"split":        unimplFunc, // TODO
+			"substr":       stdlib.SubstrFunc,
+			"timestamp":    unimplFunc, // TODO
+			"timeadd":      unimplFunc, // TODO
+			"title":        unimplFunc, // TODO
+			"transpose":    unimplFunc, // TODO
+			"trimspace":    unimplFunc, // TODO
+			"upper":        stdlib.UpperFunc,
+			"urlencode":    unimplFunc, // TODO
+			"uuid":         unimplFunc, // TODO
+			"zipmap":       unimplFunc, // TODO
+		}
+
+		if s.PureOnly {
+			// Force our few impure functions to return unknown so that we
+			// can defer evaluating them until a later pass.
+			for _, name := range impureFunctions {
+				s.funcs[name] = function.Unpredictable(s.funcs[name])
+			}
+		}
+	}
+	s.funcsLock.Unlock()
+
+	return s.funcs
+}
+
+var unimplFunc = function.New(&function.Spec{
+	Type: func([]cty.Value) (cty.Type, error) {
+		return cty.DynamicPseudoType, fmt.Errorf("function not yet implemented")
+	},
+	Impl: func([]cty.Value, cty.Type) (cty.Value, error) {
+		return cty.DynamicVal, fmt.Errorf("function not yet implemented")
+	},
+})

--- a/lang/references.go
+++ b/lang/references.go
@@ -1,0 +1,62 @@
+package lang
+
+import (
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcldec"
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/config/configschema"
+	"github.com/hashicorp/terraform/tfdiags"
+)
+
+// References finds all of the references in the given set of traversals,
+// returning diagnostics if any of the traversals cannot be interpreted as a
+// reference.
+//
+// This function does not do any de-duplication of references, since references
+// have source location information embedded in them and so any invalid
+// references that are duplicated should have errors reported for each
+// occurence.
+//
+// If the returned diagnostics contains errors then the result may be
+// incomplete or invalid. Otherwise, the returned slice has one reference per
+// given traversal, though it is not guaranteed that the references will
+// appear in the same order as the given traversals.
+func References(traversals []hcl.Traversal) ([]*addrs.Reference, tfdiags.Diagnostics) {
+	if len(traversals) == 0 {
+		return nil, nil
+	}
+
+	var diags tfdiags.Diagnostics
+	refs := make([]*addrs.Reference, 0, len(traversals))
+
+	for _, traversal := range traversals {
+		ref, refDiags := addrs.ParseRef(traversal)
+		diags = diags.Append(refDiags)
+		if ref == nil {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+
+	return refs, diags
+}
+
+// ReferencesInBlock is a helper wrapper around References that first searches
+// the given body for traversals, before converting those traversals to
+// references.
+//
+// A block schema must be provided so that this function can determine where in
+// the body variables are expected.
+func ReferencesInBlock(body hcl.Body, schema *configschema.Block) ([]*addrs.Reference, tfdiags.Diagnostics) {
+	spec := schema.DecoderSpec()
+	traversals := hcldec.Variables(body, spec)
+	return References(traversals)
+}
+
+// ReferencesInExpr is a helper wrapper around References that first searches
+// the given expression for traversals, before converting those traversals
+// to references.
+func ReferencesInExpr(expr hcl.Expression) ([]*addrs.Reference, tfdiags.Diagnostics) {
+	traversals := expr.Variables()
+	return References(traversals)
+}

--- a/lang/scope.go
+++ b/lang/scope.go
@@ -1,0 +1,28 @@
+package lang
+
+import (
+	"sync"
+
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// Scope is the main type in this package, allowing dynamic evaluation of
+// blocks and expressions based on some contextual information that informs
+// which variables and functions will be available.
+type Scope struct {
+	// Data is used to resolve references in expressions.
+	Data Data
+
+	// BaseDir is the base directory used by any interpolation functions that
+	// accept filesystem paths as arguments.
+	BaseDir string
+
+	// PureOnly can be set to true to request that any non-pure functions
+	// produce unknown value results rather than actually executing. This is
+	// important during a plan phase to avoid generating results that could
+	// then differ during apply.
+	PureOnly bool
+
+	funcs     map[string]function.Function
+	funcsLock sync.Mutex
+}

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/README.md
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/README.md
@@ -1,0 +1,184 @@
+# HCL Dynamic Blocks Extension
+
+This HCL extension implements a special block type named "dynamic" that can
+be used to dynamically generate blocks of other types by iterating over
+collection values.
+
+Normally the block structure in an HCL configuration file is rigid, even
+though dynamic expressions can be used within attribute values. This is
+convenient for most applications since it allows the overall structure of
+the document to be decoded easily, but in some applications it is desirable
+to allow dynamic block generation within certain portions of the configuration.
+
+Dynamic block generation is performed using the `dynamic` block type:
+
+```hcl
+toplevel {
+  nested {
+    foo = "static block 1"
+  }
+
+  dynamic "nested" {
+    for_each = ["a", "b", "c"]
+    iterator = nested
+    content {
+      foo = "dynamic block ${nested.value}"
+    }
+  }
+
+  nested {
+    foo = "static block 2"
+  }
+}
+```
+
+The above is interpreted as if it were written as follows:
+
+```hcl
+toplevel {
+  nested {
+    foo = "static block 1"
+  }
+
+  nested {
+    foo = "dynamic block a"
+  }
+
+  nested {
+    foo = "dynamic block b"
+  }
+
+  nested {
+    foo = "dynamic block c"
+  }
+
+  nested {
+    foo = "static block 2"
+  }
+}
+```
+
+Since HCL block syntax is not normally exposed to the possibility of unknown
+values, this extension must make some compromises when asked to iterate over
+an unknown collection. If the length of the collection cannot be statically
+recognized (because it is an unknown value of list, map, or set type) then
+the `dynamic` construct will generate a _single_ dynamic block whose iterator
+key and value are both unknown values of the dynamic pseudo-type, thus causing
+any attribute values derived from iteration to appear as unknown values. There
+is no explicit representation of the fact that the length of the collection may
+eventually be different than one.
+
+## Usage
+
+Pass a body to function `Expand` to obtain a new body that will, on access
+to its content, evaluate and expand any nested `dynamic` blocks.
+Dynamic block processing is also automatically propagated into any nested
+blocks that are returned, allowing users to nest dynamic blocks inside
+one another and to nest dynamic blocks inside other static blocks.
+
+HCL structural decoding does not normally have access to an `EvalContext`, so
+any variables and functions that should be available to the `for_each`
+and `labels` expressions must be passed in when calling `Expand`. Expressions
+within the `content` block are evaluated separately and so can be passed a
+separate `EvalContext` if desired, during normal attribute expression
+evaluation.
+
+## Detecting Variables
+
+Some applications dynamically generate an `EvalContext` by analyzing which
+variables are referenced by an expression before evaluating it.
+
+This unfortunately requires some extra effort when this analysis is required
+for the context passed to `Expand`: the HCL API requires a schema to be
+provided in order to do any analysis of the blocks in a body, but the low-level
+schema model provides a description of only one level of nested blocks at
+a time, and thus a new schema must be provided for each additional level of
+nesting.
+
+To make this arduous process as convenient as possbile, this package provides
+a helper function `WalkForEachVariables`, which returns a `WalkVariablesNode`
+instance that can be used to find variables directly in a given body and also
+determine which nested blocks require recursive calls. Using this mechanism
+requires that the caller be able to look up a schema given a nested block type.
+For _simple_ formats where a specific block type name always has the same schema
+regardless of context, a walk can be implemented as follows:
+
+```go
+func walkVariables(node dynblock.WalkVariablesNode, schema *hcl.BodySchema) []hcl.Traversal {
+	vars, children := node.Visit(schema)
+
+	for _, child := range children {
+		var childSchema *hcl.BodySchema
+		switch child.BlockTypeName {
+		case "a":
+			childSchema = &hcl.BodySchema{
+				Blocks: []hcl.BlockHeaderSchema{
+					{
+						Type:       "b",
+						LabelNames: []string{"key"},
+					},
+				},
+			}
+		case "b":
+			childSchema = &hcl.BodySchema{
+				Attributes: []hcl.AttributeSchema{
+					{
+						Name:     "val",
+						Required: true,
+					},
+				},
+			}
+		default:
+			// Should never happen, because the above cases should be exhaustive
+			// for the application's configuration format.
+			panic(fmt.Errorf("can't find schema for unknown block type %q", child.BlockTypeName))
+		}
+
+		vars = append(vars, testWalkAndAccumVars(child.Node, childSchema)...)
+	}
+}
+```
+
+### Detecting Variables with `hcldec` Specifications
+
+For applications that use the higher-level `hcldec` package to decode nested
+configuration structures into `cty` values, the same specification can be used
+to automatically drive the recursive variable-detection walk described above.
+
+The helper function `ForEachVariablesHCLDec` allows an entire recursive
+configuration structure to be analyzed in a single call given a `hcldec.Spec`
+that describes the nested block structure. This means a `hcldec`-based
+application can support dynamic blocks with only a little additional effort:
+
+```go
+func decodeBody(body hcl.Body, spec hcldec.Spec) (cty.Value, hcl.Diagnostics) {
+	// Determine which variables are needed to expand dynamic blocks
+	neededForDynamic := dynblock.ForEachVariablesHCLDec(body, spec)
+
+	// Build a suitable EvalContext and expand dynamic blocks
+	dynCtx := buildEvalContext(neededForDynamic)
+	dynBody := dynblock.Expand(body, dynCtx)
+
+	// Determine which variables are needed to fully decode the expanded body
+	// This will analyze expressions that came both from static blocks in the
+	// original body and from blocks that were dynamically added by Expand.
+	neededForDecode := hcldec.Variables(dynBody, spec)
+
+	// Build a suitable EvalContext and then fully decode the body as per the
+	// hcldec specification.
+	decCtx := buildEvalContext(neededForDecode)
+	return hcldec.Decode(dynBody, spec, decCtx)
+}
+
+func buildEvalContext(needed []hcl.Traversal) *hcl.EvalContext {
+	// (to be implemented by your application)
+}
+```
+
+# Performance
+
+This extension is going quite harshly against the grain of the HCL API, and
+so it uses lots of wrapping objects and temporary data structures to get its
+work done. HCL in general is not suitable for use in high-performance situations
+or situations sensitive to memory pressure, but that is _especially_ true for
+this extension.

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/expand_body.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/expand_body.go
@@ -1,0 +1,251 @@
+package dynblock
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// expandBody wraps another hcl.Body and expands any "dynamic" blocks found
+// inside whenever Content or PartialContent is called.
+type expandBody struct {
+	original   hcl.Body
+	forEachCtx *hcl.EvalContext
+	iteration  *iteration // non-nil if we're nested inside another "dynamic" block
+
+	// These are used with PartialContent to produce a "remaining items"
+	// body to return. They are nil on all bodies fresh out of the transformer.
+	//
+	// Note that this is re-implemented here rather than delegating to the
+	// existing support required by the underlying body because we need to
+	// retain access to the entire original body on subsequent decode operations
+	// so we can retain any "dynamic" blocks for types we didn't take consume
+	// on the first pass.
+	hiddenAttrs  map[string]struct{}
+	hiddenBlocks map[string]hcl.BlockHeaderSchema
+}
+
+func (b *expandBody) Content(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Diagnostics) {
+	extSchema := b.extendSchema(schema)
+	rawContent, diags := b.original.Content(extSchema)
+
+	blocks, blockDiags := b.expandBlocks(schema, rawContent.Blocks, false)
+	diags = append(diags, blockDiags...)
+	attrs := b.prepareAttributes(rawContent.Attributes)
+
+	content := &hcl.BodyContent{
+		Attributes:       attrs,
+		Blocks:           blocks,
+		MissingItemRange: b.original.MissingItemRange(),
+	}
+
+	return content, diags
+}
+
+func (b *expandBody) PartialContent(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Body, hcl.Diagnostics) {
+	extSchema := b.extendSchema(schema)
+	rawContent, _, diags := b.original.PartialContent(extSchema)
+	// We discard the "remain" argument above because we're going to construct
+	// our own remain that also takes into account remaining "dynamic" blocks.
+
+	blocks, blockDiags := b.expandBlocks(schema, rawContent.Blocks, true)
+	diags = append(diags, blockDiags...)
+	attrs := b.prepareAttributes(rawContent.Attributes)
+
+	content := &hcl.BodyContent{
+		Attributes:       attrs,
+		Blocks:           blocks,
+		MissingItemRange: b.original.MissingItemRange(),
+	}
+
+	remain := &expandBody{
+		original:     b.original,
+		forEachCtx:   b.forEachCtx,
+		iteration:    b.iteration,
+		hiddenAttrs:  make(map[string]struct{}),
+		hiddenBlocks: make(map[string]hcl.BlockHeaderSchema),
+	}
+	for name := range b.hiddenAttrs {
+		remain.hiddenAttrs[name] = struct{}{}
+	}
+	for typeName, blockS := range b.hiddenBlocks {
+		remain.hiddenBlocks[typeName] = blockS
+	}
+	for _, attrS := range schema.Attributes {
+		remain.hiddenAttrs[attrS.Name] = struct{}{}
+	}
+	for _, blockS := range schema.Blocks {
+		remain.hiddenBlocks[blockS.Type] = blockS
+	}
+
+	return content, remain, diags
+}
+
+func (b *expandBody) extendSchema(schema *hcl.BodySchema) *hcl.BodySchema {
+	// We augment the requested schema to also include our special "dynamic"
+	// block type, since then we'll get instances of it interleaved with
+	// all of the literal child blocks we must also include.
+	extSchema := &hcl.BodySchema{
+		Attributes: schema.Attributes,
+		Blocks:     make([]hcl.BlockHeaderSchema, len(schema.Blocks), len(schema.Blocks)+len(b.hiddenBlocks)+1),
+	}
+	copy(extSchema.Blocks, schema.Blocks)
+	extSchema.Blocks = append(extSchema.Blocks, dynamicBlockHeaderSchema)
+
+	// If we have any hiddenBlocks then we also need to register those here
+	// so that a call to "Content" on the underlying body won't fail.
+	// (We'll filter these out again once we process the result of either
+	// Content or PartialContent.)
+	for _, blockS := range b.hiddenBlocks {
+		extSchema.Blocks = append(extSchema.Blocks, blockS)
+	}
+
+	// If we have any hiddenAttrs then we also need to register these, for
+	// the same reason as we deal with hiddenBlocks above.
+	if len(b.hiddenAttrs) != 0 {
+		newAttrs := make([]hcl.AttributeSchema, len(schema.Attributes), len(schema.Attributes)+len(b.hiddenAttrs))
+		copy(newAttrs, extSchema.Attributes)
+		for name := range b.hiddenAttrs {
+			newAttrs = append(newAttrs, hcl.AttributeSchema{
+				Name:     name,
+				Required: false,
+			})
+		}
+		extSchema.Attributes = newAttrs
+	}
+
+	return extSchema
+}
+
+func (b *expandBody) prepareAttributes(rawAttrs hcl.Attributes) hcl.Attributes {
+	if len(b.hiddenAttrs) == 0 && b.iteration == nil {
+		// Easy path: just pass through the attrs from the original body verbatim
+		return rawAttrs
+	}
+
+	// Otherwise we have some work to do: we must filter out any attributes
+	// that are hidden (since a previous PartialContent call already saw these)
+	// and wrap the expressions of the inner attributes so that they will
+	// have access to our iteration variables.
+	attrs := make(hcl.Attributes, len(rawAttrs))
+	for name, rawAttr := range rawAttrs {
+		if _, hidden := b.hiddenAttrs[name]; hidden {
+			continue
+		}
+		if b.iteration != nil {
+			attr := *rawAttr // shallow copy so we can mutate it
+			attr.Expr = exprWrap{
+				Expression: attr.Expr,
+				i:          b.iteration,
+			}
+			attrs[name] = &attr
+		} else {
+			// If we have no active iteration then no wrapping is required.
+			attrs[name] = rawAttr
+		}
+	}
+	return attrs
+}
+
+func (b *expandBody) expandBlocks(schema *hcl.BodySchema, rawBlocks hcl.Blocks, partial bool) (hcl.Blocks, hcl.Diagnostics) {
+	var blocks hcl.Blocks
+	var diags hcl.Diagnostics
+
+	for _, rawBlock := range rawBlocks {
+		switch rawBlock.Type {
+		case "dynamic":
+			realBlockType := rawBlock.Labels[0]
+			if _, hidden := b.hiddenBlocks[realBlockType]; hidden {
+				continue
+			}
+
+			var blockS *hcl.BlockHeaderSchema
+			for _, candidate := range schema.Blocks {
+				if candidate.Type == realBlockType {
+					blockS = &candidate
+					break
+				}
+			}
+			if blockS == nil {
+				// Not a block type that the caller requested.
+				if !partial {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Unsupported block type",
+						Detail:   fmt.Sprintf("Blocks of type %q are not expected here.", realBlockType),
+						Subject:  &rawBlock.LabelRanges[0],
+					})
+				}
+				continue
+			}
+
+			spec, specDiags := b.decodeSpec(blockS, rawBlock)
+			diags = append(diags, specDiags...)
+			if specDiags.HasErrors() {
+				continue
+			}
+
+			if spec.forEachVal.IsKnown() {
+				for it := spec.forEachVal.ElementIterator(); it.Next(); {
+					key, value := it.Element()
+					i := b.iteration.MakeChild(spec.iteratorName, key, value)
+
+					block, blockDiags := spec.newBlock(i, b.forEachCtx)
+					diags = append(diags, blockDiags...)
+					if block != nil {
+						// Attach our new iteration context so that attributes
+						// and other nested blocks can refer to our iterator.
+						block.Body = b.expandChild(block.Body, i)
+						blocks = append(blocks, block)
+					}
+				}
+			} else {
+				// If our top-level iteration value isn't known then we're forced
+				// to compromise since HCL doesn't have any concept of an
+				// "unknown block". In this case then, we'll produce a single
+				// dynamic block with the iterator values set to DynamicVal,
+				// which at least makes the potential for a block visible
+				// in our result, even though it's not represented in a fully-accurate
+				// way.
+				i := b.iteration.MakeChild(spec.iteratorName, cty.DynamicVal, cty.DynamicVal)
+				block, blockDiags := spec.newBlock(i, b.forEachCtx)
+				diags = append(diags, blockDiags...)
+				if block != nil {
+					block.Body = b.expandChild(block.Body, i)
+					blocks = append(blocks, block)
+				}
+			}
+
+		default:
+			if _, hidden := b.hiddenBlocks[rawBlock.Type]; !hidden {
+				// A static block doesn't create a new iteration context, but
+				// it does need to inherit _our own_ iteration context in
+				// case it contains expressions that refer to our inherited
+				// iterators, or nested "dynamic" blocks.
+				expandedBlock := *rawBlock // shallow copy
+				expandedBlock.Body = b.expandChild(rawBlock.Body, b.iteration)
+				blocks = append(blocks, &expandedBlock)
+			}
+		}
+	}
+
+	return blocks, diags
+}
+
+func (b *expandBody) expandChild(child hcl.Body, i *iteration) hcl.Body {
+	ret := Expand(child, b.forEachCtx)
+	ret.(*expandBody).iteration = i
+	return ret
+}
+
+func (b *expandBody) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
+	// blocks aren't allowed in JustAttributes mode and this body can
+	// only produce blocks, so we'll just pass straight through to our
+	// underlying body here.
+	return b.original.JustAttributes()
+}
+
+func (b *expandBody) MissingItemRange() hcl.Range {
+	return b.original.MissingItemRange()
+}

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/expand_spec.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/expand_spec.go
@@ -1,0 +1,202 @@
+package dynblock
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+type expandSpec struct {
+	blockType      string
+	blockTypeRange hcl.Range
+	defRange       hcl.Range
+	forEachVal     cty.Value
+	iteratorName   string
+	labelExprs     []hcl.Expression
+	contentBody    hcl.Body
+	inherited      map[string]*iteration
+}
+
+func (b *expandBody) decodeSpec(blockS *hcl.BlockHeaderSchema, rawSpec *hcl.Block) (*expandSpec, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
+	var schema *hcl.BodySchema
+	if len(blockS.LabelNames) != 0 {
+		schema = dynamicBlockBodySchemaLabels
+	} else {
+		schema = dynamicBlockBodySchemaNoLabels
+	}
+
+	specContent, specDiags := rawSpec.Body.Content(schema)
+	diags = append(diags, specDiags...)
+	if specDiags.HasErrors() {
+		return nil, diags
+	}
+
+	//// for_each attribute
+
+	eachAttr := specContent.Attributes["for_each"]
+	eachVal, eachDiags := eachAttr.Expr.Value(b.forEachCtx)
+	diags = append(diags, eachDiags...)
+
+	if !eachVal.CanIterateElements() {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid dynamic for_each value",
+			Detail:   fmt.Sprintf("Cannot use a value of type %s in for_each. An iterable collection is required.", eachVal.Type()),
+			Subject:  eachAttr.Expr.Range().Ptr(),
+		})
+		return nil, diags
+	}
+	if eachVal.IsNull() {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid dynamic for_each value",
+			Detail:   "Cannot use a null value in for_each.",
+			Subject:  eachAttr.Expr.Range().Ptr(),
+		})
+		return nil, diags
+	}
+
+	//// iterator attribute
+
+	iteratorName := blockS.Type
+	if iteratorAttr := specContent.Attributes["iterator"]; iteratorAttr != nil {
+		itTraversal, itDiags := hcl.AbsTraversalForExpr(iteratorAttr.Expr)
+		diags = append(diags, itDiags...)
+		if itDiags.HasErrors() {
+			return nil, diags
+		}
+
+		if len(itTraversal) != 1 {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid dynamic iterator name",
+				Detail:   "Dynamic iterator must be a single variable name.",
+				Subject:  itTraversal.SourceRange().Ptr(),
+			})
+			return nil, diags
+		}
+
+		iteratorName = itTraversal.RootName()
+	}
+
+	var labelExprs []hcl.Expression
+	if labelsAttr := specContent.Attributes["labels"]; labelsAttr != nil {
+		var labelDiags hcl.Diagnostics
+		labelExprs, labelDiags = hcl.ExprList(labelsAttr.Expr)
+		diags = append(diags, labelDiags...)
+		if labelDiags.HasErrors() {
+			return nil, diags
+		}
+
+		if len(labelExprs) > len(blockS.LabelNames) {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Extraneous dynamic block label",
+				Detail:   fmt.Sprintf("Blocks of type %q require %d label(s).", blockS.Type, len(blockS.LabelNames)),
+				Subject:  labelExprs[len(blockS.LabelNames)].Range().Ptr(),
+			})
+			return nil, diags
+		} else if len(labelExprs) < len(blockS.LabelNames) {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Insufficient dynamic block labels",
+				Detail:   fmt.Sprintf("Blocks of type %q require %d label(s).", blockS.Type, len(blockS.LabelNames)),
+				Subject:  labelsAttr.Expr.Range().Ptr(),
+			})
+			return nil, diags
+		}
+	}
+
+	// Since our schema requests only blocks of type "content", we can assume
+	// that all entries in specContent.Blocks are content blocks.
+	if len(specContent.Blocks) == 0 {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Missing dynamic content block",
+			Detail:   "A dynamic block must have a nested block of type \"content\" to describe the body of each generated block.",
+			Subject:  &specContent.MissingItemRange,
+		})
+		return nil, diags
+	}
+	if len(specContent.Blocks) > 1 {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Extraneous dynamic content block",
+			Detail:   "Only one nested content block is allowed for each dynamic block.",
+			Subject:  &specContent.Blocks[1].DefRange,
+		})
+		return nil, diags
+	}
+
+	return &expandSpec{
+		blockType:      blockS.Type,
+		blockTypeRange: rawSpec.LabelRanges[0],
+		defRange:       rawSpec.DefRange,
+		forEachVal:     eachVal,
+		iteratorName:   iteratorName,
+		labelExprs:     labelExprs,
+		contentBody:    specContent.Blocks[0].Body,
+	}, diags
+}
+
+func (s *expandSpec) newBlock(i *iteration, ctx *hcl.EvalContext) (*hcl.Block, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	var labels []string
+	var labelRanges []hcl.Range
+	lCtx := i.EvalContext(ctx)
+	for _, labelExpr := range s.labelExprs {
+		labelVal, labelDiags := labelExpr.Value(lCtx)
+		diags = append(diags, labelDiags...)
+		if labelDiags.HasErrors() {
+			return nil, diags
+		}
+
+		var convErr error
+		labelVal, convErr = convert.Convert(labelVal, cty.String)
+		if convErr != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid dynamic block label",
+				Detail:   fmt.Sprintf("Cannot use this value as a dynamic block label: %s.", convErr),
+				Subject:  labelExpr.Range().Ptr(),
+			})
+			return nil, diags
+		}
+		if labelVal.IsNull() {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid dynamic block label",
+				Detail:   "Cannot use a null value as a dynamic block label.",
+				Subject:  labelExpr.Range().Ptr(),
+			})
+			return nil, diags
+		}
+		if !labelVal.IsKnown() {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid dynamic block label",
+				Detail:   "This value is not yet known. Dynamic block labels must be immediately-known values.",
+				Subject:  labelExpr.Range().Ptr(),
+			})
+			return nil, diags
+		}
+
+		labels = append(labels, labelVal.AsString())
+		labelRanges = append(labelRanges, labelExpr.Range())
+	}
+
+	block := &hcl.Block{
+		Type:        s.blockType,
+		TypeRange:   s.blockTypeRange,
+		Labels:      labels,
+		LabelRanges: labelRanges,
+		DefRange:    s.defRange,
+		Body:        s.contentBody,
+	}
+
+	return block, diags
+}

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/expr_wrap.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/expr_wrap.go
@@ -1,0 +1,42 @@
+package dynblock
+
+import (
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type exprWrap struct {
+	hcl.Expression
+	i *iteration
+}
+
+func (e exprWrap) Variables() []hcl.Traversal {
+	raw := e.Expression.Variables()
+	ret := make([]hcl.Traversal, 0, len(raw))
+
+	// Filter out traversals that refer to our iterator name or any
+	// iterator we've inherited; we're going to provide those in
+	// our Value wrapper, so the caller doesn't need to know about them.
+	for _, traversal := range raw {
+		rootName := traversal.RootName()
+		if rootName == e.i.IteratorName {
+			continue
+		}
+		if _, inherited := e.i.Inherited[rootName]; inherited {
+			continue
+		}
+		ret = append(ret, traversal)
+	}
+	return ret
+}
+
+func (e exprWrap) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+	extCtx := e.i.EvalContext(ctx)
+	return e.Expression.Value(extCtx)
+}
+
+// UnwrapExpression returns the expression being wrapped by this instance.
+// This allows the original expression to be recovered by hcl.UnwrapExpression.
+func (e exprWrap) UnwrapExpression() hcl.Expression {
+	return e.Expression
+}

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/iteration.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/iteration.go
@@ -1,0 +1,64 @@
+package dynblock
+
+import (
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type iteration struct {
+	IteratorName string
+	Key          cty.Value
+	Value        cty.Value
+	Inherited    map[string]*iteration
+}
+
+func (s *expandSpec) MakeIteration(key, value cty.Value) *iteration {
+	return &iteration{
+		IteratorName: s.iteratorName,
+		Key:          key,
+		Value:        value,
+		Inherited:    s.inherited,
+	}
+}
+
+func (i *iteration) Object() cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"key":   i.Key,
+		"value": i.Value,
+	})
+}
+
+func (i *iteration) EvalContext(base *hcl.EvalContext) *hcl.EvalContext {
+	new := base.NewChild()
+	new.Variables = map[string]cty.Value{}
+
+	for name, otherIt := range i.Inherited {
+		new.Variables[name] = otherIt.Object()
+	}
+	new.Variables[i.IteratorName] = i.Object()
+
+	return new
+}
+
+func (i *iteration) MakeChild(iteratorName string, key, value cty.Value) *iteration {
+	if i == nil {
+		// Create entirely new root iteration, then
+		return &iteration{
+			IteratorName: iteratorName,
+			Key:          key,
+			Value:        value,
+		}
+	}
+
+	inherited := map[string]*iteration{}
+	for name, otherIt := range i.Inherited {
+		inherited[name] = otherIt
+	}
+	inherited[i.IteratorName] = i
+	return &iteration{
+		IteratorName: iteratorName,
+		Key:          key,
+		Value:        value,
+		Inherited:    inherited,
+	}
+}

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/public.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/public.go
@@ -1,0 +1,44 @@
+package dynblock
+
+import (
+	"github.com/hashicorp/hcl2/hcl"
+)
+
+// Expand "dynamic" blocks in the given body, returning a new body that
+// has those blocks expanded.
+//
+// The given EvalContext is used when evaluating "for_each" and "labels"
+// attributes within dynamic blocks, allowing those expressions access to
+// variables and functions beyond the iterator variable created by the
+// iteration.
+//
+// Expand returns no diagnostics because no blocks are actually expanded
+// until a call to Content or PartialContent on the returned body, which
+// will then expand only the blocks selected by the schema.
+//
+// "dynamic" blocks are also expanded automatically within nested blocks
+// in the given body, including within other dynamic blocks, thus allowing
+// multi-dimensional iteration. However, it is not possible to
+// dynamically-generate the "dynamic" blocks themselves except through nesting.
+//
+//     parent {
+//       dynamic "child" {
+//         for_each = child_objs
+//         content {
+//           dynamic "grandchild" {
+//             for_each = child.value.children
+//             labels   = [grandchild.key]
+//             content {
+//               parent_key = child.key
+//               value      = grandchild.value
+//             }
+//           }
+//         }
+//       }
+//     }
+func Expand(body hcl.Body, ctx *hcl.EvalContext) hcl.Body {
+	return &expandBody{
+		original:   body,
+		forEachCtx: ctx,
+	}
+}

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/schema.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/schema.go
@@ -1,0 +1,50 @@
+package dynblock
+
+import "github.com/hashicorp/hcl2/hcl"
+
+var dynamicBlockHeaderSchema = hcl.BlockHeaderSchema{
+	Type:       "dynamic",
+	LabelNames: []string{"type"},
+}
+
+var dynamicBlockBodySchemaLabels = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name:     "for_each",
+			Required: true,
+		},
+		{
+			Name:     "iterator",
+			Required: false,
+		},
+		{
+			Name:     "labels",
+			Required: true,
+		},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type:       "content",
+			LabelNames: nil,
+		},
+	},
+}
+
+var dynamicBlockBodySchemaNoLabels = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name:     "for_each",
+			Required: true,
+		},
+		{
+			Name:     "iterator",
+			Required: false,
+		},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type:       "content",
+			LabelNames: nil,
+		},
+	},
+}

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/variables.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/variables.go
@@ -1,0 +1,165 @@
+package dynblock
+
+import (
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// WalkVariables begins the recursive process of walking the variables in the
+// given body that are needed by any "for_each" or "labels" attributes in
+// "dynamic" blocks. The result is a WalkVariablesNode, which can extract
+// root-level variable traversals and produce a list of child nodes that
+// also need to be processed by calling Visit.
+//
+// This function requires that the caller walk through the nested block
+// structure in the given body level-by-level so that an appropriate schema
+// can be provided at each level to inform further processing. This workflow
+// is thus easiest to use for calling applications that have some higher-level
+// schema representation available with which to drive this multi-step
+// process.
+func WalkForEachVariables(body hcl.Body) WalkVariablesNode {
+	return WalkVariablesNode{
+		body: body,
+	}
+}
+
+type WalkVariablesNode struct {
+	body hcl.Body
+	it   *iteration
+}
+
+type WalkVariablesChild struct {
+	BlockTypeName string
+	Node          WalkVariablesNode
+}
+
+// Visit returns the variable traversals required for any "dynamic" blocks
+// directly in the body associated with this node, and also returns any child
+// nodes that must be visited in order to continue the walk.
+//
+// Each child node has its associated block type name given in its BlockTypeName
+// field, which the calling application should use to determine the appropriate
+// schema for the content of each child node and pass it to the child node's
+// own Visit method to continue the walk recursively.
+func (n WalkVariablesNode) Visit(schema *hcl.BodySchema) (vars []hcl.Traversal, children []WalkVariablesChild) {
+	extSchema := n.extendSchema(schema)
+	container, _, _ := n.body.PartialContent(extSchema)
+	if container == nil {
+		return vars, children
+	}
+
+	children = make([]WalkVariablesChild, 0, len(container.Blocks))
+
+	for _, block := range container.Blocks {
+		switch block.Type {
+
+		case "dynamic":
+			blockTypeName := block.Labels[0]
+			inner, _, _ := block.Body.PartialContent(variableDetectionInnerSchema)
+			if inner == nil {
+				continue
+			}
+
+			iteratorName := blockTypeName
+			if attr, exists := inner.Attributes["iterator"]; exists {
+				iterTraversal, _ := hcl.AbsTraversalForExpr(attr.Expr)
+				if len(iterTraversal) == 0 {
+					// Ignore this invalid dynamic block, since it'll produce
+					// an error if someone tries to extract content from it
+					// later anyway.
+					continue
+				}
+				iteratorName = iterTraversal.RootName()
+			}
+			blockIt := n.it.MakeChild(iteratorName, cty.DynamicVal, cty.DynamicVal)
+
+			if attr, exists := inner.Attributes["for_each"]; exists {
+				// Filter out iterator names inherited from parent blocks
+				for _, traversal := range attr.Expr.Variables() {
+					if _, inherited := blockIt.Inherited[traversal.RootName()]; !inherited {
+						vars = append(vars, traversal)
+					}
+				}
+			}
+			if attr, exists := inner.Attributes["labels"]; exists {
+				// Filter out both our own iterator name _and_ those inherited
+				// from parent blocks, since we provide _both_ of these to the
+				// label expressions.
+				for _, traversal := range attr.Expr.Variables() {
+					ours := traversal.RootName() == iteratorName
+					_, inherited := blockIt.Inherited[traversal.RootName()]
+
+					if !(ours || inherited) {
+						vars = append(vars, traversal)
+					}
+				}
+			}
+
+			for _, contentBlock := range inner.Blocks {
+				// We only request "content" blocks in our schema, so we know
+				// any blocks we find here will be content blocks. We require
+				// exactly one content block for actual expansion, but we'll
+				// be more liberal here so that callers can still collect
+				// variables from erroneous "dynamic" blocks.
+				children = append(children, WalkVariablesChild{
+					BlockTypeName: blockTypeName,
+					Node: WalkVariablesNode{
+						body: contentBlock.Body,
+						it:   blockIt,
+					},
+				})
+			}
+
+		default:
+			children = append(children, WalkVariablesChild{
+				BlockTypeName: block.Type,
+				Node: WalkVariablesNode{
+					body: block.Body,
+					it:   n.it,
+				},
+			})
+
+		}
+	}
+
+	return vars, children
+}
+
+func (n WalkVariablesNode) extendSchema(schema *hcl.BodySchema) *hcl.BodySchema {
+	// We augment the requested schema to also include our special "dynamic"
+	// block type, since then we'll get instances of it interleaved with
+	// all of the literal child blocks we must also include.
+	extSchema := &hcl.BodySchema{
+		Attributes: schema.Attributes,
+		Blocks:     make([]hcl.BlockHeaderSchema, len(schema.Blocks), len(schema.Blocks)+1),
+	}
+	copy(extSchema.Blocks, schema.Blocks)
+	extSchema.Blocks = append(extSchema.Blocks, dynamicBlockHeaderSchema)
+
+	return extSchema
+}
+
+// This is a more relaxed schema than what's in schema.go, since we
+// want to maximize the amount of variables we can find even if there
+// are erroneous blocks.
+var variableDetectionInnerSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name:     "for_each",
+			Required: false,
+		},
+		{
+			Name:     "labels",
+			Required: false,
+		},
+		{
+			Name:     "iterator",
+			Required: false,
+		},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type: "content",
+		},
+	},
+}

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/variables_hcldec.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/variables_hcldec.go
@@ -1,0 +1,33 @@
+package dynblock
+
+import (
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcldec"
+)
+
+// ForEachVariablesHCLDec is a wrapper around WalkForEachVariables that
+// uses the given hcldec specification to automatically drive the recursive
+// walk through nested blocks in the given body.
+//
+// This provides more convenient access to all of the "for_each" and "labels"
+// dependencies in a body for applications that are already using hcldec
+// as a more convenient way to recursively decode body contents.
+func ForEachVariablesHCLDec(body hcl.Body, spec hcldec.Spec) []hcl.Traversal {
+	rootNode := WalkForEachVariables(body)
+	return walkVariablesWithHCLDec(rootNode, spec)
+}
+
+func walkVariablesWithHCLDec(node WalkVariablesNode, spec hcldec.Spec) []hcl.Traversal {
+	vars, children := node.Visit(hcldec.ImpliedSchema(spec))
+
+	if len(children) > 0 {
+		childSpecs := hcldec.ChildBlockTypes(spec)
+		for _, child := range children {
+			if childSpec, exists := childSpecs[child.BlockTypeName]; exists {
+				vars = append(vars, walkVariablesWithHCLDec(child.Node, childSpec)...)
+			}
+		}
+	}
+
+	return vars
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1717,6 +1717,12 @@
 			"revisionTime": "2017-05-04T19:02:34Z"
 		},
 		{
+			"checksumSHA1": "dJPromzLdd492RQjE/09klKRXGs=",
+			"path": "github.com/hashicorp/hcl2/ext/dynblock",
+			"revision": "5f8ed954abd873b2c09616ba0aa607892bbca7e9",
+			"revisionTime": "2018-03-08T16:30:58Z"
+		},
+		{
 			"checksumSHA1": "Tpj2tK/XrhxbIKB5xEJlfTI46M0=",
 			"path": "github.com/hashicorp/hcl2/ext/typeexpr",
 			"revision": "5f8ed954abd873b2c09616ba0aa607892bbca7e9",


### PR DESCRIPTION
Whereas package `configs` deals with the static structure of the configuration language, this new package `lang` deals with the dynamic aspects such as expression evaluation.

So far this mainly consists of populating a `hcl.EvalContext` that contains the values necessary to evaluate a block or an expression. There is also special handling here for dynamic block generation using the HCL `dynblock` extension, which is exposed in the public interface (rather than hiding it as an implementation detail of `EvalBlock`) so that the caller can then extract proper source locations for any result values using the expanded body.

This also includes the beginnings of a replacement for the function table handling that currently lives in the old "config" package, but most of the functions are not yet ported and so this will expand in subsequent commits.

(This name `lang` is also a bit of a callback to early Terraform, since the interpolation language used to live in a package here called `lang` before it was broken out into the separate library HIL. The scope of this new package is a little different than the old `lang`, since it incorporates some functionality that currently lives in the `terraform` package, but it is perhaps a spiritual successor.)
