### PR TITLE
backend/local: decode variables with cty.DynamicPseudoType

### DIFF
--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/states/statemgr"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // backend.Local implementation.
@@ -219,16 +220,7 @@ func (b *Local) contextFromPlanFile(pf *planfile.Reader, opts terraform.ContextO
 
 	variables := terraform.InputValues{}
 	for name, dyVal := range plan.VariableValues {
-		ty, err := dyVal.ImpliedType()
-		if err != nil {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				errSummary,
-				fmt.Sprintf("Invalid value for variable %q recorded in plan file: %s.", name, err),
-			))
-			continue
-		}
-		val, err := dyVal.Decode(ty)
+		val, err := dyVal.Decode(cty.DynamicPseudoType)
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,


### PR DESCRIPTION
Fixes #19147

Variables values are marshalled with an explicit type of
cty.DynamicPseudoType, but were being decoded using `Implied Type` to
try and guess the type. This was causing errors because `Implied Type`
does not expect to find a late-bound value.

(I take no credit for this, @apparentlymart figured out the bug and solution)