### PR TITLE
docs/state: Adjust mention of PGP encryption from RDS to IAM

### DIFF
--- a/website/docs/state/sensitive-data.html.md
+++ b/website/docs/state/sensitive-data.html.md
@@ -13,7 +13,7 @@ and your definition of "sensitive." The state contains resource IDs and all
 resource attributes. For resources such as databases, this may contain initial
 passwords.
 
-Some resources (such as RDS databases) have options for PGP encrypting the
+Some resources (such as AWS IAM Access Keys) have options for PGP encrypting the
 values within the state. This is implemented on a per-resource basis and
 you should assume the value is plaintext unless otherwise documented.
 


### PR DESCRIPTION
To better align with the current status of PGP usage and remove any confusion for the missing functionality.

References:
* https://www.terraform.io/docs/providers/aws/r/iam_access_key.html
* https://www.terraform.io/docs/providers/aws/r/db_instance.html