### PR TITLE
ignore_changes attributes should be quoted

### DIFF
--- a/website/docs/configuration/resources.html.md
+++ b/website/docs/configuration/resources.html.md
@@ -430,7 +430,7 @@ meta-arguments are supported:
         ignore_changes = [
           # Ignore changes to tags, e.g. because a management agent
           # updates these based on some ruleset managed elsewhere.
-          tags,
+          "tags",
         ]
       }
     }


### PR DESCRIPTION
It appears that the correct syntax for the ignore_changes list is a list of strings, so this adds quotes to the example in the documentation