### PR TITLE
Condense protocol mismatch error message

### DIFF
--- a/plugin/discovery/error.go
+++ b/plugin/discovery/error.go
@@ -22,6 +22,11 @@ const ErrorNoSuitableVersion = Error("no suitable version is available")
 // version of Terraform.
 const ErrorNoVersionCompatible = Error("no available version is compatible with this version of Terraform")
 
+// ErrorVersionIncompatible indicates that all of the versions within the
+// constraints are not compatible with the current version of Terrafrom, though
+// there does exist a version outside of the constaints that is compatible.
+const ErrorVersionIncompatible = Error("incompatible provider version")
+
 // ErrorNoSuchProvider indicates that no provider exists with a name given
 const ErrorNoSuchProvider = Error("no provider exists with the given name")
 


### PR DESCRIPTION
UI error msg to suggest compatible plugin version (https://github.com/hashicorp/terraform/pull/19976) ends up as a big wall of red text. It displays the suggested version along with more information describing why there may not be any compatible versions among what is available from the registry.

~This PR adds color distinction to break up the red block. `ProviderInstaller` can be passed the context of `colorstring.Colorize` at instantiation or falls back to the default colorizer. This may seem a little hacky but it allows `ProviderInstaller` to display to the UI high context msgs without needing to return a bunch of values to the caller to then be logged with the error~

This PR combines the redundant msg into one dynamic message and shifts the responsibility of printing the output to the caller (`init`). Utilizes the [errwrap](https://godoc.org/github.com/hashicorp/errwrap) lib to nest the detailed message to be displayed.

![image](https://user-images.githubusercontent.com/6362111/51140500-58342f80-180c-11e9-9880-b02bb425fa4d.png)

![image](https://user-images.githubusercontent.com/6362111/51140520-608c6a80-180c-11e9-87a5-3e0fa4d7ef1d.png)

