### PR TITLE
grammatical updates to comments and docs

### DIFF
--- a/backend/remote-state/s3/client_test.go
+++ b/backend/remote-state/s3/client_test.go
@@ -226,7 +226,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	}
 	client1 := s1.(*remote.State).Client
 
-	// create a old and new state version to persist
+	// create an old and new state version to persist
 	s := state.TestStateInitial()
 	sf := &statefile.File{State: s}
 	var oldState bytes.Buffer

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -1556,7 +1556,7 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 	// Create an alternate output path
 	statePath := "foo.tfstate"
 
-	// put a initial state there that needs to be backed up
+	// put an initial state there that needs to be backed up
 	err = (statemgr.NewFilesystem(statePath)).WriteState(original)
 	if err != nil {
 		t.Fatal(err)

--- a/communicator/communicator.go
+++ b/communicator/communicator.go
@@ -35,7 +35,7 @@ type Communicator interface {
 	// Upload is used to upload a single file
 	Upload(string, io.Reader) error
 
-	// UploadScript is used to upload a file as a executable script
+	// UploadScript is used to upload a file as an executable script
 	UploadScript(string, io.Reader) error
 
 	// UploadDir is used to upload a directory

--- a/config/raw_config_test.go
+++ b/config/raw_config_test.go
@@ -488,7 +488,7 @@ func TestRawConfig_implGob(t *testing.T) {
 	var _ gob.GobEncoder = new(RawConfig)
 }
 
-// verify that RawMap returns a identical copy
+// verify that RawMap returns an identical copy
 func TestNewRawConfig_rawMap(t *testing.T) {
 	raw := map[string]interface{}{
 		"foo": "${var.bar}",

--- a/configs/config.go
+++ b/configs/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	//
 	// This should only be used to display paths to the end-user in rare cases
 	// where we are talking about the static module tree, before module calls
-	// have been resolved. In most cases, a addrs.ModuleInstance describing
+	// have been resolved. In most cases, an addrs.ModuleInstance describing
 	// a node in the dynamic module tree is better, since it will then include
 	// any keys resulting from evaluating "count" and "for_each" arguments.
 	Path addrs.Module

--- a/helper/resource/state.go
+++ b/helper/resource/state.go
@@ -38,7 +38,7 @@ type StateChangeConf struct {
 // specified in the configuration using the specified Refresh() func,
 // waiting the number of seconds specified in the timeout configuration.
 //
-// If the Refresh function returns a error, exit immediately with that error.
+// If the Refresh function returns an error, exit immediately with that error.
 //
 // If the Refresh function returns a state other than the Target state or one
 // listed in Pending, return immediately with an error.

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -367,7 +367,7 @@ func (d *ResourceDiff) Get(key string) interface{} {
 }
 
 // GetChange gets the change between the state and diff, checking first to see
-// if a overridden diff exists.
+// if an overridden diff exists.
 //
 // This implementation differs from ResourceData's in the way that we first get
 // results from the exact levels for the new diff, then from state and diff as

--- a/internal/earlyconfig/config.go
+++ b/internal/earlyconfig/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	//
 	// This should only be used to display paths to the end-user in rare cases
 	// where we are talking about the static module tree, before module calls
-	// have been resolved. In most cases, a addrs.ModuleInstance describing
+	// have been resolved. In most cases, an addrs.ModuleInstance describing
 	// a node in the dynamic module tree is better, since it will then include
 	// any keys resulting from evaluating "count" and "for_each" arguments.
 	Path addrs.Module

--- a/plugin/discovery/meta_set.go
+++ b/plugin/discovery/meta_set.go
@@ -63,7 +63,7 @@ func (s PluginMetaSet) WithName(name string) PluginMetaSet {
 // WithVersion returns the subset of metas that have the given version.
 //
 // This should be used only with the "valid" result from ValidateVersions;
-// it will ignore any plugin metas that have a invalid version strings.
+// it will ignore any plugin metas that have invalid version strings.
 func (s PluginMetaSet) WithVersion(version Version) PluginMetaSet {
 	ns := make(PluginMetaSet)
 	for p := range s {

--- a/website/docs/commands/state/show.html.md
+++ b/website/docs/commands/state/show.html.md
@@ -23,7 +23,7 @@ The attributes are listed in alphabetical order (with the except of "id"
 which is always at the top). They are outputted in a way that is easy
 to parse on the command-line.
 
-This command requires a address that points to a single resource in the
+This command requires an address that points to a single resource in the
 state. Addresses are
 in [resource addressing format](/docs/commands/state/addressing.html).
 


### PR DESCRIPTION
Hi! I noticed a misuse of `a` vs `an` in the documentation. So I did a quick search of similar mistakes and made the corrections here.