### PR TITLE
build: Run "go generate" in modules mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,12 @@ cover:
 # source files, except the protobuf stubs which are built instead with
 # "make protobuf".
 generate: tools
-	# We turn off modules for "go generate" because our downstream generate
-	# commands are not all ready to deal with Go modules yet.
-	# See https://github.com/golang/go/issues/24661
-	# This also avoids downloading all of the deps that are in the vendor dir anyway.
-	GO111MODULE=off go generate ./...
+	GOFLAGS=-mod=vendor go generate ./...
+	# go fmt doesn't support -mod=vendor but it still wants to populate the
+	# module cache with everything in go.mod even though formatting requires
+	# no dependencies, and so we're disabling modules mode for this right
+	# now until the "go fmt" behavior is rationalized to either support the
+	# -mod= argument or _not_ try to install things.
 	GO111MODULE=off go fmt command/internal_plugin_list.go > /dev/null
 
 # We separate the protobuf generation because most development tasks on

--- a/plugin/mock_proto/generate.go
+++ b/plugin/mock_proto/generate.go
@@ -1,3 +1,3 @@
-//go:generate mockgen -destination mock.go github.com/hashicorp/terraform/internal/tfplugin5 ProviderClient,ProvisionerClient,Provisioner_ProvisionResourceClient,Provisioner_ProvisionResourceServer
+//go:generate bash ./generate.sh
 
 package mock_tfplugin5

--- a/plugin/mock_proto/generate.sh
+++ b/plugin/mock_proto/generate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# mockgen is particularly sensitive about what mode we run it in
+export GOFLAGS=""
+export GO111MODULE=on
+
+mockgen -destination mock.go github.com/hashicorp/terraform/internal/tfplugin5 ProviderClient,ProvisionerClient,Provisioner_ProvisionResourceClient,Provisioner_ProvisionResourceServer


### PR DESCRIPTION
It seems that all of the tools we run here are now sufficiently modules-aware to run without problems in modules mode, and indeed running _not_ in modules mode was causing problems with locating packages in `mockgen`.