### PR TITLE
helper/resource: TestCheckResourceAttrPair allow nonexist

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -1146,14 +1146,17 @@ func TestCheckModuleResourceAttrPair(mpFirst []string, nameFirst string, keyFirs
 }
 
 func testCheckResourceAttrPair(isFirst *terraform.InstanceState, nameFirst string, keyFirst string, isSecond *terraform.InstanceState, nameSecond string, keySecond string) error {
-	vFirst, ok := isFirst.Attributes[keyFirst]
-	if !ok {
-		return fmt.Errorf("%s: Attribute '%s' not found", nameFirst, keyFirst)
+	vFirst, okFirst := isFirst.Attributes[keyFirst]
+	vSecond, okSecond := isSecond.Attributes[keySecond]
+	if okFirst != okSecond {
+		if !okFirst {
+			return fmt.Errorf("%s: Attribute %q not set, but %q is set in %s as %q", nameFirst, keyFirst, keySecond, nameSecond, vSecond)
+		}
+		return fmt.Errorf("%s: Attribute %q is %q, but %q is not set in %s", nameFirst, keyFirst, vFirst, keySecond, nameSecond)
 	}
-
-	vSecond, ok := isSecond.Attributes[keySecond]
-	if !ok {
-		return fmt.Errorf("%s: Attribute '%s' not found", nameSecond, keySecond)
+	if !(okFirst || okSecond) {
+		// If they both don't exist then they are equally unset, so that's okay.
+		return nil
 	}
 
 	if vFirst != vSecond {


### PR DESCRIPTION
This checking helper is frequently used in provider tests for data sources, as a shorthand to verify that an attribute of the data source matches with the corresponding attribute on a managed resource.

Since we now leave empty collections null in more cases, this function is sometimes effectively asked to verify that a given attribute is _unset_ in both the data source and the resource, so here we slightly adjust the definition of the check to consider two nulls to be equal to one another, which at this layer manifests as the keys not being present in the state attributes map at all.

This check function didn't previously have tests, so this commit also adds a basic suite of tests, including coverage for the new behavior.

This fixes #20194.
