### PR TITLE
only force top-level id's back to unknown

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -33,6 +33,7 @@ func Provider() terraform.ResourceProvider {
 			"test_resource_list_set":         testResourceListSet(),
 			"test_resource_map":              testResourceMap(),
 			"test_resource_computed_set":     testResourceComputedSet(),
+			"test_resource_nested_id":        testResourceNestedId(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"test_data_source":    testDataSource(),

--- a/builtin/providers/test/resource_nested_id.go
+++ b/builtin/providers/test/resource_nested_id.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceNestedId() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceNestedIdCreate,
+		Read:   testResourceNestedIdRead,
+		Update: testResourceNestedIdUpdate,
+		Delete: testResourceNestedIdDelete,
+
+		Schema: map[string]*schema.Schema{
+			"list_block": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testResourceNestedIdCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("testId")
+	return nil
+}
+
+func testResourceNestedIdRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceNestedIdUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceNestedIdDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/test/resource_nested_id_test.go
+++ b/builtin/providers/test/resource_nested_id_test.go
@@ -1,0 +1,31 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestResourceNestedId_unknownId(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested_id" "foo" {
+}
+resource "test_resource_nested_id" "bar" {
+	list_block {
+		id = test_resource_nested_id.foo.id
+	}
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_nested_id.bar", "list_block.0.id", "testId"),
+				),
+			},
+		},
+	})
+}

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -665,8 +665,9 @@ func (d *InstanceDiff) applySingleAttrDiff(path []string, attrs map[string]strin
 		return result, nil
 	}
 
-	// "id" must exist and not be an empty string, or it must be unknown
-	if attr == "id" {
+	// "id" must exist and not be an empty string, or it must be unknown.
+	// This only applied to top-level "id" fields.
+	if attr == "id" && len(path) == 1 {
 		if old == "" {
 			result[attr] = config.UnknownVariableValue
 		} else {


### PR DESCRIPTION
Nested structures may have "id" fields, which should be treated
normally.

Fixes #20181