### PR TITLE
command/show and state show: honor user-specified plugin-dir

### DIFF
--- a/command/show.go
+++ b/command/show.go
@@ -45,6 +45,12 @@ func (c *ShowCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Check for user-supplied plugin path
+	if c.pluginPath, err = c.loadPluginPath(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
+		return 1
+	}
+
 	var diags tfdiags.Diagnostics
 
 	// Load the backend

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -35,6 +35,12 @@ func (c *StateShowCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
+	// Check for user-supplied plugin path
+	if c.pluginPath, err = c.loadPluginPath(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
+		return 1
+	}
+
 	// Load the backend
 	b, backendDiags := c.Backend(nil)
 	if backendDiags.HasErrors() {


### PR DESCRIPTION
Previously, these commands were not checking if the user specified a
`-plugin-dir` flag during `terraform init` and would therefore fail if
providers were not in one of the standard directories.

Fixes #20547