### PR TITLE
return state in tests even if cfg is invalid

### DIFF
--- a/helper/resource/testing_config.go
+++ b/helper/resource/testing_config.go
@@ -53,7 +53,7 @@ func testStep(opts terraform.ContextOpts, state *terraform.State, step TestStep,
 	}
 	if stepDiags := ctx.Validate(); len(stepDiags) > 0 {
 		if stepDiags.HasErrors() {
-			return nil, errwrap.Wrapf("config is invalid: {{err}}", stepDiags.Err())
+			return state, errwrap.Wrapf("config is invalid: {{err}}", stepDiags.Err())
 		}
 
 		log.Printf("[WARN] Config warnings:\n%s", stepDiags)


### PR DESCRIPTION
If a test config is invalid, there could still be previous state if the invalid config comes in a step after a valid config was applied. Currently, if that happens, resources are left dangling because the destroy step is skipped due to lack of state (see this [test log](https://ci-oss.hashicorp.engineering/repository/download/GoogleCloud_ProviderGoogleCloud/33605:id/debug-google-e5a6492-TestAccComputeFirewall_enableLogging.log) for an example). This fixes the bug.