### PR TITLE
handle Null collections in flatmaps

### DIFF
--- a/config/hcl2shim/flatmap.go
+++ b/config/hcl2shim/flatmap.go
@@ -68,6 +68,10 @@ func flatmapValueFromHCL2Primitive(m map[string]string, key string, val cty.Valu
 }
 
 func flatmapValueFromHCL2Map(m map[string]string, prefix string, val cty.Value) {
+	if val.IsNull() {
+		// Omit entirely
+		return
+	}
 	if !val.IsKnown() {
 		switch {
 		case val.Type().IsObjectType():
@@ -95,6 +99,10 @@ func flatmapValueFromHCL2Map(m map[string]string, prefix string, val cty.Value) 
 }
 
 func flatmapValueFromHCL2Seq(m map[string]string, prefix string, val cty.Value) {
+	if val.IsNull() {
+		// Omit entirely
+		return
+	}
 	if !val.IsKnown() {
 		m[prefix+"#"] = UnknownVariableValue
 		return


### PR DESCRIPTION
When creating a flatmap from a cty.Value, there may be Null collections
which don't need to be added to the flatmap at all. Skip over these to
avoid panicking in ElementIterator with a Null value.