### PR TITLE
Correcting terraform custom provider name in community-index.html.markdown

### DIFF
--- a/website/docs/providers/type/community-index.html.markdown
+++ b/website/docs/providers/type/community-index.html.markdown
@@ -54,8 +54,8 @@ please fill out this [community providers form](https://docs.google.com/forms/d/
     </tr>
     <tr>
     <td><a href-"https://github.com/geekmuse/jumpcloud-terraform-provider">JumpCloud</a></td>
-    <td><a href="https://github.com/plmwong/terraform-provider-keboola">Kaboola</a></td>
     <td><a href="https://github.com/Mongey/terraform-provider-kafka">Kafka</a></td>
+    <td><a href="https://github.com/plmwong/terraform-provider-keboola">Keboola</a></td>
     </tr>
     <tr>
     <td><a href="https://github.com/ewilde/terraform-provider-kibana">Kibana</a></td>


### PR DESCRIPTION
Corrected the naming of the 'Keboola' provider (https://github.com/plmwong/terraform-provider-keboola) and shifted it down to keep alphabetical ordering.