### PR TITLE
don't modify argument slices

### DIFF
--- a/helper/schema/field_reader_diff.go
+++ b/helper/schema/field_reader_diff.go
@@ -174,6 +174,9 @@ func (r *DiffFieldReader) readPrimitive(
 
 func (r *DiffFieldReader) readSet(
 	address []string, schema *Schema) (FieldReadResult, error) {
+	// copy address to ensure we don't modify the argument
+	address = append([]string(nil), address...)
+
 	prefix := strings.Join(address, ".") + "."
 
 	// Create the set that will be our result

--- a/helper/schema/field_reader_map.go
+++ b/helper/schema/field_reader_map.go
@@ -98,6 +98,9 @@ func (r *MapFieldReader) readPrimitive(
 
 func (r *MapFieldReader) readSet(
 	address []string, schema *Schema) (FieldReadResult, error) {
+	// copy address to ensure we don't modify the argument
+	address = append([]string(nil), address...)
+
 	// Get the number of elements in the list
 	countRaw, err := r.readPrimitive(
 		append(address, "#"), &Schema{Type: TypeInt})


### PR DESCRIPTION
There were a couple spots where argument slices weren't being copied
before `append` was called, which could possibly modify the caller's
slice data.