### PR TITLE
commands: make sure the correct flagset is used

### DIFF
--- a/command/012_config_upgrade.go
+++ b/command/012_config_upgrade.go
@@ -29,7 +29,7 @@ func (c *ZeroTwelveUpgradeCommand) Run(args []string) int {
 
 	var skipConfirm, force bool
 
-	flags := c.Meta.flagSet("0.12upgrade")
+	flags := c.Meta.extendedFlagSet("0.12upgrade")
 	flags.BoolVar(&skipConfirm, "yes", false, "skip confirmation prompt")
 	flags.BoolVar(&force, "force", false, "override duplicate upgrade heuristic")
 	if err := flags.Parse(args); err != nil {

--- a/command/apply.go
+++ b/command/apply.go
@@ -38,7 +38,7 @@ func (c *ApplyCommand) Run(args []string) int {
 		cmdName = "destroy"
 	}
 
-	cmdFlags := c.Meta.flagSet(cmdName)
+	cmdFlags := c.Meta.extendedFlagSet(cmdName)
 	cmdFlags.BoolVar(&autoApprove, "auto-approve", false, "skip interactive approval of plan before applying")
 	if c.Destroy {
 		cmdFlags.BoolVar(&destroyForce, "force", false, "deprecated: same as auto-approve")

--- a/command/console.go
+++ b/command/console.go
@@ -25,7 +25,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := c.Meta.flagSet("console")
+	cmdFlags := c.Meta.defaultFlagSet("console")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
@@ -74,6 +74,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 		c.showDiagnostics(diags)
 		return 1
 	}
+
 	{
 		var moreDiags tfdiags.Diagnostics
 		opReq.Variables, moreDiags = c.collectVariableValues()

--- a/command/debug_json2dot.go
+++ b/command/debug_json2dot.go
@@ -20,7 +20,7 @@ func (c *DebugJSON2DotCommand) Run(args []string) int {
 	if err != nil {
 		return 1
 	}
-	cmdFlags := c.Meta.flagSet("debug json2dot")
+	cmdFlags := c.Meta.extendedFlagSet("debug json2dot")
 
 	if err := cmdFlags.Parse(args); err != nil {
 		return cli.RunResultHelp

--- a/command/fmt.go
+++ b/command/fmt.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -46,14 +45,13 @@ func (c *FmtCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := flag.NewFlagSet("fmt", flag.ContinueOnError)
+	cmdFlags := c.Meta.defaultFlagSet("fmt")
 	cmdFlags.BoolVar(&c.list, "list", true, "list")
 	cmdFlags.BoolVar(&c.write, "write", true, "write")
 	cmdFlags.BoolVar(&c.diff, "diff", false, "diff")
 	cmdFlags.BoolVar(&c.check, "check", false, "check")
 	cmdFlags.BoolVar(&c.recursive, "recursive", false, "recursive")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
-
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
 	}

--- a/command/get.go
+++ b/command/get.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 
@@ -22,7 +21,7 @@ func (c *GetCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := flag.NewFlagSet("get", flag.ContinueOnError)
+	cmdFlags := c.Meta.defaultFlagSet("get")
 	cmdFlags.BoolVar(&update, "update", false, "update")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {

--- a/command/graph.go
+++ b/command/graph.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 
@@ -20,21 +19,21 @@ type GraphCommand struct {
 }
 
 func (c *GraphCommand) Run(args []string) int {
-	var moduleDepth int
-	var verbose bool
 	var drawCycles bool
 	var graphTypeStr string
+	var moduleDepth int
+	var verbose bool
 
 	args, err := c.Meta.process(args, false)
 	if err != nil {
 		return 1
 	}
 
-	cmdFlags := flag.NewFlagSet("graph", flag.ContinueOnError)
-	cmdFlags.IntVar(&moduleDepth, "module-depth", -1, "module-depth")
-	cmdFlags.BoolVar(&verbose, "verbose", false, "verbose")
+	cmdFlags := c.Meta.defaultFlagSet("graph")
 	cmdFlags.BoolVar(&drawCycles, "draw-cycles", false, "draw-cycles")
 	cmdFlags.StringVar(&graphTypeStr, "type", "", "type")
+	cmdFlags.IntVar(&moduleDepth, "module-depth", -1, "module-depth")
+	cmdFlags.BoolVar(&verbose, "verbose", false, "verbose")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -187,11 +186,8 @@ Options:
   -module-depth=n  Specifies the depth of modules to show in the output.	
                    By default this is -1, which will expand all.
 
-  -no-color        If specified, output won't contain any color.
-
   -type=plan       Type of graph to output. Can be: plan, plan-destroy, apply,
                    validate, input, refresh.
-
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/import.go
+++ b/command/import.go
@@ -37,7 +37,7 @@ func (c *ImportCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := c.Meta.flagSet("import")
+	cmdFlags := c.Meta.extendedFlagSet("import")
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", 0, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")

--- a/command/init.go
+++ b/command/init.go
@@ -50,7 +50,8 @@ func (c *InitCommand) Run(args []string) int {
 	if err != nil {
 		return 1
 	}
-	cmdFlags := c.flagSet("init")
+
+	cmdFlags := c.Meta.extendedFlagSet("init")
 	cmdFlags.BoolVar(&flagBackend, "backend", true, "")
 	cmdFlags.Var(flagConfigExtra, "backend-config", "")
 	cmdFlags.StringVar(&flagFromModule, "from-module", "", "copy the source of the given module into the directory before init")
@@ -63,7 +64,6 @@ func (c *InitCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&flagUpgrade, "upgrade", false, "")
 	cmdFlags.Var(&flagPluginPath, "plugin-dir", "plugin directory")
 	cmdFlags.BoolVar(&flagVerifyPlugins, "verify-plugins", true, "verify plugins")
-
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -1864,7 +1864,7 @@ func testMetaBackend(t *testing.T, args []string) *Meta {
 	var m Meta
 	m.Ui = new(cli.MockUi)
 	m.process(args, true)
-	f := m.flagSet("test")
+	f := m.extendedFlagSet("test")
 	if err := f.Parse(args); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/command/meta_config.go
+++ b/command/meta_config.go
@@ -389,6 +389,9 @@ func (f rawFlags) Empty() bool {
 }
 
 func (f rawFlags) AllItems() []rawFlag {
+	if f.items == nil {
+		return nil
+	}
 	return *f.items
 }
 

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -73,7 +73,7 @@ func TestMetaInputMode(t *testing.T) {
 	m := new(Meta)
 	args := []string{}
 
-	fs := m.flagSet("foo")
+	fs := m.extendedFlagSet("foo")
 	if err := fs.Parse(args); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -92,7 +92,7 @@ func TestMetaInputMode_envVar(t *testing.T) {
 	m := new(Meta)
 	args := []string{}
 
-	fs := m.flagSet("foo")
+	fs := m.extendedFlagSet("foo")
 	if err := fs.Parse(args); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -124,7 +124,7 @@ func TestMetaInputMode_disable(t *testing.T) {
 	m := new(Meta)
 	args := []string{"-input=false"}
 
-	fs := m.flagSet("foo")
+	fs := m.extendedFlagSet("foo")
 	if err := fs.Parse(args); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -160,7 +160,7 @@ func TestMetaInputMode_defaultVars(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	fs := m.flagSet("foo")
+	fs := m.extendedFlagSet("foo")
 	if err := fs.Parse(args); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -177,7 +177,7 @@ func TestMetaInputMode_vars(t *testing.T) {
 	m := new(Meta)
 	args := []string{"-var", "foo=bar"}
 
-	fs := m.flagSet("foo")
+	fs := m.extendedFlagSet("foo")
 	if err := fs.Parse(args); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/output.go
+++ b/command/output.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bytes"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"sort"
 	"strings"
@@ -31,7 +30,7 @@ func (c *OutputCommand) Run(args []string) int {
 
 	var module string
 	var jsonOutput bool
-	cmdFlags := flag.NewFlagSet("output", flag.ContinueOnError)
+	cmdFlags := c.Meta.defaultFlagSet("output")
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "json")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&module, "module", "", "module")

--- a/command/plan.go
+++ b/command/plan.go
@@ -25,12 +25,11 @@ func (c *PlanCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := c.Meta.flagSet("plan")
+	cmdFlags := c.Meta.extendedFlagSet("plan")
 	cmdFlags.BoolVar(&destroy, "destroy", false, "destroy")
 	cmdFlags.BoolVar(&refresh, "refresh", true, "refresh")
 	cmdFlags.StringVar(&outPath, "out", "", "path")
-	cmdFlags.IntVar(
-		&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
+	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.BoolVar(&detailed, "detailed-exitcode", false, "detailed-exitcode")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")

--- a/command/providers.go
+++ b/command/providers.go
@@ -29,7 +29,7 @@ func (c *ProvidersCommand) Synopsis() string {
 func (c *ProvidersCommand) Run(args []string) int {
 	c.Meta.process(args, false)
 
-	cmdFlags := c.Meta.flagSet("providers")
+	cmdFlags := c.Meta.defaultFlagSet("providers")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -21,7 +21,7 @@ func (c *RefreshCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := c.Meta.flagSet("refresh")
+	cmdFlags := c.Meta.extendedFlagSet("refresh")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", 0, "parallelism")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
@@ -72,13 +72,15 @@ func (c *RefreshCommand) Run(args []string) int {
 
 	// Build the operation
 	opReq := c.Operation(b)
-	opReq.Type = backend.OperationTypeRefresh
 	opReq.ConfigDir = configPath
+	opReq.Type = backend.OperationTypeRefresh
+
 	opReq.ConfigLoader, err = c.initConfigLoader()
 	if err != nil {
 		c.showDiagnostics(err)
 		return 1
 	}
+
 	{
 		var moreDiags tfdiags.Diagnostics
 		opReq.Variables, moreDiags = c.collectVariableValues()

--- a/command/show.go
+++ b/command/show.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -28,8 +27,7 @@ func (c *ShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := flag.NewFlagSet("show", flag.ContinueOnError)
-
+	cmdFlags := c.Meta.defaultFlagSet("show")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -87,6 +85,7 @@ func (c *ShowCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Get the schemas from the context
 	schemas := ctx.Schemas()
 
 	env := c.Workspace()

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -21,7 +21,7 @@ func (c *StateListCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := c.Meta.flagSet("state list")
+	cmdFlags := c.Meta.defaultFlagSet("state list")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	lookupId := cmdFlags.String("id", "", "Restrict output to paths with a resource having the specified ID.")
 	if err := cmdFlags.Parse(args); err != nil {

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -24,11 +24,13 @@ func (c *StateMvCommand) Run(args []string) int {
 	var backupPathOut, statePathOut string
 
 	var dryRun bool
-	cmdFlags := c.Meta.flagSet("state mv")
+	cmdFlags := c.Meta.defaultFlagSet("state mv")
 	cmdFlags.BoolVar(&dryRun, "dry-run", false, "dry run")
 	cmdFlags.StringVar(&c.backupPath, "backup", "-", "backup")
-	cmdFlags.StringVar(&c.statePath, "state", "", "path")
 	cmdFlags.StringVar(&backupPathOut, "backup-out", "-", "backup")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock states")
+	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
+	cmdFlags.StringVar(&c.statePath, "state", "", "path")
 	cmdFlags.StringVar(&statePathOut, "state-out", "", "path")
 	if err := cmdFlags.Parse(args); err != nil {
 		return cli.RunResultHelp
@@ -300,6 +302,10 @@ Options:
                       file with a backup extension. This only needs
                       to be specified if -state-out is set to a different path
                       than -state.
+
+  -lock=true          Lock the state files when locking is supported.
+
+  -lock-timeout=0s    Duration to retry a state lock.
 
   -state=PATH         Path to the source state file. Defaults to the configured
                       backend, or "terraform.tfstate"

--- a/command/state_pull.go
+++ b/command/state_pull.go
@@ -22,7 +22,7 @@ func (c *StatePullCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := c.Meta.flagSet("state pull")
+	cmdFlags := c.Meta.defaultFlagSet("state pull")
 	if err := cmdFlags.Parse(args); err != nil {
 		return cli.RunResultHelp
 	}

--- a/command/state_push.go
+++ b/command/state_push.go
@@ -26,8 +26,10 @@ func (c *StatePushCommand) Run(args []string) int {
 	}
 
 	var flagForce bool
-	cmdFlags := c.Meta.flagSet("state push")
+	cmdFlags := c.Meta.defaultFlagSet("state push")
 	cmdFlags.BoolVar(&flagForce, "force", false, "")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
+	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
 	if err := cmdFlags.Parse(args); err != nil {
 		return cli.RunResultHelp
 	}
@@ -138,6 +140,10 @@ Options:
 
   -force              Write the state even if lineages don't match or the
                       remote serial is higher.
+
+  -lock=true          Lock the state file when locking is supported.
+
+  -lock-timeout=0s    Duration to retry a state lock.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -22,15 +22,17 @@ func (c *StateRmCommand) Run(args []string) int {
 	}
 
 	var dryRun bool
-	cmdFlags := c.Meta.flagSet("state show")
+	cmdFlags := c.Meta.defaultFlagSet("state rm")
 	cmdFlags.BoolVar(&dryRun, "dry-run", false, "dry run")
 	cmdFlags.StringVar(&c.backupPath, "backup", "-", "backup")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
+	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
 	cmdFlags.StringVar(&c.statePath, "state", "", "path")
 	if err := cmdFlags.Parse(args); err != nil {
 		return cli.RunResultHelp
 	}
-	args = cmdFlags.Args()
 
+	args = cmdFlags.Args()
 	if len(args) < 1 {
 		c.Ui.Error("At least one address is required.\n")
 		return cli.RunResultHelp
@@ -164,6 +166,10 @@ Options:
                       state. This can't be disabled. If not set, Terraform
                       will write it to the same path as the statefile with
                       a backup extension.
+
+  -lock=true          Lock the state file when locking is supported.
+
+  -lock-timeout=0s    Duration to retry a state lock.
 
   -state=PATH         Path to the source state file. Defaults to the configured
                       backend, or "terraform.tfstate"

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -24,7 +24,7 @@ func (c *StateShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := c.Meta.flagSet("state show")
+	cmdFlags := c.Meta.defaultFlagSet("state show")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	if err := cmdFlags.Parse(args); err != nil {
 		return cli.RunResultHelp
@@ -66,6 +66,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	// Build the operation (required to get the schemas)
 	opReq := c.Operation(b)
 	opReq.ConfigDir = cwd
+
 	opReq.ConfigLoader, err = c.initConfigLoader()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error initializing config loader: %s", err))
@@ -78,14 +79,6 @@ func (c *StateShowCommand) Run(args []string) int {
 		c.showDiagnostics(ctxDiags)
 		return 1
 	}
-
-	// Make sure to unlock the state
-	defer func() {
-		err := opReq.StateLocker.Unlock(nil)
-		if err != nil {
-			c.Ui.Error(err.Error())
-		}
-	}()
 
 	// Get the schemas from the context
 	schemas := ctx.Schemas()

--- a/command/taint.go
+++ b/command/taint.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform/states"
-
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/command/clistate"
+	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
@@ -24,16 +23,16 @@ func (c *TaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	var allowMissing bool
 	var module string
-	cmdFlags := c.Meta.flagSet("taint")
+	var allowMissing bool
+	cmdFlags := c.Meta.defaultFlagSet("taint")
 	cmdFlags.BoolVar(&allowMissing, "allow-missing", false, "module")
-	cmdFlags.StringVar(&module, "module", "", "module")
-	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
-	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
+	cmdFlags.StringVar(&module, "module", "", "module")
+	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
+	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -198,8 +197,6 @@ Options:
   -lock=true          Lock the state file when locking is supported.
 
   -lock-timeout=0s    Duration to retry a state lock.
-
-  -no-color           If specified, output won't contain any color.
 
   -state=path         Path to read and save state (unless state-out
                       is specified). Defaults to "terraform.tfstate".

--- a/command/unlock.go
+++ b/command/unlock.go
@@ -23,8 +23,8 @@ func (c *UnlockCommand) Run(args []string) int {
 		return 1
 	}
 
-	force := false
-	cmdFlags := c.Meta.flagSet("force-unlock")
+	var force bool
+	cmdFlags := c.Meta.defaultFlagSet("force-unlock")
 	cmdFlags.BoolVar(&force, "force", false, "force")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
@@ -68,13 +68,13 @@ func (c *UnlockCommand) Run(args []string) int {
 	}
 
 	env := c.Workspace()
-	st, err := b.StateMgr(env)
+	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
 
-	_, isLocal := st.(*statemgr.Filesystem)
+	_, isLocal := stateMgr.(*statemgr.Filesystem)
 
 	if !force {
 		// Forcing this doesn't do anything, but doesn't break anything either,
@@ -103,7 +103,7 @@ func (c *UnlockCommand) Run(args []string) int {
 		}
 	}
 
-	if err := st.Unlock(lockID); err != nil {
+	if err := stateMgr.Unlock(lockID); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to unlock state: %s", err))
 		return 1
 	}

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform/states"
-
-	"github.com/hashicorp/terraform/tfdiags"
-
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/command/clistate"
+	"github.com/hashicorp/terraform/states"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // UntaintCommand is a cli.Command implementation that manually untaints
@@ -25,16 +23,16 @@ func (c *UntaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	var allowMissing bool
 	var module string
-	cmdFlags := c.Meta.flagSet("untaint")
+	var allowMissing bool
+	cmdFlags := c.Meta.defaultFlagSet("untaint")
 	cmdFlags.BoolVar(&allowMissing, "allow-missing", false, "module")
-	cmdFlags.StringVar(&module, "module", "", "module")
-	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
-	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
+	cmdFlags.StringVar(&module, "module", "", "module")
+	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
+	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -201,8 +199,6 @@ Options:
   -module=path        The module path where the resource lives. By
                       default this will be root. Child modules can be specified
                       by names. Ex. "consul" or "consul.vpc" (nested modules).
-
-  -no-color           If specified, output won't contain any color.
 
   -state=path         Path to read and save state (unless state-out
                       is specified). Defaults to "terraform.tfstate".

--- a/command/workspace_command.go
+++ b/command/workspace_command.go
@@ -22,7 +22,7 @@ func (c *WorkspaceCommand) Run(args []string) int {
 
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
-	cmdFlags := c.Meta.flagSet("workspace")
+	cmdFlags := c.Meta.extendedFlagSet("workspace")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 
 	c.Ui.Output(c.Help())

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -21,7 +21,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
-	cmdFlags := c.Meta.flagSet("workspace list")
+	cmdFlags := c.Meta.defaultFlagSet("workspace list")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -93,6 +93,7 @@ func (c *WorkspaceListCommand) Help() string {
 Usage: terraform workspace list [DIR]
 
   List Terraform workspaces.
+
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/workspace_select.go
+++ b/command/workspace_select.go
@@ -22,11 +22,12 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
-	cmdFlags := c.Meta.flagSet("workspace select")
+	cmdFlags := c.Meta.defaultFlagSet("workspace select")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
 	}
+
 	args = cmdFlags.Args()
 	if len(args) == 0 {
 		c.Ui.Error("Expected a single argument: NAME.\n")
@@ -131,6 +132,7 @@ func (c *WorkspaceSelectCommand) Help() string {
 Usage: terraform workspace select NAME [DIR]
 
   Select a different Terraform workspace.
+
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/workspace_show.go
+++ b/command/workspace_show.go
@@ -16,7 +16,7 @@ func (c *WorkspaceShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := c.Meta.flagSet("workspace show")
+	cmdFlags := c.Meta.extendedFlagSet("workspace show")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1


### PR DESCRIPTION
A lot of commands used `c.Meta.flagSet()` to create the initial flagset for the command, while quite a few of them didn’t actually use or support the flags that are then added.

So I updated a few commands to use `flag.NewFlagSet()` instead to only add the flags that are actually needed/supported.

Additionally this prevents a few commands from using locking while they actually don’t need locking (as locking is enabled as a default in `c.Meta.flagSet()`.