### PR TITLE
configs/configupgrade: detect invalid resource names and print a TODO

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/invalid-resource-name/input/resource.tf
+++ b/configs/configupgrade/test-fixtures/valid/invalid-resource-name/input/resource.tf
@@ -1,0 +1,2 @@
+resource "test_instance" "1_invalid_resource_name" {
+}

--- a/configs/configupgrade/test-fixtures/valid/invalid-resource-name/want/resource.tf
+++ b/configs/configupgrade/test-fixtures/valid/invalid-resource-name/want/resource.tf
@@ -1,0 +1,8 @@
+# TF-UPGRADE-TODO: In Terraform v0.11 and earlier, it was possible to begin a
+# resource name with a number, but it is no longer possible in Terraform v0.12.
+#
+# Rename the resource and run `terraform state mv` to apply the rename in the
+# state. Detailed information on the `state move` command can be found in the
+# documentation online: https://www.terraform.io/docs/commands/state/mv.html
+resource "test_instance" "1_invalid_resource_name" {
+}

--- a/configs/configupgrade/test-fixtures/valid/invalid-resource-name/want/resource.tf
+++ b/configs/configupgrade/test-fixtures/valid/invalid-resource-name/want/resource.tf
@@ -2,7 +2,7 @@
 # resource name with a number, but it is no longer possible in Terraform v0.12.
 #
 # Rename the resource and run `terraform state mv` to apply the rename in the
-# state. Detailed information on the `state move` command can be found in the
+# state. Detailed information on the `state mv` command can be found in the
 # documentation online: https://www.terraform.io/docs/commands/state/mv.html
 resource "test_instance" "1_invalid_resource_name" {
 }

--- a/configs/configupgrade/test-fixtures/valid/invalid-resource-name/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/invalid-resource-name/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/configs/configupgrade/test-fixtures/valid/module-source/input/main.tf
+++ b/configs/configupgrade/test-fixtures/valid/module-source/input/main.tf
@@ -1,3 +1,7 @@
+// Test note: the configupgrade tool will ignore this possibly-relative module
+// source because it does not find a local directory "foo". The example where
+// the configupgrade tool makes a recommendation about relative module sources
+// is is in relative-module-source.
 module "foo" {
   source = "foo"
 }

--- a/configs/configupgrade/test-fixtures/valid/module-source/want/main.tf
+++ b/configs/configupgrade/test-fixtures/valid/module-source/want/main.tf
@@ -1,3 +1,7 @@
+// Test note: the configupgrade tool will ignore this possibly-relative module
+// source because it does not find a local directory "foo". The example where
+// the configupgrade tool makes a recommendation about relative module sources
+// is is in relative-module-source.
 module "foo" {
   source = "foo"
 }


### PR DESCRIPTION
message

In terraform 0.11 and prior it was possible to start a resource name
with a number. This is no longer valid, as the resource name would would
be ambiguous with number values in HCL expressions.

Fixes #19919

I've applied this check to outputs and resources. 