### PR TITLE
backend/remote: add checks for all flags we currently don’t support

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -137,11 +137,13 @@ type Operation struct {
 
 	// The options below are more self-explanatory and affect the runtime
 	// behavior of the operation.
+	AutoApprove  bool
 	Destroy      bool
+	DestroyForce bool
+	ModuleDepth  int
+	Parallelism  int
 	Targets      []string
 	Variables    map[string]interface{}
-	AutoApprove  bool
-	DestroyForce bool
 
 	// Input/output/control options.
 	UIIn  terraform.UIInput

--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -24,8 +24,10 @@ import (
 )
 
 const (
-	defaultHostname = "app.terraform.io"
-	serviceID       = "tfe.v2"
+	defaultHostname    = "app.terraform.io"
+	defaultModuleDepth = -1
+	defaultParallelism = 10
+	serviceID          = "tfe.v2"
 )
 
 // Remote is an implementation of EnhancedBackend that performs all

--- a/backend/remote/backend_plan.go
+++ b/backend/remote/backend_plan.go
@@ -30,6 +30,14 @@ func (b *Remote) opPlan(stopCtx, cancelCtx context.Context, op *backend.Operatio
 		return nil, fmt.Errorf(strings.TrimSpace(fmt.Sprintf(planErrNoQueueRunRights)))
 	}
 
+	if op.ModuleDepth != defaultModuleDepth {
+		return nil, fmt.Errorf(strings.TrimSpace(planErrModuleDepthNotSupported))
+	}
+
+	if op.Parallelism != defaultParallelism {
+		return nil, fmt.Errorf(strings.TrimSpace(planErrParallelismNotSupported))
+	}
+
 	if op.Plan != nil {
 		return nil, fmt.Errorf(strings.TrimSpace(planErrPlanNotSupported))
 	}
@@ -38,8 +46,17 @@ func (b *Remote) opPlan(stopCtx, cancelCtx context.Context, op *backend.Operatio
 		return nil, fmt.Errorf(strings.TrimSpace(planErrOutPathNotSupported))
 	}
 
+	if !op.PlanRefresh {
+		return nil, fmt.Errorf(strings.TrimSpace(planErrNoRefreshNotSupported))
+	}
+
 	if op.Targets != nil {
 		return nil, fmt.Errorf(strings.TrimSpace(planErrTargetsNotSupported))
+	}
+
+	if op.Variables != nil {
+		return nil, fmt.Errorf(strings.TrimSpace(
+			fmt.Sprintf(planErrVariablesNotSupported, b.hostname, b.organization, op.Workspace)))
 	}
 
 	if (op.Module == nil || op.Module.Config().Dir == "") && !op.Destroy {
@@ -203,11 +220,25 @@ Insufficient rights to generate a plan!
 to generate plans, at least plan permissions on the workspace are required.[reset]
 `
 
+const planErrModuleDepthNotSupported = `
+Custom module depths are currently not supported!
+
+The "remote" backend does not support setting a custom module
+depth at this time.
+`
+
+const planErrParallelismNotSupported = `
+Custom parallelism values are currently not supported!
+
+The "remote" backend does not support setting a custom parallelism
+value at this time.
+`
+
 const planErrPlanNotSupported = `
 Displaying a saved plan is currently not supported!
 
-The "remote" backend currently requires configuration to be present
-and does not accept an existing saved plan as an argument at this time.
+The "remote" backend currently requires configuration to be present and
+does not accept an existing saved plan as an argument at this time.
 `
 
 const planErrOutPathNotSupported = `
@@ -217,10 +248,30 @@ The "remote" backend does not support saving the generated execution
 plan locally at this time.
 `
 
+const planErrNoRefreshNotSupported = `
+Planning without refresh is currently not supported!
+
+Currently the "remote" backend will always do an in-memory refresh of
+the Terraform state prior to generating the plan.
+`
+
 const planErrTargetsNotSupported = `
 Resource targeting is currently not supported!
 
 The "remote" backend does not support resource targeting at this time.
+`
+
+const planErrVariablesNotSupported = `
+Run variables are currently not supported!
+
+The "remote" backend does not support setting run variables at this time.
+Currently the only to way to pass variables to the remote backend is by
+creating a '*.auto.tfvars' variables file. This file will automatically
+be loaded by the "remote" backend when the workspace is configured to use
+Terraform v0.10.0 or later.
+
+Additionally you can also set variables on the workspace in the web UI:
+https://%s/app/%s/%s/variables
 `
 
 const planErrNoConfig = `

--- a/command/apply.go
+++ b/command/apply.go
@@ -147,13 +147,13 @@ func (c *ApplyCommand) Run(args []string) int {
 
 	// Build the operation
 	opReq := c.Operation()
+	opReq.AutoApprove = autoApprove
 	opReq.Destroy = c.Destroy
+	opReq.DestroyForce = destroyForce
 	opReq.Module = mod
 	opReq.Plan = plan
 	opReq.PlanRefresh = refresh
 	opReq.Type = backend.OperationTypeApply
-	opReq.AutoApprove = autoApprove
-	opReq.DestroyForce = destroyForce
 
 	op, err := c.RunOperation(b, opReq)
 	if err != nil {

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -167,9 +167,11 @@ func (m *Meta) IsLocalBackend(b backend.Backend) bool {
 func (m *Meta) Operation() *backend.Operation {
 	return &backend.Operation{
 		PlanOutBackend:   m.backendState,
+		Parallelism:      m.parallelism,
 		Targets:          m.targets,
 		UIIn:             m.UIInput(),
 		UIOut:            m.Ui,
+		Variables:        m.variables,
 		Workspace:        m.Workspace(),
 		LockState:        m.stateLock,
 		StateLockTimeout: m.stateLockTimeout,

--- a/command/plan.go
+++ b/command/plan.go
@@ -100,9 +100,10 @@ func (c *PlanCommand) Run(args []string) int {
 	opReq := c.Operation()
 	opReq.Destroy = destroy
 	opReq.Module = mod
+	opReq.ModuleDepth = moduleDepth
 	opReq.Plan = plan
-	opReq.PlanRefresh = refresh
 	opReq.PlanOutPath = outPath
+	opReq.PlanRefresh = refresh
 	opReq.Type = backend.OperationTypePlan
 
 	// Perform the operation


### PR DESCRIPTION
For Plan only:
-module-depth=n

For Plan & Apply
-parallelism=m
-refresh=false
-var “foo=bar” and -var-file=foo