### PR TITLE
increase grpc recv limit

### DIFF
--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -119,7 +119,13 @@ func (p *GRPCProvider) GetSchema() (resp providers.GetSchemaResponse) {
 	resp.ResourceTypes = make(map[string]providers.Schema)
 	resp.DataSources = make(map[string]providers.Schema)
 
-	protoResp, err := p.client.GetSchema(p.ctx, new(proto.GetProviderSchema_Request))
+	// Some providers may generate quite large schemas, and the internal default
+	// grpc response size limit is 4MB. 64MB should cover most any use case, and
+	// if we get providers nearing that we may want to consider a finer-grained
+	// API to fetch individual resource schemas.
+	// Note: this option is marked as EXPERIMENTAL in the grpc API.
+	const maxRecvSize = 64 << 20
+	protoResp, err := p.client.GetSchema(p.ctx, new(proto.GetProviderSchema_Request), grpc.MaxRecvMsgSizeCallOption{MaxRecvMsgSize: maxRecvSize})
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp

--- a/plugin/grpc_provider_test.go
+++ b/plugin/grpc_provider_test.go
@@ -26,6 +26,7 @@ func mockProviderClient(t *testing.T) *mockproto.MockProviderClient {
 	client.EXPECT().GetSchema(
 		gomock.Any(),
 		gomock.Any(),
+		gomock.Any(),
 	).Return(providerProtoSchema(), nil)
 
 	return client


### PR DESCRIPTION
Some providers may generate quite large schemas, and the internal
default grpc response size limit is 4MB. 64MB should cover most any use
case, and if we get providers nearing that we may want to consider a
finer-grained API to fetch individual resource schemas.

Fixes #20879