### PR TITLE
command/show: continued work on `terraform show -json` output

### DIFF
--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -34,8 +34,8 @@ type module struct {
 	Outputs map[string]configOutput `json:"outputs,omitempty"`
 	// Resources are sorted in a user-friendly order that is undefined at this
 	// time, but consistent.
-	Resources   []resource   `json:"resources,omitempty"`
-	ModuleCalls []moduleCall `json:"module_calls,omitempty"`
+	Resources   []resource            `json:"resources,omitempty"`
+	ModuleCalls map[string]moduleCall `json:"module_calls,omitempty"`
 }
 
 type moduleCall struct {
@@ -161,8 +161,8 @@ func marshalModule(c *configs.Config, schemas *terraform.Schemas) (module, error
 	return module, nil
 }
 
-func marshalModuleCalls(c *configs.Config, schemas *terraform.Schemas) []moduleCall {
-	var ret []moduleCall
+func marshalModuleCalls(c *configs.Config, schemas *terraform.Schemas) map[string]moduleCall {
+	ret := make(map[string]moduleCall)
 	for _, v := range c.Module.ModuleCalls {
 		mc := moduleCall{
 			ResolvedSource: v.SourceAddr,
@@ -190,7 +190,7 @@ func marshalModuleCalls(c *configs.Config, schemas *terraform.Schemas) []moduleC
 			childModule, _ := marshalModule(cc, schemas)
 			mc.Module = childModule
 		}
-		ret = append(ret, mc)
+		ret[v.Name] = mc
 
 	}
 

--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statefile"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/version"
 )
 
 // FormatVersion represents the version of the json format and will be
@@ -26,8 +27,9 @@ const FormatVersion = "0.1"
 // Plan is the top-level representation of the json format of a plan. It includes
 // the complete config and current state.
 type plan struct {
-	FormatVersion string      `json:"format_version,omitempty"`
-	PlannedValues stateValues `json:"planned_values,omitempty"`
+	FormatVersion    string      `json:"format_version,omitempty"`
+	TerraformVersion string      `json:"terraform_version,omitempty"`
+	PlannedValues    stateValues `json:"planned_values,omitempty"`
 	// ResourceChanges are sorted in a user-friendly order that is undefined at
 	// this time, but consistent.
 	ResourceChanges []resourceChange  `json:"resource_changes,omitempty"`
@@ -83,6 +85,7 @@ func Marshal(
 ) ([]byte, error) {
 
 	output := newPlan()
+	output.TerraformVersion = version.String()
 
 	// output.PlannedValues
 	err := output.marshalPlannedValues(p.Changes, schemas)

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -77,7 +77,7 @@ type resource struct {
 
 	// SchemaVersion indicates which version of the resource type schema the
 	// "values" property conforms to.
-	SchemaVersion uint64 `json:"schema_version,omitempty"`
+	SchemaVersion uint64 `json:"schema_version"`
 
 	// AttributeValues is the JSON representation of the attribute values of the
 	// resource, whose structure depends on the resource type schema. Any


### PR DESCRIPTION
@vancluever - here's the current WIP if you want to test from this branch.

- [X] command/jsonstate: do not hide SchemaVersion of '0'
- [X] command/jsonconfig: module_calls should be a map
- [x] command/jsonconfig: expressions output (work TBD)
- [x] command/jsonplan: "terraform_version" 