### PR TITLE
backend/swift: Set endpoint type in object storage client

### DIFF
--- a/backend/remote-state/swift/backend.go
+++ b/backend/remote-state/swift/backend.go
@@ -313,7 +313,8 @@ func (b *Backend) configure(ctx context.Context) error {
 	}
 
 	objClient, err := openstack.NewObjectStorageV1(config.OsClient, gophercloud.EndpointOpts{
-		Region: data.Get("region_name").(string),
+		Region:       data.Get("region_name").(string),
+		Availability: getEndpointType(config),
 	})
 	if err != nil {
 		return err
@@ -322,4 +323,14 @@ func (b *Backend) configure(ctx context.Context) error {
 	b.client = objClient
 
 	return nil
+}
+
+func getEndpointType(c *tf_openstack.Config) gophercloud.Availability {
+	if c.EndpointType == "internal" || c.EndpointType == "internalURL" {
+		return gophercloud.AvailabilityInternal
+	}
+	if c.EndpointType == "admin" || c.EndpointType == "adminURL" {
+		return gophercloud.AvailabilityAdmin
+	}
+	return gophercloud.AvailabilityPublic
 }


### PR DESCRIPTION
Previously the endpointType was only being set in the config and validated, but it wasn't being used when creating the client. This caused its value to be ignored and the "public" endpoint always being used.

This PR sets the EndpointOpts.Availability field based on the chosen EndpointType to fix this problem and use the correct endpoint URL.

The added `getEndpointType` function is similar to the private method found in the terraform-provider-openstack: https://github.com/terraform-providers/terraform-provider-openstack/blob/f5a03af19e322495208265b757da85c63b6d63af/openstack/config.go#L274-L282
I thought that for this PR it would make more sense to copy some small logic than to make this function public in the provider and then update the provider here. However, if you think it would be best to expose this method as public I can make new PR to the provider and then update this one to use it.

Please let me know what you think.