### PR TITLE
Normalization of configuration paths

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -266,6 +266,10 @@ func (m *Meta) StdinPiped() bool {
 // operation itself is unsuccessful. Use the "Result" field of the
 // returned operation object to recognize operation-level failure.
 func (m *Meta) RunOperation(b backend.Enhanced, opReq *backend.Operation) (*backend.RunningOperation, error) {
+	if opReq.ConfigDir != "" {
+		opReq.ConfigDir = m.normalizePath(opReq.ConfigDir)
+	}
+
 	op, err := b.Operation(context.Background(), opReq)
 	if err != nil {
 		return nil, fmt.Errorf("error starting operation: %s", err)

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 
@@ -423,7 +424,7 @@ func (d *evaluationStateData) GetPathAttr(addr addrs.PathAttr, rng tfdiags.Sourc
 			})
 			return cty.DynamicVal, diags
 		}
-		return cty.StringVal(wd), diags
+		return cty.StringVal(filepath.ToSlash(wd)), diags
 
 	case "module":
 		moduleConfig := d.Evaluator.Config.DescendentForInstance(d.ModulePath)
@@ -433,11 +434,11 @@ func (d *evaluationStateData) GetPathAttr(addr addrs.PathAttr, rng tfdiags.Sourc
 			panic(fmt.Sprintf("module.path read from module %s, which has no configuration", d.ModulePath))
 		}
 		sourceDir := moduleConfig.Module.SourceDir
-		return cty.StringVal(sourceDir), diags
+		return cty.StringVal(filepath.ToSlash(sourceDir)), diags
 
 	case "root":
 		sourceDir := d.Evaluator.Config.Module.SourceDir
-		return cty.StringVal(sourceDir), diags
+		return cty.StringVal(filepath.ToSlash(sourceDir)), diags
 
 	default:
 		suggestion := nameSuggestion(addr.Name, []string{"cwd", "module", "root"})

--- a/terraform/evaluate_test.go
+++ b/terraform/evaluate_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
@@ -31,6 +32,49 @@ func TestEvaluatorGetTerraformAttr(t *testing.T) {
 		}
 		if !got.RawEquals(want) {
 			t.Errorf("wrong result %q; want %q", got, want)
+		}
+	})
+}
+
+func TestEvaluatorGetPathAttr(t *testing.T) {
+	evaluator := &Evaluator{
+		Meta: &ContextMeta{
+			Env: "foo",
+		},
+		Config: &configs.Config{
+			Module: &configs.Module{
+				SourceDir: "bar/baz",
+			},
+		},
+	}
+	data := &evaluationStateData{
+		Evaluator: evaluator,
+	}
+	scope := evaluator.Scope(data, nil)
+
+	t.Run("module", func(t *testing.T) {
+		want := cty.StringVal("bar/baz")
+		got, diags := scope.Data.GetPathAttr(addrs.PathAttr{
+			Name: "module",
+		}, tfdiags.SourceRange{})
+		if len(diags) != 0 {
+			t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
+		}
+		if !got.RawEquals(want) {
+			t.Errorf("wrong result %#v; want %#v", got, want)
+		}
+	})
+
+	t.Run("root", func(t *testing.T) {
+		want := cty.StringVal("bar/baz")
+		got, diags := scope.Data.GetPathAttr(addrs.PathAttr{
+			Name: "root",
+		}, tfdiags.SourceRange{})
+		if len(diags) != 0 {
+			t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
+		}
+		if !got.RawEquals(want) {
+			t.Errorf("wrong result %#v; want %#v", got, want)
 		}
 	})
 }


### PR DESCRIPTION
This PR includes two adjustments to how we normalize configuration paths.

The first is general and applies both to the paths we show in diagnostic messages and the paths we return from `path.root` and `path.module`: previously we were normalizing these to relative paths in some commands but not others, which is both cosmetically weird and potentially problematic since `path.module` might return something different depending on which Terraform command you are running. We will now normalize these to be relative paths in all cases.

The second applies only to the `path.` references in configuration, making them always use forward slashes even on Windows systems. This addresses #14986 by relying on the fact that Windows supports both slash types as long as they are used consistently within a path. This means that moving forward all constructed paths in Terraform configurations should use forward slashes, like `"${path.module}/foo/bar"`, which will produce correct results on all supported platforms.

These two changes compliment each other by allowing paths to remain consistent across platforms. Making `path.module` and `path.root` appear relative avoids them ending up containing platform-specific prefixes like `c:\` or `/home` that would cause churn when applying the same configuration on different hosts.

Since the slash normalization behavior applies only to Windows and we run our tests on Unix there's no direct unit testing of that behavior, but I added tests for the more general behavior of `path.module` and `path.root` nonetheless, to show that they still work as before on Unix systems.
