### PR TITLE
Add documentation for  function concat

### DIFF
--- a/website/docs/configuration/functions/concat.html.md
+++ b/website/docs/configuration/functions/concat.html.md
@@ -1,0 +1,29 @@
+---
+layout: "functions"
+page_title: "concat - Functions - Configuration Language"
+sidebar_current: "docs-funcs-collection-concat"
+description: |-
+  The concat function combines two or more lists into a single list.
+---
+
+# `concat` Function
+
+-> **Note:** This page is about Terraform 0.12 and later. For Terraform 0.11 and
+earlier, see
+[0.11 Configuration Language: Interpolation Syntax](../../configuration-0-11/interpolation.html).
+
+`concat` takes two or more lists and returns a new list which contains any non-empty elements.
+
+The ordering of these elements is preserved.
+
+## Examples
+
+```
+> concat(["a", "b"], [], ["1", "", "2"])
+[
+  "a",
+  "b",
+  "1",
+  "2",
+]
+```


### PR DESCRIPTION
The documentation for this function didn't make it into the 0.12 website.
Function works as intended with 0.12 syntax.
PR closes #21141 