### PR TITLE
command/show: added test scaffold for json output

### DIFF
--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -38,9 +38,8 @@ func marshalAttributeValues(value cty.Value, schema *configschema.Block) attribu
 	return ret
 }
 
-// marshalPlannedOutputs takes a list of changes and returns two output maps,
-// the former with output values and the latter with true/false in place of
-// values indicating whether the values are known at plan time.
+// marshalPlannedOutputs takes a list of changes and returns a map of output
+// values
 func marshalPlannedOutputs(changes *plans.Changes) (map[string]output, error) {
 	if changes.Outputs == nil {
 		// No changes - we're done here!

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -233,7 +233,7 @@ func TestPlan_json_output(t *testing.T) {
 
 			eq := reflect.DeepEqual(got, want)
 			if !eq {
-				t.Fatalf("wrong result:\nGot: %#v\nWant: %#v\n", got, want)
+				t.Fatalf("wrong result: output did not match")
 			}
 
 		})

--- a/command/test-fixtures/show-json/basic-create/main.tf
+++ b/command/test-fixtures/show-json/basic-create/main.tf
@@ -1,0 +1,10 @@
+variable "test_var" {
+    default = "bar"
+}
+resource "test_instance" "test" {
+    ami = var.test_var
+}
+
+output "test" {
+    value = var.test_var
+}

--- a/command/test-fixtures/show-json/basic-create/output.json
+++ b/command/test-fixtures/show-json/basic-create/output.json
@@ -1,0 +1,77 @@
+{
+    "format_version": "0.1",
+    "planned_values": {
+        "outputs": {
+            "test": {
+                "sensitive": false,
+                "value": "bar"
+            }
+        },
+        "root_module": {
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "test",
+                    "schema_version": 0
+                }
+            ]
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "test_instance.test",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "Create"
+                ],
+                "before": null,
+                "after_unknown": {
+                    "ami": false,
+                    "id": true
+                }
+            }
+        }
+    ],
+    "output_changes": {
+        "test": {
+            "actions": [
+                "Create"
+            ],
+            "before": null,
+            "after": "bar",
+            "after_unknown": false
+        }
+    },
+    "configuration": {
+        "root_module": {
+            "outputs": {
+                "test": {
+                    "expression": {
+                        "references": [
+                            "var.test_var"
+                        ]
+                    }
+                }
+            },
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_config_key": "provider.test",
+                    "schema_version": 0,
+                    "count_expression": {},
+                    "for_each_expression": {}
+                }
+            ]
+        }
+    }
+}

--- a/command/test-fixtures/show-json/basic-delete/main.tf
+++ b/command/test-fixtures/show-json/basic-delete/main.tf
@@ -1,0 +1,10 @@
+variable "test_var" {
+    default = "bar"
+}
+resource "test_instance" "test" {
+    ami = var.test_var
+}
+
+output "test" {
+    value = var.test_var
+}

--- a/command/test-fixtures/show-json/basic-delete/output.json
+++ b/command/test-fixtures/show-json/basic-delete/output.json
@@ -1,0 +1,137 @@
+{
+    "format_version": "0.1",
+    "planned_values": {
+        "outputs": {
+            "test": {
+                "sensitive": false,
+                "value": "bar"
+            }
+        },
+        "root_module": {
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "test",
+                    "schema_version": 0,
+                    "values": {
+                        "ami": {},
+                        "id": {}
+                    }
+                }
+            ]
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "test_instance.test-delete",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test-delete",
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "Delete"
+                ],
+                "before": {
+                    "ami": "foo",
+                    "id": null
+                },
+                "after": null,
+                "after_unknown": false
+            }
+        },
+        {
+            "address": "test_instance.test",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "Update"
+                ],
+                "before": {
+                    "ami": "foo",
+                    "id": null
+                },
+                "after": {
+                    "ami": "bar",
+                    "id": null
+                },
+                "after_unknown": {
+                    "ami": false,
+                    "id": false
+                }
+            }
+        }
+    ],
+    "output_changes": {
+        "test": {
+            "actions": [
+                "Create"
+            ],
+            "before": null,
+            "after": "bar",
+            "after_unknown": false
+        }
+    },
+    "prior_state": {
+        "format_version": "0.1",
+        "values": {
+            "root_module": {
+                "resources": [
+                    {
+                        "address": "test_instance.test",
+                        "mode": "managed",
+                        "type": "test_instance",
+                        "name": "test",
+                        "provider_name": "test",
+                        "values": {
+                            "ami": {},
+                            "id": {}
+                        }
+                    },
+                    {
+                        "address": "test_instance.test-delete",
+                        "mode": "managed",
+                        "type": "test_instance",
+                        "name": "test-delete",
+                        "provider_name": "test",
+                        "values": {
+                            "ami": {},
+                            "id": {}
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "configuration": {
+        "root_module": {
+            "outputs": {
+                "test": {
+                    "expression": {
+                        "references": [
+                            "var.test_var"
+                        ]
+                    }
+                }
+            },
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_config_key": "provider.test",
+                    "schema_version": 0,
+                    "count_expression": {},
+                    "for_each_expression": {}
+                }
+            ]
+        }
+    }
+}

--- a/command/test-fixtures/show-json/basic-update/main.tf
+++ b/command/test-fixtures/show-json/basic-update/main.tf
@@ -1,0 +1,10 @@
+variable "test_var" {
+    default = "bar"
+}
+resource "test_instance" "test" {
+    ami = var.test_var
+}
+
+output "test" {
+    value = var.test_var
+}

--- a/command/test-fixtures/show-json/basic-update/output.json
+++ b/command/test-fixtures/show-json/basic-update/output.json
@@ -1,0 +1,93 @@
+{
+    "format_version": "0.1",
+    "planned_values": {
+        "outputs": {
+            "test": {
+                "sensitive": false,
+                "value": "bar"
+            }
+        },
+        "root_module": {}
+    },
+    "resource_changes": [
+        {
+            "address": "test_instance.test",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "NoOp"
+                ],
+                "before": {
+                    "ami": "bar",
+                    "id": null
+                },
+                "after": {
+                    "ami": "bar",
+                    "id": null
+                },
+                "after_unknown": {
+                    "ami": false,
+                    "id": false
+                }
+            }
+        }
+    ],
+    "output_changes": {
+        "test": {
+            "actions": [
+                "Create"
+            ],
+            "before": null,
+            "after": "bar",
+            "after_unknown": false
+        }
+    },
+    "prior_state": {
+        "format_version": "0.1",
+        "values": {
+            "root_module": {
+                "resources": [
+                    {
+                        "address": "test_instance.test",
+                        "mode": "managed",
+                        "type": "test_instance",
+                        "name": "test",
+                        "provider_name": "test",
+                        "values": {
+                            "ami": {},
+                            "id": {}
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "configuration": {
+        "root_module": {
+            "outputs": {
+                "test": {
+                    "expression": {
+                        "references": [
+                            "var.test_var"
+                        ]
+                    }
+                }
+            },
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_config_key": "provider.test",
+                    "schema_version": 0,
+                    "count_expression": {},
+                    "for_each_expression": {}
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
More test cases will be added once the basic shape of the tests is validated (I haven't decided if I hate this or not - I didn't end up going with golden files, but could?). 