### PR TITLE
Swift backend: add application credential support

### DIFF
--- a/backend/remote-state/swift/backend.go
+++ b/backend/remote-state/swift/backend.go
@@ -41,6 +41,27 @@ func New() backend.Backend {
 				Description: descriptions["user_name"],
 			},
 
+			"application_credential_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_APPLICATION_CREDENTIAL_ID", ""),
+				Description: descriptions["application_credential_id"],
+			},
+
+			"application_credential_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_APPLICATION_CREDENTIAL_NAME", ""),
+				Description: descriptions["application_credential_name"],
+			},
+
+			"application_credential_secret": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_APPLICATION_CREDENTIAL_SECRET", ""),
+				Description: descriptions["application_credential_secret"],
+			},
+
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -234,6 +255,12 @@ func init() {
 
 		"user_id": "User ID to login with.",
 
+		"application_credential_id": "Application Credential ID to login with.",
+
+		"application_credential_name": "Application Credential name to login with.",
+
+		"application_credential_secret": "Application Credential secret to login with.",
+
 		"tenant_id": "The ID of the Tenant (Identity v2) or Project (Identity v3)\n" +
 			"to login with.",
 
@@ -304,25 +331,28 @@ func (b *Backend) configure(ctx context.Context) error {
 	// Grab the resource data
 	data := schema.FromContextBackendConfig(ctx)
 	config := &tf_openstack.Config{
-		CACertFile:        data.Get("cacert_file").(string),
-		ClientCertFile:    data.Get("cert").(string),
-		ClientKeyFile:     data.Get("key").(string),
-		Cloud:             data.Get("cloud").(string),
-		DefaultDomain:     data.Get("default_domain").(string),
-		DomainID:          data.Get("domain_id").(string),
-		DomainName:        data.Get("domain_name").(string),
-		EndpointType:      data.Get("endpoint_type").(string),
-		IdentityEndpoint:  data.Get("auth_url").(string),
-		Password:          data.Get("password").(string),
-		ProjectDomainID:   data.Get("project_domain_id").(string),
-		ProjectDomainName: data.Get("project_domain_name").(string),
-		Token:             data.Get("token").(string),
-		TenantID:          data.Get("tenant_id").(string),
-		TenantName:        data.Get("tenant_name").(string),
-		UserDomainID:      data.Get("user_domain_id").(string),
-		UserDomainName:    data.Get("user_domain_name").(string),
-		Username:          data.Get("user_name").(string),
-		UserID:            data.Get("user_id").(string),
+		CACertFile:                  data.Get("cacert_file").(string),
+		ClientCertFile:              data.Get("cert").(string),
+		ClientKeyFile:               data.Get("key").(string),
+		Cloud:                       data.Get("cloud").(string),
+		DefaultDomain:               data.Get("default_domain").(string),
+		DomainID:                    data.Get("domain_id").(string),
+		DomainName:                  data.Get("domain_name").(string),
+		EndpointType:                data.Get("endpoint_type").(string),
+		IdentityEndpoint:            data.Get("auth_url").(string),
+		Password:                    data.Get("password").(string),
+		ProjectDomainID:             data.Get("project_domain_id").(string),
+		ProjectDomainName:           data.Get("project_domain_name").(string),
+		Token:                       data.Get("token").(string),
+		TenantID:                    data.Get("tenant_id").(string),
+		TenantName:                  data.Get("tenant_name").(string),
+		UserDomainID:                data.Get("user_domain_id").(string),
+		UserDomainName:              data.Get("user_domain_name").(string),
+		Username:                    data.Get("user_name").(string),
+		UserID:                      data.Get("user_id").(string),
+		ApplicationCredentialID:     data.Get("application_credential_id").(string),
+		ApplicationCredentialName:   data.Get("application_credential_name").(string),
+		ApplicationCredentialSecret: data.Get("application_credential_secret").(string),
 	}
 
 	if v, ok := data.GetOkExists("insecure"); ok {

--- a/website/docs/backends/types/swift.html.md
+++ b/website/docs/backends/types/swift.html.md
@@ -65,6 +65,19 @@ The following configuration options are supported:
  * `password` - (Optional) The Password to login with. If omitted, the
    `OS_PASSWORD` environment variable is used.
 
+ * `application_credential_id` - (Optional) (Identity v3 only) The ID of an
+    application credential to authenticate with. An
+    `application_credential_secret` has to bet set along with this parameter.
+
+ * `application_credential_name` - (Optional) (Identity v3 only) The name of an
+    application credential to authenticate with. Conflicts with the
+    `application_credential_name`, requires `user_id`, or `user_name` and
+    `domain_name` (or `domain_id`) to be set.
+
+ * `application_credential_secret` - (Optional) (Identity v3 only) The secret of an
+    application credential to authenticate with. Required by
+    `application_credential_id` or `application_credential_name`.
+
  * `token` - (Optional) Access token to login with instead of user and password.
     If omitted, the `OS_AUTH_TOKEN` variable is used.
 


### PR DESCRIPTION
This PR adds an application credential auth support to the swift backend. Application credentials auth is already supported by an openstack provider. See https://github.com/terraform-providers/terraform-provider-openstack/pull/642

/cc @jtopjian , @jbardin