### PR TITLE
Add doc change to prevent bucket name conflict in dependencies getting-started

### DIFF
--- a/website/intro/getting-started/dependencies.html.md
+++ b/website/intro/getting-started/dependencies.html.md
@@ -156,7 +156,7 @@ resource "aws_s3_bucket" "example" {
   # NOTE: S3 bucket names must be unique across _all_ AWS accounts, so
   # this name must be changed before applying this example to avoid naming
   # conflicts.
-  bucket = "terraform-getting-started-guide"
+  bucket = "terraform-getting-started-guide-<insert your unique id here>"
   acl    = "private"
 }
 


### PR DESCRIPTION
Fix suggested on issue AuthorizationHeaderMalformed for S3 remote #2774 - I can't be the only one to hit this, it's still broken in the error, looks like it's an issue with your AWS zone, but even with a defined zone it still happens to me, a unique value for the bucket (which must be globally unique) will fix it, saving newbies some annoyance.