### PR TITLE
Requires replace should not error on missing index steps

### DIFF
--- a/builtin/providers/test/resource_list.go
+++ b/builtin/providers/test/resource_list.go
@@ -25,6 +25,11 @@ func testResourceList() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
+						"force_new": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 						"sublist_block": {
 							Type:     schema.TypeList,
 							Optional: true,

--- a/builtin/providers/test/resource_list_test.go
+++ b/builtin/providers/test/resource_list_test.go
@@ -188,3 +188,33 @@ resource "test_resource_list" "bar" {
 		},
 	})
 }
+
+func TestResourceList_removedForcesNew(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "foo" {
+	list_block {
+		force_new = "ok"
+	}
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_list.foo", "list_block.0.force_new", "ok",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "foo" {
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}


### PR DESCRIPTION
RequiresReplace paths with IndexSteps that have been added or removed will fail to apply against one or the other state values. We were previously ignoring the error from apply the path to the `priorVal`, but this can happen in either direction.

Only fail if both values produce an error. In the case of a single error, make sure the other value is a valid Null of the correct type.

Fixes #20294