### PR TITLE
lang/funcs: Various fixes and refinements

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -87,7 +87,7 @@ var LengthFunc = function.New(&function.Spec{
 	Type: func(args []cty.Value) (cty.Type, error) {
 		collTy := args[0].Type()
 		switch {
-		case collTy == cty.String || collTy.IsTupleType() || collTy.IsListType() || collTy.IsMapType() || collTy.IsSetType() || collTy == cty.DynamicPseudoType:
+		case collTy == cty.String || collTy.IsTupleType() || collTy.IsObjectType() || collTy.IsListType() || collTy.IsMapType() || collTy.IsSetType() || collTy == cty.DynamicPseudoType:
 			return cty.Number, nil
 		default:
 			return cty.Number, fmt.Errorf("argument must be a string, a collection type, or a structural type")

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -1018,21 +1018,55 @@ func TestKeys(t *testing.T) {
 				"hello":   cty.NumberIntVal(1),
 				"goodbye": cty.StringVal("adieu"),
 			}),
-			cty.ListVal([]cty.Value{
+			cty.TupleVal([]cty.Value{
 				cty.StringVal("goodbye"),
 				cty.StringVal("hello"),
 			}),
 			false,
 		},
-		{ // Not a map
+		{ // for an unknown object we can still return the keys, since they are part of the type
+			cty.UnknownVal(cty.Object(map[string]cty.Type{
+				"hello":   cty.Number,
+				"goodbye": cty.String,
+			})),
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("goodbye"),
+				cty.StringVal("hello"),
+			}),
+			false,
+		},
+		{ // an empty object has no keys
+			cty.EmptyObjectVal,
+			cty.EmptyTupleVal,
+			false,
+		},
+		{ // an empty map has no keys, but the result should still be properly typed
+			cty.MapValEmpty(cty.Number),
+			cty.ListValEmpty(cty.String),
+			false,
+		},
+		{ // Unknown map has unknown keys
+			cty.UnknownVal(cty.Map(cty.String)),
+			cty.UnknownVal(cty.List(cty.String)),
+			false,
+		},
+		{ // Not a map at all, so invalid
 			cty.StringVal("foo"),
 			cty.NilVal,
 			true,
 		},
-		{ // Unknown map
-			cty.UnknownVal(cty.Map(cty.String)),
-			cty.UnknownVal(cty.List(cty.String)),
-			false,
+		{ // Can't get keys from a null object
+			cty.NullVal(cty.Object(map[string]cty.Type{
+				"hello":   cty.Number,
+				"goodbye": cty.String,
+			})),
+			cty.NilVal,
+			true,
+		},
+		{ // Can't get keys from a null map
+			cty.NullVal(cty.Map(cty.Number)),
+			cty.NilVal,
+			true,
 		},
 	}
 
@@ -2015,13 +2049,29 @@ func TestValues(t *testing.T) {
 		},
 		{
 			cty.ObjectVal(map[string]cty.Value{
-				"hello":  cty.StringVal("world"),
 				"what's": cty.StringVal("up"),
+				"hello":  cty.StringVal("world"),
 			}),
 			cty.TupleVal([]cty.Value{
 				cty.StringVal("world"),
 				cty.StringVal("up"),
 			}),
+			false,
+		},
+		{ // empty object
+			cty.EmptyObjectVal,
+			cty.EmptyTupleVal,
+			false,
+		},
+		{
+			cty.UnknownVal(cty.Object(map[string]cty.Type{
+				"what's": cty.String,
+				"hello":  cty.Bool,
+			})),
+			cty.UnknownVal(cty.Tuple([]cty.Type{
+				cty.Bool,
+				cty.String,
+			})),
 			false,
 		},
 		{ // note ordering: keys are sorted first
@@ -2051,12 +2101,20 @@ func TestValues(t *testing.T) {
 				"hello":  cty.ListVal([]cty.Value{cty.StringVal("world")}),
 				"what's": cty.UnknownVal(cty.List(cty.String)),
 			}),
-			cty.UnknownVal(cty.List(cty.List(cty.String))),
+			cty.ListVal([]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("world")}),
+				cty.UnknownVal(cty.List(cty.String)),
+			}),
 			false,
 		},
 		{ // empty m
 			cty.MapValEmpty(cty.DynamicPseudoType),
 			cty.ListValEmpty(cty.DynamicPseudoType),
+			false,
+		},
+		{ // unknown m
+			cty.UnknownVal(cty.Map(cty.String)),
+			cty.UnknownVal(cty.List(cty.String)),
 			false,
 		},
 	}

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -164,7 +164,23 @@ func TestLength(t *testing.T) {
 			cty.NumberIntVal(0),
 		},
 		{
+			cty.UnknownVal(cty.EmptyTuple),
+			cty.NumberIntVal(0),
+		},
+		{
 			cty.TupleVal([]cty.Value{cty.True}),
+			cty.NumberIntVal(1),
+		},
+		{
+			cty.EmptyObjectVal,
+			cty.NumberIntVal(0),
+		},
+		{
+			cty.UnknownVal(cty.EmptyObject),
+			cty.NumberIntVal(0),
+		},
+		{
+			cty.ObjectVal(map[string]cty.Value{"true": cty.True}),
 			cty.NumberIntVal(1),
 		},
 		{

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -1287,7 +1287,7 @@ func TestLookup(t *testing.T) {
 				}),
 				cty.UnknownVal(cty.String),
 			},
-			cty.UnknownVal(cty.String),
+			cty.DynamicVal, // if the key is unknown then we don't know which object attribute and thus can't know the type
 			false,
 		},
 	}


### PR DESCRIPTION
These commits include some fixes and refinements to the built-in function implementations:

* Object types were not being accepted for `length`, as reported in #19278.
* There was an intermittent panic bug for the `values` function due to it not consistently ordering attribute names when building the result type for values over an object. (#19204)
* There was a failing test from an earlier change to the `lookup` function's handling of unknown object values.
* While I was in the neighborhood of `values` anyway, I made some refinements to the precision of its results in some edgier cases:
  * `keys` on an unknown object type produces a known tuple result, since the attribute names are part of the type.
  * `values` on an unknown object type produces an unknown tuple result of the appropriate length.
  * `values` on a map value that is itself known but has unknown elements will now produce a _known_ list result that propagates those unknown element values, thus allowing any known elements from the map to be seen in the result.

