### PR TITLE
Add missing defaults for salt masterless

### DIFF
--- a/builtin/provisioners/salt-masterless/resource_provisioner.go
+++ b/builtin/provisioners/salt-masterless/resource_provisioner.go
@@ -58,10 +58,12 @@ func Provisioner() terraform.ResourceProvisioner {
 			"remote_state_tree": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "/srv/salt",
 			},
 			"remote_pillar_roots": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "/srv/pillar",
 			},
 			"temp_config_dir": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/provisioners/salt-masterless/resource_provisioner.go
+++ b/builtin/provisioners/salt-masterless/resource_provisioner.go
@@ -58,12 +58,12 @@ func Provisioner() terraform.ResourceProvisioner {
 			"remote_state_tree": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "/srv/salt",
+				Default:  DefaultStateTreeDir,
 			},
 			"remote_pillar_roots": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "/srv/pillar",
+				Default:  DefaultPillarRootDir,
 			},
 			"temp_config_dir": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
Defaults were added for` remote_pillar_roots`
and `remote_state_tree`.

This will fix issue [17150](https://github.com/hashicorp/terraform/issues/17150). (I *think*)