### PR TITLE
Remove links to legacy Terraform Enterprise docs

### DIFF
--- a/website/docs/commands/push.html.markdown
+++ b/website/docs/commands/push.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Command: push
 
-~> **Important:** The `terraform push` command is deprecated, and only works with [the legacy version of Terraform Enterprise](/docs/enterprise-legacy/index.html). In the current version of Terraform Enterprise, you can upload configurations using the API. See [the docs about API-driven runs](/docs/enterprise/run/api.html) for more details.
+~> **Important:** The `terraform push` command is deprecated, and only works with the legacy version of Terraform Enterprise. In the current version of Terraform Enterprise, you can upload configurations using the API. See [the docs about API-driven runs](/docs/enterprise/run/api.html) for more details.
 
 The `terraform push` command uploads your Terraform configuration to
 be managed by HashiCorp's [Terraform Enterprise](https://www.hashicorp.com/products/terraform/).

--- a/website/docs/configuration-0-11/terraform-enterprise.html.md
+++ b/website/docs/configuration-0-11/terraform-enterprise.html.md
@@ -11,7 +11,7 @@ description: |-
 -> **Note:** This page is about Terraform 0.11 and earlier, and documents a
 feature that was removed in Terraform 0.12.
 
-~> **Important:** The `terraform push` command is deprecated, and only works with [the legacy version of Terraform Enterprise](/docs/enterprise-legacy/index.html). In the current version of Terraform Enterprise, you can upload configurations using the API. See [the docs about API-driven runs](/docs/enterprise/run/api.html) for more details.
+~> **Important:** The `terraform push` command is deprecated, and only works with the legacy version of Terraform Enterprise. In the current version of Terraform Enterprise, you can upload configurations using the API. See [the docs about API-driven runs](/docs/enterprise/run/api.html) for more details.
 
 The [`terraform push` command](/docs/commands/push.html) uploads a configuration to a Terraform Enterprise (legacy) environment. The name of the environment (and the organization it's in) can be specified on the command line, or as part of the Terraform configuration in an `atlas` block.
 

--- a/website/docs/configuration/terraform-enterprise.html.md
+++ b/website/docs/configuration/terraform-enterprise.html.md
@@ -27,6 +27,5 @@ These features are no longer available on Terraform Enterprise and so the
 corresponding configuration elements and commands have been removed in
 Terraform v0.12.
 
-To migrate to the current version of Terraform Enterprise, refer to
-[the upgrade guide](/docs/enterprise/upgrade/index.html). After upgrading,
+After upgrading to the current version of Terraform Enterprise,
 any `atlas` blocks in your configuration can be safely removed.


### PR DESCRIPTION
These docs are due to be removed, so these links will shortly break. Removal is in hashicorp/terraform-website#812