### PR TITLE
Fix sample template text so it really interpolates

### DIFF
--- a/website/docs/configuration-0-11/interpolation.html.md
+++ b/website/docs/configuration-0-11/interpolation.html.md
@@ -449,7 +449,7 @@ A template data source looks like:
 
 ```hcl
 data "template_file" "example" {
-  template = "$${hello} $${world}!"
+  template = "${hello} ${world}!"
   vars {
     hello = "goodnight"
     world = "moon"


### PR DESCRIPTION
This is my first pull request to Terraform so please bear with me.

It's just a change to the docs. Without this change, the example does not work.

I just spent a while trying to figure out why my template isn't rendering the variable I want it to. I later noticed this at the top of the file:

> You can escape interpolation with double dollar signs: `$${foo}` will be rendered as a literal `${foo}`.