### PR TITLE
Support `lookup()` for `map<A, bool>`

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -686,8 +686,10 @@ var LookupFunc = function.New(&function.Spec{
 					return cty.StringVal(v.AsString()), nil
 				case ty.Equals(cty.Number):
 					return cty.NumberVal(v.AsBigFloat()), nil
+				case ty.Equals(cty.Bool):
+					return cty.BoolVal(v.True()), nil
 				default:
-					return cty.NilVal, errors.New("lookup() can only be used with flat lists")
+					return cty.NilVal, errors.New("lookup() can only be used with flat maps")
 				}
 			}
 		}


### PR DESCRIPTION
This tiny change addresses a problem when running a lookup on a flat map with string keys and boolean values. Also, replaces word `lists` with `maps`, which feels more adequate here.