### PR TITLE
website: Fix plugin path on Windows

### DIFF
--- a/website/docs/commands/cli-config.html.markdown
+++ b/website/docs/commands/cli-config.html.markdown
@@ -19,7 +19,7 @@ The configuration is placed in a single file whose location depends on the
 host operating system:
 
 * On Windows, the file must be named named `terraform.rc` and placed
-  in the relevant user's "Application Data" directory. The physical location
+  in the relevant user's `%APPDATA%` directory. The physical location
   of this directory depends on your Windows version and system configuration;
   use `$env:APPDATA` in PowerShell to find its location on your system.
 * On all other systems, the file must be named `.terraformrc` (note

--- a/website/docs/commands/init.html.markdown
+++ b/website/docs/commands/init.html.markdown
@@ -123,7 +123,7 @@ For [providers distributed by HashiCorp](/docs/providers/index.html),
 init will automatically download and install plugins if necessary. Plugins
 can also be manually installed in the user plugins directory, located at
 `~/.terraform.d/plugins` on most operating systems and
-`<APPLICATION DATA>\plugins` on Windows.
+`%APPDATA%\terraform.d\plugins` on Windows.
 
 For more information about configuring and installing providers, see
 [Configuration: Providers](/docs/configuration/providers.html).

--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -211,8 +211,8 @@ locations, depending on the host operating system:
 
 Operating system  | User plugins directory
 ------------------|-----------------------
-Windows           | `terraform.d\plugins` in your user's "Application Data" directory
-All other systems | `.terraform.d/plugins` in your user's home directory
+Windows           | `%APPDATA%\terraform.d\plugins`
+All other systems | `~/.terraform.d/plugins`
 
 Once a plugin is installed, `terraform init` can initialize it normally.
 

--- a/website/docs/plugins/basics.html.md
+++ b/website/docs/plugins/basics.html.md
@@ -39,7 +39,7 @@ in its respective documentation section.
 The [provider plugins distributed by HashiCorp](/docs/providers/index.html) are
 automatically installed by `terraform init`. Third-party plugins (both
 providers and provisioners) can be manually installed into the user plugins
-directory, located at `<APPLICATION DATA>\terraform.d\plugins` on Windows and
+directory, located at `%APPDATA%\terraform.d\plugins` on Windows and
 `~/.terraform.d/plugins` on other systems.
 
 For more information, see:


### PR DESCRIPTION
...and one other reference to the application data directory.

Companion PR to https://github.com/hashicorp/terraform-website/pull/565. 

Context:

https://docs.microsoft.com/en-us/windows/desktop/shell/knownfolderid#folderid_roamingappdata

In newer Windows versions, the folder accessible as `%APPDATA%` (and via various
APIs) is actually at something like "documents and settings\user\application
data\roaming", while earlier versions omit the "\roaming" part of the path. This
means you can confuse people by referring to the "application data" directory by
its human name, because "roaming" is the real application data directory, but it
looks like a subdirectory of "application data".

Thus, it's less confusing to just use the `%APPDATA%` variable, with the added
benefit that you can copy and paste the path and it'll just work in most places.