### PR TITLE
backend/remote: also show policies when there are no changes

### DIFF
--- a/backend/remote/backend_apply_test.go
+++ b/backend/remote/backend_apply_test.go
@@ -338,6 +338,9 @@ func TestRemote_applyNoChanges(t *testing.T) {
 	if !strings.Contains(output, "No changes. Infrastructure is up-to-date.") {
 		t.Fatalf("expected no changes in plan summery: %s", output)
 	}
+	if !strings.Contains(output, "Sentinel Result: true") {
+		t.Fatalf("expected policy check result in output: %s", output)
+	}
 }
 
 func TestRemote_applyNoApprove(t *testing.T) {
@@ -771,7 +774,7 @@ func TestRemote_applyPolicyPass(t *testing.T) {
 		t.Fatalf("expected plan summery in output: %s", output)
 	}
 	if !strings.Contains(output, "Sentinel Result: true") {
-		t.Fatalf("expected polic check result in output: %s", output)
+		t.Fatalf("expected policy check result in output: %s", output)
 	}
 	if !strings.Contains(output, "1 added, 0 changed, 0 destroyed") {
 		t.Fatalf("expected apply summery in output: %s", output)

--- a/backend/remote/backend_common.go
+++ b/backend/remote/backend_common.go
@@ -260,7 +260,7 @@ func (b *Remote) checkPolicy(stopCtx, cancelCtx context.Context, op *backend.Ope
 
 		switch pc.Status {
 		case tfe.PolicyPasses:
-			if (op.Type == backend.OperationTypeApply || i < len(r.PolicyChecks)-1) && b.CLI != nil {
+			if (r.HasChanges && op.Type == backend.OperationTypeApply || i < len(r.PolicyChecks)-1) && b.CLI != nil {
 				b.CLI.Output("\n------------------------------------------------------------------------")
 			}
 			continue

--- a/backend/remote/backend_plan.go
+++ b/backend/remote/backend_plan.go
@@ -266,10 +266,10 @@ func (b *Remote) plan(stopCtx, cancelCtx context.Context, op *backend.Operation,
 		return r, generalError("Failed to retrieve run", err)
 	}
 
-	// Return if there are no changes or the run errored. We return
-	// without an error, even if the run errored, as the error is
-	// already displayed by the output of the remote run.
-	if !r.HasChanges || r.Status == tfe.RunErrored {
+	// Return if the run errored. We return without an error, even
+	// if the run errored, as the error is already displayed by the
+	// output of the remote run.
+	if r.Status == tfe.RunErrored {
 		return r, nil
 	}
 

--- a/backend/remote/backend_plan_test.go
+++ b/backend/remote/backend_plan_test.go
@@ -287,6 +287,36 @@ func TestRemote_planNoConfig(t *testing.T) {
 	}
 }
 
+func TestRemote_planNoChanges(t *testing.T) {
+	b := testBackendDefault(t)
+
+	op, configCleanup := testOperationApply(t, "./test-fixtures/plan-no-changes")
+	defer configCleanup()
+
+	op.Workspace = backend.DefaultStateName
+
+	run, err := b.Operation(context.Background(), op)
+	if err != nil {
+		t.Fatalf("error starting operation: %v", err)
+	}
+
+	<-run.Done()
+	if run.Result != backend.OperationSuccess {
+		t.Fatalf("operation failed: %s", b.CLI.(*cli.MockUi).ErrorWriter.String())
+	}
+	if !run.PlanEmpty {
+		t.Fatalf("expected plan to be empty")
+	}
+
+	output := b.CLI.(*cli.MockUi).OutputWriter.String()
+	if !strings.Contains(output, "No changes. Infrastructure is up-to-date.") {
+		t.Fatalf("expected no changes in plan summery: %s", output)
+	}
+	if !strings.Contains(output, "Sentinel Result: true") {
+		t.Fatalf("expected policy check result in output: %s", output)
+	}
+}
+
 func TestRemote_planForceLocal(t *testing.T) {
 	// Set TF_FORCE_LOCAL_BACKEND so the remote backend will use
 	// the local backend with itself as embedded backend.
@@ -551,7 +581,7 @@ func TestRemote_planPolicyPass(t *testing.T) {
 		t.Fatalf("expected plan summery in output: %s", output)
 	}
 	if !strings.Contains(output, "Sentinel Result: true") {
-		t.Fatalf("expected polic check result in output: %s", output)
+		t.Fatalf("expected policy check result in output: %s", output)
 	}
 }
 

--- a/backend/remote/test-fixtures/apply-no-changes/policy.log
+++ b/backend/remote/test-fixtures/apply-no-changes/policy.log
@@ -1,0 +1,12 @@
+Sentinel Result: true
+
+This result means that Sentinel policies returned true and the protected
+behavior is allowed by Sentinel policies.
+
+1 policies evaluated.
+
+## Policy 1: Passthrough.sentinel (soft-mandatory)
+
+Result: true
+
+TRUE - Passthrough.sentinel:1:1 - Rule "main"

--- a/backend/remote/test-fixtures/plan-no-changes/main.tf
+++ b/backend/remote/test-fixtures/plan-no-changes/main.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "foo" {}

--- a/backend/remote/test-fixtures/plan-no-changes/plan.log
+++ b/backend/remote/test-fixtures/plan-no-changes/plan.log
@@ -1,0 +1,17 @@
+Terraform v0.11.7
+
+Configuring remote state backend...
+Initializing Terraform configuration...
+Refreshing Terraform state in-memory prior to plan...
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+
+null_resource.hello: Refreshing state... (ID: 8657651096157629581)
+
+------------------------------------------------------------------------
+
+No changes. Infrastructure is up-to-date.
+
+This means that Terraform did not detect any differences between your
+configuration and real physical resources that exist. As a result, no
+actions need to be performed.

--- a/backend/remote/test-fixtures/plan-no-changes/policy.log
+++ b/backend/remote/test-fixtures/plan-no-changes/policy.log
@@ -1,0 +1,12 @@
+Sentinel Result: true
+
+This result means that Sentinel policies returned true and the protected
+behavior is allowed by Sentinel policies.
+
+1 policies evaluated.
+
+## Policy 1: Passthrough.sentinel (soft-mandatory)
+
+Result: true
+
+TRUE - Passthrough.sentinel:1:1 - Rule "main"


### PR DESCRIPTION
This behavior was recently updated in the TFE UI, so lets follow that behavior here as well.