### PR TITLE
filter unknowns from simple lists and maps in sdk

### DIFF
--- a/builtin/providers/test/resource_map.go
+++ b/builtin/providers/test/resource_map.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -22,6 +23,15 @@ func testResourceMap() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				ValidateFunc: func(v interface{}, _ string) ([]string, []error) {
+					errs := []error{}
+					for k, v := range v.(map[string]interface{}) {
+						if v == config.UnknownVariableValue {
+							errs = append(errs, fmt.Errorf("unknown value in ValidateFunc: %q=%q", k, v))
+						}
+					}
+					return nil, errs
+				},
 			},
 			"map_values": {
 				Type:     schema.TypeMap,

--- a/builtin/providers/test/resource_map_test.go
+++ b/builtin/providers/test/resource_map_test.go
@@ -31,6 +31,35 @@ resource "test_resource_map" "foobar" {
 	})
 }
 
+func TestResourceMap_basicWithVars(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+variable "a" {
+  default = "a"
+}
+
+variable "b" {
+  default = "b"
+}
+
+resource "test_resource_map" "foobar" {
+	name = "test"
+	map_of_three = {
+		one   = var.a
+		two   = var.b
+		empty = ""
+	}
+}`,
+				Check: resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
 func TestResourceMap_computedMap(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		Providers:    testAccProviders,


### PR DESCRIPTION
While there was already a check in the sdk to filter unknowns from
validation, it missed the case where those were in simple lists and maps.

Fixes #21419