### PR TITLE
remote/backend/http: add env var config options

### DIFF
--- a/state/remote/artifactory.go
+++ b/state/remote/artifactory.go
@@ -16,35 +16,30 @@ func artifactoryFactory(conf map[string]string) (Client, error) {
 	if !ok {
 		userName = os.Getenv("ARTIFACTORY_USERNAME")
 		if userName == "" {
-			return nil, fmt.Errorf(
-				"missing 'username' configuration or ARTIFACTORY_USERNAME environment variable")
+			return nil, fmt.Errorf("missing 'username' configuration or ARTIFACTORY_USERNAME environment variable")
 		}
 	}
 	password, ok := conf["password"]
 	if !ok {
 		password = os.Getenv("ARTIFACTORY_PASSWORD")
 		if password == "" {
-			return nil, fmt.Errorf(
-				"missing 'password' configuration or ARTIFACTORY_PASSWORD environment variable")
+			return nil, fmt.Errorf("missing 'password' configuration or ARTIFACTORY_PASSWORD environment variable")
 		}
 	}
 	url, ok := conf["url"]
 	if !ok {
 		url = os.Getenv("ARTIFACTORY_URL")
 		if url == "" {
-			return nil, fmt.Errorf(
-				"missing 'url' configuration or ARTIFACTORY_URL environment variable")
+			return nil, fmt.Errorf("missing 'url' configuration or ARTIFACTORY_URL environment variable")
 		}
 	}
 	repo, ok := conf["repo"]
 	if !ok {
-		return nil, fmt.Errorf(
-			"missing 'repo' configuration")
+		return nil, fmt.Errorf("missing 'repo' configuration")
 	}
 	subpath, ok := conf["subpath"]
 	if !ok {
-		return nil, fmt.Errorf(
-			"missing 'subpath' configuration")
+		return nil, fmt.Errorf("missing 'subpath' configuration")
 	}
 
 	clientConf := &artifactory.ClientConfig{

--- a/state/remote/http_test.go
+++ b/state/remote/http_test.go
@@ -87,7 +87,7 @@ func assertError(t *testing.T, err error, expected string) {
 func TestHTTPClientFactory(t *testing.T) {
 	// missing address
 	_, err := httpFactory(map[string]string{})
-	assertError(t, err, "missing 'address' configuration")
+	assertError(t, err, "missing 'address' configuration or HTTP_REMOTE_ADDRESS environment variable")
 
 	// defaults
 	conf := map[string]string{


### PR DESCRIPTION
Allow HTTP backend's config options such as addresses and user/pass info to be configured via environment variables (similar to the other remote backend options).