### PR TITLE
Fixes `curl` example call in API docs

### DIFF
--- a/website/docs/registry/api.html.md
+++ b/website/docs/registry/api.html.md
@@ -70,7 +70,7 @@ These endpoints list modules according to some criteria.
 ### Sample Request
 
 ```text
-$ curl 'https://registry.terraform.io/v1/modules&limit=2&verified=true'
+$ curl 'https://registry.terraform.io/v1/modules?limit=2&verified=true'
 ```
 
 ### Sample Response


### PR DESCRIPTION
The example `curl` doesn't work when copy/pasted. Using proper http URL separators for query parameters fixes this and makes it uniform to all other examples.