### PR TITLE
Fix formatlist() bug when first list is empty

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -646,12 +646,15 @@ func interpolationFuncFormatList() ast.Function {
 
 				// Check length
 				if n == 0 {
+					if len(parts) == 0 {
+						return nil, fmt.Errorf("format: illegal empty list as argument %d", i)
+					}
 					// first list we've seen
 					n = len(parts)
 					continue
 				}
 				if n != len(parts) {
-					return nil, fmt.Errorf("format: mismatched list lengths: %d != %d", n, len(parts))
+					return nil, fmt.Errorf("format: mismatched list lengths: %d != %d as argument %d", n, len(parts), i)
 				}
 			}
 


### PR DESCRIPTION
formatlist() crashes when the first list passed to it is empty.
Mismatch length detection doesn't work in that case because the guard
value telling the list is the first in the argument list is 0.
Specifically check in that case that the list is not empty.

https://github.com/hashicorp/terraform/issues/18057