### PR TITLE
Module multiple provider example typo

### DIFF
--- a/website/docs/modules/usage.html.markdown
+++ b/website/docs/modules/usage.html.markdown
@@ -287,8 +287,8 @@ provider "aws" {
 module "tunnel" {
   source    = "./tunnel"
   providers = {
-    "aws.src" = "aws.usw1"
-    "aws.dst" = "aws.usw2"
+    aws.src = "aws.usw1"
+    aws.dst = "aws.usw2"
   }
 }
 ```


### PR DESCRIPTION
The example for parsing multiple providers to a module had quotationmarks arount the keys. This does not seem to be the correct format.

(note: I have not inspected the code, but the example did not work for me. When I removed the quotation marks it did work)