### PR TITLE
Add friendly error for when registry unresponsive

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -504,6 +504,8 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 				}
 
 				switch {
+				case err == discovery.ErrorServiceUnreachable:
+					c.Ui.Error(errDiscoveryServiceUnreachable)
 				case err == discovery.ErrorNoSuchProvider:
 					c.Ui.Error(fmt.Sprintf(errProviderNotFound, provider, DefaultPluginVendorDir))
 				case err == discovery.ErrorNoSuitableVersion:
@@ -876,6 +878,12 @@ To prevent automatic upgrades to new major versions that may contain breaking
 changes, it is recommended to add version = "..." constraints to the
 corresponding provider blocks in configuration, with the constraint strings
 suggested below.
+`
+
+const errDiscoveryServiceUnreachable = `
+[reset][bold][red]Registry service unreachable.[reset][red]
+
+This may indicate a network issue, or an issue with the requested Terraform Registry.
 `
 
 const errProviderNotFound = `

--- a/command/init.go
+++ b/command/init.go
@@ -884,6 +884,8 @@ const errDiscoveryServiceUnreachable = `
 [reset][bold][red]Registry service unreachable.[reset][red]
 
 This may indicate a network issue, or an issue with the requested Terraform Registry.
+
+Check https://status.hashicorp.com/ for registry status updates.
 `
 
 const errProviderNotFound = `

--- a/plugin/discovery/error.go
+++ b/plugin/discovery/error.go
@@ -51,6 +51,10 @@ const ErrorChecksumVerification = Error("unexpected plugin checksum")
 // was not signed by any known key for the publisher
 const ErrorSignatureVerification = Error("unable to verify signature")
 
+// ErrorServiceUnreachable indicates that the network was unable to connect
+// to the registry service
+const ErrorServiceUnreachable = Error("registry service is unreachable")
+
 func (err Error) Error() string {
 	return string(err)
 }

--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -125,6 +125,10 @@ func (i *ProviderInstaller) Get(provider string, req Constraints) (PluginMeta, t
 
 	// TODO: return multiple errors
 	if err != nil {
+		log.Printf("[DEBUG] %s", err)
+		if registry.IsServiceUnreachable(err) {
+			return PluginMeta{}, diags, ErrorServiceUnreachable
+		}
 		if registry.IsServiceNotProvided(err) {
 			return PluginMeta{}, diags, err
 		}

--- a/registry/client.go
+++ b/registry/client.go
@@ -62,7 +62,7 @@ func NewClient(services *disco.Disco, client *http.Client) *Client {
 func (c *Client) Discover(host svchost.Hostname, serviceID string) (*url.URL, error) {
 	service, err := c.services.DiscoverServiceURL(host, serviceID)
 	if err != nil {
-		return nil, err
+		return nil, &ServiceUnreachableError{err}
 	}
 	if !strings.HasSuffix(service.Path, "/") {
 		service.Path += "/"

--- a/registry/errors.go
+++ b/registry/errors.go
@@ -46,3 +46,18 @@ func IsServiceNotProvided(err error) bool {
 	_, ok := err.(*disco.ErrServiceNotProvided)
 	return ok
 }
+
+// ServiceUnreachableError Registry service is unreachable
+type ServiceUnreachableError struct {
+	err error
+}
+
+func (e *ServiceUnreachableError) Error() string {
+	return e.err.Error()
+}
+
+// IsServiceUnreachable returns true if the registry/discovery service was unreachable
+func IsServiceUnreachable(err error) bool {
+	_, ok := err.(*ServiceUnreachableError)
+	return ok
+}


### PR DESCRIPTION
If the registry is unresponsive, you will now get an error specific to this, rather than a misleading "provider unavailable" type error. Also adds debug logging for when errors like this may occur.