### PR TITLE
Don't add empty blocks to config, and fix ReadResource

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -26,6 +26,7 @@ func Provider() terraform.ResourceProvider {
 			"test_resource_nested":           testResourceNested(),
 			"test_resource_nested_set":       testResourceNestedSet(),
 			"test_resource_state_func":       testResourceStateFunc(),
+			"test_resource_deprecated":       testResourceDeprecated(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"test_data_source":    testDataSource(),

--- a/builtin/providers/test/resource_deprecated.go
+++ b/builtin/providers/test/resource_deprecated.go
@@ -1,0 +1,119 @@
+package test
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceDeprecated() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceDeprecatedCreate,
+		Read:   testResourceDeprecatedRead,
+		Update: testResourceDeprecatedUpdate,
+		Delete: testResourceDeprecatedDelete,
+
+		Schema: map[string]*schema.Schema{
+			"map_deprecated": {
+				Type:       schema.TypeMap,
+				Optional:   true,
+				Deprecated: "deprecated",
+			},
+			"map_removed": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Removed:  "removed",
+			},
+			"set_block_deprecated": {
+				Type:       schema.TypeSet,
+				Optional:   true,
+				MaxItems:   1,
+				Deprecated: "deprecated",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:       schema.TypeString,
+							Required:   true,
+							Deprecated: "deprecated",
+						},
+						"optional": {
+							Type:       schema.TypeString,
+							ForceNew:   true,
+							Optional:   true,
+							Deprecated: "deprecated",
+						},
+					},
+				},
+			},
+			"set_block_removed": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 1,
+				Removed:  "Removed",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"optional": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Optional: true,
+							Computed: true,
+							Removed:  "removed",
+						},
+					},
+				},
+			},
+			"list_block_deprecated": {
+				Type:       schema.TypeList,
+				Optional:   true,
+				Deprecated: "deprecated",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:       schema.TypeString,
+							Required:   true,
+							Deprecated: "deprecated",
+						},
+						"optional": {
+							Type:       schema.TypeString,
+							ForceNew:   true,
+							Optional:   true,
+							Deprecated: "deprecated",
+						},
+					},
+				},
+			},
+			"list_block_removed": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Removed:  "removed",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"optional": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Optional: true,
+							Removed:  "removed",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testResourceDeprecatedCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("testId")
+	return nil
+}
+
+func testResourceDeprecatedRead(d *schema.ResourceData, meta interface{}) error {
+
+	return nil
+}
+
+func testResourceDeprecatedUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceDeprecatedDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/test/resource_deprecated_test.go
+++ b/builtin/providers/test/resource_deprecated_test.go
@@ -1,0 +1,71 @@
+package test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+// an empty config should be ok, because no deprecated/removed fields are set.
+func TestResourceDeprecated_empty(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_deprecated" "foo" {
+}
+				`),
+			},
+		},
+	})
+}
+
+// Deprecated fields should still work
+func TestResourceDeprecated_deprecatedOK(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_deprecated" "foo" {
+	map_deprecated = {
+		"a" = "b",
+	}
+	set_block_deprecated {
+		value = "1"
+	}
+	list_block_deprecated {
+		value = "2"
+	}
+}
+				`),
+			},
+		},
+	})
+}
+
+// Declaring an empty block should trigger the error
+func TestResourceDeprecated_removedBlocks(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_deprecated" "foo" {
+	set_block_removed {
+	}
+	list_block_removed {
+	}
+}
+				`),
+				ExpectError: regexp.MustCompile("REMOVED"),
+			},
+		},
+	})
+}

--- a/config/hcl2shim/values.go
+++ b/config/hcl2shim/values.go
@@ -80,6 +80,11 @@ func ConfigValueFromHCL2Block(v cty.Value, schema *configschema.Block) map[strin
 
 		case configschema.NestingList, configschema.NestingSet:
 			l := bv.LengthInt()
+			if l == 0 {
+				// skip empty collections to better mimic how HCL1 would behave
+				continue
+			}
+
 			elems := make([]interface{}, 0, l)
 			for it := bv.ElementIterator(); it.Next(); {
 				_, ev := it.Element()
@@ -92,6 +97,11 @@ func ConfigValueFromHCL2Block(v cty.Value, schema *configschema.Block) map[strin
 			ret[name] = elems
 
 		case configschema.NestingMap:
+			if bv.LengthInt() == 0 {
+				// skip empty collections to better mimic how HCL1 would behave
+				continue
+			}
+
 			elems := make(map[string]interface{})
 			for it := bv.ElementIterator(); it.Next(); {
 				ek, ev := it.Element()

--- a/config/hcl2shim/values_test.go
+++ b/config/hcl2shim/values_test.go
@@ -151,7 +151,7 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 		},
 		{
 			cty.ObjectVal(map[string]cty.Value{
-				"address": cty.ListValEmpty(cty.EmptyObject),
+				"address": cty.ListValEmpty(cty.EmptyObject), // should be omitted altogether in result
 			}),
 			&configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{
@@ -161,9 +161,7 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 					},
 				},
 			},
-			map[string]interface{}{
-				"address": []interface{}{},
-			},
+			map[string]interface{}{},
 		},
 		{
 			cty.ObjectVal(map[string]cty.Value{
@@ -195,9 +193,7 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 					},
 				},
 			},
-			map[string]interface{}{
-				"address": []interface{}{},
-			},
+			map[string]interface{}{},
 		},
 		{
 			cty.ObjectVal(map[string]cty.Value{
@@ -229,9 +225,7 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 					},
 				},
 			},
-			map[string]interface{}{
-				"address": map[string]interface{}{},
-			},
+			map[string]interface{}{},
 		},
 		{
 			cty.NullVal(cty.EmptyObject),
@@ -240,8 +234,8 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		t.Run(fmt.Sprintf("%d-%#v", i, test.Input), func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%#v", test.Input), func(t *testing.T) {
 			got := ConfigValueFromHCL2Block(test.Input, test.Schema)
 			if !reflect.DeepEqual(got, test.Want) {
 				t.Errorf("wrong result\ninput: %#v\ngot:   %#v\nwant:  %#v", test.Input, got, test.Want)


### PR DESCRIPTION
Later changes have removed the need to add empty blocks to the config. Remove the empty blocks so we don't need to filter them out when helper/schema isn't expecting them.

Make sure ReadResource shims the state in the same manner as ApplyResourceChange.

#19955