### PR TITLE
check for errors when loading a backend config

### DIFF
--- a/command/meta_config.go
+++ b/command/meta_config.go
@@ -173,6 +173,9 @@ func (m *Meta) dirIsConfigPath(dir string) bool {
 // directory even if loadBackendConfig succeeded.)
 func (m *Meta) loadBackendConfig(rootDir string) (*configs.Backend, tfdiags.Diagnostics) {
 	mod, diags := m.loadSingleModule(rootDir)
+	if diags.HasErrors() {
+		return nil, diags
+	}
 	return mod.Backend, diags
 }
 

--- a/command/unlock_test.go
+++ b/command/unlock_test.go
@@ -49,6 +49,16 @@ func TestUnlock(t *testing.T) {
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("bad: %d\n%s\n%s", code, ui.OutputWriter.String(), ui.ErrorWriter.String())
 	}
+
+	// make sure we don't crash with arguments in the wrong order
+	args = []string{
+		"LOCK_ID",
+		"-force",
+	}
+
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: %d\n%s\n%s", code, ui.OutputWriter.String(), ui.ErrorWriter.String())
+	}
 }
 
 // Newly configured backend


### PR DESCRIPTION
We can't dereference the config module if there were any errors loading
it.

Fixes #20635