### PR TITLE
build for arm64

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,9 +15,9 @@ GIT_COMMIT=$(git rev-parse HEAD)
 GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 
 # Determine the arch/os combos we're building for
-XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
+XC_ARCH=${XC_ARCH:-"386 amd64 arm arm64"}
 XC_OS=${XC_OS:-linux darwin windows freebsd openbsd solaris}
-XC_EXCLUDE_OSARCH="!darwin/arm !darwin/386"
+XC_EXCLUDE_OSARCH="!darwin/arm !darwin/386 !darwin/arm64"
 
 # Delete the old dir
 echo "==> Removing old directory..."


### PR DESCRIPTION
This change adds a build for linux/arm64; closes #14474 .

When #14474 had first been opened, this would have been a big change; now it should be pretty simple.