### PR TITLE
helper/resource: Don't share provider instances between test steps

### DIFF
--- a/helper/resource/testing_config.go
+++ b/helper/resource/testing_config.go
@@ -24,12 +24,11 @@ import (
 func testStepConfig(
 	opts terraform.ContextOpts,
 	state *terraform.State,
-	step TestStep,
-	schemas *terraform.Schemas) (*terraform.State, error) {
-	return testStep(opts, state, step, schemas)
+	step TestStep) (*terraform.State, error) {
+	return testStep(opts, state, step)
 }
 
-func testStep(opts terraform.ContextOpts, state *terraform.State, step TestStep, schemas *terraform.Schemas) (*terraform.State, error) {
+func testStep(opts terraform.ContextOpts, state *terraform.State, step TestStep) (*terraform.State, error) {
 	if !step.Destroy {
 		if err := testStepTaint(state, step); err != nil {
 			return state, err
@@ -62,6 +61,10 @@ func testStep(opts terraform.ContextOpts, state *terraform.State, step TestStep,
 
 		log.Printf("[WARN] Config warnings:\n%s", stepDiags)
 	}
+
+	// We will need access to the schemas in order to shim to the old-style
+	// testing API.
+	schemas := ctx.Schemas()
 
 	// Refresh!
 	newState, stepDiags := ctx.Refresh()

--- a/helper/resource/testing_import_state.go
+++ b/helper/resource/testing_import_state.go
@@ -19,8 +19,8 @@ import (
 func testStepImportState(
 	opts terraform.ContextOpts,
 	state *terraform.State,
-	step TestStep,
-	schemas *terraform.Schemas) (*terraform.State, error) {
+	step TestStep) (*terraform.State, error) {
+
 	// Determine the ID to import
 	var importId string
 	switch {
@@ -61,6 +61,10 @@ func testStepImportState(
 	if stepDiags.HasErrors() {
 		return state, stepDiags.Err()
 	}
+
+	// We will need access to the schemas in order to shim to the old-style
+	// testing API.
+	schemas := ctx.Schemas()
 
 	// The test step provides the resource address as a string, so we need
 	// to parse it to get an addrs.AbsResourceAddress to pass in to the


### PR DESCRIPTION
For better realism compared to normal Terraform runs, here we switch to calling through to the underlying factory function once for each call to our GRPC-mock-wrapping factory function.

Along with this, we can also avoid manually constructing a `terraform.Schemas` object in the test harness by using the one that was constructed during `terraform.NewContext`, avoiding the need to instantiate the provider one extra time before the tests begin.

This doesn't yet fix the apparent race we're seeing in some of the test provider tests, but by limiting the lifetime of the provider objects we can at least reduce the risk of unrealistic provider state bleeding between test steps.
