### PR TITLE
command/show: add support for -json output for state

### DIFF
--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -9,6 +9,8 @@ import (
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/command/jsonconfig"
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/terraform"
@@ -107,7 +109,7 @@ func newState() *state {
 	}
 }
 
-// Marshal returns the json encoding of a terraform plan.
+// Marshal returns the json encoding of a terraform state.
 func Marshal(s *states.State, schemas *terraform.Schemas) ([]byte, error) {
 	if s.Empty() {
 		return nil, nil
@@ -122,6 +124,34 @@ func Marshal(s *states.State, schemas *terraform.Schemas) ([]byte, error) {
 	}
 
 	ret, err := json.Marshal(output)
+	return ret, err
+}
+
+// MarshalWithConfig returns the json encoding of terraform state along with the
+// current terraform configuration.
+func MarshalWithConfig(s *states.State, schemas *terraform.Schemas, c *configs.Config) ([]byte, error) {
+	if s.Empty() {
+		return nil, nil
+	}
+
+	jsonstate, err := Marshal(s, schemas)
+	if err != nil {
+		return nil, err
+	}
+	jsonconfig, err := jsonconfig.Marshal(c, schemas)
+	if err != nil {
+		return nil, err
+	}
+
+	output := struct {
+		State  json.RawMessage `json:"state"`
+		Config json.RawMessage `json:"config"`
+	}{
+		jsonstate,
+		jsonconfig,
+	}
+
+	ret, err := json.MarshalIndent(output, "", "  ")
 	return ret, err
 }
 

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -95,10 +95,7 @@ func marshalAttributeValues(value cty.Value, schema *configschema.Block) attribu
 	it := value.ElementIterator()
 	for it.Next() {
 		k, v := it.Element()
-		vJSON, err := ctyjson.Marshal(v, v.Type())
-		if err != nil {
-			return ret, err
-		}
+		vJSON, _ := ctyjson.Marshal(v, v.Type())
 		ret[k.AsString()] = json.RawMessage(vJSON)
 	}
 	return ret

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -9,8 +9,6 @@ import (
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/hashicorp/terraform/addrs"
-	"github.com/hashicorp/terraform/command/jsonconfig"
-	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/terraform"
@@ -121,34 +119,6 @@ func Marshal(s *states.State, schemas *terraform.Schemas) ([]byte, error) {
 	err := output.marshalStateValues(s, schemas)
 	if err != nil {
 		return nil, err
-	}
-
-	ret, err := json.Marshal(output)
-	return ret, err
-}
-
-// MarshalWithConfig returns the json encoding of terraform state along with the
-// current terraform configuration.
-func MarshalWithConfig(s *states.State, schemas *terraform.Schemas, c *configs.Config) ([]byte, error) {
-	if s.Empty() {
-		return nil, nil
-	}
-
-	jsonstate, err := Marshal(s, schemas)
-	if err != nil {
-		return nil, err
-	}
-	jsonconfig, err := jsonconfig.Marshal(c, schemas)
-	if err != nil {
-		return nil, err
-	}
-
-	output := struct {
-		State  json.RawMessage `json:"state"`
-		Config json.RawMessage `json:"config"`
-	}{
-		jsonstate,
-		jsonconfig,
 	}
 
 	ret, err := json.MarshalIndent(output, "", "  ")

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -95,7 +95,11 @@ func marshalAttributeValues(value cty.Value, schema *configschema.Block) attribu
 	it := value.ElementIterator()
 	for it.Next() {
 		k, v := it.Element()
-		ret[k.AsString()] = v
+		vJSON, err := ctyjson.Marshal(v, v.Type())
+		if err != nil {
+			return ret, err
+		}
+		ret[k.AsString()] = json.RawMessage(vJSON)
 	}
 	return ret
 }

--- a/command/show.go
+++ b/command/show.go
@@ -160,8 +160,7 @@ func (c *ShowCommand) Run(args []string) int {
 	}
 
 	if jsonOutput == true {
-		config := ctx.Config()
-		jsonState, err := jsonstate.MarshalWithConfig(state, schemas, config)
+		jsonState, err := jsonstate.Marshal(state, schemas)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Failed to marshal state to json: %s", err))
 			return 1


### PR DESCRIPTION
I added a function to jsonstate, MarshalWithConfig, to return a
structure that included both state and config. Naming things is hard, as
always, and I also considered 'PrettyMarshal', but that did not indicate
that this would include state and config. I am gleefully open to
suggestions on better names.
