### PR TITLE
backend/local: do not use backend operation variables

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -143,7 +143,11 @@ type Operation struct {
 	ModuleDepth  int
 	Parallelism  int
 	Targets      []string
-	Variables    map[string]interface{}
+
+	// Variables should only contain any variables passed as command
+	// arguments and not any variables read from the terraform.tfvars
+	// or *.auto.tfvars files.
+	Variables map[string]interface{}
 
 	// Input/output/control options.
 	UIIn  terraform.UIInput

--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -55,8 +55,8 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 	opts.Module = op.Module
 	opts.Targets = op.Targets
 	opts.UIInput = op.UIIn
-	if op.Variables != nil {
-		opts.Variables = op.Variables
+	for k, v := range op.Variables {
+		opts.Variables[k] = v
 	}
 
 	// Load our state

--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -55,9 +55,6 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 	opts.Module = op.Module
 	opts.Targets = op.Targets
 	opts.UIInput = op.UIIn
-	for k, v := range op.Variables {
-		opts.Variables[k] = v
-	}
 
 	// Load our state
 	// By the time we get here, the backend creation code in "command" took

--- a/backend/local/test-fixtures/apply-vars/main.tf
+++ b/backend/local/test-fixtures/apply-vars/main.tf
@@ -1,0 +1,5 @@
+variable "foo" {}
+
+resource "test_instance" "foo" {
+    foo = "${var.foo}"
+}

--- a/backend/local/test-fixtures/plan-vars/main.tf
+++ b/backend/local/test-fixtures/plan-vars/main.tf
@@ -1,0 +1,11 @@
+variable "foo" {}
+
+resource "test_instance" "foo" {
+    foo = "${var.foo}"
+
+    # This is here because at some point it caused a test failure
+    network_interface {
+      device_index = 0
+      description = "Main network interface"
+    }
+}


### PR DESCRIPTION
Previously the `local` backend didn’t merge variables but completely replaced them when any backend operation variables were set.

Before [this change](https://github.com/hashicorp/terraform/commit/67db9da000#diff-a0d5ae04114a139f2356fb16fbac7581R174) this was essentially a dead codepath (that didn't have any tests) as the backend operation would never have a value for these variables and so the complete set of variables created while getting the `ContextOpts` would be used instead: https://github.com/hashicorp/terraform/blob/v0.11/command/meta.go#L312

But the variables were added to the backend operation because the `remote` backend needs access to these command line variables so they can be set as run variables. Run variables are not yet supported in this release, but this value is still used in the current `remote` backend to detect if command line variables were set, in which case a proper error can be returned.

We could also just remove the whole code path, instead of changing the behavior to merge instead of replace the variables. Will discuss that option before merging this.

I added a few tests to guard against this issue in any future releases.

Fixes #19163

_EDIT: See the first commit for this initial solution._