### PR TITLE
backend/remote: use schema max/min items options

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -98,6 +98,8 @@ func New(services *disco.Disco) *Remote {
 				Type:        schema.TypeSet,
 				Required:    true,
 				Description: schemaDescriptions["workspaces"],
+				MinItems:    1,
+				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{
@@ -129,15 +131,8 @@ func (b *Remote) configure(ctx context.Context) error {
 	b.hostname = d.Get("hostname").(string)
 	b.organization = d.Get("organization").(string)
 
-	// Get the workspaces configuration.
-	workspaces := d.Get("workspaces").(*schema.Set)
-	if workspaces.Len() != 1 {
-		return fmt.Errorf("only one 'workspaces' block allowed")
-	}
-
-	// After checking that we have exactly one workspace block, we can now get
-	// and assert that one workspace from the set.
-	workspace := workspaces.List()[0].(map[string]interface{})
+	// Get and assert the workspaces configuration block.
+	workspace := d.Get("workspaces").(*schema.Set).List()[0].(map[string]interface{})
 
 	// Get the default workspace name and prefix.
 	b.workspace = workspace["name"].(string)

--- a/backend/remote/backend_test.go
+++ b/backend/remote/backend_test.go
@@ -43,20 +43,6 @@ func TestRemote_config(t *testing.T) {
 			},
 			err: nil,
 		},
-		"with_two_workspace_entries": {
-			config: map[string]interface{}{
-				"organization": "hashicorp",
-				"workspaces": []interface{}{
-					map[string]interface{}{
-						"name": "prod",
-					},
-					map[string]interface{}{
-						"prefix": "my-app-",
-					},
-				},
-			},
-			err: errors.New("only one 'workspaces' block allowed"),
-		},
 		"without_either_a_name_and_a_prefix": {
 			config: map[string]interface{}{
 				"organization": "hashicorp",


### PR DESCRIPTION
Using these default options prevents the need for checking this in the backend
code by just leveraging the default schema validation logic.