### PR TITLE
 don't apply unchanged attributes from legacy diffs

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -23,6 +23,7 @@ func Provider() terraform.ResourceProvider {
 			"test_resource_timeout":          testResourceTimeout(),
 			"test_resource_diff_suppress":    testResourceDiffSuppress(),
 			"test_resource_force_new":        testResourceForceNew(),
+			"test_resource_nested":           testResourceNested(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"test_data_source":    testDataSource(),

--- a/builtin/providers/test/resource_nested.go
+++ b/builtin/providers/test/resource_nested.go
@@ -1,0 +1,61 @@
+package test
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceNested() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceNestedCreate,
+		Read:   testResourceNestedRead,
+		Delete: testResourceNestedDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"optional": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"nested": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"string": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"optional": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testResourceNestedCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(fmt.Sprintf("%x", rand.Int63()))
+	return testResourceNestedRead(d, meta)
+}
+
+func testResourceNestedRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceNestedDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/test/resource_nested_test.go
+++ b/builtin/providers/test/resource_nested_test.go
@@ -1,0 +1,104 @@
+package test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceNested_basic(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested" "foo" {
+	nested {
+		string = "val"
+	}
+}
+				`),
+			},
+		},
+	})
+}
+
+func TestResourceNested_addRemove(t *testing.T) {
+	var id string
+	checkFunc := func(s *terraform.State) error {
+		root := s.ModuleByPath(addrs.RootModuleInstance)
+		res := root.Resources["test_resource_nested.foo"]
+		if res.Primary.ID == id {
+			return errors.New("expected new resource")
+		}
+		id = res.Primary.ID
+		return nil
+	}
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested" "foo" {
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested" "foo" {
+	nested {
+		string = "val"
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested" "foo" {
+	optional = true
+	nested {
+		string = "val"
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested" "foo" {
+	nested {
+		string = "val"
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested" "foo" {
+	nested {
+		string = "val"
+		optional = true
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested" "foo" {
+}
+				`),
+				Check: checkFunc,
+			},
+		},
+	})
+}

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -457,6 +457,11 @@ func (d *InstanceDiff) ApplyToValue(base cty.Value, schema *configschema.Block) 
 			continue
 		}
 
+		// sometimes helper/schema gives us values that aren't really a diff
+		if diff.Old == diff.New {
+			continue
+		}
+
 		attrs[attr] = diff.New
 	}
 


### PR DESCRIPTION
If a legacy diff has equal old and new values, don't apply the diff.
These would show up in sets, because of the overall change in set key, or because the stored value can't be differentiated from nil.

Fixes #19215