### PR TITLE
Adds TF_IN_AUTOMATION description

### DIFF
--- a/website/docs/commands/environment-variables.html.md
+++ b/website/docs/commands/environment-variables.html.md
@@ -103,6 +103,13 @@ Terraform may be unable to find providers, modules, and other artifacts.
 
 ## TF_IN_AUTOMATION
 
-When the environment variable `TF_IN_AUTOMATION` is set to any non-empty value, Terraform makes some minor adjustments to its output to de-emphasize specific commands to run. The specific changes made will vary over time, but generally-speaking Terraform will consider this variable to indicate that there is some wrapping application that will help the user with the next step.
+If `TF_IN_AUTOMATION` is set to any non-empty value, Terraform adjusts its
+output to avoid suggesting specific commands to run next. This can make the
+output more consistent and less confusing in workflows where users don't
+directly execute Terraform commands, like in CI systems or other wrapping
+applications.
+
+This is a purely cosmetic change to Terraform's human-readable output, and the
+exact output differences can change between minor Terraform versions.
 
 For more details see [Running Terraform in Automation](https://learn.hashicorp.com/terraform/development/running-terraform-in-automation).

--- a/website/docs/commands/environment-variables.html.md
+++ b/website/docs/commands/environment-variables.html.md
@@ -100,3 +100,9 @@ The data directory is used to retain data that must persist from one command
 to the next, so it's important to have this variable set consistently throughout
 all of the Terraform workflow commands (starting with `terraform init`) or else
 Terraform may be unable to find providers, modules, and other artifacts.
+
+## TF_IN_AUTOMATION
+
+When the environment variable `TF_IN_AUTOMATION` is set to any non-empty value, Terraform makes some minor adjustments to its output to de-emphasize specific commands to run. The specific changes made will vary over time, but generally-speaking Terraform will consider this variable to indicate that there is some wrapping application that will help the user with the next step.
+
+For more details see [Running Terraform in Automation](https://learn.hashicorp.com/terraform/development/running-terraform-in-automation).


### PR DESCRIPTION
Blatantly copied from https://learn.hashicorp.com/terraform/development/running-terraform-in-automation since it is missing on the [env var page]( https://www.terraform.io/docs/configuration/environment-variables.html).

On a side note, the edit link on the page https://www.terraform.io/docs/configuration/environment-variables.html is broken. It looks like the page was moved via e5e3452ffacbc83658d92210a3547162c74ad730 but that change was made on the 5th of May. Have the docs not been deployed since then?