### PR TITLE
backend/remote:  prevent running plan or apply without permissions

### DIFF
--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -853,6 +853,10 @@ func (m *mockWorkspaces) Create(ctx context.Context, organization string, option
 	w := &tfe.Workspace{
 		ID:   generateID("ws-"),
 		Name: *options.Name,
+		Permissions: &tfe.WorkspacePermissions{
+			CanQueueRun: true,
+			CanUpdate:   true,
+		},
 	}
 	if options.VCSRepo != nil {
 		w.VCSRepo = &tfe.VCSRepo{}

--- a/backend/remote/backend_plan_test.go
+++ b/backend/remote/backend_plan_test.go
@@ -2,8 +2,12 @@ package remote
 
 import (
 	"context"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform/backend"
@@ -137,6 +141,74 @@ func TestRemote_planNoConfig(t *testing.T) {
 	}
 	if !strings.Contains(run.Err.Error(), "configuration files found") {
 		t.Fatalf("expected configuration files error, got: %v", run.Err)
+	}
+}
+
+func TestRemote_planLockTimeout(t *testing.T) {
+	b := testBackendDefault(t)
+	ctx := context.Background()
+
+	// Retrieve the workspace used to run this operation in.
+	w, err := b.client.Workspaces.Read(ctx, b.organization, b.workspace)
+	if err != nil {
+		t.Fatalf("error retrieving workspace: %v", err)
+	}
+
+	// Create a new configuration version.
+	c, err := b.client.ConfigurationVersions.Create(ctx, w.ID, tfe.ConfigurationVersionCreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating configuration version: %v", err)
+	}
+
+	// Create a pending run to block this run.
+	_, err = b.client.Runs.Create(ctx, tfe.RunCreateOptions{
+		ConfigurationVersion: c,
+		Workspace:            w,
+	})
+	if err != nil {
+		t.Fatalf("error creating pending run: %v", err)
+	}
+
+	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan")
+	defer modCleanup()
+
+	input := testInput(t, map[string]string{
+		"cancel":  "yes",
+		"approve": "yes",
+	})
+
+	op := testOperationPlan()
+	op.StateLockTimeout = 5 * time.Second
+	op.Module = mod
+	op.UIIn = input
+	op.UIOut = b.CLI
+	op.Workspace = backend.DefaultStateName
+
+	_, err = b.Operation(context.Background(), op)
+	if err != nil {
+		t.Fatalf("error starting operation: %v", err)
+	}
+
+	sigint := make(chan os.Signal, 1)
+	signal.Notify(sigint, syscall.SIGINT)
+	select {
+	case <-sigint:
+		// Stop redirecting SIGINT signals.
+		signal.Stop(sigint)
+	case <-time.After(10 * time.Second):
+		t.Fatalf("expected lock timeout after 5 seconds, waited 10 seconds")
+	}
+
+	if len(input.answers) != 2 {
+		t.Fatalf("expected unused answers, got: %v", input.answers)
+	}
+
+	output := b.CLI.(*cli.MockUi).OutputWriter.String()
+	if !strings.Contains(output, "Lock timeout exceeded") {
+		t.Fatalf("missing lock timout error in output: %s", output)
+	}
+	if strings.Contains(output, "1 to add, 0 to change, 0 to destroy") {
+		t.Fatalf("unexpected plan summery in output: %s", output)
 	}
 }
 


### PR DESCRIPTION
We now first check the rights before we start to actually execute make remote calls.