### PR TITLE
backend/s3: making the Region field optional so it can be sourced from an environment variable

### DIFF
--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -39,7 +39,7 @@ func New() backend.Backend {
 
 			"region": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "The region of the S3 bucket.",
 				DefaultFunc: schema.EnvDefaultFunc("AWS_DEFAULT_REGION", nil),
 			},


### PR DESCRIPTION
As this is currently required, the tests fail with:

```
------- Stdout: -------
=== RUN   TestBackend
--- FAIL: TestBackend (0.00s)
    backend_test.go:91: TestBackendConfig on *s3.Backend with configs.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"bucket":cty.StringVal("terraform-remote-s3-test-5bf53abe"), "encrypt":cty.True, "key":cty.StringVal("testState")}}
    backend_test.go:91: Missing required attribute: The attribute "region" is required, but no definition was found.
FAIL
```

With this field being optional - this now passes:

```
=== RUN   TestBackend
2018/11/21 12:08:58 [INFO] Building AWS region structure
2018/11/21 12:08:58 [INFO] Building AWS auth structure
2018/11/21 12:08:58 [INFO] Setting AWS metadata API timeout to 100ms
2018/11/21 12:08:59 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/11/21 12:08:59 [INFO] AWS Auth provider used: "EnvProvider"
2018/11/21 12:08:59 [INFO] Initializing DeviceFarm SDK connection
2018/11/21 12:08:59 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2018/11/21 12:09:09 [DEBUG] Uploading remote state to S3: {
  Body: buffer(0xc00027fc50),
  Bucket: "terraform-remote-s3-test-5bf53cca",
  ContentLength: 156,
  ContentType: "application/json",
  Key: "env:/foo/testState",
  ServerSideEncryption: "AES256"
}
2018/11/21 12:09:14 [DEBUG] Uploading remote state to S3: {
  Body: buffer(0xc000532e10),
  Bucket: "terraform-remote-s3-test-5bf53cca",
  ContentLength: 156,
  ContentType: "application/json",
  Key: "env:/bar/testState",
  ServerSideEncryption: "AES256"
}
2018/11/21 12:09:16 [DEBUG] Uploading remote state to S3: {
  Body: buffer(0xc000582960),
  Bucket: "terraform-remote-s3-test-5bf53cca",
  ContentLength: 156,
  ContentType: "application/json",
  Key: "env:/foo/testState",
  ServerSideEncryption: "AES256"
}
2018/11/21 12:09:17 [DEBUG] Uploading remote state to S3: {
  Body: buffer(0xc000583200),
  Bucket: "terraform-remote-s3-test-5bf53cca",
  ContentLength: 387,
  ContentType: "application/json",
  Key: "env:/bar/testState",
  ServerSideEncryption: "AES256"
}
2018/11/21 12:09:29 [DEBUG] Uploading remote state to S3: {
  Body: buffer(0xc000699410),
  Bucket: "terraform-remote-s3-test-5bf53cca",
  ContentLength: 156,
  ContentType: "application/json",
  Key: "env:/foo/testState",
  ServerSideEncryption: "AES256"
}
--- PASS: TestBackend (38.27s)
```