### PR TITLE
Fix a typo in null_resource provisioner title

### DIFF
--- a/website/docs/provisioners/null_resource.html.markdown
+++ b/website/docs/provisioners/null_resource.html.markdown
@@ -4,7 +4,7 @@ page_title: "Provisioners: null_resource"
 sidebar_current: "docs-provisioners-null-resource"
 description: |-
   The `null_resource` is a resource allows you to configure provisioners that
-  are not directly associated with a single exiting resource.
+  are not directly associated with a single existing resource.
 ---
 
 # null\_resource


### PR DESCRIPTION
Fix a typo in null_resource provisioner title: `exiting` -> `existing` resource