### PR TITLE
revert #20595

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -127,6 +127,16 @@ func ResourceChange(
 		panic(fmt.Sprintf("failed to decode plan for %s while rendering diff: %s", addr, err))
 	}
 
+	// We currently have an opt-out that permits the legacy SDK to return values
+	// that defy our usual conventions around handling of nesting blocks. To
+	// avoid the rendering code from needing to handle all of these, we'll
+	// normalize first.
+	// (Ideally we'd do this as part of the SDK opt-out implementation in core,
+	// but we've added it here for now to reduce risk of unexpected impacts
+	// on other code in core.)
+	changeV.Change.Before = objchange.NormalizeObjectFromLegacySDK(changeV.Change.Before, schema)
+	changeV.Change.After = objchange.NormalizeObjectFromLegacySDK(changeV.Change.After, schema)
+
 	bodyWritten := p.writeBlockBodyDiff(schema, changeV.Before, changeV.After, 6, path)
 	if bodyWritten {
 		buf.WriteString("\n")

--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/terraform/plans/objchange"
-
 	"github.com/zclconf/go-cty/cty"
 	ctyconvert "github.com/zclconf/go-cty/cty/convert"
 	"github.com/zclconf/go-cty/cty/msgpack"
@@ -460,7 +458,6 @@ func (s *GRPCProviderServer) ReadResource(_ context.Context, req *proto.ReadReso
 	}
 
 	newStateVal = copyTimeoutValues(newStateVal, stateVal)
-	newStateVal = objchange.NormalizeObjectFromLegacySDK(newStateVal, block)
 
 	newStateMP, err := msgpack.Marshal(newStateVal, block.ImpliedType())
 	if err != nil {
@@ -597,7 +594,6 @@ func (s *GRPCProviderServer) PlanResourceChange(_ context.Context, req *proto.Pl
 	}
 
 	plannedStateVal = copyTimeoutValues(plannedStateVal, proposedNewStateVal)
-	plannedStateVal = objchange.NormalizeObjectFromLegacySDK(plannedStateVal, block)
 
 	// The old SDK code has some imprecisions that cause it to sometimes
 	// generate differences that the SDK itself does not consider significant
@@ -836,7 +832,6 @@ func (s *GRPCProviderServer) ApplyResourceChange(_ context.Context, req *proto.A
 	newStateVal = normalizeNullValues(newStateVal, plannedStateVal, false)
 
 	newStateVal = copyTimeoutValues(newStateVal, plannedStateVal)
-	newStateVal = objchange.NormalizeObjectFromLegacySDK(newStateVal, block)
 
 	newStateMP, err := msgpack.Marshal(newStateVal, block.ImpliedType())
 	if err != nil {
@@ -960,7 +955,6 @@ func (s *GRPCProviderServer) ReadDataSource(_ context.Context, req *proto.ReadDa
 	}
 
 	newStateVal = copyTimeoutValues(newStateVal, configVal)
-	newStateVal = objchange.NormalizeObjectFromLegacySDK(newStateVal, block)
 
 	newStateMP, err := msgpack.Marshal(newStateVal, block.ImpliedType())
 	if err != nil {


### PR DESCRIPTION
Revert the functionality in #20595, since it turns out there is provider code that will not work with the normalized blocks.

This retains the removal of the eval* TODOs, since it was demonstrated that it's not feasible to store the normalized values while remaining compatibility with the legacy providers.