### PR TITLE
Fix: ignore_changes docs - unexpected token while parsing list: IDENT

### DIFF
--- a/website/docs/configuration/resources.html.md
+++ b/website/docs/configuration/resources.html.md
@@ -428,7 +428,7 @@ meta-arguments are supported:
         ignore_changes = [
           # Ignore changes to tags, e.g. because a management agent
           # updates these based on some ruleset managed elsewhere.
-          tags,
+          "tags",
         ]
       }
     }


### PR DESCRIPTION
Maybe this example is somehow different but if I follow the docs literally I run into `unexpected token while parsing list: IDENT`.  Here are other examples that work:
```
  lifecycle {
    ignore_changes = [
      "node_count",
    ]
  }
```
and
```
  lifecycle {
      ignore_changes = [
        "description",
      ]
  }
```