### PR TITLE
don't re-add removed list values even when planned

### DIFF
--- a/builtin/providers/test/resource_list.go
+++ b/builtin/providers/test/resource_list.go
@@ -58,21 +58,54 @@ func testResourceList() *schema.Resource {
 					},
 				},
 			},
+			"dependent_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"val": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"computed_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
 
 func testResourceListCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId("testId")
-	return nil
+	return testResourceListRead(d, meta)
 }
 
 func testResourceListRead(d *schema.ResourceData, meta interface{}) error {
+	fixedIps := d.Get("dependent_list")
+
+	// all_fixed_ips should be set as computed with a CustomizeDiff func, but
+	// we're trying to emulate legacy provider behavior, and updating a
+	// computed field was a common case.
+	ips := []interface{}{}
+	if fixedIps != nil {
+		for _, v := range fixedIps.([]interface{}) {
+			m := v.(map[string]interface{})
+			ips = append(ips, m["val"])
+		}
+	}
+	if err := d.Set("computed_list", ips); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func testResourceListUpdate(d *schema.ResourceData, meta interface{}) error {
-	return nil
+	return testResourceListRead(d, meta)
 }
 
 func testResourceListDelete(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/test/resource_list_test.go
+++ b/builtin/providers/test/resource_list_test.go
@@ -276,3 +276,45 @@ resource "test_resource_list" "foo" {
 		},
 	})
 }
+
+func TestResourceList_addRemove(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "foo" {
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_list.foo", "computed_list.#", "0"),
+					resource.TestCheckResourceAttr("test_resource_list.foo", "dependent_list.#", "0"),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "foo" {
+	dependent_list {
+		val = "a"
+	}
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_list.foo", "computed_list.#", "1"),
+					resource.TestCheckResourceAttr("test_resource_list.foo", "dependent_list.#", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "foo" {
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_list.foo", "computed_list.#", "0"),
+					resource.TestCheckResourceAttr("test_resource_list.foo", "dependent_list.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/helper/plugin/grpc_provider_test.go
+++ b/helper/plugin/grpc_provider_test.go
@@ -716,7 +716,7 @@ func TestNormalizeFlatmapContainers(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			got := normalizeFlatmapContainers(tc.prior, tc.attrs, false)
+			got := normalizeFlatmapContainers(tc.prior, tc.attrs)
 			if !reflect.DeepEqual(tc.expect, got) {
 				t.Fatalf("expected:\n%#v\ngot:\n%#v\n", tc.expect, got)
 			}


### PR DESCRIPTION
Providers were not strict (and were not forced to be) about customizing
the diff when a computed attribute needed to be updated during apply.
The fix we have in place to prevent loss of information during the
helper/schema apply process would add in single missing value back in.

The first place this was caught was when we attempt to fix up the
flatmapped attribute. The 1->0 count error is now better handled by our
`cty.Value` normalization step, so we can remove the special apply
case here.

The next place is in `normalizeNullValues`, and since the intent was to
re-insert missing zero-value lists and sets, adding a check for a length
of 0 protects us from adding in extra elements.

The new test fixture emulates common provider behavior of re-computing
values without customizing the diff. Since we can work around it, and
core will provide appropriate warnings, the shims should try to
maintain the legacy behavior.

Fixes #20562