### PR TITLE
core: fix crash loading manifests with Windows paths

### DIFF
--- a/config/module/storage_test.go
+++ b/config/module/storage_test.go
@@ -52,6 +52,57 @@ func TestGetModule(t *testing.T) {
 	}
 }
 
+func TestManifestLoad_allLinux(t *testing.T) {
+	server := test.Registry()
+	defer server.Close()
+	disco := test.Disco(server)
+
+	storage := NewStorage("test-fixtures/manifest-load/linux-paths", disco)
+
+	manifest, err := storage.loadManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(manifest.Modules) != 2 {
+		t.Fatalf("expected 2 modules, got %+v", manifest.Modules)
+	}
+}
+
+func TestManifestLoad_allWindows(t *testing.T) {
+	server := test.Registry()
+	defer server.Close()
+	disco := test.Disco(server)
+
+	storage := NewStorage("test-fixtures/manifest-load/windows-paths", disco)
+
+	manifest, err := storage.loadManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(manifest.Modules) != 0 {
+		t.Fatalf("expected no modules, got %+v", manifest.Modules)
+	}
+}
+
+func TestManifestLoad_windowsAndLinux(t *testing.T) {
+	server := test.Registry()
+	defer server.Close()
+	disco := test.Disco(server)
+
+	storage := NewStorage("test-fixtures/manifest-load/windows-linux", disco)
+
+	manifest, err := storage.loadManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(manifest.Modules) != 2 {
+		t.Fatalf("expected 2 modules, got %+v", manifest.Modules)
+	}
+}
+
 // GitHub archives always contain the module source in a single subdirectory,
 // so the registry will return a path with with a `//*` suffix. We need to make
 // sure this doesn't intefere with our internal handling of `//` subdir.

--- a/config/module/test-fixtures/manifest-load/linux-paths/modules.json
+++ b/config/module/test-fixtures/manifest-load/linux-paths/modules.json
@@ -1,0 +1,19 @@
+{
+    "Modules": [
+        {
+            "Source": "./childC",
+            "Key": "1.childC;./childC",
+            "Version": "",
+            "Dir": ".terraform/modules/a34dacd2c3ffa3a6826b24bc1fdbab34",
+            "Root": ""
+        },
+        {
+            "Source": "./childD",
+            "Key": "1.childD;./childD",
+            "Version": "",
+            "Dir": ".terraform/modules/fbb2lcahc331b9da421bb4b91f341aa8",
+            "Root": ""
+        }
+    ]
+}
+

--- a/config/module/test-fixtures/manifest-load/windows-linux/modules.json
+++ b/config/module/test-fixtures/manifest-load/windows-linux/modules.json
@@ -1,0 +1,33 @@
+{
+    "Modules": [
+        {
+            "Source": "./childA",
+            "Key": "1.childA;./childA",
+            "Version": "",
+            "Dir": ".terraform\\modules\\6c0f4cd1c1eff966826020bc1fdb9a00",
+            "Root": ""
+        },
+        {
+            "Source": "./childB",
+            "Key": "1.childB;./childB",
+            "Version": "",
+            "Dir": ".terraform\\modules\\4c1f3cd1c1eff96a82b020bc1fdb6c28",
+            "Root": ""
+        },
+        {
+            "Source": "./childC",
+            "Key": "1.childC;./childC",
+            "Version": "",
+            "Dir": ".terraform/modules/a34dacd2c3ffa3a6826b24bc1fdbab34",
+            "Root": ""
+        },
+        {
+            "Source": "./childD",
+            "Key": "1.childD;./childD",
+            "Version": "",
+            "Dir": ".terraform/modules/fbb2lcahc331b9da421bb4b91f341aa8",
+            "Root": ""
+        }
+    ]
+}
+

--- a/config/module/test-fixtures/manifest-load/windows-paths/modules.json
+++ b/config/module/test-fixtures/manifest-load/windows-paths/modules.json
@@ -1,0 +1,19 @@
+{
+    "Modules": [
+        {
+            "Source": "./childA",
+            "Key": "1.childA;./childA",
+            "Version": "",
+            "Dir": ".terraform\\modules\\6c0f4cd1c1eff966826020bc1fdb9a00",
+            "Root": ""
+        },
+        {
+            "Source": "./childB",
+            "Key": "1.childB;./childB",
+            "Version": "",
+            "Dir": ".terraform\\modules\\4c1f3cd1c1eff96a82b020bc1fdb6c28",
+            "Root": ""
+        }
+    ]
+}
+


### PR DESCRIPTION
This commit fixes #20712 by properly filtering out any modules that are still using Windows path separators in the modules manifest.