### PR TITLE
Remove ~ from computed set values in the diffs

### DIFF
--- a/builtin/providers/test/resource_nested_set.go
+++ b/builtin/providers/test/resource_nested_set.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 
+	"github.com/hashicorp/terraform/helper/customdiff"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -17,6 +18,12 @@ func testResourceNestedSet() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
+		CustomizeDiff: customdiff.All(
+			customdiff.ForceNewIfChange("single", func(old, new, meta interface{}) bool {
+				return old.(*schema.Set).Len() == 0 || new.(*schema.Set).Len() == 0
+			}),
+		),
 
 		Schema: map[string]*schema.Schema{
 			"optional": {

--- a/helper/plugin/grpc_provider.go
+++ b/helper/plugin/grpc_provider.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/zclconf/go-cty/cty"
 	ctyconvert "github.com/zclconf/go-cty/cty/convert"
@@ -595,6 +596,14 @@ func (s *GRPCProviderServer) PlanResourceChange(_ context.Context, req *proto.Pl
 		return resp, nil
 	}
 
+	// remove the special set ~ sigil from computed values
+	for k, d := range diff.Attributes {
+		if strings.Contains(k, ".~") {
+			delete(diff.Attributes, k)
+			diff.Attributes[strings.Replace(k, ".~", ".", -1)] = d
+		}
+	}
+
 	if priorState == nil {
 		priorState = &terraform.InstanceState{}
 	}
@@ -773,6 +782,14 @@ func (s *GRPCProviderServer) ApplyResourceChange(_ context.Context, req *proto.A
 		diff = &terraform.InstanceDiff{
 			Attributes: make(map[string]*terraform.ResourceAttrDiff),
 			Meta:       make(map[string]interface{}),
+		}
+	}
+
+	// remove the special set ~ sigil from computed values
+	for k, d := range diff.Attributes {
+		if strings.Contains(k, ".~") {
+			delete(diff.Attributes, k)
+			diff.Attributes[strings.Replace(k, ".~", ".", -1)] = d
 		}
 	}
 


### PR DESCRIPTION
Make sure the Plan diff doesn't have any set values with the ~ sigil,
since they can cause multiple values to be added to the set. 

Add the same removal code back into ApplyResourceChange for good
measure. The cleaned apply config should prevent these from happening,
but it does no harm to guard against this in the event of other
unexpected helper/schema behavior.

Fixes #21072