### PR TITLE
configs/configupgrade: return if hil.Parse() produces an error.

### DIFF
--- a/configs/configupgrade/upgrade_expr.go
+++ b/configs/configupgrade/upgrade_expr.go
@@ -55,6 +55,7 @@ Value:
 					Detail:   fmt.Sprintf("Interpolation parsing failed: %s", err),
 					Subject:  hcl1PosRange(filename, tv.Pos).Ptr(),
 				})
+				return nil, diags
 			}
 
 			interpSrc, interpDiags := upgradeExpr(hilNode, filename, interp, an)


### PR DESCRIPTION
Previously the `0.12configupgrade` tool would attempt to upgrade a string even after `hil.Parse()` returned an error, which caused much `panic`.

Fixes #20917