### PR TITLE
Clarify where you run the `terraform init` command

### DIFF
--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -246,7 +246,7 @@ Operating system  | User plugins directory
 Windows           | `%APPDATA%\terraform.d\plugins`
 All other systems | `~/.terraform.d/plugins`
 
-Once a plugin is installed, `terraform init` can initialize it normally.
+Once a plugin is installed, `terraform init` can initialize it normally. You can run this command from any directory.
 
 Providers distributed by HashiCorp can also go in the user plugins directory. If
 a manually installed version meets the configuration's version constraints,

--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -246,7 +246,7 @@ Operating system  | User plugins directory
 Windows           | `%APPDATA%\terraform.d\plugins`
 All other systems | `~/.terraform.d/plugins`
 
-Once a plugin is installed, `terraform init` can initialize it normally. You can run this command from any directory.
+Once a plugin is installed, `terraform init` can initialize it normally. You must run this command from the directory where the configuration files are located.
 
 Providers distributed by HashiCorp can also go in the user plugins directory. If
 a manually installed version meets the configuration's version constraints,


### PR DESCRIPTION
The instructions don't currently specify which directory to run `terraform init` from. This PR assumes that it doesn't matter. If I'm wrong about that, please comment below and I'll change this PR or open another.