### PR TITLE
delete unknown values from apply config altogether

### DIFF
--- a/builtin/providers/test/resource.go
+++ b/builtin/providers/test/resource.go
@@ -141,6 +141,13 @@ func testResource() *schema.Resource {
 				Computed:    true,
 				Description: "copied the required field during apply, and plans computed when changed",
 			},
+			// this should return unset from GetOkExists
+			"get_ok_exists_false": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				Description: "do not set in config",
+			},
 		},
 	}
 }
@@ -184,6 +191,12 @@ func testResourceRead(d *schema.ResourceData, meta interface{}) error {
 	s := d.Get("set")
 	if s == nil || s.(*schema.Set).Len() == 0 {
 		d.Set("set", []interface{}{})
+	}
+
+	// This should not show as set unless it's set in the config
+	_, ok := d.GetOkExists("get_ok_exists_false")
+	if ok {
+		return errors.New("get_ok_exists_false should not be set")
 	}
 
 	return nil

--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -973,3 +973,22 @@ resource "test_resource" "bar" {
 		},
 	})
 }
+
+func TestResource_optionalComputedBool(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+	required = "yep"
+	required_map = {
+	    key = "value"
+	}
+}
+				`),
+			},
+		},
+	})
+}

--- a/helper/schema/shims.go
+++ b/helper/schema/shims.go
@@ -51,7 +51,7 @@ func removeConfigUnknowns(cfg map[string]interface{}) {
 		switch v := v.(type) {
 		case string:
 			if v == config.UnknownVariableValue {
-				cfg[k] = ""
+				delete(cfg, k)
 			}
 		case []interface{}:
 			for _, i := range v {

--- a/helper/schema/shims_test.go
+++ b/helper/schema/shims_test.go
@@ -3643,22 +3643,17 @@ func TestRemoveConfigUnknowns(t *testing.T) {
 	}
 
 	expect := map[string]interface{}{
-		"id": "",
 		"route_rules": []interface{}{
 			map[string]interface{}{
-				"cidr_block":        "",
 				"destination":       "0.0.0.0/0",
 				"destination_type":  "CIDR_BLOCK",
 				"network_entity_id": "1",
 			},
 			map[string]interface{}{
-				"cidr_block":       "",
 				"destination":      "0.0.0.0/0",
 				"destination_type": "CIDR_BLOCK",
 				"sub_block": []interface{}{
-					map[string]interface{}{
-						"computed": "",
-					},
+					map[string]interface{}{},
 				},
 			},
 		},
@@ -3667,6 +3662,6 @@ func TestRemoveConfigUnknowns(t *testing.T) {
 	removeConfigUnknowns(cfg)
 
 	if !reflect.DeepEqual(cfg, expect) {
-		t.Fatalf("\nexpected: %#v\ngot: %#v", expect, cfg)
+		t.Fatalf("\nexpected: %#v\ngot:      %#v", expect, cfg)
 	}
 }


### PR DESCRIPTION
`removeConfigUnknowns` need to remove the value completely from the config
map. Removing this value allows `GetOk` and `GetOkExists` to indicate if the
value was set in the config in the case of an Optional+Computed attribute.

Fixes #21007