### PR TITLE
Update go-autorest to v9.10.0

### DIFF
--- a/vendor/github.com/Azure/go-autorest/autorest/adal/README.md
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/README.md
@@ -218,6 +218,40 @@ if (err == nil) {
 }
 ```
 
+#### Username password authenticate
+
+```Go
+spt, err := adal.NewServicePrincipalTokenFromUsernamePassword(
+	oauthConfig,
+	applicationID,
+	username,
+	password,
+	resource,
+	callbacks...)
+
+if (err == nil) {
+    token := spt.Token
+}
+```
+
+#### Authorization code authenticate
+
+``` Go
+spt, err := adal.NewServicePrincipalTokenFromAuthorizationCode(
+	oauthConfig,
+	applicationID,
+	clientSecret,
+      authorizationCode,
+      redirectURI,
+	resource,
+	callbacks...)
+
+err  = spt.Refresh()
+if (err == nil) {
+    token := spt.Token
+}
+```
+
 ### Command Line Tool
 
 A command line tool is available in `cmd/adal.go` that can acquire a token for a given resource. It supports all flows mentioned above.

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/config.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/config.go
@@ -1,5 +1,19 @@
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"net/url"
@@ -18,8 +32,24 @@ type OAuthConfig struct {
 	DeviceCodeEndpoint url.URL
 }
 
+// IsZero returns true if the OAuthConfig object is zero-initialized.
+func (oac OAuthConfig) IsZero() bool {
+	return oac == OAuthConfig{}
+}
+
+func validateStringParam(param, name string) error {
+	if len(param) == 0 {
+		return fmt.Errorf("parameter '" + name + "' cannot be empty")
+	}
+	return nil
+}
+
 // NewOAuthConfig returns an OAuthConfig with tenant specific urls
 func NewOAuthConfig(activeDirectoryEndpoint, tenantID string) (*OAuthConfig, error) {
+	if err := validateStringParam(activeDirectoryEndpoint, "activeDirectoryEndpoint"); err != nil {
+		return nil, err
+	}
+	// it's legal for tenantID to be empty so don't validate it
 	const activeDirectoryEndpointTemplate = "%s/oauth2/%s?api-version=%s"
 	u, err := url.Parse(activeDirectoryEndpoint)
 	if err != nil {

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/devicetoken.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/devicetoken.go
@@ -1,5 +1,19 @@
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 /*
   This file is largely based on rjw57/oauth2device's code, with the follow differences:
    * scope -> resource, and only allow a single one

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/msi.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/msi.go
@@ -1,4 +1,6 @@
-package date
+// +build !windows
+
+package adal
 
 // Copyright 2017 Microsoft Corporation
 //
@@ -14,12 +16,5 @@ package date
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-import (
-	"strings"
-	"time"
-)
-
-// ParseTime to parse Time string to specified format.
-func ParseTime(format string, t string) (d time.Time, err error) {
-	return time.Parse(format, strings.ToUpper(t))
-}
+// msiPath is the path to the MSI Extension settings file (to discover the endpoint)
+var msiPath = "/var/lib/waagent/ManagedIdentity-Settings"

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/msi_windows.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/msi_windows.go
@@ -1,4 +1,6 @@
-package date
+// +build windows
+
+package adal
 
 // Copyright 2017 Microsoft Corporation
 //
@@ -15,11 +17,9 @@ package date
 //  limitations under the License.
 
 import (
+	"os"
 	"strings"
-	"time"
 )
 
-// ParseTime to parse Time string to specified format.
-func ParseTime(format string, t string) (d time.Time, err error) {
-	return time.Parse(format, strings.ToUpper(t))
-}
+// msiPath is the path to the MSI Extension settings file (to discover the endpoint)
+var msiPath = strings.Join([]string{os.Getenv("SystemDrive"), "WindowsAzure/Config/ManagedIdentity-Settings"}, "/")

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/persist.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/persist.go
@@ -1,5 +1,19 @@
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"encoding/json"
 	"fmt"

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/sender.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/sender.go
@@ -1,5 +1,19 @@
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"net/http"
 )

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/token.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/token.go
@@ -1,5 +1,19 @@
 package adal
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"crypto/rand"
 	"crypto/rsa"
@@ -13,14 +27,15 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/dgrijalva/jwt-go"
 )
 
 const (
 	defaultRefresh = 5 * time.Minute
-	tokenBaseDate  = "1970-01-01T00:00:00Z"
 
 	// OAuthGrantTypeDeviceCode is the "grant_type" identifier used in device flow
 	OAuthGrantTypeDeviceCode = "device_code"
@@ -28,25 +43,28 @@ const (
 	// OAuthGrantTypeClientCredentials is the "grant_type" identifier used in credential flows
 	OAuthGrantTypeClientCredentials = "client_credentials"
 
+	// OAuthGrantTypeUserPass is the "grant_type" identifier used in username and password auth flows
+	OAuthGrantTypeUserPass = "password"
+
 	// OAuthGrantTypeRefreshToken is the "grant_type" identifier used in refresh token flows
 	OAuthGrantTypeRefreshToken = "refresh_token"
 
-	// managedIdentitySettingsPath is the path to the MSI Extension settings file (to discover the endpoint)
-	managedIdentitySettingsPath = "/var/lib/waagent/ManagedIdentity-Settings"
+	// OAuthGrantTypeAuthorizationCode is the "grant_type" identifier used in authorization code flows
+	OAuthGrantTypeAuthorizationCode = "authorization_code"
 
 	// metadataHeader is the header required by MSI extension
 	metadataHeader = "Metadata"
 )
 
-var expirationBase time.Time
-
-func init() {
-	expirationBase, _ = time.Parse(time.RFC3339, tokenBaseDate)
-}
-
 // OAuthTokenProvider is an interface which should be implemented by an access token retriever
 type OAuthTokenProvider interface {
 	OAuthToken() string
+}
+
+// TokenRefreshError is an interface used by errors returned during token refresh.
+type TokenRefreshError interface {
+	error
+	Response() *http.Response
 }
 
 // Refresher is an interface for token refresh functionality
@@ -73,13 +91,21 @@ type Token struct {
 	Type     string `json:"token_type"`
 }
 
+// IsZero returns true if the token object is zero-initialized.
+func (t Token) IsZero() bool {
+	return t == Token{}
+}
+
 // Expires returns the time.Time when the Token expires.
 func (t Token) Expires() time.Time {
 	s, err := strconv.Atoi(t.ExpiresOn)
 	if err != nil {
 		s = -3600
 	}
-	return expirationBase.Add(time.Duration(s) * time.Second).UTC()
+
+	expiration := date.NewUnixTimeFromSeconds(float64(s))
+
+	return time.Time(expiration).UTC()
 }
 
 // IsExpired returns true if the Token is expired, false otherwise.
@@ -137,10 +163,36 @@ type ServicePrincipalCertificateSecret struct {
 type ServicePrincipalMSISecret struct {
 }
 
+// ServicePrincipalUsernamePasswordSecret implements ServicePrincipalSecret for username and password auth.
+type ServicePrincipalUsernamePasswordSecret struct {
+	Username string
+	Password string
+}
+
+// ServicePrincipalAuthorizationCodeSecret implements ServicePrincipalSecret for authorization code auth.
+type ServicePrincipalAuthorizationCodeSecret struct {
+	ClientSecret      string
+	AuthorizationCode string
+	RedirectURI       string
+}
+
 // SetAuthenticationValues is a method of the interface ServicePrincipalSecret.
-// MSI extension requires the authority field to be set to the real tenant authority endpoint
+func (secret *ServicePrincipalAuthorizationCodeSecret) SetAuthenticationValues(spt *ServicePrincipalToken, v *url.Values) error {
+	v.Set("code", secret.AuthorizationCode)
+	v.Set("client_secret", secret.ClientSecret)
+	v.Set("redirect_uri", secret.RedirectURI)
+	return nil
+}
+
+// SetAuthenticationValues is a method of the interface ServicePrincipalSecret.
+func (secret *ServicePrincipalUsernamePasswordSecret) SetAuthenticationValues(spt *ServicePrincipalToken, v *url.Values) error {
+	v.Set("username", secret.Username)
+	v.Set("password", secret.Password)
+	return nil
+}
+
+// SetAuthenticationValues is a method of the interface ServicePrincipalSecret.
 func (msiSecret *ServicePrincipalMSISecret) SetAuthenticationValues(spt *ServicePrincipalToken, v *url.Values) error {
-	v.Set("authority", spt.oauthConfig.AuthorityEndpoint.String())
 	return nil
 }
 
@@ -193,25 +245,46 @@ func (secret *ServicePrincipalCertificateSecret) SetAuthenticationValues(spt *Se
 type ServicePrincipalToken struct {
 	Token
 
-	secret        ServicePrincipalSecret
-	oauthConfig   OAuthConfig
-	clientID      string
-	resource      string
-	autoRefresh   bool
-	refreshWithin time.Duration
-	sender        Sender
+	secret          ServicePrincipalSecret
+	oauthConfig     OAuthConfig
+	clientID        string
+	resource        string
+	autoRefresh     bool
+	autoRefreshLock *sync.Mutex
+	refreshWithin   time.Duration
+	sender          Sender
 
 	refreshCallbacks []TokenRefreshCallback
 }
 
+func validateOAuthConfig(oac OAuthConfig) error {
+	if oac.IsZero() {
+		return fmt.Errorf("parameter 'oauthConfig' cannot be zero-initialized")
+	}
+	return nil
+}
+
 // NewServicePrincipalTokenWithSecret create a ServicePrincipalToken using the supplied ServicePrincipalSecret implementation.
 func NewServicePrincipalTokenWithSecret(oauthConfig OAuthConfig, id string, resource string, secret ServicePrincipalSecret, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+	if err := validateOAuthConfig(oauthConfig); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(id, "id"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(resource, "resource"); err != nil {
+		return nil, err
+	}
+	if secret == nil {
+		return nil, fmt.Errorf("parameter 'secret' cannot be nil")
+	}
 	spt := &ServicePrincipalToken{
 		oauthConfig:      oauthConfig,
 		secret:           secret,
 		clientID:         id,
 		resource:         resource,
 		autoRefresh:      true,
+		autoRefreshLock:  &sync.Mutex{},
 		refreshWithin:    defaultRefresh,
 		sender:           &http.Client{},
 		refreshCallbacks: callbacks,
@@ -221,6 +294,18 @@ func NewServicePrincipalTokenWithSecret(oauthConfig OAuthConfig, id string, reso
 
 // NewServicePrincipalTokenFromManualToken creates a ServicePrincipalToken using the supplied token
 func NewServicePrincipalTokenFromManualToken(oauthConfig OAuthConfig, clientID string, resource string, token Token, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+	if err := validateOAuthConfig(oauthConfig); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(clientID, "clientID"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(resource, "resource"); err != nil {
+		return nil, err
+	}
+	if token.IsZero() {
+		return nil, fmt.Errorf("parameter 'token' cannot be zero-initialized")
+	}
 	spt, err := NewServicePrincipalTokenWithSecret(
 		oauthConfig,
 		clientID,
@@ -239,6 +324,18 @@ func NewServicePrincipalTokenFromManualToken(oauthConfig OAuthConfig, clientID s
 // NewServicePrincipalToken creates a ServicePrincipalToken from the supplied Service Principal
 // credentials scoped to the named resource.
 func NewServicePrincipalToken(oauthConfig OAuthConfig, clientID string, secret string, resource string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+	if err := validateOAuthConfig(oauthConfig); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(clientID, "clientID"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(secret, "secret"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(resource, "resource"); err != nil {
+		return nil, err
+	}
 	return NewServicePrincipalTokenWithSecret(
 		oauthConfig,
 		clientID,
@@ -250,8 +347,23 @@ func NewServicePrincipalToken(oauthConfig OAuthConfig, clientID string, secret s
 	)
 }
 
-// NewServicePrincipalTokenFromCertificate create a ServicePrincipalToken from the supplied pkcs12 bytes.
+// NewServicePrincipalTokenFromCertificate creates a ServicePrincipalToken from the supplied pkcs12 bytes.
 func NewServicePrincipalTokenFromCertificate(oauthConfig OAuthConfig, clientID string, certificate *x509.Certificate, privateKey *rsa.PrivateKey, resource string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+	if err := validateOAuthConfig(oauthConfig); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(clientID, "clientID"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(resource, "resource"); err != nil {
+		return nil, err
+	}
+	if certificate == nil {
+		return nil, fmt.Errorf("parameter 'certificate' cannot be nil")
+	}
+	if privateKey == nil {
+		return nil, fmt.Errorf("parameter 'privateKey' cannot be nil")
+	}
 	return NewServicePrincipalTokenWithSecret(
 		oauthConfig,
 		clientID,
@@ -264,57 +376,175 @@ func NewServicePrincipalTokenFromCertificate(oauthConfig OAuthConfig, clientID s
 	)
 }
 
-// NewServicePrincipalTokenFromMSI creates a ServicePrincipalToken via the MSI VM Extension.
-func NewServicePrincipalTokenFromMSI(oauthConfig OAuthConfig, resource string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
-	return newServicePrincipalTokenFromMSI(oauthConfig, resource, managedIdentitySettingsPath, callbacks...)
+// NewServicePrincipalTokenFromUsernamePassword creates a ServicePrincipalToken from the username and password.
+func NewServicePrincipalTokenFromUsernamePassword(oauthConfig OAuthConfig, clientID string, username string, password string, resource string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+	if err := validateOAuthConfig(oauthConfig); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(clientID, "clientID"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(username, "username"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(password, "password"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(resource, "resource"); err != nil {
+		return nil, err
+	}
+	return NewServicePrincipalTokenWithSecret(
+		oauthConfig,
+		clientID,
+		resource,
+		&ServicePrincipalUsernamePasswordSecret{
+			Username: username,
+			Password: password,
+		},
+		callbacks...,
+	)
 }
 
-func newServicePrincipalTokenFromMSI(oauthConfig OAuthConfig, resource, settingsPath string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
-	// Read MSI settings
-	bytes, err := ioutil.ReadFile(settingsPath)
-	if err != nil {
+// NewServicePrincipalTokenFromAuthorizationCode creates a ServicePrincipalToken from the
+func NewServicePrincipalTokenFromAuthorizationCode(oauthConfig OAuthConfig, clientID string, clientSecret string, authorizationCode string, redirectURI string, resource string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+
+	if err := validateOAuthConfig(oauthConfig); err != nil {
 		return nil, err
+	}
+	if err := validateStringParam(clientID, "clientID"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(clientSecret, "clientSecret"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(authorizationCode, "authorizationCode"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(redirectURI, "redirectURI"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(resource, "resource"); err != nil {
+		return nil, err
+	}
+
+	return NewServicePrincipalTokenWithSecret(
+		oauthConfig,
+		clientID,
+		resource,
+		&ServicePrincipalAuthorizationCodeSecret{
+			ClientSecret:      clientSecret,
+			AuthorizationCode: authorizationCode,
+			RedirectURI:       redirectURI,
+		},
+		callbacks...,
+	)
+}
+
+// GetMSIVMEndpoint gets the MSI endpoint on Virtual Machines.
+func GetMSIVMEndpoint() (string, error) {
+	return getMSIVMEndpoint(msiPath)
+}
+
+func getMSIVMEndpoint(path string) (string, error) {
+	// Read MSI settings
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
 	}
 	msiSettings := struct {
 		URL string `json:"url"`
 	}{}
 	err = json.Unmarshal(bytes, &msiSettings)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
+	return msiSettings.URL, nil
+}
+
+// NewServicePrincipalTokenFromMSI creates a ServicePrincipalToken via the MSI VM Extension.
+// It will use the system assigned identity when creating the token.
+func NewServicePrincipalTokenFromMSI(msiEndpoint, resource string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+	return newServicePrincipalTokenFromMSI(msiEndpoint, resource, nil, callbacks...)
+}
+
+// NewServicePrincipalTokenFromMSIWithUserAssignedID creates a ServicePrincipalToken via the MSI VM Extension.
+// It will use the specified user assigned identity when creating the token.
+func NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, resource string, userAssignedID string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+	return newServicePrincipalTokenFromMSI(msiEndpoint, resource, &userAssignedID, callbacks...)
+}
+
+func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedID *string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+	if err := validateStringParam(msiEndpoint, "msiEndpoint"); err != nil {
+		return nil, err
+	}
+	if err := validateStringParam(resource, "resource"); err != nil {
+		return nil, err
+	}
+	if userAssignedID != nil {
+		if err := validateStringParam(*userAssignedID, "userAssignedID"); err != nil {
+			return nil, err
+		}
+	}
 	// We set the oauth config token endpoint to be MSI's endpoint
-	// We leave the authority as-is so MSI can POST it with the token request
-	msiEndpointURL, err := url.Parse(msiSettings.URL)
+	msiEndpointURL, err := url.Parse(msiEndpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	msiTokenEndpointURL, err := msiEndpointURL.Parse("/oauth2/token")
+	oauthConfig, err := NewOAuthConfig(msiEndpointURL.String(), "")
 	if err != nil {
 		return nil, err
 	}
-
-	oauthConfig.TokenEndpoint = *msiTokenEndpointURL
 
 	spt := &ServicePrincipalToken{
-		oauthConfig:      oauthConfig,
+		oauthConfig:      *oauthConfig,
 		secret:           &ServicePrincipalMSISecret{},
 		resource:         resource,
 		autoRefresh:      true,
+		autoRefreshLock:  &sync.Mutex{},
 		refreshWithin:    defaultRefresh,
 		sender:           &http.Client{},
 		refreshCallbacks: callbacks,
 	}
 
+	if userAssignedID != nil {
+		spt.clientID = *userAssignedID
+	}
+
 	return spt, nil
 }
 
+// internal type that implements TokenRefreshError
+type tokenRefreshError struct {
+	message string
+	resp    *http.Response
+}
+
+// Error implements the error interface which is part of the TokenRefreshError interface.
+func (tre tokenRefreshError) Error() string {
+	return tre.message
+}
+
+// Response implements the TokenRefreshError interface, it returns the raw HTTP response from the refresh operation.
+func (tre tokenRefreshError) Response() *http.Response {
+	return tre.resp
+}
+
+func newTokenRefreshError(message string, resp *http.Response) TokenRefreshError {
+	return tokenRefreshError{message: message, resp: resp}
+}
+
 // EnsureFresh will refresh the token if it will expire within the refresh window (as set by
-// RefreshWithin) and autoRefresh flag is on.
+// RefreshWithin) and autoRefresh flag is on.  This method is safe for concurrent use.
 func (spt *ServicePrincipalToken) EnsureFresh() error {
 	if spt.autoRefresh && spt.WillExpireIn(spt.refreshWithin) {
-		return spt.Refresh()
+		// take the lock then check to see if the token was already refreshed
+		spt.autoRefreshLock.Lock()
+		defer spt.autoRefreshLock.Unlock()
+		if spt.WillExpireIn(spt.refreshWithin) {
+			return spt.Refresh()
+		}
 	}
 	return nil
 }
@@ -333,13 +563,26 @@ func (spt *ServicePrincipalToken) InvokeRefreshCallbacks(token Token) error {
 }
 
 // Refresh obtains a fresh token for the Service Principal.
+// This method is not safe for concurrent use and should be syncrhonized.
 func (spt *ServicePrincipalToken) Refresh() error {
 	return spt.refreshInternal(spt.resource)
 }
 
 // RefreshExchange refreshes the token, but for a different resource.
+// This method is not safe for concurrent use and should be syncrhonized.
 func (spt *ServicePrincipalToken) RefreshExchange(resource string) error {
 	return spt.refreshInternal(resource)
+}
+
+func (spt *ServicePrincipalToken) getGrantType() string {
+	switch spt.secret.(type) {
+	case *ServicePrincipalUsernamePasswordSecret:
+		return OAuthGrantTypeUserPass
+	case *ServicePrincipalAuthorizationCodeSecret:
+		return OAuthGrantTypeAuthorizationCode
+	default:
+		return OAuthGrantTypeClientCredentials
+	}
 }
 
 func (spt *ServicePrincipalToken) refreshInternal(resource string) error {
@@ -351,7 +594,7 @@ func (spt *ServicePrincipalToken) refreshInternal(resource string) error {
 		v.Set("grant_type", OAuthGrantTypeRefreshToken)
 		v.Set("refresh_token", spt.RefreshToken)
 	} else {
-		v.Set("grant_type", OAuthGrantTypeClientCredentials)
+		v.Set("grant_type", spt.getGrantType())
 		err := spt.secret.SetAuthenticationValues(spt, &v)
 		if err != nil {
 			return err
@@ -374,12 +617,17 @@ func (spt *ServicePrincipalToken) refreshInternal(resource string) error {
 	if err != nil {
 		return fmt.Errorf("adal: Failed to execute the refresh request. Error = '%v'", err)
 	}
+
 	defer resp.Body.Close()
+	rb, err := ioutil.ReadAll(resp.Body)
+
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("adal: Refresh request failed. Status Code = '%d'", resp.StatusCode)
+		if err != nil {
+			return newTokenRefreshError(fmt.Sprintf("adal: Refresh request failed. Status Code = '%d'. Failed reading response body", resp.StatusCode), resp)
+		}
+		return newTokenRefreshError(fmt.Sprintf("adal: Refresh request failed. Status Code = '%d'. Response body: %s", resp.StatusCode, string(rb)), resp)
 	}
 
-	rb, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("adal: Failed to read a new service principal token during refresh. Error = '%v'", err)
 	}

--- a/vendor/github.com/Azure/go-autorest/autorest/authorization.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/authorization.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"net/http"
@@ -10,9 +24,12 @@ import (
 )
 
 const (
-	bearerChallengeHeader = "Www-Authenticate"
-	bearer                = "Bearer"
-	tenantID              = "tenantID"
+	bearerChallengeHeader       = "Www-Authenticate"
+	bearer                      = "Bearer"
+	tenantID                    = "tenantID"
+	apiKeyAuthorizerHeader      = "Ocp-Apim-Subscription-Key"
+	bingAPISdkHeader            = "X-BingApis-SDK-Client"
+	golangBingAPISdkHeaderValue = "Go-SDK"
 )
 
 // Authorizer is the interface that provides a PrepareDecorator used to supply request
@@ -28,6 +45,53 @@ type NullAuthorizer struct{}
 // WithAuthorization returns a PrepareDecorator that does nothing.
 func (na NullAuthorizer) WithAuthorization() PrepareDecorator {
 	return WithNothing()
+}
+
+// APIKeyAuthorizer implements API Key authorization.
+type APIKeyAuthorizer struct {
+	headers         map[string]interface{}
+	queryParameters map[string]interface{}
+}
+
+// NewAPIKeyAuthorizerWithHeaders creates an ApiKeyAuthorizer with headers.
+func NewAPIKeyAuthorizerWithHeaders(headers map[string]interface{}) *APIKeyAuthorizer {
+	return NewAPIKeyAuthorizer(headers, nil)
+}
+
+// NewAPIKeyAuthorizerWithQueryParameters creates an ApiKeyAuthorizer with query parameters.
+func NewAPIKeyAuthorizerWithQueryParameters(queryParameters map[string]interface{}) *APIKeyAuthorizer {
+	return NewAPIKeyAuthorizer(nil, queryParameters)
+}
+
+// NewAPIKeyAuthorizer creates an ApiKeyAuthorizer with headers.
+func NewAPIKeyAuthorizer(headers map[string]interface{}, queryParameters map[string]interface{}) *APIKeyAuthorizer {
+	return &APIKeyAuthorizer{headers: headers, queryParameters: queryParameters}
+}
+
+// WithAuthorization returns a PrepareDecorator that adds an HTTP headers and Query Paramaters
+func (aka *APIKeyAuthorizer) WithAuthorization() PrepareDecorator {
+	return func(p Preparer) Preparer {
+		return DecoratePreparer(p, WithHeaders(aka.headers), WithQueryParameters(aka.queryParameters))
+	}
+}
+
+// CognitiveServicesAuthorizer implements authorization for Cognitive Services.
+type CognitiveServicesAuthorizer struct {
+	subscriptionKey string
+}
+
+// NewCognitiveServicesAuthorizer is
+func NewCognitiveServicesAuthorizer(subscriptionKey string) *CognitiveServicesAuthorizer {
+	return &CognitiveServicesAuthorizer{subscriptionKey: subscriptionKey}
+}
+
+// WithAuthorization is
+func (csa *CognitiveServicesAuthorizer) WithAuthorization() PrepareDecorator {
+	headers := make(map[string]interface{})
+	headers[apiKeyAuthorizerHeader] = csa.subscriptionKey
+	headers[bingAPISdkHeader] = golangBingAPISdkHeaderValue
+
+	return NewAPIKeyAuthorizerWithHeaders(headers).WithAuthorization()
 }
 
 // BearerAuthorizer implements the bearer authorization
@@ -55,7 +119,11 @@ func (ba *BearerAuthorizer) WithAuthorization() PrepareDecorator {
 			if ok {
 				err := refresher.EnsureFresh()
 				if err != nil {
-					return r, NewErrorWithError(err, "azure.BearerAuthorizer", "WithAuthorization", nil,
+					var resp *http.Response
+					if tokError, ok := err.(adal.TokenRefreshError); ok {
+						resp = tokError.Response()
+					}
+					return r, NewErrorWithError(err, "azure.BearerAuthorizer", "WithAuthorization", resp,
 						"Failed to refresh the Token for request to %s", r.URL)
 				}
 			}
@@ -164,4 +232,23 @@ func newBearerChallenge(resp *http.Response) (bc bearerChallenge, err error) {
 	}
 
 	return bc, err
+}
+
+// EventGridKeyAuthorizer implements authorization for event grid using key authentication.
+type EventGridKeyAuthorizer struct {
+	topicKey string
+}
+
+// NewEventGridKeyAuthorizer creates a new EventGridKeyAuthorizer
+// with the specified topic key.
+func NewEventGridKeyAuthorizer(topicKey string) EventGridKeyAuthorizer {
+	return EventGridKeyAuthorizer{topicKey: topicKey}
+}
+
+// WithAuthorization returns a PrepareDecorator that adds the aeg-sas-key authentication header.
+func (egta EventGridKeyAuthorizer) WithAuthorization() PrepareDecorator {
+	headers := map[string]interface{}{
+		"aeg-sas-key": egta.topicKey,
+	}
+	return NewAPIKeyAuthorizerWithHeaders(headers).WithAuthorization()
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/autorest.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/autorest.go
@@ -57,6 +57,20 @@ generated clients, see the Client described below.
 */
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"net/http"
 	"time"
@@ -73,6 +87,9 @@ const (
 // ResponseHasStatusCode returns true if the status code in the HTTP Response is in the passed set
 // and false otherwise.
 func ResponseHasStatusCode(resp *http.Response, codes ...int) bool {
+	if resp == nil {
+		return false
+	}
 	return containsInt(codes, resp.StatusCode)
 }
 

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/async.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/async.go
@@ -1,7 +1,23 @@
 package azure
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -23,6 +39,152 @@ const (
 	operationSucceeded  string = "Succeeded"
 )
 
+var pollingCodes = [...]int{http.StatusNoContent, http.StatusAccepted, http.StatusCreated, http.StatusOK}
+
+// Future provides a mechanism to access the status and results of an asynchronous request.
+// Since futures are stateful they should be passed by value to avoid race conditions.
+type Future struct {
+	req  *http.Request
+	resp *http.Response
+	ps   pollingState
+}
+
+// NewFuture returns a new Future object initialized with the specified request.
+func NewFuture(req *http.Request) Future {
+	return Future{req: req}
+}
+
+// Response returns the last HTTP response or nil if there isn't one.
+func (f Future) Response() *http.Response {
+	return f.resp
+}
+
+// Status returns the last status message of the operation.
+func (f Future) Status() string {
+	if f.ps.State == "" {
+		return "Unknown"
+	}
+	return f.ps.State
+}
+
+// PollingMethod returns the method used to monitor the status of the asynchronous operation.
+func (f Future) PollingMethod() PollingMethodType {
+	return f.ps.PollingMethod
+}
+
+// Done queries the service to see if the operation has completed.
+func (f *Future) Done(sender autorest.Sender) (bool, error) {
+	// exit early if this future has terminated
+	if f.ps.hasTerminated() {
+		return true, f.errorInfo()
+	}
+
+	resp, err := sender.Do(f.req)
+	f.resp = resp
+	if err != nil || !autorest.ResponseHasStatusCode(resp, pollingCodes[:]...) {
+		return false, err
+	}
+
+	err = updatePollingState(resp, &f.ps)
+	if err != nil {
+		return false, err
+	}
+
+	if f.ps.hasTerminated() {
+		return true, f.errorInfo()
+	}
+
+	f.req, err = newPollingRequest(f.ps)
+	return false, err
+}
+
+// GetPollingDelay returns a duration the application should wait before checking
+// the status of the asynchronous request and true; this value is returned from
+// the service via the Retry-After response header.  If the header wasn't returned
+// then the function returns the zero-value time.Duration and false.
+func (f Future) GetPollingDelay() (time.Duration, bool) {
+	if f.resp == nil {
+		return 0, false
+	}
+
+	retry := f.resp.Header.Get(autorest.HeaderRetryAfter)
+	if retry == "" {
+		return 0, false
+	}
+
+	d, err := time.ParseDuration(retry + "s")
+	if err != nil {
+		panic(err)
+	}
+
+	return d, true
+}
+
+// WaitForCompletion will return when one of the following conditions is met: the long
+// running operation has completed, the provided context is cancelled, or the client's
+// polling duration has been exceeded.  It will retry failed polling attempts based on
+// the retry value defined in the client up to the maximum retry attempts.
+func (f Future) WaitForCompletion(ctx context.Context, client autorest.Client) error {
+	ctx, cancel := context.WithTimeout(ctx, client.PollingDuration)
+	defer cancel()
+
+	done, err := f.Done(client)
+	for attempts := 0; !done; done, err = f.Done(client) {
+		if attempts >= client.RetryAttempts {
+			return autorest.NewErrorWithError(err, "azure", "WaitForCompletion", f.resp, "the number of retries has been exceeded")
+		}
+		// we want delayAttempt to be zero in the non-error case so
+		// that DelayForBackoff doesn't perform exponential back-off
+		var delayAttempt int
+		var delay time.Duration
+		if err == nil {
+			// check for Retry-After delay, if not present use the client's polling delay
+			var ok bool
+			delay, ok = f.GetPollingDelay()
+			if !ok {
+				delay = client.PollingDelay
+			}
+		} else {
+			// there was an error polling for status so perform exponential
+			// back-off based on the number of attempts using the client's retry
+			// duration.  update attempts after delayAttempt to avoid off-by-one.
+			delayAttempt = attempts
+			delay = client.RetryDuration
+			attempts++
+		}
+		// wait until the delay elapses or the context is cancelled
+		delayElapsed := autorest.DelayForBackoff(delay, delayAttempt, ctx.Done())
+		if !delayElapsed {
+			return autorest.NewErrorWithError(ctx.Err(), "azure", "WaitForCompletion", f.resp, "context has been cancelled")
+		}
+	}
+	return err
+}
+
+// if the operation failed the polling state will contain
+// error information and implements the error interface
+func (f *Future) errorInfo() error {
+	if !f.ps.hasSucceeded() {
+		return f.ps
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (f Future) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&f.ps)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (f *Future) UnmarshalJSON(data []byte) error {
+	err := json.Unmarshal(data, &f.ps)
+	if err != nil {
+		return err
+	}
+	f.req, err = newPollingRequest(f.ps)
+	return err
+}
+
 // DoPollForAsynchronous returns a SendDecorator that polls if the http.Response is for an Azure
 // long-running operation. It will delay between requests for the duration specified in the
 // RetryAfter header or, if the header is absent, the passed delay. Polling may be canceled by
@@ -34,8 +196,7 @@ func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
 			if err != nil {
 				return resp, err
 			}
-			pollingCodes := []int{http.StatusAccepted, http.StatusCreated, http.StatusOK}
-			if !autorest.ResponseHasStatusCode(resp, pollingCodes...) {
+			if !autorest.ResponseHasStatusCode(resp, pollingCodes[:]...) {
 				return resp, nil
 			}
 
@@ -52,10 +213,11 @@ func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
 					break
 				}
 
-				r, err = newPollingRequest(resp, ps)
+				r, err = newPollingRequest(ps)
 				if err != nil {
 					return resp, err
 				}
+				r.Cancel = resp.Request.Cancel
 
 				delay = autorest.GetRetryAfter(resp, delay)
 				resp, err = autorest.SendWithSender(s, r,
@@ -72,20 +234,15 @@ func getAsyncOperation(resp *http.Response) string {
 }
 
 func hasSucceeded(state string) bool {
-	return state == operationSucceeded
+	return strings.EqualFold(state, operationSucceeded)
 }
 
 func hasTerminated(state string) bool {
-	switch state {
-	case operationCanceled, operationFailed, operationSucceeded:
-		return true
-	default:
-		return false
-	}
+	return strings.EqualFold(state, operationCanceled) || strings.EqualFold(state, operationFailed) || strings.EqualFold(state, operationSucceeded)
 }
 
 func hasFailed(state string) bool {
-	return state == operationFailed
+	return strings.EqualFold(state, operationFailed)
 }
 
 type provisioningTracker interface {
@@ -146,36 +303,42 @@ func (ps provisioningStatus) hasProvisioningError() bool {
 	return ps.ProvisioningError != ServiceError{}
 }
 
-type pollingResponseFormat string
+// PollingMethodType defines a type used for enumerating polling mechanisms.
+type PollingMethodType string
 
 const (
-	usesOperationResponse  pollingResponseFormat = "OperationResponse"
-	usesProvisioningStatus pollingResponseFormat = "ProvisioningStatus"
-	formatIsUnknown        pollingResponseFormat = ""
+	// PollingAsyncOperation indicates the polling method uses the Azure-AsyncOperation header.
+	PollingAsyncOperation PollingMethodType = "AsyncOperation"
+
+	// PollingLocation indicates the polling method uses the Location header.
+	PollingLocation PollingMethodType = "Location"
+
+	// PollingUnknown indicates an unknown polling method and is the default value.
+	PollingUnknown PollingMethodType = ""
 )
 
 type pollingState struct {
-	responseFormat pollingResponseFormat
-	uri            string
-	state          string
-	code           string
-	message        string
+	PollingMethod PollingMethodType `json:"pollingMethod"`
+	URI           string            `json:"uri"`
+	State         string            `json:"state"`
+	Code          string            `json:"code"`
+	Message       string            `json:"message"`
 }
 
 func (ps pollingState) hasSucceeded() bool {
-	return hasSucceeded(ps.state)
+	return hasSucceeded(ps.State)
 }
 
 func (ps pollingState) hasTerminated() bool {
-	return hasTerminated(ps.state)
+	return hasTerminated(ps.State)
 }
 
 func (ps pollingState) hasFailed() bool {
-	return hasFailed(ps.state)
+	return hasFailed(ps.State)
 }
 
 func (ps pollingState) Error() string {
-	return fmt.Sprintf("Long running operation terminated with status '%s': Code=%q Message=%q", ps.state, ps.code, ps.message)
+	return fmt.Sprintf("Long running operation terminated with status '%s': Code=%q Message=%q", ps.State, ps.Code, ps.Message)
 }
 
 //	updatePollingState maps the operation status -- retrieved from either a provisioningState
@@ -190,7 +353,7 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 	// -- The first response will always be a provisioningStatus response; only the polling requests,
 	//    depending on the header returned, may be something otherwise.
 	var pt provisioningTracker
-	if ps.responseFormat == usesOperationResponse {
+	if ps.PollingMethod == PollingAsyncOperation {
 		pt = &operationResource{}
 	} else {
 		pt = &provisioningStatus{}
@@ -198,30 +361,30 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 
 	// If this is the first request (that is, the polling response shape is unknown), determine how
 	// to poll and what to expect
-	if ps.responseFormat == formatIsUnknown {
+	if ps.PollingMethod == PollingUnknown {
 		req := resp.Request
 		if req == nil {
 			return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Original HTTP request is missing")
 		}
 
 		// Prefer the Azure-AsyncOperation header
-		ps.uri = getAsyncOperation(resp)
-		if ps.uri != "" {
-			ps.responseFormat = usesOperationResponse
+		ps.URI = getAsyncOperation(resp)
+		if ps.URI != "" {
+			ps.PollingMethod = PollingAsyncOperation
 		} else {
-			ps.responseFormat = usesProvisioningStatus
+			ps.PollingMethod = PollingLocation
 		}
 
 		// Else, use the Location header
-		if ps.uri == "" {
-			ps.uri = autorest.GetLocation(resp)
+		if ps.URI == "" {
+			ps.URI = autorest.GetLocation(resp)
 		}
 
 		// Lastly, requests against an existing resource, use the last request URI
-		if ps.uri == "" {
+		if ps.URI == "" {
 			m := strings.ToUpper(req.Method)
 			if m == http.MethodPatch || m == http.MethodPut || m == http.MethodGet {
-				ps.uri = req.URL.String()
+				ps.URI = req.URL.String()
 			}
 		}
 	}
@@ -242,23 +405,23 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 	// -- Unknown states are per-service inprogress states
 	// -- Otherwise, infer state from HTTP status code
 	if pt.hasTerminated() {
-		ps.state = pt.state()
+		ps.State = pt.state()
 	} else if pt.state() != "" {
-		ps.state = operationInProgress
+		ps.State = operationInProgress
 	} else {
 		switch resp.StatusCode {
 		case http.StatusAccepted:
-			ps.state = operationInProgress
+			ps.State = operationInProgress
 
 		case http.StatusNoContent, http.StatusCreated, http.StatusOK:
-			ps.state = operationSucceeded
+			ps.State = operationSucceeded
 
 		default:
-			ps.state = operationFailed
+			ps.State = operationFailed
 		}
 	}
 
-	if ps.state == operationInProgress && ps.uri == "" {
+	if strings.EqualFold(ps.State, operationInProgress) && ps.URI == "" {
 		return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Unable to obtain polling URI for %s %s", resp.Request.Method, resp.Request.URL)
 	}
 
@@ -267,36 +430,49 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 	// -- Response
 	// -- Otherwise, Unknown
 	if ps.hasFailed() {
-		if ps.responseFormat == usesOperationResponse {
+		if ps.PollingMethod == PollingAsyncOperation {
 			or := pt.(*operationResource)
-			ps.code = or.OperationError.Code
-			ps.message = or.OperationError.Message
+			ps.Code = or.OperationError.Code
+			ps.Message = or.OperationError.Message
 		} else {
 			p := pt.(*provisioningStatus)
 			if p.hasProvisioningError() {
-				ps.code = p.ProvisioningError.Code
-				ps.message = p.ProvisioningError.Message
+				ps.Code = p.ProvisioningError.Code
+				ps.Message = p.ProvisioningError.Message
 			} else {
-				ps.code = "Unknown"
-				ps.message = "None"
+				ps.Code = "Unknown"
+				ps.Message = "None"
 			}
 		}
 	}
 	return nil
 }
 
-func newPollingRequest(resp *http.Response, ps pollingState) (*http.Request, error) {
-	req := resp.Request
-	if req == nil {
-		return nil, autorest.NewError("azure", "newPollingRequest", "Azure Polling Error - Original HTTP request is missing")
-	}
-
-	reqPoll, err := autorest.Prepare(&http.Request{Cancel: req.Cancel},
+func newPollingRequest(ps pollingState) (*http.Request, error) {
+	reqPoll, err := autorest.Prepare(&http.Request{},
 		autorest.AsGet(),
-		autorest.WithBaseURL(ps.uri))
+		autorest.WithBaseURL(ps.URI))
 	if err != nil {
-		return nil, autorest.NewErrorWithError(err, "azure", "newPollingRequest", nil, "Failure creating poll request to %s", ps.uri)
+		return nil, autorest.NewErrorWithError(err, "azure", "newPollingRequest", nil, "Failure creating poll request to %s", ps.URI)
 	}
 
 	return reqPoll, nil
+}
+
+// AsyncOpIncompleteError is the type that's returned from a future that has not completed.
+type AsyncOpIncompleteError struct {
+	// FutureType is the name of the type composed of a azure.Future.
+	FutureType string
+}
+
+// Error returns an error message including the originating type name of the error.
+func (e AsyncOpIncompleteError) Error() string {
+	return fmt.Sprintf("%s: asynchronous operation has not completed", e.FutureType)
+}
+
+// NewAsyncOpIncompleteError creates a new AsyncOpIncompleteError with the specified parameters.
+func NewAsyncOpIncompleteError(futureType string) AsyncOpIncompleteError {
+	return AsyncOpIncompleteError{
+		FutureType: futureType,
+	}
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/azure.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/azure.go
@@ -5,6 +5,20 @@ See the included examples for more detail.
 */
 package azure
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"encoding/json"
 	"fmt"
@@ -165,7 +179,13 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 				if decodeErr != nil {
 					return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), decodeErr)
 				} else if e.ServiceError == nil {
-					e.ServiceError = &ServiceError{Code: "Unknown", Message: "Unknown service error"}
+					// Check if error is unwrapped ServiceError
+					if err := json.Unmarshal(b.Bytes(), &e.ServiceError); err != nil || e.ServiceError.Message == "" {
+						e.ServiceError = &ServiceError{
+							Code:    "Unknown",
+							Message: "Unknown service error",
+						}
+					}
 				}
 
 				e.RequestID = ExtractRequestID(resp)

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
@@ -1,9 +1,30 @@
 package azure
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 )
+
+// EnvironmentFilepathName captures the name of the environment variable containing the path to the file
+// to be used while populating the Azure Environment.
+const EnvironmentFilepathName = "AZURE_ENVIRONMENT_FILEPATH"
 
 var environments = map[string]Environment{
 	"AZURECHINACLOUD":        ChinaCloud,
@@ -23,6 +44,7 @@ type Environment struct {
 	GalleryEndpoint              string `json:"galleryEndpoint"`
 	KeyVaultEndpoint             string `json:"keyVaultEndpoint"`
 	GraphEndpoint                string `json:"graphEndpoint"`
+	ServiceBusEndpoint           string `json:"serviceBusEndpoint"`
 	StorageEndpointSuffix        string `json:"storageEndpointSuffix"`
 	SQLDatabaseDNSSuffix         string `json:"sqlDatabaseDNSSuffix"`
 	TrafficManagerDNSSuffix      string `json:"trafficManagerDNSSuffix"`
@@ -45,11 +67,12 @@ var (
 		GalleryEndpoint:              "https://gallery.azure.com/",
 		KeyVaultEndpoint:             "https://vault.azure.net/",
 		GraphEndpoint:                "https://graph.windows.net/",
+		ServiceBusEndpoint:           "https://servicebus.windows.net/",
 		StorageEndpointSuffix:        "core.windows.net",
 		SQLDatabaseDNSSuffix:         "database.windows.net",
 		TrafficManagerDNSSuffix:      "trafficmanager.net",
 		KeyVaultDNSSuffix:            "vault.azure.net",
-		ServiceBusEndpointSuffix:     "servicebus.azure.com",
+		ServiceBusEndpointSuffix:     "servicebus.windows.net",
 		ServiceManagementVMDNSSuffix: "cloudapp.net",
 		ResourceManagerVMDNSSuffix:   "cloudapp.azure.com",
 		ContainerRegistryDNSSuffix:   "azurecr.io",
@@ -62,10 +85,11 @@ var (
 		PublishSettingsURL:           "https://manage.windowsazure.us/publishsettings/index",
 		ServiceManagementEndpoint:    "https://management.core.usgovcloudapi.net/",
 		ResourceManagerEndpoint:      "https://management.usgovcloudapi.net/",
-		ActiveDirectoryEndpoint:      "https://login.microsoftonline.com/",
+		ActiveDirectoryEndpoint:      "https://login.microsoftonline.us/",
 		GalleryEndpoint:              "https://gallery.usgovcloudapi.net/",
 		KeyVaultEndpoint:             "https://vault.usgovcloudapi.net/",
-		GraphEndpoint:                "https://graph.usgovcloudapi.net/",
+		GraphEndpoint:                "https://graph.windows.net/",
+		ServiceBusEndpoint:           "https://servicebus.usgovcloudapi.net/",
 		StorageEndpointSuffix:        "core.usgovcloudapi.net",
 		SQLDatabaseDNSSuffix:         "database.usgovcloudapi.net",
 		TrafficManagerDNSSuffix:      "usgovtrafficmanager.net",
@@ -87,11 +111,12 @@ var (
 		GalleryEndpoint:              "https://gallery.chinacloudapi.cn/",
 		KeyVaultEndpoint:             "https://vault.azure.cn/",
 		GraphEndpoint:                "https://graph.chinacloudapi.cn/",
+		ServiceBusEndpoint:           "https://servicebus.chinacloudapi.cn/",
 		StorageEndpointSuffix:        "core.chinacloudapi.cn",
 		SQLDatabaseDNSSuffix:         "database.chinacloudapi.cn",
 		TrafficManagerDNSSuffix:      "trafficmanager.cn",
 		KeyVaultDNSSuffix:            "vault.azure.cn",
-		ServiceBusEndpointSuffix:     "servicebus.chinacloudapi.net",
+		ServiceBusEndpointSuffix:     "servicebus.chinacloudapi.cn",
 		ServiceManagementVMDNSSuffix: "chinacloudapp.cn",
 		ResourceManagerVMDNSSuffix:   "cloudapp.azure.cn",
 		ContainerRegistryDNSSuffix:   "azurecr.io",
@@ -108,6 +133,7 @@ var (
 		GalleryEndpoint:              "https://gallery.cloudapi.de/",
 		KeyVaultEndpoint:             "https://vault.microsoftazure.de/",
 		GraphEndpoint:                "https://graph.cloudapi.de/",
+		ServiceBusEndpoint:           "https://servicebus.cloudapi.de/",
 		StorageEndpointSuffix:        "core.cloudapi.de",
 		SQLDatabaseDNSSuffix:         "database.cloudapi.de",
 		TrafficManagerDNSSuffix:      "azuretrafficmanager.de",
@@ -119,12 +145,37 @@ var (
 	}
 )
 
-// EnvironmentFromName returns an Environment based on the common name specified
+// EnvironmentFromName returns an Environment based on the common name specified.
 func EnvironmentFromName(name string) (Environment, error) {
+	// IMPORTANT
+	// As per @radhikagupta5:
+	// This is technical debt, fundamentally here because Kubernetes is not currently accepting
+	// contributions to the providers. Once that is an option, the provider should be updated to
+	// directly call `EnvironmentFromFile`. Until then, we rely on dispatching Azure Stack environment creation
+	// from this method based on the name that is provided to us.
+	if strings.EqualFold(name, "AZURESTACKCLOUD") {
+		return EnvironmentFromFile(os.Getenv(EnvironmentFilepathName))
+	}
+
 	name = strings.ToUpper(name)
 	env, ok := environments[name]
 	if !ok {
 		return env, fmt.Errorf("autorest/azure: There is no cloud environment matching the name %q", name)
 	}
+
 	return env, nil
+}
+
+// EnvironmentFromFile loads an Environment from a configuration file available on disk.
+// This function is particularly useful in the Hybrid Cloud model, where one must define their own
+// endpoints.
+func EnvironmentFromFile(location string) (unmarshaled Environment, err error) {
+	fileContents, err := ioutil.ReadFile(location)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(fileContents, &unmarshaled)
+
+	return
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/rp.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/rp.go
@@ -1,0 +1,203 @@
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package azure
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+)
+
+// DoRetryWithRegistration tries to register the resource provider in case it is unregistered.
+// It also handles request retries
+func DoRetryWithRegistration(client autorest.Client) autorest.SendDecorator {
+	return func(s autorest.Sender) autorest.Sender {
+		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
+			rr := autorest.NewRetriableRequest(r)
+			for currentAttempt := 0; currentAttempt < client.RetryAttempts; currentAttempt++ {
+				err = rr.Prepare()
+				if err != nil {
+					return resp, err
+				}
+
+				resp, err = autorest.SendWithSender(s, rr.Request(),
+					autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...),
+				)
+				if err != nil {
+					return resp, err
+				}
+
+				if resp.StatusCode != http.StatusConflict || client.SkipResourceProviderRegistration {
+					return resp, err
+				}
+				var re RequestError
+				err = autorest.Respond(
+					resp,
+					autorest.ByUnmarshallingJSON(&re),
+				)
+				if err != nil {
+					return resp, err
+				}
+				err = re
+
+				if re.ServiceError != nil && re.ServiceError.Code == "MissingSubscriptionRegistration" {
+					regErr := register(client, r, re)
+					if regErr != nil {
+						return resp, fmt.Errorf("failed auto registering Resource Provider: %s. Original error: %s", regErr, err)
+					}
+				}
+			}
+			return resp, fmt.Errorf("failed request: %s", err)
+		})
+	}
+}
+
+func getProvider(re RequestError) (string, error) {
+	if re.ServiceError != nil {
+		if re.ServiceError.Details != nil && len(*re.ServiceError.Details) > 0 {
+			detail := (*re.ServiceError.Details)[0].(map[string]interface{})
+			return detail["target"].(string), nil
+		}
+	}
+	return "", errors.New("provider was not found in the response")
+}
+
+func register(client autorest.Client, originalReq *http.Request, re RequestError) error {
+	subID := getSubscription(originalReq.URL.Path)
+	if subID == "" {
+		return errors.New("missing parameter subscriptionID to register resource provider")
+	}
+	providerName, err := getProvider(re)
+	if err != nil {
+		return fmt.Errorf("missing parameter provider to register resource provider: %s", err)
+	}
+	newURL := url.URL{
+		Scheme: originalReq.URL.Scheme,
+		Host:   originalReq.URL.Host,
+	}
+
+	// taken from the resources SDK
+	// with almost identical code, this sections are easier to mantain
+	// It is also not a good idea to import the SDK here
+	// https://github.com/Azure/azure-sdk-for-go/blob/9f366792afa3e0ddaecdc860e793ba9d75e76c27/arm/resources/resources/providers.go#L252
+	pathParameters := map[string]interface{}{
+		"resourceProviderNamespace": autorest.Encode("path", providerName),
+		"subscriptionId":            autorest.Encode("path", subID),
+	}
+
+	const APIVersion = "2016-09-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPost(),
+		autorest.WithBaseURL(newURL.String()),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/{resourceProviderNamespace}/register", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+	)
+
+	req, err := preparer.Prepare(&http.Request{})
+	if err != nil {
+		return err
+	}
+	req.Cancel = originalReq.Cancel
+
+	resp, err := autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...),
+	)
+	if err != nil {
+		return err
+	}
+
+	type Provider struct {
+		RegistrationState *string `json:"registrationState,omitempty"`
+	}
+	var provider Provider
+
+	err = autorest.Respond(
+		resp,
+		WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&provider),
+		autorest.ByClosing(),
+	)
+	if err != nil {
+		return err
+	}
+
+	// poll for registered provisioning state
+	now := time.Now()
+	for err == nil && time.Since(now) < client.PollingDuration {
+		// taken from the resources SDK
+		// https://github.com/Azure/azure-sdk-for-go/blob/9f366792afa3e0ddaecdc860e793ba9d75e76c27/arm/resources/resources/providers.go#L45
+		preparer := autorest.CreatePreparer(
+			autorest.AsGet(),
+			autorest.WithBaseURL(newURL.String()),
+			autorest.WithPathParameters("/subscriptions/{subscriptionId}/providers/{resourceProviderNamespace}", pathParameters),
+			autorest.WithQueryParameters(queryParameters),
+		)
+		req, err = preparer.Prepare(&http.Request{})
+		if err != nil {
+			return err
+		}
+		req.Cancel = originalReq.Cancel
+
+		resp, err := autorest.SendWithSender(client, req,
+			autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...),
+		)
+		if err != nil {
+			return err
+		}
+
+		err = autorest.Respond(
+			resp,
+			WithErrorUnlessStatusCode(http.StatusOK),
+			autorest.ByUnmarshallingJSON(&provider),
+			autorest.ByClosing(),
+		)
+		if err != nil {
+			return err
+		}
+
+		if provider.RegistrationState != nil &&
+			*provider.RegistrationState == "Registered" {
+			break
+		}
+
+		delayed := autorest.DelayWithRetryAfter(resp, originalReq.Cancel)
+		if !delayed {
+			autorest.DelayForBackoff(client.PollingDelay, 0, originalReq.Cancel)
+		}
+	}
+	if !(time.Since(now) < client.PollingDuration) {
+		return errors.New("polling for resource provider registration has exceeded the polling duration")
+	}
+	return err
+}
+
+func getSubscription(path string) string {
+	parts := strings.Split(path, "/")
+	for i, v := range parts {
+		if v == "subscriptions" && (i+1) < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
+}

--- a/vendor/github.com/Azure/go-autorest/autorest/client.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/client.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"fmt"
@@ -21,6 +35,9 @@ const (
 
 	// DefaultRetryAttempts is number of attempts for retry status codes (5xx).
 	DefaultRetryAttempts = 3
+
+	// DefaultRetryDuration is the duration to wait between retries.
+	DefaultRetryDuration = 30 * time.Second
 )
 
 var (
@@ -33,7 +50,8 @@ var (
 		Version(),
 	)
 
-	statusCodesForRetry = []int{
+	// StatusCodesForRetry are a defined group of status code for which the client will retry
+	StatusCodesForRetry = []int{
 		http.StatusRequestTimeout,      // 408
 		http.StatusTooManyRequests,     // 429
 		http.StatusInternalServerError, // 500
@@ -148,6 +166,9 @@ type Client struct {
 	UserAgent string
 
 	Jar http.CookieJar
+
+	// Set to true to skip attempted registration of resource providers (false by default).
+	SkipResourceProviderRegistration bool
 }
 
 // NewClientWithUserAgent returns an instance of a Client with the UserAgent set to the passed
@@ -157,9 +178,10 @@ func NewClientWithUserAgent(ua string) Client {
 		PollingDelay:    DefaultPollingDelay,
 		PollingDuration: DefaultPollingDuration,
 		RetryAttempts:   DefaultRetryAttempts,
-		RetryDuration:   30 * time.Second,
+		RetryDuration:   DefaultRetryDuration,
 		UserAgent:       defaultUserAgent,
 	}
+	c.Sender = c.sender()
 	c.AddToUserAgent(ua)
 	return c
 }
@@ -185,12 +207,17 @@ func (c Client) Do(r *http.Request) (*http.Response, error) {
 		c.WithInspection(),
 		c.WithAuthorization())
 	if err != nil {
-		return nil, NewErrorWithError(err, "autorest/Client", "Do", nil, "Preparing request failed")
+		var resp *http.Response
+		if detErr, ok := err.(DetailedError); ok {
+			// if the authorization failed (e.g. invalid credentials) there will
+			// be a response associated with the error, be sure to return it.
+			resp = detErr.Response
+		}
+		return resp, NewErrorWithError(err, "autorest/Client", "Do", nil, "Preparing request failed")
 	}
-	resp, err := SendWithSender(c.sender(), r,
-		DoRetryForStatusCodes(c.RetryAttempts, c.RetryDuration, statusCodesForRetry...))
-	Respond(resp,
-		c.ByInspecting())
+
+	resp, err := SendWithSender(c.sender(), r)
+	Respond(resp, c.ByInspecting())
 	return resp, err
 }
 

--- a/vendor/github.com/Azure/go-autorest/autorest/date/date.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/date.go
@@ -5,6 +5,20 @@ time.Time types. And both convert to time.Time through a ToTime method.
 */
 package date
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"time"

--- a/vendor/github.com/Azure/go-autorest/autorest/date/time.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/time.go
@@ -1,5 +1,19 @@
 package date
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"regexp"
 	"time"

--- a/vendor/github.com/Azure/go-autorest/autorest/date/timerfc1123.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/timerfc1123.go
@@ -1,5 +1,19 @@
 package date
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"errors"
 	"time"

--- a/vendor/github.com/Azure/go-autorest/autorest/date/unixtime.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/unixtime.go
@@ -1,5 +1,19 @@
 package date
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"encoding/binary"

--- a/vendor/github.com/Azure/go-autorest/autorest/error.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/error.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"net/http"

--- a/vendor/github.com/Azure/go-autorest/autorest/preparer.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/preparer.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"encoding/json"
@@ -13,8 +27,9 @@ import (
 )
 
 const (
-	mimeTypeJSON     = "application/json"
-	mimeTypeFormPost = "application/x-www-form-urlencoded"
+	mimeTypeJSON        = "application/json"
+	mimeTypeOctetStream = "application/octet-stream"
+	mimeTypeFormPost    = "application/x-www-form-urlencoded"
 
 	headerAuthorization = "Authorization"
 	headerContentType   = "Content-Type"
@@ -98,6 +113,28 @@ func WithHeader(header string, value string) PrepareDecorator {
 	}
 }
 
+// WithHeaders returns a PrepareDecorator that sets the specified HTTP headers of the http.Request to
+// the passed value. It canonicalizes the passed headers name (via http.CanonicalHeaderKey) before
+// adding them.
+func WithHeaders(headers map[string]interface{}) PrepareDecorator {
+	h := ensureValueStrings(headers)
+	return func(p Preparer) Preparer {
+		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			r, err := p.Prepare(r)
+			if err == nil {
+				if r.Header == nil {
+					r.Header = make(http.Header)
+				}
+
+				for name, value := range h {
+					r.Header.Set(http.CanonicalHeaderKey(name), value)
+				}
+			}
+			return r, err
+		})
+	}
+}
+
 // WithBearerAuthorization returns a PrepareDecorator that adds an HTTP Authorization header whose
 // value is "Bearer " followed by the supplied token.
 func WithBearerAuthorization(token string) PrepareDecorator {
@@ -126,6 +163,11 @@ func AsFormURLEncoded() PrepareDecorator {
 // "application/json".
 func AsJSON() PrepareDecorator {
 	return AsContentType(mimeTypeJSON)
+}
+
+// AsOctetStream returns a PrepareDecorator that adds the "application/octet-stream" Content-Type header.
+func AsOctetStream() PrepareDecorator {
+	return AsContentType(mimeTypeOctetStream)
 }
 
 // WithMethod returns a PrepareDecorator that sets the HTTP method of the passed request. The
@@ -201,6 +243,11 @@ func WithFormData(v url.Values) PrepareDecorator {
 			r, err := p.Prepare(r)
 			if err == nil {
 				s := v.Encode()
+
+				if r.Header == nil {
+					r.Header = make(http.Header)
+				}
+				r.Header.Set(http.CanonicalHeaderKey(headerContentType), mimeTypeFormPost)
 				r.ContentLength = int64(len(s))
 				r.Body = ioutil.NopCloser(strings.NewReader(s))
 			}
@@ -416,11 +463,16 @@ func WithQueryParameters(queryParameters map[string]interface{}) PrepareDecorato
 				if r.URL == nil {
 					return r, NewError("autorest", "WithQueryParameters", "Invoked with a nil URL")
 				}
+
 				v := r.URL.Query()
 				for key, value := range parameters {
-					v.Add(key, value)
+					d, err := url.QueryUnescape(value)
+					if err != nil {
+						return r, err
+					}
+					v.Add(key, d)
 				}
-				r.URL.RawQuery = createQuery(v)
+				r.URL.RawQuery = v.Encode()
 			}
 			return r, err
 		})

--- a/vendor/github.com/Azure/go-autorest/autorest/responder.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/responder.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"encoding/json"

--- a/vendor/github.com/Azure/go-autorest/autorest/retriablerequest.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/retriablerequest.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"io"

--- a/vendor/github.com/Azure/go-autorest/autorest/retriablerequest_1.7.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/retriablerequest_1.7.go
@@ -1,17 +1,31 @@
 // +build !go1.8
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package autorest
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
 )
 
 // RetriableRequest provides facilities for retrying an HTTP request.
 type RetriableRequest struct {
-	req   *http.Request
-	br    *bytes.Reader
-	reset bool
+	req *http.Request
+	br  *bytes.Reader
 }
 
 // Prepare signals that the request is about to be sent.
@@ -19,21 +33,17 @@ func (rr *RetriableRequest) Prepare() (err error) {
 	// preserve the request body; this is to support retry logic as
 	// the underlying transport will always close the reqeust body
 	if rr.req.Body != nil {
-		if rr.reset {
-			if rr.br != nil {
-				_, err = rr.br.Seek(0, 0 /*io.SeekStart*/)
-			}
-			rr.reset = false
-			if err != nil {
-				return err
-			}
+		if rr.br != nil {
+			_, err = rr.br.Seek(0, 0 /*io.SeekStart*/)
+			rr.req.Body = ioutil.NopCloser(rr.br)
+		}
+		if err != nil {
+			return err
 		}
 		if rr.br == nil {
 			// fall back to making a copy (only do this once)
 			err = rr.prepareFromByteReader()
 		}
-		// indicates that the request body needs to be reset
-		rr.reset = true
 	}
 	return err
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/retriablerequest_1.8.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/retriablerequest_1.8.go
@@ -1,19 +1,33 @@
 // +build go1.8
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package autorest
 
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"net/http"
 )
 
 // RetriableRequest provides facilities for retrying an HTTP request.
 type RetriableRequest struct {
-	req   *http.Request
-	rc    io.ReadCloser
-	br    *bytes.Reader
-	reset bool
+	req *http.Request
+	rc  io.ReadCloser
+	br  *bytes.Reader
 }
 
 // Prepare signals that the request is about to be sent.
@@ -21,16 +35,14 @@ func (rr *RetriableRequest) Prepare() (err error) {
 	// preserve the request body; this is to support retry logic as
 	// the underlying transport will always close the reqeust body
 	if rr.req.Body != nil {
-		if rr.reset {
-			if rr.rc != nil {
-				rr.req.Body = rr.rc
-			} else if rr.br != nil {
-				_, err = rr.br.Seek(0, io.SeekStart)
-			}
-			rr.reset = false
-			if err != nil {
-				return err
-			}
+		if rr.rc != nil {
+			rr.req.Body = rr.rc
+		} else if rr.br != nil {
+			_, err = rr.br.Seek(0, io.SeekStart)
+			rr.req.Body = ioutil.NopCloser(rr.br)
+		}
+		if err != nil {
+			return err
 		}
 		if rr.req.GetBody != nil {
 			// this will allow us to preserve the body without having to
@@ -43,8 +55,6 @@ func (rr *RetriableRequest) Prepare() (err error) {
 			// fall back to making a copy (only do this once)
 			err = rr.prepareFromByteReader()
 		}
-		// indicates that the request body needs to be reset
-		rr.reset = true
 	}
 	return err
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/sender.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/sender.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"log"
@@ -201,18 +215,25 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 			rr := NewRetriableRequest(r)
 			// Increment to add the first call (attempts denotes number of retries)
 			attempts++
-			for attempt := 0; attempt < attempts; attempt++ {
+			for attempt := 0; attempt < attempts; {
 				err = rr.Prepare()
 				if err != nil {
 					return resp, err
 				}
 				resp, err = s.Do(rr.Request())
-				if err != nil || !ResponseHasStatusCode(resp, codes...) {
+				// we want to retry if err is not nil (e.g. transient network failure).  note that for failed authentication
+				// resp and err will both have a value, so in this case we don't want to retry as it will never succeed.
+				if err == nil && !ResponseHasStatusCode(resp, codes...) || IsTokenRefreshError(err) {
 					return resp, err
 				}
 				delayed := DelayWithRetryAfter(resp, r.Cancel)
 				if !delayed {
 					DelayForBackoff(backoff, attempt, r.Cancel)
+				}
+				// don't count a 429 against the number of attempts
+				// so that we continue to retry until it succeeds
+				if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
+					attempt++
 				}
 			}
 			return resp, err
@@ -223,6 +244,9 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 // DelayWithRetryAfter invokes time.After for the duration specified in the "Retry-After" header in
 // responses with status code 429
 func DelayWithRetryAfter(resp *http.Response, cancel <-chan struct{}) bool {
+	if resp == nil {
+		return false
+	}
 	retryAfter, _ := strconv.Atoi(resp.Header.Get("Retry-After"))
 	if resp.StatusCode == http.StatusTooManyRequests && retryAfter > 0 {
 		select {

--- a/vendor/github.com/Azure/go-autorest/autorest/to/convert.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/to/convert.go
@@ -3,6 +3,20 @@ Package to provides helpers to ease working with pointer values of marshalled st
 */
 package to
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 // String returns a string value for the passed string pointer. It returns the empty string if the
 // pointer is nil.
 func String(s *string) string {

--- a/vendor/github.com/Azure/go-autorest/autorest/utility.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/utility.go
@@ -1,15 +1,31 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"reflect"
-	"sort"
 	"strings"
+
+	"github.com/Azure/go-autorest/autorest/adal"
 )
 
 // EncodedAs is a series of constants specifying various data encodings
@@ -123,13 +139,38 @@ func MapToValues(m map[string]interface{}) url.Values {
 	return v
 }
 
-// String method converts interface v to string. If interface is a list, it
-// joins list elements using separator.
-func String(v interface{}, sep ...string) string {
-	if len(sep) > 0 {
-		return ensureValueString(strings.Join(v.([]string), sep[0]))
+// AsStringSlice method converts interface{} to []string. This expects a
+//that the parameter passed to be a slice or array of a type that has the underlying
+//type a string.
+func AsStringSlice(s interface{}) ([]string, error) {
+	v := reflect.ValueOf(s)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return nil, NewError("autorest", "AsStringSlice", "the value's type is not an array.")
 	}
-	return ensureValueString(v)
+	stringSlice := make([]string, 0, v.Len())
+
+	for i := 0; i < v.Len(); i++ {
+		stringSlice = append(stringSlice, v.Index(i).String())
+	}
+	return stringSlice, nil
+}
+
+// String method converts interface v to string. If interface is a list, it
+// joins list elements using the seperator. Note that only sep[0] will be used for
+// joining if any separator is specified.
+func String(v interface{}, sep ...string) string {
+	if len(sep) == 0 {
+		return ensureValueString(v)
+	}
+	stringSlice, ok := v.([]string)
+	if ok == false {
+		var err error
+		stringSlice, err = AsStringSlice(v)
+		if err != nil {
+			panic(fmt.Sprintf("autorest: Couldn't convert value to a string %s.", err))
+		}
+	}
+	return ensureValueString(strings.Join(stringSlice, sep[0]))
 }
 
 // Encode method encodes url path and query parameters.
@@ -153,26 +194,25 @@ func queryEscape(s string) string {
 	return url.QueryEscape(s)
 }
 
-// This method is same as Encode() method of "net/url" go package,
-// except it does not encode the query parameters because they
-// already come encoded. It formats values map in query format (bar=foo&a=b).
-func createQuery(v url.Values) string {
-	var buf bytes.Buffer
-	keys := make([]string, 0, len(v))
-	for k := range v {
-		keys = append(keys, k)
+// ChangeToGet turns the specified http.Request into a GET (it assumes it wasn't).
+// This is mainly useful for long-running operations that use the Azure-AsyncOperation
+// header, so we change the initial PUT into a GET to retrieve the final result.
+func ChangeToGet(req *http.Request) *http.Request {
+	req.Method = "GET"
+	req.Body = nil
+	req.ContentLength = 0
+	req.Header.Del("Content-Length")
+	return req
+}
+
+// IsTokenRefreshError returns true if the specified error implements the TokenRefreshError
+// interface.  If err is a DetailedError it will walk the chain of Original errors.
+func IsTokenRefreshError(err error) bool {
+	if _, ok := err.(adal.TokenRefreshError); ok {
+		return true
 	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		vs := v[k]
-		prefix := url.QueryEscape(k) + "="
-		for _, v := range vs {
-			if buf.Len() > 0 {
-				buf.WriteByte('&')
-			}
-			buf.WriteString(prefix)
-			buf.WriteString(v)
-		}
+	if de, ok := err.(DetailedError); ok {
+		return IsTokenRefreshError(de.Original)
 	}
-	return buf.String()
+	return false
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/validation/validation.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/validation/validation.go
@@ -3,6 +3,20 @@ Package validation provides methods for validating parameter value using reflect
 */
 package validation
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"fmt"
 	"reflect"
@@ -91,15 +105,12 @@ func validateStruct(x reflect.Value, v Constraint, name ...string) error {
 		return createError(x, v, fmt.Sprintf("field %q doesn't exist", v.Target))
 	}
 
-	if err := Validate([]Validation{
+	return Validate([]Validation{
 		{
 			TargetValue: getInterfaceValue(f),
 			Constraints: []Constraint{v},
 		},
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 func validatePtr(x reflect.Value, v Constraint) error {

--- a/vendor/github.com/Azure/go-autorest/autorest/version.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/version.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"bytes"
 	"fmt"
@@ -8,9 +22,9 @@ import (
 )
 
 const (
-	major = 8
-	minor = 0
-	patch = 0
+	major = 9
+	minor = 8
+	patch = 1
 	tag   = ""
 )
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -63,52 +63,52 @@
 			"versionExact": "v10.3.0-beta"
 		},
 		{
-			"checksumSHA1": "+4d+Y67AMKKuyR1EO33Zdt+RVx0=",
+			"checksumSHA1": "sM9XTbrCfgS5BPxpFLeM5YwOZWg=",
 			"path": "github.com/Azure/go-autorest/autorest",
-			"revision": "5432abe734f8d95c78340cd56712f912906e6514",
-			"revisionTime": "2017-08-29T19:03:17Z",
-			"version": "v8.3.1",
-			"versionExact": "v8.3.1"
+			"revision": "fc3b03a2d2d1f43fad3007038bd16f044f870722",
+			"revisionTime": "2018-02-05T16:51:11Z",
+			"version": "v9.10.0",
+			"versionExact": "v9.10.0"
 		},
 		{
-			"checksumSHA1": "hebqp0dsOKrcolVlLEzz6AVW8do=",
+			"checksumSHA1": "SOWyKVEKE3f4h7oE5/EV0a7YZmA=",
 			"path": "github.com/Azure/go-autorest/autorest/adal",
-			"revision": "5432abe734f8d95c78340cd56712f912906e6514",
-			"revisionTime": "2017-08-29T19:03:17Z",
-			"version": "v8.3.1",
-			"versionExact": "v8.3.1"
+			"revision": "fc3b03a2d2d1f43fad3007038bd16f044f870722",
+			"revisionTime": "2018-02-05T16:51:11Z",
+			"version": "v9.10.0",
+			"versionExact": "v9.10.0"
 		},
 		{
-			"checksumSHA1": "2KdBFgT4qY+fMOkBTa5vA9V0AiM=",
+			"checksumSHA1": "eX/vfJKidmIGkcmkA1I3V0y9yXw=",
 			"path": "github.com/Azure/go-autorest/autorest/azure",
-			"revision": "5432abe734f8d95c78340cd56712f912906e6514",
-			"revisionTime": "2017-08-29T19:03:17Z",
-			"version": "v8.3.1",
-			"versionExact": "v8.3.1"
+			"revision": "fc3b03a2d2d1f43fad3007038bd16f044f870722",
+			"revisionTime": "2018-02-05T16:51:11Z",
+			"version": "v9.10.0",
+			"versionExact": "v9.10.0"
 		},
 		{
-			"checksumSHA1": "LSF/pNrjhIxl6jiS6bKooBFCOxI=",
+			"checksumSHA1": "9nXCi9qQsYjxCeajJKWttxgEt0I=",
 			"path": "github.com/Azure/go-autorest/autorest/date",
-			"revision": "5432abe734f8d95c78340cd56712f912906e6514",
-			"revisionTime": "2017-08-29T19:03:17Z",
-			"version": "v8.3.1",
-			"versionExact": "v8.3.1"
+			"revision": "fc3b03a2d2d1f43fad3007038bd16f044f870722",
+			"revisionTime": "2018-02-05T16:51:11Z",
+			"version": "v9.10.0",
+			"versionExact": "v9.10.0"
 		},
 		{
-			"checksumSHA1": "Ev8qCsbFjDlMlX0N2tYAhYQFpUc=",
+			"checksumSHA1": "SbBb2GcJNm5GjuPKGL2777QywR4=",
 			"path": "github.com/Azure/go-autorest/autorest/to",
-			"revision": "5432abe734f8d95c78340cd56712f912906e6514",
-			"revisionTime": "2017-08-29T19:03:17Z",
-			"version": "v8.3.1",
-			"versionExact": "v8.3.1"
+			"revision": "fc3b03a2d2d1f43fad3007038bd16f044f870722",
+			"revisionTime": "2018-02-05T16:51:11Z",
+			"version": "v9.10.0",
+			"versionExact": "v9.10.0"
 		},
 		{
-			"checksumSHA1": "rGkTfIycpeix5TAbZS74ceGAPHI=",
+			"checksumSHA1": "HfqZyKllcHQDvTwgCaYL1jUPmW0=",
 			"path": "github.com/Azure/go-autorest/autorest/validation",
-			"revision": "5432abe734f8d95c78340cd56712f912906e6514",
-			"revisionTime": "2017-08-29T19:03:17Z",
-			"version": "v8.3.1",
-			"versionExact": "v8.3.1"
+			"revision": "fc3b03a2d2d1f43fad3007038bd16f044f870722",
+			"revisionTime": "2018-02-05T16:51:11Z",
+			"version": "v9.10.0",
+			"versionExact": "v9.10.0"
 		},
 		{
 			"checksumSHA1": "PYNaEEt9v8iAvGVUD4do0YIeR1A=",


### PR DESCRIPTION
Update go-autorest to v9.10.0 to fix #18875 since go-autorest v9.7.0 has the required fix necessary to address the Azure AD auth endpoint update for Azure US Government. See [announcement](https://blogs.msdn.microsoft.com/azuregov/2018/04/03/azure-government-aad-authority-endpoint-update/). While we could limit the update to v.9.7.0, might as well go to the highest non-major update for that version.

As indicated in the issue, even though this upgrades from 8.3 to 9.10, this isn't really a major update.

As per which references the [go-autorest's changelog notes on v9.0.0](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md#v900):

>IMPORTANT: This release was initially labeled incorrectly as v8.4.0. From the time it was released, it should have been marked v9.0.0 because it contains breaking changes to the MSI packages. We apologize for any inconvenience this causes.

Since upgrading from v8.3.0 to v.8.4.0 isn't a major update and based on the note above, upgrading from v8.4.0/v9.0.0 to v9.7.0 isn't upgrading across major releases either, this should be a low risk upgrade. Also, no breaking changes are indicated in the release that occurred between these versions.
