### PR TITLE
Use registry alias to fetch providers

### DIFF
--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -134,6 +134,7 @@ func (i *ProviderInstaller) Get(provider string, req Constraints) (PluginMeta, e
 	if len(allVersions.Versions) == 0 {
 		return PluginMeta{}, ErrorNoSuitableVersion
 	}
+	providerSource := allVersions.ID
 
 	// Filter the list of plugin versions to those which meet the version constraints
 	versions := allowedVersions(allVersions, req)
@@ -175,7 +176,7 @@ func (i *ProviderInstaller) Get(provider string, req Constraints) (PluginMeta, e
 		return PluginMeta{}, ErrorNoVersionCompatibleWithPlatform
 	}
 
-	downloadURLs, err := i.listProviderDownloadURLs(provider, versionMeta.Version)
+	downloadURLs, err := i.listProviderDownloadURLs(providerSource, versionMeta.Version)
 	providerURL := downloadURLs.DownloadURL
 
 	i.Ui.Info(fmt.Sprintf("- Downloading plugin for provider %q (%s)...", provider, versionMeta.Version))
@@ -193,6 +194,9 @@ func (i *ProviderInstaller) Get(provider string, req Constraints) (PluginMeta, e
 		}
 	}
 
+	printedProviderName := fmt.Sprintf("%s (%s)", provider, providerSource)
+	i.Ui.Info(fmt.Sprintf("- Downloading plugin for provider %q (%s)...", printedProviderName, versionMeta.Version))
+	log.Printf("[DEBUG] getting provider %q version %q", printedProviderName, versionMeta.Version)
 	err = i.install(provider, v, providerURL)
 	if err != nil {
 		return PluginMeta{}, err

--- a/plugin/discovery/get_test.go
+++ b/plugin/discovery/get_test.go
@@ -130,6 +130,7 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
 
 func testReleaseServer() *httptest.Server {
 	handler := http.NewServeMux()
+	handler.HandleFunc("/v1/providers/-/", testHandler)
 	handler.HandleFunc("/v1/providers/terraform-providers/", testHandler)
 	handler.HandleFunc("/terraform-provider-template/", testChecksumHandler)
 	handler.HandleFunc("/terraform-provider-badsig/", testChecksumHandler)
@@ -479,7 +480,7 @@ func Disco(s *httptest.Server) *disco.Disco {
 }
 
 var versionList = response.TerraformProvider{
-	ID: "test",
+	ID: "terraform-providers/test",
 	Versions: []*response.TerraformProviderVersion{
 		{Version: "1.2.1"},
 		{Version: "1.2.3"},

--- a/registry/regsrc/terraform_provider.go
+++ b/registry/regsrc/terraform_provider.go
@@ -3,6 +3,7 @@ package regsrc
 import (
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/hashicorp/terraform/svchost"
 )
@@ -10,7 +11,7 @@ import (
 var (
 	// DefaultProviderNamespace represents the namespace for canonical
 	// HashiCorp-controlled providers.
-	DefaultProviderNamespace = "terraform-providers"
+	DefaultProviderNamespace = "-"
 )
 
 // TerraformProvider describes a Terraform Registry Provider source.
@@ -31,9 +32,14 @@ func NewTerraformProvider(name, os, arch string) *TerraformProvider {
 		arch = runtime.GOARCH
 	}
 
+	// separate namespace if included
+	namespace := DefaultProviderNamespace
+	if names := strings.SplitN(name, "/", 2); len(names) == 2 {
+		namespace, name = names[0], names[1]
+	}
 	p := &TerraformProvider{
 		RawHost:      PublicRegistryHost,
-		RawNamespace: DefaultProviderNamespace,
+		RawNamespace: namespace,
 		RawName:      name,
 		OS:           os,
 		Arch:         arch,

--- a/registry/regsrc/terraform_provider_test.go
+++ b/registry/regsrc/terraform_provider_test.go
@@ -1,0 +1,48 @@
+package regsrc
+
+import (
+	"testing"
+)
+
+func TestNewTerraformProviderNamespace(t *testing.T) {
+	tests := []struct {
+		name              string
+		provider          string
+		expectedNamespace string
+		expectedName      string
+	}{
+		{
+			name:              "default",
+			provider:          "null",
+			expectedNamespace: "-",
+			expectedName:      "null",
+		}, {
+			name:              "explicit",
+			provider:          "terraform-providers/null",
+			expectedNamespace: "terraform-providers",
+			expectedName:      "null",
+		}, {
+			name:              "community",
+			provider:          "community-providers/null",
+			expectedNamespace: "community-providers",
+			expectedName:      "null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := NewTerraformProvider(tt.provider, "", "")
+
+			if actual == nil {
+				t.Fatal("NewTerraformProvider() unexpectedly returned nil provider")
+			}
+
+			if v := actual.RawNamespace; v != tt.expectedNamespace {
+				t.Fatalf("RawNamespace = %v, wanted %v", v, tt.expectedNamespace)
+			}
+			if v := actual.RawName; v != tt.expectedName {
+				t.Fatalf("RawName = %v, wanted %v", v, tt.expectedName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Uses the new registry namespace alias `-` to fetch providers from the registry. Registry returns with the appropriate provider source, if exists, and TF includes the returned namespace for user information on download. Currently, the registry only is configured to support the `terraform-providers` namespace for the `-` alias but may change in the future.

Prior to change
```
Initializing provider plugins...
- Checking for available provider plugins...
- Downloading plugin for provider "null" (1.0.0)...
```

**Success**
![image](https://user-images.githubusercontent.com/6362111/49168325-dbe99980-f2fc-11e8-9610-605c593f7770.png)

**Provider Not Found**
No error change here when a provider is not found within `terraform.d/plugins` or the registry.
![image](https://user-images.githubusercontent.com/6362111/49168388-fcb1ef00-f2fc-11e8-8e8a-a572b5966d51.png)

