### PR TITLE
configs/configupgrade: preserve in-line comments for lists

### DIFF
--- a/configs/configupgrade/test-fixtures/valid/inline-comments/input/main.tf
+++ b/configs/configupgrade/test-fixtures/valid/inline-comments/input/main.tf
@@ -7,3 +7,19 @@ variable "list" {
     "baz",
   ]
 }
+
+variable "list2" {
+  type = "list"
+
+  default = [
+    "foo",
+    "bar",
+    "baz",
+  ]
+}
+
+variable "list_the_third" {
+  type = "list"
+
+  default = ["foo", "bar", "baz"]
+}

--- a/configs/configupgrade/test-fixtures/valid/inline-comments/input/main.tf
+++ b/configs/configupgrade/test-fixtures/valid/inline-comments/input/main.tf
@@ -1,0 +1,9 @@
+variable "list" {
+  type = "list"
+
+  default = [
+    "foo", # I am a comment
+    "bar", # I am also a comment
+    "baz",
+  ]
+}

--- a/configs/configupgrade/test-fixtures/valid/inline-comments/want/main.tf
+++ b/configs/configupgrade/test-fixtures/valid/inline-comments/want/main.tf
@@ -7,3 +7,19 @@ variable "list" {
     "baz",
   ]
 }
+
+variable "list2" {
+  type = list(string)
+
+  default = [
+    "foo",
+    "bar",
+    "baz",
+  ]
+}
+
+variable "list_the_third" {
+  type = list(string)
+
+  default = ["foo", "bar", "baz"]
+}

--- a/configs/configupgrade/test-fixtures/valid/inline-comments/want/main.tf
+++ b/configs/configupgrade/test-fixtures/valid/inline-comments/want/main.tf
@@ -1,0 +1,9 @@
+variable "list" {
+  type = list(string)
+
+  default = [
+    "foo", # I am a comment
+    "bar", # I am also a comment
+    "baz",
+  ]
+}

--- a/configs/configupgrade/test-fixtures/valid/inline-comments/want/versions.tf
+++ b/configs/configupgrade/test-fixtures/valid/inline-comments/want/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/configs/configupgrade/upgrade_expr.go
+++ b/configs/configupgrade/upgrade_expr.go
@@ -168,10 +168,19 @@ Value:
 			src, moreDiags := upgradeExpr(node, filename, interp, an)
 			diags = diags.Append(moreDiags)
 			buf.Write(src)
-			if multiline {
-				buf.WriteString(",\n")
-			} else if i < len(tv.List)-1 {
-				buf.WriteString(", ")
+			if lit, ok := node.(*hcl1ast.LiteralType); ok && lit.LineComment != nil {
+				for _, comment := range lit.LineComment.List {
+					buf.WriteString(", " + comment.Text)
+				}
+				if multiline {
+					buf.WriteString("\n")
+				}
+			} else {
+				if multiline {
+					buf.WriteString(",\n")
+				} else if i < len(tv.List)-1 {
+					buf.WriteString(", ")
+				}
 			}
 		}
 		buf.WriteString("]")

--- a/configs/configupgrade/upgrade_expr.go
+++ b/configs/configupgrade/upgrade_expr.go
@@ -171,8 +171,6 @@ Value:
 			if lit, ok := node.(*hcl1ast.LiteralType); ok && lit.LineComment != nil {
 				for _, comment := range lit.LineComment.List {
 					buf.WriteString(", " + comment.Text)
-				}
-				if multiline {
 					buf.WriteString("\n")
 				}
 			} else {


### PR DESCRIPTION
The configupgrade tool was not writing `LineComments` for lists. Now it
is!

Fixes #21155