### PR TITLE
Container checks in TestCheckFuncs

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -971,7 +971,19 @@ func TestCheckModuleResourceAttr(mp []string, name string, key string, value str
 }
 
 func testCheckResourceAttr(is *terraform.InstanceState, name string, key string, value string) error {
+	// Empty containers may be elided from the state.
+	// If the intent here is to check for an empty container, allow the key to
+	// also be non-existent.
+	emptyCheck := false
+	if value == "0" && (strings.HasSuffix(key, ".#") || strings.HasSuffix(key, ".%")) {
+		emptyCheck = true
+	}
+
 	if v, ok := is.Attributes[key]; !ok || v != value {
+		if emptyCheck && !ok {
+			return nil
+		}
+
 		if !ok {
 			return fmt.Errorf("%s: Attribute '%s' not found", name, key)
 		}

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -1113,3 +1113,34 @@ resource "test_instance" "foo" {}
 const testConfigStrProvider = `
 provider "test" {}
 `
+
+func TestCheckResourceAttr_empty(t *testing.T) {
+	s := terraform.NewState()
+	s.AddModuleState(&terraform.ModuleState{
+		Path: []string{"root"},
+		Resources: map[string]*terraform.ResourceState{
+			"test_resource": &terraform.ResourceState{
+				Primary: &terraform.InstanceState{
+					Attributes: map[string]string{
+						"empty_list.#": "0",
+						"empty_map.%":  "0",
+					},
+				},
+			},
+		},
+	})
+
+	for _, key := range []string{
+		"empty_list.#",
+		"empty_map.%",
+		"missing_list.#",
+		"missing_map.%",
+	} {
+		t.Run(key, func(t *testing.T) {
+			check := TestCheckResourceAttr("test_resource", key, "0")
+			if err := check(s); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -1144,3 +1144,34 @@ func TestCheckResourceAttr_empty(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckNoResourceAttr_empty(t *testing.T) {
+	s := terraform.NewState()
+	s.AddModuleState(&terraform.ModuleState{
+		Path: []string{"root"},
+		Resources: map[string]*terraform.ResourceState{
+			"test_resource": &terraform.ResourceState{
+				Primary: &terraform.InstanceState{
+					Attributes: map[string]string{
+						"empty_list.#": "0",
+						"empty_map.%":  "0",
+					},
+				},
+			},
+		},
+	})
+
+	for _, key := range []string{
+		"empty_list.#",
+		"empty_map.%",
+		"missing_list.#",
+		"missing_map.%",
+	} {
+		t.Run(key, func(t *testing.T) {
+			check := TestCheckNoResourceAttr("test_resource", key)
+			if err := check(s); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stricter type handling in the new shims may add empty containers into the state where they were previously elided, or remove them when they actually no longer exist. Fix some of the common TestCheckFunc to catch when the user is lookin for a container count index (`*.#`, `*.%`), and allow a value of `"0"` and a missing key to be equal. 