### PR TITLE
remove indentation from json output of `show` and `providers schema`

### DIFF
--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -135,8 +135,7 @@ func Marshal(
 		return nil, fmt.Errorf("error marshaling config: %s", err)
 	}
 
-	// add some polish
-	ret, err := json.MarshalIndent(output, "", "  ")
+	ret, err := json.Marshal(output)
 	return ret, err
 }
 

--- a/command/jsonprovider/provider.go
+++ b/command/jsonprovider/provider.go
@@ -42,8 +42,7 @@ func Marshal(s *terraform.Schemas) ([]byte, error) {
 		providers.Schemas[k] = marshalProvider(v)
 	}
 
-	// add some polish for the human consumers
-	ret, err := json.MarshalIndent(providers, "", "  ")
+	ret, err := json.Marshal(providers)
 	return ret, err
 }
 

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -135,7 +135,7 @@ func Marshal(sf *statefile.File, schemas *terraform.Schemas) ([]byte, error) {
 		return nil, err
 	}
 
-	ret, err := json.MarshalIndent(output, "", "  ")
+	ret, err := json.Marshal(output)
 	return ret, err
 }
 

--- a/command/providers_schema.go
+++ b/command/providers_schema.go
@@ -45,6 +45,12 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Check for user-supplied plugin path
+	if c.pluginPath, err = c.loadPluginPath(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
+		return 1
+	}
+
 	var diags tfdiags.Diagnostics
 
 	// Load the backend

--- a/command/providers_schema.go
+++ b/command/providers_schema.go
@@ -100,7 +100,7 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 }
 
 const providersSchemaCommandHelp = `
-Usage: terraform providers schemas -json
+Usage: terraform providers schema -json
 
   Prints out a json representation of the schemas for all providers used 
   in the current configuration.


### PR DESCRIPTION
The `-json` output was noticeably slow, and the file size noticeably large. As the output was designed for machine-readability and the indentation processing is a bottleneck, it makes sense to remove the indentation. 

Removing the indentation reduced the run time of `terraform providers schema -json` on a tf configuration with the AWS provider to 1.2 seconds, down from 7 seconds on my laptop. It also reduced the output file size from 1.1M to less than .5M. 

If there is demand later, we could add some variation on a `-pretty` flag for human-readable output.