### PR TITLE
command/hook_ui: Truncate the ID considering multibyte characters

### DIFF
--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -373,7 +373,10 @@ func dropCR(data []byte) []byte {
 }
 
 func truncateId(id string, maxLen int) string {
-	totalLength := len(id)
+	// Note that the id may contain multibyte characters.
+	// We need to truncate it to maxLen characters, not maxLen bytes.
+	rid := []rune(id)
+	totalLength := len(rid)
 	if totalLength <= maxLen {
 		return id
 	}
@@ -383,11 +386,11 @@ func truncateId(id string, maxLen int) string {
 		maxLen = 5
 	}
 
-	dots := "..."
+	dots := []rune("...")
 	partLen := maxLen / 2
 
 	leftIdx := partLen - 1
-	leftPart := id[0:leftIdx]
+	leftPart := rid[0:leftIdx]
 
 	rightIdx := totalLength - partLen - 1
 
@@ -396,7 +399,7 @@ func truncateId(id string, maxLen int) string {
 		rightIdx -= overlap
 	}
 
-	rightPart := id[rightIdx:]
+	rightPart := rid[rightIdx:]
 
-	return leftPart + dots + rightPart
+	return string(leftPart) + string(dots) + string(rightPart)
 }

--- a/command/hook_ui_test.go
+++ b/command/hook_ui_test.go
@@ -252,6 +252,51 @@ func TestTruncateId(t *testing.T) {
 			Expected: "Hello world",
 			MaxLen:   12,
 		},
+		{
+			Input:    "あいうえおかきくけこさ",
+			Expected: "あ...さ",
+			MaxLen:   3,
+		},
+		{
+			Input:    "あいうえおかきくけこさ",
+			Expected: "あ...さ",
+			MaxLen:   5,
+		},
+		{
+			Input:    "あいうえおかきくけこさ",
+			Expected: "あい...さ",
+			MaxLen:   6,
+		},
+		{
+			Input:    "あいうえおかきくけこさ",
+			Expected: "あい...こさ",
+			MaxLen:   7,
+		},
+		{
+			Input:    "あいうえおかきくけこさ",
+			Expected: "あいう...こさ",
+			MaxLen:   8,
+		},
+		{
+			Input:    "あいうえおかきくけこさ",
+			Expected: "あいう...けこさ",
+			MaxLen:   9,
+		},
+		{
+			Input:    "あいうえおかきくけこさ",
+			Expected: "あいうえ...けこさ",
+			MaxLen:   10,
+		},
+		{
+			Input:    "あいうえおかきくけこさ",
+			Expected: "あいうえおかきくけこさ",
+			MaxLen:   11,
+		},
+		{
+			Input:    "あいうえおかきくけこさ",
+			Expected: "あいうえおかきくけこさ",
+			MaxLen:   12,
+		},
 	}
 	for i, tc := range testCases {
 		testName := fmt.Sprintf("%d", i)


### PR DESCRIPTION
Fixes #18822

The `tuncatedId` function had been introduced in #12261 and increased the `maxIdLen` to 80 in #13317.

Since the number of bytes itself seems to be unimportant, the ID should be truncated to 80 characters, not 80 bytes.

Please let me know if we need to truncate it to 80 bytes considering multibyte character boundaries. This will require more complex logic.

```
[terraform@fix-multibyte-trucate|✔]$ go test -v ./command -run TestTruncateId
=== RUN   TestTruncateId
=== RUN   TestTruncateId/0
=== RUN   TestTruncateId/1
=== RUN   TestTruncateId/2
=== RUN   TestTruncateId/3
=== RUN   TestTruncateId/4
=== RUN   TestTruncateId/5
=== RUN   TestTruncateId/6
=== RUN   TestTruncateId/7
=== RUN   TestTruncateId/8
=== RUN   TestTruncateId/9
=== RUN   TestTruncateId/10
=== RUN   TestTruncateId/11
=== RUN   TestTruncateId/12
=== RUN   TestTruncateId/13
=== RUN   TestTruncateId/14
=== RUN   TestTruncateId/15
=== RUN   TestTruncateId/16
=== RUN   TestTruncateId/17
--- PASS: TestTruncateId (0.00s)
    --- PASS: TestTruncateId/0 (0.00s)
    --- PASS: TestTruncateId/1 (0.00s)
    --- PASS: TestTruncateId/2 (0.00s)
    --- PASS: TestTruncateId/3 (0.00s)
    --- PASS: TestTruncateId/4 (0.00s)
    --- PASS: TestTruncateId/5 (0.00s)
    --- PASS: TestTruncateId/6 (0.00s)
    --- PASS: TestTruncateId/7 (0.00s)
    --- PASS: TestTruncateId/8 (0.00s)
    --- PASS: TestTruncateId/9 (0.00s)
    --- PASS: TestTruncateId/10 (0.00s)
    --- PASS: TestTruncateId/11 (0.00s)
    --- PASS: TestTruncateId/12 (0.00s)
    --- PASS: TestTruncateId/13 (0.00s)
    --- PASS: TestTruncateId/14 (0.00s)
    --- PASS: TestTruncateId/15 (0.00s)
    --- PASS: TestTruncateId/16 (0.00s)
    --- PASS: TestTruncateId/17 (0.00s)
PASS
ok      github.com/hashicorp/terraform/command  0.038s
```