### PR TITLE
Adding missing S3 force_path_style option to schema check.

### DIFF
--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -329,6 +329,10 @@ func dataSourceRemoteState() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"force_path_style": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"auth_url": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,


### PR DESCRIPTION
Terraform 0.11.10 added schema validation to the `terraform_remote_state` data source. We're using an S3 backend provider with the `force_path_style = true` option configured and, when moving to 0.11.10, our templates started failing with an error stating `force_path_style` was an unrecognized option for the data source. A quick look into the source showed that option was left out of the schema list. This pull adds it back in so the same option set for the S3 backend is supported by the remote state data source.