### PR TITLE
command/meta_backend: return backend config with merged one

### DIFF
--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -327,7 +327,7 @@ func (m *Meta) backendConfig(opts *BackendOpts) (*configs.Backend, int, tfdiags.
 	// We'll shallow-copy configs.Backend here so that we can replace the
 	// body without affecting others that hold this reference.
 	configCopy := *c
-	c.Config = configBody
+	configCopy.Config = configBody
 	return &configCopy, configHash, diags
 }
 


### PR DESCRIPTION
`backendConfig(opts)` returns a shallow copy of the configuration derived from input options as well as the comment on function describes.

This function merges the config and config-override given by input options and should return final merged configuration. But merged one is not returned since `configBody` is set into the original config, not the shallow copy.

**This commit fixes the bug that `-backend-config` CLI option for `terraform init` does not work.**

Following extra tests that haven't passed before are now resolved:
- `TestInit_backendConfigFile`
- `TestInit_backendConfigFileChange`
- `TestInit_backendConfigKV`
- `TestInit_backendReinitWithExtra`

**FYI:** Hashing is still obtained from config before merging overrides to follow c891ab50 commit. (But don't know why `TestInit_backendReinitConfigToExtra` still fails, out of scope)