### PR TITLE
backend/remote: compare versions without the prerelease

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -370,7 +370,7 @@ func (b *Remote) checkConstraints(c *disco.Constraints) tfdiags.Diagnostics {
 	}
 
 	// Create the version to check.
-	v, err := version.NewVersion(tfversion.String())
+	v, err := version.NewVersion(tfversion.Version)
 	if err != nil {
 		return diags.Append(checkConstraintsWarning(err))
 	}
@@ -433,7 +433,7 @@ func (b *Remote) checkConstraints(c *disco.Constraints) tfdiags.Diagnostics {
 	summary := fmt.Sprintf("Incompatible Terraform version v%s", v.String())
 	details := fmt.Sprintf(
 		"The configured Terraform Enterprise backend is compatible with Terraform "+
-			"versions >= %s, < %s%s.", c.Minimum, c.Maximum, excluding,
+			"versions >= %s, <= %s%s.", c.Minimum, c.Maximum, excluding,
 	)
 
 	if action != "" && toVersion != "" {

--- a/backend/remote/backend_test.go
+++ b/backend/remote/backend_test.go
@@ -379,7 +379,7 @@ func TestRemote_checkConstraints(t *testing.T) {
 				Maximum: "0.11.11",
 			},
 			version: "0.10.1",
-			result:  "versions >= 0.11.0, < 0.11.11.",
+			result:  "versions >= 0.11.0, <= 0.11.11.",
 		},
 		"list exclusion": {
 			constraints: &disco.Constraints{


### PR DESCRIPTION
The `go-version` package treads prereleases in a specific way, but in terms of compatibility any beta, or RC should be compatible with the final release. So we just test against the version only.