### PR TITLE
HCL fails when converting map(string)

### DIFF
--- a/config/hcl2shim/values.go
+++ b/config/hcl2shim/values.go
@@ -223,6 +223,12 @@ func HCL2ValueFromConfigValue(v interface{}) cty.Value {
 			vals[k] = HCL2ValueFromConfigValue(ev)
 		}
 		return cty.ObjectVal(vals)
+        case map[string]string{}:
+		vals := map[string]cty.Value{}
+		for k, ev := range tv {
+			vals[k] = HCL2ValueFromConfigValue(ev)
+		}
+		return cty.ObjectVal(vals)
 	default:
 		// HCL/HIL should never generate anything that isn't caught by
 		// the above, so if we get here something has gone very wrong.


### PR DESCRIPTION
While migrating a provider from 0.11 to 0.12 I started failing on
converting from map[string]string cause it wasn't recognized by the
converter in values.go