### PR TITLE
lang/blocktoattr: Apply fixup within already-fixed-up blocks too

### DIFF
--- a/lang/blocktoattr/fixup.go
+++ b/lang/blocktoattr/fixup.go
@@ -152,7 +152,8 @@ func (e *fixupBlocksExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostic
 	vals := make([]cty.Value, len(e.blocks))
 	var diags hcl.Diagnostics
 	for i, block := range e.blocks {
-		val, blockDiags := hcldec.Decode(block.Body, spec, ctx)
+		body := FixUpBlockAttrs(block.Body, schema)
+		val, blockDiags := hcldec.Decode(body, spec, ctx)
 		diags = append(diags, blockDiags...)
 		if val == cty.NilVal {
 			val = cty.UnknownVal(e.ety)

--- a/lang/blocktoattr/fixup_test.go
+++ b/lang/blocktoattr/fixup_test.go
@@ -216,7 +216,7 @@ foo {
 				}),
 			}),
 		},
-		"nested fixup": {
+		"fixup inside block": {
 			src: `
 container {
   foo {
@@ -237,6 +237,56 @@ container {
 					"container": {
 						Nesting: configschema.NestingList,
 						Block:   *fooSchema,
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"container": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"bar": cty.StringVal("baz"),
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"bar": cty.StringVal("boop"),
+							}),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"bar": cty.StringVal("beep value"),
+							}),
+						}),
+					}),
+				}),
+			}),
+		},
+		"fixup inside attribute-as-block": {
+			src: `
+container {
+  foo {
+    bar = "baz"
+  }
+  foo {
+    bar = "boop"
+  }
+}
+container {
+  foo {
+    bar = beep
+  }
+}
+`,
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"container": {
+						Type: cty.List(cty.Object(map[string]cty.Type{
+							"foo": cty.List(cty.Object(map[string]cty.Type{
+								"bar": cty.String,
+							})),
+						})),
+						Optional: true,
 					},
 				},
 			},

--- a/lang/blocktoattr/variables_test.go
+++ b/lang/blocktoattr/variables_test.go
@@ -77,6 +77,39 @@ foo {
 				},
 			},
 		},
+		"block syntax with nested blocks": {
+			src: `
+foo {
+  bar {
+    boop = baz
+  }
+}
+`,
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {
+						Type: cty.List(cty.Object(map[string]cty.Type{
+							"bar": cty.List(cty.Object(map[string]cty.Type{
+								"boop": cty.String,
+							})),
+						})),
+						Optional: true,
+					},
+				},
+			},
+			want: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{
+						Name: "baz",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 12, Byte: 26},
+							End:      hcl.Pos{Line: 4, Column: 15, Byte: 29},
+						},
+					},
+				},
+			},
+		},
 		"dynamic block syntax": {
 			src: `
 dynamic "foo" {


### PR DESCRIPTION
When a top-level list-of-object contains an attribute that is also list-of-object we need to do the fixup again inside the nested body (using our synthetic attributes-only schema) so that the attr-as-blocks mechanism can apply within the nested blocks too.

Fixes #20934.