### PR TITLE
PrepareProviderConfig

### DIFF
--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -77,8 +77,8 @@ func (s *GRPCProviderServer) getDatasourceSchemaBlock(name string) *configschema
 	return dat.CoreConfigSchema()
 }
 
-func (s *GRPCProviderServer) ValidateProviderConfig(_ context.Context, req *proto.ValidateProviderConfig_Request) (*proto.ValidateProviderConfig_Response, error) {
-	resp := &proto.ValidateProviderConfig_Response{}
+func (s *GRPCProviderServer) PrepareProviderConfig(_ context.Context, req *proto.PrepareProviderConfig_Request) (*proto.PrepareProviderConfig_Response, error) {
+	resp := &proto.PrepareProviderConfig_Response{}
 
 	block := s.getProviderSchemaBlock()
 
@@ -92,6 +92,9 @@ func (s *GRPCProviderServer) ValidateProviderConfig(_ context.Context, req *prot
 
 	warns, errs := s.provider.Validate(config)
 	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, convert.WarnsAndErrsToProto(warns, errs))
+
+	// TODO: set defaults
+	resp.PreparedConfig = req.Config
 
 	return resp, nil
 }

--- a/plugin/grpc_provider_test.go
+++ b/plugin/grpc_provider_test.go
@@ -91,19 +91,19 @@ func TestGRPCProvider_GetSchema(t *testing.T) {
 	checkDiags(t, resp.Diagnostics)
 }
 
-func TestGRPCProvider_ValidateProviderConfig(t *testing.T) {
+func TestGRPCProvider_PrepareProviderConfig(t *testing.T) {
 	client := mockProviderClient(t)
 	p := &GRPCProvider{
 		client: client,
 	}
 
-	client.EXPECT().ValidateProviderConfig(
+	client.EXPECT().PrepareProviderConfig(
 		gomock.Any(),
 		gomock.Any(),
-	).Return(&proto.ValidateProviderConfig_Response{}, nil)
+	).Return(&proto.PrepareProviderConfig_Response{}, nil)
 
 	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
-	resp := p.ValidateProviderConfig(providers.ValidateProviderConfigRequest{Config: cfg})
+	resp := p.PrepareProviderConfig(providers.PrepareProviderConfigRequest{Config: cfg})
 	checkDiags(t, resp.Diagnostics)
 }
 

--- a/plugin/mock_proto/mock.go
+++ b/plugin/mock_proto/mock.go
@@ -5,9 +5,9 @@
 package mock_proto
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	proto "github.com/hashicorp/terraform/plugin/proto"
-	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 	metadata "google.golang.org/grpc/metadata"
 	reflect "reflect"
@@ -126,6 +126,24 @@ func (mr *MockProviderClientMockRecorder) PlanResourceChange(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PlanResourceChange", reflect.TypeOf((*MockProviderClient)(nil).PlanResourceChange), varargs...)
 }
 
+// PrepareProviderConfig mocks base method
+func (m *MockProviderClient) PrepareProviderConfig(arg0 context.Context, arg1 *proto.PrepareProviderConfig_Request, arg2 ...grpc.CallOption) (*proto.PrepareProviderConfig_Response, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PrepareProviderConfig", varargs...)
+	ret0, _ := ret[0].(*proto.PrepareProviderConfig_Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PrepareProviderConfig indicates an expected call of PrepareProviderConfig
+func (mr *MockProviderClientMockRecorder) PrepareProviderConfig(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareProviderConfig", reflect.TypeOf((*MockProviderClient)(nil).PrepareProviderConfig), varargs...)
+}
+
 // ReadDataSource mocks base method
 func (m *MockProviderClient) ReadDataSource(arg0 context.Context, arg1 *proto.ReadDataSource_Request, arg2 ...grpc.CallOption) (*proto.ReadDataSource_Response, error) {
 	varargs := []interface{}{arg0, arg1}
@@ -214,24 +232,6 @@ func (m *MockProviderClient) ValidateDataSourceConfig(arg0 context.Context, arg1
 func (mr *MockProviderClientMockRecorder) ValidateDataSourceConfig(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateDataSourceConfig", reflect.TypeOf((*MockProviderClient)(nil).ValidateDataSourceConfig), varargs...)
-}
-
-// ValidateProviderConfig mocks base method
-func (m *MockProviderClient) ValidateProviderConfig(arg0 context.Context, arg1 *proto.ValidateProviderConfig_Request, arg2 ...grpc.CallOption) (*proto.ValidateProviderConfig_Response, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "ValidateProviderConfig", varargs...)
-	ret0, _ := ret[0].(*proto.ValidateProviderConfig_Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ValidateProviderConfig indicates an expected call of ValidateProviderConfig
-func (mr *MockProviderClientMockRecorder) ValidateProviderConfig(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateProviderConfig", reflect.TypeOf((*MockProviderClient)(nil).ValidateProviderConfig), varargs...)
 }
 
 // ValidateResourceTypeConfig mocks base method

--- a/plugin/proto/plugin.pb.go
+++ b/plugin/proto/plugin.pb.go
@@ -3,13 +3,12 @@
 
 package proto
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-
 import (
+	fmt "fmt"
+	proto "github.com/golang/protobuf/proto"
 	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -36,6 +35,7 @@ var Diagnostic_Severity_name = map[int32]string{
 	1: "ERROR",
 	2: "WARNING",
 }
+
 var Diagnostic_Severity_value = map[string]int32{
 	"INVALID": 0,
 	"ERROR":   1,
@@ -45,8 +45,9 @@ var Diagnostic_Severity_value = map[string]int32{
 func (x Diagnostic_Severity) String() string {
 	return proto.EnumName(Diagnostic_Severity_name, int32(x))
 }
+
 func (Diagnostic_Severity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{1, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{1, 0}
 }
 
 type Schema_NestedBlock_NestingMode int32
@@ -66,6 +67,7 @@ var Schema_NestedBlock_NestingMode_name = map[int32]string{
 	3: "SET",
 	4: "MAP",
 }
+
 var Schema_NestedBlock_NestingMode_value = map[string]int32{
 	"INVALID": 0,
 	"SINGLE":  1,
@@ -77,8 +79,9 @@ var Schema_NestedBlock_NestingMode_value = map[string]int32{
 func (x Schema_NestedBlock_NestingMode) String() string {
 	return proto.EnumName(Schema_NestedBlock_NestingMode_name, int32(x))
 }
+
 func (Schema_NestedBlock_NestingMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{5, 2, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{5, 2, 0}
 }
 
 // DynamicValue is an opaque encoding of terraform data, with the field name
@@ -95,16 +98,17 @@ func (m *DynamicValue) Reset()         { *m = DynamicValue{} }
 func (m *DynamicValue) String() string { return proto.CompactTextString(m) }
 func (*DynamicValue) ProtoMessage()    {}
 func (*DynamicValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{0}
+	return fileDescriptor_22a625af4bc1cc87, []int{0}
 }
+
 func (m *DynamicValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DynamicValue.Unmarshal(m, b)
 }
 func (m *DynamicValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DynamicValue.Marshal(b, m, deterministic)
 }
-func (dst *DynamicValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DynamicValue.Merge(dst, src)
+func (m *DynamicValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DynamicValue.Merge(m, src)
 }
 func (m *DynamicValue) XXX_Size() int {
 	return xxx_messageInfo_DynamicValue.Size(m)
@@ -130,10 +134,10 @@ func (m *DynamicValue) GetJson() []byte {
 }
 
 type Diagnostic struct {
-	Severity             Diagnostic_Severity `protobuf:"varint,1,opt,name=severity,enum=proto.Diagnostic_Severity" json:"severity,omitempty"`
-	Summary              string              `protobuf:"bytes,2,opt,name=summary" json:"summary,omitempty"`
-	Detail               string              `protobuf:"bytes,3,opt,name=detail" json:"detail,omitempty"`
-	Attribute            *AttributePath      `protobuf:"bytes,4,opt,name=attribute" json:"attribute,omitempty"`
+	Severity             Diagnostic_Severity `protobuf:"varint,1,opt,name=severity,proto3,enum=proto.Diagnostic_Severity" json:"severity,omitempty"`
+	Summary              string              `protobuf:"bytes,2,opt,name=summary,proto3" json:"summary,omitempty"`
+	Detail               string              `protobuf:"bytes,3,opt,name=detail,proto3" json:"detail,omitempty"`
+	Attribute            *AttributePath      `protobuf:"bytes,4,opt,name=attribute,proto3" json:"attribute,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}            `json:"-"`
 	XXX_unrecognized     []byte              `json:"-"`
 	XXX_sizecache        int32               `json:"-"`
@@ -143,16 +147,17 @@ func (m *Diagnostic) Reset()         { *m = Diagnostic{} }
 func (m *Diagnostic) String() string { return proto.CompactTextString(m) }
 func (*Diagnostic) ProtoMessage()    {}
 func (*Diagnostic) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{1}
+	return fileDescriptor_22a625af4bc1cc87, []int{1}
 }
+
 func (m *Diagnostic) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Diagnostic.Unmarshal(m, b)
 }
 func (m *Diagnostic) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Diagnostic.Marshal(b, m, deterministic)
 }
-func (dst *Diagnostic) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Diagnostic.Merge(dst, src)
+func (m *Diagnostic) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Diagnostic.Merge(m, src)
 }
 func (m *Diagnostic) XXX_Size() int {
 	return xxx_messageInfo_Diagnostic.Size(m)
@@ -192,7 +197,7 @@ func (m *Diagnostic) GetAttribute() *AttributePath {
 }
 
 type AttributePath struct {
-	Steps                []*AttributePath_Step `protobuf:"bytes,1,rep,name=steps" json:"steps,omitempty"`
+	Steps                []*AttributePath_Step `protobuf:"bytes,1,rep,name=steps,proto3" json:"steps,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
 	XXX_unrecognized     []byte                `json:"-"`
 	XXX_sizecache        int32                 `json:"-"`
@@ -202,16 +207,17 @@ func (m *AttributePath) Reset()         { *m = AttributePath{} }
 func (m *AttributePath) String() string { return proto.CompactTextString(m) }
 func (*AttributePath) ProtoMessage()    {}
 func (*AttributePath) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{2}
+	return fileDescriptor_22a625af4bc1cc87, []int{2}
 }
+
 func (m *AttributePath) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AttributePath.Unmarshal(m, b)
 }
 func (m *AttributePath) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_AttributePath.Marshal(b, m, deterministic)
 }
-func (dst *AttributePath) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AttributePath.Merge(dst, src)
+func (m *AttributePath) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AttributePath.Merge(m, src)
 }
 func (m *AttributePath) XXX_Size() int {
 	return xxx_messageInfo_AttributePath.Size(m)
@@ -244,16 +250,17 @@ func (m *AttributePath_Step) Reset()         { *m = AttributePath_Step{} }
 func (m *AttributePath_Step) String() string { return proto.CompactTextString(m) }
 func (*AttributePath_Step) ProtoMessage()    {}
 func (*AttributePath_Step) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{2, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{2, 0}
 }
+
 func (m *AttributePath_Step) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AttributePath_Step.Unmarshal(m, b)
 }
 func (m *AttributePath_Step) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_AttributePath_Step.Marshal(b, m, deterministic)
 }
-func (dst *AttributePath_Step) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AttributePath_Step.Merge(dst, src)
+func (m *AttributePath_Step) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AttributePath_Step.Merge(m, src)
 }
 func (m *AttributePath_Step) XXX_Size() int {
 	return xxx_messageInfo_AttributePath_Step.Size(m)
@@ -269,18 +276,22 @@ type isAttributePath_Step_Selector interface {
 }
 
 type AttributePath_Step_AttributeName struct {
-	AttributeName string `protobuf:"bytes,1,opt,name=attribute_name,json=attributeName,oneof"`
-}
-type AttributePath_Step_ElementKeyString struct {
-	ElementKeyString string `protobuf:"bytes,2,opt,name=element_key_string,json=elementKeyString,oneof"`
-}
-type AttributePath_Step_ElementKeyInt struct {
-	ElementKeyInt int64 `protobuf:"varint,3,opt,name=element_key_int,json=elementKeyInt,oneof"`
+	AttributeName string `protobuf:"bytes,1,opt,name=attribute_name,json=attributeName,proto3,oneof"`
 }
 
-func (*AttributePath_Step_AttributeName) isAttributePath_Step_Selector()    {}
+type AttributePath_Step_ElementKeyString struct {
+	ElementKeyString string `protobuf:"bytes,2,opt,name=element_key_string,json=elementKeyString,proto3,oneof"`
+}
+
+type AttributePath_Step_ElementKeyInt struct {
+	ElementKeyInt int64 `protobuf:"varint,3,opt,name=element_key_int,json=elementKeyInt,proto3,oneof"`
+}
+
+func (*AttributePath_Step_AttributeName) isAttributePath_Step_Selector() {}
+
 func (*AttributePath_Step_ElementKeyString) isAttributePath_Step_Selector() {}
-func (*AttributePath_Step_ElementKeyInt) isAttributePath_Step_Selector()    {}
+
+func (*AttributePath_Step_ElementKeyInt) isAttributePath_Step_Selector() {}
 
 func (m *AttributePath_Step) GetSelector() isAttributePath_Step_Selector {
 	if m != nil {
@@ -400,16 +411,17 @@ func (m *Stop) Reset()         { *m = Stop{} }
 func (m *Stop) String() string { return proto.CompactTextString(m) }
 func (*Stop) ProtoMessage()    {}
 func (*Stop) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{3}
+	return fileDescriptor_22a625af4bc1cc87, []int{3}
 }
+
 func (m *Stop) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Stop.Unmarshal(m, b)
 }
 func (m *Stop) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Stop.Marshal(b, m, deterministic)
 }
-func (dst *Stop) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Stop.Merge(dst, src)
+func (m *Stop) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Stop.Merge(m, src)
 }
 func (m *Stop) XXX_Size() int {
 	return xxx_messageInfo_Stop.Size(m)
@@ -430,16 +442,17 @@ func (m *Stop_Request) Reset()         { *m = Stop_Request{} }
 func (m *Stop_Request) String() string { return proto.CompactTextString(m) }
 func (*Stop_Request) ProtoMessage()    {}
 func (*Stop_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{3, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{3, 0}
 }
+
 func (m *Stop_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Stop_Request.Unmarshal(m, b)
 }
 func (m *Stop_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Stop_Request.Marshal(b, m, deterministic)
 }
-func (dst *Stop_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Stop_Request.Merge(dst, src)
+func (m *Stop_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Stop_Request.Merge(m, src)
 }
 func (m *Stop_Request) XXX_Size() int {
 	return xxx_messageInfo_Stop_Request.Size(m)
@@ -451,7 +464,7 @@ func (m *Stop_Request) XXX_DiscardUnknown() {
 var xxx_messageInfo_Stop_Request proto.InternalMessageInfo
 
 type Stop_Response struct {
-	Error                string   `protobuf:"bytes,1,opt,name=Error" json:"Error,omitempty"`
+	Error                string   `protobuf:"bytes,1,opt,name=Error,proto3" json:"Error,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -461,16 +474,17 @@ func (m *Stop_Response) Reset()         { *m = Stop_Response{} }
 func (m *Stop_Response) String() string { return proto.CompactTextString(m) }
 func (*Stop_Response) ProtoMessage()    {}
 func (*Stop_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{3, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{3, 1}
 }
+
 func (m *Stop_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Stop_Response.Unmarshal(m, b)
 }
 func (m *Stop_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Stop_Response.Marshal(b, m, deterministic)
 }
-func (dst *Stop_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Stop_Response.Merge(dst, src)
+func (m *Stop_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Stop_Response.Merge(m, src)
 }
 func (m *Stop_Response) XXX_Size() int {
 	return xxx_messageInfo_Stop_Response.Size(m)
@@ -493,7 +507,7 @@ func (m *Stop_Response) GetError() string {
 // in bytes, or the legacy flatmap format as a map of strings.
 type RawState struct {
 	Json                 []byte            `protobuf:"bytes,1,opt,name=json,proto3" json:"json,omitempty"`
-	Flatmap              map[string]string `protobuf:"bytes,2,rep,name=flatmap" json:"flatmap,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Flatmap              map[string]string `protobuf:"bytes,2,rep,name=flatmap,proto3" json:"flatmap,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -503,16 +517,17 @@ func (m *RawState) Reset()         { *m = RawState{} }
 func (m *RawState) String() string { return proto.CompactTextString(m) }
 func (*RawState) ProtoMessage()    {}
 func (*RawState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{4}
+	return fileDescriptor_22a625af4bc1cc87, []int{4}
 }
+
 func (m *RawState) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RawState.Unmarshal(m, b)
 }
 func (m *RawState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RawState.Marshal(b, m, deterministic)
 }
-func (dst *RawState) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RawState.Merge(dst, src)
+func (m *RawState) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RawState.Merge(m, src)
 }
 func (m *RawState) XXX_Size() int {
 	return xxx_messageInfo_RawState.Size(m)
@@ -542,9 +557,9 @@ type Schema struct {
 	// The version of the schema.
 	// Schemas are versioned, so that providers can upgrade a saved resource
 	// state when the schema is changed.
-	Version int64 `protobuf:"varint,1,opt,name=version" json:"version,omitempty"`
+	Version int64 `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
 	// Block is the top level configuration block for this schema.
-	Block                *Schema_Block `protobuf:"bytes,2,opt,name=block" json:"block,omitempty"`
+	Block                *Schema_Block `protobuf:"bytes,2,opt,name=block,proto3" json:"block,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -554,16 +569,17 @@ func (m *Schema) Reset()         { *m = Schema{} }
 func (m *Schema) String() string { return proto.CompactTextString(m) }
 func (*Schema) ProtoMessage()    {}
 func (*Schema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{5}
+	return fileDescriptor_22a625af4bc1cc87, []int{5}
 }
+
 func (m *Schema) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Schema.Unmarshal(m, b)
 }
 func (m *Schema) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Schema.Marshal(b, m, deterministic)
 }
-func (dst *Schema) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Schema.Merge(dst, src)
+func (m *Schema) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Schema.Merge(m, src)
 }
 func (m *Schema) XXX_Size() int {
 	return xxx_messageInfo_Schema.Size(m)
@@ -589,9 +605,9 @@ func (m *Schema) GetBlock() *Schema_Block {
 }
 
 type Schema_Block struct {
-	Version              int64                 `protobuf:"varint,1,opt,name=version" json:"version,omitempty"`
-	Attributes           []*Schema_Attribute   `protobuf:"bytes,2,rep,name=attributes" json:"attributes,omitempty"`
-	BlockTypes           []*Schema_NestedBlock `protobuf:"bytes,3,rep,name=block_types,json=blockTypes" json:"block_types,omitempty"`
+	Version              int64                 `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
+	Attributes           []*Schema_Attribute   `protobuf:"bytes,2,rep,name=attributes,proto3" json:"attributes,omitempty"`
+	BlockTypes           []*Schema_NestedBlock `protobuf:"bytes,3,rep,name=block_types,json=blockTypes,proto3" json:"block_types,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
 	XXX_unrecognized     []byte                `json:"-"`
 	XXX_sizecache        int32                 `json:"-"`
@@ -601,16 +617,17 @@ func (m *Schema_Block) Reset()         { *m = Schema_Block{} }
 func (m *Schema_Block) String() string { return proto.CompactTextString(m) }
 func (*Schema_Block) ProtoMessage()    {}
 func (*Schema_Block) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{5, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{5, 0}
 }
+
 func (m *Schema_Block) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Schema_Block.Unmarshal(m, b)
 }
 func (m *Schema_Block) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Schema_Block.Marshal(b, m, deterministic)
 }
-func (dst *Schema_Block) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Schema_Block.Merge(dst, src)
+func (m *Schema_Block) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Schema_Block.Merge(m, src)
 }
 func (m *Schema_Block) XXX_Size() int {
 	return xxx_messageInfo_Schema_Block.Size(m)
@@ -643,13 +660,13 @@ func (m *Schema_Block) GetBlockTypes() []*Schema_NestedBlock {
 }
 
 type Schema_Attribute struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Type                 []byte   `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
-	Description          string   `protobuf:"bytes,3,opt,name=description" json:"description,omitempty"`
-	Required             bool     `protobuf:"varint,4,opt,name=required" json:"required,omitempty"`
-	Optional             bool     `protobuf:"varint,5,opt,name=optional" json:"optional,omitempty"`
-	Computed             bool     `protobuf:"varint,6,opt,name=computed" json:"computed,omitempty"`
-	Sensitive            bool     `protobuf:"varint,7,opt,name=sensitive" json:"sensitive,omitempty"`
+	Description          string   `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	Required             bool     `protobuf:"varint,4,opt,name=required,proto3" json:"required,omitempty"`
+	Optional             bool     `protobuf:"varint,5,opt,name=optional,proto3" json:"optional,omitempty"`
+	Computed             bool     `protobuf:"varint,6,opt,name=computed,proto3" json:"computed,omitempty"`
+	Sensitive            bool     `protobuf:"varint,7,opt,name=sensitive,proto3" json:"sensitive,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -659,16 +676,17 @@ func (m *Schema_Attribute) Reset()         { *m = Schema_Attribute{} }
 func (m *Schema_Attribute) String() string { return proto.CompactTextString(m) }
 func (*Schema_Attribute) ProtoMessage()    {}
 func (*Schema_Attribute) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{5, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{5, 1}
 }
+
 func (m *Schema_Attribute) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Schema_Attribute.Unmarshal(m, b)
 }
 func (m *Schema_Attribute) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Schema_Attribute.Marshal(b, m, deterministic)
 }
-func (dst *Schema_Attribute) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Schema_Attribute.Merge(dst, src)
+func (m *Schema_Attribute) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Schema_Attribute.Merge(m, src)
 }
 func (m *Schema_Attribute) XXX_Size() int {
 	return xxx_messageInfo_Schema_Attribute.Size(m)
@@ -729,11 +747,11 @@ func (m *Schema_Attribute) GetSensitive() bool {
 }
 
 type Schema_NestedBlock struct {
-	TypeName             string                         `protobuf:"bytes,1,opt,name=type_name,json=typeName" json:"type_name,omitempty"`
-	Block                *Schema_Block                  `protobuf:"bytes,2,opt,name=block" json:"block,omitempty"`
-	Nesting              Schema_NestedBlock_NestingMode `protobuf:"varint,3,opt,name=nesting,enum=proto.Schema_NestedBlock_NestingMode" json:"nesting,omitempty"`
-	MinItems             int64                          `protobuf:"varint,4,opt,name=min_items,json=minItems" json:"min_items,omitempty"`
-	MaxItems             int64                          `protobuf:"varint,5,opt,name=max_items,json=maxItems" json:"max_items,omitempty"`
+	TypeName             string                         `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
+	Block                *Schema_Block                  `protobuf:"bytes,2,opt,name=block,proto3" json:"block,omitempty"`
+	Nesting              Schema_NestedBlock_NestingMode `protobuf:"varint,3,opt,name=nesting,proto3,enum=proto.Schema_NestedBlock_NestingMode" json:"nesting,omitempty"`
+	MinItems             int64                          `protobuf:"varint,4,opt,name=min_items,json=minItems,proto3" json:"min_items,omitempty"`
+	MaxItems             int64                          `protobuf:"varint,5,opt,name=max_items,json=maxItems,proto3" json:"max_items,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                       `json:"-"`
 	XXX_unrecognized     []byte                         `json:"-"`
 	XXX_sizecache        int32                          `json:"-"`
@@ -743,16 +761,17 @@ func (m *Schema_NestedBlock) Reset()         { *m = Schema_NestedBlock{} }
 func (m *Schema_NestedBlock) String() string { return proto.CompactTextString(m) }
 func (*Schema_NestedBlock) ProtoMessage()    {}
 func (*Schema_NestedBlock) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{5, 2}
+	return fileDescriptor_22a625af4bc1cc87, []int{5, 2}
 }
+
 func (m *Schema_NestedBlock) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Schema_NestedBlock.Unmarshal(m, b)
 }
 func (m *Schema_NestedBlock) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Schema_NestedBlock.Marshal(b, m, deterministic)
 }
-func (dst *Schema_NestedBlock) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Schema_NestedBlock.Merge(dst, src)
+func (m *Schema_NestedBlock) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Schema_NestedBlock.Merge(m, src)
 }
 func (m *Schema_NestedBlock) XXX_Size() int {
 	return xxx_messageInfo_Schema_NestedBlock.Size(m)
@@ -808,16 +827,17 @@ func (m *GetProviderSchema) Reset()         { *m = GetProviderSchema{} }
 func (m *GetProviderSchema) String() string { return proto.CompactTextString(m) }
 func (*GetProviderSchema) ProtoMessage()    {}
 func (*GetProviderSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{6}
+	return fileDescriptor_22a625af4bc1cc87, []int{6}
 }
+
 func (m *GetProviderSchema) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetProviderSchema.Unmarshal(m, b)
 }
 func (m *GetProviderSchema) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetProviderSchema.Marshal(b, m, deterministic)
 }
-func (dst *GetProviderSchema) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetProviderSchema.Merge(dst, src)
+func (m *GetProviderSchema) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetProviderSchema.Merge(m, src)
 }
 func (m *GetProviderSchema) XXX_Size() int {
 	return xxx_messageInfo_GetProviderSchema.Size(m)
@@ -838,16 +858,17 @@ func (m *GetProviderSchema_Request) Reset()         { *m = GetProviderSchema_Req
 func (m *GetProviderSchema_Request) String() string { return proto.CompactTextString(m) }
 func (*GetProviderSchema_Request) ProtoMessage()    {}
 func (*GetProviderSchema_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{6, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{6, 0}
 }
+
 func (m *GetProviderSchema_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetProviderSchema_Request.Unmarshal(m, b)
 }
 func (m *GetProviderSchema_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetProviderSchema_Request.Marshal(b, m, deterministic)
 }
-func (dst *GetProviderSchema_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetProviderSchema_Request.Merge(dst, src)
+func (m *GetProviderSchema_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetProviderSchema_Request.Merge(m, src)
 }
 func (m *GetProviderSchema_Request) XXX_Size() int {
 	return xxx_messageInfo_GetProviderSchema_Request.Size(m)
@@ -859,10 +880,10 @@ func (m *GetProviderSchema_Request) XXX_DiscardUnknown() {
 var xxx_messageInfo_GetProviderSchema_Request proto.InternalMessageInfo
 
 type GetProviderSchema_Response struct {
-	Provider             *Schema            `protobuf:"bytes,1,opt,name=provider" json:"provider,omitempty"`
-	ResourceSchemas      map[string]*Schema `protobuf:"bytes,2,rep,name=resource_schemas,json=resourceSchemas" json:"resource_schemas,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	DataSourceSchemas    map[string]*Schema `protobuf:"bytes,3,rep,name=data_source_schemas,json=dataSourceSchemas" json:"data_source_schemas,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Diagnostics          []*Diagnostic      `protobuf:"bytes,4,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	Provider             *Schema            `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
+	ResourceSchemas      map[string]*Schema `protobuf:"bytes,2,rep,name=resource_schemas,json=resourceSchemas,proto3" json:"resource_schemas,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	DataSourceSchemas    map[string]*Schema `protobuf:"bytes,3,rep,name=data_source_schemas,json=dataSourceSchemas,proto3" json:"data_source_schemas,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Diagnostics          []*Diagnostic      `protobuf:"bytes,4,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
@@ -872,16 +893,17 @@ func (m *GetProviderSchema_Response) Reset()         { *m = GetProviderSchema_Re
 func (m *GetProviderSchema_Response) String() string { return proto.CompactTextString(m) }
 func (*GetProviderSchema_Response) ProtoMessage()    {}
 func (*GetProviderSchema_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{6, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{6, 1}
 }
+
 func (m *GetProviderSchema_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetProviderSchema_Response.Unmarshal(m, b)
 }
 func (m *GetProviderSchema_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetProviderSchema_Response.Marshal(b, m, deterministic)
 }
-func (dst *GetProviderSchema_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetProviderSchema_Response.Merge(dst, src)
+func (m *GetProviderSchema_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetProviderSchema_Response.Merge(m, src)
 }
 func (m *GetProviderSchema_Response) XXX_Size() int {
 	return xxx_messageInfo_GetProviderSchema_Response.Size(m)
@@ -920,106 +942,117 @@ func (m *GetProviderSchema_Response) GetDiagnostics() []*Diagnostic {
 	return nil
 }
 
-type ValidateProviderConfig struct {
+type PrepareProviderConfig struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ValidateProviderConfig) Reset()         { *m = ValidateProviderConfig{} }
-func (m *ValidateProviderConfig) String() string { return proto.CompactTextString(m) }
-func (*ValidateProviderConfig) ProtoMessage()    {}
-func (*ValidateProviderConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{7}
-}
-func (m *ValidateProviderConfig) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ValidateProviderConfig.Unmarshal(m, b)
-}
-func (m *ValidateProviderConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ValidateProviderConfig.Marshal(b, m, deterministic)
-}
-func (dst *ValidateProviderConfig) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateProviderConfig.Merge(dst, src)
-}
-func (m *ValidateProviderConfig) XXX_Size() int {
-	return xxx_messageInfo_ValidateProviderConfig.Size(m)
-}
-func (m *ValidateProviderConfig) XXX_DiscardUnknown() {
-	xxx_messageInfo_ValidateProviderConfig.DiscardUnknown(m)
+func (m *PrepareProviderConfig) Reset()         { *m = PrepareProviderConfig{} }
+func (m *PrepareProviderConfig) String() string { return proto.CompactTextString(m) }
+func (*PrepareProviderConfig) ProtoMessage()    {}
+func (*PrepareProviderConfig) Descriptor() ([]byte, []int) {
+	return fileDescriptor_22a625af4bc1cc87, []int{7}
 }
 
-var xxx_messageInfo_ValidateProviderConfig proto.InternalMessageInfo
+func (m *PrepareProviderConfig) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PrepareProviderConfig.Unmarshal(m, b)
+}
+func (m *PrepareProviderConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PrepareProviderConfig.Marshal(b, m, deterministic)
+}
+func (m *PrepareProviderConfig) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PrepareProviderConfig.Merge(m, src)
+}
+func (m *PrepareProviderConfig) XXX_Size() int {
+	return xxx_messageInfo_PrepareProviderConfig.Size(m)
+}
+func (m *PrepareProviderConfig) XXX_DiscardUnknown() {
+	xxx_messageInfo_PrepareProviderConfig.DiscardUnknown(m)
+}
 
-type ValidateProviderConfig_Request struct {
-	Config               *DynamicValue `protobuf:"bytes,1,opt,name=config" json:"config,omitempty"`
+var xxx_messageInfo_PrepareProviderConfig proto.InternalMessageInfo
+
+type PrepareProviderConfig_Request struct {
+	Config               *DynamicValue `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
 }
 
-func (m *ValidateProviderConfig_Request) Reset()         { *m = ValidateProviderConfig_Request{} }
-func (m *ValidateProviderConfig_Request) String() string { return proto.CompactTextString(m) }
-func (*ValidateProviderConfig_Request) ProtoMessage()    {}
-func (*ValidateProviderConfig_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{7, 0}
-}
-func (m *ValidateProviderConfig_Request) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ValidateProviderConfig_Request.Unmarshal(m, b)
-}
-func (m *ValidateProviderConfig_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ValidateProviderConfig_Request.Marshal(b, m, deterministic)
-}
-func (dst *ValidateProviderConfig_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateProviderConfig_Request.Merge(dst, src)
-}
-func (m *ValidateProviderConfig_Request) XXX_Size() int {
-	return xxx_messageInfo_ValidateProviderConfig_Request.Size(m)
-}
-func (m *ValidateProviderConfig_Request) XXX_DiscardUnknown() {
-	xxx_messageInfo_ValidateProviderConfig_Request.DiscardUnknown(m)
+func (m *PrepareProviderConfig_Request) Reset()         { *m = PrepareProviderConfig_Request{} }
+func (m *PrepareProviderConfig_Request) String() string { return proto.CompactTextString(m) }
+func (*PrepareProviderConfig_Request) ProtoMessage()    {}
+func (*PrepareProviderConfig_Request) Descriptor() ([]byte, []int) {
+	return fileDescriptor_22a625af4bc1cc87, []int{7, 0}
 }
 
-var xxx_messageInfo_ValidateProviderConfig_Request proto.InternalMessageInfo
+func (m *PrepareProviderConfig_Request) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PrepareProviderConfig_Request.Unmarshal(m, b)
+}
+func (m *PrepareProviderConfig_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PrepareProviderConfig_Request.Marshal(b, m, deterministic)
+}
+func (m *PrepareProviderConfig_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PrepareProviderConfig_Request.Merge(m, src)
+}
+func (m *PrepareProviderConfig_Request) XXX_Size() int {
+	return xxx_messageInfo_PrepareProviderConfig_Request.Size(m)
+}
+func (m *PrepareProviderConfig_Request) XXX_DiscardUnknown() {
+	xxx_messageInfo_PrepareProviderConfig_Request.DiscardUnknown(m)
+}
 
-func (m *ValidateProviderConfig_Request) GetConfig() *DynamicValue {
+var xxx_messageInfo_PrepareProviderConfig_Request proto.InternalMessageInfo
+
+func (m *PrepareProviderConfig_Request) GetConfig() *DynamicValue {
 	if m != nil {
 		return m.Config
 	}
 	return nil
 }
 
-type ValidateProviderConfig_Response struct {
-	Diagnostics          []*Diagnostic `protobuf:"bytes,1,rep,name=diagnostics" json:"diagnostics,omitempty"`
+type PrepareProviderConfig_Response struct {
+	PreparedConfig       *DynamicValue `protobuf:"bytes,1,opt,name=prepared_config,json=preparedConfig,proto3" json:"prepared_config,omitempty"`
+	Diagnostics          []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
 }
 
-func (m *ValidateProviderConfig_Response) Reset()         { *m = ValidateProviderConfig_Response{} }
-func (m *ValidateProviderConfig_Response) String() string { return proto.CompactTextString(m) }
-func (*ValidateProviderConfig_Response) ProtoMessage()    {}
-func (*ValidateProviderConfig_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{7, 1}
-}
-func (m *ValidateProviderConfig_Response) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ValidateProviderConfig_Response.Unmarshal(m, b)
-}
-func (m *ValidateProviderConfig_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ValidateProviderConfig_Response.Marshal(b, m, deterministic)
-}
-func (dst *ValidateProviderConfig_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateProviderConfig_Response.Merge(dst, src)
-}
-func (m *ValidateProviderConfig_Response) XXX_Size() int {
-	return xxx_messageInfo_ValidateProviderConfig_Response.Size(m)
-}
-func (m *ValidateProviderConfig_Response) XXX_DiscardUnknown() {
-	xxx_messageInfo_ValidateProviderConfig_Response.DiscardUnknown(m)
+func (m *PrepareProviderConfig_Response) Reset()         { *m = PrepareProviderConfig_Response{} }
+func (m *PrepareProviderConfig_Response) String() string { return proto.CompactTextString(m) }
+func (*PrepareProviderConfig_Response) ProtoMessage()    {}
+func (*PrepareProviderConfig_Response) Descriptor() ([]byte, []int) {
+	return fileDescriptor_22a625af4bc1cc87, []int{7, 1}
 }
 
-var xxx_messageInfo_ValidateProviderConfig_Response proto.InternalMessageInfo
+func (m *PrepareProviderConfig_Response) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PrepareProviderConfig_Response.Unmarshal(m, b)
+}
+func (m *PrepareProviderConfig_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PrepareProviderConfig_Response.Marshal(b, m, deterministic)
+}
+func (m *PrepareProviderConfig_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PrepareProviderConfig_Response.Merge(m, src)
+}
+func (m *PrepareProviderConfig_Response) XXX_Size() int {
+	return xxx_messageInfo_PrepareProviderConfig_Response.Size(m)
+}
+func (m *PrepareProviderConfig_Response) XXX_DiscardUnknown() {
+	xxx_messageInfo_PrepareProviderConfig_Response.DiscardUnknown(m)
+}
 
-func (m *ValidateProviderConfig_Response) GetDiagnostics() []*Diagnostic {
+var xxx_messageInfo_PrepareProviderConfig_Response proto.InternalMessageInfo
+
+func (m *PrepareProviderConfig_Response) GetPreparedConfig() *DynamicValue {
+	if m != nil {
+		return m.PreparedConfig
+	}
+	return nil
+}
+
+func (m *PrepareProviderConfig_Response) GetDiagnostics() []*Diagnostic {
 	if m != nil {
 		return m.Diagnostics
 	}
@@ -1036,16 +1069,17 @@ func (m *UpgradeResourceState) Reset()         { *m = UpgradeResourceState{} }
 func (m *UpgradeResourceState) String() string { return proto.CompactTextString(m) }
 func (*UpgradeResourceState) ProtoMessage()    {}
 func (*UpgradeResourceState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{8}
+	return fileDescriptor_22a625af4bc1cc87, []int{8}
 }
+
 func (m *UpgradeResourceState) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpgradeResourceState.Unmarshal(m, b)
 }
 func (m *UpgradeResourceState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UpgradeResourceState.Marshal(b, m, deterministic)
 }
-func (dst *UpgradeResourceState) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpgradeResourceState.Merge(dst, src)
+func (m *UpgradeResourceState) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpgradeResourceState.Merge(m, src)
 }
 func (m *UpgradeResourceState) XXX_Size() int {
 	return xxx_messageInfo_UpgradeResourceState.Size(m)
@@ -1057,15 +1091,15 @@ func (m *UpgradeResourceState) XXX_DiscardUnknown() {
 var xxx_messageInfo_UpgradeResourceState proto.InternalMessageInfo
 
 type UpgradeResourceState_Request struct {
-	TypeName string `protobuf:"bytes,1,opt,name=type_name,json=typeName" json:"type_name,omitempty"`
+	TypeName string `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
 	// version is the schema_version number recorded in the state file
-	Version int64 `protobuf:"varint,2,opt,name=version" json:"version,omitempty"`
+	Version int64 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
 	// raw_state is the raw states as stored for the resource.  Core does
 	// not have access to the schema of prior_version, so it's the
 	// provider's responsibility to interpret this value using the
 	// appropriate older schema. The raw_state will be the json encoded
 	// state, or a legacy flat-mapped format.
-	RawState             *RawState `protobuf:"bytes,3,opt,name=raw_state,json=rawState" json:"raw_state,omitempty"`
+	RawState             *RawState `protobuf:"bytes,3,opt,name=raw_state,json=rawState,proto3" json:"raw_state,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
@@ -1075,16 +1109,17 @@ func (m *UpgradeResourceState_Request) Reset()         { *m = UpgradeResourceSta
 func (m *UpgradeResourceState_Request) String() string { return proto.CompactTextString(m) }
 func (*UpgradeResourceState_Request) ProtoMessage()    {}
 func (*UpgradeResourceState_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{8, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{8, 0}
 }
+
 func (m *UpgradeResourceState_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpgradeResourceState_Request.Unmarshal(m, b)
 }
 func (m *UpgradeResourceState_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UpgradeResourceState_Request.Marshal(b, m, deterministic)
 }
-func (dst *UpgradeResourceState_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpgradeResourceState_Request.Merge(dst, src)
+func (m *UpgradeResourceState_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpgradeResourceState_Request.Merge(m, src)
 }
 func (m *UpgradeResourceState_Request) XXX_Size() int {
 	return xxx_messageInfo_UpgradeResourceState_Request.Size(m)
@@ -1120,11 +1155,11 @@ type UpgradeResourceState_Response struct {
 	// new_state is a msgpack-encoded data structure that, when interpreted with
 	// the _current_ schema for this resource type, is functionally equivalent to
 	// that which was given in prior_state_raw.
-	UpgradedState *DynamicValue `protobuf:"bytes,1,opt,name=upgraded_state,json=upgradedState" json:"upgraded_state,omitempty"`
+	UpgradedState *DynamicValue `protobuf:"bytes,1,opt,name=upgraded_state,json=upgradedState,proto3" json:"upgraded_state,omitempty"`
 	// diagnostics describes any errors encountered during migration that could not
 	// be safely resolved, and warnings about any possibly-risky assumptions made
 	// in the upgrade process.
-	Diagnostics          []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	Diagnostics          []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -1134,16 +1169,17 @@ func (m *UpgradeResourceState_Response) Reset()         { *m = UpgradeResourceSt
 func (m *UpgradeResourceState_Response) String() string { return proto.CompactTextString(m) }
 func (*UpgradeResourceState_Response) ProtoMessage()    {}
 func (*UpgradeResourceState_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{8, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{8, 1}
 }
+
 func (m *UpgradeResourceState_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpgradeResourceState_Response.Unmarshal(m, b)
 }
 func (m *UpgradeResourceState_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UpgradeResourceState_Response.Marshal(b, m, deterministic)
 }
-func (dst *UpgradeResourceState_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpgradeResourceState_Response.Merge(dst, src)
+func (m *UpgradeResourceState_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpgradeResourceState_Response.Merge(m, src)
 }
 func (m *UpgradeResourceState_Response) XXX_Size() int {
 	return xxx_messageInfo_UpgradeResourceState_Response.Size(m)
@@ -1178,16 +1214,17 @@ func (m *ValidateResourceTypeConfig) Reset()         { *m = ValidateResourceType
 func (m *ValidateResourceTypeConfig) String() string { return proto.CompactTextString(m) }
 func (*ValidateResourceTypeConfig) ProtoMessage()    {}
 func (*ValidateResourceTypeConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{9}
+	return fileDescriptor_22a625af4bc1cc87, []int{9}
 }
+
 func (m *ValidateResourceTypeConfig) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidateResourceTypeConfig.Unmarshal(m, b)
 }
 func (m *ValidateResourceTypeConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValidateResourceTypeConfig.Marshal(b, m, deterministic)
 }
-func (dst *ValidateResourceTypeConfig) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateResourceTypeConfig.Merge(dst, src)
+func (m *ValidateResourceTypeConfig) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidateResourceTypeConfig.Merge(m, src)
 }
 func (m *ValidateResourceTypeConfig) XXX_Size() int {
 	return xxx_messageInfo_ValidateResourceTypeConfig.Size(m)
@@ -1199,8 +1236,8 @@ func (m *ValidateResourceTypeConfig) XXX_DiscardUnknown() {
 var xxx_messageInfo_ValidateResourceTypeConfig proto.InternalMessageInfo
 
 type ValidateResourceTypeConfig_Request struct {
-	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName" json:"type_name,omitempty"`
-	Config               *DynamicValue `protobuf:"bytes,2,opt,name=config" json:"config,omitempty"`
+	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
+	Config               *DynamicValue `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -1210,16 +1247,17 @@ func (m *ValidateResourceTypeConfig_Request) Reset()         { *m = ValidateReso
 func (m *ValidateResourceTypeConfig_Request) String() string { return proto.CompactTextString(m) }
 func (*ValidateResourceTypeConfig_Request) ProtoMessage()    {}
 func (*ValidateResourceTypeConfig_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{9, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{9, 0}
 }
+
 func (m *ValidateResourceTypeConfig_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidateResourceTypeConfig_Request.Unmarshal(m, b)
 }
 func (m *ValidateResourceTypeConfig_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValidateResourceTypeConfig_Request.Marshal(b, m, deterministic)
 }
-func (dst *ValidateResourceTypeConfig_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateResourceTypeConfig_Request.Merge(dst, src)
+func (m *ValidateResourceTypeConfig_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidateResourceTypeConfig_Request.Merge(m, src)
 }
 func (m *ValidateResourceTypeConfig_Request) XXX_Size() int {
 	return xxx_messageInfo_ValidateResourceTypeConfig_Request.Size(m)
@@ -1245,7 +1283,7 @@ func (m *ValidateResourceTypeConfig_Request) GetConfig() *DynamicValue {
 }
 
 type ValidateResourceTypeConfig_Response struct {
-	Diagnostics          []*Diagnostic `protobuf:"bytes,1,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	Diagnostics          []*Diagnostic `protobuf:"bytes,1,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -1255,16 +1293,17 @@ func (m *ValidateResourceTypeConfig_Response) Reset()         { *m = ValidateRes
 func (m *ValidateResourceTypeConfig_Response) String() string { return proto.CompactTextString(m) }
 func (*ValidateResourceTypeConfig_Response) ProtoMessage()    {}
 func (*ValidateResourceTypeConfig_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{9, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{9, 1}
 }
+
 func (m *ValidateResourceTypeConfig_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidateResourceTypeConfig_Response.Unmarshal(m, b)
 }
 func (m *ValidateResourceTypeConfig_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValidateResourceTypeConfig_Response.Marshal(b, m, deterministic)
 }
-func (dst *ValidateResourceTypeConfig_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateResourceTypeConfig_Response.Merge(dst, src)
+func (m *ValidateResourceTypeConfig_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidateResourceTypeConfig_Response.Merge(m, src)
 }
 func (m *ValidateResourceTypeConfig_Response) XXX_Size() int {
 	return xxx_messageInfo_ValidateResourceTypeConfig_Response.Size(m)
@@ -1292,16 +1331,17 @@ func (m *ValidateDataSourceConfig) Reset()         { *m = ValidateDataSourceConf
 func (m *ValidateDataSourceConfig) String() string { return proto.CompactTextString(m) }
 func (*ValidateDataSourceConfig) ProtoMessage()    {}
 func (*ValidateDataSourceConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{10}
+	return fileDescriptor_22a625af4bc1cc87, []int{10}
 }
+
 func (m *ValidateDataSourceConfig) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidateDataSourceConfig.Unmarshal(m, b)
 }
 func (m *ValidateDataSourceConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValidateDataSourceConfig.Marshal(b, m, deterministic)
 }
-func (dst *ValidateDataSourceConfig) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateDataSourceConfig.Merge(dst, src)
+func (m *ValidateDataSourceConfig) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidateDataSourceConfig.Merge(m, src)
 }
 func (m *ValidateDataSourceConfig) XXX_Size() int {
 	return xxx_messageInfo_ValidateDataSourceConfig.Size(m)
@@ -1313,8 +1353,8 @@ func (m *ValidateDataSourceConfig) XXX_DiscardUnknown() {
 var xxx_messageInfo_ValidateDataSourceConfig proto.InternalMessageInfo
 
 type ValidateDataSourceConfig_Request struct {
-	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName" json:"type_name,omitempty"`
-	Config               *DynamicValue `protobuf:"bytes,2,opt,name=config" json:"config,omitempty"`
+	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
+	Config               *DynamicValue `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -1324,16 +1364,17 @@ func (m *ValidateDataSourceConfig_Request) Reset()         { *m = ValidateDataSo
 func (m *ValidateDataSourceConfig_Request) String() string { return proto.CompactTextString(m) }
 func (*ValidateDataSourceConfig_Request) ProtoMessage()    {}
 func (*ValidateDataSourceConfig_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{10, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{10, 0}
 }
+
 func (m *ValidateDataSourceConfig_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidateDataSourceConfig_Request.Unmarshal(m, b)
 }
 func (m *ValidateDataSourceConfig_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValidateDataSourceConfig_Request.Marshal(b, m, deterministic)
 }
-func (dst *ValidateDataSourceConfig_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateDataSourceConfig_Request.Merge(dst, src)
+func (m *ValidateDataSourceConfig_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidateDataSourceConfig_Request.Merge(m, src)
 }
 func (m *ValidateDataSourceConfig_Request) XXX_Size() int {
 	return xxx_messageInfo_ValidateDataSourceConfig_Request.Size(m)
@@ -1359,7 +1400,7 @@ func (m *ValidateDataSourceConfig_Request) GetConfig() *DynamicValue {
 }
 
 type ValidateDataSourceConfig_Response struct {
-	Diagnostics          []*Diagnostic `protobuf:"bytes,1,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	Diagnostics          []*Diagnostic `protobuf:"bytes,1,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -1369,16 +1410,17 @@ func (m *ValidateDataSourceConfig_Response) Reset()         { *m = ValidateDataS
 func (m *ValidateDataSourceConfig_Response) String() string { return proto.CompactTextString(m) }
 func (*ValidateDataSourceConfig_Response) ProtoMessage()    {}
 func (*ValidateDataSourceConfig_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{10, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{10, 1}
 }
+
 func (m *ValidateDataSourceConfig_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidateDataSourceConfig_Response.Unmarshal(m, b)
 }
 func (m *ValidateDataSourceConfig_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValidateDataSourceConfig_Response.Marshal(b, m, deterministic)
 }
-func (dst *ValidateDataSourceConfig_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateDataSourceConfig_Response.Merge(dst, src)
+func (m *ValidateDataSourceConfig_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidateDataSourceConfig_Response.Merge(m, src)
 }
 func (m *ValidateDataSourceConfig_Response) XXX_Size() int {
 	return xxx_messageInfo_ValidateDataSourceConfig_Response.Size(m)
@@ -1406,16 +1448,17 @@ func (m *Configure) Reset()         { *m = Configure{} }
 func (m *Configure) String() string { return proto.CompactTextString(m) }
 func (*Configure) ProtoMessage()    {}
 func (*Configure) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{11}
+	return fileDescriptor_22a625af4bc1cc87, []int{11}
 }
+
 func (m *Configure) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Configure.Unmarshal(m, b)
 }
 func (m *Configure) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Configure.Marshal(b, m, deterministic)
 }
-func (dst *Configure) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Configure.Merge(dst, src)
+func (m *Configure) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Configure.Merge(m, src)
 }
 func (m *Configure) XXX_Size() int {
 	return xxx_messageInfo_Configure.Size(m)
@@ -1427,8 +1470,8 @@ func (m *Configure) XXX_DiscardUnknown() {
 var xxx_messageInfo_Configure proto.InternalMessageInfo
 
 type Configure_Request struct {
-	TerraformVersion     string        `protobuf:"bytes,1,opt,name=terraform_version,json=terraformVersion" json:"terraform_version,omitempty"`
-	Config               *DynamicValue `protobuf:"bytes,2,opt,name=config" json:"config,omitempty"`
+	TerraformVersion     string        `protobuf:"bytes,1,opt,name=terraform_version,json=terraformVersion,proto3" json:"terraform_version,omitempty"`
+	Config               *DynamicValue `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -1438,16 +1481,17 @@ func (m *Configure_Request) Reset()         { *m = Configure_Request{} }
 func (m *Configure_Request) String() string { return proto.CompactTextString(m) }
 func (*Configure_Request) ProtoMessage()    {}
 func (*Configure_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{11, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{11, 0}
 }
+
 func (m *Configure_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Configure_Request.Unmarshal(m, b)
 }
 func (m *Configure_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Configure_Request.Marshal(b, m, deterministic)
 }
-func (dst *Configure_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Configure_Request.Merge(dst, src)
+func (m *Configure_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Configure_Request.Merge(m, src)
 }
 func (m *Configure_Request) XXX_Size() int {
 	return xxx_messageInfo_Configure_Request.Size(m)
@@ -1473,7 +1517,7 @@ func (m *Configure_Request) GetConfig() *DynamicValue {
 }
 
 type Configure_Response struct {
-	Diagnostics          []*Diagnostic `protobuf:"bytes,1,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	Diagnostics          []*Diagnostic `protobuf:"bytes,1,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -1483,16 +1527,17 @@ func (m *Configure_Response) Reset()         { *m = Configure_Response{} }
 func (m *Configure_Response) String() string { return proto.CompactTextString(m) }
 func (*Configure_Response) ProtoMessage()    {}
 func (*Configure_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{11, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{11, 1}
 }
+
 func (m *Configure_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Configure_Response.Unmarshal(m, b)
 }
 func (m *Configure_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Configure_Response.Marshal(b, m, deterministic)
 }
-func (dst *Configure_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Configure_Response.Merge(dst, src)
+func (m *Configure_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Configure_Response.Merge(m, src)
 }
 func (m *Configure_Response) XXX_Size() int {
 	return xxx_messageInfo_Configure_Response.Size(m)
@@ -1520,16 +1565,17 @@ func (m *ReadResource) Reset()         { *m = ReadResource{} }
 func (m *ReadResource) String() string { return proto.CompactTextString(m) }
 func (*ReadResource) ProtoMessage()    {}
 func (*ReadResource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{12}
+	return fileDescriptor_22a625af4bc1cc87, []int{12}
 }
+
 func (m *ReadResource) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReadResource.Unmarshal(m, b)
 }
 func (m *ReadResource) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ReadResource.Marshal(b, m, deterministic)
 }
-func (dst *ReadResource) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReadResource.Merge(dst, src)
+func (m *ReadResource) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReadResource.Merge(m, src)
 }
 func (m *ReadResource) XXX_Size() int {
 	return xxx_messageInfo_ReadResource.Size(m)
@@ -1541,8 +1587,8 @@ func (m *ReadResource) XXX_DiscardUnknown() {
 var xxx_messageInfo_ReadResource proto.InternalMessageInfo
 
 type ReadResource_Request struct {
-	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName" json:"type_name,omitempty"`
-	CurrentState         *DynamicValue `protobuf:"bytes,2,opt,name=current_state,json=currentState" json:"current_state,omitempty"`
+	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
+	CurrentState         *DynamicValue `protobuf:"bytes,2,opt,name=current_state,json=currentState,proto3" json:"current_state,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -1552,16 +1598,17 @@ func (m *ReadResource_Request) Reset()         { *m = ReadResource_Request{} }
 func (m *ReadResource_Request) String() string { return proto.CompactTextString(m) }
 func (*ReadResource_Request) ProtoMessage()    {}
 func (*ReadResource_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{12, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{12, 0}
 }
+
 func (m *ReadResource_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReadResource_Request.Unmarshal(m, b)
 }
 func (m *ReadResource_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ReadResource_Request.Marshal(b, m, deterministic)
 }
-func (dst *ReadResource_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReadResource_Request.Merge(dst, src)
+func (m *ReadResource_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReadResource_Request.Merge(m, src)
 }
 func (m *ReadResource_Request) XXX_Size() int {
 	return xxx_messageInfo_ReadResource_Request.Size(m)
@@ -1587,8 +1634,8 @@ func (m *ReadResource_Request) GetCurrentState() *DynamicValue {
 }
 
 type ReadResource_Response struct {
-	NewState             *DynamicValue `protobuf:"bytes,1,opt,name=new_state,json=newState" json:"new_state,omitempty"`
-	Diagnostics          []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	NewState             *DynamicValue `protobuf:"bytes,1,opt,name=new_state,json=newState,proto3" json:"new_state,omitempty"`
+	Diagnostics          []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -1598,16 +1645,17 @@ func (m *ReadResource_Response) Reset()         { *m = ReadResource_Response{} }
 func (m *ReadResource_Response) String() string { return proto.CompactTextString(m) }
 func (*ReadResource_Response) ProtoMessage()    {}
 func (*ReadResource_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{12, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{12, 1}
 }
+
 func (m *ReadResource_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReadResource_Response.Unmarshal(m, b)
 }
 func (m *ReadResource_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ReadResource_Response.Marshal(b, m, deterministic)
 }
-func (dst *ReadResource_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReadResource_Response.Merge(dst, src)
+func (m *ReadResource_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReadResource_Response.Merge(m, src)
 }
 func (m *ReadResource_Response) XXX_Size() int {
 	return xxx_messageInfo_ReadResource_Response.Size(m)
@@ -1642,16 +1690,17 @@ func (m *PlanResourceChange) Reset()         { *m = PlanResourceChange{} }
 func (m *PlanResourceChange) String() string { return proto.CompactTextString(m) }
 func (*PlanResourceChange) ProtoMessage()    {}
 func (*PlanResourceChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{13}
+	return fileDescriptor_22a625af4bc1cc87, []int{13}
 }
+
 func (m *PlanResourceChange) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PlanResourceChange.Unmarshal(m, b)
 }
 func (m *PlanResourceChange) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PlanResourceChange.Marshal(b, m, deterministic)
 }
-func (dst *PlanResourceChange) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PlanResourceChange.Merge(dst, src)
+func (m *PlanResourceChange) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PlanResourceChange.Merge(m, src)
 }
 func (m *PlanResourceChange) XXX_Size() int {
 	return xxx_messageInfo_PlanResourceChange.Size(m)
@@ -1663,10 +1712,10 @@ func (m *PlanResourceChange) XXX_DiscardUnknown() {
 var xxx_messageInfo_PlanResourceChange proto.InternalMessageInfo
 
 type PlanResourceChange_Request struct {
-	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName" json:"type_name,omitempty"`
-	PriorState           *DynamicValue `protobuf:"bytes,2,opt,name=prior_state,json=priorState" json:"prior_state,omitempty"`
-	ProposedNewState     *DynamicValue `protobuf:"bytes,3,opt,name=proposed_new_state,json=proposedNewState" json:"proposed_new_state,omitempty"`
-	Config               *DynamicValue `protobuf:"bytes,4,opt,name=config" json:"config,omitempty"`
+	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
+	PriorState           *DynamicValue `protobuf:"bytes,2,opt,name=prior_state,json=priorState,proto3" json:"prior_state,omitempty"`
+	ProposedNewState     *DynamicValue `protobuf:"bytes,3,opt,name=proposed_new_state,json=proposedNewState,proto3" json:"proposed_new_state,omitempty"`
+	Config               *DynamicValue `protobuf:"bytes,4,opt,name=config,proto3" json:"config,omitempty"`
 	PriorPrivate         []byte        `protobuf:"bytes,5,opt,name=prior_private,json=priorPrivate,proto3" json:"prior_private,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
@@ -1677,16 +1726,17 @@ func (m *PlanResourceChange_Request) Reset()         { *m = PlanResourceChange_R
 func (m *PlanResourceChange_Request) String() string { return proto.CompactTextString(m) }
 func (*PlanResourceChange_Request) ProtoMessage()    {}
 func (*PlanResourceChange_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{13, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{13, 0}
 }
+
 func (m *PlanResourceChange_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PlanResourceChange_Request.Unmarshal(m, b)
 }
 func (m *PlanResourceChange_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PlanResourceChange_Request.Marshal(b, m, deterministic)
 }
-func (dst *PlanResourceChange_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PlanResourceChange_Request.Merge(dst, src)
+func (m *PlanResourceChange_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PlanResourceChange_Request.Merge(m, src)
 }
 func (m *PlanResourceChange_Request) XXX_Size() int {
 	return xxx_messageInfo_PlanResourceChange_Request.Size(m)
@@ -1733,10 +1783,10 @@ func (m *PlanResourceChange_Request) GetPriorPrivate() []byte {
 }
 
 type PlanResourceChange_Response struct {
-	PlannedState         *DynamicValue    `protobuf:"bytes,1,opt,name=planned_state,json=plannedState" json:"planned_state,omitempty"`
-	RequiresReplace      []*AttributePath `protobuf:"bytes,2,rep,name=requires_replace,json=requiresReplace" json:"requires_replace,omitempty"`
+	PlannedState         *DynamicValue    `protobuf:"bytes,1,opt,name=planned_state,json=plannedState,proto3" json:"planned_state,omitempty"`
+	RequiresReplace      []*AttributePath `protobuf:"bytes,2,rep,name=requires_replace,json=requiresReplace,proto3" json:"requires_replace,omitempty"`
 	PlannedPrivate       []byte           `protobuf:"bytes,3,opt,name=planned_private,json=plannedPrivate,proto3" json:"planned_private,omitempty"`
-	Diagnostics          []*Diagnostic    `protobuf:"bytes,4,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	Diagnostics          []*Diagnostic    `protobuf:"bytes,4,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
 	XXX_sizecache        int32            `json:"-"`
@@ -1746,16 +1796,17 @@ func (m *PlanResourceChange_Response) Reset()         { *m = PlanResourceChange_
 func (m *PlanResourceChange_Response) String() string { return proto.CompactTextString(m) }
 func (*PlanResourceChange_Response) ProtoMessage()    {}
 func (*PlanResourceChange_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{13, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{13, 1}
 }
+
 func (m *PlanResourceChange_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PlanResourceChange_Response.Unmarshal(m, b)
 }
 func (m *PlanResourceChange_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PlanResourceChange_Response.Marshal(b, m, deterministic)
 }
-func (dst *PlanResourceChange_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PlanResourceChange_Response.Merge(dst, src)
+func (m *PlanResourceChange_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PlanResourceChange_Response.Merge(m, src)
 }
 func (m *PlanResourceChange_Response) XXX_Size() int {
 	return xxx_messageInfo_PlanResourceChange_Response.Size(m)
@@ -1804,16 +1855,17 @@ func (m *ApplyResourceChange) Reset()         { *m = ApplyResourceChange{} }
 func (m *ApplyResourceChange) String() string { return proto.CompactTextString(m) }
 func (*ApplyResourceChange) ProtoMessage()    {}
 func (*ApplyResourceChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{14}
+	return fileDescriptor_22a625af4bc1cc87, []int{14}
 }
+
 func (m *ApplyResourceChange) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ApplyResourceChange.Unmarshal(m, b)
 }
 func (m *ApplyResourceChange) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ApplyResourceChange.Marshal(b, m, deterministic)
 }
-func (dst *ApplyResourceChange) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ApplyResourceChange.Merge(dst, src)
+func (m *ApplyResourceChange) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ApplyResourceChange.Merge(m, src)
 }
 func (m *ApplyResourceChange) XXX_Size() int {
 	return xxx_messageInfo_ApplyResourceChange.Size(m)
@@ -1825,10 +1877,10 @@ func (m *ApplyResourceChange) XXX_DiscardUnknown() {
 var xxx_messageInfo_ApplyResourceChange proto.InternalMessageInfo
 
 type ApplyResourceChange_Request struct {
-	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName" json:"type_name,omitempty"`
-	PriorState           *DynamicValue `protobuf:"bytes,2,opt,name=prior_state,json=priorState" json:"prior_state,omitempty"`
-	PlannedState         *DynamicValue `protobuf:"bytes,3,opt,name=planned_state,json=plannedState" json:"planned_state,omitempty"`
-	Config               *DynamicValue `protobuf:"bytes,4,opt,name=config" json:"config,omitempty"`
+	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
+	PriorState           *DynamicValue `protobuf:"bytes,2,opt,name=prior_state,json=priorState,proto3" json:"prior_state,omitempty"`
+	PlannedState         *DynamicValue `protobuf:"bytes,3,opt,name=planned_state,json=plannedState,proto3" json:"planned_state,omitempty"`
+	Config               *DynamicValue `protobuf:"bytes,4,opt,name=config,proto3" json:"config,omitempty"`
 	PlannedPrivate       []byte        `protobuf:"bytes,5,opt,name=planned_private,json=plannedPrivate,proto3" json:"planned_private,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
@@ -1839,16 +1891,17 @@ func (m *ApplyResourceChange_Request) Reset()         { *m = ApplyResourceChange
 func (m *ApplyResourceChange_Request) String() string { return proto.CompactTextString(m) }
 func (*ApplyResourceChange_Request) ProtoMessage()    {}
 func (*ApplyResourceChange_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{14, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{14, 0}
 }
+
 func (m *ApplyResourceChange_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ApplyResourceChange_Request.Unmarshal(m, b)
 }
 func (m *ApplyResourceChange_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ApplyResourceChange_Request.Marshal(b, m, deterministic)
 }
-func (dst *ApplyResourceChange_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ApplyResourceChange_Request.Merge(dst, src)
+func (m *ApplyResourceChange_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ApplyResourceChange_Request.Merge(m, src)
 }
 func (m *ApplyResourceChange_Request) XXX_Size() int {
 	return xxx_messageInfo_ApplyResourceChange_Request.Size(m)
@@ -1895,9 +1948,9 @@ func (m *ApplyResourceChange_Request) GetPlannedPrivate() []byte {
 }
 
 type ApplyResourceChange_Response struct {
-	NewState             *DynamicValue `protobuf:"bytes,1,opt,name=new_state,json=newState" json:"new_state,omitempty"`
+	NewState             *DynamicValue `protobuf:"bytes,1,opt,name=new_state,json=newState,proto3" json:"new_state,omitempty"`
 	Private              []byte        `protobuf:"bytes,2,opt,name=private,proto3" json:"private,omitempty"`
-	Diagnostics          []*Diagnostic `protobuf:"bytes,3,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	Diagnostics          []*Diagnostic `protobuf:"bytes,3,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -1907,16 +1960,17 @@ func (m *ApplyResourceChange_Response) Reset()         { *m = ApplyResourceChang
 func (m *ApplyResourceChange_Response) String() string { return proto.CompactTextString(m) }
 func (*ApplyResourceChange_Response) ProtoMessage()    {}
 func (*ApplyResourceChange_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{14, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{14, 1}
 }
+
 func (m *ApplyResourceChange_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ApplyResourceChange_Response.Unmarshal(m, b)
 }
 func (m *ApplyResourceChange_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ApplyResourceChange_Response.Marshal(b, m, deterministic)
 }
-func (dst *ApplyResourceChange_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ApplyResourceChange_Response.Merge(dst, src)
+func (m *ApplyResourceChange_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ApplyResourceChange_Response.Merge(m, src)
 }
 func (m *ApplyResourceChange_Response) XXX_Size() int {
 	return xxx_messageInfo_ApplyResourceChange_Response.Size(m)
@@ -1958,16 +2012,17 @@ func (m *ImportResourceState) Reset()         { *m = ImportResourceState{} }
 func (m *ImportResourceState) String() string { return proto.CompactTextString(m) }
 func (*ImportResourceState) ProtoMessage()    {}
 func (*ImportResourceState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{15}
+	return fileDescriptor_22a625af4bc1cc87, []int{15}
 }
+
 func (m *ImportResourceState) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ImportResourceState.Unmarshal(m, b)
 }
 func (m *ImportResourceState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ImportResourceState.Marshal(b, m, deterministic)
 }
-func (dst *ImportResourceState) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ImportResourceState.Merge(dst, src)
+func (m *ImportResourceState) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ImportResourceState.Merge(m, src)
 }
 func (m *ImportResourceState) XXX_Size() int {
 	return xxx_messageInfo_ImportResourceState.Size(m)
@@ -1979,8 +2034,8 @@ func (m *ImportResourceState) XXX_DiscardUnknown() {
 var xxx_messageInfo_ImportResourceState proto.InternalMessageInfo
 
 type ImportResourceState_Request struct {
-	TypeName             string   `protobuf:"bytes,1,opt,name=type_name,json=typeName" json:"type_name,omitempty"`
-	Id                   string   `protobuf:"bytes,2,opt,name=id" json:"id,omitempty"`
+	TypeName             string   `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
+	Id                   string   `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -1990,16 +2045,17 @@ func (m *ImportResourceState_Request) Reset()         { *m = ImportResourceState
 func (m *ImportResourceState_Request) String() string { return proto.CompactTextString(m) }
 func (*ImportResourceState_Request) ProtoMessage()    {}
 func (*ImportResourceState_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{15, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{15, 0}
 }
+
 func (m *ImportResourceState_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ImportResourceState_Request.Unmarshal(m, b)
 }
 func (m *ImportResourceState_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ImportResourceState_Request.Marshal(b, m, deterministic)
 }
-func (dst *ImportResourceState_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ImportResourceState_Request.Merge(dst, src)
+func (m *ImportResourceState_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ImportResourceState_Request.Merge(m, src)
 }
 func (m *ImportResourceState_Request) XXX_Size() int {
 	return xxx_messageInfo_ImportResourceState_Request.Size(m)
@@ -2025,8 +2081,8 @@ func (m *ImportResourceState_Request) GetId() string {
 }
 
 type ImportResourceState_ImportedResource struct {
-	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName" json:"type_name,omitempty"`
-	State                *DynamicValue `protobuf:"bytes,2,opt,name=state" json:"state,omitempty"`
+	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
+	State                *DynamicValue `protobuf:"bytes,2,opt,name=state,proto3" json:"state,omitempty"`
 	Private              []byte        `protobuf:"bytes,3,opt,name=private,proto3" json:"private,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
@@ -2037,16 +2093,17 @@ func (m *ImportResourceState_ImportedResource) Reset()         { *m = ImportReso
 func (m *ImportResourceState_ImportedResource) String() string { return proto.CompactTextString(m) }
 func (*ImportResourceState_ImportedResource) ProtoMessage()    {}
 func (*ImportResourceState_ImportedResource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{15, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{15, 1}
 }
+
 func (m *ImportResourceState_ImportedResource) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ImportResourceState_ImportedResource.Unmarshal(m, b)
 }
 func (m *ImportResourceState_ImportedResource) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ImportResourceState_ImportedResource.Marshal(b, m, deterministic)
 }
-func (dst *ImportResourceState_ImportedResource) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ImportResourceState_ImportedResource.Merge(dst, src)
+func (m *ImportResourceState_ImportedResource) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ImportResourceState_ImportedResource.Merge(m, src)
 }
 func (m *ImportResourceState_ImportedResource) XXX_Size() int {
 	return xxx_messageInfo_ImportResourceState_ImportedResource.Size(m)
@@ -2079,8 +2136,8 @@ func (m *ImportResourceState_ImportedResource) GetPrivate() []byte {
 }
 
 type ImportResourceState_Response struct {
-	ImportedResources    []*ImportResourceState_ImportedResource `protobuf:"bytes,1,rep,name=imported_resources,json=importedResources" json:"imported_resources,omitempty"`
-	Diagnostics          []*Diagnostic                           `protobuf:"bytes,2,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	ImportedResources    []*ImportResourceState_ImportedResource `protobuf:"bytes,1,rep,name=imported_resources,json=importedResources,proto3" json:"imported_resources,omitempty"`
+	Diagnostics          []*Diagnostic                           `protobuf:"bytes,2,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                                `json:"-"`
 	XXX_unrecognized     []byte                                  `json:"-"`
 	XXX_sizecache        int32                                   `json:"-"`
@@ -2090,16 +2147,17 @@ func (m *ImportResourceState_Response) Reset()         { *m = ImportResourceStat
 func (m *ImportResourceState_Response) String() string { return proto.CompactTextString(m) }
 func (*ImportResourceState_Response) ProtoMessage()    {}
 func (*ImportResourceState_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{15, 2}
+	return fileDescriptor_22a625af4bc1cc87, []int{15, 2}
 }
+
 func (m *ImportResourceState_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ImportResourceState_Response.Unmarshal(m, b)
 }
 func (m *ImportResourceState_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ImportResourceState_Response.Marshal(b, m, deterministic)
 }
-func (dst *ImportResourceState_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ImportResourceState_Response.Merge(dst, src)
+func (m *ImportResourceState_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ImportResourceState_Response.Merge(m, src)
 }
 func (m *ImportResourceState_Response) XXX_Size() int {
 	return xxx_messageInfo_ImportResourceState_Response.Size(m)
@@ -2134,16 +2192,17 @@ func (m *ReadDataSource) Reset()         { *m = ReadDataSource{} }
 func (m *ReadDataSource) String() string { return proto.CompactTextString(m) }
 func (*ReadDataSource) ProtoMessage()    {}
 func (*ReadDataSource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{16}
+	return fileDescriptor_22a625af4bc1cc87, []int{16}
 }
+
 func (m *ReadDataSource) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReadDataSource.Unmarshal(m, b)
 }
 func (m *ReadDataSource) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ReadDataSource.Marshal(b, m, deterministic)
 }
-func (dst *ReadDataSource) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReadDataSource.Merge(dst, src)
+func (m *ReadDataSource) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReadDataSource.Merge(m, src)
 }
 func (m *ReadDataSource) XXX_Size() int {
 	return xxx_messageInfo_ReadDataSource.Size(m)
@@ -2155,8 +2214,8 @@ func (m *ReadDataSource) XXX_DiscardUnknown() {
 var xxx_messageInfo_ReadDataSource proto.InternalMessageInfo
 
 type ReadDataSource_Request struct {
-	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName" json:"type_name,omitempty"`
-	Config               *DynamicValue `protobuf:"bytes,2,opt,name=config" json:"config,omitempty"`
+	TypeName             string        `protobuf:"bytes,1,opt,name=type_name,json=typeName,proto3" json:"type_name,omitempty"`
+	Config               *DynamicValue `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -2166,16 +2225,17 @@ func (m *ReadDataSource_Request) Reset()         { *m = ReadDataSource_Request{}
 func (m *ReadDataSource_Request) String() string { return proto.CompactTextString(m) }
 func (*ReadDataSource_Request) ProtoMessage()    {}
 func (*ReadDataSource_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{16, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{16, 0}
 }
+
 func (m *ReadDataSource_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReadDataSource_Request.Unmarshal(m, b)
 }
 func (m *ReadDataSource_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ReadDataSource_Request.Marshal(b, m, deterministic)
 }
-func (dst *ReadDataSource_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReadDataSource_Request.Merge(dst, src)
+func (m *ReadDataSource_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReadDataSource_Request.Merge(m, src)
 }
 func (m *ReadDataSource_Request) XXX_Size() int {
 	return xxx_messageInfo_ReadDataSource_Request.Size(m)
@@ -2201,8 +2261,8 @@ func (m *ReadDataSource_Request) GetConfig() *DynamicValue {
 }
 
 type ReadDataSource_Response struct {
-	State                *DynamicValue `protobuf:"bytes,1,opt,name=state" json:"state,omitempty"`
-	Diagnostics          []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	State                *DynamicValue `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
+	Diagnostics          []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -2212,16 +2272,17 @@ func (m *ReadDataSource_Response) Reset()         { *m = ReadDataSource_Response
 func (m *ReadDataSource_Response) String() string { return proto.CompactTextString(m) }
 func (*ReadDataSource_Response) ProtoMessage()    {}
 func (*ReadDataSource_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{16, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{16, 1}
 }
+
 func (m *ReadDataSource_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReadDataSource_Response.Unmarshal(m, b)
 }
 func (m *ReadDataSource_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ReadDataSource_Response.Marshal(b, m, deterministic)
 }
-func (dst *ReadDataSource_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReadDataSource_Response.Merge(dst, src)
+func (m *ReadDataSource_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReadDataSource_Response.Merge(m, src)
 }
 func (m *ReadDataSource_Response) XXX_Size() int {
 	return xxx_messageInfo_ReadDataSource_Response.Size(m)
@@ -2256,16 +2317,17 @@ func (m *GetProvisionerSchema) Reset()         { *m = GetProvisionerSchema{} }
 func (m *GetProvisionerSchema) String() string { return proto.CompactTextString(m) }
 func (*GetProvisionerSchema) ProtoMessage()    {}
 func (*GetProvisionerSchema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{17}
+	return fileDescriptor_22a625af4bc1cc87, []int{17}
 }
+
 func (m *GetProvisionerSchema) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetProvisionerSchema.Unmarshal(m, b)
 }
 func (m *GetProvisionerSchema) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetProvisionerSchema.Marshal(b, m, deterministic)
 }
-func (dst *GetProvisionerSchema) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetProvisionerSchema.Merge(dst, src)
+func (m *GetProvisionerSchema) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetProvisionerSchema.Merge(m, src)
 }
 func (m *GetProvisionerSchema) XXX_Size() int {
 	return xxx_messageInfo_GetProvisionerSchema.Size(m)
@@ -2286,16 +2348,17 @@ func (m *GetProvisionerSchema_Request) Reset()         { *m = GetProvisionerSche
 func (m *GetProvisionerSchema_Request) String() string { return proto.CompactTextString(m) }
 func (*GetProvisionerSchema_Request) ProtoMessage()    {}
 func (*GetProvisionerSchema_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{17, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{17, 0}
 }
+
 func (m *GetProvisionerSchema_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetProvisionerSchema_Request.Unmarshal(m, b)
 }
 func (m *GetProvisionerSchema_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetProvisionerSchema_Request.Marshal(b, m, deterministic)
 }
-func (dst *GetProvisionerSchema_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetProvisionerSchema_Request.Merge(dst, src)
+func (m *GetProvisionerSchema_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetProvisionerSchema_Request.Merge(m, src)
 }
 func (m *GetProvisionerSchema_Request) XXX_Size() int {
 	return xxx_messageInfo_GetProvisionerSchema_Request.Size(m)
@@ -2307,8 +2370,8 @@ func (m *GetProvisionerSchema_Request) XXX_DiscardUnknown() {
 var xxx_messageInfo_GetProvisionerSchema_Request proto.InternalMessageInfo
 
 type GetProvisionerSchema_Response struct {
-	Provisioner          *Schema       `protobuf:"bytes,1,opt,name=provisioner" json:"provisioner,omitempty"`
-	Diagnostics          []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	Provisioner          *Schema       `protobuf:"bytes,1,opt,name=provisioner,proto3" json:"provisioner,omitempty"`
+	Diagnostics          []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -2318,16 +2381,17 @@ func (m *GetProvisionerSchema_Response) Reset()         { *m = GetProvisionerSch
 func (m *GetProvisionerSchema_Response) String() string { return proto.CompactTextString(m) }
 func (*GetProvisionerSchema_Response) ProtoMessage()    {}
 func (*GetProvisionerSchema_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{17, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{17, 1}
 }
+
 func (m *GetProvisionerSchema_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetProvisionerSchema_Response.Unmarshal(m, b)
 }
 func (m *GetProvisionerSchema_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetProvisionerSchema_Response.Marshal(b, m, deterministic)
 }
-func (dst *GetProvisionerSchema_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetProvisionerSchema_Response.Merge(dst, src)
+func (m *GetProvisionerSchema_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetProvisionerSchema_Response.Merge(m, src)
 }
 func (m *GetProvisionerSchema_Response) XXX_Size() int {
 	return xxx_messageInfo_GetProvisionerSchema_Response.Size(m)
@@ -2362,16 +2426,17 @@ func (m *ValidateProvisionerConfig) Reset()         { *m = ValidateProvisionerCo
 func (m *ValidateProvisionerConfig) String() string { return proto.CompactTextString(m) }
 func (*ValidateProvisionerConfig) ProtoMessage()    {}
 func (*ValidateProvisionerConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{18}
+	return fileDescriptor_22a625af4bc1cc87, []int{18}
 }
+
 func (m *ValidateProvisionerConfig) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidateProvisionerConfig.Unmarshal(m, b)
 }
 func (m *ValidateProvisionerConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValidateProvisionerConfig.Marshal(b, m, deterministic)
 }
-func (dst *ValidateProvisionerConfig) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateProvisionerConfig.Merge(dst, src)
+func (m *ValidateProvisionerConfig) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidateProvisionerConfig.Merge(m, src)
 }
 func (m *ValidateProvisionerConfig) XXX_Size() int {
 	return xxx_messageInfo_ValidateProvisionerConfig.Size(m)
@@ -2383,7 +2448,7 @@ func (m *ValidateProvisionerConfig) XXX_DiscardUnknown() {
 var xxx_messageInfo_ValidateProvisionerConfig proto.InternalMessageInfo
 
 type ValidateProvisionerConfig_Request struct {
-	Config               *DynamicValue `protobuf:"bytes,1,opt,name=config" json:"config,omitempty"`
+	Config               *DynamicValue `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -2393,16 +2458,17 @@ func (m *ValidateProvisionerConfig_Request) Reset()         { *m = ValidateProvi
 func (m *ValidateProvisionerConfig_Request) String() string { return proto.CompactTextString(m) }
 func (*ValidateProvisionerConfig_Request) ProtoMessage()    {}
 func (*ValidateProvisionerConfig_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{18, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{18, 0}
 }
+
 func (m *ValidateProvisionerConfig_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidateProvisionerConfig_Request.Unmarshal(m, b)
 }
 func (m *ValidateProvisionerConfig_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValidateProvisionerConfig_Request.Marshal(b, m, deterministic)
 }
-func (dst *ValidateProvisionerConfig_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateProvisionerConfig_Request.Merge(dst, src)
+func (m *ValidateProvisionerConfig_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidateProvisionerConfig_Request.Merge(m, src)
 }
 func (m *ValidateProvisionerConfig_Request) XXX_Size() int {
 	return xxx_messageInfo_ValidateProvisionerConfig_Request.Size(m)
@@ -2421,7 +2487,7 @@ func (m *ValidateProvisionerConfig_Request) GetConfig() *DynamicValue {
 }
 
 type ValidateProvisionerConfig_Response struct {
-	Diagnostics          []*Diagnostic `protobuf:"bytes,1,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	Diagnostics          []*Diagnostic `protobuf:"bytes,1,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -2431,16 +2497,17 @@ func (m *ValidateProvisionerConfig_Response) Reset()         { *m = ValidateProv
 func (m *ValidateProvisionerConfig_Response) String() string { return proto.CompactTextString(m) }
 func (*ValidateProvisionerConfig_Response) ProtoMessage()    {}
 func (*ValidateProvisionerConfig_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{18, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{18, 1}
 }
+
 func (m *ValidateProvisionerConfig_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidateProvisionerConfig_Response.Unmarshal(m, b)
 }
 func (m *ValidateProvisionerConfig_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValidateProvisionerConfig_Response.Marshal(b, m, deterministic)
 }
-func (dst *ValidateProvisionerConfig_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidateProvisionerConfig_Response.Merge(dst, src)
+func (m *ValidateProvisionerConfig_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidateProvisionerConfig_Response.Merge(m, src)
 }
 func (m *ValidateProvisionerConfig_Response) XXX_Size() int {
 	return xxx_messageInfo_ValidateProvisionerConfig_Response.Size(m)
@@ -2468,16 +2535,17 @@ func (m *ProvisionResource) Reset()         { *m = ProvisionResource{} }
 func (m *ProvisionResource) String() string { return proto.CompactTextString(m) }
 func (*ProvisionResource) ProtoMessage()    {}
 func (*ProvisionResource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{19}
+	return fileDescriptor_22a625af4bc1cc87, []int{19}
 }
+
 func (m *ProvisionResource) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ProvisionResource.Unmarshal(m, b)
 }
 func (m *ProvisionResource) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ProvisionResource.Marshal(b, m, deterministic)
 }
-func (dst *ProvisionResource) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ProvisionResource.Merge(dst, src)
+func (m *ProvisionResource) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ProvisionResource.Merge(m, src)
 }
 func (m *ProvisionResource) XXX_Size() int {
 	return xxx_messageInfo_ProvisionResource.Size(m)
@@ -2489,8 +2557,8 @@ func (m *ProvisionResource) XXX_DiscardUnknown() {
 var xxx_messageInfo_ProvisionResource proto.InternalMessageInfo
 
 type ProvisionResource_Request struct {
-	Config               *DynamicValue `protobuf:"bytes,1,opt,name=config" json:"config,omitempty"`
-	Connection           *DynamicValue `protobuf:"bytes,2,opt,name=connection" json:"connection,omitempty"`
+	Config               *DynamicValue `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
+	Connection           *DynamicValue `protobuf:"bytes,2,opt,name=connection,proto3" json:"connection,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -2500,16 +2568,17 @@ func (m *ProvisionResource_Request) Reset()         { *m = ProvisionResource_Req
 func (m *ProvisionResource_Request) String() string { return proto.CompactTextString(m) }
 func (*ProvisionResource_Request) ProtoMessage()    {}
 func (*ProvisionResource_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{19, 0}
+	return fileDescriptor_22a625af4bc1cc87, []int{19, 0}
 }
+
 func (m *ProvisionResource_Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ProvisionResource_Request.Unmarshal(m, b)
 }
 func (m *ProvisionResource_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ProvisionResource_Request.Marshal(b, m, deterministic)
 }
-func (dst *ProvisionResource_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ProvisionResource_Request.Merge(dst, src)
+func (m *ProvisionResource_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ProvisionResource_Request.Merge(m, src)
 }
 func (m *ProvisionResource_Request) XXX_Size() int {
 	return xxx_messageInfo_ProvisionResource_Request.Size(m)
@@ -2535,8 +2604,8 @@ func (m *ProvisionResource_Request) GetConnection() *DynamicValue {
 }
 
 type ProvisionResource_Response struct {
-	Output               string        `protobuf:"bytes,1,opt,name=output" json:"output,omitempty"`
-	Diagnostics          []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics" json:"diagnostics,omitempty"`
+	Output               string        `protobuf:"bytes,1,opt,name=output,proto3" json:"output,omitempty"`
+	Diagnostics          []*Diagnostic `protobuf:"bytes,2,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -2546,16 +2615,17 @@ func (m *ProvisionResource_Response) Reset()         { *m = ProvisionResource_Re
 func (m *ProvisionResource_Response) String() string { return proto.CompactTextString(m) }
 func (*ProvisionResource_Response) ProtoMessage()    {}
 func (*ProvisionResource_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_ee08732ea36f2b86, []int{19, 1}
+	return fileDescriptor_22a625af4bc1cc87, []int{19, 1}
 }
+
 func (m *ProvisionResource_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ProvisionResource_Response.Unmarshal(m, b)
 }
 func (m *ProvisionResource_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ProvisionResource_Response.Marshal(b, m, deterministic)
 }
-func (dst *ProvisionResource_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ProvisionResource_Response.Merge(dst, src)
+func (m *ProvisionResource_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ProvisionResource_Response.Merge(m, src)
 }
 func (m *ProvisionResource_Response) XXX_Size() int {
 	return xxx_messageInfo_ProvisionResource_Response.Size(m)
@@ -2581,6 +2651,8 @@ func (m *ProvisionResource_Response) GetDiagnostics() []*Diagnostic {
 }
 
 func init() {
+	proto.RegisterEnum("proto.Diagnostic_Severity", Diagnostic_Severity_name, Diagnostic_Severity_value)
+	proto.RegisterEnum("proto.Schema_NestedBlock_NestingMode", Schema_NestedBlock_NestingMode_name, Schema_NestedBlock_NestingMode_value)
 	proto.RegisterType((*DynamicValue)(nil), "proto.DynamicValue")
 	proto.RegisterType((*Diagnostic)(nil), "proto.Diagnostic")
 	proto.RegisterType((*AttributePath)(nil), "proto.AttributePath")
@@ -2599,9 +2671,9 @@ func init() {
 	proto.RegisterType((*GetProviderSchema_Response)(nil), "proto.GetProviderSchema.Response")
 	proto.RegisterMapType((map[string]*Schema)(nil), "proto.GetProviderSchema.Response.DataSourceSchemasEntry")
 	proto.RegisterMapType((map[string]*Schema)(nil), "proto.GetProviderSchema.Response.ResourceSchemasEntry")
-	proto.RegisterType((*ValidateProviderConfig)(nil), "proto.ValidateProviderConfig")
-	proto.RegisterType((*ValidateProviderConfig_Request)(nil), "proto.ValidateProviderConfig.Request")
-	proto.RegisterType((*ValidateProviderConfig_Response)(nil), "proto.ValidateProviderConfig.Response")
+	proto.RegisterType((*PrepareProviderConfig)(nil), "proto.PrepareProviderConfig")
+	proto.RegisterType((*PrepareProviderConfig_Request)(nil), "proto.PrepareProviderConfig.Request")
+	proto.RegisterType((*PrepareProviderConfig_Response)(nil), "proto.PrepareProviderConfig.Response")
 	proto.RegisterType((*UpgradeResourceState)(nil), "proto.UpgradeResourceState")
 	proto.RegisterType((*UpgradeResourceState_Request)(nil), "proto.UpgradeResourceState.Request")
 	proto.RegisterType((*UpgradeResourceState_Response)(nil), "proto.UpgradeResourceState.Response")
@@ -2639,8 +2711,126 @@ func init() {
 	proto.RegisterType((*ProvisionResource)(nil), "proto.ProvisionResource")
 	proto.RegisterType((*ProvisionResource_Request)(nil), "proto.ProvisionResource.Request")
 	proto.RegisterType((*ProvisionResource_Response)(nil), "proto.ProvisionResource.Response")
-	proto.RegisterEnum("proto.Diagnostic_Severity", Diagnostic_Severity_name, Diagnostic_Severity_value)
-	proto.RegisterEnum("proto.Schema_NestedBlock_NestingMode", Schema_NestedBlock_NestingMode_name, Schema_NestedBlock_NestingMode_value)
+}
+
+func init() { proto.RegisterFile("plugin.proto", fileDescriptor_22a625af4bc1cc87) }
+
+var fileDescriptor_22a625af4bc1cc87 = []byte{
+	// 1814 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x58, 0xdb, 0x6f, 0x5b, 0x49,
+	0x19, 0xef, 0xf1, 0x89, 0x13, 0xfb, 0x73, 0x2e, 0xce, 0x34, 0x14, 0xf7, 0x6c, 0x41, 0xc1, 0xd9,
+	0x55, 0x53, 0x16, 0xb9, 0x8b, 0x8b, 0x42, 0x55, 0xad, 0x54, 0xd2, 0x6d, 0xe8, 0x5a, 0x74, 0xb3,
+	0x61, 0x5c, 0xb2, 0x12, 0x48, 0x98, 0xa9, 0xcf, 0x34, 0x3d, 0x1b, 0x9f, 0x4b, 0xe7, 0x8c, 0x93,
+	0xb5, 0x10, 0x12, 0x12, 0x8f, 0xbc, 0x2d, 0x0b, 0x2f, 0xfc, 0x13, 0xc0, 0x0b, 0x7f, 0xc2, 0xbe,
+	0x21, 0xf1, 0x06, 0xe2, 0x01, 0xa1, 0x95, 0x78, 0x42, 0x48, 0xfc, 0x07, 0x68, 0xae, 0xe7, 0xd8,
+	0x3e, 0xb1, 0x4d, 0xa2, 0x45, 0xfb, 0xe4, 0x33, 0xdf, 0xf7, 0x9b, 0xef, 0x36, 0xdf, 0x65, 0xc6,
+	0xb0, 0x9a, 0x0c, 0x86, 0x27, 0x41, 0xd4, 0x4a, 0x58, 0xcc, 0x63, 0x54, 0x96, 0x3f, 0xcd, 0xb7,
+	0x61, 0xf5, 0xf1, 0x28, 0x22, 0x61, 0xd0, 0x3f, 0x26, 0x83, 0x21, 0x45, 0x0d, 0x58, 0x09, 0xd3,
+	0x93, 0x84, 0xf4, 0x4f, 0x1b, 0xce, 0xb6, 0xb3, 0xbb, 0x8a, 0xcd, 0x12, 0x21, 0x58, 0xfa, 0x30,
+	0x8d, 0xa3, 0x46, 0x49, 0x92, 0xe5, 0x77, 0xf3, 0x6f, 0x0e, 0xc0, 0xe3, 0x80, 0x9c, 0x44, 0x71,
+	0xca, 0x83, 0x3e, 0xda, 0x83, 0x4a, 0x4a, 0xcf, 0x28, 0x0b, 0xf8, 0x48, 0xee, 0x5e, 0x6f, 0x7b,
+	0x4a, 0x5b, 0x2b, 0x03, 0xb5, 0xba, 0x1a, 0x81, 0x2d, 0x56, 0x28, 0x4d, 0x87, 0x61, 0x48, 0xd8,
+	0x48, 0x4a, 0xaf, 0x62, 0xb3, 0x44, 0x37, 0x60, 0xd9, 0xa7, 0x9c, 0x04, 0x83, 0x86, 0x2b, 0x19,
+	0x7a, 0x85, 0xda, 0x50, 0x25, 0x9c, 0xb3, 0xe0, 0xf9, 0x90, 0xd3, 0xc6, 0xd2, 0xb6, 0xb3, 0x5b,
+	0x6b, 0x6f, 0x69, 0x55, 0xfb, 0x86, 0x7e, 0x44, 0xf8, 0x4b, 0x9c, 0xc1, 0x9a, 0x77, 0xa1, 0x62,
+	0x74, 0xa3, 0x1a, 0xac, 0x74, 0x0e, 0x8f, 0xf7, 0x9f, 0x76, 0x1e, 0xd7, 0xaf, 0xa1, 0x2a, 0x94,
+	0x0f, 0x30, 0x7e, 0x1f, 0xd7, 0x1d, 0x41, 0xff, 0x60, 0x1f, 0x1f, 0x76, 0x0e, 0x9f, 0xd4, 0x4b,
+	0xcd, 0xbf, 0x38, 0xb0, 0x36, 0x26, 0x0d, 0xdd, 0x85, 0x72, 0xca, 0x69, 0x92, 0x36, 0x9c, 0x6d,
+	0x77, 0xb7, 0xd6, 0xbe, 0x59, 0xa4, 0xb2, 0xd5, 0xe5, 0x34, 0xc1, 0x0a, 0xe7, 0xfd, 0xda, 0x81,
+	0x25, 0xb1, 0x46, 0xb7, 0x61, 0xdd, 0x5a, 0xd2, 0x8b, 0x48, 0x48, 0x65, 0x80, 0xaa, 0xef, 0x5e,
+	0xc3, 0x6b, 0x96, 0x7e, 0x48, 0x42, 0x8a, 0x5a, 0x80, 0xe8, 0x80, 0x86, 0x34, 0xe2, 0xbd, 0x53,
+	0x3a, 0xea, 0xa5, 0x9c, 0x05, 0xd1, 0x89, 0x0a, 0xcb, 0xbb, 0xd7, 0x70, 0x5d, 0xf3, 0xbe, 0x47,
+	0x47, 0x5d, 0xc9, 0x41, 0xbb, 0xb0, 0x91, 0xc7, 0x07, 0x11, 0x97, 0xa1, 0x72, 0x85, 0xe4, 0x0c,
+	0xdc, 0x89, 0xf8, 0x23, 0x10, 0xa7, 0x33, 0xa0, 0x7d, 0x1e, 0xb3, 0xe6, 0x3d, 0x61, 0x56, 0x9c,
+	0x78, 0x55, 0x58, 0xc1, 0xf4, 0xd5, 0x90, 0xa6, 0xdc, 0xdb, 0x86, 0x0a, 0xa6, 0x69, 0x12, 0x47,
+	0x29, 0x45, 0x5b, 0x50, 0x3e, 0x60, 0x2c, 0x66, 0xca, 0x48, 0xac, 0x16, 0xcd, 0x8f, 0x1d, 0xa8,
+	0x60, 0x72, 0xde, 0xe5, 0x84, 0x53, 0x9b, 0x0e, 0x4e, 0x96, 0x0e, 0x68, 0x0f, 0x56, 0x5e, 0x0c,
+	0x08, 0x0f, 0x49, 0xd2, 0x28, 0xc9, 0x00, 0xdd, 0xd2, 0x01, 0x32, 0xbb, 0x5a, 0xdf, 0x55, 0xec,
+	0x83, 0x88, 0xb3, 0x11, 0x36, 0x60, 0xef, 0x01, 0xac, 0xe6, 0x19, 0xa8, 0x0e, 0xee, 0x29, 0x1d,
+	0x69, 0xe5, 0xe2, 0x53, 0x18, 0x74, 0x26, 0xf2, 0x53, 0xe7, 0x87, 0x5a, 0x3c, 0x28, 0xdd, 0x77,
+	0x9a, 0x9f, 0x96, 0x61, 0xb9, 0xdb, 0x7f, 0x49, 0x43, 0x22, 0xd2, 0xe8, 0x8c, 0xb2, 0x34, 0xd0,
+	0x56, 0xb9, 0xd8, 0x2c, 0xd1, 0x1d, 0x28, 0x3f, 0x1f, 0xc4, 0xfd, 0x53, 0xb9, 0xbd, 0xd6, 0xbe,
+	0xae, 0xcd, 0x52, 0xfb, 0x5a, 0x8f, 0x04, 0x0b, 0x2b, 0x84, 0xf7, 0x1b, 0x07, 0xca, 0x92, 0x30,
+	0x43, 0xdc, 0xb7, 0x01, 0xec, 0xa1, 0xa5, 0xda, 0xd5, 0x2f, 0x8f, 0xcb, 0xb4, 0x29, 0x81, 0x73,
+	0x50, 0xf4, 0x00, 0x6a, 0x52, 0x4b, 0x8f, 0x8f, 0x12, 0x9a, 0x36, 0xdc, 0xb1, 0x2c, 0xd2, 0x3b,
+	0x0f, 0x69, 0xca, 0xa9, 0xaf, 0x6c, 0x02, 0x89, 0x7e, 0x26, 0xc0, 0xde, 0xa7, 0x0e, 0x54, 0xad,
+	0x54, 0x11, 0xfe, 0x2c, 0x8b, 0xb0, 0xfc, 0x16, 0x34, 0x21, 0xd7, 0x54, 0xa8, 0xf8, 0x46, 0xdb,
+	0x50, 0xf3, 0x69, 0xda, 0x67, 0x41, 0xc2, 0x85, 0x23, 0xaa, 0x8a, 0xf2, 0x24, 0xe4, 0x41, 0x85,
+	0xd1, 0x57, 0xc3, 0x80, 0x51, 0x5f, 0x56, 0x52, 0x05, 0xdb, 0xb5, 0xe0, 0xc5, 0x12, 0x45, 0x06,
+	0x8d, 0xb2, 0xe2, 0x99, 0xb5, 0xe0, 0xf5, 0xe3, 0x30, 0x19, 0x72, 0xea, 0x37, 0x96, 0x15, 0xcf,
+	0xac, 0xd1, 0x2d, 0xa8, 0xa6, 0x34, 0x4a, 0x03, 0x1e, 0x9c, 0xd1, 0xc6, 0x8a, 0x64, 0x66, 0x04,
+	0xef, 0x93, 0x12, 0xd4, 0x72, 0x5e, 0xa2, 0xd7, 0xa0, 0x2a, 0x6c, 0xcd, 0x95, 0x05, 0xae, 0x08,
+	0x82, 0xac, 0x87, 0xc5, 0x8f, 0x0e, 0x3d, 0x84, 0x95, 0x88, 0xa6, 0x5c, 0xd4, 0x8b, 0x2b, 0xbb,
+	0xcf, 0x1b, 0x17, 0x46, 0x56, 0x7e, 0x07, 0xd1, 0xc9, 0x7b, 0xb1, 0x4f, 0xb1, 0xd9, 0x25, 0x0c,
+	0x09, 0x83, 0xa8, 0x17, 0x70, 0x1a, 0xa6, 0x32, 0x16, 0x2e, 0xae, 0x84, 0x41, 0xd4, 0x11, 0x6b,
+	0xc9, 0x24, 0x1f, 0x69, 0x66, 0x59, 0x33, 0xc9, 0x47, 0x92, 0xd9, 0x7c, 0xa4, 0x3c, 0xd2, 0x12,
+	0xc7, 0xdb, 0x0b, 0xc0, 0x72, 0xb7, 0x73, 0xf8, 0xe4, 0xe9, 0x41, 0xdd, 0x41, 0x15, 0x58, 0x7a,
+	0xda, 0xe9, 0x3e, 0xab, 0x97, 0xd0, 0x0a, 0xb8, 0xdd, 0x83, 0x67, 0x75, 0x57, 0x7c, 0xbc, 0xb7,
+	0x7f, 0x54, 0x5f, 0x6a, 0xfe, 0x7c, 0x09, 0x36, 0x9f, 0x50, 0x7e, 0xc4, 0xe2, 0xb3, 0xc0, 0xa7,
+	0x4c, 0x19, 0x9d, 0xaf, 0xd0, 0xbf, 0xbb, 0xb9, 0x12, 0xbd, 0x03, 0x95, 0x44, 0x23, 0x65, 0xcc,
+	0x6a, 0xed, 0xb5, 0x31, 0x6f, 0xb1, 0x65, 0x23, 0x02, 0x75, 0x46, 0xd3, 0x78, 0xc8, 0xfa, 0xb4,
+	0x97, 0x4a, 0xa6, 0x49, 0xda, 0x3d, 0xbd, 0x65, 0x4a, 0x6d, 0xcb, 0xe8, 0x11, 0x1f, 0x72, 0xa7,
+	0xa2, 0xa7, 0xaa, 0x72, 0x37, 0xd8, 0x38, 0x15, 0xbd, 0x84, 0xeb, 0x3e, 0xe1, 0xa4, 0x37, 0xa1,
+	0x45, 0x25, 0xf8, 0xfd, 0xf9, 0x5a, 0x1e, 0x13, 0x4e, 0xba, 0xd3, 0x7a, 0x36, 0xfd, 0x49, 0x3a,
+	0xba, 0x07, 0x35, 0xdf, 0x0e, 0x13, 0x71, 0x4a, 0x42, 0xc3, 0xe6, 0xd4, 0x98, 0xc1, 0x79, 0x94,
+	0xf7, 0x7d, 0xd8, 0x2a, 0xf2, 0xa3, 0xa0, 0xd1, 0xec, 0xe4, 0x1b, 0xcd, 0x54, 0x4c, 0xb3, 0xbe,
+	0xe3, 0x75, 0xe1, 0x46, 0xb1, 0xd1, 0x57, 0x10, 0xda, 0xfc, 0x93, 0x03, 0x5f, 0x3a, 0x62, 0x34,
+	0x21, 0x8c, 0x9a, 0x48, 0xbd, 0x13, 0x47, 0x2f, 0x82, 0x13, 0x6f, 0xcf, 0xa6, 0x01, 0x7a, 0x13,
+	0x96, 0xfb, 0x92, 0xa8, 0xcf, 0xdd, 0x94, 0x44, 0x7e, 0x8e, 0x63, 0x0d, 0xf1, 0x7e, 0x96, 0x4b,
+	0x99, 0xb7, 0x61, 0x23, 0x51, 0xc2, 0xfd, 0xde, 0x7c, 0x09, 0xeb, 0x06, 0xab, 0x2c, 0x98, 0x0c,
+	0x7c, 0x69, 0x91, 0xc0, 0x37, 0x7f, 0x51, 0x82, 0xad, 0x1f, 0x24, 0x27, 0x8c, 0xf8, 0xd4, 0x1e,
+	0x80, 0x18, 0x04, 0x5e, 0x94, 0xf9, 0x33, 0xb3, 0xfc, 0x73, 0x4d, 0xb8, 0x34, 0xde, 0x84, 0xbf,
+	0x01, 0x55, 0x46, 0xce, 0x7b, 0xa9, 0x10, 0x27, 0xeb, 0xbd, 0xd6, 0xde, 0x98, 0x18, 0x37, 0xb8,
+	0xc2, 0xf4, 0x97, 0xf7, 0xd3, 0x5c, 0x1c, 0x1e, 0xc0, 0xfa, 0x50, 0xd9, 0xe4, 0xeb, 0xed, 0x33,
+	0xc2, 0xb0, 0x66, 0xa0, 0x6a, 0xec, 0x5d, 0x2a, 0x0a, 0x7f, 0x70, 0xc0, 0x3b, 0x26, 0x83, 0xc0,
+	0x17, 0x36, 0xe9, 0x30, 0x88, 0xa6, 0xae, 0xcf, 0xb6, 0xbb, 0x60, 0x2c, 0xb2, 0x83, 0x2f, 0xcd,
+	0x3f, 0xf8, 0x87, 0x39, 0x87, 0x27, 0x8c, 0x76, 0x16, 0x32, 0xfa, 0x77, 0x0e, 0x34, 0x8c, 0xd1,
+	0x59, 0xa6, 0x7f, 0xa1, 0x4d, 0xfe, 0xbd, 0x03, 0x55, 0x65, 0xe0, 0x90, 0x51, 0xaf, 0x9f, 0x2f,
+	0x99, 0x4d, 0x4e, 0x19, 0x23, 0x2f, 0x62, 0x16, 0xf6, 0xf2, 0x43, 0xbd, 0x8a, 0xeb, 0x96, 0x71,
+	0xac, 0x13, 0xeb, 0xff, 0x6b, 0xf3, 0x67, 0x0e, 0xac, 0x62, 0x4a, 0x7c, 0x93, 0x17, 0xde, 0x4f,
+	0x16, 0x0c, 0xed, 0x7d, 0x58, 0xeb, 0x0f, 0x19, 0x13, 0x17, 0x3f, 0x95, 0xc4, 0x33, 0xac, 0x5d,
+	0xd5, 0x48, 0x55, 0x0b, 0xaf, 0x72, 0x36, 0xbf, 0x05, 0xd5, 0x88, 0x9e, 0xcf, 0x2f, 0x83, 0x4a,
+	0x44, 0xcf, 0xaf, 0x50, 0x01, 0xff, 0x76, 0x01, 0x1d, 0x0d, 0x48, 0x64, 0xbc, 0x7c, 0xe7, 0x25,
+	0x89, 0x4e, 0xa8, 0xf7, 0x1f, 0x67, 0x41, 0x67, 0xbf, 0x05, 0xb5, 0x84, 0x05, 0x31, 0x9b, 0xef,
+	0x2a, 0x48, 0x9c, 0x32, 0x75, 0x1f, 0x50, 0xc2, 0xe2, 0x24, 0x4e, 0xa9, 0xdf, 0xcb, 0xbc, 0x74,
+	0x2f, 0xde, 0x5c, 0x37, 0xf0, 0x43, 0xe3, 0x6d, 0x96, 0x0c, 0x4b, 0x73, 0x93, 0x01, 0xed, 0xc0,
+	0x9a, 0xb2, 0x32, 0x61, 0xc1, 0x99, 0x50, 0x55, 0x96, 0x37, 0xb1, 0x55, 0x49, 0x3c, 0x52, 0x34,
+	0xef, 0x33, 0x27, 0x17, 0xfe, 0xfb, 0xb0, 0x96, 0x0c, 0x48, 0x14, 0x2d, 0xd2, 0x89, 0x56, 0x35,
+	0x52, 0x19, 0xf6, 0x50, 0x0c, 0x75, 0x79, 0x4d, 0x4b, 0x7b, 0x8c, 0x26, 0x03, 0xd2, 0xa7, 0xfa,
+	0x2c, 0x8a, 0x1f, 0x42, 0x1b, 0x06, 0x8d, 0x15, 0x18, 0xdd, 0x86, 0x0d, 0xa3, 0xda, 0x98, 0xeb,
+	0x4a, 0x73, 0xd7, 0x35, 0x59, 0x1b, 0x7c, 0xa9, 0x89, 0xdb, 0xfc, 0xd8, 0x85, 0xeb, 0xfb, 0x49,
+	0x32, 0x18, 0x4d, 0x9c, 0xf8, 0xbf, 0x3e, 0xdf, 0x13, 0x9f, 0x8a, 0xa7, 0xbb, 0x68, 0x3c, 0xff,
+	0xa7, 0x83, 0x2e, 0x88, 0x5d, 0xb9, 0x28, 0x76, 0xde, 0x2f, 0x9d, 0x2b, 0xd5, 0x5a, 0x03, 0x56,
+	0x8c, 0x7c, 0x75, 0xa9, 0x37, 0xcb, 0xc9, 0x43, 0x71, 0x17, 0x3a, 0x94, 0x7f, 0x94, 0xe0, 0x7a,
+	0x27, 0x4c, 0x62, 0xc6, 0xc7, 0x87, 0xf1, 0xde, 0x82, 0x67, 0xb2, 0x0e, 0xa5, 0xc0, 0xd7, 0x4f,
+	0xb0, 0x52, 0xe0, 0x7b, 0x1c, 0xea, 0x4a, 0x1c, 0xb5, 0xed, 0x6b, 0xee, 0x65, 0x7e, 0xee, 0x71,
+	0x2a, 0x44, 0xde, 0x75, 0x77, 0xcc, 0x75, 0xef, 0xb7, 0xf9, 0x98, 0xfe, 0x10, 0x50, 0xa0, 0x4d,
+	0xe8, 0x99, 0x4b, 0xa9, 0x69, 0xbd, 0x6f, 0x6a, 0xf1, 0x05, 0x2e, 0xb7, 0x26, 0xed, 0xc6, 0x9b,
+	0xc1, 0x04, 0x25, 0xbd, 0x5c, 0xa7, 0xfb, 0xb3, 0x03, 0xeb, 0xa2, 0x9f, 0x67, 0x23, 0xf3, 0xf3,
+	0x19, 0x96, 0x1f, 0x8e, 0xbd, 0x05, 0xca, 0x73, 0x93, 0x4a, 0x87, 0xf5, 0x52, 0x3e, 0xfd, 0xca,
+	0x81, 0x2d, 0x73, 0x79, 0x17, 0x23, 0xb2, 0xe8, 0x71, 0x92, 0xe4, 0xec, 0xb9, 0x2b, 0x6a, 0xd7,
+	0x62, 0x8b, 0x9f, 0x27, 0x79, 0xc4, 0xe5, 0xac, 0xfa, 0xc4, 0x81, 0x9b, 0xe6, 0x82, 0x92, 0x33,
+	0xed, 0x8a, 0x17, 0xe6, 0x2b, 0x0f, 0xf4, 0xbf, 0x3a, 0xb0, 0x69, 0xcd, 0xb1, 0x53, 0xfd, 0xf4,
+	0x72, 0xe6, 0xa0, 0x7b, 0x00, 0xfd, 0x38, 0x8a, 0x68, 0x9f, 0x9b, 0x2b, 0xf0, 0x45, 0x5d, 0x30,
+	0x83, 0x79, 0x1f, 0xe4, 0x7c, 0xb8, 0x01, 0xcb, 0xf1, 0x90, 0x27, 0x43, 0xae, 0xd3, 0x4d, 0xaf,
+	0x2e, 0x15, 0xf2, 0xf6, 0x1f, 0x2b, 0x50, 0x31, 0x0f, 0x13, 0x74, 0x04, 0xd5, 0x27, 0x94, 0xeb,
+	0xff, 0x5e, 0xb6, 0x67, 0xbc, 0xf1, 0x54, 0x82, 0x7c, 0x6d, 0xee, 0x2b, 0x10, 0xf9, 0x17, 0xbc,
+	0x7e, 0xd0, 0xeb, 0x7a, 0x6f, 0x21, 0xd7, 0x6a, 0x78, 0x63, 0x0e, 0x4a, 0x6b, 0x49, 0x67, 0x5d,
+	0xc6, 0xd1, 0x1d, 0x2d, 0xe4, 0x62, 0x88, 0xd5, 0xf7, 0xf5, 0x45, 0xa0, 0x5a, 0x69, 0x78, 0xf1,
+	0x65, 0x1a, 0xdd, 0x9e, 0x90, 0x33, 0x09, 0xb0, 0x0a, 0x77, 0xe7, 0x03, 0xb5, 0x3a, 0x52, 0xfc,
+	0xec, 0x42, 0x3b, 0x5a, 0x42, 0x11, 0xd3, 0xaa, 0x79, 0x7d, 0x36, 0x48, 0xab, 0xf8, 0x4e, 0xee,
+	0xae, 0x8d, 0x1a, 0x7a, 0x8b, 0xa5, 0x58, 0x61, 0x37, 0x0b, 0x38, 0x5a, 0x42, 0x67, 0xfc, 0xe6,
+	0x8b, 0x5e, 0x33, 0xcf, 0xb7, 0x1c, 0xd1, 0xca, 0xb9, 0x55, 0xcc, 0xd4, 0xa2, 0x7e, 0x54, 0x74,
+	0xbd, 0x44, 0x26, 0xe5, 0xa6, 0x59, 0x56, 0x6c, 0x73, 0x16, 0x44, 0x0b, 0xff, 0x71, 0xe1, 0x55,
+	0x06, 0x99, 0xad, 0x05, 0x3c, 0x2b, 0x7e, 0x67, 0x26, 0x26, 0x93, 0x5f, 0x30, 0xa2, 0xac, 0xfc,
+	0xa2, 0xf1, 0x35, 0x29, 0xbf, 0x18, 0xa3, 0xe5, 0xbf, 0x3f, 0x39, 0x91, 0xd0, 0x57, 0x72, 0xc1,
+	0xcc, 0xc8, 0x56, 0xea, 0x57, 0x2f, 0x62, 0x6b, 0x81, 0xdf, 0x54, 0xff, 0x1e, 0x23, 0xfb, 0x67,
+	0x1c, 0x8f, 0x13, 0xbb, 0x79, 0x6b, 0x9c, 0xa8, 0xb6, 0xb4, 0xff, 0x59, 0x82, 0x5a, 0xae, 0x49,
+	0xa3, 0xe3, 0x7c, 0xf3, 0xd8, 0x99, 0x68, 0x0d, 0xf9, 0x19, 0x33, 0x95, 0x95, 0x17, 0x80, 0xb4,
+	0x69, 0xc9, 0x8c, 0x99, 0x80, 0x26, 0xeb, 0x67, 0x0a, 0x61, 0x95, 0xdd, 0x59, 0x00, 0x69, 0x6f,
+	0x20, 0xd3, 0xed, 0xde, 0xb6, 0xc3, 0x29, 0xce, 0x54, 0x3b, 0x2c, 0x42, 0x28, 0xc9, 0x6f, 0x39,
+	0x97, 0x08, 0xf4, 0xf3, 0x65, 0x49, 0xbc, 0xf7, 0xdf, 0x00, 0x00, 0x00, 0xff, 0xff, 0x9c, 0x86,
+	0x73, 0x1a, 0xee, 0x19, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -2657,7 +2847,7 @@ const _ = grpc.SupportPackageIsVersion4
 type ProviderClient interface {
 	// ////// Information about what a provider supports/expects
 	GetSchema(ctx context.Context, in *GetProviderSchema_Request, opts ...grpc.CallOption) (*GetProviderSchema_Response, error)
-	ValidateProviderConfig(ctx context.Context, in *ValidateProviderConfig_Request, opts ...grpc.CallOption) (*ValidateProviderConfig_Response, error)
+	PrepareProviderConfig(ctx context.Context, in *PrepareProviderConfig_Request, opts ...grpc.CallOption) (*PrepareProviderConfig_Response, error)
 	ValidateResourceTypeConfig(ctx context.Context, in *ValidateResourceTypeConfig_Request, opts ...grpc.CallOption) (*ValidateResourceTypeConfig_Response, error)
 	ValidateDataSourceConfig(ctx context.Context, in *ValidateDataSourceConfig_Request, opts ...grpc.CallOption) (*ValidateDataSourceConfig_Response, error)
 	UpgradeResourceState(ctx context.Context, in *UpgradeResourceState_Request, opts ...grpc.CallOption) (*UpgradeResourceState_Response, error)
@@ -2690,9 +2880,9 @@ func (c *providerClient) GetSchema(ctx context.Context, in *GetProviderSchema_Re
 	return out, nil
 }
 
-func (c *providerClient) ValidateProviderConfig(ctx context.Context, in *ValidateProviderConfig_Request, opts ...grpc.CallOption) (*ValidateProviderConfig_Response, error) {
-	out := new(ValidateProviderConfig_Response)
-	err := c.cc.Invoke(ctx, "/proto.Provider/ValidateProviderConfig", in, out, opts...)
+func (c *providerClient) PrepareProviderConfig(ctx context.Context, in *PrepareProviderConfig_Request, opts ...grpc.CallOption) (*PrepareProviderConfig_Response, error) {
+	out := new(PrepareProviderConfig_Response)
+	err := c.cc.Invoke(ctx, "/proto.Provider/PrepareProviderConfig", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2793,7 +2983,7 @@ func (c *providerClient) Stop(ctx context.Context, in *Stop_Request, opts ...grp
 type ProviderServer interface {
 	// ////// Information about what a provider supports/expects
 	GetSchema(context.Context, *GetProviderSchema_Request) (*GetProviderSchema_Response, error)
-	ValidateProviderConfig(context.Context, *ValidateProviderConfig_Request) (*ValidateProviderConfig_Response, error)
+	PrepareProviderConfig(context.Context, *PrepareProviderConfig_Request) (*PrepareProviderConfig_Response, error)
 	ValidateResourceTypeConfig(context.Context, *ValidateResourceTypeConfig_Request) (*ValidateResourceTypeConfig_Response, error)
 	ValidateDataSourceConfig(context.Context, *ValidateDataSourceConfig_Request) (*ValidateDataSourceConfig_Response, error)
 	UpgradeResourceState(context.Context, *UpgradeResourceState_Request) (*UpgradeResourceState_Response, error)
@@ -2831,20 +3021,20 @@ func _Provider_GetSchema_Handler(srv interface{}, ctx context.Context, dec func(
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Provider_ValidateProviderConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ValidateProviderConfig_Request)
+func _Provider_PrepareProviderConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PrepareProviderConfig_Request)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ProviderServer).ValidateProviderConfig(ctx, in)
+		return srv.(ProviderServer).PrepareProviderConfig(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/proto.Provider/ValidateProviderConfig",
+		FullMethod: "/proto.Provider/PrepareProviderConfig",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProviderServer).ValidateProviderConfig(ctx, req.(*ValidateProviderConfig_Request))
+		return srv.(ProviderServer).PrepareProviderConfig(ctx, req.(*PrepareProviderConfig_Request))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -3038,8 +3228,8 @@ var _Provider_serviceDesc = grpc.ServiceDesc{
 			Handler:    _Provider_GetSchema_Handler,
 		},
 		{
-			MethodName: "ValidateProviderConfig",
-			Handler:    _Provider_ValidateProviderConfig_Handler,
+			MethodName: "PrepareProviderConfig",
+			Handler:    _Provider_PrepareProviderConfig_Handler,
 		},
 		{
 			MethodName: "ValidateResourceTypeConfig",
@@ -3275,122 +3465,4 @@ var _Provisioner_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Metadata: "plugin.proto",
-}
-
-func init() { proto.RegisterFile("plugin.proto", fileDescriptor_plugin_ee08732ea36f2b86) }
-
-var fileDescriptor_plugin_ee08732ea36f2b86 = []byte{
-	// 1788 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x58, 0xcd, 0x8f, 0x1b, 0x49,
-	0x15, 0x4f, 0xbb, 0xc7, 0x33, 0xf6, 0xf3, 0x7c, 0x78, 0x2a, 0xa3, 0xe0, 0xf4, 0x06, 0x34, 0x78,
-	0x80, 0x4c, 0x58, 0xe4, 0x2c, 0x0e, 0x1a, 0xa2, 0x08, 0x29, 0x4c, 0x36, 0x43, 0xd6, 0x22, 0x3b,
-	0x3b, 0x94, 0xc3, 0xac, 0x04, 0x12, 0xa6, 0xe2, 0xae, 0x38, 0xbd, 0xe3, 0xfe, 0x48, 0x75, 0x79,
-	0xb2, 0x16, 0x17, 0x24, 0x8e, 0x9c, 0x58, 0x16, 0x2e, 0xfc, 0x13, 0xc0, 0x91, 0x7f, 0x60, 0xcf,
-	0xdc, 0x40, 0x1c, 0x10, 0x5a, 0x89, 0x13, 0x42, 0xe2, 0x3f, 0x40, 0xf5, 0xd9, 0x6d, 0xbb, 0xc7,
-	0x36, 0x13, 0x6d, 0xd8, 0x93, 0xbb, 0xde, 0xfb, 0xd5, 0x7b, 0xaf, 0x5e, 0xbd, 0xaf, 0x32, 0xac,
-	0x27, 0xc3, 0xd1, 0x20, 0x88, 0x5a, 0x09, 0x8b, 0x79, 0x8c, 0xca, 0xf2, 0xa7, 0xf9, 0x1d, 0x58,
-	0x7f, 0x38, 0x8e, 0x48, 0x18, 0xf4, 0x4f, 0xc9, 0x70, 0x44, 0x51, 0x03, 0xd6, 0xc2, 0x74, 0x90,
-	0x90, 0xfe, 0x59, 0xc3, 0xd9, 0x75, 0xf6, 0xd7, 0xb1, 0x59, 0x22, 0x04, 0x2b, 0x1f, 0xa4, 0x71,
-	0xd4, 0x28, 0x49, 0xb2, 0xfc, 0x6e, 0xfe, 0xcd, 0x01, 0x78, 0x18, 0x90, 0x41, 0x14, 0xa7, 0x3c,
-	0xe8, 0xa3, 0x03, 0xa8, 0xa4, 0xf4, 0x9c, 0xb2, 0x80, 0x8f, 0xe5, 0xee, 0xcd, 0xb6, 0xa7, 0xb4,
-	0xb5, 0x32, 0x50, 0xab, 0xab, 0x11, 0xd8, 0x62, 0x85, 0xd2, 0x74, 0x14, 0x86, 0x84, 0x8d, 0xa5,
-	0xf4, 0x2a, 0x36, 0x4b, 0x74, 0x0d, 0x56, 0x7d, 0xca, 0x49, 0x30, 0x6c, 0xb8, 0x92, 0xa1, 0x57,
-	0xa8, 0x0d, 0x55, 0xc2, 0x39, 0x0b, 0x9e, 0x8e, 0x38, 0x6d, 0xac, 0xec, 0x3a, 0xfb, 0xb5, 0xf6,
-	0x8e, 0x56, 0x75, 0x68, 0xe8, 0x27, 0x84, 0x3f, 0xc7, 0x19, 0xac, 0x79, 0x1b, 0x2a, 0x46, 0x37,
-	0xaa, 0xc1, 0x5a, 0xe7, 0xf8, 0xf4, 0xf0, 0x71, 0xe7, 0x61, 0xfd, 0x0a, 0xaa, 0x42, 0xf9, 0x08,
-	0xe3, 0xf7, 0x70, 0xdd, 0x11, 0xf4, 0xf7, 0x0f, 0xf1, 0x71, 0xe7, 0xf8, 0x51, 0xbd, 0xd4, 0xfc,
-	0x8b, 0x03, 0x1b, 0x13, 0xd2, 0xd0, 0x6d, 0x28, 0xa7, 0x9c, 0x26, 0x69, 0xc3, 0xd9, 0x75, 0xf7,
-	0x6b, 0xed, 0xeb, 0x45, 0x2a, 0x5b, 0x5d, 0x4e, 0x13, 0xac, 0x70, 0xde, 0x6f, 0x1c, 0x58, 0x11,
-	0x6b, 0x74, 0x13, 0x36, 0xad, 0x25, 0xbd, 0x88, 0x84, 0x54, 0x3a, 0xa8, 0xfa, 0xce, 0x15, 0xbc,
-	0x61, 0xe9, 0xc7, 0x24, 0xa4, 0xa8, 0x05, 0x88, 0x0e, 0x69, 0x48, 0x23, 0xde, 0x3b, 0xa3, 0xe3,
-	0x5e, 0xca, 0x59, 0x10, 0x0d, 0x94, 0x5b, 0xde, 0xb9, 0x82, 0xeb, 0x9a, 0xf7, 0x7d, 0x3a, 0xee,
-	0x4a, 0x0e, 0xda, 0x87, 0xad, 0x3c, 0x3e, 0x88, 0xb8, 0x74, 0x95, 0x2b, 0x24, 0x67, 0xe0, 0x4e,
-	0xc4, 0x1f, 0x80, 0xb8, 0x9d, 0x21, 0xed, 0xf3, 0x98, 0x35, 0xef, 0x08, 0xb3, 0xe2, 0xc4, 0xab,
-	0xc2, 0x1a, 0xa6, 0x2f, 0x46, 0x34, 0xe5, 0xde, 0x2e, 0x54, 0x30, 0x4d, 0x93, 0x38, 0x4a, 0x29,
-	0xda, 0x81, 0xf2, 0x11, 0x63, 0x31, 0x53, 0x46, 0x62, 0xb5, 0x68, 0x7e, 0xe4, 0x40, 0x05, 0x93,
-	0x97, 0x5d, 0x4e, 0x38, 0xb5, 0xe1, 0xe0, 0x64, 0xe1, 0x80, 0x0e, 0x60, 0xed, 0xd9, 0x90, 0xf0,
-	0x90, 0x24, 0x8d, 0x92, 0x74, 0xd0, 0x0d, 0xed, 0x20, 0xb3, 0xab, 0xf5, 0x3d, 0xc5, 0x3e, 0x8a,
-	0x38, 0x1b, 0x63, 0x03, 0xf6, 0xee, 0xc1, 0x7a, 0x9e, 0x81, 0xea, 0xe0, 0x9e, 0xd1, 0xb1, 0x56,
-	0x2e, 0x3e, 0x85, 0x41, 0xe7, 0x22, 0x3e, 0x75, 0x7c, 0xa8, 0xc5, 0xbd, 0xd2, 0x5d, 0xa7, 0xf9,
-	0x49, 0x19, 0x56, 0xbb, 0xfd, 0xe7, 0x34, 0x24, 0x22, 0x8c, 0xce, 0x29, 0x4b, 0x03, 0x6d, 0x95,
-	0x8b, 0xcd, 0x12, 0xdd, 0x82, 0xf2, 0xd3, 0x61, 0xdc, 0x3f, 0x93, 0xdb, 0x6b, 0xed, 0xab, 0xda,
-	0x2c, 0xb5, 0xaf, 0xf5, 0x40, 0xb0, 0xb0, 0x42, 0x78, 0xbf, 0x75, 0xa0, 0x2c, 0x09, 0x73, 0xc4,
-	0x7d, 0x1b, 0xc0, 0x5e, 0x5a, 0xaa, 0x8f, 0xfa, 0x85, 0x49, 0x99, 0x36, 0x24, 0x70, 0x0e, 0x8a,
-	0xee, 0x41, 0x4d, 0x6a, 0xe9, 0xf1, 0x71, 0x42, 0xd3, 0x86, 0x3b, 0x11, 0x45, 0x7a, 0xe7, 0x31,
-	0x4d, 0x39, 0xf5, 0x95, 0x4d, 0x20, 0xd1, 0x4f, 0x04, 0xd8, 0xfb, 0xc4, 0x81, 0xaa, 0x95, 0x2a,
-	0xdc, 0x9f, 0x45, 0x11, 0x96, 0xdf, 0x82, 0x26, 0xe4, 0x9a, 0x0c, 0x15, 0xdf, 0x68, 0x17, 0x6a,
-	0x3e, 0x4d, 0xfb, 0x2c, 0x48, 0xb8, 0x38, 0x88, 0xca, 0xa2, 0x3c, 0x09, 0x79, 0x50, 0x61, 0xf4,
-	0xc5, 0x28, 0x60, 0xd4, 0x97, 0x99, 0x54, 0xc1, 0x76, 0x2d, 0x78, 0xb1, 0x44, 0x91, 0x61, 0xa3,
-	0xac, 0x78, 0x66, 0x2d, 0x78, 0xfd, 0x38, 0x4c, 0x46, 0x9c, 0xfa, 0x8d, 0x55, 0xc5, 0x33, 0x6b,
-	0x74, 0x03, 0xaa, 0x29, 0x8d, 0xd2, 0x80, 0x07, 0xe7, 0xb4, 0xb1, 0x26, 0x99, 0x19, 0xc1, 0xfb,
-	0xb8, 0x04, 0xb5, 0xdc, 0x29, 0xd1, 0x1b, 0x50, 0x15, 0xb6, 0xe6, 0xd2, 0x02, 0x57, 0x04, 0x41,
-	0xe6, 0xc3, 0xf2, 0x57, 0x87, 0xee, 0xc3, 0x5a, 0x44, 0x53, 0x2e, 0xf2, 0xc5, 0x95, 0xd5, 0xe7,
-	0xab, 0x17, 0x7a, 0x56, 0x7e, 0x07, 0xd1, 0xe0, 0xdd, 0xd8, 0xa7, 0xd8, 0xec, 0x12, 0x86, 0x84,
-	0x41, 0xd4, 0x0b, 0x38, 0x0d, 0x53, 0xe9, 0x0b, 0x17, 0x57, 0xc2, 0x20, 0xea, 0x88, 0xb5, 0x64,
-	0x92, 0x0f, 0x35, 0xb3, 0xac, 0x99, 0xe4, 0x43, 0xc9, 0x6c, 0x3e, 0x50, 0x27, 0xd2, 0x12, 0x27,
-	0xcb, 0x0b, 0xc0, 0x6a, 0xb7, 0x73, 0xfc, 0xe8, 0xf1, 0x51, 0xdd, 0x41, 0x15, 0x58, 0x79, 0xdc,
-	0xe9, 0x3e, 0xa9, 0x97, 0xd0, 0x1a, 0xb8, 0xdd, 0xa3, 0x27, 0x75, 0x57, 0x7c, 0xbc, 0x7b, 0x78,
-	0x52, 0x5f, 0x69, 0xfe, 0x7c, 0x05, 0xb6, 0x1f, 0x51, 0x7e, 0xc2, 0xe2, 0xf3, 0xc0, 0xa7, 0x4c,
-	0x19, 0x9d, 0xcf, 0xd0, 0xbf, 0xbb, 0xb9, 0x14, 0xbd, 0x05, 0x95, 0x44, 0x23, 0xa5, 0xcf, 0x6a,
-	0xed, 0x8d, 0x89, 0xd3, 0x62, 0xcb, 0x46, 0x04, 0xea, 0x8c, 0xa6, 0xf1, 0x88, 0xf5, 0x69, 0x2f,
-	0x95, 0x4c, 0x13, 0xb4, 0x07, 0x7a, 0xcb, 0x8c, 0xda, 0x96, 0xd1, 0x23, 0x3e, 0xe4, 0x4e, 0x45,
-	0x4f, 0x55, 0xe6, 0x6e, 0xb1, 0x49, 0x2a, 0x7a, 0x0e, 0x57, 0x7d, 0xc2, 0x49, 0x6f, 0x4a, 0x8b,
-	0x0a, 0xf0, 0xbb, 0x8b, 0xb5, 0x3c, 0x24, 0x9c, 0x74, 0x67, 0xf5, 0x6c, 0xfb, 0xd3, 0x74, 0x74,
-	0x07, 0x6a, 0xbe, 0x6d, 0x26, 0xe2, 0x96, 0x84, 0x86, 0xed, 0x99, 0x36, 0x83, 0xf3, 0x28, 0xef,
-	0x07, 0xb0, 0x53, 0x74, 0x8e, 0x82, 0x42, 0xb3, 0x97, 0x2f, 0x34, 0x33, 0x3e, 0xcd, 0xea, 0x8e,
-	0xd7, 0x85, 0x6b, 0xc5, 0x46, 0xbf, 0x82, 0xd0, 0xe6, 0xaf, 0x1c, 0xb8, 0x76, 0x4a, 0x86, 0x81,
-	0x4f, 0x38, 0x35, 0xae, 0x7a, 0x3b, 0x8e, 0x9e, 0x05, 0x03, 0xef, 0xc0, 0xc6, 0x01, 0x7a, 0x13,
-	0x56, 0xfb, 0x92, 0xa8, 0x2f, 0xde, 0xe4, 0x44, 0xbe, 0x91, 0x63, 0x0d, 0xf1, 0xee, 0xe7, 0x62,
-	0x66, 0xca, 0x77, 0xce, 0x32, 0xbe, 0x6b, 0xfe, 0xa2, 0x04, 0x3b, 0x3f, 0x4c, 0x06, 0x8c, 0xf8,
-	0xd4, 0xfa, 0x50, 0xd4, 0x72, 0x2f, 0xca, 0x2c, 0x9a, 0x9b, 0xc1, 0xb9, 0x3a, 0x5a, 0x9a, 0xac,
-	0xa3, 0xdf, 0x80, 0x2a, 0x23, 0x2f, 0x7b, 0xa9, 0x10, 0x27, 0x53, 0xb6, 0xd6, 0xde, 0x9a, 0xea,
-	0x18, 0xb8, 0xc2, 0xf4, 0x97, 0xf7, 0xb3, 0xdc, 0x49, 0xee, 0xc1, 0xe6, 0x48, 0xd9, 0xe4, 0xeb,
-	0xed, 0x73, 0x5c, 0xb1, 0x61, 0xa0, 0xaa, 0x73, 0x4d, 0x79, 0xa1, 0xb4, 0x94, 0x17, 0xfe, 0xe8,
-	0x80, 0x67, 0x6e, 0xc6, 0xb8, 0x41, 0xd4, 0x65, 0x7d, 0x3b, 0xdd, 0x25, 0x7d, 0x91, 0x5d, 0x5d,
-	0xe9, 0x35, 0x5c, 0xdd, 0xef, 0x1d, 0x68, 0x18, 0xa3, 0xb3, 0x60, 0xfd, 0x5c, 0x9b, 0xfc, 0x07,
-	0x07, 0xaa, 0xca, 0xc0, 0x11, 0xa3, 0x5e, 0x3f, 0x1f, 0xf4, 0xdb, 0x9c, 0x32, 0x46, 0x9e, 0xc5,
-	0x2c, 0xec, 0xe5, 0xfb, 0x72, 0x15, 0xd7, 0x2d, 0xe3, 0x54, 0x07, 0xd6, 0xeb, 0xb5, 0xf9, 0x53,
-	0x07, 0xd6, 0x31, 0x25, 0xbe, 0x89, 0x0b, 0xef, 0xa7, 0x4b, 0xba, 0xf6, 0x2e, 0x6c, 0xf4, 0x47,
-	0x8c, 0x89, 0xd9, 0x4d, 0x05, 0xf1, 0x1c, 0x6b, 0xd7, 0x35, 0x52, 0xe5, 0xc2, 0x8b, 0x9c, 0xcd,
-	0x6f, 0x41, 0x35, 0xa2, 0x2f, 0x17, 0xa7, 0x41, 0x25, 0xa2, 0x2f, 0x5f, 0x21, 0x03, 0xfe, 0xed,
-	0x02, 0x3a, 0x19, 0x92, 0xc8, 0x9c, 0xf2, 0xed, 0xe7, 0x24, 0x1a, 0x50, 0xef, 0x3f, 0xce, 0x92,
-	0x87, 0xfd, 0x16, 0xd4, 0x12, 0x16, 0xc4, 0x6c, 0xf1, 0x51, 0x41, 0xe2, 0x94, 0xa9, 0x87, 0x80,
-	0x12, 0x16, 0x27, 0x71, 0x4a, 0xfd, 0x5e, 0x76, 0x4a, 0xf7, 0xe2, 0xcd, 0x75, 0x03, 0x3f, 0x36,
-	0xa7, 0xcd, 0x82, 0x61, 0x65, 0x61, 0x30, 0xa0, 0x3d, 0xd8, 0x50, 0x56, 0x26, 0x2c, 0x38, 0x17,
-	0xaa, 0xca, 0x72, 0x98, 0x5a, 0x97, 0xc4, 0x13, 0x45, 0xf3, 0x3e, 0x75, 0x72, 0xee, 0xbf, 0x0b,
-	0x1b, 0xc9, 0x90, 0x44, 0xd1, 0x32, 0x95, 0x68, 0x5d, 0x23, 0x95, 0x61, 0xf7, 0x45, 0x5f, 0x96,
-	0x93, 0x56, 0xda, 0x63, 0x34, 0x19, 0x92, 0x3e, 0xd5, 0x77, 0x51, 0xfc, 0x96, 0xd9, 0x32, 0x68,
-	0xac, 0xc0, 0xe8, 0x26, 0x6c, 0x19, 0xd5, 0xc6, 0x5c, 0x57, 0x9a, 0xbb, 0xa9, 0xc9, 0xda, 0xe0,
-	0x4b, 0x35, 0xcd, 0xe6, 0x47, 0x2e, 0x5c, 0x3d, 0x4c, 0x92, 0xe1, 0x78, 0xea, 0xc6, 0xff, 0xf5,
-	0xd9, 0xde, 0xf8, 0x8c, 0x3f, 0xdd, 0x65, 0xfd, 0xf9, 0x3f, 0x5d, 0x74, 0x81, 0xef, 0xca, 0x45,
-	0xbe, 0xf3, 0x7e, 0xe9, 0xbc, 0x52, 0xae, 0x35, 0x60, 0xcd, 0xc8, 0x57, 0x73, 0xb9, 0x59, 0x4e,
-	0x5f, 0x8a, 0xbb, 0xd4, 0xa5, 0xfc, 0xa3, 0x04, 0x57, 0x3b, 0x61, 0x12, 0x33, 0x3e, 0xd9, 0x8c,
-	0x0f, 0x96, 0xbc, 0x93, 0x4d, 0x28, 0x05, 0xbe, 0x7e, 0x45, 0x95, 0x02, 0xdf, 0xe3, 0x50, 0x57,
-	0xe2, 0xa8, 0x2d, 0x5f, 0x0b, 0xe7, 0xf1, 0x85, 0xd7, 0xa9, 0x10, 0xf9, 0xa3, 0xbb, 0x13, 0x47,
-	0xf7, 0x7e, 0x97, 0xf7, 0xe9, 0x8f, 0x00, 0x05, 0xda, 0x84, 0x9e, 0x99, 0x2b, 0x4d, 0xe9, 0x7d,
-	0x53, 0x8b, 0x2f, 0x38, 0x72, 0x6b, 0xda, 0x6e, 0xbc, 0x1d, 0x4c, 0x51, 0xd2, 0xcb, 0x55, 0xba,
-	0x3f, 0x3b, 0xb0, 0x29, 0xea, 0x79, 0xd6, 0x32, 0x3f, 0x9b, 0x66, 0xf9, 0xc1, 0xc4, 0x38, 0x5f,
-	0x5e, 0x18, 0x54, 0xda, 0xad, 0x97, 0x3a, 0xd3, 0xaf, 0x1d, 0xd8, 0x31, 0xf3, 0xb7, 0x68, 0x91,
-	0x45, 0xef, 0x8b, 0x24, 0x67, 0xcf, 0x6d, 0x91, 0xbb, 0x16, 0x5b, 0xfc, 0xc2, 0xc8, 0x23, 0x2e,
-	0x67, 0xd5, 0xc7, 0x0e, 0x5c, 0x9f, 0x98, 0x77, 0x95, 0xb0, 0xff, 0xf7, 0xc8, 0xfb, 0x57, 0x07,
-	0xb6, 0xad, 0x39, 0xb6, 0xab, 0x9f, 0x5d, 0xce, 0x1c, 0x74, 0x07, 0xa0, 0x1f, 0x47, 0x11, 0xed,
-	0x73, 0x33, 0x02, 0x5f, 0x54, 0x05, 0x33, 0x98, 0xf7, 0x7e, 0xee, 0x0c, 0xd7, 0x60, 0x35, 0x1e,
-	0xf1, 0x64, 0xc4, 0x75, 0xb8, 0xe9, 0xd5, 0xa5, 0x5c, 0xde, 0xfe, 0x53, 0x05, 0x2a, 0xe6, 0x69,
-	0x81, 0x4e, 0xa0, 0xfa, 0x88, 0x72, 0xfd, 0xf7, 0xc9, 0xee, 0x9c, 0x67, 0x9a, 0x0a, 0x90, 0x2f,
-	0x2f, 0x7c, 0xc8, 0xa1, 0xc1, 0x45, 0x0f, 0x18, 0x64, 0x1e, 0xe3, 0xc5, 0x6c, 0xab, 0xe3, 0x6b,
-	0x8b, 0x60, 0x5a, 0x51, 0x3a, 0x6f, 0x1e, 0x47, 0xb7, 0xa6, 0xa4, 0xcc, 0x42, 0xac, 0xc2, 0xaf,
-	0x2f, 0x03, 0xd5, 0x4a, 0xc3, 0x8b, 0xe7, 0x69, 0x74, 0x73, 0x4a, 0xce, 0x34, 0xc0, 0x2a, 0xdc,
-	0x5f, 0x0c, 0xd4, 0xea, 0x48, 0xf1, 0xcb, 0x0b, 0xed, 0x69, 0x09, 0x45, 0x4c, 0xab, 0xe6, 0x2b,
-	0xf3, 0x41, 0x5a, 0xc5, 0x77, 0x73, 0xe3, 0x36, 0x6a, 0xe8, 0x2d, 0x96, 0x62, 0x85, 0x5d, 0x2f,
-	0xe0, 0x68, 0x09, 0x9d, 0xc9, 0xe1, 0x17, 0xbd, 0x61, 0x5e, 0x70, 0x39, 0xa2, 0x95, 0x73, 0xa3,
-	0x98, 0xa9, 0x45, 0xfd, 0xb8, 0x68, 0xc2, 0x44, 0x26, 0xea, 0x66, 0x59, 0x56, 0x6c, 0x73, 0x1e,
-	0x44, 0x0b, 0xff, 0x49, 0xe1, 0x34, 0x83, 0xcc, 0xd6, 0x02, 0x9e, 0x15, 0xbf, 0x37, 0x17, 0x93,
-	0xc9, 0x2f, 0xe8, 0x52, 0x56, 0x7e, 0x51, 0x07, 0x9b, 0x96, 0x5f, 0x8c, 0xd1, 0xf2, 0xdf, 0x9b,
-	0x6e, 0x4a, 0xe8, 0x8b, 0x39, 0x67, 0x66, 0x64, 0x2b, 0xf5, 0x4b, 0x17, 0xb1, 0xb5, 0xc0, 0x6f,
-	0xaa, 0xff, 0x80, 0x91, 0xfd, 0x4b, 0x8d, 0xc7, 0x89, 0xdd, 0xbc, 0x33, 0x49, 0x54, 0x5b, 0xda,
-	0xff, 0x2c, 0x41, 0x2d, 0x57, 0xa7, 0xd1, 0x69, 0xbe, 0x7e, 0xec, 0x4d, 0x55, 0x87, 0x7c, 0x9b,
-	0x99, 0x89, 0xca, 0x0b, 0x40, 0xda, 0xb4, 0x64, 0x4e, 0x5b, 0x40, 0xfb, 0x45, 0x15, 0x22, 0x8f,
-	0xb0, 0xca, 0x6e, 0x2d, 0x81, 0xb4, 0x43, 0xc8, 0x6c, 0xc5, 0xb7, 0x15, 0x71, 0x86, 0x33, 0x53,
-	0x11, 0x8b, 0x10, 0x4a, 0xf2, 0x5b, 0xce, 0x25, 0x1c, 0xfd, 0x74, 0x55, 0x12, 0xef, 0xfc, 0x37,
-	0x00, 0x00, 0xff, 0xff, 0x21, 0xde, 0xf0, 0x95, 0xb4, 0x19, 0x00, 0x00,
 }

--- a/plugin/proto/plugin.proto
+++ b/plugin/proto/plugin.proto
@@ -98,7 +98,7 @@ message Schema {
 service Provider {
     //////// Information about what a provider supports/expects
     rpc GetSchema(GetProviderSchema.Request) returns (GetProviderSchema.Response);
-    rpc ValidateProviderConfig(ValidateProviderConfig.Request) returns (ValidateProviderConfig.Response);
+    rpc PrepareProviderConfig(PrepareProviderConfig.Request) returns (PrepareProviderConfig.Response);
     rpc ValidateResourceTypeConfig(ValidateResourceTypeConfig.Request) returns (ValidateResourceTypeConfig.Response);
     rpc ValidateDataSourceConfig(ValidateDataSourceConfig.Request) returns (ValidateDataSourceConfig.Response);
     rpc UpgradeResourceState(UpgradeResourceState.Request) returns (UpgradeResourceState.Response);
@@ -129,12 +129,13 @@ message GetProviderSchema {
     }
 }
 
-message ValidateProviderConfig {
+message PrepareProviderConfig {
     message Request {
         DynamicValue config = 1;
     }
     message Response {
-        repeated Diagnostic diagnostics = 1;
+        DynamicValue prepared_config = 1;
+        repeated Diagnostic diagnostics = 2;
     }
 }
 

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -14,9 +14,9 @@ type Interface interface {
 	// GetSchema returns the complete schema for the provider.
 	GetSchema() GetSchemaResponse
 
-	// ValidateProviderConfig allows the provider to validate the configuration
-	// values.
-	ValidateProviderConfig(ValidateProviderConfigRequest) ValidateProviderConfigResponse
+	// PrepareProviderConfig allows the provider to validate the configuration
+	// values, and set or override any values with defaults.
+	PrepareProviderConfig(PrepareProviderConfigRequest) PrepareProviderConfigResponse
 
 	// ValidateResourceTypeConfig allows the provider to validate the resource
 	// configuration values.
@@ -90,12 +90,14 @@ type Schema struct {
 	Block   *configschema.Block
 }
 
-type ValidateProviderConfigRequest struct {
-	// Config is the complete configuration value for the provider.
+type PrepareProviderConfigRequest struct {
+	// Config is the raw configuration value for the provider.
 	Config cty.Value
 }
 
-type ValidateProviderConfigResponse struct {
+type PrepareProviderConfigResponse struct {
+	// PreparedConfig is the configuration as prepared by the provider.
+	PreparedConfig cty.Value
 	// Diagnostics contains any warnings or errors from the method call.
 	Diagnostics tfdiags.Diagnostics
 }

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -603,7 +603,7 @@ func TestContext2Validate_providerConfig_bad(t *testing.T) {
 		),
 	})
 
-	p.ValidateProviderConfigResponse = providers.ValidateProviderConfigResponse{
+	p.PrepareProviderConfigResponse = providers.PrepareProviderConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
@@ -641,7 +641,7 @@ func TestContext2Validate_providerConfig_badEmpty(t *testing.T) {
 		),
 	})
 
-	p.ValidateProviderConfigResponse = providers.ValidateProviderConfigResponse{
+	p.PrepareProviderConfigResponse = providers.PrepareProviderConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
@@ -709,7 +709,7 @@ func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 		},
 	})
 
-	p.ValidateProviderConfigResponse = providers.ValidateProviderConfigResponse{
+	p.PrepareProviderConfigResponse = providers.PrepareProviderConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -98,11 +98,11 @@ func (n *EvalValidateProvider) Eval(ctx EvalContext) (interface{}, error) {
 		return nil, diags.NonFatalErr()
 	}
 
-	req := providers.ValidateProviderConfigRequest{
+	req := providers.PrepareProviderConfigRequest{
 		Config: configVal,
 	}
 
-	validateResp := provider.ValidateProviderConfig(req)
+	validateResp := provider.PrepareProviderConfig(req)
 	diags = diags.Append(validateResp.Diagnostics)
 
 	return nil, diags.NonFatalErr()

--- a/terraform/provider_mock.go
+++ b/terraform/provider_mock.go
@@ -26,10 +26,10 @@ type MockProvider struct {
 	GetSchemaCalled bool
 	GetSchemaReturn *ProviderSchema // This is using ProviderSchema directly rather than providers.GetSchemaResponse for compatibility with old tests
 
-	ValidateProviderConfigCalled   bool
-	ValidateProviderConfigResponse providers.ValidateProviderConfigResponse
-	ValidateProviderConfigRequest  providers.ValidateProviderConfigRequest
-	ValidateProviderConfigFn       func(providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse
+	PrepareProviderConfigCalled   bool
+	PrepareProviderConfigResponse providers.PrepareProviderConfigResponse
+	PrepareProviderConfigRequest  providers.PrepareProviderConfigRequest
+	PrepareProviderConfigFn       func(providers.PrepareProviderConfigRequest) providers.PrepareProviderConfigResponse
 
 	ValidateResourceTypeConfigCalled   bool
 	ValidateResourceTypeConfigTypeName string
@@ -133,16 +133,16 @@ func (p *MockProvider) getSchema() providers.GetSchemaResponse {
 	return ret
 }
 
-func (p *MockProvider) ValidateProviderConfig(r providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+func (p *MockProvider) PrepareProviderConfig(r providers.PrepareProviderConfigRequest) providers.PrepareProviderConfigResponse {
 	p.Lock()
 	defer p.Unlock()
 
-	p.ValidateProviderConfigCalled = true
-	p.ValidateProviderConfigRequest = r
-	if p.ValidateProviderConfigFn != nil {
-		return p.ValidateProviderConfigFn(r)
+	p.PrepareProviderConfigCalled = true
+	p.PrepareProviderConfigRequest = r
+	if p.PrepareProviderConfigFn != nil {
+		return p.PrepareProviderConfigFn(r)
 	}
-	return p.ValidateProviderConfigResponse
+	return p.PrepareProviderConfigResponse
 }
 
 func (p *MockProvider) ValidateResourceTypeConfig(r providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {


### PR DESCRIPTION
This PR changes the method name and all call sites for PrepareProviderConfig.

This does not yet include the new logic for setting the defaults, but will allow for any parallel work to be done in core while the plugin work is finished. 