### PR TITLE
website: adding examples of complex variables on the command line

### DIFF
--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -172,6 +172,8 @@ when running the `terraform plan` and `terraform apply` commands:
 
 ```
 terraform apply -var="image_id=ami-abc123"
+terraform apply -var=`image_id_list=["ami-abc123","ami-def456"]'
+terraform apply -var=`image_id_map={"us-east-1":"ami-abc123","us-east-2":"ami-def456"}'
 ```
 
 The `-var` option can be used any number of times in a single command.

--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -172,8 +172,8 @@ when running the `terraform plan` and `terraform apply` commands:
 
 ```
 terraform apply -var="image_id=ami-abc123"
-terraform apply -var=`image_id_list=["ami-abc123","ami-def456"]'
-terraform apply -var=`image_id_map={"us-east-1":"ami-abc123","us-east-2":"ami-def456"}'
+terraform apply -var='image_id_list=["ami-abc123","ami-def456"]'
+terraform apply -var='image_id_map={"us-east-1":"ami-abc123","us-east-2":"ami-def456"}'
 ```
 
 The `-var` option can be used any number of times in a single command.

--- a/website/intro/getting-started/variables.html.md
+++ b/website/intro/getting-started/variables.html.md
@@ -122,8 +122,10 @@ values are not saved, but this provides a convenient workflow when getting
 started with Terraform. UI Input is not recommended for everyday use of
 Terraform.
 
--> **Note**: UI Input is only supported for string variables. List and map
-variables must be populated via one of the other mechanisms.
+-> **Note**: In Terraform versions 0.11 and earlier, UI Input is only supported
+for string variables. List and map variables must be populated via one of the
+other mechanisms. Terraform 0.12 introduces the ability to populate complex
+variable types from the UI prompt.
 
 #### Variable Defaults
 


### PR DESCRIPTION
@nfagerlund let me know if there's a different education/documentation human I should request review from, please!

Terraform 0.12 introduces the ability to define complex variables on the command line or at the UI prompt. I've added a note to the getting started guide and a few examples to the input variable documentation. 

Fixes #18464