### PR TITLE
Do not clear out a previous set state when refreshing

### DIFF
--- a/state/remote/state.go
+++ b/state/remote/state.go
@@ -69,7 +69,6 @@ func (s *State) refreshState() error {
 	// no remote state is OK
 	if payload == nil {
 		s.readState = nil
-		s.state = nil
 		s.lineage = ""
 		s.serial = 0
 		return nil


### PR DESCRIPTION
In the case when no state existed remotely and a new one was created locally, we don’t want to blow away the new local state when refreshing.