### PR TITLE
Add client cert to http backend

### DIFF
--- a/backend/remote-state/http/backend_test.go
+++ b/backend/remote-state/http/backend_test.go
@@ -75,3 +75,66 @@ func TestHTTPClientFactory(t *testing.T) {
 			client.Password, conf["password"])
 	}
 }
+func TestHTTPClientFactoryWithTLS(t *testing.T) {
+	// defaults
+
+	conf := map[string]cty.Value{
+		"address": cty.StringVal("https://127.0.0.1:8888/foo"),
+	
+	}
+	b := backend.TestBackendConfig(t, New(), configs.SynthBody("synth", conf)).(*Backend)
+	client := b.client
+
+	if client == nil {
+		t.Fatal("Unexpected failure, address")
+	}
+	if client.URL.String() != "http://127.0.0.1:8888/foo" {
+		t.Fatalf("Expected address \"%s\", got \"%s\"", conf["address"], client.URL.String())
+	}
+	if client.UpdateMethod != "POST" {
+		t.Fatalf("Expected update_method \"%s\", got \"%s\"", "POST", client.UpdateMethod)
+	}
+	if client.LockURL != nil || client.LockMethod != "LOCK" {
+		t.Fatal("Unexpected lock_address or lock_method")
+	}
+	if client.UnlockURL != nil || client.UnlockMethod != "UNLOCK" {
+		t.Fatal("Unexpected unlock_address or unlock_method")
+	}
+	if client.Username != "" || client.Password != "" {
+		t.Fatal("Unexpected username or password")
+	}
+
+	// custom
+	conf = map[string]cty.Value{
+		"address":        cty.StringVal("http://127.0.0.1:8888/foo"),
+		"update_method":  cty.StringVal("BLAH"),
+		"lock_address":   cty.StringVal("http://127.0.0.1:8888/bar"),
+		"lock_method":    cty.StringVal("BLIP"),
+		"unlock_address": cty.StringVal("http://127.0.0.1:8888/baz"),
+		"unlock_method":  cty.StringVal("BLOOP"),
+		"username":       cty.StringVal("user"),
+		"password":       cty.StringVal("pass"),
+	}
+
+	b = backend.TestBackendConfig(t, New(), configs.SynthBody("synth", conf)).(*Backend)
+	client = b.client
+
+	if client == nil {
+		t.Fatal("Unexpected failure, update_method")
+	}
+	if client.UpdateMethod != "BLAH" {
+		t.Fatalf("Expected update_method \"%s\", got \"%s\"", "BLAH", client.UpdateMethod)
+	}
+	if client.LockURL.String() != conf["lock_address"].AsString() || client.LockMethod != "BLIP" {
+		t.Fatalf("Unexpected lock_address \"%s\" vs \"%s\" or lock_method \"%s\" vs \"%s\"", client.LockURL.String(),
+			conf["lock_address"].AsString(), client.LockMethod, conf["lock_method"])
+	}
+	if client.UnlockURL.String() != conf["unlock_address"].AsString() || client.UnlockMethod != "BLOOP" {
+		t.Fatalf("Unexpected unlock_address \"%s\" vs \"%s\" or unlock_method \"%s\" vs \"%s\"", client.UnlockURL.String(),
+			conf["unlock_address"].AsString(), client.UnlockMethod, conf["unlock_method"])
+	}
+	if client.Username != "user" || client.Password != "pass" {
+		t.Fatalf("Unexpected username \"%s\" vs \"%s\" or password \"%s\" vs \"%s\"", client.Username, conf["username"],
+			client.Password, conf["password"])
+	}
+}

--- a/backend/remote-state/http/backend_test.go
+++ b/backend/remote-state/http/backend_test.go
@@ -3,10 +3,9 @@ package http
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/zclconf/go-cty/cty"
-
-	"github.com/hashicorp/terraform/backend"
 )
 
 func TestBackend_impl(t *testing.T) {
@@ -75,12 +74,32 @@ func TestHTTPClientFactory(t *testing.T) {
 			client.Password, conf["password"])
 	}
 }
-func TestHTTPClientFactoryWithTLS(t *testing.T) {
+func TestHTTPClientFactoryWithTLSAndECDSAEncryptedKey(t *testing.T) {
 	// defaults
 
 	conf := map[string]cty.Value{
 		"address": cty.StringVal("https://127.0.0.1:8888/foo"),
-	
+		"tls_client_key": cty.StringVal(`-----BEGIN ENCRYPTED PRIVATE KEY-----
+MIHsMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAjVvKZtHlmIbAICCAAw
+DAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEL3jdkBvObn+QELgKVE2cnMEgZAl
+wgo3AjtXevJaGgep5GsW2krw9S7dC7xG9dR33Z/a9nBnO1rKm7Htf0+986w/1vmj
+4k3M2QiI/VY+tnDFE+46DLLKYtJGRT1aoAH+mwhzaQGwzJnKhbeA23aE0f7KWCAK
++f999+SeHWro7FiRZjHEYVVLGQr/I7K5Wyh24YjN2nR4CU4X+GQU25My/pgSRog=
+-----END ENCRYPTED PRIVATE KEY-----`),
+		"tls_client_cert": cty.StringVal(`-----BEGIN CERTIFICATE-----
+MIIB9jCCAZugAwIBAgIJAOi4ebDp8F1IMAoGCCqGSM49BAMCMFYxCzAJBgNVBAYT
+AlVTMQ8wDQYDVQQIDAZEZW5pYWwxFDASBgNVBAcMC1NwcmluZ2ZpZWxkMQwwCgYD
+VQQKDANEaXMxEjAQBgNVBAMMCVVTRVJfMTIzNDAgFw0xOTAyMjQwOTMxMzFaGA8y
+MTE5MDEzMTA5MzEzMVowVjELMAkGA1UEBhMCVVMxDzANBgNVBAgMBkRlbmlhbDEU
+MBIGA1UEBwwLU3ByaW5nZmllbGQxDDAKBgNVBAoMA0RpczESMBAGA1UEAwwJVVNF
+Ul8xMjM0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEipKHaB/oR5gX8KBX6779
+RPojC7d4NbOocTlDG5L+mU1RVzQ/98/c5SZYuv2Bq5Up7BziXNBm8EmA9QDMGcq9
+E6NQME4wHQYDVR0OBBYEFHdSsLG3NIFhGK9ciGJQaaZQWxFmMB8GA1UdIwQYMBaA
+FHdSsLG3NIFhGK9ciGJQaaZQWxFmMAwGA1UdEwQFMAMBAf8wCgYIKoZIzj0EAwID
+SQAwRgIhAP1s5Cbm5IyfDsB0HHpfXeDH3EPgs1VxVb5JziJg5z3bAiEA5QXuZNHQ
+Iq6lIbHyofyS9nhepycaoT/TDT5BVtrSbGs=
+-----END CERTIFICATE-----`),
+		"tls_client_key_password": cty.StringVal("password"),
 	}
 	b := backend.TestBackendConfig(t, New(), configs.SynthBody("synth", conf)).(*Backend)
 	client := b.client
@@ -88,7 +107,355 @@ func TestHTTPClientFactoryWithTLS(t *testing.T) {
 	if client == nil {
 		t.Fatal("Unexpected failure, address")
 	}
-	if client.URL.String() != "http://127.0.0.1:8888/foo" {
+	if client.URL.String() != "https://127.0.0.1:8888/foo" {
+		t.Fatalf("Expected address \"%s\", got \"%s\"", conf["address"], client.URL.String())
+	}
+	if client.UpdateMethod != "POST" {
+		t.Fatalf("Expected update_method \"%s\", got \"%s\"", "POST", client.UpdateMethod)
+	}
+	if client.LockURL != nil || client.LockMethod != "LOCK" {
+		t.Fatal("Unexpected lock_address or lock_method")
+	}
+	if client.UnlockURL != nil || client.UnlockMethod != "UNLOCK" {
+		t.Fatal("Unexpected unlock_address or unlock_method")
+	}
+	if client.Username != "" || client.Password != "" {
+		t.Fatal("Unexpected username or password")
+	}
+
+	// custom
+	conf = map[string]cty.Value{
+		"address":        cty.StringVal("http://127.0.0.1:8888/foo"),
+		"update_method":  cty.StringVal("BLAH"),
+		"lock_address":   cty.StringVal("http://127.0.0.1:8888/bar"),
+		"lock_method":    cty.StringVal("BLIP"),
+		"unlock_address": cty.StringVal("http://127.0.0.1:8888/baz"),
+		"unlock_method":  cty.StringVal("BLOOP"),
+		"username":       cty.StringVal("user"),
+		"password":       cty.StringVal("pass"),
+	}
+
+	b = backend.TestBackendConfig(t, New(), configs.SynthBody("synth", conf)).(*Backend)
+	client = b.client
+
+	if client == nil {
+		t.Fatal("Unexpected failure, update_method")
+	}
+	if client.UpdateMethod != "BLAH" {
+		t.Fatalf("Expected update_method \"%s\", got \"%s\"", "BLAH", client.UpdateMethod)
+	}
+	if client.LockURL.String() != conf["lock_address"].AsString() || client.LockMethod != "BLIP" {
+		t.Fatalf("Unexpected lock_address \"%s\" vs \"%s\" or lock_method \"%s\" vs \"%s\"", client.LockURL.String(),
+			conf["lock_address"].AsString(), client.LockMethod, conf["lock_method"])
+	}
+	if client.UnlockURL.String() != conf["unlock_address"].AsString() || client.UnlockMethod != "BLOOP" {
+		t.Fatalf("Unexpected unlock_address \"%s\" vs \"%s\" or unlock_method \"%s\" vs \"%s\"", client.UnlockURL.String(),
+			conf["unlock_address"].AsString(), client.UnlockMethod, conf["unlock_method"])
+	}
+	if client.Username != "user" || client.Password != "pass" {
+		t.Fatalf("Unexpected username \"%s\" vs \"%s\" or password \"%s\" vs \"%s\"", client.Username, conf["username"],
+			client.Password, conf["password"])
+	}
+}
+func TestHTTPClientFactoryWithTLSAndRSAEncryptedKey(t *testing.T) {
+	// defaults
+
+	conf := map[string]cty.Value{
+		"address": cty.StringVal("https://127.0.0.1:8888/foo"),
+		"tls_client_key": cty.StringVal(`-----BEGIN ENCRYPTED PRIVATE KEY-----
+MIIFHzBJBgkqhkiG9w0BBQ0wPDAbBgkqhkiG9w0BBQwwDgQILCEpWEgs7EICAggA
+MB0GCWCGSAFlAwQBKgQQuj5iy4VVTkPLkun5Gi7jkASCBNCO7grfZh+kaCcNe91b
+r5W8XPp+SkrJ4y4fo/Z8221RQAyOKUSEIskvgPiZq6Jp0dFM4Y4pwlSQB3rr6Rd8
+A/SNRdDcFqlwyq9cvhFvqCBiyGqSdH8F5t34zj2LBPtd8GqUUy1d/Ig7PHzUYmZh
+C6ABZxwdIKoZciRuzWyDTv1xWoGyciUx8lmxSFmD3k2LojqfjeB50GaIKsRp1jGs
+8imPkAZ7bM12FR0mIIg+Y+QU3kzcWNGrc2KCHYrU4T4Mxu7Y+D++pCJt7reHVqiz
+2EgIeNjb1J8UPxgspjPrOzO+sLNacZ7G3UOjpU3UD5Mk6x/99AdtXYs39vnqEkwS
+YxRAtXesusTX5jc3HVOwnLcjKRZOQPI57VnZs7t6SwmN3wjLQB0eieTb8nxBf/sn
+sllVPc/t8lTon7S5RFUfsFwvCvbj4rGtoBJdUQVMFwg4CbMw90CwNW/rLB1m1bpd
+GIkDb0gHMsS4fhWpR5SDWUkw1jCitErudWuhH41D8Bai7fHlDg2AnrhK6hHFgsNN
+u52NvFmI96ZVpDIylb3i2WUrt2ZbTbw2f23KfxIbTCbi4TkqaRRx6bq+ekOUbZxD
+7vtrOHmJeOk6wQ1Mco3bcmb28NHYaocdUHcWeUfgKdATs/MCMO89kMwR7YBshnOP
+ydAhzbh6mExm3kJK2xqye7nhgqZ9vPCHWGCkoZEjxj6dvrhTphgQES7Udx7AucD/
+3UJF+3bETcF/JdBBktdfims5mqrx+tEMKYhBM5r2PZuv+xgrF7d2UwcWpKu34MFQ
+WDeqxG32iCYOwhPPjJYaP0skTPBoQV4RvU/p/6Ot0cbrpjjY8uaFHJT5Se8uiVFd
+ElozP3+WpukAC7qDlWiPxSYeTXC1CvVLnx7b34jbESS/JdLghhc3Im1tfOp56E90
+5m3j+KzB4SDsLH4AxpQzafCweQ/u8vco+Vd6wUdF9arJoDg3vu0mPkRdKbyfGwsJ
+aHUMhUcqYoGRPbnkETsRB3ibXtIUCv7c9anrSlDb90QUSnHIknzRWk8YUdCupKUc
+oy5y7kXGsv0lvVB+UTnSYn704eFrE0QJ+YOfY/8kdZQ0Ct+jnMadxzf6Al5+Hi6R
+Xt0sfTlvxi4u+5Bqp306PiWyQNKOSUXjyf/BsOlHE35dgiY69YzxbLo/Lcg5Ju6l
+nMYbEXpLf+hnApmvpHy1W1mH6lqpkYh7wbxG/3zTHAK35les9DkZM81ne+0YCK4D
+X83iU2h4kRUxA8yrcGm3ffGATHyMmkRN9Dh1DnEWH91pYc2qi71rAXGdcfJncmoh
+iE8uyjTFPrA8YWuifhc0rfwfJJANzDQK4IbkKrxORujfREKMEk9tJKUgaNPPwpeZ
+VEO9qKWY1vBNEvosjA9JYyjlpDnW7YOoPfY5os/BijP1cU3D6ysK/ywVmN8bG6rt
+CU7NKimQ6LQcv6c9Ft90UFj0cAOBeSvAqTlvC3qULyyhPWkfQFoUVoBcuteFfZDq
+cg4a7DUl9hNd7KY2X+8GJrHOi8eMF57jkRnNNBFPQzN7O7TTPyUm/KnvWewSu/mI
+4X5IW/0hyyjFzoeQtdkGSGSXSjVEAu0ULm7ipFMaNsbc03k1UXiOFktenpavKXjU
++UiIJOm2HXEBFGXpVlS5lZMswQ==
+-----END ENCRYPTED PRIVATE KEY-----
+		
+`),
+		"tls_client_cert": cty.StringVal(`-----BEGIN CERTIFICATE-----
+MIIDgTCCAmmgAwIBAgIJAM3hc9mT29AmMA0GCSqGSIb3DQEBCwUAMFYxCzAJBgNV
+BAYTAlVTMQ8wDQYDVQQIDAZEZW5pYWwxFDASBgNVBAcMC1NwcmluZ2ZpZWxkMQww
+CgYDVQQKDANEaXMxEjAQBgNVBAMMCVVTRVJfMTIzNDAgFw0xOTAyMjQxMDUwNDZa
+GA8yMTE5MDEzMTEwNTA0NlowVjELMAkGA1UEBhMCVVMxDzANBgNVBAgMBkRlbmlh
+bDEUMBIGA1UEBwwLU3ByaW5nZmllbGQxDDAKBgNVBAoMA0RpczESMBAGA1UEAwwJ
+VVNFUl8xMjM0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu3lPs4hM
+hs4wfKwb6Z9lsL5QTXAhPK5AWSFc6w5JB1TudSWJLrCKgFQ9uPo1AgmvnBSqV4Lg
+yah5fNdzMCnL3EU9v7OgtMDsHOQWMSYZYZBKTMOnH+JPEX9Ax1Mf9zYz2ZXLwQHr
+TcPeeGDmLx2iLCtu/1z5T/XGrr9GYeP/fDvPOWNqnDqvNwu4qpi2a2mkHyYdpNxl
+RSKk+Am1HVQE+V5gNjaTueG4CKAEQWjhpqmWbxDn9/DGpuP1Mzcxizt5u0bRz7oU
+WLkZl0YYO2hnuM6fSk4Q/+Il9zDhfzepON2/nZ5vng9znzosEyxyjr8h3Ten2Ekp
+MY/PGOizBHsSqQIDAQABo1AwTjAdBgNVHQ4EFgQUlxHPYWL7czXQvvwIGFleI/Hu
+1P4wHwYDVR0jBBgwFoAUlxHPYWL7czXQvvwIGFleI/Hu1P4wDAYDVR0TBAUwAwEB
+/zANBgkqhkiG9w0BAQsFAAOCAQEAVaFKtwDNex6UOY1h4tXeMSmS3jR8VjKuvRvh
+maSVCv9ihaqAaG6fgo/9wG4pOx7V/3JRg9NR9ivkziddhhDcc1FMkQXDjzmfY2Aj
+EWKQTTcnIRpz5mGfnfsvfAwsIrx8Wu8YI9V1AHHY7EAAlEa6dkVH7CtXTnA4dN4B
+8+hIAEXwCUVXHbf1pzJLldd6KdHhJ/w0vhParWCb02bao/VK7MBAbV5DDj78WHvB
+e/lI3S9RWC3s4q8pBy5x6IrD5pZ11bEy/sX8wLIEMKD8YwcTvK4D7LKDDoNCElN+
+VTWMMKs/qfW0bp8LzzPlirxT16BNzuHQs3KLO29zgKEmzLI+Eg==
+-----END CERTIFICATE-----
+`),
+		"tls_client_key_password": cty.StringVal("password"),
+	}
+	b := backend.TestBackendConfig(t, New(), configs.SynthBody("synth", conf)).(*Backend)
+	client := b.client
+
+	if client == nil {
+		t.Fatal("Unexpected failure, address")
+	}
+	if client.URL.String() != "https://127.0.0.1:8888/foo" {
+		t.Fatalf("Expected address \"%s\", got \"%s\"", conf["address"], client.URL.String())
+	}
+	if client.UpdateMethod != "POST" {
+		t.Fatalf("Expected update_method \"%s\", got \"%s\"", "POST", client.UpdateMethod)
+	}
+	if client.LockURL != nil || client.LockMethod != "LOCK" {
+		t.Fatal("Unexpected lock_address or lock_method")
+	}
+	if client.UnlockURL != nil || client.UnlockMethod != "UNLOCK" {
+		t.Fatal("Unexpected unlock_address or unlock_method")
+	}
+	if client.Username != "" || client.Password != "" {
+		t.Fatal("Unexpected username or password")
+	}
+
+	// custom
+	conf = map[string]cty.Value{
+		"address":        cty.StringVal("http://127.0.0.1:8888/foo"),
+		"update_method":  cty.StringVal("BLAH"),
+		"lock_address":   cty.StringVal("http://127.0.0.1:8888/bar"),
+		"lock_method":    cty.StringVal("BLIP"),
+		"unlock_address": cty.StringVal("http://127.0.0.1:8888/baz"),
+		"unlock_method":  cty.StringVal("BLOOP"),
+		"username":       cty.StringVal("user"),
+		"password":       cty.StringVal("pass"),
+	}
+
+	b = backend.TestBackendConfig(t, New(), configs.SynthBody("synth", conf)).(*Backend)
+	client = b.client
+
+	if client == nil {
+		t.Fatal("Unexpected failure, update_method")
+	}
+	if client.UpdateMethod != "BLAH" {
+		t.Fatalf("Expected update_method \"%s\", got \"%s\"", "BLAH", client.UpdateMethod)
+	}
+	if client.LockURL.String() != conf["lock_address"].AsString() || client.LockMethod != "BLIP" {
+		t.Fatalf("Unexpected lock_address \"%s\" vs \"%s\" or lock_method \"%s\" vs \"%s\"", client.LockURL.String(),
+			conf["lock_address"].AsString(), client.LockMethod, conf["lock_method"])
+	}
+	if client.UnlockURL.String() != conf["unlock_address"].AsString() || client.UnlockMethod != "BLOOP" {
+		t.Fatalf("Unexpected unlock_address \"%s\" vs \"%s\" or unlock_method \"%s\" vs \"%s\"", client.UnlockURL.String(),
+			conf["unlock_address"].AsString(), client.UnlockMethod, conf["unlock_method"])
+	}
+	if client.Username != "user" || client.Password != "pass" {
+		t.Fatalf("Unexpected username \"%s\" vs \"%s\" or password \"%s\" vs \"%s\"", client.Username, conf["username"],
+			client.Password, conf["password"])
+	}
+}
+
+func TestHTTPClientFactoryWithTLSAndRSAKey(t *testing.T) {
+	// defaults
+
+	conf := map[string]cty.Value{
+		"address": cty.StringVal("https://127.0.0.1:8888/foo"),
+		"tls_client_key": cty.StringVal(`
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDSH+zGKY+LUEde
+Ft2nJ4I3kI+Tl+zD2sMZuhYQ77cddGXeuAMf4RLQxqjgwsuCas8NCoTrMuB5uK05
+GyIYXBegKDcAdJBcB/IE9dQZWJcTXIetkpVnddg86/l/npZj7E3r24N3EMBlkd2S
+c//+9yHzkivdtY60SKNUi8Na1DsQqnhTM6Rqg0VIbxAv1PR8f4K03i9mMWRdnkDe
+sxA8cZcfDsnsXwOz07CxoxWMnxyGrNrVvCR/ySQSFtLJHb+qPiWF6bbp9oNDRYpk
+JyYH1YZwTr+QG4SLwgtk7gbq1KrUBXWievKLJTlkhUxBMswwoM2bxWTDIwZLG+ro
+ZHheqjWVAgMBAAECggEAMBOz5idOO67zlVigAIXuqm3+G+QP/UQJjdJhCCEBAdFH
+Ga16sYma93/s1fhb/gwYMcCtZu8uI0uY/s7xfydbFH7/DrCc8yGyQ2ZH0EDP2FM8
+i/9VBeYVwuKvJH8Ro+1Gaue/7bc8fkDgtIisExdSglt4g/LtotxX2plb6mVS2l3s
+atysGoI5vTTuaxUO6snXOjLjTFM8NJC2gyh0l8SIyGFu9NCvAuoqC+tOWwHF/bRg
+TviMlhnDEeLtrdWtIzZ4ZkuPJR5SBrCWX9TAfjaD2L/lAxxBvREYMWVFgGgemat/
+kLEEZ3SKzLjHNvPvNUFobGhtctWuwkcVWtNh37rXIQKBgQD3s83vkNGTPfC4LjNs
+EK6njRqEnazyskAxoHUg7b4HUtTcp4My497asqtskeHe0fH2npiuQnZ4HegmOlvX
+TTOSG0m89VKjPhz7W88LboXV4CASXL4+dXSFZQKwlOMg+XLtyG7pxUHjBMlfDiCo
+4ADHNBiOL+xMPKzepAWb/NSzyQKBgQDZKd6haz9XMQxtJEec4F96cJNyQMhzhEGM
+IS9x0mDak327hBERO7JxMwg3L9UBe832CHKzxjhgmjpkosb6h8NW6oO/jnz/tM4x
+kkUC7+tR/rI0wUyhfKvpfTA1eheXuFuSG+b38tuH7jXKRie7Uu+5aWtIZFkQ9JJk
+22oIBGbhbQKBgQDOLRWe8HXhD0+MnrginQgjYqnN9Mh+Aqy4Ig0caYcg5WtUdwIX
+m+BlPQ6/AfZ1116FnqELezrM5GfVWgIUBaiFVr1b0P8F7a+F8Xc21roDudg4MIYR
+ywY/+kHw5Rzg14E4NvtLDeu3oMZUnpfEuR8ssEo4H9+Z3W8uqmwY2KvbMQKBgQC1
+RiAS+mVLMSRATtKAf0Lz/9j0vGMXGkVk5aanCofSrN99kcZ1bjGMEJ9BAep6bJAG
+WhL1Qfd5nAQ2UTJrmrxSZzxGwHhTMugTtRdqVj9GmKbFJr4C5wDRzLBbU2kyOrAl
+jKkGPHFITG4WRO2Rjq+RRBBLw4gdgSpailU+D/6ZGQKBgCxHeunRv+Qmy6rP6dfT
+MpteqR1R4WceH7juZvbNhDnltuzPaqiFTP+zuVk4C3krxVEfXxu5QhOZuHMU5z+3
+VpPIvxsMAB6/FyJqnE7GvwkstK3Lek4JkMkBJBaa28cIDNKA283eOtjoMOfaPmd4
+l+E9MKxNkH8EFhyaLhuTg5+l
+-----END PRIVATE KEY-----`),
+		"tls_client_cert": cty.StringVal(`-----BEGIN CERTIFICATE-----
+MIIDgTCCAmmgAwIBAgIJAIpW1g+5Kw+VMA0GCSqGSIb3DQEBCwUAMFYxCzAJBgNV
+BAYTAlVTMQ8wDQYDVQQIDAZEZW5pYWwxFDASBgNVBAcMC1NwcmluZ2ZpZWxkMQww
+CgYDVQQKDANEaXMxEjAQBgNVBAMMCVVTRVJfMTIzNDAgFw0xOTAyMjQxMDUzMTFa
+GA8yMTE5MDEzMTEwNTMxMVowVjELMAkGA1UEBhMCVVMxDzANBgNVBAgMBkRlbmlh
+bDEUMBIGA1UEBwwLU3ByaW5nZmllbGQxDDAKBgNVBAoMA0RpczESMBAGA1UEAwwJ
+VVNFUl8xMjM0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0h/sximP
+i1BHXhbdpyeCN5CPk5fsw9rDGboWEO+3HXRl3rgDH+ES0Mao4MLLgmrPDQqE6zLg
+ebitORsiGFwXoCg3AHSQXAfyBPXUGViXE1yHrZKVZ3XYPOv5f56WY+xN69uDdxDA
+ZZHdknP//vch85Ir3bWOtEijVIvDWtQ7EKp4UzOkaoNFSG8QL9T0fH+CtN4vZjFk
+XZ5A3rMQPHGXHw7J7F8Ds9OwsaMVjJ8chqza1bwkf8kkEhbSyR2/qj4lhem26faD
+Q0WKZCcmB9WGcE6/kBuEi8ILZO4G6tSq1AV1onryiyU5ZIVMQTLMMKDNm8VkwyMG
+Sxvq6GR4Xqo1lQIDAQABo1AwTjAdBgNVHQ4EFgQU6J3EEyfztVkQ13TnocKVjW7O
+DQkwHwYDVR0jBBgwFoAU6J3EEyfztVkQ13TnocKVjW7ODQkwDAYDVR0TBAUwAwEB
+/zANBgkqhkiG9w0BAQsFAAOCAQEADOTaO+0hWHlgqmSs/AHUwiEtjIIIDhUAd+HO
+TgtInj2MUOPWvmn9Y7zFwaXNdwtYnr45TP1ZInXDAbQznw27KeMW2xFLXMiPkfj7
+dH5ywhNljJsFXuFelu3esKzI9H/EQhoNtGBJHIUXsfm+nueDT6KaN80KcSwWajXd
+X3MnX7TRx4NtQjs7fKU0wo+4lvjkl0ED/pglQO8VnWXSN8g5+jbBQv7jzkBkX3iv
+ibNnB9ynSnA/EVucL/Q0e7k8MxcFFOKBrJ2MQ3Ne2PzRPGzEfjngweJF36nhbF4T
+nClq3nTR5gAz15YtuEyqj8MwNFGu4Z8w6AYNdR7Pwfzd8Z0lzQ==
+-----END CERTIFICATE-----`),
+		"tls_client_key_password": cty.StringVal(""),
+	}
+	b := backend.TestBackendConfig(t, New(), configs.SynthBody("synth", conf)).(*Backend)
+	client := b.client
+
+	if client == nil {
+		t.Fatal("Unexpected failure, address")
+	}
+	if client.URL.String() != "https://127.0.0.1:8888/foo" {
+		t.Fatalf("Expected address \"%s\", got \"%s\"", conf["address"], client.URL.String())
+	}
+	if client.UpdateMethod != "POST" {
+		t.Fatalf("Expected update_method \"%s\", got \"%s\"", "POST", client.UpdateMethod)
+	}
+	if client.LockURL != nil || client.LockMethod != "LOCK" {
+		t.Fatal("Unexpected lock_address or lock_method")
+	}
+	if client.UnlockURL != nil || client.UnlockMethod != "UNLOCK" {
+		t.Fatal("Unexpected unlock_address or unlock_method")
+	}
+	if client.Username != "" || client.Password != "" {
+		t.Fatal("Unexpected username or password")
+	}
+
+	// custom
+	conf = map[string]cty.Value{
+		"address":        cty.StringVal("http://127.0.0.1:8888/foo"),
+		"update_method":  cty.StringVal("BLAH"),
+		"lock_address":   cty.StringVal("http://127.0.0.1:8888/bar"),
+		"lock_method":    cty.StringVal("BLIP"),
+		"unlock_address": cty.StringVal("http://127.0.0.1:8888/baz"),
+		"unlock_method":  cty.StringVal("BLOOP"),
+		"username":       cty.StringVal("user"),
+		"password":       cty.StringVal("pass"),
+	}
+
+	b = backend.TestBackendConfig(t, New(), configs.SynthBody("synth", conf)).(*Backend)
+	client = b.client
+
+	if client == nil {
+		t.Fatal("Unexpected failure, update_method")
+	}
+	if client.UpdateMethod != "BLAH" {
+		t.Fatalf("Expected update_method \"%s\", got \"%s\"", "BLAH", client.UpdateMethod)
+	}
+	if client.LockURL.String() != conf["lock_address"].AsString() || client.LockMethod != "BLIP" {
+		t.Fatalf("Unexpected lock_address \"%s\" vs \"%s\" or lock_method \"%s\" vs \"%s\"", client.LockURL.String(),
+			conf["lock_address"].AsString(), client.LockMethod, conf["lock_method"])
+	}
+	if client.UnlockURL.String() != conf["unlock_address"].AsString() || client.UnlockMethod != "BLOOP" {
+		t.Fatalf("Unexpected unlock_address \"%s\" vs \"%s\" or unlock_method \"%s\" vs \"%s\"", client.UnlockURL.String(),
+			conf["unlock_address"].AsString(), client.UnlockMethod, conf["unlock_method"])
+	}
+	if client.Username != "user" || client.Password != "pass" {
+		t.Fatalf("Unexpected username \"%s\" vs \"%s\" or password \"%s\" vs \"%s\"", client.Username, conf["username"],
+			client.Password, conf["password"])
+	}
+}
+
+func TestHTTPClientFactoryWithTLSAndPKCS1RSAKey(t *testing.T) {
+	// defaults
+
+	conf := map[string]cty.Value{
+		"address": cty.StringVal("https://127.0.0.1:8888/foo"),
+		"tls_client_key": cty.StringVal(`-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: DES-CBC,4AA323C1023EAA14
+
+ql8NawFwFQMFHI3vTrN6ClByyu4xX6zW4KbP29KKgAS/sADj1p1zYluXsp2Y0/vF
+f/yCYIkuFquX9iXS/Ty7wnD+YKx3JRvrmayid2fteOJQ5Qj0pmKwWrjKBgvz9pwv
+8vu0g5vwmUu7lJS770Z2aPBxVDw6iTyXO7Qc1oFbVT5NEo+aFUNzxsFnCWLAeVLc
+VVYR+I/i7cnILMGDwmWPcqQexXSJPcx7W90GREBNhiioZjtrYowvOKyyCZwF9XAx
+znOcMJbCyWil9OMguIEAimWaRnpETxhH3DPx0o5fpLI9k/gJZ/uZiYpGIKjRI7Sh
+ZVa+wfykgtlCNLrg3WyS9jBNUvsuUqkLiuhut5fqq72HdQcCO6TicMvZa+z4pR41
+MERCNWwuv5+n9YVk9WimVd8sP8jH+I2/PW+lLKtIfQ5e2ODfd3e/BmrTU/coeuRk
+WHWYxa7qaPgZ5Gcd7TM2pPhS1BLVv4m0KWe1elUIbpbDHNpGcKkm7KWkZwiiFYMd
+nvEFMRQVaCpFMpDey8kW/M7Jpmv+EbC3ZrNsIbMmcncAYa4LesmCjlUzxyTjN5CE
++QJ//X4SFBl/epu0Bqg+QrJNz6IDVc8BHyYduKHph4T+hjE7VldEw8hwYk0JFG/j
+fklZ0EpWFj70OTYJFB3dwwyu5Kq5e2LHZPg1DGwq+IQXfF71oJwOKO7Z45vWRP+2
+N8mnG3BD1FHEBAEfFjNONXkilmDmZeI+77EZEHD2ziZ421AGwdbv20Qt2cTcRfcN
+yYVqrs75OJrJNwxaXPOJLPUCdvT73pOG2zne5PsqBBeykgObmdsBkQvhTXbRvSJm
+WVUfA5clNpbBfOWuhEWayH9OfhTfzfIzATrv59CDYpTs0D5v/CbNptQuRAS7084D
+TJNcMxatCdvx6wCl0wYBgqxYKW1MG3BqyX0QUmFgO9Cr/ljbx3khZvlk7aZE2TEW
+3bSMpcMejnafoIzKWFgNVgq1hcdy8qT1H7+j6yuXqcJfx2wI7jk1+ivgyuD0CqXG
+IWnM1PSN+F7njCm/HW4uEg+fuT+n5EO/4B+CdDODSaGLd/PU5NRTWDyXQ1XGk2dW
+0AtXuocjnCl0dZTsNfEn0bfhugGh8PMkhSJDcVIDJrNX9T/RYgQY3SUpPzbc4PPf
+gZOoM+R9Ul2cSCLv++smGoNwOWWN/piFXYGEtERMQDFE3ZGu3sL5ePOQF2kJoOIf
+XTCF1w+u8jdskBpVJm247w4ZhG4NTetp7f63J+YKyf+9ryTAg8gPrA+T9H+mMMO8
+T5XmSo/0XIGvFxQJoqN+SxBdVKoIe9atrg7slXIoD0rf9jAtpEYo1WoGA+oKEWFg
+rPFeOCf1Eclbo1uElS5e1yjq30TySiMlfRFICcKJ8ggZzFH6WLXjE7a0kDRyPOQu
+Q2j326pKmVD08V+cvo2XUkb/CQ2mQJw0yigeC/VQON2IjpCZAEUCzs8N3idHP1uh
+oNUyBmzo9RVeODQtWdyybePMOQsSpLMqauuHcWNxE6GYkWe7x4ZmQV/G64OX7+SW
+NTZV60U09XwxtbTAwg/tpDuz6ZhD6388J/24t7x2p4UykBd5gMTMj7a2YHf92Xvs
+-----END RSA PRIVATE KEY-----
+`),
+		"tls_client_cert": cty.StringVal(`-----BEGIN CERTIFICATE-----
+MIIDgTCCAmmgAwIBAgIJANFDBEonczdkMA0GCSqGSIb3DQEBCwUAMFYxCzAJBgNV
+BAYTAlVTMQ8wDQYDVQQIDAZEZW5pYWwxFDASBgNVBAcMC1NwcmluZ2ZpZWxkMQww
+CgYDVQQKDANEaXMxEjAQBgNVBAMMCVVTRVJfMTIzNDAgFw0xOTAyMjQxNzMzMTRa
+GA8yMTE5MDEzMTE3MzMxNFowVjELMAkGA1UEBhMCVVMxDzANBgNVBAgMBkRlbmlh
+bDEUMBIGA1UEBwwLU3ByaW5nZmllbGQxDDAKBgNVBAoMA0RpczESMBAGA1UEAwwJ
+VVNFUl8xMjM0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw1jq3r70
+AGsl4gxINHL4Np9V7RCVMbMHK50UDGLNybHvLjHJ1CRMD7IgKEhFs3QcCn6I+2oi
+ffFApLDtJzIR0gzkf8/B/EqI9xya5/xb14io7usivN80VDkWIQVb+pgxLUFO2WlE
+OhJA+1EWUYBuUEk4nCg2gMiJa+ZV8qxOzhD1MB8ohMorKT4aXYEpKz4LG2QpWhiD
+i0dMo+QChgag7se94uGf4gn6e9yV4qaNYPbgqtlBLNsRakNGtFlZ2MsffKzs1SxY
+chBsMly00cw3eytMqZSQLaygIY3x9zrsE6YNVGHGTUghxt6Ykgn4/ftDkhP6pQHP
+r0nhj4h++/u9zwIDAQABo1AwTjAdBgNVHQ4EFgQUpsgAeKFtCTrMnsQV9DYigWgJ
+AmowHwYDVR0jBBgwFoAUpsgAeKFtCTrMnsQV9DYigWgJAmowDAYDVR0TBAUwAwEB
+/zANBgkqhkiG9w0BAQsFAAOCAQEAPyo0x6Uzyj6RaEzukWQFVekJh3tkbNvHU5zd
+bkC4z6wAo/fvoT8juu79sNgBwxuArr4K3Csudq18tKZ7iB2wMK46fPpCjI8xii3f
+x7M9z/sw7eCHn+kusRPZf6M2aq4EULNK7nVjYuSqOso1akMRqFDtS3HLYMYhoydq
+eGPdgZ5ZSBs7oBedHYWcIUrYlzokxTvtFoYMSjY2xgT6GO/SoqQq7/az3BdPYRYg
+ATj7mumxFOTcRNdU61lPEBqv0C3UHjnfe7zBh2fqEj6XSBbbnC17ACGQ4F5iCxYz
+LlLLSKNIYEC0E1fIhGpBix16CkjEFFFNEuDJ/GdNl0F4Lo3Itg==
+-----END CERTIFICATE-----
+`),
+		"tls_client_key_password": cty.StringVal("password"),
+	}
+	b := backend.TestBackendConfig(t, New(), configs.SynthBody("synth", conf)).(*Backend)
+	client := b.client
+
+	if client == nil {
+		t.Fatal("Unexpected failure, address")
+	}
+	if client.URL.String() != "https://127.0.0.1:8888/foo" {
 		t.Fatalf("Expected address \"%s\", got \"%s\"", conf["address"], client.URL.String())
 	}
 	if client.UpdateMethod != "POST" {

--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 	github.com/xanzy/ssh-agent v0.2.1
 	github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 // indirect
 	github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
+	github.com/youmark/pkcs8 v0.0.0-20181201043747-70daafe5d78a
 	github.com/zclconf/go-cty v0.0.0-20190201220620-4ca19710f056
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -390,6 +390,8 @@ github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 h1:MPPkRncZLN9Kh4M
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557 h1:Jpn2j6wHkC9wJv5iMfJhKqrZJx3TahFx+7sbZ7zQdxs=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
+github.com/youmark/pkcs8 v0.0.0-20181201043747-70daafe5d78a h1:wRlvyDgRuJOLgD2vcuBUbEduzTkcN7quLip1EnX/Dl4=
+github.com/youmark/pkcs8 v0.0.0-20181201043747-70daafe5d78a/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/zclconf/go-cty v0.0.0-20181129180422-88fbe721e0f8/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9 h1:hHCAGde+QfwbqXSAqOmBd4NlOrJ6nmjWp+Nu408ezD4=
 github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/vendor/github.com/youmark/pkcs8/.gitignore
+++ b/vendor/github.com/youmark/pkcs8/.gitignore
@@ -1,0 +1,23 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test

--- a/vendor/github.com/youmark/pkcs8/.travis.yml
+++ b/vendor/github.com/youmark/pkcs8/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+go:
+  - "1.9.x"
+  - "1.10.x"
+  - master
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/youmark/pkcs8/LICENSE
+++ b/vendor/github.com/youmark/pkcs8/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 youmark
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/youmark/pkcs8/README
+++ b/vendor/github.com/youmark/pkcs8/README
@@ -1,0 +1,1 @@
+pkcs8 package: implement PKCS#8 private key parsing and conversion as defined in RFC5208 and RFC5958

--- a/vendor/github.com/youmark/pkcs8/README.md
+++ b/vendor/github.com/youmark/pkcs8/README.md
@@ -1,0 +1,21 @@
+pkcs8
+===
+OpenSSL can generate private keys in both "traditional format" and PKCS#8 format. Newer applications are advised to use more secure PKCS#8 format. Go standard crypto package provides a [function](http://golang.org/pkg/crypto/x509/#ParsePKCS8PrivateKey) to parse private key in PKCS#8 format. There is a limitation to this function. It can only handle unencrypted PKCS#8 private keys. To use this function, the user has to save the private key in file without encryption, which is a bad practice to leave private keys unprotected on file systems. In addition, Go standard package lacks the functions to convert RSA/ECDSA private keys into PKCS#8 format.
+
+pkcs8 package fills the gap here. It implements functions to process private keys in PKCS#8 format, as defined in [RFC5208](https://tools.ietf.org/html/rfc5208) and [RFC5958](https://tools.ietf.org/html/rfc5958). It can handle both unencrypted PKCS#8 PrivateKeyInfo format and EncryptedPrivateKeyInfo format with PKCS#5 (v2.0) algorithms.
+
+
+[**Godoc**](http://godoc.org/github.com/youmark/pkcs8)
+
+## Installation
+Supports Go 1.9+
+
+```text
+go get github.com/youmark/pkcs8
+```
+## dependency
+This package depends on golang.org/x/crypto/pbkdf2 package. Use the following command to retrive pbkdf2 package
+```text
+go get golang.org/x/crypto/pbkdf2
+```
+

--- a/vendor/github.com/youmark/pkcs8/pkcs8.go
+++ b/vendor/github.com/youmark/pkcs8/pkcs8.go
@@ -1,0 +1,308 @@
+// Package pkcs8 implements functions to parse and convert private keys in PKCS#8 format, as defined in RFC5208 and RFC5958
+package pkcs8
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/des"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// Copy from crypto/x509
+var (
+	oidPublicKeyRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+	oidPublicKeyDSA   = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 1}
+	oidPublicKeyECDSA = asn1.ObjectIdentifier{1, 2, 840, 10045, 2, 1}
+)
+
+// Copy from crypto/x509
+var (
+	oidNamedCurveP224 = asn1.ObjectIdentifier{1, 3, 132, 0, 33}
+	oidNamedCurveP256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}
+	oidNamedCurveP384 = asn1.ObjectIdentifier{1, 3, 132, 0, 34}
+	oidNamedCurveP521 = asn1.ObjectIdentifier{1, 3, 132, 0, 35}
+)
+
+// Copy from crypto/x509
+func oidFromNamedCurve(curve elliptic.Curve) (asn1.ObjectIdentifier, bool) {
+	switch curve {
+	case elliptic.P224():
+		return oidNamedCurveP224, true
+	case elliptic.P256():
+		return oidNamedCurveP256, true
+	case elliptic.P384():
+		return oidNamedCurveP384, true
+	case elliptic.P521():
+		return oidNamedCurveP521, true
+	}
+
+	return nil, false
+}
+
+// Unecrypted PKCS8
+var (
+	oidPKCS5PBKDF2    = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 12}
+	oidPBES2          = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 13}
+	oidAES256CBC      = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 42}
+	oidAES128CBC      = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 2}
+	oidHMACWithSHA256 = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 9}
+	oidDESEDE3CBC     = asn1.ObjectIdentifier{1, 2, 840, 113549, 3, 7}
+)
+
+type ecPrivateKey struct {
+	Version       int
+	PrivateKey    []byte
+	NamedCurveOID asn1.ObjectIdentifier `asn1:"optional,explicit,tag:0"`
+	PublicKey     asn1.BitString        `asn1:"optional,explicit,tag:1"`
+}
+
+type privateKeyInfo struct {
+	Version             int
+	PrivateKeyAlgorithm []asn1.ObjectIdentifier
+	PrivateKey          []byte
+}
+
+// Encrypted PKCS8
+type prfParam struct {
+	IdPRF     asn1.ObjectIdentifier
+	NullParam asn1.RawValue
+}
+
+type pbkdf2Params struct {
+	Salt           []byte
+	IterationCount int
+	PrfParam       prfParam `asn1:"optional"`
+}
+
+type pbkdf2Algorithms struct {
+	IdPBKDF2     asn1.ObjectIdentifier
+	PBKDF2Params pbkdf2Params
+}
+
+type pbkdf2Encs struct {
+	EncryAlgo asn1.ObjectIdentifier
+	IV        []byte
+}
+
+type pbes2Params struct {
+	KeyDerivationFunc pbkdf2Algorithms
+	EncryptionScheme  pbkdf2Encs
+}
+
+type pbes2Algorithms struct {
+	IdPBES2     asn1.ObjectIdentifier
+	PBES2Params pbes2Params
+}
+
+type encryptedPrivateKeyInfo struct {
+	EncryptionAlgorithm pbes2Algorithms
+	EncryptedData       []byte
+}
+
+// ParsePKCS8PrivateKeyRSA parses encrypted/unencrypted private keys in PKCS#8 format. To parse encrypted private keys, a password of []byte type should be provided to the function as the second parameter.
+//
+// The function can decrypt the private key encrypted with AES-256-CBC mode, and stored in PKCS #5 v2.0 format.
+func ParsePKCS8PrivateKeyRSA(der []byte, v ...[]byte) (*rsa.PrivateKey, error) {
+	key, err := ParsePKCS8PrivateKey(der, v...)
+	if err != nil {
+		return nil, err
+	}
+	typedKey, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("key block is not of type RSA")
+	}
+	return typedKey, nil
+}
+
+// ParsePKCS8PrivateKeyECDSA parses encrypted/unencrypted private keys in PKCS#8 format. To parse encrypted private keys, a password of []byte type should be provided to the function as the second parameter.
+//
+// The function can decrypt the private key encrypted with AES-256-CBC mode, and stored in PKCS #5 v2.0 format.
+func ParsePKCS8PrivateKeyECDSA(der []byte, v ...[]byte) (*ecdsa.PrivateKey, error) {
+	key, err := ParsePKCS8PrivateKey(der, v...)
+	if err != nil {
+		return nil, err
+	}
+	typedKey, ok := key.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("key block is not of type ECDSA")
+	}
+	return typedKey, nil
+}
+
+// ParsePKCS8PrivateKey parses encrypted/unencrypted private keys in PKCS#8 format. To parse encrypted private keys, a password of []byte type should be provided to the function as the second parameter.
+//
+// The function can decrypt the private key encrypted with AES-256-CBC mode, and stored in PKCS #5 v2.0 format.
+func ParsePKCS8PrivateKey(der []byte, v ...[]byte) (interface{}, error) {
+	// No password provided, assume the private key is unencrypted
+	if v == nil {
+		return x509.ParsePKCS8PrivateKey(der)
+	}
+
+	// Use the password provided to decrypt the private key
+	password := v[0]
+	var privKey encryptedPrivateKeyInfo
+	if _, err := asn1.Unmarshal(der, &privKey); err != nil {
+		return nil, errors.New("pkcs8: only PKCS #5 v2.0 supported")
+	}
+
+	if !privKey.EncryptionAlgorithm.IdPBES2.Equal(oidPBES2) {
+		return nil, errors.New("pkcs8: only PBES2 supported")
+	}
+
+	if !privKey.EncryptionAlgorithm.PBES2Params.KeyDerivationFunc.IdPBKDF2.Equal(oidPKCS5PBKDF2) {
+		return nil, errors.New("pkcs8: only PBKDF2 supported")
+	}
+
+	encParam := privKey.EncryptionAlgorithm.PBES2Params.EncryptionScheme
+	kdfParam := privKey.EncryptionAlgorithm.PBES2Params.KeyDerivationFunc.PBKDF2Params
+
+	iv := encParam.IV
+	salt := kdfParam.Salt
+	iter := kdfParam.IterationCount
+	keyHash := sha1.New
+	if kdfParam.PrfParam.IdPRF.Equal(oidHMACWithSHA256) {
+		keyHash = sha256.New
+	}
+
+	encryptedKey := privKey.EncryptedData
+	var symkey []byte
+	var block cipher.Block
+	var err error
+	switch {
+	case encParam.EncryAlgo.Equal(oidAES128CBC):
+		symkey = pbkdf2.Key(password, salt, iter, 16, keyHash)
+		block, err = aes.NewCipher(symkey)
+	case encParam.EncryAlgo.Equal(oidAES256CBC):
+		symkey = pbkdf2.Key(password, salt, iter, 32, keyHash)
+		block, err = aes.NewCipher(symkey)
+	case encParam.EncryAlgo.Equal(oidDESEDE3CBC):
+		symkey = pbkdf2.Key(password, salt, iter, 24, keyHash)
+		block, err = des.NewTripleDESCipher(symkey)
+	default:
+		return nil, errors.New("pkcs8: only AES-256-CBC, AES-128-CBC and DES-EDE3-CBC are supported")
+	}
+	if err != nil {
+		return nil, err
+	}
+	mode := cipher.NewCBCDecrypter(block, iv)
+	mode.CryptBlocks(encryptedKey, encryptedKey)
+
+	key, err := x509.ParsePKCS8PrivateKey(encryptedKey)
+	if err != nil {
+		return nil, errors.New("pkcs8: incorrect password")
+	}
+	return key, nil
+}
+
+func convertPrivateKeyToPKCS8(priv interface{}) ([]byte, error) {
+	var pkey privateKeyInfo
+
+	switch priv := priv.(type) {
+	case *ecdsa.PrivateKey:
+		eckey, err := x509.MarshalECPrivateKey(priv)
+		if err != nil {
+			return nil, err
+		}
+
+		oidNamedCurve, ok := oidFromNamedCurve(priv.Curve)
+		if !ok {
+			return nil, errors.New("pkcs8: unknown elliptic curve")
+		}
+
+		// Per RFC5958, if publicKey is present, then version is set to v2(1) else version is set to v1(0).
+		// But openssl set to v1 even publicKey is present
+		pkey.Version = 1
+		pkey.PrivateKeyAlgorithm = make([]asn1.ObjectIdentifier, 2)
+		pkey.PrivateKeyAlgorithm[0] = oidPublicKeyECDSA
+		pkey.PrivateKeyAlgorithm[1] = oidNamedCurve
+		pkey.PrivateKey = eckey
+	case *rsa.PrivateKey:
+
+		// Per RFC5958, if publicKey is present, then version is set to v2(1) else version is set to v1(0).
+		// But openssl set to v1 even publicKey is present
+		pkey.Version = 0
+		pkey.PrivateKeyAlgorithm = make([]asn1.ObjectIdentifier, 1)
+		pkey.PrivateKeyAlgorithm[0] = oidPublicKeyRSA
+		pkey.PrivateKey = x509.MarshalPKCS1PrivateKey(priv)
+	default:
+		return nil, fmt.Errorf("unsupported key type: %T", priv)
+	}
+
+	return asn1.Marshal(pkey)
+}
+
+func convertPrivateKeyToPKCS8Encrypted(priv interface{}, password []byte) ([]byte, error) {
+	// Convert private key into PKCS8 format
+	pkey, err := convertPrivateKeyToPKCS8(priv)
+	if err != nil {
+		return nil, err
+	}
+
+	// Calculate key from password based on PKCS5 algorithm
+	// Use 8 byte salt, 16 byte IV, and 2048 iteration
+	iter := 2048
+	salt := make([]byte, 8)
+	iv := make([]byte, 16)
+	_, err = rand.Read(salt)
+	if err != nil {
+		return nil, err
+	}
+	_, err = rand.Read(iv)
+	if err != nil {
+		return nil, err
+	}
+
+	key := pbkdf2.Key(password, salt, iter, 32, sha256.New)
+
+	// Use AES256-CBC mode, pad plaintext with PKCS5 padding scheme
+	padding := aes.BlockSize - len(pkey)%aes.BlockSize
+	if padding > 0 {
+		n := len(pkey)
+		pkey = append(pkey, make([]byte, padding)...)
+		for i := 0; i < padding; i++ {
+			pkey[n+i] = byte(padding)
+		}
+	}
+
+	encryptedKey := make([]byte, len(pkey))
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	mode := cipher.NewCBCEncrypter(block, iv)
+	mode.CryptBlocks(encryptedKey, pkey)
+
+	//	pbkdf2algo := pbkdf2Algorithms{oidPKCS5PBKDF2, pbkdf2Params{salt, iter, prfParam{oidHMACWithSHA256}}}
+
+	pbkdf2algo := pbkdf2Algorithms{oidPKCS5PBKDF2, pbkdf2Params{salt, iter, prfParam{oidHMACWithSHA256, asn1.RawValue{Tag: asn1.TagNull}}}}
+	pbkdf2encs := pbkdf2Encs{oidAES256CBC, iv}
+	pbes2algo := pbes2Algorithms{oidPBES2, pbes2Params{pbkdf2algo, pbkdf2encs}}
+
+	encryptedPkey := encryptedPrivateKeyInfo{pbes2algo, encryptedKey}
+
+	return asn1.Marshal(encryptedPkey)
+}
+
+// ConvertPrivateKeyToPKCS8 converts the private key into PKCS#8 format.
+// To encrypt the private key, the password of []byte type should be provided as the second parameter.
+//
+// The only supported key types are RSA and ECDSA (*rsa.PrivateKey or *ecdsa.PrivateKey for priv)
+func ConvertPrivateKeyToPKCS8(priv interface{}, v ...[]byte) ([]byte, error) {
+	if v == nil {
+		return convertPrivateKeyToPKCS8(priv)
+	}
+
+	password := v[0]
+	return convertPrivateKeyToPKCS8Encrypted(priv, password)
+}

--- a/vendor/golang.org/x/crypto/pbkdf2/pbkdf2.go
+++ b/vendor/golang.org/x/crypto/pbkdf2/pbkdf2.go
@@ -1,0 +1,77 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package pbkdf2 implements the key derivation function PBKDF2 as defined in RFC
+2898 / PKCS #5 v2.0.
+
+A key derivation function is useful when encrypting data based on a password
+or any other not-fully-random data. It uses a pseudorandom function to derive
+a secure encryption key based on the password.
+
+While v2.0 of the standard defines only one pseudorandom function to use,
+HMAC-SHA1, the drafted v2.1 specification allows use of all five FIPS Approved
+Hash Functions SHA-1, SHA-224, SHA-256, SHA-384 and SHA-512 for HMAC. To
+choose, you can pass the `New` functions from the different SHA packages to
+pbkdf2.Key.
+*/
+package pbkdf2 // import "golang.org/x/crypto/pbkdf2"
+
+import (
+	"crypto/hmac"
+	"hash"
+)
+
+// Key derives a key from the password, salt and iteration count, returning a
+// []byte of length keylen that can be used as cryptographic key. The key is
+// derived based on the method described as PBKDF2 with the HMAC variant using
+// the supplied hash function.
+//
+// For example, to use a HMAC-SHA-1 based PBKDF2 key derivation function, you
+// can get a derived key for e.g. AES-256 (which needs a 32-byte key) by
+// doing:
+//
+// 	dk := pbkdf2.Key([]byte("some password"), salt, 4096, 32, sha1.New)
+//
+// Remember to get a good random salt. At least 8 bytes is recommended by the
+// RFC.
+//
+// Using a higher iteration count will increase the cost of an exhaustive
+// search but will also make derivation proportionally slower.
+func Key(password, salt []byte, iter, keyLen int, h func() hash.Hash) []byte {
+	prf := hmac.New(h, password)
+	hashLen := prf.Size()
+	numBlocks := (keyLen + hashLen - 1) / hashLen
+
+	var buf [4]byte
+	dk := make([]byte, 0, numBlocks*hashLen)
+	U := make([]byte, hashLen)
+	for block := 1; block <= numBlocks; block++ {
+		// N.B.: || means concatenation, ^ means XOR
+		// for each block T_i = U_1 ^ U_2 ^ ... ^ U_iter
+		// U_1 = PRF(password, salt || uint(i))
+		prf.Reset()
+		prf.Write(salt)
+		buf[0] = byte(block >> 24)
+		buf[1] = byte(block >> 16)
+		buf[2] = byte(block >> 8)
+		buf[3] = byte(block)
+		prf.Write(buf[:4])
+		dk = prf.Sum(dk)
+		T := dk[len(dk)-hashLen:]
+		copy(U, T)
+
+		// U_n = PRF(password, U_(n-1))
+		for n := 2; n <= iter; n++ {
+			prf.Reset()
+			prf.Write(U)
+			U = U[:0]
+			U = prf.Sum(U)
+			for x := range U {
+				T[x] ^= U[x]
+			}
+		}
+	}
+	return dk[:keyLen]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -434,6 +434,8 @@ github.com/vmihailenco/msgpack/codes
 github.com/xanzy/ssh-agent
 # github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
 github.com/xlab/treeprint
+# github.com/youmark/pkcs8 v0.0.0-20181201043747-70daafe5d78a
+github.com/youmark/pkcs8
 # github.com/zclconf/go-cty v0.0.0-20190201220620-4ca19710f056
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/gocty
@@ -465,6 +467,7 @@ golang.org/x/crypto/ssh/knownhosts
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/openpgp
 golang.org/x/crypto/pkcs12
+golang.org/x/crypto/pbkdf2
 golang.org/x/crypto/curve25519
 golang.org/x/crypto/ed25519
 golang.org/x/crypto/internal/chacha20


### PR DESCRIPTION
This adds the possibility of working with http client certs (pkcs8 ecdsa and rsa and pkcs1 rsa private keys should work).

The documentation is missing but i wanted to reach out first before spending more time on this.