### PR TITLE
handle empty map values

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -29,6 +29,7 @@ func Provider() terraform.ResourceProvider {
 			"test_resource_deprecated":       testResourceDeprecated(),
 			"test_resource_defaults":         testResourceDefaults(),
 			"test_resource_list":             testResourceList(),
+			"test_resource_map":              testResourceMap(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"test_data_source":    testDataSource(),

--- a/builtin/providers/test/resource_map.go
+++ b/builtin/providers/test/resource_map.go
@@ -1,0 +1,52 @@
+package test
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceMap() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceMapCreate,
+		Read:   testResourceMapRead,
+		Update: testResourceMapUpdate,
+		Delete: testResourceMapDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"map_of_three": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func testResourceMapCreate(d *schema.ResourceData, meta interface{}) error {
+	// make sure all elements are passed to the map
+	m := d.Get("map_of_three").(map[string]interface{})
+	if len(m) != 3 {
+		return fmt.Errorf("expected 3 map values, got %#v\n", m)
+	}
+
+	d.SetId("testId")
+	return nil
+}
+
+func testResourceMapRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceMapUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceMapDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/test/resource_map_test.go
+++ b/builtin/providers/test/resource_map_test.go
@@ -1,0 +1,32 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestResourceMap_basic(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "test_resource_map" "foobar" {
+	name = "test"
+	map_of_three = {
+		one   = "one"
+		two   = "two"
+		empty = ""
+	}
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_map.foobar", "map_of_three.empty", "",
+					),
+				),
+			},
+		},
+	})
+}

--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -697,13 +697,6 @@ func (s *GRPCProviderServer) ApplyResourceChange(_ context.Context, req *proto.A
 		}
 	}
 
-	// strip out non-diffs
-	for k, v := range diff.Attributes {
-		if v.New == v.Old && !v.NewComputed && !v.NewRemoved {
-			delete(diff.Attributes, k)
-		}
-	}
-
 	// add NewExtra Fields that may have been stored in the private data
 	if newExtra := private[newExtraKey]; newExtra != nil {
 		for k, v := range newExtra.(map[string]interface{}) {

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -554,12 +554,10 @@ func (d *InstanceDiff) blockDiff(path []string, attrs map[string]string, schema 
 					}
 
 					// this must be a diff to keep
-
 					keep = true
 					break
 				}
 				if !keep {
-
 					delete(candidateKeys, k)
 				}
 			}
@@ -772,7 +770,7 @@ func (d *InstanceDiff) applyCollectionDiff(path []string, attrs map[string]strin
 
 	// Don't trust helper/schema to return a valid count, or even have one at
 	// all.
-	result[idx] = countFlatmapContainerValues(name+"."+idx, result)
+	result[name+"."+idx] = countFlatmapContainerValues(name+"."+idx, result)
 	return result, nil
 }
 


### PR DESCRIPTION
We stopped removing non-diff values in Plan, but forgot Apply. Our new diff handling no longer requires stripping the empty diffs out, and providers may be relying on some of the empty-value quirks in helper/schema.


Added a new test and verify that this fixes #19757