### PR TITLE
helper/schema: ResourceDiff ForceNew attribute correctness

### DIFF
--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2866,6 +2866,48 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
+			// NOTE: This case is technically impossible in the current
+			// implementation, because optional+computed values never show up in the
+			// diff. In the event behavior changes this test should ensure that the
+			// intended diff still shows up.
+			Name: "overridden removed attribute diff with a CustomizeDiff function, ForceNew not in schema",
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{},
+
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+				if err := d.SetNew("availability_zone", "bar"); err != nil {
+					return err
+				}
+				if err := d.ForceNew("availability_zone"); err != nil {
+					return err
+				}
+				return nil
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"availability_zone": &terraform.ResourceAttrDiff{
+						Old:         "",
+						New:         "bar",
+						RequiresNew: true,
+					},
+				},
+			},
+
+			Err: false,
+		},
+
+		{
+
 			Name: "overridden diff with a CustomizeDiff function, ForceNew in schema",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{


### PR DESCRIPTION
A couple of bugs have been discovered in `ResourceDiff.ForceNew`:

* `NewRemoved` is not preserved when a diff for a key is already present.
This is because the second diff that happens after customization
performs a second `getChange` on not just state and config, but also on
the pre-existing diff. This results in `Exists == true`, meaning nil is
never returned as a new value.
* `ForceNew` was doing the work of adding the key to the list of changed
keys by doing a full `SetNew` on the existing value. This has a side
effect of fetching zero values from what were otherwise undefined values
and creating diffs for these values where there should not have been
(example: `"" => "0"`).

This update fixes these scenarios by:

* Adding a new private function to check the existing diff for
`NewRemoved` keys. This is included in the check on new values in
`diffChange`.
* Keys that have been flagged as `ForceNew` (or parent keys of lists and
sets that have been flagged as `ForceNew`) are now maintained in a
separate map. `UpdatedKeys` now returns the results of both of these maps,
but otherwise these keys are ignored by `ResourceDiff`.
* Pursuant the above, values are no longer pushed into the `newDiff`
writer by ForceNew. This prevents the zero value problem, and makes for
a cleaner implementation where the provider has to "manually" `SetNew` to
update the appropriate values in the writer. It also prevents
non-computed keys from winding up in the diff, which `ResourceDiff`
normally blocks by design.

There are also a couple of tests for cases that should never come up
right now involving `Optional`/`Computed` values and `NewRemoved`, for which
explanations are given in annotations of each test. These are here to
guard against future regressions.