### PR TITLE
Fixed syntax issue in example.

### DIFF
--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -88,7 +88,7 @@ where `<NAME>` matches the label given in the declaration block:
 ```hcl
 resource "aws_instance" "example" {
   instance_type = "t2.micro"
-  ami           = var.image_id
+  ami           = "${var.image_id}"
 }
 ```
 


### PR DESCRIPTION
I believe that this syntax was valid in previous versions of Terraform, but is no longer considered valid.

This will throw the following error as is:

```
Error: Error parsing <DIRECTORY>/ec2.tf: At 3:21: Unknown token: 3:21 IDENT var.image_id
```