### PR TITLE
Add detection of Artifactory repo and subpath through the environment

### DIFF
--- a/backend/remote-state/s3/backend_test.go
+++ b/backend/remote-state/s3/backend_test.go
@@ -257,8 +257,8 @@ func TestBackendPrefixInWorkspace(t *testing.T) {
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
 
 	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
-		"bucket": bucketName,
-		"key":    "test-env.tfstate",
+		"bucket":               bucketName,
+		"key":                  "test-env.tfstate",
 		"workspace_key_prefix": "env",
 	}).(*Backend)
 

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -121,7 +121,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			Commands: map[string]bool{
 				"curl -LO https://omnitruck.chef.io/install.sh": true,
 				"bash ./install.sh -v \"11.18.6\" -c stable":    true,
-				"rm -f install.sh":                              true,
+				"rm -f install.sh": true,
 			},
 		},
 
@@ -140,7 +140,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			Commands: map[string]bool{
 				"curl -LO https://omnitruck.chef.io/install.sh": true,
 				"bash ./install.sh -v \"11.18.6\" -c current":   true,
-				"rm -f install.sh":                              true,
+				"rm -f install.sh": true,
 			},
 		},
 	}

--- a/command/init.go
+++ b/command/init.go
@@ -72,8 +72,8 @@ func (c *InitCommand) Run(args []string) int {
 	// set providerInstaller if we don't have a test version already
 	if c.providerInstaller == nil {
 		c.providerInstaller = &discovery.ProviderInstaller{
-			Dir:   c.pluginDir(),
-			Cache: c.pluginCache(),
+			Dir:                   c.pluginDir(),
+			Cache:                 c.pluginCache(),
 			PluginProtocolVersion: plugin.Handshake.ProtocolVersion,
 			SkipVerify:            !flagVerifyPlugins,
 			Ui:                    c.Ui,

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -1434,7 +1434,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 	// Ask input
 	defer testInputMap(t, map[string]string{
 		"backend-migrate-multistate-to-multistate": "yes",
-		"new-state-name":                           "env1",
+		"new-state-name": "env1",
 	})()
 
 	// Setup the meta

--- a/helper/schema/resource_timeout_test.go
+++ b/helper/schema/resource_timeout_test.go
@@ -23,28 +23,28 @@ func TestResourceTimeout_ConfigDecode_badkey(t *testing.T) {
 		ShouldErr bool
 	}{
 		{
-			Name: "Source does not define 'delete' key",
+			Name:                   "Source does not define 'delete' key",
 			ResourceDefaultTimeout: timeoutForValues(10, 0, 5, 0, 0),
 			Config:                 expectedConfigForValues(2, 0, 0, 1, 0),
 			Expected:               timeoutForValues(10, 0, 5, 0, 0),
 			ShouldErr:              true,
 		},
 		{
-			Name: "Config overrides create",
+			Name:                   "Config overrides create",
 			ResourceDefaultTimeout: timeoutForValues(10, 0, 5, 0, 0),
 			Config:                 expectedConfigForValues(2, 0, 7, 0, 0),
 			Expected:               timeoutForValues(2, 0, 7, 0, 0),
 			ShouldErr:              false,
 		},
 		{
-			Name: "Config overrides create, default provided. Should still have zero values",
+			Name:                   "Config overrides create, default provided. Should still have zero values",
 			ResourceDefaultTimeout: timeoutForValues(10, 0, 5, 0, 3),
 			Config:                 expectedConfigForValues(2, 0, 7, 0, 0),
 			Expected:               timeoutForValues(2, 0, 7, 0, 3),
 			ShouldErr:              false,
 		},
 		{
-			Name: "Use something besides 'minutes'",
+			Name:                   "Use something besides 'minutes'",
 			ResourceDefaultTimeout: timeoutForValues(10, 0, 5, 0, 3),
 			Config: []map[string]interface{}{
 				map[string]interface{}{

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2056,7 +2056,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 
 			State: &terraform.InstanceState{
 				Attributes: map[string]string{
-					"block_device.#":                                "2",
+					"block_device.#": "2",
 					"block_device.616397234.delete_on_termination":  "true",
 					"block_device.616397234.device_name":            "/dev/sda1",
 					"block_device.2801811477.delete_on_termination": "true",

--- a/plugin/discovery/get_test.go
+++ b/plugin/discovery/get_test.go
@@ -148,7 +148,7 @@ func TestProviderInstallerGet(t *testing.T) {
 
 	// attempt to use an incompatible protocol version
 	i := &ProviderInstaller{
-		Dir: tmpDir,
+		Dir:                   tmpDir,
 		PluginProtocolVersion: 5,
 		SkipVerify:            true,
 		Ui:                    cli.NewMockUi(),
@@ -159,7 +159,7 @@ func TestProviderInstallerGet(t *testing.T) {
 	}
 
 	i = &ProviderInstaller{
-		Dir: tmpDir,
+		Dir:                   tmpDir,
 		PluginProtocolVersion: 3,
 		SkipVerify:            true,
 		Ui:                    cli.NewMockUi(),
@@ -231,7 +231,7 @@ func TestProviderInstallerPurgeUnused(t *testing.T) {
 	f.Close()
 
 	i := &ProviderInstaller{
-		Dir: tmpDir,
+		Dir:                   tmpDir,
 		PluginProtocolVersion: 3,
 		SkipVerify:            true,
 		Ui:                    cli.NewMockUi(),

--- a/state/remote/artifactory.go
+++ b/state/remote/artifactory.go
@@ -12,45 +12,29 @@ import (
 const ARTIF_TFSTATE_NAME = "terraform.tfstate"
 
 func artifactoryFactory(conf map[string]string) (Client, error) {
-	userName, ok := conf["username"]
-	if !ok {
-		userName = os.Getenv("ARTIFACTORY_USERNAME")
-		if userName == "" {
-			return nil, fmt.Errorf(
-				"missing 'username' configuration or ARTIFACTORY_USERNAME environment variable")
-		}
+	userName, err := getArtifactoryVar("username", conf)
+	if err != nil {
+		return nil, err
 	}
-	password, ok := conf["password"]
-	if !ok {
-		password = os.Getenv("ARTIFACTORY_PASSWORD")
-		if password == "" {
-			return nil, fmt.Errorf(
-				"missing 'password' configuration or ARTIFACTORY_PASSWORD environment variable")
-		}
+
+	password, err := getArtifactoryVar("password", conf)
+	if err != nil {
+		return nil, err
 	}
-	url, ok := conf["url"]
-	if !ok {
-		url = os.Getenv("ARTIFACTORY_URL")
-		if url == "" {
-			return nil, fmt.Errorf(
-				"missing 'url' configuration or ARTIFACTORY_URL environment variable")
-		}
+
+	url, err := getArtifactoryVar("url", conf)
+	if err != nil {
+		return nil, err
 	}
-	repo, ok := conf["repo"]
-	if !ok {
-		repo = os.Getenv("ARTIFACTORY_REPO")
-		if repo == "" {
-			return nil, fmt.Errorf(
-				"missing 'repo' configuration or ARTIFACTORY_REPO environment variable")
-		}
+
+	repo, err := getArtifactoryVar("repo", conf)
+	if err != nil {
+		return nil, err
 	}
-	subpath, ok := conf["subpath"]
-	if !ok {
-		subpath = os.Getenv("ARTIFACTORY_SUBPATH")
-		if subpath == "" {
-			return nil, fmt.Errorf(
-				"missing 'subpath' configuration or ARTIFACTORY_SUBPATH environment variable")
-		}
+
+	subpath, err := getArtifactoryVar("subpath", conf)
+	if err != nil {
+		return nil, err
 	}
 
 	clientConf := &artifactory.ClientConfig{
@@ -69,6 +53,24 @@ func artifactoryFactory(conf map[string]string) (Client, error) {
 		subpath:      subpath,
 	}, nil
 
+}
+
+func getArtifactoryVar(vr string, conf map[string]string) (string, error) {
+	envvr := fmt.Sprintf("ARTIFACTORY_%v", strings.ToUpper(vr))
+
+	val, ok := conf[vr]
+	if !ok {
+		val = os.Getenv(envvr)
+		if val == "" {
+			return val, fmt.Errorf(
+				"missing '%v' configuration or %v environment variable",
+				vr,
+				envvr,
+			)
+		}
+	}
+
+	return val, nil
 }
 
 type ArtifactoryClient struct {

--- a/state/remote/artifactory.go
+++ b/state/remote/artifactory.go
@@ -38,13 +38,19 @@ func artifactoryFactory(conf map[string]string) (Client, error) {
 	}
 	repo, ok := conf["repo"]
 	if !ok {
-		return nil, fmt.Errorf(
-			"missing 'repo' configuration")
+		repo = os.Getenv("ARTIFACTORY_REPO")
+		if repo == "" {
+			return nil, fmt.Errorf(
+				"missing 'repo' configuration or ARTIFACTORY_REPO environment variable")
+		}
 	}
 	subpath, ok := conf["subpath"]
 	if !ok {
-		return nil, fmt.Errorf(
-			"missing 'subpath' configuration")
+		subpath = os.Getenv("ARTIFACTORY_SUBPATH")
+		if subpath == "" {
+			return nil, fmt.Errorf(
+				"missing 'subpath' configuration or ARTIFACTORY_SUBPATH environment variable")
+		}
 	}
 
 	clientConf := &artifactory.ClientConfig{

--- a/state/remote/artifactory_test.go
+++ b/state/remote/artifactory_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"os"
 	"testing"
 )
 
@@ -33,6 +34,71 @@ func TestArtifactoryFactory(t *testing.T) {
 	client, err := artifactoryFactory(config)
 	if err != nil {
 		t.Fatalf("Error for valid config")
+	}
+
+	artifactoryClient := client.(*ArtifactoryClient)
+
+	if artifactoryClient.nativeClient.Config.BaseURL != "http://artifactory.local:8081/artifactory" {
+		t.Fatalf("Incorrect url was populated")
+	}
+	if artifactoryClient.nativeClient.Config.Username != "test" {
+		t.Fatalf("Incorrect username was populated")
+	}
+	if artifactoryClient.nativeClient.Config.Password != "testpass" {
+		t.Fatalf("Incorrect password was populated")
+	}
+	if artifactoryClient.repo != "terraform-repo" {
+		t.Fatalf("Incorrect repo was populated")
+	}
+	if artifactoryClient.subpath != "myproject" {
+		t.Fatalf("Incorrect subpath was populated")
+	}
+}
+
+func TestArtifactoryFactoryEnvironmentConfig(t *testing.T) {
+	// This test just instantiates the client. Shouldn't make any actual
+	// requests nor incur any costs.
+
+	config := make(map[string]string)
+
+	_, err := artifactoryFactory(config)
+	if err.Error() != "missing 'username' configuration or ARTIFACTORY_USERNAME environment variable" {
+		t.Fatal("missing ARTIFACTORY_USERNAME should be error")
+	}
+	os.Setenv("ARTIFACTORY_USERNAME", "test")
+	err = nil
+
+	_, err = artifactoryFactory(config)
+	if err.Error() != "missing 'password' configuration or ARTIFACTORY_PASSWORD environment variable" {
+		t.Fatal("missing ARTIFACTORY_PASSWORD should be error")
+	}
+	os.Setenv("ARTIFACTORY_PASSWORD", "testpass")
+	err = nil
+
+	_, err = artifactoryFactory(config)
+	if err.Error() != "missing 'url' configuration or ARTIFACTORY_URL environment variable" {
+		t.Fatal("missing ARTIFACTORY_URL should be error")
+	}
+	os.Setenv("ARTIFACTORY_URL", "http://artifactory.local:8081/artifactory")
+	err = nil
+
+	_, err = artifactoryFactory(config)
+	if err.Error() != "missing 'repo' configuration or ARTIFACTORY_REPO environment variable" {
+		t.Fatal("missing ARTIFACTORY_REPO should be error")
+	}
+	os.Setenv("ARTIFACTORY_REPO", "terraform-repo")
+	err = nil
+
+	_, err = artifactoryFactory(config)
+	if err.Error() != "missing 'subpath' configuration or ARTIFACTORY_SUBPATH environment variable" {
+		t.Fatal("missing ARTIFACTORY_SUBPATH should be error")
+	}
+	os.Setenv("ARTIFACTORY_SUBPATH", "myproject")
+	err = nil
+
+	client, err := artifactoryFactory(config)
+	if err != nil {
+		t.Fatalf("Error for valid config: %v", err)
 	}
 
 	artifactoryClient := client.(*ArtifactoryClient)


### PR DESCRIPTION
We came across this when we wanted to specify the Artifactory remote state backend configuration through the environment.

Up until now, we've been doing this by calling:
```
terraform init \
-backend-config="repo=$ARTIFACTORY_REPO" \
-backend-config="subpath=$ARTIFACTORY_SUBPATH"
```

This is surprisingly easy to mess up on top of just being inconvenient.

I figured it would be simple enough just to add it instead of opening up an issue and making you go through more work.