### PR TITLE
add Config to the PlanResourceChangeRequest

### DIFF
--- a/providers/provider.go
+++ b/providers/provider.go
@@ -187,6 +187,12 @@ type PlanResourceChangeRequest struct {
 	// changes required to create the proposed final state.
 	ProposedNewState cty.Value
 
+	// Config is the resource configuration, before being merged with the
+	// PriorState. Any value not explicitly set in the configuration will be
+	// null. Config is supplied for reference, but Provider implementations
+	// should prefer the ProposedNewState in most circumstances.
+	Config cty.Value
+
 	// PriorPrivate is the previously saved private data returned from the
 	// provider during the last apply.
 	PriorPrivate []byte


### PR DESCRIPTION
In order for providers to determine if a computed value was unset in the
configuration, the configuration must be passed along with the prior and
proposed states. Terraform core will still handle the creation of the
ProposedNewState to ensure correctness, but the raw configuration value
will also be supplied for comparison.