### PR TITLE
backend/s3: Support DynamoDB, IAM, and STS endpoint configurations

### DIFF
--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -44,11 +44,32 @@ func New() backend.Backend {
 				DefaultFunc: schema.EnvDefaultFunc("AWS_DEFAULT_REGION", nil),
 			},
 
+			"dynamodb_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A custom endpoint for the DynamoDB API",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_DYNAMODB_ENDPOINT", ""),
+			},
+
 			"endpoint": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "A custom endpoint for the S3 API",
 				DefaultFunc: schema.EnvDefaultFunc("AWS_S3_ENDPOINT", ""),
+			},
+
+			"iam_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A custom endpoint for the IAM API",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_IAM_ENDPOINT", ""),
+			},
+
+			"sts_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A custom endpoint for the STS API",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_STS_ENDPOINT", ""),
 			},
 
 			"encrypt": {
@@ -252,7 +273,10 @@ func (b *Backend) configure(ctx context.Context) error {
 		CredsFilename:           data.Get("shared_credentials_file").(string),
 		Profile:                 data.Get("profile").(string),
 		Region:                  data.Get("region").(string),
+		DynamoDBEndpoint:        data.Get("dynamodb_endpoint").(string),
+		IamEndpoint:             data.Get("iam_endpoint").(string),
 		S3Endpoint:              data.Get("endpoint").(string),
+		StsEndpoint:             data.Get("sts_endpoint").(string),
 		SecretKey:               data.Get("secret_key").(string),
 		Token:                   data.Get("token").(string),
 		SkipCredsValidation:     data.Get("skip_credentials_validation").(bool),

--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -172,6 +172,9 @@ The following configuration options or environment variables are supported:
  * `workspace_key_prefix` - (Optional) The prefix applied to the state path
    inside the bucket. This is only relevant when using a non-default workspace.
    This defaults to "env:"
+ * `dynamodb_endpoint` / `AWS_DYNAMODB_ENDPOINT` - (Optional) A custom endpoint for the DynamoDB API.
+ * `iam_endpoint` / `AWS_IAM_ENDPOINT` - (Optional) A custom endpoint for the IAM API.
+ * `sts_endpoint` / `AWS_STS_ENDPOINT` - (Optional) A custom endpoint for the STS API.
  * `skip_credentials_validation` - (Optional) Skip the credentials validation via the STS API.
  * `skip_get_ec2_platforms` - (Optional) Skip getting the supported EC2 platforms.
  * `skip_region_validation` - (Optional) Skip validation of provided region name.


### PR DESCRIPTION
This change enables a few related use cases:
* AWS has partitions outside Commercial, GovCloud (US), and China, which are the only endpoints automatically handled by the AWS Go SDK. DynamoDB locking and credential verification can not currently be enabled in those regions.
* Allows usage of any DynamoDB-compatible API for state locking
* Allows usage of any IAM/STS-compatible API for credential verification