### PR TITLE
Correct fmt -check

### DIFF
--- a/website/docs/commands/fmt.html.markdown
+++ b/website/docs/commands/fmt.html.markdown
@@ -33,9 +33,8 @@ input (STDIN).
 
 The command-line flags are all optional. The list of available flags are:
 
-* `-list=true` - List files whose formatting differs (disabled if using STDIN)
-* `-write=true` - Write result to source file instead of STDOUT (disabled if
-    using STDIN or -check)
-* `-diff=false` - Display diffs of formatting changes
-* `-check=true` - Check if the input is formatted. Exit status will be 0 if
+* `-list=false` - Don't list the files containing formatting inconsistencies.
+* `-write=false` - Don't overwrite the input files. (This is implied by `-check` or when the input is STDIN.)
+* `-diff` - Display diffs of formatting changes
+* `-check` - Check if the input is formatted. Exit status will be 0 if
     all input is properly formatted and non-zero otherwise.

--- a/website/docs/commands/fmt.html.markdown
+++ b/website/docs/commands/fmt.html.markdown
@@ -37,5 +37,5 @@ The command-line flags are all optional. The list of available flags are:
 * `-write=true` - Write result to source file instead of STDOUT (disabled if
     using STDIN or -check)
 * `-diff=false` - Display diffs of formatting changes
-* `-check=false` - Check if the input is formatted. Exit status will be 0 if
+* `-check=true` - Check if the input is formatted. Exit status will be 0 if
     all input is properly formatted and non-zero otherwise.


### PR DESCRIPTION
With `-check=false` the exit status is always zero.
With `-check=true` the exit status is zero when all files are properly formatted and non-zero otherwise.

**Test case**
With terraform 0.11.13, run the commands below in a directory containing terraform .tf files.

`terraform fmt` - exit status is always zero
`terraform fmt -check=false` - exit status is always zero
`terraform fmt -check=true` - exit status is zero if no changes are required and non-zero otherwise.