### PR TITLE
Added 'formatdate' to the function reference sidebar.

### DIFF
--- a/website/docs/configuration/functions/formatdate.html.md
+++ b/website/docs/configuration/functions/formatdate.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "functions"
 page_title: "formatdate - Functions - Configuration Language"
-sidebar_current: "docs-funcs-string-formatdate-x"
+sidebar_current: "docs-funcs-datetime-formatdate"
 description: |-
   The formatdate function converts a timestamp into a different time format.
 ---

--- a/website/layouts/functions.erb
+++ b/website/layouts/functions.erb
@@ -283,6 +283,10 @@
               <li id="docs-funcs-datetime"<%= sidebar_current("docs-funcs-datetime") %>>
                 <a href="#docs-funcs-datetime">Date and Time Functions</a>
                 <ul class="nav nav-visible">
+                  
+                  <li<%= sidebar_current("docs-funcs-datetime-formatdate") %>>
+                    <a href="/docs/configuration/functions/formatdate.html">formatdate</a>
+                  </li>
 
                   <li<%= sidebar_current("docs-funcs-datetime-timeadd") %>>
                     <a href="/docs/configuration/functions/timeadd.html">timeadd</a>


### PR DESCRIPTION
The formatdate function wasn't shown in the function reference sidebar; I only discovered it by seeing a link at the bottom of the 'timestamp' page.