### PR TITLE
lang: Consider "dynamic" blocks when resolving references

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20190315201941-956e03eb6dda
+	github.com/hashicorp/hcl2 v0.0.0-20190318232830-f9f92da699d8
 	github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
-github.com/hashicorp/hcl2 v0.0.0-20190315201941-956e03eb6dda h1:wgPsY2p0JDBRzc7fPEUidAhpXZzSPTIuSUDATOisbYs=
-github.com/hashicorp/hcl2 v0.0.0-20190315201941-956e03eb6dda/go.mod h1:HtEzazM5AZ9fviNEof8QZB4T1Vz9UhHrGhnMPzl//Ek=
+github.com/hashicorp/hcl2 v0.0.0-20190318232830-f9f92da699d8 h1:H4X4ZtK0svjPuIRh1NJttHjJyrB1d/3ArFA1GZbuy1o=
+github.com/hashicorp/hcl2 v0.0.0-20190318232830-f9f92da699d8/go.mod h1:HtEzazM5AZ9fviNEof8QZB4T1Vz9UhHrGhnMPzl//Ek=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 h1:2yzhWGdgQUWZUCNK+AoO35V+HTsgEmcM4J9IkArh7PI=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/lang/eval.go
+++ b/lang/eval.go
@@ -25,7 +25,7 @@ import (
 func (s *Scope) ExpandBlock(body hcl.Body, schema *configschema.Block) (hcl.Body, tfdiags.Diagnostics) {
 	spec := schema.DecoderSpec()
 
-	traversals := dynblock.ForEachVariablesHCLDec(body, spec)
+	traversals := dynblock.ExpandVariablesHCLDec(body, spec)
 	refs, diags := References(traversals)
 
 	ctx, ctxDiags := s.EvalContext(refs)

--- a/lang/references.go
+++ b/lang/references.go
@@ -1,8 +1,8 @@
 package lang
 
 import (
+	"github.com/hashicorp/hcl2/ext/dynblock"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/hcl2/hcldec"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/tfdiags"
@@ -52,7 +52,13 @@ func ReferencesInBlock(body hcl.Body, schema *configschema.Block) ([]*addrs.Refe
 		return nil, nil
 	}
 	spec := schema.DecoderSpec()
-	traversals := hcldec.Variables(body, spec)
+
+	// We use dynblock.VariablesHCLDec instead of hcldec.Variables here because
+	// when we evaluate a block we'll apply the HCL dynamic block extension
+	// expansion to it first, and so we need this specialized version in order
+	// to properly understand what the dependencies will be once expanded.
+	// Otherwise, we'd miss references that only occur inside dynamic blocks.
+	traversals := dynblock.VariablesHCLDec(body, spec)
 	return References(traversals)
 }
 

--- a/terraform/test-fixtures/graph-builder-plan-dynblock/dynblock.tf
+++ b/terraform/test-fixtures/graph-builder-plan-dynblock/dynblock.tf
@@ -1,0 +1,14 @@
+resource "test_thing" "a" {
+}
+
+resource "test_thing" "b" {
+}
+
+resource "test_thing" "c" {
+  dynamic "nested" {
+    for_each = test_thing.a.list
+    content {
+      foo = test_thing.b.id
+    }
+  }
+}

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/variables_hcldec.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/variables_hcldec.go
@@ -5,15 +5,25 @@ import (
 	"github.com/hashicorp/hcl2/hcldec"
 )
 
-// ForEachVariablesHCLDec is a wrapper around WalkForEachVariables that
-// uses the given hcldec specification to automatically drive the recursive
-// walk through nested blocks in the given body.
+// VariablesHCLDec is a wrapper around WalkVariables that uses the given hcldec
+// specification to automatically drive the recursive walk through nested
+// blocks in the given body.
 //
-// This provides more convenient access to all of the "for_each" and "labels"
-// dependencies in a body for applications that are already using hcldec
-// as a more convenient way to recursively decode body contents.
-func ForEachVariablesHCLDec(body hcl.Body, spec hcldec.Spec) []hcl.Traversal {
-	rootNode := WalkForEachVariables(body)
+// This is a drop-in replacement for hcldec.Variables which is able to treat
+// blocks of type "dynamic" in the same special way that dynblock.Expand would,
+// exposing both the variables referenced in the "for_each" and "labels"
+// arguments and variables used in the nested "content" block.
+func VariablesHCLDec(body hcl.Body, spec hcldec.Spec) []hcl.Traversal {
+	rootNode := WalkVariables(body)
+	return walkVariablesWithHCLDec(rootNode, spec)
+}
+
+// ExpandVariablesHCLDec is like VariablesHCLDec but it includes only the
+// minimal set of variables required to call Expand, ignoring variables that
+// are referenced only inside normal block contents. See WalkExpandVariables
+// for more information.
+func ExpandVariablesHCLDec(body hcl.Body, spec hcldec.Spec) []hcl.Traversal {
+	rootNode := WalkExpandVariables(body)
 	return walkVariablesWithHCLDec(rootNode, spec)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl2 v0.0.0-20190315201941-956e03eb6dda
+# github.com/hashicorp/hcl2 v0.0.0-20190318232830-f9f92da699d8
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec


### PR DESCRIPTION
The `hcldec` package has no awareness of the dynamic block extension, so the `hcldec.Variables` function misses any variables declared inside `dynamic` blocks.

`dynblock.VariablesHCLDec` is a drop-in replacement for `hcldec.Variables` that _is_ aware of dynamic blocks, returning all of the same variables that `hcldec` would find naturally plus also any variables used inside the dynamic block `for_each` and `labels` arguments and inside the nested `content` block.

This fixes #20517.
