### PR TITLE
backend/local: fix incorrect set of state out path

### DIFF
--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -427,6 +427,7 @@ func (b *Local) StatePaths(name string) (string, string, string) {
 		}
 	} else {
 		statePath = filepath.Join(b.stateWorkspaceDir(), name, DefaultStateFilename)
+		stateOutPath = statePath
 	}
 
 	if stateOutPath == "" {

--- a/backend/local/backend_test.go
+++ b/backend/local/backend_test.go
@@ -87,6 +87,28 @@ func TestLocal_StatePaths(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedBackup, back)
 	}
 
+	// check with env and not defaults path"
+	testPath := "test_state"
+	b.StatePath = testPath
+	b.StateOutPath = testPath
+	path, out, back = b.StatePaths(testEnv)
+
+	expectedPath = filepath.Join(DefaultWorkspaceDir, testEnv, DefaultStateFilename)
+	expectedOut = expectedPath
+	expectedBackup = expectedPath + DefaultBackupExtension
+
+	if path != expectedPath {
+		t.Fatalf("expected %q, got %q", expectedPath, path)
+	}
+
+	if out != expectedOut {
+		t.Fatalf("expected %q, got %q", expectedOut, out)
+	}
+
+	if back != expectedBackup {
+		t.Fatalf("expected %q, got %q", expectedBackup, back)
+	}
+
 }
 
 func TestLocal_addAndRemoveStates(t *testing.T) {


### PR DESCRIPTION
Set the correct value of state out path file when the workspace
is not the default and custom state file path was set.