### PR TITLE
core: Make resource type schema versions visible to callers

### DIFF
--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -245,7 +245,7 @@ func (b *Local) renderPlan(plan *plans.Plan, schemas *terraform.Schemas) {
 			b.CLI.Output(fmt.Sprintf("(schema missing for %s)\n", rcs.ProviderAddr))
 			continue
 		}
-		rSchema := providerSchema.SchemaForResourceAddr(rcs.Addr.Resource.Resource)
+		rSchema, _ := providerSchema.SchemaForResourceAddr(rcs.Addr.Resource.Resource)
 		if rSchema == nil {
 			// Should never happen
 			b.CLI.Output(fmt.Sprintf("(schema missing for %s)\n", rcs.Addr))

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -46,7 +46,7 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 		state = &states.ResourceInstanceObject{}
 	}
 
-	schema := (*n.ProviderSchema).ResourceTypes[n.Addr.Resource.Type]
+	schema, _ := (*n.ProviderSchema).SchemaForResourceType(n.Addr.Resource.Mode, n.Addr.Resource.Type)
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
 		return nil, fmt.Errorf("provider does not support resource type %q", n.Addr.Resource.Type)

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -43,10 +43,10 @@ func (n *EvalCheckPlannedChange) Eval(ctx EvalContext) (interface{}, error) {
 	plannedChange := *n.Planned
 	actualChange := *n.Actual
 
-	schema := providerSchema.ResourceTypes[n.Addr.Resource.Type]
+	schema, _ := providerSchema.SchemaForResourceAddr(n.Addr.ContainingResource())
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
-		return nil, fmt.Errorf("provider does not support resource type %q", n.Addr.Resource.Type)
+		return nil, fmt.Errorf("provider does not support %q", n.Addr.Resource.Type)
 	}
 
 	var diags tfdiags.Diagnostics
@@ -129,7 +129,7 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 	var diags tfdiags.Diagnostics
 
 	// Evaluate the configuration
-	schema := providerSchema.ResourceTypes[n.Addr.Resource.Type]
+	schema, _ := providerSchema.SchemaForResourceAddr(n.Addr.ContainingResource())
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
 		return nil, fmt.Errorf("provider does not support resource type %q", n.Addr.Resource.Type)
@@ -833,7 +833,7 @@ func (n *EvalReadDiff) Eval(ctx EvalContext) (interface{}, error) {
 	changes := ctx.Changes()
 	addr := n.Addr.Absolute(ctx.Path())
 
-	schema := providerSchema.SchemaForResourceAddr(n.Addr.ContainingResource())
+	schema, _ := providerSchema.SchemaForResourceAddr(n.Addr.ContainingResource())
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
 		return nil, fmt.Errorf("provider does not support resource type %q", n.Addr.Resource.Type)
@@ -894,7 +894,7 @@ func (n *EvalWriteDiff) Eval(ctx EvalContext) (interface{}, error) {
 		panic("inconsistent address and/or deposed key in EvalWriteDiff")
 	}
 
-	schema := providerSchema.SchemaForResourceAddr(n.Addr.ContainingResource())
+	schema, _ := providerSchema.SchemaForResourceAddr(n.Addr.ContainingResource())
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
 		return nil, fmt.Errorf("provider does not support resource type %q", n.Addr.Resource.Type)

--- a/terraform/eval_read_data.go
+++ b/terraform/eval_read_data.go
@@ -83,7 +83,7 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 	config := *n.Config
 	provider := *n.Provider
 	providerSchema := *n.ProviderSchema
-	schema := providerSchema.DataSources[n.Addr.Resource.Type]
+	schema, _ := providerSchema.SchemaForResourceAddr(n.Addr.ContainingResource())
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
 		return nil, fmt.Errorf("provider %q does not support data source %q", n.ProviderAddr.ProviderConfig.Type, n.Addr.Resource.Type)
@@ -322,7 +322,7 @@ func (n *EvalReadDataDiff) Eval(ctx EvalContext) (interface{}, error) {
 	} else {
 		config := *n.Config
 		providerSchema := *n.ProviderSchema
-		schema := providerSchema.DataSources[n.Addr.Resource.Type]
+		schema, _ := providerSchema.SchemaForResourceAddr(n.Addr.ContainingResource())
 		if schema == nil {
 			// Should be caught during validation, so we don't bother with a pretty error here
 			return nil, fmt.Errorf("provider does not support data source %q", n.Addr.Resource.Type)
@@ -440,7 +440,7 @@ func (n *EvalReadDataApply) Eval(ctx EvalContext) (interface{}, error) {
 		return nil, diags.Err()
 	}
 
-	schema := providerSchema.DataSources[n.Addr.Resource.Type]
+	schema, _ := providerSchema.SchemaForResourceAddr(n.Addr.ContainingResource())
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
 		return nil, fmt.Errorf("provider does not support data source %q", n.Addr.Resource.Type)

--- a/terraform/eval_refresh.go
+++ b/terraform/eval_refresh.go
@@ -36,7 +36,7 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 		return nil, diags.ErrWithWarnings()
 	}
 
-	schema := (*n.ProviderSchema).ResourceTypes[n.Addr.Resource.Type]
+	schema, _ := (*n.ProviderSchema).SchemaForResourceAddr(n.Addr.ContainingResource())
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
 		return nil, fmt.Errorf("provider does not support resource type %q", n.Addr.Resource.Type)

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -373,8 +373,8 @@ func (n *EvalValidateResource) Eval(ctx EvalContext) (interface{}, error) {
 	// in the provider abstraction.
 	switch mode {
 	case addrs.ManagedResourceMode:
-		schema, exists := schema.ResourceTypes[cfg.Type]
-		if !exists {
+		schema, _ := schema.SchemaForResourceType(mode, cfg.Type)
+		if schema == nil {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid resource type",
@@ -403,8 +403,8 @@ func (n *EvalValidateResource) Eval(ctx EvalContext) (interface{}, error) {
 		}
 
 	case addrs.DataResourceMode:
-		schema, exists := schema.DataSources[cfg.Type]
-		if !exists {
+		schema, _ := schema.SchemaForResourceType(mode, cfg.Type)
+		if schema == nil {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid data source",

--- a/terraform/eval_validate_selfref.go
+++ b/terraform/eval_validate_selfref.go
@@ -40,19 +40,9 @@ func (n *EvalValidateSelfRef) Eval(ctx EvalContext) (interface{}, error) {
 	var schema *configschema.Block
 	switch tAddr := addr.(type) {
 	case addrs.Resource:
-		switch tAddr.Mode {
-		case addrs.ManagedResourceMode:
-			schema = providerSchema.ResourceTypes[tAddr.Type]
-		case addrs.DataResourceMode:
-			schema = providerSchema.DataSources[tAddr.Type]
-		}
+		schema, _ = providerSchema.SchemaForResourceAddr(tAddr)
 	case addrs.ResourceInstance:
-		switch tAddr.Resource.Mode {
-		case addrs.ManagedResourceMode:
-			schema = providerSchema.ResourceTypes[tAddr.Resource.Type]
-		case addrs.DataResourceMode:
-			schema = providerSchema.DataSources[tAddr.Resource.Type]
-		}
+		schema, _ = providerSchema.SchemaForResourceAddr(tAddr.ContainingResource())
 	}
 
 	if schema == nil {

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -798,17 +798,9 @@ func (d *evaluationStateData) getResourceInstancesAll(addr addrs.Resource, rng t
 
 func (d *evaluationStateData) getResourceSchema(addr addrs.Resource, providerAddr addrs.AbsProviderConfig) *configschema.Block {
 	providerType := providerAddr.ProviderConfig.Type
-	typeName := addr.Type
 	schemas := d.Evaluator.Schemas
-	switch addr.Mode {
-	case addrs.ManagedResourceMode:
-		return schemas.ResourceTypeConfig(providerType, typeName)
-	case addrs.DataResourceMode:
-		return schemas.DataSourceConfig(providerType, typeName)
-	default:
-		log.Printf("[WARN] Don't know how to fetch schema for resource %s", providerAddr)
-		return nil
-	}
+	schema, _ := schemas.ResourceTypeConfig(providerType, addr.Mode, addr.Type)
+	return schema
 }
 
 // coerceInstanceKey attempts to convert the given key to the type expected

--- a/terraform/evaluate_valid.go
+++ b/terraform/evaluate_valid.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
@@ -112,13 +111,7 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 	// account provider inheritance, etc but it's okay here because we're only
 	// paying attention to the type anyway.
 	providerType := cfg.ProviderConfigAddr().Type
-	var schema *configschema.Block
-	switch addr.Mode {
-	case addrs.ManagedResourceMode:
-		schema = d.Evaluator.Schemas.ResourceTypeConfig(providerType, addr.Type)
-	case addrs.DataResourceMode:
-		schema = d.Evaluator.Schemas.DataSourceConfig(providerType, addr.Type)
-	}
+	schema, _ := d.Evaluator.Schemas.ResourceTypeConfig(providerType, addr.Mode, addr.Type)
 
 	if schema == nil {
 		// Prior validation should've taken care of a resource block with an

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -47,8 +47,9 @@ type NodeAbstractResource struct {
 	// interfaces if you're running those transforms, but also be explicitly
 	// set if you already have that information.
 
-	Schema *configschema.Block // Schema for processing the configuration body
-	Config *configs.Resource   // Config is the resource in the config
+	Schema        *configschema.Block // Schema for processing the configuration body
+	SchemaVersion uint64              // Schema version of "Schema", as decided by the provider
+	Config        *configs.Resource   // Config is the resource in the config
 
 	ProvisionerSchemas map[string]*configschema.Block
 
@@ -423,8 +424,9 @@ func (n *NodeAbstractResource) AttachResourceConfig(c *configs.Resource) {
 }
 
 // GraphNodeAttachResourceSchema impl
-func (n *NodeAbstractResource) AttachResourceSchema(schema *configschema.Block) {
+func (n *NodeAbstractResource) AttachResourceSchema(schema *configschema.Block, version uint64) {
 	n.Schema = schema
+	n.SchemaVersion = version
 }
 
 // GraphNodeDotter impl.


### PR DESCRIPTION
Previously we were fetching these from the provider but then immediately discarding the version numbers because the schema API had nowhere to put them.

To avoid a late-breaking change to the internal structure of `terraform.ProviderSchema` (which is constructed directly all over the tests) we're keeping the resource type schema versions in a new map alongside the existing one with the same keys, rather than just switching to using the `providers.Schema` struct directly there.

The methods that return resource type schemas now return two arguments, intentionally creating a little API friction here so each new caller can be reminded to think about whether they need to do something with the schema version, though it can be ignored by many callers.

Since this was a breaking change to the Schemas API anyway, this also fixes another API wart where there was a separate method for fetching managed vs. data resource types and thus every caller ended up having a switch statement on "mode". Now we just accept mode as an argument and do the switch statement within the single `SchemaForResourceType` method.

The changes to `terraform/schemas.go` are the main thing here. Everything else is just updating callers for that new API.
