### PR TITLE
backend/s3: Add allowed_account_ids and forbidden_account_ids options

### DIFF
--- a/backend/remote-state/s3/backend_test.go
+++ b/backend/remote-state/s3/backend_test.go
@@ -134,6 +134,24 @@ func TestBackendConfig_conflictingEncryptionSchema(t *testing.T) {
 	}
 }
 
+func TestBackendConfig_conflictingAllowedForbiddenAccountIds(t *testing.T) {
+	testACC(t)
+	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{
+		"region":                "us-west-1",
+		"bucket":                "tf-test",
+		"key":                   "state",
+		"encrypt":               true,
+		"dynamodb_table":        "dynamoTable",
+		"allowed_account_ids":   "['123456789012']",
+		"forbidden_account_ids": "['210987654321']",
+	})
+
+	diags := New().Configure(cfg)
+	if !diags.HasErrors() {
+		t.Fatal("expected error for simultaneous usage of allowed_account_ids and forbidden_account_ids")
+	}
+}
+
 func TestBackend(t *testing.T) {
 	testACC(t)
 

--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -194,6 +194,8 @@ The following configuration options or environment variables are supported:
  This is the base64-encoded value of the key, which must decode to 256 bits. Due to the sensitivity of the value, it is recommended to set it using the `AWS_SSE_CUSTOMER_KEY` environment variable.
  Setting it inside a terraform file will cause it to be persisted to disk in `terraform.tfstate`.
  * `max_retries` - (Optional) The maximum number of times an AWS API request is retried on retryable failure. Defaults to 5.
+ * `allowed_account_ids` - (Optional) List of allowed, white listed, AWS account IDs to prevent you from mistakenly using an incorrect one (and potentially end up destroying a live environment). Conflicts with forbidden_account_ids.
+ * `forbidden_account_ids` - (Optional) List of forbidden, blacklisted, AWS account IDs to prevent you mistakenly using a wrong one (and potentially end up destroying a live environment). Conflicts with allowed_account_ids.
 
 ## Multi-account AWS Architecture
 


### PR DESCRIPTION
This is relying on the same feature implemented in the terraform-aws-provider.

It is useful to prevent getting `AccessDenied` on reading the S3 bucket when using the incorrect AWS account/profile then having to delete the local `.terraform` folder before trying with the correct AWS profile.

My knowledge in Go is still very limited and there is an issue when `allowed_accounts_ids` is omitted from the backend configuration.

It seems like when evaluating `c.AllowedAccountIds` it is not equal to `nil`:

```
func (c *Config) ValidateAccountId(accountId string) error {
	if (c.AllowedAccountIds == nil && c.ForbiddenAccountIds == nil) {
		return nil
	}
...
```
Something related to how an interface is considered nil? As mentioned here: https://dev.to/pauljlucas/go-tcha-when-nil--nil-hic 

Adding the suggested hack on the provider side make it work but I'm hoping there is a better way to solve that.
```
if ((*[2]uintptr)(unsafe.Pointer(&c.AllowedAccountIds))[1] == 0 && (*[2]uintptr)(unsafe.Pointer(&c.ForbiddenAccountIds))[1] == 0) {
	return nil
}
```

If anyone can point me to the right direction, it would be greatly appreciated. 

Thanks to @tomelliff for suggesting that could be my first contribution to Terraform.