### PR TITLE
Update golang.org/x/net/idna to handle hostname started with numeric

### DIFF
--- a/svchost/svchost_test.go
+++ b/svchost/svchost_test.go
@@ -127,6 +127,11 @@ func TestForComparison(t *testing.T) {
 			false,
 		},
 		{
+			"1example.com",
+			"1example.com",
+			false,
+		},
+		{
 			"Испытание.com",
 			"xn--80akhbyknj4f.com",
 			false,


### PR DESCRIPTION
When I try to use terraform module with a custom private registry, I found terraform doesn't handle correctly hostname started with a numeric character like `123.example.com` or `1example.com`

```
module "vpc" {
  source = "123.example.com/namespace/name/provider"
}
```

So, I updated `idna` and added a new test case.

Previously, it throws an error like:
```
--- FAIL: TestForComparison (0.00s)
    --- FAIL: TestForComparison/1example.com (0.00s)
      svchost_test.go:173: unexpected error; want success
        error: idna: invalid label "1example"
      svchost_test.go:177: wrong result
        input: 1example.com
        got:
        want:  1example.com
```