### PR TITLE
configs/configupgrade: Test for removing commas between block arguments

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/argument-commas/input/argument-commas.tf
+++ b/configs/configupgrade/test-fixtures/valid/argument-commas/input/argument-commas.tf
@@ -1,0 +1,7 @@
+locals {
+  foo = "bar", baz = "boop"
+}
+
+resource "test_instance" "foo" {
+  image = "b", type = "d"
+}

--- a/configs/configupgrade/test-fixtures/valid/argument-commas/want/argument-commas.tf
+++ b/configs/configupgrade/test-fixtures/valid/argument-commas/want/argument-commas.tf
@@ -1,0 +1,9 @@
+locals {
+  foo = "bar"
+  baz = "boop"
+}
+
+resource "test_instance" "foo" {
+  image = "b"
+  type  = "d"
+}

--- a/configs/configupgrade/test-fixtures/valid/argument-commas/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/argument-commas/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
The comma-separated syntax is now reserved only for object constructor expressions in attribute values, so the upgrade tool rewrites block arguments to be newline-separated instead.

This was already working but we didn't have an explicit test for it until now.
