### PR TITLE
pretty-print json in http requests/responses

### DIFF
--- a/helper/logging/transport.go
+++ b/helper/logging/transport.go
@@ -1,9 +1,12 @@
 package logging
 
 import (
+	"bytes"
+	"encoding/json"
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 )
 
 type transport struct {
@@ -15,7 +18,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if IsDebugOrHigher() {
 		reqData, err := httputil.DumpRequestOut(req, true)
 		if err == nil {
-			log.Printf("[DEBUG] "+logReqMsg, t.name, string(reqData))
+			log.Printf("[DEBUG] "+logReqMsg, t.name, prettyPrintJsonLines(reqData))
 		} else {
 			log.Printf("[ERROR] %s API Request error: %#v", t.name, err)
 		}
@@ -29,7 +32,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if IsDebugOrHigher() {
 		respData, err := httputil.DumpResponse(resp, true)
 		if err == nil {
-			log.Printf("[DEBUG] "+logRespMsg, t.name, string(respData))
+			log.Printf("[DEBUG] "+logRespMsg, t.name, prettyPrintJsonLines(respData))
 		} else {
 			log.Printf("[ERROR] %s API Response error: %#v", t.name, err)
 		}
@@ -40,6 +43,20 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func NewTransport(name string, t http.RoundTripper) *transport {
 	return &transport{name, t}
+}
+
+// prettyPrintJsonLines iterates through a []byte line-by-line,
+// transforming any lines that are complete json into pretty-printed json.
+func prettyPrintJsonLines(b []byte) string {
+	parts := strings.Split(string(b), "\n")
+	for i, p := range parts {
+		if b := []byte(p); json.Valid(b) {
+			var out bytes.Buffer
+			json.Indent(&out, b, "", " ")
+			parts[i] = out.String()
+		}
+	}
+	return strings.Join(parts, "\n")
 }
 
 const logReqMsg = `%s API Request Details:


### PR DESCRIPTION
log messages in provider code get passed through this function: https://github.com/hashicorp/terraform/blob/35d47201ad24d89081d55ea3057c5f7144761b2c/vendor/github.com/hashicorp/go-plugin/client.go#L754-L790

If a line contains only JSON, it looks for specific entries in the JSON map to give it instructions on how it should be printed. In this particular case, since we're just printing JSON being sent to/from a server, we don't want it to contain those special messages, we want it to get printed directly.

By pretty-printing it, we end up with no one line that contains valid JSON (so they all get printed), and we have the benefit of easier-to-read logs. Win-win!