### PR TITLE
Better handling of unknowns in sdk shims

### DIFF
--- a/builtin/providers/test/resource.go
+++ b/builtin/providers/test/resource.go
@@ -18,6 +18,13 @@ func testResource() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		CustomizeDiff: func(d *schema.ResourceDiff, _ interface{}) error {
+			if d.HasChange("required") {
+				d.SetNewComputed("planned_computed")
+			}
+			return nil
+		},
+
 		Schema: map[string]*schema.Schema{
 			"required": {
 				Type:     schema.TypeString,
@@ -129,6 +136,11 @@ func testResource() *schema.Resource {
 				Optional:    true,
 				Description: "return and error during apply",
 			},
+			"planned_computed": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "copied the required field during apply, and plans computed when changed",
+			},
 		},
 	}
 }
@@ -163,6 +175,8 @@ func testResourceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("computed_map", map[string]string{"key1": "value1"})
 	d.Set("computed_list", []string{"listval1", "listval2"})
 	d.Set("computed_set", []string{"setval1", "setval2"})
+
+	d.Set("planned_computed", d.Get("required"))
 
 	// if there is no "set" value, erroneously set it to an empty set. This
 	// might change a null value to an empty set, but we should be able to

--- a/builtin/providers/test/resource_list.go
+++ b/builtin/providers/test/resource_list.go
@@ -11,6 +11,13 @@ func testResourceList() *schema.Resource {
 		Update: testResourceListUpdate,
 		Delete: testResourceListDelete,
 
+		CustomizeDiff: func(d *schema.ResourceDiff, _ interface{}) error {
+			if d.HasChange("dependent_list") {
+				d.SetNewComputed("computed_list")
+			}
+			return nil
+		},
+
 		Schema: map[string]*schema.Schema{
 			"list_block": {
 				Type:     schema.TypeList,
@@ -51,6 +58,19 @@ func testResourceList() *schema.Resource {
 									"int": {
 										Type:     schema.TypeInt,
 										Required: true,
+									},
+								},
+							},
+						},
+						"sublist_block_optional": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"list": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 								},
 							},

--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -1144,6 +1144,14 @@ func normalizeNullValues(dst, src cty.Value, preferDst bool) cty.Value {
 	ty := dst.Type()
 
 	if !src.IsNull() && !src.IsKnown() {
+		// While this seems backwards to return src when preferDst is set, it
+		// means this might be a plan scenario, and it must retain unknown
+		// interpolated placeholders, which could be lost if we're only updating
+		// a resource. If this is a read scenario, then there shouldn't be any
+		// unknowns all.
+		if dst.IsNull() && preferDst {
+			return src
+		}
 		return dst
 	}
 

--- a/helper/plugin/grpc_provider_test.go
+++ b/helper/plugin/grpc_provider_test.go
@@ -909,7 +909,7 @@ func TestNormalizeNullValues(t *testing.T) {
 				}),
 			}),
 		},
-		// the empty list should be transferred, but the new unknown show not be overridden
+		// the empty list should be transferred, but the new unknown should not be overridden
 		{
 			Src: cty.ObjectVal(map[string]cty.Value{
 				"network_interface": cty.ListVal([]cty.Value{
@@ -938,6 +938,28 @@ func TestNormalizeNullValues(t *testing.T) {
 						"address":       cty.StringVal("address"),
 						"name":          cty.StringVal("nic0"),
 					}),
+				}),
+			}),
+			Plan: true,
+		},
+		{
+			// fix unknowns added to a map
+			Src: cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("a"),
+					"b": cty.StringVal(""),
+				}),
+			}),
+			Dst: cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("a"),
+					"b": cty.UnknownVal(cty.String),
+				}),
+			}),
+			Expect: cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("a"),
+					"b": cty.StringVal(""),
 				}),
 			}),
 			Plan: true,

--- a/helper/plugin/grpc_provider_test.go
+++ b/helper/plugin/grpc_provider_test.go
@@ -964,6 +964,43 @@ func TestNormalizeNullValues(t *testing.T) {
 			}),
 			Plan: true,
 		},
+		{
+			// fix unknowns lost from a list
+			Src: cty.ObjectVal(map[string]cty.Value{
+				"top": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"list": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"values": cty.ListVal([]cty.Value{cty.UnknownVal(cty.String)}),
+							}),
+						}),
+					}),
+				}),
+			}),
+			Dst: cty.ObjectVal(map[string]cty.Value{
+				"top": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"list": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"values": cty.NullVal(cty.List(cty.String)),
+							}),
+						}),
+					}),
+				}),
+			}),
+			Expect: cty.ObjectVal(map[string]cty.Value{
+				"top": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"list": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"values": cty.ListVal([]cty.Value{cty.UnknownVal(cty.String)}),
+							}),
+						}),
+					}),
+				}),
+			}),
+			Plan: true,
+		},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			got := normalizeNullValues(tc.Dst, tc.Src, tc.Plan)

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -699,14 +699,6 @@ func (d *InstanceDiff) applySingleAttrDiff(path []string, attrs map[string]strin
 		return result, nil
 	}
 
-	if diff.Old == diff.New && diff.New == "" {
-		// this can only be a valid empty string
-		if attrSchema.Type == cty.String {
-			result[attr] = ""
-		}
-		return result, nil
-	}
-
 	// check for missmatched diff values
 	if exists &&
 		old != diff.Old &&
@@ -715,13 +707,21 @@ func (d *InstanceDiff) applySingleAttrDiff(path []string, attrs map[string]strin
 		return result, fmt.Errorf("diff apply conflict for %s: diff expects %q, but prior value has %q", attr, diff.Old, old)
 	}
 
-	if attrSchema.Computed && diff.NewComputed {
-		result[attr] = config.UnknownVariableValue
+	if diff.NewRemoved {
+		// don't set anything in the new value
+		return map[string]string{}, nil
+	}
+
+	if diff.Old == diff.New && diff.New == "" {
+		// this can only be a valid empty string
+		if attrSchema.Type == cty.String {
+			result[attr] = ""
+		}
 		return result, nil
 	}
 
-	if diff.NewRemoved {
-		// don't set anything in the new value
+	if attrSchema.Computed && diff.NewComputed {
+		result[attr] = config.UnknownVariableValue
 		return result, nil
 	}
 
@@ -863,8 +863,10 @@ func (d *InstanceDiff) applyCollectionDiff(path []string, attrs map[string]strin
 		}
 	}
 
-	// Fill in the count value if it was missing for some reason:
-	if result[countKey] == "" {
+	// Fill in the count value if it wasn't present in the diff for some reason,
+	// or if there is no count at all.
+	_, countDiff := d.Attributes[countKey]
+	if result[countKey] == "" || (!countDiff && len(keys) != len(result)) {
 		result[countKey] = countFlatmapContainerValues(countKey, result)
 	}
 


### PR DESCRIPTION
There were a few holes in the handling of unknowns in the shims:

Because schema.ResourceDiff can't differentiate between unknown
values and new computed values, unknowns can be lost during an update.
If a planned value converted an unknown to a null, restore the unknown
so that it can be correctly replaced in the final plan.

The legacy diff process inserts unknown values into an optional+computed
map. Fix these up in post-plan normalization process, by looking for
known strings that were changed to unknown.

NewRemoved diff values were sometimes left in maps and lists. These are
no longer converted to unknown, but still need to be correctly removed.

Also fixes #20861