### PR TITLE
command/show: refresh is required to show remote state

### DIFF
--- a/command/show.go
+++ b/command/show.go
@@ -263,6 +263,10 @@ func getStateFromEnv(b backend.Backend, env string) (*statefile.File, error) {
 		return nil, fmt.Errorf("Failed to load state manager: %s", err)
 	}
 
+	if err := stateStore.RefreshState(); err != nil {
+		return nil, fmt.Errorf("Failed to load state: %s", err)
+	}
+
 	sf := statemgr.Export(stateStore)
 
 	return sf, nil


### PR DESCRIPTION
Reverting a change that slipped in #20557: the `refresh` step is required to `show` resources in remote state.

Fixes #20642

Any pointers on testing with remote state greatly appreciated - I'd like to avoid another regression.