### PR TITLE
vendor: github.com/hashicorp/go-tfe@v0.3.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90
 	github.com/hashicorp/go-safetemp v0.0.0-20180326211150-b1a1dbde6fdc // indirect
 	github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86 // indirect
-	github.com/hashicorp/go-tfe v0.3.7
+	github.com/hashicorp/go-tfe v0.3.8
 	github.com/hashicorp/go-uuid v1.0.0
 	github.com/hashicorp/go-version v1.0.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/hashicorp/go-slug v0.2.0 h1:MVdZAkTmDsUi1AT+3NQDsn8n3ssnVSIHwiM6RcUHv
 github.com/hashicorp/go-slug v0.2.0/go.mod h1:+zDycQOzGqOqMW7Kn2fp9vz/NtqpMLQlgb9JUF+0km4=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86 h1:7YOlAIO2YWnJZkQp7B5eFykaIY7C9JndqAFQyVV5BhM=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
-github.com/hashicorp/go-tfe v0.3.7 h1:YTL4qVxuQ9mRUnGrxXN3dlil7IugxyDOiOkUQANH6fg=
-github.com/hashicorp/go-tfe v0.3.7/go.mod h1:LHLchj07PCYgQqcyE5Sz+g4zrMNW+nALKbiSNTZedEs=
+github.com/hashicorp/go-tfe v0.3.8 h1:pUqxmnhZ7Dj3biugEEo2oGZ758zVQy70lx8p7p4JREY=
+github.com/hashicorp/go-tfe v0.3.8/go.mod h1:LHLchj07PCYgQqcyE5Sz+g4zrMNW+nALKbiSNTZedEs=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=

--- a/vendor/github.com/hashicorp/go-tfe/configuration_version.go
+++ b/vendor/github.com/hashicorp/go-tfe/configuration_version.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"time"
 
 	slug "github.com/hashicorp/go-slug"
@@ -183,9 +184,17 @@ func (s *configurationVersions) Read(ctx context.Context, cvID string) (*Configu
 // upload URL from a configuration version and the path to the configuration
 // files on disk.
 func (s *configurationVersions) Upload(ctx context.Context, url, path string) error {
+	file, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !file.Mode().IsDir() {
+		return errors.New("path needs to be an existing directory")
+	}
+
 	body := bytes.NewBuffer(nil)
 
-	_, err := slug.Pack(path, body, true)
+	_, err = slug.Pack(path, body, true)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/hashicorp/go-tfe/tfe.go
+++ b/vendor/github.com/hashicorp/go-tfe/tfe.go
@@ -251,13 +251,8 @@ func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Respons
 
 // configureLimiter configures the rate limiter.
 func (c *Client) configureLimiter() error {
-	u, err := c.baseURL.Parse("/")
-	if err != nil {
-		return err
-	}
-
 	// Create a new request.
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest("GET", c.baseURL.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -266,6 +261,7 @@ func (c *Client) configureLimiter() error {
 	for k, v := range c.headers {
 		req.Header[k] = v
 	}
+	req.Header.Set("Accept", "application/vnd.api+json")
 
 	// Make a single request to retrieve the rate limit headers.
 	resp, err := c.http.HTTPClient.Do(req)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -373,7 +373,7 @@ github.com/hashicorp/go-rootcerts
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.2.0
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.3.7
+# github.com/hashicorp/go-tfe v0.3.8
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.0
 github.com/hashicorp/go-uuid


### PR DESCRIPTION
Similar to https://github.com/hashicorp/terraform/pull/20310 and https://github.com/terraform-providers/terraform-provider-tfe/pull/59 this PR aligns versions of `go-tfe` in TFE provider and Terraform's `master` to make future upgrade path smoother.