### PR TITLE
Backend config and command tests

### DIFF
--- a/backend/local/cli.go
+++ b/backend/local/cli.go
@@ -14,10 +14,16 @@ func (b *Local) CLIInit(opts *backend.CLIOpts) error {
 	b.OpValidation = opts.Validation
 	b.RunningInAutomation = opts.RunningInAutomation
 
-	// Only configure state paths if we didn't do so via the configure func.
-	if b.StatePath == "" {
+	// configure any new cli options
+	if opts.StatePath != "" {
 		b.StatePath = opts.StatePath
+	}
+
+	if opts.StateOutPath != "" {
 		b.StateOutPath = opts.StateOutPath
+	}
+
+	if opts.StateBackupPath != "" {
 		b.StateBackupPath = opts.StateBackupPath
 	}
 

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -585,8 +585,9 @@ func TestApply_plan_backup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	args := []string{
-		"-state-out", statePath,
+		"-state", statePath,
 		"-backup", backupPath,
 		planPath,
 	}
@@ -964,7 +965,7 @@ func TestApply_state(t *testing.T) {
 				Name: "foo",
 			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 			&states.ResourceInstanceObjectSrc{
-				AttrsJSON: []byte(`{"ami":"bar"}`),
+				AttrsJSON: []byte(`{"ami":"foo"}`),
 				Status:    states.ObjectReady,
 			},
 			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
@@ -1006,7 +1007,7 @@ func TestApply_state(t *testing.T) {
 	actual := p.PlanResourceChangeRequest.PriorState
 	expected := cty.ObjectVal(map[string]cty.Value{
 		"id":  cty.NullVal(cty.String),
-		"ami": cty.StringVal("bar"),
+		"ami": cty.StringVal("foo"),
 	})
 	if !expected.RawEquals(actual) {
 		t.Fatalf("wrong prior state during plan\ngot: %#v\nwant: %#v", actual, expected)
@@ -1015,9 +1016,9 @@ func TestApply_state(t *testing.T) {
 	actual = p.ApplyResourceChangeRequest.PriorState
 	expected = cty.ObjectVal(map[string]cty.Value{
 		"id":  cty.NullVal(cty.String),
-		"ami": cty.StringVal("bar"),
+		"ami": cty.StringVal("foo"),
 	})
-	if actual != expected {
+	if !expected.RawEquals(actual) {
 		t.Fatalf("wrong prior state during apply\ngot: %#v\nwant: %#v", actual, expected)
 	}
 

--- a/states/statemgr/filesystem.go
+++ b/states/statemgr/filesystem.go
@@ -240,6 +240,12 @@ func (s *Filesystem) RefreshState() error {
 	}
 
 	f, err := statefile.Read(reader)
+
+	// nothing to backup if there's no initial state
+	if f == nil {
+		s.writtenBackup = true
+	}
+
 	// if there's no state we just assign the nil return value
 	if err != nil && err != statefile.ErrNoState {
 		return err


### PR DESCRIPTION
Set the backend cli options after configuration is applied. The old behavior was a mix of config and cli, and having cli override config consistently makes more sense.

Some minor fixes for command tests to get out of the way