### PR TITLE
[DOC] Change provider link for uptimerobot

### DIFF
--- a/website/docs/providers/type/community-index.html.markdown
+++ b/website/docs/providers/type/community-index.html.markdown
@@ -168,7 +168,7 @@ please fill out this [community providers form](https://docs.google.com/forms/d/
     </tr>
     <tr>
     <td><a href="https://github.com/mvisonneau/terraform-provider-updown">Updown.io</a></td>
-    <td><a href="https://github.com/SpamapS/terraform-provider-uptimerobot">Uptimerobot</a></td>
+    <td><a href="https://github.com/louy/terraform-provider-uptimerobot">Uptimerobot</a></td>
     <td><a href="https://github.com/GSLabDev/terraform-provider-vra">vRealize Automation</a></td>
     </tr>
     <tr>


### PR DESCRIPTION
Hi,

Current provider is marked as *deprecated* by his author and he suggests to use another provider.

thanks !

Thomas