### PR TITLE
lang: EvalBlock should use ReferencesInBlock

### DIFF
--- a/lang/eval.go
+++ b/lang/eval.go
@@ -47,8 +47,7 @@ func (s *Scope) ExpandBlock(body hcl.Body, schema *configschema.Block) (hcl.Body
 func (s *Scope) EvalBlock(body hcl.Body, schema *configschema.Block) (cty.Value, tfdiags.Diagnostics) {
 	spec := schema.DecoderSpec()
 
-	traversals := hcldec.Variables(body, spec)
-	refs, diags := References(traversals)
+	refs, diags := ReferencesInBlock(body, schema)
 
 	ctx, ctxDiags := s.EvalContext(refs)
 	diags = diags.Append(ctxDiags)


### PR DESCRIPTION
Previously it was calling directly to hcldec.Variables, and thus missing the special fixups we do inside `ReferencesInBlock` to deal with Terraform-specific concerns such as our attribute-as-blocks preprocessing.
