### PR TITLE
[WIP] Website documentation: Fix incorrect hcl syntax for gcs backend

### DIFF
--- a/website/docs/backends/types/gcs.html.md
+++ b/website/docs/backends/types/gcs.html.md
@@ -16,7 +16,7 @@ Stores the state as an object in a configurable prefix and bucket on [Google Clo
 
 ```hcl
 terraform {
-  backend "gcs" {
+  backend = "gcs" {
     bucket  = "tf-state-prod"
     prefix  = "terraform/state"
   }


### PR DESCRIPTION
Using a gcs backend as defined in the example I received an error.

> Error: data.terraform_remote_state.state: backend must be a single value, not a list

I have updated this example with HCL syntax that is properly importing state via a gcs backend.

Version of terraform: latest/v0.11.10

Please let me know if any other changes are required.