### PR TITLE
New Diff.Apply method

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -28,6 +28,7 @@ func Provider() terraform.ResourceProvider {
 			"test_resource_state_func":       testResourceStateFunc(),
 			"test_resource_deprecated":       testResourceDeprecated(),
 			"test_resource_defaults":         testResourceDefaults(),
+			"test_resource_list":             testResourceList(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"test_data_source":    testDataSource(),

--- a/builtin/providers/test/resource_defaults_test.go
+++ b/builtin/providers/test/resource_defaults_test.go
@@ -66,9 +66,6 @@ resource "test_resource_defaults" "foo" {
 }
 
 func TestResourceDefaults_import(t *testing.T) {
-	// FIXME: this test fails
-	return
-
 	resource.UnitTest(t, resource.TestCase{
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckResourceDestroy,

--- a/builtin/providers/test/resource_defaults_test.go
+++ b/builtin/providers/test/resource_defaults_test.go
@@ -66,6 +66,10 @@ resource "test_resource_defaults" "foo" {
 }
 
 func TestResourceDefaults_import(t *testing.T) {
+	// FIXME: The ReadResource after ImportResourceState sin't returning the
+	// complete state, yet the later refresh does.
+	return
+
 	resource.UnitTest(t, resource.TestCase{
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckResourceDestroy,

--- a/builtin/providers/test/resource_list.go
+++ b/builtin/providers/test/resource_list.go
@@ -1,0 +1,69 @@
+package test
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceList() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceListCreate,
+		Read:   testResourceListRead,
+		Update: testResourceListUpdate,
+		Delete: testResourceListDelete,
+
+		Schema: map[string]*schema.Schema{
+			"list_block": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"string": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"int": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"sublist_block": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"string": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"int": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testResourceListCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("testId")
+	return nil
+}
+
+func testResourceListRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceListUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceListDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/test/resource_list_test.go
+++ b/builtin/providers/test/resource_list_test.go
@@ -1,0 +1,114 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+// an empty config should be ok, because no deprecated/removed fields are set.
+func TestResourceList_changed(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "foo" {
+	list_block {
+		string = "a"
+		int = 1
+	}
+
+	list_block {
+		string = "b"
+		int = 2
+	}
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.#", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.0.string", "a",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.0.int", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.1.string", "b",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.1.int", "2",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "foo" {
+	list_block {
+		string = "a"
+		int = 1
+	}
+
+	list_block {
+		string = "c"
+		int = 2
+	}
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.#", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.0.string", "a",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.0.int", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.1.string", "c",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.1.int", "2",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestResourceList_sublist(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "foo" {
+	list_block {
+		sublist_block {
+			string = "a"
+			int = 1
+		}
+	}
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.0.sublist_block.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.0.sublist_block.0.string", "a",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.0.sublist_block.0.int", "1",
+					),
+				),
+			},
+		},
+	})
+}

--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -513,16 +513,6 @@ func (s *GRPCProviderServer) PlanResourceChange(_ context.Context, req *proto.Pl
 		return resp, nil
 	}
 
-	if diff != nil {
-		// strip out non-diffs
-		for k, v := range diff.Attributes {
-			if v.New == v.Old && !v.NewComputed {
-				delete(diff.Attributes, k)
-			}
-		}
-
-	}
-
 	if diff == nil || len(diff.Attributes) == 0 {
 		// schema.Provider.Diff returns nil if it ends up making a diff with no
 		// changes, but our new interface wants us to return an actual change
@@ -950,6 +940,8 @@ func normalizeFlatmapContainers(prior map[string]string, attrs map[string]string
 		// schema.
 		if isCount(k) && v == "1" {
 			ones[k] = true
+			// make sure we don't have the same key under both categories.
+			delete(zeros, k)
 		}
 	}
 

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -297,14 +297,14 @@ func newResourceConfigShimmedComputedKeys(obj cty.Value, schema *configschema.Bl
 			i := 0
 			for it := blockVal.ElementIterator(); it.Next(); i++ {
 				_, subVal := it.Element()
-				subPrefix := fmt.Sprintf("%s%d.", prefix, i)
+				subPrefix := fmt.Sprintf("%s.%s%d.", typeName, prefix, i)
 				keys := newResourceConfigShimmedComputedKeys(subVal, &blockS.Block, subPrefix)
 				ret = append(ret, keys...)
 			}
 		case configschema.NestingMap:
 			for it := blockVal.ElementIterator(); it.Next(); {
 				subK, subVal := it.Element()
-				subPrefix := fmt.Sprintf("%s%s.", prefix, subK.AsString())
+				subPrefix := fmt.Sprintf("%s.%s%s.", typeName, prefix, subK.AsString())
 				keys := newResourceConfigShimmedComputedKeys(subVal, &blockS.Block, subPrefix)
 				ret = append(ret, keys...)
 			}


### PR DESCRIPTION
The previous version assumed the diff could be applied verbatim, and
only used the schema at the top level since diffs are "flat". This
turned out to not work reliably with nested blocks. The new Apply method
is driven completely by the schema, and handles nested blocks separately
from other collections.