### PR TITLE
Provide example of the SSH method for BB private modules

### DIFF
--- a/website/docs/modules/sources.html.markdown
+++ b/website/docs/modules/sources.html.markdown
@@ -172,11 +172,17 @@ module "consul" {
 }
 ```
 
-You can also specify branches and version withs the ?ref query
+You can also specify branches and version with the `?ref` query, and use HTTPS or SSH:
 
 ```hcl
 module "consul" {
   source = "git::https://bitbucket.org/foocompany/module_name.git?ref=hotfix"
+}
+```
+
+```hcl
+module "consul" {
+  source = "git::ssh://git@bitbucket.org/foocompany/module_name.git"
 }
 ```
 


### PR DESCRIPTION
This update is relevant for the current version, but is not urgent. It provides a clearer example of referencing private Bitbucket modules via SSH; it's similar to the Generic Git option, but it's more explicit to show it in the special BB section as well.

Also a small typo fix withs > with!