### PR TITLE
Remove aws_region param from Consul example in docs

### DIFF
--- a/website/intro/getting-started/modules.html.md
+++ b/website/intro/getting-started/modules.html.md
@@ -53,7 +53,6 @@ provider "aws" {
 module "consul" {
   source = "hashicorp/consul/aws"
 
-  aws_region  = "us-east-1" # should match provider region
   num_servers = "3"
 }
 ```


### PR DESCRIPTION
The module now gets the region from the provider block. See https://github.com/hashicorp/terraform-aws-consul/pull/65 and https://github.com/hashicorp/terraform-aws-consul/issues/49 for context.