### PR TITLE
command/0.12checklist: Terraform 0.11 command to help prep for 0.12

### DIFF
--- a/command/012checklist.go
+++ b/command/012checklist.go
@@ -1,0 +1,167 @@
+package command
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform/config/module"
+)
+
+// ZeroTwelveChecklistCommand is a Command implementation that checks whether
+// a configuration is ready for upgrade to Terraform 0.12, producing a list
+// of remaining preparation steps if not.
+type ZeroTwelveChecklistCommand struct {
+	Meta
+}
+
+func (c *ZeroTwelveChecklistCommand) Help() string {
+	return zeroTwelveChecklistCommandHelp
+}
+
+func (c *ZeroTwelveChecklistCommand) Synopsis() string {
+	return "Checks whether the configuration is ready for Terraform v0.12"
+}
+
+func (c *ZeroTwelveChecklistCommand) Run(args []string) int {
+	c.Meta.process(args, false)
+
+	cmdFlags := c.Meta.flagSet("0.12checklist")
+	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
+	if err := cmdFlags.Parse(args); err != nil {
+		return 1
+	}
+
+	configPath, err := ModulePath(cmdFlags.Args())
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	// Load the config
+	root, diags := c.Module(configPath)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+	if root == nil {
+		c.Ui.Error(fmt.Sprintf(
+			"No configuration files found in the directory: %s\n\n"+
+				"This command requires configuration to run.",
+			configPath))
+		return 1
+	}
+
+	items := make(map[string][]string)
+	hasItems := zeroTwelveChecklists(root, items)
+	if !hasItems {
+		// TODO: Success message
+		return 0
+	}
+
+	// TODO: Format the checklist.
+	modKeys := make([]string, 0, len(items))
+	for k := range items {
+		modKeys = append(modKeys, k)
+	}
+	sort.Strings(modKeys)
+
+	for _, k := range modKeys {
+		modItems := items[k]
+		sort.Strings(modItems)
+
+		if k != "" {
+			fmt.Printf("# Module `%q`\n\n", k)
+		}
+
+		for _, item := range modItems {
+			fmt.Print("- [ ] ")
+			sc := bufio.NewScanner(strings.NewReader(item))
+			i := 0
+			for sc.Scan() {
+				if i == 0 {
+					fmt.Printf("%s\n", sc.Text())
+				} else {
+					fmt.Printf("  %s\n", sc.Text())
+				}
+				i++
+			}
+			fmt.Printf("\n")
+		}
+	}
+
+	return 1
+}
+
+func zeroTwelveChecklists(mod *module.Tree, into map[string][]string) bool {
+	key := strings.Join(mod.Path(), ".")
+	items := zeroTwelveChecklistForModule(mod)
+	hasItems := false
+
+	childMods := mod.Children()
+	for _, modCall := range mod.Config().Modules {
+		childMod, ok := childMods[modCall.Name]
+		if !ok {
+			// Should never happen.
+			log.Printf("[WARN] Module %s declares child module %q but its tree node is missing", key, modCall.Name)
+			continue
+		}
+		if !(strings.HasPrefix(modCall.Source, "./") || strings.HasPrefix(modCall.Source, "../")) {
+			// For non-local modules we'll still run the checks but we'll roll
+			// up into a single action item for our calling module if any
+			// changes are needed, since the changes really need to be made
+			// in the upstream repository.
+			childItems := zeroTwelveChecklistForModule(childMod)
+			if len(childItems) > 0 {
+				items = append(items, "Upgrade child module %q to a version that passes \"terraform 0.12checklist\".")
+			}
+			continue
+		}
+
+		childHasItems := zeroTwelveChecklists(childMod, into)
+		if childHasItems {
+			hasItems = true
+		}
+	}
+
+	if len(items) > 0 {
+		hasItems = true
+	}
+	into[key] = items
+	return hasItems
+}
+
+func zeroTwelveChecklistForModule(mod *module.Tree) []string {
+	var items []string
+
+	// Strings added to items must be Markdown-formatted. They can be multi-line
+	// as long as all of the lines are valid to be nested inside a list item.
+	// The caller above will eventually add the required initial indendation
+	// to make the item's content appear as part of the item.
+	//
+	// In particular, items can include fenced code blocks and sub-lists.
+	// However, it's best to keep Markdown metacharacters to a minimum so that
+	// the result is also easy to read directly with human eyes, without
+	// passing through a Markdown renderer.
+	//
+	// Each element of "items" will be rendered as a task list item using
+	// GitHub's task list extension.
+
+	return items
+}
+
+const zeroTwelveChecklistCommandHelp = `
+Usage: terraform 0.12checklist [dir]
+
+  Analyzes a configuration and produces a list of any preparation steps
+  required before upgrading to Terraform v0.12.
+
+  For best results, run this command with no Terraform changes pending, so that
+  it can analyze your infrastructure as currently deployed, rather than as
+  currently planned.
+
+  The resulting output uses Markdown formatting so you can easily copy it into
+  a Markdown-capable issue tracker. We use GitHub-flavored Markdown.
+`

--- a/command/012checklist.go
+++ b/command/012checklist.go
@@ -70,9 +70,16 @@ func (c *ZeroTwelveChecklistCommand) Run(args []string) int {
 	items := make(map[string][]string)
 	hasItems := c.zeroTwelveChecklists(root, items)
 	if !hasItems {
-		// TODO: Success message
+		fmt.Print(
+			"Looks good! We did not detect any problems that ought to be\naddressed before upgrading to Terraform v0.12.\n\n" +
+				"This tool is not perfect though, so please check the v0.12 upgrade\nguide for additional guidance, and for next steps:\n    https://www.terraform.io/upgrade-guides/0-12.html\n\n",
+		)
 		return 0
 	}
+
+	fmt.Print(
+		"After analyzing this configuration and working directory, we have identified some necessary steps that we recommend you take before upgrading to Terraform v0.12:\n\n",
+	)
 
 	modKeys := make([]string, 0, len(items))
 	for k := range items {
@@ -103,6 +110,10 @@ func (c *ZeroTwelveChecklistCommand) Run(args []string) int {
 			fmt.Printf("\n")
 		}
 	}
+
+	fmt.Print(
+		"Taking these steps before upgrading to Terraform v0.12 will simplify the upgrade process by avoiding syntax errors and other compatibility problems.\n\n",
+	)
 
 	return 1
 }

--- a/commands.go
+++ b/commands.go
@@ -70,9 +70,10 @@ func initCommands(config *Config, services *disco.Disco) {
 	// that to match.
 
 	PlumbingCommands = map[string]struct{}{
-		"state":        struct{}{}, // includes all subcommands
-		"debug":        struct{}{}, // includes all subcommands
-		"force-unlock": struct{}{},
+		"state":         struct{}{}, // includes all subcommands
+		"debug":         struct{}{}, // includes all subcommands
+		"force-unlock":  struct{}{},
+		"0.12checklist": struct{}{},
 	}
 
 	Commands = map[string]cli.CommandFactory{
@@ -262,6 +263,12 @@ func initCommands(config *Config, services *disco.Disco) {
 
 		"workspace delete": func() (cli.Command, error) {
 			return &command.WorkspaceDeleteCommand{
+				Meta: meta,
+			}, nil
+		},
+
+		"0.12checklist": func() (cli.Command, error) {
+			return &command.ZeroTwelveChecklistCommand{
 				Meta: meta,
 			}, nil
 		},


### PR DESCRIPTION
(Please note that this PR is targeted at the `v0.11` maintenance branch, not at the `master` branch.)

There's a small set of tasks that are easier to do if handled _before_ upgrading to Terraform 0.12, while still on 0.11:
* Upgrading to compatible provider versions. Not doing this doesn't actually _hurt_ once upgraded to Terraform 0.12 (it will produce suitable error messages itself if not compatible) but doing it ahead of time will allow the user to deal with any provider-level upgrade steps separately from the core upgrade, thus reducing risk compared to doing everything at once.
* Fixing any resource names that v0.12 would consider invalid because they start with digits. Dealing with this in 0.11 is easier because the 0.11 `terraform state mv` command will accept these now-invalid names while the 0.12 version will not.
* Fixing any provider aliases that v0.12 would consider invalid because they start with digits. Dealing with this in 0.11 is easier because then the user can run `terraform apply` to rewrite all of the provider assignments in the state before upgrading, whereas 0.12 would consider it a syntax error.
* Dealing with any of the above tasks on external modules the configuration refers to.

This tool can also serve a more short-lived purpose of providing a way to easily check if all of the providers used by a configuration have v0.12-compatible versions available.

The idea here is to merge this and include it in one last v0.11 release, and then the v0.12 upgrade guide would direct users to:
1. Upgrade to this final release of Terraform v0.11 to make the tool available.
2. Run `terraform init` to make sure the working directory is in a consistent state.
3. Run `terraform apply` to make sure the configuration, state, and remote objects are all consistent.
4. Run `terraform 0.12checklist` to obtain a list of preparation steps, if any, or a prompt to refer back to the upgrade guide for next steps if everything looks okay.

The main idea here is to leave the user in a state where all of the providers are already upgraded and the next step would be to upgrade to Terraform v0.12 and run `terraform 0.12upgrade` to prepare the configuration.

This extra v0.11 release should also include #21226, so upgrading to it will have benefit even if the checklist doesn't produce any tasks by avoiding imposing a strict dependency order on upgrades of different configurations in a decomposed environment that is using `terraform_remote_state` to connect between workspaces.

Because this is a best-effort tool with a very temporary scope, I elected not to write any automated tests for this since the opportunity costs of doing so would be high relative to the value. Instead, I have tested this manually against a number of configurations, including both tailored configurations designed to trigger these checks and a number of module repositories index in the Terraform Registry that use complex module trees. If it turns out that there _are_ bugs in this tool in practice, we'll use language in the 0.12 upgrade guide to warn about it and suggest workarounds.

---

The output of this tool is in GitHub-flavored Markdown format so it can easily be pasted into a Markdown-capable issue tracker, like GitHub issues. Here is an example of output from a tailored configuration I wrote to show off some of the different checklist item types:

> After analyzing this configuration and working directory, we have identified some necessary steps that we recommend you take before upgrading to Terraform v0.12:
>
> - [ ] Upgrade provider "local" to version 1.2.2 or newer.
>
>   No currently-installed version is compatible with Terraform 0.12. To upgrade, set the version constraint for this provider as follows and then run `terraform init`:
>
>         version = "~> 1.2.2"
>
> - [ ] Upgrade provider "rundeck" to a version that is compatible with Terraform 0.12.
>
>   No compatible version is available for automatic installation at this time. If this provider is still supported (not archived) then a compatible release should be available soon. For more information, check for 0.12 compatibility tasks in the provider's issue tracker.
>
> - [ ] `data "local_file" "99problems"` has a name that is not a valid identifier.
>
>   In Terraform 0.12, resource names must start with a letter. To fix this, rename the resource in the configuration and then use `terraform state mv` to mirror that name change in the state.
>
> - [ ] `provider "local"` alias "4baz" is not a valid identifier.
>
>   In Terraform 0.12, provider aliases must start with a letter. To fix this, rename the provider alias and any references to it in the configuration and then run `terraform apply` to re-attach any existing resources to the new alias name.
>
> - [ ] `resource "null_resource" "99bottlesofbeer"` has a name that is not a valid identifier.
>
>   In Terraform 0.12, resource names must start with a letter. To fix this, rename the resource in the configuration and then use `terraform state mv` to mirror that name change in the state.
>
> Taking these steps before upgrading to Terraform v0.12 will simplify the upgrade process by avoiding syntax errors and other compatibility problems.
