### PR TITLE
restrict the ComputedKeys usage to containers

### DIFF
--- a/builtin/providers/test/resource.go
+++ b/builtin/providers/test/resource.go
@@ -54,6 +54,11 @@ func testResource() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"optional_computed": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"computed_read_only": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -992,3 +992,40 @@ resource "test_resource" "foo" {
 		},
 	})
 }
+
+func TestResource_replacedOptionalComputed(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested" "a" {
+}
+
+resource "test_resource" "foo" {
+	required = "yep"
+	required_map = {
+	    key = "value"
+	}
+	optional_computed = test_resource_nested.a.id
+}
+				`),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_nested" "b" {
+}
+
+resource "test_resource" "foo" {
+	required = "yep"
+	required_map = {
+	    key = "value"
+	}
+	optional_computed = test_resource_nested.b.id
+}
+				`),
+			},
+		},
+	})
+}

--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"sync"
@@ -94,13 +95,17 @@ func (r *ConfigFieldReader) readField(
 	}
 
 	if protoVersion5 {
-		// Check if the value itself is unknown.
-		// The new protocol shims will add unknown values to this list of
-		// ComputedKeys. THis is the only way we have to indicate that a
-		// collection is unknown in the config
-		for _, unknown := range r.Config.ComputedKeys {
-			if k == unknown {
-				return FieldReadResult{Computed: true, Exists: true}, nil
+		switch schema.Type {
+		case TypeList, TypeSet, TypeMap, typeObject:
+			// Check if the value itself is unknown.
+			// The new protocol shims will add unknown values to this list of
+			// ComputedKeys. This is the only way we have to indicate that a
+			// collection is unknown in the config
+			for _, unknown := range r.Config.ComputedKeys {
+				if k == unknown {
+					log.Printf("[DEBUG] setting computed for %q from ComputedKeys", k)
+					return FieldReadResult{Computed: true, Exists: true}, nil
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Computed primitive values must see the UnknownConfigValue or they are
assumed to be unchanged. Restrict the usage of the protov5 ComputedKeys
to containers.