### PR TITLE
providers/terraform: support state format 4 in remote state

### DIFF
--- a/builtin/providers/terraform/data_source_state_test.go
+++ b/builtin/providers/terraform/data_source_state_test.go
@@ -111,6 +111,52 @@ func TestState_defaults(t *testing.T) {
 	})
 }
 
+func TestState_version4(t *testing.T) {
+	// This test is for our special support for reading state version 4 as
+	// remote state even though this Terraform version doesn't support that
+	// version for any other purpose.
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccState_version4,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStateValue("data.terraform_remote_state.foo", "from_resource", "7585419850792319264"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "string", "value"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "bool", "true"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "float", "1.2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "integer", "3"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "list.#", "2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "list.0", "value 1"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "list.1", "value 2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "set.#", "2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "set.0", "value 1"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "set.1", "value 2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "tuple.#", "2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "tuple.0", "value 1"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "tuple.1", "value 2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "mixed_tuple.#", "2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "mixed_tuple.0", "value 1"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "mixed_tuple.1.#", "1"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "mixed_tuple.1.0", "value 2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "map.%", "2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "map.a", "value 1"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "map.b", "value 2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "object.%", "2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "object.a", "value 1"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "object.b", "value 2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "mixed_object.%", "2"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "mixed_object.a", "value 1"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "mixed_object.b.#", "1"),
+					testAccCheckStateValue("data.terraform_remote_state.foo", "mixed_object.b.0", "value 2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckStateValue(id, name, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[id]
@@ -221,5 +267,14 @@ data "terraform_remote_state" "foo" {
 
 	config {
 		path = "./test-fixtures/basic.tfstate"
+	}
+}`
+
+const testAccState_version4 = `
+data "terraform_remote_state" "foo" {
+	backend = "local"
+
+	config {
+		path = "./test-fixtures/version4.tfstate"
 	}
 }`

--- a/builtin/providers/terraform/test-fixtures/version4.tfstate
+++ b/builtin/providers/terraform/test-fixtures/version4.tfstate
@@ -1,0 +1,137 @@
+{
+    "version": 4,
+    "terraform_version": "0.12.0",
+    "serial": 2,
+    "lineage": "7c976222-2974-fd2f-def5-aa1000dc1719",
+    "outputs": {
+        "bool": {
+            "value": true,
+            "type": "bool"
+        },
+        "float": {
+            "value": 1.2,
+            "type": "number"
+        },
+        "from_resource": {
+            "value": "7585419850792319264",
+            "type": "string"
+        },
+        "integer": {
+            "value": 3,
+            "type": "number"
+        },
+        "list": {
+            "value": [
+                "value 1",
+                "value 2"
+            ],
+            "type": [
+                "list",
+                "string"
+            ]
+        },
+        "map": {
+            "value": {
+                "a": "value 1",
+                "b": "value 2"
+            },
+            "type": [
+                "map",
+                "string"
+            ]
+        },
+        "mixed_object": {
+            "value": {
+                "a": "value 1",
+                "b": [
+                    "value 2"
+                ]
+            },
+            "type": [
+                "object",
+                {
+                    "a": "string",
+                    "b": [
+                        "list",
+                        "string"
+                    ]
+                }
+            ]
+        },
+        "mixed_tuple": {
+            "value": [
+                "value 1",
+                [
+                    "value 2"
+                ]
+            ],
+            "type": [
+                "tuple",
+                [
+                    "string",
+                    [
+                        "set",
+                        "string"
+                    ]
+                ]
+            ]
+        },
+        "object": {
+            "value": {
+                "a": "value 1",
+                "b": "value 2"
+            },
+            "type": [
+                "object",
+                {
+                    "a": "string",
+                    "b": "string"
+                }
+            ]
+        },
+        "set": {
+            "value": [
+                "value 1",
+                "value 2"
+            ],
+            "type": [
+                "set",
+                "string"
+            ]
+        },
+        "string": {
+            "value": "value",
+            "type": "string"
+        },
+        "tuple": {
+            "value": [
+                "value 1",
+                "value 2"
+            ],
+            "type": [
+                "tuple",
+                [
+                    "string",
+                    "string"
+                ]
+            ]
+        }
+    },
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "baz",
+            "provider": "provider.null",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "id": "7585419850792319264",
+                        "triggers": null
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -1675,7 +1675,7 @@ func TestReadStateNewVersion(t *testing.T) {
 		Version int
 	}
 
-	buf, err := json.Marshal(&out{StateVersion + 1})
+	buf, err := json.Marshal(&out{StateVersion + 2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
Although Terraform v0.11 can't generate this format or use it as the basis for new operations, we will implement it enough that `terraform_remote_state` can read it, in order to give more flexibility when upgrading from 0.11 to 0.12 in complex environments where remote state is used for connectivity between subsystems. With this in place, users have more freedom in what order they upgrade their individual subsystems to Terraform 0.12.

(Note that this PR is targeting the v0.11 branch, not the master branch. This is intended to be included in one final 0.11 release in order to reduce upgrade friction.)