### PR TITLE
backend/remote: ask to cancel a pending remote operation

### DIFF
--- a/backend/remote/backend_apply_test.go
+++ b/backend/remote/backend_apply_test.go
@@ -297,6 +297,7 @@ func TestRemote_applyLockTimeout(t *testing.T) {
 	defer modCleanup()
 
 	input := testInput(t, map[string]string{
+		"cancel":  "yes",
 		"approve": "yes",
 	})
 
@@ -322,8 +323,8 @@ func TestRemote_applyLockTimeout(t *testing.T) {
 		t.Fatalf("expected lock timeout after 5 seconds, waited 10 seconds")
 	}
 
-	if len(input.answers) != 1 {
-		t.Fatalf("expected an unused answer, got: %v", input.answers)
+	if len(input.answers) != 2 {
+		t.Fatalf("expected unused answers, got: %v", input.answers)
 	}
 
 	output := b.CLI.(*cli.MockUi).OutputWriter.String()

--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -595,6 +595,7 @@ func (m *mockRuns) Create(ctx context.Context, options tfe.RunCreateOptions) (*t
 
 	logs, _ := ioutil.ReadFile(m.client.Plans.logs[p.LogReadURL])
 	if r.IsDestroy || !bytes.Contains(logs, []byte("No changes. Infrastructure is up-to-date.")) {
+		r.Actions.IsCancelable = true
 		r.Actions.IsConfirmable = true
 		r.HasChanges = true
 		r.Permissions.CanApply = true

--- a/backend/remote/backend_plan.go
+++ b/backend/remote/backend_plan.go
@@ -140,10 +140,15 @@ func (b *Remote) plan(stopCtx, cancelCtx context.Context, op *backend.Operation,
 					return
 				}
 
-				if r.Status == tfe.RunPending {
+				if r.Status == tfe.RunPending && r.Actions.IsCancelable {
 					if b.CLI != nil {
 						b.CLI.Output(b.Colorize().Color(strings.TrimSpace(lockTimeoutErr)))
 					}
+
+					// We abuse the auto aprove flag to indicate that we do not
+					// want to ask if the remote operation should be canceled.
+					op.AutoApprove = true
+
 					p, err := os.FindProcess(os.Getpid())
 					if err != nil {
 						log.Printf("[ERROR] error searching process ID: %v", err)


### PR DESCRIPTION
Except when a lock-timeout has exceeded or auto-approve is set.