### PR TITLE
Added TLS auth to http remote client

### DIFF
--- a/backend/remote-state/http/backend.go
+++ b/backend/remote-state/http/backend.go
@@ -164,6 +164,10 @@ func (b *Backend) configure(ctx context.Context) error {
 		}
 		tlsConfig.Certificates = []tls.Certificate{certificate}
 		tlsConfig.RootCAs, _ = x509.SystemCertPool()
+		if tlsConfig.RootCAs == nil {
+			//Work around windows issue
+			tlsConfig.RootCAs = x509.NewCertPool()
+		}
 		tlsConfig.BuildNameToCertificate()
 		client.Transport.(*http.Transport).TLSClientConfig = tlsConfig
 


### PR DESCRIPTION
- Seeing as the state storage is not plugin based like providers, I'd
like to be able to run an internal on premise service that will allow me
to use whatever i want as a final storage. To do that I'd like to be
able to use TLS certificates as an authentication mechanism.

Please let me know if this is something that aligns with the terraform
roadmap or if you'd like me to rework it.

I haven't added any tests because I'd like some feedback before
proceeding with this.