### PR TITLE
configs: Handle "dynamic" blocks as special during override merging

### DIFF
--- a/configs/test-fixtures/valid-modules/override-dynamic-block-base/a_override.tf
+++ b/configs/test-fixtures/valid-modules/override-dynamic-block-base/a_override.tf
@@ -1,0 +1,6 @@
+
+resource "test" "foo" {
+  foo {
+    from = "override"
+  }
+}

--- a/configs/test-fixtures/valid-modules/override-dynamic-block-base/base.tf
+++ b/configs/test-fixtures/valid-modules/override-dynamic-block-base/base.tf
@@ -1,0 +1,9 @@
+
+resource "test" "foo" {
+  dynamic "foo" {
+    for_each = []
+    content {
+      from = "base"
+    }
+  }
+}

--- a/configs/test-fixtures/valid-modules/override-dynamic-block-override/a_override.tf
+++ b/configs/test-fixtures/valid-modules/override-dynamic-block-override/a_override.tf
@@ -1,0 +1,9 @@
+
+resource "test" "foo" {
+  dynamic "foo" {
+    for_each = []
+    content {
+      from = "override"
+    }
+  }
+}

--- a/configs/test-fixtures/valid-modules/override-dynamic-block-override/base.tf
+++ b/configs/test-fixtures/valid-modules/override-dynamic-block-override/base.tf
@@ -1,0 +1,6 @@
+
+resource "test" "foo" {
+  foo {
+    from = "base"
+  }
+}

--- a/configs/util.go
+++ b/configs/util.go
@@ -43,3 +43,21 @@ func schemaForOverrides(schema *hcl.BodySchema) *hcl.BodySchema {
 
 	return ret
 }
+
+// schemaWithDynamic takes a *hcl.BodySchema and produces a new one that
+// is equivalent except that it accepts an additional block type "dynamic" with
+// a single label, used to recognize usage of the HCL dynamic block extension.
+func schemaWithDynamic(schema *hcl.BodySchema) *hcl.BodySchema {
+	ret := &hcl.BodySchema{
+		Attributes: schema.Attributes,
+		Blocks:     make([]hcl.BlockHeaderSchema, len(schema.Blocks), len(schema.Blocks)+1),
+	}
+
+	copy(ret.Blocks, schema.Blocks)
+	ret.Blocks = append(ret.Blocks, hcl.BlockHeaderSchema{
+		Type:       "dynamic",
+		LabelNames: []string{"type"},
+	})
+
+	return ret
+}


### PR DESCRIPTION
Previously we were treating `dynamic` blocks in configuration the same as any other block type when merging config bodies, so that `dynamic` blocks in the override would override any `dynamic` blocks present in the base, without considering the `dynamic` block type specified in the first label.

It's more useful and intuitive for us to treat dynamic blocks as if they are instances of their given block type for the purpose of overriding. That means a `foo` block can be overridden by a `dynamic "foo"` block and vice-versa, while `dynamic` blocks of different types do not interact at all during overriding.

This requires us to recognize dynamic blocks and treat them specially during decoding of a merged body. We leave them unexpanded here because this package is not responsible for dynamic block expansion (that happens in the sibling `lang` package) but we do decode them enough to recognize
their labels so we can treat them as if they were blocks of the labelled type.

This fixes #20751.