### PR TITLE
new plugin shims

### DIFF
--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -16,6 +16,20 @@ import (
 	"github.com/zclconf/go-cty/cty/msgpack"
 )
 
+// NewGRPCProviderServerShim wraps a terraform.ResourceProvider in a
+// proto.ProviderServer implementation. If the provided provider is not a
+// *schema.Provider, this will return nil,
+func NewGRPCProviderServerShim(p terraform.ResourceProvider) *GRPCProviderServer {
+	sp, ok := p.(*schema.Provider)
+	if !ok {
+		return nil
+	}
+
+	return &GRPCProviderServer{
+		provider: sp,
+	}
+}
+
 // GRPCProviderServer handles the server, or plugin side of the rpc connection.
 type GRPCProviderServer struct {
 	provider *schema.Provider

--- a/helper/plugin/grpc_provisioner.go
+++ b/helper/plugin/grpc_provisioner.go
@@ -12,6 +12,19 @@ import (
 	context "golang.org/x/net/context"
 )
 
+// NewGRPCProvisionerServerShim wraps a terraform.ResourceProvisioner in a
+// proto.ProvisionerServer implementation. If the provided provisioner is not a
+// *schema.Provisioner, this will return nil,
+func NewGRPCProvisionerServerShim(p terraform.ResourceProvisioner) *GRPCProvisionerServer {
+	sp, ok := p.(*schema.Provisioner)
+	if !ok {
+		return nil
+	}
+	return &GRPCProvisionerServer{
+		provisioner: sp,
+	}
+}
+
 type GRPCProvisionerServer struct {
 	provisioner *schema.Provisioner
 }

--- a/plugin/resource_provider.go
+++ b/plugin/resource_provider.go
@@ -9,11 +9,14 @@ import (
 
 // ResourceProviderPlugin is the plugin.Plugin implementation.
 type ResourceProviderPlugin struct {
-	F func() terraform.ResourceProvider
+	ResourceProvider func() terraform.ResourceProvider
 }
 
 func (p *ResourceProviderPlugin) Server(b *plugin.MuxBroker) (interface{}, error) {
-	return &ResourceProviderServer{Broker: b, Provider: p.F()}, nil
+	return &ResourceProviderServer{
+		Broker:   b,
+		Provider: p.ResourceProvider(),
+	}, nil
 }
 
 func (p *ResourceProviderPlugin) Client(

--- a/plugin/resource_provider_test.go
+++ b/plugin/resource_provider_test.go
@@ -19,7 +19,7 @@ func TestResourceProvider_stop(t *testing.T) {
 	p := new(terraform.MockResourceProvider)
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -46,7 +46,7 @@ func TestResourceProvider_stopErrors(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -74,7 +74,7 @@ func TestResourceProvider_input(t *testing.T) {
 	p := new(terraform.MockResourceProvider)
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -116,7 +116,7 @@ func TestResourceProvider_configure(t *testing.T) {
 	p := new(terraform.MockResourceProvider)
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -149,7 +149,7 @@ func TestResourceProvider_configure_errors(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -184,7 +184,7 @@ func TestResourceProvider_configure_warnings(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -216,7 +216,7 @@ func TestResourceProvider_apply(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -255,7 +255,7 @@ func TestResourceProvider_diff(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -301,7 +301,7 @@ func TestResourceProvider_diff_error(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -340,7 +340,7 @@ func TestResourceProvider_refresh(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -378,7 +378,7 @@ func TestResourceProvider_importState(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -417,7 +417,7 @@ func TestResourceProvider_resources(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -450,7 +450,7 @@ func TestResourceProvider_readdataapply(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -488,7 +488,7 @@ func TestResourceProvider_datasources(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -521,7 +521,7 @@ func TestResourceProvider_validate(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -556,7 +556,7 @@ func TestResourceProvider_validate_errors(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -597,7 +597,7 @@ func TestResourceProvider_validate_warns(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -636,7 +636,7 @@ func TestResourceProvider_validateResource(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -674,7 +674,7 @@ func TestResourceProvider_validateResource_errors(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -718,7 +718,7 @@ func TestResourceProvider_validateResource_warns(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -760,7 +760,7 @@ func TestResourceProvider_validateDataSource(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -798,7 +798,7 @@ func TestResourceProvider_close(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProviderFunc: testProviderFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider

--- a/plugin/resource_provisioner.go
+++ b/plugin/resource_provisioner.go
@@ -10,11 +10,14 @@ import (
 
 // ResourceProvisionerPlugin is the plugin.Plugin implementation.
 type ResourceProvisionerPlugin struct {
-	F func() terraform.ResourceProvisioner
+	ResourceProvisioner func() terraform.ResourceProvisioner
 }
 
 func (p *ResourceProvisionerPlugin) Server(b *plugin.MuxBroker) (interface{}, error) {
-	return &ResourceProvisionerServer{Broker: b, Provisioner: p.F()}, nil
+	return &ResourceProvisionerServer{
+		Broker:      b,
+		Provisioner: p.ResourceProvisioner(),
+	}, nil
 }
 
 func (p *ResourceProvisionerPlugin) Client(

--- a/plugin/resource_provisioner_test.go
+++ b/plugin/resource_provisioner_test.go
@@ -19,7 +19,7 @@ func TestResourceProvisioner_stop(t *testing.T) {
 	p := new(terraform.MockResourceProvisioner)
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProvisionerFunc: testProvisionerFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -46,7 +46,7 @@ func TestResourceProvisioner_stopErrors(t *testing.T) {
 	// Create a mock provider
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProvisionerFunc: testProvisionerFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -74,7 +74,7 @@ func TestResourceProvisioner_apply(t *testing.T) {
 	p := new(terraform.MockResourceProvisioner)
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProvisionerFunc: testProvisionerFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -105,7 +105,7 @@ func TestResourceProvisioner_validate(t *testing.T) {
 	p := new(terraform.MockResourceProvisioner)
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProvisionerFunc: testProvisionerFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -139,7 +139,7 @@ func TestResourceProvisioner_validate_errors(t *testing.T) {
 	p := new(terraform.MockResourceProvisioner)
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProvisionerFunc: testProvisionerFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -179,7 +179,7 @@ func TestResourceProvisioner_validate_warns(t *testing.T) {
 	p := new(terraform.MockResourceProvisioner)
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProvisionerFunc: testProvisionerFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider
@@ -217,7 +217,7 @@ func TestResourceProvisioner_close(t *testing.T) {
 	p := new(terraform.MockResourceProvisioner)
 	client, _ := plugin.TestPluginRPCConn(t, pluginMap(&ServeOpts{
 		ProvisionerFunc: testProvisionerFixed(p),
-	}))
+	}), nil)
 	defer client.Close()
 
 	// Request the provider

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"github.com/hashicorp/go-plugin"
+	grpcplugin "github.com/hashicorp/terraform/helper/plugin"
+	"github.com/hashicorp/terraform/plugin/proto"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -28,27 +30,82 @@ var Handshake = plugin.HandshakeConfig{
 
 type ProviderFunc func() terraform.ResourceProvider
 type ProvisionerFunc func() terraform.ResourceProvisioner
+type GRPCProviderFunc func() proto.ProviderServer
+type GRPCProvisionerFunc func() proto.ProvisionerServer
 
 // ServeOpts are the configurations to serve a plugin.
 type ServeOpts struct {
 	ProviderFunc    ProviderFunc
 	ProvisionerFunc ProvisionerFunc
+
+	// Wrapped versions of the above plugins will automatically shimmed and
+	// added to the GRPC functions when possible.
+	GRPCProviderFunc    GRPCProviderFunc
+	GRPCProvisionerFunc GRPCProvisionerFunc
 }
 
 // Serve serves a plugin. This function never returns and should be the final
 // function called in the main function of the plugin.
 func Serve(opts *ServeOpts) {
+	// since the plugins may not yet be aware of the new protocol, we
+	// automatically wrap the plugins in the grpc shims.
+	if opts.GRPCProviderFunc == nil && opts.ProviderFunc != nil {
+		provider := grpcplugin.NewGRPCProviderServerShim(opts.ProviderFunc())
+		// this is almost always going to be a *schema.Provider, but check that
+		// we got back a valid provider just in case.
+		if provider != nil {
+			opts.GRPCProviderFunc = func() proto.ProviderServer {
+				return provider
+			}
+		}
+	}
+	if opts.GRPCProvisionerFunc == nil && opts.ProvisionerFunc != nil {
+		provider := grpcplugin.NewGRPCProvisionerServerShim(opts.ProvisionerFunc())
+		if provider != nil {
+			opts.GRPCProvisionerFunc = func() proto.ProvisionerServer {
+				return provider
+			}
+		}
+	}
+
 	plugin.Serve(&plugin.ServeConfig{
-		HandshakeConfig: Handshake,
-		Plugins:         pluginMap(opts),
+		HandshakeConfig:  Handshake,
+		VersionedPlugins: pluginSet(opts),
+		GRPCServer:       plugin.DefaultGRPCServer,
 	})
 }
 
-// pluginMap returns the map[string]plugin.Plugin to use for configuring a plugin
-// server or client.
+// pluginMap returns the legacy map[string]plugin.Plugin to use for configuring
+// a plugin server or client.
 func pluginMap(opts *ServeOpts) map[string]plugin.Plugin {
 	return map[string]plugin.Plugin{
-		"provider":    &ResourceProviderPlugin{F: opts.ProviderFunc},
-		"provisioner": &ResourceProvisionerPlugin{F: opts.ProvisionerFunc},
+		"provider": &ResourceProviderPlugin{
+			ResourceProvider: opts.ProviderFunc,
+		},
+		"provisioner": &ResourceProvisionerPlugin{
+			ResourceProvisioner: opts.ProvisionerFunc,
+		},
 	}
+}
+
+func pluginSet(opts *ServeOpts) map[int]plugin.PluginSet {
+	// Set the legacy netrpc plugins at version 4.
+	// The oldest version is returned in when executed by a legacy go-plugin
+	// client.
+	plugins := map[int]plugin.PluginSet{
+		4: pluginMap(opts),
+	}
+
+	// add the new protocol versions if they're configured
+	if opts.GRPCProviderFunc != nil || opts.GRPCProvisionerFunc != nil {
+		plugins[5] = plugin.PluginSet{
+			"provider": &GRPCProviderPlugin{
+				GRPCProvider: opts.GRPCProviderFunc,
+			},
+			"provisioner": &GRPCProvisionerPlugin{
+				GRPCProvisioner: opts.GRPCProvisionerFunc,
+			},
+		}
+	}
+	return plugins
 }

--- a/vendor/github.com/hashicorp/go-plugin/server.go
+++ b/vendor/github.com/hashicorp/go-plugin/server.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"sort"
 	"strconv"
+	"strings"
 	"sync/atomic"
 
 	"github.com/hashicorp/go-hclog"
@@ -36,6 +38,8 @@ type HandshakeConfig struct {
 	// ProtocolVersion is the version that clients must match on to
 	// agree they can communicate. This should match the ProtocolVersion
 	// set on ClientConfig when using a plugin.
+	// This field is not required if VersionedPlugins are being used in the
+	// Client or Server configurations.
 	ProtocolVersion uint
 
 	// MagicCookieKey and value are used as a very basic verification
@@ -46,6 +50,10 @@ type HandshakeConfig struct {
 	MagicCookieValue string
 }
 
+// PluginSet is a set of plugins provided to be registered in the plugin
+// server.
+type PluginSet map[string]Plugin
+
 // ServeConfig configures what sorts of plugins are served.
 type ServeConfig struct {
 	// HandshakeConfig is the configuration that must match clients.
@@ -55,7 +63,13 @@ type ServeConfig struct {
 	TLSProvider func() (*tls.Config, error)
 
 	// Plugins are the plugins that are served.
-	Plugins map[string]Plugin
+	// The implied version of this PluginSet is the Handshake.ProtocolVersion.
+	Plugins PluginSet
+
+	// VersionedPlugins is a map of PluginSets for specific protocol versions.
+	// These can be used to negotiate a compatible version between client and
+	// server. If this is set, Handshake.ProtocolVersion is not required.
+	VersionedPlugins map[int]PluginSet
 
 	// GRPCServer should be non-nil to enable serving the plugins over
 	// gRPC. This is a function to create the server when needed with the
@@ -72,14 +86,80 @@ type ServeConfig struct {
 	Logger hclog.Logger
 }
 
-// Protocol returns the protocol that this server should speak.
-func (c *ServeConfig) Protocol() Protocol {
-	result := ProtocolNetRPC
-	if c.GRPCServer != nil {
-		result = ProtocolGRPC
+// protocolVersion determines the protocol version and plugin set to be used by
+// the server. In the event that there is no suitable version, the last version
+// in the config is returned leaving the client to report the incompatibility.
+func protocolVersion(opts *ServeConfig) (int, Protocol, PluginSet) {
+	protoVersion := int(opts.ProtocolVersion)
+	pluginSet := opts.Plugins
+	protoType := ProtocolNetRPC
+	// check if the client sent a list of acceptable versions
+	var clientVersions []int
+	if vs := os.Getenv("PLUGIN_PROTOCOL_VERSIONS"); vs != "" {
+		for _, s := range strings.Split(vs, ",") {
+			v, err := strconv.Atoi(s)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "server sent invalid plugin version %q", s)
+				continue
+			}
+			clientVersions = append(clientVersions, v)
+		}
 	}
 
-	return result
+	// we want to iterate in reverse order, to ensure we match the newest
+	// compatible plugin version.
+	sort.Sort(sort.Reverse(sort.IntSlice(clientVersions)))
+
+	// set the old un-versioned fields as if they were versioned plugins
+	if opts.VersionedPlugins == nil {
+		opts.VersionedPlugins = make(map[int]PluginSet)
+	}
+
+	if pluginSet != nil {
+		opts.VersionedPlugins[protoVersion] = pluginSet
+	}
+
+	// sort the version to make sure we match the latest first
+	var versions []int
+	for v := range opts.VersionedPlugins {
+		versions = append(versions, v)
+	}
+
+	sort.Sort(sort.Reverse(sort.IntSlice(versions)))
+
+	// see if we have multiple versions of Plugins to choose from
+	for _, version := range versions {
+		// record each version, since we guarantee that this returns valid
+		// values even if they are not a protocol match.
+		protoVersion = version
+		pluginSet = opts.VersionedPlugins[version]
+
+		// all plugins in a set must use the same transport, so check the first
+		// for the protocol type
+		for _, p := range pluginSet {
+			switch p.(type) {
+			case GRPCPlugin:
+				protoType = ProtocolGRPC
+			default:
+				protoType = ProtocolNetRPC
+			}
+			break
+		}
+
+		for _, clientVersion := range clientVersions {
+			if clientVersion == protoVersion {
+				return protoVersion, protoType, pluginSet
+			}
+		}
+	}
+
+	// Return the lowest version as the fallback.
+	// Since we iterated over all the versions in reverse order above, these
+	// values are from the lowest version number plugins (which may be from
+	// a combination of the Handshake.ProtocolVersion and ServeConfig.Plugins
+	// fields). This allows serving the oldest version of our plugins to a
+	// legacy client that did not send a PLUGIN_PROTOCOL_VERSIONS list.
+	return protoVersion, protoType, pluginSet
 }
 
 // Serve serves the plugins given by ServeConfig.
@@ -106,6 +186,10 @@ func Serve(opts *ServeConfig) {
 				"load any plugins automatically\n")
 		os.Exit(1)
 	}
+
+	// negotiate the version and plugins
+	// start with default version in the handshake config
+	protoVersion, protoType, pluginSet := protocolVersion(opts)
 
 	// Logging goes to the original stderr
 	log.SetOutput(os.Stderr)
@@ -160,7 +244,7 @@ func Serve(opts *ServeConfig) {
 
 	// Build the server type
 	var server ServerProtocol
-	switch opts.Protocol() {
+	switch protoType {
 	case ProtocolNetRPC:
 		// If we have a TLS configuration then we wrap the listener
 		// ourselves and do it at that level.
@@ -170,7 +254,7 @@ func Serve(opts *ServeConfig) {
 
 		// Create the RPC server to dispense
 		server = &RPCServer{
-			Plugins: opts.Plugins,
+			Plugins: pluginSet,
 			Stdout:  stdout_r,
 			Stderr:  stderr_r,
 			DoneCh:  doneCh,
@@ -179,7 +263,7 @@ func Serve(opts *ServeConfig) {
 	case ProtocolGRPC:
 		// Create the gRPC server
 		server = &GRPCServer{
-			Plugins: opts.Plugins,
+			Plugins: pluginSet,
 			Server:  opts.GRPCServer,
 			TLS:     tlsConfig,
 			Stdout:  stdout_r,
@@ -188,7 +272,7 @@ func Serve(opts *ServeConfig) {
 		}
 
 	default:
-		panic("unknown server protocol: " + opts.Protocol())
+		panic("unknown server protocol: " + protoType)
 	}
 
 	// Initialize the servers
@@ -208,13 +292,13 @@ func Serve(opts *ServeConfig) {
 
 	logger.Debug("plugin address", "network", listener.Addr().Network(), "address", listener.Addr().String())
 
-	// Output the address and service name to stdout so that core can bring it up.
+	// Output the address and service name to stdout so that the client can bring it up.
 	fmt.Printf("%d|%d|%s|%s|%s%s\n",
 		CoreProtocolVersion,
-		opts.ProtocolVersion,
+		protoVersion,
 		listener.Addr().Network(),
 		listener.Addr().String(),
-		opts.Protocol(),
+		protoType,
 		extra)
 	os.Stdout.Sync()
 

--- a/vendor/github.com/hashicorp/go-plugin/testing.go
+++ b/vendor/github.com/hashicorp/go-plugin/testing.go
@@ -3,12 +3,25 @@ package plugin
 import (
 	"bytes"
 	"context"
+	"io"
 	"net"
 	"net/rpc"
 
 	"github.com/mitchellh/go-testing-interface"
 	"google.golang.org/grpc"
 )
+
+// TestOptions allows specifying options that can affect the behavior of the
+// test functions
+type TestOptions struct {
+	//ServerStdout causes the given value to be used in place of a blank buffer
+	//for RPCServer's Stdout
+	ServerStdout io.ReadCloser
+
+	//ServerStderr causes the given value to be used in place of a blank buffer
+	//for RPCServer's Stderr
+	ServerStderr io.ReadCloser
+}
 
 // The testing file contains test helpers that you can use outside of
 // this package for making it easier to test plugins themselves.
@@ -61,12 +74,20 @@ func TestRPCConn(t testing.T) (*rpc.Client, *rpc.Server) {
 
 // TestPluginRPCConn returns a plugin RPC client and server that are connected
 // together and configured.
-func TestPluginRPCConn(t testing.T, ps map[string]Plugin) (*RPCClient, *RPCServer) {
+func TestPluginRPCConn(t testing.T, ps map[string]Plugin, opts *TestOptions) (*RPCClient, *RPCServer) {
 	// Create two net.Conns we can use to shuttle our control connection
 	clientConn, serverConn := TestConn(t)
 
 	// Start up the server
 	server := &RPCServer{Plugins: ps, Stdout: new(bytes.Buffer), Stderr: new(bytes.Buffer)}
+	if opts != nil {
+		if opts.ServerStdout != nil {
+			server.Stdout = opts.ServerStdout
+		}
+		if opts.ServerStderr != nil {
+			server.Stderr = opts.ServerStderr
+		}
+	}
 	go server.ServeConn(serverConn)
 
 	// Connect the client to the server

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1654,10 +1654,10 @@
 			"revision": "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"
 		},
 		{
-			"checksumSHA1": "y3op+t01flBlSBKlzUNqH5d4XHQ=",
+			"checksumSHA1": "8X6scmZ/Xfkme6wM7KPWs6vBvsY=",
 			"path": "github.com/hashicorp/go-plugin",
-			"revision": "e53f54cbf51efde642d4711313e829a1ff0c236d",
-			"revisionTime": "2018-01-25T19:04:38Z",
+			"revision": "a4620f9913d19f03a6bf19b2f304daaaf83ea130",
+			"revisionTime": "2018-08-14T22:25:01Z",
 			"version": "master",
 			"versionExact": "master"
 		},


### PR DESCRIPTION
Add wrappers to automatically shim `schema.Provider` and `schema.Provisioner` in the plugin package. The protocol negotiation will be handled directly by the new go-plugin version. 


