### PR TITLE
Using demo.consul.io requires `scheme = "https"`

### DIFF
--- a/website/docs/backends/config.html.md
+++ b/website/docs/backends/config.html.md
@@ -18,6 +18,7 @@ Below, we show a complete example configuring the "consul" backend:
 terraform {
   backend "consul" {
     address = "demo.consul.io"
+    scheme  = "https"
     path    = "example_app/terraform_state"
   }
 }
@@ -102,6 +103,7 @@ or `backend` block:
 ```hcl
 address = "demo.consul.io"
 path    = "example_app/terraform_state"
+scheme  = "https"
 ```
 
 The same settings can alternatively be specified on the command line as
@@ -110,7 +112,8 @@ follows:
 ```
 $ terraform init \
     -backend-config="address=demo.consul.io" \
-    -backend-config="path=example_app/terraform_state"
+    -backend-config="path=example_app/terraform_state" \
+    -backend-config="scheme=https"
 ```
 
 ## Changing Configuration

--- a/website/docs/backends/types/consul.html.md
+++ b/website/docs/backends/types/consul.html.md
@@ -20,6 +20,7 @@ This backend supports [state locking](/docs/state/locking.html).
 terraform {
   backend "consul" {
     address = "demo.consul.io"
+    scheme  = "https"
     path    = "full/path"
   }
 }

--- a/website/intro/examples/consul.html.markdown
+++ b/website/intro/examples/consul.html.markdown
@@ -18,32 +18,31 @@ to process requests.
 Terraform provides a [Consul provider](/docs/providers/consul/index.html) which
 can be used to interface with Consul from inside a Terraform configuration.
 
-For our example, we use the [Consul demo cluster](http://demo.consul.io)
+For our example, we use the [Consul demo cluster](https://demo.consul.io/)
 to both read configuration and store information about a newly created EC2 instance.
-The size of the EC2 instance will be determined by the `tf\_test/size` key in Consul,
+The size of the EC2 instance will be determined by the `tf_test/size` key in Consul,
 and will default to `m1.small` if that key does not exist. Once the instance is created
-the `tf\_test/id` and `tf\_test/public\_dns` keys will be set with the computed
+the `tf_test/id` and `tf_test/public_dns` keys will be set with the computed
 values for the instance.
 
-Before we run the example, use the [Web UI](http://demo.consul.io/ui/#/nyc3/kv/)
-to set the `tf\_test/size` key to `t1.micro`. Once that is done,
+Before we run the example, use the [Web UI](https://demo.consul.io/ui/dc1/kv/)
+to set the `tf_test/size` key to `t1.micro`. Once that is done,
 copy the configuration into a configuration file (`consul.tf` works fine).
 Either provide the AWS credentials as a default value in the configuration
 or invoke `apply` with the appropriate variables set.
 
 Once the `apply` has completed, we can see the keys in Consul by
-visiting the [Web UI](http://demo.consul.io/ui/#/nyc3/kv/). We can see
-that the "tf\_test/id" and "tf\_test/public\_dns" values have been
+visiting the [Web UI](https://demo.consul.io/ui/dc1/kv/). We can see
+that the `tf_test/id` and `tf_test/public_dns` values have been
 set.
 
-We can now teardown the infrastructure following the
-[instructions here](/intro/getting-started/destroy.html). Because
-we set the `delete` property of two of the Consul keys, Terraform
-will cleanup those keys on destroy. We can verify this by using
+You can now [tear down the infrastructure](/intro/getting-started/destroy.html)
+Because we set the `delete` property of two of the Consul keys, Terraform
+will clean up those keys on destroy. We can verify this by using
 the Web UI.
 
-The point of this example is to show that Consul can be used with
-Terraform both to enable dynamic inputs, but to also store outputs.
+This example has shown that Consul can be used with Terraform both to read
+existing values and to store generated results.
 
 Inputs like AMI name, security groups, Puppet roles, bootstrap scripts,
 etc can all be loaded from Consul. This allows the specifics of an

--- a/website/intro/getting-started/remote.html.markdown
+++ b/website/intro/getting-started/remote.html.markdown
@@ -55,6 +55,7 @@ terraform {
     address = "demo.consul.io"
     path    = "getting-started-RANDOMSTRING"
     lock    = false
+    scheme  = "https"
   }
 }
 ```

--- a/website/upgrade-guides/0-9.html.markdown
+++ b/website/upgrade-guides/0-9.html.markdown
@@ -41,6 +41,7 @@ terraform {
     address    = "demo.consul.io"
     datacenter = "nyc3"
     path       = "tfdemo"
+    scheme     = "https"
   }
 }
 ```


### PR DESCRIPTION
Following the examples as they are currently will cause Terraform
to error as demo.consul.io returns a 503 if you try to use it
over http. Consistently set the scheme to https for all examples
that use demo.consul.io.