### PR TITLE
First pass at adding CODEOWNERS for remote-state backends.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# remote-state backends.
+/backend/remote-state/azure   @terraform-azure
+/backend/remote-state/gcs     @terraform-google
+/backend/remote-state/s3      @terraform-aws


### PR DESCRIPTION
First pass at adding CODEOWNERS to link remote-state backends with maintainers of the associated providers.