### PR TITLE
backend/remote: cleanup test connections

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -247,11 +247,6 @@ func (b *Remote) discover() (*url.URL, *disco.Constraints, error) {
 		return nil, nil, err
 	}
 
-	// Return early if we are a development build.
-	if tfversion.Prerelease == "dev" {
-		return service, nil, err
-	}
-
 	// We purposefully ignore the error and return the previous error, as
 	// checking for version constraints is considered optional.
 	constraints, _ := host.VersionConstraints(tfeServiceID, "terraform")

--- a/backend/remote/backend_apply_test.go
+++ b/backend/remote/backend_apply_test.go
@@ -25,7 +25,8 @@ func testOperationApply() *backend.Operation {
 }
 
 func TestRemote_applyBasic(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply")
 	defer modCleanup()
@@ -67,7 +68,8 @@ func TestRemote_applyBasic(t *testing.T) {
 }
 
 func TestRemote_applyWithoutPermissions(t *testing.T) {
-	b := testBackendNoDefault(t)
+	b, bCleanup := testBackendNoDefault(t)
+	defer bCleanup()
 
 	// Create a named workspace without permissions.
 	w, err := b.client.Workspaces.Create(
@@ -104,7 +106,8 @@ func TestRemote_applyWithoutPermissions(t *testing.T) {
 }
 
 func TestRemote_applyWithVCS(t *testing.T) {
-	b := testBackendNoDefault(t)
+	b, bCleanup := testBackendNoDefault(t)
+	defer bCleanup()
 
 	// Create a named workspace with a VCS.
 	_, err := b.client.Workspaces.Create(
@@ -144,7 +147,8 @@ func TestRemote_applyWithVCS(t *testing.T) {
 }
 
 func TestRemote_applyWithParallelism(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply")
 	defer modCleanup()
@@ -169,7 +173,8 @@ func TestRemote_applyWithParallelism(t *testing.T) {
 }
 
 func TestRemote_applyWithPlan(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply")
 	defer modCleanup()
@@ -197,7 +202,8 @@ func TestRemote_applyWithPlan(t *testing.T) {
 }
 
 func TestRemote_applyWithoutRefresh(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply")
 	defer modCleanup()
@@ -222,7 +228,8 @@ func TestRemote_applyWithoutRefresh(t *testing.T) {
 }
 
 func TestRemote_applyWithTarget(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply")
 	defer modCleanup()
@@ -250,7 +257,8 @@ func TestRemote_applyWithTarget(t *testing.T) {
 }
 
 func TestRemote_applyWithVariables(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply-variables")
 	defer modCleanup()
@@ -275,7 +283,8 @@ func TestRemote_applyWithVariables(t *testing.T) {
 }
 
 func TestRemote_applyNoConfig(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	op := testOperationApply()
 	op.Module = nil
@@ -299,7 +308,8 @@ func TestRemote_applyNoConfig(t *testing.T) {
 }
 
 func TestRemote_applyNoChanges(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply-no-changes")
 	defer modCleanup()
@@ -328,7 +338,8 @@ func TestRemote_applyNoChanges(t *testing.T) {
 }
 
 func TestRemote_applyNoApprove(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply")
 	defer modCleanup()
@@ -364,7 +375,8 @@ func TestRemote_applyNoApprove(t *testing.T) {
 }
 
 func TestRemote_applyAutoApprove(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply")
 	defer modCleanup()
@@ -407,7 +419,8 @@ func TestRemote_applyAutoApprove(t *testing.T) {
 }
 
 func TestRemote_applyWithAutoApply(t *testing.T) {
-	b := testBackendNoDefault(t)
+	b, bCleanup := testBackendNoDefault(t)
+	defer bCleanup()
 
 	// Create a named workspace that auto applies.
 	_, err := b.client.Workspaces.Create(
@@ -469,7 +482,8 @@ func TestRemote_applyForceLocal(t *testing.T) {
 	}
 	defer os.Unsetenv("TF_FORCE_LOCAL_BACKEND")
 
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply")
 	defer modCleanup()
@@ -514,7 +528,9 @@ func TestRemote_applyForceLocal(t *testing.T) {
 }
 
 func TestRemote_applyWorkspaceWithoutOperations(t *testing.T) {
-	b := testBackendNoDefault(t)
+	b, bCleanup := testBackendNoDefault(t)
+	defer bCleanup()
+
 	ctx := context.Background()
 
 	// Create a named workspace that doesn't allow operations.
@@ -572,7 +588,9 @@ func TestRemote_applyWorkspaceWithoutOperations(t *testing.T) {
 }
 
 func TestRemote_applyLockTimeout(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
+
 	ctx := context.Background()
 
 	// Retrieve the workspace used to run this operation in.
@@ -643,7 +661,8 @@ func TestRemote_applyLockTimeout(t *testing.T) {
 }
 
 func TestRemote_applyDestroy(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply-destroy")
 	defer modCleanup()
@@ -686,7 +705,8 @@ func TestRemote_applyDestroy(t *testing.T) {
 }
 
 func TestRemote_applyDestroyNoConfig(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	input := testInput(t, map[string]string{
 		"approve": "yes",
@@ -718,7 +738,8 @@ func TestRemote_applyDestroyNoConfig(t *testing.T) {
 }
 
 func TestRemote_applyPolicyPass(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply-policy-passed")
 	defer modCleanup()
@@ -763,7 +784,8 @@ func TestRemote_applyPolicyPass(t *testing.T) {
 }
 
 func TestRemote_applyPolicyHardFail(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply-policy-hard-failed")
 	defer modCleanup()
@@ -810,7 +832,8 @@ func TestRemote_applyPolicyHardFail(t *testing.T) {
 }
 
 func TestRemote_applyPolicySoftFail(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply-policy-soft-failed")
 	defer modCleanup()
@@ -856,7 +879,8 @@ func TestRemote_applyPolicySoftFail(t *testing.T) {
 }
 
 func TestRemote_applyPolicySoftFailAutoApprove(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply-policy-soft-failed")
 	defer modCleanup()
@@ -904,7 +928,8 @@ func TestRemote_applyPolicySoftFailAutoApprove(t *testing.T) {
 }
 
 func TestRemote_applyPolicySoftFailAutoApply(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	// Create a named workspace that auto applies.
 	_, err := b.client.Workspaces.Create(
@@ -963,7 +988,8 @@ func TestRemote_applyPolicySoftFailAutoApply(t *testing.T) {
 }
 
 func TestRemote_applyWithRemoteError(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/apply-with-error")
 	defer modCleanup()

--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -620,9 +620,8 @@ func (m *mockRuns) List(ctx context.Context, workspaceID string, options tfe.Run
 		return nil, tfe.ErrResourceNotFound
 	}
 
-	rl := &tfe.RunList{}
-	for _, r := range m.workspaces[w.ID] {
-		rl.Items = append(rl.Items, r)
+	rl := &tfe.RunList{
+		Items: m.workspaces[w.ID],
 	}
 
 	rl.Pagination = &tfe.Pagination{

--- a/backend/remote/backend_plan_test.go
+++ b/backend/remote/backend_plan_test.go
@@ -26,7 +26,8 @@ func testOperationPlan() *backend.Operation {
 }
 
 func TestRemote_planBasic(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan")
 	defer modCleanup()
@@ -55,7 +56,8 @@ func TestRemote_planBasic(t *testing.T) {
 }
 
 func TestRemote_planWithoutPermissions(t *testing.T) {
-	b := testBackendNoDefault(t)
+	b, bCleanup := testBackendNoDefault(t)
+	defer bCleanup()
 
 	// Create a named workspace without permissions.
 	w, err := b.client.Workspaces.Create(
@@ -92,7 +94,8 @@ func TestRemote_planWithoutPermissions(t *testing.T) {
 }
 
 func TestRemote_planWithModuleDepth(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan")
 	defer modCleanup()
@@ -117,7 +120,8 @@ func TestRemote_planWithModuleDepth(t *testing.T) {
 }
 
 func TestRemote_planWithParallelism(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan")
 	defer modCleanup()
@@ -142,7 +146,8 @@ func TestRemote_planWithParallelism(t *testing.T) {
 }
 
 func TestRemote_planWithPlan(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan")
 	defer modCleanup()
@@ -170,7 +175,8 @@ func TestRemote_planWithPlan(t *testing.T) {
 }
 
 func TestRemote_planWithPath(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan")
 	defer modCleanup()
@@ -198,7 +204,8 @@ func TestRemote_planWithPath(t *testing.T) {
 }
 
 func TestRemote_planWithoutRefresh(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan")
 	defer modCleanup()
@@ -223,7 +230,8 @@ func TestRemote_planWithoutRefresh(t *testing.T) {
 }
 
 func TestRemote_planWithTarget(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan")
 	defer modCleanup()
@@ -251,7 +259,8 @@ func TestRemote_planWithTarget(t *testing.T) {
 }
 
 func TestRemote_planWithVariables(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan-variables")
 	defer modCleanup()
@@ -276,7 +285,8 @@ func TestRemote_planWithVariables(t *testing.T) {
 }
 
 func TestRemote_planNoConfig(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	op := testOperationPlan()
 	op.Module = nil
@@ -300,7 +310,8 @@ func TestRemote_planNoConfig(t *testing.T) {
 }
 
 func TestRemote_planNoChanges(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan-no-changes")
 	defer modCleanup()
@@ -339,7 +350,8 @@ func TestRemote_planForceLocal(t *testing.T) {
 	}
 	defer os.Unsetenv("TF_FORCE_LOCAL_BACKEND")
 
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan")
 	defer modCleanup()
@@ -371,7 +383,8 @@ func TestRemote_planForceLocal(t *testing.T) {
 }
 
 func TestRemote_planWithoutOperationsEntitlement(t *testing.T) {
-	b := testBackendNoOperations(t)
+	b, bCleanup := testBackendNoOperations(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan")
 	defer modCleanup()
@@ -403,7 +416,9 @@ func TestRemote_planWithoutOperationsEntitlement(t *testing.T) {
 }
 
 func TestRemote_planWorkspaceWithoutOperations(t *testing.T) {
-	b := testBackendNoDefault(t)
+	b, bCleanup := testBackendNoDefault(t)
+	defer bCleanup()
+
 	ctx := context.Background()
 
 	// Create a named workspace that doesn't allow operations.
@@ -448,7 +463,9 @@ func TestRemote_planWorkspaceWithoutOperations(t *testing.T) {
 }
 
 func TestRemote_planLockTimeout(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
+
 	ctx := context.Background()
 
 	// Retrieve the workspace used to run this operation in.
@@ -516,7 +533,8 @@ func TestRemote_planLockTimeout(t *testing.T) {
 }
 
 func TestRemote_planDestroy(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan")
 	defer modCleanup()
@@ -541,7 +559,8 @@ func TestRemote_planDestroy(t *testing.T) {
 }
 
 func TestRemote_planDestroyNoConfig(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	op := testOperationPlan()
 	op.Destroy = true
@@ -563,7 +582,8 @@ func TestRemote_planDestroyNoConfig(t *testing.T) {
 }
 
 func TestRemote_planWithWorkingDirectory(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	options := tfe.WorkspaceUpdateOptions{
 		WorkingDirectory: tfe.String("terraform"),
@@ -602,7 +622,8 @@ func TestRemote_planWithWorkingDirectory(t *testing.T) {
 }
 
 func TestRemote_planPolicyPass(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan-policy-passed")
 	defer modCleanup()
@@ -638,7 +659,8 @@ func TestRemote_planPolicyPass(t *testing.T) {
 }
 
 func TestRemote_planPolicyHardFail(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan-policy-hard-failed")
 	defer modCleanup()
@@ -677,7 +699,8 @@ func TestRemote_planPolicyHardFail(t *testing.T) {
 }
 
 func TestRemote_planPolicySoftFail(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan-policy-soft-failed")
 	defer modCleanup()
@@ -716,7 +739,8 @@ func TestRemote_planPolicySoftFail(t *testing.T) {
 }
 
 func TestRemote_planWithRemoteError(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	mod, modCleanup := module.TestTree(t, "./test-fixtures/plan-with-error")
 	defer modCleanup()

--- a/backend/remote/backend_state_test.go
+++ b/backend/remote/backend_state_test.go
@@ -20,7 +20,8 @@ func TestRemoteClient(t *testing.T) {
 }
 
 func TestRemoteClient_stateLock(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	s1, err := b.State(backend.DefaultStateName)
 	if err != nil {

--- a/backend/remote/backend_test.go
+++ b/backend/remote/backend_test.go
@@ -21,14 +21,18 @@ func TestRemote(t *testing.T) {
 }
 
 func TestRemote_backendDefault(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
+
 	backend.TestBackendStates(t, b)
 	backend.TestBackendStateLocks(t, b, b)
 	backend.TestBackendStateForceUnlock(t, b, b)
 }
 
 func TestRemote_backendNoDefault(t *testing.T) {
-	b := testBackendNoDefault(t)
+	b, bCleanup := testBackendNoDefault(t)
+	defer bCleanup()
+
 	backend.TestBackendStates(t, b)
 }
 
@@ -207,7 +211,8 @@ func TestRemote_versionConstraints(t *testing.T) {
 }
 
 func TestRemote_localBackend(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	local, ok := b.local.(*backendLocal.Local)
 	if !ok {
@@ -221,7 +226,9 @@ func TestRemote_localBackend(t *testing.T) {
 }
 
 func TestRemote_addAndRemoveStatesDefault(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
+
 	if _, err := b.States(); err != backend.ErrNamedStatesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrNamedStatesNotSupported, err)
 	}
@@ -244,7 +251,9 @@ func TestRemote_addAndRemoveStatesDefault(t *testing.T) {
 }
 
 func TestRemote_addAndRemoveStatesNoDefault(t *testing.T) {
-	b := testBackendNoDefault(t)
+	b, bCleanup := testBackendNoDefault(t)
+	defer bCleanup()
+
 	states, err := b.States()
 	if err != nil {
 		t.Fatal(err)
@@ -323,7 +332,8 @@ func TestRemote_addAndRemoveStatesNoDefault(t *testing.T) {
 }
 
 func TestRemote_checkConstraints(t *testing.T) {
-	b := testBackendDefault(t)
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
 
 	cases := map[string]struct {
 		constraints *disco.Constraints

--- a/svchost/disco/host.go
+++ b/svchost/disco/host.go
@@ -201,8 +201,8 @@ func (h *Host) VersionConstraints(id, product string) (*Constraints, error) {
 
 	// Set a default timeout of 1 sec for the versions request (in milliseconds)
 	timeout := 1000
-	if _, err := strconv.Atoi(os.Getenv("CHECKPOINT_TIMEOUT")); err == nil {
-		timeout, _ = strconv.Atoi(os.Getenv("CHECKPOINT_TIMEOUT"))
+	if v, err := strconv.Atoi(os.Getenv("CHECKPOINT_TIMEOUT")); err == nil {
+		timeout = v
 	}
 
 	client := &http.Client{


### PR DESCRIPTION
Do not special case the `dev` prerelease and cleanup test connection to prevent file descriptor issues when running the tests on a Mac.