### PR TITLE
Remove "outputs" from resource example

### DIFF
--- a/website/docs/providers/terraform/d/remote_state.html.md
+++ b/website/docs/providers/terraform/d/remote_state.html.md
@@ -31,7 +31,7 @@ data "terraform_remote_state" "vpc" {
 
 resource "aws_instance" "foo" {
   # ...
-  subnet_id = "${data.terraform_remote_state.vpc.outputs.subnet_id}"
+  subnet_id = "${data.terraform_remote_state.vpc.subnet_id}"
 }
 ```
 


### PR DESCRIPTION
The usage of "outputs" is not correct - the defined output is directly accessible under the defined data resource, in the specific case that would be data.terraform_remote_state.vpc.subnet_id