### PR TITLE
s3 workspace_key_prefix

### DIFF
--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -2,7 +2,7 @@ package s3
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -31,7 +31,7 @@ func New() backend.Backend {
 					// s3 will strip leading slashes from an object, so while this will
 					// technically be accepted by s3, it will break our workspace hierarchy.
 					if strings.HasPrefix(v.(string), "/") {
-						return nil, []error{fmt.Errorf("key must not start with '/'")}
+						return nil, []error{errors.New("key must not start with '/'")}
 					}
 					return nil, nil
 				},
@@ -211,8 +211,15 @@ func New() backend.Backend {
 			"workspace_key_prefix": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The prefix applied to the non-default state path inside the bucket",
+				Description: "The prefix applied to the non-default state path inside the bucket.",
 				Default:     "env:",
+				ValidateFunc: func(v interface{}, s string) ([]string, []error) {
+					prefix := v.(string)
+					if strings.HasPrefix(prefix, "/") || strings.HasSuffix(prefix, "/") {
+						return nil, []error{errors.New("workspace_key_prefix must not start or end with '/'")}
+					}
+					return nil, nil
+				},
 			},
 
 			"force_path_style": {

--- a/backend/remote-state/s3/backend_test.go
+++ b/backend/remote-state/s3/backend_test.go
@@ -199,6 +199,11 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// remove the state with extra subkey
+	if err := client.Delete(); err != nil {
+		t.Fatal(err)
+	}
+
+	// delete the real workspace
 	if err := b.DeleteWorkspace("s2"); err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +221,7 @@ func TestBackendExtraPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if stateMgr.StateSnapshotMeta().Lineage == s2Lineage {
+	if s2Mgr.(*remote.State).StateSnapshotMeta().Lineage == s2Lineage {
 		t.Fatal("state s2 was not deleted")
 	}
 	s2 = s2Mgr.State()


### PR DESCRIPTION
The handling of slashes was broken around listing workspaces in
workspace_key_prefix. While it worked in most places by splitting an
extra time around the spurious slashes, it failed in the case that the
prefix ended with a slash of its own.

A test was temporarily added to verify that the backend now works with the
unusual keys, but rather than risking silent breakage around prefixes
with trailing slashes, we also add validation to prevent users from
entering keys with trailing slashes at all.

```
--- PASS: TestBackend_impl (0.00s)
--- PASS: TestBackendConfig (1.08s)
--- PASS: TestBackendConfig_invalidKey (0.00s)
--- PASS: TestBackend (18.43s)
--- PASS: TestBackendLocked (27.05s)
--- PASS: TestBackendExtraPaths (16.82s)
--- PASS: TestBackendPrefixInWorkspace (6.02s)
--- PASS: TestKeyEnv (58.52s)
--- PASS: TestRemoteClient_impl (0.00s)
--- PASS: TestRemoteClient (6.58s)
--- PASS: TestRemoteClientLocks (19.80s)
--- PASS: TestForceUnlock (18.84s)
--- PASS: TestRemoteClient_clientMD5 (14.00s)
--- PASS: TestRemoteClient_stateChecksum (21.14s)
```

related to #17508