### PR TITLE
Added sha256 to examples

### DIFF
--- a/website/docs/configuration/functions/filebase64.html.md
+++ b/website/docs/configuration/functions/filebase64.html.md
@@ -17,7 +17,7 @@ earlier, see
 a base64-encoded string.
 
 ```hcl
-filebase64(path)
+filebase64sha256(path)
 ```
 
 The result is a Base64 representation of the raw bytes in the given file.
@@ -38,7 +38,7 @@ files that are generated dynamically during a Terraform operation.
 ## Examples
 
 ```
-> filebase64("${path.module}/hello.txt")
+> filebase64sha256("${path.module}/hello.txt")
 SGVsbG8gV29ybGQ=
 ```
 


### PR DESCRIPTION
Changed filebase64 to filebase64sha256 in examples as without sha256 specified it returns: unknown function called: filebase64