### PR TITLE
helper/schema: Schema.SkipCoreTypeCheck flag

### DIFF
--- a/builtin/providers/test/resource_config_mode.go
+++ b/builtin/providers/test/resource_config_mode.go
@@ -27,6 +27,21 @@ func testResourceConfigMode() *schema.Resource {
 					},
 				},
 			},
+			"resource_as_attr_dynamic": {
+				Type:              schema.TypeList,
+				ConfigMode:        schema.SchemaConfigModeAttr,
+				SkipCoreTypeCheck: true,
+				Optional:          true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"foo": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "default",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -37,13 +52,14 @@ func testResourceConfigModeCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func testResourceConfigModeRead(d *schema.ResourceData, meta interface{}) error {
-	const k = "resource_as_attr"
-	if l, ok := d.Get(k).([]interface{}); !ok {
-		return fmt.Errorf("%s should appear as []interface{}, not %T", k, l)
-	} else {
-		for i, item := range l {
-			if _, ok := item.(map[string]interface{}); !ok {
-				return fmt.Errorf("%s[%d] should appear as map[string]interface{}, not %T", k, i, item)
+	for _, k := range []string{"resource_as_attr", "resource_as_attr_dynamic"} {
+		if l, ok := d.Get(k).([]interface{}); !ok {
+			return fmt.Errorf("%s should appear as []interface{}, not %T", k, l)
+		} else {
+			for i, item := range l {
+				if _, ok := item.(map[string]interface{}); !ok {
+					return fmt.Errorf("%s[%d] should appear as map[string]interface{}, not %T", k, i, item)
+				}
 			}
 		}
 	}

--- a/builtin/providers/test/resource_config_mode_test.go
+++ b/builtin/providers/test/resource_config_mode_test.go
@@ -23,12 +23,22 @@ resource "test_resource_config_mode" "foo" {
 			foo = "resource_as_attr 1"
 		},
 	]
+	resource_as_attr_dynamic = [
+		{
+			foo = "resource_as_attr_dynamic 0"
+		},
+		{
+		},
+	]
 }
 				`),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.#", "2"),
 					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.0.foo", "resource_as_attr 0"),
 					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.1.foo", "resource_as_attr 1"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr_dynamic.#", "2"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr_dynamic.0.foo", "resource_as_attr_dynamic 0"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr_dynamic.1.foo", "default"),
 				),
 			},
 			resource.TestStep{
@@ -39,21 +49,39 @@ resource "test_resource_config_mode" "foo" {
 			foo = "resource_as_attr 0 updated"
 		},
 	]
+	resource_as_attr_dynamic = [
+		{
+		},
+	]
 }
 				`),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.#", "1"),
 					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.0.foo", "resource_as_attr 0 updated"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr_dynamic.#", "1"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr_dynamic.0.foo", "default"),
 				),
 			},
 			resource.TestStep{
 				Config: strings.TrimSpace(`
 resource "test_resource_config_mode" "foo" {
 	resource_as_attr = []
+	resource_as_attr_dynamic = []
 }
 				`),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.#", "0"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr_dynamic.#", "0"),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_config_mode" "foo" {
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("test_resource_config_mode.foo", "resource_as_attr.#"),
+					resource.TestCheckNoResourceAttr("test_resource_config_mode.foo", "resource_as_attr_dynamic.#"),
 				),
 			},
 		},

--- a/helper/schema/core_schema_test.go
+++ b/helper/schema/core_schema_test.go
@@ -445,6 +445,28 @@ func TestSchemaMapCoreConfigSchema(t *testing.T) {
 				BlockTypes: map[string]*configschema.NestedBlock{},
 			}),
 		},
+		"skip core type check": {
+			map[string]*Schema{
+				"list": {
+					Type:              TypeList,
+					ConfigMode:        SchemaConfigModeAttr,
+					SkipCoreTypeCheck: true,
+					Optional:          true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{},
+					},
+				},
+			},
+			testResource(&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"list": {
+						Type:     cty.DynamicPseudoType,
+						Optional: true, // Just so we can progress to provider-driven validation and return the error there
+					},
+				},
+				BlockTypes: map[string]*configschema.NestedBlock{},
+			}),
+		},
 	}
 
 	for name, test := range tests {

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -95,6 +95,34 @@ type Schema struct {
 	// behavior, and SchemaConfigModeBlock is not permitted.
 	ConfigMode SchemaConfigMode
 
+	// SkipCoreTypeCheck, if set, will advertise this attribute to Terraform Core
+	// has being dynamically-typed rather than deriving a type from the schema.
+	// This has the effect of making Terraform Core skip all type-checking of
+	// the value, and thus leaves all type checking up to a combination of this
+	// SDK and the provider's own code.
+	//
+	// This flag does nothing for Terraform versions prior to v0.12, because
+	// in prior versions there was no Core-side typecheck anyway.
+	//
+	// The most practical effect of this flag is to allow object-typed schemas
+	// (specified with Elem: schema.Resource) to pass through Terraform Core
+	// even without all of the object type attributes specified, which may be
+	// useful when using ConfigMode: SchemaConfigModeAttr to achieve
+	// nested-block-like behaviors while using attribute syntax.
+	//
+	// However, by doing so we require type information to be sent and stored
+	// per-object rather than just once statically in the schema, and so this
+	// will change the wire serialization of a resource type in state. Changing
+	// the value of SkipCoreTypeCheck will therefore require a state migration
+	// if there has previously been any release of the provider compatible with
+	// Terraform v0.12.
+	//
+	// SkipCoreTypeCheck can only be set when ConfigMode is SchemaConfigModeAttr,
+	// because nested blocks cannot be decoded by Terraform Core without at
+	// least shallow information about the next level of nested attributes and
+	// blocks.
+	SkipCoreTypeCheck bool
+
 	// If one of these is set, then this item can come from the configuration.
 	// Both cannot be set. If Optional is set, the value is optional. If
 	// Required is set, the value is required.
@@ -719,6 +747,8 @@ func (m schemaMap) internalValidate(topSchemaMap schemaMap, attrsOnly bool) erro
 
 		computedOnly := v.Computed && !v.Optional
 
+		isBlock := false
+
 		switch v.ConfigMode {
 		case SchemaConfigModeBlock:
 			if _, ok := v.Elem.(*Resource); !ok {
@@ -730,17 +760,25 @@ func (m schemaMap) internalValidate(topSchemaMap schemaMap, attrsOnly bool) erro
 			if computedOnly {
 				return fmt.Errorf("%s: ConfigMode of block cannot be used for computed schema", k)
 			}
+			isBlock = true
 		case SchemaConfigModeAttr:
 			// anything goes
 		case SchemaConfigModeAuto:
 			// Since "Auto" for Elem: *Resource would create a nested block,
 			// and that's impossible inside an attribute, we require it to be
 			// explicitly overridden as mode "Attr" for clarity.
-			if _, ok := v.Elem.(*Resource); ok && attrsOnly {
-				return fmt.Errorf("%s: in *schema.Resource with ConfigMode of attribute, so must also have ConfigMode of attribute", k)
+			if _, ok := v.Elem.(*Resource); ok {
+				isBlock = true
+				if attrsOnly {
+					return fmt.Errorf("%s: in *schema.Resource with ConfigMode of attribute, so must also have ConfigMode of attribute", k)
+				}
 			}
 		default:
 			return fmt.Errorf("%s: invalid ConfigMode value", k)
+		}
+
+		if isBlock && v.SkipCoreTypeCheck {
+			return fmt.Errorf("%s: SkipCoreTypeCheck must be false unless ConfigMode is attribute", k)
 		}
 
 		if v.Computed && v.Default != nil {


### PR DESCRIPTION
When running in v0.12-and-higher mode, this will cause the SDK to report the type of the attribute as `any`, effectively skipping type checking on the Core side altogether and checking only in the SDK and provider code.

The practical impact of this is to restore the v0.11-style checking behavior of allowing object values to be missing certain attributes as long as they are marked as optional in the schema. The SDK can do this
because it uses a unified schema model for both object values and nested blocks, while Terraform Core only supports the idea of "optional" when talking about attributes in nested blocks.

This is a continuation of the pile of workarounds that also includes the `ConfigMode` and `AsSingle` fields, allowing providers to selectively opt out of some new v0.12 behaviors in situations where they conflict with
decisions made in the design of the providers in our old world where Terraform Core delegated _all_ validation to providers.

This is designed as an opt-in so that we can limit its impact only to specific cases where it's needed and minimize the risk of regressions elsewhere. Providers should use this sparingly only in situations where
prevailing usage disagrees with the new expectations of Terraform Core in v0.12.

---

So far I've not extensively tested this with any real-world providers aside from simple situations, but for review of this PR I'd like to focus mainly on whether this change lives up to its goal of making no change at all for resources that don't use this feature (minimizing risk of regressions for already-working resource types), and then based on testing against real providers I'll make subsequent PRs to further refine the behavior as we find the inevitable edge cases.

The main "architectural" change here is that whereas before we had only a single schema used by both core and the SDK, we can now send a different (less-precise) schema to Terraform Core when this flag is used, while still constructing the fully-accurate schema on the SDK side for use in our shims. This means that every use of the schema in the `grpc_provider.go` file needed a decision of which was appropriate, for which I used the following rules of thumb:

* If it's related to msgpack encoding for the wire protocol, we must use the schema as Core would see it, since the wire messages are created or consumed by Terraform Core.
* If it's related to translating data from new to old data structures or back then we must use the "for shimming" SDK-oriented schema.
* (We also previously introduced another variant of schema that ignores `AsSingle` used in exactly one place, and that is still there and unchanged from before; that third schema is itself a modification of the SDK-oriented schema.)

---

As with the other similar changes of this type, once this is approved and merged I'll also cherry-pick the first commit in this series into the v0.11 branch so that providers using this feature can still compile against the v0.11 SDK, where this setting does nothing because v0.11 _had_ no core-side type checking.
