### PR TITLE
Use proxy for installing chef-vault gem.

### DIFF
--- a/builtin/provisioners/chef/resource_provisioner_test.go
+++ b/builtin/provisioners/chef/resource_provisioner_test.go
@@ -247,7 +247,6 @@ func TestResourceProvider_fetchChefCertificates(t *testing.T) {
 func TestResourceProvider_configureVaults(t *testing.T) {
 	cases := map[string]struct {
 		Config   map[string]interface{}
-		GemCmd   string
 		KnifeCmd string
 		ConfDir  string
 		Commands map[string]bool
@@ -263,12 +262,10 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 				"vault_json":   `{"vault1": "item1"}`,
 			},
 
-			GemCmd:   linuxGemCmd,
 			KnifeCmd: linuxKnifeCmd,
 			ConfDir:  linuxConfDir,
 
 			Commands: map[string]bool{
-				fmt.Sprintf("%s install chef-vault", linuxGemCmd): true,
 				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", linuxKnifeCmd, linuxConfDir, linuxConfDir): true,
 			},
@@ -286,12 +283,10 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 				"vault_json":              `{"vault1": ["item1", "item2"]}`,
 			},
 
-			GemCmd:   linuxGemCmd,
 			KnifeCmd: linuxKnifeCmd,
 			ConfDir:  linuxConfDir,
 
 			Commands: map[string]bool{
-				fmt.Sprintf("%s install chef-vault", linuxGemCmd): true,
 				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", linuxKnifeCmd, linuxConfDir, linuxConfDir): true,
 				fmt.Sprintf("%s vault update vault1 item2 -C nodename1 -M client -c %s/client.rb "+
@@ -312,12 +307,10 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 				"recreate_client":         true,
 			},
 
-			GemCmd:   linuxGemCmd,
 			KnifeCmd: linuxKnifeCmd,
 			ConfDir:  linuxConfDir,
 
 			Commands: map[string]bool{
-				fmt.Sprintf("%s install chef-vault", linuxGemCmd): true,
 				fmt.Sprintf("%s vault remove vault1 item1 -C \"nodename1\" -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", linuxKnifeCmd, linuxConfDir, linuxConfDir): true,
 				fmt.Sprintf("%s vault remove vault1 item2 -C \"nodename1\" -M client -c %s/client.rb "+
@@ -340,12 +333,10 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 				"vault_json":   `{"vault1": "item1"}`,
 			},
 
-			GemCmd:   windowsGemCmd,
 			KnifeCmd: windowsKnifeCmd,
 			ConfDir:  windowsConfDir,
 
 			Commands: map[string]bool{
-				fmt.Sprintf("%s install chef-vault", windowsGemCmd): true,
 				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", windowsKnifeCmd, windowsConfDir, windowsConfDir): true,
 			},
@@ -363,12 +354,10 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 				"vault_json":              `{"vault1": ["item1", "item2"]}`,
 			},
 
-			GemCmd:   windowsGemCmd,
 			KnifeCmd: windowsKnifeCmd,
 			ConfDir:  windowsConfDir,
 
 			Commands: map[string]bool{
-				fmt.Sprintf("%s install chef-vault", windowsGemCmd): true,
 				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", windowsKnifeCmd, windowsConfDir, windowsConfDir): true,
 				fmt.Sprintf("%s vault update vault1 item2 -C nodename1 -M client -c %s/client.rb "+
@@ -389,12 +378,10 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 				"recreate_client":         true,
 			},
 
-			GemCmd:   windowsGemCmd,
 			KnifeCmd: windowsKnifeCmd,
 			ConfDir:  windowsConfDir,
 
 			Commands: map[string]bool{
-				fmt.Sprintf("%s install chef-vault", windowsGemCmd): true,
 				fmt.Sprintf("%s vault remove vault1 item1 -C \"nodename1\" -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", windowsKnifeCmd, windowsConfDir, windowsConfDir): true,
 				fmt.Sprintf("%s vault remove vault1 item2 -C \"nodename1\" -M client -c %s/client.rb "+
@@ -420,7 +407,7 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 			t.Fatalf("Error: %v", err)
 		}
 
-		p.configureVaults = p.configureVaultsFunc(tc.GemCmd, tc.KnifeCmd, tc.ConfDir)
+		p.configureVaults = p.configureVaultsFunc(tc.KnifeCmd, tc.ConfDir)
 		p.useSudo = !p.PreventSudo
 
 		err = p.configureVaults(o, c)

--- a/builtin/provisioners/chef/windows_provisioner_test.go
+++ b/builtin/provisioners/chef/windows_provisioner_test.go
@@ -117,6 +117,54 @@ func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 	}
 }
 
+func TestResourceProvider_windowsInstallChefVault(t *testing.T) {
+	cases := map[string]struct {
+		Config   map[string]interface{}
+		Commands map[string]bool
+	}{
+		"Default": {
+			Config: map[string]interface{}{},
+
+			Commands: map[string]bool{
+				"C:/opscode/chef/embedded/bin/gem install chef-vault": true,
+			},
+		},
+
+		"Proxy": {
+			Config: map[string]interface{}{
+				"http_proxy": "http://proxy.local",
+				"no_proxy":   []interface{}{"http://local.local", "http://local.org"},
+			},
+
+			Commands: map[string]bool{
+				"set http_proxy='http://proxy.local' && set no_proxy='http://local.local,http://local.org' && " +
+					"C:/opscode/chef/embedded/bin/gem install chef-vault": true,
+			},
+		},
+	}
+
+	o := new(terraform.MockUIOutput)
+	c := new(communicator.MockCommunicator)
+
+	for k, tc := range cases {
+		c.Commands = tc.Commands
+
+		p, err := decodeConfig(
+			schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, tc.Config),
+		)
+		if err != nil {
+			t.Fatalf("Error: %v", err)
+		}
+
+		p.useSudo = false
+
+		err = p.windowsInstallChefVault(o, c)
+		if err != nil {
+			t.Fatalf("Test %q failed: %v", k, err)
+		}
+	}
+}
+
 func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 	cases := map[string]struct {
 		Config   map[string]interface{}
@@ -246,7 +294,7 @@ $downloader = New-Object System.Net.WebClient
 
 $http_proxy = ''
 if ($http_proxy -ne '') {
-	$no_proxy = ''
+  $no_proxy = ''
   if ($no_proxy -eq ''){
     $no_proxy = "127.0.0.1"
   }
@@ -283,7 +331,7 @@ $downloader = New-Object System.Net.WebClient
 
 $http_proxy = 'http://proxy.local'
 if ($http_proxy -ne '') {
-	$no_proxy = 'http://local.local,http://local.org'
+  $no_proxy = 'http://local.local,http://local.org'
   if ($no_proxy -eq ''){
     $no_proxy = "127.0.0.1"
   }
@@ -320,7 +368,7 @@ $downloader = New-Object System.Net.WebClient
 
 $http_proxy = ''
 if ($http_proxy -ne '') {
-	$no_proxy = ''
+  $no_proxy = ''
   if ($no_proxy -eq ''){
     $no_proxy = "127.0.0.1"
   }
@@ -356,7 +404,7 @@ $downloader = New-Object System.Net.WebClient
 
 $http_proxy = ''
 if ($http_proxy -ne '') {
-	$no_proxy = ''
+  $no_proxy = ''
   if ($no_proxy -eq ''){
     $no_proxy = "127.0.0.1"
   }


### PR DESCRIPTION
Attempting to provision with vault_json enabled will currently fail if the server lies behind a proxy. This should fix #18089.