### PR TITLE
website: Remove the Sentinel section from 0.12 upgrade guide

### DIFF
--- a/website/upgrade-guides/0-12.html.markdown
+++ b/website/upgrade-guides/0-12.html.markdown
@@ -723,20 +723,6 @@ the merging feature, you must reorganize your configuration to use explicit
 merging like in the above example, or else your default map value will be
 entirely overridden by any explicitly-set value.
 
-## Upgrading Sentinel policies
-
-Terraform Enterprise users of Sentinel will need to complete the below steps to
-upgrade Sentinel to work with Terraform 0.12.
-
-1. Update Terraform configurations to 0.12
-1. Update Sentinel policies
-
-Because Sentinel is applied across all workspaces in Terraform Enterprise, all
-workspaces must be upgraded to Terraform 0.12 otherwise Sentinel policies will
-fail on versions below 0.12.
-
-More details on this upgrade process will be added prior to the final release.
-
 ## Upgrading `remote` Backend Configuration
 
 Terraform Enterprise users, and users of the Terrafrom SAAS free tier, will need


### PR DESCRIPTION
A longer-form guide will follow in the Sentinel section of the Terraform Enterprise documentation, once it's ready. For now, this section isn't saying anything useful since it was always just a stub for a guide we planned to write later.