### PR TITLE
Stop grpc server when running ACC tests

### DIFF
--- a/helper/resource/grpc_test_provider.go
+++ b/helper/resource/grpc_test_provider.go
@@ -37,7 +37,7 @@ func GRPCTestProvider(rp terraform.ResourceProvider) providers.Interface {
 	client, _ := pp.GRPCClient(context.Background(), nil, conn)
 
 	grpcClient := client.(*tfplugin.GRPCProvider)
-	grpcClient.TestListener = listener
+	grpcClient.TestServer = grpcServer
 
 	return grpcClient
 }

--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"errors"
-	"io"
 	"log"
 	"sync"
 
@@ -45,9 +44,9 @@ type GRPCProvider struct {
 	// This allows the GRPCProvider a way to shutdown the plugin process.
 	PluginClient *plugin.Client
 
-	// TestListener contains a net.Conn to close when the GRPCProvider is being
+	// TestServer contains a grpc.Server to close when the GRPCProvider is being
 	// used in an end to end test of a provider.
-	TestListener io.Closer
+	TestServer *grpc.Server
 
 	// Proto client use to make the grpc service calls.
 	client proto.ProviderClient
@@ -544,9 +543,9 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 func (p *GRPCProvider) Close() error {
 	log.Printf("[TRACE] GRPCProvider: Close")
 
-	// close the remote listener if we're running within a test
-	if p.TestListener != nil {
-		p.TestListener.Close()
+	// Make sure to stop the server if we're not running within go-plugin.
+	if p.TestServer != nil {
+		p.TestServer.Stop()
 	}
 
 	// Check this since it's not automatically inserted during plugin creation.


### PR DESCRIPTION
The grpc server does not shutdown when the listener is closed. Since
tests aren't run through go-plugin, which has a separate RPC Shutdown
channel to stop the server, we need to track and stop the server
directly.

This should fix #21104, and prevent old server instances from accumulating after tests.