### PR TITLE
core: Retain prior state if update fails with no new state

### DIFF
--- a/terraform/test-fixtures/apply-issue19908/issue19908.tf
+++ b/terraform/test-fixtures/apply-issue19908/issue19908.tf
@@ -1,0 +1,3 @@
+resource "test" "foo" {
+  baz = "updated"
+}


### PR DESCRIPTION
In an ideal world, providers are supposed to respond to errors during apply by returning a partial new state alongside the error diagnostics. In practice though, our SDK leaves the new value set to nil for certain errors, which was causing Terraform to "forget" the object altogether by assuming that the provider intended to say "null".

We now adjust that assumption to apply only in the delete case. In all other cases (including updates) we retain the prior state if the new state is given as nil. Although we could potentially fix this in the SDK itself, I expect this is a likely bug in other future SDKs for other languages too, so this new assumption is a safer one to make to be resilient to data loss when providers don't behave perfectly.

Providers that return both nil new value and no errors are considered buggy, but unfortunately that applies to the mocks in many of our tests, so for pragmatic reasons we can't generate an error for that case as we do for other "should never happen" situations. Instead, we'll just retain the prior value in the state so the user can retry.

This fixes #19908.