### PR TITLE
Document division behavior change in v0.12 upgrade guide

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20190402200843-8b450a7d58f9
+	github.com/hashicorp/hcl2 v0.0.0-20190416162332-2c5a4b7d729a
 	github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
-github.com/hashicorp/hcl2 v0.0.0-20190402200843-8b450a7d58f9 h1:zCITwiA0cog6aYr/a/McDHKtgsEpYxXvTIgugv5iu8o=
-github.com/hashicorp/hcl2 v0.0.0-20190402200843-8b450a7d58f9/go.mod h1:HtEzazM5AZ9fviNEof8QZB4T1Vz9UhHrGhnMPzl//Ek=
+github.com/hashicorp/hcl2 v0.0.0-20190416162332-2c5a4b7d729a h1:doKt9ZBCYgYQrGK6CqJsEB+8xqm3WoFyKu4TPZlyymg=
+github.com/hashicorp/hcl2 v0.0.0-20190416162332-2c5a4b7d729a/go.mod h1:HtEzazM5AZ9fviNEof8QZB4T1Vz9UhHrGhnMPzl//Ek=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 h1:2yzhWGdgQUWZUCNK+AoO35V+HTsgEmcM4J9IkArh7PI=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/vendor/github.com/hashicorp/hcl2/hcl/pos.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/pos.go
@@ -31,6 +31,9 @@ type Pos struct {
 	Byte int
 }
 
+// InitialPos is a suitable position to use to mark the start of a file.
+var InitialPos = Pos{Byte: 0, Line: 1, Column: 1}
+
 // Range represents a span of characters between two positions in a source
 // file.
 //

--- a/vendor/github.com/hashicorp/hcl2/hcl/pos_scanner.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/pos_scanner.go
@@ -29,8 +29,8 @@ type RangeScanner struct {
 	err error  // error from last scan, if any
 }
 
-// Create a new RangeScanner for the given buffer, producing ranges for the
-// given filename.
+// NewRangeScanner creates a new RangeScanner for the given buffer, producing
+// ranges for the given filename.
 //
 // Since ranges have grapheme-cluster granularity rather than byte granularity,
 // the scanner will produce incorrect results if the given SplitFunc creates
@@ -39,15 +39,19 @@ type RangeScanner struct {
 // around individual UTF-8 sequences, which will split any multi-sequence
 // grapheme clusters.
 func NewRangeScanner(b []byte, filename string, cb bufio.SplitFunc) *RangeScanner {
+	return NewRangeScannerFragment(b, filename, InitialPos, cb)
+}
+
+// NewRangeScannerFragment is like NewRangeScanner but the ranges it produces
+// will be offset by the given starting position, which is appropriate for
+// sub-slices of a file, whereas NewRangeScanner assumes it is scanning an
+// entire file.
+func NewRangeScannerFragment(b []byte, filename string, start Pos, cb bufio.SplitFunc) *RangeScanner {
 	return &RangeScanner{
 		filename: filename,
 		b:        b,
 		cb:       cb,
-		pos: Pos{
-			Byte:   0,
-			Line:   1,
-			Column: 1,
-		},
+		pos:      start,
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl2 v0.0.0-20190402200843-8b450a7d58f9
+# github.com/hashicorp/hcl2 v0.0.0-20190416162332-2c5a4b7d729a
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec

--- a/website/upgrade-guides/0-12.html.markdown
+++ b/website/upgrade-guides/0-12.html.markdown
@@ -237,7 +237,46 @@ into a list. The upgrade tool does not remove or attempt to consolidate
 any existing duplicate arguments, but other commands like `terraform validate`
 will detect and report these after upgrading.
 
+## Integer vs. Float Number Types
+
+From Terraform v0.12, the Terraform language no longer distinguishes between
+integer and float types, instead just having a single "number" type that can
+represent high-precision floating point numbers. This new type can represent
+any value that could be represented before, plus many new values due to the
+expanded precision.
+
+In most cases this change should not cause any significant behavior change, but
+please note that in particular the behavior of the division operator is now
+different: it _always_ performs floating point division, whereas before it
+would sometimes perform integer division by attempting to infer intent from
+the argument types.
+
+If you are relying on integer division behavior in your configuration, please
+use the `floor` function to obtain the previous result. A common place this
+would arise is in index operations, where the index is computed by division:
+
+```hcl
+  example = var.items[floor(count.index / var.any_number)]
+```
+
+Using a fractional number to index a list will produce an error telling you
+that this is not allowed, serving as a prompt to add `floor`:
+
+```
+Error: Invalid index
+
+The given key does not identify an element in this collection value: indexing a
+sequence requires a whole number, but the given index (0.5) has a fractional
+part.
+```
+
+Unfortunately the automatic upgrade tool cannot apply a fix for this case
+because it does not have enough information to know if floating point or integer
+division was intended by the configuration author, so this change must be made
+manually where needed.
+
 ## Terraform Configuration upgrades requiring human intervention 
+
 There are some known situations that will be detected, but not upgrade, by the
 upgrade tool. Some examples of these situatations include:
 


### PR DESCRIPTION
The division operator now always performs floating point division, whereas before it would choose between float and int division based on the types of its arguments.

This adds (via an HCL upgrade) a specific error message for when a fractional number is used as an index in HCL, and then we add additional upgrade guidance providing a specific solution to the problem: the `floor` function.

Sadly we don't have enough context in the current design of the upgrade tool to make this fix automatic. With some refactoring it may be possible to apply the fix automatically within list brackets, but since that is a relatively complex change we'll first try this manual solution prompted by an error message, because in practice so far we've seen this reported only in the context of list indexing and our error check will catch that and make the user aware of the need for a fix there.

If experience during the remaining pre-release cycles suggests that this situation is more common than initially anticipated then we may choose to spend the time to find a way to implement an automatic fix for it, but with what we know now it seems prudent to prioritize other release-blocking work so we can get to the final release sooner.

This addresses #20496, though through documentation rather than by restoring the previous behavior.