### PR TITLE
Ensure files are compressed in terraform-bundle

### DIFF
--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -234,6 +234,7 @@ func (c *PackageCommand) Run(args []string) int {
 			c.ui.Error(fmt.Sprintf("Failed to add zip entry for %s: %s", fn, err))
 			return 1
 		}
+		hdr.Method = zip.Deflate // be sure to compress files
 		w, err := outZ.CreateHeader(hdr)
 		if err != nil {
 			c.ui.Error(fmt.Sprintf("Failed to add zip entry for %s: %s", fn, err))


### PR DESCRIPTION
It appears that the FileInfoHeader method does not compress files by default. Explicitly setting Deflate fixes the issue.

If you think it's useful, I can also add some e2e validation of the resulting zip file, but I don't see any of that at the moment.