### PR TITLE
walkDestroy is a form of "apply"

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -789,7 +789,8 @@ func (i *Interpolater) resourceCountMax(
 	// If we're NOT applying, then we assume we can read the count
 	// from the state. Plan and so on may not have any state yet so
 	// we do a full interpolation.
-	if i.Operation != walkApply {
+	// Don't forget walkDestroy, which is a special case of walkApply
+	if !(i.Operation == walkApply || i.Operation == walkDestroy) {
 		if cr == nil {
 			return 0, nil
 		}

--- a/terraform/test-fixtures/plan-destroy-interpolated-count/main.tf
+++ b/terraform/test-fixtures/plan-destroy-interpolated-count/main.tf
@@ -1,0 +1,11 @@
+variable "list" {
+  default = ["1", "2"]
+}
+
+resource "aws_instance" "a" {
+  count = "${length(var.list)}"
+}
+
+output "out" {
+  value = "${aws_instance.a.*.id}"
+}


### PR DESCRIPTION
When computing the count value, make sure to include walkDestroy with
walkApply, as the former is only a special case of the latter.

When applying a saved plan, the computed count values are lost and we
can no longer query the state for those values. The apply walk was
already considered in the `resourceCountMax` function, but the destroy
walk was not.  This worked when destroying in a single operation
("terraform destroy"), since the state would still be updated with the
latest counts from the plan.

Fixes #17793