### PR TITLE
backend/remote: don’t ask questions when -auto-approve is set

### DIFF
--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -350,7 +350,7 @@ func (b *Local) Operation(ctx context.Context, op *backend.Operation) (*backend.
 	return runningOp, nil
 }
 
-// opWait wats for the operation to complete, and a stop signal or a
+// opWait waits for the operation to complete, and a stop signal or a
 // cancelation signal.
 func (b *Local) opWait(
 	doneCh <-chan struct{},

--- a/backend/remote/backend_apply.go
+++ b/backend/remote/backend_apply.go
@@ -223,7 +223,7 @@ func (b *Remote) checkPolicy(stopCtx, cancelCtx context.Context, op *backend.Ope
 		case tfe.PolicyHardFailed:
 			return fmt.Errorf(msgPrefix + " hard failed.")
 		case tfe.PolicySoftFailed:
-			if op.UIOut == nil || op.UIIn == nil ||
+			if op.UIOut == nil || op.UIIn == nil || op.AutoApprove ||
 				!pc.Actions.IsOverridable || !pc.Permissions.CanOverride {
 				return fmt.Errorf(msgPrefix + " soft failed.")
 			}


### PR DESCRIPTION
We previously asked to override a soft-failed policy, even wehn -auto-approve was set. That is now fixed by returning a policy failed error.