### PR TITLE
helper/schema: InternalValidate to reject Optional+Computed blocks

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -781,6 +781,10 @@ func (m schemaMap) internalValidate(topSchemaMap schemaMap, attrsOnly bool) erro
 			return fmt.Errorf("%s: SkipCoreTypeCheck must be false unless ConfigMode is attribute", k)
 		}
 
+		if isBlock && v.Computed && v.Optional {
+			return fmt.Errorf("%s: nested block cannot be both Computed and Optional; consider unsetting Computed and exporting defaults in a separate attribute, or use ConfigMode: SchemaConfigModeAttr to force attribute syntax so that both unset and empty can be represented", k)
+		}
+
 		if v.Computed && v.Default != nil {
 			return fmt.Errorf("%s: Default must be nil if computed", k)
 		}

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3986,6 +3986,45 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			},
 			true, // Unexpected error occurred: block: MaxItems and MinItems are only supported on lists or sets
 		},
+
+		"Optional+Computed nested block": {
+			map[string]*Schema{
+				"block": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"sub": &Schema{
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			true, // nested block cannot be both Computed and Optional
+		},
+
+		"Optional+Computed nested resource as attribute": {
+			map[string]*Schema{
+				"block": &Schema{
+					Type:       TypeString,
+					ConfigMode: SchemaConfigModeAttr,
+					Optional:   true,
+					Computed:   true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"sub": &Schema{
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			false, // Optional+Computed is fine in attribute mode
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
When `Optional`+`Computed` is used on a nested block it seems to most commonly be done under the assumption that if no blocks are specified at all then the provider will create some default ones.

In several cases providers then relied on the fact that Terraform would previously allow attribute syntax to be used with nested blocks to provide an unintended way to override those defaults and request that no objects be created at all, but Terraform v0.12 fixed that validation bug and thus broke the workaround the providers were relying on.

We've added some opt-in settings to schemas to allow providers to tweak the way the v0.12 provider shims behave to make different tradeoffs, with the intent of applying these selectively as needed, but since we want to track all of these situations down before providers make their initial v0.12-compatible releases (to avoid breaking changes later) we're going to make such schemas fail `InternalValidate` when tested against the latest SDK and use that to ensure that no cases are missed.