### PR TITLE
backend/remote: fix an error that prevents checking constraints

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -160,7 +160,7 @@ func (b *Remote) configure(ctx context.Context) error {
 	}
 
 	// Check any retrieved constraints to make sure we are compatible.
-	if constraints == nil {
+	if constraints != nil {
 		if err := b.checkConstraints(constraints); err != nil {
 			return err
 		}


### PR DESCRIPTION
This is a back ported fix from v0.12. There is no need to cut a release for this fix, but lets fix it anyway just in case we want another v0.11 release in the future.