### PR TITLE
filter nulls when shimming a config

### DIFF
--- a/config/hcl2shim/values.go
+++ b/config/hcl2shim/values.go
@@ -167,7 +167,10 @@ func ConfigValueFromHCL2(v cty.Value) interface{} {
 		it := v.ElementIterator()
 		for it.Next() {
 			_, ev := it.Element()
-			l = append(l, ConfigValueFromHCL2(ev))
+			cv := ConfigValueFromHCL2(ev)
+			if cv != nil {
+				l = append(l, cv)
+			}
 		}
 		return l
 	}

--- a/config/hcl2shim/values_test.go
+++ b/config/hcl2shim/values_test.go
@@ -232,6 +232,26 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 			&configschema.Block{},
 			nil,
 		},
+		// nulls should be filtered out of the config, since they couldn't exist
+		// in hcl.
+		{
+			cty.ObjectVal(map[string]cty.Value{
+				"list": cty.ListVal([]cty.Value{
+					cty.StringVal("ok"),
+					cty.NullVal(cty.String)}),
+			}),
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"list": {
+						Type:     cty.List(cty.String),
+						Optional: true,
+					},
+				},
+			},
+			map[string]interface{}{
+				"list": []interface{}{"ok"},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Nulls can't exist in HCL, and the legacy sdk will panic when
encountering them. The map shim already did this, just copy the same
pattern in the list case.

Fixes #20889