### PR TITLE
move provider init error to where it is generated

### DIFF
--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/hashicorp/terraform/backend"
@@ -594,25 +593,3 @@ func (b *Local) stateWorkspaceDir() string {
 
 	return DefaultWorkspaceDir
 }
-
-func (b *Local) pluginInitRequired(providerErr *terraform.ResourceProviderError) {
-	b.CLI.Output(b.Colorize().Color(fmt.Sprintf(
-		strings.TrimSpace(errPluginInit)+"\n",
-		providerErr)))
-}
-
-// this relies on multierror to format the plugin errors below the copy
-const errPluginInit = `
-[reset][bold][yellow]Plugin reinitialization required. Please run "terraform init".[reset]
-[yellow]Reason: Could not satisfy plugin requirements.
-
-Plugins are external binaries that Terraform uses to access and manipulate
-resources. The configuration provided requires plugins which can't be located,
-don't satisfy the version constraints, or are otherwise incompatible.
-
-[reset][red]%s
-
-[reset][yellow]Terraform automatically discovers provider requirements from your
-configuration, including providers used in child modules. To see the
-requirements and constraints from each module, run "terraform providers".
-`

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform/tfdiags"
 
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/hashicorp/terraform/providers"
 )
@@ -170,18 +169,6 @@ type ResourceProvider interface {
 	// ReadDataApply initializes a data instance using the configuration
 	// in a diff produced by ReadDataDiff.
 	ReadDataApply(*InstanceInfo, *InstanceDiff) (*InstanceState, error)
-}
-
-// ResourceProviderError may be returned when creating a Context if the
-// required providers cannot be satisfied. This error can then be used to
-// format a more useful message for the user.
-type ResourceProviderError struct {
-	Errors []error
-}
-
-func (e *ResourceProviderError) Error() string {
-	// use multierror to format the default output
-	return multierror.Append(nil, e.Errors...).Error()
 }
 
 // ResourceProviderCloser is an interface that providers that can close

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -3,6 +3,8 @@ package terraform
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform/tfdiags"
+
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/hashicorp/terraform/providers"
@@ -296,13 +298,35 @@ func ProviderHasDataSource(p ResourceProvider, n string) bool {
 // This should be called only with configurations that have passed calls
 // to config.Validate(), which ensures that all of the given version
 // constraints are valid. It will panic if any invalid constraints are present.
-func resourceProviderFactories(resolver providers.Resolver, reqd discovery.PluginRequirements) (map[string]providers.Factory, error) {
+func resourceProviderFactories(resolver providers.Resolver, reqd discovery.PluginRequirements) (map[string]providers.Factory, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 	ret, errs := resolver.ResolveProviders(reqd)
 	if errs != nil {
-		return nil, &ResourceProviderError{
-			Errors: errs,
+		diags = diags.Append(
+			tfdiags.Sourceless(tfdiags.Error,
+				"Could not satisfy plugin requirements",
+				errPluginInit,
+			),
+		)
+
+		for _, err := range errs {
+			diags = diags.Append(err)
 		}
+
+		return nil, diags
 	}
 
 	return ret, nil
 }
+
+const errPluginInit = `
+Plugin reinitialization required. Please run "terraform init".
+
+Plugins are external binaries that Terraform uses to access and manipulate
+resources. The configuration provided requires plugins which can't be located,
+don't satisfy the version constraints, or are otherwise incompatible.
+
+Terraform automatically discovers provider requirements from your
+configuration, including providers used in child modules. To see the
+requirements and constraints from each module, run "terraform providers".
+`


### PR DESCRIPTION
The init error was output deep in the backend by detecting a
special ResourceProviderError and formatted directly to the CLI.

Create some Diagnostics closer to where the problem is detected, and
passed that back through the normal diagnostic flow. While the output
isn't as nice yet, this restores the helpful error message and makes the
code easier to maintain. Better formatting can be handled later.

The new output would look like:
```
Error: Could not satisfy plugin requirements


Plugin reinitialization required. Please run "terraform init".

Plugins are external binaries that Terraform uses to access and manipulate
resources. The configuration provided requires plugins which can't be located,
don't satisfy the version constraints, or are otherwise incompatible.

Terraform automatically discovers provider requirements from your
configuration, including providers used in child modules. To see the
requirements and constraints from each module, run "terraform providers".


Error: provider.test: new or changed plugin executable
```


This is an preliminary measure to fix #19150 
