### PR TITLE
website: Indicate v0.12-only content

### DIFF
--- a/website/docs/commands/0.12upgrade.html.markdown
+++ b/website/docs/commands/0.12upgrade.html.markdown
@@ -12,7 +12,7 @@ The `terraform 0.12upgrade` command applies several automatic upgrade rules to
 help prepare a module that was written for Terraform v0.11 to be used
 with Terraform v0.12.
 
--> This command requires Terraform v0.12 or later.
+-> This command requires **Terraform v0.12 or later**.
 
 ## Usage
 

--- a/website/docs/commands/fmt.html.markdown
+++ b/website/docs/commands/fmt.html.markdown
@@ -9,7 +9,18 @@ description: |-
 # Command: fmt
 
 The `terraform fmt` command is used to rewrite Terraform configuration files
-to a canonical format and style.
+to a canonical format and style. This command applies a subset of
+the [Terraform language style conventions](/docs/configuration/style.html),
+along with other minor adjustments for readability.
+
+Other Terraform commands that generate Terraform configuration will produce
+configuration files that conform to the style imposed by `terraform fmt`, so
+using this style in your own files will ensure consistency.
+
+The canonical format may change in minor ways between Terraform versions, so
+after upgrading Terraform we recommend to proactively run `terraform fmt`
+on your modules along with any other changes you are making to adopt the new
+version.
 
 ## Usage
 

--- a/website/docs/commands/providers/schema.html.md
+++ b/website/docs/commands/providers/schema.html.md
@@ -11,6 +11,8 @@ description: |-
 
 The `terraform providers schema` command is used to print detailed schemas for the providers used in the current configuration.
 
+-> `terraform providers schema` requires **Terraform v0.12 or later**.
+
 ## Usage
 
 Usage: `terraform providers schema [options]`

--- a/website/docs/commands/show.html.markdown
+++ b/website/docs/commands/show.html.markdown
@@ -42,3 +42,5 @@ The command-line flags are all optional. The list of available flags are:
 * `-no-color` - Disables output with coloring
 
 * `-json` - Displays machine-readable output from a state or plan file
+
+-> JSON output via the `-json` option requires **Terraform v0.12 or later**.

--- a/website/docs/commands/state/addressing.html.md
+++ b/website/docs/commands/state/addressing.html.md
@@ -8,13 +8,13 @@ description: |-
 
 # Resource Addressing
 
-The `terraform state` subcommands make heavy use of resource addressing
-for targeting and filtering specific resources and modules within the state.
+The `terraform state` subcommands use
+[standard address syntax](/docs/internals/resource-addressing.html) to refer
+to individual resources, resource instances, and modules. This is the same
+syntax used for the `-target` option to the `apply` and `plan` commands.
 
-Resource addressing is a common feature of Terraform that is used in
-multiple locations. For example, resource addressing syntax is also used for
-the `-target` flag for apply and plan commands.
+Most state commands allow referring to individual resource instances, whole
+resources (which may have multiple instances if `count` or `for_each` is used),
+or even whole modules.
 
-Because resource addressing is unified across Terraform, it is documented
-in a single place rather than duplicating it in multiple locations. You
-can find the [resource addressing documentation here](/docs/internals/resource-addressing.html).
+For more information on the syntax, see [Resource Addressing](/docs/internals/resource-addressing.html).

--- a/website/docs/internals/resource-addressing.html.markdown
+++ b/website/docs/internals/resource-addressing.html.markdown
@@ -43,6 +43,10 @@ resource_type.resource_name[N]
    addressing a resource where `count > 1` means that the address references
    all instances.
 
+-> In Terraform v0.12 and later, a resource spec without a module path prefix
+matches only resources in the root module. In earlier versions, a resource spec
+without a module path prefix will match resources with the same type and name
+in any descendent module.
 
 ## Examples
 

--- a/website/docs/modules/composition.html.markdown
+++ b/website/docs/modules/composition.html.markdown
@@ -9,6 +9,12 @@ description: |-
 
 # Module Composition
 
+-> This section is written for **Terraform v0.12 or later**. The general patterns
+   described in this section _do_ apply to earlier versions, but the examples
+   shown are using v0.12-only syntax and features. For general information
+   on module usage in prior versions, see
+   [/docs/configuration-0-11/modules.html](the v0.11 documentation about modules).
+
 In a simple Terraform configuration with only one root module, we create a
 flat set of resources and use Terraform's expression syntax to describe the
 relationships between these resources:


### PR DESCRIPTION
We have released the v0.12-oriented content to the website early in order to support the beta process, but in some places we neglected to explicitly mark features or content as being v0.12-only.

Here we add explicit markers to the main cases we've seen where readers have reported confusion, along with some other tweaks in similar vein.
