### PR TITLE
backend/remote: log early to indicate execution started

### DIFF
--- a/backend/remote/backend_apply.go
+++ b/backend/remote/backend_apply.go
@@ -225,7 +225,7 @@ func (b *Remote) opApply(stopCtx, cancelCtx context.Context, op *backend.Operati
 const applyDefaultHeader = `
 [reset][yellow]Running apply in the remote backend. Output will stream here. Pressing Ctrl-C
 will cancel the remote apply if its still pending. If the apply started it
-will stop streaming the logs, but will not stop the apply running remotely.
-To view this run in a browser, visit:
-https://%s/app/%s/%s/runs/%s[reset]
+will stop streaming the logs, but will not stop the apply running remotely.[reset]
+
+Preparing the remote apply...
 `


### PR DESCRIPTION
If you are uploading a large repo or if TFE is experiencing peak load, it can take some time before your configuration is uploaded and the run is created.

By displaying the first 2 lines of the header before starting to prepare the run, people will know that the command started successfully and that the remote operation is being prepared.