### PR TITLE
Makes TF_DATA_DIR configurable via file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For local development of Terraform core, first make sure Go is properly installe
 Next, using [Git](https://git-scm.com/), clone this repository into `$GOPATH/src/github.com/hashicorp/terraform`.
 
 You'll need to run `make tools` to install some required tools, then `make`.  This will compile the code and then run the tests. If this exits with exit status 0, then everything is working!
-You only need torun `make tools` once (or when the tools change).
+You only need to run `make tools` once (or when the tools change).
 
 ```sh
 $ cd "$GOPATH/src/github.com/hashicorp/terraform"

--- a/commands.go
+++ b/commands.go
@@ -47,6 +47,10 @@ func initCommands(config *Config, services *disco.Disco) {
 	}
 
 	dataDir := os.Getenv("TF_DATA_DIR")
+	// If the environment variable is not set, check the config file
+	if dataDir == "" {
+		dataDir = config.DataDir
+	}
 
 	meta := command.Meta{
 		Color:            true,

--- a/config.go
+++ b/config.go
@@ -32,6 +32,10 @@ type Config struct {
 	// avoid repeatedly re-downloading over the Internet.
 	PluginCacheDir string `hcl:"plugin_cache_dir"`
 
+	// If set, changes the location where Terraform keeps its
+	// per-working-directory data, such as the current remote backend configuration.
+	DataDir string `hcl:"data_dir"`
+
 	Hosts map[string]*ConfigHost `hcl:"host"`
 
 	Credentials        map[string]map[string]interface{}   `hcl:"credentials"`

--- a/config_test.go
+++ b/config_test.go
@@ -315,3 +315,18 @@ func TestConfig_Merge_disableCheckpointSignature(t *testing.T) {
 		t.Fatalf("bad: %#v", actual)
 	}
 }
+
+func TestConfig_DataDir(t *testing.T) {
+	c, err := loadConfigFile(filepath.Join(fixtureDir, "data-dir"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := &Config{
+		DataDir: "/etc/terraform/test/.terraform",
+	}
+
+	if !reflect.DeepEqual(c, expected) {
+		t.Fatalf("bad: %#v", c)
+	}
+}

--- a/test-fixtures/data-dir
+++ b/test-fixtures/data-dir
@@ -1,0 +1,1 @@
+data_dir = "/etc/terraform/test/.terraform"


### PR DESCRIPTION
Addresses issue #3503 . This request was already possible using the `TF_DATA_DIR` environment variable, adds the ability to do so with the standard config file as well.