### PR TITLE
cli: show workspace name in destroy confirmation

### DIFF
--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -84,9 +84,16 @@ func (b *Local) opApply(
 		if mustConfirm {
 			var desc, query string
 			if op.Destroy {
-				// Default destroy message
-				desc = "Terraform will destroy all your managed infrastructure, as shown above.\n" +
-					"There is no undo. Only 'yes' will be accepted to confirm."
+				// Destroy message with workspace name
+				if op.Workspace != "default" {
+					desc = "Terraform will destroy all your managed infrastructure in the worksapce \"" +
+						op.Workspace + "\" as shown above.\n" +
+						"There is no undo. Only 'yes' will be accepted to confirm."
+				} else {
+					// Default destroy message
+					desc = "Terraform will destroy all your managed infrastructure, as shown above.\n" +
+						"There is no undo. Only 'yes' will be accepted to confirm."
+				}
 				query = "Do you really want to destroy?"
 			} else {
 				desc = "Terraform will perform the actions described above.\n" +

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -84,21 +84,21 @@ func (b *Local) opApply(
 		if mustConfirm {
 			var desc, query string
 			if op.Destroy {
-				// Destroy message with workspace name
 				if op.Workspace != "default" {
-					desc = "Terraform will destroy all your managed infrastructure in the worksapce \"" +
-						op.Workspace + "\" as shown above.\n" +
-						"There is no undo. Only 'yes' will be accepted to confirm."
+					query = "Do you really want to destroy all resources in workspace \"" + op.Workspace + "\"?"
 				} else {
-					// Default destroy message
-					desc = "Terraform will destroy all your managed infrastructure, as shown above.\n" +
-						"There is no undo. Only 'yes' will be accepted to confirm."
+					query = "Do you really want to destroy all resources?"
 				}
-				query = "Do you really want to destroy?"
+				desc = "Terraform will destroy all your managed infrastructure, as shown above.\n" +
+					"There is no undo. Only 'yes' will be accepted to confirm."
 			} else {
+				if op.Workspace != "default" {
+					query = "Do you want to perform these actions in workspace \"" + op.Workspace + "\"?"
+				} else {
+					query = "Do you want to perform these actions?"
+				}
 				desc = "Terraform will perform the actions described above.\n" +
 					"Only 'yes' will be accepted to approve."
-				query = "Do you want to perform these actions?"
 			}
 
 			if !trivialPlan {


### PR DESCRIPTION
If the workspace name is not "default", include it in the confirmation
message for `terraform destroy`.

Fixes #15480

```
Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy?
  Terraform will destroy all your managed infrastructure in the worksapce "test" as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes
```