### PR TITLE
Add force new resource caption when just showing new value

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -253,6 +253,9 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 		switch {
 		case showJustNew:
 			p.writeValue(new, action, indent+2)
+			if p.pathForcesNewResource(path) {
+				p.buf.WriteString(p.color.Color(forcesNewResourceCaption))
+			}
 		default:
 			// We show new even if it is null to emphasize the fact
 			// that it is being unset, since otherwise it is easy to

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -334,6 +334,34 @@ new line
 			Mode:   addrs.ManagedResourceMode,
 			Before: cty.ObjectVal(map[string]cty.Value{
 				"name":   cty.StringVal("name"),
+				"forced": cty.NullVal(cty.String),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"name":   cty.StringVal("name"),
+				"forced": cty.StringVal("example"),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"name":   {Type: cty.String, Optional: true},
+					"forced": {Type: cty.String, Optional: true},
+				},
+			},
+			RequiredReplace: cty.NewPathSet(cty.Path{
+				cty.GetAttrStep{Name: "forced"},
+			}),
+			Tainted: false,
+			ExpectedOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      + forced = "example" # forces replacement
+        name   = "name"
+    }
+`,
+		},
+		"force replacement with empty before value legacy": {
+			Action: plans.DeleteThenCreate,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"name":   cty.StringVal("name"),
 				"forced": cty.StringVal(""),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -329,6 +329,34 @@ new line
     }
 `,
 		},
+		"force replacement with empty before value": {
+			Action: plans.DeleteThenCreate,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"name":   cty.StringVal("name"),
+				"forced": cty.StringVal(""),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"name":   cty.StringVal("name"),
+				"forced": cty.StringVal("example"),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"name":   {Type: cty.String, Optional: true},
+					"forced": {Type: cty.String, Optional: true},
+				},
+			},
+			RequiredReplace: cty.NewPathSet(cty.Path{
+				cty.GetAttrStep{Name: "forced"},
+			}),
+			Tainted: false,
+			ExpectedOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      + forced = "example" # forces replacement
+        name   = "name"
+    }
+`,
+		},
 	}
 
 	runTestCases(t, testCases)


### PR DESCRIPTION
This PR includes a possible fix for issue #20381 

There was no check if a force new resource is needed when just adding the new value in the plan, this could solve that, but there might be better ways to do this