### PR TITLE
Better handling for empty containers and zero values in provider shims

### DIFF
--- a/builtin/providers/test/resource_nested_set.go
+++ b/builtin/providers/test/resource_nested_set.go
@@ -28,6 +28,19 @@ func testResourceNestedSet() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"type_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"single": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -98,12 +111,23 @@ func testResourceNestedSet() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-
 						"list": {
 							Type:     schema.TypeList,
 							Optional: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
+							},
+						},
+						"list_block": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"unused": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
 							},
 						},
 					},

--- a/builtin/providers/test/resource_nested_set_test.go
+++ b/builtin/providers/test/resource_nested_set_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -48,6 +49,118 @@ func TestResourceNestedSet_noSet(t *testing.T) {
 			resource.TestStep{
 				Config: strings.TrimSpace(`
 resource "test_resource_nested_set" "foo" {
+}
+				`),
+				Check: checkFunc,
+			},
+		},
+	})
+}
+
+// the empty type_list must be passed to the provider with 1 nil element
+func TestResourceNestedSet_emptyBlock(t *testing.T) {
+	checkFunc := func(s *terraform.State) error {
+		root := s.ModuleByPath(addrs.RootModuleInstance)
+		res := root.Resources["test_resource_nested_set.foo"]
+		for k, v := range res.Primary.Attributes {
+			if strings.HasPrefix(k, "type_list") && v != "1" {
+				return fmt.Errorf("unexpected set value: %s:%s", k, v)
+			}
+		}
+		return nil
+	}
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	type_list {
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+		},
+	})
+}
+
+func TestResourceNestedSet_emptyNestedListBlock(t *testing.T) {
+	checkFunc := func(s *terraform.State) error {
+		root := s.ModuleByPath(addrs.RootModuleInstance)
+		res := root.Resources["test_resource_nested_set.foo"]
+		found := false
+		for k, v := range res.Primary.Attributes {
+			if !regexp.MustCompile(`^with_list\.\d+\.list_block\.`).MatchString(k) {
+				continue
+			}
+			found = true
+
+			if strings.HasSuffix(k, ".#") {
+				if v != "1" {
+					return fmt.Errorf("expected block with no objects: got %s:%s", k, v)
+				}
+				continue
+			}
+
+			// there should be no other attribute values for an empty block
+			return fmt.Errorf("unexpected attribute: %s:%s", k, v)
+		}
+		if !found {
+			return fmt.Errorf("with_list.X.list_block not found")
+		}
+		return nil
+	}
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	with_list {
+		required = "ok"
+		list_block {
+		}
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+		},
+	})
+}
+func TestResourceNestedSet_emptyNestedList(t *testing.T) {
+	checkFunc := func(s *terraform.State) error {
+		root := s.ModuleByPath(addrs.RootModuleInstance)
+		res := root.Resources["test_resource_nested_set.foo"]
+		found := false
+		for k, v := range res.Primary.Attributes {
+			if regexp.MustCompile(`^with_list\.\d+\.list\.#$`).MatchString(k) {
+				found = true
+				if v != "0" {
+					return fmt.Errorf("expected empty list: %s, got %s", k, v)
+				}
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("with_list.X.nested_list not found")
+		}
+		return nil
+	}
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	with_list {
+		required = "ok"
+		list = []
+	}
 }
 				`),
 				Check: checkFunc,
@@ -331,6 +444,53 @@ resource "test_resource_nested_set" "foo" {
 	with_list {
 		required = "bar"
 		list = ["second value"]
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+		},
+	})
+}
+
+// This is the same as forceNewEmptyString, but we start with the empty value,
+// instead of changing it.
+func TestResourceNestedSet_nestedSetEmptyString(t *testing.T) {
+	checkFunc := func(s *terraform.State) error {
+		return nil
+	}
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	multi {
+		set {
+			required = ""
+		}
+	}
+}
+				`),
+				Check: checkFunc,
+			},
+		},
+	})
+}
+
+func TestResourceNestedSet_emptySet(t *testing.T) {
+	checkFunc := func(s *terraform.State) error {
+		return nil
+	}
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_set" "foo" {
+	multi {
 	}
 }
 				`),

--- a/builtin/providers/test/resource_nested_test.go
+++ b/builtin/providers/test/resource_nested_test.go
@@ -142,6 +142,7 @@ resource "test_resource_nested" "foo" {
 						"nested.0.nested_again.0.string": "a",
 						"nested.1.string":                "",
 						"nested.1.optional":              "false",
+						"nested.1.nested_again.#":        "0",
 					}
 					delete(got, "id") // it's random, so not useful for testing
 

--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -521,3 +521,23 @@ resource "test_resource" "two" {
 		},
 	})
 }
+
+func TestResource_emptyMapValue(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+	required     = "ok"
+	required_map = {
+		a = "a"
+		b = ""
+	}
+}
+				`),
+			},
+		},
+	})
+}

--- a/config/hcl2shim/flatmap.go
+++ b/config/hcl2shim/flatmap.go
@@ -347,10 +347,8 @@ func hcl2ValueFromFlatmapSet(m map[string]string, prefix string, ty cty.Type) (c
 		return cty.UnknownVal(ty), nil
 	}
 
-	// We actually don't really care about the "count" of a set for our
-	// purposes here, but we do need to check if it _exists_ in order to
-	// recognize the difference between null (not set at all) and empty.
-	if strCount, exists := m[prefix+"#"]; !exists {
+	strCount, exists := m[prefix+"#"]
+	if !exists {
 		return cty.NullVal(ty), nil
 	} else if strCount == UnknownVariableValue {
 		return cty.UnknownVal(ty), nil
@@ -394,7 +392,31 @@ func hcl2ValueFromFlatmapSet(m map[string]string, prefix string, ty cty.Type) (c
 		vals = append(vals, val)
 	}
 
-	if len(vals) == 0 {
+	if len(vals) == 0 && strCount == "1" {
+		// An empty set wouldn't be represented in the flatmap, so this must be
+		// a single empty object since the count is actually 1.
+		// Add an appropriately typed null value to the set.
+		var val cty.Value
+		switch {
+		case ety.IsMapType():
+			val = cty.MapValEmpty(ety)
+		case ety.IsListType():
+			val = cty.ListValEmpty(ety)
+		case ety.IsSetType():
+			val = cty.SetValEmpty(ety)
+		case ety.IsObjectType():
+			// TODO: cty.ObjectValEmpty
+			objectMap := map[string]cty.Value{}
+			for attr, ty := range ety.AttributeTypes() {
+				objectMap[attr] = cty.NullVal(ty)
+			}
+			val = cty.ObjectVal(objectMap)
+		default:
+			val = cty.NullVal(ety)
+		}
+		vals = append(vals, val)
+
+	} else if len(vals) == 0 {
 		return cty.SetValEmpty(ety), nil
 	}
 

--- a/config/hcl2shim/flatmap_test.go
+++ b/config/hcl2shim/flatmap_test.go
@@ -679,10 +679,52 @@ func TestHCL2ValueFromFlatmap(t *testing.T) {
 				}),
 			}),
 		},
+		{
+			Flatmap: map[string]string{
+				"foo.#": "1",
+			},
+			Type: cty.Object(map[string]cty.Type{
+				"foo": cty.Set(cty.Object(map[string]cty.Type{
+					"bar": cty.String,
+				})),
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+		},
+		{
+			Flatmap: map[string]string{
+				"multi.#":                "1",
+				"multi.2.set.#":          "1",
+				"multi.2.set.3.required": "val",
+			},
+			Type: cty.Object(map[string]cty.Type{
+				"multi": cty.Set(cty.Object(map[string]cty.Type{
+					"set": cty.Set(cty.Object(map[string]cty.Type{
+						"required": cty.String,
+					})),
+				})),
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"set": cty.SetVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"required": cty.StringVal("val"),
+							}),
+						}),
+					}),
+				}),
+			}),
+		},
 	}
 
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%#v as %#v", test.Flatmap, test.Type), func(t *testing.T) {
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d %#v as %#v", i, test.Flatmap, test.Type), func(t *testing.T) {
 			got, err := HCL2ValueFromFlatmap(test.Flatmap, test.Type)
 
 			if test.WantErr != "" {

--- a/config/hcl2shim/values.go
+++ b/config/hcl2shim/values.go
@@ -80,11 +80,6 @@ func ConfigValueFromHCL2Block(v cty.Value, schema *configschema.Block) map[strin
 
 		case configschema.NestingList, configschema.NestingSet:
 			l := bv.LengthInt()
-			if l == 0 {
-				// skip empty collections to better mimic how HCL1 would behave
-				continue
-			}
-
 			elems := make([]interface{}, 0, l)
 			for it := bv.ElementIterator(); it.Next(); {
 				_, ev := it.Element()
@@ -97,11 +92,6 @@ func ConfigValueFromHCL2Block(v cty.Value, schema *configschema.Block) map[strin
 			ret[name] = elems
 
 		case configschema.NestingMap:
-			if bv.LengthInt() == 0 {
-				// skip empty collections to better mimic how HCL1 would behave
-				continue
-			}
-
 			elems := make(map[string]interface{})
 			for it := bv.ElementIterator(); it.Next(); {
 				ek, ev := it.Element()

--- a/config/hcl2shim/values_test.go
+++ b/config/hcl2shim/values_test.go
@@ -151,7 +151,7 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 		},
 		{
 			cty.ObjectVal(map[string]cty.Value{
-				"address": cty.ListValEmpty(cty.EmptyObject), // should be omitted altogether in result
+				"address": cty.ListValEmpty(cty.EmptyObject),
 			}),
 			&configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{
@@ -161,7 +161,9 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 					},
 				},
 			},
-			map[string]interface{}{},
+			map[string]interface{}{
+				"address": []interface{}{},
+			},
 		},
 		{
 			cty.ObjectVal(map[string]cty.Value{
@@ -193,7 +195,9 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 					},
 				},
 			},
-			map[string]interface{}{},
+			map[string]interface{}{
+				"address": []interface{}{},
+			},
 		},
 		{
 			cty.ObjectVal(map[string]cty.Value{
@@ -225,7 +229,9 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 					},
 				},
 			},
-			map[string]interface{}{},
+			map[string]interface{}{
+				"address": map[string]interface{}{},
+			},
 		},
 		{
 			cty.NullVal(cty.EmptyObject),
@@ -234,8 +240,8 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%#v", test.Input), func(t *testing.T) {
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d-%#v", i, test.Input), func(t *testing.T) {
 			got := ConfigValueFromHCL2Block(test.Input, test.Schema)
 			if !reflect.DeepEqual(got, test.Want) {
 				t.Errorf("wrong result\ninput: %#v\ngot:   %#v\nwant:  %#v", test.Input, got, test.Want)

--- a/helper/plugin/grpc_provider_test.go
+++ b/helper/plugin/grpc_provider_test.go
@@ -673,7 +673,7 @@ func TestNormalizeFlatmapContainers(t *testing.T) {
 	}{
 		{
 			attrs:  map[string]string{"id": "1", "multi.2.set.#": "1", "multi.1.set.#": "0", "single.#": "0"},
-			expect: map[string]string{"id": "1"},
+			expect: map[string]string{"id": "1", "multi.2.set.#": "1"},
 		},
 		{
 			attrs:  map[string]string{"id": "1", "multi.2.set.#": "2", "multi.2.set.1.foo": "bar", "multi.1.set.#": "0", "single.#": "0"},
@@ -681,11 +681,15 @@ func TestNormalizeFlatmapContainers(t *testing.T) {
 		},
 		{
 			attrs:  map[string]string{"id": "78629a0f5f3f164f", "multi.#": "1"},
+			expect: map[string]string{"id": "78629a0f5f3f164f", "multi.#": "1"},
+		},
+		{
+			attrs:  map[string]string{"id": "78629a0f5f3f164f", "multi.#": "0"},
 			expect: map[string]string{"id": "78629a0f5f3f164f"},
 		},
 		{
-			attrs:  map[string]string{"multi.529860700.set.#": "1", "multi.#": "1", "id": "78629a0f5f3f164f"},
-			expect: map[string]string{"id": "78629a0f5f3f164f"},
+			attrs:  map[string]string{"multi.529860700.set.#": "0", "multi.#": "1", "id": "78629a0f5f3f164f"},
+			expect: map[string]string{"id": "78629a0f5f3f164f", "multi.#": "1"},
 		},
 		{
 			attrs:  map[string]string{"set.2.required": "bar", "set.2.list.#": "1", "set.2.list.0": "x", "set.1.list.#": "0", "set.#": "2"},

--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -420,11 +420,17 @@ func (p *GRPCProvider) ApplyResourceChange(r providers.ApplyResourceChangeReques
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
 	}
+	configMP, err := msgpack.Marshal(r.Config, resSchema.Block.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(err)
+		return resp
+	}
 
 	protoReq := &proto.ApplyResourceChange_Request{
 		TypeName:       r.TypeName,
 		PriorState:     &proto.DynamicValue{Msgpack: priorMP},
 		PlannedState:   &proto.DynamicValue{Msgpack: plannedMP},
+		Config:         &proto.DynamicValue{Msgpack: configMP},
 		PlannedPrivate: r.PlannedPrivate,
 	}
 


### PR DESCRIPTION
This contains a few improvements in the shim functions and the shimmed grpc providers. The key spots are improvements to `HCL2ValueFromFlatmap`, `ConfigValueFromHCL2Block`, and the new  `copyMissingValues` used in the plugin.

- When converting to config values from HCL2 values, ensure that empty nested blocks correspond to empty objects in the config.

- If a flatmap value has a count of 1 and no other attributes, it
usually indicates the equivalent configuration of an empty (or default
value) set block. Treat this as containing a single zero value object
and insert that into the cty.Value set.

- `copyMissingValues` copies missing values from one cty.Object to another.
If we have known zero value containers and primitives in the source,
which appear as null values in the destination, we copy over the zero
value. Sets (and lists to an extent) are more difficult, since the
before and after indexes may not correlate. In that case we take the
entire container if it's wholly known, expecting the provider to have
correctly handled the value.

Fixes #19760 
Fixes #19757. 
May help with #19754 as well.