### PR TITLE
states/statefile: upgrade legacy dependency syntax

### DIFF
--- a/states/statefile/testdata/roundtrip/v3-simple.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-simple.in.tfstate
@@ -20,7 +20,8 @@
                     "type": "null_resource",
                     "depends_on": [
                         "null_resource.foo.*",
-                        "null_resource.foobar"
+                        "null_resource.foobar",
+                        "null_resource.foobar.1"
                     ],
                     "primary": {
                         "id": "5388490630832483079",

--- a/states/statefile/testdata/roundtrip/v3-simple.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-simple.out.tfstate
@@ -25,7 +25,8 @@
                     },
                     "depends_on": [
                         "null_resource.foo",
-                        "null_resource.foobar"
+                        "null_resource.foobar",
+                        "null_resource.foobar[1]"
                     ]
                 }
             ]

--- a/states/statefile/version3_upgrade.go
+++ b/states/statefile/version3_upgrade.go
@@ -301,7 +301,7 @@ func upgradeInstanceObjectV3ToV4(rsOld *resourceStateV2, isOld *instanceStateV2,
 
 	dependencies := make([]string, len(rsOld.Dependencies))
 	for i, v := range rsOld.Dependencies {
-		dependencies[i] = strings.TrimSuffix(v, ".*")
+		dependencies[i] = parseLegacyDependency(v)
 	}
 
 	return &instanceObjectStateV4{
@@ -412,4 +412,20 @@ func simplifyImpliedValueType(ty cty.Type) cty.Type {
 		// No other normalizations are possible
 		return ty
 	}
+}
+
+func parseLegacyDependency(s string) string {
+	parts := strings.Split(s, ".")
+	ret := parts[0]
+	for _, part := range parts[1:] {
+		if part == "*" {
+			break
+		}
+		if i, err := strconv.Atoi(part); err == nil {
+			ret = ret + fmt.Sprintf("[%d]", i)
+			break
+		}
+		ret = ret + "." + part
+	}
+	return ret
 }


### PR DESCRIPTION
We used to allow "foo.1" etc as a dependency reference, but now it's "foo[1]".

Fixes #20835
