### PR TITLE
Mention `when = "create"` in provisioner documentation.

### DIFF
--- a/website/docs/provisioners/index.html.markdown
+++ b/website/docs/provisioners/index.html.markdown
@@ -31,7 +31,8 @@ how to communicate with the resource.
 ## Creation-Time Provisioners
 
 Provisioners by default run when the resource they are defined within is
-created. Creation-time provisioners are only run during _creation_, not
+created. This implicit default behavior can be made explicit by setting `when =
+"create"`. Creation-time provisioners are only run during _creation_, not
 during updating or any other lifecycle. They are meant as a means to perform
 bootstrapping of a system.
 


### PR DESCRIPTION
While working on a "null_resource" I stumbled upon the `when` property and was wondering what the default value for it was. The documentation didn't mention it so I thought it might be a nice addition 🙂