### PR TITLE
Make "v3" in etcd visible in the backend types sidebar

### DIFF
--- a/website/layouts/backend-types.erb
+++ b/website/layouts/backend-types.erb
@@ -36,7 +36,7 @@
             <a href="/docs/backends/types/etcd.html">etcd</a>
           </li>
           <li<%= sidebar_current("docs-backends-types-standard-etcdv3") %>>
-            <a href="/docs/backends/types/etcdv3.html">etcd</a>
+            <a href="/docs/backends/types/etcdv3.html">etcdv3</a>
           </li>
           <li<%= sidebar_current("docs-backends-types-standard-gcs") %>>
             <a href="/docs/backends/types/gcs.html">gcs</a>


### PR DESCRIPTION
At the moment the documentation does not show which of the two "etcd" sidebar entries is the "v3" one:

<img width="516" alt="screen shot 2018-04-25 at 15 23 02" src="https://user-images.githubusercontent.com/6195629/39252036-a428e43e-489c-11e8-8b3a-d1155e8d2884.png">

This PR addresses exactly that. It makes the "v3" bit visible.