### PR TITLE
helper/schema: CoreConfigSchema refinements

### DIFF
--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -125,6 +125,20 @@ func (s *Schema) coreConfigSchemaBlock() *configschema.NestedBlock {
 		// blocks, but we can fake it by requiring at least one item.
 		ret.MinItems = 1
 	}
+	if s.Optional && s.MinItems > 0 {
+		// Historically helper/schema would ignore MinItems if Optional were
+		// set, so we must mimic this behavior here to ensure that providers
+		// relying on that undocumented behavior can continue to operate as
+		// they did before.
+		ret.MinItems = 0
+	}
+	if s.Computed && !s.Optional {
+		// MinItems/MaxItems are meaningless for computed nested blocks, since
+		// they are never set by the user anyway. This ensures that we'll never
+		// generate weird errors about them.
+		ret.MinItems = 0
+		ret.MaxItems = 0
+	}
 
 	return ret
 }

--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -58,10 +58,39 @@ func (m schemaMap) CoreConfigSchema() *configschema.Block {
 // Elem is an instance of Schema. Use coreConfigSchemaBlock for collections
 // whose elem is a whole resource.
 func (s *Schema) coreConfigSchemaAttribute() *configschema.Attribute {
+	// The Schema.DefaultFunc capability adds some extra weirdness here since
+	// it can be combined with "Required: true" to create a sitution where
+	// required-ness is conditional. Terraform Core doesn't share this concept,
+	// so we must sniff for this possibility here and conditionally turn
+	// off the "Required" flag if it looks like the DefaultFunc is going
+	// to provide a value.
+	// This is not 100% true to the original interface of DefaultFunc but
+	// works well enough for the EnvDefaultFunc and MultiEnvDefaultFunc
+	// situations, which are the main cases we care about.
+	//
+	// Note that this also has a consequence for commands that return schema
+	// information for documentation purposes: running those for certain
+	// providers will produce different results depending on which environment
+	// variables are set. We accept that weirdness in order to keep this
+	// interface to core otherwise simple.
+	reqd := s.Required
+	opt := s.Optional
+	if reqd && s.DefaultFunc != nil {
+		v, err := s.DefaultFunc()
+		// We can't report errors from here, so we'll instead just force
+		// "Required" to false and let the provider try calling its
+		// DefaultFunc again during the validate step, where it can then
+		// return the error.
+		if err != nil || (err == nil && v != nil) {
+			reqd = false
+			opt = true
+		}
+	}
+
 	return &configschema.Attribute{
 		Type:        s.coreConfigSchemaType(),
-		Optional:    s.Optional,
-		Required:    s.Required,
+		Optional:    opt,
+		Required:    reqd,
 		Computed:    s.Computed,
 		Sensitive:   s.Sensitive,
 		Description: s.Description,

--- a/helper/schema/core_schema_test.go
+++ b/helper/schema/core_schema_test.go
@@ -224,6 +224,90 @@ func TestSchemaMapCoreConfigSchema(t *testing.T) {
 				},
 			}),
 		},
+		"sub-resource collections minitems+optional": {
+			// This particular case is an odd one where the provider gives
+			// conflicting information about whether a sub-resource is required,
+			// by marking it as optional but also requiring one item.
+			// Historically the optional-ness "won" here, and so we must
+			// honor that for compatibility with providers that relied on this
+			// undocumented interaction.
+			map[string]*Schema{
+				"list": {
+					Type:     TypeList,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{},
+					},
+					MinItems: 1,
+					MaxItems: 1,
+				},
+				"set": {
+					Type:     TypeSet,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{},
+					},
+					MinItems: 1,
+					MaxItems: 1,
+				},
+			},
+			testResource(&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"list": {
+						Nesting:  configschema.NestingList,
+						Block:    configschema.Block{},
+						MinItems: 0,
+						MaxItems: 1,
+					},
+					"set": {
+						Nesting:  configschema.NestingSet,
+						Block:    configschema.Block{},
+						MinItems: 0,
+						MaxItems: 1,
+					},
+				},
+			}),
+		},
+		"sub-resource collections minitems+computed": {
+			map[string]*Schema{
+				"list": {
+					Type:     TypeList,
+					Computed: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{},
+					},
+					MinItems: 1,
+					MaxItems: 1,
+				},
+				"set": {
+					Type:     TypeSet,
+					Computed: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{},
+					},
+					MinItems: 1,
+					MaxItems: 1,
+				},
+			},
+			testResource(&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"list": {
+						Nesting:  configschema.NestingList,
+						Block:    configschema.Block{},
+						MinItems: 0,
+						MaxItems: 0,
+					},
+					"set": {
+						Nesting:  configschema.NestingSet,
+						Block:    configschema.Block{},
+						MinItems: 0,
+						MaxItems: 0,
+					},
+				},
+			}),
+		},
 		"nested attributes and blocks": {
 			map[string]*Schema{
 				"foo": {

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -142,13 +142,17 @@ type Schema struct {
 	// used to wrap a complex structure, however less than one instance would
 	// cause instability.
 	//
-	// PromoteSingle, if true, will allow single elements to be standalone
-	// and promote them to a list. For example "foo" would be promoted to
-	// ["foo"] automatically. This is primarily for legacy reasons and the
-	// ambiguity is not recommended for new usage. Promotion is only allowed
-	// for primitive element types.
-	MaxItems      int
-	MinItems      int
+	// If the field Optional is set to true then MinItems is ignored and thus
+	// effectively zero.
+	MaxItems int
+	MinItems int
+
+	// PromoteSingle originally allowed for a single element to be assigned
+	// where a primitive list was expected, but this no longer works from
+	// Terraform v0.12 onwards (Terraform Core will require a list to be set
+	// regardless of what this is set to) and so only applies to Terraform v0.11
+	// and earlier, and so should be used only to retain this functionality
+	// for those still using v0.11 with a provider that formerly used this.
 	PromoteSingle bool
 
 	// The following fields are only valid for a TypeSet type.


### PR DESCRIPTION
The commits in this PR are addressing some real-world situations where the schema generated by `CoreConfigSchema` didn't totally reflect the pre-v0.12 behavior where Terraform did not validate configuration at all.

Each of these commits is distinct from the others aside from them all being in the same package, so I expect it will be easiest to review these commit-by-commit.

This fixes both #19139 and #19422.
