### PR TITLE
core: Don't fail on dynamic attribute values during refresh

### DIFF
--- a/terraform/eval_refresh.go
+++ b/terraform/eval_refresh.go
@@ -71,12 +71,12 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 		panic("new state is cty.NilVal")
 	}
 
-	for _, err := range schema.ImpliedType().TestConformance(resp.NewState.Type()) {
+	for _, err := range resp.NewState.Type().TestConformance(schema.ImpliedType()) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Provider produced invalid object",
 			fmt.Sprintf(
-				"Provider %q planned an invalid value for %s: %s during refresh.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
+				"Provider %q planned an invalid value for %s during refresh: %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
 				n.ProviderAddr.ProviderConfig.Type, absAddr, tfdiags.FormatError(err),
 			),
 		))

--- a/terraform/test-fixtures/refresh-dynamic/main.tf
+++ b/terraform/test-fixtures/refresh-dynamic/main.tf
@@ -1,0 +1,3 @@
+resource "test_instance" "foo" {
+  dynamic = {}
+}


### PR DESCRIPTION
Our post-refresh safety check had the constraint and real type inverted, so previously any refresh of a resource type with a dynamically-typed attribute would always fail this type check.

`TestConformance` is not commutative when `cty.DynamicPseudoType` is present because in the constraint argument it means "any type" but in the concrete type to be checked it means "unknown type". Having these inverted therefore led to a pretty confusing error message:

```
Error: Provider produced invalid object

Provider "test" planned an invalid value for test_instance.test:
.access.policy: object required, but received dynamic during refresh.

This is a bug in the provider, which should be reported in the provider's own
issue tracker.
```

This also includes a small tweak to the error message from this check since, as we can see above, the old one was a little awkward to read in practice when the error is a `cty.PathError` rendered with an attribute path prefix. The "during refresh" qualifier now comes before the first colon, so it doesn't read as a modifier of "received dynamic" in the final sentence.
