### PR TITLE
Implement new "shquote" interpolation function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -110,6 +110,7 @@ func Funcs() map[string]ast.Function {
 		"sha1":         interpolationFuncSha1(),
 		"sha256":       interpolationFuncSha256(),
 		"sha512":       interpolationFuncSha512(),
+		"shquote":      interpolationFuncShQuote(),
 		"signum":       interpolationFuncSignum(),
 		"slice":        interpolationFuncSlice(),
 		"sort":         interpolationFuncSort(),
@@ -1409,6 +1410,34 @@ func interpolationFuncSha512() ast.Function {
 			h.Write([]byte(s))
 			hash := hex.EncodeToString(h.Sum(nil))
 			return hash, nil
+		},
+	}
+}
+
+// Quotes string for direct use as shell parameters. The whole string
+// is enclosed within single-quotes, control characters are left as is.
+func interpolationFuncShQuote() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			s := args[0].(string)
+			var db strings.Builder
+			sr := strings.NewReader(s)
+			db.WriteRune('\'')
+			for {
+				r, _, err := sr.ReadRune()
+				if err != nil {
+					break
+				}
+				if r == '\'' {
+					db.WriteString("'\\''")
+				} else {
+					db.WriteRune(r)
+				}
+			}
+			db.WriteRune('\'')
+			return db.String(), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2273,6 +2273,18 @@ func TestInterpolateFuncSha512(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncShQuote(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${shquote("good 'morning")}`,
+				`'good '\''morning'`,
+				false,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncTitle(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -179,7 +179,7 @@ The supported built-in functions are:
     **This is not equivalent** of `base64encode(sha512(string))`
     since `sha512()` returns hexadecimal representation.
 
-  * `bcrypt(password, cost)` - Returns the Blowfish encrypted hash of the string 
+  * `bcrypt(password, cost)` - Returns the Blowfish encrypted hash of the string
     at the given cost. A default `cost` of 10 will be used if not provided.
 
   * `ceil(float)` - Returns the least integer value greater than or equal
@@ -378,6 +378,10 @@ The supported built-in functions are:
     SHA-512 hash of the given string.
     Example: `"${sha512("${aws_vpc.default.tags.customer}-s3-bucket")}"`
 
+  * `shquote(string)` - Returns a single-quoted string suitable for safe use
+    with Posix shells.
+    Example: `"${shquote("/tmp/space in file name")}"`
+
   * `signum(integer)` - Returns `-1` for negative numbers, `0` for `0` and `1` for positive numbers.
       This function is useful when you need to set a value for the first resource and
       a different value for the rest of the resources.
@@ -407,8 +411,8 @@ The supported built-in functions are:
    [`ignore_changes`](/docs/configuration/resources.html#ignore-changes) lifecycle attribute.
 
   * `timeadd(time, duration)` - Returns a UTC timestamp string corresponding to adding a given `duration` to `time` in RFC 3339 format.      
-    For example, `timeadd("2017-11-22T00:00:00Z", "10m")` produces a value `"2017-11-22T00:10:00Z"`. 
-    
+    For example, `timeadd("2017-11-22T00:00:00Z", "10m")` produces a value `"2017-11-22T00:10:00Z"`.
+
   * `title(string)` - Returns a copy of the string with the first characters of all the words capitalized.
 
   * `transpose(map)` - Swaps the keys and list values in a map of lists of strings. For example, transpose(map("a", list("1", "2"), "b", list("2", "3")) produces a value equivalent to map("1", list("a"), "2", list("a", "b"), "3", list("b")).


### PR DESCRIPTION
I haven't seen how to do this properly with the included functions, so I added my own. It makes it easier to robustly pass parameters to Posix shells. 

It simply encloses the whole value in single quotes, escaping only single quote itself (as `'\''`). As far as I can tell, Posix shells are supposed to handle just about anything thusly quoted, including control characters, but there may be cases I'm not aware of.

I included a simple unit test and updated the relevant documentation.


