### PR TITLE
Mildwonkey/b-flatten

### DIFF
--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -1035,7 +1035,7 @@ func TestFlatten(t *testing.T) {
 					cty.StringVal("d"),
 				}),
 			}),
-			cty.ListVal([]cty.Value{
+			cty.TupleVal([]cty.Value{
 				cty.StringVal("a"),
 				cty.StringVal("b"),
 				cty.StringVal("c"),
@@ -1054,12 +1054,50 @@ func TestFlatten(t *testing.T) {
 					cty.StringVal("d"),
 				}),
 			}),
-			cty.UnknownVal(cty.List(cty.DynamicPseudoType)),
+			cty.DynamicVal,
 			false,
 		},
 		{
 			cty.ListValEmpty(cty.String),
-			cty.ListValEmpty(cty.DynamicPseudoType),
+			cty.EmptyTupleVal,
+			false,
+		},
+		{
+			cty.SetVal([]cty.Value{
+				cty.SetVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.StringVal("b"),
+				}),
+				cty.SetVal([]cty.Value{
+					cty.StringVal("c"),
+					cty.StringVal("d"),
+				}),
+			}),
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("b"),
+				cty.StringVal("a"),
+				cty.StringVal("d"),
+				cty.StringVal("c"),
+			}),
+			false,
+		},
+		{
+			cty.TupleVal([]cty.Value{
+				cty.SetVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.StringVal("b"),
+				}),
+				cty.ListVal([]cty.Value{
+					cty.StringVal("c"),
+					cty.StringVal("d"),
+				}),
+			}),
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("b"),
+				cty.StringVal("a"),
+				cty.StringVal("c"),
+				cty.StringVal("d"),
+			}),
 			false,
 		},
 	}

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -1074,10 +1074,10 @@ func TestFlatten(t *testing.T) {
 				}),
 			}),
 			cty.TupleVal([]cty.Value{
-				cty.StringVal("b"),
 				cty.StringVal("a"),
-				cty.StringVal("d"),
+				cty.StringVal("b"),
 				cty.StringVal("c"),
+				cty.StringVal("d"),
 			}),
 			false,
 		},
@@ -1093,8 +1093,8 @@ func TestFlatten(t *testing.T) {
 				}),
 			}),
 			cty.TupleVal([]cty.Value{
-				cty.StringVal("b"),
 				cty.StringVal("a"),
+				cty.StringVal("b"),
 				cty.StringVal("c"),
 				cty.StringVal("d"),
 			}),

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -310,7 +310,7 @@ func TestFunctions(t *testing.T) {
 		"flatten": {
 			{
 				`flatten([["a", "b"], ["c", "d"]])`,
-				cty.ListVal([]cty.Value{
+				cty.TupleVal([]cty.Value{
 					cty.StringVal("a"),
 					cty.StringVal("b"),
 					cty.StringVal("c"),

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -309,7 +309,7 @@ func TestFunctions(t *testing.T) {
 
 		"flatten": {
 			{
-				`flatten([tolist(["a", "b"]), tolist(["c", "d"])])`,
+				`flatten([["a", "b"], ["c", "d"]])`,
 				cty.ListVal([]cty.Value{
 					cty.StringVal("a"),
 					cty.StringVal("b"),


### PR DESCRIPTION
HCL was converting lengths to tuples in the following case, causing `flatten` to return unexpected results:

```
> flatten([["a", "b"], ["c", "d"]])
[
  [
    "a",
    "b",
  ],
  [
    "c",
    "d",
  ],
]
```

It wasn't being caught by the unit tests because the HCL conversion happens earlier. PR #21112 added higher-level tests for functions to help us test similar issues in the future. This PR refactors `flatten()` to take lists, sets and tuples and return a flattened tuple.

Fixes #21114
 

