### PR TITLE
helper/schema: Avoid erroring out on undefined timeouts

### DIFF
--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/copystructure"
 )
@@ -105,10 +106,16 @@ func (t *ResourceTimeout) ConfigDecode(s *Resource, c *terraform.ResourceConfig)
 
 				*timeout = rt
 			}
-		} else {
-			log.Printf("[ERROR] Invalid timeout structure: %T", raw)
-			return fmt.Errorf("Invalid Timeout structure found")
+			return nil
 		}
+		if v, ok := raw.(string); ok && v == config.UnknownVariableValue {
+			// Timeout is not defined in the config
+			// Defaults will be used instead
+			return nil
+		}
+
+		log.Printf("[ERROR] Invalid timeout structure: %T", raw)
+		return fmt.Errorf("Invalid Timeout structure found")
 	}
 
 	return nil


### PR DESCRIPTION
This is to fix a bug I introduced in https://github.com/hashicorp/terraform/pull/19286

It also partially answers my question posed in that PR:

> I don't know why are we were not originally erroring out on invalid timeout types

I still believe we don't need to ignore any invalid types though.

## Before

```
$ make test TEST=./builtin/providers/test/...
```
```
==> Checking that code complies with gofmt requirements...
go generate ./...
2018/11/07 15:25:41 Generated command/internal_plugin_list.go
go list ./builtin/providers/test/... | xargs -t -n4 go test  -timeout=2m -parallel=4
go test -timeout=2m -parallel=4 github.com/hashicorp/terraform/builtin/providers/test
--- FAIL: TestResourceTimeout_read (0.01s)
    testing.go:583: Step 0 error: Error planning: [ERR] Error decoding timeout: Invalid Timeout structure found
FAIL
FAIL	github.com/hashicorp/terraform/builtin/providers/test	1.454s
```

## After

```
$ make test TEST=./builtin/providers/test/...
```
```
==> Checking that code complies with gofmt requirements...
go generate ./...
2018/11/07 15:44:05 Generated command/internal_plugin_list.go
go list ./builtin/providers/test/... | xargs -t -n4 go test -timeout=2m -parallel=4
go test -timeout=2m -parallel=4 github.com/hashicorp/terraform/builtin/providers/test
ok  	github.com/hashicorp/terraform/builtin/providers/test	1.375s
```