### PR TITLE
added role_arn env vars

### DIFF
--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -189,21 +189,21 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The role to be assumed",
-				Default:     "",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_ROLE_ARN", ""),
 			},
 
 			"session_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The session name to use when assuming the role.",
-				Default:     "",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_SESSION_NAME", ""),
 			},
 
 			"external_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The external ID to use when assuming the role",
-				Default:     "",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_EXTERNAL_ID", ""),
 			},
 
 			"assume_role_policy": {

--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -174,10 +174,10 @@ The following configuration options or environment variables are supported:
    `~/.aws/credentials` will be used.
  * `token` - (Optional) Use this to set an MFA token. It can also be
    sourced from the `AWS_SESSION_TOKEN` environment variable.
- * `role_arn` - (Optional) The role to be assumed.
+ * `role_arn` / `AWS_ROLE_ARN` - (Optional) The role to be assumed.
  * `assume_role_policy` - (Optional) The permissions applied when assuming a role.
- * `external_id` - (Optional) The external ID to use when assuming the role.
- * `session_name` - (Optional) The session name to use when assuming the role.
+ * `external_id` / `AWS_EXTERNAL_ID` - (Optional) The external ID to use when assuming the role.
+ * `session_name` / `AWS_SESSION_NAME` - (Optional) The session name to use when assuming the role.
  * `workspace_key_prefix` - (Optional) The prefix applied to the state path
    inside the bucket. This is only relevant when using a non-default workspace.
    This defaults to "env:"


### PR DESCRIPTION
This PR adds 3 environment variables to the S3 backend to make it possible to specify the`role_arn`, `external_id`, and `session_name` attributes with the environment variables `AWS_ROLE_ARN`, `AWS_EXTERNAL_ID`, and `AWS_SESSION_NAME` respectively.  All 3 can be used when marking the S3 backend assume a different role.  These affect both the actual storage of state via the `backend` stanza under the `terraform` block as well as the use of an assumed role in the `config` block of a `terraform_remote_state` data source that needs to retrieve outputs from a remote state file.

This has been asked for by a customer who currently uses Jenkins to assume AWS roles and then passes those roles to the terraform OSS binary but is now starting to use Terraform Enterprise (TFE).  They cannot pass the assumed roles from Jenkins to the TFE workspaces and want to minimize changes to their existing code.  The addition of these environment variables will let them leave their Terraform code unchanged for Terraform OSS plas/applies triggered by Jenkins while letting them add the environment variables when running the same Terraform code in TFE.

I already submitted https://github.com/terraform-providers/terraform-provider-aws/pull/8985 to add these environment roles for the AWS provider.  This PR adds them to the S3 backend.

I tested this with code that did the following, running it on an EC2 instance without any S3 permissions:

source:
```
terraform {
  backend "s3" {
    bucket = "roger-tf"
    key    = "source"
    region = "us-east-1"
  }
}

output "a_string" {
  value = "Roger"
}

output "a_number" {
  value = 1
}
```

consumer:
```
data "terraform_remote_state" "source" {
  backend = "s3"
  config = {
    bucket = "roger-tf"
    key    = "source"
    region = "us-east-1"
  }
}
output "a_string" {
  value = data.terraform_remote_state.source.outputs.a_string
}

output "a_number" {
  value = data.terraform_remote_state.source.outputs.a_number
}
```
I was able to run `terraform apply` in the source directory and see the outputs.
I was then able to run `terraform apply` in the consumer directory and see the same outputs which were retrieved from the state file of the source configuration in the S3 bucket.

By exporting TF_LOG=TRACE, I was able to see the correct role being assumed in the source and consumer for the provider:
```
2019/06/13 17:43:57 [INFO] Attempting to AssumeRole arn:aws:iam::753646501470:role/roger-terraform-assumed-role (SessionName: "session-1234", ExternalId: "1234", Policy: "")
```
I was also able to see the role being assumed for the terraform_remote_state data source:
```
552 2019/06/13 17:43:57 [TRACE] EvalReadData: working on data.terraform_remote_state.source
 553 2019/06/13 17:43:57 [TRACE] Re-validating config for data.terraform_remote_state.source
 554 2019/06/13 17:43:57 [DEBUG] Initializing remote state backend: s3
 555 2019/06/13 17:43:57 [INFO] Setting AWS metadata API timeout to 100ms
 556 2019/06/13 17:43:57 [INFO] AWS EC2 instance detected via default metadata API endpoint, EC2RoleProvider added to the auth chain
 557 2019/06/13 17:43:57 [INFO] Attempting to AssumeRole arn:aws:iam::753646501470:role/roger-terraform-assumed-role (SessionName: "sessi     on-1234", ExternalId: "1234", Policy: "")
 558 2019/06/13 17:43:57 [INFO] AWS Auth provider used: "EC2RoleProvider"
 559 2019/06/13 17:43:57 [INFO] AWS Auth provider used: "AssumeRoleProvider"
```

I updated the relevant doc file: website/docs/backends/types/s3.html.md.



