### PR TITLE
command/meta: Return backend config with overridings merged

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -509,6 +509,14 @@ func TestInit_backendReinitConfigToExtra(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ui = new(cli.MockUi)
+	c = &InitCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			Ui:               ui,
+		},
+	}
+
 	args := []string{"-input=false", "-backend-config=path=foo"}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -327,7 +327,7 @@ func (m *Meta) backendConfig(opts *BackendOpts) (*configs.Backend, int, tfdiags.
 	// We'll shallow-copy configs.Backend here so that we can replace the
 	// body without affecting others that hold this reference.
 	configCopy := *c
-	c.Config = configBody
+	configCopy.Config = configBody
 	return &configCopy, configHash, diags
 }
 


### PR DESCRIPTION
`backendConfig(opts)` returns a shallow copy of the configuration derived from input options as well as the comment on it describes.

This function merges the config and config-override given by input options and should return final merged configuration. But merged one is not returned since `configBody` is set into the original config, not the shallow copy.

**This commit fixes the bug that `-backend-config` CLI option for `terraform init` does not work.**

Following extra tests that haven't passed before are now covered:
- `TestInit_backendConfigFile`
- `TestInit_backendConfigFileChange`
- `TestInit_backendConfigKV`
- `TestInit_backendReinitWithExtra`

**FYI:** Hashing is still obtained from config before merging overrides to follow c891ab50 commit.
~~(But don't know why `TestInit_backendReinitConfigToExtra` still fails, out of scope)~~
`TestInit_backendReinitConfigToExtra` is now covered after re-creating command instance just before second `Run()` is executed. New commit added (8ccfa3c).