### PR TITLE
Add support for reading modules from GCS bucket

### DIFF
--- a/configs/configload/getter.go
+++ b/configs/configload/getter.go
@@ -22,6 +22,7 @@ var goGetterDetectors = []getter.Detector{
 	new(getter.BitBucketDetector),
 	new(getter.S3Detector),
 	new(getter.FileDetector),
+	new(getter.GCSDetector),
 }
 
 var goGetterNoDetectors = []getter.Detector{}
@@ -45,6 +46,7 @@ var goGetterDecompressors = map[string]getter.Decompressor{
 var goGetterGetters = map[string]getter.Getter{
 	"file":  new(getter.FileGetter),
 	"git":   new(getter.GitGetter),
+	"gcs":   new(getter.GCSGetter),
 	"hg":    new(getter.HgGetter),
 	"s3":    new(getter.S3Getter),
 	"http":  getterHTTPGetter,

--- a/internal/initwd/getter.go
+++ b/internal/initwd/getter.go
@@ -23,6 +23,7 @@ var goGetterDetectors = []getter.Detector{
 	new(getter.GitHubDetector),
 	new(getter.BitBucketDetector),
 	new(getter.S3Detector),
+	new(getter.GCSDetector),
 	new(getter.FileDetector),
 }
 
@@ -47,6 +48,7 @@ var goGetterDecompressors = map[string]getter.Decompressor{
 var goGetterGetters = map[string]getter.Getter{
 	"file":  new(getter.FileGetter),
 	"git":   new(getter.GitGetter),
+	"gcs":   new(getter.GCSGetter),
 	"hg":    new(getter.HgGetter),
 	"s3":    new(getter.S3Getter),
 	"http":  getterHTTPGetter,

--- a/website/docs/modules/sources.html.markdown
+++ b/website/docs/modules/sources.html.markdown
@@ -30,6 +30,8 @@ types, as listed below.
   * [HTTP URLs](#http-urls)
 
   * [S3 buckets](#s3-bucket)
+  
+  * [GCS buckets](#gcs-bucket)
 
 Each of these is described in the following sections. Module source addresses
 use a _URL-like_ syntax, but with extensions to support unambiguous selection
@@ -374,6 +376,30 @@ preferring those earlier in the list when multiple are available:
 * The default profile in the `.aws/credentials` file in your home directory.
 * If running on an EC2 instance, temporary credentials associated with the
   instance's IAM Instance Profile.
+
+## GCS Bucket
+
+You can use archives stored in Google Cloud Storage as module sources using the special `gcs::`
+prefix, followed by
+[a GCS bucket object URL](https://cloud.google.com/storage/docs/request-endpoints#typical).
+
+For example
+
+* `gcs::https://www.googleapis.com/storage/v1/BUCKET_NAME/PATH_TO_MODULE`
+* `gcs::https://www.googleapis.com/storage/v1/BUCKET_NAME/PATH/TO/module.zip`
+
+```hcl
+module "consul" {
+  source = "gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zip"
+}
+```
+
+The module installer uses Google Cloud SDK to authenticate with GCS. To set credentials you can:
+ 
+* Enter the path of your service account key file in the GOOGLE_APPLICATION_CREDENTIALS environment variable, or;                   
+* If you're running Terraform from a GCE instance, default credentials are automatically available. See [Creating and Enabling Service Accounts](https://cloud.google.com/compute/docs/authentication) for Instances for more details.                     
+* On your computer, you can make your Google identity available by running `gcloud auth application-default login`.
+
 
 ## Modules in Package Sub-directories
 


### PR DESCRIPTION
#21293 updated the go-getter dependency to v1.3.0 to fix a bug. 
That version of go-getter also added support for Google Cloud Storage buckets.

This PR adds support on the Terraform side, so getting Terraform modules from GCS URLs is now supported.
e.g.
```hcl
module "foo" {
  source = "gcs::https://www.googleapis.com/storage/v1/modules/modulefoo_v0.1.1.tar.gz"
}
```