### PR TITLE
Fix two documentation glitches

### DIFF
--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -444,7 +444,7 @@ A template data source looks like:
 
 ```hcl
 data "template_file" "example" {
-  template = "${hello} ${world}!"
+  template = "$${hello} $${world}!"
   vars {
     hello = "goodnight"
     world = "moon"
@@ -457,6 +457,8 @@ output "rendered" {
 ```
 
 Then the rendered value would be `goodnight moon!`.
+
+Note that the double dollar signs (`$$`) are needed in inline templates. Otherwise Terraform will return an error.
 
 You may use any of the built-in functions in your template. For more
 details on template usage, please see the

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -444,7 +444,7 @@ A template data source looks like:
 
 ```hcl
 data "template_file" "example" {
-  template = "$${hello} $${world}!"
+  template = "${hello} ${world}!"
   vars {
     hello = "goodnight"
     world = "moon"
@@ -468,10 +468,6 @@ Here is an example that combines the capabilities of templates with the interpol
 from `count` to give us a parameterized template, unique to each resource instance:
 
 ```hcl
-variable "count" {
-  default = 2
-}
-
 variable "hostnames" {
   default = {
     "0" = "example1.org"


### PR DESCRIPTION
As far as I understand these two things are wrong.

1) I don't think we need the double "$" in the template

2) As far as I can tell the variable "count" is not used either in this example (it is in the next example though)