### PR TITLE
Mildwonkey/f show

### DIFF
--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -25,10 +25,11 @@ type config struct {
 // provider configurations are the one concept in Terraform that can span across
 // module boundaries.
 type providerConfig struct {
-	Name          string                 `json:"name,omitempty"`
-	Alias         string                 `json:"alias,omitempty"`
-	ModuleAddress string                 `json:"module_address,omitempty"`
-	Expressions   map[string]interface{} `json:"expressions,omitempty"`
+	Name              string                 `json:"name,omitempty"`
+	Alias             string                 `json:"alias,omitempty"`
+	VersionConstraint string                 `json:"version_constraint,omitempty"`
+	ModuleAddress     string                 `json:"module_address,omitempty"`
+	Expressions       map[string]interface{} `json:"expressions,omitempty"`
 }
 
 type module struct {
@@ -71,6 +72,10 @@ type resource struct {
 
 	// ProviderConfigKey is the key into "provider_configs" (shown above) for
 	// the provider configuration that this resource is associated with.
+	//
+	// NOTE: If a given resource is in a ModuleCall, and the provider was
+	// configured outside of the module (in a higher level configuration file),
+	// the ProviderConfigKey will not match a key in the ProviderConfigs map.
 	ProviderConfigKey string `json:"provider_config_key,omitempty"`
 
 	// Provisioners is an optional field which describes any provisioners.
@@ -114,7 +119,7 @@ func Marshal(c *configs.Config, schemas *terraform.Schemas) ([]byte, error) {
 	marshalProviderConfigs(c, schemas, pcs)
 	output.ProviderConfigs = pcs
 
-	rootModule, err := marshalModule(c, schemas)
+	rootModule, err := marshalModule(c, schemas, "")
 	if err != nil {
 		return nil, err
 	}
@@ -135,12 +140,16 @@ func marshalProviderConfigs(
 
 	for k, pc := range c.Module.ProviderConfigs {
 		schema := schemas.ProviderConfig(pc.Name)
-		m[k] = providerConfig{
-			Name:          pc.Name,
-			Alias:         pc.Alias,
-			ModuleAddress: c.Path.String(),
-			Expressions:   marshalExpressions(pc.Config, schema),
+		p := providerConfig{
+			Name:              pc.Name,
+			Alias:             pc.Alias,
+			ModuleAddress:     c.Path.String(),
+			Expressions:       marshalExpressions(pc.Config, schema),
+			VersionConstraint: pc.Version.Required.String(),
 		}
+		absPC := opaqueProviderKey(k, c.Path.String())
+
+		m[absPC] = p
 	}
 
 	// Must also visit our child modules, recursively.
@@ -149,15 +158,15 @@ func marshalProviderConfigs(
 	}
 }
 
-func marshalModule(c *configs.Config, schemas *terraform.Schemas) (module, error) {
+func marshalModule(c *configs.Config, schemas *terraform.Schemas, addr string) (module, error) {
 	var module module
 	var rs []resource
 
-	managedResources, err := marshalResources(c.Module.ManagedResources, schemas)
+	managedResources, err := marshalResources(c.Module.ManagedResources, schemas, addr)
 	if err != nil {
 		return module, err
 	}
-	dataResources, err := marshalResources(c.Module.DataResources, schemas)
+	dataResources, err := marshalResources(c.Module.DataResources, schemas, addr)
 	if err != nil {
 		return module, err
 	}
@@ -245,8 +254,8 @@ func marshalModuleCalls(c *configs.Config, schemas *terraform.Schemas) map[strin
 
 		retMC.Expressions = marshalExpressions(mc.Config, schema)
 
-		for _, cc := range c.Children {
-			childModule, _ := marshalModule(cc, schemas)
+		for name, cc := range c.Children {
+			childModule, _ := marshalModule(cc, schemas, name)
 			retMC.Module = childModule
 		}
 		ret[mc.Name] = retMC
@@ -256,14 +265,14 @@ func marshalModuleCalls(c *configs.Config, schemas *terraform.Schemas) map[strin
 
 }
 
-func marshalResources(resources map[string]*configs.Resource, schemas *terraform.Schemas) ([]resource, error) {
+func marshalResources(resources map[string]*configs.Resource, schemas *terraform.Schemas, moduleAddr string) ([]resource, error) {
 	var rs []resource
 	for _, v := range resources {
 		r := resource{
 			Address:           v.Addr().String(),
 			Type:              v.Type,
 			Name:              v.Name,
-			ProviderConfigKey: v.ProviderConfigAddr().String(),
+			ProviderConfigKey: opaqueProviderKey(v.ProviderConfigAddr().StringCompact(), moduleAddr),
 		}
 
 		switch v.Mode {
@@ -331,4 +340,14 @@ func marshalResources(resources map[string]*configs.Resource, schemas *terraform
 		return rs[i].Address < rs[j].Address
 	})
 	return rs, nil
+}
+
+// opaqueProviderKey generates a unique absProviderConfig-like string from the module
+// address and provider
+func opaqueProviderKey(provider string, addr string) (key string) {
+	key = provider
+	if addr != "" {
+		key = fmt.Sprintf("%s:%s", addr, provider)
+	}
+	return key
 }

--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -295,7 +295,7 @@ func marshalResources(resources map[string]*configs.Resource, schemas *terraform
 		}
 
 		schema, schemaVer := schemas.ResourceTypeConfig(
-			v.ProviderConfigAddr().StringCompact(),
+			v.ProviderConfigAddr().Type,
 			v.Mode,
 			v.Type,
 		)

--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -177,7 +177,11 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 			continue
 		}
 
-		schema, _ := schemas.ResourceTypeConfig(rc.ProviderAddr.ProviderConfig.StringCompact(), addr.Resource.Resource.Mode, addr.Resource.Resource.Type)
+		schema, _ := schemas.ResourceTypeConfig(
+			rc.ProviderAddr.ProviderConfig.Type,
+			addr.Resource.Resource.Mode,
+			addr.Resource.Resource.Type,
+		)
 		if schema == nil {
 			return fmt.Errorf("no schema found for %s", r.Address)
 		}

--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -154,7 +154,7 @@ func marshalPlanResources(changes *plans.Changes, ris []addrs.AbsResourceInstanc
 		}
 
 		schema, schemaVer := schemas.ResourceTypeConfig(
-			resource.ProviderName,
+			r.ProviderAddr.ProviderConfig.Type,
 			r.Addr.Resource.Resource.Mode,
 			resource.Type,
 		)

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -267,7 +267,7 @@ func marshalResources(resources map[string]*states.Resource, schemas *terraform.
 			}
 
 			schema, _ := schemas.ResourceTypeConfig(
-				r.ProviderConfig.ProviderConfig.StringCompact(),
+				r.ProviderConfig.ProviderConfig.Type,
 				r.Addr.Mode,
 				r.Addr.Type,
 			)

--- a/command/test-fixtures/show-json/basic-create/output.json
+++ b/command/test-fixtures/show-json/basic-create/output.json
@@ -142,7 +142,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_config_key": "provider.test",
+                    "provider_config_key": "test",
                     "schema_version": 0,
                     "expressions": {
                         "ami": {

--- a/command/test-fixtures/show-json/basic-delete/output.json
+++ b/command/test-fixtures/show-json/basic-delete/output.json
@@ -132,7 +132,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_config_key": "provider.test",
+                    "provider_config_key": "test",
                     "schema_version": 0,
                     "expressions": {
                         "ami": {

--- a/command/test-fixtures/show-json/basic-update/output.json
+++ b/command/test-fixtures/show-json/basic-update/output.json
@@ -103,7 +103,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_config_key": "provider.test",
+                    "provider_config_key": "test",
                     "schema_version": 0,
                     "expressions": {
                         "ami": {

--- a/command/test-fixtures/show-json/modules/foo/main.tf
+++ b/command/test-fixtures/show-json/modules/foo/main.tf
@@ -9,3 +9,5 @@ resource "test_instance" "test" {
 output "test" {
   value = var.test_var
 }
+
+provider "test" {}

--- a/command/test-fixtures/show-json/modules/main.tf
+++ b/command/test-fixtures/show-json/modules/main.tf
@@ -1,9 +1,9 @@
-module "test" {
+module "module_test" {
   source   = "./foo"
   test_var = "baz"
 }
 
 output "test" {
-  value      = module.test.test
-  depends_on = [module.test]
+  value      = module.module_test.test
+  depends_on = [module.module_test]
 }

--- a/command/test-fixtures/show-json/modules/modules.json
+++ b/command/test-fixtures/show-json/modules/modules.json
@@ -1,1 +1,0 @@
-{"Modules":[{"Key":"","Source":"","Dir":"/Users/kristin/go/src/github.com/hashicorp/terraform/command/test-fixtures/show-json/modules"},{"Key":"test","Source":"./foo","Dir":"/Users/kristin/go/src/github.com/hashicorp/terraform/command/test-fixtures/show-json/modules/foo"}]}

--- a/command/test-fixtures/show-json/modules/output.json
+++ b/command/test-fixtures/show-json/modules/output.json
@@ -12,7 +12,7 @@
                 {
                     "resources": [
                         {
-                            "address": "module.test.test_instance.test[0]",
+                            "address": "module.module_test.test_instance.test[0]",
                             "mode": "managed",
                             "type": "test_instance",
                             "name": "test",
@@ -24,7 +24,7 @@
                             }
                         },
                         {
-                            "address": "module.test.test_instance.test[1]",
+                            "address": "module.module_test.test_instance.test[1]",
                             "mode": "managed",
                             "type": "test_instance",
                             "name": "test",
@@ -36,7 +36,7 @@
                             }
                         },
                         {
-                            "address": "module.test.test_instance.test[2]",
+                            "address": "module.module_test.test_instance.test[2]",
                             "mode": "managed",
                             "type": "test_instance",
                             "name": "test",
@@ -48,15 +48,15 @@
                             }
                         }
                     ],
-                    "address": "module.test"
+                    "address": "module.module_test"
                 }
             ]
         }
     },
     "resource_changes": [
         {
-            "address": "module.test.test_instance.test[0]",
-            "module_address": "module.test",
+            "address": "module.module_test.test_instance.test[0]",
+            "module_address": "module.module_test",
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
@@ -76,8 +76,8 @@
             }
         },
         {
-            "address": "module.test.test_instance.test[1]",
-            "module_address": "module.test",
+            "address": "module.module_test.test_instance.test[1]",
+            "module_address": "module.module_test",
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
@@ -97,8 +97,8 @@
             }
         },
         {
-            "address": "module.test.test_instance.test[2]",
-            "module_address": "module.test",
+            "address": "module.module_test.test_instance.test[2]",
+            "module_address": "module.module_test",
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
@@ -134,16 +134,16 @@
                 "test": {
                     "expression": {
                         "references": [
-                            "module.test.test"
+                            "module.module_test.test"
                         ]
                     },
                     "depends_on": [
-                        "module.test"
+                        "module.module_test"
                     ]
                 }
             },
             "module_calls": {
-                "test": {
+                "module_test": {
                     "source": "./foo",
                     "expressions": {
                         "test_var": {
@@ -166,7 +166,7 @@
                                 "mode": "managed",
                                 "type": "test_instance",
                                 "name": "test",
-                                "provider_config_key": "provider.test",
+                                "provider_config_key": "module_test:test",
                                 "expressions": {
                                     "ami": {
                                         "references": [
@@ -187,6 +187,12 @@
                         }
                     }
                 }
+            }
+        },
+        "provider_config": {
+            "module_test:test": {
+                "module_address": "module_test",
+                "name": "test"
             }
         }
     }


### PR DESCRIPTION
There are two unrelated bug fixes in this PR. While both are small, it may be easiest to review each commit separately.

1: jsonconfig: 
*Provider config enhancements - I was using the wrong value for the provider config key, which was causing provider configs to be overwritten. This is fixed, though - since provider inheritance is complicated - it's now possible that a resource's provider_config_key does not match anything in the map of provider_configs.  We will likely need to go back later and fix this, but for now if the provider config is missing, behave as if it were empty.
* added provider version constraint 

2: jsoneverything: fixed a bug where I was looking up schemas using the provider name, not the provider type. This causes problems when the provider name includes an alias.

