### PR TITLE
command/format: improve "source" of error messages regarding missing arguments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20190327223817-3fb4ed0d9260
+	github.com/hashicorp/hcl2 v0.0.0-20190402200843-8b450a7d58f9
 	github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,8 @@ github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh
 github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
 github.com/hashicorp/hcl2 v0.0.0-20190327223817-3fb4ed0d9260 h1:C3vhYEXk8ihs+Xvq093axRyYhfLERrZ6Uv5tfRw9yvw=
 github.com/hashicorp/hcl2 v0.0.0-20190327223817-3fb4ed0d9260/go.mod h1:HtEzazM5AZ9fviNEof8QZB4T1Vz9UhHrGhnMPzl//Ek=
+github.com/hashicorp/hcl2 v0.0.0-20190402200843-8b450a7d58f9 h1:zCITwiA0cog6aYr/a/McDHKtgsEpYxXvTIgugv5iu8o=
+github.com/hashicorp/hcl2 v0.0.0-20190402200843-8b450a7d58f9/go.mod h1:HtEzazM5AZ9fviNEof8QZB4T1Vz9UhHrGhnMPzl//Ek=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 h1:2yzhWGdgQUWZUCNK+AoO35V+HTsgEmcM4J9IkArh7PI=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/tfdiags/contextual_test.go
+++ b/tfdiags/contextual_test.go
@@ -58,8 +58,8 @@ simple_attr = "val"
 	}
 	emptySrcRng := &SourceRange{
 		Filename: "test.tf",
-		Start:    SourcePos{Line: 33, Column: 1, Byte: 440},
-		End:      SourcePos{Line: 33, Column: 1, Byte: 440},
+		Start:    SourcePos{Line: 1, Column: 1, Byte: 0},
+		End:      SourcePos{Line: 1, Column: 1, Byte: 0},
 	}
 
 	testCases := []struct {

--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/structure.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/structure.go
@@ -279,7 +279,11 @@ func (b *Body) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
 }
 
 func (b *Body) MissingItemRange() hcl.Range {
-	return b.EndRange
+	return hcl.Range{
+		Filename: b.SrcRange.Filename,
+		Start:    b.SrcRange.Start,
+		End:      b.SrcRange.Start,
+	}
 }
 
 // Attributes is the collection of attribute definitions within a body.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl2 v0.0.0-20190327223817-3fb4ed0d9260
+# github.com/hashicorp/hcl2 v0.0.0-20190402200843-8b450a7d58f9
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec


### PR DESCRIPTION
Fixes #20829

HCL2 was originally returning the end of the block as the location for missing attributes. On it's own this wasn't terribly helpful, and terraform ended up looking up the start of the block for error messages. An unintended side effect of this was that attributes missing from nested blocks returned unclear error messages  pointed to the top-level resource, not the nested block.

HCL2 has been updated to return the _start_ of the block, which leads to more precise error messages:

```
Error: Missing required argument

  on connection.tf line 5, in resource "null_resource" "foo":
   5:   connection {

The argument "host" is required, but no definition was found.


Error: Missing required argument

  on connection.tf line 11, in resource "random_id" "id":
  11: resource "random_id" "id" {

The argument "byte_length" is required, but no definition was found.
```


