### PR TITLE
update required_providers block for terraform 0.12 compatibility

### DIFF
--- a/website/docs/configuration/terraform.html.md
+++ b/website/docs/configuration/terraform.html.md
@@ -111,8 +111,8 @@ minimum version for that provider.
 
 ```hcl
 terraform {
-  required_providers = {
-    aws = ">= 1.0.0"
+  required_providers {
+    aws = ">= 2.7.0"
   }
 }
 ```


### PR DESCRIPTION
Using Terraform `v0.12.0-beta2` assigning the map as described in the example results in the error below when running `init`.
```
Error: Unsupported argument

  on terraform.tf line 12, in terraform:
  12:   required_providers = {

An argument named "required_providers" is not expected here. Did you mean to
define a block of type "required_providers"?
```

Following the error's advice and defining a `required_providers` block rather than assigning a map resolves the issue. Tested that this is actually the new 0.12 behavior by setting aws version to 2.9 (currently does not yet exist) and I receive the proper error message: _No provider "aws" plugins meet the constraint ">= 2.9"._

I've also set the required AWS provider version to 2.7 for the purpose of this example, the [first version to support 0.12](https://github.com/terraform-providers/terraform-provider-aws/blob/v2.7.0/CHANGELOG.md#270-april-18-2019).