### PR TITLE
Add ssh keepalives to ssh communicator

### DIFF
--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -34,6 +34,9 @@ const (
 
 	// DefaultTimeout is used if there is no timeout given
 	DefaultTimeout = 5 * time.Minute
+
+	// DefaultKeepAliveInterval is used if there is no interval given
+	DefaultKeepAliveInterval = 30 * time.Second
 )
 
 // connectionInfo is decoded from the ConnInfo of the resource. These are the
@@ -50,6 +53,9 @@ type connectionInfo struct {
 	Timeout    string
 	ScriptPath string        `mapstructure:"script_path"`
 	TimeoutVal time.Duration `mapstructure:"-"`
+
+	KeepAliveInterval string `mapstructure:"keep_alive_interval"`
+	KeepAliveIntervalVal time.Duration `mapstructure:"-"`
 
 	BastionUser       string `mapstructure:"bastion_user"`
 	BastionPassword   string `mapstructure:"bastion_password"`
@@ -126,6 +132,12 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 		}
 	}
 
+	if connInfo.KeepAliveInterval != "" {
+		connInfo.KeepAliveIntervalVal = safeDuration(connInfo.KeepAliveInterval, DefaultKeepAliveInterval)
+	} else {
+		connInfo.KeepAliveIntervalVal = DefaultKeepAliveInterval
+	}
+
 	return connInfo, nil
 }
 
@@ -186,6 +198,7 @@ func prepareSSHConfig(connInfo *connectionInfo) (*sshConfig, error) {
 		config:     sshConf,
 		connection: connectFunc,
 		sshAgent:   sshAgent,
+		KeepAliveInterval:  connInfo.KeepAliveIntervalVal,
 	}
 	return config, nil
 }

--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -54,7 +54,7 @@ type connectionInfo struct {
 	ScriptPath string        `mapstructure:"script_path"`
 	TimeoutVal time.Duration `mapstructure:"-"`
 
-	KeepAliveInterval string `mapstructure:"keep_alive_interval"`
+	KeepAliveInterval    string        `mapstructure:"keep_alive_interval"`
 	KeepAliveIntervalVal time.Duration `mapstructure:"-"`
 
 	BastionUser       string `mapstructure:"bastion_user"`
@@ -195,10 +195,10 @@ func prepareSSHConfig(connInfo *connectionInfo) (*sshConfig, error) {
 	}
 
 	config := &sshConfig{
-		config:     sshConf,
-		connection: connectFunc,
-		sshAgent:   sshAgent,
-		KeepAliveInterval:  connInfo.KeepAliveIntervalVal,
+		config:            sshConf,
+		connection:        connectFunc,
+		sshAgent:          sshAgent,
+		KeepAliveInterval: connInfo.KeepAliveIntervalVal,
 	}
 	return config, nil
 }

--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -17,6 +17,7 @@ func TestProvisioner_connInfo(t *testing.T) {
 				"host":        "127.0.0.1",
 				"port":        "22",
 				"timeout":     "30s",
+				"keep_alive_interval":     "1m",
 
 				"bastion_host": "127.0.1.1",
 			},
@@ -62,6 +63,9 @@ func TestProvisioner_connInfo(t *testing.T) {
 		t.Fatalf("bad: %v", conf)
 	}
 	if conf.BastionPrivateKey != "someprivatekeycontents" {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.KeepAliveInterval != "1m" {
 		t.Fatalf("bad: %v", conf)
 	}
 }

--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -10,14 +10,14 @@ func TestProvisioner_connInfo(t *testing.T) {
 	r := &terraform.InstanceState{
 		Ephemeral: terraform.EphemeralState{
 			ConnInfo: map[string]string{
-				"type":        "ssh",
-				"user":        "root",
-				"password":    "supersecret",
-				"private_key": "someprivatekeycontents",
-				"host":        "127.0.0.1",
-				"port":        "22",
-				"timeout":     "30s",
-				"keep_alive_interval":     "1m",
+				"type":                "ssh",
+				"user":                "root",
+				"password":            "supersecret",
+				"private_key":         "someprivatekeycontents",
+				"host":                "127.0.0.1",
+				"port":                "22",
+				"timeout":             "30s",
+				"keep_alive_interval": "1m",
 
 				"bastion_host": "127.0.1.1",
 			},

--- a/website/docs/provisioners/connection.html.markdown
+++ b/website/docs/provisioners/connection.html.markdown
@@ -86,6 +86,9 @@ provisioner "file" {
 * `host_key` - The public key from the remote host or the signing CA, used to
   verify the connection.
 
+* `keep_alive_interval` - The interval keepalives will be sent to the server to keep the
+  ssh session active. Defaults to 30 seconds. Should be provided as a string like `30s` or `5m`.
+
 **Additional arguments only supported by the `winrm` connection type:**
 
 * `https` - Set to `true` to connect using HTTPS instead of HTTP.


### PR DESCRIPTION
This helps resolve an issue in stigged environments where the server-side ClientAliveInterval is set to a lower value (such as 300) and ClientAliveCount is set to 0. During the ssh provisioner if there is a long pause without data the server-side will disconnect causing terraform to fail. This would resolve that issue by sending session-level keepalive requests. The overhead of the ssh keepalive is minimal and shouldn't impact performance of anything. 

This should resolve #18517 based off a cursory search of open issues. 