### PR TITLE
command/show: add "module_version" to "module_calls" in config 

### DIFF
--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -46,6 +46,7 @@ type moduleCall struct {
 	CountExpression   *expression            `json:"count_expression,omitempty"`
 	ForEachExpression *expression            `json:"for_each_expression,omitempty"`
 	Module            module                 `json:"module,omitempty"`
+	ModuleVersion     string                 `json:"module_version,omitempty"`
 }
 
 // variables is the JSON representation of the variables provided to the current
@@ -198,6 +199,7 @@ func marshalModuleCalls(c *configs.Config, schemas *terraform.Schemas) map[strin
 	for _, mc := range c.Module.ModuleCalls {
 		retMC := moduleCall{
 			ResolvedSource: mc.SourceAddr,
+			ModuleVersion:  mc.Version.Required.String(),
 		}
 		cExp := marshalExpression(mc.Count)
 		if !cExp.Empty() {

--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -41,12 +41,12 @@ type module struct {
 }
 
 type moduleCall struct {
-	ResolvedSource    string                 `json:"resolved_source,omitempty"`
+	Source            string                 `json:"source,omitempty"`
 	Expressions       map[string]interface{} `json:"expressions,omitempty"`
 	CountExpression   *expression            `json:"count_expression,omitempty"`
 	ForEachExpression *expression            `json:"for_each_expression,omitempty"`
 	Module            module                 `json:"module,omitempty"`
-	ModuleVersion     string                 `json:"module_version,omitempty"`
+	VersionConstraint string                 `json:"version_constraint,omitempty"`
 }
 
 // variables is the JSON representation of the variables provided to the current
@@ -198,8 +198,8 @@ func marshalModuleCalls(c *configs.Config, schemas *terraform.Schemas) map[strin
 	ret := make(map[string]moduleCall)
 	for _, mc := range c.Module.ModuleCalls {
 		retMC := moduleCall{
-			ResolvedSource: mc.SourceAddr,
-			ModuleVersion:  mc.Version.Required.String(),
+			Source:            mc.SourceAddr,
+			VersionConstraint: mc.Version.Required.String(),
 		}
 		cExp := marshalExpression(mc.Count)
 		if !cExp.Empty() {

--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -88,6 +88,7 @@ func marshalPlannedValues(changes *plans.Changes, schemas *terraform.Schemas) (m
 	// 		module -> [children modules]
 	moduleResourceMap := make(map[string][]addrs.AbsResourceInstance)
 	moduleMap := make(map[string][]addrs.ModuleInstance)
+	seenModules := make(map[string]bool)
 
 	for _, resource := range changes.Resources {
 		// if the resource is being deleted, skip over it.
@@ -98,7 +99,10 @@ func marshalPlannedValues(changes *plans.Changes, schemas *terraform.Schemas) (m
 			// root has no parents.
 			if containingModule != "" {
 				parent := resource.Addr.Module.Parent().String()
-				moduleMap[parent] = append(moduleMap[parent], resource.Addr.Module)
+				if !seenModules[parent] {
+					moduleMap[parent] = append(moduleMap[parent], resource.Addr.Module)
+					seenModules[parent] = true
+				}
 			}
 		}
 	}

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/helper/copy"
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/states"
@@ -146,24 +148,35 @@ func TestShow_json_output(t *testing.T) {
 		}
 
 		t.Run(entry.Name(), func(t *testing.T) {
+			td := tempDir(t)
 			inputDir := filepath.Join(fixtureDir, entry.Name())
-
-			cwd, err := os.Getwd()
-			if err != nil {
-				t.Fatalf("err: %s", err)
-			}
-			if err := os.Chdir(inputDir); err != nil {
-				t.Fatalf("err: %s", err)
-			}
-			defer os.Chdir(cwd)
+			copy.CopyDir(inputDir, td)
+			defer os.RemoveAll(td)
+			defer testChdir(t, td)()
 
 			p := showFixtureProvider()
 			ui := new(cli.MockUi)
-			pc := &PlanCommand{
-				Meta: Meta{
-					testingOverrides: metaOverridesForProvider(p),
-					Ui:               ui,
+			m := Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+			}
+
+			// init
+			ic := &InitCommand{
+				Meta: m,
+				providerInstaller: &mockProviderInstaller{
+					Providers: map[string][]string{
+						"test": []string{"1.2.3"},
+					},
+					Dir: m.pluginDir(),
 				},
+			}
+			if code := ic.Run([]string{}); code != 0 {
+				t.Fatalf("init failed\n%s", ui.ErrorWriter)
+			}
+
+			pc := &PlanCommand{
+				Meta: m,
 			}
 
 			args := []string{
@@ -171,16 +184,14 @@ func TestShow_json_output(t *testing.T) {
 			}
 
 			if code := pc.Run(args); code != 0 {
+				fmt.Println(ui.OutputWriter.String())
 				t.Fatalf("wrong exit status %d; want 0\nstderr: %s", code, ui.ErrorWriter.String())
 			}
 
 			// flush the plan output from the mock ui
 			ui.OutputWriter.Reset()
 			sc := &ShowCommand{
-				Meta: Meta{
-					testingOverrides: metaOverridesForProvider(p),
-					Ui:               ui,
-				},
+				Meta: m,
 			}
 
 			args = []string{

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -184,7 +184,6 @@ func TestShow_json_output(t *testing.T) {
 			}
 
 			if code := pc.Run(args); code != 0 {
-				fmt.Println(ui.OutputWriter.String())
 				t.Fatalf("wrong exit status %d; want 0\nstderr: %s", code, ui.ErrorWriter.String())
 			}
 

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"

--- a/command/test-fixtures/show-json/modules/foo/main.tf
+++ b/command/test-fixtures/show-json/modules/foo/main.tf
@@ -1,0 +1,11 @@
+variable "test_var" {
+  default = "bar"
+}
+resource "test_instance" "test" {
+  ami   = var.test_var
+  count = 3
+}
+
+output "test" {
+  value = var.test_var
+}

--- a/command/test-fixtures/show-json/modules/main.tf
+++ b/command/test-fixtures/show-json/modules/main.tf
@@ -1,0 +1,8 @@
+module "test" {
+  source   = "./foo"
+  test_var = "baz"
+}
+
+output "test" {
+  value = module.test.test
+}

--- a/command/test-fixtures/show-json/modules/modules.json
+++ b/command/test-fixtures/show-json/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"/Users/kristin/go/src/github.com/hashicorp/terraform/command/test-fixtures/show-json/modules"},{"Key":"test","Source":"./foo","Dir":"/Users/kristin/go/src/github.com/hashicorp/terraform/command/test-fixtures/show-json/modules/foo"}]}

--- a/command/test-fixtures/show-json/modules/output.json
+++ b/command/test-fixtures/show-json/modules/output.json
@@ -144,7 +144,7 @@
             },
             "module_calls": {
                 "test": {
-                    "resolved_source": "./foo",
+                    "source": "./foo",
                     "expressions": {
                         "test_var": {
                             "constant_value": "baz"

--- a/command/test-fixtures/show-json/modules/output.json
+++ b/command/test-fixtures/show-json/modules/output.json
@@ -1,0 +1,193 @@
+{
+    "format_version": "0.1",
+    "planned_values": {
+        "outputs": {
+            "test": {
+                "sensitive": false,
+                "value": "baz"
+            }
+        },
+        "root_module": {
+            "child_modules": [
+                {
+                    "resources": [
+                        {
+                            "address": "module.test.test_instance.test[0]",
+                            "mode": "managed",
+                            "type": "test_instance",
+                            "name": "test",
+                            "index": 0,
+                            "provider_name": "test",
+                            "schema_version": 0,
+                            "values": {
+                                "ami": "baz"
+                            }
+                        },
+                        {
+                            "address": "module.test.test_instance.test[1]",
+                            "mode": "managed",
+                            "type": "test_instance",
+                            "name": "test",
+                            "index": 1,
+                            "provider_name": "test",
+                            "schema_version": 0,
+                            "values": {
+                                "ami": "baz"
+                            }
+                        },
+                        {
+                            "address": "module.test.test_instance.test[2]",
+                            "mode": "managed",
+                            "type": "test_instance",
+                            "name": "test",
+                            "index": 2,
+                            "provider_name": "test",
+                            "schema_version": 0,
+                            "values": {
+                                "ami": "baz"
+                            }
+                        }
+                    ],
+                    "address": "module.test"
+                }
+            ]
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "module.test.test_instance.test[0]",
+            "module_address": "module.test",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "index": 0,
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "ami": "baz"
+                },
+                "after_unknown": {
+                    "ami": false,
+                    "id": true
+                }
+            }
+        },
+        {
+            "address": "module.test.test_instance.test[1]",
+            "module_address": "module.test",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "index": 1,
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "ami": "baz"
+                },
+                "after_unknown": {
+                    "ami": false,
+                    "id": true
+                }
+            }
+        },
+        {
+            "address": "module.test.test_instance.test[2]",
+            "module_address": "module.test",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "index": 2,
+            "deposed": true,
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "ami": "baz"
+                },
+                "after_unknown": {
+                    "ami": false,
+                    "id": true
+                }
+            }
+        }
+    ],
+    "output_changes": {
+        "test": {
+            "actions": [
+                "create"
+            ],
+            "before": null,
+            "after": "baz",
+            "after_unknown": false
+        }
+    },
+    "configuration": {
+        "root_module": {
+            "outputs": {
+                "test": {
+                    "expression": {
+                        "references": [
+                            "module.test.test"
+                        ]
+                    }
+                }
+            },
+            "module_calls": {
+                "test": {
+                    "resolved_source": "./foo",
+                    "expressions": {
+                        "test_var": {
+                            "constant_value": "baz"
+                        }
+                    },
+                    "module": {
+                        "outputs": {
+                            "test": {
+                                "expression": {
+                                    "references": [
+                                        "var.test_var"
+                                    ]
+                                }
+                            }
+                        },
+                        "resources": [
+                            {
+                                "address": "test_instance.test",
+                                "mode": "managed",
+                                "type": "test_instance",
+                                "name": "test",
+                                "provider_config_key": "provider.test",
+                                "expressions": {
+                                    "ami": {
+                                        "references": [
+                                            "var.test_var"
+                                        ]
+                                    }
+                                },
+                                "schema_version": 0,
+                                "count_expression": {
+                                    "constant_value": 3
+                                }
+                            }
+                        ],
+                        "variables": {
+                            "test_var": {
+                                "default": "bar"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
command/show: add "module_version" to "module_calls" in config portion  of `terraform show`.

Also extended the `terraform show -json` test to run `init` so we could
add examples with modules. This does _not_ test the "module_version"
yet, but it _did_ help expose a bug in `jsonplan` where modules were
duplicated. This is also fixed in this PR.

I'm open to renaming "module_version" (and any other feedback) - opening a PR seemed the most straightforward way to start that conversation.