### PR TITLE
Handle StateFunc in plugin shims

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -25,6 +25,7 @@ func Provider() terraform.ResourceProvider {
 			"test_resource_force_new":        testResourceForceNew(),
 			"test_resource_nested":           testResourceNested(),
 			"test_resource_nested_set":       testResourceNestedSet(),
+			"test_resource_state_func":       testResourceStateFunc(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"test_data_source":    testDataSource(),

--- a/builtin/providers/test/resource_state_func.go
+++ b/builtin/providers/test/resource_state_func.go
@@ -1,0 +1,74 @@
+package test
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceStateFunc() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceStateFuncCreate,
+		Read:   testResourceStateFuncRead,
+		Update: testResourceStateFuncUpdate,
+		Delete: testResourceStateFuncDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"optional": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"state_func": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  true,
+				StateFunc: stateFuncHash,
+			},
+			"state_func_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func stateFuncHash(v interface{}) string {
+	hash := sha1.Sum([]byte(v.(string)))
+	return hex.EncodeToString(hash[:])
+}
+
+func testResourceStateFuncCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(fmt.Sprintf("%x", rand.Int63()))
+
+	// if we have a reference for the actual data in the state_func field,
+	// compare it
+	if data, ok := d.GetOk("state_func_value"); ok {
+		expected := data.(string)
+		got := d.Get("state_func").(string)
+		if expected != got {
+			return fmt.Errorf("expected state_func value:%q, got%q", expected, got)
+		}
+	}
+
+	return testResourceStateFuncRead(d, meta)
+}
+
+func testResourceStateFuncRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceStateFuncUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceStateFuncDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/test/resource_state_func_test.go
+++ b/builtin/providers/test/resource_state_func_test.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestResourceStateFunc_basic(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_state_func" "foo" {
+}
+				`),
+				Check: resource.TestCheckNoResourceAttr("test_resource_state_func.foo", "state_func"),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_state_func" "foo" {
+	state_func = "data"
+	state_func_value = "data"
+}
+				`),
+				Check: resource.TestCheckResourceAttr("test_resource_state_func.foo", "state_func", stateFuncHash("data")),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_state_func" "foo" {
+}
+				`),
+				Check: resource.TestCheckNoResourceAttr("test_resource_state_func.foo", "state_func"),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_state_func" "foo" {
+	optional = "added"
+	state_func = "data"
+	state_func_value = "data"
+}
+				`),
+				Check: resource.TestCheckResourceAttr("test_resource_state_func.foo", "state_func", stateFuncHash("data")),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_state_func" "foo" {
+	optional = "added"
+	state_func = "changed"
+	state_func_value = "changed"
+}
+				`),
+				Check: resource.TestCheckResourceAttr("test_resource_state_func.foo", "state_func", stateFuncHash("changed")),
+			},
+		},
+	})
+}

--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -358,6 +358,13 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
 	}
+
+	configMP, err := msgpack.Marshal(r.Config, resSchema.Block.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(err)
+		return resp
+	}
+
 	propMP, err := msgpack.Marshal(r.ProposedNewState, resSchema.Block.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
@@ -367,6 +374,7 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 	protoReq := &proto.PlanResourceChange_Request{
 		TypeName:         r.TypeName,
 		PriorState:       &proto.DynamicValue{Msgpack: priorMP},
+		Config:           &proto.DynamicValue{Msgpack: configMP},
 		ProposedNewState: &proto.DynamicValue{Msgpack: propMP},
 		PriorPrivate:     r.PriorPrivate,
 	}


### PR DESCRIPTION
Any state modifying functions can only be run once during the plan-apply
cycle. When regenerating the Diff during ApplyResourceChange,
strip out all StateFunc and CustomizeDiff functions from the schema.

During PlanResourceChange, store any NewExtra data from the Diff in the
PlannedPrivate data, and re-insert the NewExtra data into the Diff
generated during ApplyResourceChange.