### PR TITLE
Fix winrm default ssl port

### DIFF
--- a/communicator/winrm/provisioner.go
+++ b/communicator/winrm/provisioner.go
@@ -18,7 +18,7 @@ const (
 
 	// DefaultPort is used if there is no port given
 	DefaultPort = 5985
-	
+
 	// DefaultSslPort is used if there is no port given and HTTPS is true
 	DefaultSslPort = 5986
 

--- a/communicator/winrm/provisioner.go
+++ b/communicator/winrm/provisioner.go
@@ -18,6 +18,9 @@ const (
 
 	// DefaultPort is used if there is no port given
 	DefaultPort = 5985
+	
+	// DefaultSslPort is used if there is no port given and HTTPS is true
+	DefaultSslPort = 5986
 
 	// DefaultScriptPath is used as the path to copy the file to
 	// for remote execution if not provided otherwise.
@@ -80,7 +83,11 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 	connInfo.Host = shared.IpFormat(connInfo.Host)
 
 	if connInfo.Port == 0 {
-		connInfo.Port = DefaultPort
+		if connInfo.HTTPS {
+			connInfo.Port = DefaultSslPort
+		} else {
+			connInfo.Port = DefaultPort
+		}
 	}
 	if connInfo.ScriptPath == "" {
 		connInfo.ScriptPath = DefaultScriptPath

--- a/communicator/winrm/provisioner.go
+++ b/communicator/winrm/provisioner.go
@@ -19,8 +19,8 @@ const (
 	// DefaultPort is used if there is no port given
 	DefaultPort = 5985
 
-	// DefaultHttpsPort is used if there is no port given and HTTPS is true
-	DefaultHttpsPort = 5986
+	// DefaultHTTPSPort is used if there is no port given and HTTPS is true
+	DefaultHTTPSPort = 5986
 
 	// DefaultScriptPath is used as the path to copy the file to
 	// for remote execution if not provided otherwise.
@@ -84,7 +84,7 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 
 	if connInfo.Port == 0 {
 		if connInfo.HTTPS {
-			connInfo.Port = DefaultHttpsPort
+			connInfo.Port = DefaultHTTPSPort
 		} else {
 			connInfo.Port = DefaultPort
 		}

--- a/communicator/winrm/provisioner.go
+++ b/communicator/winrm/provisioner.go
@@ -19,8 +19,8 @@ const (
 	// DefaultPort is used if there is no port given
 	DefaultPort = 5985
 
-	// DefaultSslPort is used if there is no port given and HTTPS is true
-	DefaultSslPort = 5986
+	// DefaultHttpsPort is used if there is no port given and HTTPS is true
+	DefaultHttpsPort = 5986
 
 	// DefaultScriptPath is used as the path to copy the file to
 	// for remote execution if not provided otherwise.
@@ -84,7 +84,7 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 
 	if connInfo.Port == 0 {
 		if connInfo.HTTPS {
-			connInfo.Port = DefaultSslPort
+			connInfo.Port = DefaultHttpsPort
 		} else {
 			connInfo.Port = DefaultPort
 		}

--- a/communicator/winrm/provisioner_test.go
+++ b/communicator/winrm/provisioner_test.go
@@ -6,6 +6,31 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestProvisioner_defaultSslPort(t *testing.T) {
+	r := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: map[string]string{
+				"type":     "winrm",
+				"user":     "Administrator",
+				"password": "supersecret",
+				"host":     "127.0.0.1",
+				"https":    "true",
+			},
+		},
+	}
+
+	conf, err := parseConnectionInfo(r)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if conf.Port != 5986 {
+		t.Fatalf("expected: %v: got: %v", 5986, conf)
+	}
+	if conf.HTTPS != true {
+		t.Fatalf("expected: %v: got: %v", true, conf)
+	}
+}
+
 func TestProvisioner_connInfo(t *testing.T) {
 	r := &terraform.InstanceState{
 		Ephemeral: terraform.EphemeralState{

--- a/communicator/winrm/provisioner_test.go
+++ b/communicator/winrm/provisioner_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestProvisioner_defaultSslPort(t *testing.T) {
+func TestProvisioner_defaultHTTPSPort(t *testing.T) {
 	r := &terraform.InstanceState{
 		Ephemeral: terraform.EphemeralState{
 			ConnInfo: map[string]string{


### PR DESCRIPTION
lost quite a bit of time here trying to get winrm provisioner working due to the wrong default port being selected when Https, so have create a fix so hopefully no one else bumps into this.  Never written a line of Go in my life so hope it passes muster, but it is relatively straight forward.