### PR TITLE
Show access credentials in the Terraform S3 backend example

### DIFF
--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -28,6 +28,9 @@ terraform {
     bucket = "mybucket"
     key    = "path/to/my/key"
     region = "us-east-1"
+
+    shared_credentials_file = "~/.aws/credentials"
+    profile = "mfa"
   }
 }
 ```
@@ -35,7 +38,9 @@ terraform {
 This assumes we have a bucket created called `mybucket`. The
 Terraform state is written to the key `path/to/my/key`.
 
-Note that for the access credentials we recommend using a
+The backend needs its own access credentials, similar to a provider,
+so this example uses a profile named `mfa` and shared AWS credentials.
+But note that we recommend using a
 [partial configuration](/docs/backends/config.html).
 
 ### S3 Bucket Permissions


### PR DESCRIPTION
I had a bunch of trouble until finding [this](https://stackoverflow.com/questions/51847646/cant-use-s3-backend-with-terraform-missing-credentials), and something like what I've proposed here would clarify things.