### PR TITLE
core: Allow data resource count to be unknown during refresh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/xanzy/ssh-agent v0.2.1
 	github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 // indirect
 	github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
-	github.com/zclconf/go-cty v0.0.0-20190320224746-fd76348b9329
+	github.com/zclconf/go-cty v0.0.0-20190425000443-8c00057b05d7
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6Ut
 github.com/zclconf/go-cty v0.0.0-20181129180422-88fbe721e0f8/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9 h1:hHCAGde+QfwbqXSAqOmBd4NlOrJ6nmjWp+Nu408ezD4=
 github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
-github.com/zclconf/go-cty v0.0.0-20190320224746-fd76348b9329 h1:ne520NlvoncW5zfBGkmP4EJhyd6ruSaSyhzobv0Vz9w=
-github.com/zclconf/go-cty v0.0.0-20190320224746-fd76348b9329/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+github.com/zclconf/go-cty v0.0.0-20190425000443-8c00057b05d7 h1:GppzGMnuVhCyg/BNYMI39tu1peZ1E/XVg+ZsLUyNdhk=
+github.com/zclconf/go-cty v0.0.0-20190425000443-8c00057b05d7/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=

--- a/plans/objchange/compatible_test.go
+++ b/plans/objchange/compatible_test.go
@@ -1070,7 +1070,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 				}),
 			}),
 			[]string{
-				`.block: planned set element cty.Value{ty: cty.Object(map[string]cty.Type{"foo":cty.String}), v: map[string]interface {}{"foo":"hello"}} does not correlate with any element in actual`,
+				`.block: planned set element cty.ObjectVal(map[string]cty.Value{"foo":cty.StringVal("hello")}) does not correlate with any element in actual`,
 			},
 		},
 		{

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -976,6 +976,65 @@ func TestContext2Refresh_stateBasic(t *testing.T) {
 	}
 }
 
+func TestContext2Refresh_dataCount(t *testing.T) {
+	p := testProvider("test")
+	m := testModule(t, "refresh-data-count")
+
+	// This test is verifying that a data resource count can refer to a
+	// resource attribute that can't be known yet during refresh (because
+	// the resource in question isn't in the state at all). In that case,
+	// we skip the data resource during refresh and process it during the
+	// subsequent plan step instead.
+	//
+	// Normally it's an error for "count" to be computed, but during the
+	// refresh step we allow it because we _expect_ to be working with an
+	// incomplete picture of the world sometimes, particularly when we're
+	// creating object for the first time against an empty state.
+	//
+	// For more information, see:
+	//    https://github.com/hashicorp/terraform/issues/21047
+
+	p.GetSchemaReturn = &ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test": {
+				Attributes: map[string]*configschema.Attribute{
+					"things": {Type: cty.List(cty.String), Optional: true},
+				},
+			},
+		},
+		DataSources: map[string]*configschema.Block{
+			"test": {},
+		},
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		ProviderResolver: providers.ResolverFixed(
+			map[string]providers.Factory{
+				"test": testProviderFuncFixed(p),
+			},
+		),
+		Config: m,
+	})
+
+	s, diags := ctx.Refresh()
+	if p.ReadResourceCalled {
+		// The managed resource doesn't exist in the state yet, so there's
+		// nothing to refresh.
+		t.Errorf("ReadResource was called, but should not have been")
+	}
+	if p.ReadDataSourceCalled {
+		// The data resource should've been skipped because its count cannot
+		// be determined yet.
+		t.Errorf("ReadDataSource was called, but should not have been")
+	}
+
+	if diags.HasErrors() {
+		t.Fatalf("refresh errors: %s", diags.Err())
+	}
+
+	checkStateString(t, s, `<no state>`)
+}
+
 func TestContext2Refresh_dataOrphan(t *testing.T) {
 	p := testProvider("null")
 	state := MustShimLegacyState(&State{

--- a/terraform/eval_count.go
+++ b/terraform/eval_count.go
@@ -23,36 +23,10 @@ import (
 // the "count" behavior should not be enabled for this resource at all.
 //
 // If error diagnostics are returned then the result is always the meaningless
-// placeholder value -1, except in one case: if the count expression evaluates
-// to an unknown number value then the result is zero, allowing this situation
-// to be treated by the caller as special if needed. For example, an early
-// graph walk may wish to just silently skip resources with unknown counts
-// to allow them to be dealt with in a later graph walk where more information
-// is available.
+// placeholder value -1.
 func evaluateResourceCountExpression(expr hcl.Expression, ctx EvalContext) (int, tfdiags.Diagnostics) {
-	if expr == nil {
-		return -1, nil
-	}
-
-	var diags tfdiags.Diagnostics
-	var count int
-
-	countVal, countDiags := ctx.EvaluateExpr(expr, cty.Number, nil)
-	diags = diags.Append(countDiags)
-	if diags.HasErrors() {
-		return -1, diags
-	}
-
-	switch {
-	case countVal.IsNull():
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid count argument",
-			Detail:   `The given "count" argument value is null. An integer is required.`,
-			Subject:  expr.Range().Ptr(),
-		})
-		return -1, diags
-	case !countVal.IsKnown():
+	count, known, diags := evaluateResourceCountExpressionKnown(expr, ctx)
+	if !known {
 		// Currently this is a rather bad outcome from a UX standpoint, since we have
 		// no real mechanism to deal with this situation and all we can do is produce
 		// an error message.
@@ -65,11 +39,36 @@ func evaluateResourceCountExpression(expr hcl.Expression, ctx EvalContext) (int,
 			Detail:   `The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first apply only the resources that the count depends on.`,
 			Subject:  expr.Range().Ptr(),
 		})
-		// We return zero+errors in this one case to allow callers to handle
-		// an unknown count as special. This is rarely necessary, but is used
-		// by the validate walk in particular so that it can just skip
-		// validation in this case, assuming a later walk will take care of it.
-		return 0, diags
+	}
+	return count, diags
+}
+
+// evaluateResourceCountExpressionKnown is like evaluateResourceCountExpression
+// except that it handles an unknown result by returning count = 0 and
+// a known = false, rather than by reporting the unknown value as an error
+// diagnostic.
+func evaluateResourceCountExpressionKnown(expr hcl.Expression, ctx EvalContext) (count int, known bool, diags tfdiags.Diagnostics) {
+	if expr == nil {
+		return -1, true, nil
+	}
+
+	countVal, countDiags := ctx.EvaluateExpr(expr, cty.Number, nil)
+	diags = diags.Append(countDiags)
+	if diags.HasErrors() {
+		return -1, true, diags
+	}
+
+	switch {
+	case countVal.IsNull():
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid count argument",
+			Detail:   `The given "count" argument value is null. An integer is required.`,
+			Subject:  expr.Range().Ptr(),
+		})
+		return -1, true, diags
+	case !countVal.IsKnown():
+		return 0, false, diags
 	}
 
 	err := gocty.FromCtyValue(countVal, &count)
@@ -80,7 +79,7 @@ func evaluateResourceCountExpression(expr hcl.Expression, ctx EvalContext) (int,
 			Detail:   fmt.Sprintf(`The given "count" argument value is unsuitable: %s.`, err),
 			Subject:  expr.Range().Ptr(),
 		})
-		return -1, diags
+		return -1, true, diags
 	}
 	if count < 0 {
 		diags = diags.Append(&hcl.Diagnostic{
@@ -89,10 +88,10 @@ func evaluateResourceCountExpression(expr hcl.Expression, ctx EvalContext) (int,
 			Detail:   `The given "count" argument value is unsuitable: negative numbers are not supported.`,
 			Subject:  expr.Range().Ptr(),
 		})
-		return -1, diags
+		return -1, true, diags
 	}
 
-	return count, diags
+	return count, true, diags
 }
 
 // fixResourceCountSetTransition is a helper function to fix up the state when a

--- a/terraform/node_data_refresh.go
+++ b/terraform/node_data_refresh.go
@@ -27,10 +27,15 @@ var (
 func (n *NodeRefreshableDataResource) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	var diags tfdiags.Diagnostics
 
-	count, countDiags := evaluateResourceCountExpression(n.Config.Count, ctx)
+	count, countKnown, countDiags := evaluateResourceCountExpressionKnown(n.Config.Count, ctx)
 	diags = diags.Append(countDiags)
 	if countDiags.HasErrors() {
 		return nil, diags.Err()
+	}
+	if !countKnown {
+		// If the count isn't known yet, we'll skip refreshing and try expansion
+		// again during the plan walk.
+		return nil, nil
 	}
 
 	// Next we need to potentially rename an instance address in the state

--- a/terraform/test-fixtures/refresh-data-count/refresh-data-count.tf
+++ b/terraform/test-fixtures/refresh-data-count/refresh-data-count.tf
@@ -1,0 +1,7 @@
+resource "test" "foo" {
+  things = ["foo"]
+}
+
+data "test" "foo" {
+  count = length(test.foo.things)
+}

--- a/vendor/github.com/zclconf/go-cty/cty/gocty/out.go
+++ b/vendor/github.com/zclconf/go-cty/cty/gocty/out.go
@@ -1,10 +1,9 @@
 package gocty
 
 import (
+	"math"
 	"math/big"
 	"reflect"
-
-	"math"
 
 	"github.com/zclconf/go-cty/cty"
 )
@@ -112,11 +111,7 @@ func fromCtyBool(val cty.Value, target reflect.Value, path cty.Path) error {
 	switch target.Kind() {
 
 	case reflect.Bool:
-		if val.True() {
-			target.Set(reflect.ValueOf(true))
-		} else {
-			target.Set(reflect.ValueOf(false))
-		}
+		target.SetBool(val.True())
 		return nil
 
 	default:
@@ -175,8 +170,7 @@ func fromCtyNumberInt(bf *big.Float, target reflect.Value, path cty.Path) error 
 		return path.NewErrorf("value must be a whole number, between %d and %d", min, max)
 	}
 
-	target.Set(reflect.ValueOf(iv).Convert(target.Type()))
-
+	target.SetInt(iv)
 	return nil
 }
 
@@ -202,25 +196,13 @@ func fromCtyNumberUInt(bf *big.Float, target reflect.Value, path cty.Path) error
 		return path.NewErrorf("value must be a whole number, between 0 and %d inclusive", max)
 	}
 
-	target.Set(reflect.ValueOf(iv).Convert(target.Type()))
-
+	target.SetUint(iv)
 	return nil
 }
 
 func fromCtyNumberFloat(bf *big.Float, target reflect.Value, path cty.Path) error {
 	switch target.Kind() {
-	case reflect.Float32:
-		fv, accuracy := bf.Float32()
-		if accuracy != big.Exact {
-			// We allow the precision to be truncated as part of our conversion,
-			// but we don't want to silently introduce infinities.
-			if math.IsInf(float64(fv), 0) {
-				return path.NewErrorf("value must be between %f and %f inclusive", -math.MaxFloat32, math.MaxFloat32)
-			}
-		}
-		target.Set(reflect.ValueOf(fv))
-		return nil
-	case reflect.Float64:
+	case reflect.Float32, reflect.Float64:
 		fv, accuracy := bf.Float64()
 		if accuracy != big.Exact {
 			// We allow the precision to be truncated as part of our conversion,
@@ -229,7 +211,7 @@ func fromCtyNumberFloat(bf *big.Float, target reflect.Value, path cty.Path) erro
 				return path.NewErrorf("value must be between %f and %f inclusive", -math.MaxFloat64, math.MaxFloat64)
 			}
 		}
-		target.Set(reflect.ValueOf(fv))
+		target.SetFloat(fv)
 		return nil
 	default:
 		panic("unsupported kind of float")
@@ -239,17 +221,17 @@ func fromCtyNumberFloat(bf *big.Float, target reflect.Value, path cty.Path) erro
 func fromCtyNumberBig(bf *big.Float, target reflect.Value, path cty.Path) error {
 	switch {
 
-	case bigFloatType.AssignableTo(target.Type()):
+	case bigFloatType.ConvertibleTo(target.Type()):
 		// Easy!
-		target.Set(reflect.ValueOf(bf).Elem())
+		target.Set(reflect.ValueOf(bf).Elem().Convert(target.Type()))
 		return nil
 
-	case bigIntType.AssignableTo(target.Type()):
+	case bigIntType.ConvertibleTo(target.Type()):
 		bi, accuracy := bf.Int(nil)
 		if accuracy != big.Exact {
 			return path.NewErrorf("value must be a whole number")
 		}
-		target.Set(reflect.ValueOf(bi).Elem())
+		target.Set(reflect.ValueOf(bi).Elem().Convert(target.Type()))
 		return nil
 
 	default:
@@ -259,9 +241,8 @@ func fromCtyNumberBig(bf *big.Float, target reflect.Value, path cty.Path) error 
 
 func fromCtyString(val cty.Value, target reflect.Value, path cty.Path) error {
 	switch target.Kind() {
-
 	case reflect.String:
-		target.Set(reflect.ValueOf(val.AsString()))
+		target.SetString(val.AsString())
 		return nil
 
 	default:

--- a/vendor/github.com/zclconf/go-cty/cty/path.go
+++ b/vendor/github.com/zclconf/go-cty/cty/path.go
@@ -51,6 +51,11 @@ func (p Path) Index(v Value) Path {
 	return ret
 }
 
+// IndexPath is a convenience method to start a new Path with an IndexStep.
+func IndexPath(v Value) Path {
+	return Path{}.Index(v)
+}
+
 // GetAttr returns a new Path that is the reciever with a GetAttrStep appended
 // to the end.
 //
@@ -64,6 +69,11 @@ func (p Path) GetAttr(name string) Path {
 		Name: name,
 	}
 	return ret
+}
+
+// GetAttrPath is a convenience method to start a new Path with a GetAttrStep.
+func GetAttrPath(name string) Path {
+	return Path{}.GetAttr(name)
 }
 
 // Apply applies each of the steps in turn to successive values starting with

--- a/vendor/github.com/zclconf/go-cty/cty/value_init.go
+++ b/vendor/github.com/zclconf/go-cty/cty/value_init.go
@@ -56,6 +56,18 @@ func ParseNumberVal(s string) (Value, error) {
 	return NumberVal(f), nil
 }
 
+// MustParseNumberVal is like ParseNumberVal but it will panic in case of any
+// error. It can be used during initialization or any other situation where
+// the given string is a constant or otherwise known to be correct by the
+// caller.
+func MustParseNumberVal(s string) Value {
+	ret, err := ParseNumberVal(s)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
 // NumberIntVal returns a Value of type Number whose internal value is equal
 // to the given integer.
 func NumberIntVal(v int64) Value {

--- a/vendor/github.com/zclconf/go-cty/cty/value_ops.go
+++ b/vendor/github.com/zclconf/go-cty/cty/value_ops.go
@@ -3,12 +3,13 @@ package cty
 import (
 	"fmt"
 	"math/big"
-
 	"reflect"
 
 	"github.com/zclconf/go-cty/cty/set"
 )
 
+// GoString is an implementation of fmt.GoStringer that produces concise
+// source-like representations of values suitable for use in debug messages.
 func (val Value) GoString() string {
 	if val == NilVal {
 		return "cty.NilVal"
@@ -32,9 +33,8 @@ func (val Value) GoString() string {
 	case Bool:
 		if val.v.(bool) {
 			return "cty.True"
-		} else {
-			return "cty.False"
 		}
+		return "cty.False"
 	case Number:
 		fv := val.v.(*big.Float)
 		// We'll try to use NumberIntVal or NumberFloatVal if we can, since
@@ -45,19 +45,42 @@ func (val Value) GoString() string {
 		if rfv, accuracy := fv.Float64(); accuracy == big.Exact {
 			return fmt.Sprintf("cty.NumberFloatVal(%#v)", rfv)
 		}
-		return fmt.Sprintf("cty.NumberVal(new(big.Float).Parse(\"%#v\", 10))", fv)
+		return fmt.Sprintf("cty.MustParseNumberVal(%q)", fv.Text('f', -1))
 	case String:
 		return fmt.Sprintf("cty.StringVal(%#v)", val.v)
 	}
 
 	switch {
 	case val.ty.IsSetType():
-		vals := val.v.(set.Set).Values()
-		if vals == nil || len(vals) == 0 {
-			return fmt.Sprintf("cty.SetValEmpty()")
-		} else {
-			return fmt.Sprintf("cty.SetVal(%#v)", vals)
+		vals := val.AsValueSlice()
+		if len(vals) == 0 {
+			return fmt.Sprintf("cty.SetValEmpty(%#v)", val.ty.ElementType())
 		}
+		return fmt.Sprintf("cty.SetVal(%#v)", vals)
+	case val.ty.IsListType():
+		vals := val.AsValueSlice()
+		if len(vals) == 0 {
+			return fmt.Sprintf("cty.ListValEmpty(%#v)", val.ty.ElementType())
+		}
+		return fmt.Sprintf("cty.ListVal(%#v)", vals)
+	case val.ty.IsMapType():
+		vals := val.AsValueMap()
+		if len(vals) == 0 {
+			return fmt.Sprintf("cty.MapValEmpty(%#v)", val.ty.ElementType())
+		}
+		return fmt.Sprintf("cty.MapVal(%#v)", vals)
+	case val.ty.IsTupleType():
+		if val.ty.Equals(EmptyTuple) {
+			return "cty.EmptyTupleVal"
+		}
+		vals := val.AsValueSlice()
+		return fmt.Sprintf("cty.TupleVal(%#v)", vals)
+	case val.ty.IsObjectType():
+		if val.ty.Equals(EmptyObject) {
+			return "cty.EmptyObjectVal"
+		}
+		vals := val.AsValueMap()
+		return fmt.Sprintf("cty.ObjectVal(%#v)", vals)
 	case val.ty.IsCapsuleType():
 		return fmt.Sprintf("cty.CapsuleVal(%#v, %#v)", val.ty, val.v)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -434,7 +434,7 @@ github.com/vmihailenco/msgpack/codes
 github.com/xanzy/ssh-agent
 # github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
 github.com/xlab/treeprint
-# github.com/zclconf/go-cty v0.0.0-20190320224746-fd76348b9329
+# github.com/zclconf/go-cty v0.0.0-20190425000443-8c00057b05d7
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/convert


### PR DESCRIPTION
The count for a data resource can potentially depend on a managed resource that isn't recorded in the state yet, in which case references to it will always return unknown.

Ideally we'd do the data refreshes during the plan phase as discussed in #17034, which would avoid this problem by planning the managed resources in the same walk, but for now we'll just skip refreshing any data resources with an unknown count during refresh and defer that work to the apply phase, just as we'd do if there were unknown values in the main configuration for the data resource.

This fixes #21047, by deferring the data resources in its repro config to apply time, and thus allowing the plan/apply flow to complete.

![](https://user-images.githubusercontent.com/20180/56765934-13019100-675d-11e9-9d64-99d49fdf3333.png)

Once #17034 is resolved in a later release, we should be able to get this done during the plan phase instead, but this is a reasonable compromise for now.

---

This also includes a `cty` vendor upgrade that I did to get more readable `GoString` output for values while I was debugging this. It doesn't affect any normal-flow code in Terraform, aside from some of our developer-oriented error messages.
