### PR TITLE
backend/remote: use `state.v2` for remote state only

### DIFF
--- a/backend/remote-state/etcdv2/backend.go
+++ b/backend/remote-state/etcdv2/backend.go
@@ -24,7 +24,7 @@ func New() backend.Backend {
 			"endpoints": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "A space-separated list of the etcd endpoints<Paste>",
+				Description: "A space-separated list of the etcd endpoints",
 			},
 			"username": &schema.Schema{
 				Type:        schema.TypeString,

--- a/backend/remote/testing.go
+++ b/backend/remote/testing.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"testing"
 
 	tfe "github.com/hashicorp/go-tfe"
@@ -184,6 +185,7 @@ func testServer(t *testing.T) *httptest.Server {
 	mux.HandleFunc("/well-known/terraform.json", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		io.WriteString(w, `{
+  "state.v2": "/api/v2/",
   "tfe.v2.1": "/api/v2/",
   "versions.v1": "/v1/versions/"
 }`)
@@ -192,12 +194,12 @@ func testServer(t *testing.T) *httptest.Server {
 	// Respond to service version constraints calls.
 	mux.HandleFunc("/v1/versions/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, `{
-  "service": "tfe.v2.1",
+		io.WriteString(w, fmt.Sprintf(`{
+  "service": "%s",
   "product": "terraform",
   "minimum": "0.1.0",
   "maximum": "10.0.0"
-}`)
+}`, path.Base(r.URL.Path)))
 	})
 
 	// Respond to the initial query to read the hashicorp org entitlements.
@@ -259,6 +261,7 @@ func testServer(t *testing.T) *httptest.Server {
 // localhost to a local test server.
 func testDisco(s *httptest.Server) *disco.Disco {
 	services := map[string]interface{}{
+		"state.v2":    fmt.Sprintf("%s/api/v2/", s.URL),
 		"tfe.v2.1":    fmt.Sprintf("%s/api/v2/", s.URL),
 		"versions.v1": fmt.Sprintf("%s/v1/versions/", s.URL),
 	}


### PR DESCRIPTION
The API surface area is much smaller when we use the remote backend for remote state only.

So in order to try and prevent any backwards incompatibilities when TF runs inside of TFE, we’ve split up the discovery services into `state.v2` (which can be used for remote state only configurations, so when running in TFE) and `tfe.v2.1` (which can be used for all remote configurations).