### PR TITLE
Validate provisioner connection blocks

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -5675,11 +5675,8 @@ func TestContext2Apply_provisionerDestroyRefInvalid(t *testing.T) {
 		},
 	})
 
-	if _, diags := ctx.Plan(); diags.HasErrors() {
-		t.Fatalf("plan errors: %s", diags.Err())
-	}
-
-	if _, diags := ctx.Apply(); diags == nil {
+	// this was an apply test, but this is now caught in Validation
+	if diags := ctx.Validate(); !diags.HasErrors() {
 		t.Fatal("expected error")
 	}
 }

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -218,6 +218,10 @@ var connectionBlockSupersetSchema = &configschema.Block{
 		// by the config loader and stored away in a separate field.
 
 		// Common attributes for both connection types
+		"host": {
+			Type:     cty.String,
+			Required: true,
+		},
 		"type": {
 			Type:     cty.String,
 			Optional: true,
@@ -227,10 +231,6 @@ var connectionBlockSupersetSchema = &configschema.Block{
 			Optional: true,
 		},
 		"password": {
-			Type:     cty.String,
-			Optional: true,
-		},
-		"host": {
 			Type:     cty.String,
 			Optional: true,
 		},

--- a/terraform/eval_validate_test.go
+++ b/terraform/eval_validate_test.go
@@ -374,8 +374,9 @@ func TestEvalValidateProvisioner_valid(t *testing.T) {
 			Config: hcl.EmptyBody(),
 		},
 		ConnConfig: &configs.Connection{
-			//Type:   "ssh",
-			Config: hcl.EmptyBody(),
+			Config: configs.SynthBody("", map[string]cty.Value{
+				"host": cty.StringVal("foo"),
+			}),
 		},
 	}
 
@@ -421,6 +422,7 @@ func TestEvalValidateProvisioner_warning(t *testing.T) {
 		},
 		ConnConfig: &configs.Connection{
 			Config: configs.SynthBody("", map[string]cty.Value{
+				"host": cty.StringVal("localhost"),
 				"type": cty.StringVal("ssh"),
 			}),
 		},
@@ -442,7 +444,7 @@ func TestEvalValidateProvisioner_warning(t *testing.T) {
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(err)
 	if len(diags) != 1 {
-		t.Fatalf("wrong number of diagsnostics in %#v; want one warning", diags)
+		t.Fatalf("wrong number of diagnostics in %s; want one warning", diags.ErrWithWarnings())
 	}
 
 	if got, want := diags[0].Description().Summary, mp.ValidateProvisionerConfigResponse.Diagnostics[0].Description().Summary; got != want {
@@ -492,7 +494,7 @@ func TestEvalValidateProvisioner_connectionInvalid(t *testing.T) {
 
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(err)
-	if len(diags) != 2 {
+	if len(diags) != 3 {
 		t.Fatalf("wrong number of diagnostics; want two errors\n\n%s", diags.Err())
 	}
 

--- a/terraform/node_resource_validate.go
+++ b/terraform/node_resource_validate.go
@@ -71,6 +71,7 @@ func (n *NodeValidatableResource) EvalTree() EvalNode {
 					Schema:           &provisionerSchema,
 					Config:           p,
 					ResourceHasCount: hasCount,
+					ConnConfig:       p.Connection,
 				},
 			)
 		}

--- a/terraform/test-fixtures/apply-provisioner-conninfo/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-conninfo/main.tf
@@ -12,12 +12,14 @@ resource "aws_instance" "foo" {
 
 resource "aws_instance" "bar" {
     connection {
+        host = "localhost"
         type = "telnet"
     }
 
     provisioner "shell" {
         foo = "${aws_instance.foo.value}"
         connection {
+            host = "localhost"
             type = "telnet"
             user = "superuser"
             port = 2222

--- a/terraform/test-fixtures/graph-provisioners/main.tf
+++ b/terraform/test-fixtures/graph-provisioners/main.tf
@@ -25,6 +25,7 @@ resource "aws_load_balancer" "weblb" {
     provisioner "shell" {
         cmd = "add ${aws_instance.web.id}"
         connection {
+            host = "localhost"
             type = "magic"
             user = "${aws_security_group.firewall.id}"
         }


### PR DESCRIPTION
Catch errors in provisioners connection blocks during Validate rather than Apply.

Make `host` a required field, to better alert users that the old automatic connection mechanism is no longer used.