### PR TITLE
Don't fail decoding null values from plan changes

### DIFF
--- a/plans/changes_src.go
+++ b/plans/changes_src.go
@@ -166,13 +166,21 @@ type ChangeSrc struct {
 // to call the corresponding Decode method of that struct rather than working
 // directly with its embedded Change.
 func (cs *ChangeSrc) Decode(ty cty.Type) (*Change, error) {
-	before, err := cs.Before.Decode(ty)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding 'before' value: %s", err)
+	var err error
+	before := cty.NullVal(ty)
+	after := cty.NullVal(ty)
+
+	if len(cs.Before) > 0 {
+		before, err = cs.Before.Decode(ty)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding 'before' value: %s", err)
+		}
 	}
-	after, err := cs.After.Decode(ty)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding 'after' value: %s", err)
+	if len(cs.After) > 0 {
+		after, err = cs.After.Decode(ty)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding 'after' value: %s", err)
+		}
 	}
 	return &Change{
 		Action: cs.Action,

--- a/plans/dynamic_value.go
+++ b/plans/dynamic_value.go
@@ -86,7 +86,7 @@ func (v DynamicValue) ImpliedType() (cty.Type, error) {
 
 // Copy produces a copy of the receiver with a distinct backing array.
 func (v DynamicValue) Copy() DynamicValue {
-	if len(v) == 0 {
+	if v == nil {
 		return nil
 	}
 


### PR DESCRIPTION
An empty change value cannot be decoded, so return a `cty.NullVal` to indicate the absence of a state value in this case.

Fixes #19149