### PR TITLE
configs/configupgrade: Upgrade rules for our various "meta-arguments"

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/depends-on/input/depends-on.tf
+++ b/configs/configupgrade/test-fixtures/valid/depends-on/input/depends-on.tf
@@ -1,0 +1,17 @@
+resource "test_instance" "foo" {
+  depends_on = [
+    "test_instance.bar",
+    "test_instance.bar.0",
+    "test_instance.bar.*",
+    "test_instance.bar.invalid",
+    "data.test_instance.baz",
+    "data.test_instance.baz.invalid",
+    "module.foo.bar",
+    "module.foo",
+  ]
+}
+
+output "foo" {
+  value      = "a"
+  depends_on = ["test_instance.foo"]
+}

--- a/configs/configupgrade/test-fixtures/valid/depends-on/want/depends-on.tf
+++ b/configs/configupgrade/test-fixtures/valid/depends-on/want/depends-on.tf
@@ -1,0 +1,17 @@
+resource "test_instance" "foo" {
+  depends_on = [
+    test_instance.bar,
+    test_instance.bar[0],
+    test_instance.bar,
+    test_instance.bar,
+    data.test_instance.baz,
+    data.test_instance.baz,
+    module.foo.bar,
+    module.foo,
+  ]
+}
+
+output "foo" {
+  value      = "a"
+  depends_on = [test_instance.foo]
+}

--- a/configs/configupgrade/test-fixtures/valid/depends-on/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/depends-on/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/configs/configupgrade/test-fixtures/valid/lifecycle/input/lifecycle.tf
+++ b/configs/configupgrade/test-fixtures/valid/lifecycle/input/lifecycle.tf
@@ -1,0 +1,29 @@
+resource "test_instance" "foo" {
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = true
+  }
+}
+
+resource "test_instance" "bar" {
+  lifecycle {
+    ignore_changes = ["*"]
+  }
+}
+
+resource "test_instance" "baz" {
+  lifecycle {
+    ignore_changes = [
+      "image",
+      "tags.name",
+    ]
+  }
+}
+
+resource "test_instance" "boop" {
+  lifecycle {
+    ignore_changes = [
+      "image",
+    ]
+  }
+}

--- a/configs/configupgrade/test-fixtures/valid/lifecycle/want/lifecycle.tf
+++ b/configs/configupgrade/test-fixtures/valid/lifecycle/want/lifecycle.tf
@@ -1,0 +1,27 @@
+resource "test_instance" "foo" {
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = true
+  }
+}
+
+resource "test_instance" "bar" {
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "test_instance" "baz" {
+  lifecycle {
+    ignore_changes = [
+      image,
+      tags.name,
+    ]
+  }
+}
+
+resource "test_instance" "boop" {
+  lifecycle {
+    ignore_changes = [image]
+  }
+}

--- a/configs/configupgrade/test-fixtures/valid/lifecycle/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/lifecycle/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/configs/configupgrade/test-fixtures/valid/noop/input/modules.tf
+++ b/configs/configupgrade/test-fixtures/valid/noop/input/modules.tf
@@ -1,0 +1,3 @@
+module "foo" {
+  source = "./foo"
+}

--- a/configs/configupgrade/test-fixtures/valid/noop/input/resources.tf
+++ b/configs/configupgrade/test-fixtures/valid/noop/input/resources.tf
@@ -1,3 +1,11 @@
 
 resource "test_instance" "example" {
+  connection {
+    host = "127.0.0.1"
+  }
+  provisioner "local-exec" {
+    connection {
+      host = "127.0.0.2"
+    }
+  }
 }

--- a/configs/configupgrade/test-fixtures/valid/noop/want/modules.tf
+++ b/configs/configupgrade/test-fixtures/valid/noop/want/modules.tf
@@ -1,0 +1,3 @@
+module "foo" {
+  source = "./foo"
+}

--- a/configs/configupgrade/test-fixtures/valid/noop/want/resources.tf
+++ b/configs/configupgrade/test-fixtures/valid/noop/want/resources.tf
@@ -1,3 +1,11 @@
 
 resource "test_instance" "example" {
+  connection {
+    host = "127.0.0.1"
+  }
+  provisioner "local-exec" {
+    connection {
+      host = "127.0.0.2"
+    }
+  }
 }

--- a/configs/configupgrade/test-fixtures/valid/provider-addrs/input/provider-addrs.tf
+++ b/configs/configupgrade/test-fixtures/valid/provider-addrs/input/provider-addrs.tf
@@ -1,0 +1,16 @@
+provider "test" {
+  alias = "baz"
+}
+
+resource "test_instance" "foo" {
+  provider = "test.baz"
+}
+
+module "bar" {
+  source = "./baz"
+
+  providers = {
+    test     = "test.baz"
+    test.foo = "test"
+  }
+}

--- a/configs/configupgrade/test-fixtures/valid/provider-addrs/want/provider-addrs.tf
+++ b/configs/configupgrade/test-fixtures/valid/provider-addrs/want/provider-addrs.tf
@@ -1,0 +1,16 @@
+provider "test" {
+  alias = "baz"
+}
+
+resource "test_instance" "foo" {
+  provider = test.baz
+}
+
+module "bar" {
+  source = "./baz"
+
+  providers = {
+    test     = test.baz
+    test.foo = test
+  }
+}

--- a/configs/configupgrade/test-fixtures/valid/provider-addrs/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/provider-addrs/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/configs/configupgrade/upgrade_body.go
+++ b/configs/configupgrade/upgrade_body.go
@@ -353,3 +353,23 @@ func schemaNoInterpBodyRules(filename string, schema *configschema.Block, an *an
 
 	return ret
 }
+
+// justAttributesBodyRules constructs body content rules that just use the
+// standard interpolated attribute mapping for every name already present
+// in the given body object.
+//
+// This is a little weird vs. just processing directly the attributes, but
+// has the advantage that the caller can then apply overrides to the result
+// as necessary to deal with any known names that need special handling.
+//
+// Any attribute rules created by this function do not have a specific wanted
+// value type specified, instead setting it to just cty.DynamicPseudoType.
+func justAttributesBodyRules(filename string, body *hcl1ast.ObjectType, an *analysis) bodyContentRules {
+	rules := make(bodyContentRules, len(body.List.Items))
+	args := body.List.Items
+	for _, arg := range args {
+		name := arg.Keys[0].Token.Value().(string)
+		rules[name] = normalAttributeRule(filename, cty.DynamicPseudoType, an)
+	}
+	return rules
+}

--- a/configs/configupgrade/upgrade_expr.go
+++ b/configs/configupgrade/upgrade_expr.go
@@ -392,6 +392,18 @@ Value:
 	return buf.Bytes(), diags
 }
 
+func upgradeTraversalExpr(val interface{}, filename string, an *analysis) ([]byte, tfdiags.Diagnostics) {
+	if lit, ok := val.(*hcl1ast.LiteralType); ok && lit.Token.Type == hcl1token.STRING {
+		trStr := lit.Token.Value().(string)
+		trSrc := []byte(trStr)
+		_, trDiags := hcl2syntax.ParseTraversalAbs(trSrc, "", hcl2.Pos{})
+		if !trDiags.HasErrors() {
+			return trSrc, nil
+		}
+	}
+	return upgradeExpr(val, filename, false, an)
+}
+
 var hilArithmeticOpSyms = map[hilast.ArithmeticOp]string{
 	hilast.ArithmeticOpAdd: " + ",
 	hilast.ArithmeticOpSub: " - ",

--- a/configs/configupgrade/upgrade_native.go
+++ b/configs/configupgrade/upgrade_native.go
@@ -329,6 +329,24 @@ func (u *Upgrader) upgradeNativeSyntaxResource(filename string, buf *bytes.Buffe
 	rules["depends_on"] = dependsOnAttributeRule(filename, an)
 	rules["provider"] = maybeBareTraversalAttributeRule(filename, an)
 	rules["lifecycle"] = nestedBlockRule(filename, lifecycleBlockBodyRules(filename, an), an, adhocComments)
+	rules["connection"] = func(buf *bytes.Buffer, blockAddr string, item *hcl1ast.ObjectItem) tfdiags.Diagnostics {
+		// TODO: For the few resource types that were setting ConnInfo in
+		// state after create/update in prior versions, generate the additional
+		// explicit connection settings that are now required if and only if
+		// there's at least one provisioner block.
+		// For now, we just pass this through as-is.
+		hcl1printer.Fprint(buf, item)
+		buf.WriteByte('\n')
+		return nil
+	}
+	rules["provisioner"] = func(buf *bytes.Buffer, blockAddr string, item *hcl1ast.ObjectItem) tfdiags.Diagnostics {
+		// TODO: Look up the provisioner schema and map this properly to ensure
+		// any references get properly updated.
+		// For now, we just pass this through as-is.
+		hcl1printer.Fprint(buf, item)
+		buf.WriteByte('\n')
+		return nil
+	}
 
 	printComments(buf, item.LeadComment)
 	printBlockOpen(buf, blockType, labels, item.LineComment)

--- a/configs/configupgrade/upgrade_native.go
+++ b/configs/configupgrade/upgrade_native.go
@@ -327,6 +327,7 @@ func (u *Upgrader) upgradeNativeSyntaxResource(filename string, buf *bytes.Buffe
 	rules := schemaDefaultBodyRules(filename, schema, an, adhocComments)
 	rules["count"] = normalAttributeRule(filename, cty.Number, an)
 	rules["provider"] = maybeBareTraversalAttributeRule(filename, an)
+	rules["lifecycle"] = nestedBlockRule(filename, lifecycleBlockBodyRules(filename, an), an, adhocComments)
 
 	printComments(buf, item.LeadComment)
 	printBlockOpen(buf, blockType, labels, item.LineComment)

--- a/configs/configupgrade/upgrade_native.go
+++ b/configs/configupgrade/upgrade_native.go
@@ -326,6 +326,7 @@ func (u *Upgrader) upgradeNativeSyntaxResource(filename string, buf *bytes.Buffe
 
 	rules := schemaDefaultBodyRules(filename, schema, an, adhocComments)
 	rules["count"] = normalAttributeRule(filename, cty.Number, an)
+	rules["depends_on"] = dependsOnAttributeRule(filename, an)
 	rules["provider"] = maybeBareTraversalAttributeRule(filename, an)
 	rules["lifecycle"] = nestedBlockRule(filename, lifecycleBlockBodyRules(filename, an), an, adhocComments)
 


### PR DESCRIPTION
Aside from `module` blocks (which missed the cutoff for the last PR), we previously had all of the support for mapping the parts of the configuration that are either user-defined or provider-schema-defined, but we were missing most of the rules for meta-arguments (the arguments defined by Terraform Core itself, across all blocks of a particular type).

This set of commits implements at least _initial_ rules for all of the meta-arguments that existed in Terraform v0.11; some of these will see further improvements in later commits, but the goal here was just to reach the point where all valid names are handled in _some_ way so we can begin testing this with real-world configurations at the same time as wrapping up the remaining features.

In particular, this currently lacks special handling for `provisioner` and `connection` blocks inside resources, so those will just pass through verbatim for now. Some upgrade rules are required for these but we'll need to add some more features to the analysis pass first so we have all the required information.
