### PR TITLE
Corrects and clarifies that access_token is not a required

### DIFF
--- a/website/docs/backends/types/terraform-enterprise.html.md
+++ b/website/docs/backends/types/terraform-enterprise.html.md
@@ -60,10 +60,11 @@ data "terraform_remote_state" "foo" {
 The following configuration options / environment variables are supported:
 
 * `name` - (Required) Full name of the workspace (`<ORGANIZATION>/<WORKSPACE>`).
-* `ATLAS_TOKEN`/ `access_token`  - (Required) A Terraform Enterprise [user API
+* `ATLAS_TOKEN`/ `access_token`  - (Optional) A Terraform Enterprise [user API
   token](/docs/enterprise/users-teams-organizations/users.html#api-tokens). We
   recommend using the `ATLAS_TOKEN` environment variable rather than setting
-  `access_token` in the configuration.
+  `access_token` in the configuration. If not set, the token will be requested
+  during a `terraform init` and saved locally.
 * `address` - (Optional) The URL of a Terraform Enterprise instance. Defaults to
   the SaaS version of Terraform Enterprise, at `"https://app.terraform.io"`; if
   you use a private install, provide its URL here.


### PR DESCRIPTION
Corrects documentation stating backend terraform-enterprise's access_token is required, when it can be collected at time of `terraform init`.