### PR TITLE
command/format: Render null in red

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -420,7 +420,7 @@ func (p *blockBodyDiffPrinter) writeValue(val cty.Value, action plans.Action, in
 		return
 	}
 	if val.IsNull() {
-		p.buf.WriteString("null")
+		p.buf.WriteString(p.color.Color("[red]null[reset]"))
 		return
 	}
 


### PR DESCRIPTION
I thought it would be even nicer to render the whole line as red, but then the whole ` -> null` part becomes kinda redundant and I assume we want to keep it there for non-colorized outputs as minus signs alone might not be immediately obvious.

## Before

![screen shot 2018-12-11 at 20 58 02](https://user-images.githubusercontent.com/287584/49829894-9bbbf980-fd87-11e8-9927-9a2b996e3a97.png)

## After

![screen shot 2018-12-11 at 20 59 01](https://user-images.githubusercontent.com/287584/49829910-a4143480-fd87-11e8-9062-54eaa55a1613.png)
