### PR TITLE
plans/objchange: Fix handling of dynamic block placeholders

### DIFF
--- a/builtin/providers/test/resource_list_test.go
+++ b/builtin/providers/test/resource_list_test.go
@@ -447,3 +447,37 @@ resource "test_resource_list" "bar" {
 		},
 	})
 }
+
+func TestResourceList_dynamicList(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "a" {
+	dependent_list {
+		val = "a"
+	}
+
+	dependent_list {
+		val = "b"
+	}
+}
+resource "test_resource_list" "b" {
+	list_block {
+		string = "constant"
+	}
+	dynamic "list_block" {
+		for_each = test_resource_list.a.computed_list
+		content {
+		  string = list_block.value
+		}
+	}
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20190416162332-2c5a4b7d729a
+	github.com/hashicorp/hcl2 v0.0.0-20190430183046-3dfebdfc4595
 	github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
-github.com/hashicorp/hcl2 v0.0.0-20190416162332-2c5a4b7d729a h1:doKt9ZBCYgYQrGK6CqJsEB+8xqm3WoFyKu4TPZlyymg=
-github.com/hashicorp/hcl2 v0.0.0-20190416162332-2c5a4b7d729a/go.mod h1:HtEzazM5AZ9fviNEof8QZB4T1Vz9UhHrGhnMPzl//Ek=
+github.com/hashicorp/hcl2 v0.0.0-20190430183046-3dfebdfc4595 h1:CwO/McByYktKSdPL6+0BZVGz+aVE5zKvlWFaJxC8SV0=
+github.com/hashicorp/hcl2 v0.0.0-20190430183046-3dfebdfc4595/go.mod h1:OgIP5mGUm80YLeF5RnP9A2NLyjNfSURGAVVTGR/a8Ds=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 h1:2yzhWGdgQUWZUCNK+AoO35V+HTsgEmcM4J9IkArh7PI=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
@@ -401,8 +401,8 @@ github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557 h1:Jpn2j6wHkC9wJv5iMfJhKqrZJx3TahFx+7sbZ7zQdxs=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/zclconf/go-cty v0.0.0-20181129180422-88fbe721e0f8/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
-github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9 h1:hHCAGde+QfwbqXSAqOmBd4NlOrJ6nmjWp+Nu408ezD4=
-github.com/zclconf/go-cty v0.0.0-20190124225737-a385d646c1e9/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+github.com/zclconf/go-cty v0.0.0-20190426224007-b18a157db9e2 h1:Ai1LhlYNEqE39zGU07qHDNJ41iZVPZfZr1dSCoXrp1w=
+github.com/zclconf/go-cty v0.0.0-20190426224007-b18a157db9e2/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190430221426-d36a6f0dbffd h1:NZOOU7h+pDtcKo6xlqm8PwnarS8nJ+6+I83jT8ZfLPI=
 github.com/zclconf/go-cty v0.0.0-20190430221426-d36a6f0dbffd/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=

--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -93,6 +93,18 @@ func (r *ConfigFieldReader) readField(
 		}
 	}
 
+	if protoVersion5 {
+		// Check if the value itself is unknown.
+		// The new protocol shims will add unknown values to this list of
+		// ComputedKeys. THis is the only way we have to indicate that a
+		// collection is unknown in the config
+		for _, unknown := range r.Config.ComputedKeys {
+			if k == unknown {
+				return FieldReadResult{Computed: true, Exists: true}, nil
+			}
+		}
+	}
+
 	switch schema.Type {
 	case TypeBool, TypeFloat, TypeInt, TypeString:
 		return r.readPrimitive(k, schema)

--- a/plans/objchange/compatible_test.go
+++ b/plans/objchange/compatible_test.go
@@ -12,6 +12,29 @@ import (
 )
 
 func TestAssertObjectCompatible(t *testing.T) {
+	schemaWithFoo := configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"foo": {Type: cty.String, Optional: true},
+		},
+	}
+	fooBlockValue := cty.ObjectVal(map[string]cty.Value{
+		"foo": cty.StringVal("bar"),
+	})
+	schemaWithFooBar := configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"foo": {Type: cty.String, Optional: true},
+			"bar": {Type: cty.String, Optional: true},
+		},
+	}
+	fooBarBlockValue := cty.ObjectVal(map[string]cty.Value{
+		"foo": cty.StringVal("bar"),
+		"bar": cty.NullVal(cty.String), // simulating the situation where bar isn't set in the config at all
+	})
+	fooBarBlockDynamicPlaceholder := cty.ObjectVal(map[string]cty.Value{
+		"foo": cty.UnknownVal(cty.String),
+		"bar": cty.NullVal(cty.String), // simulating the situation where bar isn't set in the config at all
+	})
+
 	tests := []struct {
 		Schema   *configschema.Block
 		Planned  cty.Value
@@ -681,11 +704,9 @@ func TestAssertObjectCompatible(t *testing.T) {
 				},
 			},
 			cty.ObjectVal(map[string]cty.Value{
-				"id":  cty.UnknownVal(cty.String),
 				"key": cty.EmptyObjectVal,
 			}),
 			cty.ObjectVal(map[string]cty.Value{
-				"id":  cty.UnknownVal(cty.String),
 				"key": cty.EmptyObjectVal,
 			}),
 			nil,
@@ -700,11 +721,9 @@ func TestAssertObjectCompatible(t *testing.T) {
 				},
 			},
 			cty.ObjectVal(map[string]cty.Value{
-				"id":  cty.UnknownVal(cty.String),
 				"key": cty.UnknownVal(cty.EmptyObject),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
-				"id":  cty.UnknownVal(cty.String),
 				"key": cty.EmptyObjectVal,
 			}),
 			nil,
@@ -806,20 +825,18 @@ func TestAssertObjectCompatible(t *testing.T) {
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"key": {
 						Nesting: configschema.NestingList,
-						Block:   configschema.Block{},
+						Block:   schemaWithFoo,
 					},
 				},
 			},
 			cty.ObjectVal(map[string]cty.Value{
-				"id": cty.UnknownVal(cty.String),
 				"key": cty.ListVal([]cty.Value{
-					cty.EmptyObjectVal,
+					fooBlockValue,
 				}),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
-				"id": cty.UnknownVal(cty.String),
 				"key": cty.ListVal([]cty.Value{
-					cty.EmptyObjectVal,
+					fooBlockValue,
 				}),
 			}),
 			nil,
@@ -829,21 +846,19 @@ func TestAssertObjectCompatible(t *testing.T) {
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"key": {
 						Nesting: configschema.NestingList,
-						Block:   configschema.Block{},
+						Block:   schemaWithFoo,
 					},
 				},
 			},
 			cty.ObjectVal(map[string]cty.Value{
-				"id": cty.UnknownVal(cty.String),
 				"key": cty.TupleVal([]cty.Value{
-					cty.EmptyObjectVal,
-					cty.EmptyObjectVal,
+					fooBlockValue,
+					fooBlockValue,
 				}),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
-				"id": cty.UnknownVal(cty.String),
 				"key": cty.TupleVal([]cty.Value{
-					cty.EmptyObjectVal,
+					fooBlockValue,
 				}),
 			}),
 			[]string{
@@ -855,24 +870,76 @@ func TestAssertObjectCompatible(t *testing.T) {
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"key": {
 						Nesting: configschema.NestingList,
-						Block:   configschema.Block{},
+						Block:   schemaWithFoo,
 					},
 				},
 			},
 			cty.ObjectVal(map[string]cty.Value{
-				"id":  cty.UnknownVal(cty.String),
 				"key": cty.TupleVal([]cty.Value{}),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
-				"id": cty.UnknownVal(cty.String),
 				"key": cty.TupleVal([]cty.Value{
-					cty.EmptyObjectVal,
-					cty.EmptyObjectVal,
+					fooBlockValue,
+					fooBlockValue,
 				}),
 			}),
 			[]string{
 				`.key: block count changed from 0 to 2`,
 			},
+		},
+		{
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"key": {
+						Nesting: configschema.NestingList,
+						Block:   schemaWithFooBar,
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"key": cty.ListVal([]cty.Value{
+					fooBarBlockDynamicPlaceholder, // the presence of this disables some of our checks
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"key": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.StringVal("hello"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.StringVal("world"),
+					}),
+				}),
+			}),
+			nil, // a single block whose attrs are all unknown is allowed to expand into multiple, because that's how dynamic blocks behave when for_each is unknown
+		},
+		{
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"key": {
+						Nesting: configschema.NestingList,
+						Block:   schemaWithFooBar,
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"key": cty.ListVal([]cty.Value{
+					fooBarBlockValue,              // the presence of one static block does not negate that the following element looks like a dynamic placeholder
+					fooBarBlockDynamicPlaceholder, // the presence of this disables some of our checks
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"key": cty.ListVal([]cty.Value{
+					fooBlockValue,
+					cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.StringVal("hello"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.StringVal("world"),
+					}),
+				}),
+			}),
+			nil, // as above, the presence of a block whose attrs are all unknown indicates dynamic block expansion, so our usual count checks don't apply
 		},
 
 		// NestingSet blocks
@@ -881,14 +948,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"block": {
 						Nesting: configschema.NestingSet,
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"foo": {
-									Type:     cty.String,
-									Optional: true,
-								},
-							},
-						},
+						Block:   schemaWithFoo,
 					},
 				},
 			},
@@ -919,14 +979,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"block": {
 						Nesting: configschema.NestingSet,
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"foo": {
-									Type:     cty.String,
-									Optional: true,
-								},
-							},
-						},
+						Block:   schemaWithFoo,
 					},
 				},
 			},
@@ -957,14 +1010,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"block": {
 						Nesting: configschema.NestingSet,
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"foo": {
-									Type:     cty.String,
-									Optional: true,
-								},
-							},
-						},
+						Block:   schemaWithFoo,
 					},
 				},
 			},
@@ -995,14 +1041,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"block": {
 						Nesting: configschema.NestingSet,
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"foo": {
-									Type:     cty.String,
-									Optional: true,
-								},
-							},
-						},
+						Block:   schemaWithFoo,
 					},
 				},
 			},
@@ -1038,14 +1077,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"block": {
 						Nesting: configschema.NestingSet,
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"foo": {
-									Type:     cty.String,
-									Optional: true,
-								},
-							},
-						},
+						Block:   schemaWithFoo,
 					},
 				},
 			},
@@ -1082,14 +1114,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"block": {
 						Nesting: configschema.NestingSet,
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"foo": {
-									Type:     cty.String,
-									Optional: true,
-								},
-							},
-						},
+						Block:   schemaWithFoo,
 					},
 				},
 			},
@@ -1112,8 +1137,8 @@ func TestAssertObjectCompatible(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%#v and %#v", test.Planned, test.Actual), func(t *testing.T) {
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%02d: %#v and %#v", i, test.Planned, test.Actual), func(t *testing.T) {
 			errs := AssertObjectCompatible(test.Schema, test.Planned, test.Actual)
 
 			wantErrs := make(map[string]struct{})

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -297,14 +297,14 @@ func newResourceConfigShimmedComputedKeys(obj cty.Value, schema *configschema.Bl
 			i := 0
 			for it := blockVal.ElementIterator(); it.Next(); i++ {
 				_, subVal := it.Element()
-				subPrefix := fmt.Sprintf("%s.%s%d.", typeName, prefix, i)
+				subPrefix := fmt.Sprintf("%s%s.%d.", prefix, typeName, i)
 				keys := newResourceConfigShimmedComputedKeys(subVal, &blockS.Block, subPrefix)
 				ret = append(ret, keys...)
 			}
 		case configschema.NestingMap:
 			for it := blockVal.ElementIterator(); it.Next(); {
 				subK, subVal := it.Element()
-				subPrefix := fmt.Sprintf("%s.%s%s.", typeName, prefix, subK.AsString())
+				subPrefix := fmt.Sprintf("%s%s.%s.", prefix, typeName, subK.AsString())
 				keys := newResourceConfigShimmedComputedKeys(subVal, &blockS.Block, subPrefix)
 				ret = append(ret, keys...)
 			}

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -930,6 +930,58 @@ func TestNewResourceConfigShimmed(t *testing.T) {
 			},
 		},
 		{
+			Name: "unknown in nested blocks",
+			Val: cty.ObjectVal(map[string]cty.Value{
+				"bar": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"baz": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"list": cty.UnknownVal(cty.List(cty.String)),
+							}),
+						}),
+					}),
+				}),
+			}),
+			Schema: &configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"bar": {
+						Block: configschema.Block{
+							BlockTypes: map[string]*configschema.NestedBlock{
+								"baz": {
+									Block: configschema.Block{
+										Attributes: map[string]*configschema.Attribute{
+											"list": {Type: cty.List(cty.String),
+												Optional: true,
+											},
+										},
+									},
+									Nesting: configschema.NestingList,
+								},
+							},
+						},
+						Nesting: configschema.NestingList,
+					},
+				},
+			},
+			Expected: &ResourceConfig{
+				ComputedKeys: []string{"bar.0.baz.0.list"},
+				Raw: map[string]interface{}{
+					"bar": []interface{}{map[string]interface{}{
+						"baz": []interface{}{map[string]interface{}{
+							"list": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						}},
+					}},
+				},
+				Config: map[string]interface{}{
+					"bar": []interface{}{map[string]interface{}{
+						"baz": []interface{}{map[string]interface{}{
+							"list": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						}},
+					}},
+				},
+			},
+		},
+		{
 			Name: "null blocks",
 			Val: cty.ObjectVal(map[string]cty.Value{
 				"bar": cty.NullVal(cty.Map(cty.String)),

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/expand_body.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/expand_body.go
@@ -213,6 +213,16 @@ func (b *expandBody) expandBlocks(schema *hcl.BodySchema, rawBlocks hcl.Blocks, 
 				diags = append(diags, blockDiags...)
 				if block != nil {
 					block.Body = b.expandChild(block.Body, i)
+
+					// We additionally force all of the leaf attribute values
+					// in the result to be unknown so the calling application
+					// can, if necessary, use that as a heuristic to detect
+					// when a single nested block might be standing in for
+					// multiple blocks yet to be expanded. This retains the
+					// structure of the generated body but forces all of its
+					// leaf attribute values to be unknown.
+					block.Body = unknownBody{block.Body}
+
 					blocks = append(blocks, block)
 				}
 			}

--- a/vendor/github.com/hashicorp/hcl2/ext/dynblock/unknown_body.go
+++ b/vendor/github.com/hashicorp/hcl2/ext/dynblock/unknown_body.go
@@ -1,0 +1,84 @@
+package dynblock
+
+import (
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// unknownBody is a funny body that just reports everything inside it as
+// unknown. It uses a given other body as a sort of template for what attributes
+// and blocks are inside -- including source location information -- but
+// subsitutes unknown values of unknown type for all attributes.
+//
+// This rather odd process is used to handle expansion of dynamic blocks whose
+// for_each expression is unknown. Since a block cannot itself be unknown,
+// we instead arrange for everything _inside_ the block to be unknown instead,
+// to give the best possible approximation.
+type unknownBody struct {
+	template hcl.Body
+}
+
+var _ hcl.Body = unknownBody{}
+
+func (b unknownBody) Content(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Diagnostics) {
+	content, diags := b.template.Content(schema)
+	content = b.fixupContent(content)
+
+	// We're intentionally preserving the diagnostics reported from the
+	// inner body so that we can still report where the template body doesn't
+	// match the requested schema.
+	return content, diags
+}
+
+func (b unknownBody) PartialContent(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Body, hcl.Diagnostics) {
+	content, remain, diags := b.template.PartialContent(schema)
+	content = b.fixupContent(content)
+	remain = unknownBody{remain} // remaining content must also be wrapped
+
+	// We're intentionally preserving the diagnostics reported from the
+	// inner body so that we can still report where the template body doesn't
+	// match the requested schema.
+	return content, remain, diags
+}
+
+func (b unknownBody) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
+	attrs, diags := b.template.JustAttributes()
+	attrs = b.fixupAttrs(attrs)
+
+	// We're intentionally preserving the diagnostics reported from the
+	// inner body so that we can still report where the template body doesn't
+	// match the requested schema.
+	return attrs, diags
+}
+
+func (b unknownBody) MissingItemRange() hcl.Range {
+	return b.template.MissingItemRange()
+}
+
+func (b unknownBody) fixupContent(got *hcl.BodyContent) *hcl.BodyContent {
+	ret := &hcl.BodyContent{}
+	ret.Attributes = b.fixupAttrs(got.Attributes)
+	if len(got.Blocks) > 0 {
+		ret.Blocks = make(hcl.Blocks, 0, len(got.Blocks))
+		for _, gotBlock := range got.Blocks {
+			new := *gotBlock                      // shallow copy
+			new.Body = unknownBody{gotBlock.Body} // nested content must also be marked unknown
+			ret.Blocks = append(ret.Blocks, &new)
+		}
+	}
+
+	return ret
+}
+
+func (b unknownBody) fixupAttrs(got hcl.Attributes) hcl.Attributes {
+	if len(got) == 0 {
+		return nil
+	}
+	ret := make(hcl.Attributes, len(got))
+	for name, gotAttr := range got {
+		new := *gotAttr // shallow copy
+		new.Expr = hcl.StaticExpr(cty.DynamicVal, gotAttr.Expr.Range())
+		ret[name] = &new
+	}
+	return ret
+}

--- a/vendor/github.com/hashicorp/hcl2/hcl/json/scanner.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/json/scanner.go
@@ -153,7 +153,7 @@ func byteCanStartKeyword(b byte) bool {
 	// in the parser, where we can generate better diagnostics.
 	// So e.g. we want to be able to say:
 	//   unrecognized keyword "True". Did you mean "true"?
-	case b >= 'a' || b <= 'z' || b >= 'A' || b <= 'Z':
+	case isAlphabetical(b):
 		return true
 	default:
 		return false
@@ -167,7 +167,7 @@ Byte:
 	for i = 0; i < len(buf); i++ {
 		b := buf[i]
 		switch {
-		case (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_':
+		case isAlphabetical(b) || b == '_':
 			p.Pos.Byte++
 			p.Pos.Column++
 		default:
@@ -290,4 +290,8 @@ func posRange(start, end pos) hcl.Range {
 
 func (t token) GoString() string {
 	return fmt.Sprintf("json.token{json.%s, []byte(%q), %#v}", t.Type, t.Bytes, t.Range)
+}
+
+func isAlphabetical(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl2 v0.0.0-20190416162332-2c5a4b7d729a
+# github.com/hashicorp/hcl2 v0.0.0-20190430183046-3dfebdfc4595
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec


### PR DESCRIPTION
If a `dynamic` block (in the HCL dynamic block extension sense) has an unknown value for its `for_each` argument, it gets expanded to a single placeholder block with all of its attributes set to a unknown values.

We can use this as part of a heuristic to relax our object compatibility checks for situations where the plan included an object that appears to be (but isn't necessarily) such a placeholder, allowing for the fact that the one placeholder block could be replaced with zero or more real blocks once the `for_each` value is known.

Previously our heuristic was too strict: it would match only if the only block present was a `dynamic` placeholder. In practice, users may mix `dynamic` blocks with static blocks of the same type, so we need to be more liberal to avoid generating incorrect incompatibility errors in such cases.

This will fix #21157.

Fixing this exposed a bug in the SDK shim layer because the `objchange` logic is no longer masking it. The SDK was not properly handling lists attributes that are entirely unknown.
