### PR TITLE
Update resource_provisioner.go

### DIFF
--- a/builtin/provisioners/habitat/resource_provisioner.go
+++ b/builtin/provisioners/habitat/resource_provisioner.go
@@ -680,7 +680,7 @@ func (p *provisioner) startHabService(o terraform.UIOutput, comm communicator.Co
 	}
 
 	if service.URL != "" {
-		options += fmt.Sprintf("--url %s", service.URL)
+		options += fmt.Sprintf(" --url %s", service.URL)
 	}
 
 	if service.Group != "" {


### PR DESCRIPTION
fix spacing for service url.

resolves #18399