### PR TITLE
change chef linux provisioner to use user:group chown syntax

### DIFF
--- a/builtin/provisioners/chef/linux_provisioner.go
+++ b/builtin/provisioners/chef/linux_provisioner.go
@@ -92,7 +92,7 @@ func (p *provisioner) linuxCreateConfigFiles(o terraform.UIOutput, comm communic
 			if err := p.runCommand(o, comm, fmt.Sprintf(chmod, hintsDir, 600)); err != nil {
 				return err
 			}
-			if err := p.runCommand(o, comm, "chown -R root.root "+hintsDir); err != nil {
+			if err := p.runCommand(o, comm, "chown -R root:root "+hintsDir); err != nil {
 				return err
 			}
 		}
@@ -106,7 +106,7 @@ func (p *provisioner) linuxCreateConfigFiles(o terraform.UIOutput, comm communic
 		if err := p.runCommand(o, comm, fmt.Sprintf(chmod, linuxConfDir, 600)); err != nil {
 			return err
 		}
-		if err := p.runCommand(o, comm, "chown -R root.root "+linuxConfDir); err != nil {
+		if err := p.runCommand(o, comm, "chown -R root:root "+linuxConfDir); err != nil {
 			return err
 		}
 	}

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -193,10 +193,10 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 				"sudo " + fmt.Sprintf(chmod, path.Join(linuxConfDir, "ohai/hints"), 666): true,
 				"sudo chmod 755 " + path.Join(linuxConfDir, "ohai/hints"):                true,
 				"sudo " + fmt.Sprintf(chmod, path.Join(linuxConfDir, "ohai/hints"), 600): true,
-				"sudo chown -R root.root " + path.Join(linuxConfDir, "ohai/hints"):       true,
+				"sudo chown -R root:root " + path.Join(linuxConfDir, "ohai/hints"):       true,
 				"sudo chmod 755 " + linuxConfDir:                                         true,
 				"sudo " + fmt.Sprintf(chmod, linuxConfDir, 600):                          true,
-				"sudo chown -R root.root " + linuxConfDir:                                true,
+				"sudo chown -R root:root " + linuxConfDir:                                true,
 			},
 
 			Uploads: map[string]string{


### PR DESCRIPTION
`chown user.group` appears to _work_ in linux but not documented (at least not in the `chown` man page). It also simply doesn't work at all in freebsd (at least on my pfsense machine based on freebsd 11). This changes the provisioner to use the more standard `chown user:group` syntax.

Please let me know if this introduces some obscure compatibility issue I'm not aware of.