### PR TITLE
backend/azurerm: support for authenticating via msi

### DIFF
--- a/backend/remote-state/azure/arm_client.go
+++ b/backend/remote-state/azure/arm_client.go
@@ -50,10 +50,12 @@ func buildArmClient(config BackendConfig) (*ArmClient, error) {
 		SubscriptionID: config.SubscriptionID,
 		TenantID:       config.TenantID,
 		Environment:    config.Environment,
+		MsiEndpoint:    config.MsiEndpoint,
 
 		// Feature Toggles
-		SupportsClientSecretAuth: true,
-		// TODO: support for Azure CLI / Client Certificate / MSI
+		SupportsClientSecretAuth:       true,
+		SupportsManagedServiceIdentity: config.UseMsi,
+		// TODO: support for Azure CLI / Client Certificate auth
 	}
 	armConfig, err := builder.Build()
 	if err != nil {

--- a/backend/remote-state/azure/backend.go
+++ b/backend/remote-state/azure/backend.go
@@ -78,6 +78,20 @@ func New() backend.Backend {
 				DefaultFunc: schema.EnvDefaultFunc("ARM_TENANT_ID", ""),
 			},
 
+			"use_msi": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Should Managed Service Identity be used?.",
+				DefaultFunc: schema.EnvDefaultFunc("ARM_USE_MSI", false),
+			},
+
+			"msi_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The Managed Service Identity Endpoint.",
+				DefaultFunc: schema.EnvDefaultFunc("ARM_MSI_ENDPOINT", ""),
+			},
+
 			// TODO: rename these fields
 			// TODO: support for custom resource manager endpoints
 		},
@@ -106,9 +120,11 @@ type BackendConfig struct {
 	ClientID          string
 	ClientSecret      string
 	Environment       string
+	MsiEndpoint       string
 	ResourceGroupName string
 	SubscriptionID    string
 	TenantID          string
+	UseMsi            bool
 }
 
 func (b *Backend) configure(ctx context.Context) error {
@@ -127,10 +143,12 @@ func (b *Backend) configure(ctx context.Context) error {
 		ClientID:           data.Get("arm_client_id").(string),
 		ClientSecret:       data.Get("arm_client_secret").(string),
 		Environment:        data.Get("environment").(string),
+		MsiEndpoint:        data.Get("msi_endpoint").(string),
 		ResourceGroupName:  data.Get("resource_group_name").(string),
 		StorageAccountName: data.Get("storage_account_name").(string),
 		SubscriptionID:     data.Get("arm_subscription_id").(string),
 		TenantID:           data.Get("arm_tenant_id").(string),
+		UseMsi:             data.Get("use_msi").(bool),
 	}
 
 	armClient, err := buildArmClient(config)

--- a/backend/remote-state/azure/backend_test.go
+++ b/backend/remote-state/azure/backend_test.go
@@ -77,6 +77,7 @@ func TestBackendManagedServiceIdentityBasic(t *testing.T) {
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
+		"resource_group_name":  res.resourceGroup,
 		"use_msi":              true,
 		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
 		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),

--- a/backend/remote-state/azure/backend_test.go
+++ b/backend/remote-state/azure/backend_test.go
@@ -59,6 +59,33 @@ func TestBackendAccessKeyBasic(t *testing.T) {
 	backend.TestBackendStates(t, b)
 }
 
+func TestBackendManagedServiceIdentityBasic(t *testing.T) {
+	testAccAzureBackendRunningInAzure(t)
+	rs := acctest.RandString(4)
+	res := testResourceNames(rs, "testState")
+	armClient := buildTestClient(t, res)
+
+	ctx := context.TODO()
+	err := armClient.buildTestResources(ctx, &res)
+	if err != nil {
+		armClient.destroyTestResources(ctx, res)
+		t.Fatalf("Error creating Test Resources: %q", err)
+	}
+	defer armClient.destroyTestResources(ctx, res)
+
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
+		"storage_account_name": res.storageAccountName,
+		"container_name":       res.storageContainerName,
+		"key":                  res.storageKeyName,
+		"use_msi":              true,
+		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
+		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),
+		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+	})).(*Backend)
+
+	backend.TestBackendStates(t, b)
+}
+
 func TestBackendServicePrincipalBasic(t *testing.T) {
 	testAccAzureBackend(t)
 	rs := acctest.RandString(4)

--- a/backend/remote-state/azure/client_test.go
+++ b/backend/remote-state/azure/client_test.go
@@ -63,6 +63,7 @@ func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
+		"resource_group_name":  res.resourceGroup,
 		"use_msi":              true,
 		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
 		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),
@@ -95,12 +96,12 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
-		"resource_group_name": res.resourceGroup,
-		"arm_subscription_id": os.Getenv("ARM_SUBSCRIPTION_ID"),
-		"arm_tenant_id":       os.Getenv("ARM_TENANT_ID"),
-		"arm_client_id":       os.Getenv("ARM_CLIENT_ID"),
-		"arm_client_secret":   os.Getenv("ARM_CLIENT_SECRET"),
-		"environment":         os.Getenv("ARM_ENVIRONMENT"),
+		"resource_group_name":  res.resourceGroup,
+		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
+		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),
+		"arm_client_id":        os.Getenv("ARM_CLIENT_ID"),
+		"arm_client_secret":    os.Getenv("ARM_CLIENT_SECRET"),
+		"environment":          os.Getenv("ARM_ENVIRONMENT"),
 	})).(*Backend)
 
 	state, err := b.StateMgr(backend.DefaultStateName)
@@ -170,24 +171,24 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
-		"resource_group_name": res.resourceGroup,
-		"arm_subscription_id": os.Getenv("ARM_SUBSCRIPTION_ID"),
-		"arm_tenant_id":       os.Getenv("ARM_TENANT_ID"),
-		"arm_client_id":       os.Getenv("ARM_CLIENT_ID"),
-		"arm_client_secret":   os.Getenv("ARM_CLIENT_SECRET"),
-		"environment":         os.Getenv("ARM_ENVIRONMENT"),
+		"resource_group_name":  res.resourceGroup,
+		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
+		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),
+		"arm_client_id":        os.Getenv("ARM_CLIENT_ID"),
+		"arm_client_secret":    os.Getenv("ARM_CLIENT_SECRET"),
+		"environment":          os.Getenv("ARM_ENVIRONMENT"),
 	})).(*Backend)
 
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
-		"resource_group_name": res.resourceGroup,
-		"arm_subscription_id": os.Getenv("ARM_SUBSCRIPTION_ID"),
-		"arm_tenant_id":       os.Getenv("ARM_TENANT_ID"),
-		"arm_client_id":       os.Getenv("ARM_CLIENT_ID"),
-		"arm_client_secret":   os.Getenv("ARM_CLIENT_SECRET"),
-		"environment":         os.Getenv("ARM_ENVIRONMENT"),
+		"resource_group_name":  res.resourceGroup,
+		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
+		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),
+		"arm_client_id":        os.Getenv("ARM_CLIENT_ID"),
+		"arm_client_secret":    os.Getenv("ARM_CLIENT_SECRET"),
+		"environment":          os.Getenv("ARM_ENVIRONMENT"),
 	})).(*Backend)
 
 	s1, err := b1.StateMgr(backend.DefaultStateName)

--- a/backend/remote-state/azure/client_test.go
+++ b/backend/remote-state/azure/client_test.go
@@ -45,6 +45,38 @@ func TestRemoteClientAccessKeyBasic(t *testing.T) {
 	remote.TestClient(t, state.(*remote.State).Client)
 }
 
+func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
+	testAccAzureBackendRunningInAzure(t)
+	rs := acctest.RandString(4)
+	res := testResourceNames(rs, "testState")
+	armClient := buildTestClient(t, res)
+
+	ctx := context.TODO()
+	err := armClient.buildTestResources(ctx, &res)
+	if err != nil {
+		armClient.destroyTestResources(ctx, res)
+		t.Fatalf("Error creating Test Resources: %q", err)
+	}
+	defer armClient.destroyTestResources(ctx, res)
+
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
+		"storage_account_name": res.storageAccountName,
+		"container_name":       res.storageContainerName,
+		"key":                  res.storageKeyName,
+		"use_msi":              true,
+		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
+		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),
+		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+	})).(*Backend)
+
+	state, err := b.StateMgr(backend.DefaultStateName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remote.TestClient(t, state.(*remote.State).Client)
+}
+
 func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 	testAccAzureBackend(t)
 	rs := acctest.RandString(4)
@@ -63,12 +95,12 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
-		"resource_group_name":  res.resourceGroup,
-		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
-		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),
-		"arm_client_id":        os.Getenv("ARM_CLIENT_ID"),
-		"arm_client_secret":    os.Getenv("ARM_CLIENT_SECRET"),
-		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"resource_group_name": res.resourceGroup,
+		"arm_subscription_id": os.Getenv("ARM_SUBSCRIPTION_ID"),
+		"arm_tenant_id":       os.Getenv("ARM_TENANT_ID"),
+		"arm_client_id":       os.Getenv("ARM_CLIENT_ID"),
+		"arm_client_secret":   os.Getenv("ARM_CLIENT_SECRET"),
+		"environment":         os.Getenv("ARM_ENVIRONMENT"),
 	})).(*Backend)
 
 	state, err := b.StateMgr(backend.DefaultStateName)
@@ -138,24 +170,24 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
-		"resource_group_name":  res.resourceGroup,
-		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
-		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),
-		"arm_client_id":        os.Getenv("ARM_CLIENT_ID"),
-		"arm_client_secret":    os.Getenv("ARM_CLIENT_SECRET"),
-		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"resource_group_name": res.resourceGroup,
+		"arm_subscription_id": os.Getenv("ARM_SUBSCRIPTION_ID"),
+		"arm_tenant_id":       os.Getenv("ARM_TENANT_ID"),
+		"arm_client_id":       os.Getenv("ARM_CLIENT_ID"),
+		"arm_client_secret":   os.Getenv("ARM_CLIENT_SECRET"),
+		"environment":         os.Getenv("ARM_ENVIRONMENT"),
 	})).(*Backend)
 
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
-		"resource_group_name":  res.resourceGroup,
-		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
-		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),
-		"arm_client_id":        os.Getenv("ARM_CLIENT_ID"),
-		"arm_client_secret":    os.Getenv("ARM_CLIENT_SECRET"),
-		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"resource_group_name": res.resourceGroup,
+		"arm_subscription_id": os.Getenv("ARM_SUBSCRIPTION_ID"),
+		"arm_tenant_id":       os.Getenv("ARM_TENANT_ID"),
+		"arm_client_id":       os.Getenv("ARM_CLIENT_ID"),
+		"arm_client_secret":   os.Getenv("ARM_CLIENT_SECRET"),
+		"environment":         os.Getenv("ARM_ENVIRONMENT"),
 	})).(*Backend)
 
 	s1, err := b1.StateMgr(backend.DefaultStateName)

--- a/backend/remote-state/azure/helpers_test.go
+++ b/backend/remote-state/azure/helpers_test.go
@@ -21,6 +21,15 @@ func testAccAzureBackend(t *testing.T) {
 	}
 }
 
+// these kind of tests can only run when within Azure (e.g. MSI)
+func testAccAzureBackendRunningInAzure(t *testing.T) {
+	testAccAzureBackend(t)
+
+	if os.Getenv("TF_RUNNING_IN_AZURE") == "" {
+		t.Skip("Skipping test since not running in Azure")
+	}
+}
+
 func buildTestClient(t *testing.T, res resourceNames) *ArmClient {
 	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	tenantID := os.Getenv("ARM_TENANT_ID")

--- a/website/docs/backends/types/azurerm.html.md
+++ b/website/docs/backends/types/azurerm.html.md
@@ -27,6 +27,21 @@ terraform {
 }
 ```
 
+When authenticating using Managed Service Identity (MSI):
+
+```hcl
+terraform {
+  backend "azurerm" {
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    use_msi              = true
+    arm_subscription_id  = "00000000-0000-0000-0000-000000000000"
+    arm_tenant_id        = "00000000-0000-0000-0000-000000000000"
+  }
+}
+```
+
 When authenticating using the Access Key associated with the Storage Account:
 
 ```hcl
@@ -60,6 +75,22 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
+When authenticating using Managed Service Identity (MSI):
+
+```hcl
+data "terraform_remote_state" "foo" {
+  backend = "azurerm"
+  config = {
+    storage_account_name = "terraform123abc"
+    container_name       = "terraform-state"
+    key                  = "prod.terraform.tfstate"
+    use_msi              = true
+    arm_subscription_id  = "00000000-0000-0000-0000-000000000000"
+    arm_tenant_id        = "00000000-0000-0000-0000-000000000000"
+  }
+}
+```
+
 When authenticating using the Access Key associated with the Storage Account:
 
 ```hcl
@@ -88,6 +119,18 @@ The following configuration options are supported:
 * `key` - (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.
 
 * `environment` - (Optional) The Azure Environment which should be used. This can also be sourced from the `ARM_ENVIRONMENT` environment variable. Possible values are `public`, `china`, `german`, `stack` and `usgovernment`. Defaults to `public`.
+
+---
+
+When authenticating using the Managed Service Identity (MSI) - the following fields are also supported:
+
+* `arm_subscription_id` - (Optional) The Subscription ID in which the Storage Account exists. This can also be sourced from the `ARM_SUBSCRIPTION_ID` environment variable.
+
+* `arm_tenant_id` - (Optional) The Tenant ID in which the Subscription exists. This can also be sourced from the `ARM_TENANT_ID` environment variable.
+
+* `msi_endpoint` - (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified. This can also be sourced from the `ARM_MSI_ENDPOINT` environment variable.
+
+* `use_msi` - (Optional) Should Managed Service Identity authentication be used? This can also be sourced from the `ARM_USE_MSI` environment variable.
 
 ---
 


### PR DESCRIPTION
Requires a feature-toggled acceptance test, since this could only be run from within an Azure VM

Fixes #18425