### PR TITLE
added certificate authentication for ssh authentication

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -125,11 +125,13 @@ func (c *Communicator) Connect(o terraform.UIOutput) (err error) {
 				"  User: %s\n"+
 				"  Password: %t\n"+
 				"  Private key: %t\n"+
+				"  Certificate: %t\n"+
 				"  SSH Agent: %t\n"+
 				"  Checking Host Key: %t",
 			c.connInfo.Host, c.connInfo.User,
 			c.connInfo.Password != "",
 			c.connInfo.PrivateKey != "",
+			c.connInfo.Certificate != "",
 			c.connInfo.Agent,
 			c.connInfo.HostKey != "",
 		))

--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -40,16 +40,17 @@ const (
 // only keys we look at. If a PrivateKey is given, that is used instead
 // of a password.
 type connectionInfo struct {
-	User       string
-	Password   string
-	PrivateKey string `mapstructure:"private_key"`
-	Host       string
-	HostKey    string `mapstructure:"host_key"`
-	Port       int
-	Agent      bool
-	Timeout    string
-	ScriptPath string        `mapstructure:"script_path"`
-	TimeoutVal time.Duration `mapstructure:"-"`
+	User        string
+	Password    string
+	PrivateKey  string `mapstructure:"private_key"`
+	Certificate string `mapstructure:"certificate"`
+	Host        string
+	HostKey     string `mapstructure:"host_key"`
+	Port        int
+	Agent       bool
+	Timeout     string
+	ScriptPath  string        `mapstructure:"script_path"`
+	TimeoutVal  time.Duration `mapstructure:"-"`
 
 	BastionUser       string `mapstructure:"bastion_user"`
 	BastionPassword   string `mapstructure:"bastion_password"`
@@ -150,12 +151,13 @@ func prepareSSHConfig(connInfo *connectionInfo) (*sshConfig, error) {
 	host := fmt.Sprintf("%s:%d", connInfo.Host, connInfo.Port)
 
 	sshConf, err := buildSSHClientConfig(sshClientConfigOpts{
-		user:       connInfo.User,
-		host:       host,
-		privateKey: connInfo.PrivateKey,
-		password:   connInfo.Password,
-		hostKey:    connInfo.HostKey,
-		sshAgent:   sshAgent,
+		user:        connInfo.User,
+		host:        host,
+		privateKey:  connInfo.PrivateKey,
+		password:    connInfo.Password,
+		hostKey:     connInfo.HostKey,
+		certificate: connInfo.Certificate,
+		sshAgent:    sshAgent,
 	})
 	if err != nil {
 		return nil, err
@@ -191,12 +193,13 @@ func prepareSSHConfig(connInfo *connectionInfo) (*sshConfig, error) {
 }
 
 type sshClientConfigOpts struct {
-	privateKey string
-	password   string
-	sshAgent   *sshAgent
-	user       string
-	host       string
-	hostKey    string
+	privateKey  string
+	password    string
+	sshAgent    *sshAgent
+	certificate string
+	user        string
+	host        string
+	hostKey     string
 }
 
 func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
@@ -234,11 +237,23 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 	}
 
 	if opts.privateKey != "" {
-		pubKeyAuth, err := readPrivateKey(opts.privateKey)
-		if err != nil {
-			return nil, err
+		if opts.certificate != "" {
+			log.Println(fmt.Sprintf("[DEBUG] using client certificate for authentication"))
+
+			certSigner, err := signCertWithPrivateKey(opts.privateKey, opts.certificate)
+			if err != nil {
+				return nil, err
+			}
+			conf.Auth = append(conf.Auth, certSigner)
+		} else {
+			log.Println(fmt.Sprintf("[DEBUG] using private key for authentication"))
+
+			pubKeyAuth, err := readPrivateKey(opts.privateKey)
+			if err != nil {
+				return nil, err
+			}
+			conf.Auth = append(conf.Auth, pubKeyAuth)
 		}
-		conf.Auth = append(conf.Auth, pubKeyAuth)
 	}
 
 	if opts.password != "" {
@@ -252,6 +267,31 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 	}
 
 	return conf, nil
+}
+
+// Create a Cert Signer and return ssh.AuthMethod
+func signCertWithPrivateKey(pk string, certificate string) (ssh.AuthMethod, error) {
+	rawPk, err := ssh.ParseRawPrivateKey([]byte(pk))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse private key %q: %s", pk, err)
+	}
+
+	pcert, _, _, _, err := ssh.ParseAuthorizedKey([]byte(certificate))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse certificate %q: %s", certificate, err)
+	}
+
+	usigner, err := ssh.NewSignerFromKey(rawPk)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create signer from raw private key %q: %s", rawPk, err)
+	}
+
+	ucertSigner, err := ssh.NewCertSigner(pcert.(*ssh.Certificate), usigner)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create cert signer %q: %s", usigner, err)
+	}
+
+	return ssh.PublicKeys(ucertSigner), nil
 }
 
 func readPrivateKey(pk string) (ssh.AuthMethod, error) {

--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -14,6 +14,7 @@ func TestProvisioner_connInfo(t *testing.T) {
 				"user":        "root",
 				"password":    "supersecret",
 				"private_key": "someprivatekeycontents",
+				"certificate": "somecertificate",
 				"host":        "127.0.0.1",
 				"port":        "22",
 				"timeout":     "30s",
@@ -35,6 +36,9 @@ func TestProvisioner_connInfo(t *testing.T) {
 		t.Fatalf("bad: %v", conf)
 	}
 	if conf.PrivateKey != "someprivatekeycontents" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.Certificate != "somecertificate" {
 		t.Fatalf("bad: %v", conf)
 	}
 	if conf.Host != "127.0.0.1" {
@@ -74,6 +78,7 @@ func TestProvisioner_connInfoIpv6(t *testing.T) {
 				"user":        "root",
 				"password":    "supersecret",
 				"private_key": "someprivatekeycontents",
+				"certificate": "somecertificate",
 				"host":        "::1",
 				"port":        "22",
 				"timeout":     "30s",
@@ -105,6 +110,7 @@ func TestProvisioner_connInfoHostname(t *testing.T) {
 				"user":        "root",
 				"password":    "supersecret",
 				"private_key": "someprivatekeycontents",
+				"certificate": "somecertificate",
 				"host":        "example.com",
 				"port":        "22",
 				"timeout":     "30s",

--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -106,15 +106,13 @@ func TestProvisioner_connInfoHostname(t *testing.T) {
 	r := &terraform.InstanceState{
 		Ephemeral: terraform.EphemeralState{
 			ConnInfo: map[string]string{
-				"type":        "ssh",
-				"user":        "root",
-				"password":    "supersecret",
-				"private_key": "someprivatekeycontents",
-				"certificate": "somecertificate",
-				"host":        "example.com",
-				"port":        "22",
-				"timeout":     "30s",
-
+				"type":         "ssh",
+				"user":         "root",
+				"password":     "supersecret",
+				"private_key":  "someprivatekeycontents",
+				"host":         "example.com",
+				"port":         "22",
+				"timeout":      "30s",
 				"bastion_host": "example.com",
 			},
 		},

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -144,6 +144,7 @@ func (n *EvalValidateProvisioner) validateConnConfig(connConfig *ResourceConfig)
 
 		// For type=ssh only (enforced in ssh communicator)
 		PrivateKey        interface{} `mapstructure:"private_key"`
+		Certificate       interface{} `mapstructure:"certificate"`
 		HostKey           interface{} `mapstructure:"host_key"`
 		Agent             interface{} `mapstructure:"agent"`
 		BastionHost       interface{} `mapstructure:"bastion_host"`

--- a/website/docs/provisioners/connection.html.markdown
+++ b/website/docs/provisioners/connection.html.markdown
@@ -77,6 +77,10 @@ provisioner "file" {
   function](/docs/configuration/interpolation.html#file_path_). This takes
   preference over the password if provided.
 
+* `certificate` - The contents of an signed CA Certificate. These can
+  be loaded from a file on disk using the [`file()` interpolation
+  function](/docs/configuration/interpolation.html#file_path_). Note: Must provide `private_key` when using this.
+
 * `agent` - Set to `false` to disable using `ssh-agent` to authenticate. On Windows the
   only supported SSH authentication agent is
   [Pageant](http://the.earth.li/~sgtatham/putty/0.66/htmldoc/Chapter9.html#pageant).


### PR DESCRIPTION
This pull request addresses #14413. It adds certificate support for the ssh provisioner. It adds a new parameter `certificate` which is used to authenticate ssh sessions. I updated the provisioner_test and docs to reflect this.