### PR TITLE
command/format: Include variable values as additional context in diagnostic messages

### DIFF
--- a/command/format/diagnostic.go
+++ b/command/format/diagnostic.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl2/hcl"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/mitchellh/colorstring"
 	wordwrap "github.com/mitchellh/go-wordwrap"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Diagnostic formats a single diagnostic message.
@@ -82,7 +84,7 @@ func Diagnostic(diag tfdiags.Diagnostic, sources map[string][]byte, color *color
 			// loaded through the main loader. We may load things in other
 			// ways in weird cases, so we'll tolerate it at the expense of
 			// a not-so-helpful error message.
-			fmt.Fprintf(&buf, "  on %s line %d:\n  (source code not available)\n\n", highlightRange.Filename, highlightRange.Start.Line)
+			fmt.Fprintf(&buf, "  on %s line %d:\n  (source code not available)\n", highlightRange.Filename, highlightRange.Start.Line)
 		} else {
 			contextStr := sourceCodeContextStr(src, highlightRange)
 			if contextStr != "" {
@@ -111,8 +113,59 @@ func Diagnostic(diag tfdiags.Diagnostic, sources map[string][]byte, color *color
 				}
 			}
 
-			buf.WriteByte('\n')
 		}
+
+		if fromExpr := diag.FromExpr(); fromExpr != nil {
+			// We may also be able to generate information about the dynamic
+			// values of relevant variables at the point of evaluation, then.
+			// This is particularly useful for expressions that get evaluated
+			// multiple times with different values, such as blocks using
+			// "count" and "for_each", or within "for" expressions.
+			expr := fromExpr.Expression
+			ctx := fromExpr.EvalContext
+			vars := expr.Variables()
+			stmts := make([]string, 0, len(vars))
+			seen := make(map[string]struct{}, len(vars))
+		Traversals:
+			for _, traversal := range vars {
+				for len(traversal) > 1 {
+					val, diags := traversal.TraverseAbs(ctx)
+					if diags.HasErrors() {
+						// Skip anything that generates errors, since we probably
+						// already have the same error in our diagnostics set
+						// already.
+						traversal = traversal[:len(traversal)-1]
+						continue
+					}
+
+					traversalStr := traversalStr(traversal)
+					if _, exists := seen[traversalStr]; exists {
+						continue Traversals // don't show duplicates when the same variable is referenced multiple times
+					}
+					switch {
+					case !val.IsKnown():
+						// Can't say anything about this yet, then.
+						continue Traversals
+					case val.IsNull():
+						stmts = append(stmts, fmt.Sprintf(color.Color("[bold]%s[reset] is null"), traversalStr))
+					default:
+						stmts = append(stmts, fmt.Sprintf(color.Color("[bold]%s[reset] is %s"), traversalStr, compactValueStr(val)))
+					}
+					seen[traversalStr] = struct{}{}
+				}
+			}
+
+			sort.Strings(stmts) // FIXME: Should maybe use a traversal-aware sort that can sort numeric indexes properly?
+
+			if len(stmts) > 0 {
+				fmt.Fprint(&buf, color.Color("    [dark_gray]|----------------[reset]\n"))
+			}
+			for _, stmt := range stmts {
+				fmt.Fprintf(&buf, color.Color("    [dark_gray]|[reset] %s\n"), stmt)
+			}
+		}
+
+		buf.WriteByte('\n')
 	}
 
 	if desc.Detail != "" {
@@ -154,4 +207,97 @@ func sourceCodeContextStr(src []byte, rng hcl.Range) string {
 	}
 
 	return hcled.ContextString(file, offset)
+}
+
+// traversalStr produces a representation of an HCL traversal that is compact,
+// resembles HCL native syntax, and is suitable for display in the UI.
+func traversalStr(traversal hcl.Traversal) string {
+	// This is a specialized subset of traversal rendering tailored to
+	// producing helpful contextual messages in diagnostics. It is not
+	// comprehensive nor intended to be used for other purposes.
+
+	var buf bytes.Buffer
+	for _, step := range traversal {
+		switch tStep := step.(type) {
+		case hcl.TraverseRoot:
+			buf.WriteString(tStep.Name)
+		case hcl.TraverseAttr:
+			buf.WriteByte('.')
+			buf.WriteString(tStep.Name)
+		case hcl.TraverseIndex:
+			buf.WriteByte('[')
+			if keyTy := tStep.Key.Type(); keyTy.IsPrimitiveType() {
+				buf.WriteString(compactValueStr(tStep.Key))
+			} else {
+				// We'll just use a placeholder for more complex values,
+				// since otherwise our result could grow ridiculously long.
+				buf.WriteString("...")
+			}
+			buf.WriteByte(']')
+		}
+	}
+	return buf.String()
+}
+
+// compactValueStr produces a compact, single-line summary of a given value
+// that is suitable for display in the UI.
+//
+// For primitives it returns a full representation, while for more complex
+// types it instead summarizes the type, size, etc to produce something
+// that is hopefully still somewhat useful but not as verbose as a rendering
+// of the entire data structure.
+func compactValueStr(val cty.Value) string {
+	// This is a specialized subset of value rendering tailored to producing
+	// helpful but concise messages in diagnostics. It is not comprehensive
+	// nor intended to be used for other purposes.
+
+	ty := val.Type()
+	switch {
+	case val.IsNull():
+		return "null"
+	case !val.IsKnown():
+		// Should never happen here because we should filter before we get
+		// in here, but we'll do something reasonable rather than panic.
+		return "(not yet known)"
+	case ty == cty.Bool:
+		if val.True() {
+			return "true"
+		}
+		return "false"
+	case ty == cty.Number:
+		bf := val.AsBigFloat()
+		return bf.Text('g', 10)
+	case ty == cty.String:
+		// Go string syntax is not exactly the same as HCL native string syntax,
+		// but we'll accept the minor edge-cases where this is different here
+		// for now, just to get something reasonable here.
+		return fmt.Sprintf("%q", val.AsString())
+	case ty.IsCollectionType() || ty.IsTupleType():
+		l := val.LengthInt()
+		switch l {
+		case 0:
+			return "empty " + ty.FriendlyName()
+		case 1:
+			return ty.FriendlyName() + " with 1 element"
+		default:
+			return fmt.Sprintf("%s with %d elements", ty.FriendlyName(), l)
+		}
+	case ty.IsObjectType():
+		atys := ty.AttributeTypes()
+		l := len(atys)
+		switch l {
+		case 0:
+			return "object with no attributes"
+		case 1:
+			var name string
+			for k := range atys {
+				name = k
+			}
+			return fmt.Sprintf("object with 1 attribute %q", name)
+		default:
+			return fmt.Sprintf("object with %d attributes", l)
+		}
+	default:
+		return ty.FriendlyName()
+	}
 }

--- a/tfdiags/diagnostic.go
+++ b/tfdiags/diagnostic.go
@@ -1,9 +1,18 @@
 package tfdiags
 
+import (
+	"github.com/hashicorp/hcl2/hcl"
+)
+
 type Diagnostic interface {
 	Severity() Severity
 	Description() Description
 	Source() Source
+
+	// FromExpr returns the expression-related context for the diagnostic, if
+	// available. Returns nil if the diagnostic is not related to an
+	// expression evaluation.
+	FromExpr() *FromExpr
 }
 
 type Severity rune
@@ -23,4 +32,9 @@ type Description struct {
 type Source struct {
 	Subject *SourceRange
 	Context *SourceRange
+}
+
+type FromExpr struct {
+	Expression  hcl.Expression
+	EvalContext *hcl.EvalContext
 }

--- a/tfdiags/diagnostic_base.go
+++ b/tfdiags/diagnostic_base.go
@@ -2,9 +2,9 @@ package tfdiags
 
 // diagnosticBase can be embedded in other diagnostic structs to get
 // default implementations of Severity and Description. This type also
-// has a default implementation of Source that returns no source location
-// information, so embedders should generally override that method to
-// return more useful results.
+// has default implementations of Source and FromExpr that return no source
+// location or expression-related information, so embedders should generally
+// override those method to return more useful results where possible.
 type diagnosticBase struct {
 	severity Severity
 	summary  string
@@ -24,4 +24,8 @@ func (d diagnosticBase) Description() Description {
 
 func (d diagnosticBase) Source() Source {
 	return Source{}
+}
+
+func (d diagnosticBase) FromExpr() *FromExpr {
+	return nil
 }

--- a/tfdiags/error.go
+++ b/tfdiags/error.go
@@ -21,3 +21,8 @@ func (e nativeError) Source() Source {
 	// No source information available for a native error
 	return Source{}
 }
+
+func (e nativeError) FromExpr() *FromExpr {
+	// Native errors are not expression-related
+	return nil
+}

--- a/tfdiags/hcl.go
+++ b/tfdiags/hcl.go
@@ -40,6 +40,16 @@ func (d hclDiagnostic) Source() Source {
 	return ret
 }
 
+func (d hclDiagnostic) FromExpr() *FromExpr {
+	if d.diag.Expression == nil || d.diag.EvalContext == nil {
+		return nil
+	}
+	return &FromExpr{
+		Expression:  d.diag.Expression,
+		EvalContext: d.diag.EvalContext,
+	}
+}
+
 // SourceRangeFromHCL constructs a SourceRange from the corresponding range
 // type within the HCL package.
 func SourceRangeFromHCL(hclRange hcl.Range) SourceRange {

--- a/tfdiags/rpc_friendly.go
+++ b/tfdiags/rpc_friendly.go
@@ -48,6 +48,12 @@ func (d *rpcFriendlyDiag) Source() Source {
 	}
 }
 
+func (d rpcFriendlyDiag) FromExpr() *FromExpr {
+	// RPC-friendly diagnostics cannot preserve expression information because
+	// expressions themselves are not RPC-friendly.
+	return nil
+}
+
 func init() {
 	gob.Register((*rpcFriendlyDiag)(nil))
 }

--- a/tfdiags/simple_warning.go
+++ b/tfdiags/simple_warning.go
@@ -20,6 +20,11 @@ func (e simpleWarning) Description() Description {
 }
 
 func (e simpleWarning) Source() Source {
-	// No source information available for a native error
+	// No source information available for a simple warning
 	return Source{}
+}
+
+func (e simpleWarning) FromExpr() *FromExpr {
+	// Simple warnings are not expression-related
+	return nil
 }


### PR DESCRIPTION
When an error occurs evaluating an expression, HCL annotates the diagnostic with information about what was being evaluated and in what context. Here we use that information to include additional contextual information in the diagnostics output.

![](https://user-images.githubusercontent.com/20180/47124922-6dadb380-d235-11e8-985e-6bec8c63690f.png)

This is particularly useful when the error relates to an expression that gets evaluated multiple times, and therefore the static source location information is not enough to fully understand what's going on. For example:
* Any expression within a block with `count` or `for_each` set.
* The sub-expressions of a `for` expression.

This is just a first pass at a rendering approach for this, with the expectation that we'll iterate on it further in later releases. I just wanted to get this in here now so that those experimenting with our early release will get this extra context, and ideally also include it in any GitHub issues that result from bugs found during testing. Since there were not already tests present for the diagnostic rendering, I've not added any new ones for this change. Again, we'll need to catch up with that in a later commit.
