### PR TITLE
failing count refs

### DIFF
--- a/builtin/providers/test/data_source.go
+++ b/builtin/providers/test/data_source.go
@@ -31,6 +31,17 @@ func testDataSource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"input_map": {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"output_map": {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
 		},
 	}
 }
@@ -45,5 +56,8 @@ func testDataSourceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("output", "some output")
 	}
 
+	if inputMap, hasInput := d.GetOk("input_map"); hasInput {
+		d.Set("output_map", inputMap)
+	}
 	return nil
 }

--- a/builtin/providers/test/data_source_test.go
+++ b/builtin/providers/test/data_source_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -185,6 +186,55 @@ data "test_data_source" "x" {
 data "test_data_source" "y" {
   input = data.test_data_source.x.nil == "something" ? "something" : "else"
 }`,
+			},
+		},
+	})
+}
+
+// referencing test_data_source.one.output_map["a"] should produce an error when
+// there's a count, but instead we end up with an unknown value after apply.
+func TestDataSource_indexedCountOfOne(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: strings.TrimSpace(`
+data "test_data_source" "one" {
+	count = 1
+  input_map = {
+		"a" = "b"
+	}
+}
+
+data "test_data_source" "two" {
+	input_map = {
+		"x" = data.test_data_source.one.output_map["a"]
+	}
+}
+				`),
+				ExpectError: regexp.MustCompile("value does not have any attributes"),
+			},
+		},
+	})
+}
+
+// Verify that we can destroy when a data source references something with a
+// count of 1.
+func TestDataSource_countRefDestroyError(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: strings.TrimSpace(`
+data "test_data_source" "one" {
+  count = 1
+  input = "a"
+}
+
+data "test_data_source" "two" {
+  input = data.test_data_source.one[0].output
+}
+				`),
 			},
 		},
 	})

--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -493,3 +493,31 @@ resource "test_resource" "foo" {
 		},
 	})
 }
+
+// Verify that we can destroy when a managed resource references something with
+// a count of 1.
+func TestResource_countRefDestroyError(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: strings.TrimSpace(`
+resource "test_resource" "one" {
+	count = 1
+	required     = "ok"
+	required_map = {
+	  key = "val"
+	}
+}
+
+resource "test_resource" "two" {
+	required     = test_resource.one[0].id
+	required_map = {
+	  key = "val"
+	}
+}
+				`),
+			},
+		},
+	})
+}

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -289,6 +289,7 @@ func (ctx *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, keyData
 		Evaluator:       ctx.Evaluator,
 		ModulePath:      ctx.PathValue,
 		InstanceKeyData: keyData,
+		Operation:       ctx.Evaluator.Operation,
 	}
 	return ctx.Evaluator.Scope(data, self)
 }

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -91,6 +91,10 @@ type evaluationStateData struct {
 	// since the user specifies in that case which variable name to locally
 	// shadow.)
 	InstanceKeyData InstanceKeyEvalData
+
+	// Operation records the type of walk the evaluationStateData is being used
+	// for.
+	Operation walkOperation
 }
 
 // InstanceKeyEvalData is used during evaluation to specify which values,
@@ -503,6 +507,12 @@ func (d *evaluationStateData) GetResourceInstance(addr addrs.ResourceInstance, r
 		// (In practice we should only end up here during the validate walk,
 		// since later walks should have at least partial states populated
 		// for all resources in the configuration.)
+		return cty.DynamicVal, diags
+	}
+
+	// Break out early during validation, because resource may not be expanded
+	// yet and indexed references may show up as invalid.
+	if d.Operation == walkValidate {
 		return cty.DynamicVal, diags
 	}
 


### PR DESCRIPTION
One of these tests is fixed with a recent hcl2 update.
The other is fixed by not checking state to expand EachMode during validation.
