### PR TITLE
init always prompts for migration with most remote backend configurations

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -299,7 +299,7 @@ func (c *InitCommand) Run(args []string) int {
 
 	if back == nil {
 		// If we didn't initialize a backend then we'll try to at least
-		// instantiate one. This might fail if it wasn't already initalized
+		// instantiate one. This might fail if it wasn't already initialized
 		// by a previous run, so we must still expect that "back" may be nil
 		// in code that follows.
 		var backDiags tfdiags.Diagnostics
@@ -673,6 +673,12 @@ func (c *InitCommand) backendConfigOverrideBody(flags rawFlags, schema *configsc
 		newBody := configs.SynthBody("-backend-config=...", synthVals)
 		mergeBody(newBody)
 		synthVals = make(map[string]cty.Value)
+	}
+
+	if len(items) == 1 && items[0].Value == "" {
+		// Explicitly remove all -backend-config options.
+		// We do this by setting an empty but non-nil ConfigOverrides.
+		return configs.SynthBody("-backend-config=''", synthVals), diags
 	}
 
 	for _, item := range items {

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -454,6 +454,22 @@ func TestInit_backendConfigKVReInit(t *testing.T) {
 	if cfg["path"] != "test" {
 		t.Fatalf(`expected backend path="test", got path="%v"`, cfg["path"])
 	}
+
+	// override the -backend-config options by settings
+	args = []string{"-input=false", "-backend-config", ""}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+
+	// make sure the backend is configured how we expect
+	configState = testDataStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
+	cfg = map[string]interface{}{}
+	if err := json.Unmarshal(configState.Backend.ConfigRaw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg["path"] != nil {
+		t.Fatalf(`expected backend path="<nil>", got path="%v"`, cfg["path"])
+	}
 }
 
 func TestInit_backendConfigKVReInitWithConfigDiff(t *testing.T) {

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -671,7 +671,7 @@ func TestInit_inputFalse(t *testing.T) {
 	}
 
 	// A missing input=false should abort rather than loop infinitely
-	args = []string{"-backend-config=path=bar"}
+	args = []string{"-backend-config=path=baz"}
 	if code := c.Run(args); code == 0 {
 		t.Fatal("init should have failed", ui.OutputWriter)
 	}

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -823,6 +823,8 @@ func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr *state.
 		return nil, diags
 	}
 
+	fmt.Println("HERE")
+
 	// Perform the migration
 	err := m.backendMigrateState(&backendMigrateOpts{
 		OneType: s.Backend.Type,

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -185,9 +185,8 @@ func (m *Meta) BackendForPlan(settings plans.Backend) (backend.Enhanced, tfdiags
 	if validateDiags.HasErrors() {
 		return nil, diags
 	}
-	configVal = newVal
 
-	configureDiags := b.Configure(configVal)
+	configureDiags := b.Configure(newVal)
 	diags = diags.Append(configureDiags)
 
 	// If the backend supports CLI initialization, do it.
@@ -922,9 +921,8 @@ func (m *Meta) backend_C_r_S_unchanged(c *configs.Backend, cHash int, sMgr *stat
 	if validDiags.HasErrors() {
 		return nil, diags
 	}
-	configVal = newVal
 
-	configDiags := b.Configure(configVal)
+	configDiags := b.Configure(newVal)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, diags
@@ -1051,9 +1049,8 @@ func (m *Meta) backendInitFromConfig(c *configs.Backend) (backend.Backend, cty.V
 	if validateDiags.HasErrors() {
 		return nil, cty.NilVal, diags
 	}
-	configVal = newVal
 
-	configureDiags := b.Configure(configVal)
+	configureDiags := b.Configure(newVal)
 	diags = diags.Append(configureDiags.InConfigBody(c.Config))
 
 	return b, configVal, diags
@@ -1082,9 +1079,8 @@ func (m *Meta) backendInitFromSaved(s *terraform.BackendState) (backend.Backend,
 	if validateDiags.HasErrors() {
 		return nil, diags
 	}
-	configVal = newVal
 
-	configureDiags := b.Configure(configVal)
+	configureDiags := b.Configure(newVal)
 	diags = diags.Append(configureDiags)
 
 	return b, diags

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -463,12 +463,11 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 
 	// Potentially changing a backend configuration
 	case c != nil && !s.Backend.Empty():
-		// If we're not initializing, then it's sufficient for the configuration
-		// hashes to match, since that suggests that the static backend
-		// settings in the configuration files are unchanged. (The only
-		// record we have of CLI overrides is in the settings cache in this
-		// case, so we have no other source to compare with.
-		if !opts.Init && uint64(cHash) == s.Backend.Hash {
+		// We are not going to migrate if were not initializing and the hashes
+		// match indicating that the stored config is valid. If we are
+		// initializing, then we also assume the the backend config is OK if
+		// the hashes match, as long as we're not providing any new overrides.
+		if (uint64(cHash) == s.Backend.Hash) && (!opts.Init || opts.ConfigOverride == nil) {
 			log.Printf("[TRACE] Meta.Backend: using already-initialized, unchanged %q backend configuration", c.Type)
 			return m.backend_C_r_S_unchanged(c, cHash, sMgr)
 		}
@@ -822,8 +821,6 @@ func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr *state.
 	if oldBDiags.HasErrors() {
 		return nil, diags
 	}
-
-	fmt.Println("HERE")
 
 	// Perform the migration
 	err := m.backendMigrateState(&backendMigrateOpts{

--- a/command/meta_backend_migrate.go
+++ b/command/meta_backend_migrate.go
@@ -98,6 +98,7 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 	// Multi-state to multi-state. We merge the states together (migrating
 	// each from the source to the destination one by one).
 	case !oneSingle && !twoSingle:
+		fmt.Printf("STATES: %q\n", oneStates)
 		// If the source only has one state and it is the default,
 		// treat it as if it doesn't support multi-state.
 		if len(oneStates) == 1 && oneStates[0] == backend.DefaultStateName {

--- a/command/meta_backend_migrate.go
+++ b/command/meta_backend_migrate.go
@@ -98,7 +98,6 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 	// Multi-state to multi-state. We merge the states together (migrating
 	// each from the source to the destination one by one).
 	case !oneSingle && !twoSingle:
-		fmt.Printf("STATES: %q\n", oneStates)
 		// If the source only has one state and it is the default,
 		// treat it as if it doesn't support multi-state.
 		if len(oneStates) == 1 && oneStates[0] == backend.DefaultStateName {


### PR DESCRIPTION
This was the same outcome, caused by 2 different issues.
The first was that `init` is supposed to be idempotent, and calling init with no `-backend-config` flags should accept the stored config if the hash matches.
Second was that when the config did need to be compared, the saved result had already been pre-processed by `PrepareConfig` and was no longer identical to the given config.

Fixes #21189