### PR TITLE
Fix permission for the lock.json

### DIFF
--- a/command/plugins_lock.go
+++ b/command/plugins_lock.go
@@ -82,5 +82,5 @@ func (pf *pluginSHA256LockFile) Write(digests map[string][]byte) error {
 		filepath.Dir(pf.Filename), os.ModePerm,
 	) // ignore error since WriteFile below will generate a better one anyway
 
-	return ioutil.WriteFile(pf.Filename, buf, os.ModePerm)
+	return ioutil.WriteFile(pf.Filename, buf, 0644)
 }


### PR DESCRIPTION
the `lock.json` under .terraform/plugins/<arch>/lock.json is now with execution bit `0655`, which is unsafe and not required, better to have `0644`.