### PR TITLE
backend/local: fix panic in tests

### DIFF
--- a/backend/local/backend_test.go
+++ b/backend/local/backend_test.go
@@ -182,7 +182,7 @@ var errTestDelegateState = errors.New("State called")
 var errTestDelegateStates = errors.New("States called")
 var errTestDelegateDeleteState = errors.New("Delete called")
 
-func (b *testDelegateBackend) State(name string) (statemgr.Full, error) {
+func (b *testDelegateBackend) StateMgr(name string) (statemgr.Full, error) {
 	if b.stateErr {
 		return nil, errTestDelegateState
 	}
@@ -190,14 +190,14 @@ func (b *testDelegateBackend) State(name string) (statemgr.Full, error) {
 	return s, nil
 }
 
-func (b *testDelegateBackend) States() ([]string, error) {
+func (b *testDelegateBackend) Workspaces() ([]string, error) {
 	if b.statesErr {
 		return nil, errTestDelegateStates
 	}
 	return []string{"default"}, nil
 }
 
-func (b *testDelegateBackend) DeleteState(name string) error {
+func (b *testDelegateBackend) DeleteWorkspace(name string) error {
 	if b.deleteErr {
 		return errTestDelegateDeleteState
 	}


### PR DESCRIPTION
update the function names in the `testDelegateBackend` to match what was being
called in TestLocal_multiStateBackend (matching the test behavior in
master)