### PR TITLE
Fixed method for grabbing public ip of server

### DIFF
--- a/website/intro/getting-started/provision.html.md
+++ b/website/intro/getting-started/provision.html.md
@@ -24,12 +24,11 @@ To define a provisioner, modify the resource block defining the
 "example" EC2 instance to look like the following:
 
 ```hcl
-resource "aws_instance" "example" {
-  ami           = "ami-b374d5a5"
-  instance_type = "t2.micro"
-
+resource "aws_eip" "ip" {
+  instance = "${aws_instance.example.id}"
+  
   provisioner "local-exec" {
-    command = "echo ${aws_instance.example.public_ip} > ip_address.txt"
+    command = "echo ${aws_eip.ip.public_ip} > ip_address.txt"
   }
 }
 ```


### PR DESCRIPTION
Previous method provided a different, incorrect ip. Not sure what happens. Perhaps a temporary public ip gets assigned by AWS which is then overwritten by the elastic ip? 

In any case, this works. 
Just trying to help get these instructions to work for people new to Terraform like myself.