### PR TITLE
Add support for unescaped output in jsonencode

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -1502,6 +1502,16 @@ func TestInterpolateFuncJSONEncode(t *testing.T) {
 				`{"foo":["bar"]}`,
 				false,
 			},
+			{
+				`${jsonencode("< & >")}`,
+				`"\u003c \u0026 \u003e"`,
+				false,
+			},
+			{
+				`${jsonencode(">", false)}`,
+				`">"`,
+				false,
+			},
 		},
 	})
 }

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -289,9 +289,11 @@ The supported built-in functions are:
       * `join(",", aws_instance.foo.*.id)`
       * `join(",", var.ami_list)`
 
-  * `jsonencode(value)` - Returns a JSON-encoded representation of the given
+  * `jsonencode(value, [escape HTML])` - Returns a JSON-encoded representation of the given
       value, which can contain arbitrarily-nested lists and maps. Note that if
-      the value is a string then its value will be placed in quotes.
+      the value is a string then its value will be placed in quotes. By default the HTML
+      characters `<`, `>` and `&` are escaped to the corresponding UTF-16 code, set the second
+      parameter to `false` to disable this.
 
   * `keys(map)` - Returns a lexically sorted list of the map keys.
 


### PR DESCRIPTION
`jsonencode` uses json.Marshal, which escapes certain HTML characters. https://golang.org/pkg/encoding/json/#Marshal

We are using the Fastly provider, and generating JSON-formatted logs. The Fastly VCL format code for the final request status (`%>s`) includes the `>` character, so we need to be able to remove the character escapes.

https://docs.fastly.com/guides/streaming-logs/custom-log-formats

I've implemented this by replacing the quoted Unicode escape so the original character is rendered, maybe this is too broad a solution? The encoding/json docs suggest using a custom Encoder, but I couldn't find guidance on how to implement that.