### PR TITLE
slicing a list with unknowns should not be unknown

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -1041,9 +1041,6 @@ var SliceFunc = function.New(&function.Spec{
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
 		inputList := args[0]
-		if !inputList.IsWhollyKnown() {
-			return cty.UnknownVal(retType), nil
-		}
 		var startIndex, endIndex int
 
 		if err = gocty.FromCtyValue(args[1], &startIndex); err != nil {

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -2332,9 +2332,23 @@ func TestSlice(t *testing.T) {
 			}),
 			false,
 		},
-		{ // unknowns in the list
+		{ // slice only an unknown value
 			listWithUnknowns,
 			cty.NumberIntVal(1),
+			cty.NumberIntVal(2),
+			cty.ListVal([]cty.Value{cty.UnknownVal(cty.String)}),
+			false,
+		},
+		{ // slice multiple values, which contain an unknown
+			listWithUnknowns,
+			cty.NumberIntVal(0),
+			cty.NumberIntVal(2),
+			listWithUnknowns,
+			false,
+		},
+		{ // an unknown list should be slicable, returning an unknown list
+			cty.UnknownVal(cty.List(cty.String)),
+			cty.NumberIntVal(0),
 			cty.NumberIntVal(2),
 			cty.UnknownVal(cty.List(cty.String)),
 			false,


### PR DESCRIPTION
When slicing a list containing unknown values, the list itself is known,
and slice should return the proper slice of that list.

This fixes the superficial problem shown in #21157, but a deeper fix for unknown values in dynamic blocks is needed as well.