### PR TITLE
backend/remote: fix a backend init bug

### DIFF
--- a/backend/init/init.go
+++ b/backend/init/init.go
@@ -3,7 +3,6 @@
 package init
 
 import (
-	"os"
 	"sync"
 
 	"github.com/hashicorp/terraform/backend"
@@ -45,14 +44,8 @@ func Init(services *disco.Disco) {
 
 	backends = map[string]backend.InitFn{
 		// Enhanced backends.
-		"local": func() backend.Backend { return backendLocal.New() },
-		"remote": func() backend.Backend {
-			b := backendRemote.New(services)
-			if os.Getenv("TF_FORCE_LOCAL_BACKEND") != "" {
-				return backendLocal.NewWithBackend(b)
-			}
-			return b
-		},
+		"local":  func() backend.Backend { return backendLocal.New() },
+		"remote": func() backend.Backend { return backendRemote.New(services) },
 
 		// Remote State backends.
 		"atlas":   func() backend.Backend { return backendAtlas.New() },

--- a/backend/init/init_test.go
+++ b/backend/init/init_test.go
@@ -1,11 +1,8 @@
 package init
 
 import (
-	"os"
 	"reflect"
 	"testing"
-
-	backendLocal "github.com/hashicorp/terraform/backend/local"
 )
 
 func TestInit_backend(t *testing.T) {
@@ -62,49 +59,6 @@ func TestInit_backend(t *testing.T) {
 
 		if bType != b.Type {
 			t.Fatalf("expected backend %q to be %q, got: %q", b.Name, b.Type, bType)
-		}
-	}
-}
-
-func TestInit_forceLocalBackend(t *testing.T) {
-	// Initialize the backends map
-	Init(nil)
-
-	enhancedBackends := []struct {
-		Name string
-		Type string
-	}{
-		{
-			"local",
-			"nil",
-		}, {
-			"remote",
-			"*remote.Remote",
-		},
-	}
-
-	// Set the TF_FORCE_LOCAL_BACKEND flag so all enhanced backends will
-	// return a local.Local backend with themselves as embedded backend.
-	if err := os.Setenv("TF_FORCE_LOCAL_BACKEND", "1"); err != nil {
-		t.Fatalf("error setting environment variable TF_FORCE_LOCAL_BACKEND: %v", err)
-	}
-
-	// Make sure we always get the local backend.
-	for _, b := range enhancedBackends {
-		f := Backend(b.Name)
-
-		local, ok := f().(*backendLocal.Local)
-		if !ok {
-			t.Fatalf("expected backend %q to be \"*local.Local\", got: %T", b.Name, f())
-		}
-
-		bType := "nil"
-		if local.Backend != nil {
-			bType = reflect.TypeOf(local.Backend).String()
-		}
-
-		if bType != b.Type {
-			t.Fatalf("expected local.Backend to be %s, got: %s", b.Type, bType)
 		}
 	}
 }

--- a/backend/local/cli.go
+++ b/backend/local/cli.go
@@ -6,12 +6,6 @@ import (
 
 // backend.CLI impl.
 func (b *Local) CLIInit(opts *backend.CLIOpts) error {
-	if cli, ok := b.Backend.(backend.CLI); ok {
-		if err := cli.CLIInit(opts); err != nil {
-			return err
-		}
-	}
-
 	b.CLI = opts.CLI
 	b.CLIColor = opts.CLIColor
 	b.ContextOpts = opts.ContextOpts

--- a/backend/remote/cli.go
+++ b/backend/remote/cli.go
@@ -6,8 +6,15 @@ import (
 
 // CLIInit implements backend.CLI
 func (b *Remote) CLIInit(opts *backend.CLIOpts) error {
+	if cli, ok := b.local.(backend.CLI); ok {
+		if err := cli.CLIInit(opts); err != nil {
+			return err
+		}
+	}
+
 	b.CLI = opts.CLI
 	b.CLIColor = opts.CLIColor
 	b.ContextOpts = opts.ContextOpts
+
 	return nil
 }


### PR DESCRIPTION
The `init` bits in this PR were missed during the initial backport of the free remote state storage code back in Januari. The issue didn't surface until a recent change made last week and unfortunately local testing with the `TF_FORCE_LOCAL_BACKEND` flag didn't catch this either. 