### PR TITLE
Correct relative symlinks

### DIFF
--- a/helper/copy/copy.go
+++ b/helper/copy/copy.go
@@ -93,7 +93,7 @@ func CopyDir(src string, dst string) (err error) {
 
 		// If the entry is a symlink, we copy the contents
 		for entry.Mode()&os.ModeSymlink != 0 {
-			target, err := os.Readlink(srcPath)
+			target, err := filepath.EvalSymlinks(srcPath)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
When srcPath contains a relative path symlink os.Readlink fails.
This patch corrects this behavior.  Terraform doesn't run into
this issue currently.  However, I ran into this issue when using
the CopyDir function in my own project [1].  Since CopyFile and
CopyDir are not built into golang, Terraform's copy package
sufficed.

[1] https://github.com/retr0h/go-gilt/blob/golang-port/copy/copy.go