### PR TITLE
backend/remote: change how to fall back to a local backend

### DIFF
--- a/backend/init/init.go
+++ b/backend/init/init.go
@@ -3,7 +3,6 @@
 package init
 
 import (
-	"os"
 	"sync"
 
 	"github.com/hashicorp/terraform/backend"
@@ -48,14 +47,8 @@ func Init(services *disco.Disco) {
 
 	backends = map[string]backend.InitFn{
 		// Enhanced backends.
-		"local": func() backend.Backend { return backendLocal.New() },
-		"remote": func() backend.Backend {
-			b := backendRemote.New(services)
-			if os.Getenv("TF_FORCE_LOCAL_BACKEND") != "" {
-				return backendLocal.NewWithBackend(b)
-			}
-			return b
-		},
+		"local":  func() backend.Backend { return backendLocal.New() },
+		"remote": func() backend.Backend { return backendRemote.New(services) },
 
 		// Remote State backends.
 		"artifactory": func() backend.Backend { return backendArtifactory.New() },

--- a/backend/init/init_test.go
+++ b/backend/init/init_test.go
@@ -1,11 +1,8 @@
 package init
 
 import (
-	"os"
 	"reflect"
 	"testing"
-
-	backendLocal "github.com/hashicorp/terraform/backend/local"
 )
 
 func TestInit_backend(t *testing.T) {
@@ -42,44 +39,5 @@ func TestInit_backend(t *testing.T) {
 				t.Fatalf("expected backend %q to be %q, got: %q", b.Name, b.Type, bType)
 			}
 		})
-	}
-}
-
-func TestInit_forceLocalBackend(t *testing.T) {
-	// Initialize the backends map
-	Init(nil)
-
-	enhancedBackends := []struct {
-		Name string
-		Type string
-	}{
-		{"local", "nil"},
-		{"remote", "*remote.Remote"},
-	}
-
-	// Set the TF_FORCE_LOCAL_BACKEND flag so all enhanced backends will
-	// return a local.Local backend with themselves as embedded backend.
-	if err := os.Setenv("TF_FORCE_LOCAL_BACKEND", "1"); err != nil {
-		t.Fatalf("error setting environment variable TF_FORCE_LOCAL_BACKEND: %v", err)
-	}
-	defer os.Unsetenv("TF_FORCE_LOCAL_BACKEND")
-
-	// Make sure we always get the local backend.
-	for _, b := range enhancedBackends {
-		f := Backend(b.Name)
-
-		local, ok := f().(*backendLocal.Local)
-		if !ok {
-			t.Fatalf("expected backend %q to be \"*local.Local\", got: %T", b.Name, f())
-		}
-
-		bType := "nil"
-		if local.Backend != nil {
-			bType = reflect.TypeOf(local.Backend).String()
-		}
-
-		if bType != b.Type {
-			t.Fatalf("expected local.Backend to be %s, got: %s", b.Type, bType)
-		}
 	}
 }

--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -258,9 +258,6 @@ func (b *Local) DeleteWorkspace(name string) error {
 }
 
 func (b *Local) StateMgr(name string) (statemgr.Full, error) {
-	statePath, stateOutPath, backupPath := b.StatePaths(name)
-	log.Printf("[TRACE] backend/local: state manager for workspace %q will:\n - read initial snapshot from %s\n - write new snapshots to %s\n - create any backup at %s", name, statePath, stateOutPath, backupPath)
-
 	// If we have a backend handling state, delegate to that.
 	if b.Backend != nil {
 		return b.Backend.StateMgr(name)
@@ -273,6 +270,9 @@ func (b *Local) StateMgr(name string) (statemgr.Full, error) {
 	if err := b.createState(name); err != nil {
 		return nil, err
 	}
+
+	statePath, stateOutPath, backupPath := b.StatePaths(name)
+	log.Printf("[TRACE] backend/local: state manager for workspace %q will:\n - read initial snapshot from %s\n - write new snapshots to %s\n - create any backup at %s", name, statePath, stateOutPath, backupPath)
 
 	s := statemgr.NewFilesystemBetweenPaths(statePath, stateOutPath)
 	if backupPath != "" {

--- a/backend/local/backend_apply_test.go
+++ b/backend/local/backend_apply_test.go
@@ -25,8 +25,8 @@ import (
 func TestLocal_applyBasic(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
-	p := TestLocalProvider(t, b, "test", applyFixtureSchema())
 
+	p := TestLocalProvider(t, b, "test", applyFixtureSchema())
 	p.ApplyResourceChangeResponse = providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{
 		"id":  cty.StringVal("yes"),
 		"ami": cty.StringVal("bar"),
@@ -95,8 +95,8 @@ func TestLocal_applyEmptyDir(t *testing.T) {
 func TestLocal_applyEmptyDirDestroy(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
-	p := TestLocalProvider(t, b, "test", &terraform.ProviderSchema{})
 
+	p := TestLocalProvider(t, b, "test", &terraform.ProviderSchema{})
 	p.ApplyResourceChangeResponse = providers.ApplyResourceChangeResponse{}
 
 	op, configCleanup := testOperationApply(t, "./test-fixtures/empty")
@@ -122,6 +122,7 @@ func TestLocal_applyEmptyDirDestroy(t *testing.T) {
 func TestLocal_applyError(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
+
 	p := TestLocalProvider(t, b, "test", nil)
 	p.GetSchemaReturn = &terraform.ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{

--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -188,7 +188,6 @@ func (b *Local) opPlan(
 }
 
 func (b *Local) renderPlan(plan *plans.Plan, schemas *terraform.Schemas) {
-
 	counts := map[plans.Action]int{}
 	for _, change := range plan.Changes.Resources {
 		counts[change.Action]++

--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -25,6 +25,8 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/colorstring"
 	"github.com/zclconf/go-cty/cty"
+
+	backendLocal "github.com/hashicorp/terraform/backend/local"
 )
 
 const (
@@ -49,27 +51,35 @@ type Remote struct {
 	// Operation. See Operation for more details.
 	ContextOpts *terraform.ContextOpts
 
-	// client is the remote backend API client
+	// client is the remote backend API client.
 	client *tfe.Client
 
-	// hostname of the remote backend server
+	// hostname of the remote backend server.
 	hostname string
 
-	// organization is the organization that contains the target workspaces
+	// organization is the organization that contains the target workspaces.
 	organization string
 
-	// workspace is used to map the default workspace to a remote workspace
+	// workspace is used to map the default workspace to a remote workspace.
 	workspace string
 
-	// prefix is used to filter down a set of workspaces that use a single
+	// prefix is used to filter down a set of workspaces that use a single.
 	// configuration
 	prefix string
 
-	// schema defines the configuration for the backend
+	// schema defines the configuration for the backend.
 	schema *schema.Backend
 
 	// services is used for service discovery
 	services *disco.Disco
+
+	// local, if non-nil, will be used for all enhanced behavior. This
+	// allows local behavior with the remote backend functioning as remote
+	// state storage backend.
+	local backend.Enhanced
+
+	// forceLocal, if true, will force the use of the local backend.
+	forceLocal bool
 
 	// opLock locks operations
 	opLock sync.Mutex
@@ -84,6 +94,7 @@ func New(services *disco.Disco) *Remote {
 	}
 }
 
+// ConfigSchema implements backend.Enhanced.
 func (b *Remote) ConfigSchema() *configschema.Block {
 	return &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
@@ -126,6 +137,7 @@ func (b *Remote) ConfigSchema() *configschema.Block {
 	}
 }
 
+// ValidateConfig implements backend.Enhanced.
 func (b *Remote) ValidateConfig(obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
@@ -173,6 +185,7 @@ func (b *Remote) ValidateConfig(obj cty.Value) tfdiags.Diagnostics {
 	return diags
 }
 
+// Configure implements backend.Enhanced.
 func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
@@ -255,7 +268,30 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 					`Terraform Enterprise client: %s.`, err,
 			),
 		))
+		return diags
 	}
+
+	// Check if the organization exists.
+	_, err = b.client.Organizations.Read(context.Background(), b.organization)
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			err = fmt.Errorf("organization %s does not exist", b.organization)
+		}
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Failed to read organization settings",
+			fmt.Sprintf(
+				`The "remote" backend encountered an unexpected error while reading the `+
+					`organization settings: %s.`, err,
+			),
+			cty.Path{cty.GetAttrStep{Name: "organization"}},
+		))
+		return diags
+	}
+
+	// Configure a local backend for when we need to run operations locally.
+	b.local = backendLocal.NewWithBackend(b)
+	b.forceLocal = os.Getenv("TF_FORCE_LOCAL_BACKEND") != ""
 
 	return diags
 }
@@ -292,103 +328,7 @@ func (b *Remote) token(hostname string) (string, error) {
 	return "", nil
 }
 
-// Workspaces returns a filtered list of remote workspace names.
-func (b *Remote) Workspaces() ([]string, error) {
-	if b.prefix == "" {
-		return nil, backend.ErrWorkspacesNotSupported
-	}
-	return b.workspaces()
-}
-
-func (b *Remote) workspaces() ([]string, error) {
-	// Check if the configured organization exists.
-	_, err := b.client.Organizations.Read(context.Background(), b.organization)
-	if err != nil {
-		if err == tfe.ErrResourceNotFound {
-			return nil, fmt.Errorf("organization %s does not exist", b.organization)
-		}
-		return nil, err
-	}
-
-	options := tfe.WorkspaceListOptions{}
-	switch {
-	case b.workspace != "":
-		options.Search = tfe.String(b.workspace)
-	case b.prefix != "":
-		options.Search = tfe.String(b.prefix)
-	}
-
-	// Create a slice to contain all the names.
-	var names []string
-
-	for {
-		wl, err := b.client.Workspaces.List(context.Background(), b.organization, options)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, w := range wl.Items {
-			if b.workspace != "" && w.Name == b.workspace {
-				names = append(names, backend.DefaultStateName)
-				continue
-			}
-			if b.prefix != "" && strings.HasPrefix(w.Name, b.prefix) {
-				names = append(names, strings.TrimPrefix(w.Name, b.prefix))
-			}
-		}
-
-		// Exit the loop when we've seen all pages.
-		if wl.CurrentPage >= wl.TotalPages {
-			break
-		}
-
-		// Update the page number to get the next page.
-		options.PageNumber = wl.NextPage
-	}
-
-	// Sort the result so we have consistent output.
-	sort.StringSlice(names).Sort()
-
-	return names, nil
-}
-
-// DeleteWorkspace removes the remote workspace if it exists.
-func (b *Remote) DeleteWorkspace(name string) error {
-	if b.workspace == "" && name == backend.DefaultStateName {
-		return backend.ErrDefaultWorkspaceNotSupported
-	}
-	if b.prefix == "" && name != backend.DefaultStateName {
-		return backend.ErrWorkspacesNotSupported
-	}
-
-	// Configure the remote workspace name.
-	switch {
-	case name == backend.DefaultStateName:
-		name = b.workspace
-	case b.prefix != "" && !strings.HasPrefix(name, b.prefix):
-		name = b.prefix + name
-	}
-
-	// Check if the configured organization exists.
-	_, err := b.client.Organizations.Read(context.Background(), b.organization)
-	if err != nil {
-		if err == tfe.ErrResourceNotFound {
-			return fmt.Errorf("organization %s does not exist", b.organization)
-		}
-		return err
-	}
-
-	client := &remoteClient{
-		client:       b.client,
-		organization: b.organization,
-		workspace:    name,
-	}
-
-	return client.Delete()
-}
-
-// StateMgr returns the latest state of the given remote workspace. The
-// workspace will be created if it doesn't exist.
+// StateMgr implements backend.Enhanced.
 func (b *Remote) StateMgr(name string) (state.State, error) {
 	if b.workspace == "" && name == backend.DefaultStateName {
 		return nil, backend.ErrDefaultWorkspaceNotSupported
@@ -447,18 +387,111 @@ func (b *Remote) StateMgr(name string) (state.State, error) {
 	return &remote.State{Client: client}, nil
 }
 
-// Operation implements backend.Enhanced
-func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend.RunningOperation, error) {
-	// Configure the remote workspace name.
-	switch {
-	case op.Workspace == backend.DefaultStateName:
-		op.Workspace = b.workspace
-	case b.prefix != "" && !strings.HasPrefix(op.Workspace, b.prefix):
-		op.Workspace = b.prefix + op.Workspace
+// DeleteWorkspace implements backend.Enhanced.
+func (b *Remote) DeleteWorkspace(name string) error {
+	if b.workspace == "" && name == backend.DefaultStateName {
+		return backend.ErrDefaultWorkspaceNotSupported
+	}
+	if b.prefix == "" && name != backend.DefaultStateName {
+		return backend.ErrWorkspacesNotSupported
 	}
 
+	// Configure the remote workspace name.
+	switch {
+	case name == backend.DefaultStateName:
+		name = b.workspace
+	case b.prefix != "" && !strings.HasPrefix(name, b.prefix):
+		name = b.prefix + name
+	}
+
+	client := &remoteClient{
+		client:       b.client,
+		organization: b.organization,
+		workspace:    name,
+	}
+
+	return client.Delete()
+}
+
+// Workspaces implements backend.Enhanced.
+func (b *Remote) Workspaces() ([]string, error) {
+	if b.prefix == "" {
+		return nil, backend.ErrWorkspacesNotSupported
+	}
+	return b.workspaces()
+}
+
+// workspaces returns a filtered list of remote workspace names.
+func (b *Remote) workspaces() ([]string, error) {
+	options := tfe.WorkspaceListOptions{}
+	switch {
+	case b.workspace != "":
+		options.Search = tfe.String(b.workspace)
+	case b.prefix != "":
+		options.Search = tfe.String(b.prefix)
+	}
+
+	// Create a slice to contain all the names.
+	var names []string
+
+	for {
+		wl, err := b.client.Workspaces.List(context.Background(), b.organization, options)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, w := range wl.Items {
+			if b.workspace != "" && w.Name == b.workspace {
+				names = append(names, backend.DefaultStateName)
+				continue
+			}
+			if b.prefix != "" && strings.HasPrefix(w.Name, b.prefix) {
+				names = append(names, strings.TrimPrefix(w.Name, b.prefix))
+			}
+		}
+
+		// Exit the loop when we've seen all pages.
+		if wl.CurrentPage >= wl.TotalPages {
+			break
+		}
+
+		// Update the page number to get the next page.
+		options.PageNumber = wl.NextPage
+	}
+
+	// Sort the result so we have consistent output.
+	sort.StringSlice(names).Sort()
+
+	return names, nil
+}
+
+// Operation implements backend.Enhanced.
+func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend.RunningOperation, error) {
+	// Get the remote workspace name.
+	workspace := op.Workspace
+	switch {
+	case op.Workspace == backend.DefaultStateName:
+		workspace = b.workspace
+	case b.prefix != "" && !strings.HasPrefix(op.Workspace, b.prefix):
+		workspace = b.prefix + op.Workspace
+	}
+
+	// Retrieve the workspace for this operation.
+	w, err := b.client.Workspaces.Read(ctx, b.organization, workspace)
+	if err != nil {
+		return nil, generalError("Failed to retrieve workspace", err)
+	}
+
+	// Check if we need to use the local backend to run the operation.
+	if b.forceLocal || !w.Operations {
+		return b.local.Operation(ctx, op)
+	}
+
+	// Set the remote workspace name.
+	op.Workspace = w.Name
+
 	// Determine the function to call for our operation
-	var f func(context.Context, context.Context, *backend.Operation) (*tfe.Run, error)
+	var f func(context.Context, context.Context, *backend.Operation, *tfe.Workspace) (*tfe.Run, error)
 	switch op.Type {
 	case backend.OperationTypePlan:
 		f = b.opPlan
@@ -499,7 +532,7 @@ func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend
 
 		defer b.opLock.Unlock()
 
-		r, opErr := f(stopCtx, cancelCtx, op)
+		r, opErr := f(stopCtx, cancelCtx, op, w)
 		if opErr != nil && opErr != context.Canceled {
 			b.ReportResult(runningOp, opErr)
 			return

--- a/backend/remote/backend_apply.go
+++ b/backend/remote/backend_apply.go
@@ -12,14 +12,8 @@ import (
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
-func (b *Remote) opApply(stopCtx, cancelCtx context.Context, op *backend.Operation) (*tfe.Run, error) {
+func (b *Remote) opApply(stopCtx, cancelCtx context.Context, op *backend.Operation, w *tfe.Workspace) (*tfe.Run, error) {
 	log.Printf("[INFO] backend/remote: starting Apply operation")
-
-	// Retrieve the workspace used to run this operation in.
-	w, err := b.client.Workspaces.Read(stopCtx, b.organization, op.Workspace)
-	if err != nil {
-		return nil, generalError("Failed to retrieve workspace", err)
-	}
 
 	var diags tfdiags.Diagnostics
 

--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -905,8 +905,9 @@ func (m *mockWorkspaces) List(ctx context.Context, organization string, options 
 
 func (m *mockWorkspaces) Create(ctx context.Context, organization string, options tfe.WorkspaceCreateOptions) (*tfe.Workspace, error) {
 	w := &tfe.Workspace{
-		ID:   generateID("ws-"),
-		Name: *options.Name,
+		ID:         generateID("ws-"),
+		Name:       *options.Name,
+		Operations: !strings.HasSuffix(*options.Name, "no-operations"),
 		Permissions: &tfe.WorkspacePermissions{
 			CanQueueRun: true,
 			CanUpdate:   true,

--- a/backend/remote/backend_plan.go
+++ b/backend/remote/backend_plan.go
@@ -18,14 +18,8 @@ import (
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
-func (b *Remote) opPlan(stopCtx, cancelCtx context.Context, op *backend.Operation) (*tfe.Run, error) {
+func (b *Remote) opPlan(stopCtx, cancelCtx context.Context, op *backend.Operation, w *tfe.Workspace) (*tfe.Run, error) {
 	log.Printf("[INFO] backend/remote: starting Plan operation")
-
-	// Retrieve the workspace used to run this operation in.
-	w, err := b.client.Workspaces.Read(stopCtx, b.organization, op.Workspace)
-	if err != nil {
-		return nil, generalError("Failed to retrieve workspace", err)
-	}
 
 	var diags tfdiags.Diagnostics
 

--- a/backend/remote/cli.go
+++ b/backend/remote/cli.go
@@ -6,9 +6,16 @@ import (
 
 // CLIInit implements backend.CLI
 func (b *Remote) CLIInit(opts *backend.CLIOpts) error {
+	if cli, ok := b.local.(backend.CLI); ok {
+		if err := cli.CLIInit(opts); err != nil {
+			return err
+		}
+	}
+
 	b.CLI = opts.CLI
 	b.CLIColor = opts.CLIColor
 	b.ShowDiagnostics = opts.ShowDiagnostics
 	b.ContextOpts = opts.ContextOpts
+
 	return nil
 }

--- a/backend/remote/remote_test.go
+++ b/backend/remote/remote_test.go
@@ -1,0 +1,28 @@
+package remote
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/logging"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if testing.Verbose() {
+		// if we're verbose, use the logging requested by TF_LOG
+		logging.SetOutput()
+	} else {
+		// otherwise silence all logs
+		log.SetOutput(ioutil.Discard)
+	}
+
+	// Make sure TF_FORCE_LOCAL_BACKEND is unset
+	os.Unsetenv("TF_FORCE_LOCAL_BACKEND")
+
+	os.Exit(m.Run())
+}

--- a/backend/remote/test-fixtures/apply-destroy/apply.log
+++ b/backend/remote/test-fixtures/apply-destroy/apply.log
@@ -1,3 +1,6 @@
+Terraform v0.11.10
+
+Initializing plugins and modules...
 null_resource.hello: Destroying... (ID: 8657651096157629581)
 null_resource.hello: Destruction complete after 0s
 

--- a/backend/remote/test-fixtures/apply-policy-passed/apply.log
+++ b/backend/remote/test-fixtures/apply-policy-passed/apply.log
@@ -1,3 +1,6 @@
+Terraform v0.11.10
+
+Initializing plugins and modules...
 null_resource.hello: Creating...
 null_resource.hello: Creation complete after 0s (ID: 8657651096157629581)
 

--- a/backend/remote/test-fixtures/apply-policy-soft-failed/apply.log
+++ b/backend/remote/test-fixtures/apply-policy-soft-failed/apply.log
@@ -1,3 +1,6 @@
+Terraform v0.11.10
+
+Initializing plugins and modules...
 null_resource.hello: Creating...
 null_resource.hello: Creation complete after 0s (ID: 8657651096157629581)
 

--- a/backend/remote/test-fixtures/apply-variables/apply.log
+++ b/backend/remote/test-fixtures/apply-variables/apply.log
@@ -1,3 +1,6 @@
+Terraform v0.11.10
+
+Initializing plugins and modules...
 null_resource.hello: Creating...
 null_resource.hello: Creation complete after 0s (ID: 8657651096157629581)
 

--- a/backend/remote/test-fixtures/apply/apply.log
+++ b/backend/remote/test-fixtures/apply/apply.log
@@ -1,3 +1,6 @@
+Terraform v0.11.10
+
+Initializing plugins and modules...
 null_resource.hello: Creating...
 null_resource.hello: Creation complete after 0s (ID: 8657651096157629581)
 

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90
 	github.com/hashicorp/go-safetemp v0.0.0-20180326211150-b1a1dbde6fdc // indirect
 	github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86 // indirect
-	github.com/hashicorp/go-tfe v0.3.0
+	github.com/hashicorp/go-tfe v0.3.1
 	github.com/hashicorp/go-uuid v1.0.0
 	github.com/hashicorp/go-version v0.0.0-20180322230233-23480c066577
 	github.com/hashicorp/golang-lru v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/hashicorp/go-slug v0.1.0 h1:MJGEiOwRGrQCBmMMZABHqIESySFJ4ajrsjgDI4/aF
 github.com/hashicorp/go-slug v0.1.0/go.mod h1:+zDycQOzGqOqMW7Kn2fp9vz/NtqpMLQlgb9JUF+0km4=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86 h1:7YOlAIO2YWnJZkQp7B5eFykaIY7C9JndqAFQyVV5BhM=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
-github.com/hashicorp/go-tfe v0.3.0 h1:X0oM8RNKgMlmaMOEzLkx8/RTIC3d2K30R8+G4cSXJPc=
-github.com/hashicorp/go-tfe v0.3.0/go.mod h1:SRMjgjY06SfEKstIPRUVMtQfhSYR2H3GHVop0lfedkY=
+github.com/hashicorp/go-tfe v0.3.1 h1:178hBlqjBsXohfcJ2/t2RM8c29IviQrEkj+mqdbkQzM=
+github.com/hashicorp/go-tfe v0.3.1/go.mod h1:SRMjgjY06SfEKstIPRUVMtQfhSYR2H3GHVop0lfedkY=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v0.0.0-20180322230233-23480c066577 h1:at4+18LrM8myamuV7/vT6x2s1JNXp2k4PsSbt4I02X4=

--- a/vendor/github.com/hashicorp/go-tfe/tfe.go
+++ b/vendor/github.com/hashicorp/go-tfe/tfe.go
@@ -289,25 +289,6 @@ func (c *Client) configureLimiter() error {
 	return nil
 }
 
-// ListOptions is used to specify pagination options when making API requests.
-// Pagination allows breaking up large result sets into chunks, or "pages".
-type ListOptions struct {
-	// The page number to request. The results vary based on the PageSize.
-	PageNumber int `url:"page[number],omitempty"`
-
-	// The number of elements returned in a single page.
-	PageSize int `url:"page[size],omitempty"`
-}
-
-// Pagination is used to return the pagination details of an API request.
-type Pagination struct {
-	CurrentPage  int `json:"current-page"`
-	PreviousPage int `json:"prev-page"`
-	NextPage     int `json:"next-page"`
-	TotalPages   int `json:"total-pages"`
-	TotalCount   int `json:"total-count"`
-}
-
 // newRequest creates an API request. A relative URL path can be provided in
 // path, in which case it is resolved relative to the apiVersionPath of the
 // Client. Relative URL paths should always be specified without a preceding
@@ -477,6 +458,25 @@ func (c *Client) do(ctx context.Context, req *retryablehttp.Request, v interface
 	pagination.Set(reflect.ValueOf(p))
 
 	return nil
+}
+
+// ListOptions is used to specify pagination options when making API requests.
+// Pagination allows breaking up large result sets into chunks, or "pages".
+type ListOptions struct {
+	// The page number to request. The results vary based on the PageSize.
+	PageNumber int `url:"page[number],omitempty"`
+
+	// The number of elements returned in a single page.
+	PageSize int `url:"page[size],omitempty"`
+}
+
+// Pagination is used to return the pagination details of an API request.
+type Pagination struct {
+	CurrentPage  int `json:"current-page"`
+	PreviousPage int `json:"prev-page"`
+	NextPage     int `json:"next-page"`
+	TotalPages   int `json:"total-pages"`
+	TotalCount   int `json:"total-count"`
 }
 
 func parsePagination(body io.Reader) (*Pagination, error) {

--- a/vendor/github.com/hashicorp/go-tfe/workspace.go
+++ b/vendor/github.com/hashicorp/go-tfe/workspace.go
@@ -66,6 +66,7 @@ type Workspace struct {
 	Locked               bool                  `jsonapi:"attr,locked"`
 	MigrationEnvironment string                `jsonapi:"attr,migration-environment"`
 	Name                 string                `jsonapi:"attr,name"`
+	Operations           bool                  `jsonapi:"attr,operations"`
 	Permissions          *WorkspacePermissions `jsonapi:"attr,permissions"`
 	TerraformVersion     string                `jsonapi:"attr,terraform-version"`
 	VCSRepo              *VCSRepo              `jsonapi:"attr,vcs-repo"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -315,7 +315,7 @@ github.com/hashicorp/go-rootcerts
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.1.0
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.3.0
+# github.com/hashicorp/go-tfe v0.3.1
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.0
 github.com/hashicorp/go-uuid


### PR DESCRIPTION
In order to support free organizations, we need a way to load the `remote` backend and then, depending on the used offering/plan, enable or disable remote operations.

In other words, we should be able to dynamically fall back to the `local` backend if needed, after first configuring the `remote` backend.

To make this work we need to change the way this was done previously when the env var `TF_FORCE_LOCAL_BACKEND` was set. The clear difference of course being that the env var would be available on startup, while the used offering/plan is only known after being able to connect to TFE.