### PR TITLE
Chef: Gracefully Handle RFC062 Exit Codes

### DIFF
--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -391,7 +391,7 @@ func applyFn(ctx context.Context) error {
 
 	o.Output("Starting initial Chef-Client run...")
 
-	for attempt := 0; attempt < p.MaxRetries; attempt++ {
+	for attempt := 0; attempt <= p.MaxRetries; attempt++ {
 		// Make sure to (re)connect before trying to run Chef-Client.
 		if err := communicator.Retry(retryCtx, func() error {
 			return comm.Connect(o)
@@ -423,7 +423,11 @@ func applyFn(ctx context.Context) error {
 			err = nil
 		}
 
-		if p.RetryOnExitCode[exitError.ExitStatus] {
+		if !p.RetryOnExitCode[exitError.ExitStatus] {
+			return err
+		}
+
+		if attempt < p.MaxRetries {
 			o.Output(fmt.Sprintf("Waiting %s before retrying Chef-Client run...", p.WaitForRetry))
 			time.Sleep(p.WaitForRetry)
 		}

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"text/template"
+	"time"
 
 	"github.com/hashicorp/terraform/communicator"
 	"github.com/hashicorp/terraform/communicator/remote"
@@ -114,6 +115,9 @@ type provisioner struct {
 	UserKey               string
 	Vaults                map[string][]string
 	Version               string
+	RetryOnExitCode       []int
+	WaitForRetry          int
+	MaxRetries            int
 
 	cleanupUserKeyCmd     string
 	createConfigFiles     provisionFn
@@ -252,6 +256,23 @@ func Provisioner() terraform.ResourceProvisioner {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			// Same defaults as Test-Kitchen
+			// https://github.com/test-kitchen/test-kitchen/blob/e5998e0dd1aa42601c55659da78f9b112ff9f8ee/lib/kitchen/provisioner/base.rb#L36-38
+			"retry_on_exit_code": &schema.Schema{
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+				Optional: true,
+			},
+			"max_retries": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+			},
+			"wait_for_retry": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  30,
+			},
 		},
 
 		ApplyFunc:    applyFn,
@@ -315,6 +336,10 @@ func applyFn(ctx context.Context) error {
 	retryCtx, cancel := context.WithTimeout(ctx, comm.Timeout())
 	defer cancel()
 
+	// Graceful retry of RFC062 exit codes
+	var attempt int
+retry:
+
 	// Wait and retry until we establish the connection
 	err = communicator.Retry(retryCtx, func() error {
 		return comm.Connect(o)
@@ -334,44 +359,79 @@ func applyFn(ctx context.Context) error {
 	}
 	defer once.Do(cleanupUserKey)
 
-	if !p.SkipInstall {
-		if err := p.installChefClient(o, comm); err != nil {
-			return err
-		}
-	}
-
-	o.Output("Creating configuration files...")
-	if err := p.createConfigFiles(o, comm); err != nil {
-		return err
-	}
-
-	if !p.SkipRegister {
-		if p.FetchChefCertificates {
-			o.Output("Fetch Chef certificates...")
-			if err := p.fetchChefCertificates(o, comm); err != nil {
+	if attempt == 0 {
+		if !p.SkipInstall {
+			if err := p.installChefClient(o, comm); err != nil {
 				return err
 			}
 		}
 
-		o.Output("Generate the private key...")
-		if err := p.generateClientKey(o, comm); err != nil {
+		o.Output("Creating configuration files...")
+		if err := p.createConfigFiles(o, comm); err != nil {
 			return err
 		}
-	}
 
-	if p.Vaults != nil {
-		o.Output("Configure Chef vaults...")
-		if err := p.configureVaults(o, comm); err != nil {
-			return err
+		if !p.SkipRegister {
+			if p.FetchChefCertificates {
+				o.Output("Fetch Chef certificates...")
+				if err := p.fetchChefCertificates(o, comm); err != nil {
+					return err
+				}
+			}
+
+			o.Output("Generate the private key...")
+			if err := p.generateClientKey(o, comm); err != nil {
+				return err
+			}
 		}
+
+		if p.Vaults != nil {
+			o.Output("Configure Chef vaults...")
+			if err := p.configureVaults(o, comm); err != nil {
+				return err
+			}
+		}
+
+		// Cleanup the user key before we run Chef-Client to prevent issues
+		// with rights caused by changing settings during the run.
+		once.Do(cleanupUserKey)
+
+		o.Output("Starting initial Chef-Client run...")
 	}
 
-	// Cleanup the user key before we run Chef-Client to prevent issues
-	// with rights caused by changing settings during the run.
-	once.Do(cleanupUserKey)
-
-	o.Output("Starting initial Chef-Client run...")
 	if err := p.runChefClient(o, comm); err != nil {
+		// Allow RFC062 Exit Codes
+		// https://github.com/chef/chef-rfc/blob/master/rfc062-exit-status.md
+		exitError, ok := err.(*remote.ExitError)
+		if !ok {
+			return fmt.Errorf("Expected remote.ExitError but got: %w", err)
+		}
+		exitStatus := exitError.ExitStatus
+		switch exitStatus {
+		case 35:
+			o.Output("Reboot has been scheduled in the run state")
+			err = nil
+		case 37:
+			o.Output("Reboot needs to be completed")
+			err = nil
+		case 213:
+			o.Output("Chef has exited during a client upgrade")
+			err = nil
+		}
+
+		if len(p.RetryOnExitCode) == 0 || attempt == p.MaxRetries {
+			return err
+		}
+
+		for _, code := range p.RetryOnExitCode {
+			if code == exitStatus {
+				o.Output(fmt.Sprintf("Waiting %v seconds before reconnecting & re-running Chef...", p.WaitForRetry))
+				time.Sleep(time.Duration(p.WaitForRetry) * time.Second)
+				attempt++
+				goto retry
+			}
+		}
+
 		return err
 	}
 
@@ -745,6 +805,9 @@ func decodeConfig(d *schema.ResourceData) (*provisioner, error) {
 		UserName:              d.Get("user_name").(string),
 		UserKey:               d.Get("user_key").(string),
 		Version:               d.Get("version").(string),
+		RetryOnExitCode:       getIntList(d.Get("retry_on_exit_code")),
+		WaitForRetry:          d.Get("wait_for_retry").(int),
+		MaxRetries:            d.Get("max_retries").(int),
 	}
 
 	// Make sure the supplied URL has a trailing slash
@@ -792,6 +855,24 @@ func decodeConfig(d *schema.ResourceData) (*provisioner, error) {
 	}
 
 	return p, nil
+}
+
+func getIntList(v interface{}) []int {
+	var result []int
+
+	switch v := v.(type) {
+	case nil:
+		return result
+	case []interface{}:
+		for _, vv := range v {
+			if vv, ok := vv.(int); ok {
+				result = append(result, vv)
+			}
+		}
+		return result
+	default:
+		panic(fmt.Sprintf("Unsupported type: %T", v))
+	}
 }
 
 func getStringList(v interface{}) []string {

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -52,9 +52,8 @@ func New(s *terraform.InstanceState) (*Communicator, error) {
 
 // Connect implementation of communicator.Communicator interface
 func (c *Communicator) Connect(o terraform.UIOutput) error {
-	if c.client != nil {
-		return nil
-	}
+	// Set the client to nil since we'll (re)create it
+	c.client = nil
 
 	params := winrm.DefaultParameters
 	params.Timeout = formatDuration(c.Timeout())

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -58,7 +58,7 @@ func (c *Communicator) Connect(o terraform.UIOutput) error {
 
 	params := winrm.DefaultParameters
 	params.Timeout = formatDuration(c.Timeout())
-	if c.connInfo.NTLM == true {
+	if c.connInfo.NTLM {
 		params.TransportDecorator = func() winrm.Transporter { return &winrm.ClientNTLM{} }
 	}
 
@@ -189,7 +189,7 @@ func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
 		MaxOperationsPerShell: 15, // lowest common denominator
 	}
 
-	if c.connInfo.NTLM == true {
+	if c.connInfo.NTLM {
 		config.TransportDecorator = func() winrm.Transporter { return &winrm.ClientNTLM{} }
 	}
 

--- a/website/docs/provisioners/chef.html.markdown
+++ b/website/docs/provisioners/chef.html.markdown
@@ -111,7 +111,8 @@ The following arguments are supported:
 
 * `https_proxy (string)` - (Optional) The proxy server for Chef Client HTTPS connections.
 
-* `max_retries (integer)` - (Optional) The number of times to retry the provisioning process after receiving an exit code in the `retry_on_error` list. Defaults to `1`
+* `max_retries (integer)` - (Optional) The number of times to retry the provisioning process
+  after receiving an exit code in the `retry_on_error` list. Defaults to `1`
 
 * `named_run_list (string)` - (Optional) The name of an alternate run-list to invoke during the
   initial Chef Client run. The run-list must already exist in the Policyfile that defines
@@ -135,7 +136,9 @@ The following arguments are supported:
 * `recreate_client (boolean)` - (Optional) If `true`, first delete any existing Chef Node and
   Client before registering the new Chef Client.
 
-* `retry_on_error (list of integers)` - (Optional) The error codes upon which Terraform should gracefully retry the provisioning process.  Intended for use with [Chef RFC062 codes.](https://github.com/chef-boneyard/chef-rfc/blob/69a19f632cceffe965bafaad6765e3376068fd5b/rfc062-exit-status.md)
+* `retry_on_error (list of integers)` - (Optional) The error codes upon which Terraform should
+  gracefully retry the provisioning process. Intended for use with
+  [Chef RFC062 codes](https://github.com/chef-boneyard/chef-rfc/blob/master/rfc062-exit-status.md).
 
 * `run_list (array)` - (Optional) A list with recipes that will be invoked during the initial
   Chef Client run. The run-list will also be saved to the Chef Server after a successful
@@ -176,4 +179,6 @@ The following arguments are supported:
 * `version (string)` - (Optional) The Chef Client version to install on the remote machine.
   If not set, the latest available version will be installed.
 
-* `wait_for_retry (integer)` - (Optional) - Amount of time in seconds to wait before retrying the provisionining process after receiving an exit code in the `retry_on_error` list.  Defaults to `30`.
+* `wait_for_retry (integer)` - (Optional) - Amount of time in seconds to wait before
+  retrying the provisionining process after receiving an exit code in the `retry_on_error`
+  list.  Defaults to `30`.

--- a/website/docs/provisioners/chef.html.markdown
+++ b/website/docs/provisioners/chef.html.markdown
@@ -112,7 +112,7 @@ The following arguments are supported:
 * `https_proxy (string)` - (Optional) The proxy server for Chef Client HTTPS connections.
 
 * `max_retries (integer)` - (Optional) The number of times to retry the provisioning process
-  after receiving an exit code in the `retry_on_error` list. Defaults to `1`
+  after receiving an exit code in the `retry_on_error` list. Defaults to `0`
 
 * `named_run_list (string)` - (Optional) The name of an alternate run-list to invoke during the
   initial Chef Client run. The run-list must already exist in the Policyfile that defines
@@ -136,9 +136,10 @@ The following arguments are supported:
 * `recreate_client (boolean)` - (Optional) If `true`, first delete any existing Chef Node and
   Client before registering the new Chef Client.
 
-* `retry_on_error (list of integers)` - (Optional) The error codes upon which Terraform should
+* `retry_on_error (array)` - (Optional) The error codes upon which Terraform should
   gracefully retry the provisioning process. Intended for use with
   [Chef RFC062 codes](https://github.com/chef-boneyard/chef-rfc/blob/master/rfc062-exit-status.md).
+  (Defaults to `[35, 37, 213]`)
 
 * `run_list (array)` - (Optional) A list with recipes that will be invoked during the initial
   Chef Client run. The run-list will also be saved to the Chef Server after a successful

--- a/website/docs/provisioners/chef.html.markdown
+++ b/website/docs/provisioners/chef.html.markdown
@@ -60,8 +60,6 @@ resource "aws_instance" "web" {
     version         = "15.10.13"
     # If you have a self signed cert on your chef server change this to :verify_none
     ssl_verify_mode = ":verify_peer"
-    # Gracefully handle Chef upgrades, reboots, etc.
-    retry_on_exit_code = [35, 213]
   }
 }
 ```

--- a/website/docs/provisioners/chef.html.markdown
+++ b/website/docs/provisioners/chef.html.markdown
@@ -57,9 +57,11 @@ resource "aws_instance" "web" {
     recreate_client = true
     user_name       = "bork"
     user_key        = "${file("../bork.pem")}"
-    version         = "12.4.1"
+    version         = "15.10.13"
     # If you have a self signed cert on your chef server change this to :verify_none
     ssl_verify_mode = ":verify_peer"
+    # Gracefully handle Chef upgrades, reboots, etc.
+    retry_on_exit_code = [35, 213]
   }
 }
 ```
@@ -109,6 +111,8 @@ The following arguments are supported:
 
 * `https_proxy (string)` - (Optional) The proxy server for Chef Client HTTPS connections.
 
+* `max_retries (integer)` - (Optional) The number of times to retry the provisioning process after receiving an exit code in the `retry_on_error` list. Defaults to `1`
+
 * `named_run_list (string)` - (Optional) The name of an alternate run-list to invoke during the
   initial Chef Client run. The run-list must already exist in the Policyfile that defines
   `policy_name`. Only applies when `use_policyfile` is `true`.
@@ -130,6 +134,8 @@ The following arguments are supported:
 
 * `recreate_client (boolean)` - (Optional) If `true`, first delete any existing Chef Node and
   Client before registering the new Chef Client.
+
+* `retry_on_error (list of integers)` - (Optional) The error codes upon which Terraform should gracefully retry the provisioning process.  Intended for use with [Chef RFC062 codes.](https://github.com/chef-boneyard/chef-rfc/blob/69a19f632cceffe965bafaad6765e3376068fd5b/rfc062-exit-status.md)
 
 * `run_list (array)` - (Optional) A list with recipes that will be invoked during the initial
   Chef Client run. The run-list will also be saved to the Chef Server after a successful
@@ -169,3 +175,5 @@ The following arguments are supported:
 
 * `version (string)` - (Optional) The Chef Client version to install on the remote machine.
   If not set, the latest available version will be installed.
+
+* `wait_for_retry (integer)` - (Optional) - Amount of time in seconds to wait before retrying the provisionining process after receiving an exit code in the `retry_on_error` list.  Defaults to `30`.


### PR DESCRIPTION
Allows exit code 35 and 37 which do not imply Chef failure.

https://github.com/chef/chef-rfc/blob/master/rfc062-exit-status.md

Should help with #15134 and #16551
