### PR TITLE
Chef Solo provisioner

### DIFF
--- a/builtin/bins/provisioner-chef-solo/main.go
+++ b/builtin/bins/provisioner-chef-solo/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/provisioners/chef-solo"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProvisionerFunc: chefsolo.Provisioner,
+	})
+}

--- a/builtin/provisioners/chef-solo/apply.go
+++ b/builtin/provisioners/chef-solo/apply.go
@@ -1,0 +1,217 @@
+package chefsolo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var osDefaults = map[string]provisioner{
+	"unix": {
+		StagingDirectory: "/tmp/terraform-chef-solo",
+		InstallCommand:   "sh -c 'command -v chef-solo || (curl -LO https://omnitruck.chef.io/install.sh && sh install.sh{{if .Version}} -v {{.Version}}{{end}})'",
+		ExecuteCommand:   "chef-solo --no-color -c {{.ConfigPath}}",
+		createDirCommand: "sh -c 'mkdir -p %q; chmod 777 %q'",
+	},
+	"windows": {
+		StagingDirectory: "C:/Windows/Temp/terraform-chef-solo",
+		InstallCommand:   "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; Install-Project{{if .Version}} -version {{.Version}}{{end}}\"",
+		ExecuteCommand:   "C:/opscode/chef/bin/chef-solo.bat --no-color -c {{.ConfigPath}}",
+		createDirCommand: "cmd /c if not exist %q mkdir %q",
+	},
+}
+
+type soloRb struct {
+	CookbookPaths              string
+	Environment                string
+	EnvironmentsPath           string
+	DataBagsPath               string
+	EncryptedDataBagSecretPath string
+	JSON                       map[string]interface{}
+	JSONPath                   string
+	KeepLog                    bool
+	LogPath                    string
+	RolesPath                  string
+	StagingDirectory           string
+}
+
+// defaultConfigTemplate
+var defaultSoloRbTemplate = `
+         {{- if (not (eq (len .CookbookPaths) 0)) -}}         cookbook_path             [{{.CookbookPaths}}]
+{{ end }}{{- if (not (eq .EncryptedDataBagSecretPath "")) -}} encrypted_data_bag_secret "{{.EncryptedDataBagSecretPath}}"
+{{ end }}{{- if (not (eq .Environment "")) -}}                environment               "{{.Environment}}"
+{{ end }}{{- if (not (eq .EnvironmentsPath "")) -}}           environment_path          "{{.EnvironmentsPath}}"
+{{ end }}{{- if (not (eq .DataBagsPath "")) -}}               data_bag_path             "{{.DataBagsPath}}"
+{{ end }}{{- if (not (eq (len .JSON) 0)) -}}                  json_attribs              "{{.JSONPath}}"
+{{ end }}{{- if .KeepLog -}}                                  log_location              "{{.LogPath}}"
+{{ end }}{{- if (not (eq .RolesPath "")) -}}                  role_path                 "{{.RolesPath}}"
+{{ end }}`
+
+func applyFn(ctx context.Context) error {
+	o := ctx.Value(schema.ProvOutputKey).(terraform.UIOutput)
+	s := ctx.Value(schema.ProvRawStateKey).(*terraform.InstanceState)
+	data := ctx.Value(schema.ProvConfigDataKey).(*schema.ResourceData)
+
+	comm, err := getCommunicator(ctx, o, s)
+	if err != nil {
+		return fmt.Errorf("Couldn't get a new communicator: %v", err)
+	}
+
+	p, err := decodeConfig(data)
+	if err != nil {
+		return fmt.Errorf("Couldn't decode provisioner config: %v", err)
+	}
+
+	p.GuestOSType, err = getGuestOSType(s)
+	if err != nil {
+		return fmt.Errorf("Couldn't find out the OS based on the instance state: %v", err)
+	}
+
+	// Setup based on OS
+	setIfEmpty(&p.StagingDirectory, osDefaults[p.GuestOSType].StagingDirectory)
+	setIfEmpty(&p.InstallCommand, osDefaults[p.GuestOSType].InstallCommand)
+	setIfEmpty(&p.ExecuteCommand, osDefaults[p.GuestOSType].ExecuteCommand)
+
+	p.InstallCommand = renderTemplate(p.InstallCommand, p)
+	p.ExecuteCommand = renderTemplate(p.ExecuteCommand, struct {
+		ConfigPath string
+	}{
+		fmt.Sprintf("%s/solo.rb", p.StagingDirectory),
+	})
+
+	o.Output("Creating configuration...")
+	if err := p.createAndUploadConfiguration(o, comm); err != nil {
+		return fmt.Errorf("Error creating configuration: %v", err)
+	}
+	o.Output("Installing Chef-Solo...")
+	if !p.SkipInstall {
+		if err := p.runCommand(o, comm, p.InstallCommand); err != nil {
+			return fmt.Errorf("Error installing Chef: %v", err)
+		}
+	}
+	o.Output("Starting Chef-Solo...")
+	if err := p.runCommand(o, comm, p.ExecuteCommand); err != nil {
+		return fmt.Errorf("Error executing Chef: %v", err)
+	}
+
+	return nil
+}
+
+func (p *provisioner) createAndUploadConfiguration(o terraform.UIOutput, comm communicator.Communicator) error {
+	if err := p.createDir(o, comm, p.StagingDirectory); err != nil {
+		return fmt.Errorf("Error creating staging directory: %v", err)
+	}
+	if err := p.uploadCookbooks(o, comm); err != nil {
+		return fmt.Errorf("Error uploading cookbooks: %v", err)
+	}
+	if err := p.uploadDir(o, comm, p.getRemotePath(p.RolesPath), p.RolesPath); err != nil {
+		return fmt.Errorf("Error uploading roles: %v", err)
+	}
+	if err := p.uploadDir(o, comm, p.getRemotePath(p.EnvironmentsPath), p.EnvironmentsPath); err != nil {
+		return fmt.Errorf("Error uploading roles: %v", err)
+	}
+	if err := p.uploadDir(o, comm, p.getRemotePath(p.DataBagsPath), p.DataBagsPath); err != nil {
+		return fmt.Errorf("Error uploading data bags: %v", err)
+	}
+	if err := p.uploadFile(o, comm, p.getRemotePath(p.EncryptedDataBagSecretPath), p.EncryptedDataBagSecretPath); err != nil {
+		return fmt.Errorf("Error uploading encrypted data bag secret: %v", err)
+	}
+	if err := p.createAndUploadJSONAttributes(o, comm); err != nil {
+		return fmt.Errorf("Error creating and uploading the JSON attributes: %v", err)
+	}
+	if err := p.createAndUploadSoloRb(o, comm); err != nil {
+		return fmt.Errorf("Error creating and uploading the solo.rb config file: %v", err)
+	}
+	return nil
+}
+
+// maps the local cookbook paths to remote cookbook paths
+func (p *provisioner) getRemoteCookbookPaths() []string {
+	remoteCookbookPaths := make([]string, 0, len(p.CookbookPaths))
+	for i := range p.CookbookPaths {
+		remotePath := p.getRemotePath(fmt.Sprintf("cookbooks-%d", i))
+		remoteCookbookPaths = append(remoteCookbookPaths, remotePath)
+	}
+	return remoteCookbookPaths
+}
+
+func (p *provisioner) getRemotePath(localPath string) string {
+	if localPath != "" {
+		return fmt.Sprintf("%s/%s", p.StagingDirectory, localPath)
+	}
+	return ""
+}
+
+// uploads the cookbooks from the local cookbook paths to remote cookbook paths
+func (p *provisioner) uploadCookbooks(o terraform.UIOutput, comm communicator.Communicator) error {
+	for i, remotePath := range p.getRemoteCookbookPaths() {
+		localPath := p.CookbookPaths[i]
+		if err := p.uploadDir(o, comm, remotePath, localPath); err != nil {
+			return fmt.Errorf("Error uploading cookbooks: %v", err)
+		}
+	}
+	return nil
+}
+
+// get the node attributes, add the `run_list` if it's specified, and upload it
+func (p *provisioner) createAndUploadJSONAttributes(o terraform.UIOutput, comm communicator.Communicator) error {
+	o.Output("Creating Chef JSON attributes file...")
+
+	jsonData := make(map[string]interface{})
+	for k, v := range p.JSON {
+		jsonData[k] = v
+	}
+	if len(p.RunList) > 0 {
+		jsonData["run_list"] = p.RunList
+	}
+	jsonBytes, err := json.MarshalIndent(jsonData, "", "  ")
+	if err != nil {
+		return err
+	}
+	remotePath := filepath.ToSlash(filepath.Join(p.StagingDirectory, "attributes.json"))
+	if err := comm.Upload(remotePath, bytes.NewReader(jsonBytes)); err != nil {
+		return fmt.Errorf("Error creating the Chef JSON attributes file: %v", err)
+	}
+	return nil
+}
+
+// creates and uploads the solo.rb config file for Chef Solo to use
+func (p *provisioner) createAndUploadSoloRb(o terraform.UIOutput, comm communicator.Communicator) error {
+	o.Output("Creating solo.rb config filed...")
+
+	quotedRemotePaths := make([]string, len(p.CookbookPaths)+len(p.RemoteCookbookPaths))
+	for i, remotePath := range p.getRemoteCookbookPaths() {
+		quotedRemotePaths[i] = fmt.Sprintf(`"%s"`, remotePath)
+	}
+	for i, remotePath := range p.RemoteCookbookPaths {
+		i = len(p.CookbookPaths) + i
+		quotedRemotePaths[i] = fmt.Sprintf(`"%s"`, remotePath)
+	}
+
+	soloRbConfig := renderTemplate(p.ConfigTemplate, &soloRb{
+		CookbookPaths:              strings.Join(quotedRemotePaths, ","),
+		DataBagsPath:               p.getRemotePath(p.DataBagsPath),
+		EncryptedDataBagSecretPath: p.getRemotePath(p.EncryptedDataBagSecretPath),
+		Environment:                p.Environment,
+		EnvironmentsPath:           p.getRemotePath(p.EnvironmentsPath),
+		JSON:                       p.JSON,
+		JSONPath:                   fmt.Sprintf("%s/attributes.json", p.StagingDirectory),
+		KeepLog:                    p.KeepLog,
+		LogPath:                    fmt.Sprintf("%s/chef.log", p.StagingDirectory),
+		RolesPath:                  p.getRemotePath(p.RolesPath),
+		StagingDirectory:           p.StagingDirectory,
+	})
+
+	remoteSoloRbPath := filepath.ToSlash(filepath.Join(p.StagingDirectory, "solo.rb"))
+	if err := comm.Upload(remoteSoloRbPath, strings.NewReader(soloRbConfig)); err != nil {
+		return fmt.Errorf("Error creating the solo.rb file: %v", err)
+	}
+	return nil
+}

--- a/builtin/provisioners/chef-solo/apply_test.go
+++ b/builtin/provisioners/chef-solo/apply_test.go
@@ -1,0 +1,213 @@
+package chefsolo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestApply_UploadCookbooks(t *testing.T) {
+	// setup
+	happyCases := map[string]provisioner{
+		"unix": {
+			GuestOSType:      "unix",
+			StagingDirectory: osDefaults["unix"].StagingDirectory,
+			CookbookPaths:    []string{"chef/cookbooks/", "chef/bookcooks/"},
+			PreventSudo:      true,
+		},
+		"windows": {
+			GuestOSType:      "windows",
+			StagingDirectory: osDefaults["windows"].StagingDirectory,
+			CookbookPaths:    []string{"chef/cookbooks/", "chef/bookcooks/"},
+		},
+	}
+
+	o := new(terraform.MockUIOutput)
+	comm := new(communicator.MockCommunicator)
+	comm.UploadDirs = map[string]string{}
+	comm.Commands = map[string]bool{}
+
+	for k, p := range happyCases {
+		// setup result
+		for i, path := range p.CookbookPaths {
+			remotePath := fmt.Sprintf("%s/cookbooks-%d", p.StagingDirectory, i)
+			comm.UploadDirs[path] = remotePath
+			comm.Commands[fmt.Sprintf(osDefaults[p.GuestOSType].createDirCommand, remotePath, remotePath)] = true
+		}
+		// do it
+		if err := p.uploadCookbooks(o, comm); err != nil {
+			t.Fatalf("Test %q failed: %v", k, err)
+		}
+	}
+}
+
+func TestApply_CreateAndUploadJSONAttributes(t *testing.T) {
+	// setup
+	jsonAttributes := map[string]interface{}{
+		"run_list": []string{"x", "y"},
+		"a": map[string]interface{}{
+			"b": 1,
+			"c": true,
+		},
+	}
+	happyCases := map[string]provisioner{
+		"unix": {
+			StagingDirectory: osDefaults["unix"].StagingDirectory,
+			JSON:             jsonAttributes,
+		},
+		"windows": {
+			StagingDirectory: osDefaults["windows"].StagingDirectory,
+			JSON:             jsonAttributes,
+		},
+	}
+	sadCases := map[string]provisioner{
+		"run-list-overwritten": {
+			StagingDirectory: osDefaults["unix"].StagingDirectory,
+			JSON:             jsonAttributes,
+			RunList:          []string{"x", "z"},
+		},
+	}
+
+	o := new(terraform.MockUIOutput)
+	comm := new(communicator.MockCommunicator)
+
+	// setup result
+	marshalled := `{"a":{"b":1,"c":true},"run_list":["x","y"]}`
+	var expected bytes.Buffer
+	json.Indent(&expected, []byte(marshalled), "", "  ")
+
+	// continue setup result by case and then do it
+	for k, p := range happyCases {
+		comm.Uploads = map[string]string{
+			fmt.Sprintf("%s/%s", p.StagingDirectory, "attributes.json"): expected.String(),
+		}
+		if err := p.createAndUploadJSONAttributes(o, comm); err != nil {
+			t.Fatalf("Test %q failed: %v", k, err)
+		}
+	}
+	for k, p := range sadCases {
+		comm.Uploads = map[string]string{
+			fmt.Sprintf("%s/%s", p.StagingDirectory, "attributes.json"): expected.String(),
+		}
+		if err := p.createAndUploadJSONAttributes(o, comm); err == nil {
+			t.Fatalf("Test %q failed. Expected failure but got nil.", k)
+		}
+	}
+}
+
+func TestApply_CreateAndUploadSoloRb_Happy(t *testing.T) {
+	// setup
+	happyCases := map[string]struct {
+		config   map[string]interface{}
+		expected string
+	}{
+		"unix empty config defaults": {
+			config: map[string]interface{}{
+				"staging_directory": osDefaults["unix"].StagingDirectory,
+			},
+			expected: `log_location              "/tmp/terraform-chef-solo/chef.log"`,
+		},
+		"unix role_path": {
+			config: map[string]interface{}{
+				"keep_log":          false,
+				"roles_path":        "a/b/c",
+				"staging_directory": osDefaults["unix"].StagingDirectory,
+			},
+			expected: fmt.Sprintf(
+				`role_path                 "%s/a/b/c"`,
+				osDefaults["unix"].StagingDirectory,
+			),
+		},
+		"windows cookbook_path": {
+			config: map[string]interface{}{
+				"cookbook_paths":    []string{"a/b/", "c/d/"},
+				"keep_log":          false,
+				"staging_directory": osDefaults["windows"].StagingDirectory,
+			},
+			expected: fmt.Sprintf(
+				`cookbook_path             ["%[1]s/cookbooks-0","%[1]s/cookbooks-1"]`,
+				osDefaults["windows"].StagingDirectory,
+			),
+		},
+		"unix json_attribs": {
+			config: map[string]interface{}{
+				"json":              `{ "a": "b" }`,
+				"keep_log":          false,
+				"staging_directory": osDefaults["unix"].StagingDirectory,
+			},
+			expected: fmt.Sprintf(
+				`json_attribs              "%s/attributes.json"`,
+				osDefaults["unix"].StagingDirectory,
+			),
+		},
+		"unix several": {
+			config: map[string]interface{}{
+				"cookbook_paths":    []string{"a/b/", "c/d/"},
+				"environments_path": "x/y/z",
+				"json":              `{ "a": "b" }`,
+				"keep_log":          false,
+				"roles_path":        "a/b/c",
+				"staging_directory": osDefaults["unix"].StagingDirectory,
+			},
+			expected: fmt.Sprintf(
+				`cookbook_path             ["%[1]s/cookbooks-0","%[1]s/cookbooks-1"]`+"\n"+
+					`environment_path          "%[1]s/x/y/z"`+"\n"+
+					`json_attribs              "%[1]s/attributes.json"`+"\n"+
+					`role_path                 "%[1]s/a/b/c"`+"\n",
+				osDefaults["unix"].StagingDirectory,
+			),
+		},
+	}
+
+	o := new(terraform.MockUIOutput)
+	comm := new(communicator.MockCommunicator)
+
+	// continue setup result by case and then do it
+	for k, tc := range happyCases {
+		comm.Uploads = map[string]string{
+			fmt.Sprintf("%s/%s", tc.config["staging_directory"], "solo.rb"): tc.expected,
+		}
+		p, _ := decodeConfig(
+			schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, tc.config),
+		)
+		if err := p.createAndUploadSoloRb(o, comm); err != nil {
+			t.Fatalf("Test %q failed: %v", k, err)
+		}
+	}
+}
+
+func TestApply_CreateAndUploadSoloRb_Unhappy(t *testing.T) {
+	// setup
+	unhappyCases := map[string]struct {
+		config   map[string]interface{}
+		expected string
+	}{
+		"forgot staging directory": {
+			config: map[string]interface{}{
+				"cookbook_paths": []string{"doesn't matter"},
+			},
+			expected: "doesn't matter either",
+		},
+	}
+
+	o := new(terraform.MockUIOutput)
+	comm := new(communicator.MockCommunicator)
+
+	// continue setup result by case and then do it
+	for k, tc := range unhappyCases {
+		comm.Uploads = map[string]string{
+			fmt.Sprintf("%s/%s", tc.config["staging_directory"], "solo.rb"): tc.expected,
+		}
+		p, _ := decodeConfig(
+			schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, tc.config),
+		)
+		if err := p.createAndUploadSoloRb(o, comm); err == nil {
+			t.Fatalf("Test %q failed. Expected failure but got nil.", k)
+		}
+	}
+}

--- a/builtin/provisioners/chef-solo/config.go
+++ b/builtin/provisioners/chef-solo/config.go
@@ -1,0 +1,150 @@
+package chefsolo
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+type provisioner struct {
+	Environment                string
+	ConfigTemplate             string
+	CookbookPaths              []string
+	DataBagsPath               string
+	EncryptedDataBagSecretPath string
+	EnvironmentsPath           string
+	ExecuteCommand             string
+	InstallCommand             string
+	GuestOSType                string
+	JSON                       map[string]interface{}
+	KeepLog                    bool
+	PreventSudo                bool
+	RemoteCookbookPaths        []string
+	RolesPath                  string
+	RunList                    []string
+	SkipInstall                bool
+	StagingDirectory           string
+	Version                    string
+
+	createDirCommand string
+}
+
+// Provisioner returns a Chef Solo provisioner
+func Provisioner() terraform.ResourceProvisioner {
+	return &schema.Provisioner{
+		Schema: map[string]*schema.Schema{
+			"environment": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"config_template": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  defaultSoloRbTemplate,
+			},
+			"cookbook_paths": &schema.Schema{
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"data_bags_path": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"encrypted_data_bag_secret_path": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"environments_path": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"execute_command": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"guest_os_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"install_command": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"json": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"keep_log": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"prevent_sudo": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"remote_cookbook_paths": &schema.Schema{
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"roles_path": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"run_list": &schema.Schema{
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"skip_install": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"staging_directory": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"version": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+		ApplyFunc:    applyFn,
+		ValidateFunc: func(c *terraform.ResourceConfig) (ws []string, es []error) { return },
+	}
+}
+
+// takes the data from the provisioner schema
+func decodeConfig(d *schema.ResourceData) (*provisioner, error) {
+	p := &provisioner{
+		ConfigTemplate:             d.Get("config_template").(string),
+		CookbookPaths:              getStringList(d.Get("cookbook_paths")),
+		DataBagsPath:               d.Get("data_bags_path").(string),
+		EncryptedDataBagSecretPath: d.Get("encrypted_data_bag_secret_path").(string),
+		Environment:                d.Get("environment").(string),
+		EnvironmentsPath:           d.Get("environments_path").(string),
+		ExecuteCommand:             d.Get("execute_command").(string),
+		GuestOSType:                d.Get("guest_os_type").(string),
+		InstallCommand:             d.Get("install_command").(string),
+		KeepLog:                    d.Get("keep_log").(bool),
+		PreventSudo:                d.Get("prevent_sudo").(bool),
+		RemoteCookbookPaths:        getStringList(d.Get("remote_cookbook_paths")),
+		RunList:                    getStringList(d.Get("run_list")),
+		RolesPath:                  d.Get("roles_path").(string),
+		StagingDirectory:           d.Get("staging_directory").(string),
+		SkipInstall:                d.Get("skip_install").(bool),
+		Version:                    d.Get("version").(string),
+	}
+	if unparsed, ok := d.GetOk("json"); ok {
+		var parsed map[string]interface{}
+		if err := json.Unmarshal([]byte(unparsed.(string)), &parsed); err != nil {
+			return nil, fmt.Errorf("Error parsing `json`: %#v", err)
+		}
+		p.JSON = parsed
+	}
+	return p, nil
+}

--- a/builtin/provisioners/chef-solo/config_test.go
+++ b/builtin/provisioners/chef-solo/config_test.go
@@ -1,0 +1,32 @@
+package chefsolo
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceProvisioner_impl(t *testing.T) {
+	var _ terraform.ResourceProvisioner = Provisioner()
+}
+
+func TestProvisioner(t *testing.T) {
+	if err := Provisioner().(*schema.Provisioner).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestConfig_DecodeConfig_Happy(t *testing.T) {
+	config := map[string]interface{}{
+		"cookbook_paths": []interface{}{"chef/cookbooks", "chef/bookcooks"},
+		"run_list":       []interface{}{"cookbook::recipe", "bookcook::recipe"},
+		"json":           `{"hey":"hi", "a":{"b":"c", "d":10, "e":true, "f":null}}`,
+	}
+	_, err := decodeConfig(
+		schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, config),
+	)
+	if err != nil {
+		t.Fatalf("Happy path failed: %v", "Error should not have triggered")
+	}
+}

--- a/builtin/provisioners/chef-solo/util.go
+++ b/builtin/provisioners/chef-solo/util.go
@@ -1,0 +1,189 @@
+package chefsolo
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/communicator/remote"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/go-linereader"
+)
+
+func getCommunicator(ctx context.Context, o terraform.UIOutput, s *terraform.InstanceState) (communicator.Communicator, error) {
+	comm, err := communicator.New(s)
+	if err != nil {
+		return nil, err
+	}
+	retryCtx, cancel := context.WithTimeout(ctx, comm.Timeout())
+	defer cancel()
+
+	// Wait and retry until we establish the connection
+	err = communicator.Retry(retryCtx, func() error {
+		return comm.Connect(o)
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer comm.Disconnect()
+
+	return comm, err
+}
+
+func getGuestOSType(state *terraform.InstanceState) (string, error) {
+	switch t := state.Ephemeral.ConnInfo["type"]; t {
+	case "ssh", "": // The default connection type is ssh, so if the type is empty assume ssh
+		return "unix", nil
+	case "winrm":
+		return "windows", nil
+	default:
+		return "", fmt.Errorf("Can't find OS type based on the connection type: %s", t)
+	}
+}
+
+func setIfEmpty(variable interface{}, defaultVal interface{}) {
+	switch v := variable.(type) {
+	case *string:
+		if *v == "" {
+			*v = defaultVal.(string)
+		}
+	case *bool:
+		if *v == false {
+			*v = defaultVal.(bool)
+		}
+	case *int:
+		if *v == 0 {
+			*v = defaultVal.(int)
+		}
+	default:
+		fmt.Errorf("Unsupported type %T", v)
+	}
+}
+
+// parses text as a template and executes it using the data
+func renderTemplate(text string, data interface{}) string {
+	var buff bytes.Buffer
+	template.Must(template.New("").Parse(text)).Execute(&buff, data)
+	return buff.String()
+}
+
+func getStringList(v interface{}) []string {
+	var result []string
+
+	switch v := v.(type) {
+	case nil:
+		return result
+	case []interface{}:
+		for _, vv := range v {
+			if vv, ok := vv.(string); ok {
+				result = append(result, vv)
+			}
+		}
+		return result
+	default:
+		panic(fmt.Sprintf("Unsupported type: %T", v))
+	}
+}
+
+func (p *provisioner) createDir(o terraform.UIOutput, comm communicator.Communicator, dir string) error {
+	cmd := fmt.Sprintf(osDefaults[p.GuestOSType].createDirCommand, dir, dir)
+
+	o.Output(fmt.Sprintf("Creating directory: %s", dir))
+	if err := p.runCommand(o, comm, cmd); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *provisioner) uploadDir(o terraform.UIOutput, comm communicator.Communicator, dst string, src string) error {
+	if src == "" {
+		return nil
+	}
+
+	if err := p.createDir(o, comm, dst); err != nil {
+		return err
+	}
+
+	src = strings.TrimSuffix(src, "/") + "/"
+
+	o.Output(fmt.Sprintf("Uploading local directory %s to %s", src, dst))
+	return comm.UploadDir(dst, src)
+}
+
+func (p *provisioner) uploadFile(o terraform.UIOutput, comm communicator.Communicator, dst string, src string) error {
+	if src == "" {
+		return nil
+	}
+	f, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return comm.Upload(dst, f)
+}
+
+// runCommand is used to run already prepared commands
+func (p *provisioner) runCommand(o terraform.UIOutput, comm communicator.Communicator, command string) error {
+	// Unless prevented, prefix the command with sudo
+	if !p.PreventSudo && p.GuestOSType == "unix" {
+		command = "sudo " + command
+	}
+
+	outR, outW := io.Pipe()
+	errR, errW := io.Pipe()
+	go p.copyOutput(o, outR)
+	go p.copyOutput(o, errR)
+	defer outW.Close()
+	defer errW.Close()
+
+	cmd := &remote.Cmd{
+		Command: command,
+		Stdout:  outW,
+		Stderr:  errW,
+	}
+
+	err := comm.Start(cmd)
+	if err != nil {
+		return fmt.Errorf("Error executing command %q: %v", cmd.Command, err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *provisioner) copyOutput(o terraform.UIOutput, r io.Reader) {
+	lr := linereader.New(r)
+	for line := range lr.Ch {
+		o.Output(line)
+	}
+}
+
+// Output implementation of terraform.UIOutput interface
+func (p *provisioner) Output(output string) {
+	logFile := path.Join("logfiles", "dummy-node")
+	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY, 0666)
+	if err != nil {
+		log.Printf("Error creating logfile %s: %v", logFile, err)
+		return
+	}
+	defer f.Close()
+
+	// These steps are needed to remove any ANSI escape codes used to colorize
+	// the output and to make sure we have proper line endings before writing
+	// the string to the logfile.
+	re := regexp.MustCompile(`\x1b\[[0-9;]+m`)
+	output = re.ReplaceAllString(output, "")
+	output = strings.Replace(output, "\r", "\n", -1)
+}

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	chefprovisioner "github.com/hashicorp/terraform/builtin/provisioners/chef"
+	chefsoloprovisioner "github.com/hashicorp/terraform/builtin/provisioners/chef-solo"
 	fileprovisioner "github.com/hashicorp/terraform/builtin/provisioners/file"
 	habitatprovisioner "github.com/hashicorp/terraform/builtin/provisioners/habitat"
 	localexecprovisioner "github.com/hashicorp/terraform/builtin/provisioners/local-exec"
@@ -18,6 +19,7 @@ var InternalProviders = map[string]plugin.ProviderFunc{}
 
 var InternalProvisioners = map[string]plugin.ProvisionerFunc{
 	"chef":            chefprovisioner.Provisioner,
+	"chef-solo":       chefsoloprovisioner.Provisioner,
 	"file":            fileprovisioner.Provisioner,
 	"habitat":         habitatprovisioner.Provisioner,
 	"local-exec":      localexecprovisioner.Provisioner,

--- a/command/internal_plugin_test.go
+++ b/command/internal_plugin_test.go
@@ -24,7 +24,7 @@ func TestInternalPlugin_InternalProviders(t *testing.T) {
 }
 
 func TestInternalPlugin_InternalProvisioners(t *testing.T) {
-	for _, name := range []string{"chef", "file", "local-exec", "remote-exec", "salt-masterless"} {
+	for _, name := range []string{"chef", "chef-solo", "file", "local-exec", "remote-exec", "salt-masterless"} {
 		if _, ok := InternalProvisioners[name]; !ok {
 			t.Errorf("Expected to find %s in InternalProvisioners", name)
 		}

--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -83,6 +83,7 @@ func makeProviderMap(items []plugin) string {
 // makeProvisionerMap creates a map of provisioners like this:
 //
 //	"chef":            chefprovisioner.Provisioner,
+//	"chef-solo":       chefsoloprovisioner.Provisioner,
 //	"salt-masterless": saltmasterlessprovisioner.Provisioner,
 //	"file":            fileprovisioner.Provisioner,
 //	"local-exec":      localexecprovisioner.Provisioner,

--- a/website/docs/provisioners/chef-solo.html.markdown
+++ b/website/docs/provisioners/chef-solo.html.markdown
@@ -1,0 +1,282 @@
+---
+description: |
+    The Chef solo Terraform provisioner installs and configures software on machines
+    spun up by Terraform by using [chef-solo](https://docs.chef.io/chef_solo.html).
+    It is inspired and based off the Chef Solo Packer provisioner.
+layout: docs
+page_title: 'Chef Solo - Provisioners'
+sidebar_current: 'docs-provisioners-chef-solo'
+---
+
+# Chef Solo Provisioner
+
+Type: `chef-solo`
+
+The Chef solo Terraform provisioner installs and configures software on machines
+spun up by Terraform by using [chef-solo](https://docs.chef.io/chef_solo.html).
+It is inspired and based off the Chef solo Packer provisioner.
+
+Cookbooks can be uploaded from your local machine to the remote machine or remote
+paths can be used. The provisioner will also install Chef onto your machine if it
+isn't already installed, using the official Chef installers provided by Chef Inc.
+
+## Example Usages
+
+The following example is fully functional and expects cookbooks in the "cookbooks"
+directory relative to your working directory. It will install the specified
+version of Chef, upload the "cookbooks" directory to the remote machine,
+and execute the `book::recipe` recipe using the specified JSON attributes.
+
+```hcl
+resource "aws_instance" "web" {
+  # ...
+
+  provisioner "chef-solo" {
+    version         = "12"
+    cookbook_paths  = ["cookbooks"]
+    run_list        = ["book::recipe"]
+    json            = <<-EOF
+      {
+        "a": "b",
+        "c": "d"
+      }
+    EOF
+  }
+}
+```
+
+Specifying static JSON attributes only gets us so far though, in which case we can use
+[template files](https://www.terraform.io/docs/providers/template/d/file.html)
+instead. For example, if we want to pass in the IP of a resource managed by Terraform,
+we can create a `attributes.json.tpl` file locally with the following contents:
+
+```json
+{
+  "node": {
+    "web": "${web_node_ip}"
+  }
+}
+```
+
+Now our Terraform script would look like this:
+
+```hcl
+resource "aws_instance" "web" {
+  # ...
+
+  provisioner "chef-solo" {
+    version         = "12"
+    cookbook_paths  = ["cookbooks"]
+    run_list        = ["book::recipe"]
+    json            = "${data.template_file.web_attributes.rendered}"
+  }
+}
+
+data "template_file" "web_attributes": {
+  template = "${file("attributes.json.tpl")}"
+  vars {
+    web_node_ip = ${aws_instance.web.private_ip}"
+  }
+}
+```
+
+This renders the template file with the provided IP so that it's available when
+running Chef solo.
+
+## Configuration Reference
+
+The reference of available configuration options is listed below. No
+configuration is actually required, but at least `run_list` is recommended.
+Unless otherwise specified, the default values of all the options are empty.
+
+-   `config_template` (string) - The contents of a
+    [solo.rb](https://docs.chef.io/config_rb_solo.html) config template.
+    By default, Terraform will only set configuration it needs to match the
+    settings provided in the provisioner configuration. If you need to set any
+    configuration that this provisioner doesn't support, then you should use a
+    custom configuration template. See the dedicated "Chef Configuration" section
+    below for more details.
+
+-   `cookbook_paths` (array of strings) - This is an array of paths to Chef
+    "cookbooks" directories on your local filesystem. These will be uploaded
+    to the remote machine in the directory specified by the `staging_directory`.
+
+-   `data_bags_path` (string) - The path to the data bags directory on your
+    local filesystem. These will be uploaded to the remote machine in the
+    directory specified by the `staging_directory`.
+
+-   `encrypted_data_bag_secret_path` (string) - The path to the file containing
+    the secret for encrypted data bags.
+
+-   `environment` (string) - The name of the Chef environment to use when
+    uploading different Chef environments via `environments_path`.
+
+-   `environments_path` (string) - The path to the "environments" directory on
+    your local filesystem. These will be uploaded to the remote machine in the
+    directory specified by the `staging_directory`.
+
+-   `execute_command` (string) - The command used to execute Chef. This has
+    various configuration template variables available to use. See below for
+    more information.
+
+-   `guest_os_type` (string) - The target guest OS type, either "unix" or
+    "windows". Setting this to "windows" will cause the provisioner to use
+    Windows friendly paths and commands. By default, this is detected by the
+    connection type you're using for provisioning, i.e. "unix" for "ssh",
+    and "windows" for "winrm".
+
+-   `install_command` (string) - The command used to install Chef. This has
+    various configuration template variables available to use. See below for
+    more information.
+
+-   `json` (object) - An arbitrary mapping of JSON that will be available as
+    node attributes while running Chef.
+
+-   `keep_log` (boolean) - By default, the log for the Chef run will be logged to
+    "`staging_directory`/chef.log". Set this to "false" if you don't want to
+    keep the log.
+
+-   `prevent_sudo` (boolean) - By default, the configured commands that are
+    executed to install and run Chef are executed with `sudo`. If this is true,
+    then the sudo will be omitted. This is ignored when `guest_os_type` is
+    "windows".
+
+-   `remote_cookbook_paths` (array of strings) - A list of paths on the remote
+    machine where cookbooks will already exist. These may exist from a previous
+    provisioner or step. If specified, Chef will be configured to look for
+    cookbooks here.
+
+-   `roles_path` (string) - The path to the "roles" directory on your
+    local filesystem. These will be uploaded to the remote machine in the
+    directory specified by the `staging_directory`.
+
+-   `run_list` (array of strings) - The [run
+    list](https://docs.chef.io/run_lists.html) for Chef.
+
+-   `skip_install` (boolean) - If true, Chef will not automatically be installed
+    on the machine using the Chef omnibus installers. By default, this is false.
+
+-   `staging_directory` (string) - This is the directory where all the
+    configuration of Chef by Terraform will be placed. By default this is
+    "/tmp/terraform-chef-solo" when `guest_os_type` is unix and
+    "C:/Windows/Temp/terraform-chef-solo" when windows. This directory doesn't
+    need to exist but must have proper permissions so that the user that Terraform
+    uses is able to create directories and write into this directory. If the permissions
+    are not correct, use a shell provisioner prior to this to configure it properly.
+
+-   `version` (string) - The version of Chef to be installed. If left empty,
+    this will install the latest version of Chef.
+
+## Chef Configuration
+
+By default, Terraform creates a simple Chef "solo.rb" configuration file in order to
+set the options specified by the provisioner. If you'd like to set your own custom
+configurations not supported above and don't want to submit a feature request, you
+can always specify a different configuration template through the `config_template`
+setting. However, if you found it useful, then someone else might too! So please do
+submit those requests!
+
+The "solo.rb" file is generated from a [Golang
+template](https://golang.org/pkg/text/template/), and has the following variables
+available to use. All of them take the value of the correspondingly named configuration settings above. 
+
+-   `CookbookPaths` is the path(s) to the cookbooks that were uploaded to the machine.
+     Note that these paths are already quoted. See below example.
+-   `DataBagsPath` is the path to the data bags directory.
+-   `EncryptedDataBagSecretPath` - The path to the encrypted data bag secret.
+-   `Environment` - The current Chef environment.
+-   `EnvironmentsPath` - The path to the environments directory..
+-   `JSON` - The JSON attributes. You typically would not need to use these directly
+     in the template.
+-   `KeepLog` - A boolean flag for whether or not you want to keep the log.
+-   `RolesPath` - The path to the roles directory.
+
+In addition to the above variables, we have the following variables that do not match
+any configuration settings.
+
+-   `JSONPath` - The path to where the JSON attributes file is.
+     This has the value of "{{.StagingDirectory}}/attributes.json".
+-   `LogPath` - The path to where the log file is stored.
+     This has the value of "{{.StagingDirectory}}/chef.log".
+
+### How do I use any of this?
+
+For example, right now this provisioner does not support the Chef "log\_level"
+setting available in the "solo.rb" file. If we'd like to set it, we'd have to provide
+our own configuration template. It would look something like this.
+
+```hcl
+resource "aws_instance" "web" {
+  # ...
+
+  provisioner "chef-solo" {
+    config_template = <<-EOF
+      cookbook_path   [{{.CookbookPaths}}]
+      json_attribs    "{{.JSONPath}}"
+      log_location    "{{.StagingDirectory}}/my-chef-log"
+      log_level       :debug
+    EOF
+    cookbook_paths  = ["cookbooks"]
+    run_list        = ["book::recipe"]
+  }
+}
+```
+
+The above Terraform code will create a "solo.rb" file with a debug "log\_level"
+to be used for the Chef run.
+
+## Execute Command
+
+By default, Terraform uses the following command to execute Chef for UNIX systems:
+
+```liquid
+chef-solo --no-color -c {{.ConfigPath}}
+```
+
+When `prevent_sudo` is false, the above command is prefaced with sudo.
+
+And the following for Windows systems:
+
+```liquid
+C:/opscode/chef/bin/chef-solo.bat --no-color -c {{.ConfigPath}}
+```
+
+While you can change this command through the `execute_command` setting, the
+only template variable available to you here is "{{.ConfigPath}}" which will
+evaluate to the path of the "solo.rb" config file.
+
+This might be useful if you'd like to use `chef-client --local-mode` instead
+of `chef-solo` if some configuration setting is not supported by Chef Solo.
+
+```hcl
+resource "aws_instance" "web" {
+  # ...
+
+  provisioner "chef-solo" {
+    config_template = <<- EOF
+      # ...
+    EOF
+    execute_command = "chef-client -z -c {{.ConfigPath}}"
+  }
+}
+```
+
+## Install Command
+
+By default, Terraform uses the following command to execute Chef for UNIX systems:
+
+```liquid
+sh -c 'command -v chef-solo || (curl -LO https://omnitruck.chef.io/install.sh && sh install.sh{{if .Version}} -v {{.Version}}{{end}})'
+```
+
+When `prevent_sudo` is false, the above command is prefaced with sudo.
+
+And the following for Windows systems:
+
+```liquid
+powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; Install-Project{{if .Version}} -version {{.Version}}{{end}}\"
+```
+
+Similarly, you can change this through the `install_command` setting. The only
+template variable available to you here is "{{.Version}}" which evaluates to whatever
+the `version` setting is.

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -246,6 +246,10 @@
             <a href="/docs/provisioners/chef.html">chef</a>
           </li>
 
+          <li<%= sidebar_current("docs-provisioners-chef-solo") %>>
+            <a href="/docs/provisioners/chef-solo.html">chef-solo</a>
+          </li>
+
           <li<%= sidebar_current("docs-provisioners-connection") %>>
             <a href="/docs/provisioners/connection.html">connection</a>
           </li>


### PR DESCRIPTION
I don't know if you guys want another builtin provisioner for Terraform, but I really liked the [Packer provisioner for Chef Solo](https://www.packer.io/docs/provisioners/chef-solo.html), so I wrote this provisioner in that style.

Overview:
- The behavior and documentation is very similar to Packer's Chef Solo provisioner, so hopefully it's familiar to users.
- In case the existing exposed settings don't satisfy someone's needs, templating the Chef config file, execute command, and install command are all supported.
- Dynamic attributes are intended to be set by using `template_file`s and passing the rendered template as JSON attributes to the Chef config.

Lemme know what you think!