### PR TITLE
core: Validate module references

### DIFF
--- a/repl/session_test.go
+++ b/repl/session_test.go
@@ -95,9 +95,22 @@ func TestSession_basicState(t *testing.T) {
 			State: state,
 			Inputs: []testSessionInput{
 				{
+					Input:         "module.child",
+					Error:         true,
+					ErrorContains: `No module call named "child" is declared in the root module.`,
+				},
+			},
+		})
+	})
+
+	t.Run("missing module referencing just one output", func(t *testing.T) {
+		testSession(t, testSessionTest{
+			State: state,
+			Inputs: []testSessionInput{
+				{
 					Input:         "module.child.foo",
 					Error:         true,
-					ErrorContains: `The configuration contains no module.child`,
+					ErrorContains: `No module call named "child" is declared in the root module.`,
 				},
 			},
 		})

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -296,8 +296,8 @@ func (d *evaluationStateData) GetModuleInstance(addr addrs.ModuleCallInstance, r
 	// type even if our data is incomplete for some reason.
 	moduleConfig := d.Evaluator.Config.DescendentForInstance(moduleAddr)
 	if moduleConfig == nil {
-		// should never happen, since we can't be evaluating in a module
-		// that wasn't mentioned in configuration.
+		// should never happen, since this should've been caught during
+		// static validation.
 		panic(fmt.Sprintf("output value read from %s, which has no configuration", moduleAddr))
 	}
 	outputConfigs := moduleConfig.Module.Outputs


### PR DESCRIPTION
Previously we were making an invalid assumption in evaluating module call references (like `module.foo`) that the module must exist, which is incorrect for that particular case because it's a reference to a child module, not to an object within the current module.

However, now that we have the mechanism for static validation of references, we'll deal with this one there so it can be caught sooner. That then makes the original assumption valid, though for a different reason.

This fixes #19483.
