### PR TITLE
Fixes a misleading error message

### DIFF
--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -259,7 +259,7 @@ func readPrivateKey(pk string) (ssh.AuthMethod, error) {
 	// show a nicer error if the private key has a password.
 	block, _ := pem.Decode([]byte(pk))
 	if block == nil {
-		return nil, fmt.Errorf("Failed to read key %q: no key found", pk)
+		return nil, fmt.Errorf("Failed to decode key")
 	}
 	if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
 		return nil, fmt.Errorf(


### PR DESCRIPTION
Looking back at the history of this provisioner, it looks as though it used to always take a file path, but now takes contents (i.e. the key itself) see: 7ffa66d1a536428dcd.

Looking at the doc for `pem.decode` I suppose that knowing that, the old error message still makes sense (i.e. there was no key found in the passed in string) but personally I found it misleading (as a terraform user) - it made me think that terraform was using the key as a file path.

Fixed https://github.com/hashicorp/terraform/issues/19242 while I was there.