### PR TITLE
StateUpgrade redux

### DIFF
--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -1507,8 +1507,7 @@ func TestResource_ValidateUpgradeState(t *testing.T) {
 		t.Fatal("StateUpgraders cannot skip versions")
 	}
 
-	// add the missing version
-	// out of order upgraders should be OK
+	// add the missing version, but fail because it's still out of order
 	r.StateUpgraders = append(r.StateUpgraders, StateUpgrader{
 		Version: 1,
 		Type: cty.Object(map[string]cty.Type{
@@ -1518,6 +1517,11 @@ func TestResource_ValidateUpgradeState(t *testing.T) {
 			return m, nil
 		},
 	})
+	if err := r.InternalValidate(nil, true); err == nil {
+		t.Fatal("upgraders must be defined in order")
+	}
+
+	r.StateUpgraders[1], r.StateUpgraders[2] = r.StateUpgraders[2], r.StateUpgraders[1]
 	if err := r.InternalValidate(nil, true); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
It turns out that state upgrades need to be handled differently since
providers are going to be backwards compatible. This means that new
state upgrades may still be stored in the flatmap format when used wih
terraform 0.11. Because we can't account for the specific version which
could produce a legacy state, all future state upgrades need to record
the schema types for decoding.

Rather than defining a single Upgrade function for states, we now have a
list of functions, each of which handle upgrading a specific version to
the next. In practice this isn't much different from the way many
resources implement upgrades themselves, with a separate function for
each version dispatched from the MigrateState function. The only added
burden is the recording of the schema type, and we intend to supply
tools and helper function to prevent the need to copy the entire
existing schema in all cases.