### PR TITLE
Make sure the state is locked before it is used

### DIFF
--- a/command/taint.go
+++ b/command/taint.go
@@ -77,10 +77,6 @@ func (c *TaintCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
-	if err := st.RefreshState(); err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
-		return 1
-	}
 
 	if c.stateLock {
 		stateLocker := clistate.NewLocker(context.Background(), c.stateLockTimeout, c.Ui, c.Colorize())
@@ -89,6 +85,11 @@ func (c *TaintCommand) Run(args []string) int {
 			return 1
 		}
 		defer stateLocker.Unlock(nil)
+	}
+
+	if err := st.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		return 1
 	}
 
 	// Get the actual state structure

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -65,10 +65,6 @@ func (c *UntaintCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
-	if err := st.RefreshState(); err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
-		return 1
-	}
 
 	if c.stateLock {
 		stateLocker := clistate.NewLocker(context.Background(), c.stateLockTimeout, c.Ui, c.Colorize())
@@ -77,6 +73,11 @@ func (c *UntaintCommand) Run(args []string) int {
 			return 1
 		}
 		defer stateLocker.Unlock(nil)
+	}
+
+	if err := st.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		return 1
 	}
 
 	// Get the actual state structure


### PR DESCRIPTION
Both the `taint` and `untaint` commands had a small logical error that caused them you first get the state and then lock it.