### PR TITLE
backend/remote: use the can-queue-apply permission

### DIFF
--- a/backend/remote/backend_apply.go
+++ b/backend/remote/backend_apply.go
@@ -16,7 +16,9 @@ import (
 func (b *Remote) opApply(stopCtx, cancelCtx context.Context, op *backend.Operation, w *tfe.Workspace) (*tfe.Run, error) {
 	log.Printf("[INFO] backend/remote: starting Apply operation")
 
-	if !w.Permissions.CanUpdate {
+	// We should remove the `CanUpdate` part of this test, but for now
+	// (to remain compatible with tfe.v2.1) we'll leave it in here.
+	if !w.Permissions.CanUpdate && !w.Permissions.CanQueueApply {
 		return nil, fmt.Errorf(strings.TrimSpace(applyErrNoUpdateRights))
 	}
 

--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -972,6 +972,15 @@ func (m *mockWorkspaces) Delete(ctx context.Context, organization, workspace str
 	return nil
 }
 
+func (m *mockWorkspaces) RemoveVCSConnection(ctx context.Context, organization, workspace string) (*tfe.Workspace, error) {
+	w, ok := m.workspaceNames[workspace]
+	if !ok {
+		return nil, tfe.ErrResourceNotFound
+	}
+	w.VCSRepo = nil
+	return w, nil
+}
+
 func (m *mockWorkspaces) Lock(ctx context.Context, workspaceID string, options tfe.WorkspaceLockOptions) (*tfe.Workspace, error) {
 	w, ok := m.workspaceIDs[workspaceID]
 	if !ok {

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90
 	github.com/hashicorp/go-safetemp v0.0.0-20180326211150-b1a1dbde6fdc // indirect
 	github.com/hashicorp/go-sockaddr v1.0.0 // indirect
-	github.com/hashicorp/go-tfe v0.3.8
+	github.com/hashicorp/go-tfe v0.3.10
 	github.com/hashicorp/go-uuid v1.0.0
 	github.com/hashicorp/go-version v1.0.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/hashicorp/go-slug v0.2.0 h1:MVdZAkTmDsUi1AT+3NQDsn8n3ssnVSIHwiM6RcUHv
 github.com/hashicorp/go-slug v0.2.0/go.mod h1:+zDycQOzGqOqMW7Kn2fp9vz/NtqpMLQlgb9JUF+0km4=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
-github.com/hashicorp/go-tfe v0.3.8 h1:pUqxmnhZ7Dj3biugEEo2oGZ758zVQy70lx8p7p4JREY=
-github.com/hashicorp/go-tfe v0.3.8/go.mod h1:LHLchj07PCYgQqcyE5Sz+g4zrMNW+nALKbiSNTZedEs=
+github.com/hashicorp/go-tfe v0.3.10 h1:6uPnPHNPxXDe3k/Vt6fovygYTaWJ8f/7zdHc++f7NJU=
+github.com/hashicorp/go-tfe v0.3.10/go.mod h1:LHLchj07PCYgQqcyE5Sz+g4zrMNW+nALKbiSNTZedEs=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=

--- a/vendor/github.com/hashicorp/go-tfe/organization.go
+++ b/vendor/github.com/hashicorp/go-tfe/organization.go
@@ -80,7 +80,7 @@ type Organization struct {
 	CreatedAt              time.Time                `jsonapi:"attr,created-at,iso8601"`
 	Email                  string                   `jsonapi:"attr,email"`
 	EnterprisePlan         EnterprisePlanType       `jsonapi:"attr,enterprise-plan"`
-	OwnersTeamSamlRoleID   string                   `jsonapi:"attr,owners-team-saml-role-id"`
+	OwnersTeamSAMLRoleID   string                   `jsonapi:"attr,owners-team-saml-role-id"`
 	Permissions            *OrganizationPermissions `jsonapi:"attr,permissions"`
 	SAMLEnabled            bool                     `jsonapi:"attr,saml-enabled"`
 	SessionRemember        int                      `jsonapi:"attr,session-remember"`
@@ -157,6 +157,18 @@ type OrganizationCreateOptions struct {
 
 	// Admin email address.
 	Email *string `jsonapi:"attr,email"`
+
+	// Session expiration (minutes).
+	SessionRemember *int `jsonapi:"attr,session-remember,omitempty"`
+
+	// Session timeout after inactivity (minutes).
+	SessionTimeout *int `jsonapi:"attr,session-timeout,omitempty"`
+
+	// Authentication policy.
+	CollaboratorAuthPolicy *AuthPolicyType `jsonapi:"attr,collaborator-auth-policy,omitempty"`
+
+	// The name of the "owners" team
+	OwnersTeamSAMLRoleID *string `jsonapi:"attr,owners-team-saml-role-id,omitempty"`
 }
 
 func (o OrganizationCreateOptions) valid() error {
@@ -235,6 +247,9 @@ type OrganizationUpdateOptions struct {
 
 	// Authentication policy.
 	CollaboratorAuthPolicy *AuthPolicyType `jsonapi:"attr,collaborator-auth-policy,omitempty"`
+
+	// The name of the "owners" team
+	OwnersTeamSAMLRoleID *string `jsonapi:"attr,owners-team-saml-role-id,omitempty"`
 }
 
 // Update attributes of an existing organization.

--- a/vendor/github.com/hashicorp/go-tfe/run.go
+++ b/vendor/github.com/hashicorp/go-tfe/run.go
@@ -122,10 +122,16 @@ type RunPermissions struct {
 
 // RunStatusTimestamps holds the timestamps for individual run statuses.
 type RunStatusTimestamps struct {
-	ErroredAt  time.Time `json:"errored-at"`
-	FinishedAt time.Time `json:"finished-at"`
-	QueuedAt   time.Time `json:"queued-at"`
-	StartedAt  time.Time `json:"started-at"`
+	ErroredAt            time.Time `json:"errored-at"`
+	FinishedAt           time.Time `json:"finished-at"`
+	QueuedAt             time.Time `json:"queued-at"`
+	StartedAt            time.Time `json:"started-at"`
+	ApplyingAt           time.Time `json:"applying-at"`
+	AppliedAt            time.Time `json:"applied-at"`
+	PlanningAt           time.Time `json:"planning-at"`
+	PlannedAt            time.Time `json:"planned-at"`
+	PlannedAndFinishedAt time.Time `json:"planned-and-finished-at"`
+	PlanQueuabledAt      time.Time `json:"plan-queueable-at"`
 }
 
 // RunListOptions represents the options for listing runs.

--- a/vendor/github.com/hashicorp/go-tfe/tfe.go
+++ b/vendor/github.com/hashicorp/go-tfe/tfe.go
@@ -35,9 +35,6 @@ const (
 )
 
 var (
-	// random is used to generate pseudo-random numbers.
-	random = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 	// ErrWorkspaceLocked is returned when trying to lock a
 	// locked workspace.
 	ErrWorkspaceLocked = errors.New("workspace already locked")
@@ -232,8 +229,11 @@ func rateLimitRetry(ctx context.Context, resp *http.Response, err error) (bool, 
 // the reset time retrieved from the headers. But if the final wait time is
 // less then min, min will be used instead.
 func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+	// rnd is used to generate pseudo-random numbers.
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	// First create some jitter bounded by the min and max durations.
-	jitter := time.Duration(rand.Float64() * float64(max-min))
+	jitter := time.Duration(rnd.Float64() * float64(max-min))
 
 	if resp != nil {
 		if v := resp.Header.Get(headerRateReset); v != "" {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -339,7 +339,7 @@ github.com/hashicorp/go-rootcerts
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.2.0
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.3.8
+# github.com/hashicorp/go-tfe v0.3.10
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.0
 github.com/hashicorp/go-uuid


### PR DESCRIPTION
Previously we checked can-update in order to determine if a user had the
required permissions to apply a run, but that wasn't sufficient. So we
added a new permission, can-queue-apply, that we now use instead.