### PR TITLE
Implement Silence option for SSH driver

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -58,6 +58,10 @@ type sshConfig struct {
 	// noPty, if true, will not request a pty from the remote end.
 	noPty bool
 
+	// silence, if true, disable output of cmd stdout
+	// will only print errors
+	silence bool
+
 	// sshAgent is a struct surrounding the agent.Agent client and the net.Conn
 	// to the SSH Agent. It is nil if no SSH agent is configured
 	sshAgent *sshAgent
@@ -256,7 +260,11 @@ func (c *Communicator) Start(cmd *remote.Cmd) error {
 
 	// Setup our session
 	session.Stdin = cmd.Stdin
-	session.Stdout = cmd.Stdout
+	if c.config.silence {
+		session.Stdout = nil
+	} else {
+		session.Stdout = cmd.Stdout
+	}
 	session.Stderr = cmd.Stderr
 
 	if !c.config.noPty {

--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -47,6 +47,7 @@ type connectionInfo struct {
 	HostKey    string `mapstructure:"host_key"`
 	Port       int
 	Agent      bool
+	Silence    bool
 	Timeout    string
 	ScriptPath string        `mapstructure:"script_path"`
 	TimeoutVal time.Duration `mapstructure:"-"`
@@ -126,6 +127,12 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 		}
 	}
 
+	if s.Ephemeral.ConnInfo["silence"] != "true" {
+		connInfo.Silence = false
+	} else {
+		connInfo.Silence = true
+	}
+
 	return connInfo, nil
 }
 
@@ -186,6 +193,8 @@ func prepareSSHConfig(connInfo *connectionInfo) (*sshConfig, error) {
 		config:     sshConf,
 		connection: connectFunc,
 		sshAgent:   sshAgent,
+		noPty:      connInfo.Silence,
+		silence:    connInfo.Silence,
 	}
 	return config, nil
 }
@@ -197,6 +206,7 @@ type sshClientConfigOpts struct {
 	user       string
 	host       string
 	hostKey    string
+	silence    bool
 }
 
 func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -144,6 +144,7 @@ func (n *EvalValidateProvisioner) validateConnConfig(connConfig *ResourceConfig)
 
 		// For type=ssh only (enforced in ssh communicator)
 		PrivateKey        interface{} `mapstructure:"private_key"`
+		Silence           interface{} `mapstructure:"silence"`
 		HostKey           interface{} `mapstructure:"host_key"`
 		Agent             interface{} `mapstructure:"agent"`
 		BastionHost       interface{} `mapstructure:"bastion_host"`


### PR DESCRIPTION
This option allow the user to silence stdout coming from ssh commands. It
can be very, very useful if you have commands that output a lot of logs.