### PR TITLE
backend (s3/azure): Source config from environment variables

### DIFF
--- a/backend/remote-state/azure/backend.go
+++ b/backend/remote-state/azure/backend.go
@@ -16,18 +16,21 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The name of the storage account.",
+				DefaultFunc: schema.EnvDefaultFunc("ARM_STORAGE_ACCOUNT_NAME", nil),
 			},
 
 			"container_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The container name.",
+				DefaultFunc: schema.EnvDefaultFunc("ARM_STORAGE_CONTAINER_NAME", nil),
 			},
 
 			"key": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The blob key.",
+				DefaultFunc: schema.EnvDefaultFunc("ARM_STORAGE_BLOB_KEY", nil),
 			},
 
 			"environment": {

--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -21,12 +21,14 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The name of the S3 bucket",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_S3_BUCKET", nil),
 			},
 
 			"key": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The path to the state file inside the bucket",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_S3_KEY", nil),
 				ValidateFunc: func(v interface{}, s string) ([]string, []error) {
 					// s3 will strip leading slashes from an object, so while this will
 					// technically be accepted by s3, it will break our workspace hierarchy.

--- a/website/docs/backends/types/azurerm.html.md
+++ b/website/docs/backends/types/azurerm.html.md
@@ -145,11 +145,11 @@ data "terraform_remote_state" "foo" {
 
 The following configuration options are supported:
 
-* `storage_account_name` - (Required) The Name of [the Storage Account](https://www.terraform.io/docs/providers/azurerm/r/storage_account.html).
+* `storage_account_name` - (Required) The Name of [the Storage Account](https://www.terraform.io/docs/providers/azurerm/r/storage_account.html). This can also be sourced from the `ARM_STORAGE_ACCOUNT_NAME` environment variable.
 
-* `container_name` - (Required) The Name of [the Storage Container](https://www.terraform.io/docs/providers/azurerm/r/storage_container.html) within the Storage Account.
+* `container_name` - (Required) The Name of [the Storage Container](https://www.terraform.io/docs/providers/azurerm/r/storage_container.html) within the Storage Account. This can also be sourced from the `ARM_STORAGE_CONTAINER_NAME` environment variable.
 
-* `key` - (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.
+* `key` - (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container. When using workspaces, the workspace state blob key will be prefixed with this value. This can also be sourced from the `ARM_STORAGE_BLOB_KEY` environment variable.
 
 * `environment` - (Optional) The Azure Environment which should be used. This can also be sourced from the `ARM_ENVIRONMENT` environment variable. Possible values are `public`, `china`, `german`, `stack` and `usgovernment`. Defaults to `public`.
 

--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -136,8 +136,8 @@ data.terraform_remote_state.network:
 
 The following configuration options or environment variables are supported:
 
- * `bucket` - (Required) The name of the S3 bucket.
- * `key` - (Required) The path to the state file inside the bucket. When using
+ * `bucket` / `AWS_S3_BUCKET` - (Required) The name of the S3 bucket.
+ * `key` / `AWS_S3_KEY` - (Required) The path to the state file inside the bucket. When using
    a non-default [workspace](/docs/state/workspaces.html), the state path will
    be `/workspace_key_prefix/workspace_name/key`
  * `region` / `AWS_DEFAULT_REGION` - (Optional) The region of the S3
@@ -163,8 +163,7 @@ The following configuration options or environment variables are supported:
  * `shared_credentials_file`  - (Optional) This is the path to the
    shared credentials file. If this is not set and a profile is specified,
    `~/.aws/credentials` will be used.
- * `token` - (Optional) Use this to set an MFA token. It can also be
-   sourced from the `AWS_SESSION_TOKEN` environment variable.
+ * `token` / `AWS_SESSION_TOKEN` - (Optional) Use this to set an MFA token.
  * `role_arn` - (Optional) The role to be assumed.
  * `assume_role_policy` - (Optional) The permissions applied when assuming a role.
  * `external_id` - (Optional) The external ID to use when assuming the role.


### PR DESCRIPTION
Allows customizing the remote state targets through environment variables.
Solves #17288, #12067, #13022, #12270, and [many other requests to interpolate backend configuration](https://www.google.com/search?q=terraform+interpolate+backend+config). See discussion that prompted this [here](https://github.com/hashicorp/terraform/issues/17288#issuecomment-462899292).

Common usage pattern is to separate Terraform state into S3 bucket/Azure Storage Account for production while all lower environments (dev/QA) can reside in the same location. This gives developers the freedom and sandbox they require to build using Terraform and gives operations folks comfort in separating dev and prod. 

Because S3 Buckets and Azure Storage Account must be unique across all AWS/Azure accounts, there will always be name conflicts. Therefore, a different name must be used for the different environments. It's much easier (and better supported) in CI/CD systems to inject the bucket/storage account name via environment variables than in command line switches.

More use cases outlined in the links above prompted me to also include the `key` as an environment variable. For example, the author of #12270 is using a variable in `key` to create a generic backend config for use by other applications that get stored in a centralized S3 bucket per region.