### PR TITLE
 communicator/ssh: fix Upload to avoid copying files to determine size

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -353,16 +353,16 @@ func (c *Communicator) Upload(path string, input io.Reader) error {
 	size := int64(0)
 
 	switch src := input.(type) {
-	case *os.File:
+	case interface {
+		Stat() (os.FileInfo, error)
+	}:
 		fi, err := src.Stat()
 		if err == nil {
 			size = fi.Size()
 		}
-	case *bytes.Buffer:
-		size = int64(src.Len())
-	case *bytes.Reader:
-		size = int64(src.Len())
-	case *strings.Reader:
+	case interface {
+		Len() int
+	}:
 		size = int64(src.Len())
 	}
 

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -355,7 +355,7 @@ func (c *Communicator) Upload(path string, input io.Reader) error {
 	switch src := input.(type) {
 	case *os.File:
 		fi, err := src.Stat()
-		if err != nil {
+		if err == nil {
 			size = fi.Size()
 		}
 	case *bytes.Buffer:


### PR DESCRIPTION
The optimization not to copy instances of *os.File in Upload does not work due to wrong error handling.
This PR fixes the issue. I have also piggybacked a change in the type switch to handle any anything that can report length or os stats.