### PR TITLE
Making spacing consistent everywhere

### DIFF
--- a/command/push.go
+++ b/command/push.go
@@ -400,7 +400,7 @@ Options:
   -vcs=true            If true (default), push will upload only files
                        committed to your VCS, if detected.
 
-  -no-color           If specified, output won't contain any color.
+  -no-color            If specified, output won't contain any color.
 
 `
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
Issue: hashicorp/terraform#18775

`terraform push --help` shows `-no-color` description misaligned.