### PR TITLE
Add custom share option for docs/guides

### DIFF
--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -1,3 +1,10 @@
+<% content_for(:custom_share) do %>
+  <meta name="twitter:card" content="summary" />
+  <meta property="og:image" content="<%= image_url("og-image-small.png") %>"/>
+  <meta property="og:image:width" content="100"/>
+  <meta property="og:image:height" content="100"/>
+<% end %>
+
 <% wrap_layout :inner do %>
   <% content_for :sidebar do %>
     <ul class="nav docs-sidenav">

--- a/website/layouts/guides.erb
+++ b/website/layouts/guides.erb
@@ -1,3 +1,10 @@
+<% content_for(:custom_share) do %>
+  <meta name="twitter:card" content="summary" />
+  <meta property="og:image" content="<%= image_url("og-image-small.png") %>"/>
+  <meta property="og:image:width" content="100"/>
+  <meta property="og:image:height" content="100"/>
+<% end %>
+
 <% wrap_layout :inner do %>
   <% content_for :sidebar do %>
     <ul class="nav docs-sidenav">


### PR DESCRIPTION
Related to: https://github.com/hashicorp/terraform-website/pull/553

This PR will use custom sharing metadata to ensure that smaller images unfurl when sharing docs and guides.