### PR TITLE
Don't allow unknown values in the config when generating the apply Diff

### DIFF
--- a/builtin/providers/test/resource_state_func_test.go
+++ b/builtin/providers/test/resource_state_func_test.go
@@ -58,3 +58,28 @@ resource "test_resource_state_func" "foo" {
 		},
 	})
 }
+
+func TestResourceStateFunc_getOkSetElem(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_state_func" "foo" {
+}
+
+resource "test_resource_state_func" "bar" {
+	set_block {
+		required = "foo"
+		optional = test_resource_state_func.foo.id
+	}
+	set_block {
+		required = test_resource_state_func.foo.id
+	}
+}
+				`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
The synthetic config value used to create the Apply diff should contain
no unknown config values. Any remaining UnknownConfigValues were due to
that being used as a placeholder for values yet to be computed, and
these should be marked NewComputed in the diff.

Fixes: #20958