### PR TITLE
configs/configupgrade: Detect and fix element(...) usage with sets

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/element-of-set/input/element-of-set.tf
+++ b/configs/configupgrade/test-fixtures/valid/element-of-set/input/element-of-set.tf
@@ -1,0 +1,7 @@
+resource "test_instance" "a" {
+  subnet_ids = ["boop"] # this attribute takes a set of strings
+}
+
+output "b" {
+  value = "${element(test_instance.a.subnet_ids, 0)}"
+}

--- a/configs/configupgrade/test-fixtures/valid/element-of-set/want/element-of-set.tf
+++ b/configs/configupgrade/test-fixtures/valid/element-of-set/want/element-of-set.tf
@@ -1,0 +1,7 @@
+resource "test_instance" "a" {
+  subnet_ids = ["boop"] # this attribute takes a set of strings
+}
+
+output "b" {
+  value = element(tolist(test_instance.a.subnet_ids), 0)
+}

--- a/configs/configupgrade/test-fixtures/valid/element-of-set/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/element-of-set/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/configs/configupgrade/upgrade_test.go
+++ b/configs/configupgrade/upgrade_test.go
@@ -195,6 +195,7 @@ var testProviders = map[string]providers.Factory{
 						"image":           {Type: cty.String, Optional: true},
 						"tags":            {Type: cty.Map(cty.String), Optional: true},
 						"security_groups": {Type: cty.List(cty.String), Optional: true},
+						"subnet_ids":      {Type: cty.Set(cty.String), Optional: true},
 					},
 					BlockTypes: map[string]*configschema.NestedBlock{
 						"network": {


### PR DESCRIPTION
Although sets do not have indexed elements, in Terraform 0.11 and earlier `element(...)` would work with sets because we'd automatically convert them to lists before entry into HIL -- with an arbitrary-but-consistent ordering -- and thus return an arbitrary-but-consistent element from the list.

The `element(...)` function in Terraform 0.12 does not allow this because it is not safe in general, but there was an existing pattern relying on this in Terraform 0.11 configs which this upgrade rule is intended to preserve:

```hcl
resource "example" "example" {
  count = "${length(any_set_attribute)}"

  foo = "${element(any_set_attribute, count.index}"
}
```

The above works because the exact indices assigned in the conversion are irrelevant: we're just asking Terraform to create one resource for each distinct element in the set.

This upgrade rule therefore inserts an explicit conversion to list if it is able to successfully prove that the given expression will return a set type:

```hcl
  foo = "${element(tolist(any_set_attribute), count.index}"
```

This makes the conversion explicit, allowing users to decide if it is safe and rework the configuration if not. Since our static type analysis functionality focuses mainly on resource type attributes, in practice this rule will only apply when the given expression is a statically-checkable resource reference. Since sets are an SDK-only concept in Terraform 0.11 and earlier anyway, in practice that works out just right: it's not possible for sets to appear anywhere else in older versions.
