### PR TITLE
configs: NewEmptyConfig function

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -73,6 +73,17 @@ type Config struct {
 	Version *version.Version
 }
 
+// NewEmptyConfig constructs a single-node configuration tree with an empty
+// root module. This is generally a pretty useless thing to do, so most callers
+// should instead use BuildConfig.
+func NewEmptyConfig() *Config {
+	ret := &Config{}
+	ret.Root = ret
+	ret.Children = make(map[string]*Config)
+	ret.Module = &Module{}
+	return ret
+}
+
 // Depth returns the number of "hops" the receiver is from the root of its
 // module tree, with the root module having a depth of zero.
 func (c *Config) Depth() int {


### PR DESCRIPTION
This is useful for creating a valid placeholder configuration, but not much else. Most callers should use `BuildConfig` to build a configuration that actually has something in it.

The motivation for writing this is that there are a few places in core where we stub out a configuration pointer to avoid crashes, and so having this allows a more direct port of those codepaths to use the new config types.