### PR TITLE
Contains for strings

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -79,6 +79,7 @@ func Funcs() map[string]ast.Function {
 		"compact":      interpolationFuncCompact(),
 		"concat":       interpolationFuncConcat(),
 		"contains":     interpolationFuncContains(),
+		"scontains":    interpolationFuncStringContains(),
 		"dirname":      interpolationFuncDirname(),
 		"distinct":     interpolationFuncDistinct(),
 		"element":      interpolationFuncElement(),
@@ -521,6 +522,23 @@ func interpolationFuncPathExpand() ast.Function {
 		ReturnType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {
 			return homedir.Expand(args[0].(string))
+		},
+	}
+}
+
+// interpolationFuncCeil returns the the least integer value greater than or equal to the argument
+func interpolationFuncStringContains() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString, ast.TypeString},
+		ReturnType: ast.TypeInt,
+		Callback: func(args []interface{}) (interface{}, error) {
+			s := args[0].(string)
+			ss := args[1].(string)
+			if strings.Contains(s, ss) {
+				return 1, nil
+			} else {
+				return 0, nil
+			}
 		},
 	}
 }


### PR DESCRIPTION
Just a little interpolation that allows to check if a string contains some other substring ,  this is just an attempt please let me know if it is a possibility?

```
variable "pepe" { 
	type = "string"
	default =  "example"
}


data "external" "example" { 
count = "${scontains(var.pepe,"ple")}"
program = ["bash","c.sh"]
}
output "pepe" { 
	value = "${scontains(var.pepe,"ple")}"
}

output "dada" { 
	value = "${data.external.example.*.result}"
}
```
output 
```
data.external.example: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

dada = [
    {
        a = 1
    }
]
pepe = 1
```
