### PR TITLE
Addition of lifecyle only_add

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -115,6 +115,7 @@ func (r *Resource) Copy() *Resource {
 type ResourceLifecycle struct {
 	CreateBeforeDestroy bool     `mapstructure:"create_before_destroy"`
 	PreventDestroy      bool     `mapstructure:"prevent_destroy"`
+	OnlyAdd             bool     `mapstructure:"only_add"`
 	IgnoreChanges       []string `mapstructure:"ignore_changes"`
 }
 
@@ -123,6 +124,7 @@ func (r *ResourceLifecycle) Copy() *ResourceLifecycle {
 	n := &ResourceLifecycle{
 		CreateBeforeDestroy: r.CreateBeforeDestroy,
 		PreventDestroy:      r.PreventDestroy,
+		OnlyAdd:             r.OnlyAdd,
 		IgnoreChanges:       make([]string, len(r.IgnoreChanges)),
 	}
 	copy(n.IgnoreChanges, r.IgnoreChanges)

--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -1012,7 +1012,7 @@ func loadManagedResourcesHcl(list *ast.ObjectList) ([]*Resource, error) {
 			}
 
 			// Check for invalid keys
-			valid := []string{"create_before_destroy", "ignore_changes", "prevent_destroy"}
+			valid := []string{"create_before_destroy", "ignore_changes", "prevent_destroy", "only_add"}
 			if err := checkHCLKeys(o.Items[0].Val, valid); err != nil {
 				return nil, multierror.Prefix(err, fmt.Sprintf(
 					"%s[%s]:", t, k))

--- a/config/loader_hcl2.go
+++ b/config/loader_hcl2.go
@@ -90,6 +90,7 @@ func (t *hcl2Configurable) Config() (*Config, error) {
 	}
 	type resourceLifecycle struct {
 		CreateBeforeDestroy *bool     `hcl:"create_before_destroy,attr"`
+		OnlyAdd             *bool     `hcl:"only_add,attr"`
 		PreventDestroy      *bool     `hcl:"prevent_destroy,attr"`
 		IgnoreChanges       *[]string `hcl:"ignore_changes,attr"`
 	}
@@ -314,6 +315,9 @@ func (t *hcl2Configurable) Config() (*Config, error) {
 			var l ResourceLifecycle
 			if rawR.Lifecycle.CreateBeforeDestroy != nil {
 				l.CreateBeforeDestroy = *rawR.Lifecycle.CreateBeforeDestroy
+			}
+			if rawR.Lifecycle.OnlyAdd != nil {
+				l.OnlyAdd = *rawR.Lifecycle.OnlyAdd
 			}
 			if rawR.Lifecycle.PreventDestroy != nil {
 				l.PreventDestroy = *rawR.Lifecycle.PreventDestroy

--- a/config/test-fixtures/only-add-string.tf
+++ b/config/test-fixtures/only-add-string.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "web" {
+    ami = "foo"
+    lifecycle {
+        only_add = "true"
+    }
+}
+
+resource "aws_instance" "bar" {
+    ami = "foo"
+}

--- a/configs/resource.go
+++ b/configs/resource.go
@@ -25,11 +25,13 @@ type ManagedResource struct {
 
 	CreateBeforeDestroy bool
 	PreventDestroy      bool
+	OnlyAdd             bool
 	IgnoreChanges       []hcl.Traversal
 	IgnoreAllChanges    bool
 
 	CreateBeforeDestroySet bool
 	PreventDestroySet      bool
+	OnlyAddSet             bool
 
 	DeclRange hcl.Range
 	TypeRange hcl.Range
@@ -110,6 +112,12 @@ func decodeResourceBlock(block *hcl.Block) (*ManagedResource, hcl.Diagnostics) {
 				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &r.CreateBeforeDestroy)
 				diags = append(diags, valDiags...)
 				r.CreateBeforeDestroySet = true
+			}
+
+			if attr, exists := lcContent.Attributes["only_add"]; exists {
+				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &r.OnlyAdd)
+				diags = append(diags, valDiags...)
+				r.OnlyAddSet = true
 			}
 
 			if attr, exists := lcContent.Attributes["prevent_destroy"]; exists {
@@ -414,6 +422,9 @@ var resourceLifecycleBlockSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{
 			Name: "create_before_destroy",
+		},
+		{
+			Name: "only_add",
 		},
 		{
 			Name: "prevent_destroy",

--- a/terraform/eval_check_only_add.go
+++ b/terraform/eval_check_only_add.go
@@ -1,0 +1,27 @@
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/config"
+)
+
+// EvalOnlyAdd is an EvalNode implementation that turns off the destroy flag if it is ever set
+type EvalCheckOnlyAdd struct {
+	Resource   *config.Resource
+	ResourceId string
+	Diff       **InstanceDiff
+}
+
+func (n *EvalCheckOnlyAdd) Eval(ctx EvalContext) (interface{}, error) {
+	if n.Diff == nil || *n.Diff == nil || n.Resource == nil {
+		return nil, nil
+	}
+
+	diff := *n.Diff
+	onlyAdd := n.Resource.Lifecycle.OnlyAdd
+
+	if diff.GetDestroy() && onlyAdd {
+		diff.SetDestroy(false)
+	}
+
+	return nil, nil
+}

--- a/terraform/node_resource_plan_destroy.go
+++ b/terraform/node_resource_plan_destroy.go
@@ -40,6 +40,10 @@ func (n *NodePlanDestroyableResource) EvalTree() EvalNode {
 				State:  &state,
 				Output: &diff,
 			},
+			&EvalCheckOnlyAdd{
+				Resource: n.Config,
+				Diff:     &diff,
+			},
 			&EvalCheckPreventDestroy{
 				Resource: n.Config,
 				Diff:     &diff,

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -170,6 +170,10 @@ func (n *NodePlannableResourceInstance) evalTreeManagedResource(
 				OutputDiff:  &diff,
 				OutputState: &state,
 			},
+			&EvalCheckOnlyAdd{
+				Resource: n.Config,
+				Diff:     &diff,
+			},
 			&EvalCheckPreventDestroy{
 				Resource: n.Config,
 				Diff:     &diff,

--- a/terraform/node_resource_plan_orphan.go
+++ b/terraform/node_resource_plan_orphan.go
@@ -40,6 +40,11 @@ func (n *NodePlannableResourceOrphan) EvalTree() EvalNode {
 				State:  &state,
 				Output: &diff,
 			},
+			&EvalCheckOnlyAdd{
+				Resource:   n.Config,
+				ResourceId: stateId,
+				Diff:       &diff,
+			},
 			&EvalCheckPreventDestroy{
 				Resource:   n.Config,
 				ResourceId: stateId,

--- a/terraform/test-fixtures/plan-only-add-bad/main.tf
+++ b/terraform/test-fixtures/plan-only-add-bad/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+  require_new = "yes"
+
+  lifecycle {
+    only_add = true
+  }
+}

--- a/terraform/test-fixtures/plan-only-add-count-bad/main.tf
+++ b/terraform/test-fixtures/plan-only-add-count-bad/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "foo" {
+  count = "1"
+  current = "${count.index+1}"
+
+  lifecycle {
+     only_add = true
+  }
+}

--- a/terraform/test-fixtures/plan-only-add-count-good/main.tf
+++ b/terraform/test-fixtures/plan-only-add-count-good/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "foo" {
+  count = "2"
+  current = "${count.index}"
+
+  lifecycle {
+    only_add = true
+  }
+}

--- a/terraform/test-fixtures/plan-only-add-good/main.tf
+++ b/terraform/test-fixtures/plan-only-add-good/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "foo" {
+  lifecycle {
+     only_add = true
+  }
+}

--- a/website/docs/configuration/resources.html.md
+++ b/website/docs/configuration/resources.html.md
@@ -71,6 +71,11 @@ There are **meta-parameters** available to all resources:
     example, this can be used to create an new DNS record before removing an old
     record.
 
+  - `only_add` (bool) - This flag is used to ensure that terraform will perform
+     only additions of new resources.  Resources with `only_add` will not be
+     destroyed.  Unlike `prevent_destroy`, which results in an error when resources
+     would be destroyed, `only_add` will continue with remaining resource plans.
+
   - `prevent_destroy` (bool) - This flag provides extra protection against the
     destruction of a given resource. When this is set to `true`, any plan that
     includes a destroy of this resource will return an error message.


### PR DESCRIPTION
The `only_add` lifecycle allows resources to be created, but never destroyed.  This lifecycle is different from `prevent_destroy` . Prevent destroy will cause a Terraform plan to fail with an error message if a resource is slated for destruction.  This is a very useful case, but not always ideal.  

The scenario for adding this is as follow:

* Consul K/V stores are used to track how many resources are needed.  These keys are fed into Terraform's "count" parameter for each module

* When Load Balancers detect more nodes are needed, the Consul KV stores are updated, terraform adds new nodes.

* When Load Balancers detect less nodes are needed, Consult KV stores are updated again -- however, terraform cannot tear down the nodes, as a unique tear down process happens inside the individual nodes. (They terminate themselves)  With the presence of `only_add` Terraform will act only when counts increase, and ignore cases where the count of nodes decreases. 