### PR TITLE
backend/remote: make sure we show the correct error

### DIFF
--- a/svchost/disco/host.go
+++ b/svchost/disco/host.go
@@ -30,8 +30,8 @@ type Constraints struct {
 	Service   string   `json:"service"`
 	Product   string   `json:"product"`
 	Minimum   string   `json:"minimum"`
-	Excluding []string `json:"excluding"`
 	Maximum   string   `json:"maximum"`
+	Excluding []string `json:"excluding"`
 }
 
 // ErrServiceNotProvided is returned when the service is not provided.


### PR DESCRIPTION
Previously we would show two errors when there was a version constraint
error. But of course one is enough.