### PR TITLE
Update remote.html.markdown

### DIFF
--- a/website/intro/getting-started/remote.html.markdown
+++ b/website/intro/getting-started/remote.html.markdown
@@ -52,7 +52,7 @@ First, configure the backend in your configuration:
 ```hcl
 terraform {
   backend "consul" {
-    address = "demo.consul.io"
+    address = "https://demo.consul.io"
     path    = "getting-started-RANDOMSTRING"
     lock    = false
   }


### PR DESCRIPTION
Added https:// to URL address to correct the connection

Without this addition, the example results in:

> Error inspecting states in the "consul" backend:
>     Unexpected response code: 503    