### PR TITLE
remove the partially-known ~ set sigil in diffs

### DIFF
--- a/builtin/providers/test/resource_computed_set_test.go
+++ b/builtin/providers/test/resource_computed_set_test.go
@@ -50,3 +50,22 @@ resource "test_resource_computed_set" "foo" {
 		},
 	})
 }
+
+func TestResourceComputedSet_ruleTest(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_computed_set" "foo" {
+	rule {
+		ip_protocol = "udp"
+		cidr = "0.0.0.0/0"
+	}
+}
+				`),
+			},
+		},
+	})
+}

--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -747,6 +747,17 @@ func (s *GRPCProviderServer) ApplyResourceChange(_ context.Context, req *proto.A
 		}
 	}
 
+	// We need to fix any sets that may be using the "~" index prefix to
+	// indicate partially computed. The special sigil isn't really used except
+	// as a clue to visually indicate that the set isn't wholly known.
+	for k, d := range diff.Attributes {
+		if strings.Contains(k, ".~") {
+			delete(diff.Attributes, k)
+			k = strings.Replace(k, ".~", ".", -1)
+			diff.Attributes[k] = d
+		}
+	}
+
 	// add NewExtra Fields that may have been stored in the private data
 	if newExtra := private[newExtraKey]; newExtra != nil {
 		for k, v := range newExtra.(map[string]interface{}) {


### PR DESCRIPTION
The NewExtra values are stored outside the diff from plan, and the
original keys may not contain the ~ prefix. Adding the NewExtra back
into the diff with the mismatched key was causing an entire new set
element to be populated. Since this symbol isn't used to apply the diff in
helper/schema, we can simply strip them out.

Fixes #20486