### PR TITLE
Fix drift caused from gofmt when running make dev and go 1.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 language: go
 go:
-- "1.10.1"
+- "1.11"
 
 # add TF_CONSUL_TEST=1 to run consul tests
 # they were causing timouts in travis

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All documentation is available on the [Terraform website](http://www.terraform.i
 Developing Terraform
 --------------------
 
-If you wish to work on Terraform itself or any of its built-in providers, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.10+ is *required*). Alternatively, you can use the Vagrantfile in the root of this repo to stand up a virtual machine with the appropriate dev tooling already set up for you.
+If you wish to work on Terraform itself or any of its built-in providers, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). Alternatively, you can use the Vagrantfile in the root of this repo to stand up a virtual machine with the appropriate dev tooling already set up for you.
 
 This repository contains only Terraform core, which includes the command line interface and the main graph engine. Providers are implemented as plugins that each have their own repository in [the `terraform-providers` organization](https://github.com/terraform-providers) on GitHub. Instructions for developing each provider are in the associated README file. For more information, see [the provider development overview](https://www.terraform.io/docs/plugins/provider.html).
 

--- a/backend/remote-state/s3/backend_test.go
+++ b/backend/remote-state/s3/backend_test.go
@@ -257,8 +257,8 @@ func TestBackendPrefixInWorkspace(t *testing.T) {
 	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
 
 	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
-		"bucket": bucketName,
-		"key":    "test-env.tfstate",
+		"bucket":               bucketName,
+		"key":                  "test-env.tfstate",
 		"workspace_key_prefix": "env",
 	}).(*Backend)
 

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -121,7 +121,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			Commands: map[string]bool{
 				"curl -LO https://omnitruck.chef.io/install.sh": true,
 				"bash ./install.sh -v \"11.18.6\" -c stable":    true,
-				"rm -f install.sh":                              true,
+				"rm -f install.sh": true,
 			},
 		},
 
@@ -140,7 +140,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 			Commands: map[string]bool{
 				"curl -LO https://omnitruck.chef.io/install.sh": true,
 				"bash ./install.sh -v \"11.18.6\" -c current":   true,
-				"rm -f install.sh":                              true,
+				"rm -f install.sh": true,
 			},
 		},
 	}

--- a/command/init.go
+++ b/command/init.go
@@ -72,8 +72,8 @@ func (c *InitCommand) Run(args []string) int {
 	// set providerInstaller if we don't have a test version already
 	if c.providerInstaller == nil {
 		c.providerInstaller = &discovery.ProviderInstaller{
-			Dir:   c.pluginDir(),
-			Cache: c.pluginCache(),
+			Dir:                   c.pluginDir(),
+			Cache:                 c.pluginCache(),
 			PluginProtocolVersion: plugin.Handshake.ProtocolVersion,
 			SkipVerify:            !flagVerifyPlugins,
 			Ui:                    c.Ui,

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -1434,7 +1434,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 	// Ask input
 	defer testInputMap(t, map[string]string{
 		"backend-migrate-multistate-to-multistate": "yes",
-		"new-state-name":                           "env1",
+		"new-state-name": "env1",
 	})()
 
 	// Setup the meta

--- a/helper/schema/resource_timeout_test.go
+++ b/helper/schema/resource_timeout_test.go
@@ -23,28 +23,28 @@ func TestResourceTimeout_ConfigDecode_badkey(t *testing.T) {
 		ShouldErr bool
 	}{
 		{
-			Name: "Source does not define 'delete' key",
+			Name:                   "Source does not define 'delete' key",
 			ResourceDefaultTimeout: timeoutForValues(10, 0, 5, 0, 0),
 			Config:                 expectedConfigForValues(2, 0, 0, 1, 0),
 			Expected:               timeoutForValues(10, 0, 5, 0, 0),
 			ShouldErr:              true,
 		},
 		{
-			Name: "Config overrides create",
+			Name:                   "Config overrides create",
 			ResourceDefaultTimeout: timeoutForValues(10, 0, 5, 0, 0),
 			Config:                 expectedConfigForValues(2, 0, 7, 0, 0),
 			Expected:               timeoutForValues(2, 0, 7, 0, 0),
 			ShouldErr:              false,
 		},
 		{
-			Name: "Config overrides create, default provided. Should still have zero values",
+			Name:                   "Config overrides create, default provided. Should still have zero values",
 			ResourceDefaultTimeout: timeoutForValues(10, 0, 5, 0, 3),
 			Config:                 expectedConfigForValues(2, 0, 7, 0, 0),
 			Expected:               timeoutForValues(2, 0, 7, 0, 3),
 			ShouldErr:              false,
 		},
 		{
-			Name: "Use something besides 'minutes'",
+			Name:                   "Use something besides 'minutes'",
 			ResourceDefaultTimeout: timeoutForValues(10, 0, 5, 0, 3),
 			Config: []map[string]interface{}{
 				map[string]interface{}{

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2056,7 +2056,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 
 			State: &terraform.InstanceState{
 				Attributes: map[string]string{
-					"block_device.#":                                "2",
+					"block_device.#": "2",
 					"block_device.616397234.delete_on_termination":  "true",
 					"block_device.616397234.device_name":            "/dev/sda1",
 					"block_device.2801811477.delete_on_termination": "true",

--- a/plugin/discovery/get_test.go
+++ b/plugin/discovery/get_test.go
@@ -148,7 +148,7 @@ func TestProviderInstallerGet(t *testing.T) {
 
 	// attempt to use an incompatible protocol version
 	i := &ProviderInstaller{
-		Dir: tmpDir,
+		Dir:                   tmpDir,
 		PluginProtocolVersion: 5,
 		SkipVerify:            true,
 		Ui:                    cli.NewMockUi(),
@@ -159,7 +159,7 @@ func TestProviderInstallerGet(t *testing.T) {
 	}
 
 	i = &ProviderInstaller{
-		Dir: tmpDir,
+		Dir:                   tmpDir,
 		PluginProtocolVersion: 3,
 		SkipVerify:            true,
 		Ui:                    cli.NewMockUi(),
@@ -231,7 +231,7 @@ func TestProviderInstallerPurgeUnused(t *testing.T) {
 	f.Close()
 
 	i := &ProviderInstaller{
-		Dir: tmpDir,
+		Dir:                   tmpDir,
 		PluginProtocolVersion: 3,
 		SkipVerify:            true,
 		Ui:                    cli.NewMockUi(),

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2408,10 +2408,10 @@
 			"revisionTime": "2017-06-05T21:53:11Z"
 		},
 		{
-			"checksumSHA1": "iHiMTBffQvWYlOLu3130JXuQpgQ=",
+			"checksumSHA1": "VNhImVFfxO7x8Kp1BrM2zgp4vi0=",
 			"path": "github.com/xanzy/ssh-agent",
-			"revision": "ba9c9e33906f58169366275e3450db66139a31a9",
-			"revisionTime": "2015-12-15T15:34:51Z"
+			"revision": "640f0ab560aeb89d523bb6ac322b1244d5c3796c",
+			"revisionTime": "2018-07-03T18:17:07Z"
 		},
 		{
 			"checksumSHA1": "xtw+Llokq30p1Gn+Q8JBZ7NtE+I=",


### PR DESCRIPTION
A fresh checkout of `origin/master` does not build atm using the `dev` target because `master` has not been formatted using `gofmt` from Go 1.11 (this has been the case for a while if you've been running devel).

```
% pwd
$GOPATH/src/github.com/hashicorp/terraform
% git status | head -n 2
# On branch master
# Your branch is up to date with 'origin/master'.
% git rev-parse HEAD
7cfeffe36b0be61ca812d33995e184e02a76c0dc
% make dev
==> Checking that code complies with gofmt requirements...
gofmt needs running on the following files:
./plugin/discovery/get_test.go
./backend/remote-state/s3/backend_test.go
./command/meta_backend_test.go
./command/init.go
./helper/schema/schema_test.go
./helper/schema/resource_timeout_test.go
./builtin/provisioners/chef/linux_provisioner_test.go
You can use the command: `make fmt` to reformat code.
make: *** [fmtcheck] Error 1
Exit 2
% make fmt
gofmt -w $(find . -name '*.go' | grep -v vendor)
% git status -s
 M backend/remote-state/s3/backend_test.go
 M builtin/provisioners/chef/linux_provisioner_test.go
 M command/init.go
 M command/meta_backend_test.go
 M helper/schema/resource_timeout_test.go
 M helper/schema/schema_test.go
 M plugin/discovery/get_test.go
```

None of the drift in question is especially new but now that Go 1.11 has been released and gofmt's formatting guidelines have been updated, it would be *really* nice if the code in `master` built with the current version of Go in order to avoid having to fight this drift locally.  Bump travis to 1.11 while I'm here.

* 8mo: https://github.com/hashicorp/terraform/blame/master/backend/remote-state/s3/backend_test.go#L260-L261
* 6mo: https://github.com/hashicorp/terraform/blame/master/builtin/provisioners/chef/linux_provisioner_test.go#L124
* 1yr: https://github.com/hashicorp/terraform/blame/7cfeffe36b0be61ca812d33995e184e02a76c0dc/command/init.go#L75-L76
* 12d: https://github.com/hashicorp/terraform/blame/7cfeffe36b0be61ca812d33995e184e02a76c0dc/command/meta_backend_test.go#L1437
* 2yr: https://github.com/hashicorp/terraform/blame/7cfeffe36b0be61ca812d33995e184e02a76c0dc/helper/schema/resource_timeout_test.go#L26
* 4yr: https://github.com/hashicorp/terraform/blame/7cfeffe36b0be61ca812d33995e184e02a76c0dc/helper/schema/schema_test.go#L2059
* 1yr: https://github.com/hashicorp/terraform/blame/7cfeffe36b0be61ca812d33995e184e02a76c0dc/plugin/discovery/get_test.go#L151