### PR TITLE
helper/schema: Use a more targeted shim for nested set diff applying

### DIFF
--- a/builtin/providers/test/diff_apply_test.go
+++ b/builtin/providers/test/diff_apply_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -136,6 +137,6 @@ func TestDiffApply_set(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(attrs, expected) {
-		t.Fatalf("\nexpected: %#v\ngot: %#v\n", expected, attrs)
+		t.Fatalf("wrong result\ngot: %s\nwant: %s\n", spew.Sdump(attrs), spew.Sdump(expected))
 	}
 }

--- a/builtin/providers/test/resource_config_mode.go
+++ b/builtin/providers/test/resource_config_mode.go
@@ -18,6 +18,7 @@ func testResourceConfigMode() *schema.Resource {
 				Type:       schema.TypeList,
 				ConfigMode: schema.SchemaConfigModeAttr,
 				Optional:   true,
+				Computed:   true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"foo": {

--- a/builtin/providers/test/resource_config_mode_test.go
+++ b/builtin/providers/test/resource_config_mode_test.go
@@ -100,6 +100,20 @@ resource "test_resource_config_mode" "foo" {
 			resource.TestStep{
 				Config: strings.TrimSpace(`
 resource "test_resource_config_mode" "foo" {
+	resource_as_attr_dynamic = [
+		{
+		},
+	]
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr.#", "1"),
+					resource.TestCheckResourceAttr("test_resource_config_mode.foo", "resource_as_attr_dynamic.#", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_config_mode" "foo" {
 	resource_as_attr = []
 	resource_as_attr_dynamic = []
 }

--- a/helper/schema/shims.go
+++ b/helper/schema/shims.go
@@ -133,9 +133,10 @@ func LegacyResourceSchema(r *Resource) *Resource {
 	return newResource
 }
 
-// LegacySchema takes a *Schema and returns a deep copy with 0.12 specific
-// features removed. This is used by the shims to get a configschema that
-// directly matches the structure of the schema.Resource.
+// LegacySchema takes a *Schema and returns a deep copy with some 0.12-specific
+// features disabled. This is used by the shims to get a configschema that
+// better reflects the given schema.Resource, without any adjustments we
+// make for when sending a schema to Terraform Core.
 func LegacySchema(s *Schema) *Schema {
 	if s == nil {
 		return nil
@@ -143,7 +144,6 @@ func LegacySchema(s *Schema) *Schema {
 	// start with a shallow copy
 	newSchema := new(Schema)
 	*newSchema = *s
-	newSchema.ConfigMode = SchemaConfigModeAuto
 	newSchema.SkipCoreTypeCheck = false
 
 	switch e := newSchema.Elem.(type) {


### PR DESCRIPTION
We previously attempted to make the special diff apply behavior for nested sets of objects work with attribute mode by totally discarding attribute mode for all shims.

In practice, that is too broad a solution: there are lots of other shimming behaviors that we _don't_ want when attribute mode is enabled. In particular, we need to make sure that the difference between null and
empty can be seen in configuration.

As a compromise then, we will give all of the shims access to the real `ConfigMode` and then do a more specialized fixup within the diff-apply logic: we'll construct a synthetic nested block schema and then use that to run our existing logic to deal with nested sets of objects, while using the previous behavior in all other cases.

In effect, this means that the special new behavior only applies when the provider uses the opt-in `ConfigMode` setting on a particular attribute, and thus this change has much less risk of causing broad, unintended regressions elsewhere.
