### PR TITLE
helper/validation: Backport All(), Any(), and IntInSlice() functions

### DIFF
--- a/helper/validation/validation.go
+++ b/helper/validation/validation.go
@@ -28,6 +28,24 @@ func All(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc {
 	}
 }
 
+// Any returns a SchemaValidateFunc which tests if the provided value
+// passes any of the provided SchemaValidateFunc
+func Any(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		var allErrors []error
+		var allWarnings []string
+		for _, validator := range validators {
+			validatorWarnings, validatorErrors := validator(i, k)
+			if len(validatorWarnings) == 0 && len(validatorErrors) == 0 {
+				return []string{}, []error{}
+			}
+			allWarnings = append(allWarnings, validatorWarnings...)
+			allErrors = append(allErrors, validatorErrors...)
+		}
+		return allWarnings, allErrors
+	}
+}
+
 // IntBetween returns a SchemaValidateFunc which tests if the provided value
 // is of type int and is between min and max (inclusive)
 func IntBetween(min, max int) schema.SchemaValidateFunc {

--- a/helper/validation/validation_test.go
+++ b/helper/validation/validation_test.go
@@ -41,6 +41,41 @@ func TestValidationAll(t *testing.T) {
 	})
 }
 
+func TestValidationAny(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: 43,
+			f: Any(
+				IntAtLeast(42),
+				IntAtMost(5),
+			),
+		},
+		{
+			val: 4,
+			f: Any(
+				IntAtLeast(42),
+				IntAtMost(5),
+			),
+		},
+		{
+			val: 7,
+			f: Any(
+				IntAtLeast(42),
+				IntAtMost(5),
+			),
+			expectedErr: regexp.MustCompile("expected [\\w]+ to be at least \\(42\\), got 7"),
+		},
+		{
+			val: 7,
+			f: Any(
+				IntAtLeast(42),
+				IntAtMost(5),
+			),
+			expectedErr: regexp.MustCompile("expected [\\w]+ to be at most \\(5\\), got 7"),
+		},
+	})
+}
+
 func TestValidationIntBetween(t *testing.T) {
 	runTestCases(t, []testCase{
 		{

--- a/helper/validation/validation_test.go
+++ b/helper/validation/validation_test.go
@@ -13,6 +13,34 @@ type testCase struct {
 	expectedErr *regexp.Regexp
 }
 
+func TestValidationAll(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "valid",
+			f: All(
+				StringLenBetween(5, 42),
+				StringMatch(regexp.MustCompile(`[a-zA-Z0-9]+`), "value must be alphanumeric"),
+			),
+		},
+		{
+			val: "foo",
+			f: All(
+				StringLenBetween(5, 42),
+				StringMatch(regexp.MustCompile(`[a-zA-Z0-9]+`), "value must be alphanumeric"),
+			),
+			expectedErr: regexp.MustCompile("expected length of [\\w]+ to be in the range \\(5 - 42\\), got foo"),
+		},
+		{
+			val: "!!!!!",
+			f: All(
+				StringLenBetween(5, 42),
+				StringMatch(regexp.MustCompile(`[a-zA-Z0-9]+`), "value must be alphanumeric"),
+			),
+			expectedErr: regexp.MustCompile("value must be alphanumeric"),
+		},
+	})
+}
+
 func TestValidationIntBetween(t *testing.T) {
 	runTestCases(t, []testCase{
 		{
@@ -78,6 +106,25 @@ func TestValidationIntAtMost(t *testing.T) {
 			val:         "1",
 			f:           IntAtMost(0),
 			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be int"),
+		},
+	})
+}
+
+func TestValidationIntInSlice(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: 42,
+			f:   IntInSlice([]int{1, 42}),
+		},
+		{
+			val:         42,
+			f:           IntInSlice([]int{10, 20}),
+			expectedErr: regexp.MustCompile("expected [\\w]+ to be one of \\[10 20\\], got 42"),
+		},
+		{
+			val:         "InvalidValue",
+			f:           IntInSlice([]int{10, 20}),
+			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be an integer"),
 		},
 	})
 }


### PR DESCRIPTION
My apologies, I was really trying to avoid this one. I am okay with it being rejected. 😅 

These two commits were merged into master right after the 0.12 cutover, with the hope that we could shortly thereafter update the provider SDK to have access to these for cleaning up the sprawling AWS provider custom validation functions. Since concurrent 0.11 SDK acceptance testing after updating to 0.12 SDK is a current goal which would further delay access to these, it would be wonderful to backport these now to avoid compilation issues and so we can open issues in the provider repository to help start the validation function cleanup process sooner rather than (potentially much) later.