### PR TITLE
Minor spelling fixes

### DIFF
--- a/website/docs/backends/types/oss.html.md
+++ b/website/docs/backends/types/oss.html.md
@@ -91,5 +91,5 @@ The following configuration options or environment variables are supported:
    ACL](https://www.alibabacloud.com/help/doc-detail/52284.htm)
    to be applied to the state file.
 
--> **Note:** If you want to store state in the custom OSS endpoint, you can specify a enviornment variable `OSS_ENDPOINT`, like "oss-cn-beijing-internal.aliyuncs.com"
+-> **Note:** If you want to store state in the custom OSS endpoint, you can specify a environment variable `OSS_ENDPOINT`, like "oss-cn-beijing-internal.aliyuncs.com"
 

--- a/website/docs/configuration/attr-as-blocks.html.md
+++ b/website/docs/configuration/attr-as-blocks.html.md
@@ -55,7 +55,7 @@ However, in some cases existing provider features were relying on the
 conflation of these two concepts in the language of Terraform v0.11 and earlier,
 using nested block syntax in most cases but using argument syntax to represent
 explicitly the idea of removing all existing objects of that type, since the
-absense of any blocks was interpreted as "ignore any existing objects".
+absence of any blocks was interpreted as "ignore any existing objects".
 
 The information on this page only applies to certain special arguments that
 were relying on this usage pattern prior to Terraform v0.12. The documentation

--- a/website/upgrade-guides/0-12.html.markdown
+++ b/website/upgrade-guides/0-12.html.markdown
@@ -179,7 +179,7 @@ Terraform v0.12.
 
 We recommend using this command in a clean version control work tree, so that
 you can easily see the proposed changes as a diff against the latest commit.
-If you have uncommited changes already present, we recommend aborting this
+If you have uncommitted changes already present, we recommend aborting this
 command and dealing with them before running this command again.
 
 Would you like to upgrade the module in the current directory?
@@ -405,7 +405,7 @@ rewrite automatically to just refer to the list directly:
   example = var.any_list
 ```
 
-However, an unintended side-effect of this compatiblity mechanism was to
+However, an unintended side-effect of this compatibility mechanism was to
 also flatten mixed lists of single-value and list expressions into a single
 list automatically. We didn't intend for this to be a part of the language, but
 in retrospect it was an obvious consequence of how the compatibility mechanism


### PR DESCRIPTION
`docker run    -v $(pwd):/scripts    --workdir=/scripts    nickg/misspell:latest    misspell -w -source=text website/`