### PR TITLE
configs/configupgrade: Silently ignore and trim .% and .# in ignore_changes

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/ignore-changes-flatmap-colls/input/ignore-changes-flatmap-colls.tf
+++ b/configs/configupgrade/test-fixtures/valid/ignore-changes-flatmap-colls/input/ignore-changes-flatmap-colls.tf
@@ -1,0 +1,8 @@
+resource "test_instance" "foo" {
+  lifecycle {
+    ignore_changes = [
+      "a.%",
+      "b.#",
+    ]
+  }
+}

--- a/configs/configupgrade/test-fixtures/valid/ignore-changes-flatmap-colls/want/ignore-changes-flatmap-colls.tf
+++ b/configs/configupgrade/test-fixtures/valid/ignore-changes-flatmap-colls/want/ignore-changes-flatmap-colls.tf
@@ -1,0 +1,8 @@
+resource "test_instance" "foo" {
+  lifecycle {
+    ignore_changes = [
+      a,
+      b,
+    ]
+  }
+}

--- a/configs/configupgrade/test-fixtures/valid/ignore-changes-flatmap-colls/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/ignore-changes-flatmap-colls/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Prior to Terraform 0.12, `ignore_changes` was implemented in a `flatmap`-oriented fashion and so users found that they could (and in fact, were often forced to) use the internal `.%` and `.#` suffixes that `flatmap` uses to ignore changes to the number of elements in a list or map.

Terraform 0.12 no longer uses that representation, so we'll interpret ignoring changes to the length as ignoring changes to the entire collection. While this is not a totally-equivalent change, in practice this pattern was most often used in conjunction with specific keys from a map in order to _effectively_ ignore the entire map, even though Terraform didn't really support that.

In the unlikely event that only the length was being ignored, that would've done nothing particularly useful in 0.11 and prior but will be replaced here with a superset ignore rule, thus making the configuration _less_ sensitive to change, rather than more, and thus this is the conservative path less likely to cause "requires replacement" changes after upgrading.
