### PR TITLE
Remove duplicate discovery logging

### DIFF
--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -190,9 +190,6 @@ func (i *ProviderInstaller) Get(provider string, req Constraints) (PluginMeta, e
 	downloadURLs, err := i.listProviderDownloadURLs(providerSource, versionMeta.Version)
 	providerURL := downloadURLs.DownloadURL
 
-	i.Ui.Info(fmt.Sprintf("- Downloading plugin for provider %q (%s)...", provider, versionMeta.Version))
-	log.Printf("[DEBUG] getting provider %q version %q", provider, versionMeta.Version)
-
 	if !i.SkipVerify {
 		sha256, err := i.getProviderChecksum(downloadURLs)
 		if err != nil {


### PR DESCRIPTION
During provider discovery, the provider is logged twice
1. https://github.com/hashicorp/terraform/blob/30eead2df5028805c980bbd0134a3fa28cc0262c/plugin/discovery/get.go#L193
2. https://github.com/hashicorp/terraform/blob/30eead2df5028805c980bbd0134a3fa28cc0262c/plugin/discovery/get.go#L209
![image](https://user-images.githubusercontent.com/6362111/51211679-e9260c00-18db-11e9-8d86-77950f852a71.png)

Removes the first print since the second one includes more information (the expanded namespace/name)