### PR TITLE
Fix description for state mv and push sub-commands

### DIFF
--- a/website/docs/commands/state/mv.html.md
+++ b/website/docs/commands/state/mv.html.md
@@ -3,7 +3,7 @@ layout: "commands-state"
 page_title: "Command: state mv"
 sidebar_current: "docs-state-sub-mv"
 description: |-
-  The `terraform state rm` command removes items from the Terraform state.
+  The `terraform state mv` command moves items in the Terraform state.
 ---
 
 # Command: state mv

--- a/website/docs/commands/state/push.html.md
+++ b/website/docs/commands/state/push.html.md
@@ -3,7 +3,7 @@ layout: "commands-state"
 page_title: "Command: state push"
 sidebar_current: "docs-state-sub-push"
 description: |-
-  The `terraform state rm` command removes items from the Terraform state.
+  The `terraform state push` command pushes items to the Terraform state.
 ---
 
 # Command: state push


### PR DESCRIPTION
### Reasoning for docs update

The description for the `state mv` and `state push` had descriptions for the `state rm` command. It only shows up in places like Slack which renders link previews, so low impact.