### PR TITLE
Fixing help print out for Terraform workspace command.

### DIFF
--- a/command/workspace_command.go
+++ b/command/workspace_command.go
@@ -33,7 +33,7 @@ func (c *WorkspaceCommand) Help() string {
 	helpText := `
 Usage: terraform workspace
 
-  Create, list, change and delete Terraform workspaces.
+  new, list, change and delete Terraform workspaces.
 
 `
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
This prints out the correct command for creating a new workspace which is new, not create. This fixes #18832 .