### PR TITLE
vendor: go get github.com/hashicorp/hcl2@master

### DIFF
--- a/command/test-fixtures/init-sniff-version-error/init-sniff-version-error.tf
+++ b/command/test-fixtures/init-sniff-version-error/init-sniff-version-error.tf
@@ -1,0 +1,9 @@
+# The following is invalid because we don't permit multiple nested blocks
+# all one one line. Instead, we require the backend block to be on a line
+# of its own.
+# The purpose of this test case is to see that HCL still produces a valid-enough
+# AST that we can try to sniff in this block for a terraform_version argument
+# without crashing, since we do that during init to try to give a better
+# error message if we detect that the configuration is for a newer Terraform
+# version.
+terraform { backend "local" {} }

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl2 v0.0.0-20190503210054-6e4ec17113ca
+	github.com/hashicorp/hcl2 v0.0.0-20190514214226-6a61d80ae3d0
 	github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
-github.com/hashicorp/hcl2 v0.0.0-20190503210054-6e4ec17113ca h1:roLn75Q2QkZE1V3kitKaOazz0INIj53v4OlH4kJzWbA=
-github.com/hashicorp/hcl2 v0.0.0-20190503210054-6e4ec17113ca/go.mod h1:4oI94iqF3GB10QScn46WqbG0kgTUpha97SAzzg2+2ec=
+github.com/hashicorp/hcl2 v0.0.0-20190514214226-6a61d80ae3d0 h1:5Hbw6YJOLDh8XV2z9woGJHyCpCthyYmaG6i97/jvw2g=
+github.com/hashicorp/hcl2 v0.0.0-20190514214226-6a61d80ae3d0/go.mod h1:4oI94iqF3GB10QScn46WqbG0kgTUpha97SAzzg2+2ec=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 h1:2yzhWGdgQUWZUCNK+AoO35V+HTsgEmcM4J9IkArh7PI=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/parser.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/parser.go
@@ -417,6 +417,17 @@ Token:
 		p.recoverAfterBodyItem()
 	}
 
+	// We must never produce a nil body, since the caller may attempt to
+	// do analysis of a partial result when there's an error, so we'll
+	// insert a placeholder if we otherwise failed to produce a valid
+	// body due to one of the syntax error paths above.
+	if body == nil && diags.HasErrors() {
+		body = &Body{
+			SrcRange: hcl.RangeBetween(oBrace.Range, cBraceRange),
+			EndRange: cBraceRange,
+		}
+	}
+
 	return &Block{
 		Type:   blockType,
 		Labels: labels,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl2 v0.0.0-20190503210054-6e4ec17113ca
+# github.com/hashicorp/hcl2 v0.0.0-20190514214226-6a61d80ae3d0
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec


### PR DESCRIPTION
This includes a small fix to ensure the parser doesn't produce an invalid body for block parsing syntax errors, and instead produces an incomplete result that calling applications like Terraform can still analyze.

The problem here was affecting our version-constraint-sniffing code, which intentionally tried to find a core version constraint even if there's a syntax error so that it can report that a new version of Terraform is a likely cause of the syntax error. It was working in most cases, unless it was the "terraform" block itself that contained the error, because then we'd try to analyze a broken `hcl.Block` with a `nil` body.

Includes a new test for `terraform init` that exercises this recovery codepath.

This fixes #21290.
