### PR TITLE
Fix False Error when no Outputs are Defined

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -112,14 +112,14 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	if !jsonOutput && (state.Empty() || len(mod.OutputValues) == 0) {
-		c.Ui.Error(
+		c.Ui.Output(
 			"The state file either has no outputs defined, or all the defined\n" +
 				"outputs are empty. Please define an output in your configuration\n" +
 				"with the `output` keyword and run `terraform refresh` for it to\n" +
 				"become available. If you are using interpolation, please verify\n" +
 				"the interpolated value is not empty. You can use the \n" +
 				"`terraform console` command to assist.")
-		return 1
+		return 0
 	}
 
 	if name == "" {


### PR DESCRIPTION
Addresses #18975 -- terraform returns an error when there are no outputs defined. This should arguably exit with a return code of 0 and simply log that there were no outputs defined.

There are probably better ways of doing this but I saw the issue was sitting around for a bit and thought I'd take a stab at it!