### PR TITLE
configs: Start using the new "addrs" package types for modules

### DIFF
--- a/addrs/module.go
+++ b/addrs/module.go
@@ -1,5 +1,9 @@
 package addrs
 
+import (
+	"strings"
+)
+
 // Module is an address for a module call within configuration. This is
 // the static counterpart of ModuleInstance, representing a traversal through
 // the static module call tree in configuration and does not take into account
@@ -18,6 +22,13 @@ type Module []string
 // Note that this is not the root of the dynamic module tree, which is instead
 // represented by RootModuleInstance.
 var RootModule Module
+
+func (m Module) String() string {
+	if len(m) == 0 {
+		return ""
+	}
+	return strings.Join([]string(m), ".")
+}
 
 // Child returns the address of a child call in the receiver, identified by the
 // given name.

--- a/addrs/module_instance.go
+++ b/addrs/module_instance.go
@@ -1,5 +1,7 @@
 package addrs
 
+import "bytes"
+
 // ModuleInstance is an address for a particular module instance within the
 // dynamic module tree. This is an extension of the static traversals
 // represented by type Module that deals with the possibility of a single
@@ -39,4 +41,23 @@ func (m ModuleInstance) Parent() ModuleInstance {
 		return m
 	}
 	return m[:len(m)-1]
+}
+
+// String returns a string representation of the receiver, in the format used
+// within e.g. user-provided resource addresses.
+//
+// The address of the root module has the empty string as its representation.
+func (m ModuleInstance) String() string {
+	var buf bytes.Buffer
+	sep := ""
+	for _, step := range m {
+		buf.WriteString(sep)
+		buf.WriteString("module.")
+		buf.WriteString(step.Name)
+		if step.InstanceKey != NoKey {
+			buf.WriteString(step.InstanceKey.String())
+		}
+		sep = "."
+	}
+	return buf.String()
 }


### PR DESCRIPTION
We initially just mimicked our old practice of using `[]string` for module paths here, but the `addrs` package now gives us a pair of types that better capture the two different kinds of module addresses we are dealing with: static addresses (nodes in the configuration tree) and dynamic/instance addresses (which can represent the situation where multiple instances are created from a single module call).

This distinction still remains rather artificial since we don't yet have support for `count` or `for_each` on module calls (#953), but this is intended to lay the foundations for that to be added later, and in the meantime just gives us some handy helper functions for formatting these address types as strings.
