### PR TITLE
clarify getting started provisioning exec check

### DIFF
--- a/website/intro/getting-started/provision.html.md
+++ b/website/intro/getting-started/provision.html.md
@@ -73,7 +73,7 @@ Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
 
 Terraform will output anything from provisioners to the console,
 but in this case there is no output. However, we can verify
-everything worked by looking at the `ip_address.txt` file:
+everything worked by looking at the `ip_address.txt` file on your local machine:
 
 ```
 $ cat ip_address.txt


### PR DESCRIPTION
I was just going through the Getting Started guide.

The guide has not yet explained how to configure ssh access.
I wasted a lot of time trying to figure out how to SSH in. (e.g. maybe Terraform automatically uses `~/.ssh/id_rsa.pub`)

When I got to this point I didn't know about the different kind of provisioners.
Since `local-exec` is *inside* the `resource` block, I assumed that `local` means local inside that resource.

So this PR just clarifies where to expect that file.