### PR TITLE
command/format: Don't panic when item removed from list of objects

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -1067,7 +1067,7 @@ func ctySequenceDiff(old, new []cty.Value) []*plans.Change {
 	var oldI, newI, lcsI int
 	for oldI < len(old) || newI < len(new) || lcsI < len(lcs) {
 		for oldI < len(old) && (lcsI >= len(lcs) || !old[oldI].RawEquals(lcs[lcsI])) {
-			isObjectDiff := old[oldI].Type().IsObjectType() && new[newI].Type().IsObjectType()
+			isObjectDiff := old[oldI].Type().IsObjectType() && (newI >= len(new) || new[newI].Type().IsObjectType())
 			if isObjectDiff && newI < len(new) {
 				ret = append(ret, &plans.Change{
 					Action: plans.Update,

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -761,7 +761,7 @@ func TestResourceChange_JSON(t *testing.T) {
     }
 `,
 		},
-		"JSON list of objects": {
+		"JSON list of objects - adding item": {
 			Action: plans.Update,
 			Mode:   addrs.ManagedResourceMode,
 			Before: cty.ObjectVal(map[string]cty.Value{
@@ -790,6 +790,41 @@ func TestResourceChange_JSON(t *testing.T) {
                 },
               + {
                   + two = "222"
+                },
+            ]
+        )
+    }
+`,
+		},
+		"JSON list of objects - removing item": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.StringVal("i-02ae66f368e8518a9"),
+				"json_field": cty.StringVal(`[{"one": "111"}, {"two": "222"}]`),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.UnknownVal(cty.String),
+				"json_field": cty.StringVal(`[{"one": "111"}]`),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":         {Type: cty.String, Optional: true, Computed: true},
+					"json_field": {Type: cty.String, Optional: true},
+				},
+			},
+			RequiredReplace: cty.NewPathSet(),
+			Tainted:         false,
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ [
+                {
+                    one = "111"
+                },
+              - {
+                  - two = "222"
                 },
             ]
         )


### PR DESCRIPTION
Due to these tests happening in the wrong order, removing an object from the end of a sequence of objects would previously cause a bounds-check panic.

Rather than a more severe rework of the logic here, for now we'll just introduce an extra precondition to prevent the panic. The code that follows already handles the case where there _is_ no new object (i.e. the "old" object is being deleted) as long as we're able to pass through this type-checking logic.

The new "JSON list of objects - removing item" test covers this problem by rendering a diff for an object being removed from the end of a list of objects within a JSON value.

This fixes #20750.
