### PR TITLE
Resolve build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ bin: fmtcheck generate
 # dev creates binaries for testing Terraform locally. These are put
 # into ./bin/ as well as $GOPATH/bin
 dev: fmtcheck generate
-	go install -mod=vendor .
+	GO111MODULE=on go install -mod=vendor .
 
 quickdev: generate
 	go install -mod=vendor .
@@ -32,7 +32,7 @@ plugin-dev: generate
 # we run this one package at a time here because running the entire suite in
 # one command creates memory usage issues when running in Travis-CI.
 test: fmtcheck generate
-	go list -mod=vendor $(TEST) | xargs -t -n4 go test $(TESTARGS) -mod=vendor -timeout=2m -parallel=4
+	GO111MODULE=on go list -mod=vendor $(TEST) | GO111MODULE=on xargs -t -n4 go test $(TESTARGS) -mod=vendor -timeout=2m -parallel=4
 
 # testacc runs acceptance tests
 testacc: fmtcheck generate

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -67,7 +67,10 @@ func TestInit_multipleArgs(t *testing.T) {
 
 func TestInit_fromModule_explicitDest(t *testing.T) {
 	dir := tempDir(t)
-	err := os.Mkdir(dir, os.ModePerm)
+	err := os.MkdirAll(dir, os.ModePerm)
+	defer os.RemoveAll(dir)
+	defer testChdir(t, dir)()
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugin/discovery/get_test.go
+++ b/plugin/discovery/get_test.go
@@ -170,12 +170,12 @@ func TestVersionListing(t *testing.T) {
 	}
 
 	if len(versions) != len(expected) {
-		t.Fatalf("Received wrong number of versions. expected: %q, got: %q", expected, versions)
+		t.Fatalf("Received wrong number of versions. expected: %v, got: %v", expected, versions)
 	}
 
 	for i, v := range versions {
 		if v.Version != expected[i].Version {
-			t.Fatalf("incorrect version: %q, expected %q", v, expected[i])
+			t.Fatalf("incorrect version: %v, expected %v", v, expected[i])
 		}
 	}
 }

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -232,7 +232,7 @@ func TestLookupProviderVersions(t *testing.T) {
 		for _, v := range resp.Versions {
 			_, err := version.NewVersion(v.Version)
 			if err != nil {
-				t.Fatalf("invalid version %q: %s", v, err)
+				t.Fatalf("invalid version %v: %s", v, err)
 			}
 		}
 	}


### PR DESCRIPTION
These commits attempt to resolve multiple build failures when attempting to run **make** and **make dev** with go version go1.12 linux/amd64 on 4.18.0-1011-azure #11~18.04.1-Ubuntu server.

Build errors:
<script src="https://gist.github.com/BradAF/e9dea1e5ddd0143e7ba620d7070211b2.js"></script>


