### PR TITLE
Add option to compress state file for s3 remote state

### DIFF
--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -226,6 +226,13 @@ func New() backend.Backend {
 				Description: "The maximum number of times an AWS API request is retried on retryable failure.",
 				Default:     5,
 			},
+
+			"compression": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Enable gzip compression before sending sate file into bucket",
+				Default:     false,
+			},
 		},
 	}
 
@@ -248,6 +255,7 @@ type Backend struct {
 	kmsKeyID             string
 	ddbTable             string
 	workspaceKeyPrefix   string
+	compression          bool
 }
 
 func (b *Backend) configure(ctx context.Context) error {
@@ -264,6 +272,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	b.acl = data.Get("acl").(string)
 	b.kmsKeyID = data.Get("kms_key_id").(string)
 	b.workspaceKeyPrefix = data.Get("workspace_key_prefix").(string)
+	b.compression = data.Get("compression").(bool)
 
 	b.ddbTable = data.Get("dynamodb_table").(string)
 	if b.ddbTable == "" {

--- a/backend/remote-state/s3/backend_state.go
+++ b/backend/remote-state/s3/backend_state.go
@@ -111,6 +111,7 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 		acl:                  b.acl,
 		kmsKeyID:             b.kmsKeyID,
 		ddbTable:             b.ddbTable,
+		compression:          b.compression,
 	}
 
 	return client, nil

--- a/backend/remote-state/s3/backend_test.go
+++ b/backend/remote-state/s3/backend_test.go
@@ -40,6 +40,7 @@ func TestBackendConfig(t *testing.T) {
 		"key":            "state",
 		"encrypt":        true,
 		"dynamodb_table": "dynamoTable",
+		"compression":    true,
 	}
 
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
@@ -52,6 +53,9 @@ func TestBackendConfig(t *testing.T) {
 	}
 	if b.keyName != "state" {
 		t.Fatalf("Incorrect keyName was populated")
+	}
+	if !b.compression {
+		t.Fatalf("Incorrect compression was populated")
 	}
 
 	credentials, err := b.s3Client.Config.Credentials.Get()


### PR DESCRIPTION
Thanks to that option (optional, default to false), we will be able to use gzip compression for state file

## Acceptance tests output
```bash
$ make testacc TEST=./backend/remote-state/s3 TESTARGS='-run=TestRemoteClient_stateChecksum'
TF_ACC=1 go test ./backend/remote-state/s3 -v -run=TestRemoteClient_stateChecksum -mod=vendor -timeout 120m
=== RUN   TestRemoteClient_stateChecksum
=== RUN   TestRemoteClient_stateChecksum/with_compression
=== RUN   TestRemoteClient_stateChecksum/without_compression
--- PASS: TestRemoteClient_stateChecksum (31.97s)
    --- PASS: TestRemoteClient_stateChecksum/with_compression (17.22s)
        client_test.go:225: TestBackendConfig on *s3.Backend with configs.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"bucket":cty.StringVal("terraform-remote-s3-test-5c647859"), "compression":cty.True, "dynamodb_table":cty.StringVal("terraform-remote-s3-test-5c647859"), "key":cty.StringVal("te
stState")}}
        backend_test.go:370: creating S3 bucket terraform-remote-s3-test-5c647859 in eu-west-2
        client_test.go:258: TestBackendConfig on *s3.Backend with configs.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"bucket":cty.StringVal("terraform-remote-s3-test-5c647859"), "key":cty.StringVal("testState")}}
    --- PASS: TestRemoteClient_stateChecksum/without_compression (14.76s)
        client_test.go:225: TestBackendConfig on *s3.Backend with configs.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"bucket":cty.StringVal("terraform-remote-s3-test-5c64786a"), "compression":cty.False, "dynamodb_table":cty.StringVal("terraform-remote-s3-test-5c64786a"), "key":cty.StringVal("t
estState")}}
        backend_test.go:370: creating S3 bucket terraform-remote-s3-test-5c64786a in eu-west-2
        client_test.go:258: TestBackendConfig on *s3.Backend with configs.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"bucket":cty.StringVal("terraform-remote-s3-test-5c64786a"), "key":cty.StringVal("testState")}}
PASS
ok      github.com/hashicorp/terraform/backend/remote-state/s3  32.017s
```
Logs truncated





Solves #20328 