### PR TITLE
Change ENTRYPOINT to CMD for Terraform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY . .
 RUN /bin/bash scripts/build.sh
 
 WORKDIR $GOPATH
-ENTRYPOINT ["terraform"]
+CMD ["terraform"]

--- a/scripts/docker-release/Dockerfile-release
+++ b/scripts/docker-release/Dockerfile-release
@@ -41,4 +41,4 @@ RUN apk add --no-cache git openssh
 
 COPY --from=build ["/bin/terraform", "/bin/terraform"]
 
-ENTRYPOINT ["/bin/terraform"]
+CMD ["/bin/terraform"]


### PR DESCRIPTION
This PR changes the Terraform `Dockerfile`'s to use `CMD` instead of `ENTRYPOINT`. This is how a majority of the official Docker images are designed. This design comes from a set of guidelines that have been put into place by the core Docker team for official images. You can find these guidelines here: https://github.com/docker-library/official-images#consistency

In our case, a recent plugin update has caused Jenkins to now follow this design convention more closely. We have already forked the Terraform image to workaround the problem for now, but it would be good for the Terraform (and Hashicorp) images to be updated to match this convention. An example of this Jenkins change can be found here: https://issues.jenkins-ci.org/browse/JENKINS-49446