### PR TITLE
prune chained outputs during destroy

### DIFF
--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -115,19 +115,6 @@ func (n *NodeDestroyableOutput) Path() []string {
 	return n.PathValue
 }
 
-// RemovableIfNotTargeted
-func (n *NodeDestroyableOutput) RemoveIfNotTargeted() bool {
-	// We need to add this so that this node will be removed if
-	// it isn't targeted or a dependency of a target.
-	return true
-}
-
-// This will keep the destroy node in the graph if its corresponding output
-// node is also in the destroy graph.
-func (n *NodeDestroyableOutput) TargetDownstream(targetedDeps, untargetedDeps *dag.Set) bool {
-	return true
-}
-
 // GraphNodeReferencer
 func (n *NodeDestroyableOutput) References() []string {
 	var result []string

--- a/terraform/test-fixtures/apply-destroy-outputs/main.tf
+++ b/terraform/test-fixtures/apply-destroy-outputs/main.tf
@@ -1,14 +1,26 @@
 resource "aws_instance" "foo" {
-    id = "foo"
-    num = "2"
+  id = "foo"
+  num = "2"
 }
 
 resource "aws_instance" "bar" {
-    id = "bar"
-    foo = "{aws_instance.foo.num}"
-    dep = "foo"
+  id = "bar"
+  foo = "{aws_instance.foo.num}"
+  dep = "foo"
 }
 
 output "foo" {
-    value = "${aws_instance.foo.id}"
+  value = "${aws_instance.foo.id}"
+}
+
+module "moda" {
+  source = "./moda"
+}
+
+output "from_moda" {
+  value = "${module.moda.foo}"
+}
+
+output "from_modb" {
+  value = "${module.moda.from_modb}"
 }

--- a/terraform/test-fixtures/apply-destroy-outputs/moda/main.tf
+++ b/terraform/test-fixtures/apply-destroy-outputs/moda/main.tf
@@ -1,0 +1,16 @@
+resource "aws_instance" "foo" {
+  id = "foo"
+  val = "${module.modb.foo}"
+}
+
+module "modb" {
+  source = "./modb"
+}
+
+output "foo" {
+  value = "${aws_instance.foo.id}"
+}
+
+output "from_modb" {
+  value = "${module.modb.foo}"
+}

--- a/terraform/test-fixtures/apply-destroy-outputs/moda/modb/main.tf
+++ b/terraform/test-fixtures/apply-destroy-outputs/moda/modb/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+  id = "foo"
+}
+
+output "foo" {
+  value = "${aws_instance.foo.id}"
+}

--- a/terraform/transform_output.go
+++ b/terraform/transform_output.go
@@ -87,6 +87,14 @@ func (t *DestroyOutputTransformer) Transform(g *Graph) error {
 		deps.Add(v)
 
 		for _, d := range deps.List() {
+			// Destroyable outputs don't need to depend on other destroyable
+			// outputs. This shouldn't make a difference in destroy operation,
+			// but we want to ensure the graph is identical regardless of the
+			// order that these nodes are added to avoid masking other issues
+			// later on.
+			if _, ok := d.(*NodeDestroyableOutput); ok {
+				continue
+			}
 			log.Printf("[TRACE] %s depends on %s", node.Name(), dag.VertexName(d))
 			g.Connect(dag.BasicEdge(node, d))
 		}


### PR DESCRIPTION
When multiple outputs are chained together, the module output destroy
nodes will also depend on the descendant. A normal output destruction
creates a single dependant destroy node, but in this case an unused
output can have multiple. Rather than only checking for an output's own
destroy node when pruning, check if dependants are _all_ output destroy
nodes

Fixes #17862