### PR TITLE
Remove a leftover test log file

### DIFF
--- a/terraform/test_failure
+++ b/terraform/test_failure
@@ -1,9 +1,0 @@
---- FAIL: TestContext2Plan_moduleProviderInherit (0.01s)
-	context_plan_test.go:552: bad: []string{"child"}
-map[string]dag.Vertex{}
-"module.middle.null"
-map[string]dag.Vertex{}
-"module.middle.module.inner.null"
-map[string]dag.Vertex{}
-"aws"
-FAIL


### PR DESCRIPTION
Just ran into this file by chance. It seems to be a piece of a test log.
I presume it was never meant to be checked in.

@svanharmelen Can you please review?