### PR TITLE
fix `Publishing Modules` link of website documentation.

### DIFF
--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -361,7 +361,7 @@
         <a href="/docs/modules/index.html">Modules</a>
         <ul class="nav">
           <li<%= sidebar_current("docs-modules-publish") %>>
-            <a href="/docs/modules/create.html">Publishing Modules</a>
+            <a href="/docs/modules/publish.html">Publishing Modules</a>
           </li>
 
           <li<%= sidebar_current("docs-modules-sources") %>>


### PR DESCRIPTION
Currently links to [Creating Modules](https://www.terraform.io/docs/modules/create.html) page.
Should link to [Publishing Modules](https://www.terraform.io/docs/modules/publish.html) page.

fixes #20636