### PR TITLE
vendor: update kardianos/osext to support android

### DIFF
--- a/vendor/github.com/kardianos/osext/README.md
+++ b/vendor/github.com/kardianos/osext/README.md
@@ -4,6 +4,9 @@
 
 ## Find the current Executable and ExecutableFolder.
 
+As of go1.8 the Executable function may be found in `os`. The Executable function
+in the std lib `os` package is used if available.
+
 There is sometimes utility in finding the current executable file
 that is running. This can be used for upgrading the current executable
 or finding resources located relative to the executable file. Both

--- a/vendor/github.com/kardianos/osext/osext_go18.go
+++ b/vendor/github.com/kardianos/osext/osext_go18.go
@@ -1,0 +1,9 @@
+//+build go1.8,!openbsd
+
+package osext
+
+import "os"
+
+func executable() (string, error) {
+	return os.Executable()
+}

--- a/vendor/github.com/kardianos/osext/osext_plan9.go
+++ b/vendor/github.com/kardianos/osext/osext_plan9.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//+build !go1.8
+
 package osext
 
 import (

--- a/vendor/github.com/kardianos/osext/osext_procfs.go
+++ b/vendor/github.com/kardianos/osext/osext_procfs.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux netbsd solaris dragonfly
+// +build !go1.8,android !go1.8,linux !go1.8,netbsd !go1.8,solaris !go1.8,dragonfly
 
 package osext
 
@@ -16,7 +16,7 @@ import (
 
 func executable() (string, error) {
 	switch runtime.GOOS {
-	case "linux":
+	case "linux", "android":
 		const deletedTag = " (deleted)"
 		execpath, err := os.Readlink("/proc/self/exe")
 		if err != nil {

--- a/vendor/github.com/kardianos/osext/osext_sysctl.go
+++ b/vendor/github.com/kardianos/osext/osext_sysctl.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin freebsd openbsd
+// +build !go1.8,darwin !go1.8,freebsd openbsd
 
 package osext
 

--- a/vendor/github.com/kardianos/osext/osext_windows.go
+++ b/vendor/github.com/kardianos/osext/osext_windows.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//+build !go1.8
+
 package osext
 
 import (


### PR DESCRIPTION
In order to get rid of ``Couldn't start Terraform: ExecPath not implemented for android``