### PR TITLE
Change import message to 'prepared'

### DIFF
--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -319,7 +319,7 @@ func (h *UiHook) PostImportState(addr addrs.AbsResourceInstance, imported []prov
 		"[reset][bold][green]%s: Import prepared!", addr)))
 	for _, s := range imported {
 		h.ui.Output(h.Colorize.Color(fmt.Sprintf(
-			"[reset][green]  Prepared %s",
+			"[reset][green]  Prepared %s for import",
 			s.TypeName,
 		)))
 	}

--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -316,10 +316,10 @@ func (h *UiHook) PostImportState(addr addrs.AbsResourceInstance, imported []prov
 	h.once.Do(h.init)
 
 	h.ui.Output(h.Colorize.Color(fmt.Sprintf(
-		"[reset][bold][green]%s: Import complete!", addr)))
+		"[reset][bold][green]%s: Import prepared!", addr)))
 	for _, s := range imported {
 		h.ui.Output(h.Colorize.Color(fmt.Sprintf(
-			"[reset][green]  Imported %s",
+			"[reset][green]  Prepared %s",
 			s.TypeName,
 		)))
 	}


### PR DESCRIPTION
Fixes #20017 

Changes proposed:
* hook_ui: Change the "Import complete!" message to "Import prepared!" and then list resources as "prepared" instead of "imported".