### PR TITLE
Avoid requiring Bazaar to compile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,11 @@ require (
 	google.golang.org/api v0.1.0
 	google.golang.org/grpc v1.18.0
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.1 // indirect
-	labix.org/v2/mgo v0.0.0-20140701140051-000000000287 // indirect
-	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
+	labix.org/v2/mgo v0.0.0-00010101000000-000000000000 // indirect
+	launchpad.net/gocheck v0.0.0-00010101000000-000000000000 // indirect
+)
+
+replace (
+	labix.org/v2/mgo => gopkg.in/mgo.v2 v2.0.0-20140701140051-2e26580ebcca
+	launchpad.net/gocheck => github.com/go-check/check v0.0.0-20140225173054-eb6ee6f84d0a848c7f11b46cd11f28875ba56b1c
 )

--- a/go.mod
+++ b/go.mod
@@ -117,11 +117,4 @@ require (
 	google.golang.org/api v0.1.0
 	google.golang.org/grpc v1.18.0
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.1 // indirect
-	labix.org/v2/mgo v0.0.0-00010101000000-000000000000 // indirect
-	launchpad.net/gocheck v0.0.0-00010101000000-000000000000 // indirect
-)
-
-replace (
-	labix.org/v2/mgo => gopkg.in/mgo.v2 v2.0.0-20140701140051-2e26580ebcca
-	launchpad.net/gocheck => github.com/go-check/check v0.0.0-20140225173054-eb6ee6f84d0a848c7f11b46cd11f28875ba56b1c
 )

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
-github.com/go-check/check v0.0.0-20140225173054-eb6ee6f84d0a848c7f11b46cd11f28875ba56b1c h1:TqRyTxY0/rGuBL9d27vPo9h1RtwwK4rhy6lHehEzpPk=
-github.com/go-check/check v0.0.0-20140225173054-eb6ee6f84d0a848c7f11b46cd11f28875ba56b1c/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -502,8 +500,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/mgo.v2 v2.0.0-20140701140051-2e26580ebcca h1:KeoXx6F3rxsXCvdnQ7S97eswW29xmxoD9AX+TiG6HwU=
-gopkg.in/mgo.v2 v2.0.0-20140701140051-2e26580ebcca/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/vmihailenco/msgpack.v2 v2.9.1 h1:kb0VV7NuIojvRfzwslQeP3yArBqJHW9tOl4t38VS1jM=
 gopkg.in/vmihailenco/msgpack.v2 v2.9.1/go.mod h1:/3Dn1Npt9+MYyLpYYXjInO/5jvMLamn+AEGwNEOatn8=

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
+github.com/go-check/check v0.0.0-20140225173054-eb6ee6f84d0a848c7f11b46cd11f28875ba56b1c h1:TqRyTxY0/rGuBL9d27vPo9h1RtwwK4rhy6lHehEzpPk=
+github.com/go-check/check v0.0.0-20140225173054-eb6ee6f84d0a848c7f11b46cd11f28875ba56b1c/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -210,8 +212,6 @@ github.com/hashicorp/memberlist v0.1.0 h1:qSsCiC0WYD39lbSitKNt40e30uorm2Ss/d4JGU
 github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc3W6JvZwjxxsE=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb h1:ZbgmOQt8DOg796figP87/EFCVx2v2h9yRvwHF/zceX4=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
-github.com/hashicorp/terraform-config-inspect v0.0.0-20190208230122-b0707673339c h1:nCnsfi66NloVlmquh5dLox5yBwQk5CV5s2roWvbstnE=
-github.com/hashicorp/terraform-config-inspect v0.0.0-20190208230122-b0707673339c/go.mod h1:ItvqtvbC3K23FFET62ZwnkwtpbKZm8t8eMcWjmVVjD8=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190327195015-8022a2663a70 h1:oZm5nE11yhzsTRz/YrUyDMSvixePqjoZihwn8ipuOYI=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190327195015-8022a2663a70/go.mod h1:ItvqtvbC3K23FFET62ZwnkwtpbKZm8t8eMcWjmVVjD8=
 github.com/hashicorp/vault v0.10.4 h1:4x0lHxui/ZRp/B3E0Auv1QNBJpzETqHR2kQD3mHSBJU=
@@ -502,6 +502,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/mgo.v2 v2.0.0-20140701140051-2e26580ebcca h1:KeoXx6F3rxsXCvdnQ7S97eswW29xmxoD9AX+TiG6HwU=
+gopkg.in/mgo.v2 v2.0.0-20140701140051-2e26580ebcca/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/vmihailenco/msgpack.v2 v2.9.1 h1:kb0VV7NuIojvRfzwslQeP3yArBqJHW9tOl4t38VS1jM=
 gopkg.in/vmihailenco/msgpack.v2 v2.9.1/go.mod h1:/3Dn1Npt9+MYyLpYYXjInO/5jvMLamn+AEGwNEOatn8=
@@ -512,9 +514,5 @@ grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJd
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
-labix.org/v2/mgo v0.0.0-20140701140051-000000000287 h1:L0cnkNl4TfAXzvdrqsYEmxOHOCv2p5I3taaReO8BWFs=
-labix.org/v2/mgo v0.0.0-20140701140051-000000000287/go.mod h1:Lg7AYkt1uXJoR9oeSZ3W/8IXLdvOfIITgZnommstyz4=
-launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
-launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
 sourcegraph.com/sourcegraph/go-diff v0.5.0/go.mod h1:kuch7UrkMzY0X+p9CRK03kfuPQ2zzQcaEFbx8wA8rck=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=


### PR DESCRIPTION
There are two transitive dependencies present on the current three which
are hosted on `bzr`, which increases the tooling required to compile
Terraform, and fails to compile the new version on Windwos.  This
affects plugin providers as well, making it harder to compile plugins
on Winows.

If `bzr` is not installed, fetching dependencies will fail:

<details>
<summary> Error when Bazaar is not installed</summary>

```
go: launchpad.net/gocheck@v0.0.0-20140225173054-000000000087: bzr
branch --use-existing-dir https://launchpad.net/~niemeyer/gocheck/trunk
. in
C:\Users\bltav\go\pkg\mod\cache\vcs\f46ce2ae80d31f9b0a29099baa203e3b6d269dace4e5357a2cf74bd109e13339:
exec: "bzr": executable file not found in %PATH%
go: labix.org/v2/mgo@v0.0.0-20140701140051-000000000287: bzr branch
--use-existing-dir https://launchpad.net/mgo/v2 . in
C:\Users\bltav\go\pkg\mod\cache\vcs\ca61c737a32b1e09a0919e15375f9c2b6aa09860cc097f1333b3c3d29e040ea8:
exec: "bzr": executable file not found in %PATH%
go: error loading module requirements
```

</details>

When bazaar is installed, but running on Windows, we have a different
failure

<details>

<summary> Error executing Bazaar checkout on Windows </summary>

```
o: launchpad.net/[email blocked].0-20140225173054-000000000087: bzr branch --use-existing-dir https://launchpad.net/~niemeyer/gocheck/trunk . in c:\gopath\pkg\mod\cache\vcs\f46ce2ae80d31f9b0a29099baa203e3b6d269dace4e5357a2cf74bd109e13339: exit status 4:
bzr: ERROR: httplib.IncompleteRead: IncompleteRead(34 bytes read)

Traceback (most recent call last):
File "bzrlib\commands.pyo", line 920, in exception_to_return_code
File "bzrlib\commands.pyo", line 1131, in run_bzr
File "bzrlib\commands.pyo", line 673, in run_argv_aliases
File "bzrlib\commands.pyo", line 695, in run
File "bzrlib\cleanup.pyo", line 136, in run_simple
File "bzrlib\cleanup.pyo", line 166, in _do_with_cleanups
File "bzrlib\builtins.pyo", line 1438, in run
File "bzrlib\controldir.pyo", line 779, in open_tree_or_branch
File "bzrlib\controldir.pyo", line 459, in _get_tree_branch
File "bzrlib\bzrdir.pyo", line 1082, in open_branch
File "bzrlib\branch.pyo", line 2375, in open
File "bzrlib\controldir.pyo", line 687, in open
File "bzrlib\controldir.pyo", line 716, in open_from_transport
File "bzrlib\transport\__init__.pyo", line 1718, in do_catching_redirections
File "bzrlib\controldir.pyo", line 704, in find_format
File "bzrlib\controldir.pyo", line 1149, in find_format
File "C:/Program Files (x86)/Bazaar/plugins\git\__init__.py", line 235, in probe_transport
File "C:/Program Files (x86)/Bazaar/plugins\git\__init__.py", line 182, in probe_http_transport
File "socket.pyo", line 348, in read
File "httplib.pyo", line 522, in read
File "httplib.pyo", line 565, in _read_chunked
IncompleteRead: IncompleteRead(34 bytes read)

bzr 2.5.1 on python 2.6.6 (Windows-post2008Server-6.2.9200)
arguments: ['bzr', 'branch', '--use-existing-dir',
'https://launchpad.net/~niemeyer/gocheck/trunk', '.']
plugins: bzrtools[2.5.0], changelog_merge[2.5.1], colo[0.4.0],
explorer[1.2.2], fastimport[0.14.0dev], git[0.6.8], launchpad[2.5.1],
loom[2.3.0dev], netrc_credential_store[2.5.1], news_merge[2.5.1],
pipeline[1.4.0], qbzr[0.22.3], rewrite[0.6.4dev], svn[1.2.2],
upload[1.2.0dev], xmloutput[0.8.8]
encoding: 'cp1252', fsenc: 'mbcs', lang: None

*** Bazaar has encountered an internal error. This probably indicates a
bug in Bazaar. You can help us fix it by filing a bug report at
https://bugs.launchpad.net/bzr/+filebug
including this traceback and a description of the problem.
```

</details>

There are a couple of error reports starting to show up on GitHub and on
the internet regarding those dependencies.

The alternative here is to provide another path to resolve the
dependencies, where `bzr` is not involved.

This commit uses the `replace` directive to point the transitive
dependencies to HTTPS and git mirrors of the dependencies, making it
possible to resolve dependencies and compile again on Windows.

The other changes are caused by running `go mod tidy`.