### PR TITLE
website: re-arrange how we include the "other docs" sidebar section

### DIFF
--- a/website/docs/configuration/syntax-json.html.md
+++ b/website/docs/configuration/syntax-json.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "JSON Configuration Syntax - Configuration Language"
-sidebar_current: "docs-config-json-syntax"
+sidebar_current: "docs-config-syntax-json"
 description: |-
   In addition to the native syntax that is most commonly used with Terraform,
   the Terraform language can also be expressed in a JSON-compatible syntax.

--- a/website/docs/state/workspaces.html.md
+++ b/website/docs/state/workspaces.html.md
@@ -31,6 +31,7 @@ Multiple workspaces are currently supported by the following backends:
  * [Local](/docs/backends/types/local.html)
  * [Manta](/docs/backends/types/manta.html)
  * [Postgres](/docs/backends/types/pg.html)
+ * [Remote](/docs/backends/types/remote.html)
  * [S3](/docs/backends/types/s3.html)
 
 In the 0.9 line of Terraform releases, this concept was known as "environment".

--- a/website/layouts/backend-types.erb
+++ b/website/layouts/backend-types.erb
@@ -72,37 +72,7 @@
       </li>
     </ul>
 
-    <h4>Other Docs</h4>
-
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/downloads.html">Download Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-      </li>
-
-      <li>
-        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-      </li>
-    </ul>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Terraform CLI" }) %>
   <% end %>
 
   <%= yield %>

--- a/website/layouts/commands-providers.erb
+++ b/website/layouts/commands-providers.erb
@@ -1,12 +1,12 @@
 <% wrap_layout :inner do %>
     <% content_for :sidebar do %>
       <h4><a href="/docs/index.html">Terraform CLI</a></h4>
-  
+
       <ul class="nav docs-sidenav">
         <li<%= sidebar_current("docs-commands") %>>
           <a class="back" href="/docs/commands/index.html">Commands (CLI)</a>
           <ul class="nav">
-  
+
             <li<%= sidebar_current("docs-commands-providers") %>>
               <a href="/docs/commands/providers.html">providers</a>
               <ul class="nav">
@@ -15,44 +15,15 @@
                 </li>
               </ul>
             </li>
-  
+
           </ul>
         </li>
-  
+
       </ul>
-  
-      <h4>Other Docs</h4>
-  
-      <ul class="nav docs-sidenav">
-        <li>
-          <a class="back" href="/downloads.html">Download Terraform</a>
-        </li>
-  
-        <li>
-          <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-        </li>
-  
-        <li>
-          <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-        </li>
-  
-        <li>
-          <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-        </li>
-  
-        <li>
-          <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-        </li>
-  
-        <li>
-          <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-        </li>
-  
-        <li>
-          <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-        </li>
-      </ul>
+
+      <%= partial("layouts/otherdocs", :locals => { :skip => "Terraform CLI" }) %>
+
     <% end %>
-  
+
     <%= yield %>
-<% end %>          
+<% end %>

--- a/website/layouts/commands-state.erb
+++ b/website/layouts/commands-state.erb
@@ -45,37 +45,8 @@
 
     </ul>
 
-    <h4>Other Docs</h4>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Terraform CLI" }) %>
 
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/downloads.html">Download Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-      </li>
-
-      <li>
-        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-      </li>
-    </ul>
   <% end %>
 
   <%= yield %>

--- a/website/layouts/commands-workspace.erb
+++ b/website/layouts/commands-workspace.erb
@@ -33,37 +33,8 @@
 
     </ul>
 
-    <h4>Other Docs</h4>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Terraform CLI" }) %>
 
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/downloads.html">Download Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-      </li>
-
-      <li>
-        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-      </li>
-    </ul>
   <% end %>
 
   <%= yield %>

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -451,37 +451,7 @@
 
     </ul>
 
-    <h4>Other Docs</h4>
-
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/downloads.html">Download Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-      </li>
-
-      <li>
-        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-      </li>
-    </ul>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Terraform CLI" }) %>
   <% end %>
 
   <%= yield %>

--- a/website/layouts/downloads.erb
+++ b/website/layouts/downloads.erb
@@ -12,37 +12,7 @@
       </li>
     </ul>
 
-    <h4>Other Docs</h4>
-
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/index.html">Terraform CLI</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-      </li>
-
-      <li>
-        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-      </li>
-    </ul>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Download Terraform" }) %>
   <% end %>
 
   <%= yield %>

--- a/website/layouts/functions.erb
+++ b/website/layouts/functions.erb
@@ -420,37 +420,7 @@
       </li>
     </ul>
 
-    <h4>Other Docs</h4>
-
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/downloads.html">Download Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-      </li>
-
-      <li>
-        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-      </li>
-    </ul>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Terraform CLI" }) %>
   <% end %>
 
   <%= yield %>

--- a/website/layouts/guides.erb
+++ b/website/layouts/guides.erb
@@ -52,37 +52,7 @@
       </li>
     </ul>
 
-    <h4>Other Docs</h4>
-
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/downloads.html">Download Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/index.html">Terraform CLI</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-      </li>
-    </ul>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Guides and Whitepapers" }) %>
   <% end %>
 
   <%= yield %>

--- a/website/layouts/intro.erb
+++ b/website/layouts/intro.erb
@@ -92,37 +92,7 @@
       </li>
     </ul>
 
-    <h4>Other Docs</h4>
-
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/downloads.html">Download Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/index.html">Terraform CLI</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-      </li>
-
-      <li>
-        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-      </li>
-    </ul>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Introduction to Terraform" }) %>
   <% end %>
 
   <%= yield %>

--- a/website/layouts/registry.erb
+++ b/website/layouts/registry.erb
@@ -28,37 +28,7 @@
       </li>
     </ul>
 
-    <h4>Other Docs</h4>
-
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/downloads.html">Download Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/index.html">Terraform CLI</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-      </li>
-
-      <li>
-        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-      </li>
-    </ul>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Terraform Registry" }) %>
   <% end %>
 
   <%= yield %>


### PR DESCRIPTION
Updating this got onerous almost immediately, so let's use a partial instead and only update these links in one place. 

This depends on https://github.com/hashicorp/terraform-website/pull/699, so I'm leaving it in draft state until it's OK to merge. 

This PR also includes two other tiny docs site fixes that didn't seem worth their own PRs, but if anyone has any reservations about that I'll go ahead and rebase them out into their own thing(s). 