### PR TITLE
command/show (plan -json): fix panic

### DIFF
--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -215,10 +215,6 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 						return cty.False, nil
 					}
 
-					if !val.Type().IsPrimitiveType() {
-						return val, nil // just pass through non-primitives; they already contain our transform results
-					}
-
 					if val.IsKnown() {
 						return cty.False, nil
 					}

--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -210,17 +210,7 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 				if err != nil {
 					return err
 				}
-				afterUnknown, _ = cty.Transform(changeV.After, func(path cty.Path, val cty.Value) (cty.Value, error) {
-					if val.IsNull() {
-						return cty.False, nil
-					}
-
-					if val.IsKnown() {
-						return cty.False, nil
-					}
-
-					return cty.True, nil
-				})
+				afterUnknown = cty.EmptyObjectVal
 			} else {
 				filteredAfter := omitUnknowns(changeV.After)
 				if filteredAfter.IsNull() {

--- a/command/jsonplan/values_test.go
+++ b/command/jsonplan/values_test.go
@@ -173,7 +173,7 @@ func TestMarshalPlanResources(t *testing.T) {
 		Want   []resource
 		Err    bool
 	}{
-		"create with unkonwns": {
+		"create with unknowns": {
 			Action: plans.Create,
 			Before: cty.NullVal(cty.EmptyObject),
 			After: cty.ObjectVal(map[string]cty.Value{

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -221,7 +220,6 @@ func TestShow_json_output(t *testing.T) {
 			json.Unmarshal([]byte(byteValue), &want)
 
 			if !cmp.Equal(got, want) {
-				fmt.Println(ui.OutputWriter.String())
 				t.Fatalf("wrong result:\n %v\n", cmp.Diff(got, want))
 			}
 

--- a/command/test-fixtures/show-json/basic-delete/output.json
+++ b/command/test-fixtures/show-json/basic-delete/output.json
@@ -48,10 +48,7 @@
                     "ami": "bar",
                     "id": "placeholder"
                 },
-                "after_unknown": {
-                    "ami": false,
-                    "id": false
-                }
+                "after_unknown": {}
             }
         },
         {
@@ -69,7 +66,7 @@
                     "id": "placeholder"
                 },
                 "after": null,
-                "after_unknown": false
+                "after_unknown": {}
             }
         }
     ],

--- a/command/test-fixtures/show-json/basic-update/output.json
+++ b/command/test-fixtures/show-json/basic-update/output.json
@@ -48,10 +48,7 @@
                     "ami": "bar",
                     "id": "placeholder"
                 },
-                "after_unknown": {
-                    "ami": false,
-                    "id": false
-                }
+                "after_unknown": {}
             }
         }
     ],


### PR DESCRIPTION
We were somewhat inconsistent with return values in "after_unknown". This commit fixes that by removing some redundant (and panicky) code.

Fixes #21415 (via #21448)

With bonus fixes: typo, embarrassing debug code.