### PR TITLE
plans/objchange: Don't presume unknown for values unset in config

### DIFF
--- a/backend/local/backend_apply_test.go
+++ b/backend/local/backend_apply_test.go
@@ -123,8 +123,7 @@ func TestLocal_applyError(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
 
-	p := TestLocalProvider(t, b, "test", nil)
-	p.GetSchemaReturn = &terraform.ProviderSchema{
+	schema := &terraform.ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -134,6 +133,7 @@ func TestLocal_applyError(t *testing.T) {
 			},
 		},
 	}
+	p := TestLocalProvider(t, b, "test", schema)
 
 	var lock sync.Mutex
 	errored := false

--- a/backend/local/testing.go
+++ b/backend/local/testing.go
@@ -6,7 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statemgr"
@@ -38,9 +42,14 @@ func TestLocal(t *testing.T) (*Local, func()) {
 			// function, t.Helper doesn't apply and so the log source
 			// isn't correctly shown in the test log output. This seems
 			// unavoidable as long as this is happening so indirectly.
-			t.Log(diag.Description().Summary)
+			desc := diag.Description()
+			if desc.Detail != "" {
+				t.Logf("%s: %s", desc.Summary, desc.Detail)
+			} else {
+				t.Log(desc.Summary)
+			}
 			if local.CLI != nil {
-				local.CLI.Error(diag.Description().Summary)
+				local.CLI.Error(desc.Summary)
 			}
 		}
 	}
@@ -59,10 +68,34 @@ func TestLocal(t *testing.T) (*Local, func()) {
 func TestLocalProvider(t *testing.T, b *Local, name string, schema *terraform.ProviderSchema) *terraform.MockProvider {
 	// Build a mock resource provider for in-memory operations
 	p := new(terraform.MockProvider)
+
+	if schema == nil {
+		schema = &terraform.ProviderSchema{} // default schema is empty
+	}
 	p.GetSchemaReturn = schema
+
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+		rSchema, _ := schema.SchemaForResourceType(addrs.ManagedResourceMode, req.TypeName)
+		if rSchema == nil {
+			rSchema = &configschema.Block{} // default schema is empty
+		}
+		plannedVals := map[string]cty.Value{}
+		for name, attrS := range rSchema.Attributes {
+			val := req.ProposedNewState.GetAttr(name)
+			if attrS.Computed && val.IsNull() {
+				val = cty.UnknownVal(attrS.Type)
+			}
+			plannedVals[name] = val
+		}
+		for name := range rSchema.BlockTypes {
+			// For simplicity's sake we just copy the block attributes over
+			// verbatim, since this package's mock providers are all relatively
+			// simple -- we're testing the backend, not esoteric provider features.
+			plannedVals[name] = req.ProposedNewState.GetAttr(name)
+		}
+
 		return providers.PlanResourceChangeResponse{
-			PlannedState:   req.ProposedNewState,
+			PlannedState:   cty.ObjectVal(plannedVals),
 			PlannedPrivate: req.PriorPrivate,
 		}
 	}

--- a/builtin/providers/test/resource_list_test.go
+++ b/builtin/providers/test/resource_list_test.go
@@ -133,3 +133,58 @@ resource "test_resource_list" "foo" {
 		},
 	})
 }
+
+func TestResourceList_interpolationChanges(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "foo" {
+	list_block {
+		string = "x"
+	}
+}
+resource "test_resource_list" "bar" {
+	list_block {
+		string = test_resource_list.foo.id
+	}
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.0.string", "x",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.bar", "list_block.0.string", "testId",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "baz" {
+	list_block {
+		string = "x"
+		int = 1
+	}
+}
+resource "test_resource_list" "bar" {
+	list_block {
+		string = test_resource_list.baz.id
+		int = 3
+	}
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_list.baz", "list_block.0.string", "x",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_list.bar", "list_block.0.string", "testId",
+					),
+				),
+			},
+		},
+	})
+}

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -244,13 +244,29 @@ func showFixtureProvider() *terraform.MockProvider {
 	p := testProvider()
 	p.GetSchemaReturn = showFixtureSchema()
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+		idVal := req.ProposedNewState.GetAttr("id")
+		amiVal := req.ProposedNewState.GetAttr("ami")
+		if idVal.IsNull() {
+			idVal = cty.UnknownVal(cty.String)
+		}
 		return providers.PlanResourceChangeResponse{
-			PlannedState: req.ProposedNewState,
+			PlannedState: cty.ObjectVal(map[string]cty.Value{
+				"id":  idVal,
+				"ami": amiVal,
+			}),
 		}
 	}
 	p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+		idVal := req.PlannedState.GetAttr("id")
+		amiVal := req.PlannedState.GetAttr("ami")
+		if !idVal.IsKnown() {
+			idVal = cty.StringVal("placeholder")
+		}
 		return providers.ApplyResourceChangeResponse{
-			NewState: cty.UnknownAsNull(req.PlannedState),
+			NewState: cty.ObjectVal(map[string]cty.Value{
+				"id":  idVal,
+				"ami": amiVal,
+			}),
 		}
 	}
 	return p

--- a/command/test-fixtures/show-json/basic-delete/output.json
+++ b/command/test-fixtures/show-json/basic-delete/output.json
@@ -18,7 +18,7 @@
                     "schema_version": 0,
                     "values": {
                         "ami": "bar",
-                        "id": null
+                        "id": "placeholder"
                     }
                 }
             ]
@@ -37,11 +37,11 @@
                 ],
                 "before": {
                     "ami": "foo",
-                    "id": null
+                    "id": "placeholder"
                 },
                 "after": {
                     "ami": "bar",
-                    "id": null
+                    "id": "placeholder"
                 },
                 "after_unknown": {
                     "ami": false,
@@ -61,7 +61,7 @@
                 ],
                 "before": {
                     "ami": "foo",
-                    "id": null
+                    "id": "placeholder"
                 },
                 "after": null,
                 "after_unknown": false

--- a/command/test-fixtures/show-json/basic-delete/terraform.tfstate
+++ b/command/test-fixtures/show-json/basic-delete/terraform.tfstate
@@ -14,7 +14,8 @@
         {
           "schema_version": 0,
           "attributes": {
-            "ami": "foo"
+            "ami": "foo",
+            "id": "placeholder"
           }
         }
       ]
@@ -28,7 +29,8 @@
         {
           "schema_version": 0,
           "attributes": {
-            "ami": "foo"
+            "ami": "foo",
+            "id": "placeholder"
           }
         }
       ]

--- a/command/test-fixtures/show-json/basic-update/output.json
+++ b/command/test-fixtures/show-json/basic-update/output.json
@@ -18,7 +18,7 @@
                     "schema_version": 0,
                     "values": {
                         "ami": "bar",
-                        "id": null
+                        "id": "placeholder"
                     }
                 }
             ]
@@ -37,11 +37,11 @@
                 ],
                 "before": {
                     "ami": "bar",
-                    "id": null
+                    "id": "placeholder"
                 },
                 "after": {
                     "ami": "bar",
-                    "id": null
+                    "id": "placeholder"
                 },
                 "after_unknown": {
                     "ami": false,

--- a/command/test-fixtures/show-json/basic-update/terraform.tfstate
+++ b/command/test-fixtures/show-json/basic-update/terraform.tfstate
@@ -14,7 +14,8 @@
                 {
                     "schema_version": 0,
                     "attributes": {
-                        "ami": "bar"
+                        "ami": "bar",
+                        "id": "placeholder"
                     }
                 }
             ]

--- a/configs/configschema/coerce_value_test.go
+++ b/configs/configschema/coerce_value_test.go
@@ -436,6 +436,101 @@ func TestCoerceValue(t *testing.T) {
 			}),
 			``,
 		},
+		"dynamic value attributes": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"foo": {
+						Nesting: NestingMap,
+						Block: Block{
+							Attributes: map[string]*Attribute{
+								"bar": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+								"baz": {
+									Type:     cty.DynamicPseudoType,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ObjectVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("beep"),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+						"baz": cty.NumberIntVal(8),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ObjectVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("beep"),
+						"baz": cty.NullVal(cty.DynamicPseudoType),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+						"baz": cty.NumberIntVal(8),
+					}),
+				}),
+			}),
+			``,
+		},
+		"dynamic attributes in map": {
+			// Convert a block represented as a map to an object if a
+			// DynamicPseudoType causes the element types to mismatch.
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"foo": {
+						Nesting: NestingMap,
+						Block: Block{
+							Attributes: map[string]*Attribute{
+								"bar": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+								"baz": {
+									Type:     cty.DynamicPseudoType,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.MapVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("beep"),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ObjectVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("beep"),
+						"baz": cty.NullVal(cty.DynamicPseudoType),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+						"baz": cty.NullVal(cty.DynamicPseudoType),
+					}),
+				}),
+			}),
+			``,
+		},
 	}
 
 	for name, test := range tests {

--- a/helper/plugin/unknown.go
+++ b/helper/plugin/unknown.go
@@ -1,0 +1,89 @@
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// SetUnknowns takes a cty.Value, and compares it to the schema setting any null
+// leaf values which are computed as unknown.
+func SetUnknowns(val cty.Value, schema *configschema.Block) cty.Value {
+	if val.IsNull() || !val.IsKnown() {
+		return val
+	}
+
+	valMap := val.AsValueMap()
+	newVals := make(map[string]cty.Value)
+
+	for name, attr := range schema.Attributes {
+		v := valMap[name]
+
+		if attr.Computed && v.IsNull() {
+			newVals[name] = cty.UnknownVal(attr.Type)
+			continue
+		}
+
+		newVals[name] = v
+	}
+
+	for name, blockS := range schema.BlockTypes {
+		blockVal := valMap[name]
+		if blockVal.IsNull() || !blockVal.IsKnown() {
+			newVals[name] = blockVal
+			continue
+		}
+
+		blockType := blockS.Block.ImpliedType()
+
+		switch blockS.Nesting {
+		case configschema.NestingSingle:
+			newVals[name] = SetUnknowns(blockVal, &blockS.Block)
+		case configschema.NestingSet, configschema.NestingList:
+			listVals := blockVal.AsValueSlice()
+			newListVals := make([]cty.Value, 0, len(listVals))
+
+			for _, v := range listVals {
+				newListVals = append(newListVals, SetUnknowns(v, &blockS.Block))
+			}
+
+			switch blockS.Nesting {
+			case configschema.NestingSet:
+				switch len(newListVals) {
+				case 0:
+					newVals[name] = cty.SetValEmpty(blockType)
+				default:
+					newVals[name] = cty.SetVal(newListVals)
+				}
+			case configschema.NestingList:
+				switch len(newListVals) {
+				case 0:
+					newVals[name] = cty.ListValEmpty(blockType)
+				default:
+					newVals[name] = cty.ListVal(newListVals)
+				}
+			}
+
+		case configschema.NestingMap:
+			mapVals := blockVal.AsValueMap()
+			newMapVals := make(map[string]cty.Value)
+
+			for k, v := range mapVals {
+				newMapVals[k] = SetUnknowns(v, &blockS.Block)
+			}
+
+			switch len(newMapVals) {
+			case 0:
+				newVals[name] = cty.MapValEmpty(blockType)
+			default:
+				newVals[name] = cty.MapVal(newMapVals)
+			}
+
+		default:
+			panic(fmt.Sprintf("failed to set unknown values for nested block %q", name))
+		}
+	}
+
+	return cty.ObjectVal(newVals)
+}

--- a/helper/plugin/unknown.go
+++ b/helper/plugin/unknown.go
@@ -8,10 +8,33 @@ import (
 )
 
 // SetUnknowns takes a cty.Value, and compares it to the schema setting any null
-// leaf values which are computed as unknown.
+// values which are computed to unknown.
 func SetUnknowns(val cty.Value, schema *configschema.Block) cty.Value {
-	if val.IsNull() || !val.IsKnown() {
+	if !val.IsKnown() {
 		return val
+	}
+
+	// If the object was null, we still need to handle the top level attributes
+	// which might be computed, but we don't need to expand the blocks.
+	if val.IsNull() {
+		objMap := map[string]cty.Value{}
+		allNull := true
+		for name, attr := range schema.Attributes {
+			switch {
+			case attr.Computed:
+				objMap[name] = cty.UnknownVal(attr.Type)
+				allNull = false
+			default:
+				objMap[name] = cty.NullVal(attr.Type)
+			}
+		}
+
+		// If this object has no unknown attributes, then we can leave it null.
+		if allNull {
+			return val
+		}
+
+		return cty.ObjectVal(objMap)
 	}
 
 	valMap := val.AsValueMap()
@@ -35,12 +58,18 @@ func SetUnknowns(val cty.Value, schema *configschema.Block) cty.Value {
 			continue
 		}
 
-		blockType := blockS.Block.ImpliedType()
+		blockValType := blockVal.Type()
+		blockElementType := blockS.Block.ImpliedType()
 
-		switch blockS.Nesting {
-		case configschema.NestingSingle:
+		// This switches on the value type here, so we can correctly switch
+		// between Tuples/Lists and Maps/Objects.
+		switch {
+		case blockS.Nesting == configschema.NestingSingle:
+			// NestingSingle is the only exception here, where we treat the
+			// block directly as an object
 			newVals[name] = SetUnknowns(blockVal, &blockS.Block)
-		case configschema.NestingSet, configschema.NestingList:
+
+		case blockValType.IsSetType(), blockValType.IsListType(), blockValType.IsTupleType():
 			listVals := blockVal.AsValueSlice()
 			newListVals := make([]cty.Value, 0, len(listVals))
 
@@ -48,24 +77,26 @@ func SetUnknowns(val cty.Value, schema *configschema.Block) cty.Value {
 				newListVals = append(newListVals, SetUnknowns(v, &blockS.Block))
 			}
 
-			switch blockS.Nesting {
-			case configschema.NestingSet:
+			switch {
+			case blockValType.IsSetType():
 				switch len(newListVals) {
 				case 0:
-					newVals[name] = cty.SetValEmpty(blockType)
+					newVals[name] = cty.SetValEmpty(blockElementType)
 				default:
 					newVals[name] = cty.SetVal(newListVals)
 				}
-			case configschema.NestingList:
+			case blockValType.IsListType():
 				switch len(newListVals) {
 				case 0:
-					newVals[name] = cty.ListValEmpty(blockType)
+					newVals[name] = cty.ListValEmpty(blockElementType)
 				default:
 					newVals[name] = cty.ListVal(newListVals)
 				}
+			case blockValType.IsTupleType():
+				newVals[name] = cty.TupleVal(newListVals)
 			}
 
-		case configschema.NestingMap:
+		case blockValType.IsMapType(), blockValType.IsObjectType():
 			mapVals := blockVal.AsValueMap()
 			newMapVals := make(map[string]cty.Value)
 
@@ -73,15 +104,26 @@ func SetUnknowns(val cty.Value, schema *configschema.Block) cty.Value {
 				newMapVals[k] = SetUnknowns(v, &blockS.Block)
 			}
 
-			switch len(newMapVals) {
-			case 0:
-				newVals[name] = cty.MapValEmpty(blockType)
-			default:
-				newVals[name] = cty.MapVal(newMapVals)
+			switch {
+			case blockValType.IsMapType():
+				switch len(newMapVals) {
+				case 0:
+					newVals[name] = cty.MapValEmpty(blockElementType)
+				default:
+					newVals[name] = cty.MapVal(newMapVals)
+				}
+			case blockValType.IsObjectType():
+				if len(newMapVals) == 0 {
+					// We need to populate empty values to make a valid object.
+					for attr, ty := range blockElementType.AttributeTypes() {
+						newMapVals[attr] = cty.NullVal(ty)
+					}
+				}
+				newVals[name] = cty.ObjectVal(newMapVals)
 			}
 
 		default:
-			panic(fmt.Sprintf("failed to set unknown values for nested block %q", name))
+			panic(fmt.Sprintf("failed to set unknown values for nested block %q:%#v", name, blockValType))
 		}
 	}
 

--- a/helper/plugin/unknown_test.go
+++ b/helper/plugin/unknown_test.go
@@ -1,0 +1,353 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestSetUnknowns(t *testing.T) {
+	for n, tc := range map[string]struct {
+		Schema   *configschema.Block
+		Val      cty.Value
+		Expected cty.Value
+	}{
+		"empty": {
+			&configschema.Block{},
+			cty.EmptyObjectVal,
+			cty.EmptyObjectVal,
+		},
+		"no prior": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {
+						Type:     cty.String,
+						Optional: true,
+					},
+					"bar": {
+						Type:     cty.String,
+						Computed: true,
+					},
+				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"baz": {
+						Nesting: configschema.NestingSingle,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"boz": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+								"biz": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{}),
+			cty.ObjectVal(map[string]cty.Value{
+				"bar": cty.UnknownVal(cty.String),
+			}),
+		},
+		"no prior with set": {
+			// the set value should remain null
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"baz": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"boz": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{}),
+			cty.ObjectVal(map[string]cty.Value{}),
+		},
+		"prior attributes": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {
+						Type:     cty.String,
+						Optional: true,
+					},
+					"bar": {
+						Type:     cty.String,
+						Computed: true,
+					},
+					"baz": {
+						Type:     cty.String,
+						Optional: true,
+						Computed: true,
+					},
+					"boz": {
+						Type:     cty.String,
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("bonjour"),
+				"bar": cty.StringVal("petit dejeuner"),
+				"baz": cty.StringVal("grande dejeuner"),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("bonjour"),
+				"bar": cty.StringVal("petit dejeuner"),
+				"baz": cty.StringVal("grande dejeuner"),
+				"boz": cty.UnknownVal(cty.String),
+			}),
+		},
+		"prior nested single": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingSingle,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"bar": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+								"baz": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ObjectVal(map[string]cty.Value{
+					"bar": cty.StringVal("beep"),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ObjectVal(map[string]cty.Value{
+					"bar": cty.StringVal("beep"),
+					"baz": cty.UnknownVal(cty.String),
+				}),
+			}),
+		},
+		"prior nested list": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingList,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"bar": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+								"baz": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("bap"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("blep"),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("bap"),
+						"baz": cty.UnknownVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("blep"),
+						"baz": cty.UnknownVal(cty.String),
+					}),
+				}),
+			}),
+		},
+		"prior nested map": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingMap,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"bar": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+								"baz": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.MapVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.NullVal(cty.String),
+						"baz": cty.StringVal("boop"),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("blep"),
+						"baz": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.MapVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.UnknownVal(cty.String),
+						"baz": cty.StringVal("boop"),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("blep"),
+						"baz": cty.UnknownVal(cty.String),
+					}),
+				}),
+			}),
+		},
+		"prior nested set": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"bar": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"baz": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("blep"),
+						"baz": cty.NullVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+						"baz": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("blep"),
+						"baz": cty.UnknownVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+						"baz": cty.UnknownVal(cty.String),
+					}),
+				}),
+			}),
+		},
+		"sets differing only by unknown": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"bar": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"baz": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+						"baz": cty.NullVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+						"baz": cty.UnknownVal(cty.String),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+						"baz": cty.UnknownVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+						"baz": cty.UnknownVal(cty.String),
+					}),
+				}),
+			}),
+		},
+	} {
+		t.Run(n, func(t *testing.T) {
+			// coerce the values because SetUnknowns expects the values to be
+			// complete, and so we can take shortcuts writing them in the
+			// test.
+			v, err := tc.Schema.CoerceValue(tc.Val)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected, err := tc.Schema.CoerceValue(tc.Expected)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := SetUnknowns(v, tc.Schema)
+			if !got.RawEquals(expected) {
+				t.Fatalf("\nexpected: %#v\ngot:      %#v\n", expected, got)
+			}
+		})
+	}
+}

--- a/lang/funcs/string.go
+++ b/lang/funcs/string.go
@@ -39,10 +39,18 @@ var JoinFunc = function.New(&function.Spec{
 		}
 
 		items := make([]string, 0, l)
-		for _, list := range listVals {
+		for ai, list := range listVals {
+			ei := 0
 			for it := list.ElementIterator(); it.Next(); {
 				_, val := it.Element()
+				if val.IsNull() {
+					if len(listVals) > 1 {
+						return cty.UnknownVal(cty.String), function.NewArgErrorf(ai+1, "element %d of list %d is null; cannot concatenate null values", ei, ai+1)
+					}
+					return cty.UnknownVal(cty.String), function.NewArgErrorf(ai+1, "element %d is null; cannot concatenate null values", ei)
+				}
 				items = append(items, val.AsString())
+				ei++
 			}
 		}
 

--- a/plans/objchange/all_null.go
+++ b/plans/objchange/all_null.go
@@ -1,0 +1,68 @@
+package objchange
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// AllAttributesNull constructs a non-null cty.Value of the object type implied
+// by the given schema that has all of its leaf attributes set to null and all
+// of its nested block collections set to zero-length.
+//
+// This simulates what would result from decoding an empty configuration block
+// with the given schema, except that it does not produce errors
+func AllAttributesNull(schema *configschema.Block) cty.Value {
+	vals := make(map[string]cty.Value)
+	ty := schema.ImpliedType()
+
+	for name := range schema.Attributes {
+		aty := ty.AttributeType(name)
+		vals[name] = cty.NullVal(aty)
+	}
+
+	for name, blockS := range schema.BlockTypes {
+		aty := ty.AttributeType(name)
+
+		switch blockS.Nesting {
+		case configschema.NestingSingle:
+			// NestingSingle behaves like an object attribute, which decodes
+			// as null when it's not present in configuration.
+			vals[name] = cty.NullVal(aty)
+		default:
+			// All other nesting types decode as "empty" when not present, but
+			// empty values take different forms depending on the type.
+			switch {
+			case aty.IsListType():
+				vals[name] = cty.ListValEmpty(aty.ElementType())
+			case aty.IsSetType():
+				vals[name] = cty.SetValEmpty(aty.ElementType())
+			case aty.IsMapType():
+				vals[name] = cty.MapValEmpty(aty.ElementType())
+			case aty.Equals(cty.DynamicPseudoType):
+				// We use DynamicPseudoType in situations where there's a
+				// nested attribute of DynamicPseudoType, since the schema
+				// system cannot predict the final type until it knows exactly
+				// how many elements there will be. However, since we're
+				// trying to behave as if there are _no_ elements, we know
+				// we're producing either an empty tuple or empty object
+				// and just need to distinguish these two cases.
+				switch blockS.Nesting {
+				case configschema.NestingList:
+					vals[name] = cty.EmptyTupleVal
+				case configschema.NestingMap:
+					vals[name] = cty.EmptyObjectVal
+				}
+			}
+		}
+
+		// By the time we get down here we should always have set a value.
+		// If not, that suggests a missing case in the above switches.
+		if _, ok := vals[name]; !ok {
+			panic(fmt.Sprintf("failed to create empty value for nested block %q", name))
+		}
+	}
+
+	return cty.ObjectVal(vals)
+}

--- a/plans/objchange/objchange.go
+++ b/plans/objchange/objchange.go
@@ -26,10 +26,11 @@ import (
 // block where _all_ attributes are computed.
 func ProposedNewObject(schema *configschema.Block, prior, config cty.Value) cty.Value {
 	if prior.IsNull() {
-		// In this case, we will treat the prior value as unknown so that
-		// any computed attributes not overridden in config will show as
-		// unknown values, rather than null values.
-		prior = cty.UnknownVal(schema.ImpliedType())
+		// In this case, we will construct a synthetic prior value that is
+		// similar to the result of decoding an empty configuration block,
+		// which simplifies our handling of the top-level attributes/blocks
+		// below by giving us one non-null level of object to pull values from.
+		prior = AllAttributesNull(schema)
 	}
 	if config.IsNull() || !config.IsKnown() {
 		// This is a weird situation, but we'll allow it anyway to free

--- a/plans/objchange/objchange_test.go
+++ b/plans/objchange/objchange_test.go
@@ -44,6 +44,11 @@ func TestProposedNewObject(t *testing.T) {
 									Optional: true,
 									Computed: true,
 								},
+								"biz": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
 							},
 						},
 					},
@@ -55,13 +60,26 @@ func TestProposedNewObject(t *testing.T) {
 				"bar": cty.NullVal(cty.String),
 				"baz": cty.ObjectVal(map[string]cty.Value{
 					"boz": cty.StringVal("world"),
+
+					// An unknown in the config represents a situation where
+					// an argument is explicitly set to an expression result
+					// that is derived from an unknown value. This is distinct
+					// from leaving it null, which allows the provider itself
+					// to decide the value during PlanResourceChange.
+					"biz": cty.UnknownVal(cty.String),
 				}),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
 				"foo": cty.StringVal("hello"),
-				"bar": cty.UnknownVal(cty.String),
+
+				// unset computed attributes are null in the proposal; provider
+				// usually changes them to "unknown" during PlanResourceChange,
+				// to indicate that the value will be decided during apply.
+				"bar": cty.NullVal(cty.String),
+
 				"baz": cty.ObjectVal(map[string]cty.Value{
 					"boz": cty.StringVal("world"),
+					"biz": cty.UnknownVal(cty.String), // explicit unknown preserved from config
 				}),
 			}),
 		},
@@ -468,7 +486,49 @@ func TestProposedNewObject(t *testing.T) {
 					}),
 					cty.ObjectVal(map[string]cty.Value{
 						"bar": cty.StringVal("bosh"),
-						"baz": cty.UnknownVal(cty.String),
+						"baz": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+		},
+		"sets differing only by unknown": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"multi": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"optional": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"optional": cty.UnknownVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"optional": cty.UnknownVal(cty.String),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					// These remain distinct because unknown values never
+					// compare equal. They may be consolidated together once
+					// the values become known, though.
+					cty.ObjectVal(map[string]cty.Value{
+						"optional": cty.UnknownVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"optional": cty.UnknownVal(cty.String),
 					}),
 				}),
 			}),


### PR DESCRIPTION
Previously we would construct a proposed new state with unknown values in place of any not-set-in-config computed attributes, trying to save the provider a little work in specifying that itself.

Unfortunately that turns out to be problematic because it conflates two concerns: attributes can be explicitly set in configuration to an unknown value, in which case the final result of that unknown overrides any default value the provider might normally populate.

In other words, this allows the provider to recognize in the proposed new state the difference between an Optional+Computed attribute being set to unknown in the config vs not being set in the config at all.

The provider now has the responsibility to replace these proposed null values with unknown values during PlanResourceChange if it expects to select a value during the apply step. It may also populate a known value if the final result can be predicted at plan time, as is the case for constant defaults specified in the provider code.

This change comes from a realization that from core's perspective the `helper/schema` ideas of zero values, explicit default values, and `CustomizeDiff` tweaks are all just examples of "defaults", and by allowing the provider to see during plan whether these attributes are being explicitly set in configuration and thus decide whether the default will be provided immediately during plan or deferred until apply.