### PR TITLE
config/hcl2shim: ValuesSDKEquivalent float64 comparison of numbers

### DIFF
--- a/config/hcl2shim/values_equiv_test.go
+++ b/config/hcl2shim/values_equiv_test.go
@@ -2,12 +2,19 @@ package hcl2shim
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/zclconf/go-cty/cty"
 )
 
 func TestValuesSDKEquivalent(t *testing.T) {
+	piBig, _, err := big.ParseFloat("3.14159265358979323846264338327950288419716939937510582097494459", 10, 512, big.ToZero)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pi64, _ := piBig.Float64()
+
 	tests := []struct {
 		A, B cty.Value
 		Want bool
@@ -53,6 +60,21 @@ func TestValuesSDKEquivalent(t *testing.T) {
 		{
 			cty.NullVal(cty.Number),
 			cty.Zero,
+			true,
+		},
+		{
+			cty.NumberVal(piBig),
+			cty.Zero,
+			false,
+		},
+		{
+			cty.NumberFloatVal(pi64),
+			cty.Zero,
+			false,
+		},
+		{
+			cty.NumberFloatVal(pi64),
+			cty.NumberVal(piBig),
 			true,
 		},
 


### PR DESCRIPTION
The SDK uses only the native `int` and `float64` types internally for values that are specified as being "number" in schema, so for SDK purposes only a `float64` level of precision is significant.

To avoid any weirdness introduced as we shim and un-shim numbers, we'll reduce floating point numbers to `float64` precision before comparing them to try to mimic the result the SDK itself would've gotten from comparing its own `float64` versions of these values using the Go `==` operator.