### PR TITLE
Ensure matching modules with metadata when requested

### DIFF
--- a/config/module/versions.go
+++ b/config/module/versions.go
@@ -25,9 +25,10 @@ func newest(versions []string, constraint string) (string, error) {
 		return "", err
 	}
 
-	// Store whether the constraint is an explicit equality that
-	// contains a metadata requirement, so we can return a specific
-	// if requested metadata version
+	// Find any build metadata in the constraints, and
+	// store whether the constraint is an explicit equality that
+	// contains a build metadata requirement, so we can return a specific,
+	// if requested, build metadata version
 	var constraintMetas []string
 	var equalsConstraint bool
 	for i := range cs {

--- a/config/module/versions.go
+++ b/config/module/versions.go
@@ -42,7 +42,7 @@ func newest(versions []string, constraint string) (string, error) {
 	}
 
 	if (len(cs) > 1 || !equalsConstraint) && len(constraintMetas) > 0 {
-		return "", fmt.Errorf("Constraints including metadata must have explicit equality, or are otherwise too ambiguous: %s", cs.String())
+		return "", fmt.Errorf("Constraints including build metadata must have explicit equality, or are otherwise too ambiguous: %s", cs.String())
 	}
 
 	// If the version string includes metadata, this is valid in go-version,

--- a/config/module/versions.go
+++ b/config/module/versions.go
@@ -54,10 +54,15 @@ func newest(versions []string, constraint string) (string, error) {
 		return iv.GreaterThan(jv)
 	})
 
-	// Store whether the constraint contains a metadata requirement,
-	// so we can check if we should be returning a specific metadata version
-	constraintMeta := strings.SplitAfterN(cs.String(), "+", 2)
-	equalsConstraint := explicitEqualityConstraint.MatchString(cs.String())
+	// Store whether the constraint is an explicit equality that
+	// contains a metadata requirement, so we can return a specific
+	// if requested metadata version
+	var constraintMeta []string
+	var equalsConstraint bool
+	if len(cs) == 1 {
+		constraintMeta = strings.SplitAfterN(cs.String(), "+", 2)
+		equalsConstraint = explicitEqualityConstraint.MatchString(cs.String())
+	}
 
 	// versions are now in order, so just find the first which satisfies the
 	// constraint
@@ -68,7 +73,7 @@ func newest(versions []string, constraint string) (string, error) {
 		}
 		if cs.Check(v) {
 			// Constraint has metadata and is explicit equality
-			if len(constraintMeta) > 1 && equalsConstraint {
+			if equalsConstraint && len(constraintMeta) > 1 {
 				if constraintMeta[1] != v.Metadata() {
 					continue
 				}

--- a/config/module/versions.go
+++ b/config/module/versions.go
@@ -3,7 +3,9 @@ package module
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
+	"strings"
 
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/registry/response"
@@ -58,6 +60,24 @@ func newest(versions []string, constraint string) (string, error) {
 			continue
 		}
 		if cs.Check(v) {
+			// We matched the constraint. But did it??
+			// If the constraint is an equal for something with build data
+			// we should see if our match IS that
+			// >0.9.0+def [< 0.9.0+abc]
+			constraintMeta := strings.SplitAfterN(cs.String(), "+", 2)
+			fmt.Println(constraintMeta[1])
+			// if we have some metadata there
+			// does the version have metadata?
+			fmt.Println(v.Metadata())
+			// What kind of constraint do we have?
+			// if it is pure equality, does our metadata match??
+
+			ourregex := regexp.MustCompile("^=[0-9]")
+			if ourregex.MatchString(cs.String()) {
+				if constraintMeta[1] != v.Metadata() {
+					continue
+				}
+			}
 			return versions[i], nil
 		}
 	}

--- a/config/module/versions.go
+++ b/config/module/versions.go
@@ -41,13 +41,12 @@ func newest(versions []string, constraint string) (string, error) {
 		equalsConstraint = explicitEqualityConstraint.MatchString(cs.String())
 	}
 
-	if (len(cs) > 1 || !equalsConstraint) && len(constraintMetas) > 0 {
-		return "", fmt.Errorf("Constraints including build metadata must have explicit equality, or are otherwise too ambiguous: %s", cs.String())
-	}
-
 	// If the version string includes metadata, this is valid in go-version,
 	// However, it's confusing as to what expected behavior should be,
 	// so give an error so the user can do something more logical
+	if (len(cs) > 1 || !equalsConstraint) && len(constraintMetas) > 0 {
+		return "", fmt.Errorf("Constraints including build metadata must have explicit equality, or are otherwise too ambiguous: %s", cs.String())
+	}
 
 	switch len(versions) {
 	case 0:

--- a/config/module/versions_test.go
+++ b/config/module/versions_test.go
@@ -78,9 +78,14 @@ func TestNewestModulesWithMetadata(t *testing.T) {
 	}
 
 	// respect explicit equality, but >/</~ will be ignored
-	expected = "0.9.0"
-	m, _ = newestVersion(mpv.Versions, "~>0.9.0+abc")
-	if m.Version != expected {
-		t.Fatalf("expected version %q, got %q", expected, m.Version)
+	_, err := newestVersion(mpv.Versions, "~>0.9.0+abc")
+	if err == nil {
+		t.Fatalf("expected an error, but did not get one")
+	}
+
+	// if there's build metadata in one of multiple constraints, expect an error
+	_, err = newestVersion(mpv.Versions, ">0.8.0+abc, <1.0.0")
+	if err == nil {
+		t.Fatalf("expected an error, but did not get one")
 	}
 }

--- a/config/module/versions_test.go
+++ b/config/module/versions_test.go
@@ -63,20 +63,23 @@ func TestNewestModulesWithMetadata(t *testing.T) {
 	mpv := &response.ModuleProviderVersions{
 		Source: "registry/test/module",
 		Versions: []*response.ModuleVersion{
-			{Version: "0.0.4"},
-			{Version: "0.3.1"},
-			{Version: "2.0.1"},
-			{Version: "1.2.0"},
 			{Version: "0.9.0"},
 			{Version: "0.9.0+def"},
 			{Version: "0.9.0+abc"},
 			{Version: "0.9.0+xyz"},
-			{Version: "0.9.0+trees"},
 		},
 	}
+
 	// with metadata and explicit version request
 	expected := "0.9.0+def"
 	m, _ := newestVersion(mpv.Versions, "=0.9.0+def")
+	if m.Version != expected {
+		t.Fatalf("expected version %q, got %q", expected, m.Version)
+	}
+
+	// respect explicit equality, but >/</~ will be ignored
+	expected = "0.9.0"
+	m, _ = newestVersion(mpv.Versions, "~>0.9.0+abc")
 	if m.Version != expected {
 		t.Fatalf("expected version %q, got %q", expected, m.Version)
 	}

--- a/config/module/versions_test.go
+++ b/config/module/versions_test.go
@@ -58,3 +58,26 @@ func TestNewestInvalidModuleVersion(t *testing.T) {
 		t.Fatalf("expected version %q, got %q", expected, m.Version)
 	}
 }
+
+func TestNewestModulesWithMetadata(t *testing.T) {
+	mpv := &response.ModuleProviderVersions{
+		Source: "registry/test/module",
+		Versions: []*response.ModuleVersion{
+			{Version: "0.0.4"},
+			{Version: "0.3.1"},
+			{Version: "2.0.1"},
+			{Version: "1.2.0"},
+			{Version: "0.9.0"},
+			{Version: "0.9.0+def"},
+			{Version: "0.9.0+abc"},
+			{Version: "0.9.0+xyz"},
+			{Version: "0.9.0+trees"},
+		},
+	}
+	// with metadata and explicit version request
+	expected := "0.9.0+def"
+	m, _ := newestVersion(mpv.Versions, "=0.9.0+def")
+	if m.Version != expected {
+		t.Fatalf("expected version %q, got %q", expected, m.Version)
+	}
+}

--- a/config/module/versions_test.go
+++ b/config/module/versions_test.go
@@ -77,13 +77,12 @@ func TestNewestModulesWithMetadata(t *testing.T) {
 		t.Fatalf("expected version %q, got %q", expected, m.Version)
 	}
 
-	// respect explicit equality, but >/</~ will be ignored
+	// respect explicit equality, but >/</~, or metadata in multiple constraints, will give an error
 	_, err := newestVersion(mpv.Versions, "~>0.9.0+abc")
 	if err == nil {
 		t.Fatalf("expected an error, but did not get one")
 	}
 
-	// if there's build metadata in one of multiple constraints, expect an error
 	_, err = newestVersion(mpv.Versions, ">0.8.0+abc, <1.0.0")
 	if err == nil {
 		t.Fatalf("expected an error, but did not get one")


### PR DESCRIPTION
When explicitly requesting a module with metadata information (ex. `1.0+abc`), go-version does not differentiate between versions based on build number. According to semver:

> Build metadata SHOULD be ignored when determining version precedence.

So when comparing versions (including on equality) go-version will not factor in build/metadata, since it generally follows this spec.

As such, this PR adds a bit of logic to make sure that Terraform matches versions exactly when exact matches are requested for a version with metadata.

Addresses #20814  