### PR TITLE
Fix panic on invalid depends_on root.

### DIFF
--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -373,7 +373,7 @@ func (n *EvalValidateResource) Eval(ctx EvalContext) (interface{}, error) {
 	for _, traversal := range n.Config.DependsOn {
 		ref, refDiags := addrs.ParseRef(traversal)
 		diags = diags.Append(refDiags)
-		if len(ref.Remaining) != 0 {
+		if !refDiags.HasErrors() && len(ref.Remaining) != 0 {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid depends_on reference",


### PR DESCRIPTION
Assume "ref" can be nil and report an invalid reference to
the user instead of crashing.

This is a regression from terraform 0.11 and now fails in 0.12.0.

Including test case.
