### PR TITLE
 website: References to Resource Attributes

### DIFF
--- a/website/docs/configuration/expressions.html.md
+++ b/website/docs/configuration/expressions.html.md
@@ -497,7 +497,7 @@ For example, if `var.list` is a list of strings, then the following expression
 produces a list of strings with all-uppercase letters:
 
 ```hcl
-[for s in var.list: upper(s)]
+[for s in var.list : upper(s)]
 ```
 
 This `for` expression iterates over each element of `var.list`, and then
@@ -511,7 +511,7 @@ it produces. The above example uses `[` and `]`, which produces a tuple. If
 expressions must be provided separated by the `=>` symbol:
 
 ```hcl
-{for s in var.list: s => upper(s)}
+{for s in var.list : s => upper(s)}
 ```
 
 This expression produces an object whose attributes are the original elements
@@ -522,7 +522,7 @@ from the source collection, which can produce a value with fewer elements than
 the source:
 
 ```
-[for s in var.list: upper(s) if s != ""]
+[for s in var.list : upper(s) if s != ""]
 ```
 
 The source value can also be an object or map value, in which case two
@@ -530,7 +530,7 @@ temporary variable names can be provided to access the keys and values
 respectively:
 
 ```
-[for k, v in var.map: length(k) + length(v)]
+[for k, v in var.map : length(k) + length(v)]
 ```
 
 Finally, if the result type is an object (using `{` and `}` delimiters) then
@@ -538,7 +538,7 @@ the value result expression can be followed by the `...` symbol to group
 together results that have a common key:
 
 ```
-{for s in var.list: substr(s, 0, 1) => s... if s != ""}
+{for s in var.list : substr(s, 0, 1) => s... if s != ""}
 ```
 
 ## Splat Expressions
@@ -550,7 +550,7 @@ If `var.list` is a list of objects that all have an attribute `id`, then
 a list of the ids could be produced with the following `for` expression:
 
 ```hcl
-[for o in var.list: o.id]
+[for o in var.list : o.id]
 ```
 
 This is equivalent to the following _splat expression:_
@@ -572,7 +572,7 @@ var.list[*].interfaces[0].name
 The above expression is equivalent to the following `for` expression:
 
 ```hcl
-[for o in var.list: o.interfaces[0].name]
+[for o in var.list : o.interfaces[0].name]
 ```
 
 Splat expressions also have another useful effect: if they are applied to
@@ -609,7 +609,7 @@ This form has a subtly different behavior, equivalent to the following
 `for` expression:
 
 ```
-[for o in var.list: o.interfaces][0].name
+[for o in var.list : o.interfaces][0].name
 ```
 
 Notice that with the attribute-only splat expression the index operation


### PR DESCRIPTION
Since references to attributes of resources are by far the most common reference type, and the mapping of resource type config to the attributes is not always obvious, here we give some real examples of patterns for accessing different configuration constructs within resource blocks along with the resource type's exported attributes.

Since we don't have any real examples of labelled nested blocks yet (the current SDK doesn't support them) I've included a hypothetical example for now just to establish the patterns around them in preparation for beginning to introduce them as we roll out this feature in the SDK.

While I was in this file anyway, I also fixed up some `for` expression examples that were not following the way the whitespace gets set by `terraform fmt`. (The extra spaces reflected here are a pragmatic compromise made by the HCL formatter so that the colon in `? :` and the colon in `for` expressions can be treated the same, since in practice they are too "far away" from each other for it to reliably distinguish these two.)
