### PR TITLE
added make install to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ echo "Upgrading packages ..."
 apt-get update ${APT_OPTS} >/dev/null
 apt-get upgrade ${APT_OPTS} >/dev/null
 echo "Installing prerequisites ..."
-apt-get install ${APT_OPTS} build-essential curl git-core libpcre3-dev mercurial pkg-config zip >/dev/null
+apt-get install ${APT_OPTS} build-essential curl git-core libpcre3-dev mercurial pkg-config zip make >/dev/null
 
 # Install Go
 echo "Downloading go (${GOVERSION}) ..."


### PR DESCRIPTION
Getting started using Vagrant requires the user to run `make` commands in the VM

This command fails because `make` isn't installed inside the VM by default. 

This PR adds `make` to the `apt-get install` command
 
The documentation is already written assuming that make is installed:
https://github.com/hashicorp/terraform#developing-terraform