### PR TITLE
lang/eval: Apply attr-as-nested-block fixup in EvalBlock

### DIFF
--- a/builtin/providers/test/resource_config_mode_test.go
+++ b/builtin/providers/test/resource_config_mode_test.go
@@ -44,6 +44,41 @@ resource "test_resource_config_mode" "foo" {
 			resource.TestStep{
 				Config: strings.TrimSpace(`
 resource "test_resource_config_mode" "foo" {
+	# Due to a preprocessing fixup we do in lang.EvalBlock, it's allowed
+	# to specify resource_as_attr members using one or more nested blocks
+	# instead of attribute syntax, if desired. This should be equivalent
+	# to the previous config.
+	#
+	# This allowance is made for backward-compatibility with existing providers
+	# before Terraform v0.12 that were expecting nested block types to also
+	# support attribute syntax; it should not be used for any new use-cases.
+	resource_as_attr {
+		foo = "resource_as_attr 0"
+	}
+	resource_as_attr {
+		foo = "resource_as_attr 1"
+	}
+	resource_as_attr_dynamic = [
+		{
+			foo = "resource_as_attr_dynamic 0"
+		},
+		{
+		},
+	]
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.#", "2"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.0.foo", "resource_as_attr 0"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.1.foo", "resource_as_attr 1"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr_dynamic.#", "2"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr_dynamic.0.foo", "resource_as_attr_dynamic 0"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr_dynamic.1.foo", "default"),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_config_mode" "foo" {
 	resource_as_attr = [
 		{
 			foo = "resource_as_attr 0 updated"

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20190318232830-f9f92da699d8
+	github.com/hashicorp/hcl2 v0.0.0-20190327223817-3fb4ed0d9260
 	github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,6 @@ github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c/go.mod h1:ahL
 github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104 h1:9iQ/zrTOJqzP+kH37s6xNb6T1RysiT7fnDD3DJbspVw=
-github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-plugin v0.0.0-20190322172744-52e1c4730856 h1:FHiCaU46W1WoqApsaGGIKbNkhQ6v71hJrOf2INQMLUo=
 github.com/hashicorp/go-plugin v0.0.0-20190322172744-52e1c4730856/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-retryablehttp v0.5.1 h1:Vsx5XKPqPs3M6sM4U4GWyUqFS8aBiL9U5gkgvpkg4SE=
@@ -202,8 +200,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
-github.com/hashicorp/hcl2 v0.0.0-20190318232830-f9f92da699d8 h1:H4X4ZtK0svjPuIRh1NJttHjJyrB1d/3ArFA1GZbuy1o=
-github.com/hashicorp/hcl2 v0.0.0-20190318232830-f9f92da699d8/go.mod h1:HtEzazM5AZ9fviNEof8QZB4T1Vz9UhHrGhnMPzl//Ek=
+github.com/hashicorp/hcl2 v0.0.0-20190327223817-3fb4ed0d9260 h1:C3vhYEXk8ihs+Xvq093axRyYhfLERrZ6Uv5tfRw9yvw=
+github.com/hashicorp/hcl2 v0.0.0-20190327223817-3fb4ed0d9260/go.mod h1:HtEzazM5AZ9fviNEof8QZB4T1Vz9UhHrGhnMPzl//Ek=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 h1:2yzhWGdgQUWZUCNK+AoO35V+HTsgEmcM4J9IkArh7PI=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/lang/blocktoattr/doc.go
+++ b/lang/blocktoattr/doc.go
@@ -1,0 +1,5 @@
+// Package blocktoattr includes some helper functions that can perform
+// preprocessing on a HCL body where a configschema.Block schema is available
+// in order to allow list and set attributes defined in the schema to be
+// optionally written by the user as block syntax.
+package blocktoattr

--- a/lang/blocktoattr/fixup.go
+++ b/lang/blocktoattr/fixup.go
@@ -1,0 +1,271 @@
+package blocktoattr
+
+import (
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcldec"
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// FixUpBlockAttrs takes a raw HCL body and adds some additional normalization
+// functionality to allow attributes that are specified as having list or set
+// type in the schema to be written with HCL block syntax as multiple nested
+// blocks with the attribute name as the block type.
+//
+// This partially restores some of the block/attribute confusion from HCL 1
+// so that existing patterns that depended on that confusion can continue to
+// be used in the short term while we settle on a longer-term strategy.
+//
+// Most of the fixup work is actually done when the returned body is
+// subsequently decoded, so while FixUpBlockAttrs always succeeds, the eventual
+// decode of the body might not, if the content of the body is so ambiguous
+// that there's no safe way to map it to the schema.
+func FixUpBlockAttrs(body hcl.Body, schema *configschema.Block) hcl.Body {
+	// The schema should never be nil, but in practice it seems to be sometimes
+	// in the presence of poorly-configured test mocks, so we'll be robust
+	// by synthesizing an empty one.
+	if schema == nil {
+		schema = &configschema.Block{}
+	}
+
+	// We'll do a quick sniff first to see if there's even anything ambiguous
+	// in this schema. (We still need to wrap it even if not, just in case we
+	// need to do fixup inside nested blocks.
+	ambiguousNames := make(map[string]struct{})
+	for name, attrS := range schema.Attributes {
+		aty := attrS.Type
+		if (aty.IsListType() || aty.IsSetType()) && aty.ElementType().IsObjectType() {
+			ambiguousNames[name] = struct{}{}
+		}
+	}
+
+	return &fixupBody{
+		original: body,
+		schema:   schema,
+		names:    ambiguousNames,
+	}
+}
+
+type fixupBody struct {
+	original hcl.Body
+	schema   *configschema.Block
+	names    map[string]struct{}
+}
+
+// Content decodes content from the body. The given schema must be the lower-level
+// representation of the same schema that was previously passed to FixUpBlockAttrs,
+// or else the result is undefined.
+func (b *fixupBody) Content(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Diagnostics) {
+	schema = b.effectiveSchema(schema)
+	content, diags := b.original.Content(schema)
+	return b.fixupContent(content), diags
+}
+
+func (b *fixupBody) PartialContent(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Body, hcl.Diagnostics) {
+	schema = b.effectiveSchema(schema)
+	content, remain, diags := b.original.PartialContent(schema)
+	remain = &fixupBody{
+		original: remain,
+		schema:   b.schema,
+		names:    b.names,
+	}
+	return b.fixupContent(content), remain, diags
+}
+
+func (b *fixupBody) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
+	// FixUpBlockAttrs is not intended to be used in situations where we'd use
+	// JustAttributes, so we just pass this through verbatim to complete our
+	// implementation of hcl.Body.
+	return b.original.JustAttributes()
+}
+
+func (b *fixupBody) MissingItemRange() hcl.Range {
+	return b.original.MissingItemRange()
+}
+
+// effectiveSchema produces a derived *hcl.BodySchema by sniffing the body's
+// content to determine whether the author has used attribute or block syntax
+// for each of the ambigious attributes where both are permitted.
+//
+// The resulting schema will always contain all of the same names that are
+// in the given schema, but some attribute schemas may instead be replaced by
+// block header schemas.
+func (b *fixupBody) effectiveSchema(given *hcl.BodySchema) *hcl.BodySchema {
+	ret := &hcl.BodySchema{}
+
+	appearsAsBlock := make(map[string]struct{})
+	{
+		// We'll construct some throwaway schemas here just to probe for
+		// whether each of our ambiguous names seems to be being used as
+		// an attribute or a block. We need to check both because in JSON
+		// syntax we rely on the schema to decide between attribute or block
+		// interpretation and so JSON will always answer yes to both of
+		// these questions and we want to prefer the attribute interpretation
+		// in that case.
+		var probeSchema hcl.BodySchema
+
+		for name := range b.names {
+			probeSchema = hcl.BodySchema{
+				Attributes: []hcl.AttributeSchema{
+					{
+						Name: name,
+					},
+				},
+			}
+			content, _, _ := b.original.PartialContent(&probeSchema)
+			if _, exists := content.Attributes[name]; exists {
+				// Can decode as an attribute, so we'll go with that.
+				continue
+			}
+			probeSchema = hcl.BodySchema{
+				Blocks: []hcl.BlockHeaderSchema{
+					{
+						Type: name,
+					},
+				},
+			}
+			content, _, _ = b.original.PartialContent(&probeSchema)
+			if len(content.Blocks) > 0 {
+				// No attribute present and at least one block present, so
+				// we'll need to rewrite this one as a block for a successful
+				// result.
+				appearsAsBlock[name] = struct{}{}
+			}
+		}
+	}
+
+	for _, attrS := range given.Attributes {
+		if _, exists := appearsAsBlock[attrS.Name]; exists {
+			ret.Blocks = append(ret.Blocks, hcl.BlockHeaderSchema{
+				Type: attrS.Name,
+			})
+		} else {
+			ret.Attributes = append(ret.Attributes, attrS)
+		}
+	}
+
+	// Anything that is specified as a block type in the input schema remains
+	// that way by just passing through verbatim.
+	ret.Blocks = append(ret.Blocks, given.Blocks...)
+
+	return ret
+}
+
+func (b *fixupBody) fixupContent(content *hcl.BodyContent) *hcl.BodyContent {
+	var ret hcl.BodyContent
+	ret.Attributes = make(hcl.Attributes)
+	for name, attr := range content.Attributes {
+		ret.Attributes[name] = attr
+	}
+	blockAttrVals := make(map[string][]*hcl.Block)
+	for _, block := range content.Blocks {
+		if _, exists := b.names[block.Type]; exists {
+			// If we get here then we've found a block type whose instances need
+			// to be re-interpreted as a list-of-objects attribute. We'll gather
+			// those up and fix them up below.
+			blockAttrVals[block.Type] = append(blockAttrVals[block.Type], block)
+			continue
+		}
+
+		// We need to now re-wrap our inner body so it will be subject to the
+		// same attribute-as-block fixup when recursively decoded.
+		retBlock := *block // shallow copy
+		if blockS, ok := b.schema.BlockTypes[block.Type]; ok {
+			// Would be weird if not ok, but we'll allow it for robustness; body just won't be fixed up, then
+			retBlock.Body = FixUpBlockAttrs(retBlock.Body, &blockS.Block)
+		}
+
+		ret.Blocks = append(ret.Blocks, &retBlock)
+	}
+	// No we'll install synthetic attributes for each of our fixups. We can't
+	// do this exactly because HCL's information model expects an attribute
+	// to be a single decl but we have multiple separate blocks. We'll
+	// approximate things, then, by using only our first block for the source
+	// location information. (We are guaranteed at least one by the above logic.)
+	for name, blocks := range blockAttrVals {
+		ret.Attributes[name] = &hcl.Attribute{
+			Name: name,
+			Expr: &fixupBlocksExpr{
+				blocks: blocks,
+				ety:    b.schema.Attributes[name].Type.ElementType(),
+			},
+
+			Range:     blocks[0].DefRange,
+			NameRange: blocks[0].TypeRange,
+		}
+	}
+	return &ret
+}
+
+type fixupBlocksExpr struct {
+	blocks hcl.Blocks
+	ety    cty.Type
+}
+
+func (e *fixupBlocksExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+	// In order to produce a suitable value for our expression we need to
+	// now decode the whole descendent block structure under each of our block
+	// bodies.
+	//
+	// That requires us to do something rather strange: we must construct a
+	// synthetic block type schema derived from the element type of the
+	// attribute, thus inverting our usual direction of lowering a schema
+	// into an implied type. Because a type is less detailed than a schema,
+	// the result is imprecise and in particular will just consider all
+	// the attributes to be optional and let the provider eventually decide
+	// whether to return errors if they turn out to be null when required.
+	schema := schemaForCtyType(e.ety) // this schema's ImpliedType will match e.ety
+	spec := schema.DecoderSpec()
+
+	vals := make([]cty.Value, len(e.blocks))
+	var diags hcl.Diagnostics
+	for i, block := range e.blocks {
+		val, blockDiags := hcldec.Decode(block.Body, spec, ctx)
+		diags = append(diags, blockDiags...)
+		if val == cty.NilVal {
+			val = cty.UnknownVal(e.ety)
+		}
+		vals[i] = val
+	}
+	if len(vals) == 0 {
+		return cty.ListValEmpty(e.ety), diags
+	}
+	return cty.ListVal(vals), diags
+}
+
+func (e *fixupBlocksExpr) Variables() []hcl.Traversal {
+	var ret []hcl.Traversal
+	schema := schemaForCtyType(e.ety)
+	spec := schema.DecoderSpec()
+	for _, block := range e.blocks {
+		ret = append(ret, hcldec.Variables(block.Body, spec)...)
+	}
+	return ret
+}
+
+func (e *fixupBlocksExpr) Range() hcl.Range {
+	// This is not really an appropriate range for the expression but it's
+	// the best we can do from here.
+	return e.blocks[0].DefRange
+}
+
+func (e *fixupBlocksExpr) StartRange() hcl.Range {
+	return e.blocks[0].DefRange
+}
+
+// schemaForCtyType converts a cty object type into an approximately-equivalent
+// configschema.Block. If the given type is not an object type then this
+// function will panic.
+func schemaForCtyType(ty cty.Type) *configschema.Block {
+	atys := ty.AttributeTypes()
+	ret := &configschema.Block{
+		Attributes: make(map[string]*configschema.Attribute, len(atys)),
+	}
+	for name, aty := range atys {
+		ret.Attributes[name] = &configschema.Attribute{
+			Type:     aty,
+			Optional: true,
+		}
+	}
+	return ret
+}

--- a/lang/blocktoattr/fixup_test.go
+++ b/lang/blocktoattr/fixup_test.go
@@ -1,0 +1,348 @@
+package blocktoattr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl2/ext/dynblock"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+	hcljson "github.com/hashicorp/hcl2/hcl/json"
+	"github.com/hashicorp/hcl2/hcldec"
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestFixUpBlockAttrs(t *testing.T) {
+	fooSchema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"foo": {
+				Type: cty.List(cty.Object(map[string]cty.Type{
+					"bar": cty.String,
+				})),
+				Optional: true,
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		src      string
+		json     bool
+		schema   *configschema.Block
+		want     cty.Value
+		wantErrs bool
+	}{
+		"empty": {
+			src:    ``,
+			schema: &configschema.Block{},
+			want:   cty.EmptyObjectVal,
+		},
+		"empty JSON": {
+			src:    `{}`,
+			json:   true,
+			schema: &configschema.Block{},
+			want:   cty.EmptyObjectVal,
+		},
+		"unset": {
+			src:    ``,
+			schema: fooSchema,
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(fooSchema.Attributes["foo"].Type),
+			}),
+		},
+		"unset JSON": {
+			src:    `{}`,
+			json:   true,
+			schema: fooSchema,
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(fooSchema.Attributes["foo"].Type),
+			}),
+		},
+		"no fixup required, with one value": {
+			src: `
+foo = [
+  {
+    bar = "baz"
+  },
+]
+`,
+			schema: fooSchema,
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("baz"),
+					}),
+				}),
+			}),
+		},
+		"no fixup required, with two values": {
+			src: `
+foo = [
+  {
+    bar = "baz"
+  },
+  {
+    bar = "boop"
+  },
+]
+`,
+			schema: fooSchema,
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("baz"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+					}),
+				}),
+			}),
+		},
+		"no fixup required, with values, JSON": {
+			src:    `{"foo": [{"bar": "baz"}]}`,
+			json:   true,
+			schema: fooSchema,
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("baz"),
+					}),
+				}),
+			}),
+		},
+		"no fixup required, empty": {
+			src: `
+foo = []
+`,
+			schema: fooSchema,
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListValEmpty(fooSchema.Attributes["foo"].Type.ElementType()),
+			}),
+		},
+		"no fixup required, empty, JSON": {
+			src:    `{"foo":[]}`,
+			json:   true,
+			schema: fooSchema,
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListValEmpty(fooSchema.Attributes["foo"].Type.ElementType()),
+			}),
+		},
+		"fixup one block": {
+			src: `
+foo {
+  bar = "baz"
+}
+`,
+			schema: fooSchema,
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("baz"),
+					}),
+				}),
+			}),
+		},
+		"fixup one block omitting attribute": {
+			src: `
+foo {}
+`,
+			schema: fooSchema,
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+		},
+		"fixup two blocks": {
+			src: `
+foo {
+  bar = baz
+}
+foo {
+  bar = "boop"
+}
+`,
+			schema: fooSchema,
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("baz value"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+					}),
+				}),
+			}),
+		},
+		"interaction with dynamic block generation": {
+			src: `
+dynamic "foo" {
+  for_each = ["baz", beep]
+  content {
+    bar = foo.value
+  }
+}
+`,
+			schema: fooSchema,
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("baz"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("beep value"),
+					}),
+				}),
+			}),
+		},
+		"both attribute and block syntax": {
+			src: `
+foo = []
+foo {
+  bar = "baz"
+}
+`,
+			schema:   fooSchema,
+			wantErrs: true, // Unsupported block type (user must be consistent about whether they consider foo to be a block type or an attribute)
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("baz"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+					}),
+				}),
+			}),
+		},
+		"nested fixup": {
+			src: `
+container {
+  foo {
+    bar = "baz"
+  }
+  foo {
+    bar = "boop"
+  }
+}
+container {
+  foo {
+    bar = beep
+  }
+}
+`,
+			schema: &configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"container": {
+						Nesting: configschema.NestingList,
+						Block:   *fooSchema,
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"container": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"bar": cty.StringVal("baz"),
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"bar": cty.StringVal("boop"),
+							}),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"bar": cty.StringVal("beep value"),
+							}),
+						}),
+					}),
+				}),
+			}),
+		},
+		"nested fixup with dynamic block generation": {
+			src: `
+container {
+  dynamic "foo" {
+    for_each = ["baz", beep]
+    content {
+      bar = foo.value
+    }
+  }
+}
+`,
+			schema: &configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"container": {
+						Nesting: configschema.NestingList,
+						Block:   *fooSchema,
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"container": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"bar": cty.StringVal("baz"),
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"bar": cty.StringVal("beep value"),
+							}),
+						}),
+					}),
+				}),
+			}),
+		},
+	}
+
+	ctx := &hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"bar":  cty.StringVal("bar value"),
+			"baz":  cty.StringVal("baz value"),
+			"beep": cty.StringVal("beep value"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var f *hcl.File
+			var diags hcl.Diagnostics
+			if test.json {
+				f, diags = hcljson.Parse([]byte(test.src), "test.tf.json")
+			} else {
+				f, diags = hclsyntax.ParseConfig([]byte(test.src), "test.tf", hcl.Pos{Line: 1, Column: 1})
+			}
+			if diags.HasErrors() {
+				for _, diag := range diags {
+					t.Errorf("unexpected diagnostic: %s", diag)
+				}
+				t.FailNow()
+			}
+
+			// We'll expand dynamic blocks in the body first, to mimic how
+			// we process this fixup when using the main "lang" package API.
+			spec := test.schema.DecoderSpec()
+			body := dynblock.Expand(f.Body, ctx)
+
+			body = FixUpBlockAttrs(body, test.schema)
+			got, diags := hcldec.Decode(body, spec, ctx)
+
+			if test.wantErrs {
+				if !diags.HasErrors() {
+					t.Errorf("succeeded, but want error\ngot: %#v", got)
+				}
+				return
+			}
+
+			if !test.want.RawEquals(got) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.want)
+			}
+			for _, diag := range diags {
+				t.Errorf("unexpected diagnostic: %s", diag)
+			}
+		})
+	}
+}

--- a/lang/blocktoattr/schema.go
+++ b/lang/blocktoattr/schema.go
@@ -7,6 +7,9 @@ import (
 )
 
 func ambiguousNames(schema *configschema.Block) map[string]struct{} {
+	if schema == nil {
+		return nil
+	}
 	ambiguousNames := make(map[string]struct{})
 	for name, attrS := range schema.Attributes {
 		aty := attrS.Type

--- a/lang/blocktoattr/schema.go
+++ b/lang/blocktoattr/schema.go
@@ -1,0 +1,114 @@
+package blocktoattr
+
+import (
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func ambiguousNames(schema *configschema.Block) map[string]struct{} {
+	ambiguousNames := make(map[string]struct{})
+	for name, attrS := range schema.Attributes {
+		aty := attrS.Type
+		if (aty.IsListType() || aty.IsSetType()) && aty.ElementType().IsObjectType() {
+			ambiguousNames[name] = struct{}{}
+		}
+	}
+	return ambiguousNames
+}
+
+func effectiveSchema(given *hcl.BodySchema, body hcl.Body, ambiguousNames map[string]struct{}, dynamicExpanded bool) *hcl.BodySchema {
+	ret := &hcl.BodySchema{}
+
+	appearsAsBlock := make(map[string]struct{})
+	{
+		// We'll construct some throwaway schemas here just to probe for
+		// whether each of our ambiguous names seems to be being used as
+		// an attribute or a block. We need to check both because in JSON
+		// syntax we rely on the schema to decide between attribute or block
+		// interpretation and so JSON will always answer yes to both of
+		// these questions and we want to prefer the attribute interpretation
+		// in that case.
+		var probeSchema hcl.BodySchema
+
+		for name := range ambiguousNames {
+			probeSchema = hcl.BodySchema{
+				Attributes: []hcl.AttributeSchema{
+					{
+						Name: name,
+					},
+				},
+			}
+			content, _, _ := body.PartialContent(&probeSchema)
+			if _, exists := content.Attributes[name]; exists {
+				// Can decode as an attribute, so we'll go with that.
+				continue
+			}
+			probeSchema = hcl.BodySchema{
+				Blocks: []hcl.BlockHeaderSchema{
+					{
+						Type: name,
+					},
+				},
+			}
+			content, _, _ = body.PartialContent(&probeSchema)
+			if len(content.Blocks) > 0 {
+				// No attribute present and at least one block present, so
+				// we'll need to rewrite this one as a block for a successful
+				// result.
+				appearsAsBlock[name] = struct{}{}
+			}
+		}
+		if !dynamicExpanded {
+			// If we're deciding for a context where dynamic blocks haven't
+			// been expanded yet then we need to probe for those too.
+			probeSchema = hcl.BodySchema{
+				Blocks: []hcl.BlockHeaderSchema{
+					{
+						Type:       "dynamic",
+						LabelNames: []string{"type"},
+					},
+				},
+			}
+			content, _, _ := body.PartialContent(&probeSchema)
+			for _, block := range content.Blocks {
+				if _, exists := ambiguousNames[block.Labels[0]]; exists {
+					appearsAsBlock[block.Labels[0]] = struct{}{}
+				}
+			}
+		}
+	}
+
+	for _, attrS := range given.Attributes {
+		if _, exists := appearsAsBlock[attrS.Name]; exists {
+			ret.Blocks = append(ret.Blocks, hcl.BlockHeaderSchema{
+				Type: attrS.Name,
+			})
+		} else {
+			ret.Attributes = append(ret.Attributes, attrS)
+		}
+	}
+
+	// Anything that is specified as a block type in the input schema remains
+	// that way by just passing through verbatim.
+	ret.Blocks = append(ret.Blocks, given.Blocks...)
+
+	return ret
+}
+
+// schemaForCtyType converts a cty object type into an approximately-equivalent
+// configschema.Block. If the given type is not an object type then this
+// function will panic.
+func schemaForCtyType(ty cty.Type) *configschema.Block {
+	atys := ty.AttributeTypes()
+	ret := &configschema.Block{
+		Attributes: make(map[string]*configschema.Attribute, len(atys)),
+	}
+	for name, aty := range atys {
+		ret.Attributes[name] = &configschema.Attribute{
+			Type:     aty,
+			Optional: true,
+		}
+	}
+	return ret
+}

--- a/lang/blocktoattr/variables.go
+++ b/lang/blocktoattr/variables.go
@@ -1,0 +1,43 @@
+package blocktoattr
+
+import (
+	"github.com/hashicorp/hcl2/ext/dynblock"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcldec"
+	"github.com/hashicorp/terraform/configs/configschema"
+)
+
+// ExpandedVariables finds all of the global variables referenced in the
+// given body with the given schema while taking into account the possibilities
+// both of "dynamic" blocks being expanded and the possibility of certain
+// attributes being written instead as nested blocks as allowed by the
+// FixUpBlockAttrs function.
+//
+// This function exists to allow variables to be analyzed prior to dynamic
+// block expansion while also dealing with the fact that dynamic block expansion
+// might in turn produce nested blocks that are subject to FixUpBlockAttrs.
+//
+// This is intended as a drop-in replacement for dynblock.VariablesHCLDec,
+// which is itself a drop-in replacement for hcldec.Variables.
+func ExpandedVariables(body hcl.Body, schema *configschema.Block) []hcl.Traversal {
+	rootNode := dynblock.WalkVariables(body)
+	return walkVariables(rootNode, body, schema)
+}
+
+func walkVariables(node dynblock.WalkVariablesNode, body hcl.Body, schema *configschema.Block) []hcl.Traversal {
+	givenRawSchema := hcldec.ImpliedSchema(schema.DecoderSpec())
+	ambiguousNames := ambiguousNames(schema)
+	effectiveRawSchema := effectiveSchema(givenRawSchema, body, ambiguousNames, false)
+	vars, children := node.Visit(effectiveRawSchema)
+
+	for _, child := range children {
+		if blockS, exists := schema.BlockTypes[child.BlockTypeName]; exists {
+			vars = append(vars, walkVariables(child.Node, child.Body(), &blockS.Block)...)
+		} else if attrS, exists := schema.Attributes[child.BlockTypeName]; exists {
+			synthSchema := schemaForCtyType(attrS.Type.ElementType())
+			vars = append(vars, walkVariables(child.Node, child.Body(), synthSchema)...)
+		}
+	}
+
+	return vars
+}

--- a/lang/blocktoattr/variables_test.go
+++ b/lang/blocktoattr/variables_test.go
@@ -1,0 +1,140 @@
+package blocktoattr
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+	hcljson "github.com/hashicorp/hcl2/hcl/json"
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestExpandedVariables(t *testing.T) {
+	fooSchema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"foo": {
+				Type: cty.List(cty.Object(map[string]cty.Type{
+					"bar": cty.String,
+				})),
+				Optional: true,
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		src    string
+		json   bool
+		schema *configschema.Block
+		want   []hcl.Traversal
+	}{
+		"empty": {
+			src:    ``,
+			schema: &configschema.Block{},
+			want:   nil,
+		},
+		"attribute syntax": {
+			src: `
+foo = [
+  {
+    bar = baz
+  },
+]
+`,
+			schema: fooSchema,
+			want: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{
+						Name: "baz",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 11, Byte: 23},
+							End:      hcl.Pos{Line: 4, Column: 14, Byte: 26},
+						},
+					},
+				},
+			},
+		},
+		"block syntax": {
+			src: `
+foo {
+  bar = baz
+}
+`,
+			schema: fooSchema,
+			want: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{
+						Name: "baz",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 9, Byte: 15},
+							End:      hcl.Pos{Line: 3, Column: 12, Byte: 18},
+						},
+					},
+				},
+			},
+		},
+		"dynamic block syntax": {
+			src: `
+dynamic "foo" {
+  for_each = beep
+  content {
+    bar = baz
+  }
+}
+`,
+			schema: fooSchema,
+			want: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{
+						Name: "beep",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 14, Byte: 30},
+							End:      hcl.Pos{Line: 3, Column: 18, Byte: 34},
+						},
+					},
+				},
+				{
+					hcl.TraverseRoot{
+						Name: "baz",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 5, Column: 11, Byte: 57},
+							End:      hcl.Pos{Line: 5, Column: 14, Byte: 60},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var f *hcl.File
+			var diags hcl.Diagnostics
+			if test.json {
+				f, diags = hcljson.Parse([]byte(test.src), "test.tf.json")
+			} else {
+				f, diags = hclsyntax.ParseConfig([]byte(test.src), "test.tf", hcl.Pos{Line: 1, Column: 1})
+			}
+			if diags.HasErrors() {
+				for _, diag := range diags {
+					t.Errorf("unexpected diagnostic: %s", diag)
+				}
+				t.FailNow()
+			}
+
+			got := ExpandedVariables(f.Body, test.schema)
+
+			co := cmpopts.IgnoreUnexported(hcl.TraverseRoot{})
+			if !cmp.Equal(got, test.want, co) {
+				t.Errorf("wrong result\n%s", cmp.Diff(test.want, got, co))
+			}
+		})
+	}
+
+}

--- a/terraform/test-fixtures/graph-builder-plan-attr-as-blocks/attr-as-blocks.tf
+++ b/terraform/test-fixtures/graph-builder-plan-attr-as-blocks/attr-as-blocks.tf
@@ -1,0 +1,8 @@
+resource "test_thing" "a" {
+}
+
+resource "test_thing" "b" {
+  nested {
+    foo = test_thing.a.id
+  }
+}

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/variables.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/variables.go
@@ -47,6 +47,18 @@ type WalkVariablesChild struct {
 	Node          WalkVariablesNode
 }
 
+// Body returns the HCL Body associated with the child node, in case the caller
+// wants to do some sort of inspection of it in order to decide what schema
+// to pass to Visit.
+//
+// Most implementations should just fetch a fixed schema based on the
+// BlockTypeName field and not access this. Deciding on a schema dynamically
+// based on the body is a strange thing to do and generally necessary only if
+// your caller is already doing other bizarre things with HCL bodies.
+func (c WalkVariablesChild) Body() hcl.Body {
+	return c.Node.body
+}
+
 // Visit returns the variable traversals required for any "dynamic" blocks
 // directly in the body associated with this node, and also returns any child
 // nodes that must be visited in order to continue the walk.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl2 v0.0.0-20190318232830-f9f92da699d8
+# github.com/hashicorp/hcl2 v0.0.0-20190327223817-3fb4ed0d9260
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec


### PR DESCRIPTION
For any block content we evaluate dynamically via this API, we'll make a special allowance for users to optionally write members of a list attribute instead as a sequence of nested blocks, thus allowing some
existing provider features that were assuming this capability to continue to support it after v0.12.

This should not be used for any new provider features, and subsequent work we will define a new pattern that allows the same or better expressiveness without relying on distinguishing between two configurations that appear logically equivalent.

---

This provides a path forward for the few cases in existing providers where a nested block type was declared as `Optional`+`Computed` in the schema and the provider logic then distinguished between unset (no blocks at all) vs. explicitly empty by relying on the Terraform v0.11 bug that allowed attribute syntax to be used to define blocks in some cases:

```
nested_object {
  # ...
}

nested_object = []
```

For this specific confluence of assumptions only, we can set the schema `ConfigMode` for `nested_object` to be `SchemaConfigModeAttr`, ensure that `SkipCoreTypeCheck` remains false (because this fixup depends on having accurate type information in Terraform Core), and then continue to show in the resource type documentation the use of nested block syntax even though the schema actually describes the name as being an attribute.

---

So far this does not include a corresponding fixup for the `terraform 0.12upgrade` tool, so it will attempt to migrate use of these attributes to attribute syntax. Before v0.12.0 final release we'll decide on a suitable heuristic for the upgrade tool to recognize when this workaround seems to be in use in the provider and make it prefer to use nested block syntax in that scenario, in spite of what the resource type schema seems to require.
