### PR TITLE
help: Make version and help flags consistent

### DIFF
--- a/help.go
+++ b/help.go
@@ -32,7 +32,7 @@ func helpFunc(commands map[string]cli.CommandFactory) string {
 	// website/source/docs/commands/index.html.markdown; if you
 	// change this then consider updating that to match.
 	helpText := fmt.Sprintf(`
-Usage: terraform [--version] [--help] <command> [args]
+Usage: terraform [-version] [-help] <command> [args]
 
 The available commands for execution are listed below.
 The most common, useful commands are shown first, followed by


### PR DESCRIPTION
These flags are presented as POSIX/GNU-style long-form flags
(double-dash), whereas the rest of our CLI flags as seen in sub-commands
are presented as single-dash options.

While both work in both cases (on part of the flag package allowing
double dashes as well), we converge around the single-dash form, so the
basic help text here should be consistent.