### PR TITLE
lang/funcs: fix error when `matchkeys` encountered a variable

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -800,7 +800,13 @@ var MatchkeysFunc = function.New(&function.Spec{
 		},
 	},
 	Type: func(args []cty.Value) (cty.Type, error) {
-		if !args[1].Type().Equals(args[2].Type()) {
+		argTypes := make([]cty.Type, 2)
+		for i := 0; i < 2; i++ {
+			argTypes[i] = args[i+1].Type()
+		}
+
+		ty, _ := convert.UnifyUnsafe(argTypes)
+		if ty == cty.NilType {
 			return cty.NilType, errors.New("lists must be of the same type")
 		}
 

--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -800,14 +800,7 @@ var MatchkeysFunc = function.New(&function.Spec{
 		},
 	},
 	Type: func(args []cty.Value) (cty.Type, error) {
-		// Verify that args[1] (keys) and args[2] (searchset) are of the same
-		// (or unifiable) type
-		argTypes := make([]cty.Type, 2)
-		for i := 0; i < 2; i++ {
-			argTypes[i] = args[i+1].Type()
-		}
-
-		ty, _ := convert.UnifyUnsafe(argTypes)
+		ty, _ := convert.UnifyUnsafe([]cty.Type{args[1].Type(), args[2].Type()})
 		if ty == cty.NilType {
 			return cty.NilType, errors.New("keys and searchset must be of the same type")
 		}
@@ -830,11 +823,7 @@ var MatchkeysFunc = function.New(&function.Spec{
 		// Keys and searchset must be the same type.
 		// We can skip error checking here because we've already verified that
 		// they can be unified in the Type function
-		argTypes := make([]cty.Type, 2)
-		for i := 0; i < 2; i++ {
-			argTypes[i] = args[i+1].Type()
-		}
-		ty, _ := convert.UnifyUnsafe(argTypes)
+		ty, _ := convert.UnifyUnsafe([]cty.Type{args[1].Type(), args[2].Type()})
 		keys, _ := convert.Convert(args[1], ty)
 		searchset, _ := convert.Convert(args[2], ty)
 

--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -800,6 +800,8 @@ var MatchkeysFunc = function.New(&function.Spec{
 		},
 	},
 	Type: func(args []cty.Value) (cty.Type, error) {
+		// Verify that args[1] (keys) and args[2] (searchset) are of the same
+		// (or unifiable) type
 		argTypes := make([]cty.Type, 2)
 		for i := 0; i < 2; i++ {
 			argTypes[i] = args[i+1].Type()
@@ -807,9 +809,10 @@ var MatchkeysFunc = function.New(&function.Spec{
 
 		ty, _ := convert.UnifyUnsafe(argTypes)
 		if ty == cty.NilType {
-			return cty.NilType, errors.New("lists must be of the same type")
+			return cty.NilType, errors.New("keys and searchset must be of the same type")
 		}
 
+		// the return type is based on args[0] (values)
 		return args[0].Type(), nil
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
@@ -822,10 +825,18 @@ var MatchkeysFunc = function.New(&function.Spec{
 		}
 
 		output := make([]cty.Value, 0)
-
 		values := args[0]
-		keys := args[1]
-		searchset := args[2]
+
+		// Keys and searchset must be the same type.
+		// We can skip error checking here because we've already verified that
+		// they can be unified in the Type function
+		argTypes := make([]cty.Type, 2)
+		for i := 0; i < 2; i++ {
+			argTypes[i] = args[i+1].Type()
+		}
+		ty, _ := convert.UnifyUnsafe(argTypes)
+		keys, _ := convert.Convert(args[1], ty)
+		searchset, _ := convert.Convert(args[2], ty)
 
 		// if searchset is empty, return an empty list.
 		if searchset.LengthInt() == 0 {

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -1896,6 +1896,37 @@ func TestMatchkeys(t *testing.T) {
 			cty.ListValEmpty(cty.String),
 			false,
 		},
+		{ // complex values: values is a different type from keys and searchset
+			cty.ListVal([]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"foo": cty.StringVal("bar"),
+				}),
+				cty.MapVal(map[string]cty.Value{
+					"foo": cty.StringVal("baz"),
+				}),
+				cty.MapVal(map[string]cty.Value{
+					"foo": cty.StringVal("beep"),
+				}),
+			}),
+			cty.ListVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("b"),
+				cty.StringVal("c"),
+			}),
+			cty.ListVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("c"),
+			}),
+			cty.ListVal([]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"foo": cty.StringVal("bar"),
+				}),
+				cty.MapVal(map[string]cty.Value{
+					"foo": cty.StringVal("beep"),
+				}),
+			}),
+			false,
+		},
 		// errors
 		{ // different types
 			cty.ListVal([]cty.Value{

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -1883,8 +1883,7 @@ func TestMatchkeys(t *testing.T) {
 			cty.UnknownVal(cty.List(cty.String)),
 			false,
 		},
-		// errors
-		{ // different types
+		{ // different types that can be unified
 			cty.ListVal([]cty.Value{
 				cty.StringVal("a"),
 			}),
@@ -1894,9 +1893,10 @@ func TestMatchkeys(t *testing.T) {
 			cty.ListVal([]cty.Value{
 				cty.StringVal("a"),
 			}),
-			cty.NilVal,
-			true,
+			cty.ListValEmpty(cty.String),
+			false,
 		},
+		// errors
 		{ // different types
 			cty.ListVal([]cty.Value{
 				cty.StringVal("a"),

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -459,6 +459,13 @@ func TestFunctions(t *testing.T) {
 					cty.StringVal("a"),
 				}),
 			},
+			{ // mixing types in searchset
+				`matchkeys(["a", "b", "c"], [1, 2, 3], [1, "3"])`,
+				cty.ListVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.StringVal("c"),
+				}),
+			},
 		},
 
 		"max": {


### PR DESCRIPTION
`matchkeys` was returning a (false) error if the searchset was a
variable, since then the type of the keylist and searchset parameters
would not match.

This does slightly change the behavior: previously matchkeys would
produce an error if the parameters were not of the same type, for e.g.
if searchset was a list of strings and keylist was a list of integers.
  This no longer produces an error.