### PR TITLE
update provider naming convention in readme

### DIFF
--- a/tools/terraform-bundle/README.md
+++ b/tools/terraform-bundle/README.md
@@ -114,7 +114,7 @@ To include custom plugins in the bundle file, create a local directory "./plugin
 and put all the plugins you want to include there. Optionally, you can use the
 `-plugin-dir` flag to specify a location where to find the plugins. To be recognized
 as a valid plugin, the file must have a name of the form
-`terraform-provider-<NAME>-v<VERSION>`. In
+`terraform-provider-<NAME>_v<VERSION>`. In
 addition, ensure that the plugin is built using the same operating system and
 architecture used for Terraform Enterprise. Typically this will be `linux` and `amd64`.
 


### PR DESCRIPTION
This updates the provider naming convention in the terraform-bundle readme to use an underscore rather than a hyphen before the version identifier.

This makes it so that the tool can identify the custom provider and its version properly when parsing the given directory for custom providers. (I confirmed in testing that terraform-bundle ignores files with a hyphen between the provider name and the version identifier.)

This is related to [PR 19196](https://github.com/hashicorp/terraform/pull/19196), which appears to fix the same error in a different part of the readme.