### PR TITLE
backend/local: preserve serial and lineage on failure

### DIFF
--- a/states/statemgr/filesystem.go
+++ b/states/statemgr/filesystem.go
@@ -49,7 +49,7 @@ type Filesystem struct {
 	lockID string
 
 	// created is set to true if stateFileOut didn't exist before we created it.
-	// This is mostly so we can clean up emtpy files during tests, but doesn't
+	// This is mostly so we can clean up empty files during tests, but doesn't
 	// hurt to remove file we never wrote to.
 	created bool
 

--- a/states/statemgr/migrate.go
+++ b/states/statemgr/migrate.go
@@ -31,7 +31,7 @@ type Migrator interface {
 	// the given file and the current file and complete the update only if
 	// that function returns nil. If force is set this may override such
 	// checks, but some backends do not support forcing and so will act
-	// as if force is always true.
+	// as if force is always false.
 	WriteStateForMigration(f *statefile.File, force bool) error
 }
 


### PR DESCRIPTION
When failing to write the state, the local backend writes the state to a local file called `errrored.tfstate`. Previously it would do so by creating a new state file which would use a new serial and lineage. By exorting the existing state file and directly assigning the new state, the serial and lineage are preserved.