### PR TITLE
format/state: added missing newline in the `outputs` output

### DIFF
--- a/command/format/state.go
+++ b/command/format/state.go
@@ -73,6 +73,7 @@ func State(opts *StateOpts) string {
 			v := m.OutputValues[k]
 			p.buf.WriteString(fmt.Sprintf("%s = ", k))
 			p.writeValue(v.Value, plans.NoOp, 0)
+			p.buf.WriteString("\n\n")
 		}
 	}
 


### PR DESCRIPTION
I stumbled across some unpleasant formatting that I hadn't caught earlier: 

Before:
```
new = "hi dad"pets = [
    "Pet: linus-closing-dove",
    "Pet: linus-usable-reindeer",
    "Pet: linus-united-shark",
]
```

After:
```
new = "hi dad"

pets = [
    "Pet: linus-closing-dove",
    "Pet: linus-usable-reindeer",
    "Pet: linus-united-shark",
]
```