### PR TITLE
configs/configupgrade: do not panic on HEREDOCs.

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/heredoc/input/heredoc.tf
+++ b/configs/configupgrade/test-fixtures/valid/heredoc/input/heredoc.tf
@@ -1,0 +1,10 @@
+locals {
+  cert_options = <<EOF
+--cert-file=/etc/ssl/etcd/server.crt \
+  --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
+  --peer-client-cert-auth=trueEOF
+}
+
+output "local" {
+  value = "${local.cert_options}"
+}

--- a/configs/configupgrade/test-fixtures/valid/heredoc/want/heredoc.tf
+++ b/configs/configupgrade/test-fixtures/valid/heredoc/want/heredoc.tf
@@ -1,0 +1,11 @@
+locals {
+  cert_options = <<EOF
+--cert-file=/etc/ssl/etcd/server.crt \
+  --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
+  --peer-client-cert-auth=trueEOF
+
+}
+
+output "local" {
+value = local.cert_options
+}

--- a/configs/configupgrade/test-fixtures/valid/heredoc/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/heredoc/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/configs/configupgrade/upgrade_expr.go
+++ b/configs/configupgrade/upgrade_expr.go
@@ -62,8 +62,13 @@ Value:
 			diags = diags.Append(interpDiags)
 
 		case hcl1token.HEREDOC:
-			// TODO: Implement
-			panic("HEREDOC not supported yet")
+			// TODO: Implement more complex handling to upgrade any
+			// interpolation sequences inside.
+
+			// TODO: If a heredoc has its termination delimeter inline (which is
+			// a bug that worked in terraform 0.11, so we need to support it
+			// here), move the delimiter to a new line.
+			buf.WriteString(tv.Text)
 
 		case hcl1token.BOOL:
 			if litVal.(bool) {

--- a/go.mod
+++ b/go.mod
@@ -70,13 +70,13 @@ require (
 	github.com/hashicorp/go-uuid v1.0.0
 	github.com/hashicorp/go-version v1.0.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
-	github.com/hashicorp/hcl v1.0.0
+	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
 	github.com/hashicorp/hcl2 v0.0.0-20190130225218-89dbc5eb3d9e
 	github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250
 	github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3
 	github.com/hashicorp/memberlist v0.1.0 // indirect
 	github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb // indirect
-	github.com/hashicorp/terraform-config-inspect v0.0.0-20190129165904-67302cb0361b
+	github.com/hashicorp/terraform-config-inspect v0.0.0-20190208230122-b0707673339c
 	github.com/hashicorp/vault v0.0.0-20161029210149-9a60bf2a50e4
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a // indirect
 	github.com/jonboulle/clockwork v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,12 @@ github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnn
 github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
+github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
+github.com/hashicorp/hcl v0.0.0-20180320202055-f40e974e75af h1:g6buE1uPu/jBP1YRkIqjoqBz5CraM5TukA+MmymQQXA=
+github.com/hashicorp/hcl v0.0.0-20180320202055-f40e974e75af/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
+github.com/hashicorp/hcl v0.0.0-20180403142333-25340db58d11 h1:/WXmgbjMlEHeC4Pbb5h/TfV3cAe6HuKDKdlWz1eoBd4=
+github.com/hashicorp/hcl v0.0.0-20180403142333-25340db58d11/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
@@ -173,6 +179,9 @@ github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb h1:ZbgmOQt8DOg796fi
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190129165904-67302cb0361b h1:A+sv28TB1pIfYHFBnEDUYIKA12RTVLsYjvu9JS+dxz8=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190129165904-67302cb0361b/go.mod h1:nKgb1xGwu9K9mk77DQJoM/XD19kEyrKFNstmjxB6/48=
+github.com/hashicorp/terraform-config-inspect v0.0.0-20190208170851-de963d052d6d h1:6sogMHZHRQKJz4qCUZBvNU9ajPeJ7PK/P6c8UexD+pY=
+github.com/hashicorp/terraform-config-inspect v0.0.0-20190208170851-de963d052d6d/go.mod h1:ItvqtvbC3K23FFET62ZwnkwtpbKZm8t8eMcWjmVVjD8=
+github.com/hashicorp/terraform-config-inspect v0.0.0-20190208230122-b0707673339c/go.mod h1:ItvqtvbC3K23FFET62ZwnkwtpbKZm8t8eMcWjmVVjD8=
 github.com/hashicorp/vault v0.0.0-20161029210149-9a60bf2a50e4 h1:SGDekHLK2IRoVS7Fb4olLyWvc2VmwKgyFC05j6X3NII=
 github.com/hashicorp/vault v0.0.0-20161029210149-9a60bf2a50e4/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=

--- a/vendor/github.com/hashicorp/hcl/.travis.yml
+++ b/vendor/github.com/hashicorp/hcl/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 language: go
 
 go:
-  - 1.x
-  - tip
+  - 1.8
 
 branches:
   only:

--- a/vendor/github.com/hashicorp/hcl/go.mod
+++ b/vendor/github.com/hashicorp/hcl/go.mod
@@ -1,3 +1,0 @@
-module github.com/hashicorp/hcl
-
-require github.com/davecgh/go-spew v1.1.1

--- a/vendor/github.com/hashicorp/hcl/go.sum
+++ b/vendor/github.com/hashicorp/hcl/go.sum
@@ -1,2 +1,0 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/vendor/github.com/hashicorp/hcl/hcl/parser/parser.go
+++ b/vendor/github.com/hashicorp/hcl/hcl/parser/parser.go
@@ -197,18 +197,9 @@ func (p *Parser) objectItem() (*ast.ObjectItem, error) {
 			keyStr = append(keyStr, k.Token.Text)
 		}
 
-		return nil, &PosError{
-			Pos: p.tok.Pos,
-			Err: fmt.Errorf(
-				"key '%s' expected start of object ('{') or assignment ('=')",
-				strings.Join(keyStr, " ")),
-		}
-	}
-
-	// key=#comment
-	// val
-	if p.lineComment != nil {
-		o.LineComment, p.lineComment = p.lineComment, nil
+		return nil, fmt.Errorf(
+			"key '%s' expected start of object ('{') or assignment ('=')",
+			strings.Join(keyStr, " "))
 	}
 
 	// do a look-ahead for line comment
@@ -328,10 +319,7 @@ func (p *Parser) objectType() (*ast.ObjectType, error) {
 
 	// No error, scan and expect the ending to be a brace
 	if tok := p.scan(); tok.Type != token.RBRACE {
-		return nil, &PosError{
-			Pos: tok.Pos,
-			Err: fmt.Errorf("object expected closing RBRACE got: %s", tok.Type),
-		}
+		return nil, fmt.Errorf("object expected closing RBRACE got: %s", tok.Type)
 	}
 
 	o.List = l

--- a/vendor/github.com/hashicorp/hcl/hcl/printer/nodes.go
+++ b/vendor/github.com/hashicorp/hcl/hcl/printer/nodes.go
@@ -252,14 +252,6 @@ func (p *printer) objectItem(o *ast.ObjectItem) []byte {
 		}
 	}
 
-	// If key and val are on different lines, treat line comments like lead comments.
-	if o.LineComment != nil && o.Val.Pos().Line != o.Keys[0].Pos().Line {
-		for _, comment := range o.LineComment.List {
-			buf.WriteString(comment.Text)
-			buf.WriteByte(newline)
-		}
-	}
-
 	for i, k := range o.Keys {
 		buf.WriteString(k.Token.Text)
 		buf.WriteByte(blank)
@@ -273,7 +265,7 @@ func (p *printer) objectItem(o *ast.ObjectItem) []byte {
 
 	buf.Write(p.output(o.Val))
 
-	if o.LineComment != nil && o.Val.Pos().Line == o.Keys[0].Pos().Line {
+	if o.Val.Pos().Line == o.Keys[0].Pos().Line && o.LineComment != nil {
 		buf.WriteByte(blank)
 		for _, comment := range o.LineComment.List {
 			buf.WriteString(comment.Text)
@@ -517,13 +509,8 @@ func (p *printer) alignedItems(items []*ast.ObjectItem) []byte {
 
 // list returns the printable HCL form of an list type.
 func (p *printer) list(l *ast.ListType) []byte {
-	if p.isSingleLineList(l) {
-		return p.singleLineList(l)
-	}
-
 	var buf bytes.Buffer
 	buf.WriteString("[")
-	buf.WriteByte(newline)
 
 	var longestLine int
 	for _, item := range l.List {
@@ -536,112 +523,115 @@ func (p *printer) list(l *ast.ListType) []byte {
 		}
 	}
 
-	haveEmptyLine := false
+	insertSpaceBeforeItem := false
+	lastHadLeadComment := false
 	for i, item := range l.List {
-		// If we have a lead comment, then we want to write that first
-		leadComment := false
-		if lit, ok := item.(*ast.LiteralType); ok && lit.LeadComment != nil {
-			leadComment = true
-
-			// Ensure an empty line before every element with a
-			// lead comment (except the first item in a list).
-			if !haveEmptyLine && i != 0 {
-				buf.WriteByte(newline)
-			}
-
-			for _, comment := range lit.LeadComment.List {
-				buf.Write(p.indent([]byte(comment.Text)))
-				buf.WriteByte(newline)
-			}
-		}
-
-		// also indent each line
-		val := p.output(item)
-		curLen := len(val)
-		buf.Write(p.indent(val))
-
-		// if this item is a heredoc, then we output the comma on
-		// the next line. This is the only case this happens.
-		comma := []byte{','}
+		// Keep track of whether this item is a heredoc since that has
+		// unique behavior.
+		heredoc := false
 		if lit, ok := item.(*ast.LiteralType); ok && lit.Token.Type == token.HEREDOC {
-			buf.WriteByte(newline)
-			comma = p.indent(comma)
+			heredoc = true
 		}
 
-		buf.Write(comma)
-
-		if lit, ok := item.(*ast.LiteralType); ok && lit.LineComment != nil {
-			// if the next item doesn't have any comments, do not align
-			buf.WriteByte(blank) // align one space
-			for i := 0; i < longestLine-curLen; i++ {
-				buf.WriteByte(blank)
-			}
-
-			for _, comment := range lit.LineComment.List {
-				buf.WriteString(comment.Text)
-			}
-		}
-
-		buf.WriteByte(newline)
-
-		// Ensure an empty line after every element with a
-		// lead comment (except the first item in a list).
-		haveEmptyLine = leadComment && i != len(l.List)-1
-		if haveEmptyLine {
-			buf.WriteByte(newline)
-		}
-	}
-
-	buf.WriteString("]")
-	return buf.Bytes()
-}
-
-// isSingleLineList returns true if:
-// * they were previously formatted entirely on one line
-// * they consist entirely of literals
-// * there are either no heredoc strings or the list has exactly one element
-// * there are no line comments
-func (printer) isSingleLineList(l *ast.ListType) bool {
-	for _, item := range l.List {
 		if item.Pos().Line != l.Lbrack.Line {
-			return false
-		}
-
-		lit, ok := item.(*ast.LiteralType)
-		if !ok {
-			return false
-		}
-
-		if lit.Token.Type == token.HEREDOC && len(l.List) != 1 {
-			return false
-		}
-
-		if lit.LineComment != nil {
-			return false
-		}
-	}
-
-	return true
-}
-
-// singleLineList prints a simple single line list.
-// For a definition of "simple", see isSingleLineList above.
-func (p *printer) singleLineList(l *ast.ListType) []byte {
-	buf := &bytes.Buffer{}
-
-	buf.WriteString("[")
-	for i, item := range l.List {
-		if i != 0 {
-			buf.WriteString(", ")
-		}
-
-		// Output the item itself
-		buf.Write(p.output(item))
-
-		// The heredoc marker needs to be at the end of line.
-		if lit, ok := item.(*ast.LiteralType); ok && lit.Token.Type == token.HEREDOC {
+			// multiline list, add newline before we add each item
 			buf.WriteByte(newline)
+			insertSpaceBeforeItem = false
+
+			// If we have a lead comment, then we want to write that first
+			leadComment := false
+			if lit, ok := item.(*ast.LiteralType); ok && lit.LeadComment != nil {
+				leadComment = true
+
+				// If this isn't the first item and the previous element
+				// didn't have a lead comment, then we need to add an extra
+				// newline to properly space things out. If it did have a
+				// lead comment previously then this would be done
+				// automatically.
+				if i > 0 && !lastHadLeadComment {
+					buf.WriteByte(newline)
+				}
+
+				for _, comment := range lit.LeadComment.List {
+					buf.Write(p.indent([]byte(comment.Text)))
+					buf.WriteByte(newline)
+				}
+			}
+
+			// also indent each line
+			val := p.output(item)
+			curLen := len(val)
+			buf.Write(p.indent(val))
+
+			// if this item is a heredoc, then we output the comma on
+			// the next line. This is the only case this happens.
+			comma := []byte{','}
+			if heredoc {
+				buf.WriteByte(newline)
+				comma = p.indent(comma)
+			}
+
+			buf.Write(comma)
+
+			if lit, ok := item.(*ast.LiteralType); ok && lit.LineComment != nil {
+				// if the next item doesn't have any comments, do not align
+				buf.WriteByte(blank) // align one space
+				for i := 0; i < longestLine-curLen; i++ {
+					buf.WriteByte(blank)
+				}
+
+				for _, comment := range lit.LineComment.List {
+					buf.WriteString(comment.Text)
+				}
+			}
+
+			lastItem := i == len(l.List)-1
+			if lastItem {
+				buf.WriteByte(newline)
+			}
+
+			if leadComment && !lastItem {
+				buf.WriteByte(newline)
+			}
+
+			lastHadLeadComment = leadComment
+		} else {
+			if insertSpaceBeforeItem {
+				buf.WriteByte(blank)
+				insertSpaceBeforeItem = false
+			}
+
+			// Output the item itself
+			// also indent each line
+			val := p.output(item)
+			curLen := len(val)
+			buf.Write(val)
+
+			// If this is a heredoc item we always have to output a newline
+			// so that it parses properly.
+			if heredoc {
+				buf.WriteByte(newline)
+			}
+
+			// If this isn't the last element, write a comma.
+			if i != len(l.List)-1 {
+				buf.WriteString(",")
+				insertSpaceBeforeItem = true
+			}
+
+			if lit, ok := item.(*ast.LiteralType); ok && lit.LineComment != nil {
+				// if the next item doesn't have any comments, do not align
+				buf.WriteByte(blank) // align one space
+				for i := 0; i < longestLine-curLen; i++ {
+					buf.WriteByte(blank)
+				}
+
+				for _, comment := range lit.LineComment.List {
+					buf.WriteString(comment.Text)
+				}
+			}
 		}
+
 	}
 
 	buf.WriteString("]")

--- a/vendor/github.com/hashicorp/hcl/json/scanner/scanner.go
+++ b/vendor/github.com/hashicorp/hcl/json/scanner/scanner.go
@@ -246,7 +246,7 @@ func (s *Scanner) scanNumber(ch rune) token.Type {
 	return token.NUMBER
 }
 
-// scanMantissa scans the mantissa beginning from the rune. It returns the next
+// scanMantissa scans the mantissa begining from the rune. It returns the next
 // non decimal rune. It's used to determine wheter it's a fraction or exponent.
 func (s *Scanner) scanMantissa(ch rune) rune {
 	scanned := false

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -340,7 +340,7 @@ github.com/hashicorp/go-tfe
 github.com/hashicorp/go-uuid
 # github.com/hashicorp/go-version v1.0.0
 github.com/hashicorp/go-version
-# github.com/hashicorp/hcl v1.0.0
+# github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
 github.com/hashicorp/hcl
 github.com/hashicorp/hcl/hcl/ast
 github.com/hashicorp/hcl/hcl/parser
@@ -372,7 +372,7 @@ github.com/hashicorp/hil/scanner
 github.com/hashicorp/logutils
 # github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb
 github.com/hashicorp/serf/coordinate
-# github.com/hashicorp/terraform-config-inspect v0.0.0-20190129165904-67302cb0361b
+# github.com/hashicorp/terraform-config-inspect v0.0.0-20190208170851-de963d052d6d
 github.com/hashicorp/terraform-config-inspect/tfconfig
 # github.com/hashicorp/vault v0.0.0-20161029210149-9a60bf2a50e4
 github.com/hashicorp/vault/helper/pgpkeys


### PR DESCRIPTION
Previously, configupgrade would panic if it encountered a HEREDOC. For
the time being, we will simply print out the HEREDOC as-is.

Unfortunately, we discovered that terraform 0.11's version of HCL
allowed for HEREDOCs with the termination delimiter inline (instead of
on a newline, which is technically correct). Since 0.12configupgrade
needs to be bug-compatible with terraform 0.11, we must roll back to the
same version of HCL used in terraform 0.11.