### PR TITLE
0.12upgrade: Return error for invalid reference

### DIFF
--- a/configs/configupgrade/upgrade_expr.go
+++ b/configs/configupgrade/upgrade_expr.go
@@ -286,6 +286,13 @@ Value:
 		}
 
 		parts = upgradeTraversalParts(parts, an) // might add/remove/change parts
+
+		vDiags := validateHilAddress(tv.Name, filename)
+		if len(vDiags) > 0 {
+			diags = diags.Append(vDiags)
+			break
+		}
+
 		first, remain := parts[0], parts[1:]
 		buf.WriteString(first)
 		seenSplat := false
@@ -612,6 +619,43 @@ Value:
 	}
 
 	return buf.Bytes(), diags
+}
+
+func validateHilAddress(address, filename string) tfdiags.Diagnostics {
+	parts := strings.Split(address, ".")
+	var diags tfdiags.Diagnostics
+
+	label, ok := getResourceLabel(parts)
+	if ok && !hcl2syntax.ValidIdentifier(label) {
+		// We can't get any useful source location out of HIL unfortunately
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			fmt.Sprintf("Invalid address (%s) in ./%s", address, filename),
+			// The label could be invalid for another reason
+			// but this is the most likely, so we add it as hint
+			"Labels of resources and data sources can no longer start with digits."))
+	}
+
+	return diags
+}
+
+func getResourceLabel(parts []string) (string, bool) {
+	if len(parts) < 1 {
+		return "", false
+	}
+
+	if parts[0] == "data" {
+		if len(parts) < 3 {
+			return "", false
+		}
+		return parts[2], true
+	}
+
+	if len(parts) < 2 {
+		return "", false
+	}
+
+	return parts[1], true
 }
 
 func upgradeHeredocBody(buf *bytes.Buffer, val *hilast.Output, filename string, an *analysis) tfdiags.Diagnostics {


### PR DESCRIPTION
Previously `0.12upgrade` would turn invalid HCL1 references like these

```hcl
output "id" {
  value = "${aws_instance.1web.id}"
}
```
into
```hcl
output "id" {
  value = aws_instance["1web"].id
}
```
which isn't valid Terraform 0.12 config.

This happened because the logic converting dotted syntax into square bracketed one doesn't differentiate between resource labels and attributes, latter of which allows `[]`. I didn't fix that logic, but just added an error which means we won't even reach that codepath in such case.

### After patch

```
Would you like to upgrade the module in the current directory?
  Only 'yes' will be accepted to confirm.

  Enter a value: yes

-----------------------------------------------------------------------------

Error: Invalid address (aws_instance.1web.id) in ./main.tf

Labels of resources and data sources can no longer start with digits.

```

----

This patch admittedly means people will hit error more often than they'll see the comment, but the existing logic around invalid labels which is adding these comments is not becoming entirely obsolete.

If user has configuration *with no references* to these resources, we'd still successfully convert their configs and add the comment as before.