### PR TITLE
command/jsonplan: "deposed" should be a string, not a bool.

### DIFF
--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -242,7 +242,9 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 			AfterUnknown: a,
 		}
 
-		r.Deposed = rc.DeposedKey == states.NotDeposed
+		if rc.DeposedKey != states.NotDeposed {
+			r.Deposed = rc.DeposedKey.String()
+		}
 
 		key := addr.Resource.Key
 		if key != nil {

--- a/command/jsonplan/resource.go
+++ b/command/jsonplan/resource.go
@@ -56,7 +56,7 @@ type resourceChange struct {
 	// "deposed", if set, indicates that this action applies to a "deposed"
 	// object of the given instance rather than to its "current" object. Omitted
 	// for changes to the current object.
-	Deposed bool `json:"deposed,omitempty"`
+	Deposed string `json:"deposed,omitempty"`
 
 	// Change describes the change that will be made to this object
 	Change change `json:"change,omitempty"`

--- a/command/test-fixtures/show-json/basic-create/output.json
+++ b/command/test-fixtures/show-json/basic-create/output.json
@@ -60,7 +60,6 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
-            "deposed": true,
             "change": {
                 "actions": [
                     "create"
@@ -81,7 +80,6 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
-            "deposed": true,
             "change": {
                 "actions": [
                     "create"
@@ -102,7 +100,6 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
-            "deposed": true,
             "change": {
                 "actions": [
                     "create"

--- a/command/test-fixtures/show-json/basic-delete/output.json
+++ b/command/test-fixtures/show-json/basic-delete/output.json
@@ -35,7 +35,6 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
-            "deposed": true,
             "change": {
                 "actions": [
                     "update"
@@ -59,7 +58,6 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test-delete",
-            "deposed": true,
             "change": {
                 "actions": [
                     "delete"

--- a/command/test-fixtures/show-json/basic-update/output.json
+++ b/command/test-fixtures/show-json/basic-update/output.json
@@ -35,7 +35,6 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
-            "deposed": true,
             "change": {
                 "actions": [
                     "no-op"


### PR DESCRIPTION
🙄 No excuses, just user error on my part.

@vancluever you'll want to make note of this, I used the wrong type entirely for the "deposed" key in "resource_changes". 