### PR TITLE
helper/schema: ConfigMode field in *Schema

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -33,6 +33,7 @@ func Provider() terraform.ResourceProvider {
 			"test_resource_list_set":         testResourceListSet(),
 			"test_resource_map":              testResourceMap(),
 			"test_resource_computed_set":     testResourceComputedSet(),
+			"test_resource_config_mode":      testResourceConfigMode(),
 			"test_resource_nested_id":        testResourceNestedId(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{

--- a/builtin/providers/test/resource_config_mode.go
+++ b/builtin/providers/test/resource_config_mode.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceConfigMode() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceConfigModeCreate,
+		Read:   testResourceConfigModeRead,
+		Delete: testResourceConfigModeDelete,
+		Update: testResourceConfigModeUpdate,
+
+		Schema: map[string]*schema.Schema{
+			"resource_as_attr": {
+				Type:       schema.TypeList,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Optional:   true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"foo": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testResourceConfigModeCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("placeholder")
+	return testResourceConfigModeRead(d, meta)
+}
+
+func testResourceConfigModeRead(d *schema.ResourceData, meta interface{}) error {
+	const k = "resource_as_attr"
+	if l, ok := d.Get(k).([]interface{}); !ok {
+		return fmt.Errorf("%s should appear as []interface{}, not %T", k, l)
+	} else {
+		for i, item := range l {
+			if _, ok := item.(map[string]interface{}); !ok {
+				return fmt.Errorf("%s[%d] should appear as map[string]interface{}, not %T", k, i, item)
+			}
+		}
+	}
+	return nil
+}
+
+func testResourceConfigModeUpdate(d *schema.ResourceData, meta interface{}) error {
+	return testResourceConfigModeRead(d, meta)
+}
+
+func testResourceConfigModeDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/test/resource_config_mode_test.go
+++ b/builtin/providers/test/resource_config_mode_test.go
@@ -1,0 +1,61 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestResourceConfigMode(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_config_mode" "foo" {
+	resource_as_attr = [
+		{
+			foo = "resource_as_attr 0"
+		},
+		{
+			foo = "resource_as_attr 1"
+		},
+	]
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.#", "2"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.0.foo", "resource_as_attr 0"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.1.foo", "resource_as_attr 1"),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_config_mode" "foo" {
+	resource_as_attr = [
+		{
+			foo = "resource_as_attr 0 updated"
+		},
+	]
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.#", "1"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.0.foo", "resource_as_attr 0 updated"),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_config_mode" "foo" {
+	resource_as_attr = []
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -54,14 +54,27 @@ func (m schemaMap) CoreConfigSchema() *configschema.Block {
 				continue
 			}
 		}
-		switch schema.Elem.(type) {
-		case *Schema, ValueType:
+		switch schema.ConfigMode {
+		case SchemaConfigModeAttr:
 			ret.Attributes[name] = schema.coreConfigSchemaAttribute()
-		case *Resource:
+		case SchemaConfigModeBlock:
 			ret.BlockTypes[name] = schema.coreConfigSchemaBlock()
-		default:
-			// Should never happen for a valid schema
-			panic(fmt.Errorf("invalid Schema.Elem %#v; need *Schema or *Resource", schema.Elem))
+		default: // SchemaConfigModeAuto, or any other invalid value
+			if schema.Computed && !schema.Optional {
+				// Computed-only schemas are always handled as attributes,
+				// because they never appear in configuration.
+				ret.Attributes[name] = schema.coreConfigSchemaAttribute()
+				continue
+			}
+			switch schema.Elem.(type) {
+			case *Schema, ValueType:
+				ret.Attributes[name] = schema.coreConfigSchemaAttribute()
+			case *Resource:
+				ret.BlockTypes[name] = schema.coreConfigSchemaBlock()
+			default:
+				// Should never happen for a valid schema
+				panic(fmt.Errorf("invalid Schema.Elem %#v; need *Schema or *Resource", schema.Elem))
+			}
 		}
 	}
 
@@ -181,9 +194,10 @@ func (s *Schema) coreConfigSchemaType() cty.Type {
 			// common one so we'll just shim it.
 			elemType = (&Schema{Type: set}).coreConfigSchemaType()
 		case *Resource:
-			// In practice we don't actually use this for normal schema
-			// construction because we construct a NestedBlock in that
-			// case instead. See schemaMap.CoreConfigSchema.
+			// By default we construct a NestedBlock in this case, but this
+			// behavior is selected either for computed-only schemas or
+			// when ConfigMode is explicitly SchemaConfigModeBlock.
+			// See schemaMap.CoreConfigSchema for the exact rules.
 			elemType = set.coreConfigSchema().ImpliedType()
 		default:
 			if set != nil {

--- a/helper/schema/core_schema_test.go
+++ b/helper/schema/core_schema_test.go
@@ -298,19 +298,14 @@ func TestSchemaMapCoreConfigSchema(t *testing.T) {
 				},
 			},
 			testResource(&configschema.Block{
-				Attributes: map[string]*configschema.Attribute{},
-				BlockTypes: map[string]*configschema.NestedBlock{
+				Attributes: map[string]*configschema.Attribute{
 					"list": {
-						Nesting:  configschema.NestingList,
-						Block:    configschema.Block{},
-						MinItems: 0,
-						MaxItems: 0,
+						Type:     cty.List(cty.EmptyObject),
+						Computed: true,
 					},
 					"set": {
-						Nesting:  configschema.NestingSet,
-						Block:    configschema.Block{},
-						MinItems: 0,
-						MaxItems: 0,
+						Type:     cty.Set(cty.EmptyObject),
+						Computed: true,
 					},
 				},
 			}),

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -75,6 +75,26 @@ type Schema struct {
 	//
 	Type ValueType
 
+	// ConfigMode allows for overriding the default behaviors for mapping
+	// schema entries onto configuration constructs.
+	//
+	// By default, the Elem field is used to choose whether a particular
+	// schema is represented in configuration as an attribute or as a nested
+	// block; if Elem is a *schema.Resource then it's a block and it's an
+	// attribute otherwise.
+	//
+	// If Elem is *schema.Resource then setting ConfigMode to
+	// SchemaConfigModeAttr will force it to be represented in configuration
+	// as an attribute, which means that the Computed flag can be used to
+	// provide default elements when the argument isn't set at all, while still
+	// allowing the user to force zero elements by explicitly assigning an
+	// empty list.
+	//
+	// When Computed is set without Optional, the attribute is not settable
+	// in configuration at all and so SchemaConfigModeAttr is the automatic
+	// behavior, and SchemaConfigModeBlock is not permitted.
+	ConfigMode SchemaConfigMode
+
 	// If one of these is set, then this item can come from the configuration.
 	// Both cannot be set. If Optional is set, the value is optional. If
 	// Required is set, the value is required.
@@ -226,6 +246,17 @@ type Schema struct {
 	// values.
 	Sensitive bool
 }
+
+// SchemaConfigMode is used to influence how a schema item is mapped into a
+// corresponding configuration construct, using the ConfigMode field of
+// Schema.
+type SchemaConfigMode int
+
+const (
+	SchemaConfigModeAuto SchemaConfigMode = iota
+	SchemaConfigModeAttr
+	SchemaConfigModeBlock
+)
 
 // SchemaDiffSuppressFunc is a function which can be used to determine
 // whether a detected diff on a schema element is "valid" or not, and
@@ -648,6 +679,10 @@ func (m schemaMap) Validate(c *terraform.ResourceConfig) ([]string, []error) {
 // from a unit test (and not in user-path code) to verify that a schema
 // is properly built.
 func (m schemaMap) InternalValidate(topSchemaMap schemaMap) error {
+	return m.internalValidate(topSchemaMap, false)
+}
+
+func (m schemaMap) internalValidate(topSchemaMap schemaMap, attrsOnly bool) error {
 	if topSchemaMap == nil {
 		topSchemaMap = m
 	}
@@ -666,6 +701,32 @@ func (m schemaMap) InternalValidate(topSchemaMap schemaMap) error {
 
 		if !v.Required && !v.Optional && !v.Computed {
 			return fmt.Errorf("%s: One of optional, required, or computed must be set", k)
+		}
+
+		computedOnly := v.Computed && !v.Optional
+
+		switch v.ConfigMode {
+		case SchemaConfigModeBlock:
+			if _, ok := v.Elem.(*Resource); !ok {
+				return fmt.Errorf("%s: ConfigMode of block is allowed only when Elem is *schema.Resource", k)
+			}
+			if attrsOnly {
+				return fmt.Errorf("%s: ConfigMode of block cannot be used in child of schema with ConfigMode of attribute", k)
+			}
+			if computedOnly {
+				return fmt.Errorf("%s: ConfigMode of block cannot be used for computed schema", k)
+			}
+		case SchemaConfigModeAttr:
+			// anything goes
+		case SchemaConfigModeAuto:
+			// Since "Auto" for Elem: *Resource would create a nested block,
+			// and that's impossible inside an attribute, we require it to be
+			// explicitly overridden as mode "Attr" for clarity.
+			if _, ok := v.Elem.(*Resource); ok && attrsOnly {
+				return fmt.Errorf("%s: in *schema.Resource with ConfigMode of attribute, so must also have ConfigMode of attribute", k)
+			}
+		default:
+			return fmt.Errorf("%s: invalid ConfigMode value", k)
 		}
 
 		if v.Computed && v.Default != nil {
@@ -732,7 +793,9 @@ func (m schemaMap) InternalValidate(topSchemaMap schemaMap) error {
 
 			switch t := v.Elem.(type) {
 			case *Resource:
-				if err := t.InternalValidate(topSchemaMap, true); err != nil {
+				attrsOnly := attrsOnly || v.ConfigMode == SchemaConfigModeAttr
+
+				if err := schemaMap(t.Schema).internalValidate(topSchemaMap, attrsOnly); err != nil {
 					return err
 				}
 			case *Schema:

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3836,6 +3836,94 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			},
 			false,
 		},
+
+		"ConfigModeBlock with Elem *Resource": {
+			map[string]*Schema{
+				"block": &Schema{
+					Type:       TypeList,
+					ConfigMode: SchemaConfigModeBlock,
+					Optional:   true,
+					Elem:       &Resource{},
+				},
+			},
+			false,
+		},
+
+		"ConfigModeBlock Computed with Elem *Resource": {
+			map[string]*Schema{
+				"block": &Schema{
+					Type:       TypeList,
+					ConfigMode: SchemaConfigModeBlock,
+					Computed:   true,
+					Elem:       &Resource{},
+				},
+			},
+			true, // ConfigMode of block cannot be used for computed schema
+		},
+
+		"ConfigModeBlock with Elem *Schema": {
+			map[string]*Schema{
+				"block": &Schema{
+					Type:       TypeList,
+					ConfigMode: SchemaConfigModeBlock,
+					Optional:   true,
+					Elem: &Schema{
+						Type: TypeString,
+					},
+				},
+			},
+			true,
+		},
+
+		"ConfigModeBlock with no Elem": {
+			map[string]*Schema{
+				"block": &Schema{
+					Type:       TypeString,
+					ConfigMode: SchemaConfigModeBlock,
+					Optional:   true,
+				},
+			},
+			true,
+		},
+
+		"ConfigModeBlock inside ConfigModeAttr": {
+			map[string]*Schema{
+				"block": &Schema{
+					Type:       TypeList,
+					ConfigMode: SchemaConfigModeAttr,
+					Optional:   true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"sub": &Schema{
+								Type:       TypeList,
+								ConfigMode: SchemaConfigModeBlock,
+								Elem:       &Resource{},
+							},
+						},
+					},
+				},
+			},
+			true, // ConfigMode of block cannot be used in child of schema with ConfigMode of attribute
+		},
+
+		"ConfigModeAuto with *Resource inside ConfigModeAttr": {
+			map[string]*Schema{
+				"block": &Schema{
+					Type:       TypeList,
+					ConfigMode: SchemaConfigModeAttr,
+					Optional:   true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"sub": &Schema{
+								Type: TypeList,
+								Elem: &Resource{},
+							},
+						},
+					},
+				},
+			},
+			true, // in *schema.Resource with ConfigMode of attribute, so must also have ConfigMode of attribute
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
This allows a provider developer slightly more control over how an SDK schema is mapped into the Terraform configuration language, overriding some default assumptions.

`ConfigMode` overrides the default assumption that a schema with an Elem of type `*Resource` is to be mapped to configuration as a nested block, allowing mapping as an attribute containing an object type instead.

This should rarely be needed, but it can be useful in situations where the provider was assuming attribute-like behaviors in 0.11 (such as ability to explicitly assign an empty list) which were possible because 0.11 didn't enforce the use of block syntax for nested resources. For some real examples, see #20505.

Since this uses the attribute syntax, this'll work best for SDK schema attributes that already had plural names, suggesting that they were representing a single attribute containing multiple objects:

```hcl
  thingies = [
    {
      foo = "bar"
    },
  ]
```

```hcl
  thingies = []
```

Back-compatibility with Terraform 0.11 may require this to be used with singular-named attributes in situations where prevailing usage was inconsistent about whether a particular name was an attribute or a block, which is less-ideal but can be used in a pinch to avoid or defer a breaking change:

```hcl
  thingy = [
    {
      foo = "bar"
    },
    {
      baz = "boop"
    },
  ]
```

Along with the explicit forcing of attribute mode in config, this also includes an implicit rule that `Computed`-only (that is, not also `Optional`) attributes are _always_ represented as attributes, since it is confusing and strange to use the configuration-only idea of nested block syntax for an attribute that can't be specified in configuration anyway. This results in better UX in the `terraform plan` output because the exact structure of the result can be shown, rather than confusing the user by showing the result as a nested block diff when no such nested block was present.

These behaviors only apply when a provider is being used with Terraform v0.12 or later. They are ignored altogether in Terraform v0.11 mode, since attribute vs. block syntax is not enforced in v0.11 anyway. We are adding this primarily to allow the v0.12 version of a resource type schema to be specified to match the prevailing usage of it in existing configurations, in situations where the default mapping to v0.12 concepts is not appropriate.

This is split into two commits because the first commit will need to be cherry-picked onto the `v0.11` branch to enable the downgrade-and-acctest regression testing strategy for ensuring that provider logic continues to behave correctly with v0.11 as future changes are made. I will do that as soon as this is merged, so approval of this PR also implies approval to place the first commit on the `v0.11` branch (just to avoid a pointness second review round-trip.)
