### PR TITLE
Attempt to fix #17838

### DIFF
--- a/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/builtin/provisioners/local-exec/resource_provisioner.go
@@ -60,7 +60,6 @@ func applyFn(ctx context.Context) error {
 	environment := data.Get("environment").(map[string]interface{})
 
 	var env []string
-	env = make([]string, len(environment))
 	for k := range environment {
 		entry := fmt.Sprintf("%s=%s", k, environment[k].(string))
 		env = append(env, entry)


### PR DESCRIPTION
Fixes #17838  

Before the fix the slice that contains the environment variables was intialized with empty keys, which prevented the export of the configured variables in Windows systems.