### PR TITLE
vendor: go get github.com/hashicorp/hcl2@master

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/heredoc-flush/want/heredoc.tf
+++ b/configs/configupgrade/test-fixtures/valid/heredoc-flush/want/heredoc.tf
@@ -11,5 +11,5 @@ EOF
 }
 
 output "local" {
-value = local.cert_options
+  value = local.cert_options
 }

--- a/configs/configupgrade/test-fixtures/valid/heredoc-sameline/want/heredoc.tf
+++ b/configs/configupgrade/test-fixtures/valid/heredoc-sameline/want/heredoc.tf
@@ -8,5 +8,5 @@ EOF
 }
 
 output "local" {
-value = local.cert_options
+  value = local.cert_options
 }

--- a/configs/configupgrade/test-fixtures/valid/heredoc-standard/want/heredoc.tf
+++ b/configs/configupgrade/test-fixtures/valid/heredoc-standard/want/heredoc.tf
@@ -12,5 +12,5 @@ EOF
 }
 
 output "local" {
-value = local.cert_options
+  value = local.cert_options
 }

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20190226234159-7e26f2f34612
+	github.com/hashicorp/hcl2 v0.0.0-20190315201941-956e03eb6dda
 	github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
-github.com/hashicorp/hcl2 v0.0.0-20190226234159-7e26f2f34612 h1:6r7kHL9FVohHX5vd/qvoLLV+BAbHjZKu0kjfgoT9CjE=
-github.com/hashicorp/hcl2 v0.0.0-20190226234159-7e26f2f34612/go.mod h1:HtEzazM5AZ9fviNEof8QZB4T1Vz9UhHrGhnMPzl//Ek=
+github.com/hashicorp/hcl2 v0.0.0-20190315201941-956e03eb6dda h1:wgPsY2p0JDBRzc7fPEUidAhpXZzSPTIuSUDATOisbYs=
+github.com/hashicorp/hcl2 v0.0.0-20190315201941-956e03eb6dda/go.mod h1:HtEzazM5AZ9fviNEof8QZB4T1Vz9UhHrGhnMPzl//Ek=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 h1:2yzhWGdgQUWZUCNK+AoO35V+HTsgEmcM4J9IkArh7PI=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/vendor/github.com/hashicorp/hcl2/hcl/json/structure.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/json/structure.go
@@ -499,6 +499,8 @@ func (e *expression) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 			return cty.DynamicVal, diags
 		}
 		return cty.ObjectVal(attrs), diags
+	case *nullVal:
+		return cty.NullVal(cty.DynamicPseudoType), nil
 	default:
 		// Default to DynamicVal so that ASTs containing invalid nodes can
 		// still be partially-evaluated.

--- a/vendor/github.com/hashicorp/hcl2/hclwrite/format.go
+++ b/vendor/github.com/hashicorp/hcl2/hclwrite/format.go
@@ -79,12 +79,12 @@ func formatIndent(lines []formatLine) {
 		netBrackets := 0
 		for _, token := range line.lead {
 			netBrackets += tokenBracketChange(token)
-		}
-		for _, token := range line.assign {
-			netBrackets += tokenBracketChange(token)
 			if token.Type == hclsyntax.TokenOHeredoc {
 				inHeredoc = true
 			}
+		}
+		for _, token := range line.assign {
+			netBrackets += tokenBracketChange(token)
 		}
 
 		switch {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl2 v0.0.0-20190226234159-7e26f2f34612
+# github.com/hashicorp/hcl2 v0.0.0-20190315201941-956e03eb6dda
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec


### PR DESCRIPTION
This includes two upstream fixes:

- Handle explicit JSON `null` consistently during decode of JSON syntax.
- Properly detect the end of a "heredoc" when formatting to avoid messing up indentation of other lines following the heredoc. (Fixes #20563)
