### PR TITLE
helper/resource tests

### DIFF
--- a/helper/resource/testing_import_state_test.go
+++ b/helper/resource/testing_import_state_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestTest_importState(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := testProvider()
 	mp.ImportStateReturn = []*terraform.InstanceState{
 		&terraform.InstanceState{
@@ -59,6 +61,8 @@ func TestTest_importState(t *testing.T) {
 }
 
 func TestTest_importStateFail(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := testProvider()
 	mp.ImportStateReturn = []*terraform.InstanceState{
 		&terraform.InstanceState{
@@ -109,6 +113,8 @@ func TestTest_importStateFail(t *testing.T) {
 }
 
 func TestTest_importStateDetectId(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := testProvider()
 	mp.DiffReturn = nil
 	mp.ApplyFn = func(
@@ -183,6 +189,8 @@ func TestTest_importStateDetectId(t *testing.T) {
 }
 
 func TestTest_importStateIdPrefix(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := testProvider()
 	mp.DiffReturn = nil
 	mp.ApplyFn = func(
@@ -258,6 +266,8 @@ func TestTest_importStateIdPrefix(t *testing.T) {
 }
 
 func TestTest_importStateVerify(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := testProvider()
 	mp.DiffReturn = nil
 	mp.ApplyFn = func(
@@ -328,6 +338,8 @@ func TestTest_importStateVerify(t *testing.T) {
 }
 
 func TestTest_importStateVerifyFail(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := testProvider()
 	mp.DiffReturn = nil
 	mp.ApplyFn = func(
@@ -391,6 +403,8 @@ func TestTest_importStateVerifyFail(t *testing.T) {
 }
 
 func TestTest_importStateIdFunc(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := testProvider()
 	mp.ImportStateFn = func(
 		info *terraform.InstanceInfo, id string) ([]*terraform.InstanceState, error) {
@@ -449,6 +463,8 @@ func TestTest_importStateIdFunc(t *testing.T) {
 }
 
 func TestTest_importStateIdFuncFail(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := testProvider()
 	mp.ImportStateFn = func(
 		info *terraform.InstanceInfo, id string) ([]*terraform.InstanceState, error) {

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -55,6 +55,8 @@ func TestParallelTest(t *testing.T) {
 }
 
 func TestTest(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := &resetProvider{
 		MockResourceProvider: testProvider(),
 	}
@@ -136,6 +138,8 @@ func TestTest(t *testing.T) {
 }
 
 func TestTest_plan_only(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := testProvider()
 	mp.ApplyReturn = &terraform.InstanceState{
 		ID: "foo",
@@ -188,6 +192,8 @@ STATE:
 }
 
 func TestTest_idRefresh(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	// Refresh count should be 3:
 	//   1.) initial Ref/Plan/Apply
 	//   2.) post Ref/Plan/Apply for plan-check
@@ -240,6 +246,8 @@ func TestTest_idRefresh(t *testing.T) {
 }
 
 func TestTest_idRefreshCustomName(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	// Refresh count should be 3:
 	//   1.) initial Ref/Plan/Apply
 	//   2.) post Ref/Plan/Apply for plan-check
@@ -292,6 +300,8 @@ func TestTest_idRefreshCustomName(t *testing.T) {
 }
 
 func TestTest_idRefreshFail(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	// Refresh count should be 3:
 	//   1.) initial Ref/Plan/Apply
 	//   2.) post Ref/Plan/Apply for plan-check
@@ -354,6 +364,8 @@ func TestTest_idRefreshFail(t *testing.T) {
 }
 
 func TestTest_empty(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	destroyCalled := false
 	checkDestroyFn := func(*terraform.State) error {
 		destroyCalled = true
@@ -374,6 +386,8 @@ func TestTest_empty(t *testing.T) {
 }
 
 func TestTest_noEnv(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	// Unset the variable
 	if err := os.Setenv(TestEnvVar, ""); err != nil {
 		t.Fatalf("err: %s", err)
@@ -389,6 +403,8 @@ func TestTest_noEnv(t *testing.T) {
 }
 
 func TestTest_preCheck(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	called := false
 
 	mt := new(mockT)
@@ -402,6 +418,8 @@ func TestTest_preCheck(t *testing.T) {
 }
 
 func TestTest_skipFunc(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	preCheckCalled := false
 	skipped := false
 
@@ -442,6 +460,8 @@ func TestTest_skipFunc(t *testing.T) {
 }
 
 func TestTest_stepError(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := testProvider()
 	mp.ApplyReturn = &terraform.InstanceState{
 		ID: "foo",
@@ -510,6 +530,8 @@ func TestTest_factoryError(t *testing.T) {
 }
 
 func TestTest_resetError(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := &resetProvider{
 		MockResourceProvider: testProvider(),
 		TestResetError:       fmt.Errorf("provider reset error"),
@@ -533,6 +555,8 @@ func TestTest_resetError(t *testing.T) {
 }
 
 func TestTest_expectError(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	cases := []struct {
 		name     string
 		planErr  bool
@@ -929,6 +953,8 @@ func mockSweeperFunc(s string) error {
 }
 
 func TestTest_Taint(t *testing.T) {
+	t.Fatal("test requires new provider implementation")
+
 	mp := testProvider()
 	mp.DiffFn = func(
 		_ *terraform.InstanceInfo,

--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -508,7 +508,17 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 
 // closing the grpc connection is final, and terraform will call it at the end of every phase.
 func (p *GRPCProvider) Close() error {
-	// check this since it's not automatically inserted during plugin creation
+	log.Printf("[TRACE] GRPCProvider: PlanResourceChange")
+
+	// close the remote listener if we're running within a test
+	if p.TestListener != nil {
+		p.TestListener.Close()
+	}
+
+	// Check this since it's not automatically inserted during plugin creation.
+	// It's currently only inserted by the command package, because that is
+	// where the factory is built and is the only point with access to the
+	// plugin.Client.
 	if p.PluginClient == nil {
 		log.Println("[DEBUG] provider has no plugin.Client")
 		return nil


### PR DESCRIPTION
The resource don't have a go-plugin client to call Stop on, but we can inject the listener side of the mock grpc connection to get closed instead.

The resource tests will require a new mock provider, build on helper/schema rather than the old core MockResourceProvider. 