### PR TITLE
Copy TF version to helper/schema provider

### DIFF
--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -390,6 +390,8 @@ func (s *GRPCProviderServer) Configure(_ context.Context, req *proto.Configure_R
 		return resp, nil
 	}
 
+	s.provider.TerraformVersion = req.TerraformVersion
+
 	config := terraform.NewResourceConfigShimmed(configVal, block)
 	err = s.provider.Configure(config)
 	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -64,6 +64,8 @@ type Provider struct {
 	stopCtx       context.Context
 	stopCtxCancel context.CancelFunc
 	stopOnce      sync.Once
+
+	TerraformVersion string
 }
 
 // ConfigureFunc is the function used to configure a Provider.


### PR DESCRIPTION
Quick PR to plumb `terraform_version` from the protobuf on to the actual provider values prior to configure being called.