### PR TITLE
backend/s3: Add debug logging and user agent

### DIFF
--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -10,7 +10,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	awsbase "github.com/hashicorp/aws-sdk-go-base"
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/version"
 )
 
 // New creates a new backend for S3 remote state.
@@ -296,6 +298,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		AssumeRolePolicy:      data.Get("assume_role_policy").(string),
 		AssumeRoleSessionName: data.Get("session_name").(string),
 		CredsFilename:         data.Get("shared_credentials_file").(string),
+		DebugLogging:          logging.IsDebugOrHigher(),
 		IamEndpoint:           data.Get("iam_endpoint").(string),
 		MaxRetries:            data.Get("max_retries").(int),
 		Profile:               data.Get("profile").(string),
@@ -305,6 +308,11 @@ func (b *Backend) configure(ctx context.Context) error {
 		SkipMetadataApiCheck:  data.Get("skip_metadata_api_check").(bool),
 		StsEndpoint:           data.Get("sts_endpoint").(string),
 		Token:                 data.Get("token").(string),
+		UserAgentProducts: []*awsbase.UserAgentProduct{
+			{Name: "APN", Version: "1.0"},
+			{Name: "HashiCorp", Version: "1.0"},
+			{Name: "Terraform", Version: version.String()},
+		},
 	}
 
 	sess, err := awsbase.GetSession(cfg)


### PR DESCRIPTION
Porting over previous behavior from terraform-provider-aws.

Output from acceptance testing:

```
--- PASS: TestBackend_impl (0.00s)
--- PASS: TestBackendConfig (0.37s)
--- PASS: TestBackendConfig_invalidKey (0.00s)
--- PASS: TestBackend (3.02s)
--- PASS: TestBackendLocked (9.69s)
--- PASS: TestBackendExtraPaths (3.15s)
--- PASS: TestBackendPrefixInWorkspace (1.85s)
--- PASS: TestKeyEnv (8.88s)
--- PASS: TestRemoteClient_impl (0.00s)
--- PASS: TestRemoteClient (2.22s)
--- PASS: TestRemoteClientLocks (12.14s)
--- PASS: TestForceUnlock (12.73s)
--- PASS: TestRemoteClient_clientMD5 (8.53s)
--- PASS: TestRemoteClient_stateChecksum (9.59s)
```