### PR TITLE
Always try to select a workspace after initialization (v0.12)

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -299,7 +299,7 @@ func (c *InitCommand) Run(args []string) int {
 
 	if back == nil {
 		// If we didn't initialize a backend then we'll try to at least
-		// instantiate one. This might fail if it wasn't already initalized
+		// instantiate one. This might fail if it wasn't already initialized
 		// by a previous run, so we must still expect that "back" may be nil
 		// in code that follows.
 		var backDiags tfdiags.Diagnostics


### PR DESCRIPTION
There are a number of use cases that can require a user to select a workspace after initializing Terraform.

To make sure we cover all these use cases, we will always call the selectWorkspace method to verify a valid workspace is already selected or (if needed) offer to select one before moving on.

Fixes #21224