### PR TITLE
Fix backend/swift docs

### DIFF
--- a/website/docs/backends/types/swift.html.md
+++ b/website/docs/backends/types/swift.html.md
@@ -106,4 +106,4 @@ The following configuration options are supported:
    Swift [object versioning](https://docs.openstack.org/developer/swift/latest/overview_object_versioning.html) is enabled on the container created at `path`.
 
  * `expire_after` - (Optional) How long should the `terraform.tfstate` created at `container`
-   be retained for? Supported durations: `m` - Minutes, `h` - Hours, `d` - Days.
+   be retained for? If specified, Swift [expiring object support](https://docs.openstack.org/developer/swift/latest/overview_expiring_objects.html) is enabled on the state. Supported durations: `m` - Minutes, `h` - Hours, `d` - Days.

--- a/website/docs/backends/types/swift.html.md
+++ b/website/docs/backends/types/swift.html.md
@@ -12,7 +12,7 @@ description: |-
 
 Stores the state as an artifact in [Swift](http://docs.openstack.org/developer/swift/latest/).
 
-~> Warning! It is highly recommended that you enable [Object Versioning](https://docs.openstack.org/developer/swift/latest/overview_object_versioning.html) by setting the [`expire_after`](https://www.terraform.io/docs/backends/types/swift.html#archive_container) configuration. This allows for state recovery in the case of accidental deletions and human error.
+~> Warning! It is highly recommended that you enable [Object Versioning](https://docs.openstack.org/developer/swift/latest/overview_object_versioning.html) by setting the [`archive_container`](https://www.terraform.io/docs/backends/types/swift.html#archive_container) configuration. This allows for state recovery in the case of accidental deletions and human error.
 
 ## Example Configuration
 

--- a/website/docs/backends/types/swift.html.md
+++ b/website/docs/backends/types/swift.html.md
@@ -19,11 +19,12 @@ Stores the state as an artifact in [Swift](http://docs.openstack.org/developer/s
 ```hcl
 terraform {
   backend "swift" {
-    container = "terraform-state"
+    container         = "terraform-state"
+    archive_container = "terraform-state-archive"
   }
 }
 ```
-This will create a container called `terraform-state` and an object within that container called `tfstate.tf`.
+This will create a container called `terraform-state` and an object within that container called `tfstate.tf`. It will enable versioning using the `terraform-state-archive` container to contain the older version.
 
 -> Note: Currently, the object name is statically defined as 'tfstate.tf'. Therefore Swift [pseudo-folders](https://docs.openstack.org/user-guide/cli-swift-pseudo-hierarchical-folders-directories.html) are not currently supported.
 
@@ -36,7 +37,8 @@ For the access credentials we recommend using a
 data "terraform_remote_state" "foo" {
   backend = "swift"
   config = {
-    container = "terraform_state"
+    container         = "terraform_state"
+    archive_container = "terraform_state-archive"
   }
 }
 ```

--- a/website/docs/backends/types/swift.html.md
+++ b/website/docs/backends/types/swift.html.md
@@ -12,14 +12,14 @@ description: |-
 
 Stores the state as an artifact in [Swift](http://docs.openstack.org/developer/swift/).
 
-~> Warning! It is highly recommended that you enable [Object Versioning](https://docs.openstack.org/developer/swift/overview_object_versioning.html) by setting the [`expire_after`](https://www.terraform.io/docs/backends/types/swift.html#archive_path) configuration. This allows for state recovery in the case of accidental deletions and human error.
+~> Warning! It is highly recommended that you enable [Object Versioning](https://docs.openstack.org/developer/swift/overview_object_versioning.html) by setting the [`expire_after`](https://www.terraform.io/docs/backends/types/swift.html#archive_container) configuration. This allows for state recovery in the case of accidental deletions and human error.
 
 ## Example Configuration
 
 ```hcl
 terraform {
   backend "swift" {
-    path = "terraform-state"
+    container = "terraform-state"
   }
 }
 ```
@@ -36,7 +36,7 @@ For the access credentials we recommend using a
 data "terraform_remote_state" "foo" {
   backend = "swift"
   config = {
-    path = "terraform_state"
+    container = "terraform_state"
   }
 }
 ```
@@ -105,5 +105,5 @@ The following configuration options are supported:
    The path to store archived copied of `terraform.tfstate`. If specified,
    Swift [object versioning](https://docs.openstack.org/developer/swift/overview_object_versioning.html) is enabled on the container created at `path`.
 
- * `expire_after` - (Optional) How long should the `terraform.tfstate` created at `path`
+ * `expire_after` - (Optional) How long should the `terraform.tfstate` created at `container`
    be retained for? Supported durations: `m` - Minutes, `h` - Hours, `d` - Days.

--- a/website/docs/backends/types/swift.html.md
+++ b/website/docs/backends/types/swift.html.md
@@ -109,3 +109,4 @@ The following configuration options are supported:
 
  * `expire_after` - (Optional) How long should the `terraform.tfstate` created at `container`
    be retained for? If specified, Swift [expiring object support](https://docs.openstack.org/developer/swift/latest/overview_expiring_objects.html) is enabled on the state. Supported durations: `m` - Minutes, `h` - Hours, `d` - Days.
+   ~> **NOTE:** Since Terraform is inherently stateful - we'd strongly recommend against auto-expiring Statefiles.

--- a/website/docs/backends/types/swift.html.md
+++ b/website/docs/backends/types/swift.html.md
@@ -10,9 +10,9 @@ description: |-
 
 **Kind: Standard (with no locking)**
 
-Stores the state as an artifact in [Swift](http://docs.openstack.org/developer/swift/).
+Stores the state as an artifact in [Swift](http://docs.openstack.org/developer/swift/latest/).
 
-~> Warning! It is highly recommended that you enable [Object Versioning](https://docs.openstack.org/developer/swift/overview_object_versioning.html) by setting the [`expire_after`](https://www.terraform.io/docs/backends/types/swift.html#archive_container) configuration. This allows for state recovery in the case of accidental deletions and human error.
+~> Warning! It is highly recommended that you enable [Object Versioning](https://docs.openstack.org/developer/swift/latest/overview_object_versioning.html) by setting the [`expire_after`](https://www.terraform.io/docs/backends/types/swift.html#archive_container) configuration. This allows for state recovery in the case of accidental deletions and human error.
 
 ## Example Configuration
 
@@ -99,11 +99,11 @@ The following configuration options are supported:
    If omitted the `OS_KEY` environment variable is used.
 
  * `archive_container` - (Optional) The container to create to store archived copies
-   of the Terraform state file. If specified, Swift [object versioning](https://docs.openstack.org/developer/swift/overview_object_versioning.html) is enabled on the container created at `container`.
+   of the Terraform state file. If specified, Swift [object versioning](https://docs.openstack.org/developer/swift/latest/overview_object_versioning.html) is enabled on the container created at `container`.
 
  * `archive_path` - (Optional) DEPRECATED: Use `archive_container` instead.
    The path to store archived copied of `terraform.tfstate`. If specified,
-   Swift [object versioning](https://docs.openstack.org/developer/swift/overview_object_versioning.html) is enabled on the container created at `path`.
+   Swift [object versioning](https://docs.openstack.org/developer/swift/latest/overview_object_versioning.html) is enabled on the container created at `path`.
 
  * `expire_after` - (Optional) How long should the `terraform.tfstate` created at `container`
    be retained for? Supported durations: `m` - Minutes, `h` - Hours, `d` - Days.


### PR DESCRIPTION
The docs contained an error telling people to use `expire_after` when they really wanted object versioning. This error is actually quite damaging because instead of not even retaining versions of the state, it is outright deleted after a given amount of time. Fixed up the examples and other bits to not use deprecated items. Fixed bad links to the OpenStack Swift project. Added more links to the OpenStack Swift project. fixes #19005 