### PR TITLE
website: Update options for graph command

### DIFF
--- a/website/docs/commands/graph.html.markdown
+++ b/website/docs/commands/graph.html.markdown
@@ -37,11 +37,10 @@ Options:
                       This helps when diagnosing cycle errors.
 
 * `-module-depth=n` - Specifies the depth of modules to show in the output.
-                      By default this is -1, which will expand all.
+                      By default this is `-1`, which will expand all.
 
-* `-no-color`       - If specified, output won't contain any color.
-
-* `-type=plan`      - Type of graph to output. Can be: plan, plan-destroy, apply, legacy.
+* `-type=plan`      - Type of graph to output. Can be: `plan`, `plan-destroy`, `apply`,
+                      `validate`, `input`, `refresh`.
 
 ## Generating Images
 


### PR DESCRIPTION
'legacy' doesn't seem to be a thing anymore, and we were missing some
of the other values for -type. Also -no-color doesn't seem to be
relevant to this command.