### PR TITLE
command/0.12checklist: Detect reserved variable names

### DIFF
--- a/command/012checklist.go
+++ b/command/012checklist.go
@@ -157,7 +157,7 @@ func (c *ZeroTwelveChecklistCommand) zeroTwelveChecklists(mod *module.Tree, into
 			// in the upstream repository.
 			childItems := c.zeroTwelveChecklistForModule(childMod)
 			if len(childItems) > 0 {
-				items = append(items, fmt.Sprintf("Upgrade child module %q to a version that passes \"terraform 0.12checklist\".", strings.Join(mod.Path(), ".")))
+				items = append(items, fmt.Sprintf("Upgrade child module %q to a version that passes \"terraform 0.12checklist\".", strings.Join(childMod.Path(), ".")))
 			}
 			continue
 		}


### PR DESCRIPTION
(Please note that this is targeted at the `v0.11` branch, not the `master` branch)

Although it's not super important to deal with these before upgrading to 0.12, some prior warning of it during checklist will be helpful to those with complicated, decomposed environments so that they can avoid starting on the upgrade process and then finding out partway that they have some module somewhere that needs a breaking change to fix this.

Because it requires a breaking change to the module to resolve, this is something that may be better dealt with as a separate change before beginning the 0.12 upgrade, to avoid changing too much at once.

As with the previous work on this tool, I tested this manually rather than via automated tests, as an opportunity cost tradeoff for a "best effort" codepath that will only live for a single minor release.

---

Also includes a small fix to the messages about needing to upgrade child modules, to use the correct child module path.
