### PR TITLE
lang: Fix crash in lookup function

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -516,7 +516,7 @@ var LookupFunc = function.New(&function.Spec{
 		switch {
 		case ty.IsObjectType():
 			if !args[1].IsKnown() {
-				return args[2].Type(), nil
+				return cty.DynamicPseudoType, nil
 			}
 
 			key := args[1].AsString()

--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -512,9 +512,14 @@ var LookupFunc = function.New(&function.Spec{
 		}
 
 		ty := args[0].Type()
-		key := args[1].AsString()
+
 		switch {
 		case ty.IsObjectType():
+			if !args[1].IsKnown() {
+				return args[2].Type(), nil
+			}
+
+			key := args[1].AsString()
 			if ty.HasAttribute(key) {
 				return args[0].GetAttr(key).Type(), nil
 			} else if len(args) == 3 {

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -1255,6 +1255,25 @@ func TestLookup(t *testing.T) {
 			cty.UnknownVal(cty.String),
 			false,
 		},
+		{
+			[]cty.Value{
+				simpleMap,
+				cty.UnknownVal(cty.String),
+			},
+			cty.UnknownVal(cty.String),
+			false,
+		},
+		{
+			[]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("a"),
+					"bar": cty.StringVal("b"),
+				}),
+				cty.UnknownVal(cty.String),
+			},
+			cty.UnknownVal(cty.String),
+			false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Previously a config like this:

```hcl
locals {
  terraform_versions = {
    "terraform-provider-aws" = "0.10+"
  }
}
provider "github" {
  organization = var.organization_name
  token = var.github_token
}

data "github_repositories" "providers" {
  query = "org:${var.organization_name} archived:false aws OR azurerm OR google OR opc OR vsphere OR kubernetes"
}

data "github_repository" "provider" {
  count = length(data.github_repositories.providers.full_names)
  full_name = sort(data.github_repositories.providers.full_names)[count.index]
}

data "template_file" "readme" {
  count = length(data.github_repository.provider.*.ssh_clone_url)

  template = file("./templates/README.md")

  vars = {
    go_version = lookup(local.go_versions, data.github_repository.provider.*.name[count.index], local.default_go_version)
  }
}
```

caused a crash:

https://gist.github.com/radeksimko/012c83a42c9f6b647912b62b77e4f8ed