### PR TITLE
provider timeouts

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -20,6 +20,7 @@ func Provider() terraform.ResourceProvider {
 			"test_resource":                  testResource(),
 			"test_resource_gh12183":          testResourceGH12183(),
 			"test_resource_with_custom_diff": testResourceCustomDiff(),
+			"test_resource_timeout":          testResourceTimeout(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"test_data_source":    testDataSource(),

--- a/builtin/providers/test/resource_timeout.go
+++ b/builtin/providers/test/resource_timeout.go
@@ -1,0 +1,120 @@
+package test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceTimeout() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceTimeoutCreate,
+		Read:   testResourceTimeoutRead,
+		Update: testResourceTimeoutUpdate,
+		Delete: testResourceTimeoutDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(time.Second),
+			Update: schema.DefaultTimeout(time.Second),
+			Delete: schema.DefaultTimeout(time.Second),
+		},
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"create_delay": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"read_delay": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"update_delay": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"delete_delay": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func testResourceTimeoutCreate(d *schema.ResourceData, meta interface{}) error {
+	delayString := d.Get("create_delay").(string)
+	var delay time.Duration
+	var err error
+	if delayString != "" {
+		delay, err = time.ParseDuration(delayString)
+		if err != nil {
+			return err
+		}
+	}
+
+	if delay > d.Timeout(schema.TimeoutCreate) {
+		return fmt.Errorf("timeout while creating resource")
+	}
+
+	d.SetId("testId")
+
+	return testResourceRead(d, meta)
+}
+
+func testResourceTimeoutRead(d *schema.ResourceData, meta interface{}) error {
+	delayString := d.Get("read_delay").(string)
+	var delay time.Duration
+	var err error
+	if delayString != "" {
+		delay, err = time.ParseDuration(delayString)
+		if err != nil {
+			return err
+		}
+	}
+
+	if delay > d.Timeout(schema.TimeoutRead) {
+		return fmt.Errorf("timeout while reading resource")
+	}
+
+	return nil
+}
+
+func testResourceTimeoutUpdate(d *schema.ResourceData, meta interface{}) error {
+	delayString := d.Get("update_delay").(string)
+	var delay time.Duration
+	var err error
+	if delayString != "" {
+		delay, err = time.ParseDuration(delayString)
+		if err != nil {
+			return err
+		}
+	}
+
+	if delay > d.Timeout(schema.TimeoutUpdate) {
+		return fmt.Errorf("timeout while updating resource")
+	}
+	return nil
+}
+
+func testResourceTimeoutDelete(d *schema.ResourceData, meta interface{}) error {
+	delayString := d.Get("delete_delay").(string)
+	var delay time.Duration
+	var err error
+	if delayString != "" {
+		delay, err = time.ParseDuration(delayString)
+		if err != nil {
+			return err
+		}
+	}
+
+	if delay > d.Timeout(schema.TimeoutDelete) {
+		return fmt.Errorf("timeout while deleting resource")
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/test/resource_timeout_test.go
+++ b/builtin/providers/test/resource_timeout_test.go
@@ -1,0 +1,91 @@
+package test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestResourceTimeout_create(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_timeout" "foo" {
+	create_delay = "2s"
+	timeouts {
+		create = "1s"
+	}
+}
+				`),
+				ExpectError: regexp.MustCompile("timeout while creating resource"),
+			},
+		},
+	})
+}
+func TestResourceTimeout_update(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_timeout" "foo" {
+	update_delay = "1s"
+	timeouts {
+		update = "1s"
+	}
+}
+				`),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_timeout" "foo" {
+	update_delay = "2s"
+	timeouts {
+		update = "1s"
+	}
+}
+				`),
+				ExpectError: regexp.MustCompile("timeout while updating resource"),
+			},
+		},
+	})
+}
+
+func TestResourceTimeout_read(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_timeout" "foo" {
+}
+				`),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_timeout" "foo" {
+	read_delay = "30m"
+}
+				`),
+				ExpectError: regexp.MustCompile("timeout while reading resource"),
+			},
+			// we need to remove the read_delay so that the resource can be
+			// destroyed in the final step, but expect an error here from the
+			// pre-existing delay.
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_timeout" "foo" {
+}
+				`),
+				ExpectError: regexp.MustCompile("timeout while reading resource"),
+			},
+		},
+	})
+}

--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -463,7 +463,7 @@ func (s *GRPCProviderServer) PlanResourceChange(_ context.Context, req *proto.Pl
 	}
 	priorState.Meta = priorPrivate
 
-	// turn the propsed state into a legacy configuration
+	// turn the proposed state into a legacy configuration
 	config := terraform.NewResourceConfigShimmed(proposedNewStateVal, block)
 
 	diff, err := s.provider.SimpleDiff(info, priorState, config)

--- a/helper/resource/testing_config.go
+++ b/helper/resource/testing_config.go
@@ -77,7 +77,7 @@ func testStep(opts terraform.ContextOpts, state *terraform.State, step TestStep,
 		}
 
 		// We need to keep a copy of the state prior to destroying
-		// such that destroy steps can verify their behaviour in the check
+		// such that destroy steps can verify their behavior in the check
 		// function
 		stateBeforeApplication := state.DeepCopy()
 

--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -172,48 +172,52 @@ func (r *Resource) CoreConfigSchema() *configschema.Block {
 		}
 	}
 
-	// insert configured timeout values into the schema
-	if r.Timeouts != nil {
+	_, timeoutsAttr := block.Attributes[TimeoutsConfigKey]
+	_, timeoutsBlock := block.BlockTypes[TimeoutsConfigKey]
+
+	// Insert configured timeout values into the schema, as long as the schema
+	// didn't define anything else by that name.
+	if r.Timeouts != nil && !timeoutsAttr && !timeoutsBlock {
 		timeouts := configschema.Block{
 			Attributes: map[string]*configschema.Attribute{},
 		}
 
 		if r.Timeouts.Create != nil {
-			timeouts.Attributes["create"] = &configschema.Attribute{
+			timeouts.Attributes[TimeoutCreate] = &configschema.Attribute{
 				Type:     cty.String,
 				Optional: true,
 			}
 		}
 
 		if r.Timeouts.Read != nil {
-			timeouts.Attributes["read"] = &configschema.Attribute{
+			timeouts.Attributes[TimeoutRead] = &configschema.Attribute{
 				Type:     cty.String,
 				Optional: true,
 			}
 		}
 
 		if r.Timeouts.Update != nil {
-			timeouts.Attributes["update"] = &configschema.Attribute{
+			timeouts.Attributes[TimeoutUpdate] = &configschema.Attribute{
 				Type:     cty.String,
 				Optional: true,
 			}
 		}
 
 		if r.Timeouts.Delete != nil {
-			timeouts.Attributes["delete"] = &configschema.Attribute{
+			timeouts.Attributes[TimeoutDelete] = &configschema.Attribute{
 				Type:     cty.String,
 				Optional: true,
 			}
 		}
 
 		if r.Timeouts.Default != nil {
-			timeouts.Attributes["default"] = &configschema.Attribute{
+			timeouts.Attributes[TimeoutDefault] = &configschema.Attribute{
 				Type:     cty.String,
 				Optional: true,
 			}
 		}
 
-		block.BlockTypes["timeouts"] = &configschema.NestedBlock{
+		block.BlockTypes[TimeoutsConfigKey] = &configschema.NestedBlock{
 			Nesting: configschema.NestingSingle,
 			Block:   timeouts,
 		}

--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -172,6 +172,53 @@ func (r *Resource) CoreConfigSchema() *configschema.Block {
 		}
 	}
 
+	// insert configured timeout values into the schema
+	if r.Timeouts != nil {
+		timeouts := configschema.Block{
+			Attributes: map[string]*configschema.Attribute{},
+		}
+
+		if r.Timeouts.Create != nil {
+			timeouts.Attributes["create"] = &configschema.Attribute{
+				Type:     cty.String,
+				Optional: true,
+			}
+		}
+
+		if r.Timeouts.Read != nil {
+			timeouts.Attributes["read"] = &configschema.Attribute{
+				Type:     cty.String,
+				Optional: true,
+			}
+		}
+
+		if r.Timeouts.Update != nil {
+			timeouts.Attributes["update"] = &configschema.Attribute{
+				Type:     cty.String,
+				Optional: true,
+			}
+		}
+
+		if r.Timeouts.Delete != nil {
+			timeouts.Attributes["delete"] = &configschema.Attribute{
+				Type:     cty.String,
+				Optional: true,
+			}
+		}
+
+		if r.Timeouts.Default != nil {
+			timeouts.Attributes["default"] = &configschema.Attribute{
+				Type:     cty.String,
+				Optional: true,
+			}
+		}
+
+		block.BlockTypes["timeouts"] = &configschema.NestedBlock{
+			Nesting: configschema.NestingSingle,
+			Block:   timeouts,
+		}
+	}
+
 	return block
 }
 

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -276,7 +276,7 @@ func newResourceConfigShimmedComputedKeys(obj cty.Value, schema *configschema.Bl
 		}
 
 		blockVal := obj.GetAttr(typeName)
-		if !blockVal.IsKnown() || blockVal.IsNull() {
+		if blockVal.IsNull() || !blockVal.IsKnown() {
 			continue
 		}
 


### PR DESCRIPTION
Resource timeouts were a separate config block, but did not exist in the
resource schema. Insert any defined timeouts when generating the
configshema.Block so that the fields can be accepted and validated by
core.

helper/schema will remove "timeouts" from the config, and stash them in
the diff.Meta map. Terraform sees "timeouts" as a regular config block,
so needs them to be present in the state in order to not show a diff.
Have the GRPCProviderServer shim copy all timeout values into any state
it returns to provide consistent diffs in core.

