### PR TITLE
Make the test compile again

### DIFF
--- a/backend/local/backend_refresh_test.go
+++ b/backend/local/backend_refresh_test.go
@@ -189,9 +189,8 @@ func TestLocal_refreshValidate(t *testing.T) {
 	}
 	<-run.Done()
 
-	// what are we validating?
-	if !p.ValidateProviderConfigCalled {
-		t.Fatal("validate should be called")
+	if !p.PrepareProviderConfigCalled {
+		t.Fatal("Prepare provider config should be called")
 	}
 
 	checkState(t, b.StateOutPath, `

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -797,8 +797,8 @@ func TestApply_planNoModuleFiles(t *testing.T) {
 		planPath,
 	}
 	apply.Run(args)
-	if p.ValidateProviderConfigCalled {
-		t.Fatal("Validate should not be called with a plan")
+	if p.PrepareProviderConfigCalled {
+		t.Fatal("Prepare provider config should not be called with a plan")
 	}
 }
 


### PR DESCRIPTION
Not sure if these checks still make sense, but without this change the test don’t compile for the related packages.