### PR TITLE
Don't crash if there's an invalid interpolation inside a block label

### DIFF
--- a/configs/test-fixtures/invalid-files/interp-in-data-label.tf
+++ b/configs/test-fixtures/invalid-files/interp-in-data-label.tf
@@ -1,0 +1,2 @@
+data "null_resource" "foo_${interpolations_invalid_here}" {
+}

--- a/configs/test-fixtures/invalid-files/interp-in-rsrc-label.tf
+++ b/configs/test-fixtures/invalid-files/interp-in-rsrc-label.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo_${interpolations_invalid_here}" {
+}

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/hashicorp/go-version v1.0.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20181215005721-253da47fd604
+	github.com/hashicorp/hcl2 v0.0.0-20181219223929-62acf2ce821d
 	github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250
 	github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3
 	github.com/hashicorp/memberlist v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/hashicorp/hcl2 v0.0.0-20181214235302-dac4796ca146 h1:y2SWlAjINnc8OYpc
 github.com/hashicorp/hcl2 v0.0.0-20181214235302-dac4796ca146/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
 github.com/hashicorp/hcl2 v0.0.0-20181215005721-253da47fd604 h1:k660QMbAqhL4vxSNPmvOAjzZJ7BQiwTrT8pa8RH3OEA=
 github.com/hashicorp/hcl2 v0.0.0-20181215005721-253da47fd604/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
+github.com/hashicorp/hcl2 v0.0.0-20181219223929-62acf2ce821d h1:sd9/19rMHTRn7UTYTBoGIzm93cHopNrpuv+jnx/LY34=
+github.com/hashicorp/hcl2 v0.0.0-20181219223929-62acf2ce821d/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250 h1:fooK5IvDL/KIsi4LxF/JH68nVdrBSiGNPhS2JAQjtjo=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250/go.mod h1:KHvg/R2/dPtaePb16oW4qIyzkMxXOL38xjRN64adsts=
 github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3 h1:oD64EFjELI9RY9yoWlfua58r+etdnoIC871z+rr6lkA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -351,7 +351,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl2 v0.0.0-20181215005721-253da47fd604
+# github.com/hashicorp/hcl2 v0.0.0-20181219223929-62acf2ce821d
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec


### PR DESCRIPTION
This fixes #19327, which turned out to be specifically related to the handling of invalid labels in the HCL parser.
