### PR TITLE
added new interpolation function uuidv5 

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/hil"
 	"github.com/hashicorp/hil/ast"
 	"github.com/mitchellh/go-homedir"
+	uuidv5 "github.com/satori/go.uuid"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -111,6 +112,7 @@ func Funcs() map[string]ast.Function {
 		"pathexpand":       interpolationFuncPathExpand(),
 		"pow":              interpolationFuncPow(),
 		"uuid":             interpolationFuncUUID(),
+		"uuidv5":           interpolationFuncUUIDV5(),
 		"replace":          interpolationFuncReplace(),
 		"rsadecrypt":       interpolationFuncRsaDecrypt(),
 		"sha1":             interpolationFuncSha1(),
@@ -1500,6 +1502,33 @@ func interpolationFuncUUID() ast.Function {
 		ReturnType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {
 			return uuid.GenerateUUID()
+		},
+	}
+}
+
+func interpolationFuncUUIDV5() ast.Function {
+	return ast.Function{
+		ArgTypes: []ast.Type{
+			ast.TypeString, // namespace
+			ast.TypeString, // name
+		},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			var namespace uuidv5.UUID
+			switch {
+			case args[0].(string) == "dns":
+				namespace = uuidv5.NamespaceDNS
+			case args[0].(string) == "url":
+				namespace = uuidv5.NamespaceURL
+			case args[0].(string) == "oid":
+				namespace = uuidv5.NamespaceOID
+			case args[0].(string) == "x500":
+				namespace = uuidv5.NamespaceX500
+			default:
+				return nil, fmt.Errorf("uuidv5() doesn't support namespace %s", args[0].(string))
+			}
+			val := args[1].(string)
+			return uuidv5.NewV5(namespace, val).String(), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2451,6 +2451,38 @@ func TestInterpolateFuncUUID(t *testing.T) {
 	}
 }
 
+func TestInterpolateFuncUUIDV5(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${uuidv5("dns", "tada")}`,
+				"faa898db-9b9d-5b75-86a9-149e7bb8e3b8",
+				false,
+			},
+			{
+				`${uuidv5("url", "tada")}`,
+				"2c1ff6b4-211f-577e-94de-d978b0caa16e",
+				false,
+			},
+			{
+				`${uuidv5("oid", "tada")}`,
+				"61eeea26-5176-5288-87fc-232d6ed30d2f",
+				false,
+			},
+			{
+				`${uuidv5("x500", "tada")}`,
+				"7e12415e-f7c9-57c3-9e43-52dc9950d264",
+				false,
+			},
+			{
+				`${uuidv5("tada", "tada")}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncTimestamp(t *testing.T) {
 	currentTime := time.Now().UTC()
 	ast, err := hil.Parse("${timestamp()}")

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -421,6 +421,8 @@ The supported built-in functions are:
 
   * `uuid()` - Returns a random UUID string. This string will change with every invocation of the function, so in order to prevent diffs on every plan & apply, it must be used with the [`ignore_changes`](/docs/configuration/resources.html#ignore-changes) lifecycle attribute.
 
+  * `uuidv5(string, string)` - Returns a UUID V5 string representation of the value in the specified namespace. Supported namespaces are "dns", "url", "oid" and "x500". Example: `uuidv5("dns", "www.terraform.io")`
+
   * `values(map)` - Returns a list of the map values, in the order of the keys
     returned by the `keys` function. This function only works on flat maps and
     will return an error for maps that include nested lists or maps.


### PR DESCRIPTION
it  would be nice, if this interpolation function could be added, so it can be used in different use cases.

My use-case for this function is, that it will be used in aws_route53_record resources, so that the sub-domain isn't easily guessed, but anyone knowing the dns name can convert it back to plain text.

```
resource "aws_route53_record" "client-name-or-domain" {
  zone_id = "${aws_route53_zone.primary.zone_id}"
  name    = "${uuidv5("dns", "client-name-or-domain")}.example.com"
  type    = "A"
  ttl     = "300"
  records = ["${aws_eip.lb.public_ip}"]
}
```