### PR TITLE
backend/migrations: migrate the default state

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -22,14 +22,14 @@ const DefaultStateName = "default"
 // This must be returned rather than a custom error so that the Terraform
 // CLI can detect it and handle it appropriately.
 var (
+	// ErrDefaultStateNotSupported is returned when an operation does not support
+	// using the default state, but requires a named state to be selected.
+	ErrDefaultStateNotSupported = errors.New("default state not supported\n" +
+		"You can create a new workspace with the \"workspace new\" command.")
+
 	// ErrNamedStatesNotSupported is returned when a named state operation
 	// isn't supported.
 	ErrNamedStatesNotSupported = errors.New("named states not supported")
-
-	// ErrDefaultStateNotSupported is returned when an operation does not support
-	// using the default state, but requires a named state to be selected.
-	ErrDefaultStateNotSupported = errors.New("default state not supported\n\n" +
-		"You can create a new workspace wth the \"workspace new\" command")
 
 	// ErrOperationNotSupported is returned when an unsupported operation
 	// is detected by the configured backend.

--- a/command/test-fixtures/backend-change-multi-to-no-default-with-default/local-state.tfstate
+++ b/command/test-fixtures/backend-change-multi-to-no-default-with-default/local-state.tfstate
@@ -2,5 +2,5 @@
     "version": 3,
     "terraform_version": "0.8.2",
     "serial": 7,
-    "lineage": "backend-change"
+    "lineage": "backend-change-env1"
 }


### PR DESCRIPTION
Certain backends (currently only the `remote` backend) do not support using both the default and named workspaces at the same time.

To make the migration easier for users that currently use both types of workspaces, this commit adds logic to ask the user for a new workspace name during the migration process.