### PR TITLE
Document that ValidateFunc works on maps.

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -279,7 +279,8 @@ type Schema struct {
 	// guaranteed to be of the proper Schema type, and it can yield warnings or
 	// errors based on inspection of that value.
 	//
-	// ValidateFunc currently only works for primitive types and maps.
+	// ValidateFunc currently only works for primitive types and TypeList / TypeSet
+	// of primitive type elements.
 	ValidateFunc SchemaValidateFunc
 
 	// Sensitive ensures that the attribute's value does not get displayed in

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -279,8 +279,8 @@ type Schema struct {
 	// guaranteed to be of the proper Schema type, and it can yield warnings or
 	// errors based on inspection of that value.
 	//
-	// ValidateFunc currently only works for primitive types and TypeList / TypeSet
-	// of primitive type elements.
+	// ValidateFunc is honored only when the schema's Type is set to TypeInt, 
+	// TypeFloat, TypeString, TypeBool, or TypeMap. It is ignored for all other types.
 	ValidateFunc SchemaValidateFunc
 
 	// Sensitive ensures that the attribute's value does not get displayed in

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -279,7 +279,7 @@ type Schema struct {
 	// guaranteed to be of the proper Schema type, and it can yield warnings or
 	// errors based on inspection of that value.
 	//
-	// ValidateFunc is honored only when the schema's Type is set to TypeInt, 
+	// ValidateFunc is honored only when the schema's Type is set to TypeInt,
 	// TypeFloat, TypeString, TypeBool, or TypeMap. It is ignored for all other types.
 	ValidateFunc SchemaValidateFunc
 

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -279,7 +279,7 @@ type Schema struct {
 	// guaranteed to be of the proper Schema type, and it can yield warnings or
 	// errors based on inspection of that value.
 	//
-	// ValidateFunc currently only works for primitive types.
+	// ValidateFunc currently only works for primitive types and maps.
 	ValidateFunc SchemaValidateFunc
 
 	// Sensitive ensures that the attribute's value does not get displayed in


### PR DESCRIPTION
This change documents that `ValidateFunc` is also available for use on TypeMap attributes.
Support for map validation has been added through https://github.com/hashicorp/terraform/pull/3505