### PR TITLE
helper/pathorcontents: Skip one test when root

### DIFF
--- a/helper/pathorcontents/read_test.go
+++ b/helper/pathorcontents/read_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"strings"
 	"testing"
 
@@ -63,6 +64,14 @@ func TestRead_TildePath(t *testing.T) {
 }
 
 func TestRead_PathNoPermission(t *testing.T) {
+	// This skip condition is intended to get this test out of the way of users
+	// who are building and testing Terraform from within a Linux-based Docker
+	// container, where it is common for processes to be running as effectively
+	// root within the container.
+	if u, err := user.Current(); err == nil && u.Uid == "0" {
+		t.Skip("This test is invalid when running as root, since root can read every file")
+	}
+
 	isPath := true
 	f, cleanup := testTempFile(t)
 	defer cleanup()


### PR DESCRIPTION
One of the tests in this package doesn't work when the tests are run as
root - like inside of a docker container. The test is still useful to
specify `pathorcontents` behavior when a file is not readable, so it's
better to skip than just delete it. See linked issue for further
disussion.

Closes #7707