### PR TITLE
configs/configupgrade: Fix up uses of the .count pseudo-attribute

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/resource-count-ref/input/resource-count-ref.tf
+++ b/configs/configupgrade/test-fixtures/valid/resource-count-ref/input/resource-count-ref.tf
@@ -1,0 +1,29 @@
+resource "test_instance" "one" {
+}
+
+resource "test_instance" "many" {
+  count = 2
+}
+
+data "terraform_remote_state" "one" {
+}
+
+data "terraform_remote_state" "many" {
+  count = 2
+}
+
+output "managed_one" {
+  value = "${test_instance.one.count}"
+}
+
+output "managed_many" {
+  value = "${test_instance.many.count}"
+}
+
+output "data_one" {
+  value = "${data.terraform_remote_state.one.count}"
+}
+
+output "data_many" {
+  value = "${data.terraform_remote_state.many.count}"
+}

--- a/configs/configupgrade/test-fixtures/valid/resource-count-ref/want/resource-count-ref.tf
+++ b/configs/configupgrade/test-fixtures/valid/resource-count-ref/want/resource-count-ref.tf
@@ -1,0 +1,29 @@
+resource "test_instance" "one" {
+}
+
+resource "test_instance" "many" {
+  count = 2
+}
+
+data "terraform_remote_state" "one" {
+}
+
+data "terraform_remote_state" "many" {
+  count = 2
+}
+
+output "managed_one" {
+  value = 1
+}
+
+output "managed_many" {
+  value = length(test_instance.many)
+}
+
+output "data_one" {
+  value = 1
+}
+
+output "data_many" {
+  value = length(data.terraform_remote_state.many)
+}

--- a/configs/configupgrade/test-fixtures/valid/resource-count-ref/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/resource-count-ref/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Terraform 0.11 and prior had an odd special case where a resource attribute access for `.count` would be resolved as the count for the whole resource, rather than as an attribute of an individual instance as
for all other attributes.

Because Terraform 0.12 makes `test_instance.foo` appear as a list when the `count` argument is set (so it can be used in other expressions), it's no longer possible to have an attribute in that position: lists don't have attributes. Fortunately we don't really need that special case anymore since it doesn't do anything we can't now do with the `length(...)` function.

This upgrade rule, then, detects references like `test_instance.foo.count` and rewrites to `length(test_instance.foo)`. As a special case, if `test_instance.foo` doesn't have `count` set then it just rewrites as the constant `1`, which mimics what would've happened at evaluation time in that case in Terraform 0.11.