### PR TITLE
Update remote apply warnings to use correct its/it's

### DIFF
--- a/backend/remote/backend_apply.go
+++ b/backend/remote/backend_apply.go
@@ -242,7 +242,7 @@ func (b *Remote) opApply(stopCtx, cancelCtx context.Context, op *backend.Operati
 
 const applyDefaultHeader = `
 [reset][yellow]Running apply in the remote backend. Output will stream here. Pressing Ctrl-C
-will cancel the remote apply if its still pending. If the apply started it
+will cancel the remote apply if it's still pending. If the apply started it
 will stop streaming the logs, but will not stop the apply running remotely.[reset]
 
 Preparing the remote apply...


### PR DESCRIPTION
Previously, the remote apply CLI warnings said: ```...its still pending```, w/ this PR they'll now read ```...it's still pending``` so that they are grammatically correct! 


Docs update here: [#819](https://github.com/hashicorp/terraform-website/pull/819)