### PR TITLE
command/test: Clarify failure (add full path)

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -85,7 +85,8 @@ func TestInit_fromModule_explicitDest(t *testing.T) {
 		// is causing a terraform.tfstate to get left behind in our directory
 		// here, which can interfere with our init process in a way that
 		// isn't relevant to this test.
-		t.Fatalf("some other test has left terraform.tfstate behind")
+		fullPath, _ := filepath.Abs(DefaultStateFilename)
+		t.Fatalf("some other test has left terraform.tfstate behind:\n%s", fullPath)
 	}
 
 	args := []string{


### PR DESCRIPTION
Somehow I keep running into this failure and I think the message is not making it immediately obvious where to look for the offending `terraform.tfstate`, so I think printing full path might help.