### PR TITLE
Add wildcard for tainting/untaining

### DIFF
--- a/command/untaint.go
+++ b/command/untaint.go
@@ -6,7 +6,9 @@ import (
 	"log"
 	"strings"
 
+	"github.com/gobwas/glob"
 	"github.com/hashicorp/terraform/command/clistate"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 // UntaintCommand is a cli.Command implementation that manually untaints
@@ -120,9 +122,23 @@ func (c *UntaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Get the resource we're looking for
-	rs, ok := mod.Resources[name]
-	if !ok {
+	g, err := glob.Compile(name)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"The glob %s is not correct.",
+			name))
+	}
+
+	// Get the resources we're looking for
+	resources := make(map[string]*terraform.ResourceState)
+	if err == nil {
+		for key, rs := range mod.Resources {
+			if g.Match(key) {
+				resources[key] = rs
+			}
+		}
+	}
+	if len(resources) == 0 {
 		if allowMissing {
 			return c.allowMissingExit(name, module)
 		}
@@ -134,8 +150,13 @@ func (c *UntaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Untaint the resource
-	rs.Untaint()
+	for target, rs := range resources {
+		// Untaint the resource
+		rs.Untaint()
+		c.Ui.Output(fmt.Sprintf(
+			"The resource %s in the module %s has been successfully untainted!",
+			target, module))
+	}
 
 	log.Printf("[INFO] Writing state output to: %s", c.Meta.StateOutPath())
 	if err := st.WriteState(s); err != nil {
@@ -147,9 +168,6 @@ func (c *UntaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.Ui.Output(fmt.Sprintf(
-		"The resource %s in the module %s has been successfully untainted!",
-		name, module))
 	return 0
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1327,6 +1327,54 @@
 			"revisionTime": "2018-01-28T22:55:04Z"
 		},
 		{
+			"checksumSHA1": "/RE0VzeaXdaBUNeNMUXWqzly7qY=",
+			"path": "github.com/gobwas/glob",
+			"revision": "f00a7392b43971b2fdb562418faab1f18da2067a",
+			"revisionTime": "2018-04-02T14:15:43Z"
+		},
+		{
+			"checksumSHA1": "UIxNdlqa2kcYi5EEe79/WzyPiz4=",
+			"path": "github.com/gobwas/glob/compiler",
+			"revision": "f00a7392b43971b2fdb562418faab1f18da2067a",
+			"revisionTime": "2018-04-02T14:15:43Z"
+		},
+		{
+			"checksumSHA1": "jNdbCxBabqjv9tREXA4Nx45Y4wg=",
+			"path": "github.com/gobwas/glob/match",
+			"revision": "f00a7392b43971b2fdb562418faab1f18da2067a",
+			"revisionTime": "2018-04-02T14:15:43Z"
+		},
+		{
+			"checksumSHA1": "2KhDNUE98XhHnIgg2S9E4gcWoig=",
+			"path": "github.com/gobwas/glob/syntax",
+			"revision": "f00a7392b43971b2fdb562418faab1f18da2067a",
+			"revisionTime": "2018-04-02T14:15:43Z"
+		},
+		{
+			"checksumSHA1": "FPIMdPSazNZGNU+ZmPtIeZpVHFU=",
+			"path": "github.com/gobwas/glob/syntax/ast",
+			"revision": "f00a7392b43971b2fdb562418faab1f18da2067a",
+			"revisionTime": "2018-04-02T14:15:43Z"
+		},
+		{
+			"checksumSHA1": "umyztSrQrQIl9JgwhDDb6wrSLeI=",
+			"path": "github.com/gobwas/glob/syntax/lexer",
+			"revision": "f00a7392b43971b2fdb562418faab1f18da2067a",
+			"revisionTime": "2018-04-02T14:15:43Z"
+		},
+		{
+			"checksumSHA1": "vux29fN5O22F3QPLOnjQ37278vg=",
+			"path": "github.com/gobwas/glob/util/runes",
+			"revision": "f00a7392b43971b2fdb562418faab1f18da2067a",
+			"revisionTime": "2018-04-02T14:15:43Z"
+		},
+		{
+			"checksumSHA1": "Sxp2AHWkkLkIq6w9aMcLmzcwD6w=",
+			"path": "github.com/gobwas/glob/util/strings",
+			"revision": "f00a7392b43971b2fdb562418faab1f18da2067a",
+			"revisionTime": "2018-04-02T14:15:43Z"
+		},
+		{
 			"checksumSHA1": "q3Bc7JpLWBqhZ4M7oreGo34RSkc=",
 			"path": "github.com/golang/protobuf/proto",
 			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",


### PR DESCRIPTION
I think wildcards in taint command could really be useful so I created this proposal to stir up the discussion. 
The exact format of wildcards can be decided but this works for now. It supports commands like:
`terraform taint aws_instance.*`
`terraform taint --module=foo "*"` (double qoutes are required so bash doesn't expand it)
`terraform untaint *test*`

Taint and untaint should work the same.

It removes some error messages so it could be considered a breaking change.
Closes #1768 
Closes #16651
Conflicts with #12289 
