### PR TITLE
there is always an implied workspace of "default"

### DIFF
--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -104,17 +104,14 @@ func dataSourceRemoteStateRead(d *cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		return cty.NilVal, diags
 	}
 
-	var name string
+	name := backend.DefaultStateName
 
 	if workspaceVal := d.GetAttr("workspace"); !workspaceVal.IsNull() {
 		newState["workspace"] = workspaceVal
-		ws := workspaceVal.AsString()
-		if ws != backend.DefaultStateName {
-			name = ws
-		}
-	} else {
-		newState["workspace"] = cty.NullVal(cty.String)
+		name = workspaceVal.AsString()
 	}
+
+	newState["workspace"] = cty.StringVal(name)
 
 	state, err := b.StateMgr(name)
 	if err != nil {

--- a/builtin/providers/terraform/data_source_state_test.go
+++ b/builtin/providers/terraform/data_source_state_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/apparentlymart/go-dump/dump"
+	"github.com/hashicorp/terraform/backend"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -34,7 +35,7 @@ func TestState_basic(t *testing.T) {
 				"outputs": cty.ObjectVal(map[string]cty.Value{
 					"foo": cty.StringVal("bar"),
 				}),
-				"workspace": cty.NullVal(cty.String),
+				"workspace": cty.StringVal(backend.DefaultStateName),
 				"defaults":  cty.NullVal(cty.DynamicPseudoType),
 			}),
 			false,
@@ -68,7 +69,7 @@ func TestState_basic(t *testing.T) {
 						cty.StringVal("test2"),
 					}),
 				}),
-				"workspace": cty.NullVal(cty.String),
+				"workspace": cty.StringVal(backend.DefaultStateName),
 				"defaults":  cty.NullVal(cty.DynamicPseudoType),
 			}),
 			false,
@@ -89,7 +90,7 @@ func TestState_basic(t *testing.T) {
 					"map":  cty.NullVal(cty.DynamicPseudoType),
 					"list": cty.NullVal(cty.DynamicPseudoType),
 				}),
-				"workspace": cty.NullVal(cty.String),
+				"workspace": cty.StringVal(backend.DefaultStateName),
 				"defaults":  cty.NullVal(cty.DynamicPseudoType),
 			}),
 			false,
@@ -115,7 +116,7 @@ func TestState_basic(t *testing.T) {
 				"outputs": cty.ObjectVal(map[string]cty.Value{
 					"foo": cty.StringVal("bar"),
 				}),
-				"workspace": cty.NullVal(cty.String),
+				"workspace": cty.StringVal(backend.DefaultStateName),
 			}),
 			false,
 		},
@@ -133,7 +134,7 @@ func TestState_basic(t *testing.T) {
 				}),
 				"defaults":  cty.NullVal(cty.DynamicPseudoType),
 				"outputs":   cty.EmptyObjectVal,
-				"workspace": cty.NullVal(cty.String),
+				"workspace": cty.StringVal(backend.DefaultStateName),
 			}),
 			true,
 		},


### PR DESCRIPTION
Fetching a state requires a workspace name, which should default to
"default"

Fixes #19217