### PR TITLE
[RFC] Allow the values function to handle maps containing complex types

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -1223,14 +1223,9 @@ func interpolationFuncValues(vs map[string]ast.Variable) ast.Function {
 
 			sort.Strings(keys)
 
-			values := make([]string, len(keys))
+			values := make([]interface{}, len(keys))
 			for index, key := range keys {
-				if value, ok := mapVar[key].Value.(string); ok {
-					values[index] = value
-				} else {
-					return "", fmt.Errorf("values(): %q has element with bad type %s",
-						key, mapVar[key].Type)
-				}
+				values[index] = mapVar[key]
 			}
 
 			variable, err := hil.InterfaceToVariable(values)

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2003,11 +2003,61 @@ func TestInterpolateFuncValues(t *testing.T) {
 				Value: "astring",
 				Type:  ast.TypeString,
 			},
+			"var.nestedmap": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"bar": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "baz",
+							},
+						},
+					},
+				},
+			},
+			"var.mapoflists": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							{
+								Type:  ast.TypeString,
+								Value: "bar",
+							},
+							{
+								Type:  ast.TypeString,
+								Value: "baz",
+							},
+						},
+					},
+				},
+			},
 		},
 		Cases: []testFunctionCase{
 			{
 				`${values(var.foo)}`,
 				[]interface{}{"quack", "baz"},
+				false,
+			},
+
+			// Map of lists
+			{
+				`${values(var.mapoflists)}`,
+				[]interface{}{
+					[]interface{}{"bar", "baz"},
+				},
+				false,
+			},
+
+			// Map of maps
+			{
+				`${values(var.nestedmap)}`,
+				[]interface{}{
+					map[string]interface{}{"bar": "baz"},
+				},
 				false,
 			},
 
@@ -2028,13 +2078,6 @@ func TestInterpolateFuncValues(t *testing.T) {
 			// Not a map
 			{
 				`${values(var.str)}`,
-				nil,
-				true,
-			},
-
-			// Map of lists
-			{
-				`${values(map("one", list()))}`,
 				nil,
 				true,
 			},


### PR DESCRIPTION
The `values` function is currently only capable of handling maps of keys to strings. This makes for limitations on how data may be entered into a module as it can be quite difficult to access that data from inside said module.

Looking at the code, I have not been able to see any reason why this limitation is in place. In this PR, I've relaxed this requirement with no negative impacts to the broader test suite. I understand that there may be further reasons for this limitation. If so, I'm hoping that this PR will highlight beneficial additions to documentation and tests which should be added to the suite.

* Change the output type of the values function to be a an empty
interface.
* Remove code designed to verify that the values are simple strings.
* Update unit tests to match expecte behavior