### PR TITLE
configs: do not panic if module version is a variable

### DIFF
--- a/configs/test-fixtures/invalid-files/version-variable.tf
+++ b/configs/test-fixtures/invalid-files/version-variable.tf
@@ -1,0 +1,6 @@
+variable "module_version" { default = "v1.0" }
+
+module "foo" {
+  source  = "./ff"
+  version = var.module_version
+}

--- a/configs/version_constraint.go
+++ b/configs/version_constraint.go
@@ -24,6 +24,9 @@ func decodeVersionConstraint(attr *hcl.Attribute) (VersionConstraint, hcl.Diagno
 	}
 
 	val, diags := attr.Expr.Value(nil)
+	if diags.HasErrors() {
+		return ret, diags
+	}
 	var err error
 	val, err = convert.Convert(val, cty.String)
 	if err != nil {


### PR DESCRIPTION
In the current PR, I've added a check if the version attribute `IsWhollyKnown()` and return some diagnostics. This results in two error messages:

```
$ ./terraform init
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Variables not allowed

  on pets.tf line 11, in module "pets":
  11:   version = var.module_version

Variables may not be used here.


Error: Invalid version constraint

  on pets.tf line 11, in module "pets":
  11:   version = var.module_version

A string value is required for version.
```

I could choose to return from `decodeVersionConstraint` in this scenario without any additional diagnostics, which gives a much nicer looking output. My only hesitation is based in not knowing where else this function is used.

```
$ ./terraform init
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Variables not allowed

  on pets.tf line 11, in module "pets":
  11:   version = var.module_version

Variables may not be used here.
```
