### PR TITLE
Ensure we have providers when scaling in counted data sources

### DIFF
--- a/states/sync.go
+++ b/states/sync.go
@@ -179,7 +179,7 @@ func (s *SyncState) ResourceInstanceObject(addr addrs.AbsResourceInstance, gen G
 	if inst == nil {
 		return nil
 	}
-	return inst.GetGeneration(gen)
+	return inst.GetGeneration(gen).DeepCopy()
 }
 
 // SetResourceMeta updates the resource-level metadata for the resource at

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -212,6 +212,10 @@ func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
 	absAddr := n.Addr.Absolute(ctx.Path())
 	state := ctx.State()
 
+	if n.ProviderAddr.ProviderConfig.Type == "" {
+		return nil, fmt.Errorf("failed to write state for %s, missing provider type", absAddr)
+	}
+
 	obj := *n.State
 	if obj == nil || obj.Value.IsNull() {
 		// No need to encode anything: we'll just write it directly.

--- a/terraform/node_data_destroy.go
+++ b/terraform/node_data_destroy.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/states"
 )
 
@@ -14,10 +15,26 @@ type NodeDestroyableDataResource struct {
 func (n *NodeDestroyableDataResource) EvalTree() EvalNode {
 	addr := n.ResourceInstanceAddr()
 
+	var providerSchema *ProviderSchema
+	// We don't need the provider, but we're calling EvalGetProvider to load the
+	// schema.
+	var provider providers.Interface
+
 	// Just destroy it.
 	var state *states.ResourceInstanceObject
-	return &EvalWriteState{
-		Addr:  addr.Resource,
-		State: &state, // state is nil here
+	return &EvalSequence{
+		Nodes: []EvalNode{
+			&EvalGetProvider{
+				Addr:   n.ResolvedProvider,
+				Output: &provider,
+				Schema: &providerSchema,
+			},
+			&EvalWriteState{
+				Addr:           addr.Resource,
+				State:          &state,
+				ProviderAddr:   n.ResolvedProvider,
+				ProviderSchema: &providerSchema,
+			},
+		},
 	}
 }

--- a/terraform/node_data_destroy.go
+++ b/terraform/node_data_destroy.go
@@ -5,14 +5,14 @@ import (
 	"github.com/hashicorp/terraform/states"
 )
 
-// NodeDestroyableDataResource represents a resource that is "destroyable":
+// NodeDestroyableDataResourceInstance represents a resource that is "destroyable":
 // it is ready to be destroyed.
-type NodeDestroyableDataResource struct {
+type NodeDestroyableDataResourceInstance struct {
 	*NodeAbstractResourceInstance
 }
 
 // GraphNodeEvalable
-func (n *NodeDestroyableDataResource) EvalTree() EvalNode {
+func (n *NodeDestroyableDataResourceInstance) EvalTree() EvalNode {
 	addr := n.ResourceInstanceAddr()
 
 	var providerSchema *ProviderSchema

--- a/terraform/node_data_refresh.go
+++ b/terraform/node_data_refresh.go
@@ -56,8 +56,9 @@ func (n *NodeRefreshableDataResource) DynamicExpand(ctx EvalContext) (*Graph, er
 	// We also need a destroyable resource for orphans that are a result of a
 	// scaled-in count.
 	concreteResourceDestroyable := func(a *NodeAbstractResourceInstance) dag.Vertex {
-		// Add the config since we don't do that via transforms
+		// Add the config and provider since we don't do that via transforms
 		a.Config = n.Config
+		a.ResolvedProvider = n.ResolvedProvider
 
 		return &NodeDestroyableDataResource{
 			NodeAbstractResourceInstance: a,

--- a/terraform/node_data_refresh.go
+++ b/terraform/node_data_refresh.go
@@ -60,7 +60,7 @@ func (n *NodeRefreshableDataResource) DynamicExpand(ctx EvalContext) (*Graph, er
 		a.Config = n.Config
 		a.ResolvedProvider = n.ResolvedProvider
 
-		return &NodeDestroyableDataResource{
+		return &NodeDestroyableDataResourceInstance{
 			NodeAbstractResourceInstance: a,
 		}
 	}

--- a/terraform/node_data_refresh_test.go
+++ b/terraform/node_data_refresh_test.go
@@ -152,20 +152,20 @@ func TestNodeRefreshableDataResourceDynamicExpand_scaleIn(t *testing.T) {
 	expected := `data.aws_instance.foo[0] - *terraform.NodeRefreshableDataResourceInstance
 data.aws_instance.foo[1] - *terraform.NodeRefreshableDataResourceInstance
 data.aws_instance.foo[2] - *terraform.NodeRefreshableDataResourceInstance
-data.aws_instance.foo[3] - *terraform.NodeDestroyableDataResource
+data.aws_instance.foo[3] - *terraform.NodeDestroyableDataResourceInstance
 root - terraform.graphNodeRoot
   data.aws_instance.foo[0] - *terraform.NodeRefreshableDataResourceInstance
   data.aws_instance.foo[1] - *terraform.NodeRefreshableDataResourceInstance
   data.aws_instance.foo[2] - *terraform.NodeRefreshableDataResourceInstance
-  data.aws_instance.foo[3] - *terraform.NodeDestroyableDataResource
+  data.aws_instance.foo[3] - *terraform.NodeDestroyableDataResourceInstance
 `
 	if expected != actual {
 		t.Fatalf("Expected:\n%s\nGot:\n%s", expected, actual)
 	}
 
-	var destroyableDataResource *NodeDestroyableDataResource
+	var destroyableDataResource *NodeDestroyableDataResourceInstance
 	for _, v := range g.Vertices() {
-		if r, ok := v.(*NodeDestroyableDataResource); ok {
+		if r, ok := v.(*NodeDestroyableDataResourceInstance); ok {
 			destroyableDataResource = r
 		}
 	}
@@ -175,6 +175,6 @@ root - terraform.graphNodeRoot
 	}
 
 	if destroyableDataResource.ResolvedProvider.ProviderConfig.Type == "" {
-		t.Fatal("NodeDestroyableDataResource missing provider config")
+		t.Fatal("NodeDestroyableDataResourceInstance missing provider config")
 	}
 }

--- a/terraform/node_data_refresh_test.go
+++ b/terraform/node_data_refresh_test.go
@@ -128,6 +128,11 @@ func TestNodeRefreshableDataResourceDynamicExpand_scaleIn(t *testing.T) {
 				"foo",
 			),
 			Config: m.Module.DataResources["data.aws_instance.foo"],
+			ResolvedProvider: addrs.AbsProviderConfig{
+				ProviderConfig: addrs.ProviderConfig{
+					Type: "aws",
+				},
+			},
 		},
 	}
 
@@ -156,5 +161,20 @@ root - terraform.graphNodeRoot
 `
 	if expected != actual {
 		t.Fatalf("Expected:\n%s\nGot:\n%s", expected, actual)
+	}
+
+	var destroyableDataResource *NodeDestroyableDataResource
+	for _, v := range g.Vertices() {
+		if r, ok := v.(*NodeDestroyableDataResource); ok {
+			destroyableDataResource = r
+		}
+	}
+
+	if destroyableDataResource == nil {
+		t.Fatal("failed to find a destroyableDataResource")
+	}
+
+	if destroyableDataResource.ResolvedProvider.ProviderConfig.Type == "" {
+		t.Fatal("NodeDestroyableDataResource missing provider config")
 	}
 }

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -149,7 +149,7 @@ func (n *NodeRefreshableManagedResourceInstance) EvalTree() EvalNode {
 				NodeAbstractResourceInstance: n.NodeAbstractResourceInstance,
 			}
 		} else {
-			dn = &NodeDestroyableDataResource{
+			dn = &NodeDestroyableDataResourceInstance{
 				NodeAbstractResourceInstance: n.NodeAbstractResourceInstance,
 			}
 		}

--- a/terraform/transform_attach_state.go
+++ b/terraform/transform_attach_state.go
@@ -59,7 +59,9 @@ func (t *AttachStateTransformer) Transform(g *Graph) error {
 			continue
 		}
 
-		an.AttachResourceState(rs)
+		// make sure to attach a copy of the state, so instances can modify the
+		// same ResourceState.
+		an.AttachResourceState(rs.DeepCopy())
 	}
 
 	return nil


### PR DESCRIPTION
First some fixed to make sure we're not mutating shared state and causing any extra races:
- ResourceInstanceObject needs to return a copy
- attach a deep copy of ResourceState

Then we need to make sure that NodeDestroyableDataResource has a ResolvedProvider to
call EvalWriteState. This entails setting the ResolvedProvider in
concreteResourceDestroyable, as well as calling EvalGetProvider in
NodeDestroyableDataResource to load the provider schema.

Even though writing the state for a data destroy node should just be
removing the instance, every instance written sets the Provider for the
entire resource. This means that when scaling back a counted data
source, if the removed instances are written last, the data source will
be missing the provider in the state.
