### PR TITLE
command/format: take noop changes from lcs

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -1101,8 +1101,8 @@ func ctySequenceDiff(old, new []cty.Value) []*plans.Change {
 		if lcsI < len(lcs) {
 			ret = append(ret, &plans.Change{
 				Action: plans.NoOp,
-				Before: new[newI],
-				After:  new[newI],
+				Before: lcs[lcsI],
+				After:  lcs[lcsI],
 			})
 
 			// All of our indexes advance together now, since the line


### PR DESCRIPTION
When rendering the diff, the NoOp changes should come from the LCS
sequence, rather than the new sequence. The two indexes will not align
in many cases, adding the wrong new object or indexing out of bounds.

Fixes: #21073