### PR TITLE
vendor: go get github.com/zclconf/go-cty/cty@master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/xanzy/ssh-agent v0.2.1
 	github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 // indirect
 	github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
-	github.com/zclconf/go-cty v0.0.0-20190201220620-4ca19710f056
+	github.com/zclconf/go-cty v0.0.0-20190320224746-fd76348b9329
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -399,8 +399,8 @@ github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6Ut
 github.com/zclconf/go-cty v0.0.0-20181129180422-88fbe721e0f8/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9 h1:hHCAGde+QfwbqXSAqOmBd4NlOrJ6nmjWp+Nu408ezD4=
 github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
-github.com/zclconf/go-cty v0.0.0-20190201220620-4ca19710f056 h1:C6LhH3JHz2k6tnw5sYXBc8rD8SD/qFp6EhiZAcVyalk=
-github.com/zclconf/go-cty v0.0.0-20190201220620-4ca19710f056/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+github.com/zclconf/go-cty v0.0.0-20190320224746-fd76348b9329 h1:ne520NlvoncW5zfBGkmP4EJhyd6ruSaSyhzobv0Vz9w=
+github.com/zclconf/go-cty v0.0.0-20190320224746-fd76348b9329/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=

--- a/vendor/github.com/zclconf/go-cty/cty/convert/unify.go
+++ b/vendor/github.com/zclconf/go-cty/cty/convert/unify.go
@@ -200,8 +200,7 @@ func unifyObjectTypesToMap(types []cty.Type, unsafe bool) (cty.Type, []Conversio
 			conversions[i] = GetConversion(ty, retTy)
 		}
 		if conversions[i] == nil {
-			// Shouldn't be reachable, since we were able to unify
-			return unifyObjectTypesToMap(types, unsafe)
+			return cty.NilType, nil
 		}
 	}
 	return retTy, conversions

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -434,7 +434,7 @@ github.com/vmihailenco/msgpack/codes
 github.com/xanzy/ssh-agent
 # github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
 github.com/xlab/treeprint
-# github.com/zclconf/go-cty v0.0.0-20190201220620-4ca19710f056
+# github.com/zclconf/go-cty v0.0.0-20190320224746-fd76348b9329
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/convert


### PR DESCRIPTION
This includes a fix to prevent unintentional infinite recursion when trying to unify multiple object types to a single type for conversion to `list(any)`.

Sadly I wasn't able to reproduce the problem as reported (in #20728), so therefore I wasn't able to write a Terraform test for it, but I have confirmed that the cty behavior here was incorrect anyway (recursively
calling the same function we're already in with the same arguments is clearly not productive) and so this change will allow whatever situation that was to terminate with a type conversion error, rather than causing a stack overflow.

It's likely that there is another bug lurking under this, since the problematic code here was supposed to be unreachable, but avoiding the crash is the priority for now. If the problem re-surfaces then it should
at least be an error message with some additional context about what the goal of the caller was.

This also includes an unrelated fix for the gocty package, which doesn't affect Terraform because it makes very little use of that package.

This should fix #20728 by replacing the panic with a proper type conversion error.