### PR TITLE
Export resource deprecation.

### DIFF
--- a/helper/schema/data_source_resource_shim.go
+++ b/helper/schema/data_source_resource_shim.go
@@ -32,7 +32,7 @@ func DataSourceResourceShim(name string, dataSource *Resource) *Resource {
 
 	// FIXME: Link to some further docs either on the website or in the
 	// changelog, once such a thing exists.
-	dataSource.Deprecated = fmt.Sprintf(
+	dataSource.DeprecationMessage = fmt.Sprintf(
 		"using %s as a resource is deprecated; consider using the data source instead",
 		name,
 	)

--- a/helper/schema/data_source_resource_shim.go
+++ b/helper/schema/data_source_resource_shim.go
@@ -32,7 +32,7 @@ func DataSourceResourceShim(name string, dataSource *Resource) *Resource {
 
 	// FIXME: Link to some further docs either on the website or in the
 	// changelog, once such a thing exists.
-	dataSource.deprecationMessage = fmt.Sprintf(
+	dataSource.Deprecated = fmt.Sprintf(
 		"using %s as a resource is deprecated; consider using the data source instead",
 		name,
 	)

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -124,7 +124,7 @@ type Resource struct {
 	Importer *ResourceImporter
 
 	// If non-empty, this string is emitted as a warning during Validate.
-	Deprecated string
+	DeprecationMessage string
 
 	// Timeouts allow users to specify specific time durations in which an
 	// operation should time out, to allow them to extend an action to suit their
@@ -267,8 +267,8 @@ func (r *Resource) Diff(
 func (r *Resource) Validate(c *terraform.ResourceConfig) ([]string, []error) {
 	warns, errs := schemaMap(r.Schema).Validate(c)
 
-	if r.Deprecated != "" {
-		warns = append(warns, r.Deprecated)
+	if r.DeprecationMessage != "" {
+		warns = append(warns, r.DeprecationMessage)
 	}
 
 	return warns, errs

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -124,9 +124,7 @@ type Resource struct {
 	Importer *ResourceImporter
 
 	// If non-empty, this string is emitted as a warning during Validate.
-	// This is a private interface for now, for use by DataSourceResourceShim,
-	// and not for general use. (But maybe later...)
-	deprecationMessage string
+	Deprecated string
 
 	// Timeouts allow users to specify specific time durations in which an
 	// operation should time out, to allow them to extend an action to suit their
@@ -269,8 +267,8 @@ func (r *Resource) Diff(
 func (r *Resource) Validate(c *terraform.ResourceConfig) ([]string, []error) {
 	warns, errs := schemaMap(r.Schema).Validate(c)
 
-	if r.deprecationMessage != "" {
-		warns = append(warns, r.deprecationMessage)
+	if r.Deprecated != "" {
+		warns = append(warns, r.Deprecated)
 	}
 
 	return warns, errs

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -850,6 +850,20 @@ func TestResourceInternalValidate(t *testing.T) {
 			false,
 			true,
 		},
+		14: { // Deprecated resource
+			&Resource{
+				Read: func(d *ResourceData, meta interface{}) error { return nil },
+				Schema: map[string]*Schema{
+					"goo": &Schema{
+						Type:     TypeInt,
+						Optional: true,
+					},
+				},
+				Deprecated: "This resource has been deprecated.",
+			},
+			true,
+			true,
+		},
 	}
 
 	for i, tc := range cases {

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -859,7 +859,7 @@ func TestResourceInternalValidate(t *testing.T) {
 						Optional: true,
 					},
 				},
-				Deprecated: "This resource has been deprecated.",
+				DeprecationMessage: "This resource has been deprecated.",
 			},
 			true,
 			true,


### PR DESCRIPTION
We already had the functionality to make resources deprecated, which was
used when migrating resources to data sources, but the functionality was
unexported, so only the schema package could do it. Now it's exported,
meaning providers can mark entire resources as deprecated. I also added
a test in hopefully-the-right place?