### PR TITLE
Make the Atlas backend work after updating depencies

### DIFF
--- a/backend/atlas/state_client.go
+++ b/backend/atlas/state_client.go
@@ -2,6 +2,7 @@ package atlas
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"crypto/tls"
 	"crypto/x509"
@@ -231,7 +232,7 @@ func (c *stateClient) http() (*retryablehttp.Client, error) {
 	}
 	rc := retryablehttp.NewClient()
 
-	rc.CheckRetry = func(resp *http.Response, err error) (bool, error) {
+	rc.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 		if err != nil {
 			// don't bother retrying if the certs don't match
 			if err, ok := err.(*url.Error); ok {
@@ -239,10 +240,8 @@ func (c *stateClient) http() (*retryablehttp.Client, error) {
 					return false, nil
 				}
 			}
-			// continue retrying
-			return true, nil
 		}
-		return retryablehttp.DefaultRetryPolicy(resp, err)
+		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 	}
 
 	t := cleanhttp.DefaultTransport()

--- a/backend/atlas/state_client_test.go
+++ b/backend/atlas/state_client_test.go
@@ -2,6 +2,7 @@ package atlas
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"crypto/tls"
 	"crypto/x509"
@@ -83,12 +84,12 @@ func TestStateClient_noRetryOnBadCerts(t *testing.T) {
 	// Instrument CheckRetry to make sure we didn't retry
 	retries := 0
 	oldCheck := httpClient.CheckRetry
-	httpClient.CheckRetry = func(resp *http.Response, err error) (bool, error) {
+	httpClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 		if retries > 0 {
 			t.Fatal("retried after certificate error")
 		}
 		retries++
-		return oldCheck(resp, err)
+		return oldCheck(ctx, resp, err)
 	}
 
 	_, err = client.Get()

--- a/go.mod
+++ b/go.mod
@@ -62,11 +62,11 @@ require (
 	github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c // indirect
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-plugin v0.0.0-20181002195811-1faddcf740b6
-	github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6
+	github.com/hashicorp/go-retryablehttp v0.5.0
 	github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90
 	github.com/hashicorp/go-safetemp v0.0.0-20180326211150-b1a1dbde6fdc // indirect
 	github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86 // indirect
-	github.com/hashicorp/go-tfe v0.2.9
+	github.com/hashicorp/go-tfe v0.3.0
 	github.com/hashicorp/go-uuid v1.0.0
 	github.com/hashicorp/go-version v0.0.0-20180322230233-23480c066577
 	github.com/hashicorp/golang-lru v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-plugin v0.0.0-20181002195811-1faddcf740b6 h1:czAJ5CXRPr+6vd6RGdJelApnxNbK3dAkakgBwLEWfrc=
 github.com/hashicorp/go-plugin v0.0.0-20181002195811-1faddcf740b6/go.mod h1:JSqWYsict+jzcj0+xElxyrBQRPNoiWQuddnxArJ7XHQ=
-github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6 h1:qCv4319q2q7XKn0MQbi8p37hsJ+9Xo8e6yojA73JVxk=
-github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6/go.mod h1:fXcdFsQoipQa7mwORhKad5jmDCeSy/RCGzWA08PO0lM=
+github.com/hashicorp/go-retryablehttp v0.5.0 h1:aVN0FYnPwAgZI/hVzqwfMiM86ttcHTlQKbBVeVmXPIs=
+github.com/hashicorp/go-retryablehttp v0.5.0/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90 h1:9HVkPxOpo+yO93Ah4yrO67d/qh0fbLLWbKqhYjyHq9A=
 github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90/go.mod h1:o4zcYY1e0GEZI6eSEr+43QDYmuGglw1qSO6qdHUHCgg=
 github.com/hashicorp/go-safetemp v0.0.0-20180326211150-b1a1dbde6fdc h1:wAa9fGALVHfjYxZuXRnmuJG2CnwRpJYOTvY6YdErAh0=
@@ -147,10 +147,8 @@ github.com/hashicorp/go-slug v0.1.0 h1:MJGEiOwRGrQCBmMMZABHqIESySFJ4ajrsjgDI4/aF
 github.com/hashicorp/go-slug v0.1.0/go.mod h1:+zDycQOzGqOqMW7Kn2fp9vz/NtqpMLQlgb9JUF+0km4=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86 h1:7YOlAIO2YWnJZkQp7B5eFykaIY7C9JndqAFQyVV5BhM=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
-github.com/hashicorp/go-tfe v0.2.7 h1:Cy0irO9Qfgdn7FmvxSoXIQrRa3iM/kFmp/c0oCboCow=
-github.com/hashicorp/go-tfe v0.2.7/go.mod h1:WJgjAJVdnXYPOWF6j66VI20djUGfeFjeayIgUDhohsU=
-github.com/hashicorp/go-tfe v0.2.9 h1:CmxjF5zBKh5XBf2fMseJPaSKxKIauIIS4r+6+hNX8JM=
-github.com/hashicorp/go-tfe v0.2.9/go.mod h1:WJgjAJVdnXYPOWF6j66VI20djUGfeFjeayIgUDhohsU=
+github.com/hashicorp/go-tfe v0.3.0 h1:X0oM8RNKgMlmaMOEzLkx8/RTIC3d2K30R8+G4cSXJPc=
+github.com/hashicorp/go-tfe v0.3.0/go.mod h1:SRMjgjY06SfEKstIPRUVMtQfhSYR2H3GHVop0lfedkY=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v0.0.0-20180322230233-23480c066577 h1:at4+18LrM8myamuV7/vT6x2s1JNXp2k4PsSbt4I02X4=

--- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
+++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
@@ -49,6 +49,9 @@ var (
 	// a new client. It is purposely private to avoid modifications.
 	defaultClient = NewClient()
 
+	// random is used to generate pseudo-random numbers.
+	random = rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	// We need to consume response bodies to maintain http connections, but
 	// limit the size we consume to respReadLimit.
 	respReadLimit = int64(4096)
@@ -319,14 +322,11 @@ func LinearJitterBackoff(min, max time.Duration, attemptNum int, resp *http.Resp
 		return min * time.Duration(attemptNum)
 	}
 
-	// Seed rand; doing this every time is fine
-	rand := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
-
 	// Pick a random number that lies somewhere between the min and max and
 	// multiply by the attemptNum. attemptNum starts at zero so we always
 	// increment here. We first get a random percentage, then apply that to the
 	// difference between min and max, and add to min.
-	jitter := rand.Float64() * float64(max-min)
+	jitter := random.Float64() * float64(max-min)
 	jitterMin := int64(jitter) + int64(min)
 	return time.Duration(jitterMin * int64(attemptNum))
 }

--- a/vendor/github.com/hashicorp/go-retryablehttp/go.mod
+++ b/vendor/github.com/hashicorp/go-retryablehttp/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/go-retryablehttp
+
+require github.com/hashicorp/go-cleanhttp v0.5.0

--- a/vendor/github.com/hashicorp/go-retryablehttp/go.sum
+++ b/vendor/github.com/hashicorp/go-retryablehttp/go.sum
@@ -1,0 +1,2 @@
+github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
+github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-tfe/go.mod
+++ b/vendor/github.com/hashicorp/go-tfe/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.0
-	github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6
+	github.com/hashicorp/go-retryablehttp v0.5.0
 	github.com/hashicorp/go-slug v0.1.0
 	github.com/hashicorp/go-uuid v1.0.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/vendor/github.com/hashicorp/go-tfe/go.sum
+++ b/vendor/github.com/hashicorp/go-tfe/go.sum
@@ -4,8 +4,8 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6 h1:qCv4319q2q7XKn0MQbi8p37hsJ+9Xo8e6yojA73JVxk=
-github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6/go.mod h1:fXcdFsQoipQa7mwORhKad5jmDCeSy/RCGzWA08PO0lM=
+github.com/hashicorp/go-retryablehttp v0.5.0 h1:aVN0FYnPwAgZI/hVzqwfMiM86ttcHTlQKbBVeVmXPIs=
+github.com/hashicorp/go-retryablehttp v0.5.0/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-slug v0.1.0 h1:MJGEiOwRGrQCBmMMZABHqIESySFJ4ajrsjgDI4/aFI0=
 github.com/hashicorp/go-slug v0.1.0/go.mod h1:+zDycQOzGqOqMW7Kn2fp9vz/NtqpMLQlgb9JUF+0km4=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=

--- a/vendor/github.com/hashicorp/go-tfe/policy_set.go
+++ b/vendor/github.com/hashicorp/go-tfe/policy_set.go
@@ -16,7 +16,7 @@ var _ PolicySets = (*policySets)(nil)
 //
 // TFE API docs: https://www.terraform.io/docs/enterprise/api/policies.html
 type PolicySets interface {
-	// List all the policy sets for a given organization
+	// List all the policy sets for a given organization.
 	List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error)
 
 	// Create a policy set and associate it with an organization.
@@ -34,11 +34,11 @@ type PolicySets interface {
 	// Remove policies from a policy set.
 	RemovePolicies(ctx context.Context, policySetID string, options PolicySetRemovePoliciesOptions) error
 
-	// Attach a policy set to workspaces.
-	AttachToWorkspaces(ctx context.Context, policySetID string, options PolicySetAttachToWorkspacesOptions) error
+	// Add workspaces to a policy set.
+	AddWorkspaces(ctx context.Context, policySetID string, options PolicySetAddWorkspacesOptions) error
 
-	// Detach a policy set from workspaces.
-	DetachFromWorkspaces(ctx context.Context, policySetID string, options PolicySetDetachFromWorkspacesOptions) error
+	// Remove workspaces from a policy set.
+	RemoveWorkspaces(ctx context.Context, policySetID string, options PolicySetRemoveWorkspacesOptions) error
 
 	// Delete a policy set by its ID.
 	Delete(ctx context.Context, policyID string) error
@@ -49,7 +49,7 @@ type policySets struct {
 	client *Client
 }
 
-// PolicySetList represents a list of policy sets..
+// PolicySetList represents a list of policy sets.
 type PolicySetList struct {
 	*Pagination
 	Items []*PolicySet
@@ -80,7 +80,7 @@ type PolicySetListOptions struct {
 	Search *string `url:"search[name],omitempty"`
 }
 
-// List all the policies for a given organization
+// List all the policies for a given organization.
 func (s *policySets) List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error) {
 	if !validStringID(&organization) {
 		return nil, errors.New("invalid value for organization")
@@ -118,7 +118,7 @@ type PolicySetCreateOptions struct {
 	// The initial members of the policy set.
 	Policies []*Policy `jsonapi:"relation,policies,omitempty"`
 
-	// The initial list of workspaces the policy set should be attached to.
+	// The initial list of workspaces for which the policy set should be enforced.
 	Workspaces []*Workspace `jsonapi:"relation,workspaces,omitempty"`
 }
 
@@ -229,7 +229,8 @@ func (s *policySets) Update(ctx context.Context, policySetID string, options Pol
 	return ps, err
 }
 
-// PolicySetAddPoliciesOptions represents the options for adding policies to a policy set.
+// PolicySetAddPoliciesOptions represents the options for adding policies
+// to a policy set.
 type PolicySetAddPoliciesOptions struct {
 	/// The policies to add to the policy set.
 	Policies []*Policy
@@ -263,7 +264,8 @@ func (s *policySets) AddPolicies(ctx context.Context, policySetID string, option
 	return s.client.do(ctx, req, nil)
 }
 
-// PolicySetRemovePoliciesOptions represents the options for removing policies from a policy set.
+// PolicySetRemovePoliciesOptions represents the options for removing
+// policies from a policy set.
 type PolicySetRemovePoliciesOptions struct {
 	/// The policies to remove from the policy set.
 	Policies []*Policy
@@ -297,13 +299,14 @@ func (s *policySets) RemovePolicies(ctx context.Context, policySetID string, opt
 	return s.client.do(ctx, req, nil)
 }
 
-// PolicySetAttachToWorkspacesOptions represents the options for attaching a policy set to workspaces.
-type PolicySetAttachToWorkspacesOptions struct {
-	/// The workspaces on which to attach the policy set.
+// PolicySetAddWorkspacesOptions represents the options for adding workspaces
+// to a policy set.
+type PolicySetAddWorkspacesOptions struct {
+	/// The workspaces to add to the policy set.
 	Workspaces []*Workspace
 }
 
-func (o PolicySetAttachToWorkspacesOptions) valid() error {
+func (o PolicySetAddWorkspacesOptions) valid() error {
 	if o.Workspaces == nil {
 		return errors.New("workspaces is required")
 	}
@@ -313,8 +316,8 @@ func (o PolicySetAttachToWorkspacesOptions) valid() error {
 	return nil
 }
 
-// Attach a policy set to workspaces
-func (s *policySets) AttachToWorkspaces(ctx context.Context, policySetID string, options PolicySetAttachToWorkspacesOptions) error {
+// Add workspaces to a policy set.
+func (s *policySets) AddWorkspaces(ctx context.Context, policySetID string, options PolicySetAddWorkspacesOptions) error {
 	if !validStringID(&policySetID) {
 		return errors.New("invalid value for policy set ID")
 	}
@@ -331,13 +334,14 @@ func (s *policySets) AttachToWorkspaces(ctx context.Context, policySetID string,
 	return s.client.do(ctx, req, nil)
 }
 
-// PolicySetDetachFromWorkspacesOptions represents the options for detaching a policy set from workspaces.
-type PolicySetDetachFromWorkspacesOptions struct {
-	/// The workspaces from which to detach the policy set.
+// PolicySetRemoveWorkspacesOptions represents the options for removing
+// workspaces from a policy set.
+type PolicySetRemoveWorkspacesOptions struct {
+	/// The workspaces to remove from the policy set.
 	Workspaces []*Workspace
 }
 
-func (o PolicySetDetachFromWorkspacesOptions) valid() error {
+func (o PolicySetRemoveWorkspacesOptions) valid() error {
 	if o.Workspaces == nil {
 		return errors.New("workspaces is required")
 	}
@@ -347,8 +351,8 @@ func (o PolicySetDetachFromWorkspacesOptions) valid() error {
 	return nil
 }
 
-// Detach a policy set from workspaces
-func (s *policySets) DetachFromWorkspaces(ctx context.Context, policySetID string, options PolicySetDetachFromWorkspacesOptions) error {
+// Remove workspaces from a policy set.
+func (s *policySets) RemoveWorkspaces(ctx context.Context, policySetID string, options PolicySetRemoveWorkspacesOptions) error {
 	if !validStringID(&policySetID) {
 		return errors.New("invalid value for policy set ID")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,7 @@ github.com/hashicorp/go-hclog
 github.com/hashicorp/go-multierror
 # github.com/hashicorp/go-plugin v0.0.0-20181002195811-1faddcf740b6
 github.com/hashicorp/go-plugin
-# github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6
+# github.com/hashicorp/go-retryablehttp v0.5.0
 github.com/hashicorp/go-retryablehttp
 # github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90
 github.com/hashicorp/go-rootcerts
@@ -315,7 +315,7 @@ github.com/hashicorp/go-rootcerts
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.1.0
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.2.9
+# github.com/hashicorp/go-tfe v0.3.0
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.0
 github.com/hashicorp/go-uuid


### PR DESCRIPTION
Newer versions of the retryablehttp package use a context, so we need to
add that in our custom `CheckRetry` function.

In addition I removed the `return true, nil` to continue retrying in
case of an error, and instead directly call the `DefaultRetryPolicy`.
This is because the `DefaultRetryPolicy` will now also take the context
into consideration.