### PR TITLE
Add details about using lock=true when consul ACL is enabled

### DIFF
--- a/website/docs/backends/types/consul.html.md
+++ b/website/docs/backends/types/consul.html.md
@@ -55,7 +55,7 @@ The following configuration options / environment variables are supported:
  * `http_auth` / `CONSUL_HTTP_AUTH` - (Optional) HTTP Basic Authentication credentials to be used when
    communicating with Consul, in the format of either `user` or `user:pass`.
  * `gzip` - (Optional) `true` to compress the state data using gzip, or `false` (the default) to leave it uncompressed.
- * `lock` - (Optional) `false` to disable locking. This defaults to true, but will require session permissions with Consul to perform locking.
+ * `lock` - (Optional) `false` to disable locking. This defaults to true, but will require session permissions with Consul and at least kv write permissions on `$path/.lock` to perform locking. 
  * `ca_file` / `CONSUL_CAFILE` - (Optional) A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.
  * `cert_file` / `CONSUL_CLIENT_CERT` - (Optional) A path to a PEM-encoded certificate provided to the remote agent; requires use of `key_file`.
  * `key_file` / `CONSUL_CLIENT_KEY` - (Optional) A path to a PEM-encoded private key, required if `cert_file` is specified.


### PR DESCRIPTION
The Terraform docs currently do not make it clear how state locks are acquired in Consul. The docs specify that the token must have session permissions with Consul if locking is enabled.

As it turns out, if Consul's ACL is enabled and you try to use a Consul token with session permissions but not at least `write` on `$path/.lock`, running any Terraform commands that touch state leads to non-obvious `403` errors whose resolution is digging into the source for the Consul backend.

This PR addresses https://github.com/hashicorp/terraform/issues/19963.