### PR TITLE
Update wrong usage workspace command description

### DIFF
--- a/command/workspace_command.go
+++ b/command/workspace_command.go
@@ -33,7 +33,7 @@ func (c *WorkspaceCommand) Help() string {
 	helpText := `
 Usage: terraform workspace
 
-  Create, list, change and delete Terraform workspaces.
+  New, list, select and delete Terraform workspaces.
 
 `
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
Small update to the workspace command description to include available sub-commands, rather than similar looking but wrong ones.

resolves #18832 
resolves #18762