### PR TITLE
backend/azurerm: support for custom resource manager endpoints

### DIFF
--- a/backend/remote-state/azure/arm_client.go
+++ b/backend/remote-state/azure/arm_client.go
@@ -97,17 +97,17 @@ func buildArmClient(config BackendConfig) (*ArmClient, error) {
 
 func buildArmEnvironment(config BackendConfig) (*azure.Environment, error) {
 	if config.CustomResourceManagerEndpoint != "" {
-		log.Printf("Loading Environment from Endpoint %q", config.CustomResourceManagerEndpoint)
+		log.Printf("[DEBUG] Loading Environment from Endpoint %q", config.CustomResourceManagerEndpoint)
 		return authentication.LoadEnvironmentFromUrl(config.CustomResourceManagerEndpoint)
 	}
 
-	log.Printf("Loading Environment %q", config.Environment)
+	log.Printf("[DEBUG] Loading Environment %q", config.Environment)
 	return authentication.DetermineEnvironment(config.Environment)
 }
 
 func (c ArmClient) getBlobClient(ctx context.Context) (*storage.BlobStorageClient, error) {
 	if c.accessKey != "" {
-		log.Printf("Building the Blob Client from an Access Token")
+		log.Printf("[DEBUG] Building the Blob Client from an Access Token")
 		storageClient, err := storage.NewBasicClientOnSovereignCloud(c.storageAccountName, c.accessKey, c.environment)
 		if err != nil {
 			return nil, fmt.Errorf("Error creating storage client for storage account %q: %s", c.storageAccountName, err)
@@ -117,7 +117,7 @@ func (c ArmClient) getBlobClient(ctx context.Context) (*storage.BlobStorageClien
 	}
 
 	if c.sasToken != "" {
-		log.Printf("Building the Blob Client from a SAS Token")
+		log.Printf("[DEBUG] Building the Blob Client from a SAS Token")
 		token := strings.TrimPrefix(c.sasToken, "?")
 		uri, err := url.ParseQuery(token)
 		if err != nil {
@@ -129,7 +129,7 @@ func (c ArmClient) getBlobClient(ctx context.Context) (*storage.BlobStorageClien
 		return &client, nil
 	}
 
-	log.Printf("Building the Blob Client from an Access Token (using user credentials)")
+	log.Printf("[DEBUG] Building the Blob Client from an Access Token (using user credentials)")
 	keys, err := c.storageAccountsClient.ListKeys(ctx, c.resourceGroupName, c.storageAccountName)
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving keys for Storage Account %q: %s", c.storageAccountName, err)

--- a/backend/remote-state/azure/backend.go
+++ b/backend/remote-state/azure/backend.go
@@ -99,6 +99,13 @@ func New() backend.Backend {
 				DefaultFunc: schema.EnvDefaultFunc("ARM_MSI_ENDPOINT", ""),
 			},
 
+			"endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A custom Endpoint used to access the Azure Resource Manager API's.",
+				DefaultFunc: schema.EnvDefaultFunc("ARM_ENDPOINT", ""),
+			},
+
 			// Deprecated fields
 			"arm_client_id": {
 				Type:        schema.TypeString,
@@ -127,8 +134,6 @@ func New() backend.Backend {
 				Description: "The Tenant ID.",
 				Deprecated:  "`arm_tenant_id` has been replaced by `tenant_id`",
 			},
-
-			// TODO: support for custom resource manager endpoints
 		},
 	}
 
@@ -151,16 +156,17 @@ type BackendConfig struct {
 	StorageAccountName string
 
 	// Optional
-	AccessKey         string
-	ClientID          string
-	ClientSecret      string
-	Environment       string
-	MsiEndpoint       string
-	ResourceGroupName string
-	SasToken          string
-	SubscriptionID    string
-	TenantID          string
-	UseMsi            bool
+	AccessKey                     string
+	ClientID                      string
+	ClientSecret                  string
+	CustomResourceManagerEndpoint string
+	Environment                   string
+	MsiEndpoint                   string
+	ResourceGroupName             string
+	SasToken                      string
+	SubscriptionID                string
+	TenantID                      string
+	UseMsi                        bool
 }
 
 func (b *Backend) configure(ctx context.Context) error {
@@ -180,17 +186,18 @@ func (b *Backend) configure(ctx context.Context) error {
 	tenantId := valueFromDeprecatedField(data, "tenant_id", "arm_tenant_id")
 
 	config := BackendConfig{
-		AccessKey:          data.Get("access_key").(string),
-		ClientID:           clientId,
-		ClientSecret:       clientSecret,
-		Environment:        data.Get("environment").(string),
-		MsiEndpoint:        data.Get("msi_endpoint").(string),
-		ResourceGroupName:  data.Get("resource_group_name").(string),
-		SasToken:           data.Get("sas_token").(string),
-		StorageAccountName: data.Get("storage_account_name").(string),
-		SubscriptionID:     subscriptionId,
-		TenantID:           tenantId,
-		UseMsi:             data.Get("use_msi").(bool),
+		AccessKey:                     data.Get("access_key").(string),
+		ClientID:                      clientId,
+		ClientSecret:                  clientSecret,
+		CustomResourceManagerEndpoint: data.Get("endpoint").(string),
+		Environment:                   data.Get("environment").(string),
+		MsiEndpoint:                   data.Get("msi_endpoint").(string),
+		ResourceGroupName:             data.Get("resource_group_name").(string),
+		SasToken:                      data.Get("sas_token").(string),
+		StorageAccountName:            data.Get("storage_account_name").(string),
+		SubscriptionID:                subscriptionId,
+		TenantID:                      tenantId,
+		UseMsi:                        data.Get("use_msi").(bool),
 	}
 
 	armClient, err := buildArmClient(config)

--- a/backend/remote-state/azure/backend_test.go
+++ b/backend/remote-state/azure/backend_test.go
@@ -55,6 +55,7 @@ func TestBackendAccessKeyBasic(t *testing.T) {
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	backend.TestBackendStates(t, b)
@@ -82,6 +83,7 @@ func TestBackendManagedServiceIdentityBasic(t *testing.T) {
 		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
 		"tenant_id":            os.Getenv("ARM_TENANT_ID"),
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	backend.TestBackendStates(t, b)
@@ -111,6 +113,7 @@ func TestBackendSASTokenBasic(t *testing.T) {
 		"key":                  res.storageKeyName,
 		"sas_token":            *sasToken,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	backend.TestBackendStates(t, b)
@@ -139,6 +142,43 @@ func TestBackendServicePrincipalBasic(t *testing.T) {
 		"client_id":            os.Getenv("ARM_CLIENT_ID"),
 		"client_secret":        os.Getenv("ARM_CLIENT_SECRET"),
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
+	})).(*Backend)
+
+	backend.TestBackendStates(t, b)
+}
+
+func TestBackendServicePrincipalCustomEndpoint(t *testing.T) {
+	testAccAzureBackend(t)
+
+	// this is only applicable for Azure Stack.
+	endpoint := os.Getenv("ARM_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("Skipping as ARM_ENDPOINT isn't configured")
+	}
+
+	rs := acctest.RandString(4)
+	res := testResourceNames(rs, "testState")
+	armClient := buildTestClient(t, res)
+
+	ctx := context.TODO()
+	err := armClient.buildTestResources(ctx, &res)
+	defer armClient.destroyTestResources(ctx, res)
+	if err != nil {
+		t.Fatalf("Error creating Test Resources: %q", err)
+	}
+
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
+		"storage_account_name": res.storageAccountName,
+		"container_name":       res.storageContainerName,
+		"key":                  res.storageKeyName,
+		"resource_group_name":  res.resourceGroup,
+		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
+		"tenant_id":            os.Getenv("ARM_TENANT_ID"),
+		"client_id":            os.Getenv("ARM_CLIENT_ID"),
+		"client_secret":        os.Getenv("ARM_CLIENT_SECRET"),
+		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             endpoint,
 	})).(*Backend)
 
 	backend.TestBackendStates(t, b)
@@ -163,6 +203,7 @@ func TestBackendAccessKeyLocked(t *testing.T) {
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
@@ -171,6 +212,7 @@ func TestBackendAccessKeyLocked(t *testing.T) {
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	backend.TestBackendStateLocks(t, b1, b2)
@@ -200,6 +242,7 @@ func TestBackendServicePrincipalLocked(t *testing.T) {
 		"client_id":            os.Getenv("ARM_CLIENT_ID"),
 		"client_secret":        os.Getenv("ARM_CLIENT_SECRET"),
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
@@ -212,6 +255,7 @@ func TestBackendServicePrincipalLocked(t *testing.T) {
 		"client_id":            os.Getenv("ARM_CLIENT_ID"),
 		"client_secret":        os.Getenv("ARM_CLIENT_SECRET"),
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	backend.TestBackendStateLocks(t, b1, b2)

--- a/backend/remote-state/azure/backend_test.go
+++ b/backend/remote-state/azure/backend_test.go
@@ -144,34 +144,6 @@ func TestBackendServicePrincipalBasic(t *testing.T) {
 	backend.TestBackendStates(t, b)
 }
 
-func TestBackendServicePrincipalDeprecatedFields(t *testing.T) {
-	testAccAzureBackend(t)
-	rs := acctest.RandString(4)
-	res := testResourceNames(rs, "testState")
-	armClient := buildTestClient(t, res)
-
-	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
-	if err != nil {
-		t.Fatalf("Error creating Test Resources: %q", err)
-	}
-
-	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"storage_account_name": res.storageAccountName,
-		"container_name":       res.storageContainerName,
-		"key":                  res.storageKeyName,
-		"resource_group_name":  res.resourceGroup,
-		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
-		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),
-		"arm_client_id":        os.Getenv("ARM_CLIENT_ID"),
-		"arm_client_secret":    os.Getenv("ARM_CLIENT_SECRET"),
-		"environment":          os.Getenv("ARM_ENVIRONMENT"),
-	})).(*Backend)
-
-	backend.TestBackendStates(t, b)
-}
-
 func TestBackendAccessKeyLocked(t *testing.T) {
 	testAccAzureBackend(t)
 	rs := acctest.RandString(4)

--- a/backend/remote-state/azure/backend_test.go
+++ b/backend/remote-state/azure/backend_test.go
@@ -144,6 +144,34 @@ func TestBackendServicePrincipalBasic(t *testing.T) {
 	backend.TestBackendStates(t, b)
 }
 
+func TestBackendServicePrincipalDeprecatedFields(t *testing.T) {
+	testAccAzureBackend(t)
+	rs := acctest.RandString(4)
+	res := testResourceNames(rs, "testState")
+	armClient := buildTestClient(t, res)
+
+	ctx := context.TODO()
+	err := armClient.buildTestResources(ctx, &res)
+	defer armClient.destroyTestResources(ctx, res)
+	if err != nil {
+		t.Fatalf("Error creating Test Resources: %q", err)
+	}
+
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
+		"storage_account_name": res.storageAccountName,
+		"container_name":       res.storageContainerName,
+		"key":                  res.storageKeyName,
+		"resource_group_name":  res.resourceGroup,
+		"arm_subscription_id":  os.Getenv("ARM_SUBSCRIPTION_ID"),
+		"arm_tenant_id":        os.Getenv("ARM_TENANT_ID"),
+		"arm_client_id":        os.Getenv("ARM_CLIENT_ID"),
+		"arm_client_secret":    os.Getenv("ARM_CLIENT_SECRET"),
+		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+	})).(*Backend)
+
+	backend.TestBackendStates(t, b)
+}
+
 func TestBackendAccessKeyLocked(t *testing.T) {
 	testAccAzureBackend(t)
 	rs := acctest.RandString(4)

--- a/backend/remote-state/azure/client_test.go
+++ b/backend/remote-state/azure/client_test.go
@@ -35,6 +35,7 @@ func TestRemoteClientAccessKeyBasic(t *testing.T) {
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	state, err := b.StateMgr(backend.DefaultStateName)
@@ -67,6 +68,7 @@ func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
 		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
 		"tenant_id":            os.Getenv("ARM_TENANT_ID"),
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	state, err := b.StateMgr(backend.DefaultStateName)
@@ -101,6 +103,7 @@ func TestRemoteClientSasTokenBasic(t *testing.T) {
 		"key":                  res.storageKeyName,
 		"sas_token":            *sasToken,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	state, err := b.StateMgr(backend.DefaultStateName)
@@ -134,6 +137,7 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 		"client_id":            os.Getenv("ARM_CLIENT_ID"),
 		"client_secret":        os.Getenv("ARM_CLIENT_SECRET"),
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	state, err := b.StateMgr(backend.DefaultStateName)
@@ -163,6 +167,7 @@ func TestRemoteClientAccessKeyLocks(t *testing.T) {
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
@@ -171,6 +176,7 @@ func TestRemoteClientAccessKeyLocks(t *testing.T) {
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	s1, err := b1.StateMgr(backend.DefaultStateName)
@@ -209,6 +215,7 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 		"client_id":            os.Getenv("ARM_CLIENT_ID"),
 		"client_secret":        os.Getenv("ARM_CLIENT_SECRET"),
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
@@ -221,6 +228,7 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 		"client_id":            os.Getenv("ARM_CLIENT_ID"),
 		"client_secret":        os.Getenv("ARM_CLIENT_SECRET"),
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
+		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
 	s1, err := b1.StateMgr(backend.DefaultStateName)

--- a/website/docs/backends/types/azurerm.html.md
+++ b/website/docs/backends/types/azurerm.html.md
@@ -152,6 +152,10 @@ The following configuration options are supported:
 
 * `environment` - (Optional) The Azure Environment which should be used. This can also be sourced from the `ARM_ENVIRONMENT` environment variable. Possible values are `public`, `china`, `german`, `stack` and `usgovernment`. Defaults to `public`.
 
+* `endpoint` - (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the `ARM_ENDPOINT` environment variable.
+
+~> **NOTE:** An `endpoint` should only be configured when using Azure Stack.
+
 ---
 
 When authenticating using the Managed Service Identity (MSI) - the following fields are also supported:


### PR DESCRIPTION
This allows the AzureRM Backend to be used with Azure Stack

Needs to be merged after #19448