### PR TITLE
normalize all objects read from the provider

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -122,16 +122,6 @@ func ResourceChange(
 		panic(fmt.Sprintf("failed to decode plan for %s while rendering diff: %s", addr, err))
 	}
 
-	// We currently have an opt-out that permits the legacy SDK to return values
-	// that defy our usual conventions around handling of nesting blocks. To
-	// avoid the rendering code from needing to handle all of these, we'll
-	// normalize first.
-	// (Ideally we'd do this as part of the SDK opt-out implementation in core,
-	// but we've added it here for now to reduce risk of unexpected impacts
-	// on other code in core.)
-	changeV.Change.Before = objchange.NormalizeObjectFromLegacySDK(changeV.Change.Before, schema)
-	changeV.Change.After = objchange.NormalizeObjectFromLegacySDK(changeV.Change.After, schema)
-
 	bodyWritten := p.writeBlockBodyDiff(schema, changeV.Before, changeV.After, 6, path)
 	if bodyWritten {
 		buf.WriteString("\n")

--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform/plans/objchange"
+
 	"github.com/zclconf/go-cty/cty"
 	ctyconvert "github.com/zclconf/go-cty/cty/convert"
 	"github.com/zclconf/go-cty/cty/msgpack"
@@ -458,6 +460,7 @@ func (s *GRPCProviderServer) ReadResource(_ context.Context, req *proto.ReadReso
 	}
 
 	newStateVal = copyTimeoutValues(newStateVal, stateVal)
+	newStateVal = objchange.NormalizeObjectFromLegacySDK(newStateVal, block)
 
 	newStateMP, err := msgpack.Marshal(newStateVal, block.ImpliedType())
 	if err != nil {
@@ -594,6 +597,7 @@ func (s *GRPCProviderServer) PlanResourceChange(_ context.Context, req *proto.Pl
 	}
 
 	plannedStateVal = copyTimeoutValues(plannedStateVal, proposedNewStateVal)
+	plannedStateVal = objchange.NormalizeObjectFromLegacySDK(plannedStateVal, block)
 
 	// The old SDK code has some imprecisions that cause it to sometimes
 	// generate differences that the SDK itself does not consider significant
@@ -832,6 +836,7 @@ func (s *GRPCProviderServer) ApplyResourceChange(_ context.Context, req *proto.A
 	newStateVal = normalizeNullValues(newStateVal, plannedStateVal, false)
 
 	newStateVal = copyTimeoutValues(newStateVal, plannedStateVal)
+	newStateVal = objchange.NormalizeObjectFromLegacySDK(newStateVal, block)
 
 	newStateMP, err := msgpack.Marshal(newStateVal, block.ImpliedType())
 	if err != nil {
@@ -955,6 +960,7 @@ func (s *GRPCProviderServer) ReadDataSource(_ context.Context, req *proto.ReadDa
 	}
 
 	newStateVal = copyTimeoutValues(newStateVal, configVal)
+	newStateVal = objchange.NormalizeObjectFromLegacySDK(newStateVal, block)
 
 	newStateMP, err := msgpack.Marshal(newStateVal, block.ImpliedType())
 	if err != nil {

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -203,12 +203,6 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 				// on the planned value, and thus get a different result during the
 				// apply phase. This will usually lead to a "Provider produced invalid plan"
 				// error that incorrectly blames the downstream resource for the change.
-				//
-				// TODO: Ideally we should use objchange.NormalizeObjectFromLegacySDK
-				// here so the rest of Terraform is shielded from some of the oddities
-				// of the legacy SDK, but for the moment we've done that only in
-				// format.ResourceChange to reduce the risk of unexpected impacts
-				// elsewhere.
 
 			} else {
 				for _, err := range errs {

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -229,12 +229,6 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 				fmt.Fprintf(&buf, "\n      - %s", tfdiags.FormatError(err))
 			}
 			log.Print(buf.String())
-
-			// TODO: Ideally we should use objchange.NormalizeObjectFromLegacySDK
-			// here so the rest of Terraform is shielded from some of the oddities
-			// of the legacy SDK, but for the moment we've done that only in
-			// format.ResourceChange to reduce the risk of unexpected impacts
-			// elsewhere.
 		} else {
 			for _, err := range errs {
 				diags = diags.Append(tfdiags.Sourceless(


### PR DESCRIPTION
Use `objchange.NormalizeObjectFromLegacySDK` to ensure that all objects
returned from the provider match what is expected based on the
configuration according to the schemas.

This is intended to provide additional warnings about blocks that are unexpectedly altered, most commonly blocks that are marked as "computed" in `helper/schema`, which we don't intend to support in the same manner going forward.

