### PR TITLE
Fix inaccuracy

### DIFF
--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -40,9 +40,11 @@ variable.
 
 #### User list variables
 
-The syntax is `"${var.LIST}"`. For example, `"${var.subnets}"`
-would get the value of the `subnets` list, as a list. You can also
-return list elements by index: `${var.subnets[idx]}`.
+The syntax is `["${var.LIST}"]`. For example, `["${var.subnets}"]`
+would get the value of the `subnets` list, as a list. The surrounding
+brackets are necessary for the value to retain its type of `list`. To
+return an individual element, omit the surrounding brackets and provide
+an index: `${var.subnets[idx]}`.
 
 #### Attributes of your own resource
 


### PR DESCRIPTION
This fixes a mismatch between docs and behavior. Although the described behavior is unintuitive, it matches the reality of how Terraform currently works. #13869 has further details and a small repo where you can quickly verify the behavior we're seeing.

I hope that the bug is fixed and this commit can be rolled back, but in the meantime, I think it would be good for the docs to be accurate to prevent confusion.