### PR TITLE
command/output: get the state path from the workspace or CLI argument

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -28,11 +28,11 @@ func (c *OutputCommand) Run(args []string) int {
 		return 1
 	}
 
-	var module string
+	var module, statePath string
 	var jsonOutput bool
 	cmdFlags := c.Meta.defaultFlagSet("output")
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "json")
-	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
+	cmdFlags.StringVar(&statePath, "state", "", "path")
 	cmdFlags.StringVar(&module, "module", "", "module")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
@@ -51,6 +51,10 @@ func (c *OutputCommand) Run(args []string) int {
 	name := ""
 	if len(args) > 0 {
 		name = args[0]
+	}
+
+	if statePath != "" {
+		c.Meta.statePath = statePath
 	}
 
 	var diags tfdiags.Diagnostics


### PR DESCRIPTION
Previously this command was setting the state path to the default state
file, instead of honoring the path set in the backend configuration.

Fixes #20983