### PR TITLE
only add "id" to top-level resources

### DIFF
--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -73,7 +73,7 @@ func (s *Schema) coreConfigSchemaAttribute() *configschema.Attribute {
 // of Resource, and will panic otherwise.
 func (s *Schema) coreConfigSchemaBlock() *configschema.NestedBlock {
 	ret := &configschema.NestedBlock{}
-	if nested := s.Elem.(*Resource).CoreConfigSchema(); nested != nil {
+	if nested := s.Elem.(*Resource).coreConfigSchema(); nested != nil {
 		ret.Block = *nested
 	}
 	switch s.Type {
@@ -126,7 +126,7 @@ func (s *Schema) coreConfigSchemaType() cty.Type {
 			// In practice we don't actually use this for normal schema
 			// construction because we construct a NestedBlock in that
 			// case instead. See schemaMap.CoreConfigSchema.
-			elemType = set.CoreConfigSchema().ImpliedType()
+			elemType = set.coreConfigSchema().ImpliedType()
 		default:
 			if set != nil {
 				// Should never happen for a valid schema

--- a/helper/schema/core_schema_test.go
+++ b/helper/schema/core_schema_test.go
@@ -304,9 +304,9 @@ func TestSchemaMapCoreConfigSchema(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := schemaMap(test.Schema).CoreConfigSchema()
-			if !cmp.Equal(got, test.Want, typeComparer) {
-				cmp.Diff(got, test.Want, typeComparer)
+			got := (&Resource{Schema: test.Schema}).CoreConfigSchema()
+			if !cmp.Equal(got, test.Want, equateEmpty, typeComparer) {
+				t.Error(cmp.Diff(got, test.Want, equateEmpty, typeComparer))
 			}
 		})
 	}


### PR DESCRIPTION
The original code assumed a Resource was a top-level construct only, but it's overloaded to also represent nested blocks which don't require the "id" attribute. Rather than try to guess where a `Resource` is going to be located, make a separate `CoreConfigResourceSchema` method for the top level blocks.

Due to a typo not calling `t.Error` in the tests, refactoring the id insertion didn't fail when it should have, and the previous PR never really worked.