### PR TITLE
Fix broken links to /docs/enterprise/run/api.html

### DIFF
--- a/website/docs/commands/push.html.markdown
+++ b/website/docs/commands/push.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Command: push
 
-~> **Important:** The `terraform push` command is deprecated, and only works with [the legacy version of Terraform Enterprise](/docs/enterprise-legacy/index.html). In the current version of Terraform Enterprise, you can upload configurations using the API. See [the docs about API-driven runs](/docs/enterprise/workspaces/run-api.html) for more details.
+~> **Important:** The `terraform push` command is deprecated, and only works with [the legacy version of Terraform Enterprise](/docs/enterprise-legacy/index.html). In the current version of Terraform Enterprise, you can upload configurations using the API. See [the docs about API-driven runs](/docs/enterprise/run/api.html) for more details.
 
 The `terraform push` command uploads your Terraform configuration to
 be managed by HashiCorp's [Terraform Enterprise](https://www.hashicorp.com/products/terraform/).

--- a/website/docs/configuration/terraform-enterprise.html.md
+++ b/website/docs/configuration/terraform-enterprise.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Terraform Push Configuration
 
-~> **Important:** The `terraform push` command is deprecated, and only works with [the legacy version of Terraform Enterprise](/docs/enterprise-legacy/index.html). In the current version of Terraform Enterprise, you can upload configurations using the API. See [the docs about API-driven runs](/docs/enterprise/workspaces/run-api.html) for more details.
+~> **Important:** The `terraform push` command is deprecated, and only works with [the legacy version of Terraform Enterprise](/docs/enterprise-legacy/index.html). In the current version of Terraform Enterprise, you can upload configurations using the API. See [the docs about API-driven runs](/docs/enterprise/run/api.html) for more details.
 
 The [`terraform push` command](/docs/commands/push.html) uploads a configuration to a Terraform Enterprise (legacy) environment. The name of the environment (and the organization it's in) can be specified on the command line, or as part of the Terraform configuration in an `atlas` block.
 


### PR DESCRIPTION
We had a couple broken links pointing to the docs for the run API. This
updates them to the new location.