### PR TITLE
Fixes a misleading error message

### DIFF
--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -259,7 +259,7 @@ func readPrivateKey(pk string) (ssh.AuthMethod, error) {
 	// show a nicer error if the private key has a password.
 	block, _ := pem.Decode([]byte(pk))
 	if block == nil {
-		return nil, fmt.Errorf("Failed to read key %q: no key found", pk)
+		return nil, fmt.Errorf("Failed to decode key")
 	}
 	if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
 		return nil, fmt.Errorf(


### PR DESCRIPTION
Looking back at the history of this provisioner, it looks as though it used to always take a file path, but now takes contents (i.e. the key itself). I guess that explains the old error messsage (implying that a key _file_ couldn't be found) - but this is no longer the case.

Fixed https://github.com/hashicorp/terraform/issues/19242 while I was there.