### PR TITLE
website: Fix some broken links

### DIFF
--- a/website/docs/configuration/data-sources.html.md
+++ b/website/docs/configuration/data-sources.html.md
@@ -102,7 +102,7 @@ only within Terraform itself, calculating some results and exposing them
 for use elsewhere.
 
 For example, local-only data sources exist for
-[rendering templates](/docs/providers/template/d/template_file.html),
+[rendering templates](/docs/providers/template/d/file.html),
 [reading local files](/docs/providers/local/d/file.html), and
 [rendering AWS IAM policies](/docs/providers/aws/d/iam_policy_document.html).
 

--- a/website/docs/configuration/functions/jsondecode.html.md
+++ b/website/docs/configuration/functions/jsondecode.html.md
@@ -19,7 +19,7 @@ of the result of decoding that string.
 The JSON encoding is defined in [RFC 7159](https://tools.ietf.org/html/rfc7159).
 
 This function maps JSON values to
-[Terraform language values](./expressions.html#types-and-values)
+[Terraform language values](../expressions.html#types-and-values)
 in the following way:
 
 | JSON type | Terraform type                                               |

--- a/website/docs/configuration/functions/jsonencode.html.md
+++ b/website/docs/configuration/functions/jsonencode.html.md
@@ -17,7 +17,7 @@ earlier, see
 The JSON encoding is defined in [RFC 7159](https://tools.ietf.org/html/rfc7159).
 
 This fucntion maps
-[Terraform language values](./expressions.html#types-and-values)
+[Terraform language values](../expressions.html#types-and-values)
 to JSON values in the following way:
 
 | Terraform type | JSON type |

--- a/website/docs/configuration/functions/timestamp.html.md
+++ b/website/docs/configuration/functions/timestamp.html.md
@@ -24,7 +24,7 @@ The result of this function will change every second, so using this function
 directly with resource attributes will cause a diff to be detected on every
 Terraform run. We do not recommend using this function in resource attributes,
 but in rare cases it can be used in conjunction with
-[the `ignore_changes` lifecycle meta-argument](./resources.html#ignore_changes)
+[the `ignore_changes` lifecycle meta-argument](../resources.html#ignore_changes)
 to take the timestamp only on initial creation of the resource.
 
 Due to the constantly changing return value, the result of this function cannot

--- a/website/docs/configuration/functions/uuid.html.md
+++ b/website/docs/configuration/functions/uuid.html.md
@@ -23,7 +23,7 @@ This function produces a new value each time it is called, and so using it
 directly in resource arguments will result in spurious diffs. We do not
 recommend using the `uuid` function in resource configurations, but it can
 be used with care in conjunction with
-[the `ignore_changes` lifecycle meta-argument](./resources.html#ignore_changes).
+[the `ignore_changes` lifecycle meta-argument](../resources.html#ignore_changes).
 
 In most cases we recommend using [the `random` provider](/docs/providers/random/index.html)
 instead, since it allows the one-time generation of random values that are


### PR DESCRIPTION
In all the shuffling of these docs for v0.12 some of the links ended up not lining up quite right.