### PR TITLE
always write the current state terraform_version

### DIFF
--- a/states/statefile/roundtrip_test.go
+++ b/states/statefile/roundtrip_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+
+	tfversion "github.com/hashicorp/terraform/version"
 )
 
 func TestRoundtrip(t *testing.T) {
@@ -19,6 +21,8 @@ func TestRoundtrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	currentVersion := tfversion.Version
 
 	for _, info := range entries {
 		const inSuffix = ".in.tfstate"
@@ -56,7 +60,7 @@ func TestRoundtrip(t *testing.T) {
 			}
 			oSrcGot := buf.Bytes()
 
-			var oGot, oWant interface{}
+			var oGot, oWant map[string]interface{}
 			err = json.Unmarshal(oSrcGot, &oGot)
 			if err != nil {
 				t.Fatalf("result isn't JSON: %s", err)
@@ -65,6 +69,9 @@ func TestRoundtrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("wanted result isn't JSON: %s", err)
 			}
+
+			// A newly written state should always reflect the current terraform version.
+			oWant["terraform_version"] = currentVersion
 
 			problems := deep.Equal(oGot, oWant)
 			sort.Strings(problems)

--- a/states/statefile/write.go
+++ b/states/statefile/write.go
@@ -2,11 +2,16 @@ package statefile
 
 import (
 	"io"
+
+	tfversion "github.com/hashicorp/terraform/version"
 )
 
 // Write writes the given state to the given writer in the current state
 // serialization format.
 func Write(s *File, w io.Writer) error {
+	// Always record the current terraform version in the state.
+	s.TerraformVersion = tfversion.SemVer
+
 	diags := writeStateV4(s, w)
 	return diags.Err()
 }


### PR DESCRIPTION
Any time a new state is written, the current terraform version should be
recorded.

Fixes #21379