### PR TITLE
process state even after provider.Apply errors

### DIFF
--- a/builtin/providers/test/resource.go
+++ b/builtin/providers/test/resource.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -123,12 +124,22 @@ func testResource() *schema.Resource {
 					},
 				},
 			},
+			"apply_error": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "return and error during apply",
+			},
 		},
 	}
 }
 
 func testResourceCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId("testId")
+
+	errMsg, _ := d.Get("apply_error").(string)
+	if errMsg != "" {
+		return errors.New(errMsg)
+	}
 
 	// Required must make it through to Create
 	if _, ok := d.GetOk("required"); !ok {
@@ -156,6 +167,10 @@ func testResourceRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func testResourceUpdate(d *schema.ResourceData, meta interface{}) error {
+	errMsg, _ := d.Get("apply_error").(string)
+	if errMsg != "" {
+		return errors.New(errMsg)
+	}
 	return nil
 }
 

--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -620,6 +621,58 @@ resource "test_resource" "foo" {
 	}
 }
 				`),
+			},
+		},
+	})
+}
+
+func TestResource_updateError(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+  required     = "first"
+  required_map = {
+    a = "a"
+  }
+}
+`),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+  required     = "second"
+  required_map = {
+    a = "a"
+  }
+  apply_error = "update_error"
+}
+`),
+				ExpectError: regexp.MustCompile("update_error"),
+			},
+		},
+	})
+}
+
+func TestResource_applyError(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+  required     = "second"
+  required_map = {
+    a = "a"
+  }
+  apply_error = "apply_error"
+}
+`),
+				ExpectError: regexp.MustCompile("apply_error"),
 			},
 		},
 	})


### PR DESCRIPTION
Terraform core expects a sane state even when the provider returns an
error. Make sure at the prior state is always the default value to
return, and then alway attempt to process any state returned by
provider.Apply.

This should fix the bulk of the `Provider produced inconsistent result after apply` issues when there is a resource error.