### PR TITLE
command/show: test -json output

### DIFF
--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -3,6 +3,7 @@ package jsonconfig
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"
@@ -244,5 +245,8 @@ func marshalResources(resources map[string]*configs.Resource, schemas *terraform
 
 		rs = append(rs, r)
 	}
+	sort.Slice(rs, func(i, j int) bool {
+		return rs[i].Address < rs[j].Address
+	})
 	return rs, nil
 }

--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -3,6 +3,7 @@ package jsonplan
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/zclconf/go-cty/cty"
 
@@ -209,6 +210,10 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 		p.ResourceChanges = append(p.ResourceChanges, r)
 
 	}
+
+	sort.Slice(p.ResourceChanges, func(i, j int) bool {
+		return p.ResourceChanges[i].Address < p.ResourceChanges[j].Address
+	})
 
 	return nil
 }

--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -38,9 +38,8 @@ func marshalAttributeValues(value cty.Value, schema *configschema.Block) attribu
 	return ret
 }
 
-// marshalPlannedOutputs takes a list of changes and returns two output maps,
-// the former with output values and the latter with true/false in place of
-// values indicating whether the values are known at plan time.
+// marshalPlannedOutputs takes a list of changes and returns a map of output
+// values
 func marshalPlannedOutputs(changes *plans.Changes) (map[string]output, error) {
 	if changes.Outputs == nil {
 		// No changes - we're done here!

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -3,6 +3,7 @@ package jsonstate
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
@@ -272,6 +273,10 @@ func marshalResources(resources map[string]*states.Resource, schemas *terraform.
 		}
 
 	}
+
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Address < ret[j].Address
+	})
 
 	return ret, nil
 }

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -233,7 +233,7 @@ func TestPlan_json_output(t *testing.T) {
 
 			eq := reflect.DeepEqual(got, want)
 			if !eq {
-				t.Fatalf("wrong result:\nGot: %#v\nWant: %#v\n", got, want)
+				t.Fatalf("wrong result: output did not match")
 			}
 
 		})

--- a/command/test-fixtures/show-json/basic-create/main.tf
+++ b/command/test-fixtures/show-json/basic-create/main.tf
@@ -1,0 +1,10 @@
+variable "test_var" {
+    default = "bar"
+}
+resource "test_instance" "test" {
+    ami = var.test_var
+}
+
+output "test" {
+    value = var.test_var
+}

--- a/command/test-fixtures/show-json/basic-create/output.json
+++ b/command/test-fixtures/show-json/basic-create/output.json
@@ -1,0 +1,77 @@
+{
+    "format_version": "0.1",
+    "planned_values": {
+        "outputs": {
+            "test": {
+                "sensitive": false,
+                "value": "bar"
+            }
+        },
+        "root_module": {
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "test",
+                    "schema_version": 0
+                }
+            ]
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "test_instance.test",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "Create"
+                ],
+                "before": null,
+                "after_unknown": {
+                    "ami": false,
+                    "id": true
+                }
+            }
+        }
+    ],
+    "output_changes": {
+        "test": {
+            "actions": [
+                "Create"
+            ],
+            "before": null,
+            "after": "bar",
+            "after_unknown": false
+        }
+    },
+    "configuration": {
+        "root_module": {
+            "outputs": {
+                "test": {
+                    "expression": {
+                        "references": [
+                            "var.test_var"
+                        ]
+                    }
+                }
+            },
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_config_key": "provider.test",
+                    "schema_version": 0,
+                    "count_expression": {},
+                    "for_each_expression": {}
+                }
+            ]
+        }
+    }
+}

--- a/command/test-fixtures/show-json/basic-delete/main.tf
+++ b/command/test-fixtures/show-json/basic-delete/main.tf
@@ -1,0 +1,10 @@
+variable "test_var" {
+    default = "bar"
+}
+resource "test_instance" "test" {
+    ami = var.test_var
+}
+
+output "test" {
+    value = var.test_var
+}

--- a/command/test-fixtures/show-json/basic-delete/output.json
+++ b/command/test-fixtures/show-json/basic-delete/output.json
@@ -26,24 +26,6 @@
     },
     "resource_changes": [
         {
-            "address": "test_instance.test-delete",
-            "mode": "managed",
-            "type": "test_instance",
-            "name": "test-delete",
-            "deposed": true,
-            "change": {
-                "actions": [
-                    "Delete"
-                ],
-                "before": {
-                    "ami": "foo",
-                    "id": null
-                },
-                "after": null,
-                "after_unknown": false
-            }
-        },
-        {
             "address": "test_instance.test",
             "mode": "managed",
             "type": "test_instance",
@@ -65,6 +47,24 @@
                     "ami": false,
                     "id": false
                 }
+            }
+        },
+        {
+            "address": "test_instance.test-delete",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test-delete",
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "Delete"
+                ],
+                "before": {
+                    "ami": "foo",
+                    "id": null
+                },
+                "after": null,
+                "after_unknown": false
             }
         }
     ],

--- a/command/test-fixtures/show-json/basic-delete/output.json
+++ b/command/test-fixtures/show-json/basic-delete/output.json
@@ -1,0 +1,137 @@
+{
+    "format_version": "0.1",
+    "planned_values": {
+        "outputs": {
+            "test": {
+                "sensitive": false,
+                "value": "bar"
+            }
+        },
+        "root_module": {
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "test",
+                    "schema_version": 0,
+                    "values": {
+                        "ami": {},
+                        "id": {}
+                    }
+                }
+            ]
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "test_instance.test-delete",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test-delete",
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "Delete"
+                ],
+                "before": {
+                    "ami": "foo",
+                    "id": null
+                },
+                "after": null,
+                "after_unknown": false
+            }
+        },
+        {
+            "address": "test_instance.test",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "Update"
+                ],
+                "before": {
+                    "ami": "foo",
+                    "id": null
+                },
+                "after": {
+                    "ami": "bar",
+                    "id": null
+                },
+                "after_unknown": {
+                    "ami": false,
+                    "id": false
+                }
+            }
+        }
+    ],
+    "output_changes": {
+        "test": {
+            "actions": [
+                "Create"
+            ],
+            "before": null,
+            "after": "bar",
+            "after_unknown": false
+        }
+    },
+    "prior_state": {
+        "format_version": "0.1",
+        "values": {
+            "root_module": {
+                "resources": [
+                    {
+                        "address": "test_instance.test",
+                        "mode": "managed",
+                        "type": "test_instance",
+                        "name": "test",
+                        "provider_name": "test",
+                        "values": {
+                            "ami": {},
+                            "id": {}
+                        }
+                    },
+                    {
+                        "address": "test_instance.test-delete",
+                        "mode": "managed",
+                        "type": "test_instance",
+                        "name": "test-delete",
+                        "provider_name": "test",
+                        "values": {
+                            "ami": {},
+                            "id": {}
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "configuration": {
+        "root_module": {
+            "outputs": {
+                "test": {
+                    "expression": {
+                        "references": [
+                            "var.test_var"
+                        ]
+                    }
+                }
+            },
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_config_key": "provider.test",
+                    "schema_version": 0,
+                    "count_expression": {},
+                    "for_each_expression": {}
+                }
+            ]
+        }
+    }
+}

--- a/command/test-fixtures/show-json/basic-delete/terraform.tfstate
+++ b/command/test-fixtures/show-json/basic-delete/terraform.tfstate
@@ -1,0 +1,37 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.0",
+  "serial": 7,
+  "lineage": "configuredUnchanged",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "test_instance",
+      "name": "test",
+      "provider": "provider.test",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "ami": "foo"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "test_instance",
+      "name": "test-delete",
+      "provider": "provider.test",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "ami": "foo"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/command/test-fixtures/show-json/basic-update/main.tf
+++ b/command/test-fixtures/show-json/basic-update/main.tf
@@ -1,0 +1,10 @@
+variable "test_var" {
+    default = "bar"
+}
+resource "test_instance" "test" {
+    ami = var.test_var
+}
+
+output "test" {
+    value = var.test_var
+}

--- a/command/test-fixtures/show-json/basic-update/output.json
+++ b/command/test-fixtures/show-json/basic-update/output.json
@@ -1,0 +1,93 @@
+{
+    "format_version": "0.1",
+    "planned_values": {
+        "outputs": {
+            "test": {
+                "sensitive": false,
+                "value": "bar"
+            }
+        },
+        "root_module": {}
+    },
+    "resource_changes": [
+        {
+            "address": "test_instance.test",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "NoOp"
+                ],
+                "before": {
+                    "ami": "bar",
+                    "id": null
+                },
+                "after": {
+                    "ami": "bar",
+                    "id": null
+                },
+                "after_unknown": {
+                    "ami": false,
+                    "id": false
+                }
+            }
+        }
+    ],
+    "output_changes": {
+        "test": {
+            "actions": [
+                "Create"
+            ],
+            "before": null,
+            "after": "bar",
+            "after_unknown": false
+        }
+    },
+    "prior_state": {
+        "format_version": "0.1",
+        "values": {
+            "root_module": {
+                "resources": [
+                    {
+                        "address": "test_instance.test",
+                        "mode": "managed",
+                        "type": "test_instance",
+                        "name": "test",
+                        "provider_name": "test",
+                        "values": {
+                            "ami": {},
+                            "id": {}
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "configuration": {
+        "root_module": {
+            "outputs": {
+                "test": {
+                    "expression": {
+                        "references": [
+                            "var.test_var"
+                        ]
+                    }
+                }
+            },
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_config_key": "provider.test",
+                    "schema_version": 0,
+                    "count_expression": {},
+                    "for_each_expression": {}
+                }
+            ]
+        }
+    }
+}

--- a/command/test-fixtures/show-json/basic-update/terraform.tfstate
+++ b/command/test-fixtures/show-json/basic-update/terraform.tfstate
@@ -1,0 +1,23 @@
+{
+    "version": 4,
+    "terraform_version": "0.12.0",
+    "serial": 7,
+    "lineage": "configuredUnchanged",
+    "outputs": {},
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "provider": "provider.test",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "ami": "bar"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
* added a test framework for json output and a few starting tests (the directory layout might change with time, I've already thought about adding a folder for `delete` plans)
* added sorting to resource slices to simplify tests - as a bonus this matches behavior elsewhere in terraform

(will squash)