### PR TITLE
backend: Undeclared variables in -var-file is a warning, not an error

### DIFF
--- a/backend/unparsed_value.go
+++ b/backend/unparsed_value.go
@@ -48,10 +48,18 @@ func ParseVariableValues(vv map[string]UnparsedVariableValue, decls map[string]*
 			case terraform.ValueFromConfig, terraform.ValueFromAutoFile, terraform.ValueFromNamedFile:
 				// These source types have source ranges, so we can produce
 				// a nice error message with good context.
+				//
+				// This one is a warning for now because there is an existing
+				// pattern of providing a file containing the superset of
+				// variables across all configurations in an organization. This
+				// is deprecated in v0.12.0 because it's more important to give
+				// feedback to users who make typos. Those using this approach
+				// should migrate to using environment variables instead before
+				// this becomes an error in a future major release.
 				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
+					Severity: hcl.DiagWarning,
 					Summary:  "Value for undeclared variable",
-					Detail:   fmt.Sprintf("The root module does not declare a variable named %q. To use this value, add a \"variable\" block to the configuration.", name),
+					Detail:   fmt.Sprintf("The root module does not declare a variable named %q. To use this value, add a \"variable\" block to the configuration.\n\nUsing a variables file to set an undeclared variable is deprecated and will become an error in a future release. If you wish to provide certain \"global\" settings to all configurations in your organization, use TF_VAR_... environment variables to set these instead.", name),
 					Subject:  val.SourceRange.ToHCL().Ptr(),
 				})
 			case terraform.ValueFromEnvVar:


### PR DESCRIPTION
In Terraform 0.11 and earlier we just silently ignored undeclared variables in `-var-file` and the 
automatically-loaded `.tfvars` files. This was a bad user experience for anyone who made a typo in a variable name and got no feedback about it, so we made this an error for 0.12.

However, several users are now relying on the silent-ignore behavior for automation scenarios where they pass the same `.tfvars` file to all configurations in their organization and expect Terraform to ignore any settings that are not relevant to a specific configuration. We never intentionally supported that, but we don't want to immediately break that workflow during 0.12 upgrade.

As a compromise, then, we'll make this a warning for v0.12.0 that contains a deprecation notice suggesting to move to using environment variables for this "cross-configuration variables" use-case. We don't produce errors for undeclared variables in environment variables, even though that potentially causes the same UX annoyance as ignoring them in vars files, because environment variables are assumed to live in the user's session and this it would be very inconvenient to have to unset such variables when moving between directories. Their "ambientness" makes them a better fit for these automatically-assigned general variable values that may or may not be used by a particular configuration.

This can revert to being an error in a future major release, after users have had the opportunity to migrate their automation solutions over to use environment variables.

We don't seem to have any tests covering this specific situation right now. That isn't ideal, but this change is so straightforward that it would be relatively expensive to build new targeted test cases for it and so I instead just hand-tested that it is indeed now producing a warning where we were previously producing an error. Hopefully if there is any more substantial work done on this codepath in future that will be our prompt to add some unit tests for this.

This closes #19424.
