### PR TITLE
Adding TelefonicaOpenCloud Documentation Links

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -133,23 +133,23 @@ down to see all providers.
     </tr>
     <tr>
     <td><a href="/docs/providers/spotinst/index.html">Spotinst</a></td>
+    <td><a href="/docs/provders/telefonicaopencloud/index.html">TelefonicaOpenCloud</a></td>
     <td><a href="/docs/providers/template/index.html">Template</a></td>
-    <td><a href="/docs/providers/terraform/index.html">Terraform</a></td>
     </tr>
     <tr>
+    <td><a href="/docs/providers/terraform/index.html">Terraform</a></td>
     <td><a href="/docs/providers/terraform-enterprise/index.html">Terraform Enterprise</a></td>
     <td><a href="/docs/providers/tls/index.html">TLS</a></td>
-    <td><a href="/docs/providers/triton/index.html">Triton</a></td>
     </tr>
     <tr>
+    <td><a href="/docs/providers/triton/index.html">Triton</a></td>
     <td><a href="/docs/providers/ultradns/index.html">UltraDNS</a></td>
     <td><a href="/docs/providers/vault/index.html">Vault</a></td>
-    <td><a href="/docs/providers/vcd/index.html">VMware vCloud Director</a></td>
     </tr>
     <tr>
+    <td><a href="/docs/providers/vcd/index.html">VMware vCloud Director</a></td>
     <td><a href="/docs/providers/nsxt/index.html">VMware NSX-T</a></td>
     <td><a href="/docs/providers/vsphere/index.html">VMware vSphere</a></td>
-    <td><a></a></td>
     </tr>
 </table>
 

--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -133,7 +133,7 @@ down to see all providers.
     </tr>
     <tr>
     <td><a href="/docs/providers/spotinst/index.html">Spotinst</a></td>
-    <td><a href="/docs/provders/telefonicaopencloud/index.html">TelefonicaOpenCloud</a></td>
+    <td><a href="/docs/providers/telefonicaopencloud/index.html">TelefonicaOpenCloud</a></td>
     <td><a href="/docs/providers/template/index.html">Template</a></td>
     </tr>
     <tr>

--- a/website/docs/providers/type/cloud-index.html.markdown
+++ b/website/docs/providers/type/cloud-index.html.markdown
@@ -49,6 +49,8 @@ vendor in close collaboration with HashiCorp, and are tested by HashiCorp.
 
 [SoftLayer](/docs/providers/softlayer/index.html)
 
+[TelefonicaOpenCloud](/docs/providers/telefonicaopencloud/index.html)
+
 [Triton](/docs/providers/triton/index.html)
 
 [vCloud Director](/docs/providers/vcd/index.html)


### PR DESCRIPTION
Adding Telefonica as a new Terraform provider. This links will allow navigations from terraform.io