### PR TITLE
build: Periodic refresh of our go.googlesource.com cookie

### DIFF
--- a/scripts/gogetcookie.sh
+++ b/scripts/gogetcookie.sh
@@ -4,5 +4,5 @@ chmod 0600 ~/.gitcookies
 git config --global http.cookiefile ~/.gitcookies
 
 tr , \\t <<\__END__ >>~/.gitcookies
-go.googlesource.com,FALSE,/,TRUE,2147483647,o,git-admin.hashicorptest.com=1/F-KiU2h0C3CsGR-W37nUzB2LOSfI24YXa71rjfd4qUI
+go.googlesource.com,FALSE,/,TRUE,2147483647,o,git-admin.hashicorptest.com=1/ba6U_xcdflHTPlB4ScWE5O63YMMlvbYtHxP8M_yufDs5-YdA8pqbXQZAtKwT7ROb
 __END__


### PR DESCRIPTION
Just as with 336b352d6fe4, this refreshes our rate limit bypass cookie for `go.googlesource.com` since the old one has apparently expired.

I did this by visiting https://go.googlesource.com/ and selecting "Generate Password" from the top navigation. This cookie belongs to a test account used by the Terraform team and should not be used by
non-Terraform codebases; please generate your own!
