### PR TITLE
Update docs for 0.12 terraform_remote_state data source

### DIFF
--- a/website/docs/providers/terraform/d/remote_state.html.md
+++ b/website/docs/providers/terraform/d/remote_state.html.md
@@ -31,7 +31,7 @@ data "terraform_remote_state" "vpc" {
 
 resource "aws_instance" "foo" {
   # ...
-  subnet_id = "${data.terraform_remote_state.vpc.subnet_id}"
+  subnet_id = "${data.terraform_remote_state.vpc.outputs.subnet_id}"
 }
 ```
 
@@ -52,11 +52,9 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the above, the following attributes are exported:
 
-* `backend` - See Argument Reference above.
-* `config` - See Argument Reference above.
-* `<OUTPUT NAME>` - Each root-level [output](/docs/configuration/outputs.html)
+* `outputs` - Each root-level [output](/docs/configuration/outputs.html)
   in the remote state appears as a top level attribute on the data source.
 
 ## Root Outputs Only


### PR DESCRIPTION
In 0.12, the outputs for a data source of terraform_remote_state are nested under the 'outputs' attribute [1]. This updates the docs to make this change clearer.

Worked with @radeksimko at Terraform hackday, who has submitted a related upgrade guide [2]

[1] https://github.com/hashicorp/terraform/blob/1f4d2f4c5008cbf4e2da61b65f1cb98183bc4884/builtin/providers/terraform/data_source_state.go#L16-L43
[2] https://github.com/hashicorp/terraform/pull/20243/commits/d8e00191b7d8e9cd2dfad7c07e21aa0b86c887d4