### PR TITLE
helper/schema: Parse timeouts for the data sources

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -387,6 +387,16 @@ func (r *Resource) ReadDataApply(
 		return nil, err
 	}
 
+	// Instance Diff shoould have the timeout info, need to copy it over to the
+	// ResourceData meta
+	rt := ResourceTimeout{}
+	if _, ok := d.Meta[TimeoutKey]; ok {
+		if err := rt.DiffDecode(d); err != nil {
+			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
+		}
+	}
+	data.timeouts = &rt
+
 	err = r.Read(data, meta)
 	state := data.State()
 	if state != nil && state.ID == "" {


### PR DESCRIPTION
Timeouts are not considered for data sources, however it is useful for `Read` actions. This PR adds an ability for users to specify at least Read timeouts (`timeout := d.Timeout(schema.TimeoutRead)`)