### PR TITLE
command/show: fixing bugs in modulecalls

### DIFF
--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -99,9 +99,12 @@ func marshalPlannedValues(changes *plans.Changes, schemas *terraform.Schemas) (m
 			// root has no parents.
 			if containingModule != "" {
 				parent := resource.Addr.Module.Parent().String()
-				if !seenModules[parent] {
+				// we likely will see multiple resources in one module, so we
+				// only need to report the "parent" module for each child module
+				// once.
+				if !seenModules[containingModule] {
 					moduleMap[parent] = append(moduleMap[parent], resource.Addr.Module)
-					seenModules[parent] = true
+					seenModules[containingModule] = true
 				}
 			}
 		}

--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -121,6 +121,10 @@ func marshalPlannedValues(changes *plans.Changes, schemas *terraform.Schemas) (m
 	if err != nil {
 		return ret, err
 	}
+	sort.Slice(childModules, func(i, j int) bool {
+		return childModules[i].Address < childModules[j].Address
+	})
+
 	ret.ChildModules = childModules
 
 	return ret, nil

--- a/command/test-fixtures/show-json/modules/bar/main.tf
+++ b/command/test-fixtures/show-json/modules/bar/main.tf
@@ -1,0 +1,11 @@
+variable "test_var" {
+  default = "bar-var"
+}
+
+output "test" {
+  value = var.test_var
+}
+
+resource "test_instance" "test" {
+  ami = var.test_var
+}

--- a/command/test-fixtures/show-json/modules/foo/main.tf
+++ b/command/test-fixtures/show-json/modules/foo/main.tf
@@ -1,5 +1,5 @@
 variable "test_var" {
-  default = "bar"
+  default = "foo-var"
 }
 resource "test_instance" "test" {
   ami   = var.test_var

--- a/command/test-fixtures/show-json/modules/main.tf
+++ b/command/test-fixtures/show-json/modules/main.tf
@@ -1,9 +1,13 @@
-module "module_test" {
+module "module_test_foo" {
   source   = "./foo"
   test_var = "baz"
 }
 
+module "module_test_bar" {
+  source = "./bar"
+}
+
 output "test" {
-  value      = module.module_test.test
-  depends_on = [module.module_test]
+  value      = module.module_test_foo.test
+  depends_on = [module.module_test_foo]
 }

--- a/command/test-fixtures/show-json/modules/output.json
+++ b/command/test-fixtures/show-json/modules/output.json
@@ -12,7 +12,23 @@
                 {
                     "resources": [
                         {
-                            "address": "module.module_test.test_instance.test[0]",
+                            "address": "module.module_test_bar.test_instance.test",
+                            "mode": "managed",
+                            "type": "test_instance",
+                            "name": "test",
+                            "provider_name": "test",
+                            "schema_version": 0,
+                            "values": {
+                                "ami": "bar-var"
+                            }
+                        }
+                    ],
+                    "address": "module.module_test_bar"
+                },
+                {
+                    "resources": [
+                        {
+                            "address": "module.module_test_foo.test_instance.test[0]",
                             "mode": "managed",
                             "type": "test_instance",
                             "name": "test",
@@ -24,7 +40,7 @@
                             }
                         },
                         {
-                            "address": "module.module_test.test_instance.test[1]",
+                            "address": "module.module_test_foo.test_instance.test[1]",
                             "mode": "managed",
                             "type": "test_instance",
                             "name": "test",
@@ -36,7 +52,7 @@
                             }
                         },
                         {
-                            "address": "module.module_test.test_instance.test[2]",
+                            "address": "module.module_test_foo.test_instance.test[2]",
                             "mode": "managed",
                             "type": "test_instance",
                             "name": "test",
@@ -48,15 +64,35 @@
                             }
                         }
                     ],
-                    "address": "module.module_test"
+                    "address": "module.module_test_foo"
                 }
             ]
         }
     },
     "resource_changes": [
         {
-            "address": "module.module_test.test_instance.test[0]",
-            "module_address": "module.module_test",
+            "address": "module.module_test_bar.test_instance.test",
+            "module_address": "module.module_test_bar",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "ami": "bar-var"
+                },
+                "after_unknown": {
+                    "ami": false,
+                    "id": true
+                }
+            }
+        },
+        {
+            "address": "module.module_test_foo.test_instance.test[0]",
+            "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
@@ -76,8 +112,8 @@
             }
         },
         {
-            "address": "module.module_test.test_instance.test[1]",
-            "module_address": "module.module_test",
+            "address": "module.module_test_foo.test_instance.test[1]",
+            "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
@@ -97,8 +133,8 @@
             }
         },
         {
-            "address": "module.module_test.test_instance.test[2]",
-            "module_address": "module.module_test",
+            "address": "module.module_test_foo.test_instance.test[2]",
+            "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
@@ -134,16 +170,52 @@
                 "test": {
                     "expression": {
                         "references": [
-                            "module.module_test.test"
+                            "module.module_test_foo.test"
                         ]
                     },
                     "depends_on": [
-                        "module.module_test"
+                        "module.module_test_foo"
                     ]
                 }
             },
             "module_calls": {
-                "module_test": {
+                "module_test_bar": {
+                    "source": "./bar",
+                    "module": {
+                        "outputs": {
+                            "test": {
+                                "expression": {
+                                    "references": [
+                                        "var.test_var"
+                                    ]
+                                }
+                            }
+                        },
+                        "resources": [
+                            {
+                                "address": "test_instance.test",
+                                "mode": "managed",
+                                "type": "test_instance",
+                                "name": "test",
+                                "provider_config_key": "module_test_bar:test",
+                                "expressions": {
+                                    "ami": {
+                                        "references": [
+                                            "var.test_var"
+                                        ]
+                                    }
+                                },
+                                "schema_version": 0
+                            }
+                        ],
+                        "variables": {
+                            "test_var": {
+                                "default": "bar-var"
+                            }
+                        }
+                    }
+                },
+                "module_test_foo": {
                     "source": "./foo",
                     "expressions": {
                         "test_var": {
@@ -166,7 +238,7 @@
                                 "mode": "managed",
                                 "type": "test_instance",
                                 "name": "test",
-                                "provider_config_key": "module_test:test",
+                                "provider_config_key": "module_test_foo:test",
                                 "expressions": {
                                     "ami": {
                                         "references": [
@@ -182,7 +254,7 @@
                         ],
                         "variables": {
                             "test_var": {
-                                "default": "bar"
+                                "default": "foo-var"
                             }
                         }
                     }
@@ -190,8 +262,8 @@
             }
         },
         "provider_config": {
-            "module_test:test": {
-                "module_address": "module_test",
+            "module_test_foo:test": {
+                "module_address": "module_test_foo",
                 "name": "test"
             }
         }


### PR DESCRIPTION
jsonconfig and jsonplan both had subtle bugs with the logic for
marshaling module calls that only showed up when multiple modules were
referenced. This PR fixes those bugs and extends the existing tests to
include multiple modules.

It turns out having a dozen variables with similar names (mc! cm! cc!) is terribly confusing. Splitting things out into smaller functions greatly helped. 