### PR TITLE
New Attribute and Diff handling in shims

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -24,6 +24,7 @@ func Provider() terraform.ResourceProvider {
 			"test_resource_diff_suppress":    testResourceDiffSuppress(),
 			"test_resource_force_new":        testResourceForceNew(),
 			"test_resource_nested":           testResourceNested(),
+			"test_resource_nested_set":       testResourceNestedSet(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"test_data_source":    testDataSource(),

--- a/builtin/providers/test/resource_diff_suppress.go
+++ b/builtin/providers/test/resource_diff_suppress.go
@@ -1,23 +1,36 @@
 package test
 
 import (
+	"fmt"
+	"math/rand"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func testResourceDiffSuppress() *schema.Resource {
+	diffSuppress := func(k, old, new string, d *schema.ResourceData) bool {
+		if old == "" || strings.Contains(new, "replace") {
+			return false
+		}
+		return true
+	}
+
 	return &schema.Resource{
 		Create: testResourceDiffSuppressCreate,
 		Read:   testResourceDiffSuppressRead,
-		Update: testResourceDiffSuppressUpdate,
 		Delete: testResourceDiffSuppressDelete,
+		Update: testResourceDiffSuppressUpdate,
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
+			"optional": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"val_to_upper": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -29,18 +42,48 @@ func testResourceDiffSuppress() *schema.Resource {
 					return strings.ToUpper(old) == strings.ToUpper(new)
 				},
 			},
-			"optional": {
-				Type:     schema.TypeString,
+			"network": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "default",
+				ForceNew:         true,
+				DiffSuppressFunc: diffSuppress,
+			},
+			"subnetwork": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: diffSuppress,
+			},
+
+			"node_pool": {
+				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+					},
+				},
 			},
 		},
 	}
 }
 
 func testResourceDiffSuppressCreate(d *schema.ResourceData, meta interface{}) error {
-	d.SetId("testId")
+	d.Set("network", "modified")
+	d.Set("subnetwork", "modified")
 
-	return testResourceRead(d, meta)
+	id := fmt.Sprintf("%x", rand.Int63())
+	d.SetId(id)
+	return nil
 }
 
 func testResourceDiffSuppressRead(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/test/resource_diff_suppress_test.go
+++ b/builtin/providers/test/resource_diff_suppress_test.go
@@ -1,10 +1,14 @@
 package test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/addrs"
+
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestResourceDiffSuppress_create(t *testing.T) {
@@ -41,6 +45,81 @@ resource "test_resource_diff_suppress" "foo" {
 	optional = "more"
 }
 				`),
+			},
+		},
+	})
+}
+
+func TestResourceDiffSuppress_updateIgnoreChanges(t *testing.T) {
+	// None of these steps should replace the instance
+	id := ""
+	checkFunc := func(s *terraform.State) error {
+		root := s.ModuleByPath(addrs.RootModuleInstance)
+		res := root.Resources["test_resource_diff_suppress.foo"]
+		if id != "" && res.Primary.ID != id {
+			return errors.New("expected no resource replacement")
+		}
+		id = res.Primary.ID
+		return nil
+	}
+
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_diff_suppress" "foo" {
+	val_to_upper = "foo"
+
+	network    = "foo"
+	subnetwork = "foo"
+
+	node_pool {
+	  name = "default-pool"
+	}
+	lifecycle {
+		ignore_changes = ["node_pool"]
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_diff_suppress" "foo" {
+	val_to_upper = "foo"
+
+	network    = "ignored"
+	subnetwork = "ignored"
+
+	node_pool {
+		name = "default-pool"
+	}
+	lifecycle {
+		ignore_changes = ["node_pool"]
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_diff_suppress" "foo" {
+	val_to_upper = "foo"
+
+	network    = "ignored"
+	subnetwork = "ignored"
+
+	node_pool {
+		name = "ignored"
+	}
+	lifecycle {
+		ignore_changes = ["node_pool"]
+	}
+}
+			`),
+				Check: checkFunc,
 			},
 		},
 	})

--- a/builtin/providers/test/resource_nested_set.go
+++ b/builtin/providers/test/resource_nested_set.go
@@ -44,6 +44,37 @@ func testResourceNestedSet() *schema.Resource {
 					},
 				},
 			},
+			"multi": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"set": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"required": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+									"optional_int": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+
+						"optional": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Optional: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/builtin/providers/test/resource_nested_set.go
+++ b/builtin/providers/test/resource_nested_set.go
@@ -23,6 +23,11 @@ func testResourceNestedSet() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"force_new": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"single": {
 				Type:     schema.TypeSet,
 				Optional: true,

--- a/builtin/providers/test/resource_nested_set.go
+++ b/builtin/providers/test/resource_nested_set.go
@@ -1,0 +1,82 @@
+package test
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceNestedSet() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceNestedSetCreate,
+		Read:   testResourceNestedSetRead,
+		Delete: testResourceNestedSetDelete,
+		Update: testResourceNestedSetUpdate,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"optional": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"single": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Required: true,
+						},
+
+						"optional": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testResourceNestedSetCreate(d *schema.ResourceData, meta interface{}) error {
+	id := fmt.Sprintf("%x", rand.Int63())
+	d.SetId(id)
+
+	// replicate some awkward handling of a computed value in a set
+	set := d.Get("single").(*schema.Set)
+	l := set.List()
+	if len(l) == 1 {
+		if s, ok := l[0].(map[string]interface{}); ok {
+			if v, _ := s["optional"].(string); v == "" {
+				s["optional"] = id
+			}
+		}
+	}
+
+	d.Set("single", set)
+
+	return testResourceNestedRead(d, meta)
+}
+
+func testResourceNestedSetRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceNestedSetDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func testResourceNestedSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/builtin/providers/test/resource_nested_set.go
+++ b/builtin/providers/test/resource_nested_set.go
@@ -63,13 +63,22 @@ func testResourceNestedSet() *schema.Resource {
 										Type:     schema.TypeInt,
 										Optional: true,
 									},
+									"bool": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
 								},
 							},
 						},
 
 						"optional": {
-							Type:     schema.TypeString,
-							ForceNew: true,
+							Type: schema.TypeString,
+							// commenting this causes it to get missed during apply
+							//ForceNew: true,
+							Optional: true,
+						},
+						"bool": {
+							Type:     schema.TypeBool,
 							Optional: true,
 						},
 					},

--- a/builtin/providers/test/resource_nested_set_test.go
+++ b/builtin/providers/test/resource_nested_set_test.go
@@ -127,3 +127,79 @@ resource "test_resource_nested_set" "foo" {
 		},
 	})
 }
+func TestResourceNestedSet_multi(t *testing.T) {
+	checkFunc := func(s *terraform.State) error {
+		return nil
+	}
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	multi {
+		optional = "bar"
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+}
+								`),
+				Check: checkFunc,
+			},
+
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	multi {
+		set {
+			required = "val"
+		}
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	multi {
+		set {
+			required = "new"
+		}
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	multi {
+		set {
+			required = "new"
+			optional_int = 3
+		}
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+		},
+	})
+}

--- a/builtin/providers/test/resource_nested_set_test.go
+++ b/builtin/providers/test/resource_nested_set_test.go
@@ -200,6 +200,24 @@ resource "test_resource_nested_set" "foo" {
 				`),
 				Check: checkFunc,
 			},
+
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	single {
+		value = "bar"
+		optional = "baz"
+	}
+	multi {
+		set {
+			required = "new"
+			optional_int = 3
+		}
+	}
+}
+			`),
+				Check: checkFunc,
+			},
 		},
 	})
 }

--- a/builtin/providers/test/resource_nested_set_test.go
+++ b/builtin/providers/test/resource_nested_set_test.go
@@ -1,0 +1,129 @@
+package test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceNestedSet_basic(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	single {
+		value = "bar"
+	}
+}
+				`),
+			},
+		},
+	})
+}
+
+// The set should not be generated because of it's computed value
+func TestResourceNestedSet_noSet(t *testing.T) {
+	checkFunc := func(s *terraform.State) error {
+		root := s.ModuleByPath(addrs.RootModuleInstance)
+		res := root.Resources["test_resource_nested_set.foo"]
+		for k, v := range res.Primary.Attributes {
+			if strings.HasPrefix(k, "single") && k != "single.#" {
+				return fmt.Errorf("unexpected set value: %s:%s", k, v)
+			}
+		}
+		return nil
+	}
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+}
+				`),
+				Check: checkFunc,
+			},
+		},
+	})
+}
+
+func TestResourceNestedSet_addRemove(t *testing.T) {
+	var id string
+	checkFunc := func(s *terraform.State) error {
+		root := s.ModuleByPath(addrs.RootModuleInstance)
+		res := root.Resources["test_resource_nested_set.foo"]
+		if res.Primary.ID == id {
+			return errors.New("expected new resource")
+		}
+		id = res.Primary.ID
+		return nil
+	}
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	single {
+		value = "bar"
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	single {
+		value = "bar"
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	single {
+		value = "bar"
+		optional = "baz"
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+}
+			   	`),
+				Check: checkFunc,
+			},
+		},
+	})
+}

--- a/config/hcl2shim/flatmap_test.go
+++ b/config/hcl2shim/flatmap_test.go
@@ -635,6 +635,50 @@ func TestHCL2ValueFromFlatmap(t *testing.T) {
 				}),
 			}),
 		},
+		{
+			Flatmap: map[string]string{
+				"single.#":                 "1",
+				"single.~1.value":          "a",
+				"single.~1.optional":       UnknownVariableValue,
+				"two.#":                    "2",
+				"two.~2381914684.value":    "a",
+				"two.~2381914684.optional": UnknownVariableValue,
+				"two.~2798940671.value":    "b",
+				"two.~2798940671.optional": UnknownVariableValue,
+			},
+			Type: cty.Object(map[string]cty.Type{
+				"single": cty.Set(
+					cty.Object(map[string]cty.Type{
+						"value":    cty.String,
+						"optional": cty.String,
+					}),
+				),
+				"two": cty.Set(
+					cty.Object(map[string]cty.Type{
+						"optional": cty.String,
+						"value":    cty.String,
+					}),
+				),
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"single": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"value":    cty.StringVal("a"),
+						"optional": cty.UnknownVal(cty.String),
+					}),
+				}),
+				"two": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"value":    cty.StringVal("a"),
+						"optional": cty.UnknownVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"value":    cty.StringVal("b"),
+						"optional": cty.UnknownVal(cty.String),
+					}),
+				}),
+			}),
+		},
 	}
 
 	for _, test := range tests {

--- a/configs/configschema/coerce_value.go
+++ b/configs/configschema/coerce_value.go
@@ -113,7 +113,7 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("insufficient items for attribute %q; must have at least %d", typeName, blockS.MinItems)
 				}
 				if l > blockS.MaxItems && blockS.MaxItems > 0 {
-					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("too many items for attribute %q; must have at least %d", typeName, blockS.MinItems)
+					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("too many items for attribute %q; cannot have more than %d", typeName, blockS.MaxItems)
 				}
 				if l == 0 {
 					attrs[typeName] = cty.ListValEmpty(blockS.ImpliedType())
@@ -161,7 +161,7 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("insufficient items for attribute %q; must have at least %d", typeName, blockS.MinItems)
 				}
 				if l > blockS.MaxItems && blockS.MaxItems > 0 {
-					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("too many items for attribute %q; must have at least %d", typeName, blockS.MinItems)
+					return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("too many items for attribute %q; cannot have more than %d", typeName, blockS.MaxItems)
 				}
 				if l == 0 {
 					attrs[typeName] = cty.SetValEmpty(blockS.ImpliedType())

--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -610,7 +610,6 @@ func (s *GRPCProviderServer) ApplyResourceChange(_ context.Context, req *proto.A
 		Type: req.TypeName,
 	}
 
-	//priorState := terraform.NewInstanceStateShimmedFromValue(priorStateVal, res.SchemaVersion)
 	priorState, err := res.ShimInstanceStateFromValue(priorStateVal)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)

--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -71,7 +71,7 @@ func shimNewState(newState *states.State, schemas *terraform.Schemas) (*terrafor
 			}
 
 			if resSchema == nil {
-				return nil, fmt.Errorf("mising resource schema for %q in %q", resType, providerType)
+				return nil, fmt.Errorf("missing resource schema for %q in %q", resType, providerType)
 			}
 
 			for key, i := range res.Instances {

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -155,6 +155,27 @@ type Resource struct {
 	Timeouts *ResourceTimeout
 }
 
+// ShimInstanceStateFromValue converts a cty.Value to a
+// terraform.InstanceState.
+func (r *Resource) ShimInstanceStateFromValue(state cty.Value) (*terraform.InstanceState, error) {
+	// Get the raw shimmed value. While this is correct, the set hashes don't
+	// match those from the Schema.
+	s := terraform.NewInstanceStateShimmedFromValue(state, r.SchemaVersion)
+
+	// We now rebuild the state through the ResourceData, so that the set indexes
+	// match what helper/schema expects.
+	data, err := schemaMap(r.Schema).Data(s, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	s = data.State()
+	if s == nil {
+		s = &terraform.InstanceState{}
+	}
+	return s, nil
+}
+
 // See Resource documentation.
 type CreateFunc func(*ResourceData, interface{}) error
 
@@ -550,8 +571,7 @@ func (r *Resource) upgradeState(s *terraform.InstanceState, meta interface{}) (*
 		return nil, err
 	}
 
-	s = InstanceStateFromStateValue(stateVal, r.SchemaVersion)
-	return s, nil
+	return r.ShimInstanceStateFromValue(stateVal)
 }
 
 // InternalValidate should be called to validate the structure

--- a/helper/schema/shims.go
+++ b/helper/schema/shims.go
@@ -23,7 +23,10 @@ func DiffFromValues(prior, planned cty.Value, res *Resource) (*terraform.Instanc
 // only needs to be created for the apply operation, and any customizations
 // have already been done.
 func diffFromValues(prior, planned cty.Value, res *Resource, cust CustomizeDiffFunc) (*terraform.InstanceDiff, error) {
-	instanceState := terraform.NewInstanceStateShimmedFromValue(prior, res.SchemaVersion)
+	instanceState, err := res.ShimInstanceStateFromValue(prior)
+	if err != nil {
+		return nil, err
+	}
 
 	configSchema := res.CoreConfigSchema()
 

--- a/helper/schema/shims.go
+++ b/helper/schema/shims.go
@@ -23,7 +23,7 @@ func DiffFromValues(prior, planned cty.Value, res *Resource) (*terraform.Instanc
 // only needs to be created for the apply operation, and any customizations
 // have already been done.
 func diffFromValues(prior, planned cty.Value, res *Resource, cust CustomizeDiffFunc) (*terraform.InstanceDiff, error) {
-	instanceState := InstanceStateFromStateValue(prior, res.SchemaVersion)
+	instanceState := terraform.NewInstanceStateShimmedFromValue(prior, res.SchemaVersion)
 
 	configSchema := res.CoreConfigSchema()
 
@@ -84,12 +84,4 @@ func JSONMapToStateValue(m map[string]interface{}, block *configschema.Block) (c
 // ID as the "id" attribute.
 func StateValueFromInstanceState(is *terraform.InstanceState, ty cty.Type) (cty.Value, error) {
 	return is.AttrsAsObjectValue(ty)
-}
-
-// InstanceStateFromStateValue converts a cty.Value to a
-// terraform.InstanceState. This function requires the schema version used by
-// the provider, because the legacy providers used the private Meta data in the
-// InstanceState to store the schema version.
-func InstanceStateFromStateValue(state cty.Value, schemaVersion int) *terraform.InstanceState {
-	return terraform.NewInstanceStateShimmedFromValue(state, schemaVersion)
 }

--- a/helper/schema/shims_test.go
+++ b/helper/schema/shims_test.go
@@ -599,6 +599,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"availability_zone": "foo",
 				},
@@ -901,6 +902,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"delete": "false",
 				},
@@ -952,43 +954,6 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 
 			Err: false,
 		},
-
-		/*
-			// disabled for shims
-			// there is no longer any "list promotion"
-			{
-				Name: "List decode with promotion",
-				Schema: map[string]*Schema{
-					"ports": &Schema{
-						Type:          TypeList,
-						Required:      true,
-						Elem:          &Schema{Type: TypeInt},
-						PromoteSingle: true,
-					},
-				},
-
-				State: nil,
-
-				Config: map[string]interface{}{
-					"ports": "5",
-				},
-
-				Diff: &terraform.InstanceDiff{
-					Attributes: map[string]*terraform.ResourceAttrDiff{
-						"ports.#": &terraform.ResourceAttrDiff{
-							Old: "0",
-							New: "1",
-						},
-						"ports.0": &terraform.ResourceAttrDiff{
-							Old: "",
-							New: "5",
-						},
-					},
-				},
-
-				Err: false,
-			},
-		*/
 
 		{
 			Name: "List decode with promotion with list",
@@ -1109,6 +1074,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"ports.#": "3",
 					"ports.0": "1",
@@ -1137,6 +1103,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"ports.#": "2",
 					"ports.0": "1",
@@ -1353,6 +1320,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"ports.#": "0",
 				},
@@ -1493,6 +1461,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"ports.#": "2",
 					"ports.1": "1",
@@ -1528,55 +1497,6 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			Err: false,
 		},
 
-		/*
-			// disabled for shims
-			// you can't remove a required attribute
-			{
-				Name: "Set-7",
-				Schema: map[string]*Schema{
-					"ports": &Schema{
-						Type:     TypeSet,
-						Required: true,
-						Elem:     &Schema{Type: TypeInt},
-						Set: func(a interface{}) int {
-							return a.(int)
-						},
-					},
-				},
-
-				State: &terraform.InstanceState{
-					Attributes: map[string]string{
-						"ports.#": "2",
-						"ports.1": "1",
-						"ports.2": "2",
-					},
-				},
-
-				Config: map[string]interface{}{},
-
-				Diff: &terraform.InstanceDiff{
-					Attributes: map[string]*terraform.ResourceAttrDiff{
-						"ports.#": &terraform.ResourceAttrDiff{
-							Old: "2",
-							New: "0",
-						},
-						"ports.1": &terraform.ResourceAttrDiff{
-							Old:        "1",
-							New:        "0",
-							NewRemoved: true,
-						},
-						"ports.2": &terraform.ResourceAttrDiff{
-							Old:        "2",
-							New:        "0",
-							NewRemoved: true,
-						},
-					},
-				},
-
-				Err: false,
-			},
-		*/
-
 		{
 			Name: "Set-8",
 			Schema: map[string]*Schema{
@@ -1592,6 +1512,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"availability_zone": "bar",
 					"ports.#":           "1",
@@ -1634,6 +1555,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"ingress.#":           "2",
 					"ingress.80.ports.#":  "1",
@@ -1718,6 +1640,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"availability_zone": "foo",
 					"port":              "80",
@@ -1734,7 +1657,42 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "",
+			Name: "computed",
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:         TypeString,
+					Computed:     true,
+					ComputedWhen: []string{"port"},
+				},
+
+				"port": &Schema{
+					Type:     TypeInt,
+					Optional: true,
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{
+				"port": 80,
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"availability_zone": &terraform.ResourceAttrDiff{
+						NewComputed: true,
+					},
+					"port": &terraform.ResourceAttrDiff{
+						New: "80",
+					},
+				},
+			},
+
+			Err: false,
+		},
+
+		{
+			Name: "computed, exists",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:         TypeString,
@@ -1749,6 +1707,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"port": "80",
 				},
@@ -1758,13 +1717,8 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 				"port": 80,
 			},
 
-			Diff: &terraform.InstanceDiff{
-				Attributes: map[string]*terraform.ResourceAttrDiff{
-					"availability_zone": &terraform.ResourceAttrDiff{
-						NewComputed: true,
-					},
-				},
-			},
+			// there is no computed diff when the instance exists already
+			Diff: nil,
 
 			Err: false,
 		},
@@ -1811,6 +1765,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"config_vars.%":   "1",
 					"config_vars.foo": "bar",
@@ -1850,6 +1805,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"vars.%":   "1",
 					"vars.foo": "bar",
@@ -1889,6 +1845,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"vars.%":   "1",
 					"vars.foo": "bar",
@@ -1912,6 +1869,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"config_vars.#":     "1",
 					"config_vars.0.%":   "1",
@@ -1954,6 +1912,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"config_vars.#":     "1",
 					"config_vars.0.%":   "2",
@@ -2005,6 +1964,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"availability_zone": "bar",
 					"address":           "foo",
@@ -2049,6 +2009,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"availability_zone": "bar",
 					"ports.#":           "1",
@@ -2088,6 +2049,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"instances.#": "0",
 				},
@@ -2275,6 +2237,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"vars.%": "0",
 				},
@@ -2303,7 +2266,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name:   " - Empty",
+			Name:   "Empty",
 			Schema: map[string]*Schema{},
 
 			State: &terraform.InstanceState{},
@@ -2324,6 +2287,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"some_threshold": "567.8",
 				},
@@ -2376,6 +2340,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"block_device.#": "2",
 					"block_device.616397234.delete_on_termination":  "true",
@@ -2410,6 +2375,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"port": "false",
 				},
@@ -2453,6 +2419,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"route.#": "0",
 				},
@@ -2476,6 +2443,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"active": "true",
 				},
@@ -2503,6 +2471,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"instances.#": "1",
 					"instances.3": "foo",
@@ -2615,6 +2584,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"metadata_keys.#": "0",
 				},
@@ -2675,6 +2645,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			Config: nil,
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"tags.%": "0",
 				},
@@ -2743,7 +2714,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: ": StateFunc in nested set (#1759)",
+			Name: "StateFunc in nested set (#1759)",
 			Schema: map[string]*Schema{
 				"service_account": &Schema{
 					Type:     TypeList,
@@ -2823,6 +2794,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"instances.#": "2",
 					"instances.3": "333",
@@ -2875,6 +2847,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"one":   "false",
 					"two":   "true",
@@ -2913,6 +2886,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			Schema: map[string]*Schema{},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"id": "someid",
 				},
@@ -2942,6 +2916,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"ports.#": "3",
 					"ports.1": "1",
@@ -2990,6 +2965,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"description": "foo",
 				},
@@ -3023,7 +2999,9 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 				},
 			},
 
-			State: &terraform.InstanceState{},
+			State: &terraform.InstanceState{
+				ID: "id",
+			},
 
 			Config: map[string]interface{}{
 				"foo": "${var.foo}",
@@ -3063,6 +3041,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"ports.#": "3",
 					"ports.1": "1",
@@ -3103,6 +3082,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"config.#": "2",
 					"config.0": "a",
@@ -3310,6 +3290,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"ports.#": "3",
 					"ports.1": "1",
@@ -3362,6 +3343,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			Schema: map[string]*Schema{},
 
 			State: &terraform.InstanceState{
+				ID: "someid",
 				Attributes: map[string]string{
 					"id": "someid",
 				},
@@ -3397,6 +3379,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"etag":       "foo",
 					"version_id": "1",
@@ -3442,6 +3425,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"foo": "bar",
 				},
@@ -3471,6 +3455,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"attr": "bar",
 				},
@@ -3508,6 +3493,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
+				ID: "id",
 				Attributes: map[string]string{
 					"unrelated_set.#":  "0",
 					"stream_enabled":   "true",
@@ -3549,11 +3535,10 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			}
 
 			{
-				d, err := InternalMap(tc.Schema).Diff(tc.State, terraform.NewResourceConfig(c), tc.CustomizeDiff, nil, false)
+				d, err := schemaMap(tc.Schema).Diff(tc.State, terraform.NewResourceConfig(c), tc.CustomizeDiff, nil, false)
 				if err != nil != tc.Err {
 					t.Fatalf("err: %s", err)
 				}
-
 				if !cmp.Equal(d, tc.Diff, equateEmpty) {
 					t.Fatal(cmp.Diff(d, tc.Diff, equateEmpty))
 				}
@@ -3597,6 +3582,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 			}
 
 			res := &Resource{Schema: tc.Schema}
+
 			d, err := diffFromValues(stateVal, configVal, res, tc.CustomizeDiff)
 			if err != nil {
 				if !tc.Err {

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -450,11 +450,6 @@ func (d *InstanceDiff) Apply(attrs map[string]string, schema *configschema.Block
 }
 
 func (d *InstanceDiff) applyDiff(attrs map[string]string, schema *configschema.Block) (map[string]string, error) {
-	// We always build a new value here, even if the given diff is "empty",
-	// because we might be planning to create a new instance that happens
-	// to have no attributes set, and so we want to produce an empty object
-	// rather than just echoing back the null old value.
-
 	// Rather applying the diff to mutate the attrs, we'll copy new values into
 	// here to avoid the possibility of leaving stale values.
 	result := map[string]string{}
@@ -513,7 +508,6 @@ func (d *InstanceDiff) applyAttrDiff(attrName string, oldAttrs map[string]string
 		return result, nil
 	}
 
-	// skip "id", as we already handled it
 	if attrName == "id" {
 		if old == "" {
 			result["id"] = config.UnknownVariableValue


### PR DESCRIPTION
This implements a couple a major changes to make the shimmed diffs work with the legacy provider code.

First, all handling of shimmed state now goes through the `ResourceData` struct, which rebuilds the flatmapped sets so that the keys match in the attributes and the diffs. Since this is what happens in the legacy Apply phase, the behavior should match.

The other major piece is `InstanceDiff.Apply`, which removes one unnecessary cycle of shimming, and applies the diff to the flatmapped attributes. The new application algorithm handles various types differently, based on the observed edge cases produced by the helper/schema package, and builds a new attribute map from scratch to prevent old mismatched set items from being preserved.

To clean up the diffs and attributes, all empty attribute diffs are stripped from resource diffs to prevent any non-existent zero values from sneaking in. Then all flatmapped attributes are stripped of empty containers (lists, maps, sets) before being shimmed and returned in a response. This should prevent mismatched states with zero vs null containers after apply.