### PR TITLE
Document AWS_SDK_LOAD_CONFIG on s3 backend

### DIFF
--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -166,7 +166,9 @@ The following configuration options or environment variables are supported:
    locking and consistency. The table must have a primary key named LockID. If
    not present, locking will be disabled.
  * `profile` - (Optional) This is the AWS profile name as set in the
-   shared credentials file.
+   shared credentials file. It can also be sourced from the `AWS_PROFILE`
+   environment variable if `AWS_SDK_LOAD_CONFIG` is set to a truthy value,
+   e.g. `AWS_SDK_LOAD_CONFIG=1`.
  * `shared_credentials_file`  - (Optional) This is the path to the
    shared credentials file. If this is not set and a profile is specified,
    `~/.aws/credentials` will be used.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

**Changes proposed in this pull request:**

* Document AWS_SDK_LOAD_CONFIG requirement when setting the S3 Backend AWS profile through the AWS_PROFILE variable.

**Fixes:**

There are multiple (closed) issues about this with calls for documentation, such as:

* https://github.com/terraform-providers/terraform-provider-aws/issues/233
* https://github.com/terraform-providers/terraform-provider-aws/issues/1184
* https://github.com/hashicorp/terraform/issues/18402

I've run some tests and confirmed that this is an issue both when configuring the S3 backend and when configuring the AWS provider (see other PR https://github.com/terraform-providers/terraform-provider-aws/pull/8451). I can detail the results if required, but given the number of existing issues and the aws-sdk-go documentation I think this behavior is as "confirmed" as it gets.

**Notes:**

AWS_SDK_LOAD_CONFIG is a configuration specific to AWS Golang SDK (and JavaScript SDK as well -- and no other SDK, as far as I can tell).

Per the [AWS documentation](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/sessions.html#sessions-with-shared-config), this must be set when using the Go SDK, otherwise AWS_PROFILE is ignored:

> By default NewSession only loads credentials from the shared credentials file (`~/.aws/credentials`). If the AWS_SDK_LOAD_CONFIG environment variable is set to a truthy value, the session is created from the configuration values from the shared configuration (`~/.aws/config`) and shared credentials (`~/.aws/credentials`) files. See Sessions with a Shared Configuration File for more information.

This variable is not particularly well documented and seems to be a source of confusion, being limited to only two SDKs (Boto does not have it and profiles work on the fly). Personally if there's approval from the maintainers I'd edit the code to act as if AWS_SDK_LOAD_CONFIG is set true, but documenting seems to be the next best thing.