### PR TITLE
command/show (-json): fix panic if a moduleCall has a nil config

### DIFF
--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -238,8 +238,7 @@ func marshalModuleCalls(c *configs.Config, schemas *terraform.Schemas) map[strin
 }
 
 func marshalModuleCall(c *configs.Config, mc *configs.ModuleCall, schemas *terraform.Schemas) moduleCall {
-	// It's possible, though unlikely, to have a module call with a nil config
-	// https://github.com/hashicorp/terraform/issues/21543
+	// It is possible to have a module call with a nil config.
 	if c == nil {
 		return moduleCall{}
 	}

--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -238,6 +238,12 @@ func marshalModuleCalls(c *configs.Config, schemas *terraform.Schemas) map[strin
 }
 
 func marshalModuleCall(c *configs.Config, mc *configs.ModuleCall, schemas *terraform.Schemas) moduleCall {
+	// It's possible, though unlikely, to have a module call with a nil config
+	// https://github.com/hashicorp/terraform/issues/21543
+	if c == nil {
+		return moduleCall{}
+	}
+
 	ret := moduleCall{
 		Source:            mc.SourceAddr,
 		VersionConstraint: mc.Version.Required.String(),

--- a/command/test-fixtures/show-json/nested-modules/main.tf
+++ b/command/test-fixtures/show-json/nested-modules/main.tf
@@ -1,0 +1,3 @@
+module "my_module" {
+  source = "./modules"
+}

--- a/command/test-fixtures/show-json/nested-modules/modules/main.tf
+++ b/command/test-fixtures/show-json/nested-modules/modules/main.tf
@@ -1,0 +1,3 @@
+module "more" {
+  source = "./more-modules"
+}

--- a/command/test-fixtures/show-json/nested-modules/modules/more-modules/main.tf
+++ b/command/test-fixtures/show-json/nested-modules/modules/more-modules/main.tf
@@ -1,0 +1,4 @@
+variable "misspelled" {
+  default     = "ehllo"
+  descriptoni = "I am a misspelled attribute"
+}

--- a/command/test-fixtures/show-json/nested-modules/output.json
+++ b/command/test-fixtures/show-json/nested-modules/output.json
@@ -1,0 +1,23 @@
+{
+    "format_version": "0.1",
+    "terraform_version": "0.12.1-dev",
+    "planned_values": {
+        "root_module": {}
+    },
+    "configuration": {
+        "root_module": {
+            "module_calls": {
+                "my_module": {
+                    "source": "./modules",
+                    "module": {
+                        "module_calls": {
+                            "more": {
+                                "module": {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the unlikely event that a moduleCall has a nil config - for example,
if a nested module call includes a variable with a typo in an
attribute - continue gracefully.

I am concerned that there are repercussions for sentinel users, so I've opened #21568 to capture the root cause. 

Fixes #21543 