### PR TITLE
states/statemgr: use -mod=vendor to run the state locking helper

### DIFF
--- a/states/statemgr/filesystem_test.go
+++ b/states/statemgr/filesystem_test.go
@@ -56,7 +56,7 @@ func TestFilesystemLocks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := exec.Command("go", "run", "testdata/lockstate.go", s.path).CombinedOutput()
+	out, err := exec.Command("go", "run", "-mod=vendor", "testdata/lockstate.go", s.path).CombinedOutput()
 	if err != nil {
 		t.Fatal("unexpected lock failure", err, string(out))
 	}


### PR DESCRIPTION
This ensures that we test using the same source as we're using everywhere else, and more tactically also ensures that when running in Travis-CI we won't try to download all of the dependencies of Terraform during this test.

In the long run we will look for a more global solution to this, rather than adding this to all of our embedded `go` command calls directly, but this is intended as a low-risk solution to get the build working again in
the mean time.