### PR TITLE
plugin: Use correct schema when marshaling/unmarshaling imported resource objects

### DIFF
--- a/builtin/providers/test/resource_import_other.go
+++ b/builtin/providers/test/resource_import_other.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -26,23 +28,9 @@ func testResourceImportOther() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
-			"nested": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"string": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "default nested",
-						},
-						"optional": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
+			"computed": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -74,10 +62,13 @@ func testResourceImportOtherUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func testResourceImportOtherRead(d *schema.ResourceData, meta interface{}) error {
+	err := d.Set("computed", "hello!")
+	if err != nil {
+		return fmt.Errorf("failed to set 'computed' attribute: %s", err)
+	}
 	return nil
 }
 
 func testResourceImportOtherDelete(d *schema.ResourceData, meta interface{}) error {
-	d.SetId("")
 	return nil
 }

--- a/builtin/providers/test/resource_import_other_test.go
+++ b/builtin/providers/test/resource_import_other_test.go
@@ -38,6 +38,8 @@ resource "test_resource_import_other" "foo" {
 						return fmt.Errorf("no instance with id import_other_main in state")
 					} else if got, want := is.Ephemeral.Type, "test_resource_import_other"; got != want {
 						return fmt.Errorf("import_other_main has wrong type %q; want %q", got, want)
+					} else if got, want := is.Attributes["computed"], "hello!"; got != want {
+						return fmt.Errorf("import_other_main has wrong value %q for its computed attribute; want %q", got, want)
 					}
 					if is, ok := byID["import_other_other"]; !ok {
 						return fmt.Errorf("no instance with id import_other_other in state")

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/xanzy/ssh-agent v0.2.0
 	github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 // indirect
 	github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
-	github.com/zclconf/go-cty v0.0.0-20190130221141-d7fe3fa0020f
+	github.com/zclconf/go-cty v0.0.0-20190201220620-4ca19710f056
 	go.opencensus.io v0.17.0 // indirect
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6Ut
 github.com/zclconf/go-cty v0.0.0-20181129180422-88fbe721e0f8/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9 h1:hHCAGde+QfwbqXSAqOmBd4NlOrJ6nmjWp+Nu408ezD4=
 github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
-github.com/zclconf/go-cty v0.0.0-20190130221141-d7fe3fa0020f h1:QdzpIo5V8FV8SHsXCXpgSXOquZEF7YozbNcYnEnGZvA=
-github.com/zclconf/go-cty v0.0.0-20190130221141-d7fe3fa0020f/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+github.com/zclconf/go-cty v0.0.0-20190201220620-4ca19710f056 h1:C6LhH3JHz2k6tnw5sYXBc8rD8SD/qFp6EhiZAcVyalk=
+github.com/zclconf/go-cty v0.0.0-20190201220620-4ca19710f056/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 go.opencensus.io v0.17.0 h1:2Cu88MYg+1LU+WVD+NWwYhyP0kKgRlN9QjWGaX0jKTE=
 go.opencensus.io v0.17.0/go.mod h1:mp1VrMQxhlqqDpKvH4UcQUa4YwlzNmymAjPrDdfxNpI=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=

--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -459,8 +459,6 @@ func (p *GRPCProvider) ApplyResourceChange(r providers.ApplyResourceChangeReques
 func (p *GRPCProvider) ImportResourceState(r providers.ImportResourceStateRequest) (resp providers.ImportResourceStateResponse) {
 	log.Printf("[TRACE] GRPCProvider: ImportResourceState")
 
-	resSchema := p.getResourceSchema(r.TypeName)
-
 	protoReq := &proto.ImportResourceState_Request{
 		TypeName: r.TypeName,
 		Id:       r.ID,
@@ -479,6 +477,7 @@ func (p *GRPCProvider) ImportResourceState(r providers.ImportResourceStateReques
 			Private:  imported.Private,
 		}
 
+		resSchema := p.getResourceSchema(resource.TypeName)
 		state := cty.NullVal(resSchema.Block.ImpliedType())
 		if imported.State != nil {
 			state, err = msgpack.Unmarshal(imported.State.Msgpack, resSchema.Block.ImpliedType())

--- a/vendor/github.com/zclconf/go-cty/cty/type_conform.go
+++ b/vendor/github.com/zclconf/go-cty/cty/type_conform.go
@@ -50,23 +50,20 @@ func testConformance(given Type, want Type, path Path, errs *[]error) {
 		givenAttrs := given.AttributeTypes()
 		wantAttrs := want.AttributeTypes()
 
-		if len(givenAttrs) != len(wantAttrs) {
-			// Something is missing from one of them.
-			for k := range givenAttrs {
-				if _, exists := wantAttrs[k]; !exists {
-					*errs = append(
-						*errs,
-						errorf(path, "unsupported attribute %q", k),
-					)
-				}
+		for k := range givenAttrs {
+			if _, exists := wantAttrs[k]; !exists {
+				*errs = append(
+					*errs,
+					errorf(path, "unsupported attribute %q", k),
+				)
 			}
-			for k := range wantAttrs {
-				if _, exists := givenAttrs[k]; !exists {
-					*errs = append(
-						*errs,
-						errorf(path, "missing required attribute %q", k),
-					)
-				}
+		}
+		for k := range wantAttrs {
+			if _, exists := givenAttrs[k]; !exists {
+				*errs = append(
+					*errs,
+					errorf(path, "missing required attribute %q", k),
+				)
 			}
 		}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -482,7 +482,7 @@ github.com/vmihailenco/msgpack/codes
 github.com/xanzy/ssh-agent
 # github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
 github.com/xlab/treeprint
-# github.com/zclconf/go-cty v0.0.0-20190130221141-d7fe3fa0020f
+# github.com/zclconf/go-cty v0.0.0-20190201220620-4ca19710f056
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/convert


### PR DESCRIPTION
Previously we were using the type name requested in the import to select the schema, but a provider is free to return additional objects of other types as part of an import result, and so it's important that we perform schema selection separately for each returned object.

If we don't do this, we get confusing downstream errors where the resulting object decodes to the wrong type and breaks various invariants expected by Terraform Core.

The `testResourceImportOther` test in the test provider didn't catch this previously because it happened to have an identical schema to the other resource type being imported. Now the schema is changed and also there's a computed attribute we can set as part of the refresh phase to make sure we're completing the `Read` call properly during import. Refresh _was_ working correctly, but we didn't have any tests for it as part of the import flow in the test provider.

This fixes #20186. That originally appeared as a panic during refresh due to a bug in `cty`, which is also fixed by the vendor update in this PR. Fixing the `cty` crash then exposed the marshaling bug we're fixing here.
