### PR TITLE
Add DateAdd function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -79,6 +79,7 @@ func Funcs() map[string]ast.Function {
 		"compact":      interpolationFuncCompact(),
 		"concat":       interpolationFuncConcat(),
 		"contains":     interpolationFuncContains(),
+		"dateadd":      interpolationFuncDateAdd(),
 		"dirname":      interpolationFuncDirname(),
 		"distinct":     interpolationFuncDistinct(),
 		"element":      interpolationFuncElement(),
@@ -1528,6 +1529,30 @@ func interpolationFuncTimeAdd() ast.Function {
 			}
 
 			return ts.Add(duration).Format(time.RFC3339), nil
+		},
+	}
+}
+
+func interpolationFuncDateAdd() ast.Function {
+	return ast.Function{
+		ArgTypes: []ast.Type{
+			ast.TypeString, // input timestamp string in RFC3339 format
+			ast.TypeInt, // input int for years
+			ast.TypeInt, // input int for months
+			ast.TypeInt, // input int for days
+		},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+
+			ts, err := time.Parse(time.RFC3339, args[0].(string))
+			if err != nil {
+				return nil, err
+			}
+			years := args[1].(int)
+			months := args[2].(int)
+			days := args[3].(int)
+
+			return ts.AddDate(years, months, days).Format(time.RFC3339), nil
 		},
 	}
 }

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -1537,9 +1537,9 @@ func interpolationFuncDateAdd() ast.Function {
 	return ast.Function{
 		ArgTypes: []ast.Type{
 			ast.TypeString, // input timestamp string in RFC3339 format
-			ast.TypeInt, // input int for years
-			ast.TypeInt, // input int for months
-			ast.TypeInt, // input int for days
+			ast.TypeInt,    // input int for years
+			ast.TypeInt,    // input int for months
+			ast.TypeInt,    // input int for days
 		},
 		ReturnType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/hil"
 	"github.com/hashicorp/hil/ast"
-	"github.com/mitchellh/go-homedir"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -2451,6 +2450,48 @@ func TestInterpolateFuncTimeAdd(t *testing.T) {
 			},
 			{ // Invalid format duration (day is not supported by ParseDuration)
 				`${timeadd("2017-11-22T00:00:00Z", "1d")}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
+func TestInterpolateFuncDateAdd(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{ //add a year
+				`${dateadd("2017-11-22T00:00:00Z", "1","0","0")}`,
+				"2018-11-22T00:00:01Z",
+				false,
+			},
+			{ //add a month
+				`${dateadd("2017-11-22T00:00:00Z", "0","1","0")}`,
+				"2018-12-22T00:00:01Z",
+				false,
+			},
+			{ //add a day
+				`${dateadd("2017-11-22T00:00:00Z", "0","0","1")}`,
+				"2018-11-23T00:00:01Z",
+				false,
+			},
+			{ //support subtraction
+				`${dateadd("2017-11-22T00:00:00Z", "0","0","-1")}`,
+				"2018-11-21T00:00:01Z",
+				false,
+			},
+			{ // Invalid format timestamp
+				`${dateadd("2017-11-22", "0","0","0")}`,
+				nil,
+				true,
+			},
+			{ // Missing arguments
+				`${dateadd("2017-11-22T00:00:00Z", "1")}`,
+				nil,
+				true,
+			},
+			{ // Missing arguments
+				`${dateadd("2017-11-22T00:00:00Z", "1","1")}`,
 				nil,
 				true,
 			},

--- a/config/time_funcs.go
+++ b/config/time_funcs.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+type DateTimeDuration struct {
+	Years        int
+	Months       int
+	Days         int
+	Hours        int
+	Minutes      int
+	Seconds      int
+	Milliseconds int
+	Microseconds int
+	Nanoseconds  int
+}
+
+func AddStructDate(d DateTimeDuration, t time.Time) time.Time {
+	nt := t.AddDate(d.Years, d.Months, d.Days)
+	return nt
+}
+
+func main() {
+	dtd := DateTimeDuration{Years: 1, Months: 2, Days: 5}
+	nd := AddStructDate(dtd, time.Date(2018, time.September, 16, 0, 0, 0, 0, time.UTC))
+	fmt.Printf("Check out my sweet date %s", nd)
+}

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -229,6 +229,9 @@ The supported built-in functions are:
   * `contains(list, element)` - Returns *true* if a list contains the given element
      and returns *false* otherwise. Examples: `contains(var.list_of_strings, "an_element")`
 
+  * `dateadd(time, years, months, days)` - Returns a UTC timestamp string corresponding to adding given `years`, `months`, and `days` to `time` in RFC 3339 format.      
+    For example, `dateadd("2017-03-14T00:00:00Z", "1","0","0")` produces a value `"2018-03-14T00:10:00Z"`. 
+
   * `dirname(path)` - Returns all but the last element of path, typically the path's directory.
 
   * `distinct(list)` - Removes duplicate items from a list. Keeps the first


### PR DESCRIPTION
Hi!  First PR on Terraform.  I have added a function to the interpolation_funcs.go called dateadd.  It is similar in nature to timeadd, except it deals with dates.  I have added the function, some tests for it, and updated the website docs to include the new function.  LMK if anything needs to be changed or improved prior to accepting the request.

Thanks!