### PR TITLE
command/jsonconfig: display module variables in config output

### DIFF
--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -173,9 +173,14 @@ func marshalModule(c *configs.Config, schemas *terraform.Schemas) (module, error
 	if len(c.Module.Variables) > 0 {
 		vars := make(variables, len(c.Module.Variables))
 		for k, v := range c.Module.Variables {
-			defaultValJSON, err := ctyjson.Marshal(v.Default, v.Default.Type())
-			if err != nil {
-				return module, err
+			var defaultValJSON []byte
+			if v.Default == cty.NilVal {
+				defaultValJSON = nil
+			} else {
+				defaultValJSON, err = ctyjson.Marshal(v.Default, v.Default.Type())
+				if err != nil {
+					return module, err
+				}
 			}
 			vars[k] = &variable{
 				Default:     defaultValJSON,

--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"
@@ -36,6 +37,7 @@ type module struct {
 	// time, but consistent.
 	Resources   []resource            `json:"resources,omitempty"`
 	ModuleCalls map[string]moduleCall `json:"module_calls,omitempty"`
+	Variables   variables             `json:"variables,omitempty"`
 }
 
 type moduleCall struct {
@@ -44,6 +46,15 @@ type moduleCall struct {
 	CountExpression   *expression            `json:"count_expression,omitempty"`
 	ForEachExpression *expression            `json:"for_each_expression,omitempty"`
 	Module            module                 `json:"module,omitempty"`
+}
+
+// variables is the JSON representation of the variables provided to the current
+// plan.
+type variables map[string]*variable
+
+type variable struct {
+	Default     json.RawMessage `json:"default,omitempty"`
+	Description string          `json:"description,omitempty"`
 }
 
 // Resource is the representation of a resource in the config
@@ -158,6 +169,22 @@ func marshalModule(c *configs.Config, schemas *terraform.Schemas) (module, error
 	}
 	module.Outputs = outputs
 	module.ModuleCalls = marshalModuleCalls(c, schemas)
+
+	if len(c.Module.Variables) > 0 {
+		vars := make(variables, len(c.Module.Variables))
+		for k, v := range c.Module.Variables {
+			defaultValJSON, err := ctyjson.Marshal(v.Default, v.Default.Type())
+			if err != nil {
+				return module, err
+			}
+			vars[k] = &variable{
+				Default:     defaultValJSON,
+				Description: v.Description,
+			}
+		}
+		module.Variables = vars
+	}
+
 	return module, nil
 }
 

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -321,6 +321,6 @@ type plan struct {
 	PlannedValues   map[string]interface{} `json:"planned_values,omitempty"`
 	ResourceChanges []interface{}          `json:"resource_changes,omitempty"`
 	OutputChanges   map[string]interface{} `json:"output_changes,omitempty"`
-	PriorState      string                 `json:"prior_state,omitempty"`
-	Config          string                 `json:"configuration,omitempty"`
+	PriorState      map[string]interface{} `json:"prior_state,omitempty"`
+	Config          map[string]interface{} `json:"configuration,omitempty"`
 }

--- a/command/test-fixtures/show-json/basic-create/output.json
+++ b/command/test-fixtures/show-json/basic-create/output.json
@@ -147,12 +147,23 @@
                     "name": "test",
                     "provider_config_key": "provider.test",
                     "schema_version": 0,
+                    "expressions": {
+                        "ami": {
+                            "references": [
+                                "var.test_var"
+                            ]
+                        }
+                    },
                     "count_expression": {
                         "constant_value": 3
-                    },
-                    "for_each_expression": {}
+                    }
                 }
-            ]
+            ],
+            "variables": {
+                "test_var": {
+                    "default": "bar"
+                }
+            }
         }
     }
 }

--- a/command/test-fixtures/show-json/basic-delete/output.json
+++ b/command/test-fixtures/show-json/basic-delete/output.json
@@ -85,29 +85,32 @@
     },
     "prior_state": {
         "format_version": "0.1",
+        "terraform_version": "0.12.0",
         "values": {
             "root_module": {
                 "resources": [
                     {
                         "address": "test_instance.test",
+                        "schema_version": 0,
                         "mode": "managed",
                         "type": "test_instance",
                         "name": "test",
                         "provider_name": "test",
                         "values": {
-                            "ami": {},
-                            "id": {}
+                            "ami": "foo",
+                            "id": "placeholder"
                         }
                     },
                     {
                         "address": "test_instance.test-delete",
+                        "schema_version": 0,
                         "mode": "managed",
                         "type": "test_instance",
                         "name": "test-delete",
                         "provider_name": "test",
                         "values": {
-                            "ami": {},
-                            "id": {}
+                            "ami": "foo",
+                            "id": "placeholder"
                         }
                     }
                 ]
@@ -133,10 +136,20 @@
                     "name": "test",
                     "provider_config_key": "provider.test",
                     "schema_version": 0,
-                    "count_expression": {},
-                    "for_each_expression": {}
+                    "expressions": {
+                        "ami": {
+                            "references": [
+                                "var.test_var"
+                            ]
+                        }
+                    }
                 }
-            ]
+            ],
+            "variables": {
+                "test_var": {
+                    "default": "bar"
+                }
+            }
         }
     }
 }

--- a/command/test-fixtures/show-json/basic-update/output.json
+++ b/command/test-fixtures/show-json/basic-update/output.json
@@ -67,6 +67,7 @@
     },
     "prior_state": {
         "format_version": "0.1",
+        "terraform_version": "0.12.0",
         "values": {
             "root_module": {
                 "resources": [
@@ -75,10 +76,11 @@
                         "mode": "managed",
                         "type": "test_instance",
                         "name": "test",
+                        "schema_version": 0,
                         "provider_name": "test",
                         "values": {
-                            "ami": {},
-                            "id": {}
+                            "ami": "bar",
+                            "id": "placeholder"
                         }
                     }
                 ]
@@ -104,10 +106,20 @@
                     "name": "test",
                     "provider_config_key": "provider.test",
                     "schema_version": 0,
-                    "count_expression": {},
-                    "for_each_expression": {}
+                    "expressions": {
+                        "ami": {
+                            "references": [
+                                "var.test_var"
+                            ]
+                        }
+                    }
                 }
-            ]
+            ],
+            "variables": {
+                "test_var": {
+                    "default": "bar"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The tests have been updated to reflect this.

Example output (truncated):
```json
    "configuration": {
        "root_module": {
            "outputs": { },
            "resources": [ ],
            "variables": {
                "test_var": {
                    "default": "bar"
                }
            }
        }
    }
```