### PR TITLE
helper/schema: Remove comment about nested schema.Resources having their own lifecycle

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -148,7 +148,8 @@ type Schema struct {
 	// Elem represents the element type. For a TypeMap, it must be a *Schema
 	// with a Type of TypeString, otherwise it may be either a *Schema or a
 	// *Resource. If it is *Schema, the element type is just a simple value.
-	// If it is *Resource, the element type is a complex structure.
+	// If it is *Resource, the element type is a complex structure,
+	// potentially managed via its own CRUD actions on the API.
 	Elem interface{}
 
 	// The following fields are only set for a TypeList or TypeSet.

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -148,8 +148,7 @@ type Schema struct {
 	// Elem represents the element type. For a TypeMap, it must be a *Schema
 	// with a Type of TypeString, otherwise it may be either a *Schema or a
 	// *Resource. If it is *Schema, the element type is just a simple value.
-	// If it is *Resource, the element type is a complex structure,
-	// potentially with its own lifecycle.
+	// If it is *Resource, the element type is a complex structure.
 	Elem interface{}
 
 	// The following fields are only set for a TypeList or TypeSet.


### PR DESCRIPTION
This comment seems to imply that you can put CRUD functions on nested schema.Resource objects.

The comment goes back to the first commit to this file, but AFAICT this functionality has never been implemented.