### PR TITLE
Don't allow nulls in calls to merge

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -876,7 +876,6 @@ var MergeFunc = function.New(&function.Spec{
 		Name:             "maps",
 		Type:             cty.DynamicPseudoType,
 		AllowDynamicType: true,
-		AllowNull:        true,
 	},
 	Type: function.StaticReturnType(cty.DynamicPseudoType),
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -2045,6 +2045,17 @@ func TestMerge(t *testing.T) {
 			cty.NilVal,
 			true,
 		},
+
+		{ // argument error, for a null type
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("b"),
+				}),
+				cty.NullVal(cty.String),
+			},
+			cty.NilVal,
+			true,
+		},
 		{ // merge maps of maps
 			[]cty.Value{
 				cty.MapVal(map[string]cty.Value{


### PR DESCRIPTION
Addresses #21695

Previously, if you called `merge` and one of the values was null, it would panic. Instead, by removing this line, it will give the user an error so they can fix it.