### PR TITLE
command: Remove promise of plan -validate-only from validate docs

### DIFF
--- a/command/validate.go
+++ b/command/validate.go
@@ -234,11 +234,6 @@ Usage: terraform validate [options] [dir]
   state. It is thus primarily useful for general verification of reusable
   modules, including correctness of attribute names and value types.
 
-  To verify configuration in the context of a particular run (a particular
-  target workspace, operation variables, etc), use the following command
-  instead:
-      terraform plan -validate-only
-
   It is safe to run this command automatically, for example as a post-save
   check in a text editor or as a test step for a re-usable module in a CI
   system.
@@ -249,6 +244,10 @@ Usage: terraform validate [options] [dir]
       terraform init -backend=false
 
   If dir is not specified, then the current directory will be used.
+
+  To verify configuration in the context of a particular run (a particular
+  target workspace, operation variables, etc), use the terraform plan
+  subcommand instead, which includes an implied validation check.
 
 Options:
 


### PR DESCRIPTION
We brought forward a new implementation of `terraform validate` that was originally scheduled for a later release after finding that it would be simpler than reworking the old implementation for new v0.12 assumptions, but we didn't yet implement `terraform plan -validate-only` in spite of it being mentioned in the updated docs for `terraform validate`.

For now then, the documentation will make the weaker suggestion of running `terraform plan` to validate a particular _run_ rather than a particular _module_, which is the closest thing we have for now. At some point after v0.12.0 we will evaluate whether a validate-only mode for `terraform plan` (which would then run without configuring the providers at all) is needed.

This fixes #19259.
