### PR TITLE
mildwonkey/backend-local-tests

### DIFF
--- a/backend/local/backend_apply_test.go
+++ b/backend/local/backend_apply_test.go
@@ -122,7 +122,17 @@ func TestLocal_applyEmptyDirDestroy(t *testing.T) {
 func TestLocal_applyError(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
-	p := TestLocalProvider(t, b, "test", applyFixtureSchema())
+	p := TestLocalProvider(t, b, "test", nil)
+	p.GetSchemaReturn = &terraform.ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_instance": {
+				Attributes: map[string]*configschema.Attribute{
+					"ami": {Type: cty.String, Optional: true},
+					"id":  {Type: cty.String, Computed: true},
+				},
+			},
+		},
+	}
 
 	var lock sync.Mutex
 	errored := false

--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -171,7 +171,6 @@ func (b *Local) opPlan(
 					path, path,
 				))
 			}
-
 		}
 	}
 }

--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -8,11 +8,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/configs/configload"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/plans/planfile"
+	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
@@ -133,7 +135,7 @@ func TestLocal_planRefreshFalse(t *testing.T) {
 	defer cleanup()
 
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
-	terraform.TestStateFile(t, b.StatePath, testPlanState())
+	testStateFile(t, b.StatePath, testPlanState())
 
 	op, configCleanup := testOperationPlan(t, "./test-fixtures/plan")
 	defer configCleanup()
@@ -161,7 +163,7 @@ func TestLocal_planDestroy(t *testing.T) {
 	defer cleanup()
 
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
-	terraform.TestStateFile(t, b.StatePath, testPlanState())
+	testStateFile(t, b.StatePath, testPlanState())
 
 	outDir := testTempDir(t)
 	defer os.RemoveAll(outDir)
@@ -202,7 +204,7 @@ func TestLocal_planOutPathNoChange(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
 	TestLocalProvider(t, b, "test", planFixtureSchema())
-	terraform.TestStateFile(t, b.StatePath, testPlanState())
+	testStateFile(t, b.StatePath, testPlanState())
 
 	outDir := testTempDir(t)
 	defer os.RemoveAll(outDir)
@@ -222,14 +224,10 @@ func TestLocal_planOutPathNoChange(t *testing.T) {
 	}
 
 	plan := testReadPlan(t, planPath)
-	// This statement can be removed when the test is fixed and replaced with the
-	// commented-out test below.
-	if plan == nil {
-		t.Fatalf("plan is nil")
+
+	if !plan.Changes.Empty() {
+		t.Fatalf("expected empty plan to be written")
 	}
-	// if !plan.Changes.Empty() {
-	// 	t.Fatalf("expected empty plan to be written")
-	// }
 }
 
 // TestLocal_planScaleOutNoDupeCount tests a Refresh/Plan sequence when a
@@ -242,29 +240,7 @@ func TestLocal_planScaleOutNoDupeCount(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
 	TestLocalProvider(t, b, "test", planFixtureSchema())
-	state := &terraform.State{
-		Version: 2,
-		Modules: []*terraform.ModuleState{
-			&terraform.ModuleState{
-				Path: []string{"root"},
-				Resources: map[string]*terraform.ResourceState{
-					"test_instance.foo.0": &terraform.ResourceState{
-						Type: "test_instance",
-						Primary: &terraform.InstanceState{
-							ID: "bar",
-						},
-					},
-					"test_instance.foo.1": &terraform.ResourceState{
-						Type: "test_instance",
-						Primary: &terraform.InstanceState{
-							ID: "bar",
-						},
-					},
-				},
-			},
-		},
-	}
-	terraform.TestStateFile(t, b.StatePath, state)
+	testStateFile(t, b.StatePath, testPlanState())
 
 	actual := new(CountHook)
 	b.ContextOpts.Hooks = append(b.ContextOpts.Hooks, actual)
@@ -309,24 +285,32 @@ func testOperationPlan(t *testing.T, configDir string) (*backend.Operation, func
 	}, configCleanup
 }
 
-// testPlanState is just a common state that we use for testing refresh.
-func testPlanState() *terraform.State {
-	return &terraform.State{
-		Version: 2,
-		Modules: []*terraform.ModuleState{
-			&terraform.ModuleState{
-				Path: []string{"root"},
-				Resources: map[string]*terraform.ResourceState{
-					"test_instance.foo": &terraform.ResourceState{
-						Type: "test_instance",
-						Primary: &terraform.InstanceState{
-							ID: "bar",
-						},
-					},
-				},
-			},
+// testPlanState is just a common state that we use for testing plan.
+func testPlanState() *states.State {
+	state := states.NewState()
+	rootModule := state.RootModule()
+	rootModule.SetResourceInstanceCurrent(
+		addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "test_instance",
+			Name: "foo",
+		}.Instance(addrs.IntKey(0)),
+		&states.ResourceInstanceObjectSrc{
+			Status:        states.ObjectReady,
+			SchemaVersion: 1,
+			AttrsJSON: []byte(`{
+				"ami": "bar",
+				"network_interface": [{
+					"device_index": 0,
+					"description": "Main network interface"
+				}]
+			}`),
 		},
-	}
+		addrs.ProviderConfig{
+			Type: "test",
+		}.Absolute(addrs.RootModuleInstance),
+	)
+	return state
 }
 
 func testReadPlan(t *testing.T, path string) *plans.Plan {

--- a/backend/local/backend_refresh_test.go
+++ b/backend/local/backend_refresh_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/providers"
+
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/configs/configload"
 	"github.com/hashicorp/terraform/configs/configschema"
@@ -19,8 +21,10 @@ func TestLocal_refresh(t *testing.T) {
 	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
 	terraform.TestStateFile(t, b.StatePath, testRefreshState())
 
-	// p.RefreshFn = nil
-	// p.RefreshReturn = &terraform.InstanceState{ID: "yes"}
+	p.ReadResourceFn = nil
+	p.ReadResourceResponse = providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("yes"),
+	})}
 
 	op, configCleanup := testOperationRefresh(t, "./test-fixtures/refresh")
 	defer configCleanup()
@@ -45,11 +49,12 @@ test_instance.foo:
 func TestLocal_refreshNoConfig(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
-	p := TestLocalProvider(t, b, "test", &terraform.ProviderSchema{})
+	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
 	terraform.TestStateFile(t, b.StatePath, testRefreshState())
-
-	// p.RefreshFn = nil
-	// p.RefreshReturn = &terraform.InstanceState{ID: "yes"}
+	p.ReadResourceFn = nil
+	p.ReadResourceResponse = providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("yes"),
+	})}
 
 	op, configCleanup := testOperationRefresh(t, "./test-fixtures/empty")
 	defer configCleanup()
@@ -75,11 +80,12 @@ test_instance.foo:
 func TestLocal_refreshNilModuleWithInput(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
-	p := TestLocalProvider(t, b, "test", &terraform.ProviderSchema{})
+	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
 	terraform.TestStateFile(t, b.StatePath, testRefreshState())
-
-	// p.RefreshFn = nil
-	// p.RefreshReturn = &terraform.InstanceState{ID: "yes"}
+	p.ReadResourceFn = nil
+	p.ReadResourceResponse = providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("yes"),
+	})}
 
 	b.OpInput = true
 
@@ -106,7 +112,7 @@ test_instance.foo:
 func TestLocal_refreshInput(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
-	p := TestLocalProvider(t, b, "test", nil)
+	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
 	terraform.TestStateFile(t, b.StatePath, testRefreshState())
 
 	p.GetSchemaReturn = &terraform.ProviderSchema{
@@ -119,10 +125,15 @@ func TestLocal_refreshInput(t *testing.T) {
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
+					"id":  {Type: cty.String, Optional: true},
 				},
 			},
 		},
 	}
+	p.ReadResourceFn = nil
+	p.ReadResourceResponse = providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("yes"),
+	})}
 	p.ConfigureFn = func(c *terraform.ResourceConfig) error {
 		if v, ok := c.Get("value"); !ok || v != "bar" {
 			return fmt.Errorf("no value set")
@@ -130,9 +141,6 @@ func TestLocal_refreshInput(t *testing.T) {
 
 		return nil
 	}
-
-	// p.RefreshFn = nil
-	// p.RefreshReturn = &terraform.InstanceState{ID: "yes"}
 
 	// Enable input asking since it is normally disabled by default
 	b.OpInput = true
@@ -164,9 +172,10 @@ func TestLocal_refreshValidate(t *testing.T) {
 	defer cleanup()
 	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
 	terraform.TestStateFile(t, b.StatePath, testRefreshState())
-
-	// p.RefreshFn = nil
-	// p.RefreshReturn = &terraform.InstanceState{ID: "yes"}
+	p.ReadResourceFn = nil
+	p.ReadResourceResponse = providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("yes"),
+	})}
 
 	// Enable validation
 	b.OpValidation = true
@@ -234,6 +243,7 @@ func refreshFixtureSchema() *terraform.ProviderSchema {
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
 					"ami": {Type: cty.String, Optional: true},
+					"id":  {Type: cty.String, Computed: true},
 				},
 			},
 		},

--- a/backend/local/test-fixtures/apply-error/main.tf
+++ b/backend/local/test-fixtures/apply-error/main.tf
@@ -3,5 +3,5 @@ resource "test_instance" "foo" {
 }
 
 resource "test_instance" "bar" {
-    error = "true"
+    ami = "error"
 }

--- a/backend/local/test-fixtures/plan-scaleout/main.tf
+++ b/backend/local/test-fixtures/plan-scaleout/main.tf
@@ -1,5 +1,5 @@
 resource "test_instance" "foo" {
-  count = 3
+  count = 2
   ami   = "bar"
 
   # This is here because at some point it caused a test failure

--- a/backend/local/testing.go
+++ b/backend/local/testing.go
@@ -61,18 +61,15 @@ func TestLocalProvider(t *testing.T, b *Local, name string, schema *terraform.Pr
 			PlannedPrivate: req.PriorPrivate,
 		}
 	}
-	// p.DiffReturn = &terraform.InstanceDiff{}
-
-	// p.RefreshFn = func(
-	// 	info *terraform.InstanceInfo,
-	// 	s *terraform.InstanceState) (*terraform.InstanceState, error) {
-	// 	return s, nil
-	// }
-	// p.ResourcesReturn = []terraform.ResourceType{
-	// 	terraform.ResourceType{
-	// 		Name: "test_instance",
-	// 	},
-	// }
+	p.DiffFn = func(
+		info *terraform.InstanceInfo,
+		s *terraform.InstanceState,
+		r *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+		return nil, nil
+	}
+	p.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
+		return providers.ReadResourceResponse{NewState: req.PriorState}
+	}
 
 	// Initialize the opts
 	if b.ContextOpts == nil {

--- a/backend/local/testing.go
+++ b/backend/local/testing.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/providers"
+	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statemgr"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
@@ -60,12 +61,6 @@ func TestLocalProvider(t *testing.T, b *Local, name string, schema *terraform.Pr
 			PlannedState:   req.ProposedNewState,
 			PlannedPrivate: req.PriorPrivate,
 		}
-	}
-	p.DiffFn = func(
-		info *terraform.InstanceInfo,
-		s *terraform.InstanceState,
-		r *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
-		return nil, nil
 	}
 	p.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
 		return providers.ReadResourceResponse{NewState: req.PriorState}
@@ -126,4 +121,9 @@ func testTempDir(t *testing.T) string {
 	}
 
 	return d
+}
+
+func testStateFile(t *testing.T, path string, s *states.State) {
+	stateFile := statemgr.NewFilesystem(path)
+	stateFile.WriteState(s)
 }

--- a/plans/planfile/tfplan.go
+++ b/plans/planfile/tfplan.go
@@ -277,6 +277,10 @@ func changeFromTfplan(rawChange *planproto.Change) (*plans.ChangeSrc, error) {
 }
 
 func valueFromTfplan(rawV *planproto.DynamicValue) (plans.DynamicValue, error) {
+	if rawV.Msgpack == nil {
+		return plans.DynamicValue(nil), nil
+	}
+
 	if len(rawV.Msgpack) == 0 { // len(0) because that's the default value for a "bytes" in protobuf
 		return nil, fmt.Errorf("dynamic value does not have msgpack serialization")
 	}

--- a/plans/planfile/tfplan.go
+++ b/plans/planfile/tfplan.go
@@ -277,10 +277,6 @@ func changeFromTfplan(rawChange *planproto.Change) (*plans.ChangeSrc, error) {
 }
 
 func valueFromTfplan(rawV *planproto.DynamicValue) (plans.DynamicValue, error) {
-	if rawV.Msgpack == nil {
-		return plans.DynamicValue(nil), nil
-	}
-
 	if len(rawV.Msgpack) == 0 { // len(0) because that's the default value for a "bytes" in protobuf
 		return nil, fmt.Errorf("dynamic value does not have msgpack serialization")
 	}


### PR DESCRIPTION
refactored for v0.12
todo: tests which write and read a planfile are failing due to the planfile package's handling of empty  backend configuration - solution TBD. 