### PR TITLE
Separate issue templates for Bugs vs. Features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Let us know about an unexpected error, a crash, or an incorrect behavior.
+
+---
+
 <!--
 Hi there,
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,59 @@
+---
+name: Feature request
+about: Suggest a new feature or other enhancement.
+
+---
+
+<!--
+Hi there,
+
+Thank you for opening an issue. Please note that we try to keep the Terraform issue tracker reserved for bug reports and feature requests. For general usage questions, please see: https://www.terraform.io/community.html.
+
+If your issue relates to a specific Terraform provider, please open it in the provider's own repository. The index of providers is at https://github.com/terraform-providers .
+-->
+
+### Current Terraform Version
+<!---
+Run `terraform -v` to show the version, and paste the result between the ``` marks below. This will record which version was current at the time of your feature request, to help manage the request backlog.
+
+If you're not using the latest version, please check to see if something related to your request has already been implemented in a later version.
+-->
+
+```
+...
+```
+
+### Use-cases
+<!---
+In order to properly evaluate a feature request, it is necessary to understand the use-cases for it.
+
+Please describe below the _end goal_ you are trying to achieve that has led you to request this feature.
+
+Please keep this section focused on the problem and not on the suggested solution. We'll get to that in a moment, below!
+-->
+
+### Attempted Solutions
+<!---
+If you've already tried to solve the problem within Terraform's existing features and found a limitation that prevented you from succeeding, please describe it below in as much detail as possible.
+
+Ideally, this would include real configuration snippets that you tried, real Terraform command lines you ran, and what results you got in each case.
+
+Please remove any sensitive information such as passwords before sharing configuration snippets and command lines.
+--->
+
+### Proposal
+<!---
+If you have an idea for a way to address the problem via a change to Terraform features, please describe it below.
+
+In this section, it's helpful to include specific examples of how what you are suggesting might look in configuration files, or on the command line, since that allows us to understand the full picture of what you are proposing.
+
+If you're not sure of some details, don't worry! When we evaluate the feature request we may suggest modifications as necessary to work within the design constraints of Terraform Core.
+-->
+
+### References
+<!--
+Are there any other GitHub issues, whether open or closed, that are related to the problem you've described above or to the suggested solution? If so, please create a list below that mentions each of them. For example:
+
+- #6017
+
+-->


### PR DESCRIPTION
Here our prior existing single template becomes the "Bug report" template, and we introduce a second "Feature request" template that is more appropriate for gathering context about a feature request.