### PR TITLE
command/format: Add test to cover update of sensitive field

### DIFF
--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -240,6 +240,35 @@ new line
     }
 `,
 		},
+		"update with equal sensitive field": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":       cty.StringVal("blah"),
+				"str":      cty.StringVal("before"),
+				"password": cty.StringVal("top-secret"),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":       cty.UnknownVal(cty.String),
+				"str":      cty.StringVal("after"),
+				"password": cty.StringVal("top-secret"),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":       {Type: cty.String, Computed: true},
+					"str":      {Type: cty.String, Optional: true},
+					"password": {Type: cty.String, Optional: true, Sensitive: true},
+				},
+			},
+			RequiredReplace: cty.NewPathSet(),
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id       = "blah" -> (known after apply)
+        password = (sensitive value)
+      ~ str      = "before" -> "after"
+    }
+`,
+		},
 	}
 
 	runTestCases(t, testCases)


### PR DESCRIPTION
This is a test case which would fail in `0.11` where we just simply rendered all sensitive fields as changed when any other field in the resource was being changed.

https://github.com/hashicorp/terraform/blob/ac4fff416318bf0915a0ab80e062a99ef3724334/command/format/plan.go#L316-L318

The behaviour seems to have been fixed at some point during the 0.12 overhaul I guess, so this will just ensure we won't reintroduce the same bug ever again.