### PR TITLE
helper/resource: Add ability to pre-taint resources

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -266,6 +266,15 @@ type TestStep struct {
 	// below.
 	PreConfig func()
 
+	// Taint is a list of resource addresses to taint prior to the execution of
+	// the step. Be sure to only include this at a step where the referenced
+	// address will be present in state, as it will fail the test if the resource
+	// is missing.
+	//
+	// This option is ignored on ImportState tests, and currently only works for
+	// resources in the root module path.
+	Taint []string
+
 	//---------------------------------------------------------------
 	// Test modes. One of the following groups of settings must be
 	// set to determine what the test step will do. Ideally we would've


### PR DESCRIPTION
This adds the `Taint` field to the acceptance testing framework, allowing
the ability to pre-taint resources at the beginning of a particular
`TestStep`. This can be useful for when an explicit `ForceNew` is required
for a specific resource for troubleshooting things like diff mismatches,
etc.

The field accepts resource addresses as a list of strings. To keep
things simple for the time being, only addresses in the root module are
accepted. If we ever want to expand this past that, I'd be almost
inclined to add some facilities to the core terraform package to help
translate actual module resource addresses (ie:
`module.foo.module.bar.some_resource.baz`) into the correct state, versus
the current convention in some acceptance testing facilities that take
the module address as a list of strings (ie: `[]string{"root", "foo",
"bar"}`).