### PR TITLE
command/format: Ignore removal of empty strings

### DIFF
--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -50,6 +50,27 @@ func TestResourceChange_primitiveTypes(t *testing.T) {
     }
 `,
 		},
+		"deletion (empty string)": {
+			Action: plans.Delete,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":                 cty.StringVal("i-02ae66f368e8518a9"),
+				"intentionally_long": cty.StringVal(""),
+			}),
+			After: cty.NullVal(cty.EmptyObject),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":                 {Type: cty.String, Computed: true},
+					"intentionally_long": {Type: cty.String, Optional: true},
+				},
+			},
+			RequiredReplace: cty.NewPathSet(),
+			ExpectedOutput: `  # test_instance.example will be destroyed
+  - resource "test_instance" "example" {
+      - id = "i-02ae66f368e8518a9" -> null
+    }
+`,
+		},
 		"string in-place update": {
 			Action: plans.Update,
 			Mode:   addrs.ManagedResourceMode,


### PR DESCRIPTION
Example plan below gets reduced this way by 4 fields/lines.  🎉 🚿 

### Before

<img width="836" alt="screen shot 2019-01-13 at 23 01 39" src="https://user-images.githubusercontent.com/287584/51091798-5f652a00-1787-11e9-88ee-bfdd9206d8f7.png">

### After

<img width="836" alt="screen shot 2019-01-13 at 23 02 46" src="https://user-images.githubusercontent.com/287584/51091801-67bd6500-1787-11e9-9dd6-6c2d97fabf74.png">
