### PR TITLE
configs/configupgrade: Prefer block syntax for list-of-object attributes

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/list-of-obj-as-block/input/list-of-obj-as-block.tf
+++ b/configs/configupgrade/test-fixtures/valid/list-of-obj-as-block/input/list-of-obj-as-block.tf
@@ -1,0 +1,15 @@
+resource "test_instance" "from_list" {
+  list_of_obj = [
+    {},
+    {},
+  ]
+}
+
+resource "test_instance" "already_blocks" {
+  list_of_obj {}
+  list_of_obj {}
+}
+
+resource "test_instance" "empty" {
+  list_of_obj = []
+}

--- a/configs/configupgrade/test-fixtures/valid/list-of-obj-as-block/want/list-of-obj-as-block.tf
+++ b/configs/configupgrade/test-fixtures/valid/list-of-obj-as-block/want/list-of-obj-as-block.tf
@@ -1,0 +1,17 @@
+resource "test_instance" "from_list" {
+  list_of_obj {
+  }
+  list_of_obj {
+  }
+}
+
+resource "test_instance" "already_blocks" {
+  list_of_obj {
+  }
+  list_of_obj {
+  }
+}
+
+resource "test_instance" "empty" {
+  list_of_obj = []
+}

--- a/configs/configupgrade/test-fixtures/valid/list-of-obj-as-block/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/list-of-obj-as-block/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/configs/configupgrade/upgrade_test.go
+++ b/configs/configupgrade/upgrade_test.go
@@ -198,6 +198,7 @@ var testProviders = map[string]providers.Factory{
 						"tags":            {Type: cty.Map(cty.String), Optional: true},
 						"security_groups": {Type: cty.List(cty.String), Optional: true},
 						"subnet_ids":      {Type: cty.Set(cty.String), Optional: true},
+						"list_of_obj":     {Type: cty.List(cty.EmptyObject), Optional: true},
 					},
 					BlockTypes: map[string]*configschema.NestedBlock{
 						"network": {

--- a/lang/blocktoattr/fixup.go
+++ b/lang/blocktoattr/fixup.go
@@ -146,7 +146,7 @@ func (e *fixupBlocksExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostic
 	// the result is imprecise and in particular will just consider all
 	// the attributes to be optional and let the provider eventually decide
 	// whether to return errors if they turn out to be null when required.
-	schema := schemaForCtyType(e.ety) // this schema's ImpliedType will match e.ety
+	schema := SchemaForCtyElementType(e.ety) // this schema's ImpliedType will match e.ety
 	spec := schema.DecoderSpec()
 
 	vals := make([]cty.Value, len(e.blocks))
@@ -167,7 +167,7 @@ func (e *fixupBlocksExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostic
 
 func (e *fixupBlocksExpr) Variables() []hcl.Traversal {
 	var ret []hcl.Traversal
-	schema := schemaForCtyType(e.ety)
+	schema := SchemaForCtyElementType(e.ety)
 	spec := schema.DecoderSpec()
 	for _, block := range e.blocks {
 		ret = append(ret, hcldec.Variables(block.Body, spec)...)

--- a/lang/blocktoattr/variables.go
+++ b/lang/blocktoattr/variables.go
@@ -34,7 +34,7 @@ func walkVariables(node dynblock.WalkVariablesNode, body hcl.Body, schema *confi
 		if blockS, exists := schema.BlockTypes[child.BlockTypeName]; exists {
 			vars = append(vars, walkVariables(child.Node, child.Body(), &blockS.Block)...)
 		} else if attrS, exists := schema.Attributes[child.BlockTypeName]; exists {
-			synthSchema := schemaForCtyType(attrS.Type.ElementType())
+			synthSchema := SchemaForCtyElementType(attrS.Type.ElementType())
 			vars = append(vars, walkVariables(child.Node, child.Body(), synthSchema)...)
 		}
 	}


### PR DESCRIPTION
In order to preserve pre-v0.12 idiom for list-of-object attributes, we'll prefer to use block syntax for them except for the special situation where the user explicitly assigns an empty list, where attribute syntax is
required in order to allow existing provider logic to differentiate from an implicit lack of blocks.

This is a continuation of #20837.