### PR TITLE
Make vocabulary more consistent

### DIFF
--- a/website/docs/import/index.html.md
+++ b/website/docs/import/index.html.md
@@ -26,7 +26,7 @@ version of Terraform will also generate configuration.
 
 Because of this, prior to running `terraform import` it is necessary to write
 manually a `resource` configuration block for the resource, to which the
-imported object will be attached.
+imported object will be mapped.
 
 While this may seem tedious, it still gives Terraform users an avenue for
 importing existing resources. A future version of Terraform will fully generate


### PR DESCRIPTION
In the terraform state documentation the verb "map" is widely used to
describe the relationship between an item in the state and in the real world
whereas the verb "attach" is not used anywhere.