### PR TITLE
command: Update "terraform get" to use the new module installer

### DIFF
--- a/command/get.go
+++ b/command/get.go
@@ -1,10 +1,9 @@
 package command
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform/config/module"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // GetCommand is a Command implementation that takes a Terraform
@@ -34,13 +33,11 @@ func (c *GetCommand) Run(args []string) int {
 		return 1
 	}
 
-	mode := module.GetModeGet
-	if update {
-		mode = module.GetModeUpdate
-	}
+	path = c.normalizePath(path)
 
-	if err := getModules(&c.Meta, path, mode); err != nil {
-		c.Ui.Error(err.Error())
+	diags := getModules(&c.Meta, path, update)
+	c.showDiagnostics(diags)
+	if diags.HasErrors() {
 		return 1
 	}
 
@@ -61,10 +58,10 @@ Usage: terraform get [options] PATH
 
 Options:
 
-  -update=false       If true, modules already downloaded will be checked
-                      for updates and updated if necessary.
+  -update             Check already-downloaded modules for available updates
+                      and install the newest versions available.
 
-  -no-color           If specified, output won't contain any color.
+  -no-color           Disable text coloring in the output.
 
 `
 	return strings.TrimSpace(helpText)
@@ -74,16 +71,10 @@ func (c *GetCommand) Synopsis() string {
 	return "Download and install modules for the configuration"
 }
 
-func getModules(m *Meta, path string, mode module.GetMode) error {
-	mod, err := module.NewTreeModule("", path)
-	if err != nil {
-		return fmt.Errorf("Error loading configuration: %s", err)
+func getModules(m *Meta, path string, upgrade bool) tfdiags.Diagnostics {
+	hooks := uiModuleInstallHooks{
+		Ui:             m.Ui,
+		ShowLocalPaths: true,
 	}
-
-	err = mod.Load(m.moduleStorage(m.DataDir(), mode))
-	if err != nil {
-		return fmt.Errorf("Error loading modules: %s", err)
-	}
-
-	return nil
+	return m.installModules(path, upgrade, hooks)
 }

--- a/command/get_test.go
+++ b/command/get_test.go
@@ -30,10 +30,7 @@ func TestGet(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "module.foo") {
-		t.Fatalf("doesn't look like get: %s", output)
-	}
-	if strings.Contains(output, "(update)") {
+	if !strings.Contains(output, "- foo in") {
 		t.Fatalf("doesn't look like get: %s", output)
 	}
 }
@@ -78,10 +75,7 @@ func TestGet_noArgs(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "module.foo") {
-		t.Fatalf("doesn't look like get: %s", output)
-	}
-	if strings.Contains(output, "(update)") {
+	if !strings.Contains(output, "- foo in") {
 		t.Fatalf("doesn't look like get: %s", output)
 	}
 }
@@ -108,7 +102,7 @@ func TestGet_update(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `Updating source "./foo"`) {
+	if !strings.Contains(output, `- foo in`) {
 		t.Fatalf("doesn't look like get: %s", output)
 	}
 }


### PR DESCRIPTION
We missed this on the initial update pass because this was calling directly into the module package API rather than going through the `Meta` methods that we updated for the new config loader.

`m.installModules` here is the same method that `terraform init` is using for this purpose, ensuring the two will behave the same way. This changes the output a little compared to the old installer, but it still includes
the important information about where each module is coming from.

This fixes #20024.