### PR TITLE
Allow all planned computed diff fields

### DIFF
--- a/builtin/providers/test/resource.go
+++ b/builtin/providers/test/resource.go
@@ -19,7 +19,7 @@ func testResource() *schema.Resource {
 		},
 
 		CustomizeDiff: func(d *schema.ResourceDiff, _ interface{}) error {
-			if d.HasChange("required") {
+			if d.HasChange("optional") {
 				d.SetNewComputed("planned_computed")
 			}
 			return nil
@@ -176,7 +176,7 @@ func testResourceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("computed_list", []string{"listval1", "listval2"})
 	d.Set("computed_set", []string{"setval1", "setval2"})
 
-	d.Set("planned_computed", d.Get("required"))
+	d.Set("planned_computed", d.Get("optional"))
 
 	// if there is no "set" value, erroneously set it to an empty set. This
 	// might change a null value to an empty set, but we should be able to

--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -611,17 +611,6 @@ func (s *GRPCProviderServer) PlanResourceChange(_ context.Context, req *proto.Pl
 		priorState = &terraform.InstanceState{}
 	}
 
-	// if we're not creating a new resource, remove any new computed fields
-	if !create {
-		for attr, d := range diff.Attributes {
-			// If there's no change, then don't let this go through as NewComputed.
-			// This usually only happens when Old and New are both empty.
-			if d.NewComputed && d.Old == d.New {
-				delete(diff.Attributes, attr)
-			}
-		}
-	}
-
 	// now we need to apply the diff to the prior state, so get the planned state
 	plannedAttrs, err := diff.Apply(priorState.Attributes, res.CoreConfigSchemaWhenShimmed())
 	schema.FixupAsSingleInstanceStateOut(


### PR DESCRIPTION
Stripping out the unchanged NewComputed diffs was a patch for some provider behavior which was fixed in other ways, and is no longer needed.

Removing this behavior allows us to implement correct CusomizeDiffFuncs in
providers so that they can mark fields with empty values as computed
during a plan.