### PR TITLE
helper/validation: Add All() and IntInSlice() SchemaValidateFunc

### DIFF
--- a/helper/validation/validation_test.go
+++ b/helper/validation/validation_test.go
@@ -13,6 +13,34 @@ type testCase struct {
 	expectedErr *regexp.Regexp
 }
 
+func TestValidationAll(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "valid",
+			f: All(
+				StringLenBetween(5, 42),
+				StringMatch(regexp.MustCompile(`[a-zA-Z0-9]+`), "value must be alphanumeric"),
+			),
+		},
+		{
+			val: "foo",
+			f: All(
+				StringLenBetween(5, 42),
+				StringMatch(regexp.MustCompile(`[a-zA-Z0-9]+`), "value must be alphanumeric"),
+			),
+			expectedErr: regexp.MustCompile("expected length of [\\w]+ to be in the range \\(5 - 42\\), got foo"),
+		},
+		{
+			val: "!!!!!",
+			f: All(
+				StringLenBetween(5, 42),
+				StringMatch(regexp.MustCompile(`[a-zA-Z0-9]+`), "value must be alphanumeric"),
+			),
+			expectedErr: regexp.MustCompile("value must be alphanumeric"),
+		},
+	})
+}
+
 func TestValidationIntBetween(t *testing.T) {
 	runTestCases(t, []testCase{
 		{
@@ -78,6 +106,25 @@ func TestValidationIntAtMost(t *testing.T) {
 			val:         "1",
 			f:           IntAtMost(0),
 			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be int"),
+		},
+	})
+}
+
+func TestValidationIntInSlice(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: 42,
+			f:   IntInSlice([]int{1, 42}),
+		},
+		{
+			val:         42,
+			f:           IntInSlice([]int{10, 20}),
+			expectedErr: regexp.MustCompile("expected [\\w]+ to be one of \\[10 20\\], got 42"),
+		},
+		{
+			val:         "InvalidValue",
+			f:           IntInSlice([]int{10, 20}),
+			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be an integer"),
 		},
 	})
 }


### PR DESCRIPTION
`All()` combines the outputs of multiple `SchemaValidateFunc`, to reduce the usage of custom validation functions that implement standard validation functions.

Example provider usage:

```go
ValidateFunc: validation.All(
  validation.StringLenBetween(5, 42),
  validation.StringMatch(regexp.MustCompile(`[a-zA-Z0-9]+`), "value must be alphanumeric"),
),
```

`IntInSlice()` is the `int` equivalent of `StringInSlice()`

Example provider usage:

```go
ValidateFunc: validation.IntInSlice([]int{30, 60, 120})
```

Output from unit testing:

```
$ make test TEST=./helper/validation
==> Checking that code complies with gofmt requirements...
go generate ./...
2018/10/17 14:16:03 Generated command/internal_plugin_list.go
go list ./helper/validation | xargs -t -n4 go test  -timeout=2m -parallel=4
go test -timeout=2m -parallel=4 github.com/hashicorp/terraform/helper/validation
ok  	github.com/hashicorp/terraform/helper/validation	1.106s
```