### PR TITLE
Prerelease versions are filtered for plugin protocol mismatches

### DIFF
--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -416,12 +416,18 @@ func (i *ProviderInstaller) listProviderDownloadURLs(name, version string) (*res
 }
 
 // findClosestProtocolCompatibleVersion searches for the provider version with the closest protocol match.
-//
+// Prerelease versions are filtered.
 func (i *ProviderInstaller) findClosestProtocolCompatibleVersion(versions []*response.TerraformProviderVersion) (*response.TerraformProviderVersion, error) {
 	// Loop through all the provider versions to find the earliest and latest
 	// versions that match the installer protocol to then select the closest of the two
 	var latest, earliest *response.TerraformProviderVersion
 	for _, version := range versions {
+		// Prereleases are filtered and will not be suggested
+		v, err := VersionStr(version.Version).Parse()
+		if err != nil || v.IsPrerelease() {
+			continue
+		}
+
 		if err := i.checkPluginProtocol(version); err == nil {
 			if earliest == nil {
 				// Found the first provider version with compatible protocol

--- a/plugin/discovery/get_test.go
+++ b/plugin/discovery/get_test.go
@@ -314,6 +314,63 @@ func TestFindClosestProtocolCompatibleVersion(t *testing.T) {
 			},
 			"2.5.0",
 			false,
+		}, {
+			"compatible prereleses are filtered",
+			5,
+			[]*response.TerraformProviderVersion{
+				&response.TerraformProviderVersion{
+					Version:   "2.0.0-alpha",
+					Protocols: []string{"4.0", "5.0"},
+				},
+			},
+			"",
+			true,
+		}, {
+			"suggests latest non-prerelease",
+			4,
+			[]*response.TerraformProviderVersion{
+				&response.TerraformProviderVersion{
+					Version:   "2.0.0-alpha",
+					Protocols: []string{"4.0", "5.0"},
+				},
+				&response.TerraformProviderVersion{
+					Version:   "2.0.0",
+					Protocols: []string{"4.0", "5.0"},
+				},
+				&response.TerraformProviderVersion{
+					Version:   "2.5.0-pre",
+					Protocols: []string{"4.0", "5.0"},
+				},
+				&response.TerraformProviderVersion{
+					Version:   "2.5.0",
+					Protocols: []string{"4.0", "5.0"},
+				},
+			},
+			"2.5.0",
+			false,
+		}, {
+			"suggests earliest non-prerelease",
+			5,
+			[]*response.TerraformProviderVersion{
+				&response.TerraformProviderVersion{
+					Version:   "2.0.0-alpha",
+					Protocols: []string{"4.0", "5.0"},
+				},
+				&response.TerraformProviderVersion{
+					Version:   "2.0.0",
+					Protocols: []string{"4.0", "5.0"},
+				},
+				&response.TerraformProviderVersion{
+					Version:   "2.6.0",
+					Protocols: []string{"4.0", "5.0"},
+				},
+				&response.TerraformProviderVersion{
+					Version:   "3.0.0",
+					Protocols: []string{"5.0"},
+				},
+			},
+			"2.0.0",
+			false,
 		},
 	}
 

--- a/plugin/discovery/version.go
+++ b/plugin/discovery/version.go
@@ -55,6 +55,11 @@ func (v Version) Equal(other Version) bool {
 	return v.raw.Equal(other.raw)
 }
 
+// IsPrerelease determines if version is a prerelease
+func (v Version) IsPrerelease() bool {
+	return v.raw.Prerelease() != ""
+}
+
 // MinorUpgradeConstraintStr returns a ConstraintStr that would permit
 // minor upgrades relative to the receiving version.
 func (v Version) MinorUpgradeConstraintStr() ConstraintStr {


### PR DESCRIPTION
Previous PR https://github.com/hashicorp/terraform/pull/19976 added UI msg to suggest version for users to update their config, but also suggested pre-releases if it is the only one available.

Terraform should not suggest pre-releases, and if needed users can select a pre-release with the provider version constraint to the pre-release.