### PR TITLE
configs/configupgrade: Don't panic if analyzer fails

### DIFF
--- a/configs/configupgrade/upgrade.go
+++ b/configs/configupgrade/upgrade.go
@@ -35,11 +35,11 @@ func (u *Upgrader) Upgrade(input ModuleSources, dir string) (ModuleSources, tfdi
 	var diags tfdiags.Diagnostics
 
 	an, err := u.analyze(input)
-	an.ModuleDir = dir
 	if err != nil {
 		diags = diags.Append(err)
 		return ret, diags
 	}
+	an.ModuleDir = dir
 
 	for name, src := range input {
 		ext := fileExt(name)


### PR DESCRIPTION
Previously we were trying to access a field of the analysis object before checking if analysis produced errors. The analysis function usually returns a nil analysis on error, so this would result in a panic whenever
that happened.

Now we'll dereference the analysis object pointer only after checking for errors, so we'll get a chance to report the analysis error to the user.

We don't have a new test covering this here because I didn't actually have a repro for this situation: in this case, it's clear that the old code was incorrect in retrospect, so I just fixed it. The new codepath still fails, but it fails in a way that returns useful context to the user, rather than panicking.

This will fix #20908 by removing the panic and allowing the real analysis error to shine through. That may then lead to us finding an analysis bug underneath, but we'll cross that bridge when we come to it.
