### PR TITLE
configs/configupgrade: Preserve comments on items in object exprs

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/noop/input/resources.tf
+++ b/configs/configupgrade/test-fixtures/valid/noop/input/resources.tf
@@ -1,5 +1,10 @@
 
 resource "test_instance" "example" {
+  tags = {
+    # Thingy thing
+    name = "foo bar baz" # this is a terrible name
+  }
+
   connection {
     host = "127.0.0.1"
   }

--- a/configs/configupgrade/test-fixtures/valid/noop/want/resources.tf
+++ b/configs/configupgrade/test-fixtures/valid/noop/want/resources.tf
@@ -1,5 +1,10 @@
 
 resource "test_instance" "example" {
+  tags = {
+    # Thingy thing
+    name = "foo bar baz" # this is a terrible name
+  }
+
   connection {
     host = "127.0.0.1"
   }

--- a/configs/configupgrade/upgrade_expr.go
+++ b/configs/configupgrade/upgrade_expr.go
@@ -192,9 +192,22 @@ Value:
 			diags = diags.Append(moreDiags)
 			valueSrc, moreDiags := upgradeExpr(item.Val, filename, interp, an)
 			diags = diags.Append(moreDiags)
+			if item.LeadComment != nil {
+				for _, c := range item.LeadComment.List {
+					buf.WriteString(c.Text)
+					buf.WriteByte('\n')
+				}
+			}
+
 			buf.Write(keySrc)
 			buf.WriteString(" = ")
 			buf.Write(valueSrc)
+			if item.LineComment != nil {
+				for _, c := range item.LineComment.List {
+					buf.WriteByte(' ')
+					buf.WriteString(c.Text)
+				}
+			}
 			buf.WriteString("\n")
 		}
 		buf.WriteString("}")


### PR DESCRIPTION
The expression upgrade functionality mostly ignores comments because in the old language the syntax prevented comments from appearing in the middle of expressions, but there was one exception: object expressions.

Because HCL 1 used `ObjectType` both for blocks and for object expressions, that is the one situation where something we consider to be an expression could have inline attached comments in the old language.

We migrate these here so we don't lose these comments that don't appear anywhere else. Other comments get gathered up into a general comments set maintained inside the analysis object and so will be printed out as required _between_ expressions (or rather: between _attributes_), just as they did before.

This fixes #21005.
