### PR TITLE
(WIP) Allow undeclared vars

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -189,12 +189,13 @@ type Operation struct {
 
 	// The options below are more self-explanatory and affect the runtime
 	// behavior of the operation.
-	AutoApprove  bool
-	Destroy      bool
-	DestroyForce bool
-	Parallelism  int
-	Targets      []addrs.Targetable
-	Variables    map[string]UnparsedVariableValue
+	AutoApprove         bool
+	AllowUndeclaredVars bool
+	Destroy             bool
+	DestroyForce        bool
+	Parallelism         int
+	Targets             []addrs.Targetable
+	Variables           map[string]UnparsedVariableValue
 
 	// Input/output/control options.
 	UIIn  terraform.UIInput

--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -136,13 +136,15 @@ func (b *Local) contextDirect(op *backend.Operation, opts terraform.ContextOpts)
 	}
 	opts.Config = config
 
-	variables, varDiags := backend.ParseVariableValues(op.Variables, config.Module.Variables)
-	diags = diags.Append(varDiags)
+	if !op.AllowUndeclaredVars {
+		variables, varDiags := backend.ParseVariableValues(op.Variables, config.Module.Variables)
+		diags = diags.Append(varDiags)
+		if op.Variables != nil {
+			opts.Variables = variables
+		}
+	}
 	if diags.HasErrors() {
 		return nil, nil, diags
-	}
-	if op.Variables != nil {
-		opts.Variables = variables
 	}
 
 	tfCtx, ctxDiags := terraform.NewContext(&opts)

--- a/command/apply.go
+++ b/command/apply.go
@@ -27,7 +27,7 @@ type ApplyCommand struct {
 }
 
 func (c *ApplyCommand) Run(args []string) int {
-	var destroyForce, refresh, autoApprove bool
+	var destroyForce, refresh, autoApprove, allowUndeclaredVars bool
 	args, err := c.Meta.process(args, true)
 	if err != nil {
 		return 1
@@ -50,6 +50,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
+	cmdFlags.BoolVar(&allowUndeclaredVars, "allow-undeclared-vars", false, "allow-undeclared-vars")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -180,6 +181,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	opReq.ConfigDir = configPath
 	opReq.Destroy = c.Destroy
 	opReq.DestroyForce = destroyForce
+	opReq.AllowUndeclaredVars = allowUndeclaredVars
 	opReq.PlanFile = planFile
 	opReq.PlanRefresh = refresh
 	opReq.Type = backend.OperationTypeApply

--- a/command/plan.go
+++ b/command/plan.go
@@ -17,7 +17,7 @@ type PlanCommand struct {
 }
 
 func (c *PlanCommand) Run(args []string) int {
-	var destroy, refresh, detailed bool
+	var destroy, refresh, detailed, allowUndeclaredVars bool
 	var outPath string
 
 	args, err := c.Meta.process(args, true)
@@ -34,6 +34,7 @@ func (c *PlanCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&detailed, "detailed-exitcode", false, "detailed-exitcode")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
+	cmdFlags.BoolVar(&allowUndeclaredVars, "allow-undeclared-vars", false, "allow-undeclared-vars")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -96,6 +97,7 @@ func (c *PlanCommand) Run(args []string) int {
 	opReq := c.Operation(b)
 	opReq.ConfigDir = configPath
 	opReq.Destroy = destroy
+	opReq.AllowUndeclaredVars = allowUndeclaredVars
 	opReq.PlanRefresh = refresh
 	opReq.PlanOutPath = outPath
 	opReq.PlanRefresh = refresh


### PR DESCRIPTION
* https://github.com/hashicorp/terraform/issues/19424

This adds the flag `-allow-undeclared-vars` which skips the parsing of
variables, which would otherwise generate an Error/Warning when a `-var`
is passed to `apply`/`plan` without being defined in a variable block

Without flag:
```
$ terraform plan -var foo=bar
Error: Value for undeclared variable

A variable named "foo" was assigned on the command line, but the root module
does not declare a variable of that name. To use this value, add a "variable"
block to the configuration.
```

With flag:
```
$ terraform apply -var foo=bar -allow-undeclared-vars

Refreshing Terraform state in-memory prior to plan...
...
```