### PR TITLE
command/format: Avoid rendering body on destruction

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -100,6 +100,11 @@ func ResourceChange(
 		buf.WriteString(addr.String())
 	}
 
+	if change.Action == plans.Delete {
+		buf.WriteString("\n")
+		return buf.String()
+	}
+
 	buf.WriteString(" {\n")
 
 	p := blockBodyDiffPrinter{

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -45,9 +45,7 @@ func TestResourceChange_primitiveTypes(t *testing.T) {
 			},
 			RequiredReplace: cty.NewPathSet(),
 			ExpectedOutput: `  # test_instance.example will be destroyed
-  - resource "test_instance" "example" {
-      - id = "i-02ae66f368e8518a9" -> null
-    }
+  - resource "test_instance" "example"
 `,
 		},
 		"string in-place update": {


### PR DESCRIPTION
Attributes any resource are generally uninteresting on destruction as they'll all become `null`. This is also bringing us much closer to `0.11` output which already reflected this.

## 0.11

![screen shot 2018-12-11 at 16 13 04](https://user-images.githubusercontent.com/287584/49813581-aa8eb600-fd5f-11e8-9844-ce4c7fa867e4.png)

## 0.12 before

![screen shot 2018-12-11 at 16 06 23](https://user-images.githubusercontent.com/287584/49813161-c2196f00-fd5e-11e8-8d69-1bff014a129d.png)

## 0.12 after

![screen shot 2018-12-11 at 16 08 03](https://user-images.githubusercontent.com/287584/49813254-fa20b200-fd5e-11e8-8235-cc357ace5755.png)

