### PR TITLE
backend/remote: allow enhanced backends to pass custom exit codes

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -188,6 +188,10 @@ type RunningOperation struct {
 	// the operation has completed.
 	Err error
 
+	// ExitCode can be used to set a custom exit code. This enables enhanced
+	// backends to set specific exit codes that miror any remote exit codes.
+	ExitCode int
+
 	// PlanEmpty is populated after a Plan operation completes without error
 	// to note whether a plan is empty or has changes.
 	PlanEmpty bool

--- a/backend/remote/backend_apply_test.go
+++ b/backend/remote/backend_apply_test.go
@@ -49,6 +49,9 @@ func TestRemote_applyBasic(t *testing.T) {
 	if run.Err != nil {
 		t.Fatalf("error running operation: %v", run.Err)
 	}
+	if run.PlanEmpty {
+		t.Fatalf("expected a non-empty plan")
+	}
 
 	if len(input.answers) > 0 {
 		t.Fatalf("expected no unused answers, got: %v", input.answers)
@@ -132,6 +135,9 @@ func TestRemote_applyWithVCS(t *testing.T) {
 	if run.Err == nil {
 		t.Fatalf("expected an apply error, got: %v", run.Err)
 	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
+	}
 	if !strings.Contains(run.Err.Error(), "not allowed for workspaces with a VCS") {
 		t.Fatalf("expected a VCS error, got: %v", run.Err)
 	}
@@ -181,6 +187,9 @@ func TestRemote_applyWithPlan(t *testing.T) {
 
 	if run.Err == nil {
 		t.Fatalf("expected an apply error, got: %v", run.Err)
+	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
 	}
 	if !strings.Contains(run.Err.Error(), "saved plan is currently not supported") {
 		t.Fatalf("expected a saved plan error, got: %v", run.Err)
@@ -232,6 +241,9 @@ func TestRemote_applyWithTarget(t *testing.T) {
 	if run.Err == nil {
 		t.Fatalf("expected an apply error, got: %v", run.Err)
 	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
+	}
 	if !strings.Contains(run.Err.Error(), "targeting is currently not supported") {
 		t.Fatalf("expected a targeting error, got: %v", run.Err)
 	}
@@ -278,6 +290,9 @@ func TestRemote_applyNoConfig(t *testing.T) {
 	if run.Err == nil {
 		t.Fatalf("expected an apply error, got: %v", run.Err)
 	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
+	}
 	if !strings.Contains(run.Err.Error(), "configuration files found") {
 		t.Fatalf("expected configuration files error, got: %v", run.Err)
 	}
@@ -301,6 +316,9 @@ func TestRemote_applyNoChanges(t *testing.T) {
 	<-run.Done()
 	if run.Err != nil {
 		t.Fatalf("error running operation: %v", run.Err)
+	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
 	}
 
 	output := b.CLI.(*cli.MockUi).OutputWriter.String()
@@ -333,6 +351,9 @@ func TestRemote_applyNoApprove(t *testing.T) {
 	<-run.Done()
 	if run.Err == nil {
 		t.Fatalf("expected an apply error, got: %v", run.Err)
+	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
 	}
 	if !strings.Contains(run.Err.Error(), "Apply discarded") {
 		t.Fatalf("expected an apply discarded error, got: %v", run.Err)
@@ -367,6 +388,9 @@ func TestRemote_applyAutoApprove(t *testing.T) {
 	<-run.Done()
 	if run.Err != nil {
 		t.Fatalf("error running operation: %v", run.Err)
+	}
+	if run.PlanEmpty {
+		t.Fatalf("expected a non-empty plan")
 	}
 
 	if len(input.answers) != 1 {
@@ -479,6 +503,9 @@ func TestRemote_applyDestroy(t *testing.T) {
 	if run.Err != nil {
 		t.Fatalf("error running operation: %v", run.Err)
 	}
+	if run.PlanEmpty {
+		t.Fatalf("expected a non-empty plan")
+	}
 
 	if len(input.answers) > 0 {
 		t.Fatalf("expected no unused answers, got: %v", input.answers)
@@ -516,6 +543,9 @@ func TestRemote_applyDestroyNoConfig(t *testing.T) {
 	if run.Err != nil {
 		t.Fatalf("unexpected apply error: %v", run.Err)
 	}
+	if run.PlanEmpty {
+		t.Fatalf("expected a non-empty plan")
+	}
 
 	if len(input.answers) > 0 {
 		t.Fatalf("expected no unused answers, got: %v", input.answers)
@@ -546,6 +576,9 @@ func TestRemote_applyPolicyPass(t *testing.T) {
 	<-run.Done()
 	if run.Err != nil {
 		t.Fatalf("error running operation: %v", run.Err)
+	}
+	if run.PlanEmpty {
+		t.Fatalf("expected a non-empty plan")
 	}
 
 	if len(input.answers) > 0 {
@@ -588,6 +621,9 @@ func TestRemote_applyPolicyHardFail(t *testing.T) {
 	<-run.Done()
 	if run.Err == nil {
 		t.Fatalf("expected an apply error, got: %v", run.Err)
+	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
 	}
 	if !strings.Contains(run.Err.Error(), "hard failed") {
 		t.Fatalf("expected a policy check error, got: %v", run.Err)
@@ -634,6 +670,9 @@ func TestRemote_applyPolicySoftFail(t *testing.T) {
 	if run.Err != nil {
 		t.Fatalf("error running operation: %v", run.Err)
 	}
+	if run.PlanEmpty {
+		t.Fatalf("expected a non-empty plan")
+	}
 
 	if len(input.answers) > 0 {
 		t.Fatalf("expected no unused answers, got: %v", input.answers)
@@ -677,6 +716,9 @@ func TestRemote_applyPolicySoftFailAutoApprove(t *testing.T) {
 	if run.Err != nil {
 		t.Fatalf("error running operation: %v", run.Err)
 	}
+	if run.PlanEmpty {
+		t.Fatalf("expected a non-empty plan")
+	}
 
 	if len(input.answers) > 0 {
 		t.Fatalf("expected no unused answers, got: %v", input.answers)
@@ -691,5 +733,34 @@ func TestRemote_applyPolicySoftFailAutoApprove(t *testing.T) {
 	}
 	if !strings.Contains(output, "1 added, 0 changed, 0 destroyed") {
 		t.Fatalf("missing apply summery in output: %s", output)
+	}
+}
+
+func TestRemote_applyWithRemoteError(t *testing.T) {
+	b := testBackendDefault(t)
+
+	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply-with-error")
+	defer modCleanup()
+
+	op := testOperationApply()
+	op.Module = mod
+	op.Workspace = backend.DefaultStateName
+
+	run, err := b.Operation(context.Background(), op)
+	if err != nil {
+		t.Fatalf("error starting operation: %v", err)
+	}
+
+	<-run.Done()
+	if run.Err != nil {
+		t.Fatalf("error running operation: %v", run.Err)
+	}
+	if run.ExitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", run.ExitCode)
+	}
+
+	output := b.CLI.(*cli.MockUi).OutputWriter.String()
+	if !strings.Contains(output, "null_resource.foo: 1 error") {
+		t.Fatalf("missing apply error in output: %s", output)
 	}
 }

--- a/backend/remote/backend_plan_test.go
+++ b/backend/remote/backend_plan_test.go
@@ -44,6 +44,9 @@ func TestRemote_planBasic(t *testing.T) {
 	if run.Err != nil {
 		t.Fatalf("error running operation: %v", run.Err)
 	}
+	if run.PlanEmpty {
+		t.Fatal("expected a non-empty plan")
+	}
 
 	output := b.CLI.(*cli.MockUi).OutputWriter.String()
 	if !strings.Contains(output, "1 to add, 0 to change, 0 to destroy") {
@@ -158,6 +161,9 @@ func TestRemote_planWithPlan(t *testing.T) {
 	if run.Err == nil {
 		t.Fatalf("expected a plan error, got: %v", run.Err)
 	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
+	}
 	if !strings.Contains(run.Err.Error(), "saved plan is currently not supported") {
 		t.Fatalf("expected a saved plan error, got: %v", run.Err)
 	}
@@ -182,6 +188,9 @@ func TestRemote_planWithPath(t *testing.T) {
 
 	if run.Err == nil {
 		t.Fatalf("expected a plan error, got: %v", run.Err)
+	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
 	}
 	if !strings.Contains(run.Err.Error(), "generated plan is currently not supported") {
 		t.Fatalf("expected a generated plan error, got: %v", run.Err)
@@ -233,6 +242,9 @@ func TestRemote_planWithTarget(t *testing.T) {
 	if run.Err == nil {
 		t.Fatalf("expected a plan error, got: %v", run.Err)
 	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
+	}
 	if !strings.Contains(run.Err.Error(), "targeting is currently not supported") {
 		t.Fatalf("expected a targeting error, got: %v", run.Err)
 	}
@@ -278,6 +290,9 @@ func TestRemote_planNoConfig(t *testing.T) {
 
 	if run.Err == nil {
 		t.Fatalf("expected a plan error, got: %v", run.Err)
+	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
 	}
 	if !strings.Contains(run.Err.Error(), "configuration files found") {
 		t.Fatalf("expected configuration files error, got: %v", run.Err)
@@ -372,6 +387,9 @@ func TestRemote_planDestroy(t *testing.T) {
 	if run.Err != nil {
 		t.Fatalf("unexpected plan error: %v", run.Err)
 	}
+	if run.PlanEmpty {
+		t.Fatalf("expected a non-empty plan")
+	}
 }
 
 func TestRemote_planDestroyNoConfig(t *testing.T) {
@@ -390,6 +408,9 @@ func TestRemote_planDestroyNoConfig(t *testing.T) {
 	<-run.Done()
 	if run.Err != nil {
 		t.Fatalf("unexpected plan error: %v", run.Err)
+	}
+	if run.PlanEmpty {
+		t.Fatalf("expected a non-empty plan")
 	}
 }
 
@@ -422,9 +443,41 @@ func TestRemote_planWithWorkingDirectory(t *testing.T) {
 	if run.Err != nil {
 		t.Fatalf("error running operation: %v", run.Err)
 	}
+	if run.PlanEmpty {
+		t.Fatalf("expected a non-empty plan")
+	}
 
 	output := b.CLI.(*cli.MockUi).OutputWriter.String()
 	if !strings.Contains(output, "1 to add, 0 to change, 0 to destroy") {
 		t.Fatalf("missing plan summery in output: %s", output)
+	}
+}
+
+func TestRemote_planWithRemoteError(t *testing.T) {
+	b := testBackendDefault(t)
+
+	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan-with-error")
+	defer modCleanup()
+
+	op := testOperationPlan()
+	op.Module = mod
+	op.Workspace = backend.DefaultStateName
+
+	run, err := b.Operation(context.Background(), op)
+	if err != nil {
+		t.Fatalf("error starting operation: %v", err)
+	}
+
+	<-run.Done()
+	if run.Err != nil {
+		t.Fatalf("error running operation: %v", run.Err)
+	}
+	if run.ExitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", run.ExitCode)
+	}
+
+	output := b.CLI.(*cli.MockUi).OutputWriter.String()
+	if !strings.Contains(output, "null_resource.foo: 1 error") {
+		t.Fatalf("missing plan error in output: %s", output)
 	}
 }

--- a/backend/remote/test-fixtures/apply-with-error/main.tf
+++ b/backend/remote/test-fixtures/apply-with-error/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "foo" {
+  triggers {
+    random = "${guid()}"
+  }
+}

--- a/backend/remote/test-fixtures/apply-with-error/plan.log
+++ b/backend/remote/test-fixtures/apply-with-error/plan.log
@@ -1,0 +1,10 @@
+Terraform v0.11.7
+
+Configuring remote state backend...
+Initializing Terraform configuration...
+
+Error: null_resource.foo: 1 error(s) occurred:
+
+* null_resource.foo: 1:3: unknown function called: guid in:
+
+${guid()}

--- a/backend/remote/test-fixtures/plan-with-error/main.tf
+++ b/backend/remote/test-fixtures/plan-with-error/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "foo" {
+  triggers {
+    random = "${guid()}"
+  }
+}

--- a/backend/remote/test-fixtures/plan-with-error/plan.log
+++ b/backend/remote/test-fixtures/plan-with-error/plan.log
@@ -1,0 +1,10 @@
+Terraform v0.11.7
+
+Configuring remote state backend...
+Initializing Terraform configuration...
+
+Error: null_resource.foo: 1 error(s) occurred:
+
+* null_resource.foo: 1:3: unknown function called: guid in:
+
+${guid()}

--- a/command/apply.go
+++ b/command/apply.go
@@ -177,7 +177,7 @@ func (c *ApplyCommand) Run(args []string) int {
 		}
 	}
 
-	return 0
+	return op.ExitCode
 }
 
 func (c *ApplyCommand) Help() string {

--- a/command/plan.go
+++ b/command/plan.go
@@ -121,7 +121,7 @@ func (c *PlanCommand) Run(args []string) int {
 		return 2
 	}
 
-	return 0
+	return op.ExitCode
 }
 
 func (c *PlanCommand) Help() string {


### PR DESCRIPTION
In some cases this is needed to keep the UX clean and to make sure any remote exit codes are passed through to the local process.

The most obvious example for this is when using the "remote" backend. This backend runs Terraform remotely and stream the output back to the local terminal.

When an error occurs during the remote execution, all the needed error information will already be in the streamed output. So if we then return an error ourselves, users will get the same errors twice.

By allowing the backend to specify the correct exit code, the UX remains the same while preserving the correct exit codes.