### PR TITLE
terraform_remote_state docs have incorrect example for "config" argument

### DIFF
--- a/website/docs/providers/terraform/d/remote_state.html.md
+++ b/website/docs/providers/terraform/d/remote_state.html.md
@@ -36,7 +36,6 @@ resource "aws_instance" "foo" {
 }
 
 # Terraform <= 0.11
-
 resource "aws_instance" "foo" {
   # ...
   subnet_id = "${data.terraform_remote_state.vpc.subnet_id}"

--- a/website/docs/providers/terraform/d/remote_state.html.md
+++ b/website/docs/providers/terraform/d/remote_state.html.md
@@ -22,6 +22,22 @@ use interpolations when configuring them.
 ## Example Usage
 
 ```hcl
+# Terraform >= 0.12
+
+data "terraform_remote_state" "vpc" {
+  backend = "atlas"
+  config = {
+    name = "hashicorp/vpc-prod"
+  }
+}
+
+resource "aws_instance" "foo" {
+  # ...
+  subnet_id = data.terraform_remote_state.vpc.outputs.subnet_id
+}
+
+# Terraform <= 0.11
+
 data "terraform_remote_state" "vpc" {
   backend = "atlas"
   config {
@@ -29,13 +45,6 @@ data "terraform_remote_state" "vpc" {
   }
 }
 
-# Terraform >= 0.12
-resource "aws_instance" "foo" {
-  # ...
-  subnet_id = data.terraform_remote_state.vpc.outputs.subnet_id
-}
-
-# Terraform <= 0.11
 resource "aws_instance" "foo" {
   # ...
   subnet_id = "${data.terraform_remote_state.vpc.subnet_id}"

--- a/website/docs/providers/terraform/d/remote_state.html.md
+++ b/website/docs/providers/terraform/d/remote_state.html.md
@@ -22,7 +22,6 @@ use interpolations when configuring them.
 ## Example Usage
 
 ```hcl
-# Terraform >= 0.12
 
 data "terraform_remote_state" "vpc" {
   backend = "atlas"
@@ -31,19 +30,14 @@ data "terraform_remote_state" "vpc" {
   }
 }
 
+# Terraform >= 0.12
+
 resource "aws_instance" "foo" {
   # ...
   subnet_id = data.terraform_remote_state.vpc.outputs.subnet_id
 }
 
 # Terraform <= 0.11
-
-data "terraform_remote_state" "vpc" {
-  backend = "atlas"
-  config {
-    name = "hashicorp/vpc-prod"
-  }
-}
 
 resource "aws_instance" "foo" {
   # ...

--- a/website/docs/providers/terraform/d/remote_state.html.md
+++ b/website/docs/providers/terraform/d/remote_state.html.md
@@ -22,7 +22,6 @@ use interpolations when configuring them.
 ## Example Usage
 
 ```hcl
-
 data "terraform_remote_state" "vpc" {
   backend = "atlas"
   config = {

--- a/website/docs/providers/terraform/d/remote_state.html.md
+++ b/website/docs/providers/terraform/d/remote_state.html.md
@@ -30,7 +30,6 @@ data "terraform_remote_state" "vpc" {
 }
 
 # Terraform >= 0.12
-
 resource "aws_instance" "foo" {
   # ...
   subnet_id = data.terraform_remote_state.vpc.outputs.subnet_id


### PR DESCRIPTION
There is a sight difference in the syntax between 0.11 and 0.12 in defining terraform_remote_state.