### PR TITLE
configs/configupgrade: Normalize number literals to decimal

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/number-literals/input/number-literals.tf
+++ b/configs/configupgrade/test-fixtures/valid/number-literals/input/number-literals.tf
@@ -1,0 +1,7 @@
+locals {
+  decimal_int          = 1
+  decimal_float        = 1.5
+  decimal_float_tricky = 0.1
+  hex_int              = 0xff
+  octal_int            = 0777
+}

--- a/configs/configupgrade/test-fixtures/valid/number-literals/want/number-literals.tf
+++ b/configs/configupgrade/test-fixtures/valid/number-literals/want/number-literals.tf
@@ -1,0 +1,7 @@
+locals {
+  decimal_int          = 1
+  decimal_float        = 1.5
+  decimal_float_tricky = 0.1
+  hex_int              = 255
+  octal_int            = 511
+}

--- a/configs/configupgrade/test-fixtures/valid/number-literals/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/number-literals/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/configs/configupgrade/upgrade_expr.go
+++ b/configs/configupgrade/upgrade_expr.go
@@ -143,8 +143,17 @@ Value:
 				buf.WriteString("false")
 			}
 
+		case hcl1token.NUMBER:
+			num := tv.Value()
+			buf.WriteString(strconv.FormatInt(num.(int64), 10))
+
+		case hcl1token.FLOAT:
+			num := tv.Value()
+			buf.WriteString(strconv.FormatFloat(num.(float64), 'f', -1, 64))
+
 		default:
-			// For everything else (NUMBER, FLOAT) we'll just pass through the given bytes verbatim.
+			// For everything else we'll just pass through the given bytes verbatim,
+			// but we should't get here because the above is intended to be exhaustive.
 			buf.WriteString(tv.Text)
 
 		}


### PR DESCRIPTION
The v0.12 language supports numeric constants only in decimal notation, as a simplification of the language. For rare situations where a different base is more appropriate, such as unix-style file modes, we've found it better for providers to accept a string containing a representation in the appropriate base, since that way the interpretation can be validated and it will be displayed in the same way in the rendered plan diff, in outputs, etc.

We use `hcl1token.Token.Value()` here to mimick how HCL 1 itself would have interpreted these, and then format them back out in the canonical form, which implicitly converts any non-decimal constants to decimal on the way through.

This closes #20933 by addressing the v0.12.0-release-blocking part. That issue also raised a situation where the parse error reporting is not ideal, but we do not plan to fix that for now and will save it for later polish; for the moment we'll leave it untracked and see if it is encountered often enough post-upgrade to be raised again, and prioritize accordingly.
