### PR TITLE
terraform state ls: add alias command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -302,6 +302,13 @@ func initCommands(config *Config) {
 			}, nil
 		},
 
+		// Alias
+		"state ls": func() (cli.Command, error) {
+			return &command.StateListCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"state rm": func() (cli.Command, error) {
 			return &command.StateRmCommand{
 				StateMeta: command.StateMeta{


### PR DESCRIPTION
Make it more consistent with the other commands:

	terraform state cp
	terraform state rm
	terraform state ls

I am sure I am not the only one always typing `terraform state ls`. This is a quick POC that works. If the idea is accepted, let me know what else needs to be done to make it merge-worthy.