### PR TITLE
core: Detect and reject self-referencing local values

### DIFF
--- a/terraform/eval_local_test.go
+++ b/terraform/eval_local_test.go
@@ -34,6 +34,11 @@ func TestEvalLocal(t *testing.T) {
 			"",
 			false,
 		},
+		{
+			"Hello, ${local.foo}",
+			nil,
+			true, // self-referencing
+		},
 	}
 
 	for _, test := range tests {
@@ -64,8 +69,9 @@ func TestEvalLocal(t *testing.T) {
 
 			ms := ctx.StateState.Module(addrs.RootModuleInstance)
 			gotLocals := ms.LocalValues
-			wantLocals := map[string]cty.Value{
-				"foo": hcl2shim.HCL2ValueFromConfigValue(test.Want),
+			wantLocals := map[string]cty.Value{}
+			if test.Want != nil {
+				wantLocals["foo"] = hcl2shim.HCL2ValueFromConfigValue(test.Want)
 			}
 
 			if !reflect.DeepEqual(gotLocals, wantLocals) {


### PR DESCRIPTION
We already catch indirect cycles through the normal cycle detector, but we never create self-edges in the graph so we need to handle a direct self-reference separately here.

The prior behavior was simply to produce an incorrect result (since the local value wasn't assigned a new value yet).

This fixes #18503.

![Error: Self-referencing local value.](https://user-images.githubusercontent.com/20180/50244388-acbacb00-0384-11e9-852a-23ae88bef469.png)
