### PR TITLE
lang/funcs: Fix filebase64sha256 function hashing algorithm

### DIFF
--- a/lang/funcs/crypto.go
+++ b/lang/funcs/crypto.go
@@ -39,7 +39,7 @@ var Base64Sha256Func = makeStringHashFunction(sha256.New, base64.StdEncoding.Enc
 // MakeFileBase64Sha256Func constructs a function that is like Base64Sha256Func but reads the
 // contents of a file rather than hashing a given literal string.
 func MakeFileBase64Sha256Func(baseDir string) function.Function {
-	return makeFileHashFunction(baseDir, sha512.New, base64.StdEncoding.EncodeToString)
+	return makeFileHashFunction(baseDir, sha256.New, base64.StdEncoding.EncodeToString)
 }
 
 // Base64Sha512Func constructs a function that computes the SHA256 hash of a given string

--- a/lang/funcs/crypto_test.go
+++ b/lang/funcs/crypto_test.go
@@ -64,12 +64,12 @@ func TestFileBase64Sha256(t *testing.T) {
 	}{
 		{
 			cty.StringVal("testdata/hello.txt"),
-			cty.StringVal("LHT9F+2v2A6ER7DUZ0HuJDt+t03SFJoKsbkkb7MDgvJ+hT2FhXGeDmfL2g2qj1FnEGRhXWRa4nrLFb+xRH9Fmw=="),
+			cty.StringVal("pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4="),
 			false,
 		},
 		{
 			cty.StringVal("testdata/icon.png"),
-			cty.StringVal("wSInO/tKEOaLGCAY2h/7gtLWMpzyLJ0ijFh95JTpYrPzXQYgviAdL9ZgpD9EAte8On+drvhFvjIFsfQUwxbNPQ=="),
+			cty.StringVal("47U1q9IZW093SmAzdC820Skpn8vHPvc8szud/Y3ezpo="),
 			false,
 		},
 		{
@@ -79,7 +79,7 @@ func TestFileBase64Sha256(t *testing.T) {
 		},
 	}
 
-	fileSHA256 := MakeFileBase64Sha512Func(".")
+	fileSHA256 := MakeFileBase64Sha256Func(".")
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("filebase64sha256(%#v)", test.Path), func(t *testing.T) {


### PR DESCRIPTION
Closes #20652

The implementation and testing were incorrectly referencing SHA-512 instead of SHA-256.