### PR TITLE
Fixing typo in zsh autocomplete README

### DIFF
--- a/contrib/zsh-completion/README.md
+++ b/contrib/zsh-completion/README.md
@@ -2,10 +2,10 @@
 
 ## Install
 ```console
-% terraform -install-autocomplete
+% terraform --install-autocomplete
 ```
 
 ## Uninstall
 ```console
-% terraform -uninstall-autocomplete
+% terraform --uninstall-autocomplete
 ```


### PR DESCRIPTION
Using Terraform v0.11.8 on latest Mac OS X and zsh

```
terraform -install-autocomplete
```
which is mentioned in the current version of README doesn't do anything. However, using double hyphen

```
terraform --install-autocomplete
```

adds this line to ~/.zshrc:

```
complete -o nospace -C /usr/local/Cellar/terraform/0.11.8/bin/terraform terraform
```

Similarly 

```
terraform --uninstall-autocomplete
```
successfully removes that line from ~/.zshrc
Fixes #18867 