### PR TITLE
configs/configupgrade: Upgrade of provisioner and connection blocks

### DIFF
--- a/configs/configupgrade/analysis.go
+++ b/configs/configupgrade/analysis.go
@@ -262,7 +262,20 @@ func (u *Upgrader) analyze(ms ModuleSources) (*analysis, error) {
 		ret.ProviderSchemas[name] = schema
 	}
 
-	// TODO: Also ProvisionerSchemas
+	for name, fn := range u.Provisioners {
+		log.Printf("[TRACE] Fetching schema from provisioner %q", name)
+		provisioner, err := fn()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load provisioner %q: %s", name, err)
+		}
+
+		resp := provisioner.GetSchema()
+		if resp.Diagnostics.HasErrors() {
+			return nil, resp.Diagnostics.Err()
+		}
+
+		ret.ProvisionerSchemas[name] = resp.Provisioner
+	}
 
 	return ret, nil
 }

--- a/configs/configupgrade/test-fixtures/valid/noop/input/resources.tf
+++ b/configs/configupgrade/test-fixtures/valid/noop/input/resources.tf
@@ -3,7 +3,7 @@ resource "test_instance" "example" {
   connection {
     host = "127.0.0.1"
   }
-  provisioner "local-exec" {
+  provisioner "test" {
     connection {
       host = "127.0.0.2"
     }

--- a/configs/configupgrade/test-fixtures/valid/noop/want/resources.tf
+++ b/configs/configupgrade/test-fixtures/valid/noop/want/resources.tf
@@ -3,7 +3,7 @@ resource "test_instance" "example" {
   connection {
     host = "127.0.0.1"
   }
-  provisioner "local-exec" {
+  provisioner "test" {
     connection {
       host = "127.0.0.2"
     }

--- a/configs/configupgrade/test-fixtures/valid/provisioner/input/provisioner.tf
+++ b/configs/configupgrade/test-fixtures/valid/provisioner/input/provisioner.tf
@@ -1,8 +1,18 @@
 resource "test_instance" "foo" {
+  connection {
+    type = "ssh"
+    host = "${self.private_ip}"
+  }
+
   provisioner "test" {
     commands = "${list("a", "b", "c")}"
 
     when       = "create"
     on_failure = "fail"
+
+    connection {
+      type = "winrm"
+      host = "${self.public_ip}"
+    }
   }
 }

--- a/configs/configupgrade/test-fixtures/valid/provisioner/input/provisioner.tf
+++ b/configs/configupgrade/test-fixtures/valid/provisioner/input/provisioner.tf
@@ -1,7 +1,8 @@
-resource "test_instance" "foo" {
+variable "login_username" {}
+
+resource "aws_instance" "foo" {
   connection {
-    type = "ssh"
-    host = "${self.private_ip}"
+    user = "${var.login_username}"
   }
 
   provisioner "test" {
@@ -12,7 +13,7 @@ resource "test_instance" "foo" {
 
     connection {
       type = "winrm"
-      host = "${self.public_ip}"
+      user = "${var.login_username}"
     }
   }
 }

--- a/configs/configupgrade/test-fixtures/valid/provisioner/input/provisioner.tf
+++ b/configs/configupgrade/test-fixtures/valid/provisioner/input/provisioner.tf
@@ -1,0 +1,8 @@
+resource "test_instance" "foo" {
+  provisioner "test" {
+    commands = "${list("a", "b", "c")}"
+
+    when       = "create"
+    on_failure = "fail"
+  }
+}

--- a/configs/configupgrade/test-fixtures/valid/provisioner/want/provisioner.tf
+++ b/configs/configupgrade/test-fixtures/valid/provisioner/want/provisioner.tf
@@ -1,8 +1,18 @@
 resource "test_instance" "foo" {
+  connection {
+    type = "ssh"
+    host = self.private_ip
+  }
+
   provisioner "test" {
     commands = ["a", "b", "c"]
 
     when       = create
     on_failure = fail
+
+    connection {
+      type = "winrm"
+      host = self.public_ip
+    }
   }
 }

--- a/configs/configupgrade/test-fixtures/valid/provisioner/want/provisioner.tf
+++ b/configs/configupgrade/test-fixtures/valid/provisioner/want/provisioner.tf
@@ -1,7 +1,11 @@
-resource "test_instance" "foo" {
+variable "login_username" {
+}
+
+resource "aws_instance" "foo" {
   connection {
+    host = coalesce(self.public_ip, self.private_ip)
     type = "ssh"
-    host = self.private_ip
+    user = var.login_username
   }
 
   provisioner "test" {
@@ -11,8 +15,9 @@ resource "test_instance" "foo" {
     on_failure = fail
 
     connection {
+      host = coalesce(self.public_ip, self.private_ip)
       type = "winrm"
-      host = self.public_ip
+      user = var.login_username
     }
   }
 }

--- a/configs/configupgrade/test-fixtures/valid/provisioner/want/provisioner.tf
+++ b/configs/configupgrade/test-fixtures/valid/provisioner/want/provisioner.tf
@@ -1,0 +1,8 @@
+resource "test_instance" "foo" {
+  provisioner "test" {
+    commands = ["a", "b", "c"]
+
+    when       = create
+    on_failure = fail
+  }
+}

--- a/configs/configupgrade/test-fixtures/valid/provisioner/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/provisioner/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/configs/configupgrade/upgrade_body.go
+++ b/configs/configupgrade/upgrade_body.go
@@ -514,8 +514,8 @@ func lifecycleBlockBodyRules(filename string, an *analysis) bodyContentRules {
 			if !ok {
 				diags = diags.Append(&hcl2.Diagnostic{
 					Severity: hcl2.DiagError,
-					Summary:  "Invalid providers argument",
-					Detail:   `The "providers" argument must be a map from provider addresses in the child module to corresponding provider addresses in this module.`,
+					Summary:  "Invalid ignore_changes argument",
+					Detail:   `The "ignore_changes" argument must be a list of attribute expressions relative to this resource.`,
 					Subject:  hcl1PosRange(filename, item.Keys[0].Pos()).Ptr(),
 				})
 				return diags

--- a/configs/configupgrade/upgrade_native.go
+++ b/configs/configupgrade/upgrade_native.go
@@ -329,24 +329,8 @@ func (u *Upgrader) upgradeNativeSyntaxResource(filename string, buf *bytes.Buffe
 	rules["depends_on"] = dependsOnAttributeRule(filename, an)
 	rules["provider"] = maybeBareTraversalAttributeRule(filename, an)
 	rules["lifecycle"] = nestedBlockRule(filename, lifecycleBlockBodyRules(filename, an), an, adhocComments)
-	rules["connection"] = func(buf *bytes.Buffer, blockAddr string, item *hcl1ast.ObjectItem) tfdiags.Diagnostics {
-		// TODO: For the few resource types that were setting ConnInfo in
-		// state after create/update in prior versions, generate the additional
-		// explicit connection settings that are now required if and only if
-		// there's at least one provisioner block.
-		// For now, we just pass this through as-is.
-		hcl1printer.Fprint(buf, item)
-		buf.WriteByte('\n')
-		return nil
-	}
-	rules["provisioner"] = func(buf *bytes.Buffer, blockAddr string, item *hcl1ast.ObjectItem) tfdiags.Diagnostics {
-		// TODO: Look up the provisioner schema and map this properly to ensure
-		// any references get properly updated.
-		// For now, we just pass this through as-is.
-		hcl1printer.Fprint(buf, item)
-		buf.WriteByte('\n')
-		return nil
-	}
+	rules["connection"] = connectionBlockRule(filename, an, adhocComments)
+	rules["provisioner"] = provisionerBlockRule(filename, an, adhocComments)
 
 	printComments(buf, item.LeadComment)
 	printBlockOpen(buf, blockType, labels, item.LineComment)

--- a/configs/configupgrade/upgrade_native.go
+++ b/configs/configupgrade/upgrade_native.go
@@ -329,8 +329,10 @@ func (u *Upgrader) upgradeNativeSyntaxResource(filename string, buf *bytes.Buffe
 	rules["depends_on"] = dependsOnAttributeRule(filename, an)
 	rules["provider"] = maybeBareTraversalAttributeRule(filename, an)
 	rules["lifecycle"] = nestedBlockRule(filename, lifecycleBlockBodyRules(filename, an), an, adhocComments)
-	rules["connection"] = connectionBlockRule(filename, an, adhocComments)
-	rules["provisioner"] = provisionerBlockRule(filename, an, adhocComments)
+	if addr.Mode == addrs.ManagedResourceMode {
+		rules["connection"] = connectionBlockRule(filename, addr.Type, an, adhocComments)
+		rules["provisioner"] = provisionerBlockRule(filename, addr.Type, an, adhocComments)
+	}
 
 	printComments(buf, item.LeadComment)
 	printBlockOpen(buf, blockType, labels, item.LineComment)

--- a/configs/configupgrade/upgrade_test.go
+++ b/configs/configupgrade/upgrade_test.go
@@ -250,6 +250,18 @@ var testProviders = map[string]providers.Factory{
 		}
 		return p, nil
 	}),
+	"aws": providers.Factory(func() (providers.Interface, error) {
+		// This is here only so we can test the provisioner connection info
+		// migration behavior, which is resource-type specific. Do not use
+		// it in any other tests.
+		p := &terraform.MockProvider{}
+		p.GetSchemaReturn = &terraform.ProviderSchema{
+			ResourceTypes: map[string]*configschema.Block{
+				"aws_instance": {},
+			},
+		}
+		return p, nil
+	}),
 }
 
 var testProvisioners = map[string]provisioners.Factory{

--- a/configs/configupgrade/upgrade_test.go
+++ b/configs/configupgrade/upgrade_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/providers"
+	"github.com/hashicorp/terraform/provisioners"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -39,7 +40,8 @@ func TestUpgradeValid(t *testing.T) {
 			inputDir := filepath.Join(fixtureDir, entry.Name(), "input")
 			wantDir := filepath.Join(fixtureDir, entry.Name(), "want")
 			u := &Upgrader{
-				Providers: providers.ResolverFixed(testProviders),
+				Providers:    providers.ResolverFixed(testProviders),
+				Provisioners: testProvisioners,
 			}
 
 			inputSrc, err := LoadModule(inputDir)
@@ -243,6 +245,21 @@ var testProviders = map[string]providers.Factory{
 					Attributes: map[string]*configschema.Attribute{
 						"backend": {Type: cty.String, Optional: true},
 					},
+				},
+			},
+		}
+		return p, nil
+	}),
+}
+
+var testProvisioners = map[string]provisioners.Factory{
+	"test": provisioners.Factory(func() (provisioners.Interface, error) {
+		p := &terraform.MockProvisioner{}
+		p.GetSchemaResponse = provisioners.GetSchemaResponse{
+			Provisioner: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"commands":    {Type: cty.List(cty.String), Optional: true},
+					"interpreter": {Type: cty.String, Optional: true},
 				},
 			},
 		}

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -309,6 +309,18 @@ var connectionBlockSupersetSchema = &configschema.Block{
 	},
 }
 
+// connectionBlockSupersetSchema is a schema representing the superset of all
+// possible arguments for "connection" blocks across all supported connection
+// types.
+//
+// This currently lives here because we've not yet updated our communicator
+// subsystem to be aware of schema itself. It's exported only for use in the
+// configs/configupgrade package and should not be used from anywhere else.
+// The caller may not modify any part of the returned schema data structure.
+func ConnectionBlockSupersetSchema() *configschema.Block {
+	return connectionBlockSupersetSchema
+}
+
 // EvalValidateResource is an EvalNode implementation that validates
 // the configuration of a resource.
 type EvalValidateResource struct {


### PR DESCRIPTION
This is mostly the same principle as for other schema-driven blocks, and is just a matter of wiring in a step to look up the appropriate schema and then run the normal migration steps based on it.

It has one additional function that we've not done anywhere else, though: it adds additional arguments to `connection` blocks to compensate for the fact that provider-supplied defaults are no longer supported in v0.12, under the principle of "explicit is better than implicit".

For compatibility, the upgrade tool will insert expressions that are as close as possible to the logic the provider formerly implemented, or in a few rare cases a `TF-UPGRADE-TODO` comment to prompt to fix it up manually.

---

Some of the existing resource type implementations have incredibly complicated implementations of selecting a single host IP address to use and don't expose the result of that as an attribute, so for now we handle those via a complicated Terraform language expression achieving the same result. Ideally these providers would introduce a new attribute that exports the same address formerly exported as the hostname before their initial v0.12-compatible release, in which case we can simplify these to just reference the attribute in question. (That would be preferable also because it would allow use of that exported attribute in other contexts, such as in a null_resource provisioner somewhere else or in an output to allow a caller to deal with the SSH part itself.)

The new `connection` block arguments will be added only if there is already a `connection` block present. In principle it is possible that a provider could set enough of these arguments that the provisioners would've worked with no `connection` block at all before, but in practice only one (the `oneandone` provider) was able to give both a hostname and some possibly-valid credentials, so we're accepting here an assumption that if any remote-access provisioners are present and working then a `connection` block would've been present too, which avoids us needing to make tricky guesses about whether we should be inserting resource-level or provisioner-level connection blocks, whether particular provisioner types even _need_ connection blocks, etc.
