### PR TITLE
attach resource config during import

### DIFF
--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -770,6 +771,15 @@ func TestContextImport_customProvider(t *testing.T) {
 			},
 		),
 	})
+
+	// There should not be any implicit providers configured, only the single
+	// aliased provider in the configuration.
+	p.ConfigureFn = func(c *ResourceConfig) error {
+		if c.Config["foo"] != "bar" {
+			return errors.New("invalid config")
+		}
+		return nil
+	}
 
 	p.ImportStateReturn = []*InstanceState{
 		&InstanceState{

--- a/terraform/graph_builder_import.go
+++ b/terraform/graph_builder_import.go
@@ -52,6 +52,9 @@ func (b *ImportGraphBuilder) Steps() []GraphTransformer {
 		// Add the import steps
 		&ImportStateTransformer{Targets: b.ImportTargets},
 
+		// Attach the configuration to any resources
+		&AttachResourceConfigTransformer{Module: b.Module},
+
 		TransformProviders(b.Providers, concreteProvider, mod),
 
 		// This validates that the providers only depend on variables

--- a/terraform/test-fixtures/import-provider-alias/main.tf
+++ b/terraform/test-fixtures/import-provider-alias/main.tf
@@ -2,3 +2,7 @@ provider "aws" {
   foo = "bar"
   alias = "alias"
 }
+
+resource "aws_instance" "foo" {
+  provider = "aws.alias"
+}


### PR DESCRIPTION
Since we require that a resource exist in the config for import, we also
need to ensure that the configuration is attached to the resource in the
graph so that the post-import refresh configures the correct provider.

This prevents the import from failing if it can't configure a default provider, which was noted in https://github.com/hashicorp/terraform/issues/14325#issuecomment-383303637