### PR TITLE
Change the UptimeRobot provider

### DIFF
--- a/website/docs/providers/type/community-index.html.markdown
+++ b/website/docs/providers/type/community-index.html.markdown
@@ -157,7 +157,7 @@ please fill out this [community providers form](https://docs.google.com/forms/d/
     <td><a href="https://github.com/mvisonneau/terraform-provider-updown">Updown.io</a></td>
     </tr>
     <tr>
-    <td><a href="https://github.com/SpamapS/terraform-provider-uptimerobot">Uptimerobot</a></td>
+    <td><a href="https://github.com/louy/terraform-provider-uptimerobot">Uptimerobot</a></td>
     <td><a href="https://github.com/GSLabDev/terraform-provider-vra">vRealize Automation</a></td>
     <td><a href="https://github.com/PortOfPortland/terraform-provider-windns">Win DNS</a></td>
     </tr>


### PR DESCRIPTION
I've got some errors using the actual [UptimeRobot provider](https://github.com/SpamapS/terraform-provider-uptimerobot/).
Another provider [exists](https://github.com/louy/terraform-provider-uptimerobot) and it works fine.

An issue is open by the author (@louy)  : https://github.com/hashicorp/terraform/issues/18167

Author of the actual provider, update his project as **DEPRECATED**. 

See: https://github.com/SpamapS/terraform-provider-uptimerobot/