### PR TITLE
core: processIgnoreChanges drops NewComputed+ForcesNew only diffs

### DIFF
--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -240,6 +240,11 @@ func (n *EvalDiff) processIgnoreChanges(diff *InstanceDiff) error {
 				continue
 			}
 
+			// Sometimes appear as RequiresNew e.g. null_resource.triggers.%
+			if strings.HasSuffix(k, "%") || strings.HasSuffix(k, "#") {
+				continue
+			}
+
 			// If any RequiresNew attribute isn't ignored, we need to keep the diff
 			// as-is to be able to replace the resource.
 			if v.RequiresNew && !ignorableAttrKeys[k] {

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -236,7 +236,7 @@ func (n *EvalDiff) processIgnoreChanges(diff *InstanceDiff) error {
 				// id will always be changed if we intended to replace this instance
 				continue
 			}
-			if v.Empty() || v.NewComputed {
+			if v.Empty() {
 				continue
 			}
 


### PR DESCRIPTION
Fix for #17855

Sometimes a resource is set for destroy/create when it only has computed attributes creating that change. I haven't been able to get the null_resource to do this as it doesn't set NewComputed on the triggers.

If you have an ignore_changes lifecycle set on any valid attribute those computed values get ignored. The resource is then not recreated.

Please see issue for full details.