### PR TITLE
jsonplan: remove "proposed_unknown" structure in favor of "after_unknown" field in "change"

### DIFF
--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -160,7 +160,6 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 				}
 			} else {
 				afterUnknown = true
-				// TODO: what is the expected value if after is not known?
 			}
 		}
 


### PR DESCRIPTION
New Output:

```json
  "resource_changes": [
    {
      "address": "module.all_the_pets.module.inception.random_pet.sub_module_pets[0]",
      "module_address": "module.all_the_pets.module.inception",
      "mode": "managed",
      "type": "random_pet",
      "name": "sub_module_pets",
      "index": 0,
      "deposed": true,
      "change": {
        "actions": [
          "Create"
        ],
        "after_unknown": true
      }
    },
  ],
  "output_changes": {
    "new": {
      "actions": [
        "Create"
      ],
      "after": "hi dad",
      "after_unknown": false
    },
    "pets": {
      "actions": [
        "Create"
      ],
      "after_unknown": true
    }
  },
```