### PR TITLE
Add aliases for taint and untaint

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -212,6 +212,12 @@ func initCommands(config *Config) {
 			}, nil
 		},
 
+		"grundle": func() (cli.Command, error) {
+			return &command.TaintCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"validate": func() (cli.Command, error) {
 			return &command.ValidateCommand{
 				Meta: meta,
@@ -229,6 +235,12 @@ func initCommands(config *Config) {
 		},
 
 		"untaint": func() (cli.Command, error) {
+			return &command.UntaintCommand{
+				Meta: meta,
+			}, nil
+		},
+
+		"degrundle": func() (cli.Command, error) {
 			return &command.UntaintCommand{
 				Meta: meta,
 			}, nil


### PR DESCRIPTION
We keep mistyping `terraform taint` as `terraform grundle`. My team has this aliased internally but figured this would be a useful default for the entire community.