### PR TITLE
Replaces words 'non-beta version' for 'semantic patch version'

### DIFF
--- a/website/docs/configuration-0-11/providers.html.md
+++ b/website/docs/configuration-0-11/providers.html.md
@@ -128,8 +128,8 @@ syntax to specify a _range_ of versions that are acceptable:
 
 * `>= 1.2.0`: version 1.2.0 or newer
 * `<= 1.2.0`: version 1.2.0 or older
-* `~> 1.2.0`: any non-beta version `>= 1.2.0` and `< 1.3.0`, e.g. `1.2.X`
-* `~> 1.2`: any non-beta version `>= 1.2.0` and `< 2.0.0`, e.g. `1.X.Y`
+* `~> 1.2.0`: any semantic patch version `>= 1.2.0` and `< 1.3.0`, e.g. `1.2.X`
+* `~> 1.2`: any semantic patch version `>= 1.2.0` and `< 2.0.0`, e.g. `1.X.Y`
 * `>= 1.0.0, <= 2.0.0`: any version between 1.0.0 and 2.0.0 inclusive
 
 When `terraform init` is re-run with providers already installed, it will

--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -140,8 +140,8 @@ specify a _range_ of versions that are acceptable:
 
 * `>= 1.2.0`: version 1.2.0 or newer
 * `<= 1.2.0`: version 1.2.0 or older
-* `~> 1.2.0`: any non-beta version `>= 1.2.0` and `< 1.3.0`, e.g. `1.2.X`
-* `~> 1.2`: any non-beta version `>= 1.2.0` and `< 2.0.0`, e.g. `1.X.Y`
+* `~> 1.2.0`: any semantic patch version `>= 1.2.0` and `< 1.3.0`, e.g. `1.2.X`
+* `~> 1.2`: any semantic patch version `>= 1.2.0` and `< 2.0.0`, e.g. `1.X.Y`
 * `>= 1.0.0, <= 2.0.0`: any version between 1.0.0 and 2.0.0 inclusive
 
 When `terraform init` is re-run with providers already installed, it will

--- a/website/docs/modules/usage.html.markdown
+++ b/website/docs/modules/usage.html.markdown
@@ -94,8 +94,8 @@ syntax to specify a _range_ of versions that are acceptable:
 
 * `>= 1.2.0`: version 1.2.0 or newer
 * `<= 1.2.0`: version 1.2.0 or older
-* `~> 1.2.0`: any non-beta version `>= 1.2.0` and `< 1.3.0`, e.g. `1.2.X`
-* `~> 1.2`: any non-beta version `>= 1.2.0` and `< 2.0.0`, e.g. `1.X.Y`
+* `~> 1.2.0`: any semantic patch version `>= 1.2.0` and `< 1.3.0`, e.g. `1.2.X`
+* `~> 1.2`: any semantic patch version `>= 1.2.0` and `< 2.0.0`, e.g. `1.X.Y`
 * `>= 1.0.0, <= 2.0.0`: any version between 1.0.0 and 2.0.0 inclusive
 
 When depending on third-party modules, references to specific versions are


### PR DESCRIPTION
This patch corrects wording to use semantic versioning terminology (as referenced in other places of the docs).