### PR TITLE
website: add missing article

### DIFF
--- a/website/intro/getting-started/modules.html.md
+++ b/website/intro/getting-started/modules.html.md
@@ -180,7 +180,7 @@ a few minutes.
 ## Module Outputs
 
 Just as the module instance had input arguments such as `num_servers` above,
-module can also produce _output_ values, similar to resource attributes.
+a module can also produce _output_ values, similar to resource attributes.
 
 [The module's outputs reference](https://registry.terraform.io/modules/hashicorp/consul/aws?tab=outputs)
 describes all of the different values it produces. Overall, it exposes the


### PR DESCRIPTION
I think "a module" is better than "modules" in this case because it makes it clear that one module can have more than one output value.