### PR TITLE
website: Large, on-brand link preview image for marketing pages (/intro/*)

### DIFF
--- a/website/layouts/intro.erb
+++ b/website/layouts/intro.erb
@@ -1,4 +1,9 @@
 <% wrap_layout :inner do %>
+  <% content_for(:custom_share) do %>
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta property="og:image" content="<%= image_url("og-image-large.png") %>"/>
+  <% end %>
+
   <% content_for :sidebar do %>
     <h4><a href="/intro/index.html">Introduction to Terraform</a></h4>
 


### PR DESCRIPTION
Companion PR to https://github.com/hashicorp/terraform-website/pull/677. Supersedes https://github.com/hashicorp/terraform/pull/19685.

Although /intro/getting-started includes docs content, those pages currently
redirect to the Learn platform, and so shouldn't be affected by the large unfurl
image.