### PR TITLE
allow implicit empty strings in lists

### DIFF
--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -677,3 +677,58 @@ resource "test_resource" "foo" {
 		},
 	})
 }
+
+func TestResource_emptyStrings(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+  required     = "second"
+  required_map = {
+    a = "a"
+  }
+
+  list = [""]
+}
+`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource.foo", "list.0", ""),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+  required     = "second"
+  required_map = {
+    a = "a"
+  }
+
+  list = ["", "b"]
+}
+`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource.foo", "list.0", ""),
+					resource.TestCheckResourceAttr("test_resource.foo", "list.1", "b"),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+  required     = "second"
+  required_map = {
+    a = "a"
+  }
+
+  list = [""]
+}
+`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource.foo", "list.0", ""),
+				),
+			},
+		},
+	})
+}

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -811,9 +811,10 @@ func (d *InstanceDiff) applyCollectionDiff(path []string, attrs map[string]strin
 		}
 	}
 
-	// Don't trust helper/schema to return a valid count, or even have one at
-	// all.
-	result[name+"."+idx] = countFlatmapContainerValues(name+"."+idx, result)
+	// Fill in the count value if it was missing for some reason:
+	if result[name+"."+idx] == "" {
+		result[name+"."+idx] = countFlatmapContainerValues(name+"."+idx, result)
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
The helper/schema handling of lists loses empty string values, but
retains the correct count. Only re-count the values if the count is
missing entirely, and allow our shims to re-populate the zero values.