### PR TITLE
remove overly restrictive if-statement

### DIFF
--- a/backend/remote-state/azure/backend.go
+++ b/backend/remote-state/azure/backend.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -203,10 +202,6 @@ func (b *Backend) configure(ctx context.Context) error {
 	armClient, err := buildArmClient(config)
 	if err != nil {
 		return err
-	}
-
-	if config.AccessKey == "" && config.SasToken == "" && config.ResourceGroupName == "" {
-		return fmt.Errorf("Either an Access Key / SAS Token or the Resource Group for the Storage Account must be specified")
 	}
 
 	b.armClient = armClient


### PR DESCRIPTION
I've been trying to use the azurerm state backend with Azure CLI to no avail with terraform v0.11.13.

I've documented my conclusions on a related issue in https://github.com/hashicorp/terraform/issues/18325#issuecomment-475310867

After more investigation and some `git blame` commands, I've traced down the introduction of the problem to PR https://github.com/hashicorp/terraform/pull/19465

The PR simply toggles the feature flag for Azure CLI support, relying on the implementation of github.com/hashicorp/go-azure-helpers/authentication which has proven its worth in the azure terraform provider.

However, there is a (legacy?) dragon lurking in the code in the form of the following if-statement:

```
	if config.AccessKey == "" && config.SasToken == "" && config.ResourceGroupName == "" {	
		return fmt.Errorf("Either an Access Key / SAS Token or the Resource Group for the Storage Account must be specified")	
	}
```

This if-statement prevents usage of the Azure CLI as an authentication method, since in that case you would only provide the `storage_account_name`, `container_name` and `key`. That obviously does not satisfy the above condition.

I can't find any evidence that the changes in that PR were verified/tested manually, and there also aren't my automated tests that cover Azure CLI usage with the azurerm state backend.

I'm inclined to think the if-statement should simply be removed. All tests still pass after removing it.