### PR TITLE
backend/remote: handle empty results correctly

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -369,7 +369,7 @@ func (b *Remote) states() ([]string, error) {
 		}
 
 		// Exit the loop when we've seen all pages.
-		if wl.CurrentPage == wl.TotalPages {
+		if wl.CurrentPage >= wl.TotalPages {
 			break
 		}
 


### PR DESCRIPTION
The pagination info of a list call that returns an empty list contains:

```go
CurrentPage: 1
TotalPages: 0
```

So checking if we have seen all pages using `CurrentPage == TotalPages` will not work and will result in an endless loop.

The tests are updated so they will fail (timeout after 1m) if this is handled incorreclty.