### PR TITLE
plugin/discovery: Parse warnings from TF Registry

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -494,7 +494,8 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 		}
 
 		for provider, reqd := range missing {
-			_, err := c.providerInstaller.Get(provider, reqd.Versions)
+			_, providerDiags, err := c.providerInstaller.Get(provider, reqd.Versions)
+			diags = diags.Append(providerDiags)
 
 			if err != nil {
 				constraint := reqd.Versions.String()

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statemgr"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 func TestInit_empty(t *testing.T) {
@@ -964,8 +965,8 @@ func TestInit_getProviderHaveLegacyVersion(t *testing.T) {
 			testingOverrides: metaOverridesForProvider(testProvider()),
 			Ui:               ui,
 		},
-		providerInstaller: callbackPluginInstaller(func(provider string, req discovery.Constraints) (discovery.PluginMeta, error) {
-			return discovery.PluginMeta{}, fmt.Errorf("EXPECTED PROVIDER ERROR %s", provider)
+		providerInstaller: callbackPluginInstaller(func(provider string, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error) {
+			return discovery.PluginMeta{}, tfdiags.Diagnostics{}, fmt.Errorf("EXPECTED PROVIDER ERROR %s", provider)
 		}),
 	}
 
@@ -1174,9 +1175,9 @@ func TestInit_pluginDirProvidersDoesNotGet(t *testing.T) {
 
 	c := &InitCommand{
 		Meta: m,
-		providerInstaller: callbackPluginInstaller(func(provider string, req discovery.Constraints) (discovery.PluginMeta, error) {
+		providerInstaller: callbackPluginInstaller(func(provider string, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error) {
 			t.Fatalf("plugin installer should not have been called for %q", provider)
-			return discovery.PluginMeta{}, nil
+			return discovery.PluginMeta{}, tfdiags.Diagnostics{}, nil
 		}),
 	}
 

--- a/command/plugins_test.go
+++ b/command/plugins_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 func TestMultiVersionProviderResolver(t *testing.T) {
@@ -146,16 +147,17 @@ func (i *mockProviderInstaller) FileName(provider, version string) string {
 	return fmt.Sprintf("terraform-provider-%s_v%s_x4", provider, version)
 }
 
-func (i *mockProviderInstaller) Get(provider string, req discovery.Constraints) (discovery.PluginMeta, error) {
+func (i *mockProviderInstaller) Get(provider string, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error) {
+	var diags tfdiags.Diagnostics
 	noMeta := discovery.PluginMeta{}
 	versions := i.Providers[provider]
 	if len(versions) == 0 {
-		return noMeta, fmt.Errorf("provider %q not found", provider)
+		return noMeta, diags, fmt.Errorf("provider %q not found", provider)
 	}
 
 	err := os.MkdirAll(i.Dir, 0755)
 	if err != nil {
-		return noMeta, fmt.Errorf("error creating plugins directory: %s", err)
+		return noMeta, diags, fmt.Errorf("error creating plugins directory: %s", err)
 	}
 
 	for _, v := range versions {
@@ -170,18 +172,18 @@ func (i *mockProviderInstaller) Get(provider string, req discovery.Constraints) 
 			path := filepath.Join(i.Dir, name)
 			f, err := os.Create(path)
 			if err != nil {
-				return noMeta, fmt.Errorf("error fetching provider: %s", err)
+				return noMeta, diags, fmt.Errorf("error fetching provider: %s", err)
 			}
 			f.Close()
 			return discovery.PluginMeta{
 				Name:    provider,
 				Version: discovery.VersionStr(v),
 				Path:    path,
-			}, nil
+			}, diags, nil
 		}
 	}
 
-	return noMeta, fmt.Errorf("no suitable version for provider %q found with constraints %s", provider, req)
+	return noMeta, diags, fmt.Errorf("no suitable version for provider %q found with constraints %s", provider, req)
 }
 
 func (i *mockProviderInstaller) PurgeUnused(map[string]discovery.PluginMeta) (discovery.PluginMetaSet, error) {
@@ -197,7 +199,7 @@ func (i *mockProviderInstaller) PurgeUnused(map[string]discovery.PluginMeta) (di
 
 type callbackPluginInstaller func(provider string, req discovery.Constraints) (discovery.PluginMeta, error)
 
-func (cb callbackPluginInstaller) Get(provider string, req discovery.Constraints) (discovery.PluginMeta, error) {
+func (cb callbackPluginInstaller) Get(provider string, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error) {
 	return cb(provider, req)
 }
 

--- a/command/plugins_test.go
+++ b/command/plugins_test.go
@@ -197,7 +197,7 @@ func (i *mockProviderInstaller) PurgeUnused(map[string]discovery.PluginMeta) (di
 	return ret, nil
 }
 
-type callbackPluginInstaller func(provider string, req discovery.Constraints) (discovery.PluginMeta, error)
+type callbackPluginInstaller func(provider string, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error)
 
 func (cb callbackPluginInstaller) Get(provider string, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error) {
 	return cb(provider, req)

--- a/plugin/discovery/get_test.go
+++ b/plugin/discovery/get_test.go
@@ -415,7 +415,7 @@ func TestProviderInstallerGet(t *testing.T) {
 		Ui:                    cli.NewMockUi(),
 		registry:              registry.NewClient(Disco(server), nil),
 	}
-	_, err = i.Get("test", AllVersions)
+	_, _, err = i.Get("test", AllVersions)
 
 	if err != ErrorNoVersionCompatibleWithPlatform {
 		t.Fatal("want error for incompatible version")
@@ -432,20 +432,20 @@ func TestProviderInstallerGet(t *testing.T) {
 	}
 
 	{
-		_, err := i.Get("test", ConstraintStr(">9.0.0").MustParse())
+		_, _, err := i.Get("test", ConstraintStr(">9.0.0").MustParse())
 		if err != ErrorNoSuitableVersion {
 			t.Fatal("want error for mismatching constraints")
 		}
 	}
 
 	{
-		_, err := i.Get("nonexist", AllVersions)
+		_, _, err := i.Get("nonexist", AllVersions)
 		if err != ErrorNoSuchProvider {
 			t.Fatal("want error for no such provider")
 		}
 	}
 
-	gotMeta, err := i.Get("test", AllVersions)
+	gotMeta, _, err := i.Get("test", AllVersions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -503,7 +503,7 @@ func TestProviderInstallerGet_cache(t *testing.T) {
 		Arch:                  "mockarch",
 	}
 
-	gotMeta, err := i.Get("test", AllVersions)
+	gotMeta, _, err := i.Get("test", AllVersions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/response/terraform_provider.go
+++ b/registry/response/terraform_provider.go
@@ -32,6 +32,7 @@ type TerraformProviderVersion struct {
 type TerraformProviderVersions struct {
 	ID       string                      `json:"id"`
 	Versions []*TerraformProviderVersion `json:"versions"`
+	Warnings []string                    `json:"warnings"`
 }
 
 // TerraformProviderPlatform is the Terraform-specific response structure for a

--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -181,7 +181,7 @@ func (c *PackageCommand) Run(args []string) int {
 			} else { //attempt to get from the public registry if not found locally
 				c.ui.Output(fmt.Sprintf("- Checking for provider plugin on %s...",
 					releaseHost))
-				_, err := installer.Get(name, constraint)
+				_, _, err := installer.Get(name, constraint)
 				if err != nil {
 					c.ui.Error(fmt.Sprintf("- Failed to resolve %s provider %s: %s", name, constraint, err))
 					return 1


### PR DESCRIPTION
Terraform Registry (and other registry implementations) can now return an
array of warnings with the versions response. These warnings are now
displayed to the user during a `terraform init`.