### PR TITLE
Allow providers to re-validate the final resource config

### DIFF
--- a/builtin/providers/test/resource_list.go
+++ b/builtin/providers/test/resource_list.go
@@ -95,7 +95,19 @@ func testResourceList() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-
+			"min_items": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 2,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"val": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 			"never_set": {
 				Type:     schema.TypeList,
 				MaxItems: 1,

--- a/builtin/providers/test/resource_list_test.go
+++ b/builtin/providers/test/resource_list_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -477,6 +478,57 @@ resource "test_resource_list" "b" {
 }
 				`),
 				Check: resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func TestResourceList_dynamicMinItems(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+variable "a" {
+  type = list(number)
+  default = [1]
+}
+
+resource "test_resource_list" "b" {
+	dynamic "min_items" {
+		for_each = var.a
+		content {
+		  val = "foo"
+		}
+	}
+}
+				`),
+				ExpectError: regexp.MustCompile(`attribute supports 2`),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_list" "a" {
+	dependent_list {
+		val = "a"
+	}
+
+	dependent_list {
+		val = "b"
+	}
+}
+resource "test_resource_list" "b" {
+	list_block {
+		string = "constant"
+	}
+	dynamic "min_items" {
+		for_each = test_resource_list.a.computed_list
+		content {
+		  val = min_items.value
+		}
+	}
+}
+				`),
 			},
 		},
 	})

--- a/terraform/eval_read_data.go
+++ b/terraform/eval_read_data.go
@@ -179,6 +179,17 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 		)
 	}
 
+	log.Printf("[TRACE] Re-validating config for %s", absAddr)
+	validateResp := provider.ValidateDataSourceConfig(
+		providers.ValidateDataSourceConfigRequest{
+			TypeName: n.Addr.Resource.Type,
+			Config:   configVal,
+		},
+	)
+	if validateResp.Diagnostics.HasErrors() {
+		return nil, validateResp.Diagnostics.InConfigBody(n.Config.Config).Err()
+	}
+
 	// If we get down here then our configuration is complete and we're read
 	// to actually call the provider to read the data.
 	log.Printf("[TRACE] EvalReadData: %s configuration is complete, so reading from provider", absAddr)


### PR DESCRIPTION
The provider's validate methods are called along with the static config validation early on, but will contain many unknown values that can't be checked for content.

By re-running the provider validate functions before plan (and read for data sources), the provider gets a chance to see the complete config, and return diagnostics about any new values which may not be valid.

Fixes #21225.
Fixes #21436, which was partially fixed by an earlier commit that prevented unknown values from going through validation, but as a side effect prevented their validation altogether.
This also closes #21315, since it will allow the provider to reject unexpected null values that would have otherwise been skipped due to being unknown during Validate. 