### PR TITLE
command: Use vendoring when building helper programs in tests

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -798,7 +798,7 @@ func testLockState(sourceDir, path string) (func(), error) {
 	source := filepath.Join(sourceDir, "statelocker.go")
 	lockBin := filepath.Join(buildDir, "statelocker")
 
-	out, err := exec.Command("go", "build", "-o", lockBin, source).CombinedOutput()
+	out, err := exec.Command("go", "build", "-mod=vendor", "-o", lockBin, source).CombinedOutput()
 	if err != nil {
 		cleanFunc()
 		return nil, fmt.Errorf("%s %s", err, out)

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -236,6 +236,7 @@ func GoBuild(pkgPath, tmpPrefix string) string {
 
 	cmd := exec.Command(
 		"go", "build",
+		"-mod=vendor",
 		"-o", tmpFilename,
 		pkgPath,
 	)


### PR DESCRIPTION
In a couple places in tests we execute a child `go build` to make a helper program. Now that we're running in module mode, `go build` will normally default to downloading and caching dependencies, which we don't want because we're still using vendoring for the moment.

Therefore we need to instruct these child builds to use vendoring too, avoiding the need to download all of the dependencies and ensuring that we'll be building with the same dependencies that we'd use for a normal build.

(The main motivation of doing this now is actually to avoid wastefully re-downloading all of our dependencies when running tests in Travis-CI.)