### PR TITLE
set user-agent to terraform version for remote http state calls

### DIFF
--- a/state/remote/http.go
+++ b/state/remote/http.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform/state"
+	"github.com/hashicorp/terraform/version"
 )
 
 func httpFactory(conf map[string]string) (Client, error) {
@@ -144,7 +145,8 @@ func (c *HTTPClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	if c.Username != "" {
 		req.SetBasicAuth(c.Username, c.Password)
 	}
-
+	// Setup Useragent
+	req.Header.Set("User-Agent", version.String())
 	// Work with data/body
 	if data != nil {
 		req.Header.Set("Content-Type", "application/json")

--- a/state/remote/http_test.go
+++ b/state/remote/http_test.go
@@ -3,14 +3,14 @@ package remote
 import (
 	"bytes"
 	"fmt"
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/terraform/version"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"testing"
-
-	"github.com/hashicorp/go-cleanhttp"
 )
 
 func TestHTTPClient_impl(t *testing.T) {
@@ -153,6 +153,10 @@ type testHTTPHandler struct {
 }
 
 func (h *testHTTPHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("User-Agent") != version.String() {
+		w.WriteHeader(500)
+		return
+	}
 	switch r.Method {
 	case "GET":
 		w.Write(h.Data)


### PR DESCRIPTION
test has been updated as well to check for a correct user agent

This is a small proof of concept, and I am open to updating the user agent format.


Issue: https://github.com/hashicorp/terraform/issues/18547