### PR TITLE
Fixes for maps in shims

### DIFF
--- a/builtin/providers/test/resource_map.go
+++ b/builtin/providers/test/resource_map.go
@@ -23,6 +23,16 @@ func testResourceMap() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"map_values": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"computed_map": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -35,15 +45,20 @@ func testResourceMapCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId("testId")
-	return nil
+	return testResourceMapRead(d, meta)
 }
 
 func testResourceMapRead(d *schema.ResourceData, meta interface{}) error {
+	var computedMap map[string]interface{}
+	if v, ok := d.GetOk("map_values"); ok {
+		computedMap = v.(map[string]interface{})
+	}
+	d.Set("computed_map", computedMap)
 	return nil
 }
 
 func testResourceMapUpdate(d *schema.ResourceData, meta interface{}) error {
-	return nil
+	return testResourceMapRead(d, meta)
 }
 
 func testResourceMapDelete(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/test/resource_map_test.go
+++ b/builtin/providers/test/resource_map_test.go
@@ -30,3 +30,80 @@ resource "test_resource_map" "foobar" {
 		},
 	})
 }
+
+func TestResourceMap_computedMap(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "test_resource_map" "foobar" {
+	name = "test"
+	map_of_three = {
+		one   = "one"
+		two   = "two"
+		empty = ""
+	}
+	map_values = {
+		a = "1"
+		b = "2"
+	}
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_map.foobar", "computed_map.a", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_map.foobar", "computed_map.b", "2",
+					),
+				),
+			},
+			{
+				Config: `
+resource "test_resource_map" "foobar" {
+	name = "test"
+	map_of_three = {
+		one   = "one"
+		two   = "two"
+		empty = ""
+	}
+	map_values = {
+		a = "3"
+		b = "4"
+	}
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_map.foobar", "computed_map.a", "3",
+					),
+					resource.TestCheckResourceAttr(
+						"test_resource_map.foobar", "computed_map.b", "4",
+					),
+				),
+			},
+			{
+				Config: `
+resource "test_resource_map" "foobar" {
+	name = "test"
+	map_of_three = {
+		one   = "one"
+		two   = "two"
+		empty = ""
+	}
+	map_values = {
+		a = "3"
+	}
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_map.foobar", "computed_map.a", "3",
+					),
+					resource.TestCheckNoResourceAttr(
+						"test_resource_map.foobar", "computed_map.b",
+					),
+				),
+			},
+		},
+	})
+}

--- a/helper/plugin/grpc_provider_test.go
+++ b/helper/plugin/grpc_provider_test.go
@@ -667,7 +667,7 @@ func TestGetSchemaTimeouts(t *testing.T) {
 func TestNormalizeNullValues(t *testing.T) {
 	for i, tc := range []struct {
 		Src, Dst, Expect cty.Value
-		Plan             bool
+		Apply            bool
 	}{
 		{
 			// The known set value is copied over the null set value
@@ -690,6 +690,7 @@ func TestNormalizeNullValues(t *testing.T) {
 					}),
 				}),
 			}),
+			Apply: true,
 		},
 		{
 			// A zero set value is kept
@@ -702,7 +703,6 @@ func TestNormalizeNullValues(t *testing.T) {
 			Expect: cty.ObjectVal(map[string]cty.Value{
 				"set": cty.SetValEmpty(cty.String),
 			}),
-			Plan: true,
 		},
 		{
 			// The known set value is copied over the null set value
@@ -724,7 +724,6 @@ func TestNormalizeNullValues(t *testing.T) {
 					"foo": cty.String,
 				}))),
 			}),
-			Plan: true,
 		},
 		{
 			// The empty map is copied over the null map
@@ -737,6 +736,7 @@ func TestNormalizeNullValues(t *testing.T) {
 			Expect: cty.ObjectVal(map[string]cty.Value{
 				"map": cty.MapValEmpty(cty.String),
 			}),
+			Apply: true,
 		},
 		{
 			// A zero value primitive is copied over a null primitive
@@ -749,6 +749,7 @@ func TestNormalizeNullValues(t *testing.T) {
 			Expect: cty.ObjectVal(map[string]cty.Value{
 				"string": cty.StringVal(""),
 			}),
+			Apply: true,
 		},
 		{
 			// Plan primitives are kept
@@ -761,7 +762,6 @@ func TestNormalizeNullValues(t *testing.T) {
 			Expect: cty.ObjectVal(map[string]cty.Value{
 				"string": cty.NullVal(cty.String),
 			}),
-			Plan: true,
 		},
 		{
 			// The null map is retained, because the src was unknown
@@ -774,6 +774,7 @@ func TestNormalizeNullValues(t *testing.T) {
 			Expect: cty.ObjectVal(map[string]cty.Value{
 				"map": cty.NullVal(cty.Map(cty.String)),
 			}),
+			Apply: true,
 		},
 		{
 			// the nul set is retained, because the src set contains an unknown value
@@ -794,6 +795,7 @@ func TestNormalizeNullValues(t *testing.T) {
 					"foo": cty.String,
 				}))),
 			}),
+			Apply: true,
 		},
 		{
 			// Retain don't re-add unexpected planned values in a map
@@ -813,7 +815,6 @@ func TestNormalizeNullValues(t *testing.T) {
 					"a": cty.StringVal("a"),
 				}),
 			}),
-			Plan: true,
 		},
 		{
 			// Remove extra values after apply
@@ -833,7 +834,7 @@ func TestNormalizeNullValues(t *testing.T) {
 					"a": cty.StringVal("a"),
 				}),
 			}),
-			Plan: false,
+			Apply: true,
 		},
 		{
 			Src: cty.ObjectVal(map[string]cty.Value{
@@ -843,7 +844,6 @@ func TestNormalizeNullValues(t *testing.T) {
 			Expect: cty.ObjectVal(map[string]cty.Value{
 				"a": cty.NullVal(cty.String),
 			}),
-			Plan: true,
 		},
 
 		// a list in an object in a list, going from null to empty
@@ -877,6 +877,7 @@ func TestNormalizeNullValues(t *testing.T) {
 					}),
 				}),
 			}),
+			Apply: true,
 		},
 
 		// a list in an object in a list, going from empty to null
@@ -910,6 +911,7 @@ func TestNormalizeNullValues(t *testing.T) {
 					}),
 				}),
 			}),
+			Apply: true,
 		},
 		// the empty list should be transferred, but the new unknown should not be overridden
 		{
@@ -942,7 +944,6 @@ func TestNormalizeNullValues(t *testing.T) {
 					}),
 				}),
 			}),
-			Plan: true,
 		},
 		{
 			// fix unknowns added to a map
@@ -964,7 +965,6 @@ func TestNormalizeNullValues(t *testing.T) {
 					"b": cty.StringVal(""),
 				}),
 			}),
-			Plan: true,
 		},
 		{
 			// fix unknowns lost from a list
@@ -1001,11 +1001,10 @@ func TestNormalizeNullValues(t *testing.T) {
 					}),
 				}),
 			}),
-			Plan: true,
 		},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			got := normalizeNullValues(tc.Dst, tc.Src, tc.Plan)
+			got := normalizeNullValues(tc.Dst, tc.Src, tc.Apply)
 			if !got.RawEquals(tc.Expect) {
 				t.Fatalf("\nexpected: %#v\ngot:      %#v\n", tc.Expect, got)
 			}

--- a/helper/plugin/grpc_provider_test.go
+++ b/helper/plugin/grpc_provider_test.go
@@ -796,26 +796,6 @@ func TestNormalizeNullValues(t *testing.T) {
 			}),
 		},
 		{
-			// Retain the zero value within the map
-			Src: cty.ObjectVal(map[string]cty.Value{
-				"map": cty.MapVal(map[string]cty.Value{
-					"a": cty.StringVal("a"),
-					"b": cty.StringVal(""),
-				}),
-			}),
-			Dst: cty.ObjectVal(map[string]cty.Value{
-				"map": cty.MapVal(map[string]cty.Value{
-					"a": cty.StringVal("a"),
-				}),
-			}),
-			Expect: cty.ObjectVal(map[string]cty.Value{
-				"map": cty.MapVal(map[string]cty.Value{
-					"a": cty.StringVal("a"),
-					"b": cty.StringVal(""),
-				}),
-			}),
-		},
-		{
 			// Retain don't re-add unexpected planned values in a map
 			Src: cty.ObjectVal(map[string]cty.Value{
 				"map": cty.MapVal(map[string]cty.Value{
@@ -834,6 +814,26 @@ func TestNormalizeNullValues(t *testing.T) {
 				}),
 			}),
 			Plan: true,
+		},
+		{
+			// Remove extra values after apply
+			Src: cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("a"),
+					"b": cty.StringVal("b"),
+				}),
+			}),
+			Dst: cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("a"),
+				}),
+			}),
+			Expect: cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("a"),
+				}),
+			}),
+			Plan: false,
 		},
 		{
 			Src: cty.ObjectVal(map[string]cty.Value{


### PR DESCRIPTION
Make sure values removed from a map during apply are not copied into the
new map when the plan didn't correctly mark a computed map as unknown.

Fixes #21070 as far as core is concerned. The provider will need a couple updates as well.