### PR TITLE
🎨[cmd/output]Add Colorize to output command

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -160,19 +160,19 @@ func (c *OutputCommand) Run(args []string) int {
 				c.showDiagnostics(diags)
 				return 1
 			}
-			if !nocolor {
-				c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", string(jsonOutputs))))
+			if nocolor {
+				c.Ui.Output(string(jsonOutputs))
 				return 0
 			} else {
-				c.Ui.Output(string(jsonOutputs))
+				c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", string(jsonOutputs))))
 				return 0
 			}
 		} else {
-			if !nocolor {
-				c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", outputsAsString(state, moduleAddr, false))))
+			if nocolor {
+				c.Ui.Output(outputsAsString(state, moduleAddr, false))
 				return 0
 			} else {
-				c.Ui.Output(outputsAsString(state, moduleAddr, false))
+				c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", outputsAsString(state, moduleAddr, false))))
 				return 0
 			}
 		}
@@ -194,11 +194,11 @@ func (c *OutputCommand) Run(args []string) int {
 		if err != nil {
 			return 1
 		}
-		if !nocolor {
-			c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", string(jsonOutput))))
+		if nocolor {
+			c.Ui.Output(string(jsonOutput))
 		} else {
 
-			c.Ui.Output(string(jsonOutput))
+			c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", string(jsonOutput))))
 		}
 	} else {
 		// Our formatter still wants an old-style raw interface{} value, so
@@ -211,11 +211,11 @@ func (c *OutputCommand) Run(args []string) int {
 			c.showDiagnostics(diags)
 			return 1
 		}
-		if !nocolor {
-			c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", result)))
+		if nocolor {
+			c.Ui.Output(result)
 		} else {
 
-			c.Ui.Output(result)
+			c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", result)))
 		}
 	}
 

--- a/command/output.go
+++ b/command/output.go
@@ -161,7 +161,7 @@ func (c *OutputCommand) Run(args []string) int {
 				return 1
 			}
 			if !nocolor {
-				c.Ui.Output(c.Colorize().Color("[green] string(jsonOutputs [reset] \n"))
+				c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", string(jsonOutputs))))
 				return 0
 			} else {
 				c.Ui.Output(string(jsonOutputs))
@@ -169,7 +169,7 @@ func (c *OutputCommand) Run(args []string) int {
 			}
 		} else {
 			if !nocolor {
-				c.Ui.Output(c.Colorize().Color("[green] outputsAsString(state, moduleAddr, false [reset] \n"))
+				c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", outputsAsString(state, moduleAddr, false))))
 				return 0
 			} else {
 				c.Ui.Output(outputsAsString(state, moduleAddr, false))
@@ -195,7 +195,7 @@ func (c *OutputCommand) Run(args []string) int {
 			return 1
 		}
 		if !nocolor {
-			c.Ui.Output(c.Colorize().Color("[green] string(jsonOutput [reset] \n"))
+			c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", string(jsonOutput))))
 		} else {
 
 			c.Ui.Output(string(jsonOutput))
@@ -212,7 +212,7 @@ func (c *OutputCommand) Run(args []string) int {
 			return 1
 		}
 		if !nocolor {
-			c.Ui.Output(c.Colorize().Color("[green] result [reset] \n"))
+			c.Ui.Output(c.Colorize().Color(fmt.Sprintf("[green]%s[reset]", result)))
 		} else {
 
 			c.Ui.Output(result)

--- a/command/output.go
+++ b/command/output.go
@@ -29,9 +29,10 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	var module string
-	var jsonOutput bool
+	var jsonOutput, nocolor bool
 	cmdFlags := c.Meta.defaultFlagSet("output")
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "json")
+	cmdFlags.BoolVar(&nocolor, "no-color", false, "no-color")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&module, "module", "", "module")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
@@ -159,11 +160,21 @@ func (c *OutputCommand) Run(args []string) int {
 				c.showDiagnostics(diags)
 				return 1
 			}
-			c.Ui.Output(string(jsonOutputs))
-			return 0
+			if !nocolor {
+				c.Ui.Output(c.Colorize().Color("[green] string(jsonOutputs [reset] \n"))
+				return 0
+			} else {
+				c.Ui.Output(string(jsonOutputs))
+				return 0
+			}
 		} else {
-			c.Ui.Output(outputsAsString(state, moduleAddr, false))
-			return 0
+			if !nocolor {
+				c.Ui.Output(c.Colorize().Color("[green] outputsAsString(state, moduleAddr, false [reset] \n"))
+				return 0
+			} else {
+				c.Ui.Output(outputsAsString(state, moduleAddr, false))
+				return 0
+			}
 		}
 	}
 
@@ -183,8 +194,12 @@ func (c *OutputCommand) Run(args []string) int {
 		if err != nil {
 			return 1
 		}
+		if !nocolor {
+			c.Ui.Output(c.Colorize().Color("[green] string(jsonOutput [reset] \n"))
+		} else {
 
-		c.Ui.Output(string(jsonOutput))
+			c.Ui.Output(string(jsonOutput))
+		}
 	} else {
 		// Our formatter still wants an old-style raw interface{} value, so
 		// for now we'll just shim it.
@@ -196,7 +211,12 @@ func (c *OutputCommand) Run(args []string) int {
 			c.showDiagnostics(diags)
 			return 1
 		}
-		c.Ui.Output(result)
+		if !nocolor {
+			c.Ui.Output(c.Colorize().Color("[green] result [reset] \n"))
+		} else {
+
+			c.Ui.Output(result)
+		}
 	}
 
 	return 0


### PR DESCRIPTION
* Original PR #17454 implementation changed with `command/output.go` diverging from 2/27/2018.  

Implementation for colorize to add flag to check for `-no-color` to output command and allow success color _(green)_ to be shown when no-color is not passed to command flag.  

 Resolves issue #17453

