### PR TITLE
 fixes for the remaining tests

### DIFF
--- a/helper/plugin/grpc_provider_test.go
+++ b/helper/plugin/grpc_provider_test.go
@@ -662,7 +662,7 @@ func TestNormalizeFlatmapContainers(t *testing.T) {
 			expect: map[string]string{"id": "78629a0f5f3f164f"},
 		},
 		{
-			attrs:  map[string]string{"set.2.required": "bar", "set.2.list.#": "1", "set.2.list.0": "x", "set.1.list.#": "0"},
+			attrs:  map[string]string{"set.2.required": "bar", "set.2.list.#": "1", "set.2.list.0": "x", "set.1.list.#": "0", "set.#": "2"},
 			expect: map[string]string{"set.2.list.#": "1", "set.2.list.0": "x", "set.2.required": "bar", "set.#": "1"},
 		},
 	} {

--- a/states/state_string.go
+++ b/states/state_string.go
@@ -164,8 +164,13 @@ func (m *Module) testString() string {
 			}
 		}
 		attrKeys := make([]string, 0, len(attributes))
-		for ak, _ := range attributes {
+		for ak, val := range attributes {
 			if ak == "id" {
+				continue
+			}
+
+			// don't show empty containers in the output
+			if val == "0" && (strings.HasSuffix(ak, ".#") || strings.HasSuffix(ak, ".%")) {
 				continue
 			}
 

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -2159,7 +2159,8 @@ func TestContext2Plan_computedList(t *testing.T) {
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.bar":
 			checkVals(t, objectVal(t, schema, map[string]cty.Value{
-				"foo": cty.UnknownVal(cty.String),
+				"list": cty.UnknownVal(cty.List(cty.String)),
+				"foo":  cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo":
 			checkVals(t, objectVal(t, schema, map[string]cty.Value{

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -563,7 +563,7 @@ func (d *InstanceDiff) applyCollectionDiff(attrName string, oldAttrs map[string]
 	// check the index first for special handling
 	for k, diff := range d.Attributes {
 		// check the index value, which can be set, and 0
-		if k == attrName+".#" || k == attrName+".%" {
+		if k == attrName+".#" || k == attrName+".%" || k == attrName {
 			if diff.NewRemoved {
 				return result, nil
 			}

--- a/terraform/provider_mock.go
+++ b/terraform/provider_mock.go
@@ -282,6 +282,7 @@ func (p *MockProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 		}
 		priorState := NewInstanceStateShimmedFromValue(r.PriorState, 0)
 		cfg := NewResourceConfigShimmed(r.Config, schema)
+
 		legacyDiff, err := p.DiffFn(info, priorState, cfg)
 
 		var res providers.PlanResourceChangeResponse
@@ -294,6 +295,7 @@ func (p *MockProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 			if err != nil {
 				res.Diagnostics = res.Diagnostics.Append(err)
 			}
+
 			res.PlannedState = newVal
 
 			var requiresNew []string


### PR DESCRIPTION
It's possible that a computed collection could be handled by the
attribute name, rather than the index count value.

Use a new testDiffFn for some tests, which don't work with the old
function that can't determine `computed` without the schema.

add missing key-value from test