### PR TITLE
states/statemgr: Avoid HTML escaping when printing LockInfo

### DIFF
--- a/states/statemgr/locker.go
+++ b/states/statemgr/locker.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
 	"math/rand"
 	"os"
 	"os/user"
 	"strings"
+	"text/template"
 	"time"
 
 	uuid "github.com/hashicorp/go-uuid"


### PR DESCRIPTION
I assume the intention here was to escape "early" and prevent any potential leakage of HTML-unsafe characters to TFE (or any other UI of that type), but I believe that TFE should just not rely on Terraform, especially when it has the right context to know _when_ to escape.

### Before

![screen shot 2019-01-15 at 11 00 07](https://user-images.githubusercontent.com/287584/51176405-bddbf680-18b4-11e9-8d01-fd6cad65b4aa.png)

### After

![screen shot 2019-01-15 at 10 59 21](https://user-images.githubusercontent.com/287584/51176379-abfa5380-18b4-11e9-81d6-9002aca91298.png)
