### PR TITLE
Terraform format and syntax correction

### DIFF
--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -125,7 +125,7 @@ to the provider configuration block:
 provider "aws" {
   version = "~> 1.0"
 
-  region     = "us-east-1"
+  region = "us-east-1"
 }
 ```
 
@@ -205,7 +205,7 @@ meta-argument to a `<PROVIDER NAME>.<ALIAS>` reference:
 
 ```hcl
 resource "aws_instance" "foo" {
-  provider = aws.west
+  provider = "aws.west"
 
   # ...
 }
@@ -219,7 +219,7 @@ provider names inside the module:
 module "aws_vpc" {
   source = "./aws_vpc"
   providers = {
-    aws = aws.west
+    aws = "aws.west"
   }
 }
 ```

--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -205,7 +205,7 @@ meta-argument to a `<PROVIDER NAME>.<ALIAS>` reference:
 
 ```hcl
 resource "aws_instance" "foo" {
-  provider = "aws.west"
+  provider = aws.west
 
   # ...
 }
@@ -219,7 +219,7 @@ provider names inside the module:
 module "aws_vpc" {
   source = "./aws_vpc"
   providers = {
-    aws = "aws.west"
+    aws = aws.west
   }
 }
 ```


### PR DESCRIPTION
Ran a format on the example code blocks provided and added quotes around the provider alias example for `"aws.west"` to allow it to be formatted without errors and to bring it in line with the example found [here](https://www.terraform.io/docs/configuration-0-11/providers.html).