### PR TITLE
 backend/remote: add the run ID to associate state

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -278,6 +279,9 @@ func (b *Remote) State(workspace string) (state.State, error) {
 		client:       b.client,
 		organization: b.organization,
 		workspace:    workspace,
+
+		// This is optionally set during Terraform Enterprise runs.
+		runID: os.Getenv("TFE_RUN_ID"),
 	}
 
 	return &remote.State{Client: client}, nil

--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -343,7 +343,12 @@ func (m *mockStateVersions) List(ctx context.Context, options tfe.StateVersionLi
 
 func (m *mockStateVersions) Create(ctx context.Context, workspaceID string, options tfe.StateVersionCreateOptions) (*tfe.StateVersion, error) {
 	id := generateID("sv-")
+	runID := os.Getenv("TFE_RUN_ID")
 	url := fmt.Sprintf("https://app.terraform.io/_archivist/%s", id)
+
+	if runID != "" && (options.Run == nil || runID != options.Run.ID) {
+		return nil, fmt.Errorf("option.Run.ID does not contain the ID exported by TFE_RUN_ID")
+	}
 
 	sv := &tfe.StateVersion{
 		ID:          id,

--- a/backend/remote/backend_state_test.go
+++ b/backend/remote/backend_state_test.go
@@ -1,9 +1,12 @@
 package remote
 
 import (
+	"bytes"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/state/remote"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestRemoteClient_impl(t *testing.T) {
@@ -13,4 +16,26 @@ func TestRemoteClient_impl(t *testing.T) {
 func TestRemoteClient(t *testing.T) {
 	client := testRemoteClient(t)
 	remote.TestClient(t, client)
+}
+
+func TestRemoteClient_withRunID(t *testing.T) {
+	// Set the TFE_RUN_ID environment variable before creating the client!
+	if err := os.Setenv("TFE_RUN_ID", generateID("run-")); err != nil {
+		t.Fatalf("error setting env var TFE_RUN_ID: %v", err)
+	}
+
+	// Create a new test client.
+	client := testRemoteClient(t)
+
+	// Create a new empty state.
+	state := bytes.NewBuffer(nil)
+	if err := terraform.WriteState(terraform.NewState(), state); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Store the new state to verify (this will be done
+	// by the mock that is used) that the run ID is set.
+	if err := client.Put(state.Bytes()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 }


### PR DESCRIPTION
If a run ID is available, we need to make sure we pass that when creating a new state version so the state will be properly associated with the run.