### PR TITLE
Typos and small documentation change

### DIFF
--- a/website/docs/backends/types/etcdv3.html.md
+++ b/website/docs/backends/types/etcdv3.html.md
@@ -10,7 +10,7 @@ description: |-
 
 **Kind: Standard (with locking)**
 
-Stores the state in the [etcd](https://coreos.com/etcd/) KV store wit a given prefix.
+Stores the state in the [etcd](https://coreos.com/etcd/) KV store with a given prefix.
 
 This backend supports [state locking](/docs/state/locking.html).
 

--- a/website/docs/commands/import.html.md
+++ b/website/docs/commands/import.html.md
@@ -116,7 +116,7 @@ $ terraform import aws_instance.foo i-abcd1234
 
 ## Example: Import to Module
 
-The example below will import an AWS instance into a module:
+This example will import a particular aws_instance module known as `foo` based on the source module called `bar`
 
 ```shell
 $ terraform import module.foo.aws_instance.bar i-abcd1234

--- a/website/upgrade-guides/0-11.html.markdown
+++ b/website/upgrade-guides/0-11.html.markdown
@@ -68,7 +68,7 @@ explicitly by beginning the string with either `./` (for a module in a child
 directory) or `../` (for a module in the parent directory).
 
 **Action:** Update existing module `source` values containing relative paths
-to start eith either `./` or `../` to prevent misinterpretation of the source
+to start with either `./` or `../` to prevent misinterpretation of the source
 as a Terraform Registry module.
 
 ## Interactions Between Providers and Modules
@@ -270,7 +270,7 @@ configurations, see [_Providers Within Modules_](/docs/modules/usage.html#provid
 
 ## Error Checking for Output Values
 
-Prior to Terraform 0.11, if an error occured when evaluating the `value`
+Prior to Terraform 0.11, if an error occurred when evaluating the `value`
 expression within an `output` block then it would be silently ignored and
 the empty string used as the result. This was inconvenient because it made it
 very hard to debug errors within output expressions.


### PR DESCRIPTION
The "import module" example was a little confusing, I tried my best to clarify. Using foo & bar for the example is a little opaque, as it is unclear which is source module and which is an instance of that module. It is a difficult concept to explain without the person being in front of you. 