### PR TITLE
Fix shims with deeper nested containers

### DIFF
--- a/builtin/providers/test/resource_nested.go
+++ b/builtin/providers/test/resource_nested.go
@@ -56,6 +56,34 @@ func testResourceNested() *schema.Resource {
 					},
 				},
 			},
+			"list_block": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"sub_list_block": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"bool": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"set": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -65,7 +93,18 @@ func testResourceNestedCreate(d *schema.ResourceData, meta interface{}) error {
 	return testResourceNestedRead(d, meta)
 }
 
+func testResourceNestedUpdate(d *schema.ResourceData, meta interface{}) error {
+	return testResourceNestedRead(d, meta)
+}
+
 func testResourceNestedRead(d *schema.ResourceData, meta interface{}) error {
+	set := []map[string]interface{}{map[string]interface{}{
+		"sub_list_block": []map[string]interface{}{map[string]interface{}{
+			"bool": false,
+			"set":  schema.NewSet(schema.HashString, nil),
+		}},
+	}}
+	d.Set("list_block", set)
 	return nil
 }
 

--- a/builtin/providers/test/resource_nested_test.go
+++ b/builtin/providers/test/resource_nested_test.go
@@ -31,6 +31,9 @@ resource "test_resource_nested" "foo" {
 					resource.TestCheckResourceAttr(
 						"test_resource_nested.foo", "nested.1877647874.string", "val",
 					),
+					resource.TestCheckResourceAttr(
+						"test_resource_nested.foo", "list_block.0.sub_list_block.0.bool", "false",
+					),
 				),
 			},
 		},
@@ -195,6 +198,10 @@ resource "test_resource_nested" "foo" {
 						"nested.140280279.string":                       "",
 						"nested.140280279.optional":                     "false",
 						"nested.140280279.nested_again.#":               "0",
+						"list_block.#":                                  "1",
+						"list_block.0.sub_list_block.#":                 "1",
+						"list_block.0.sub_list_block.0.bool":            "false",
+						"list_block.0.sub_list_block.0.set.#":           "0",
 					}
 					delete(got, "id") // it's random, so not useful for testing
 


### PR DESCRIPTION
Since ResourceData and schemaMap themselves don't always agree on what the state should look like, run the final applied state through a round trip in the shims to try and get a stable value. The output from `ApplyResourceChange` may not have been invalid, but it needs to agree with what the next `PlanResourceChange` produces. 

Fixes #19754 (that test will still fail due to an import error, but that will be addressed in a later PR)