### PR TITLE
validate integers when using protoV5

### DIFF
--- a/builtin/providers/test/resource.go
+++ b/builtin/providers/test/resource.go
@@ -153,6 +153,10 @@ func testResource() *schema.Resource {
 				Optional:    true,
 				Description: "do not set in config",
 			},
+			"int": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 		},
 	}
 }

--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -1029,3 +1029,24 @@ resource "test_resource" "foo" {
 		},
 	})
 }
+
+func TestResource_floatInIntAttr(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+	required = "yep"
+	required_map = {
+	    key = "value"
+	}
+	int = 40.2
+}
+				`),
+				ExpectError: regexp.MustCompile(`must be a whole number, got 40.2`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
The new type system only has a Number type, but helper schema
differentiates between Int and Float values. Verify that a new config
value is an integer during Validate, because the existing WeakDecode
validation will decode a float value into an integer while the config
FieldReader will attempt to parse the float exactly.

Fixes #21272