### PR TITLE
configs/configupgrade: Fix up legacy redundant list bracket usage

### DIFF
--- a/configs/configupgrade/analysis_expr.go
+++ b/configs/configupgrade/analysis_expr.go
@@ -1,0 +1,156 @@
+package configupgrade
+
+import (
+	"log"
+
+	hcl2 "github.com/hashicorp/hcl2/hcl"
+	hcl2syntax "github.com/hashicorp/hcl2/hcl/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/lang"
+	"github.com/hashicorp/terraform/tfdiags"
+)
+
+// InferExpressionType attempts to determine a result type for the given
+// expression source code, which should already have been upgraded to new
+// expression syntax.
+//
+// If self is non-nil, it will determine the meaning of the special "self"
+// reference.
+//
+// If such an inference isn't possible, either because of limitations of
+// static analysis or because of errors in the expression, the result is
+// cty.DynamicPseudoType indicating "unknown".
+func (an *analysis) InferExpressionType(src []byte, self addrs.Referenceable) cty.Type {
+	expr, diags := hcl2syntax.ParseExpression(src, "", hcl2.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		// If there's a syntax error then analysis is impossible.
+		return cty.DynamicPseudoType
+	}
+
+	data := analysisData{an}
+	scope := &lang.Scope{
+		Data:     data,
+		SelfAddr: self,
+		PureOnly: false,
+		BaseDir:  ".",
+	}
+	val, _ := scope.EvalExpr(expr, cty.DynamicPseudoType)
+
+	// Value will be cty.DynamicVal if either inference was impossible or
+	// if there was an error, leading to cty.DynamicPseudoType here.
+	return val.Type()
+}
+
+// analysisData is an implementation of lang.Data that returns unknown values
+// of suitable types in order to achieve approximate dynamic analysis of
+// expression result types, which we need for some upgrade rules.
+//
+// Unlike a usual implementation of this interface, this one never returns
+// errors and will instead just return cty.DynamicVal if it can't produce
+// an exact type for any reason. This can then allow partial upgrading to
+// proceed and the caller can emit warning comments for ambiguous situations.
+//
+// N.B.: Source ranges in the data methods are meaningless, since they are
+// just relative to the byte array passed to InferExpressionType, not to
+// any real input file.
+type analysisData struct {
+	an *analysis
+}
+
+var _ lang.Data = (*analysisData)(nil)
+
+func (d analysisData) StaticValidateReferences(refs []*addrs.Reference, self addrs.Referenceable) tfdiags.Diagnostics {
+	// This implementation doesn't do any static validation.
+	return nil
+}
+
+func (d analysisData) GetCountAttr(addr addrs.CountAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// All valid count attributes are numbers
+	log.Printf("[TRACE] configupgrade: Determining type for %s", addr)
+	return cty.UnknownVal(cty.Number), nil
+}
+
+func (d analysisData) GetResourceInstance(instAddr addrs.ResourceInstance, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	log.Printf("[TRACE] configupgrade: Determining type for %s", instAddr)
+	addr := instAddr.Resource
+
+	// Our analysis pass should've found a suitable schema for every resource
+	// type in the module.
+	providerType, ok := d.an.ResourceProviderType[addr]
+	if !ok {
+		// Should not be possible, since analysis visits every resource block.
+		log.Printf("[TRACE] configupgrade: analysis.GetResourceInstance doesn't have a provider type for %s", addr)
+		return cty.DynamicVal, nil
+	}
+	providerSchema, ok := d.an.ProviderSchemas[providerType]
+	if !ok {
+		// Should not be possible, since analysis loads schema for every provider.
+		log.Printf("[TRACE] configupgrade: analysis.GetResourceInstance doesn't have a provider schema for for %q", providerType)
+		return cty.DynamicVal, nil
+	}
+	schema, _ := providerSchema.SchemaForResourceAddr(addr)
+	if schema == nil {
+		// Should not be possible, since analysis loads schema for every provider.
+		log.Printf("[TRACE] configupgrade: analysis.GetResourceInstance doesn't have a schema for for %s", addr)
+		return cty.DynamicVal, nil
+	}
+
+	objTy := schema.ImpliedType()
+
+	// We'll emulate the normal evaluator's behavor of deciding whether to
+	// return a list or a single object type depending on whether count is
+	// set and whether an instance key is given in the address.
+	if d.an.ResourceHasCount[addr] {
+		if instAddr.Key == addrs.NoKey {
+			log.Printf("[TRACE] configupgrade: %s refers to counted instance without a key, so result is a list of %#v", instAddr, objTy)
+			return cty.UnknownVal(cty.List(objTy)), nil
+		}
+		log.Printf("[TRACE] configupgrade: %s refers to counted instance with a key, so result is single object", instAddr)
+		return cty.UnknownVal(objTy), nil
+	}
+
+	if instAddr.Key != addrs.NoKey {
+		log.Printf("[TRACE] configupgrade: %s refers to non-counted instance with a key, which is invalid", instAddr)
+		return cty.DynamicVal, nil
+	}
+	log.Printf("[TRACE] configupgrade: %s refers to non-counted instance without a key, so result is single object", instAddr)
+	return cty.UnknownVal(objTy), nil
+}
+
+func (d analysisData) GetLocalValue(addrs.LocalValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// We can only predict these in general by recursively evaluating their
+	// expressions, which creates some undesirable complexity here so for
+	// now we'll just skip analyses with locals and see if this complexity
+	// is warranted with real-world testing.
+	return cty.DynamicVal, nil
+}
+
+func (d analysisData) GetModuleInstance(addrs.ModuleCallInstance, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// We only work on one module at a time during upgrading, so we have no
+	// information about the outputs of a child module.
+	return cty.DynamicVal, nil
+}
+
+func (d analysisData) GetModuleInstanceOutput(addrs.ModuleCallOutput, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// We only work on one module at a time during upgrading, so we have no
+	// information about the outputs of a child module.
+	return cty.DynamicVal, nil
+}
+
+func (d analysisData) GetPathAttr(addrs.PathAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// All valid path attributes are strings
+	return cty.UnknownVal(cty.String), nil
+}
+
+func (d analysisData) GetTerraformAttr(addrs.TerraformAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// All valid "terraform" attributes are strings
+	return cty.UnknownVal(cty.String), nil
+}
+
+func (d analysisData) GetInputVariable(addrs.InputVariable, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// TODO: Collect shallow type information (list vs. map vs. string vs. unknown)
+	// in analysis and then return a similarly-approximate type here.
+	return cty.DynamicVal, nil
+}

--- a/configs/configupgrade/analysis_expr.go
+++ b/configs/configupgrade/analysis_expr.go
@@ -68,7 +68,6 @@ func (d analysisData) StaticValidateReferences(refs []*addrs.Reference, self add
 
 func (d analysisData) GetCountAttr(addr addrs.CountAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	// All valid count attributes are numbers
-	log.Printf("[TRACE] configupgrade: Determining type for %s", addr)
 	return cty.UnknownVal(cty.Number), nil
 }
 
@@ -149,8 +148,20 @@ func (d analysisData) GetTerraformAttr(addrs.TerraformAttr, tfdiags.SourceRange)
 	return cty.UnknownVal(cty.String), nil
 }
 
-func (d analysisData) GetInputVariable(addrs.InputVariable, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d analysisData) GetInputVariable(addr addrs.InputVariable, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	// TODO: Collect shallow type information (list vs. map vs. string vs. unknown)
 	// in analysis and then return a similarly-approximate type here.
-	return cty.DynamicVal, nil
+	log.Printf("[TRACE] configupgrade: Determining type for %s", addr)
+	name := addr.Name
+	typeName := d.an.VariableTypes[name]
+	switch typeName {
+	case "list":
+		return cty.UnknownVal(cty.List(cty.DynamicPseudoType)), nil
+	case "map":
+		return cty.UnknownVal(cty.Map(cty.DynamicPseudoType)), nil
+	case "string":
+		return cty.UnknownVal(cty.String), nil
+	default:
+		return cty.DynamicVal, nil
+	}
 }

--- a/configs/configupgrade/test-fixtures/valid/redundant-list/input/redundant-list.tf
+++ b/configs/configupgrade/test-fixtures/valid/redundant-list/input/redundant-list.tf
@@ -1,0 +1,52 @@
+variable "listy" {
+  type = "list"
+}
+
+resource "test_instance" "other" {
+  count = 2
+}
+
+resource "test_instance" "bad1" {
+  security_groups = ["${test_instance.other.*.id}"]
+}
+
+resource "test_instance" "bad2" {
+  security_groups = ["${var.listy}"]
+}
+
+resource "test_instance" "bad3" {
+  security_groups = ["${module.foo.outputs_always_dynamic}"]
+}
+
+resource "test_instance" "bad4" {
+  security_groups = ["${list("a", "b", "c")}"]
+}
+
+# The rest of these should keep the same amount of list-ness
+
+resource "test_instance" "ok1" {
+  security_groups = []
+}
+
+resource "test_instance" "ok2" {
+  security_groups = ["notalist"]
+}
+
+resource "test_instance" "ok3" {
+  security_groups = ["${path.module}"]
+}
+
+resource "test_instance" "ok4" {
+  security_groups = [["foo"], ["bar"]]
+}
+
+resource "test_instance" "ok5" {
+  security_groups = "${test_instance.other.*.id}"
+}
+
+resource "test_instance" "ok6" {
+  security_groups = [
+    "${test_instance.other1.*.id}",
+    "${test_instance.other2.*.id}",
+  ]
+}

--- a/configs/configupgrade/test-fixtures/valid/redundant-list/want/redundant-list.tf
+++ b/configs/configupgrade/test-fixtures/valid/redundant-list/want/redundant-list.tf
@@ -1,0 +1,60 @@
+variable "listy" {
+  type = list(string)
+}
+
+resource "test_instance" "other" {
+  count = 2
+}
+
+resource "test_instance" "bad1" {
+  security_groups = test_instance.other.*.id
+}
+
+resource "test_instance" "bad2" {
+  security_groups = var.listy
+}
+
+resource "test_instance" "bad3" {
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibilty in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  security_groups = [module.foo.outputs_always_dynamic]
+}
+
+resource "test_instance" "bad4" {
+  security_groups = ["a", "b", "c"]
+}
+
+# The rest of these should keep the same amount of list-ness
+
+resource "test_instance" "ok1" {
+  security_groups = []
+}
+
+resource "test_instance" "ok2" {
+  security_groups = ["notalist"]
+}
+
+resource "test_instance" "ok3" {
+  security_groups = [path.module]
+}
+
+resource "test_instance" "ok4" {
+  security_groups = [["foo"], ["bar"]]
+}
+
+resource "test_instance" "ok5" {
+  security_groups = test_instance.other.*.id
+}
+
+resource "test_instance" "ok6" {
+  security_groups = [
+    test_instance.other1.*.id,
+    test_instance.other2.*.id,
+  ]
+}

--- a/configs/configupgrade/test-fixtures/valid/redundant-list/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/redundant-list/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/configs/configupgrade/upgrade_expr.go
+++ b/configs/configupgrade/upgrade_expr.go
@@ -9,6 +9,7 @@ import (
 
 	hcl2 "github.com/hashicorp/hcl2/hcl"
 	hcl2syntax "github.com/hashicorp/hcl2/hcl/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 
 	hcl1ast "github.com/hashicorp/hcl/hcl/ast"
 	hcl1printer "github.com/hashicorp/hcl/hcl/printer"
@@ -545,4 +546,8 @@ func upgradeTerraformRemoteStateTraversalParts(parts []string, an *analysis) []s
 	newParts[attrIdx] = "outputs"
 	copy(newParts[attrIdx+1:], parts[attrIdx:])
 	return newParts
+}
+
+func typeIsSettableFromTupleCons(ty cty.Type) bool {
+	return ty.IsListType() || ty.IsTupleType() || ty.IsSetType()
 }

--- a/configs/configupgrade/upgrade_test.go
+++ b/configs/configupgrade/upgrade_test.go
@@ -190,10 +190,11 @@ var testProviders = map[string]providers.Factory{
 			ResourceTypes: map[string]*configschema.Block{
 				"test_instance": {
 					Attributes: map[string]*configschema.Attribute{
-						"id":    {Type: cty.String, Computed: true},
-						"type":  {Type: cty.String, Optional: true},
-						"image": {Type: cty.String, Optional: true},
-						"tags":  {Type: cty.Map(cty.String), Optional: true},
+						"id":              {Type: cty.String, Computed: true},
+						"type":            {Type: cty.String, Optional: true},
+						"image":           {Type: cty.String, Optional: true},
+						"tags":            {Type: cty.Map(cty.String), Optional: true},
+						"security_groups": {Type: cty.List(cty.String), Optional: true},
 					},
 					BlockTypes: map[string]*configschema.NestedBlock{
 						"network": {

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/hashicorp/go-version v0.0.0-20180322230233-23480c066577
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20181204002630-cd67ba1b25f3
+	github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200
 	github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250
 	github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3
 	github.com/hashicorp/memberlist v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,7 +47,6 @@ github.com/blang/semver v0.0.0-20170202183821-4a1e882c79dc h1:J/iAaGTCZYfT/allw6
 github.com/blang/semver v0.0.0-20170202183821-4a1e882c79dc/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
-github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e h1:D64GF/Xr5zSUnM3q1Jylzo4sK7szhP/ON+nb2DB5XJA=
 github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -92,7 +91,6 @@ github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 h1:u4bArs140e9+A
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -118,7 +116,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.5.1 h1:3scN4iuXkNOyP98jF55Lv8a9j1o/Iwv
 github.com/grpc-ecosystem/grpc-gateway v1.5.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089 h1:1eDpXAxTh0iPv+1kc9/gfSI2pxRERDsTk/lNGolwHn8=
 github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+sfyn/OOI=
-github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357 h1:Rem2+U35z1QtPQc6r+WolF7yXiefXqDKyk+lN2pE164=
 github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -137,7 +134,6 @@ github.com/hashicorp/go-immutable-radix v0.0.0-20180129170900-7f3cd4390caa h1:0n
 github.com/hashicorp/go-immutable-radix v0.0.0-20180129170900-7f3cd4390caa/go.mod h1:6ij3Z20p+OhOkCSrA0gImAWoHYQRGbnlcuk6XYTiaRw=
 github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c h1:BTAbnbegUIMB6xmQCwWE8yRzbA4XSpnZY5hvRJC188I=
 github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
-github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0 h1:j30noezaCfvNLcdMYSvHLv81DxYRSt1grlpseG67vhU=
 github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
@@ -163,8 +159,10 @@ github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCO
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
-github.com/hashicorp/hcl2 v0.0.0-20181204002630-cd67ba1b25f3 h1:zWjLqvzzWtY+hxisvREouIFI0+8xhForyG5SqoxRvfQ=
-github.com/hashicorp/hcl2 v0.0.0-20181204002630-cd67ba1b25f3/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
+github.com/hashicorp/hcl2 v0.0.0-20181206005933-df9794be1f23 h1:RcXTRSKSKCJYXxI7yaOwAH1lYfZIzxhQhW2bFC8hABE=
+github.com/hashicorp/hcl2 v0.0.0-20181206005933-df9794be1f23/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
+github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200 h1:F/nGtDwtQsuw7ZHmiLpHsPWNljDC24kiSHSGUnou9sw=
+github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250 h1:fooK5IvDL/KIsi4LxF/JH68nVdrBSiGNPhS2JAQjtjo=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250/go.mod h1:KHvg/R2/dPtaePb16oW4qIyzkMxXOL38xjRN64adsts=
 github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3 h1:oD64EFjELI9RY9yoWlfua58r+etdnoIC871z+rr6lkA=
@@ -310,7 +308,6 @@ github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5 h1:cMjKdf4PxEBN9K5HaD9UM
 github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ulikunitz/xz v0.5.4 h1:zATC2OoZ8H1TZll3FpbX+ikwmadbO699PE06cIkm9oU=
 github.com/ulikunitz/xz v0.5.4/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
-github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvcciqcxEHac4CYj89xI=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
@@ -330,15 +327,12 @@ go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.9.1 h1:XCJQEf3W6eZaVwhRBof6ImoYGJSITeKWsyeh3HFu/5o=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
-golang.org/x/crypto v0.0.0-20180816225734-aabede6cba87 h1:gCHhzI+1R9peHIMyiWVxoVaWlk1cYK7VThX5ptLtbXY=
 golang.org/x/crypto v0.0.0-20180816225734-aabede6cba87/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869 h1:kkXA53yGe04D0adEYJwEVQjeBppL01Exg+fnMjfUraU=
 golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85 h1:et7+NAX3lLIk5qUCTA9QelBjGE/NkhzYw/mhnr0s7nI=
 golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20180811021610-c39426892332 h1:efGso+ep0DjyCBJPjvoz0HI6UldX4Md2F1rZFe1ir0E=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -346,7 +340,6 @@ golang.org/x/net v0.0.0-20181129055619-fae4c4e3ad76 h1:xx5MUFyRQRbPk6VjWjIE1epE/
 golang.org/x/net v0.0.0-20181129055619-fae4c4e3ad76/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced h1:4oqSq7eft7MdPKBGQK11X9WYUxmj6ZLgGTqYIbY1kyw=
 golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -361,7 +354,6 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181015145326-625cd1887957 h1:jwCmWUTrTFfjsobRuGurnCQeW4NZKijaIf6yAXwLR0E=
 google.golang.org/api v0.0.0-20181015145326-625cd1887957/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
-google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.3.0 h1:FBSsiFRMz3LBeXIomRnVzrQwSDj4ibvcRexLG0LZGQk=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -377,7 +369,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/vmihailenco/msgpack.v2 v2.9.1 h1:kb0VV7NuIojvRfzwslQeP3yArBqJHW9tOl4t38VS1jM=
 gopkg.in/vmihailenco/msgpack.v2 v2.9.1/go.mod h1:/3Dn1Npt9+MYyLpYYXjInO/5jvMLamn+AEGwNEOatn8=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/lang/eval.go
+++ b/lang/eval.go
@@ -88,16 +88,18 @@ func (s *Scope) EvalExpr(expr hcl.Expression, wantType cty.Type) (cty.Value, tfd
 	val, evalDiags := expr.Value(ctx)
 	diags = diags.Append(evalDiags)
 
-	var convErr error
-	val, convErr = convert.Convert(val, wantType)
-	if convErr != nil {
-		val = cty.UnknownVal(wantType)
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Incorrect value type",
-			Detail:   fmt.Sprintf("Invalid expression value: %s.", tfdiags.FormatError(convErr)),
-			Subject:  expr.Range().Ptr(),
-		})
+	if wantType != cty.DynamicPseudoType {
+		var convErr error
+		val, convErr = convert.Convert(val, wantType)
+		if convErr != nil {
+			val = cty.UnknownVal(wantType)
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Incorrect value type",
+				Detail:   fmt.Sprintf("Invalid expression value: %s.", tfdiags.FormatError(convErr)),
+				Subject:  expr.Range().Ptr(),
+			})
+		}
 	}
 
 	return val, diags

--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -528,7 +528,7 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 
 // closing the grpc connection is final, and terraform will call it at the end of every phase.
 func (p *GRPCProvider) Close() error {
-	log.Printf("[TRACE] GRPCProvider: PlanResourceChange")
+	log.Printf("[TRACE] GRPCProvider: Close")
 
 	// close the remote listener if we're running within a test
 	if p.TestListener != nil {

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -182,7 +182,7 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 		if n.Schema == nil {
 			// Should never happens, but we'll log if it does so that we can
 			// see this easily when debugging.
-			log.Printf("[WARN] no schema is attached to %s, so references cannot be detected", n.Name())
+			log.Printf("[WARN] no schema is attached to %s, so config references cannot be detected", n.Name())
 		}
 
 		refs, _ := lang.ReferencesInExpr(c.Count)
@@ -220,6 +220,13 @@ func (n *NodeAbstractResourceInstance) References() []*addrs.Reference {
 	// embedded abstract resource, which knows how to extract dependencies
 	// from configuration.
 	if n.Config != nil {
+		if n.Schema == nil {
+			// We'll produce a log message about this out here so that
+			// we can include the full instance address, since the equivalent
+			// message in NodeAbstractResource.References cannot see it.
+			log.Printf("[WARN] no schema is attached to %s, so config references cannot be detected", n.Name())
+			return nil
+		}
 		return n.NodeAbstractResource.References()
 	}
 

--- a/terraform/transform_resource_count.go
+++ b/terraform/transform_resource_count.go
@@ -43,6 +43,7 @@ func (t *ResourceCountTransformer) Transform(g *Graph) error {
 		addr := t.Addr.Instance(key)
 
 		abstract := NewNodeAbstractResourceInstance(addr)
+		abstract.Schema = t.Schema
 		var node dag.Vertex = abstract
 		if f := t.Concrete; f != nil {
 			node = f(abstract)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -344,7 +344,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl2 v0.0.0-20181204002630-cd67ba1b25f3
+# github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec


### PR DESCRIPTION
In early versions of Terraform where the interpolation language didn't have any real list support, list brackets around a single string was the signal to split the string on a special uuid separator to produce a list just in time for processing, giving expressions like this:

```hcl
    foo = ["${test_instance.foo.*.id}"]
```

Logically this is weird because it looks like it should produce a list of lists of strings, but in practice the outer list was just a marker to enable the splitting behavior.

When we added real list support in Terraform 0.7 we retained support for this behavior by trimming off extra levels of list during evaluation, and inadvertently continued relying on this notation for correct type checking.

During the Terraform 0.10 line we fixed the type checker bugs (a few remaining bugs notwithstanding) so that it was finally possible to use the more intuitive form:

```hcl
    foo = "${test_instance.foo.*.id}"
```

...but we continued trimming off extra levels of list for backward compatibility.

Terraform 0.12 now finally removes that compatibility shim, causing redundant list brackets to be interpreted as a list of lists.

This new upgrade rule attempts to identify situations that are relying on the old compatibility behavior and trim off the redundant extra brackets. It's not possible to do this fully-generally using only static analysis, but we can gather enough information through or partial type inference mechanism here to deal with the most common situations automatically and produce a `TF-UPGRADE-TODO` comment for more complex scenarios where the user intent isn't decidable with only static analysis.

In particular, this handles automatically by far the most common situation of wrapping list brackets around a splat expression like the first example above. After this and the other upgrade rules are applied, the first example above will become:

```hcl
    foo = test_instance.foo.*.id
```

This commit series includes a new capability in the `configupgrade` package of performing approximate type inference for an already-upgraded expression, which is a best effort to produce as precise a result type as possible and fall back on `cty.DynamicPseudoType` if not enough information is available via static analysis only.

---

One of the commits in this series is a workaround for a bug in `cty/convert` where it's losing type information when converting an unknown value to `cty.DynamicPseudoType` (zclconf/go-cty#13). I chose to do the fix here to keep momentum rather than context switching. I do intend also to fix it in `cty` at a later point, at which point the special case here in Terraform will be redundant but harmless.
