### PR TITLE
Create show.html.md for workspace command

### DIFF
--- a/website/docs/commands/workspace/show.html.md
+++ b/website/docs/commands/workspace/show.html.md
@@ -1,0 +1,24 @@
+---
+layout: "commands-workspace"
+page_title: "Command: workspace show"
+sidebar_current: "docs-workspace-sub-show"
+description: |-
+  The terraform workspace show command is used to output the current workspace.
+---
+
+# Command: workspace show
+
+The `terraform workspace show` command is used to output the current workspace.
+
+## Usage
+
+Usage: `terraform workspace show`
+
+The command will display the current workspace.
+
+## Example
+
+```
+$ terraform workspace show
+development
+```


### PR DESCRIPTION
The `terraform workspace show` command was not included in the workspace documentation. This PR aims to complete the documentation to include it.