### PR TITLE
Move DNSMadeEasy provider to community providers

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -49,107 +49,102 @@ down to see all providers.
     <tr>
     <td><a href="/docs/providers/do/index.html">DigitalOcean</a></td>
     <td><a href="/docs/providers/dns/index.html">DNS</a></td>
-    <td><a href="/docs/providers/dme/index.html">DNSMadeEasy</a></td>
+    <td><a href="/docs/providers/dnsimple/index.html">DNSimple</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/dnsimple/index.html">DNSimple</a></td>
     <td><a href="/docs/providers/docker/index.html">Docker</a></td>
     <td><a href="/docs/providers/dyn/index.html">Dyn</a></td>
+    <td><a href="/docs/providers/external/index.html">External</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/external/index.html">External</a></td>
     <td><a href="/docs/providers/fastly/index.html">Fastly</a></td>
     <td><a href="/docs/providers/flexibleengine/index.html">FlexibleEngine</a></td>
+    <td><a href="/docs/providers/github/index.html">GitHub</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/github/index.html">GitHub</a></td>
     <td><a href="/docs/providers/gitlab/index.html">Gitlab</a></td>
     <td><a href="/docs/providers/google/index.html">Google Cloud</a></td>
+    <td><a href="/docs/providers/grafana/index.html">Grafana</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/grafana/index.html">Grafana</a></td>
     <td><a href="/docs/providers/heroku/index.html">Heroku</a></td>
     <td><a href="/docs/providers/hcloud/index.html">Hetzner Cloud</a></td>
+    <td><a href="/docs/providers/http/index.html">HTTP</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/http/index.html">HTTP</a></td>
     <td><a href="/docs/providers/icinga2/index.html">Icinga2</a></td>
     <td><a href="/docs/providers/ignition/index.html">Ignition</a></td>
+    <td><a href="/docs/providers/influxdb/index.html">InfluxDB</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/influxdb/index.html">InfluxDB</a></td>
     <td><a href="/docs/providers/kubernetes/index.html">Kubernetes</a></td>
     <td><a href="/docs/providers/librato/index.html">Librato</a></td>
+    <td><a href="/docs/providers/local/index.html">Local</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/local/index.html">Local</a></td>
     <td><a href="/docs/providers/logentries/index.html">Logentries</a></td>
     <td><a href="/docs/providers/logicmonitor/index.html">LogicMonitor</a></td>
+    <td><a href="/docs/providers/mailgun/index.html">Mailgun</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/mailgun/index.html">Mailgun</a></td>
     <td><a href="/docs/providers/mysql/index.html">MySQL</a></td>
     <td><a href="/docs/providers/newrelic/index.html">New Relic</a></td>
+    <td><a href="/docs/providers/nomad/index.html">Nomad</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/nomad/index.html">Nomad</a></td>
     <td><a href="/docs/providers/ns1/index.html">NS1</a></td>
     <td><a href="/docs/providers/null/index.html">Null</a></td>
+    <td><a href="/docs/providers/oneandone/index.html">1&1</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/oneandone/index.html">1&1</a></td>
     <td><a href="/docs/providers/openstack/index.html">OpenStack</a></td>
     <td><a href="/docs/providers/opentelekomcloud/index.html">OpenTelekomCloud</a></td>
+    <td><a href="/docs/providers/opsgenie/index.html">OpsGenie</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/opsgenie/index.html">OpsGenie</a></td>
     <td><a href="/docs/providers/opc/index.html">Oracle Public Cloud</a></td>
     <td><a href="/docs/providers/oraclepaas/index.html">Oracle Cloud Platform </a></td>
+    <td><a href="/docs/providers/ovh/index.html">OVH</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/ovh/index.html">OVH</a></td>
     <td><a href="/docs/providers/packet/index.html">Packet</a></td>
     <td><a href="/docs/providers/pagerduty/index.html">PagerDuty</a></td>
+    <td><a href="/docs/providers/panos/index.html">Palo Alto Networks</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/panos/index.html">Palo Alto Networks</a></td>
     <td><a href="/docs/providers/postgresql/index.html">PostgreSQL</a></td>
     <td><a href="/docs/providers/powerdns/index.html">PowerDNS</a></td>
+    <td><a href="/docs/providers/profitbricks/index.html">ProfitBricks</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/profitbricks/index.html">ProfitBricks</a></td>
     <td><a href="/docs/providers/rabbitmq/index.html">RabbitMQ</a></td>
     <td><a href="/docs/providers/rancher/index.html">Rancher</a></td>
+    <td><a href="/docs/providers/random/index.html">Random</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/random/index.html">Random</a></td>
     <td><a href="/docs/providers/rundeck/index.html">Rundeck</a></td>
     <td><a href="/docs/providers/scaleway/index.html">Scaleway</a></td>
+    <td><a href="/docs/providers/softlayer/index.html">SoftLayer</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/softlayer/index.html">SoftLayer</a></td>
     <td><a href="/docs/providers/statuscake/index.html">StatusCake</a></td>
     <td><a href="/docs/providers/spotinst/index.html">Spotinst</a></td>
+    <td><a href="/docs/providers/template/index.html">Template</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/template/index.html">Template</a></td>
     <td><a href="/docs/providers/terraform/index.html">Terraform</a></td>
     <td><a href="/docs/providers/terraform-enterprise/index.html">Terraform Enterprise</a></td>
+    <td><a href="/docs/providers/tls/index.html">TLS</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/tls/index.html">TLS</a></td>
     <td><a href="/docs/providers/triton/index.html">Triton</a></td>
     <td><a href="/docs/providers/ultradns/index.html">UltraDNS</a></td>
+    <td><a href="/docs/providers/vault/index.html">Vault</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/vault/index.html">Vault</a></td>
     <td><a href="/docs/providers/vcd/index.html">VMware vCloud Director</a></td>
     <td><a href="/docs/providers/nsxt/index.html">VMware NSX-T</a></td>
-    </tr>
-    <tr>
     <td><a href="/docs/providers/vsphere/index.html">VMware vSphere</a></td>
-    <td><a></a></td>
-    <td><a></a></td>
     </tr>
 </table>
 

--- a/website/docs/providers/type/community-index.html.markdown
+++ b/website/docs/providers/type/community-index.html.markdown
@@ -30,66 +30,66 @@ please fill out this [community providers form](https://docs.google.com/forms/d/
     <tr>
     <td><a href="https://github.com/nicolai86/terraform-provider-couchdb">CouchDB</a></td>
     <td><a href="https://github.com/rackn/terraform-provider-drp/">Digital Rebar</a></td>
-    <td><a href="https://github.com/gstruct/terraform-provider-dockermachine">Docker Machine</a></td>
+    <td><a href="https://github.com/terraform-providers/terraform-provider-dme">DNSMadeEasy</a></td>
     </tr>
     <tr>
+    <td><a href="https://github.com/gstruct/terraform-provider-dockermachine">Docker Machine</a></td>
     <td><a href="https://github.com/tiramiseb/terraform-provider-gandi">Gandi</a></td>
     <td><a href="https://github.com/Mastercard/terraform-provider-restapi">Generic Rest API</a></td>
-    <td><a href="https://github.com/MikeSouza/terraform-provider-glue">Glue</a></td>
     </tr>
-    <tr>   
+    <tr>
+    <td><a href="https://github.com/MikeSouza/terraform-provider-glue">Glue</a></td>
     <td><a href="https://github.com/drewsonne/terraform-provider-gocd">GoCD</a></td>
     <td><a href="https://github.com/sethvargo/terraform-provider-googlecalendar">Google Calendar</a></td>
-    <td><a href="https://github.com/DeviaVir/terraform-provider-gsuite">Google G Suite</a></td>
     </tr>
     <tr>
+    <td><a href="https://github.com/DeviaVir/terraform-provider-gsuite">Google G Suite</a></td>
     <td><a href="https://github.com/mcuadros/terraform-provider-helm">Helm</a></td>
     <td><a href="https://github.com/hetznercloud/terraform-provider-hcloud">Hetzner Cloud</a></td>
-    <td><a href="https://github.com/GSLabDev/terraform-provider-httpfileupload">HTTP File Upload</a></td>
     </tr>
     <tr>
+    <td><a href="https://github.com/GSLabDev/terraform-provider-httpfileupload">HTTP File Upload</a></td>
     <td><a href="https://github.com/HewlettPackard/terraform-provider-oneview">HP OneView</a></td>
     <td><a href="https://github.com/sky-uk/terraform-provider-infoblox">Infoblox</a></td>
-    <td><a href="https://github.com/anubhavmishra/terraform-provider-jira">Jira</a></td>
     </tr>
     <tr>
+    <td><a href="https://github.com/anubhavmishra/terraform-provider-jira">Jira</a></td>
     <td><a href-"https://github.com/geekmuse/jumpcloud-terraform-provider">JumpCloud</a></td>
     <td><a href="https://github.com/plmwong/terraform-provider-keboola">Kaboola</a></td>
-    <td><a href="https://github.com/Mongey/terraform-provider-kafka">Kafka</a></td>
     </tr>
     <tr>
+    <td><a href="https://github.com/Mongey/terraform-provider-kafka">Kafka</a></td>
     <td><a href="https://github.com/ewilde/terraform-provider-kibana">Kibana</a></td>
     <td><a href="https://github.com/kevholditch/terraform-provider-kong">Kong</a></td>
-    <td><a href="https://github.com/sl1pm4t/terraform-provider-lxd">LXD</a></td>
     </tr>
     <tr>
+    <td><a href="https://github.com/sl1pm4t/terraform-provider-lxd">LXD</a></td>
     <td><a href="https://github.com/coreos/terraform-provider-matchbox">Matchbox</a></td>
     <td><a href="https://github.com/akshaykarle/terraform-provider-mongodbatlas">MongoDB Atlas</a></td>
-    <td><a href="https://github.com/nutanix/terraform-provider-nutanix">Nutanix</a></td>
     </tr>
     <tr>
+    <td><a href="https://github.com/nutanix/terraform-provider-nutanix">Nutanix</a></td>
     <td><a href="https://github.com/GSLabDev/terraform-provider-odl">Open Day Light</a></td>
     <td><a href="https://github.com/camptocamp/terraform-provider-pass">Pass</a></td>
-    <td><a href="https://github.com/camptocamp/terraform-provider-puppetca">Puppet CA</a></td>
     </tr>
     <tr>
+    <td><a href="https://github.com/camptocamp/terraform-provider-puppetca">Puppet CA</a></td>
     <td><a href="https://github.com/camptocamp/terraform-provider-puppetdb">PuppetDB</a></td>
     <td><a href="https://github.com/yunify/terraform-provider-qingcloud">QingCloud</a></td>
-    <td><a href="https://github.com/frankfarrell/terraform-provider-redshift">Redshift</a></td>
     </tr>
     <tr>
+    <td><a href="https://github.com/frankfarrell/terraform-provider-redshift">Redshift</a></td>
     <td><a href="https://github.com/yamamoto-febc/terraform-provider-rke">RKE</a></td>
     <td><a href="https://github.com/ewilde/terraform-provider-runscope">Runscope</a></td>
-    <td><a href="https://github.com/sacloud/terraform-provider-sakuracloud">SakuraCloud</a></td>
     </tr>
     <tr>
+    <td><a href="https://github.com/sacloud/terraform-provider-sakuracloud">SakuraCloud</a></td>
     <td><a href="https://github.com/jianyuan/terraform-provider-sentry">Sentry</a></td>
     <td><a href="https://github.com/Yelp/terraform-provider-signalform">SignalFx</a></td>
-    <td><a href="https://github.com/GSLabDev/terraform-provider-scvmm">SCVMM</a></td>
     </tr>
     <tr>
+    <td><a href="https://github.com/GSLabDev/terraform-provider-scvmm">SCVMM</a></td>
     <td><a href="https://github.com/GSLabDev/terraform-provider-vra">vRealize Automation</a></td>
-    <td><a></a></td>
     <td><a></a></td>
     </tr>
 

--- a/website/docs/providers/type/network-index.html.markdown
+++ b/website/docs/providers/type/network-index.html.markdown
@@ -23,8 +23,6 @@ in close collaboration with HashiCorp, and are tested by HashiCorp.
 
 [DNSimple](/docs/providers/dnsimple/index.html)
 
-[DNSMadeEasy](/docs/providers/dme/index.html)
-
 [HTTP](/docs/providers/http/index.html)
 
 [NS1](/docs/providers/ns1/index.html)


### PR DESCRIPTION
This is quite a bold pull request, made in response to some major issues with the DNS Made Easy provider which I think should render it as no longer supported by Hashicorp. The provider has a [major bug](https://github.com/terraform-providers/terraform-provider-dme/issues/1) where changes to existing resources are said to be applied, but are not, which means the only way to really use the provider is to taint every resource that you want to modify. In production, this is of course rarely a suitable thing to do to a DNS record.

Given that the provider doesn't support making changes to existing records, I think including it on a list of official Terraform providers is disingenuous. It leaves a potential user to start using it to discover that it isn't really usable.

The provider also doesn't appear to gracefully [handle DNS Made Easy's API rate limits](https://github.com/terraform-providers/terraform-provider-dme/issues/2), which makes it close to unusable when dealing with a large portfolio of resources.

Issues and pull requests to fix major issues have been open in the repository since at least June and October last year, respectively, without any attention from maintainers.

Examples:
* https://github.com/terraform-providers/terraform-provider-dme/issues/1 (reported again at [#11](https://github.com/terraform-providers/terraform-provider-dme/issues/11))
* https://github.com/terraform-providers/terraform-provider-dme/issues/2
* https://github.com/terraform-providers/terraform-provider-dme/pull/7

Given this, I think the provider should be considered in the docs as a community provider and not a core Terraform one, to avoid misleading potential users as to its suitability.

_Note: Although the only effective change in the commit is removing DME from the main index and network index, and adding it to the community index, the table columns have also been adjusted to ensure that three providers remain in each row._