### PR TITLE
don't set defaults for deprecated or removed

### DIFF
--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -115,6 +115,11 @@ func (s *GRPCProviderServer) PrepareProviderConfig(_ context.Context, req *proto
 			return val, nil
 		}
 
+		// this is deprecated, so don't set it
+		if attrSchema.Deprecated != "" || attrSchema.Removed != "" {
+			return val, nil
+		}
+
 		// find a default value if it exists
 		def, err := attrSchema.DefaultValue()
 		if err != nil {
@@ -129,6 +134,7 @@ func (s *GRPCProviderServer) PrepareProviderConfig(_ context.Context, req *proto
 		// create a cty.Value and make sure it's the correct type
 		tmpVal := hcl2shim.HCL2ValueFromConfigValue(def)
 		val, err = ctyconvert.Convert(tmpVal, val.Type())
+
 		return val, err
 	})
 

--- a/helper/plugin/grpc_provider_test.go
+++ b/helper/plugin/grpc_provider_test.go
@@ -533,6 +533,23 @@ func TestPrepareProviderConfig(t *testing.T) {
 				"foo": cty.StringVal("true"),
 			}),
 		},
+		{
+			Name: "test deprecated default",
+			Schema: map[string]*schema.Schema{
+				"foo": &schema.Schema{
+					Type:     schema.TypeString,
+					Required: true,
+					Default:  "do not use",
+					Removed:  "don't use this",
+				},
+			},
+			ConfigVal: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(cty.String),
+			}),
+			ExpectConfig: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(cty.String),
+			}),
+		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			server := &GRPCProviderServer{


### PR DESCRIPTION
These may still have defaults set, even if they are not intended to be
used.