### PR TITLE
Shim computed containers

### DIFF
--- a/builtin/providers/test/resource_diff_suppress.go
+++ b/builtin/providers/test/resource_diff_suppress.go
@@ -81,6 +81,10 @@ func testResourceDiffSuppressCreate(d *schema.ResourceData, meta interface{}) er
 	d.Set("network", "modified")
 	d.Set("subnetwork", "modified")
 
+	if _, ok := d.GetOk("node_pool"); !ok {
+		d.Set("node_pool", []string{})
+	}
+
 	id := fmt.Sprintf("%x", rand.Int63())
 	d.SetId(id)
 	return nil

--- a/builtin/providers/test/resource_nested_set.go
+++ b/builtin/providers/test/resource_nested_set.go
@@ -92,7 +92,6 @@ func testResourceNestedSet() *schema.Resource {
 			"with_list": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"required": {
@@ -131,7 +130,7 @@ func testResourceNestedSetCreate(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("single", set)
 
-	return testResourceNestedRead(d, meta)
+	return testResourceNestedSetRead(d, meta)
 }
 
 func testResourceNestedSetRead(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -473,3 +473,23 @@ resource "test_resource" "foo" {
 		},
 	})
 }
+
+func TestResource_unknownFuncInMap(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+	required           = "ok"
+	required_map = {
+	  key = "${uuid()}"
+	}
+}
+				`),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}

--- a/plans/objchange/compatible.go
+++ b/plans/objchange/compatible.go
@@ -197,9 +197,11 @@ func assertValueCompatible(planned, actual cty.Value, path cty.Path) []error {
 			return nil
 		}
 		errs = append(errs, path.NewErrorf("was %#v, but now null", planned))
+		return errs
 	}
 	if planned.IsNull() {
 		errs = append(errs, path.NewErrorf("was null, but now %#v", actual))
+		return errs
 	}
 
 	ty := planned.Type()


### PR DESCRIPTION
When normalizing flatmapped containers, compare the attributes to the
prior state and preserve pre-existing zero-length or unknown values. A
zero-length value that was previously unknown is preserved as a
zero-length value, as that may have been computed as such by the
provider.

This also fixes a crash in  `plans/objchange` by returning early to prevent iterating on a null value.

Fixes #19469