### PR TITLE
helper/schema: Add "part" to ConflictsWith validation error

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -674,7 +674,7 @@ func (m schemaMap) InternalValidate(topSchemaMap schemaMap) error {
 
 					var ok bool
 					if target, ok = sm[part]; !ok {
-						return fmt.Errorf("%s: ConflictsWith references unknown attribute (%s)", k, key)
+						return fmt.Errorf("%s: ConflictsWith references unknown attribute (%s) at part (%s)", k, key, part)
 					}
 
 					if subResource, ok := target.Elem.(*Resource); ok {


### PR DESCRIPTION
Small update to include the "part" in the error message for people doing nested resources.

There didn't seem to be any change needed in the unittests.