### PR TITLE
[Website] Provider name change "Selectel"

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -147,7 +147,7 @@ down to see all providers.
     <td><a href="/docs/providers/scaleway/index.html">Scaleway</a></td>
     </tr>
     <tr>
-    <td><a href="/docs/providers/selvpc/index.html">SelVPC</a></td>
+    <td><a href="/docs/providers/selvpc/index.html">Selectel</a></td>
     <td><a href="/docs/providers/softlayer/index.html">SoftLayer</a></td>
     <td><a href="/docs/providers/statuscake/index.html">StatusCake</a></td>
     </tr>

--- a/website/docs/providers/type/cloud-index.html.markdown
+++ b/website/docs/providers/type/cloud-index.html.markdown
@@ -55,7 +55,7 @@ vendor in close collaboration with HashiCorp, and are tested by HashiCorp.
 
 [Scaleway](/docs/providers/scaleway/index.html)
 
-[SelVPC](/docs/provider/selvpc/index.html)
+[Selectel](/docs/provider/selvpc/index.html)
 
 [SoftLayer](/docs/providers/softlayer/index.html)
 

--- a/website/docs/providers/type/network-index.html.markdown
+++ b/website/docs/providers/type/network-index.html.markdown
@@ -35,6 +35,4 @@ in close collaboration with HashiCorp, and are tested by HashiCorp.
 
 [PowerDNS](/docs/providers/powerdns/index.html)
 
-[SelVPC](/docs/providers/selvpc/index.html)
-
 [UltraDNS](/docs/providers/ultradns/index.html)


### PR DESCRIPTION
Changing the Terraform provider link from "selvpc' -> "selectel" and move link to cloud providers