### PR TITLE
Allows undeclared variables from named files (-var-file=...)

### DIFF
--- a/backend/unparsed_value.go
+++ b/backend/unparsed_value.go
@@ -51,7 +51,7 @@ func ParseVariableValues(vv map[string]UnparsedVariableValue, decls map[string]*
 
 		if !declared {
 			switch val.SourceType {
-			case terraform.ValueFromConfig, terraform.ValueFromAutoFile, terraform.ValueFromNamedFile:
+			case terraform.ValueFromConfig, terraform.ValueFromAutoFile:
 				// These source types have source ranges, so we can produce
 				// a nice error message with good context.
 				//
@@ -72,9 +72,9 @@ func ParseVariableValues(vv map[string]UnparsedVariableValue, decls map[string]*
 				}
 				seenUndeclaredInFile++
 
-			case terraform.ValueFromEnvVar:
+			case terraform.ValueFromEnvVar, terraform.ValueFromNamedFile:
 				// We allow and ignore undeclared names for environment
-				// variables, because users will often set these globally
+				// variables and those set in named files, because users will often set these globally
 				// when they are used across many (but not necessarily all)
 				// configurations.
 			case terraform.ValueFromCLIArg:

--- a/backend/unparsed_value_test.go
+++ b/backend/unparsed_value_test.go
@@ -12,11 +12,17 @@ import (
 
 func TestParseVariableValuesUndeclared(t *testing.T) {
 	vv := map[string]UnparsedVariableValue{
-		"undeclared0": testUnparsedVariableValue("0"),
-		"undeclared1": testUnparsedVariableValue("1"),
-		"undeclared2": testUnparsedVariableValue("2"),
-		"undeclared3": testUnparsedVariableValue("3"),
-		"undeclared4": testUnparsedVariableValue("4"),
+		// these two shouldn't generate a diag message
+		"undeclared0": testUnparsedFileVariableValue("0"),
+		"undeclared1": testUnparsedEnvVariableValue("1"),
+		// these two should generate 2 diag messages
+		"undeclared2": testUnparsedAutoFileVariableValue("2"),
+		"undeclared3": testUnparsedConfigVariableValue("3"),
+		// add more undeclared values that generate a diag to test suppression
+		"undeclared4": testUnparsedConfigVariableValue("4"),
+		"undeclared5": testUnparsedConfigVariableValue("5"),
+		"undeclared6": testUnparsedConfigVariableValue("6"),
+		"undeclared7": testUnparsedConfigVariableValue("7"),
 	}
 	decls := map[string]*configs.Variable{}
 
@@ -45,9 +51,9 @@ func TestParseVariableValuesUndeclared(t *testing.T) {
 	}
 }
 
-type testUnparsedVariableValue string
+type testUnparsedFileVariableValue string
 
-func (v testUnparsedVariableValue) ParseVariableValue(mode configs.VariableParsingMode) (*terraform.InputValue, tfdiags.Diagnostics) {
+func (v testUnparsedFileVariableValue) ParseVariableValue(mode configs.VariableParsingMode) (*terraform.InputValue, tfdiags.Diagnostics) {
 	return &terraform.InputValue{
 		Value:      cty.StringVal(string(v)),
 		SourceType: terraform.ValueFromNamedFile,
@@ -56,5 +62,32 @@ func (v testUnparsedVariableValue) ParseVariableValue(mode configs.VariableParsi
 			Start:    tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
 			End:      tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
 		},
+	}, nil
+}
+
+type testUnparsedEnvVariableValue string
+
+func (v testUnparsedEnvVariableValue) ParseVariableValue(mode configs.VariableParsingMode) (*terraform.InputValue, tfdiags.Diagnostics) {
+	return &terraform.InputValue{
+		Value:      cty.StringVal(string(v)),
+		SourceType: terraform.ValueFromEnvVar,
+	}, nil
+}
+
+type testUnparsedAutoFileVariableValue string
+
+func (v testUnparsedAutoFileVariableValue) ParseVariableValue(mode configs.VariableParsingMode) (*terraform.InputValue, tfdiags.Diagnostics) {
+	return &terraform.InputValue{
+		Value:      cty.StringVal(string(v)),
+		SourceType: terraform.ValueFromAutoFile,
+	}, nil
+}
+
+type testUnparsedConfigVariableValue string
+
+func (v testUnparsedConfigVariableValue) ParseVariableValue(mode configs.VariableParsingMode) (*terraform.InputValue, tfdiags.Diagnostics) {
+	return &terraform.InputValue{
+		Value:      cty.StringVal(string(v)),
+		SourceType: terraform.ValueFromConfig,
 	}, nil
 }


### PR DESCRIPTION
## Rationale

Many people use terraform together with terragrunt or other tools.
With terragrunt specifically, a common project structure can be as follows:
```
|---- infrastructure
       |
       |---- production
       |          |---- env.tfvars
       |          |---- ecs-cluster
       |          |          |- terragrunt.hcl
       |          |---- ecs-service
       |                     |- terragrunt.hcl
       |---- staging
       |          |---- env.tfvars
       |          |---- ecs-cluster
       |          |          |-terragrunt.hcl
       |          |---- ecs-service
       |                     |- terragrunt.hcl
       |
       |--- common.tfvars
```
Here, `ecs-cluster` and `ecs-service` are terragrunt modules.

The files `common.tfvars` are plugged together with correct `env.tfvars` depending on the environment as var files:
```
terraform plan -var-file=/some/project/infra/common.tfvars -var-file=/some/project/infra/production/env.tfvars
```
This allows setting some variables globally for the project, plus it makes it possible to override them in `env.tfvars` or on per-module basis.

However, some modules don't have **all** variables declared, for example `ecs-service` module doesn't need to declare a variable like `ecs_cluster_instance_type`, because it doesn't use it. But it is convenient to set it in `env.vars` to make it a source of configuration for this environment, rather than setting variables in every module folder.

Since terraform 0.12 there is a warning for every undeclared variable, which can get really messy if you use it with terragrunt:
```
...
Plan: 2 to add, 0 to change, 0 to destroy.

Warning: Values for undeclared variables

In addition to the other similar warnings shown, 10 other variable(s) defined
without being declared.

<<3 more warning with large text>>
```
I actually raised this some time ago: https://github.com/gruntwork-io/terragrunt/issues/466#issuecomment-496720495

To make it work in the current state, some nasty hacks has to be introduced as per https://github.com/gruntwork-io/terragrunt/issues/737 like having terragrunt to convert variables to env vars.

Instead, this PR just allows undeclared variables set via named files.
Plus adds a few more test cases to check for other undeclared var sources.
