### PR TITLE
Fix Google Cloud Platform name across docs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -23,5 +23,5 @@ repositories contain documentation specific to their provider:
 * [CenturyLink Cloud Examples](https://github.com/terraform-providers/terraform-provider-clc/tree/master/examples)
 * [Consul Examples](https://github.com/terraform-providers/terraform-provider-consul/tree/master/examples)
 * [DigitalOcean Examples](https://github.com/terraform-providers/terraform-provider-digitalocean/tree/master/examples)
-* [Google Cloud Examples](https://github.com/terraform-providers/terraform-provider-google/tree/master/examples)
+* [Google Cloud Platform Examples](https://github.com/terraform-providers/terraform-provider-google/tree/master/examples)
 * [OpenStack Examples](https://github.com/terraform-providers/terraform-provider-openstack/tree/master/examples)

--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -74,7 +74,7 @@ down to see all providers.
   </tr>
   <tr>
     <td><a href="/docs/providers/gitlab/index.html">Gitlab</a></td>
-    <td><a href="/docs/providers/google/index.html">Google Cloud</a></td>
+    <td><a href="/docs/providers/google/index.html">Google Cloud Platform</a></td>
     <td><a href="/docs/providers/grafana/index.html">Grafana</a></td>
   </tr>
   <tr>

--- a/website/docs/providers/type/major-index.html.markdown
+++ b/website/docs/providers/type/major-index.html.markdown
@@ -27,7 +27,7 @@ tested by HashiCorp.
 
 [Azure Stack](/docs/providers/azurestack/index.html)
 
-[Google Cloud](/docs/providers/google/index.html)
+[Google Cloud Platform](/docs/providers/google/index.html)
 
 [Oracle Cloud Infrastructure](/docs/providers/oci/index.html)
 


### PR DESCRIPTION
The `google` provider supports GCP, not necessarily Google Cloud as a whole.

Update the naming on this index page to match [the provider README](https://github.com/terraform-providers/terraform-provider-google#terraform-provider-for-google-cloud-platform) and the [provider docs changes](https://github.com/terraform-providers/terraform-provider-google/blob/master/website/docs/index.html.markdown#google-cloud-platform-provider) coming in the next release.