### PR TITLE
fix instance replacement

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -22,6 +22,7 @@ func Provider() terraform.ResourceProvider {
 			"test_resource_with_custom_diff": testResourceCustomDiff(),
 			"test_resource_timeout":          testResourceTimeout(),
 			"test_resource_diff_suppress":    testResourceDiffSuppress(),
+			"test_resource_force_new":        testResourceForceNew(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"test_data_source":    testDataSource(),

--- a/builtin/providers/test/resource_force_new.go
+++ b/builtin/providers/test/resource_force_new.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceForceNew() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceForceNewCreate,
+		Read:   testResourceForceNewRead,
+		Delete: testResourceForceNewDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"triggers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func testResourceForceNewCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("testId")
+	return testResourceForceNewRead(d, meta)
+}
+
+func testResourceForceNewRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceForceNewDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/test/resource_force_new_test.go
+++ b/builtin/providers/test/resource_force_new_test.go
@@ -1,0 +1,79 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestResourceForceNew_create(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_force_new" "foo" {
+  triggers = {
+	"a" = "foo"
+  }
+}`),
+			},
+		},
+	})
+}
+func TestResourceForceNew_update(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_force_new" "foo" {
+  triggers = {
+	"a" = "foo"
+  }
+}`),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_force_new" "foo" {
+  triggers = {
+	"a" = "bar"
+  }
+}`),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_force_new" "foo" {
+  triggers = {
+	"b" = "bar"
+  }
+}`),
+			},
+		},
+	})
+}
+
+func TestResourceForceNew_remove(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_force_new" "foo" {
+  triggers = {
+	"a" = "bar"
+  }
+}`),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_force_new" "foo" {
+}			`),
+			},
+		},
+	})
+}

--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -443,3 +443,33 @@ output "value_from_map_from_list" {
 func testAccCheckResourceDestroy(s *terraform.State) error {
 	return nil
 }
+
+func TestResource_removeForceNew(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+	required           = "yep"
+	required_map = {
+	  key = "value"
+	}
+	optional_force_new = "here"
+}
+				`),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+	required           = "yep"
+	required_map = {
+	  key = "value"
+	}
+}
+				`),
+			},
+		},
+	})
+}

--- a/config/hcl2shim/paths.go
+++ b/config/hcl2shim/paths.go
@@ -28,6 +28,10 @@ func RequiresReplace(attrs []string, ty cty.Type) ([]cty.Path, error) {
 		paths = append(paths, p)
 	}
 
+	// now trim off any trailing paths that aren't GetAttrSteps, since only an
+	// attribute itself can require replacement
+	paths = trimPaths(paths)
+
 	// There may be redundant paths due to set elements or index attributes
 	// Do some ugly n^2 filtering, but these are always fairly small sets.
 	for i := 0; i < len(paths)-1; i++ {
@@ -42,6 +46,30 @@ func RequiresReplace(attrs []string, ty cty.Type) ([]cty.Path, error) {
 	}
 
 	return paths, nil
+}
+
+// trimPaths removes any trailing steps that aren't of type GetAttrSet, since
+// only an attribute itself can require replacement
+func trimPaths(paths []cty.Path) []cty.Path {
+	var trimmed []cty.Path
+	for _, path := range paths {
+		path = trimPath(path)
+		if len(path) > 0 {
+			trimmed = append(trimmed, path)
+		}
+	}
+	return trimmed
+}
+
+func trimPath(path cty.Path) cty.Path {
+	for len(path) > 0 {
+		_, isGetAttr := path[len(path)-1].(cty.GetAttrStep)
+		if isGetAttr {
+			break
+		}
+		path = path[:len(path)-1]
+	}
+	return path
 }
 
 // requiresReplacePath takes a key from a flatmap along with the cty.Type

--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -399,12 +399,12 @@ func (s *GRPCProviderServer) ReadResource(_ context.Context, req *proto.ReadReso
 		// The old provider API used an empty id to signal that the remote
 		// object appears to have been deleted, but our new protocol expects
 		// to see a null value (in the cty sense) in that case.
-		newConfigMP, err := msgpack.Marshal(cty.NullVal(block.ImpliedType()), block.ImpliedType())
+		newStateMP, err := msgpack.Marshal(cty.NullVal(block.ImpliedType()), block.ImpliedType())
 		if err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 		}
 		resp.NewState = &proto.DynamicValue{
-			Msgpack: newConfigMP,
+			Msgpack: newStateMP,
 		}
 		return resp, nil
 	}

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -310,11 +310,15 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 		// from known prior values to unknown values, unless the provider is
 		// able to predict new values for any of these computed attributes.
 		nullPriorVal := cty.NullVal(schema.ImpliedType())
+
+		// create a new proposed value from the null state and the config
+		proposedNewVal = objchange.ProposedNewObject(schema, nullPriorVal, configVal)
+
 		resp = provider.PlanResourceChange(providers.PlanResourceChangeRequest{
 			TypeName:         n.Addr.Resource.Type,
 			Config:           configVal,
 			PriorState:       nullPriorVal,
-			ProposedNewState: configVal,
+			ProposedNewState: proposedNewVal,
 			PriorPrivate:     plannedPrivate,
 		})
 		// We need to tread carefully here, since if there are any warnings


### PR DESCRIPTION
Fields that were in the RequiresNew list must only be for object attributes. Trim off any trailing index steps from the set of paths.

Create a new proposed value when replacing an instance, using the null state and the config. This ensures that all unknown values are properly set.