### PR TITLE
Fix panic on init for go-getter modules w version

### DIFF
--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -480,6 +480,14 @@ func (i *ModuleInstaller) installGoGetterModule(req *earlyconfig.ModuleRequest, 
 	packageAddr, _ := splitAddrSubdir(req.SourceAddr)
 	hooks.Download(key, packageAddr, nil)
 
+	if len(req.VersionConstraints) != 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid version constraint",
+			fmt.Sprintf("Cannot apply a version constraint to module %q (at %s:%d) because it has a non Registry URL.", req.Name, req.CallPos.Filename, req.CallPos.Line),
+		))
+	}
+
 	modDir, err := getter.getWithGoGetter(instPath, req.SourceAddr)
 	if err != nil {
 		if _, ok := err.(*MaybeRelativePathErr); ok {

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -486,6 +486,7 @@ func (i *ModuleInstaller) installGoGetterModule(req *earlyconfig.ModuleRequest, 
 			"Invalid version constraint",
 			fmt.Sprintf("Cannot apply a version constraint to module %q (at %s:%d) because it has a non Registry URL.", req.Name, req.CallPos.Filename, req.CallPos.Line),
 		))
+		return nil, diags
 	}
 
 	modDir, err := getter.getWithGoGetter(instPath, req.SourceAddr)

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -111,6 +111,22 @@ func TestModuleInstaller_error(t *testing.T) {
 	}
 }
 
+func TestModuleInstaller_invalid_version_constraint_error(t *testing.T) {
+	fixtureDir := filepath.Clean("test-fixtures/invalid-version-constraint")
+	dir, done := tempChdir(t, fixtureDir)
+	defer done()
+
+	hooks := &testInstallHooks{}
+
+	modulesDir := filepath.Join(dir, ".terraform/modules")
+	inst := NewModuleInstaller(modulesDir, nil)
+	_, diags := inst.InstallModules(".", false, hooks)
+
+	if !diags.HasErrors() {
+		t.Fatal("expected error")
+	}
+}
+
 func TestModuleInstaller_symlink(t *testing.T) {
 	fixtureDir := filepath.Clean("test-fixtures/local-module-symlink")
 	dir, done := tempChdir(t, fixtureDir)

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -124,6 +124,8 @@ func TestModuleInstaller_invalid_version_constraint_error(t *testing.T) {
 
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
+	} else {
+		assertDiagnosticSummary(t, diags, "Invalid version constraint")
 	}
 }
 

--- a/internal/initwd/test-fixtures/invalid-version-constraint/.gitignore
+++ b/internal/initwd/test-fixtures/invalid-version-constraint/.gitignore
@@ -1,0 +1,1 @@
+.terraform/*

--- a/internal/initwd/test-fixtures/invalid-version-constraint/root.tf
+++ b/internal/initwd/test-fixtures/invalid-version-constraint/root.tf
@@ -1,5 +1,7 @@
-# This fixture depends on a github repo at:
+# This fixture references the github repo at:
 #     https://github.com/hashicorp/terraform-aws-module-installer-acctest
+# However, due to the nature of this test (verifying early error), the URL will not be contacted,
+# and the test is safe to execute as part of the normal test suite.
 
 module "acctest_root" {
   source  = "github.com/hashicorp/terraform-aws-module-installer-acctest"

--- a/internal/initwd/test-fixtures/invalid-version-constraint/root.tf
+++ b/internal/initwd/test-fixtures/invalid-version-constraint/root.tf
@@ -1,0 +1,7 @@
+# This fixture depends on a github repo at:
+#     https://github.com/hashicorp/terraform-aws-module-installer-acctest
+
+module "acctest_root" {
+  source  = "github.com/hashicorp/terraform-aws-module-installer-acctest"
+  version = "0.0.1"
+}


### PR DESCRIPTION
Fixes #21328

If the `version` attribute is used on modules whose source will be retrieve with `go-getter` (not Registry or local relative file paths), then Terraform will panic and crash.

This PR fixes the panic by preventing the use of the `version` attribute for module sources that would be retrieved with go-getter. I'm not sure if there are any cases where the version constraint should be allowed in that scenario? 