### PR TITLE
don't try to treat "null" as json in diff output

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -496,7 +496,9 @@ func (p *blockBodyDiffPrinter) writeValue(val cty.Value, action plans.Action, in
 				// Special behavior for JSON strings containing array or object
 				src := []byte(val.AsString())
 				ty, err := ctyjson.ImpliedType(src)
-				if err == nil && !ty.IsPrimitiveType() {
+				// check for the special case of "null", which decodes to nil,
+				// and just allow it to be printed out directly
+				if err == nil && !ty.IsPrimitiveType() && val.AsString() != "null" {
 					jv, err := ctyjson.Unmarshal(src, ty)
 					if err == nil {
 						p.buf.WriteString("jsonencode(")

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -32,6 +32,26 @@ func TestResourceChange_primitiveTypes(t *testing.T) {
     }
 `,
 		},
+		"creation (null string)": {
+			Action: plans.Create,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.NullVal(cty.EmptyObject),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"string": cty.StringVal("null"),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"string": {Type: cty.String, Optional: true},
+				},
+			},
+			RequiredReplace: cty.NewPathSet(),
+			Tainted:         false,
+			ExpectedOutput: `  # test_instance.example will be created
+  + resource "test_instance" "example" {
+      + string = "null"
+    }
+`,
+		},
 		"deletion": {
 			Action: plans.Delete,
 			Mode:   addrs.ManagedResourceMode,


### PR DESCRIPTION
Trying to decode and write "null" as json will panic, since it decodes
to nil.

Fixes #20634