### PR TITLE
command/show: add provider name to resource changes

### DIFF
--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -269,6 +269,7 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 		r.ModuleAddress = addr.Module.String()
 		r.Name = addr.Resource.Resource.Name
 		r.Type = addr.Resource.Resource.Type
+		r.ProviderName = rc.ProviderAddr.ProviderConfig.StringCompact()
 
 		p.ResourceChanges = append(p.ResourceChanges, r)
 

--- a/command/jsonplan/resource.go
+++ b/command/jsonplan/resource.go
@@ -49,9 +49,10 @@ type resourceChange struct {
 	// "managed" or "data"
 	Mode string `json:"mode,omitempty"`
 
-	Type  string            `json:"type,omitempty"`
-	Name  string            `json:"name,omitempty"`
-	Index addrs.InstanceKey `json:"index,omitempty"`
+	Type         string            `json:"type,omitempty"`
+	Name         string            `json:"name,omitempty"`
+	Index        addrs.InstanceKey `json:"index,omitempty"`
+	ProviderName string            `json:"provider_name,omitempty"`
 
 	// "deposed", if set, indicates that this action applies to a "deposed"
 	// object of the given instance rather than to its "current" object. Omitted

--- a/command/test-fixtures/show-json/basic-create/output.json
+++ b/command/test-fixtures/show-json/basic-create/output.json
@@ -59,6 +59,7 @@
             "index": 0,
             "mode": "managed",
             "type": "test_instance",
+            "provider_name": "test",
             "name": "test",
             "change": {
                 "actions": [
@@ -79,6 +80,7 @@
             "index": 1,
             "mode": "managed",
             "type": "test_instance",
+            "provider_name": "test",
             "name": "test",
             "change": {
                 "actions": [
@@ -99,6 +101,7 @@
             "index": 2,
             "mode": "managed",
             "type": "test_instance",
+            "provider_name": "test",
             "name": "test",
             "change": {
                 "actions": [

--- a/command/test-fixtures/show-json/basic-delete/output.json
+++ b/command/test-fixtures/show-json/basic-delete/output.json
@@ -34,6 +34,7 @@
             "address": "test_instance.test",
             "mode": "managed",
             "type": "test_instance",
+            "provider_name": "test",
             "name": "test",
             "change": {
                 "actions": [
@@ -57,6 +58,7 @@
             "address": "test_instance.test-delete",
             "mode": "managed",
             "type": "test_instance",
+            "provider_name": "test",
             "name": "test-delete",
             "change": {
                 "actions": [

--- a/command/test-fixtures/show-json/basic-update/output.json
+++ b/command/test-fixtures/show-json/basic-update/output.json
@@ -34,6 +34,7 @@
             "address": "test_instance.test",
             "mode": "managed",
             "type": "test_instance",
+            "provider_name": "test",
             "name": "test",
             "change": {
                 "actions": [

--- a/command/test-fixtures/show-json/modules/output.json
+++ b/command/test-fixtures/show-json/modules/output.json
@@ -76,6 +76,7 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
+            "provider_name": "test",
             "change": {
                 "actions": [
                     "create"
@@ -95,6 +96,7 @@
             "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
+            "provider_name": "test",
             "name": "test",
             "index": 0,
             "change": {
@@ -116,6 +118,7 @@
             "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
+            "provider_name": "test",
             "name": "test",
             "index": 1,
             "change": {
@@ -137,6 +140,7 @@
             "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
+            "provider_name": "test",
             "name": "test",
             "index": 2,
             "change": {


### PR DESCRIPTION
`"provider_name"` currently appears in `planned_values.resources`, but not `"resource_changes"`.