### PR TITLE
command/show: differentiate between state schemas and plan schemas.

### DIFF
--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -91,7 +91,11 @@ func Marshal(
 	p *plans.Plan,
 	sf *statefile.File,
 	schemas *terraform.Schemas,
+	stateSchemas *terraform.Schemas,
 ) ([]byte, error) {
+	if stateSchemas == nil {
+		stateSchemas = schemas
+	}
 
 	output := newPlan()
 	output.TerraformVersion = version.String()
@@ -120,7 +124,7 @@ func Marshal(
 	}
 
 	// output.PriorState
-	output.PriorState, err = jsonstate.Marshal(sf, schemas)
+	output.PriorState, err = jsonstate.Marshal(sf, stateSchemas)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling prior state: %s", err)
 	}


### PR DESCRIPTION
When a planfile is supplied to the `terraform show -json` command, the
context that loads only included schemas for resources in the plan. We
found an edge case where removing a data source from the configuration
(though only if there are no managed resources from the same provider)
would cause jsonstate.Marshal to fail because the provider schema wasn't
in the plan context.

jsonplan.Marshal now takes two schemas, one for plan and one for state.
If the state schema is nil it will simply use the plan schemas.