### PR TITLE
Add required DynamoDB IAM permissions for state locking to S3 backend docs

### DIFF
--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -199,7 +199,7 @@ Your administrative AWS account will contain at least the following items:
   workspace.
 
 Provide the S3 bucket name and DynamoDB table name to Terraform within the
-S3 backend configuration using the `bucket` and `lock_table` arguments
+S3 backend configuration using the `bucket` and `dynamodb_table` arguments
 respectively, and configure a suitable `workspace_key_prefix` to contain
 the states of the various workspaces that will subsequently be created for
 this configuration.

--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -67,6 +67,34 @@ This is seen in the following AWS IAM Statement:
 }
 ```
 
+### DynamoDB Table Permissions
+
+If you are using state locking, Terraform will need the following AWS IAM
+permissions on the DynamoDB table (`arn:aws:dynamodb:::table/mytable`):
+
+* `dynamodb:GetItem`
+* `dynamodb:PutItem`
+* `dynamodb:DeleteItem`
+
+This is seen in the following AWS IAM Statement:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:DeleteItem"
+      ],
+      "Resource": "arn:aws:dynamodb:*:*:table/mytable"
+    }
+  ]
+}
+```
+
 ## Using the S3 remote state
 
 To make use of the S3 remote state we can use the


### PR DESCRIPTION
When setting up remote state locking with S3 and DynamoDB, I had to Google around to check which  IAM permissions Terraform requires for the DynamoDB table. The S3 bucket permissions are documented, so I thought it would be helpful to also document the DynamoDB table ones.

I also spotted a reference to the deprecated `lock_table` argument and updated it to `dynamodb_table`.

Relevant Terraform versions: 0.9+