### PR TITLE
Bump protocol version to 5

### DIFF
--- a/command/import_test.go
+++ b/command/import_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/helper/copy"
-	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/terraform"
@@ -804,7 +803,7 @@ func TestImport_pluginDir(t *testing.T) {
 			Ui:         cli.NewMockUi(),
 		},
 		providerInstaller: &discovery.ProviderInstaller{
-			PluginProtocolVersion: plugin.Handshake.ProtocolVersion,
+			PluginProtocolVersion: discovery.PluginInstallProtocolVersion,
 		},
 	}
 	if code := initCmd.Run(nil); code != 0 {

--- a/command/init.go
+++ b/command/init.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform/configs/configupgrade"
 	"github.com/hashicorp/terraform/internal/earlyconfig"
 	"github.com/hashicorp/terraform/internal/initwd"
-	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/terraform"
@@ -85,7 +84,7 @@ func (c *InitCommand) Run(args []string) int {
 		c.providerInstaller = &discovery.ProviderInstaller{
 			Dir:                   c.pluginDir(),
 			Cache:                 c.pluginCache(),
-			PluginProtocolVersion: plugin.Handshake.ProtocolVersion,
+			PluginProtocolVersion: discovery.PluginInstallProtocolVersion,
 			SkipVerify:            !flagVerifyPlugins,
 			Ui:                    c.Ui,
 			Services:              c.Services,

--- a/plugin/discovery/requirements.go
+++ b/plugin/discovery/requirements.go
@@ -4,6 +4,12 @@ import (
 	"bytes"
 )
 
+// PluginInstallProtocolVersion is the protocol version TF-core
+// supports to communicate with servers, and is used to resolve
+// plugin discovery with terraform registry, in addition to
+// any specified plugin version constraints
+const PluginInstallProtocolVersion = 5
+
 // PluginRequirements describes a set of plugins (assumed to be of a consistent
 // kind) that are required to exist and have versions within the given
 // corresponding sets.

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -7,11 +7,18 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-// The constants below are the names of the plugins that can be dispensed
-// from the plugin server.
 const (
+	// The constants below are the names of the plugins that can be dispensed
+	// from the plugin server.
 	ProviderPluginName    = "provider"
 	ProvisionerPluginName = "provisioner"
+
+	// DefaultProtocolVersion is the protocol version assumed for legacy clients that don't specify
+	// a particular version during their handshake. This is the version used when Terraform 0.10
+	// and 0.11 launch plugins that were built with support for both versions 4 and 5, and must
+	// stay unchanged at 4 until we intentionally build plugins that are not compatible with 0.10 and
+	// 0.11.
+	DefaultProtocolVersion = 4
 )
 
 // Handshake is the HandshakeConfig used to configure clients and servers.
@@ -21,7 +28,7 @@ var Handshake = plugin.HandshakeConfig{
 	// one or the other that makes it so that they can't safely communicate.
 	// This could be adding a new interface value, it could be how
 	// helper/schema computes diffs, etc.
-	ProtocolVersion: 4,
+	ProtocolVersion: DefaultProtocolVersion,
 
 	// The magic cookie values should NEVER be changed.
 	MagicCookieKey:   "TF_PLUGIN_MAGIC_COOKIE",

--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -14,7 +14,6 @@ import (
 	"io"
 
 	getter "github.com/hashicorp/go-getter"
-	"github.com/hashicorp/terraform/plugin"
 	discovery "github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/mitchellh/cli"
 )
@@ -150,12 +149,13 @@ func (c *PackageCommand) Run(args []string) int {
 		// FIXME: This is incorrect because it uses the protocol version of
 		// this tool, rather than of the Terraform binary we just downloaded.
 		// But we can't get this information from a Terraform binary, so
-		// we'll just ignore this for now as we only have one protocol version
-		// in play anyway. If a new protocol version shows up later we will
-		// probably deal with this by just matching version ranges and
-		// hard-coding the knowledge of which Terraform version uses which
-		// protocol version.
-		PluginProtocolVersion: plugin.Handshake.ProtocolVersion,
+		// we'll just ignore this for now and use the same plugin installer
+		// protocol version for terraform-bundle as the terraform shipped
+		// with this release.
+		//
+		// NOTE: To target older versions of terraform, use the terraform-bundle
+		// from the same tag.
+		PluginProtocolVersion: discovery.PluginInstallProtocolVersion,
 
 		OS:   osName,
 		Arch: archName,


### PR DESCRIPTION
Provider installer has been relying on the server protocol to resolve plugin protocol compatibility during discovery, which was protocol 4. This PR updates the installer to filter on protocol `5` instead
* Separates TF client protocol from referencing server protocol
* Bumps TF client protocol to 5
* Keeps default server protocol to 4
* Bumps `terraform-bundle` protocol to 5 for plugin discovery

**Note**: to target bundling an older terraform version, use the `terraform-bundle` of the same release or tag