### PR TITLE
core: Validate depends_on and ignore_changes traversals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/hashicorp/go-version v1.0.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20181214235302-dac4796ca146
+	github.com/hashicorp/hcl2 v0.0.0-20181215005721-253da47fd604
 	github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250
 	github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3
 	github.com/hashicorp/memberlist v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/hashicorp/hcl2 v0.0.0-20181214224644-4c4fdbdcc016 h1:rWpgzURetj/et0J6
 github.com/hashicorp/hcl2 v0.0.0-20181214224644-4c4fdbdcc016/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
 github.com/hashicorp/hcl2 v0.0.0-20181214235302-dac4796ca146 h1:y2SWlAjINnc8OYpcVZ0vJDDaX++nzctjoOnB8Y+pqaI=
 github.com/hashicorp/hcl2 v0.0.0-20181214235302-dac4796ca146/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
+github.com/hashicorp/hcl2 v0.0.0-20181215005721-253da47fd604 h1:k660QMbAqhL4vxSNPmvOAjzZJ7BQiwTrT8pa8RH3OEA=
+github.com/hashicorp/hcl2 v0.0.0-20181215005721-253da47fd604/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250 h1:fooK5IvDL/KIsi4LxF/JH68nVdrBSiGNPhS2JAQjtjo=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250/go.mod h1:KHvg/R2/dPtaePb16oW4qIyzkMxXOL38xjRN64adsts=
 github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3 h1:oD64EFjELI9RY9yoWlfua58r+etdnoIC871z+rr6lkA=

--- a/lang/eval.go
+++ b/lang/eval.go
@@ -154,6 +154,10 @@ func (s *Scope) EvalContext(refs []*addrs.Reference) (*hcl.EvalContext, tfdiags.
 }
 
 func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceable) (*hcl.EvalContext, tfdiags.Diagnostics) {
+	if s == nil {
+		panic("attempt to construct EvalContext for nil Scope")
+	}
+
 	var diags tfdiags.Diagnostics
 	vals := make(map[string]cty.Value)
 	funcs := s.Functions()

--- a/vendor/github.com/hashicorp/hcl2/hcl/traversal_for_expr.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/traversal_for_expr.go
@@ -52,11 +52,14 @@ func AbsTraversalForExpr(expr Expression) (Traversal, Diagnostics) {
 func RelTraversalForExpr(expr Expression) (Traversal, Diagnostics) {
 	traversal, diags := AbsTraversalForExpr(expr)
 	if len(traversal) > 0 {
+		ret := make(Traversal, len(traversal))
+		copy(ret, traversal)
 		root := traversal[0].(TraverseRoot)
-		traversal[0] = TraverseAttr{
+		ret[0] = TraverseAttr{
 			Name:     root.Name,
 			SrcRange: root.SrcRange,
 		}
+		return ret, diags
 	}
 	return traversal, diags
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -344,7 +344,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl2 v0.0.0-20181214235302-dac4796ca146
+# github.com/hashicorp/hcl2 v0.0.0-20181215005721-253da47fd604
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec


### PR DESCRIPTION
Both `depends_on` and `ignore_changes` contain references to objects that we can validate.

Historically Terraform has not validated these, instead just ignoring references to non-existent objects. Since there is no reason to refer to something that doesn't exist, we'll now verify this and return errors so
that users get explicit feedback on any typos they may have made, rather than just wondering why what they added seems to have no effect.

This is particularly important for `ignore_changes` because users have historically used strange values here to try to exploit the fact that Terraform was resolving `ignore_changes` against a flatmap. This will give them explicit feedback for any odd constructs that the configuration upgrade tool doesn't know how to detect and fix.

---

In the process of working on this I spotted a nasty little bug down in HCL2 land, so this PR includes a vendor update for that too. Without that update, certain uses of `ignore_changes` could cause a panic due to the configuration AST getting accidentally mutated.
