### PR TITLE
configs: Re-unify the ManagedResource and DataResource types

### DIFF
--- a/configs/module.go
+++ b/configs/module.go
@@ -21,8 +21,8 @@ type Module struct {
 
 	ModuleCalls map[string]*ModuleCall
 
-	ManagedResources map[string]*ManagedResource
-	DataResources    map[string]*DataResource
+	ManagedResources map[string]*Resource
+	DataResources    map[string]*Resource
 }
 
 // File describes the contents of a single configuration file.
@@ -49,8 +49,8 @@ type File struct {
 
 	ModuleCalls []*ModuleCall
 
-	ManagedResources []*ManagedResource
-	DataResources    []*DataResource
+	ManagedResources []*Resource
+	DataResources    []*Resource
 }
 
 // NewModule takes a list of primary files and a list of override files and
@@ -70,8 +70,8 @@ func NewModule(primaryFiles, overrideFiles []*File) (*Module, hcl.Diagnostics) {
 		Locals:               map[string]*Local{},
 		Outputs:              map[string]*Output{},
 		ModuleCalls:          map[string]*ModuleCall{},
-		ManagedResources:     map[string]*ManagedResource{},
-		DataResources:        map[string]*DataResource{},
+		ManagedResources:     map[string]*Resource{},
+		DataResources:        map[string]*Resource{},
 	}
 
 	for _, file := range primaryFiles {

--- a/configs/module_merge.go
+++ b/configs/module_merge.go
@@ -3,6 +3,8 @@ package configs
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform/addrs"
+
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
@@ -188,54 +190,14 @@ func (mc *ModuleCall) merge(omc *ModuleCall) hcl.Diagnostics {
 	return diags
 }
 
-func (r *ManagedResource) merge(or *ManagedResource) hcl.Diagnostics {
+func (r *Resource) merge(or *Resource) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
-	if or.Connection != nil {
-		r.Connection = or.Connection
+	if r.Mode != or.Mode {
+		// This is always a programming error, since managed and data resources
+		// are kept in separate maps in the configuration structures.
+		panic(fmt.Errorf("can't merge %s into %s", or.Mode, r.Mode))
 	}
-	if or.Count != nil {
-		r.Count = or.Count
-	}
-	if or.CreateBeforeDestroySet {
-		r.CreateBeforeDestroy = or.CreateBeforeDestroy
-		r.CreateBeforeDestroySet = or.CreateBeforeDestroySet
-	}
-	if or.ForEach != nil {
-		r.ForEach = or.ForEach
-	}
-	if len(or.IgnoreChanges) != 0 {
-		r.IgnoreChanges = or.IgnoreChanges
-	}
-	if or.PreventDestroySet {
-		r.PreventDestroy = or.PreventDestroy
-		r.PreventDestroySet = or.PreventDestroySet
-	}
-	if or.ProviderConfigRef != nil {
-		r.ProviderConfigRef = or.ProviderConfigRef
-	}
-	if len(or.Provisioners) != 0 {
-		r.Provisioners = or.Provisioners
-	}
-
-	r.Config = MergeBodies(r.Config, or.Config)
-
-	// We don't allow depends_on to be overridden because that is likely to
-	// cause confusing misbehavior.
-	if len(r.DependsOn) != 0 {
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Unsupported override",
-			Detail:   "The depends_on argument may not be overridden.",
-			Subject:  r.DependsOn[0].SourceRange().Ptr(), // the first item is the closest range we have
-		})
-	}
-
-	return diags
-}
-
-func (r *DataResource) merge(or *DataResource) hcl.Diagnostics {
-	var diags hcl.Diagnostics
 
 	if or.Count != nil {
 		r.Count = or.Count
@@ -246,17 +208,38 @@ func (r *DataResource) merge(or *DataResource) hcl.Diagnostics {
 	if or.ProviderConfigRef != nil {
 		r.ProviderConfigRef = or.ProviderConfigRef
 	}
+	if r.Mode == addrs.ManagedResourceMode {
+		// or.Managed is always non-nil for managed resource mode
+
+		if or.Managed.Connection != nil {
+			r.Managed.Connection = or.Managed.Connection
+		}
+		if or.Managed.CreateBeforeDestroySet {
+			r.Managed.CreateBeforeDestroy = or.Managed.CreateBeforeDestroy
+			r.Managed.CreateBeforeDestroySet = or.Managed.CreateBeforeDestroySet
+		}
+		if len(or.Managed.IgnoreChanges) != 0 {
+			r.Managed.IgnoreChanges = or.Managed.IgnoreChanges
+		}
+		if or.Managed.PreventDestroySet {
+			r.Managed.PreventDestroy = or.Managed.PreventDestroy
+			r.Managed.PreventDestroySet = or.Managed.PreventDestroySet
+		}
+		if len(or.Managed.Provisioners) != 0 {
+			r.Managed.Provisioners = or.Managed.Provisioners
+		}
+	}
 
 	r.Config = MergeBodies(r.Config, or.Config)
 
 	// We don't allow depends_on to be overridden because that is likely to
 	// cause confusing misbehavior.
-	if len(r.DependsOn) != 0 {
+	if len(or.DependsOn) != 0 {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Unsupported override",
 			Detail:   "The depends_on argument may not be overridden.",
-			Subject:  r.DependsOn[0].SourceRange().Ptr(), // the first item is the closest range we have
+			Subject:  or.DependsOn[0].SourceRange().Ptr(), // the first item is the closest range we have
 		})
 	}
 

--- a/terraform/resource_address_test.go
+++ b/terraform/resource_address_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform/addrs"
+
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/configs"
 )
@@ -1046,7 +1048,7 @@ func TestResourceAddressWholeModuleAddress(t *testing.T) {
 	}
 }
 
-func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
+func TestResourceAddressMatchesResourceConfig(t *testing.T) {
 	root := []string(nil)
 	child := []string{"child"}
 	grandchild := []string{"child", "grandchild"}
@@ -1055,7 +1057,7 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 	tests := []struct {
 		Addr       *ResourceAddress
 		ModulePath []string
-		Resource   *configs.ManagedResource
+		Resource   *configs.Resource
 		Want       bool
 	}{
 		{
@@ -1066,7 +1068,8 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 				Index: -1,
 			},
 			root,
-			&configs.ManagedResource{
+			&configs.Resource{
+				Mode: addrs.ManagedResourceMode,
 				Type: "null_resource",
 				Name: "baz",
 			},
@@ -1081,7 +1084,8 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 				Index: -1,
 			},
 			child,
-			&configs.ManagedResource{
+			&configs.Resource{
+				Mode: addrs.ManagedResourceMode,
 				Type: "null_resource",
 				Name: "baz",
 			},
@@ -1096,7 +1100,8 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 				Index: -1,
 			},
 			grandchild,
-			&configs.ManagedResource{
+			&configs.Resource{
+				Mode: addrs.ManagedResourceMode,
 				Type: "null_resource",
 				Name: "baz",
 			},
@@ -1108,7 +1113,8 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 				Index: -1,
 			},
 			child,
-			&configs.ManagedResource{
+			&configs.Resource{
+				Mode: addrs.ManagedResourceMode,
 				Type: "null_resource",
 				Name: "baz",
 			},
@@ -1120,7 +1126,8 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 				Index: -1,
 			},
 			grandchild,
-			&configs.ManagedResource{
+			&configs.Resource{
+				Mode: addrs.ManagedResourceMode,
 				Type: "null_resource",
 				Name: "baz",
 			},
@@ -1134,7 +1141,8 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 				Index: -1,
 			},
 			irrelevant,
-			&configs.ManagedResource{
+			&configs.Resource{
+				Mode: addrs.ManagedResourceMode,
 				Type: "null_resource",
 				Name: "baz",
 			},
@@ -1148,7 +1156,8 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 				Index: -1,
 			},
 			irrelevant,
-			&configs.ManagedResource{
+			&configs.Resource{
+				Mode: addrs.ManagedResourceMode,
 				Type: "null_resource",
 				Name: "pizza",
 			},
@@ -1162,7 +1171,8 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 				Index: -1,
 			},
 			irrelevant,
-			&configs.ManagedResource{
+			&configs.Resource{
+				Mode: addrs.ManagedResourceMode,
 				Type: "aws_instance",
 				Name: "baz",
 			},
@@ -1177,7 +1187,8 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 				Index: -1,
 			},
 			child,
-			&configs.ManagedResource{
+			&configs.Resource{
+				Mode: addrs.ManagedResourceMode,
 				Type: "null_resource",
 				Name: "baz",
 			},
@@ -1192,7 +1203,8 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 				Index: -1,
 			},
 			grandchild,
-			&configs.ManagedResource{
+			&configs.Resource{
+				Mode: addrs.ManagedResourceMode,
 				Type: "null_resource",
 				Name: "baz",
 			},
@@ -1202,7 +1214,7 @@ func TestResourceAddressMatchesManagedResourceConfig(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%02d-%s", i, test.Addr), func(t *testing.T) {
-			got := test.Addr.MatchesManagedResourceConfig(test.ModulePath, test.Resource)
+			got := test.Addr.MatchesResourceConfig(test.ModulePath, test.Resource)
 			if got != test.Want {
 				t.Errorf(
 					"wrong result\naddr: %s\nmod:  %#v\nrsrc: %#v\ngot:  %#v\nwant: %#v",


### PR DESCRIPTION
Initially the intent here was to tease these apart a little more since they don't really share much actual behavior in common in core, but in practice it'll take a lot of refactoring to tease apart these assumptions in core right now and so we'll keep these things unified at the configuration layer in the interests of minimizing disruption at the core layer.

The two types are still kept in separate maps to help reinforce the fact that they are separate concepts with some behaviors in common, rather than the same concept.