### PR TITLE
taint command for module not working in docs

### DIFF
--- a/website/docs/commands/taint.html.markdown
+++ b/website/docs/commands/taint.html.markdown
@@ -76,6 +76,6 @@ The resource aws_security_group.allow_all in the module root has been marked as 
 This example will only taint a resource within a module:
 
 ```
-$ terraform taint -module=couchbase aws_instance.cb_node[9]"
+$ terraform taint -module=couchbase aws_instance.cb_node[9]
 Resource instance module.couchbase.aws_instance.cb_node[9] has been marked as tainted!
 ```

--- a/website/docs/commands/taint.html.markdown
+++ b/website/docs/commands/taint.html.markdown
@@ -76,6 +76,6 @@ The resource aws_security_group.allow_all in the module root has been marked as 
 This example will only taint a resource within a module:
 
 ```
-$ terraform taint "module.couchbase.aws_instance.cb_node[9]"
+$ terraform taint -module=couchbase aws_instance.cb_node[9]"
 Resource instance module.couchbase.aws_instance.cb_node[9] has been marked as tainted!
 ```


### PR DESCRIPTION
Doc link: https://www.terraform.io/docs/commands/taint.html#example-tainting-a-resource-within-a-module

Solution: https://github.com/hashicorp/terraform/issues/1680#issuecomment-96672268

in my case
```
tf taint "module.filebeat.kubernetes_daemonset.daemonset"
Failed to parse resource name: Malformed resource state key: module.filebeat.kubernetes_daemonset.daemonset
```

```
tf taint -module=filebeat kubernetes_daemonset.daemonset
The resource kubernetes_daemonset.daemonset in the module root.filebeat has been marked as tainted!
```