### PR TITLE
command/jsonconfig: add missing fields from configuration output

### DIFF
--- a/command/test-fixtures/show-json/modules/main.tf
+++ b/command/test-fixtures/show-json/modules/main.tf
@@ -4,5 +4,6 @@ module "test" {
 }
 
 output "test" {
-  value = module.test.test
+  value      = module.test.test
+  depends_on = [module.test]
 }

--- a/command/test-fixtures/show-json/modules/output.json
+++ b/command/test-fixtures/show-json/modules/output.json
@@ -61,7 +61,6 @@
             "type": "test_instance",
             "name": "test",
             "index": 0,
-            "deposed": true,
             "change": {
                 "actions": [
                     "create"
@@ -83,7 +82,6 @@
             "type": "test_instance",
             "name": "test",
             "index": 1,
-            "deposed": true,
             "change": {
                 "actions": [
                     "create"
@@ -105,7 +103,6 @@
             "type": "test_instance",
             "name": "test",
             "index": 2,
-            "deposed": true,
             "change": {
                 "actions": [
                     "create"
@@ -139,7 +136,10 @@
                         "references": [
                             "module.test.test"
                         ]
-                    }
+                    },
+                    "depends_on": [
+                        "module.test"
+                    ]
                 }
             },
             "module_calls": {


### PR DESCRIPTION
Display depends_on for resources and outputs, and description for
outputs.

I've added an example "depends_on" into a test as well. This also includes a bonus fix for a broken test I merged earlier today. 