### PR TITLE
core: Split Replace changes into separate Delete/Create changes during apply walk

### DIFF
--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -8,15 +8,14 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/terraform/addrs"
-
-	"github.com/hashicorp/terraform/configs/configschema"
-	"github.com/hashicorp/terraform/config/hcl2shim"
-
-	"github.com/hashicorp/terraform/config"
 	"github.com/mitchellh/copystructure"
 	"github.com/mitchellh/reflectwalk"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/config/hcl2shim"
+	"github.com/hashicorp/terraform/configs/configschema"
 )
 
 // ResourceProvisionerConfig is used to pair a provisioner
@@ -247,15 +246,19 @@ func NewResourceConfigShimmed(val cty.Value, schema *configschema.Block) *Resour
 	ret := &ResourceConfig{}
 
 	legacyVal := hcl2shim.ConfigValueFromHCL2(val)
-	ret.Config = legacyVal.(map[string]interface{}) // guaranteed compatible because we require an object type
-	ret.Raw = ret.Config
+	if legacyVal != nil {
+		ret.Config = legacyVal.(map[string]interface{}) // guaranteed compatible because we require an object type
 
-	// Now we need to walk through our structure and find any unknown values,
-	// producing the separate list ComputedKeys to represent these. We use the
-	// schema here so that we can preserve the expected invariant
-	// that an attribute is always either wholly known or wholly unknown, while
-	// a child block can be partially unknown.
-	ret.ComputedKeys = newResourceConfigShimmedComputedKeys(val, schema, "")
+		// Now we need to walk through our structure and find any unknown values,
+		// producing the separate list ComputedKeys to represent these. We use the
+		// schema here so that we can preserve the expected invariant
+		// that an attribute is always either wholly known or wholly unknown, while
+		// a child block can be partially unknown.
+		ret.ComputedKeys = newResourceConfigShimmedComputedKeys(val, schema, "")
+	} else {
+		ret.Config = make(map[string]interface{})
+	}
+	ret.Raw = ret.Config
 
 	return ret
 }


### PR DESCRIPTION
Since we do our deletes using a separate graph node from all of the other actions, and a "Replace" change implies both a delete _and_ a create, we need to pretend at apply time that a single replace change was actually two separate changes.

This will also early-exit eval if a destroy node finds a non-Delete change or if an apply node finds a Delete change. These should not happen in practice because we leave these nodes out of the graph when they are not needed for the given action, but we do this here for robustness so as not to have an invisible dependency between the graph builder and the eval phase.

---

This PR also includes a small set of fixes for other issues that were revealed by fixing this one.
