### PR TITLE
Improve section-to-section navigation via sidebar navs

### DIFF
--- a/website/docs/backends/types/etcd.html.md
+++ b/website/docs/backends/types/etcd.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "backend-types"
 page_title: "Backend Type: etcd"
-sidebar_current: "docs-backends-types-standard-etcd"
+sidebar_current: "docs-backends-types-standard-etcdv2"
 description: |-
   Terraform can store state remotely in etcd 2.x.
 ---

--- a/website/docs/commands/env.html.markdown
+++ b/website/docs/commands/env.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Command: env"
-sidebar_current: "docs-commands-env"
+sidebar_current: "docs-commands-envcmd"
 description: |-
   The terraform env command is a deprecated, legacy form of "terraform workspace".
 ---

--- a/website/docs/commands/state/addressing.html.md
+++ b/website/docs/commands/state/addressing.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-state"
 page_title: "Command: state resource addressing"
-sidebar_current: "docs-state-address"
+sidebar_current: "docs-commands-state-address"
 description: |-
   The `terraform state` command is used for advanced state management.
 ---

--- a/website/docs/commands/state/index.html.md
+++ b/website/docs/commands/state/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-state"
 page_title: "Command: state"
-sidebar_current: "docs-state-index"
+sidebar_current: "docs-commands-state-index"
 description: |-
   The `terraform state` command is used for advanced state management.
 ---

--- a/website/docs/commands/state/list.html.md
+++ b/website/docs/commands/state/list.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-state"
 page_title: "Command: state list"
-sidebar_current: "docs-state-sub-list"
+sidebar_current: "docs-commands-state-sub-list"
 description: |-
   The terraform state list command is used to list resources within a Terraform state.
 ---

--- a/website/docs/commands/state/mv.html.md
+++ b/website/docs/commands/state/mv.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-state"
 page_title: "Command: state mv"
-sidebar_current: "docs-state-sub-mv"
+sidebar_current: "docs-commands-state-sub-mv"
 description: |-
   The `terraform state mv` command moves items in the Terraform state.
 ---

--- a/website/docs/commands/state/pull.html.md
+++ b/website/docs/commands/state/pull.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-state"
 page_title: "Command: state pull"
-sidebar_current: "docs-state-sub-pull"
+sidebar_current: "docs-commands-state-sub-pull"
 description: |-
   The `terraform state pull` command is used to manually download and output the state from remote state.
 ---

--- a/website/docs/commands/state/push.html.md
+++ b/website/docs/commands/state/push.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-state"
 page_title: "Command: state push"
-sidebar_current: "docs-state-sub-push"
+sidebar_current: "docs-commands-state-sub-push"
 description: |-
   The `terraform state push` command pushes items to the Terraform state.
 ---

--- a/website/docs/commands/state/rm.html.md
+++ b/website/docs/commands/state/rm.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-state"
 page_title: "Command: state rm"
-sidebar_current: "docs-state-sub-rm"
+sidebar_current: "docs-commands-state-sub-rm"
 description: |-
   The `terraform state rm` command removes items from the Terraform state.
 ---

--- a/website/docs/commands/state/show.html.md
+++ b/website/docs/commands/state/show.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-state"
 page_title: "Command: state show"
-sidebar_current: "docs-state-sub-show"
+sidebar_current: "docs-commands-state-sub-show"
 description: |-
   The `terraform state show` command is used to show the attributes of a single resource in the Terraform state.
 ---

--- a/website/docs/commands/workspace/delete.html.md
+++ b/website/docs/commands/workspace/delete.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-workspace"
 page_title: "Command: workspace delete"
-sidebar_current: "docs-workspace-sub-delete"
+sidebar_current: "docs-commands-workspace-sub-delete"
 description: |-
   The terraform workspace delete command is used to delete a workspace.
 ---

--- a/website/docs/commands/workspace/index.html.md
+++ b/website/docs/commands/workspace/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-workspace"
 page_title: "Command: workspace"
-sidebar_current: "docs-workspace-index"
+sidebar_current: "docs-commands-workspace-index"
 description: |-
   The terraform workspace command is used to manage workspaces.
 ---

--- a/website/docs/commands/workspace/list.html.md
+++ b/website/docs/commands/workspace/list.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-workspace"
 page_title: "Command: workspace list"
-sidebar_current: "docs-workspace-sub-list"
+sidebar_current: "docs-commands-workspace-sub-list"
 description: |-
   The terraform workspace list command is used to list all existing workspaces.
 ---

--- a/website/docs/commands/workspace/new.html.md
+++ b/website/docs/commands/workspace/new.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-workspace"
 page_title: "Command: workspace new"
-sidebar_current: "docs-workspace-sub-new"
+sidebar_current: "docs-commands-workspace-sub-new"
 description: |-
   The terraform workspace new command is used to create a new workspace.
 ---

--- a/website/docs/commands/workspace/select.html.md
+++ b/website/docs/commands/workspace/select.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "commands-workspace"
 page_title: "Command: workspace select"
-sidebar_current: "docs-workspace-sub-select"
+sidebar_current: "docs-commands-workspace-sub-select"
 description: |-
   The terraform workspace select command is used to choose a workspace.
 ---

--- a/website/guides/terraform-provider-development-program.html.md
+++ b/website/guides/terraform-provider-development-program.html.md
@@ -1,5 +1,5 @@
 ---
-layout: "guides"
+layout: "extend"
 page_title: "Terraform Provider Development Program"
 sidebar_current: "guides-terraform-provider-development-program"
 description: This guide is intended for vendors who're interested in having their platform supported by Teraform. The guide walks vendors through the steps involved in creating a provider and applying for it to be included with Terraform.
@@ -16,7 +16,7 @@ checkpoints.
 -> **Building your own provider?** If you're building your own provider and
 aren't interested in having HashiCorp officially approve and regularly test the
 provider, refer to the [Writing Custom Providers guide][writing] and the
-[Extending Terraform][extending] section. 
+[Extending Terraform][extending] section.
 
 ## What is a Terraform Provider?
 

--- a/website/layouts/backend-types.erb
+++ b/website/layouts/backend-types.erb
@@ -1,65 +1,103 @@
 <% wrap_layout :inner do %>
   <% content_for :sidebar do %>
+    <h4><a href="/docs/index.html">Terraform CLI</a></h4>
+
+    <ul class="nav docs-sidenav">
+      <li<%= sidebar_current("docs-backends") %>>
+        <a class="back" href="/docs/backends/index.html">Backends</a>
+        <ul class="nav nav-visible">
+
+          <li<%= sidebar_current("docs-backends-types") %>>
+            <a href="/docs/backends/types/index.html">Backend Types</a>
+            <ul class="nav nav-visible">
+
+              <li id="docs-backends-types-enhanced"<%= sidebar_current("docs-backends-types-enhanced-") %>>
+                <a href="#docs-backends-types-enhanced">Enhanced Backends</a>
+                <ul class="nav nav-visible">
+                  <li<%= sidebar_current("docs-backends-types-enhanced-local") %>>
+                    <a href="/docs/backends/types/local.html">local</a>
+                  </li>
+                  <li<%= sidebar_current("docs-backends-types-enhanced-remote") %>>
+                    <a href="/docs/backends/types/remote.html">remote</a>
+                  </li>
+                </ul>
+              </li>
+
+
+              <li id="docs-backends-types-standard"<%= sidebar_current("docs-backends-types-standard-") %>>
+                <a href=#docs-backends-types-standard>Standard Backends</a>
+                <ul class="nav nav-visible">
+                  <li<%= sidebar_current("docs-backends-types-standard-artifactory") %>>
+                    <a href="/docs/backends/types/artifactory.html">artifactory</a>
+                  </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-azurerm") %>>
+                    <a href="/docs/backends/types/azurerm.html">azurerm</a>
+                  </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-consul") %>>
+                    <a href="/docs/backends/types/consul.html">consul</a>
+                  </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-etcdv2") %>>
+                    <a href="/docs/backends/types/etcd.html">etcd</a>
+                  </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-etcdv3") %>>
+                    <a href="/docs/backends/types/etcdv3.html">etcdv3</a>
+                  </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-gcs") %>>
+                    <a href="/docs/backends/types/gcs.html">gcs</a>
+                  </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-http") %>>
+                    <a href="/docs/backends/types/http.html">http</a>
+                  </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-manta") %>>
+                    <a href="/docs/backends/types/manta.html">manta</a>
+                  </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-s3") %>>
+                    <a href="/docs/backends/types/s3.html">s3</a>
+                  </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-swift") %>>
+                    <a href="/docs/backends/types/swift.html">swift</a>
+                  </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-terraform-enterprise") %>>
+                    <a href="/docs/backends/types/terraform-enterprise.html">terraform enterprise</a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+
+      </li>
+    </ul>
+
+    <h4>Other Docs</h4>
+
     <ul class="nav docs-sidenav">
       <li>
-        <a class="back" href="/docs/backends/index.html">Backends</a>
+        <a class="back" href="/downloads.html">Download Terraform</a>
       </li>
 
-      <li<%= sidebar_current("docs-backends-types-index") %>>
-        <a class="back" href="/docs/backends/types/index.html">Backend Types</a>
+      <li>
+        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
       </li>
 
-      <h4>Enhanced Backends</h4>
-
-      <li<%= sidebar_current("docs-backends-types-enhanced-") %>>
-        <ul class="nav nav-visible">
-          <li<%= sidebar_current("docs-backends-types-enhanced-local") %>>
-            <a href="/docs/backends/types/local.html">local</a>
-          </li>
-          <li<%= sidebar_current("docs-backends-types-enhanced-remote") %>>
-            <a href="/docs/backends/types/remote.html">remote</a>
-          </li>
-        </ul>
+      <li>
+        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
       </li>
 
-      <h4>Standard Backends</h4>
+      <li>
+        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
+      </li>
 
-      <li<%= sidebar_current("docs-backends-types-standard-") %>>
-        <ul class="nav nav-visible">
-          <li<%= sidebar_current("docs-backends-types-standard-artifactory") %>>
-            <a href="/docs/backends/types/artifactory.html">artifactory</a>
-          </li>
-          <li<%= sidebar_current("docs-backends-types-standard-azurerm") %>>
-            <a href="/docs/backends/types/azurerm.html">azurerm</a>
-          </li>
-          <li<%= sidebar_current("docs-backends-types-standard-consul") %>>
-            <a href="/docs/backends/types/consul.html">consul</a>
-          </li>
-          <li<%= sidebar_current("docs-backends-types-standard-etcd") %>>
-            <a href="/docs/backends/types/etcd.html">etcd</a>
-          </li>
-          <li<%= sidebar_current("docs-backends-types-standard-etcdv3") %>>
-            <a href="/docs/backends/types/etcdv3.html">etcdv3</a>
-          </li>
-          <li<%= sidebar_current("docs-backends-types-standard-gcs") %>>
-            <a href="/docs/backends/types/gcs.html">gcs</a>
-          </li>
-          <li<%= sidebar_current("docs-backends-types-standard-http") %>>
-            <a href="/docs/backends/types/http.html">http</a>
-          </li>
-          <li<%= sidebar_current("docs-backends-types-standard-manta") %>>
-            <a href="/docs/backends/types/manta.html">manta</a>
-          </li>
-          <li<%= sidebar_current("docs-backends-types-standard-s3") %>>
-            <a href="/docs/backends/types/s3.html">s3</a>
-          </li>
-          <li<%= sidebar_current("docs-backends-types-standard-swift") %>>
-            <a href="/docs/backends/types/swift.html">swift</a>
-          </li>
-          <li<%= sidebar_current("docs-backends-types-standard-terraform-enterprise") %>>
-            <a href="/docs/backends/types/terraform-enterprise.html">terraform enterprise</a>
-          </li>
-        </ul>
+      <li>
+        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
       </li>
     </ul>
   <% end %>

--- a/website/layouts/commands-state.erb
+++ b/website/layouts/commands-state.erb
@@ -1,49 +1,81 @@
 <% wrap_layout :inner do %>
   <% content_for :sidebar do %>
-    <div class="docs-sidebar hidden-print affix-top" role="complementary">
-      <ul class="nav docs-sidenav">
-        <li<%= sidebar_current("docs-home") %>>
-          <a href="/docs/commands/index.html">All Commands</a>
-        </li>
+    <h4><a href="/docs/index.html">Terraform CLI</a></h4>
 
-        <li<%= sidebar_current("docs-state-index") %>>
-          <a href="/docs/commands/state/index.html">State Command</a>
-        </li>
+    <ul class="nav docs-sidenav">
+      <li<%= sidebar_current("docs-commands") %>>
+        <a class="back" href="/docs/commands/index.html">Commands (CLI)</a>
+        <ul class="nav">
 
-        <li<%= sidebar_current("docs-state-address") %>>
-          <a href="/docs/commands/state/addressing.html">Resource Addressing</a>
-        </li>
+          <li<%= sidebar_current("docs-commands-state") %>>
+            <a href="/docs/commands/state/index.html">state</a>
+            <ul class="nav">
+              <li<%= sidebar_current("docs-commands-state-address") %>>
+                <a href="/docs/commands/state/addressing.html">Resource Addressing</a>
+              </li>
 
-        <li<%= sidebar_current("docs-state-sub") %>>
-          <a href="#">Subcommands</a>
-          <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-state-sub-list") %>>
-              <a href="/docs/commands/state/list.html">list</a>
-            </li>
+              <li<%= sidebar_current("docs-commands-state-sub-list") %>>
+                <a href="/docs/commands/state/list.html">list</a>
+              </li>
 
-            <li<%= sidebar_current("docs-state-sub-mv") %>>
-              <a href="/docs/commands/state/mv.html">mv</a>
-            </li>
+              <li<%= sidebar_current("docs-commands-state-sub-mv") %>>
+                <a href="/docs/commands/state/mv.html">mv</a>
+              </li>
 
-            <li<%= sidebar_current("docs-state-sub-pull") %>>
-              <a href="/docs/commands/state/pull.html">pull</a>
-            </li>
+              <li<%= sidebar_current("docs-commands-state-sub-pull") %>>
+                <a href="/docs/commands/state/pull.html">pull</a>
+              </li>
 
-            <li<%= sidebar_current("docs-state-sub-push") %>>
-              <a href="/docs/commands/state/push.html">push</a>
-            </li>
+              <li<%= sidebar_current("docs-commands-state-sub-push") %>>
+                <a href="/docs/commands/state/push.html">push</a>
+              </li>
 
-            <li<%= sidebar_current("docs-state-sub-rm") %>>
-              <a href="/docs/commands/state/rm.html">rm</a>
-            </li>
+              <li<%= sidebar_current("docs-commands-state-sub-rm") %>>
+                <a href="/docs/commands/state/rm.html">rm</a>
+              </li>
 
-            <li<%= sidebar_current("docs-state-sub-show") %>>
-              <a href="/docs/commands/state/show.html">show</a>
-            </li>
-          </ul>
-        </li>
-      </ul>
-    </div>
+              <li<%= sidebar_current("docs-commands-state-sub-show") %>>
+                <a href="/docs/commands/state/show.html">show</a>
+              </li>
+            </ul>
+          </li>
+
+        </ul>
+      </li>
+
+    </ul>
+
+    <h4>Other Docs</h4>
+
+    <ul class="nav docs-sidenav">
+      <li>
+        <a class="back" href="/downloads.html">Download Terraform</a>
+      </li>
+
+      <li>
+        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
+      </li>
+
+      <li>
+        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
+      </li>
+    </ul>
   <% end %>
 
   <%= yield %>

--- a/website/layouts/commands-workspace.erb
+++ b/website/layouts/commands-workspace.erb
@@ -1,37 +1,69 @@
 <% wrap_layout :inner do %>
   <% content_for :sidebar do %>
-    <div class="docs-sidebar hidden-print affix-top" role="complementary">
-      <ul class="nav docs-sidenav">
-        <li<%= sidebar_current("docs-home") %>>
-          <a href="/docs/commands/index.html">All Commands</a>
-        </li>
+    <h4><a href="/docs/index.html">Terraform CLI</a></h4>
 
-        <li<%= sidebar_current("docs-workspace-index") %>>
-          <a href="/docs/commands/workspace/index.html">Workspace Command</a>
-        </li>
+    <ul class="nav docs-sidenav">
+      <li<%= sidebar_current("docs-commands") %>>
+        <a class="back" href="/docs/commands/index.html">Commands (CLI)</a>
+        <ul class="nav">
 
-        <li<%= sidebar_current("docs-workspace-sub") %>>
-          <a href="#">Subcommands</a>
-          <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-workspace-sub-list") %>>
-              <a href="/docs/commands/workspace/list.html">list</a>
-            </li>
+          <li<%= sidebar_current("docs-commands-workspace") %>>
+            <a href="/docs/commands/workspace/index.html">workspace</a>
+            <ul class="nav">
+              <li<%= sidebar_current("docs-commands-workspace-sub-list") %>>
+                <a href="/docs/commands/workspace/list.html">list</a>
+              </li>
 
-            <li<%= sidebar_current("docs-workspace-sub-select") %>>
-              <a href="/docs/commands/workspace/select.html">select</a>
-            </li>
+              <li<%= sidebar_current("docs-commands-workspace-sub-select") %>>
+                <a href="/docs/commands/workspace/select.html">select</a>
+              </li>
 
-            <li<%= sidebar_current("docs-workspace-sub-new") %>>
-              <a href="/docs/commands/workspace/new.html">new</a>
-            </li>
+              <li<%= sidebar_current("docs-commands-workspace-sub-new") %>>
+                <a href="/docs/commands/workspace/new.html">new</a>
+              </li>
 
-            <li<%= sidebar_current("docs-workspace-sub-delete") %>>
-              <a href="/docs/commands/workspace/delete.html">delete</a>
-            </li>
-          </ul>
-        </li>
-      </ul>
-    </div>
+              <li<%= sidebar_current("docs-commands-workspace-sub-delete") %>>
+                <a href="/docs/commands/workspace/delete.html">delete</a>
+              </li>
+            </ul>
+          </li>
+
+        </ul>
+      </li>
+
+    </ul>
+
+    <h4>Other Docs</h4>
+
+    <ul class="nav docs-sidenav">
+      <li>
+        <a class="back" href="/downloads.html">Download Terraform</a>
+      </li>
+
+      <li>
+        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
+      </li>
+
+      <li>
+        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
+      </li>
+    </ul>
   <% end %>
 
   <%= yield %>

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -1,5 +1,7 @@
 <% wrap_layout :inner do %>
   <% content_for :sidebar do %>
+    <h4><a href="/docs/index.html">Terraform CLI</a></h4>
+
     <ul class="nav docs-sidenav">
       <li<%= sidebar_current("docs-config") %>>
         <a href="/docs/configuration/index.html">Configuration Language</a>
@@ -69,6 +71,14 @@
       <li<%= sidebar_current("docs-commands") %>>
         <a href="/docs/commands/index.html">Commands (CLI)</a>
         <ul class="nav">
+          <li<%= sidebar_current("docs-commands-cli-config") %>>
+            <a href="/docs/commands/cli-config.html">CLI Config File</a>
+          </li>
+
+          <li<%= sidebar_current("docs-commands-environment-variables") %>>
+            <a href="/docs/commands/environment-variables.html">Environment Variables</a>
+          </li>
+
           <li<%= sidebar_current("docs-commands-apply") %>>
             <a href="/docs/commands/apply.html">apply</a>
           </li>
@@ -81,7 +91,7 @@
             <a href="/docs/commands/destroy.html">destroy</a>
           </li>
 
-          <li<%= sidebar_current("docs-commands-env") %>>
+          <li<%= sidebar_current("docs-commands-envcmd") %>>
             <a href="/docs/commands/env.html">env</a>
           </li>
 
@@ -151,14 +161,6 @@
 
           <li<%= sidebar_current("docs-commands-workspace") %>>
             <a href="/docs/commands/workspace/index.html">workspace</a>
-          </li>
-
-          <li<%= sidebar_current("docs-commands-cli-config") %>>
-            <a href="/docs/commands/cli-config.html">CLI Config File</a>
-          </li>
-
-          <li<%= sidebar_current("docs-commands-environment-variables") %>>
-            <a href="/docs/commands/environment-variables.html">Environment Variables</a>
           </li>
         </ul>
       </li>
@@ -295,10 +297,6 @@
             <a href="/docs/modules/sources.html">Sources</a>
           </li>
 
-          <li<%= sidebar_current("docs-registry") %>>
-            <a href="/docs/registry/index.html">Registry</a>
-          </li>
-
           <li<%= sidebar_current("docs-modules-create") %>>
             <a href="/docs/modules/create.html">Creating Modules</a>
           </li>
@@ -376,20 +374,38 @@
         </ul>
       </li>
 
-      <hr>
+    </ul>
 
-      <li<%= sidebar_current("docs-enterprise2-home") %>>
+    <h4>Other Docs</h4>
+
+    <ul class="nav docs-sidenav">
+      <li>
+        <a class="back" href="/downloads.html">Download Terraform</a>
+      </li>
+
+      <li>
+        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
+      </li>
+
+      <li>
         <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise-home") %>>
-        <a class="back" href="/docs/enterprise-legacy/index.html">Terraform Enterprise (legacy)</a>
+      <li>
+        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
       </li>
 
-      <li<%= sidebar_current("docs-github-actions-home") %>>
+      <li>
+        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
+      </li>
+
+      <li>
         <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
       </li>
 
+      <li>
+        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
+      </li>
     </ul>
   <% end %>
 

--- a/website/layouts/downloads.erb
+++ b/website/layouts/downloads.erb
@@ -1,5 +1,7 @@
 <% wrap_layout :inner do %>
   <% content_for :sidebar do %>
+    <h4><a href="/downloads.html">Downloads</a></h4>
+
     <ul class="nav docs-sidenav">
       <li<%= sidebar_current("downloads-terraform") %>>
         <a href="/downloads.html">Download Terraform</a>
@@ -7,26 +9,38 @@
 
       <li<%= sidebar_current("upgrade-guides") %>>
         <a href="/upgrade-guides/index.html">Upgrade Guides</a>
-        <ul class="nav">
-          <li<%= sidebar_current("upgrade-guides-0-12") %>>
-            <a href="/upgrade-guides/0-12.html">Upgrading to v0.12</a>
-          </li>
-          <li<%= sidebar_current("upgrade-guides-0-11") %>>
-            <a href="/upgrade-guides/0-11.html">Upgrading to v0.11</a>
-          </li>
-          <li<%= sidebar_current("upgrade-guides-0-10") %>>
-            <a href="/upgrade-guides/0-10.html">Upgrading to v0.10</a>
-          </li>
-          <li<%= sidebar_current("upgrade-guides-0-9") %>>
-            <a href="/upgrade-guides/0-9.html">Upgrading to v0.9</a>
-          </li>
-          <li<%= sidebar_current("upgrade-guides-0-8") %>>
-            <a href="/upgrade-guides/0-8.html">Upgrading to v0.8</a>
-          </li>
-          <li<%= sidebar_current("upgrade-guides-0-7") %>>
-            <a href="/upgrade-guides/0-7.html">Upgrading to v0.7</a>
-          </li>
-        </ul>
+      </li>
+    </ul>
+
+    <h4>Other Docs</h4>
+
+    <ul class="nav docs-sidenav">
+      <li>
+        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/index.html">Terraform CLI</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
+      </li>
+
+      <li>
+        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
       </li>
     </ul>
   <% end %>

--- a/website/layouts/functions.erb
+++ b/website/layouts/functions.erb
@@ -1,420 +1,457 @@
 <% wrap_layout :inner do %>
-    <% content_for :sidebar do %>
-      <div class="docs-sidebar hidden-print affix-top" role="complementary">
-        <ul class="nav docs-sidenav">
-          <li<%= sidebar_current("docs-config-index") %>>
-            <a class="back" href="/docs/configuration/index.html">Terraform Language</a>
-          </li>
+  <% content_for :sidebar do %>
+    <h4><a href="/docs/index.html">Terraform CLI</a></h4>
 
+    <ul class="nav docs-sidenav">
+      <li<%= sidebar_current("docs-config-index") %>>
+        <a class="back" href="/docs/configuration/index.html">Configuration Language</a>
+        <ul class="nav nav-visible">
           <li<%= sidebar_current("docs-config-functions") %>>
-            <a class="back" href="/docs/configuration/functions.html">Functions</a>
-          </li>
+            <a href="/docs/configuration/functions.html">Functions</a>
+            <ul class="nav nav-visible">
+              <li id="docs-funcs-numeric"<%= sidebar_current("docs-funcs-numeric") %>>
+                <a href="#docs-funcs-numeric">Numeric Functions</a>
+                <ul class="nav nav-visible">
 
-          <li<%= sidebar_current("docs-funcs-numeric") %>>
-            <a href="#docs-funcs-numeric">Numeric Functions</a>
-            <ul class="nav nav-visible" id="docs-funcs-numeric">
+                  <li<%= sidebar_current("docs-funcs-numeric-abs") %>>
+                    <a href="/docs/configuration/functions/abs.html">abs</a>
+                  </li>
 
-              <li<%= sidebar_current("docs-funcs-numeric-abs") %>>
-                <a href="/docs/configuration/functions/abs.html">abs</a>
+                  <li<%= sidebar_current("docs-funcs-numeric-ceil") %>>
+                    <a href="/docs/configuration/functions/ceil.html">ceil</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-numeric-floor") %>>
+                    <a href="/docs/configuration/functions/floor.html">floor</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-numeric-log") %>>
+                    <a href="/docs/configuration/functions/log.html">log</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-numeric-max") %>>
+                    <a href="/docs/configuration/functions/max.html">max</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-numeric-min") %>>
+                    <a href="/docs/configuration/functions/min.html">min</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-numeric-pow") %>>
+                    <a href="/docs/configuration/functions/pow.html">pow</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-numeric-signum") %>>
+                    <a href="/docs/configuration/functions/signum.html">signum</a>
+                  </li>
+
+                </ul>
               </li>
 
-              <li<%= sidebar_current("docs-funcs-numeric-ceil") %>>
-                <a href="/docs/configuration/functions/ceil.html">ceil</a>
+              <li id="docs-funcs-string"<%= sidebar_current("docs-funcs-string") %>>
+                <a href="#docs-funcs-string">String Functions</a>
+                <ul class="nav nav-visible">
+
+                  <li<%= sidebar_current("docs-funcs-string-chomp") %>>
+                    <a href="/docs/configuration/functions/chomp.html">chomp</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-string-format-x") %>>
+                    <a href="/docs/configuration/functions/format.html">format</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-string-formatlist") %>>
+                    <a href="/docs/configuration/functions/formatlist.html">formatlist</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-string-indent") %>>
+                    <a href="/docs/configuration/functions/indent.html">indent</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-string-join") %>>
+                    <a href="/docs/configuration/functions/join.html">join</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-string-lower") %>>
+                    <a href="/docs/configuration/functions/lower.html">lower</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-string-replace") %>>
+                    <a href="/docs/configuration/functions/replace.html">replace</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-string-split") %>>
+                    <a href="/docs/configuration/functions/split.html">split</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-string-substr") %>>
+                    <a href="/docs/configuration/functions/substr.html">substr</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-string-title") %>>
+                    <a href="/docs/configuration/functions/title.html">title</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-string-trimspace") %>>
+                    <a href="/docs/configuration/functions/trimspace.html">trimspace</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-string-upper") %>>
+                    <a href="/docs/configuration/functions/upper.html">upper</a>
+                  </li>
+
+                </ul>
               </li>
 
-              <li<%= sidebar_current("docs-funcs-numeric-floor") %>>
-                <a href="/docs/configuration/functions/floor.html">floor</a>
+              <li id="docs-funcs-collection"<%= sidebar_current("docs-funcs-collection") %>>
+                <a href="#docs-funcs-collection">Collection Functions</a>
+                <ul class="nav nav-visible">
+
+                  <li<%= sidebar_current("docs-funcs-collection-chunklist") %>>
+                    <a href="/docs/configuration/functions/chunklist.html">chunklist</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-coalesce-x") %>>
+                    <a href="/docs/configuration/functions/coalesce.html">coalesce</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-coalescelist") %>>
+                    <a href="/docs/configuration/functions/coalescelist.html">coalescelist</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-compact") %>>
+                    <a href="/docs/configuration/functions/compact.html">compact</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-contains") %>>
+                    <a href="/docs/configuration/functions/contains.html">contains</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-distinct") %>>
+                    <a href="/docs/configuration/functions/distinct.html">distinct</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-element") %>>
+                    <a href="/docs/configuration/functions/element.html">element</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-flatten") %>>
+                    <a href="/docs/configuration/functions/flatten.html">flatten</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-index") %>>
+                    <a href="/docs/configuration/functions/index.html">index</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-keys") %>>
+                    <a href="/docs/configuration/functions/keys.html">keys</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-length") %>>
+                    <a href="/docs/configuration/functions/length.html">length</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-list") %>>
+                    <a href="/docs/configuration/functions/list.html">list</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-lookup") %>>
+                    <a href="/docs/configuration/functions/lookup.html">lookup</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-map") %>>
+                    <a href="/docs/configuration/functions/map.html">map</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-matchkeys") %>>
+                    <a href="/docs/configuration/functions/matchkeys.html">matchkeys</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-merge") %>>
+                    <a href="/docs/configuration/functions/merge.html">merge</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-sethaselement") %>>
+                    <a href="/docs/configuration/functions/sethaselement.html">sethaselement</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-setintersection") %>>
+                    <a href="/docs/configuration/functions/setintersection.html">setintersection</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-setproduct") %>>
+                    <a href="/docs/configuration/functions/setproduct.html">setproduct</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-setunion") %>>
+                    <a href="/docs/configuration/functions/setunion.html">setunion</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-slice") %>>
+                    <a href="/docs/configuration/functions/slice.html">slice</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-sort") %>>
+                    <a href="/docs/configuration/functions/sort.html">sort</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-transpose") %>>
+                    <a href="/docs/configuration/functions/transpose.html">transpose</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-values") %>>
+                    <a href="/docs/configuration/functions/values.html">values</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-collection-zipmap") %>>
+                    <a href="/docs/configuration/functions/zipmap.html">zipmap</a>
+                  </li>
+
+                </ul>
               </li>
 
-              <li<%= sidebar_current("docs-funcs-numeric-log") %>>
-                <a href="/docs/configuration/functions/log.html">log</a>
+              <li id="docs-funcs-encoding"<%= sidebar_current("docs-funcs-encoding") %>>
+                <a href="#docs-funcs-encoding">Encoding Functions</a>
+                <ul class="nav nav-visible">
+
+                  <li<%= sidebar_current("docs-funcs-encoding-base64decode") %>>
+                    <a href="/docs/configuration/functions/base64decode.html">base64decode</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-encoding-base64encode") %>>
+                    <a href="/docs/configuration/functions/base64encode.html">base64encode</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-encoding-base64gzip") %>>
+                    <a href="/docs/configuration/functions/base64gzip.html">base64gzip</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-encoding-csvdecode") %>>
+                    <a href="/docs/configuration/functions/csvdecode.html">csvdecode</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-encoding-jsondecode") %>>
+                    <a href="/docs/configuration/functions/jsondecode.html">jsondecode</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-encoding-jsonencode") %>>
+                    <a href="/docs/configuration/functions/jsonencode.html">jsonencode</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-encoding-urlencode") %>>
+                    <a href="/docs/configuration/functions/urlencode.html">urlencode</a>
+                  </li>
+
+                </ul>
               </li>
 
-              <li<%= sidebar_current("docs-funcs-numeric-max") %>>
-                <a href="/docs/configuration/functions/max.html">max</a>
+              <li id="docs-funcs-file"<%= sidebar_current("docs-funcs-file") %>>
+                <a href="#docs-funcs-file">Filesystem Functions</a>
+                <ul class="nav nav-visible">
+
+                  <li<%= sidebar_current("docs-funcs-file-dirname") %>>
+                    <a href="/docs/configuration/functions/dirname.html">dirname</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-file-pathexpand") %>>
+                    <a href="/docs/configuration/functions/pathexpand.html">pathexpand</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-file-basename") %>>
+                    <a href="/docs/configuration/functions/basename.html">basename</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-file-file-x") %>>
+                    <a href="/docs/configuration/functions/file.html">file</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-file-file-exists") %>>
+                    <a href="/docs/configuration/functions/fileexists.html">fileexists</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-file-filebase64") %>>
+                    <a href="/docs/configuration/functions/filebase64.html">filebase64</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-file-templatefile") %>>
+                    <a href="/docs/configuration/functions/templatefile.html">templatefile</a>
+                  </li>
+
+                </ul>
               </li>
 
-              <li<%= sidebar_current("docs-funcs-numeric-min") %>>
-                <a href="/docs/configuration/functions/min.html">min</a>
+              <li id="docs-funcs-datetime"<%= sidebar_current("docs-funcs-datetime") %>>
+                <a href="#docs-funcs-datetime">Date and Time Functions</a>
+                <ul class="nav nav-visible">
+
+                  <li<%= sidebar_current("docs-funcs-datetime-timeadd") %>>
+                    <a href="/docs/configuration/functions/timeadd.html">timeadd</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-datetime-timestamp") %>>
+                    <a href="/docs/configuration/functions/timestamp.html">timestamp</a>
+                  </li>
+
+                </ul>
               </li>
 
-              <li<%= sidebar_current("docs-funcs-numeric-pow") %>>
-                <a href="/docs/configuration/functions/pow.html">pow</a>
+              <li id="docs-funcs-crypto"<%= sidebar_current("docs-funcs-crypto") %>>
+                <a href="#docs-funcs-crypto">Hash and Crypto Functions</a>
+                <ul class="nav nav-visible">
+
+                  <li<%= sidebar_current("docs-funcs-crypto-base64sha256") %>>
+                    <a href="/docs/configuration/functions/base64sha256.html">base64sha256</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-base64sha512") %>>
+                    <a href="/docs/configuration/functions/base64sha512.html">base64sha512</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-bcrypt") %>>
+                    <a href="/docs/configuration/functions/bcrypt.html">bcrypt</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-filebase64sha256") %>>
+                    <a href="/docs/configuration/functions/filebase64sha256.html">filebase64sha256</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-filebase64sha512") %>>
+                    <a href="/docs/configuration/functions/filebase64sha512.html">filebase64sha512</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-filemd5") %>>
+                    <a href="/docs/configuration/functions/filemd5.html">filemd5</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-filesha1") %>>
+                    <a href="/docs/configuration/functions/filesha1.html">filesha1</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-filesha256") %>>
+                    <a href="/docs/configuration/functions/filesha256.html">filesha256</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-filesha512") %>>
+                    <a href="/docs/configuration/functions/filesha512.html">filesha512</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-md5") %>>
+                    <a href="/docs/configuration/functions/md5.html">md5</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-rsadecrypt") %>>
+                    <a href="/docs/configuration/functions/rsadecrypt.html">rsadecrypt</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-sha1") %>>
+                    <a href="/docs/configuration/functions/sha1.html">sha1</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-sha256") %>>
+                    <a href="/docs/configuration/functions/sha256.html">sha256</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-sha512") %>>
+                    <a href="/docs/configuration/functions/sha512.html">sha512</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-crypto-uuid") %>>
+                    <a href="/docs/configuration/functions/uuid.html">uuid</a>
+                  </li>
+
+                </ul>
               </li>
 
-              <li<%= sidebar_current("docs-funcs-numeric-signum") %>>
-                <a href="/docs/configuration/functions/signum.html">signum</a>
+              <li id="docs-funcs-ipnet"<%= sidebar_current("docs-funcs-ipnet") %>>
+                <a href="#docs-funcs-ipnet">IP Network Functions</a>
+                <ul class="nav nav-visible">
+
+                  <li<%= sidebar_current("docs-funcs-ipnet-cidrhost") %>>
+                    <a href="/docs/configuration/functions/cidrhost.html">cidrhost</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-ipnet-cidrnetmask") %>>
+                    <a href="/docs/configuration/functions/cidrnetmask.html">cidrnetmask</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-ipnet-cidrsubnet") %>>
+                    <a href="/docs/configuration/functions/cidrsubnet.html">cidrsubnet</a>
+                  </li>
+
+                </ul>
+              </li>
+
+              <li<%= sidebar_current("docs-funcs-conversion") %>>
+                <a href="#docs-funcs-conversion">Type Conversion Functions</a>
+                <ul class="nav nav-visible" id="docs-funcs-conversion">
+
+                  <li<%= sidebar_current("docs-funcs-conversion-tobool") %>>
+                    <a href="/docs/configuration/functions/tobool.html">tobool</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-conversion-tolist") %>>
+                    <a href="/docs/configuration/functions/tolist.html">tolist</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-conversion-tomap") %>>
+                    <a href="/docs/configuration/functions/tomap.html">tomap</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-conversion-tonumber") %>>
+                    <a href="/docs/configuration/functions/tonumber.html">tonumber</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-conversion-toset") %>>
+                    <a href="/docs/configuration/functions/toset.html">toset</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-funcs-conversion-tostring") %>>
+                    <a href="/docs/configuration/functions/tostring.html">tostring</a>
+                  </li>
+
+                </ul>
               </li>
 
             </ul>
           </li>
 
-          <li<%= sidebar_current("docs-funcs-string") %>>
-            <a href="#docs-funcs-string">String Functions</a>
-            <ul class="nav nav-visible" id="docs-funcs-string">
-
-              <li<%= sidebar_current("docs-funcs-string-chomp") %>>
-                <a href="/docs/configuration/functions/chomp.html">chomp</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-string-format-x") %>>
-                <a href="/docs/configuration/functions/format.html">format</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-string-formatlist") %>>
-                <a href="/docs/configuration/functions/formatlist.html">formatlist</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-string-indent") %>>
-                <a href="/docs/configuration/functions/indent.html">indent</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-string-join") %>>
-                <a href="/docs/configuration/functions/join.html">join</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-string-lower") %>>
-                <a href="/docs/configuration/functions/lower.html">lower</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-string-replace") %>>
-                <a href="/docs/configuration/functions/replace.html">replace</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-string-split") %>>
-                <a href="/docs/configuration/functions/split.html">split</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-string-substr") %>>
-                <a href="/docs/configuration/functions/substr.html">substr</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-string-title") %>>
-                <a href="/docs/configuration/functions/title.html">title</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-string-trimspace") %>>
-                <a href="/docs/configuration/functions/trimspace.html">trimspace</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-string-upper") %>>
-                <a href="/docs/configuration/functions/upper.html">upper</a>
-              </li>
-
-            </ul>
-
-          <li<%= sidebar_current("docs-funcs-collection") %>>
-            <a href="#docs-funcs-collection">Collection Functions</a>
-            <ul class="nav nav-visible" id="docs-funcs-collection">
-
-              <li<%= sidebar_current("docs-funcs-collection-chunklist") %>>
-                <a href="/docs/configuration/functions/chunklist.html">chunklist</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-coalesce-x") %>>
-                <a href="/docs/configuration/functions/coalesce.html">coalesce</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-coalescelist") %>>
-                <a href="/docs/configuration/functions/coalescelist.html">coalescelist</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-compact") %>>
-                <a href="/docs/configuration/functions/compact.html">compact</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-contains") %>>
-                <a href="/docs/configuration/functions/contains.html">contains</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-distinct") %>>
-                <a href="/docs/configuration/functions/distinct.html">distinct</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-element") %>>
-                <a href="/docs/configuration/functions/element.html">element</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-flatten") %>>
-                <a href="/docs/configuration/functions/flatten.html">flatten</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-index") %>>
-                <a href="/docs/configuration/functions/index.html">index</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-keys") %>>
-                <a href="/docs/configuration/functions/keys.html">keys</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-length") %>>
-                <a href="/docs/configuration/functions/length.html">length</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-list") %>>
-                <a href="/docs/configuration/functions/list.html">list</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-lookup") %>>
-                <a href="/docs/configuration/functions/lookup.html">lookup</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-map") %>>
-                <a href="/docs/configuration/functions/map.html">map</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-matchkeys") %>>
-                <a href="/docs/configuration/functions/matchkeys.html">matchkeys</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-merge") %>>
-                <a href="/docs/configuration/functions/merge.html">merge</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-sethaselement") %>>
-                <a href="/docs/configuration/functions/sethaselement.html">sethaselement</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-setintersection") %>>
-                <a href="/docs/configuration/functions/setintersection.html">setintersection</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-setproduct") %>>
-                <a href="/docs/configuration/functions/setproduct.html">setproduct</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-setunion") %>>
-                <a href="/docs/configuration/functions/setunion.html">setunion</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-slice") %>>
-                <a href="/docs/configuration/functions/slice.html">slice</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-sort") %>>
-                <a href="/docs/configuration/functions/sort.html">sort</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-transpose") %>>
-                <a href="/docs/configuration/functions/transpose.html">transpose</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-values") %>>
-                <a href="/docs/configuration/functions/values.html">values</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-collection-zipmap") %>>
-                <a href="/docs/configuration/functions/zipmap.html">zipmap</a>
-              </li>
-
-            </ul>
-          </li>
-
-          <li<%= sidebar_current("docs-funcs-encoding") %>>
-            <a href="#docs-funcs-encoding">Encoding Functions</a>
-            <ul class="nav nav-visible" id="docs-funcs-encoding">
-
-              <li<%= sidebar_current("docs-funcs-encoding-base64decode") %>>
-                <a href="/docs/configuration/functions/base64decode.html">base64decode</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-encoding-base64encode") %>>
-                <a href="/docs/configuration/functions/base64encode.html">base64encode</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-encoding-base64gzip") %>>
-                <a href="/docs/configuration/functions/base64gzip.html">base64gzip</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-encoding-csvdecode") %>>
-                <a href="/docs/configuration/functions/csvdecode.html">csvdecode</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-encoding-jsondecode") %>>
-                <a href="/docs/configuration/functions/jsondecode.html">jsondecode</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-encoding-jsonencode") %>>
-                <a href="/docs/configuration/functions/jsonencode.html">jsonencode</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-encoding-urlencode") %>>
-                <a href="/docs/configuration/functions/urlencode.html">urlencode</a>
-              </li>
-
-            </ul>
-          </li>
-
-          <li<%= sidebar_current("docs-funcs-file") %>>
-            <a href="#docs-funcs-file">Filesystem Functions</a>
-            <ul class="nav nav-visible" id="docs-funcs-file">
-
-              <li<%= sidebar_current("docs-funcs-file-dirname") %>>
-                <a href="/docs/configuration/functions/dirname.html">dirname</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-file-pathexpand") %>>
-                <a href="/docs/configuration/functions/pathexpand.html">pathexpand</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-file-basename") %>>
-                <a href="/docs/configuration/functions/basename.html">basename</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-file-file-x") %>>
-                <a href="/docs/configuration/functions/file.html">file</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-file-file-exists") %>>
-                <a href="/docs/configuration/functions/fileexists.html">fileexists</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-file-filebase64") %>>
-                <a href="/docs/configuration/functions/filebase64.html">filebase64</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-file-templatefile") %>>
-                <a href="/docs/configuration/functions/templatefile.html">templatefile</a>
-              </li>
-
-            </ul>
-          </li>
-
-          <li<%= sidebar_current("docs-funcs-datetime") %>>
-            <a href="#docs-funcs-datetime">Date and Time Functions</a>
-            <ul class="nav nav-visible" id="docs-funcs-datetime">
-
-              <li<%= sidebar_current("docs-funcs-datetime-timeadd") %>>
-                <a href="/docs/configuration/functions/timeadd.html">timeadd</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-datetime-timestamp") %>>
-                <a href="/docs/configuration/functions/timestamp.html">timestamp</a>
-              </li>
-
-            </ul>
-          </li>
-
-          <li<%= sidebar_current("docs-funcs-crypto") %>>
-            <a href="#docs-funcs-crypto">Hash and Crypto Functions</a>
-            <ul class="nav nav-visible" id="docs-funcs-crypto">
-
-              <li<%= sidebar_current("docs-funcs-crypto-base64sha256") %>>
-                <a href="/docs/configuration/functions/base64sha256.html">base64sha256</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-base64sha512") %>>
-                <a href="/docs/configuration/functions/base64sha512.html">base64sha512</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-bcrypt") %>>
-                <a href="/docs/configuration/functions/bcrypt.html">bcrypt</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-filebase64sha256") %>>
-                <a href="/docs/configuration/functions/filebase64sha256.html">filebase64sha256</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-filebase64sha512") %>>
-                <a href="/docs/configuration/functions/filebase64sha512.html">filebase64sha512</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-filemd5") %>>
-                <a href="/docs/configuration/functions/filemd5.html">filemd5</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-filesha1") %>>
-                <a href="/docs/configuration/functions/filesha1.html">filesha1</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-filesha256") %>>
-                <a href="/docs/configuration/functions/filesha256.html">filesha256</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-filesha512") %>>
-                <a href="/docs/configuration/functions/filesha512.html">filesha512</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-md5") %>>
-                <a href="/docs/configuration/functions/md5.html">md5</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-rsadecrypt") %>>
-                <a href="/docs/configuration/functions/rsadecrypt.html">rsadecrypt</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-sha1") %>>
-                <a href="/docs/configuration/functions/sha1.html">sha1</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-sha256") %>>
-                <a href="/docs/configuration/functions/sha256.html">sha256</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-sha512") %>>
-                <a href="/docs/configuration/functions/sha512.html">sha512</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-crypto-uuid") %>>
-                <a href="/docs/configuration/functions/uuid.html">uuid</a>
-              </li>
-
-            </ul>
-          </li>
-
-          <li<%= sidebar_current("docs-funcs-ipnet") %>>
-            <a href="#docs-funcs-ipnet">IP Network Functions</a>
-            <ul class="nav nav-visible" id="docs-funcs-ipnet">
-
-              <li<%= sidebar_current("docs-funcs-ipnet-cidrhost") %>>
-                <a href="/docs/configuration/functions/cidrhost.html">cidrhost</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-ipnet-cidrnetmask") %>>
-                <a href="/docs/configuration/functions/cidrnetmask.html">cidrnetmask</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-ipnet-cidrsubnet") %>>
-                <a href="/docs/configuration/functions/cidrsubnet.html">cidrsubnet</a>
-              </li>
-
-            </ul>
-          </li>
-
-          <li<%= sidebar_current("docs-funcs-conversion") %>>
-            <a href="#docs-funcs-conversion">Type Conversion Functions</a>
-            <ul class="nav nav-visible" id="docs-funcs-conversion">
-
-              <li<%= sidebar_current("docs-funcs-conversion-tobool") %>>
-                <a href="/docs/configuration/functions/tobool.html">tobool</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-conversion-tolist") %>>
-                <a href="/docs/configuration/functions/tolist.html">tolist</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-conversion-tomap") %>>
-                <a href="/docs/configuration/functions/tomap.html">tomap</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-conversion-tonumber") %>>
-                <a href="/docs/configuration/functions/tonumber.html">tonumber</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-conversion-toset") %>>
-                <a href="/docs/configuration/functions/toset.html">toset</a>
-              </li>
-
-              <li<%= sidebar_current("docs-funcs-conversion-tostring") %>>
-                <a href="/docs/configuration/functions/tostring.html">tostring</a>
-              </li>
-
-            </ul>
-          </li>
 
         </ul>
-      </div>
-    <% end %>
+      </li>
+    </ul>
 
-    <%= yield %>
+    <h4>Other Docs</h4>
+
+    <ul class="nav docs-sidenav">
+      <li>
+        <a class="back" href="/downloads.html">Download Terraform</a>
+      </li>
+
+      <li>
+        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
+      </li>
+
+      <li>
+        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
+      </li>
+    </ul>
   <% end %>
+
+  <%= yield %>
+<% end %>

--- a/website/layouts/guides.erb
+++ b/website/layouts/guides.erb
@@ -1,5 +1,7 @@
 <% wrap_layout :inner do %>
   <% content_for :sidebar do %>
+    <h4><a href="/guides/index.html">Guides and Whitepapers</a></h4>
+
     <ul class="nav docs-sidenav">
       <li<%= sidebar_current("guides-getting-started") %>>
         <a href="/intro/getting-started/install.html">Getting Started</a>
@@ -24,8 +26,61 @@
       <li<%= sidebar_current("guides-running-terraform-in-automation") %>>
         <a href="/guides/running-terraform-in-automation.html">Running Terraform in Automation</a>
       </li>
-      <li<%= sidebar_current("guides-terraform-provider-development-program") %>>
-        <a href="/guides/terraform-provider-development-program.html">Terraform Provider Development Program</a>
+
+      <li<%= sidebar_current("upgrade-guides") %>>
+        <a href="/upgrade-guides/index.html">Upgrade Guides</a>
+        <ul class="nav">
+          <li<%= sidebar_current("upgrade-guides-0-12") %>>
+            <a href="/upgrade-guides/0-12.html">Upgrading to v0.12</a>
+          </li>
+          <li<%= sidebar_current("upgrade-guides-0-11") %>>
+            <a href="/upgrade-guides/0-11.html">Upgrading to v0.11</a>
+          </li>
+          <li<%= sidebar_current("upgrade-guides-0-10") %>>
+            <a href="/upgrade-guides/0-10.html">Upgrading to v0.10</a>
+          </li>
+          <li<%= sidebar_current("upgrade-guides-0-9") %>>
+            <a href="/upgrade-guides/0-9.html">Upgrading to v0.9</a>
+          </li>
+          <li<%= sidebar_current("upgrade-guides-0-8") %>>
+            <a href="/upgrade-guides/0-8.html">Upgrading to v0.8</a>
+          </li>
+          <li<%= sidebar_current("upgrade-guides-0-7") %>>
+            <a href="/upgrade-guides/0-7.html">Upgrading to v0.7</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+
+    <h4>Other Docs</h4>
+
+    <ul class="nav docs-sidenav">
+      <li>
+        <a class="back" href="/downloads.html">Download Terraform</a>
+      </li>
+
+      <li>
+        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/index.html">Terraform CLI</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
       </li>
     </ul>
   <% end %>

--- a/website/layouts/intro.erb
+++ b/website/layouts/intro.erb
@@ -1,5 +1,7 @@
 <% wrap_layout :inner do %>
   <% content_for :sidebar do %>
+    <h4><a href="/intro/index.html">Introduction to Terraform</a></h4>
+
     <ul class="nav docs-sidenav">
       <li<%= sidebar_current("what") %>>
         <a href="/intro/index.html">What is Terraform?</a>
@@ -82,6 +84,38 @@
             <a href="/intro/examples/consul.html">Consul</a>
           </li>
         </ul>
+      </li>
+    </ul>
+
+    <h4>Other Docs</h4>
+
+    <ul class="nav docs-sidenav">
+      <li>
+        <a class="back" href="/downloads.html">Download Terraform</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/index.html">Terraform CLI</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
+      </li>
+
+      <li>
+        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
       </li>
     </ul>
   <% end %>

--- a/website/layouts/registry.erb
+++ b/website/layouts/registry.erb
@@ -1,48 +1,65 @@
 <% wrap_layout :inner do %>
-	<% content_for :sidebar do %>
-		<ul class="nav docs-sidenav">
-			<li<%= sidebar_current("docs-home") %>>
-				<a class="back" href="/docs/index.html">Documentation Home</a>
-			</li>
+  <% content_for :sidebar do %>
+    <h4><a href="/docs/registry/index.html">Terraform Registry</a></h4>
 
-			<li<%= sidebar_current("docs-registry-home") %>>
-				<a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-			</li>
+    <ul class="nav docs-sidenav">
+      <li<%= sidebar_current("docs-registry-use") %>>
+        <a href="/docs/registry/modules/use.html">Finding and Using Modules</a>
+      </li>
 
-			<hr>
+      <li<%= sidebar_current("docs-registry-publish") %>>
+        <a href="/docs/registry/modules/publish.html">Publishing Modules</a>
+      </li>
 
-			<li class="active">
-				<a href="#">Modules</a>
-				<ul class="nav">
-					<li<%= sidebar_current("docs-registry-use") %>>
-						<a href="/docs/registry/modules/use.html">Finding and Using Modules</a>
-					</li>
+      <li<%= sidebar_current("docs-registry-verified") %>>
+        <a href="/docs/registry/modules/verified.html">Verified Modules</a>
+      </li>
 
-					<li<%= sidebar_current("docs-registry-publish") %>>
-						<a href="/docs/registry/modules/publish.html">Publishing Modules</a>
-					</li>
+      <li<%= sidebar_current("docs-registry-private") %>>
+        <a href="/docs/registry/private.html">Private Registries</a>
+      </li>
 
-					<li<%= sidebar_current("docs-registry-verified") %>>
-						<a href="/docs/registry/modules/verified.html">Verified Modules</a>
-					</li>
-				</ul>
-			</li>
+      <li<%= sidebar_current("docs-registry-api") %>>
+        <a href="/docs/registry/api.html">Registry API</a>
+      </li>
 
-			<li<%= sidebar_current("docs-registry-private") %>>
-				<a href="/docs/registry/private.html">Private Registry</a>
-			</li>
+      <li<%= sidebar_current("docs-registry-support") %>>
+        <a href="/docs/registry/support.html">Registry Support</a>
+      </li>
+    </ul>
 
-			<hr>
+    <h4>Other Docs</h4>
 
-			<li<%= sidebar_current("docs-registry-api") %>>
-				<a href="/docs/registry/api.html">API</a>
-			</li>
+    <ul class="nav docs-sidenav">
+      <li>
+        <a class="back" href="/downloads.html">Download Terraform</a>
+      </li>
 
-			<li<%= sidebar_current("docs-registry-support") %>>
-				<a href="/docs/registry/support.html">Support</a>
-			</li>
-		</ul>
-	<% end %>
+      <li>
+        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
+      </li>
 
-	<%= yield %>
+      <li>
+        <a class="back" href="/docs/index.html">Terraform CLI</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
+      </li>
+
+      <li>
+        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
+      </li>
+
+      <li>
+        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
+      </li>
+    </ul>
+  <% end %>
+
+  <%= yield %>
 <% end %>

--- a/website/upgrade-guides/0-10.html.markdown
+++ b/website/upgrade-guides/0-10.html.markdown
@@ -1,5 +1,5 @@
 ---
-layout: "downloads"
+layout: "guides"
 page_title: "Upgrading to Terraform 0.10"
 sidebar_current: "upgrade-guides-0-10"
 description: |-

--- a/website/upgrade-guides/0-11.html.markdown
+++ b/website/upgrade-guides/0-11.html.markdown
@@ -1,5 +1,5 @@
 ---
-layout: "downloads"
+layout: "guides"
 page_title: "Upgrading to Terraform 0.11"
 sidebar_current: "upgrade-guides-0-11"
 description: |-

--- a/website/upgrade-guides/0-12.html.markdown
+++ b/website/upgrade-guides/0-12.html.markdown
@@ -1,5 +1,5 @@
 ---
-layout: "downloads"
+layout: "guides"
 page_title: "Upgrading to Terraform 0.12"
 sidebar_current: "upgrade-guides-0-12"
 description: |-

--- a/website/upgrade-guides/0-7.html.markdown
+++ b/website/upgrade-guides/0-7.html.markdown
@@ -1,5 +1,5 @@
 ---
-layout: "downloads"
+layout: "guides"
 page_title: "Upgrading to Terraform 0.7"
 sidebar_current: "upgrade-guides-0-7"
 description: |-

--- a/website/upgrade-guides/0-8.html.markdown
+++ b/website/upgrade-guides/0-8.html.markdown
@@ -1,5 +1,5 @@
 ---
-layout: "downloads"
+layout: "guides"
 page_title: "Upgrading to Terraform 0.8"
 sidebar_current: "upgrade-guides-0-8"
 description: |-

--- a/website/upgrade-guides/0-9.html.markdown
+++ b/website/upgrade-guides/0-9.html.markdown
@@ -1,5 +1,5 @@
 ---
-layout: "downloads"
+layout: "guides"
 page_title: "Upgrading to Terraform 0.9"
 sidebar_current: "upgrade-guides-0-9"
 description: |-

--- a/website/upgrade-guides/index.html.markdown
+++ b/website/upgrade-guides/index.html.markdown
@@ -1,5 +1,5 @@
 ---
-layout: "downloads"
+layout: "guides"
 page_title: "Upgrade Guides"
 sidebar_current: "upgrade-guides"
 description: |-


### PR DESCRIPTION
Let's review and deal with this after the new year, but in summary: 

- The Terraform website is broken into several silos of documentation content, with the top nav being the only way of reaching some of these. 
- That's bad. 
    - Mostly because the sidebar navs are so comprehensive in most sections (Terraform CLI and TFE in particular) that it SEEMS like you should be able to get anywhere from them.
    - But also because the content is so similar (documentation for Terraform-related stuff) that it doesn't seem like it should be in separate top-level sections. 
- So let's make it easier to get around by making it so you can get anywhere using the sidebars. 

Companion PR in terraform-website at https://github.com/hashicorp/terraform-website/pull/617