### PR TITLE
Remove pre-alpha cost estimation logic from remote backend

### DIFF
--- a/backend/remote/backend_common.go
+++ b/backend/remote/backend_common.go
@@ -227,57 +227,6 @@ func (b *Remote) parseVariableValues(op *backend.Operation) (terraform.InputValu
 	return result, diags
 }
 
-func (b *Remote) costEstimation(stopCtx, cancelCtx context.Context, op *backend.Operation, r *tfe.Run) error {
-	if r.CostEstimation == nil {
-		return nil
-	}
-
-	if b.CLI != nil {
-		b.CLI.Output("\n------------------------------------------------------------------------\n")
-	}
-
-	logs, err := b.client.CostEstimations.Logs(stopCtx, r.CostEstimation.ID)
-	if err != nil {
-		return generalError("Failed to retrieve cost estimation logs", err)
-	}
-	scanner := bufio.NewScanner(logs)
-
-	// Retrieve the cost estimation to get its current status.
-	ce, err := b.client.CostEstimations.Read(stopCtx, r.CostEstimation.ID)
-	if err != nil {
-		return generalError("Failed to retrieve cost estimation", err)
-	}
-
-	msgPrefix := "Cost estimation"
-	if b.CLI != nil {
-		b.CLI.Output(b.Colorize().Color(msgPrefix + ":\n"))
-	}
-
-	for scanner.Scan() {
-		if b.CLI != nil {
-			b.CLI.Output(b.Colorize().Color(scanner.Text()))
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return generalError("Failed to read logs", err)
-	}
-
-	switch ce.Status {
-	case tfe.CostEstimationFinished:
-		if len(r.PolicyChecks) == 0 && r.HasChanges && op.Type == backend.OperationTypeApply && b.CLI != nil {
-			b.CLI.Output("\n------------------------------------------------------------------------")
-		}
-		return nil
-	case tfe.CostEstimationErrored:
-		return fmt.Errorf(msgPrefix + " errored.")
-	case tfe.CostEstimationCanceled:
-		return fmt.Errorf(msgPrefix + " canceled.")
-	default:
-		return fmt.Errorf("Unknown or unexpected cost estimation state: %s", ce.Status)
-	}
-}
-
 func (b *Remote) checkPolicy(stopCtx, cancelCtx context.Context, op *backend.Operation, r *tfe.Run) error {
 	if b.CLI != nil {
 		b.CLI.Output("\n------------------------------------------------------------------------\n")

--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -21,7 +21,6 @@ import (
 type mockClient struct {
 	Applies               *mockApplies
 	ConfigurationVersions *mockConfigurationVersions
-	CostEstimations       *mockCostEstimations
 	Organizations         *mockOrganizations
 	Plans                 *mockPlans
 	PolicyChecks          *mockPolicyChecks
@@ -34,7 +33,6 @@ func newMockClient() *mockClient {
 	c := &mockClient{}
 	c.Applies = newMockApplies(c)
 	c.ConfigurationVersions = newMockConfigurationVersions(c)
-	c.CostEstimations = newMockCostEstimations(c)
 	c.Organizations = newMockOrganizations(c)
 	c.Plans = newMockPlans(c)
 	c.PolicyChecks = newMockPolicyChecks(c)
@@ -212,84 +210,6 @@ func (m *mockConfigurationVersions) Upload(ctx context.Context, url, path string
 	m.uploadPaths[cv.ID] = path
 	cv.Status = tfe.ConfigurationUploaded
 	return nil
-}
-
-type mockCostEstimations struct {
-	client      *mockClient
-	estimations map[string]*tfe.CostEstimation
-	logs        map[string]string
-}
-
-func newMockCostEstimations(client *mockClient) *mockCostEstimations {
-	return &mockCostEstimations{
-		client:      client,
-		estimations: make(map[string]*tfe.CostEstimation),
-		logs:        make(map[string]string),
-	}
-}
-
-// create is a helper function to create a mock cost estimation that uses the
-// configured working directory to find the logfile.
-func (m *mockCostEstimations) create(cvID, workspaceID string) (*tfe.CostEstimation, error) {
-	id := generateID("ce-")
-
-	ce := &tfe.CostEstimation{
-		ID:     id,
-		Status: tfe.CostEstimationQueued,
-	}
-
-	w, ok := m.client.Workspaces.workspaceIDs[workspaceID]
-	if !ok {
-		return nil, tfe.ErrResourceNotFound
-	}
-
-	logfile := filepath.Join(
-		m.client.ConfigurationVersions.uploadPaths[cvID],
-		w.WorkingDirectory,
-		"ce.log",
-	)
-
-	if _, err := os.Stat(logfile); os.IsNotExist(err) {
-		return nil, nil
-	}
-
-	m.logs[ce.ID] = logfile
-	m.estimations[ce.ID] = ce
-
-	return ce, nil
-}
-
-func (m *mockCostEstimations) Read(ctx context.Context, costEstimationID string) (*tfe.CostEstimation, error) {
-	ce, ok := m.estimations[costEstimationID]
-	if !ok {
-		return nil, tfe.ErrResourceNotFound
-	}
-	return ce, nil
-}
-
-func (m *mockCostEstimations) Logs(ctx context.Context, costEstimationID string) (io.Reader, error) {
-	ce, ok := m.estimations[costEstimationID]
-	if !ok {
-		return nil, tfe.ErrResourceNotFound
-	}
-
-	logfile, ok := m.logs[ce.ID]
-	if !ok {
-		return nil, tfe.ErrResourceNotFound
-	}
-
-	if _, err := os.Stat(logfile); os.IsNotExist(err) {
-		return bytes.NewBufferString("logfile does not exist"), nil
-	}
-
-	logs, err := ioutil.ReadFile(logfile)
-	if err != nil {
-		return nil, err
-	}
-
-	ce.Status = tfe.CostEstimationFinished
-
-	return bytes.NewBuffer(logs), nil
 }
 
 // mockInput is a mock implementation of terraform.UIInput.
@@ -732,25 +652,19 @@ func (m *mockRuns) Create(ctx context.Context, options tfe.RunCreateOptions) (*t
 		return nil, err
 	}
 
-	ce, err := m.client.CostEstimations.create(options.ConfigurationVersion.ID, options.Workspace.ID)
-	if err != nil {
-		return nil, err
-	}
-
 	pc, err := m.client.PolicyChecks.create(options.ConfigurationVersion.ID, options.Workspace.ID)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &tfe.Run{
-		ID:             generateID("run-"),
-		Actions:        &tfe.RunActions{IsCancelable: true},
-		Apply:          a,
-		CostEstimation: ce,
-		HasChanges:     false,
-		Permissions:    &tfe.RunPermissions{},
-		Plan:           p,
-		Status:         tfe.RunPending,
+		ID:          generateID("run-"),
+		Actions:     &tfe.RunActions{IsCancelable: true},
+		Apply:       a,
+		HasChanges:  false,
+		Permissions: &tfe.RunPermissions{},
+		Plan:        p,
+		Status:      tfe.RunPending,
 	}
 
 	if pc != nil {

--- a/backend/remote/backend_plan.go
+++ b/backend/remote/backend_plan.go
@@ -290,14 +290,6 @@ func (b *Remote) plan(stopCtx, cancelCtx context.Context, op *backend.Operation,
 		return r, nil
 	}
 
-	// Show any cost estimation output.
-	if r.CostEstimation != nil {
-		err = b.costEstimation(stopCtx, cancelCtx, op, r)
-		if err != nil {
-			return r, err
-		}
-	}
-
 	// Check any configured sentinel policies.
 	if len(r.PolicyChecks) > 0 {
 		err = b.checkPolicy(stopCtx, cancelCtx, op, r)

--- a/backend/remote/backend_plan_test.go
+++ b/backend/remote/backend_plan_test.go
@@ -655,40 +655,6 @@ func TestRemote_planWithWorkingDirectory(t *testing.T) {
 	}
 }
 
-func TestRemote_costEstimation(t *testing.T) {
-	b, bCleanup := testBackendDefault(t)
-	defer bCleanup()
-
-	op, configCleanup := testOperationPlan(t, "./test-fixtures/plan-cost-estimation")
-	defer configCleanup()
-
-	op.Workspace = backend.DefaultStateName
-
-	run, err := b.Operation(context.Background(), op)
-	if err != nil {
-		t.Fatalf("error starting operation: %v", err)
-	}
-
-	<-run.Done()
-	if run.Result != backend.OperationSuccess {
-		t.Fatalf("operation failed: %s", b.CLI.(*cli.MockUi).ErrorWriter.String())
-	}
-	if run.PlanEmpty {
-		t.Fatalf("expected a non-empty plan")
-	}
-
-	output := b.CLI.(*cli.MockUi).OutputWriter.String()
-	if !strings.Contains(output, "Running plan in the remote backend") {
-		t.Fatalf("expected remote backend header in output: %s", output)
-	}
-	if !strings.Contains(output, "SKU") {
-		t.Fatalf("expected cost estimation result in output: %s", output)
-	}
-	if !strings.Contains(output, "1 to add, 0 to change, 0 to destroy") {
-		t.Fatalf("expected plan summary in output: %s", output)
-	}
-}
-
 func TestRemote_planPolicyPass(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()

--- a/backend/remote/testing.go
+++ b/backend/remote/testing.go
@@ -115,7 +115,6 @@ func testBackend(t *testing.T, obj cty.Value) (*Remote, func()) {
 	b.CLI = cli.NewMockUi()
 	b.client.Applies = mc.Applies
 	b.client.ConfigurationVersions = mc.ConfigurationVersions
-	b.client.CostEstimations = mc.CostEstimations
 	b.client.Organizations = mc.Organizations
 	b.client.Plans = mc.Plans
 	b.client.PolicyChecks = mc.PolicyChecks


### PR DESCRIPTION
This feature's being restructured, and this has been dead code for a while now. It won't need to be in the remote backend until this feature sees a real release. We can safely remove references to this and, even if folks are running 0.12.0 when the feature is ultimately released, the remote backend won't break for them (although it won't support the newer version of the feature).