### PR TITLE
plugin/discovery: verify registry checksum

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -532,6 +532,11 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 				case err == discovery.ErrorNoVersionCompatible:
 					// Generic version incompatible msg
 					c.Ui.Error(fmt.Sprintf(errProviderIncompatible, provider, constraint))
+				case err == discovery.ErrorSignatureVerification:
+					c.Ui.Error(fmt.Sprintf(errSignatureVerification, provider))
+				case err == discovery.ErrorChecksumVerification,
+					err == discovery.ErrorMissingChecksumVerification:
+					c.Ui.Error(fmt.Sprintf(errChecksumVerification, provider))
 				default:
 					c.Ui.Error(fmt.Sprintf(errProviderInstallError, provider, err.Error(), DefaultPluginVendorDir))
 				}
@@ -928,7 +933,7 @@ const errProviderInstallError = `
 
 Terraform analyses the configuration and state and automatically downloads
 plugins for the providers used. However, when attempting to download this
-plugin an unexpected error occured.
+plugin an unexpected error occurred.
 
 This may be caused if for some reason Terraform is unable to reach the
 plugin repository. The repository may be unreachable if access is blocked
@@ -958,4 +963,19 @@ and placing the plugin's executable file in one of the directories given in
 by -plugin-dir on the command line, or in the following directory if custom
 plugin directories are not set:
     %[2]s
+`
+
+const errChecksumVerification = `
+[reset][bold][red]Error verifying checksum for provider %[1]q[reset][red]
+The checksum for provider distribution from the Terraform Registry
+did not match the source. This may mean that the distributed files
+were changed after this version was released to the Registry.
+`
+
+const errSignatureVerification = `
+[reset][bold][red]Error verifying GPG signature for provider %[1]q[reset][red]
+Terraform was unable to verify the GPG signature of the downloaded provider
+files using the keys downloaded from the Terraform Registry. This may mean that
+the publisher of the provider removed the key it was signed with, or that the
+distributed files were changed after this version was released.
 `

--- a/plugin/discovery/error.go
+++ b/plugin/discovery/error.go
@@ -35,6 +35,22 @@ const ErrorNoSuchProvider = Error("no provider exists with the given name")
 // requested platform
 const ErrorNoVersionCompatibleWithPlatform = Error("no available version is compatible for the requested platform")
 
+// ErrorMissingChecksumVerification indicates that either the provider
+// distribution is missing the SHA256SUMS file or the checksum file does
+// not contain a checksum for the binary plugin
+const ErrorMissingChecksumVerification = Error("unable to verify checksum")
+
+// ErrorChecksumVerification indicates that the current checksum of the
+// provider plugin has changed since the initial release and is not trusted
+// to download
+const ErrorChecksumVerification = Error("unexpected plugin checksum")
+
+// ErrorSignatureVerification indicates that the digital signature for a
+// provider distribution could not be verified for one of the following
+// reasons: missing signature file, missing public key, or the signature
+// was not signed by any known key for the publisher
+const ErrorSignatureVerification = Error("unable to verify signature")
+
 func (err Error) Error() string {
 	return string(err)
 }

--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -211,6 +211,16 @@ func (i *ProviderInstaller) Get(provider string, req Constraints) (PluginMeta, t
 	providerURL := downloadURLs.DownloadURL
 
 	if !i.SkipVerify {
+		// Terraform verifies the integrity of a provider release before downloading
+		// the plugin binary. The digital signature (SHA256SUMS.sig) on the
+		// release distribution (SHA256SUMS) is verified with the public key of the
+		// publisher provided in the Terraform Registry response, ensuring that
+		// everything is as intended by the publisher. The checksum of the provider
+		// plugin is expected in the SHA256SUMS file and is double checked to match
+		// the checksum of the original published release to the Registry. This
+		// enforces immutability of releases between the Registry and the plugin's
+		// host location. Lastly, the integrity of the binary is verified upon
+		// download matches the Registry and signed checksum.
 		sha256, err := i.getProviderChecksum(downloadURLs)
 		if err != nil {
 			return PluginMeta{}, diags, err

--- a/plugin/discovery/signature.go
+++ b/plugin/discovery/signature.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"bytes"
-	"log"
 	"strings"
 
 	"golang.org/x/crypto/openpgp"
@@ -13,7 +12,7 @@ import (
 func verifySig(data, sig []byte, armor string) (*openpgp.Entity, error) {
 	el, err := openpgp.ReadArmoredKeyRing(strings.NewReader(armor))
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	return openpgp.CheckDetachedSignature(el, bytes.NewReader(data), bytes.NewReader(sig))


### PR DESCRIPTION
* Forces immutability of providers between the Registry and the hosting location
* Improves the verification error messages during provider discovery.

Below are screenshots of checksum and signature error messages 
![image](https://user-images.githubusercontent.com/6362111/54779421-1eedb680-4be5-11e9-801c-57b5e973f97f.png)

![image](https://user-images.githubusercontent.com/6362111/54779908-63c61d00-4be6-11e9-9ab9-e85c5a3d8852.png)
