### PR TITLE
Add missing quotation marks

### DIFF
--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -205,7 +205,7 @@ meta-argument to a `<PROVIDER NAME>.<ALIAS>` reference:
 
 ```hcl
 resource "aws_instance" "foo" {
-  provider = aws.west
+  provider = "aws.west"
 
   # ...
 }
@@ -219,7 +219,7 @@ provider names inside the module:
 module "aws_vpc" {
   source = "./aws_vpc"
   providers = {
-    aws = aws.west
+    aws = "aws.west"
   }
 }
 ```


### PR DESCRIPTION
`<PROVIDER NAME>.<ALIAS>` references must be quoted, in both examples (resources and modules).
Error otherwise, in both cases:  
> Unknown token: 13:11 IDENT aws.secondary