### PR TITLE
Improve list block handling in diff application

### DIFF
--- a/builtin/providers/test/resource_list_test.go
+++ b/builtin/providers/test/resource_list_test.go
@@ -20,6 +20,27 @@ resource "test_resource_list" "foo" {
 		string = "a"
 		int = 1
 	}
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.0.string", "a",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.0.int", "1",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "foo" {
+	list_block {
+		string = "a"
+		int = 1
+	}
 
 	list_block {
 		string = "b"

--- a/builtin/providers/test/resource_nested_set_test.go
+++ b/builtin/providers/test/resource_nested_set_test.go
@@ -59,16 +59,6 @@ resource "test_resource_nested_set" "foo" {
 
 // the empty type_list must be passed to the provider with 1 nil element
 func TestResourceNestedSet_emptyBlock(t *testing.T) {
-	checkFunc := func(s *terraform.State) error {
-		root := s.ModuleByPath(addrs.RootModuleInstance)
-		res := root.Resources["test_resource_nested_set.foo"]
-		for k, v := range res.Primary.Attributes {
-			if strings.HasPrefix(k, "type_list") && v != "1" {
-				return fmt.Errorf("unexpected set value: %s:%s", k, v)
-			}
-		}
-		return nil
-	}
 	resource.UnitTest(t, resource.TestCase{
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckResourceDestroy,
@@ -80,7 +70,9 @@ resource "test_resource_nested_set" "foo" {
 	}
 }
 				`),
-				Check: checkFunc,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_nested_set.foo", "type_list.#", "1"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
Values removed from a list are only sometimes present in the diff and marked as `NewRemoved`. When Applying the diff, any change to the list length needs to be taken into account to remove extra elements. 

We also need to remove all `RequiresNew` flags during apply. Terraform is now performing completely separate operations for replace/destroy/create, the diff doesn't need to track this, and if any value as `RequiresNew` set it will cause the resource to drop the pre-existing state.

Fixes #20141

(Should also help with issues like #19760, but those have a couple other blockers which need verifying as well)

