### PR TITLE
make: Only limit test runs in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,14 @@ plugin-dev: generate
 	mv $(GOPATH)/bin/$(PLUGIN) $(GOPATH)/bin/terraform-$(PLUGIN)
 
 # test runs the unit tests
-# we run this one package at a time here because running the entire suite in
-# one command creates memory usage issues when running in Travis-CI.
 test: fmtcheck generate
+ifeq ($(CI), true)
+	# we run this one package at a time here because running the entire suite in
+	# one command creates memory usage issues when running in Travis-CI.
 	go list -mod=vendor $(TEST) | xargs -t -n4 go test $(TESTARGS) -mod=vendor -timeout=2m -parallel=4
+else
+	go test $(TEST) $(TESTARGS) -mod=vendor -timeout=2m
+endif
 
 # testacc runs acceptance tests
 testacc: fmtcheck generate


### PR DESCRIPTION
I found myself running raw `go test` just because it's much faster (on my laptop locally).

```
CI=true TESTARGS='-count=1' time make test
...
      197.83 real       226.56 user        51.92 sys
```

```
TESTARGS='-count=1' time make test
...
       87.65 real       225.33 user        43.46 sys
```

So I'm proposing we only care about the memory consumption in CI (detected by `CI=true` ENV variable).
https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables

That way there's less reasons to avoid `make test` for regular test runs during development.