### PR TITLE
Added in kabob, camel, snake and splitwords interpolation

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2960,3 +2960,150 @@ H7CurtMwALQ/n/6LUKFmjRZjqbKX9SO2QSaC3grd6sY9Tu+bZjLe
 		},
 	})
 }
+
+func TestInterpolateFuncSplitWords(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				// no arguments
+				`${splitwords()}`,
+				nil,
+				true,
+			},
+			{
+				// camelCase
+				`${splitwords("camelCase")}`,
+				[]interface{}{"camel", "Case"},
+				false,
+			},
+			{
+				// camelCase with spaces
+				`${splitwords("camelCase kcMerrill")}`,
+				[]interface{}{"camel", "Case", "kc", "Merrill"},
+				false,
+			},
+			{
+				// kebob-case
+				`${splitwords("KEBOB-CASE")}`,
+				[]interface{}{"KEBOB", "CASE"},
+				false,
+			},
+			{
+				// snake_case
+				`${splitwords("snake_Case")}`,
+				[]interface{}{"snake", "Case"},
+				false,
+			},
+		},
+	})
+}
+func TestInterpolateFuncCamelCase(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				// no arguments
+				`${camelcase()}`,
+				nil,
+				true,
+			},
+			{
+				// camelCase
+				`${camelcase("camelCase")}`,
+				"camelCase",
+				false,
+			},
+			{
+				// camelCase with spaces
+				`${camelcase("camelCase kcMerrill")}`,
+				"camelCaseKcMerrill",
+				false,
+			},
+			{
+				// kebob-case
+				`${camelcase("KEBOB-CASE")}`,
+				"kebobCase",
+				false,
+			},
+			{
+				// snake_case
+				`${camelcase("snake_Case")}`,
+				"snakeCase",
+				false,
+			},
+		},
+	})
+}
+
+func TestInterpolateFuncKabobCase(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				// no arguments
+				`${kabobcase()}`,
+				nil,
+				true,
+			},
+			{
+				// camelCase
+				`${kabobcase("camelCase")}`,
+				"camel-case",
+				false,
+			},
+			{
+				// camelCase with spaces
+				`${kabobcase("camelCase kcMerrill")}`,
+				"camel-case-kc-merrill",
+				false,
+			},
+			{
+				// kebob-case
+				`${kabobcase("KEBOB-CASE")}`,
+				"kebob-case",
+				false,
+			},
+			{
+				// snake_case
+				`${kabobcase("Snake_Case")}`,
+				"snake-case",
+				false,
+			},
+		},
+	})
+}
+
+func TestInterpolateFuncSnakeCase(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				// no arguments
+				`${snakecase()}`,
+				nil,
+				true,
+			},
+			{
+				// camelCase
+				`${snakecase("camelCase")}`,
+				"camel_case",
+				false,
+			},
+			{
+				// camelCase with spaces
+				`${snakecase("camelCase kcMerrill")}`,
+				"camel_case_kc_merrill",
+				false,
+			},
+			{
+				// kebob-case
+				`${snakecase("kebob-case")}`,
+				"kebob_case",
+				false,
+			},
+			{
+				// snake_case
+				`${snakecase("Snake_Case")}`,
+				"snake_case",
+				false,
+			},
+		},
+	})
+}

--- a/vendor/github.com/fatih/camelcase/LICENSE.md
+++ b/vendor/github.com/fatih/camelcase/LICENSE.md
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Fatih Arslan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/fatih/camelcase/README.md
+++ b/vendor/github.com/fatih/camelcase/README.md
@@ -1,0 +1,58 @@
+# CamelCase [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/fatih/camelcase) [![Build Status](http://img.shields.io/travis/fatih/camelcase.svg?style=flat-square)](https://travis-ci.org/fatih/camelcase)
+
+CamelCase is a Golang (Go) package to split the words of a camelcase type
+string into a slice of words. It can be used to convert a camelcase word (lower
+or upper case) into any type of word.
+
+## Splitting rules:
+
+1. If string is not valid UTF-8, return it without splitting as
+   single item array.
+2. Assign all unicode characters into one of 4 sets: lower case
+   letters, upper case letters, numbers, and all other characters.
+3. Iterate through characters of string, introducing splits
+   between adjacent characters that belong to different sets.
+4. Iterate through array of split strings, and if a given string
+   is upper case:
+   * if subsequent string is lower case:
+     * move last character of upper case string to beginning of
+       lower case string
+
+## Install
+
+```bash
+go get github.com/fatih/camelcase
+```
+
+## Usage and examples
+
+```go
+splitted := camelcase.Split("GolangPackage")
+
+fmt.Println(splitted[0], splitted[1]) // prints: "Golang", "Package"
+```
+
+Both lower camel case and upper camel case are supported. For more info please
+check: [http://en.wikipedia.org/wiki/CamelCase](http://en.wikipedia.org/wiki/CamelCase)
+
+Below are some example cases:
+
+```
+"" =>                     []
+"lowercase" =>            ["lowercase"]
+"Class" =>                ["Class"]
+"MyClass" =>              ["My", "Class"]
+"MyC" =>                  ["My", "C"]
+"HTML" =>                 ["HTML"]
+"PDFLoader" =>            ["PDF", "Loader"]
+"AString" =>              ["A", "String"]
+"SimpleXMLParser" =>      ["Simple", "XML", "Parser"]
+"vimRPCPlugin" =>         ["vim", "RPC", "Plugin"]
+"GL11Version" =>          ["GL", "11", "Version"]
+"99Bottles" =>            ["99", "Bottles"]
+"May5" =>                 ["May", "5"]
+"BFG9000" =>              ["BFG", "9000"]
+"BöseÜberraschung" =>     ["Böse", "Überraschung"]
+"Two  spaces" =>          ["Two", "  ", "spaces"]
+"BadUTF8\xe2\xe2\xa1" =>  ["BadUTF8\xe2\xe2\xa1"]
+```

--- a/vendor/github.com/fatih/camelcase/camelcase.go
+++ b/vendor/github.com/fatih/camelcase/camelcase.go
@@ -1,0 +1,90 @@
+// Package camelcase is a micro package to split the words of a camelcase type
+// string into a slice of words.
+package camelcase
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Split splits the camelcase word and returns a list of words. It also
+// supports digits. Both lower camel case and upper camel case are supported.
+// For more info please check: http://en.wikipedia.org/wiki/CamelCase
+//
+// Examples
+//
+//   "" =>                     [""]
+//   "lowercase" =>            ["lowercase"]
+//   "Class" =>                ["Class"]
+//   "MyClass" =>              ["My", "Class"]
+//   "MyC" =>                  ["My", "C"]
+//   "HTML" =>                 ["HTML"]
+//   "PDFLoader" =>            ["PDF", "Loader"]
+//   "AString" =>              ["A", "String"]
+//   "SimpleXMLParser" =>      ["Simple", "XML", "Parser"]
+//   "vimRPCPlugin" =>         ["vim", "RPC", "Plugin"]
+//   "GL11Version" =>          ["GL", "11", "Version"]
+//   "99Bottles" =>            ["99", "Bottles"]
+//   "May5" =>                 ["May", "5"]
+//   "BFG9000" =>              ["BFG", "9000"]
+//   "BöseÜberraschung" =>     ["Böse", "Überraschung"]
+//   "Two  spaces" =>          ["Two", "  ", "spaces"]
+//   "BadUTF8\xe2\xe2\xa1" =>  ["BadUTF8\xe2\xe2\xa1"]
+//
+// Splitting rules
+//
+//  1) If string is not valid UTF-8, return it without splitting as
+//     single item array.
+//  2) Assign all unicode characters into one of 4 sets: lower case
+//     letters, upper case letters, numbers, and all other characters.
+//  3) Iterate through characters of string, introducing splits
+//     between adjacent characters that belong to different sets.
+//  4) Iterate through array of split strings, and if a given string
+//     is upper case:
+//       if subsequent string is lower case:
+//         move last character of upper case string to beginning of
+//         lower case string
+func Split(src string) (entries []string) {
+	// don't split invalid utf8
+	if !utf8.ValidString(src) {
+		return []string{src}
+	}
+	entries = []string{}
+	var runes [][]rune
+	lastClass := 0
+	class := 0
+	// split into fields based on class of unicode character
+	for _, r := range src {
+		switch true {
+		case unicode.IsLower(r):
+			class = 1
+		case unicode.IsUpper(r):
+			class = 2
+		case unicode.IsDigit(r):
+			class = 3
+		default:
+			class = 4
+		}
+		if class == lastClass {
+			runes[len(runes)-1] = append(runes[len(runes)-1], r)
+		} else {
+			runes = append(runes, []rune{r})
+		}
+		lastClass = class
+	}
+	// handle upper case -> lower case sequences, e.g.
+	// "PDFL", "oader" -> "PDF", "Loader"
+	for i := 0; i < len(runes)-1; i++ {
+		if unicode.IsUpper(runes[i][0]) && unicode.IsLower(runes[i+1][0]) {
+			runes[i+1] = append([]rune{runes[i][len(runes[i])-1]}, runes[i+1]...)
+			runes[i] = runes[i][:len(runes[i])-1]
+		}
+	}
+	// construct []string from results
+	for _, s := range runes {
+		if len(s) > 0 {
+			entries = append(entries, string(s))
+		}
+	}
+	return
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1159,6 +1159,12 @@
 			"revisionTime": "2017-08-19T15:36:34Z"
 		},
 		{
+			"checksumSHA1": "kR64D1QzAOSM9LHOnTPdbigC8q0=",
+			"path": "github.com/fatih/camelcase",
+			"revision": "44e46d280b43ec1531bb25252440e34f1b800b65",
+			"revisionTime": "2017-10-27T10:42:57Z"
+		},
+		{
 			"checksumSHA1": "zKO4Yu8oaruG1xC9jkKRm9ywZvI=",
 			"path": "github.com/fsouza/go-dockerclient",
 			"revision": "1d4f4ae73768d3ca16a6fb964694f58dc5eba601",

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -182,6 +182,9 @@ The supported built-in functions are:
   * `bcrypt(password, cost)` - Returns the Blowfish encrypted hash of the string 
     at the given cost. A default `cost` of 10 will be used if not provided.
 
+  * `camelcase(string)` - Returns a camel cased string based on a kabob cased
+    or snake cased string.
+
   * `ceil(float)` - Returns the least integer value greater than or equal
       to the argument.
 
@@ -293,6 +296,9 @@ The supported built-in functions are:
       value, which can contain arbitrarily-nested lists and maps. Note that if
       the value is a string then its value will be placed in quotes.
 
+  * `kabobcase(string)` - Returns a kabob cased string based on a camel cased
+    or snake cased string.
+
   * `keys(map)` - Returns a lexically sorted list of the map keys.
 
   * `length(list)` - Returns the number of members in a given list or map, or the number of characters in a given string.
@@ -387,6 +393,9 @@ The supported built-in functions are:
   * `slice(list, from, to)` - Returns the portion of `list` between `from` (inclusive) and `to` (exclusive).
       Example: `slice(var.list_of_strings, 0, length(var.list_of_strings) - 1)`
 
+  * `snakecase(string)` - Returns a snake cased string based on a camel cased
+    or kabob cased string.
+
   * `sort(list)` - Returns a lexographically sorted list of the strings contained in
       the list passed as an argument. Sort may only be used with lists which contain only
       strings.
@@ -399,6 +408,8 @@ The supported built-in functions are:
       in brackets to indicate that the output is actually a list, e.g.
       `a_resource_param = ["${split(",", var.CSV_STRING)}"]`.
       Example: `split(",", module.amod.server_ids)`
+
+  * `splitwords(string)` - Returns a list of strings separated by "_", "-" or camel cased words. 
 
   * `substr(string, offset, length)` - Extracts a substring from the input string. A negative offset is interpreted as being equivalent to a positive offset measured backwards from the end of the string. A length of `-1` is interpreted as meaning "until the end of the string".
 


### PR DESCRIPTION
We run into quite a bit of situations where we get camel cased words, kabob cased words, snake case words and need to transform them into different variations. Be it back to camel case, snake case kabob case etc ...

This comes up quite a bit in automation, for example, a group permission could be based off of a snake/kabob cased repository and we would need to transform that back into camel case. Some places we require kabob case or snake case, and in others we require camel case. 

These interpolation functions should help cutdown on a lot of code that requires splitting, joining and in the rare cases where we're not sure if it's camel/kabob/snake cased. 

This also I believe will resolve/help with #18008. 

[x] Documentation updated to reflect new interpolation functions
[x] No specific version of terraform(unsure?)
[x] I believe I've added sufficient test coverage