### PR TITLE
website: update docs with working remote backend configuration

### DIFF
--- a/website/intro/getting-started/remote.html.markdown
+++ b/website/intro/getting-started/remote.html.markdown
@@ -54,6 +54,7 @@ terraform {
   backend "consul" {
     address = "demo.consul.io"
     path    = "getting-started-RANDOMSTRING"
+    scheme  = "https"
     lock    = false
   }
 }


### PR DESCRIPTION
If you try to initialize your terraform root module with the backend as listed in the docs it will throw a 503 error and fail. If you add the `scheme = "https"` line it will work correctly. It seems that the demo consul server only supports https for communication.

This was found through the official [Gitter](https://gitter.im/hashicorp-terraform/Lobby) chat where terraform beginners were not able to follow the docs due to this error.