### PR TITLE
Add support for HTTP proxy env vars.

### DIFF
--- a/backend/remote-state/artifactory/backend.go
+++ b/backend/remote-state/artifactory/backend.go
@@ -2,8 +2,8 @@ package artifactory
 
 import (
 	"context"
-	"net/http"
 
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/state"
@@ -66,12 +66,10 @@ func (b *Backend) configure(ctx context.Context) error {
 	subpath := data.Get("subpath").(string)
 
 	clientConf := &artifactory.ClientConfig{
-		BaseURL:  url,
-		Username: userName,
-		Password: password,
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-		},
+		BaseURL:   url,
+		Username:  userName,
+		Password:  password,
+		Transport: cleanhttp.DefaultPooledTransport(),
 	}
 	nativeClient := artifactory.NewClient(clientConf)
 

--- a/backend/remote-state/artifactory/backend.go
+++ b/backend/remote-state/artifactory/backend.go
@@ -2,6 +2,7 @@ package artifactory
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -68,6 +69,9 @@ func (b *Backend) configure(ctx context.Context) error {
 		BaseURL:  url,
 		Username: userName,
 		Password: password,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
 	}
 	nativeClient := artifactory.NewClient(clientConf)
 


### PR DESCRIPTION
Added a minimal transport to the artifactory client so that it support proxy environment variables. This should fix this issue https://github.com/hashicorp/terraform/issues/9403 .

Upstream there's this issue opened https://github.com/lusis/go-artifactory/issues/9 but I think there might need to be some refactor on terraform's side to support the latest client.