### PR TITLE
an empty object state should decode into null

### DIFF
--- a/states/instance_object_src.go
+++ b/states/instance_object_src.go
@@ -69,17 +69,20 @@ type ResourceInstanceObjectSrc struct {
 func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObject, error) {
 	var val cty.Value
 	var err error
-	if os.AttrsFlat != nil {
+	switch {
+	case os.AttrsFlat != nil:
 		// Legacy mode. We'll do our best to unpick this from the flatmap.
 		val, err = hcl2shim.HCL2ValueFromFlatmap(os.AttrsFlat, ty)
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	case os.AttrsJSON != nil:
 		val, err = ctyjson.Unmarshal(os.AttrsJSON, ty)
 		if err != nil {
 			return nil, err
 		}
+	default:
+		val = cty.NullVal(ty)
 	}
 
 	return &ResourceInstanceObject{

--- a/states/state_test.go
+++ b/states/state_test.go
@@ -115,3 +115,18 @@ func TestState(t *testing.T) {
 		t.Error(problem)
 	}
 }
+
+func TestEmptyState(t *testing.T) {
+	// An empty state should decode into a null value
+	var src ResourceInstanceObjectSrc
+	ty := cty.Object(map[string]cty.Type{"id": cty.String})
+
+	obj, err := src.Decode(ty)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !obj.Value.IsNull() {
+		t.Fatalf("object value should be null, got %#v\n", obj.Value)
+	}
+}


### PR DESCRIPTION
The default Decode path would return an EOF error if the state was
empty.  Return a null cty.Value instead.