### PR TITLE
vendor: go get github.com/zclconf/go-cty@master

### DIFF
--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -2564,12 +2564,12 @@ func TestResourceChange_nestedSet(t *testing.T) {
       ~ ami = "ami-BEFORE" -> "ami-AFTER"
         id  = "i-02ae66f368e8518a9"
 
-      - root_block_device {
-          - volume_type = "gp2" -> null
-        }
       + root_block_device {
           + new_field   = "new_value"
           + volume_type = "gp2"
+        }
+      - root_block_device {
+          - volume_type = "gp2" -> null
         }
     }
 `,
@@ -2624,11 +2624,11 @@ func TestResourceChange_nestedSet(t *testing.T) {
       ~ ami = "ami-BEFORE" -> "ami-AFTER"
         id  = "i-02ae66f368e8518a9"
 
-      - root_block_device { # forces replacement
-          - volume_type = "gp2" -> null
-        }
       + root_block_device { # forces replacement
           + volume_type = "different"
+        }
+      - root_block_device { # forces replacement
+          - volume_type = "gp2" -> null
         }
     }
 `,

--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/xanzy/ssh-agent v0.2.1
 	github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 // indirect
 	github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
-	github.com/zclconf/go-cty v0.0.0-20190426224007-b18a157db9e2
+	github.com/zclconf/go-cty v0.0.0-20190430221426-d36a6f0dbffd
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -403,8 +403,8 @@ github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6Ut
 github.com/zclconf/go-cty v0.0.0-20181129180422-88fbe721e0f8/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9 h1:hHCAGde+QfwbqXSAqOmBd4NlOrJ6nmjWp+Nu408ezD4=
 github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
-github.com/zclconf/go-cty v0.0.0-20190426224007-b18a157db9e2 h1:Ai1LhlYNEqE39zGU07qHDNJ41iZVPZfZr1dSCoXrp1w=
-github.com/zclconf/go-cty v0.0.0-20190426224007-b18a157db9e2/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+github.com/zclconf/go-cty v0.0.0-20190430221426-d36a6f0dbffd h1:NZOOU7h+pDtcKo6xlqm8PwnarS8nJ+6+I83jT8ZfLPI=
+github.com/zclconf/go-cty v0.0.0-20190430221426-d36a6f0dbffd/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -2005,12 +2005,12 @@ func TestReverse(t *testing.T) {
 		},
 		{
 			cty.SetVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
-			cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			cty.ListVal([]cty.Value{cty.StringVal("b"), cty.StringVal("a")}), // set-of-string iterates in lexicographical order
 			"",
 		},
 		{
-			cty.SetVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c")}),
-			cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("c"), cty.StringVal("b")}),
+			cty.SetVal([]cty.Value{cty.StringVal("b"), cty.StringVal("a"), cty.StringVal("c")}),
+			cty.ListVal([]cty.Value{cty.StringVal("c"), cty.StringVal("b"), cty.StringVal("a")}), // set-of-string iterates in lexicographical order
 			"",
 		},
 		{

--- a/vendor/github.com/zclconf/go-cty/cty/set/iterator.go
+++ b/vendor/github.com/zclconf/go-cty/cty/set/iterator.go
@@ -1,36 +1,15 @@
 package set
 
 type Iterator struct {
-	bucketIds []int
-	vals      map[int][]interface{}
-	bucketIdx int
-	valIdx    int
+	vals []interface{}
+	idx  int
 }
 
 func (it *Iterator) Value() interface{} {
-	return it.currentBucket()[it.valIdx]
+	return it.vals[it.idx]
 }
 
 func (it *Iterator) Next() bool {
-	if it.bucketIdx == -1 {
-		// init
-		if len(it.bucketIds) == 0 {
-			return false
-		}
-
-		it.valIdx = 0
-		it.bucketIdx = 0
-		return true
-	}
-
-	it.valIdx++
-	if it.valIdx >= len(it.currentBucket()) {
-		it.valIdx = 0
-		it.bucketIdx++
-	}
-	return it.bucketIdx < len(it.bucketIds)
-}
-
-func (it *Iterator) currentBucket() []interface{} {
-	return it.vals[it.bucketIds[it.bucketIdx]]
+	it.idx++
+	return it.idx < len(it.vals)
 }

--- a/vendor/github.com/zclconf/go-cty/cty/set/rules.go
+++ b/vendor/github.com/zclconf/go-cty/cty/set/rules.go
@@ -23,3 +23,21 @@ type Rules interface {
 	// be equivalent.
 	Equivalent(interface{}, interface{}) bool
 }
+
+// OrderedRules is an extension of Rules that can apply a partial order to
+// element values. When a set's Rules implements OrderedRules an iterator
+// over the set will return items in the order described by the rules.
+//
+// If the given order is not a total order (that is, some pairs of non-equivalent
+// elements do not have a defined order) then the resulting iteration order
+// is undefined but consistent for a particular version of cty. The exact
+// order in that case is not part of the contract and is subject to change
+// between versions.
+type OrderedRules interface {
+	Rules
+
+	// Less returns true if and only if the first argument should sort before
+	// the second argument. If the second argument should sort before the first
+	// or if there is no defined order for the values, return false.
+	Less(interface{}, interface{}) bool
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -434,7 +434,7 @@ github.com/vmihailenco/msgpack/codes
 github.com/xanzy/ssh-agent
 # github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
 github.com/xlab/treeprint
-# github.com/zclconf/go-cty v0.0.0-20190426224007-b18a157db9e2
+# github.com/zclconf/go-cty v0.0.0-20190430221426-d36a6f0dbffd
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/convert


### PR DESCRIPTION
`cty` now guarantees that sets of primitive values will iterate in a reasonable order. Previously it was the caller's responsibility to deal with that, but we invariably neglected to do so, causing inconsistent ordering. Since `cty` prioritizes consistent behavior over performance, it now imposes its own sort on set elements as part of iterating over them so that calling applications don't have to worry so much about it.

This change also causes `cty` to consistently push unknown and null values in sets to the end of iteration, where before that was undefined. This means that our diff output will now consistently list additions before removals when showing sets, rather than the ordering being undefined as before.

The ordering of known, non-null, non-primitive values is still not contractually fixed but remains consistent for a particular version of `cty`.

The main idea here is to ensure that any time we convert from set to list or set to tuple in the language itself we will always produce the same order, which wasn't true before.
