### PR TITLE
docs: elaborate on supported remote backend versions

### DIFF
--- a/website/docs/backends/types/remote.html.md
+++ b/website/docs/backends/types/remote.html.md
@@ -10,13 +10,17 @@ description: |-
 
 **Kind: Enhanced**
 
-The remote backend stores state and runs operations remotely. When running
-`terraform plan` or `terraform apply` with this backend, the actual execution
-occurs in Terraform Enterprise, with log output streaming to the local terminal.
-
-To use this backend you need a Terraform Enterprise account on
+The remote backend runs operations and stores state remotely in Terraform
+Enterprise. When running `terraform plan` or `terraform apply` with this
+backend, the actual execution and storage of state occurs in Terraform
+Enterprise with log output streaming to the local terminal. To use this backend
+you need a Terraform Enterprise account on
 [app.terraform.io](https://app.terraform.io) or have a private instance of
 Terraform Enterprise (version v201809-1 or newer).
+
+With a Free-Tier account, state is stored in Terraform Enterprise after
+operations are executed on the local machine. With a Pro or Premium tier
+account, both state storage and operations are done remotely.
 
 -> Note: We recommend using at least Terraform v0.11.13 with the remote backend.
 

--- a/website/docs/backends/types/remote.html.md
+++ b/website/docs/backends/types/remote.html.md
@@ -10,19 +10,21 @@ description: |-
 
 **Kind: Enhanced**
 
-The remote backend runs operations and stores state remotely in Terraform
-Enterprise. When running `terraform plan` or `terraform apply` with this
-backend, the actual execution and storage of state occurs in Terraform
-Enterprise with log output streaming to the local terminal. To use this backend
-you need a Terraform Enterprise account on
-[app.terraform.io](https://app.terraform.io) or have a private instance of
+-> **Note:** We recommend using Terraform v0.11.13 or newer with this
+backend. This backend requires either a Terraform Enterprise account on
+[app.terraform.io](https://app.terraform.io) or a private instance of
 Terraform Enterprise (version v201809-1 or newer).
 
-With a Free-Tier account, state is stored in Terraform Enterprise after
-operations are executed on the local machine. With a Pro or Premium tier
-account, both state storage and operations are done remotely.
+The remote backend stores state and runs operations in Terraform Enterprise.
 
--> Note: We recommend using at least Terraform v0.11.13 with the remote backend.
+When used with a Pro or Premium tier Terraform Enterprise account, operations
+like `terraform plan` or `terraform apply` are executed in Terraform
+Enterprise's run environment, with log output streaming to the local terminal.
+Remote plans and applies use variable values from the associated Terraform
+Enterprise workspace.
+
+When used with a free Terraform Enterprise account, operations are executed on
+the local machine and state is stored in Terraform Enterprise.
 
 ## Command Support
 

--- a/website/docs/backends/types/remote.html.md
+++ b/website/docs/backends/types/remote.html.md
@@ -18,17 +18,19 @@ To use this backend you need a Terraform Enterprise account on
 [app.terraform.io](https://app.terraform.io) or have a private instance of
 Terraform Enterprise (version v201809-1 or newer).
 
+-> Note: We recommend using at least Terraform v0.11.13 with the remote backend.
+
 ## Command Support
 
 Currently the remote backend supports the following Terraform commands:
 
 - `apply`
-- `console`
+- `console` (supported in Terraform >= v0.11.12)
 - `destroy` (requires manually setting `CONFIRM_DESTROY=1` on the workspace)
 - `fmt`
 - `get`
-- `graph`
-- `import`
+- `graph` (supported in Terraform >= v0.11.12)
+- `import` (supported in Terraform >= v0.11.12)
 - `init`
 - `output`
 - `plan`


### PR DESCRIPTION
This PR adds a few lines to the docs to indicate which commands are
supported by what version of the remote backend and it makes a
recommendation about which version to use.