### PR TITLE
website: Fix incorrect example in Module Composition page

### DIFF
--- a/website/docs/modules/composition.html.markdown
+++ b/website/docs/modules/composition.html.markdown
@@ -194,12 +194,12 @@ implementations would have the following variable declared:
 
 ```hcl
 variable "recordsets" {
-  type = object({
+  type = list(object({
     name    = string
     type    = string
     ttl     = number
     records = list(string)
-  })
+  }))
 }
 ```
 


### PR DESCRIPTION
The example above treats recordsets as a list, but the declaration was for a single object.