### PR TITLE
null eval from output

### DIFF
--- a/plans/changes.go
+++ b/plans/changes.go
@@ -254,6 +254,7 @@ func (oc *OutputChange) Encode() (*OutputChangeSrc, error) {
 		return nil, err
 	}
 	return &OutputChangeSrc{
+		Addr:      oc.Addr,
 		ChangeSrc: *cs,
 		Sensitive: oc.Sensitive,
 	}, err

--- a/plans/changes_sync.go
+++ b/plans/changes_sync.go
@@ -133,8 +133,8 @@ func (cs *ChangesSync) RemoveOutputChange(addr addrs.AbsOutputValue) {
 	defer cs.lock.Unlock()
 
 	addrStr := addr.String()
-	for i, r := range cs.changes.Resources {
-		if r.Addr.String() != addrStr {
+	for i, o := range cs.changes.Outputs {
+		if o.Addr.String() != addrStr {
 			continue
 		}
 		copy(cs.changes.Outputs[i:], cs.changes.Outputs[i+1:])

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -5551,30 +5551,32 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 	}
 
 	for _, res := range plan.Changes.Resources {
-		if res.Action != plans.Create {
-			t.Fatalf("expected resource creation, got %s", res.Action)
-		}
-		ric, err := res.Decode(ty)
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Run(fmt.Sprintf("%s %s", res.Action, res.Addr), func(t *testing.T) {
+			if res.Action != plans.Create {
+				t.Fatalf("expected resource creation, got %s", res.Action)
+			}
+			ric, err := res.Decode(ty)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		var expected cty.Value
-		switch i := ric.Addr.String(); i {
-		case "test_resource.root":
-			expected = objectVal(t, schema, map[string]cty.Value{
-				"id":       cty.UnknownVal(cty.String),
-				"required": cty.UnknownVal(cty.String),
-			})
-		case "module.mod.test_resource.for_output":
-			expected = objectVal(t, schema, map[string]cty.Value{
-				"id":       cty.UnknownVal(cty.String),
-				"required": cty.StringVal("val"),
-			})
-		default:
-			t.Fatal("unknown instance:", i)
-		}
+			var expected cty.Value
+			switch i := ric.Addr.String(); i {
+			case "test_resource.root":
+				expected = objectVal(t, schema, map[string]cty.Value{
+					"id":       cty.UnknownVal(cty.String),
+					"required": cty.UnknownVal(cty.String),
+				})
+			case "module.mod.test_resource.for_output":
+				expected = objectVal(t, schema, map[string]cty.Value{
+					"id":       cty.UnknownVal(cty.String),
+					"required": cty.StringVal("val"),
+				})
+			default:
+				t.Fatal("unknown instance:", i)
+			}
 
-		checkVals(t, expected, ric.After)
+			checkVals(t, expected, ric.After)
+		})
 	}
 }

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -5580,3 +5580,70 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestContext2Plan_requiredModuleObject(t *testing.T) {
+	m := testModule(t, "plan-required-whole-mod")
+	p := testProvider("test")
+	p.GetSchemaReturn = &ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_resource": {
+				Attributes: map[string]*configschema.Attribute{
+					"id":       {Type: cty.String, Computed: true},
+					"required": {Type: cty.String, Required: true},
+				},
+			},
+		},
+	}
+	p.DiffFn = testDiffFn
+
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		ProviderResolver: providers.ResolverFixed(
+			map[string]providers.Factory{
+				"test": testProviderFuncFixed(p),
+			},
+		),
+	})
+
+	plan, diags := ctx.Plan()
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	schema := p.GetSchemaReturn.ResourceTypes["test_resource"]
+	ty := schema.ImpliedType()
+
+	if len(plan.Changes.Resources) != 2 {
+		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
+	}
+
+	for _, res := range plan.Changes.Resources {
+		t.Run(fmt.Sprintf("%s %s", res.Action, res.Addr), func(t *testing.T) {
+			if res.Action != plans.Create {
+				t.Fatalf("expected resource creation, got %s", res.Action)
+			}
+			ric, err := res.Decode(ty)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var expected cty.Value
+			switch i := ric.Addr.String(); i {
+			case "test_resource.root":
+				expected = objectVal(t, schema, map[string]cty.Value{
+					"id":       cty.UnknownVal(cty.String),
+					"required": cty.UnknownVal(cty.String),
+				})
+			case "module.mod.test_resource.for_output":
+				expected = objectVal(t, schema, map[string]cty.Value{
+					"id":       cty.UnknownVal(cty.String),
+					"required": cty.StringVal("val"),
+				})
+			default:
+				t.Fatal("unknown instance:", i)
+			}
+
+			checkVals(t, expected, ric.After)
+		})
+	}
+}

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -310,11 +310,15 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 		// from known prior values to unknown values, unless the provider is
 		// able to predict new values for any of these computed attributes.
 		nullPriorVal := cty.NullVal(schema.ImpliedType())
+
+		// create a new proposed value from the null state and the config
+		proposedNewVal = objchange.ProposedNewObject(schema, nullPriorVal, configVal)
+
 		resp = provider.PlanResourceChange(providers.PlanResourceChangeRequest{
 			TypeName:         n.Addr.Resource.Type,
 			Config:           configVal,
 			PriorState:       nullPriorVal,
-			ProposedNewState: configVal,
+			ProposedNewState: proposedNewVal,
 			PriorPrivate:     plannedPrivate,
 		})
 		// We need to tread carefully here, since if there are any warnings

--- a/terraform/test-fixtures/plan-required-output/main.tf
+++ b/terraform/test-fixtures/plan-required-output/main.tf
@@ -1,0 +1,7 @@
+resource "test_resource" "root" {
+  required = module.mod.object.id
+}
+
+module "mod" {
+  source = "./mod"
+}

--- a/terraform/test-fixtures/plan-required-output/mod/main.tf
+++ b/terraform/test-fixtures/plan-required-output/mod/main.tf
@@ -1,0 +1,7 @@
+resource "test_resource" "for_output" {
+  required = "val"
+}
+
+output "object" {
+  value = test_resource.for_output
+}

--- a/terraform/test-fixtures/plan-required-whole-mod/main.tf
+++ b/terraform/test-fixtures/plan-required-whole-mod/main.tf
@@ -1,0 +1,17 @@
+resource "test_resource" "root" {
+  required = local.object.id
+}
+
+locals {
+  # This indirection is here to force the evaluator to produce the whole
+  # module object here rather than just fetching the single "object" output.
+  # This makes this fixture different than plan-required-output, which just
+  # accesses module.mod.object.id directly and thus visits a different
+  # codepath in the evaluator.
+  mod    = module.mod
+  object = local.mod.object
+}
+
+module "mod" {
+  source = "./mod"
+}

--- a/terraform/test-fixtures/plan-required-whole-mod/mod/main.tf
+++ b/terraform/test-fixtures/plan-required-whole-mod/mod/main.tf
@@ -1,0 +1,7 @@
+resource "test_resource" "for_output" {
+  required = "val"
+}
+
+output "object" {
+  value = test_resource.for_output
+}


### PR DESCRIPTION
Failing minimal test for #19223

The issue is that the evaluation of the config (from `EvaluateBlock`) returns a `Null` value for the `required` field when referencing an attribute in a module output, rather than `Unknown`.