### PR TITLE
command/state_list.go: fix bug loading user-defined state

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -77,7 +77,7 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	if err := stateStore.RefreshState(); err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to refresh state: %s", err))
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
 

--- a/command/output.go
+++ b/command/output.go
@@ -77,7 +77,7 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	if err := stateStore.RefreshState(); err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		c.Ui.Error(fmt.Sprintf("Failed to refresh state: %s", err))
 		return 1
 	}
 

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -23,13 +23,18 @@ func (c *StateListCommand) Run(args []string) int {
 		return 1
 	}
 
+	var statePath string
 	cmdFlags := c.Meta.defaultFlagSet("state list")
-	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
+	cmdFlags.StringVar(&statePath, "state", "", "path")
 	lookupId := cmdFlags.String("id", "", "Restrict output to paths with a resource having the specified ID.")
 	if err := cmdFlags.Parse(args); err != nil {
 		return cli.RunResultHelp
 	}
 	args = cmdFlags.Args()
+
+	if statePath != "" {
+		c.Meta.statePath = statePath
+	}
 
 	// Load the backend
 	b, backendDiags := c.Backend(nil)

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -51,7 +51,7 @@ func (c *StateListCommand) Run(args []string) int {
 		return 1
 	}
 	if err := stateMgr.RefreshState(); err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to refresh state: %s", err))
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
 


### PR DESCRIPTION
If the user supplied a state path via the `-state` flag and terraform
was running in a workspace other than `default`, the state was not being
loaded properly. Fixes #19920