### PR TITLE
s3 backend: minor typo in putMD5 comment

### DIFF
--- a/backend/remote-state/s3/client.go
+++ b/backend/remote-state/s3/client.go
@@ -270,7 +270,7 @@ func (c *RemoteClient) getMD5() ([]byte, error) {
 	return sum, nil
 }
 
-// store the hash of the state to that clients can check for stale state files.
+// store the hash of the state so that clients can check for stale state files.
 func (c *RemoteClient) putMD5(sum []byte) error {
 	if c.ddbTable == "" {
 		return nil


### PR DESCRIPTION
This PR is a minor typo correction in a comment in the S3 backend. It is purely a documentation update and does not add or remove any additional functionality.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>