### PR TITLE
lang/funcs: better type handling in interpolation funcs

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -268,7 +268,7 @@ var ContainsFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{
 			Name: "list",
-			Type: cty.List(cty.DynamicPseudoType),
+			Type: cty.DynamicPseudoType,
 		},
 		{
 			Name: "value",
@@ -277,8 +277,14 @@ var ContainsFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.Bool),
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
+		arg := args[0]
+		ty := arg.Type()
 
-		_, err = Index(args[0], args[1])
+		if !ty.IsListType() && !ty.IsTupleType() && !ty.IsSetType() {
+			return cty.NilVal, errors.New("argument must be list, tuple, or set")
+		}
+
+		_, err = Index(cty.TupleVal(arg.AsValueSlice()), args[1])
 		if err != nil {
 			return cty.False, nil
 		}

--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -379,7 +379,7 @@ var ChunklistFunc = function.New(&function.Spec{
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
 		listVal := args[0]
-		if !listVal.IsWhollyKnown() {
+		if !listVal.IsKnown() {
 			return cty.UnknownVal(retType), nil
 		}
 

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -993,13 +993,29 @@ func TestChunklist(t *testing.T) {
 				cty.UnknownVal(cty.String),
 			}),
 			cty.NumberIntVal(1),
+			cty.ListVal([]cty.Value{
+				cty.ListVal([]cty.Value{
+					cty.StringVal("a"),
+				}),
+				cty.ListVal([]cty.Value{
+					cty.StringVal("b"),
+				}),
+				cty.ListVal([]cty.Value{
+					cty.UnknownVal(cty.String),
+				}),
+			}),
+			false,
+		},
+		{
+			cty.UnknownVal(cty.List(cty.String)),
+			cty.NumberIntVal(1),
 			cty.UnknownVal(cty.List(cty.List(cty.String))),
 			false,
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("chunklist(%#v, %#v)", test.List, test.Size), func(t *testing.T) {
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d-chunklist(%#v, %#v)", i, test.List, test.Size), func(t *testing.T) {
 			got, err := Chunklist(test.List, test.Size)
 
 			if test.Err {

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -721,6 +721,26 @@ func TestContains(t *testing.T) {
 			cty.BoolVal(true),
 			false,
 		},
+		{ // set val
+			cty.SetVal([]cty.Value{
+				cty.StringVal("quick"),
+				cty.StringVal("brown"),
+				cty.StringVal("fox"),
+			}),
+			cty.StringVal("quick"),
+			cty.BoolVal(true),
+			false,
+		},
+		{ // tuple val
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("quick"),
+				cty.StringVal("brown"),
+				cty.NumberIntVal(3),
+			}),
+			cty.NumberIntVal(3),
+			cty.BoolVal(true),
+			false,
+		},
 	}
 
 	for _, test := range tests {

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -592,9 +592,16 @@ func TestFunctions(t *testing.T) {
 
 		"slice": {
 			{
-				`slice(["a", "b", "c", "d"], 1, 3)`,
+				// force a list type here for testing
+				`slice(list("a", "b", "c", "d"), 1, 3)`,
 				cty.ListVal([]cty.Value{
 					cty.StringVal("b"), cty.StringVal("c"),
+				}),
+			},
+			{
+				`slice(["a", "b", 3, 4], 1, 3)`,
+				cty.TupleVal([]cty.Value{
+					cty.StringVal("b"), cty.NumberIntVal(3),
 				}),
 			},
 		},

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -155,7 +155,7 @@ func TestFunctions(t *testing.T) {
 
 			{
 				`coalescelist(["first", "second"], ["third", "fourth"])`,
-				cty.ListVal([]cty.Value{
+				cty.TupleVal([]cty.Value{
 					cty.StringVal("first"), cty.StringVal("second"),
 				}),
 			},
@@ -163,8 +163,15 @@ func TestFunctions(t *testing.T) {
 
 		"coalescelist": {
 			{
-				`coalescelist(["a", "b"], ["c", "d"])`,
+				`coalescelist(list("a", "b"), list("c", "d"))`,
 				cty.ListVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.StringVal("b"),
+				}),
+			},
+			{
+				`coalescelist(["a", "b"], ["c", "d"])`,
+				cty.TupleVal([]cty.Value{
 					cty.StringVal("a"),
 					cty.StringVal("b"),
 				}),


### PR DESCRIPTION
Allow for more precise type handling 

- `slice`
  - Handle tuples, and return precise types for the result. 
  - Return a slice even when individual elements are unknown

- `flatten`
  - Flatten can still return tuples or lists even when individual element are unknown.
  - Handle individual elements as well as series.

- `chunklist`
  - Should be able to return chunks containing unknown values

- `coalescelist`
  - Should accept lists and tuples, and return a dynamic types when the arguments are not homogeneous.

- `contains`
  - Sets are no longer going to be automatically converted, so we need to handle those in contains.