### PR TITLE
Clear RequiresNew for lifecycle ignored attributes

### DIFF
--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -242,8 +242,11 @@ func (n *EvalDiff) processIgnoreChanges(diff *InstanceDiff) error {
 
 			// If any RequiresNew attribute isn't ignored, we need to keep the diff
 			// as-is to be able to replace the resource.
-			if v.RequiresNew && !ignorableAttrKeys[k] {
-				return nil
+			if v.RequiresNew {
+				if !ignorableAttrKeys[k] {
+					return nil
+				}
+				v.RequiresNew = false
 			}
 		}
 


### PR DESCRIPTION
This is a follow-up for an issue reported at
https://github.com/terraform-providers/terraform-provider-google/issues/2498

Not sure if this is the proper way to fix it. But it seemed logical that ignored attributes should not be the cause of 'RequiresNew' for a diff.
So the patch clears this flag for any such attributes.