### PR TITLE
core: Specialized errors for incorrect indexes in resource reference

### DIFF
--- a/builtin/providers/test/data_source_test.go
+++ b/builtin/providers/test/data_source_test.go
@@ -192,7 +192,7 @@ data "test_data_source" "y" {
 }
 
 // referencing test_data_source.one.output_map["a"] should produce an error when
-// there's a count, but instead we end up with an unknown value after apply.
+// there's a count.
 func TestDataSource_indexedCountOfOne(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		Providers: testAccProviders,
@@ -212,7 +212,7 @@ data "test_data_source" "two" {
 	}
 }
 				`),
-				ExpectError: regexp.MustCompile("value does not have any attributes"),
+				ExpectError: regexp.MustCompile("Because data.test_data_source.one has \"count\" set, its attributes must be accessed on specific instances"),
 			},
 		},
 	})

--- a/terraform/evaluate_valid_test.go
+++ b/terraform/evaluate_valid_test.go
@@ -1,0 +1,102 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/lang"
+)
+
+func TestStaticValidateReferences(t *testing.T) {
+	tests := []struct {
+		Ref     string
+		WantErr string
+	}{
+		{
+			"aws_instance.no_count",
+			``,
+		},
+		{
+			"aws_instance.count",
+			``,
+		},
+		{
+			"aws_instance.count[0]",
+			``,
+		},
+		{
+			"aws_instance.nonexist",
+			`Reference to undeclared resource: A managed resource "aws_instance" "nonexist" has not been declared in the root module.`,
+		},
+		{
+			"aws_instance.no_count[0]",
+			`Unexpected resource instance key: Because aws_instance.no_count does not have "count" or "for_each" set, references to it must not include an index key. Remove the bracketed index to refer to the single instance of this resource.`,
+		},
+		{
+			"aws_instance.count.foo",
+			// In this case we return two errors that are somewhat redundant with
+			// one another, but we'll accept that because they both report the
+			// problem from different perspectives and so give the user more
+			// opportunity to understand what's going on here.
+			`2 problems:
+
+- Missing resource instance key: Because aws_instance.count has "count" set, its attributes must be accessed on specific instances.
+
+For example, to correlate with indices of a referring resource, use:
+    aws_instance.count[count.index]
+- Unsupported attribute: This object has no argument, nested block, or exported attribute named "foo".`,
+		},
+	}
+
+	cfg := testModule(t, "static-validate-refs")
+	evaluator := &Evaluator{
+		Config: cfg,
+		Schemas: &Schemas{
+			Providers: map[string]*ProviderSchema{
+				"aws": {
+					ResourceTypes: map[string]*configschema.Block{
+						"aws_instance": {},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Ref, func(t *testing.T) {
+			traversal, hclDiags := hclsyntax.ParseTraversalAbs([]byte(test.Ref), "", hcl.Pos{Line: 1, Column: 1})
+			if hclDiags.HasErrors() {
+				t.Fatal(hclDiags.Error())
+			}
+
+			refs, diags := lang.References([]hcl.Traversal{traversal})
+			if diags.HasErrors() {
+				t.Fatal(diags.Err())
+			}
+
+			data := &evaluationStateData{
+				Evaluator: evaluator,
+			}
+
+			diags = data.StaticValidateReferences(refs, nil)
+			if diags.HasErrors() {
+				if test.WantErr == "" {
+					t.Fatalf("Unexpected diagnostics: %s", diags.Err())
+				}
+
+				gotErr := diags.Err().Error()
+				if gotErr != test.WantErr {
+					t.Fatalf("Wrong diagnostics\ngot:  %s\nwant: %s", gotErr, test.WantErr)
+				}
+				return
+			}
+
+			if test.WantErr != "" {
+				t.Fatalf("Expected diagnostics, but got none\nwant: %s", test.WantErr)
+			}
+		})
+	}
+}

--- a/terraform/test-fixtures/static-validate-refs/static-validate-refs.tf
+++ b/terraform/test-fixtures/static-validate-refs/static-validate-refs.tf
@@ -1,0 +1,6 @@
+resource "aws_instance" "no_count" {
+}
+
+resource "aws_instance" "count" {
+  count = 1
+}


### PR DESCRIPTION
In prior versions of Terraform we permitted inconsistent use of indexes in resource references, but in as of 0.12 the index usage must correlate properly with whether `count` is set on the resource.

Since users are likely to have existing configurations with incorrect usage, here we introduce some specialized error messages for situations where we can detect such issues statically. This seems to cover all of the common patterns we've seen in practice.

Some usage patterns will fall back on a less-helpful dynamic error here, but no configurations coming from 0.11 can end up that way because 0.11 did not permit forms such as `aws_instance.no_count[count.index].bar` that this validation would not be able to "see".

Our configuration upgrade tool also contains a fix for this already, but it takes a more conservative approach of adding the index `[0]` rather than `[count.index]` because it can't be sure (without human help) if correlation of indices is what was intended.

This addresses #19216 in two ways:
* It gives a more helpful error message for what is in practice a usage error rather than an evaluation error.
* By implementing it as a static check, it will be returned even on the initial `terraform apply` in that example, whereas in alpha1 we'd catch it only after the resources were initially created and so we could see the incorrect "each mode" in state.

![](https://user-images.githubusercontent.com/20180/50309242-fa056e00-0452-11e9-9828-b065cc73b628.png)
