### PR TITLE
website: Additional information about "dynamic" blocks

### DIFF
--- a/website/docs/configuration/expressions.html.md
+++ b/website/docs/configuration/expressions.html.md
@@ -673,11 +673,22 @@ Since the `for_each` argument accepts any collection or structural value,
 you can use a `for` expression or splat expression to transform an existing
 collection.
 
+The iterator object (`ingress` in the example above) has two attributes:
+
+* `key` is the map key or list element index for the current element. If the
+  `for_each` exression produces a _set_ value then `key` is identical to
+  `value` and should not be used.
+* `value` is the value of the current element.
+
 A `dynamic` block can only generate arguments that belong to the resource type,
 data source, provider or provisioner being configured. It is _not_ possible
 to generate meta-argument blocks such as `lifecycle` and `provisioner`
 blocks, since Terraform must process these before it is safe to evaluate
 expressions.
+
+If you need to iterate over combinations of values from multiple collections,
+use [`setproduct`](./functions/setproduct.html) to create a single collection
+containing all of the combinations.
 
 ### Best Practices for `dynamic` Blocks
 


### PR DESCRIPTION
Based on some common questions and feedback since the v0.12.0 release, here we add some small additional content to the documentation for "dynamic" blocks, covering how to access the keys of the collection being iterated over and how to fold multiple collections into a single one to achieve the effect of a nested iteration.

These have each come up a couple times already, but the ones I have to hand are #21533 and terraform-providers/terraform-provider-aws#8830.
