### PR TITLE
backend/remote: compare versions without the prerelease

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -261,7 +261,7 @@ func (b *Remote) checkConstraints(c *disco.Constraints) error {
 	}
 
 	// Create the version to check.
-	v, err := version.NewVersion(tfversion.String())
+	v, err := version.NewVersion(tfversion.Version)
 	if err != nil {
 		return checkConstraintsWarning(err)
 	}
@@ -324,7 +324,7 @@ func (b *Remote) checkConstraints(c *disco.Constraints) error {
 	summary := fmt.Sprintf("Incompatible Terraform version v%s", v.String())
 	details := fmt.Sprintf(
 		"The configured Terraform Enterprise backend is compatible with Terraform\n"+
-			"versions >= %s, < %s%s.", c.Minimum, c.Maximum, excluding,
+			"versions >= %s, <= %s%s.", c.Minimum, c.Maximum, excluding,
 	)
 
 	if action != "" && toVersion != "" {

--- a/backend/remote/backend_test.go
+++ b/backend/remote/backend_test.go
@@ -298,7 +298,7 @@ func TestRemote_checkConstraints(t *testing.T) {
 				Maximum: "0.11.11",
 			},
 			version: "0.10.1",
-			result:  "versions >= 0.11.0, < 0.11.11.",
+			result:  "versions >= 0.11.0, <= 0.11.11.",
 		},
 		"list exclusion": {
 			constraints: &disco.Constraints{


### PR DESCRIPTION
Back ported from v0.12 in case we decide to release a v0.11.12 somewhere down the line.