### PR TITLE
helper/resource: Add ParallelTest() function to allow opt-in acceptance testing concurrency with t.Parallel()

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -418,6 +418,17 @@ func LogOutput(t TestT) (logOutput io.Writer, err error) {
 	return
 }
 
+// ParallelTest performs an acceptance test on a resource, allowing concurrency
+// with other ParallelTest.
+//
+// Tests will fail if they do not properly handle conditions to allow multiple
+// tests to occur against the same resource or service (e.g. random naming).
+// All other requirements of the Test function also apply to this function.
+func ParallelTest(t TestT, c TestCase) {
+	t.Parallel()
+	Test(t, c)
+}
+
 // Test performs an acceptance test on a resource.
 //
 // Tests are not run unless an environmental variable "TF_ACC" is
@@ -1128,6 +1139,7 @@ type TestT interface {
 	Fatal(args ...interface{})
 	Skip(args ...interface{})
 	Name() string
+	Parallel()
 }
 
 // This is set to true by unit tests to alter some behavior

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -45,6 +45,15 @@ func (p *resetProvider) TestReset() error {
 	return p.TestResetError
 }
 
+func TestParallelTest(t *testing.T) {
+	mt := new(mockT)
+	ParallelTest(mt, TestCase{})
+
+	if !mt.ParallelCalled {
+		t.Fatal("Parallel() not called")
+	}
+}
+
 func TestTest(t *testing.T) {
 	mp := &resetProvider{
 		MockResourceProvider: testProvider(),
@@ -111,6 +120,9 @@ func TestTest(t *testing.T) {
 
 	if mt.failed() {
 		t.Fatalf("test failed: %s", mt.failMessage())
+	}
+	if mt.ParallelCalled {
+		t.Fatal("Parallel() called")
 	}
 	if !checkStep {
 		t.Fatal("didn't call check for step")
@@ -692,12 +704,13 @@ func TestComposeTestCheckFunc(t *testing.T) {
 
 // mockT implements TestT for testing
 type mockT struct {
-	ErrorCalled bool
-	ErrorArgs   []interface{}
-	FatalCalled bool
-	FatalArgs   []interface{}
-	SkipCalled  bool
-	SkipArgs    []interface{}
+	ErrorCalled    bool
+	ErrorArgs      []interface{}
+	FatalCalled    bool
+	FatalArgs      []interface{}
+	ParallelCalled bool
+	SkipCalled     bool
+	SkipArgs       []interface{}
 
 	f bool
 }
@@ -712,6 +725,10 @@ func (t *mockT) Fatal(args ...interface{}) {
 	t.FatalCalled = true
 	t.FatalArgs = args
 	t.f = true
+}
+
+func (t *mockT) Parallel() {
+	t.ParallelCalled = true
 }
 
 func (t *mockT) Skip(args ...interface{}) {


### PR DESCRIPTION
Please note: this is an alternate implementation to #16807, using a separate function rather than requiring adjustment to each existing `TestCase` and submitted just for an additional reference point. The preferred solution may be either implementation or a combination of the two! I think more importantly we should continue the conversation for supporting this type of functionality as its been implemented or requested by a few of the major providers. 😄 

While this initial implementation is a very simple wrapper function, implementing this in the helper/resource package provides some downstream benefits:
* Provides a standard interface for plugin developers to enable parallel acceptance testing
* Existing plugins can simply convert `resource.Test` to `resource.ParallelTest` references (as appropriate) to enable the functionality, rather than worrying about additional line(s) to each acceptance test function or `TestCase`
* Potential enhancements to ParallelTest (e.g. adding an environment variable to skip enabling the behavior) are consistently propagated