### PR TITLE
Improve the method to find out go files in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION?="0.3.32"
 TEST?=./...
-GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
+GOFMT_FILES?=$$(find . -not -path "./vendor/*" -type f -name '*.go')
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 
 default: test


### PR DESCRIPTION
Properly exclude files under "./vendor/" path, and find "files" only.
The original method "might" found "directories" with the same naming,
or, might exclude occasionally exclude the go files with "vendor" string
in any part of its path.