### PR TITLE
Only display status link if public registry used

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -504,7 +504,7 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 				}
 
 				switch {
-				case err == discovery.ErrorServiceUnreachable:
+				case err == discovery.ErrorServiceUnreachable, err == discovery.ErrorPublicRegistryUnreachable:
 					c.Ui.Error(errDiscoveryServiceUnreachable)
 				case err == discovery.ErrorNoSuchProvider:
 					c.Ui.Error(fmt.Sprintf(errProviderNotFound, provider, DefaultPluginVendorDir))
@@ -884,8 +884,6 @@ const errDiscoveryServiceUnreachable = `
 [reset][bold][red]Registry service unreachable.[reset][red]
 
 This may indicate a network issue, or an issue with the requested Terraform Registry.
-
-Check https://status.hashicorp.com/ for registry status updates.
 `
 
 const errProviderNotFound = `

--- a/plugin/discovery/error.go
+++ b/plugin/discovery/error.go
@@ -55,6 +55,10 @@ const ErrorSignatureVerification = Error("unable to verify signature")
 // to the registry service
 const ErrorServiceUnreachable = Error("registry service is unreachable")
 
+// ErrorPublicRegistryUnreachable indicates that the network was unable to connect
+// to the public registry in particular, so we can show a link to the statuspage
+const ErrorPublicRegistryUnreachable = Error("registry service is unreachable, check https://status.hashicorp.com/ for status updates")
+
 func (err Error) Error() string {
 	return string(err)
 }

--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -127,6 +127,10 @@ func (i *ProviderInstaller) Get(provider string, req Constraints) (PluginMeta, t
 	if err != nil {
 		log.Printf("[DEBUG] %s", err)
 		if registry.IsServiceUnreachable(err) {
+			registryHost, err := i.hostname()
+			if err == nil && registryHost == regsrc.PublicRegistryHost.Raw {
+				return PluginMeta{}, diags, ErrorPublicRegistryUnreachable
+			}
 			return PluginMeta{}, diags, ErrorServiceUnreachable
 		}
 		if registry.IsServiceNotProvided(err) {


### PR DESCRIPTION
Updates to throw a specific error if using the defined public registry vs. another registry, so that we only display info to go to status.hashicorp.com if you're using the public registry.

cc @findkim 