### PR TITLE
Fix invalid timeouts in plan

### DIFF
--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -243,6 +243,7 @@ func (r *Resource) CoreConfigSchema() *configschema.Block {
 		if r.Timeouts.Create != nil {
 			timeouts.Attributes[TimeoutCreate] = &configschema.Attribute{
 				Type:     cty.String,
+				Computed: true,
 				Optional: true,
 			}
 		}
@@ -250,6 +251,7 @@ func (r *Resource) CoreConfigSchema() *configschema.Block {
 		if r.Timeouts.Read != nil {
 			timeouts.Attributes[TimeoutRead] = &configschema.Attribute{
 				Type:     cty.String,
+				Computed: true,
 				Optional: true,
 			}
 		}
@@ -257,6 +259,7 @@ func (r *Resource) CoreConfigSchema() *configschema.Block {
 		if r.Timeouts.Update != nil {
 			timeouts.Attributes[TimeoutUpdate] = &configschema.Attribute{
 				Type:     cty.String,
+				Computed: true,
 				Optional: true,
 			}
 		}
@@ -264,6 +267,7 @@ func (r *Resource) CoreConfigSchema() *configschema.Block {
 		if r.Timeouts.Delete != nil {
 			timeouts.Attributes[TimeoutDelete] = &configschema.Attribute{
 				Type:     cty.String,
+				Computed: true,
 				Optional: true,
 			}
 		}
@@ -271,6 +275,7 @@ func (r *Resource) CoreConfigSchema() *configschema.Block {
 		if r.Timeouts.Default != nil {
 			timeouts.Attributes[TimeoutDefault] = &configschema.Attribute{
 				Type:     cty.String,
+				Computed: true,
 				Optional: true,
 			}
 		}

--- a/plans/objchange/plan_valid.go
+++ b/plans/objchange/plan_valid.go
@@ -39,13 +39,10 @@ func AssertPlanValid(schema *configschema.Block, priorState, config, plannedStat
 func assertPlanValid(schema *configschema.Block, priorState, config, plannedState cty.Value, path cty.Path) []error {
 	var errs []error
 	if plannedState.IsNull() && !config.IsNull() {
-		errs = append(errs, path.NewErrorf("planned for absense but config wants existence"))
+		errs = append(errs, path.NewErrorf("planned for absence but config wants existence"))
 		return errs
 	}
-	if config.IsNull() && !plannedState.IsNull() {
-		errs = append(errs, path.NewErrorf("planned for existence but config wants absense"))
-		return errs
-	}
+
 	if plannedState.IsNull() {
 		// No further checks possible if the planned value is null
 		return errs
@@ -65,6 +62,13 @@ func assertPlanValid(schema *configschema.Block, priorState, config, plannedStat
 		moreErrs := assertPlannedValueValid(attrS, priorV, configV, plannedV, path)
 		errs = append(errs, moreErrs...)
 	}
+
+	// We checked the possible block attributes, but there are no nested blocks
+	// to check if the config is null.
+	if config.IsNull() {
+		return errs
+	}
+
 	for name, blockS := range schema.BlockTypes {
 		path := append(path, cty.GetAttrStep{Name: name})
 		plannedV := plannedState.GetAttr(name)

--- a/plans/objchange/plan_valid_test.go
+++ b/plans/objchange/plan_valid_test.go
@@ -540,6 +540,43 @@ func TestAssertPlanValid(t *testing.T) {
 			}),
 			nil,
 		},
+
+		// A block may be null in config, but contain computed elements added by
+		// the provider. This mimics how timeouts are added for the legacy sdk.
+		"computed elements in block": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"a": {
+						Nesting: configschema.NestingSingle,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"b": {
+									Type:     cty.String,
+									Computed: true,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.NullVal(cty.Object(map[string]cty.Type{
+				"a": cty.Object(map[string]cty.Type{
+					"b": cty.String,
+				}),
+			})),
+			cty.NullVal(cty.Object(map[string]cty.Type{
+				"a": cty.Object(map[string]cty.Type{
+					"b": cty.String,
+				}),
+			})),
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.ObjectVal(map[string]cty.Value{
+					"b": cty.StringVal("c value"),
+				}),
+			}),
+			nil,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
The synthetic timeout attributes need to be computed in CoreSchema, so that defaults can be inserted by the provider.

These were still caught by the `AssertPlanValid` however, because they may appear in a block which is missing from the config entirely. Since the individual attributes are each going to be checked, we can skip the `config.IsNull() && !plannedState.IsNull()` and report the individual attributes that don't match.