### PR TITLE
command/format: Fix rendering of attribute-agnostic diagnostics

### DIFF
--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -148,11 +148,11 @@ func TestOutputWithoutValueShouldFail(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("Should have failed: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
-	wantError := `The attribute "value" is required, but no definition was found.`
+	wantError := `The argument "value" is required, but no definition was found.`
 	if !strings.Contains(ui.ErrorWriter.String(), wantError) {
 		t.Fatalf("Missing error string %q\n\n'%s'", wantError, ui.ErrorWriter.String())
 	}
-	wantError = `An attribute named "values" is not expected here. Did you mean "value"?`
+	wantError = `An argument named "values" is not expected here. Did you mean "value"?`
 	if !strings.Contains(ui.ErrorWriter.String(), wantError) {
 		t.Fatalf("Missing error string %q\n\n'%s'", wantError, ui.ErrorWriter.String())
 	}

--- a/configs/parser_config_test.go
+++ b/configs/parser_config_test.go
@@ -102,7 +102,7 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 		{
 			"invalid-files/unexpected-attr.tf",
 			hcl.DiagError,
-			"Unsupported attribute",
+			"Unsupported argument",
 		},
 		{
 			"invalid-files/unexpected-block.tf",

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/hashicorp/go-version v0.0.0-20180322230233-23480c066577
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20180925175540-3f1c5474d4f7
+	github.com/hashicorp/hcl2 v0.0.0-20181126233546-67424e43b184
 	github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250
 	github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3
 	github.com/hashicorp/memberlist v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/blang/semver v0.0.0-20170202183821-4a1e882c79dc h1:J/iAaGTCZYfT/allw6
 github.com/blang/semver v0.0.0-20170202183821-4a1e882c79dc/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
+github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e h1:D64GF/Xr5zSUnM3q1Jylzo4sK7szhP/ON+nb2DB5XJA=
+github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20161106042343-c914be64f07d h1:aG5FcWiZTOhPQzYIxwxSR1zEOxzL32fwr1CsaCfhO6w=
@@ -166,6 +168,10 @@ github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+Db
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl2 v0.0.0-20180925175540-3f1c5474d4f7 h1:lNBI8nmNlIpLl8Lqf+9JLBmNGrU91Nlt71q7cGpZi+k=
 github.com/hashicorp/hcl2 v0.0.0-20180925175540-3f1c5474d4f7/go.mod h1:hrRmgPTdXWuNLpHcv7cRXL+ofoFsY76vDylTzH8eu3E=
+github.com/hashicorp/hcl2 v0.0.0-20181123160133-f901b36da204 h1:/rUVBMdrcpWOwNw5KFhqrbMVnbgsN1zJOp5sAEx2XXQ=
+github.com/hashicorp/hcl2 v0.0.0-20181123160133-f901b36da204/go.mod h1:4nBvwJRETsbpa0LQ7FbXXVFmo0Crvhya1Dmpbm7cVow=
+github.com/hashicorp/hcl2 v0.0.0-20181126233546-67424e43b184 h1:cBDzEsx+Tm9vHp9WiUeBlhPazwbbKJxOiRAT+pVLuag=
+github.com/hashicorp/hcl2 v0.0.0-20181126233546-67424e43b184/go.mod h1:4nBvwJRETsbpa0LQ7FbXXVFmo0Crvhya1Dmpbm7cVow=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250 h1:fooK5IvDL/KIsi4LxF/JH68nVdrBSiGNPhS2JAQjtjo=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250/go.mod h1:KHvg/R2/dPtaePb16oW4qIyzkMxXOL38xjRN64adsts=
 github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3 h1:oD64EFjELI9RY9yoWlfua58r+etdnoIC871z+rr6lkA=

--- a/vendor/github.com/hashicorp/hcl2/gohcl/doc.go
+++ b/vendor/github.com/hashicorp/hcl2/gohcl/doc.go
@@ -40,6 +40,10 @@
 // present then any attributes or blocks not matched by another valid tag
 // will cause an error diagnostic.
 //
+// Only a subset of this tagging/typing vocabulary is supported for the
+// "Encode" family of functions. See the EncodeIntoBody docs for full details
+// on the constraints there.
+//
 // Broadly-speaking this package deals with two types of error. The first is
 // errors in the configuration itself, which are returned as diagnostics
 // written with the configuration author as the target audience. The second

--- a/vendor/github.com/hashicorp/hcl2/gohcl/encode.go
+++ b/vendor/github.com/hashicorp/hcl2/gohcl/encode.go
@@ -1,0 +1,191 @@
+package gohcl
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/hashicorp/hcl2/hclwrite"
+	"github.com/zclconf/go-cty/cty/gocty"
+)
+
+// EncodeIntoBody replaces the contents of the given hclwrite Body with
+// attributes and blocks derived from the given value, which must be a
+// struct value or a pointer to a struct value with the struct tags defined
+// in this package.
+//
+// This function can work only with fully-decoded data. It will ignore any
+// fields tagged as "remain", any fields that decode attributes into either
+// hcl.Attribute or hcl.Expression values, and any fields that decode blocks
+// into hcl.Attributes values. This function does not have enough information
+// to complete the decoding of these types.
+//
+// Any fields tagged as "label" are ignored by this function. Use EncodeAsBlock
+// to produce a whole hclwrite.Block including block labels.
+//
+// As long as a suitable value is given to encode and the destination body
+// is non-nil, this function will always complete. It will panic in case of
+// any errors in the calling program, such as passing an inappropriate type
+// or a nil body.
+//
+// The layout of the resulting HCL source is derived from the ordering of
+// the struct fields, with blank lines around nested blocks of different types.
+// Fields representing attributes should usually precede those representing
+// blocks so that the attributes can group togather in the result. For more
+// control, use the hclwrite API directly.
+func EncodeIntoBody(val interface{}, dst *hclwrite.Body) {
+	rv := reflect.ValueOf(val)
+	ty := rv.Type()
+	if ty.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+		ty = rv.Type()
+	}
+	if ty.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("value is %s, not struct", ty.Kind()))
+	}
+
+	tags := getFieldTags(ty)
+	populateBody(rv, ty, tags, dst)
+}
+
+// EncodeAsBlock creates a new hclwrite.Block populated with the data from
+// the given value, which must be a struct or pointer to struct with the
+// struct tags defined in this package.
+//
+// If the given struct type has fields tagged with "label" tags then they
+// will be used in order to annotate the created block with labels.
+//
+// This function has the same constraints as EncodeIntoBody and will panic
+// if they are violated.
+func EncodeAsBlock(val interface{}, blockType string) *hclwrite.Block {
+	rv := reflect.ValueOf(val)
+	ty := rv.Type()
+	if ty.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+		ty = rv.Type()
+	}
+	if ty.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("value is %s, not struct", ty.Kind()))
+	}
+
+	tags := getFieldTags(ty)
+	labels := make([]string, len(tags.Labels))
+	for i, lf := range tags.Labels {
+		lv := rv.Field(lf.FieldIndex)
+		// We just stringify whatever we find. It should always be a string
+		// but if not then we'll still do something reasonable.
+		labels[i] = fmt.Sprintf("%s", lv.Interface())
+	}
+
+	block := hclwrite.NewBlock(blockType, labels)
+	populateBody(rv, ty, tags, block.Body())
+	return block
+}
+
+func populateBody(rv reflect.Value, ty reflect.Type, tags *fieldTags, dst *hclwrite.Body) {
+	nameIdxs := make(map[string]int, len(tags.Attributes)+len(tags.Blocks))
+	namesOrder := make([]string, 0, len(tags.Attributes)+len(tags.Blocks))
+	for n, i := range tags.Attributes {
+		nameIdxs[n] = i
+		namesOrder = append(namesOrder, n)
+	}
+	for n, i := range tags.Blocks {
+		nameIdxs[n] = i
+		namesOrder = append(namesOrder, n)
+	}
+	sort.SliceStable(namesOrder, func(i, j int) bool {
+		ni, nj := namesOrder[i], namesOrder[j]
+		return nameIdxs[ni] < nameIdxs[nj]
+	})
+
+	dst.Clear()
+
+	prevWasBlock := false
+	for _, name := range namesOrder {
+		fieldIdx := nameIdxs[name]
+		field := ty.Field(fieldIdx)
+		fieldTy := field.Type
+		fieldVal := rv.Field(fieldIdx)
+
+		if fieldTy.Kind() == reflect.Ptr {
+			fieldTy = fieldTy.Elem()
+			fieldVal = fieldVal.Elem()
+		}
+
+		if _, isAttr := tags.Attributes[name]; isAttr {
+
+			if exprType.AssignableTo(fieldTy) || attrType.AssignableTo(fieldTy) {
+				continue // ignore undecoded fields
+			}
+			if !fieldVal.IsValid() {
+				continue // ignore (field value is nil pointer)
+			}
+			if fieldTy.Kind() == reflect.Ptr && fieldVal.IsNil() {
+				continue // ignore
+			}
+			if prevWasBlock {
+				dst.AppendNewline()
+				prevWasBlock = false
+			}
+
+			valTy, err := gocty.ImpliedType(fieldVal.Interface())
+			if err != nil {
+				panic(fmt.Sprintf("cannot encode %T as HCL expression: %s", fieldVal.Interface(), err))
+			}
+
+			val, err := gocty.ToCtyValue(fieldVal.Interface(), valTy)
+			if err != nil {
+				// This should never happen, since we should always be able
+				// to decode into the implied type.
+				panic(fmt.Sprintf("failed to encode %T as %#v: %s", fieldVal.Interface(), valTy, err))
+			}
+
+			dst.SetAttributeValue(name, val)
+
+		} else { // must be a block, then
+			elemTy := fieldTy
+			isSeq := false
+			if elemTy.Kind() == reflect.Slice || elemTy.Kind() == reflect.Array {
+				isSeq = true
+				elemTy = elemTy.Elem()
+			}
+
+			if bodyType.AssignableTo(elemTy) || attrsType.AssignableTo(elemTy) {
+				continue // ignore undecoded fields
+			}
+			prevWasBlock = false
+
+			if isSeq {
+				l := fieldVal.Len()
+				for i := 0; i < l; i++ {
+					elemVal := fieldVal.Index(i)
+					if !elemVal.IsValid() {
+						continue // ignore (elem value is nil pointer)
+					}
+					if elemTy.Kind() == reflect.Ptr && elemVal.IsNil() {
+						continue // ignore
+					}
+					block := EncodeAsBlock(elemVal.Interface(), name)
+					if !prevWasBlock {
+						dst.AppendNewline()
+						prevWasBlock = true
+					}
+					dst.AppendBlock(block)
+				}
+			} else {
+				if !fieldVal.IsValid() {
+					continue // ignore (field value is nil pointer)
+				}
+				if elemTy.Kind() == reflect.Ptr && fieldVal.IsNil() {
+					continue // ignore
+				}
+				block := EncodeAsBlock(fieldVal.Interface(), name)
+				if !prevWasBlock {
+					dst.AppendNewline()
+					prevWasBlock = true
+				}
+				dst.AppendBlock(block)
+			}
+		}
+	}
+}

--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/expression.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/expression.go
@@ -132,7 +132,7 @@ type RelativeTraversalExpr struct {
 }
 
 func (e *RelativeTraversalExpr) walkChildNodes(w internalWalkFunc) {
-	e.Source = w(e.Source).(Expression)
+	w(e.Source)
 }
 
 func (e *RelativeTraversalExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -181,8 +181,8 @@ type FunctionCallExpr struct {
 }
 
 func (e *FunctionCallExpr) walkChildNodes(w internalWalkFunc) {
-	for i, arg := range e.Args {
-		e.Args[i] = w(arg).(Expression)
+	for _, arg := range e.Args {
+		w(arg)
 	}
 }
 
@@ -463,9 +463,9 @@ type ConditionalExpr struct {
 }
 
 func (e *ConditionalExpr) walkChildNodes(w internalWalkFunc) {
-	e.Condition = w(e.Condition).(Expression)
-	e.TrueResult = w(e.TrueResult).(Expression)
-	e.FalseResult = w(e.FalseResult).(Expression)
+	w(e.Condition)
+	w(e.TrueResult)
+	w(e.FalseResult)
 }
 
 func (e *ConditionalExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -593,8 +593,8 @@ type IndexExpr struct {
 }
 
 func (e *IndexExpr) walkChildNodes(w internalWalkFunc) {
-	e.Collection = w(e.Collection).(Expression)
-	e.Key = w(e.Key).(Expression)
+	w(e.Collection)
+	w(e.Key)
 }
 
 func (e *IndexExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -625,8 +625,8 @@ type TupleConsExpr struct {
 }
 
 func (e *TupleConsExpr) walkChildNodes(w internalWalkFunc) {
-	for i, expr := range e.Exprs {
-		e.Exprs[i] = w(expr).(Expression)
+	for _, expr := range e.Exprs {
+		w(expr)
 	}
 }
 
@@ -674,9 +674,9 @@ type ObjectConsItem struct {
 }
 
 func (e *ObjectConsExpr) walkChildNodes(w internalWalkFunc) {
-	for i, item := range e.Items {
-		e.Items[i].KeyExpr = w(item.KeyExpr).(Expression)
-		e.Items[i].ValueExpr = w(item.ValueExpr).(Expression)
+	for _, item := range e.Items {
+		w(item.KeyExpr)
+		w(item.ValueExpr)
 	}
 }
 
@@ -792,7 +792,7 @@ func (e *ObjectConsKeyExpr) walkChildNodes(w internalWalkFunc) {
 	// We only treat our wrapped expression as a real expression if we're
 	// not going to interpret it as a literal.
 	if e.literalName() == "" {
-		e.Wrapped = w(e.Wrapped).(Expression)
+		w(e.Wrapped)
 	}
 }
 
@@ -1157,7 +1157,7 @@ func (e *ForExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 }
 
 func (e *ForExpr) walkChildNodes(w internalWalkFunc) {
-	e.CollExpr = w(e.CollExpr).(Expression)
+	w(e.CollExpr)
 
 	scopeNames := map[string]struct{}{}
 	if e.KeyVar != "" {
@@ -1170,17 +1170,17 @@ func (e *ForExpr) walkChildNodes(w internalWalkFunc) {
 	if e.KeyExpr != nil {
 		w(ChildScope{
 			LocalNames: scopeNames,
-			Expr:       &e.KeyExpr,
+			Expr:       e.KeyExpr,
 		})
 	}
 	w(ChildScope{
 		LocalNames: scopeNames,
-		Expr:       &e.ValExpr,
+		Expr:       e.ValExpr,
 	})
 	if e.CondExpr != nil {
 		w(ChildScope{
 			LocalNames: scopeNames,
-			Expr:       &e.CondExpr,
+			Expr:       e.CondExpr,
 		})
 	}
 }
@@ -1266,8 +1266,8 @@ func (e *SplatExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 }
 
 func (e *SplatExpr) walkChildNodes(w internalWalkFunc) {
-	e.Source = w(e.Source).(Expression)
-	e.Each = w(e.Each).(Expression)
+	w(e.Source)
+	w(e.Each)
 }
 
 func (e *SplatExpr) Range() hcl.Range {

--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/expression_ops.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/expression_ops.go
@@ -129,8 +129,8 @@ type BinaryOpExpr struct {
 }
 
 func (e *BinaryOpExpr) walkChildNodes(w internalWalkFunc) {
-	e.LHS = w(e.LHS).(Expression)
-	e.RHS = w(e.RHS).(Expression)
+	w(e.LHS)
+	w(e.RHS)
 }
 
 func (e *BinaryOpExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -212,7 +212,7 @@ type UnaryOpExpr struct {
 }
 
 func (e *UnaryOpExpr) walkChildNodes(w internalWalkFunc) {
-	e.Val = w(e.Val).(Expression)
+	w(e.Val)
 }
 
 func (e *UnaryOpExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {

--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/expression_template.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/expression_template.go
@@ -16,8 +16,8 @@ type TemplateExpr struct {
 }
 
 func (e *TemplateExpr) walkChildNodes(w internalWalkFunc) {
-	for i, part := range e.Parts {
-		e.Parts[i] = w(part).(Expression)
+	for _, part := range e.Parts {
+		w(part)
 	}
 }
 
@@ -98,7 +98,7 @@ type TemplateJoinExpr struct {
 }
 
 func (e *TemplateJoinExpr) walkChildNodes(w internalWalkFunc) {
-	e.Tuple = w(e.Tuple).(Expression)
+	w(e.Tuple)
 }
 
 func (e *TemplateJoinExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -184,7 +184,7 @@ type TemplateWrapExpr struct {
 }
 
 func (e *TemplateWrapExpr) walkChildNodes(w internalWalkFunc) {
-	e.Wrapped = w(e.Wrapped).(Expression)
+	w(e.Wrapped)
 }
 
 func (e *TemplateWrapExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {

--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/navigation.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/navigation.go
@@ -3,6 +3,8 @@ package hclsyntax
 import (
 	"bytes"
 	"fmt"
+
+	"github.com/hashicorp/hcl2/hcl"
 )
 
 type navigation struct {
@@ -38,4 +40,20 @@ func (n navigation) ContextString(offset int) string {
 		fmt.Fprintf(buf, " %q", label)
 	}
 	return buf.String()
+}
+
+func (n navigation) ContextDefRange(offset int) hcl.Range {
+	var block *Block
+	for _, candidate := range n.root.Blocks {
+		if candidate.Range().ContainsOffset(offset) {
+			block = candidate
+			break
+		}
+	}
+
+	if block == nil {
+		return hcl.Range{}
+	}
+
+	return block.DefRange()
 }

--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/node.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/node.go
@@ -19,4 +19,4 @@ type Node interface {
 	Range() hcl.Range
 }
 
-type internalWalkFunc func(Node) Node
+type internalWalkFunc func(Node)

--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/parser.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/parser.go
@@ -273,7 +273,10 @@ Token:
 			return &Block{
 				Type:   blockType,
 				Labels: labels,
-				Body:   nil,
+				Body:   &Body{
+					SrcRange: ident.Range,
+					EndRange: ident.Range,
+				},
 
 				TypeRange:       ident.Range,
 				LabelRanges:     labelRanges,

--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/variables.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/variables.go
@@ -72,15 +72,15 @@ func (w *variablesWalker) Exit(n Node) hcl.Diagnostics {
 // that the child scope struct wraps.
 type ChildScope struct {
 	LocalNames map[string]struct{}
-	Expr       *Expression // pointer because it can be replaced on walk
+	Expr       Expression
 }
 
 func (e ChildScope) walkChildNodes(w internalWalkFunc) {
-	*(e.Expr) = w(*(e.Expr)).(Expression)
+	w(e.Expr)
 }
 
 // Range returns the range of the expression that the ChildScope is
 // encapsulating. It isn't really very useful to call Range on a ChildScope.
 func (e ChildScope) Range() hcl.Range {
-	return (*e.Expr).Range()
+	return e.Expr.Range()
 }

--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/walk.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/walk.go
@@ -15,9 +15,8 @@ type VisitFunc func(node Node) hcl.Diagnostics
 // and returned as a single set.
 func VisitAll(node Node, f VisitFunc) hcl.Diagnostics {
 	diags := f(node)
-	node.walkChildNodes(func(node Node) Node {
+	node.walkChildNodes(func(node Node) {
 		diags = append(diags, VisitAll(node, f)...)
-		return node
 	})
 	return diags
 }
@@ -33,47 +32,10 @@ type Walker interface {
 // Enter and Exit functions.
 func Walk(node Node, w Walker) hcl.Diagnostics {
 	diags := w.Enter(node)
-	node.walkChildNodes(func(node Node) Node {
+	node.walkChildNodes(func(node Node) {
 		diags = append(diags, Walk(node, w)...)
-		return node
 	})
 	moreDiags := w.Exit(node)
 	diags = append(diags, moreDiags...)
 	return diags
-}
-
-// Transformer is an interface used with Transform
-type Transformer interface {
-	// Transform accepts a node and returns a replacement node along with
-	// a flag for whether to also visit child nodes. If the flag is false,
-	// none of the child nodes will be visited and the TransformExit method
-	// will not be called for the node.
-	//
-	// It is acceptable and appropriate for Transform to return the same node
-	// it was given, for situations where no transform is needed.
-	Transform(node Node) (Node, bool, hcl.Diagnostics)
-
-	// TransformExit signals the end of transformations of child nodes of the
-	// given node. If Transform returned a new node, the given node is the
-	// node that was returned, rather than the node that was originally
-	// encountered.
-	TransformExit(node Node) hcl.Diagnostics
-}
-
-// Transform allows for in-place transformations of an AST starting with a
-// particular node. The provider Transformer implementation drives the
-// transformation process. The return value is the node that replaced the
-// given top-level node.
-func Transform(node Node, t Transformer) (Node, hcl.Diagnostics) {
-	newNode, descend, diags := t.Transform(node)
-	if !descend {
-		return newNode, diags
-	}
-	node.walkChildNodes(func(node Node) Node {
-		newNode, newDiags := Transform(node, t)
-		diags = append(diags, newDiags...)
-		return newNode
-	})
-	diags = append(diags, t.TransformExit(newNode)...)
-	return newNode, diags
 }

--- a/vendor/github.com/hashicorp/hcl2/hcled/navigation.go
+++ b/vendor/github.com/hashicorp/hcl2/hcled/navigation.go
@@ -18,3 +18,17 @@ func ContextString(file *hcl.File, offset int) string {
 	}
 	return ""
 }
+
+type contextDefRanger interface {
+	ContextDefRange(offset int) hcl.Range
+}
+
+func ContextDefRange(file *hcl.File, offset int) hcl.Range {
+	if cser, ok := file.Nav.(contextDefRanger); ok {
+		defRange := cser.ContextDefRange(offset)
+		if !defRange.Empty() {
+			return defRange
+		}
+	}
+	return file.Body.MissingItemRange()
+}

--- a/vendor/github.com/hashicorp/hcl2/hclwrite/ast.go
+++ b/vendor/github.com/hashicorp/hcl2/hclwrite/ast.go
@@ -12,6 +12,17 @@ type File struct {
 	body     *node
 }
 
+// NewEmptyFile constructs a new file with no content, ready to be mutated
+// by other calls that append to its body.
+func NewEmptyFile() *File {
+	f := &File{
+		inTree: newInTree(),
+	}
+	body := newBody()
+	f.body = f.children.Append(body)
+	return f
+}
+
 // Body returns the root body of the file, which contains the top-level
 // attributes and blocks.
 func (f *File) Body() *Body {
@@ -22,7 +33,7 @@ func (f *File) Body() *Body {
 //
 // The tokens first have a simple formatting pass applied that adjusts only
 // the spaces between them.
-func (f *File) WriteTo(wr io.Writer) (int, error) {
+func (f *File) WriteTo(wr io.Writer) (int64, error) {
 	tokens := f.inTree.children.BuildTokens(nil)
 	format(tokens)
 	return tokens.WriteTo(wr)

--- a/vendor/github.com/hashicorp/hcl2/hclwrite/ast_attribute.go
+++ b/vendor/github.com/hashicorp/hcl2/hclwrite/ast_attribute.go
@@ -1,0 +1,48 @@
+package hclwrite
+
+import (
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+)
+
+type Attribute struct {
+	inTree
+
+	leadComments *node
+	name         *node
+	expr         *node
+	lineComments *node
+}
+
+func newAttribute() *Attribute {
+	return &Attribute{
+		inTree: newInTree(),
+	}
+}
+
+func (a *Attribute) init(name string, expr *Expression) {
+	expr.assertUnattached()
+
+	nameTok := newIdentToken(name)
+	nameObj := newIdentifier(nameTok)
+	a.leadComments = a.children.Append(newComments(nil))
+	a.name = a.children.Append(nameObj)
+	a.children.AppendUnstructuredTokens(Tokens{
+		{
+			Type:  hclsyntax.TokenEqual,
+			Bytes: []byte{'='},
+		},
+	})
+	a.expr = a.children.Append(expr)
+	a.expr.list = a.children
+	a.lineComments = a.children.Append(newComments(nil))
+	a.children.AppendUnstructuredTokens(Tokens{
+		{
+			Type:  hclsyntax.TokenNewline,
+			Bytes: []byte{'\n'},
+		},
+	})
+}
+
+func (a *Attribute) Expr() *Expression {
+	return a.expr.content.(*Expression)
+}

--- a/vendor/github.com/hashicorp/hcl2/hclwrite/ast_block.go
+++ b/vendor/github.com/hashicorp/hcl2/hclwrite/ast_block.go
@@ -1,0 +1,74 @@
+package hclwrite
+
+import (
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type Block struct {
+	inTree
+
+	leadComments *node
+	typeName     *node
+	labels       nodeSet
+	open         *node
+	body         *node
+	close        *node
+}
+
+func newBlock() *Block {
+	return &Block{
+		inTree: newInTree(),
+		labels: newNodeSet(),
+	}
+}
+
+// NewBlock constructs a new, empty block with the given type name and labels.
+func NewBlock(typeName string, labels []string) *Block {
+	block := newBlock()
+	block.init(typeName, labels)
+	return block
+}
+
+func (b *Block) init(typeName string, labels []string) {
+	nameTok := newIdentToken(typeName)
+	nameObj := newIdentifier(nameTok)
+	b.leadComments = b.children.Append(newComments(nil))
+	b.typeName = b.children.Append(nameObj)
+	for _, label := range labels {
+		labelToks := TokensForValue(cty.StringVal(label))
+		labelObj := newQuoted(labelToks)
+		labelNode := b.children.Append(labelObj)
+		b.labels.Add(labelNode)
+	}
+	b.open = b.children.AppendUnstructuredTokens(Tokens{
+		{
+			Type:  hclsyntax.TokenOBrace,
+			Bytes: []byte{'{'},
+		},
+		{
+			Type:  hclsyntax.TokenNewline,
+			Bytes: []byte{'\n'},
+		},
+	})
+	body := newBody() // initially totally empty; caller can append to it subsequently
+	b.body = b.children.Append(body)
+	b.close = b.children.AppendUnstructuredTokens(Tokens{
+		{
+			Type:  hclsyntax.TokenCBrace,
+			Bytes: []byte{'}'},
+		},
+		{
+			Type:  hclsyntax.TokenNewline,
+			Bytes: []byte{'\n'},
+		},
+	})
+}
+
+// Body returns the body that represents the content of the receiving block.
+//
+// Appending to or otherwise modifying this body will make changes to the
+// tokens that are generated between the blocks open and close braces.
+func (b *Block) Body() *Body {
+	return b.body.content.(*Body)
+}

--- a/vendor/github.com/hashicorp/hcl2/hclwrite/doc.go
+++ b/vendor/github.com/hashicorp/hcl2/hclwrite/doc.go
@@ -4,4 +4,8 @@
 // It operates at a different level of abstraction than the main HCL parser
 // and AST, since details such as the placement of comments and newlines
 // are preserved when unchanged.
+//
+// The hclwrite API follows a similar principle to XML/HTML DOM, allowing nodes
+// to be read out, created and inserted, etc. Nodes represent syntax constructs
+// rather than semantic concepts.
 package hclwrite

--- a/vendor/github.com/hashicorp/hcl2/hclwrite/node.go
+++ b/vendor/github.com/hashicorp/hcl2/hclwrite/node.go
@@ -104,6 +104,11 @@ func (ns *nodes) BuildTokens(to Tokens) Tokens {
 	return to
 }
 
+func (ns *nodes) Clear() {
+	ns.first = nil
+	ns.last = nil
+}
+
 func (ns *nodes) Append(c nodeContent) *node {
 	n := &node{
 		content: c,

--- a/vendor/github.com/hashicorp/hcl2/hclwrite/parser.go
+++ b/vendor/github.com/hashicorp/hcl2/hclwrite/parser.go
@@ -372,6 +372,7 @@ func parseTraversal(nativeTraversal hcl.Traversal, from inputTokens) (before inp
 		before, step, after := parseTraversalStep(nativeStep, stepAfter)
 		children.AppendUnstructuredTokens(before.Tokens())
 		children.AppendNode(step)
+		traversal.steps.Add(step)
 		stepAfter = after
 	}
 

--- a/vendor/github.com/hashicorp/hcl2/hclwrite/tokens.go
+++ b/vendor/github.com/hashicorp/hcl2/hclwrite/tokens.go
@@ -51,7 +51,7 @@ func (ts Tokens) Columns() int {
 // WriteTo takes an io.Writer and writes the bytes for each token to it,
 // along with the spacing that separates each token. In other words, this
 // allows serializing the tokens to a file or other such byte stream.
-func (ts Tokens) WriteTo(wr io.Writer) (int, error) {
+func (ts Tokens) WriteTo(wr io.Writer) (int64, error) {
 	// We know we're going to be writing a lot of small chunks of repeated
 	// space characters, so we'll prepare a buffer of these that we can
 	// easily pass to wr.Write without any further allocation.
@@ -60,7 +60,7 @@ func (ts Tokens) WriteTo(wr io.Writer) (int, error) {
 		spaces[i] = ' '
 	}
 
-	var n int
+	var n int64
 	var err error
 	for _, token := range ts {
 		if err != nil {
@@ -74,7 +74,7 @@ func (ts Tokens) WriteTo(wr io.Writer) (int, error) {
 			}
 			var thisN int
 			thisN, err = wr.Write(spaces[:thisChunk])
-			n += thisN
+			n += int64(thisN)
 			if err != nil {
 				return n, err
 			}
@@ -82,7 +82,7 @@ func (ts Tokens) WriteTo(wr io.Writer) (int, error) {
 
 		var thisN int
 		thisN, err = wr.Write(token.Bytes)
-		n += thisN
+		n += int64(thisN)
 	}
 
 	return n, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -343,7 +343,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl2 v0.0.0-20180925175540-3f1c5474d4f7
+# github.com/hashicorp/hcl2 v0.0.0-20181126233546-67424e43b184
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec


### PR DESCRIPTION
Depends on https://github.com/hashicorp/hcl2/pull/58

## Before

<img width="602" alt="screen shot 2018-11-23 at 17 14 47" src="https://user-images.githubusercontent.com/287584/48954972-9f581f80-ef43-11e8-8071-47be0f45df2e.png">

## After

<img width="668" alt="screen shot 2018-11-23 at 17 22 11" src="https://user-images.githubusercontent.com/287584/48955138-5bb1e580-ef44-11e8-8344-3b38a0844131.png">

----

I'm thinking maybe we should suppress the "context string" to avoid the duplication, i.e.

```
  on /var/workspace/tf-test/repro-case/main.tf line 21:
  21: resource "aws_instance" "web" {
```
but then we might need the context in the future, more complex cases when we figure out how to render snippets with interpolated `count.index`? I'm not sure.

----

It is worth mentioning that there is currently *no context* rendered for errors returned during refresh or import, because the relevant `EvalNode` implementations (e.g. `EvalRefresh`) don't have access to config at all, so there is no way to match it at this point.

If we want to avoid passing config to these `EvalNode`s we might need to consider adding context in the form of IDs or something like that. 🤔 

With all that said this is a problem to be solved in a future PR.