### PR TITLE
Fix provider import tests

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -901,14 +901,14 @@ func parseVariableAsHCL(name string, input string, targetType config.VariableTyp
 	}
 }
 
-// shimLegacyState is a helper that takes the legacy state type and
+// ShimLegacyState is a helper that takes the legacy state type and
 // converts it to the new state type.
 //
 // This is implemented as a state file upgrade, so it will not preserve
 // parts of the state structure that are not included in a serialized state,
 // such as the resolved results of any local values, outputs in non-root
 // modules, etc.
-func shimLegacyState(legacy *State) (*states.State, error) {
+func ShimLegacyState(legacy *State) (*states.State, error) {
 	if legacy == nil {
 		return nil, nil
 	}
@@ -928,7 +928,7 @@ func shimLegacyState(legacy *State) (*states.State, error) {
 // the conversion does not succeed. This is primarily intended for tests where
 // the given legacy state is an object constructed within the test.
 func MustShimLegacyState(legacy *State) *states.State {
-	ret, err := shimLegacyState(legacy)
+	ret, err := ShimLegacyState(legacy)
 	if err != nil {
 		panic(err)
 	}

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -37,8 +37,7 @@ func TestContextImport_basic(t *testing.T) {
 				Addr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ID: "bar",
 			},
 		},
 	})
@@ -77,8 +76,7 @@ func TestContextImport_countIndex(t *testing.T) {
 				Addr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.IntKey(0),
 				),
-				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ID: "bar",
 			},
 		},
 	})
@@ -135,8 +133,7 @@ func TestContextImport_collision(t *testing.T) {
 				Addr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ID: "bar",
 			},
 		},
 	})
@@ -179,8 +176,7 @@ func TestContextImport_missingType(t *testing.T) {
 				Addr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ID: "bar",
 			},
 		},
 	})
@@ -233,8 +229,7 @@ func TestContextImport_moduleProvider(t *testing.T) {
 				Addr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ID: "bar",
 			},
 		},
 	})
@@ -291,8 +286,7 @@ func TestContextImport_providerModule(t *testing.T) {
 				Addr: addrs.RootModuleInstance.Child("child", addrs.NoKey).ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ID: "bar",
 			},
 		},
 	})
@@ -349,8 +343,7 @@ func TestContextImport_providerVarConfig(t *testing.T) {
 				Addr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ID: "bar",
 			},
 		},
 	})

--- a/terraform/test-fixtures/import-provider-resource/main.tf
+++ b/terraform/test-fixtures/import-provider-resource/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  foo = data.template_data_source.d.foo
+}
+
+data "template_data_source" "d" {
+  foo = "bar"
+}

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -16,10 +16,18 @@ type ImportStateTransformer struct {
 
 func (t *ImportStateTransformer) Transform(g *Graph) error {
 	for _, target := range t.Targets {
+		// The ProviderAddr may not be supplied for non-aliased providers.
+		// This will be populated if the targets come from the cli, but tests
+		// may not specify implied provider addresses.
+		providerAddr := target.ProviderAddr
+		if providerAddr.ProviderConfig.Type == "" {
+			providerAddr = target.Addr.Resource.Resource.DefaultProviderConfig().Absolute(target.Addr.Module)
+		}
+
 		node := &graphNodeImportState{
 			Addr:         target.Addr,
 			ID:           target.ID,
-			ProviderAddr: target.ProviderAddr,
+			ProviderAddr: providerAddr,
 		}
 		g.Add(node)
 	}


### PR DESCRIPTION
- Insert missing implied providers for imports when building the graph.
- Remove empty flatmapped containers from the import test states, so they can be more easily compared.

Fixes #19421