### PR TITLE
docs: Differentiate 0.11/0.12 in terraform_remote_state

### DIFF
--- a/website/docs/providers/terraform/d/remote_state.html.md
+++ b/website/docs/providers/terraform/d/remote_state.html.md
@@ -29,9 +29,16 @@ data "terraform_remote_state" "vpc" {
   }
 }
 
+# Terraform >= 0.12
 resource "aws_instance" "foo" {
   # ...
   subnet_id = "${data.terraform_remote_state.vpc.outputs.subnet_id}"
+}
+
+# Terraform <= 0.11
+resource "aws_instance" "foo" {
+  # ...
+  subnet_id = "${data.terraform_remote_state.vpc.subnet_id}"
 }
 ```
 
@@ -54,7 +61,9 @@ The following arguments are supported:
 
 In addition to the above, the following attributes are exported:
 
-* `outputs` - Each root-level [output](/docs/configuration/outputs.html)
+* (v0.12+) `outputs` - Each root-level [output](/docs/configuration/outputs.html)
+  in the remote state appears as a top level attribute on the data source.
+* (<= v0.11) `<OUTPUT NAME>` - Each root-level [output](/docs/configuration/outputs.html)
   in the remote state appears as a top level attribute on the data source.
 
 ## Root Outputs Only


### PR DESCRIPTION
I don't want this PR to set precedence in how we version docs as this would be a tedious and manual, hence unscalable process. We have plans to address this in the long run and offer versioned docs in a more scalable way, but there are other things which have had higher priority on the roadmap.

Until then we'll have to accept some level of discomfort as a result of this unfortunately.

I think this one in particular is justified because `terraform_remote_state` data source has significant user base and we are introducing a change which is unfortunately breaking the user experience.