### PR TITLE
Docs: reference resource by index, fixes #18184

### DIFF
--- a/website/docs/commands/destroy.html.markdown
+++ b/website/docs/commands/destroy.html.markdown
@@ -25,7 +25,7 @@ argument.
 If `-auto-approve` is set, then the destroy confirmation will not be shown.
 
 The `-target` flag, instead of affecting "dependencies" will instead also
-destroy any resources that _depend on_ the target(s) specified.
+destroy any resources that _depend on_ the target(s) specified. For more information, see [the targeting docs from `terraform plan`](/docs/commands/plan.html#resource-targeting).
 
 The behavior of any `terraform destroy` command can be previewed at any time
 with an equivalent `terraform plan -destroy` command.

--- a/website/docs/commands/plan.html.markdown
+++ b/website/docs/commands/plan.html.markdown
@@ -97,7 +97,7 @@ to specify the constraint. The resource address is interpreted as follows:
 
 * If the given address has a _resource spec_, only the specified resource
   is targeted. If the named resource uses `count` and no explicit index
-  is specified in the address, all of the instances sharing the given
+  is specified in the address (i.e. aws_instance.example[3]), all of the instances sharing the given
   resource name are targeted.
 
 * The the given address _does not_ have a resource spec, and instead just


### PR DESCRIPTION
Updated Resource Targeting section of `terraform plan` docs to include targeting a specific index of a resource and added a reference to it in `terraform destroy` that mirrors the reference in `terraform apply`. This closes #18184