### PR TITLE
helper/schema: Expose ResourceDiff IsSet method

### DIFF
--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -49,6 +49,18 @@ type getResult struct {
 	Schema         *Schema
 }
 
+// hasZeroValue determines if the value contained in getResult is
+// equal to the Zero value (unset).
+func (r *getResult) hasZeroValue() bool {
+	zero := r.Schema.Type.Zero()
+	value := r.Value
+
+	if eq, ok := value.(Equal); ok {
+		return eq.Equal(zero)
+	}
+	return reflect.DeepEqual(value, zero)
+}
+
 // UnsafeSetFieldRaw allows setting arbitrary values in state to arbitrary
 // values, bypassing schema. This MUST NOT be used in normal circumstances -
 // it exists only to support the remote_state data source.

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -421,6 +421,14 @@ func (d *ResourceDiff) NewValueKnown(key string) bool {
 	return !r.Computed
 }
 
+// Exists returns true if the given key has a value whether it is computed or
+// not. If the return value is false, this means that the field is not a
+// computed field and does not have an explicitely set value.
+func (d *ResourceDiff) Exists(key string) bool {
+	r := d.get(strings.Split(key, "."), "newDiff")
+	return r.Exists
+}
+
 // HasChange checks to see if there is a change between state and the diff, or
 // in the overridden diff.
 func (d *ResourceDiff) HasChange(key string) bool {


### PR DESCRIPTION
* Adds an IsSet method that tells if the attribute has a value or not in the config. (It can be computed or not).
* The reason for this feature is that for this PR: https://github.com/terraform-providers/terraform-provider-aws/pull/5002, I need to tell in the CustomizeDiff function if an attribute has been set. Right now, there is no way to know from inside that function if an attribute is set when that attribute's value comes from interpolation (All ResourceDiff methods filter out computed values).

Let me know what you think!
Thanks