### PR TITLE
helper/resource: Shim back to old state must preserve schema version

### DIFF
--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -88,6 +88,11 @@ func shimNewState(newState *states.State, schemas *terraform.Schemas) (*terrafor
 						Tainted:    i.Current.Status == states.ObjectTainted,
 					},
 				}
+				if i.Current.SchemaVersion != 0 {
+					resState.Primary.Meta = map[string]interface{}{
+						"schema_version": i.Current.SchemaVersion,
+					}
+				}
 
 				for _, dep := range i.Current.Dependencies {
 					resState.Dependencies = append(resState.Dependencies, dep.String())
@@ -118,6 +123,11 @@ func shimNewState(newState *states.State, schemas *terraform.Schemas) (*terrafor
 						ID:         flatmap["id"],
 						Attributes: flatmap,
 						Tainted:    dep.Status == states.ObjectTainted,
+					}
+					if dep.SchemaVersion != 0 {
+						deposed.Meta = map[string]interface{}{
+							"schema_version": dep.SchemaVersion,
+						}
 					}
 
 					resState.Deposed = append(resState.Deposed, deposed)

--- a/helper/resource/state_shim_test.go
+++ b/helper/resource/state_shim_test.go
@@ -3,9 +3,8 @@ package resource
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform/configs/configschema"
-
 	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/zclconf/go-cty/cty"
@@ -29,8 +28,9 @@ func TestStateShim(t *testing.T) {
 			Name: "foo",
 		}.Instance(addrs.NoKey),
 		&states.ResourceInstanceObjectSrc{
-			Status:    states.ObjectReady,
-			AttrsFlat: map[string]string{"id": "foo", "bazzle": "dazzle"},
+			Status:        states.ObjectReady,
+			AttrsFlat:     map[string]string{"id": "foo", "bazzle": "dazzle"},
+			SchemaVersion: 7,
 			Dependencies: []addrs.Referenceable{
 				addrs.ResourceInstance{
 					Resource: addrs.Resource{
@@ -208,6 +208,9 @@ func TestStateShim(t *testing.T) {
 							Attributes: map[string]string{
 								"id":     "foo",
 								"bazzle": "dazzle",
+							},
+							Meta: map[string]interface{}{
+								"schema_version": 7,
 							},
 						},
 						Dependencies: []string{"test_thing.baz"},


### PR DESCRIPTION
We use a shim to convert from the new state model back to the old because the provider test API is still using the old API throughout. However, the shim was not preserving the schema version recorded in the new-style state and so a round-trip through this shim would cause the schema versions to all revert to zero.

This can cause trouble with the destroy phase of provider tests because (for API legacy reasons) we round-trip from old state back to new again before the destroy phase and thus causing the providers to try to upgrade from state version zero even though the data was already latest, which can cause errors because state upgrades are generally not idempotent.

This fixes #19753.