### PR TITLE
Habitat provisioner updates

### DIFF
--- a/builtin/provisioners/habitat/linux_provisioner.go
+++ b/builtin/provisioners/habitat/linux_provisioner.go
@@ -112,6 +112,10 @@ func (p *provisioner) linuxStartHabitat(o terraform.UIOutput, comm communicator.
 		options += fmt.Sprintf(" --listen-http %s", p.ListenHTTP)
 	}
 
+	if p.Peer != "" {
+		options += fmt.Sprintf(" %s", p.Peer)
+	}
+
 	if len(p.Peers) > 0 {
 		if len(p.Peers) == 1 {
 			options += fmt.Sprintf(" --peer %s", p.Peers[0])

--- a/builtin/provisioners/habitat/linux_provisioner.go
+++ b/builtin/provisioners/habitat/linux_provisioner.go
@@ -348,7 +348,7 @@ func (p *provisioner) uploadUserTOML(o terraform.UIOutput, comm communicator.Com
 }
 
 func (p *provisioner) linuxGetCommand(command string) string {
-	// Always set HAB_NONINTERACTIVE & HAB_NO_COLOR
+	// Always set HAB_NONINTERACTIVE & HAB_NOCOLORING
 	env := fmt.Sprintf("env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true")
 
 	// Set license acceptance

--- a/builtin/provisioners/habitat/linux_provisioner.go
+++ b/builtin/provisioners/habitat/linux_provisioner.go
@@ -348,8 +348,8 @@ func (p *provisioner) uploadUserTOML(o terraform.UIOutput, comm communicator.Com
 }
 
 func (p *provisioner) linuxGetCommand(command string) string {
-	// Always set HAB_NONINTERACTIVE
-	env := fmt.Sprintf("env HAB_NONINTERACTIVE=true")
+	// Always set HAB_NONINTERACTIVE & HAB_NO_COLOR
+	env := fmt.Sprintf("env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true")
 
 	// Set license acceptance
 	if p.License != "" {

--- a/builtin/provisioners/habitat/linux_provisioner.go
+++ b/builtin/provisioners/habitat/linux_provisioner.go
@@ -1,0 +1,371 @@
+package habitat
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/terraform"
+	"path"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+const installURL = "https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh"
+const systemdUnit = `[Unit]
+Description=Habitat Supervisor
+
+[Service]
+ExecStart=/bin/hab sup run{{ .SupOptions }}
+Restart=on-failure
+{{ if .GatewayAuthToken -}}
+Environment="HAB_SUP_GATEWAY_AUTH_TOKEN={{ .GatewayAuthToken }}"
+{{ end -}}
+{{ if .BuilderAuthToken -}}
+Environment="HAB_AUTH_TOKEN={{ .BuilderAuthToken }}"
+{{ end -}}
+{{ if .License -}}
+Environment="HAB_LICENSE={{ .License }}"
+{{ end -}}
+
+[Install]
+WantedBy=default.target
+`
+
+func (p *provisioner) linuxInstallHabitat(o terraform.UIOutput, comm communicator.Communicator) error {
+	// Download the hab installer
+	if err := p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("curl --silent -L0 %s > install.sh", installURL))); err != nil {
+		return err
+	}
+
+	// Run the hab install script
+	var command string
+	if p.Version == "" {
+		command = p.linuxGetCommand(fmt.Sprintf("bash ./install.sh "))
+	} else {
+		command = p.linuxGetCommand(fmt.Sprintf("bash ./install.sh -v %s", p.Version))
+	}
+
+	if err := p.runCommand(o, comm, command); err != nil {
+		return err
+	}
+
+	// Create the hab user
+	if err := p.createHabUser(o, comm); err != nil {
+		return err
+	}
+
+	// Cleanup the installer
+	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("rm -f install.sh")))
+}
+
+func (p *provisioner) createHabUser(o terraform.UIOutput, comm communicator.Communicator) error {
+	var addUser bool
+
+	// Install busybox to get us the user tools we need
+	if err := p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("hab install core/busybox"))); err != nil {
+		return err
+	}
+
+	// Check for existing hab user
+	if err := p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("hab pkg exec core/busybox id hab"))); err != nil {
+		o.Output("No existing hab user detected, creating...")
+		addUser = true
+	}
+
+	if addUser {
+		return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("hab pkg exec core/busybox adduser -D -g \"\" hab")))
+	}
+
+	return nil
+}
+
+func (p *provisioner) linuxStartHabitat(o terraform.UIOutput, comm communicator.Communicator) error {
+	// Install the supervisor first
+	var command string
+	if p.Version == "" {
+		command += p.linuxGetCommand(fmt.Sprintf("hab install core/hab-sup"))
+	} else {
+		command += p.linuxGetCommand(fmt.Sprintf("hab install core/hab-sup/%s", p.Version))
+	}
+
+	if err := p.runCommand(o, comm, command); err != nil {
+		return err
+	}
+
+	// Build up supervisor options
+	options := ""
+	if p.PermanentPeer {
+		options += " --permanent-peer"
+	}
+
+	if p.ListenCtl != "" {
+		options += fmt.Sprintf(" --listen-ctl %s", p.ListenCtl)
+	}
+
+	if p.ListenGossip != "" {
+		options += fmt.Sprintf(" --listen-gossip %s", p.ListenGossip)
+	}
+
+	if p.ListenHTTP != "" {
+		options += fmt.Sprintf(" --listen-http %s", p.ListenHTTP)
+	}
+
+	if len(p.Peers) > 0 {
+		if len(p.Peers) == 1 {
+			options += fmt.Sprintf(" --peer %s", p.Peers[0])
+		} else {
+			options += fmt.Sprintf(" --peer %s", strings.Join(p.Peers, " --peer "))
+		}
+	}
+
+	if p.RingKey != "" {
+		options += fmt.Sprintf(" --ring %s", p.RingKey)
+	}
+
+	if p.URL != "" {
+		options += fmt.Sprintf(" --url %s", p.URL)
+	}
+
+	if p.Channel != "" {
+		options += fmt.Sprintf(" --channel %s", p.Channel)
+	}
+
+	if p.Events != "" {
+		options += fmt.Sprintf(" --events %s", p.Events)
+	}
+
+	if p.Organization != "" {
+		options += fmt.Sprintf(" --org %s", p.Organization)
+	}
+
+	if p.HttpDisable == true {
+		options += fmt.Sprintf(" --http-disable")
+	}
+
+	if p.AutoUpdate == true {
+		options += fmt.Sprintf(" --auto-update")
+	}
+
+	p.SupOptions = options
+
+	// Start hab depending on service type
+	switch p.ServiceType {
+	case "unmanaged":
+		return p.linuxStartHabitatUnmanaged(o, comm, options)
+	case "systemd":
+		return p.linuxStartHabitatSystemd(o, comm, options)
+	default:
+		return errors.New("unsupported service type")
+	}
+}
+
+// This func is a little different than the others since we need to expose HAB_AUTH_TOKEN and HAB_LICENSE to a shell
+// sub-process that's actually running the supervisor.
+func (p *provisioner) linuxStartHabitatUnmanaged(o terraform.UIOutput, comm communicator.Communicator, options string) error {
+	var token string
+	var license string
+
+	// Create the sup directory for the log file
+	if err := p.runCommand(o, comm, p.linuxGetCommand("mkdir -p /hab/sup/default && chmod o+w /hab/sup/default")); err != nil {
+		return err
+	}
+
+	// Set HAB_AUTH_TOKEN if provided
+	if p.BuilderAuthToken != "" {
+		token = fmt.Sprintf("HAB_AUTH_TOKEN=%s ", p.BuilderAuthToken)
+	}
+
+	// Set HAB_LICENSE if provided
+	if p.License != "" {
+		license = fmt.Sprintf("HAB_LICENSE=%s ", p.License)
+	}
+
+	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("(env %s%s setsid hab sup run%s > /hab/sup/default/sup.log 2>&1 <&1 &) ; sleep 1", token, license, options)))
+}
+
+func (p *provisioner) linuxStartHabitatSystemd(o terraform.UIOutput, comm communicator.Communicator, options string) error {
+	// Create a new template and parse the client config into it
+	unitString := template.Must(template.New("hab-supervisor.service").Parse(systemdUnit))
+
+	var buf bytes.Buffer
+	err := unitString.Execute(&buf, p)
+	if err != nil {
+		return fmt.Errorf("error executing %s.service template: %s", p.ServiceName, err)
+	}
+
+	if err := p.linuxUploadSystemdUnit(o, comm, &buf); err != nil {
+		return err
+	}
+
+	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("systemctl enable %s && systemctl start %s", p.ServiceName, p.ServiceName)))
+}
+
+func (p *provisioner) linuxUploadSystemdUnit(o terraform.UIOutput, comm communicator.Communicator, contents *bytes.Buffer) error {
+	destination := fmt.Sprintf("/etc/systemd/system/%s.service", p.ServiceName)
+
+	if p.UseSudo {
+		tempPath := fmt.Sprintf("/tmp/%s.service", p.ServiceName)
+		if err := comm.Upload(tempPath, contents); err != nil {
+			return err
+		}
+
+		return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("mv %s %s", tempPath, destination)))
+	}
+
+	return comm.Upload(destination, contents)
+}
+
+func (p *provisioner) linuxUploadRingKey(o terraform.UIOutput, comm communicator.Communicator) error {
+	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf(`echo -e "%s" | hab ring key import`, p.RingKeyContent)))
+}
+
+func (p *provisioner) linuxUploadCtlSecret(o terraform.UIOutput, comm communicator.Communicator) error {
+	destination := fmt.Sprintf("/hab/sup/default/CTL_SECRET")
+	// Create the destination directory
+	err := p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("mkdir -p %s", filepath.Dir(destination))))
+	if err != nil {
+		return err
+	}
+
+	keyContent := strings.NewReader(p.CtlSecret)
+	if p.UseSudo {
+		tempPath := fmt.Sprintf("/tmp/CTL_SECRET")
+		if err := comm.Upload(tempPath, keyContent); err != nil {
+			return err
+		}
+
+		return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("mv %s %s && chown root:root %s && chmod 0600 %s", tempPath, destination, destination, destination)))
+	}
+
+	return comm.Upload(destination, keyContent)
+}
+
+//
+// Habitat Services
+//
+func (p *provisioner) linuxStartHabitatService(o terraform.UIOutput, comm communicator.Communicator, service Service) error {
+	var options string
+
+	if err := p.linuxInstallHabitatPackage(o, comm, service); err != nil {
+		return err
+	}
+	if err := p.uploadUserTOML(o, comm, service); err != nil {
+		return err
+	}
+
+	// Upload service group key
+	if service.ServiceGroupKey != "" {
+		err := p.uploadServiceGroupKey(o, comm, service.ServiceGroupKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	if service.Topology != "" {
+		options += fmt.Sprintf(" --topology %s", service.Topology)
+	}
+
+	if service.Strategy != "" {
+		options += fmt.Sprintf(" --strategy %s", service.Strategy)
+	}
+
+	if service.Channel != "" {
+		options += fmt.Sprintf(" --channel %s", service.Channel)
+	}
+
+	if service.URL != "" {
+		options += fmt.Sprintf(" --url %s", service.URL)
+	}
+
+	if service.Group != "" {
+		options += fmt.Sprintf(" --group %s", service.Group)
+	}
+
+	for _, bind := range service.Binds {
+		options += fmt.Sprintf(" --bind %s", bind.toBindString())
+	}
+
+	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("hab svc load %s %s", service.Name, options)))
+}
+
+// In the future we'll remove the dedicated install once the synchronous load feature in hab-sup is
+// available. Until then we install here to provide output and a noisy failure mechanism because
+// if you install with the pkg load, it occurs asynchronously and fails quietly.
+func (p *provisioner) linuxInstallHabitatPackage(o terraform.UIOutput, comm communicator.Communicator, service Service) error {
+	var options string
+
+	if service.Channel != "" {
+		options += fmt.Sprintf(" --channel %s", service.Channel)
+	}
+
+	if service.URL != "" {
+		options += fmt.Sprintf(" --url %s", service.URL)
+	}
+
+	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("hab pkg install %s %s", service.Name, options)))
+}
+
+func (p *provisioner) uploadServiceGroupKey(o terraform.UIOutput, comm communicator.Communicator, key string) error {
+	keyName := strings.Split(key, "\n")[1]
+	o.Output("Uploading service group key: " + keyName)
+	keyFileName := fmt.Sprintf("%s.box.key", keyName)
+	destPath := path.Join("/hab/cache/keys", keyFileName)
+	keyContent := strings.NewReader(key)
+	if p.UseSudo {
+		tempPath := path.Join("/tmp", keyFileName)
+		if err := comm.Upload(tempPath, keyContent); err != nil {
+			return err
+		}
+
+		return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("mv %s %s", tempPath, destPath)))
+	}
+
+	return comm.Upload(destPath, keyContent)
+}
+
+func (p *provisioner) uploadUserTOML(o terraform.UIOutput, comm communicator.Communicator, service Service) error {
+	// Create the hab svc directory to lay down the user.toml before loading the service
+	o.Output("Uploading user.toml for service: " + service.Name)
+	destDir := fmt.Sprintf("/hab/user/%s/config", service.getPackageName(service.Name))
+	command := p.linuxGetCommand(fmt.Sprintf("mkdir -p %s", destDir))
+	if err := p.runCommand(o, comm, command); err != nil {
+		return err
+	}
+
+	userToml := strings.NewReader(service.UserTOML)
+
+	if p.UseSudo {
+		if err := comm.Upload(fmt.Sprintf("/tmp/user-%s.toml", service.getServiceNameChecksum()), userToml); err != nil {
+			return err
+		}
+		command = p.linuxGetCommand(fmt.Sprintf("mv /tmp/user-%s.toml %s/user.toml", service.getServiceNameChecksum(), destDir))
+		return p.runCommand(o, comm, command)
+	}
+
+	return comm.Upload(path.Join(destDir, "user.toml"), userToml)
+}
+
+func (p *provisioner) linuxGetCommand(command string) string {
+	// Always set HAB_NONINTERACTIVE
+	env := fmt.Sprintf("env HAB_NONINTERACTIVE=true")
+
+	// Set license acceptance
+	if p.License != "" {
+		env += fmt.Sprintf(" HAB_LICENSE=%s", p.License)
+	}
+
+	// Set builder auth token
+	if p.BuilderAuthToken != "" {
+		env += fmt.Sprintf(" HAB_AUTH_TOKEN=%s", p.BuilderAuthToken)
+	}
+
+	if p.UseSudo {
+		command = fmt.Sprintf("%s sudo -E /bin/bash -c '%s'", env, command)
+	} else {
+		command = fmt.Sprintf("%s /bin/bash -c '%s'", env, command)
+	}
+
+	return command
+}

--- a/builtin/provisioners/habitat/linux_provisioner_test.go
+++ b/builtin/provisioners/habitat/linux_provisioner_test.go
@@ -11,7 +11,7 @@ const linuxDefaultSystemdUnitFileContents = `[Unit]
 Description=Habitat Supervisor
 
 [Service]
-ExecStart=/bin/hab sup run --peer 1.2.3.4 --auto-update
+ExecStart=/bin/hab sup run --peer host1 --peer 1.2.3.4 --auto-update
 Restart=on-failure
 [Install]
 WantedBy=default.target`
@@ -20,7 +20,7 @@ const linuxCustomSystemdUnitFileContents = `[Unit]
 Description=Habitat Supervisor
 
 [Service]
-ExecStart=/bin/hab sup run --listen-ctl 192.168.0.1:8443 --listen-gossip 192.168.10.1:9443 --listen-http 192.168.20.1:8080 --peer 1.2.3.4 --peer 5.6.7.8 --peer foo.example.com
+ExecStart=/bin/hab sup run --listen-ctl 192.168.0.1:8443 --listen-gossip 192.168.10.1:9443 --listen-http 192.168.20.1:8080 --peer host1 --peer host2 --peer 1.2.3.4 --peer 5.6.7.8 --peer foo.example.com
 Restart=on-failure
 Environment="HAB_SUP_GATEWAY_AUTH_TOKEN=ea7-beef"
 Environment="HAB_AUTH_TOKEN=dead-beef"
@@ -37,7 +37,6 @@ func TestLinuxProvisioner_linuxInstallHabitat(t *testing.T) {
 				"version":     "0.79.1",
 				"auto_update": true,
 				"use_sudo":    true,
-				"peers":       []string{"1.2.3.4"},
 			},
 
 			Commands: map[string]bool{
@@ -53,7 +52,6 @@ func TestLinuxProvisioner_linuxInstallHabitat(t *testing.T) {
 				"version":     "0.79.1",
 				"auto_update": true,
 				"use_sudo":    false,
-				"peers":       []string{"1.2.3.4"},
 			},
 
 			Commands: map[string]bool{
@@ -70,7 +68,6 @@ func TestLinuxProvisioner_linuxInstallHabitat(t *testing.T) {
 				"license":     "accept-no-persist",
 				"auto_update": true,
 				"use_sudo":    true,
-				"peers":       []string{"1.2.3.4"},
 			},
 
 			Commands: map[string]bool{
@@ -115,6 +112,7 @@ func TestLinuxProvisioner_linuxStartHabitat(t *testing.T) {
 				"auto_update":  true,
 				"use_sudo":     true,
 				"service_name": "hab-sup",
+				"peer":         "--peer host1",
 				"peers":        []string{"1.2.3.4"},
 			},
 
@@ -134,6 +132,7 @@ func TestLinuxProvisioner_linuxStartHabitat(t *testing.T) {
 				"auto_update":  true,
 				"use_sudo":     false,
 				"service_name": "hab-sup",
+				"peer":         "--peer host1",
 				"peers":        []string{"1.2.3.4"},
 			},
 
@@ -153,13 +152,14 @@ func TestLinuxProvisioner_linuxStartHabitat(t *testing.T) {
 				"auto_update":  true,
 				"use_sudo":     true,
 				"service_type": "unmanaged",
+				"peer":         "--peer host1",
 				"peers":        []string{"1.2.3.4"},
 			},
 
 			Commands: map[string]bool{
 				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'hab install core/hab-sup/0.81.0'":                                                                                                      true,
 				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'mkdir -p /hab/sup/default && chmod o+w /hab/sup/default'":                                                                              true,
-				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c '(env HAB_LICENSE=accept-no-persist  setsid hab sup run --peer 1.2.3.4 --auto-update > /hab/sup/default/sup.log 2>&1 <&1 &) ; sleep 1'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c '(env HAB_LICENSE=accept-no-persist  setsid hab sup run --peer host1 --peer 1.2.3.4 --auto-update > /hab/sup/default/sup.log 2>&1 <&1 &) ; sleep 1'": true,
 			},
 
 			Uploads: map[string]string{
@@ -172,6 +172,7 @@ func TestLinuxProvisioner_linuxStartHabitat(t *testing.T) {
 				"auto_update":        false,
 				"use_sudo":           true,
 				"service_name":       "hab-sup",
+				"peer":               "--peer host1 --peer host2",
 				"peers":              []string{"1.2.3.4", "5.6.7.8", "foo.example.com"},
 				"listen_ctl":         "192.168.0.1:8443",
 				"listen_gossip":      "192.168.10.1:9443",

--- a/builtin/provisioners/habitat/linux_provisioner_test.go
+++ b/builtin/provisioners/habitat/linux_provisioner_test.go
@@ -41,11 +41,11 @@ func TestLinuxProvisioner_linuxInstallHabitat(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'curl --silent -L0 https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh > install.sh'": true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'bash ./install.sh -v 0.79.1'":                                                                                          true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab install core/busybox'":                                                                                             true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab pkg exec core/busybox adduser -D -g \"\" hab'":                                                                     true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'rm -f install.sh'":                                                                                                     true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'curl --silent -L0 https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh > install.sh'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'bash ./install.sh -v 0.79.1'":                                                                                          true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab install core/busybox'":                                                                                             true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab pkg exec core/busybox adduser -D -g \"\" hab'":                                                                     true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'rm -f install.sh'":                                                                                                     true,
 			},
 		},
 		"Installation without sudo": {
@@ -57,11 +57,11 @@ func TestLinuxProvisioner_linuxInstallHabitat(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"env HAB_NONINTERACTIVE=true /bin/bash -c 'curl --silent -L0 https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh > install.sh'": true,
-				"env HAB_NONINTERACTIVE=true /bin/bash -c 'bash ./install.sh -v 0.79.1'":                                                                                          true,
-				"env HAB_NONINTERACTIVE=true /bin/bash -c 'hab install core/busybox'":                                                                                             true,
-				"env HAB_NONINTERACTIVE=true /bin/bash -c 'hab pkg exec core/busybox adduser -D -g \"\" hab'":                                                                     true,
-				"env HAB_NONINTERACTIVE=true /bin/bash -c 'rm -f install.sh'":                                                                                                     true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true /bin/bash -c 'curl --silent -L0 https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh > install.sh'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true /bin/bash -c 'bash ./install.sh -v 0.79.1'":                                                                                          true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true /bin/bash -c 'hab install core/busybox'":                                                                                             true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true /bin/bash -c 'hab pkg exec core/busybox adduser -D -g \"\" hab'":                                                                     true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true /bin/bash -c 'rm -f install.sh'":                                                                                                     true,
 			},
 		},
 		"Installation with Habitat license acceptance": {
@@ -74,11 +74,11 @@ func TestLinuxProvisioner_linuxInstallHabitat(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'curl --silent -L0 https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh > install.sh'": true,
-				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'bash ./install.sh -v 0.81.0'":                                                                                          true,
-				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'hab install core/busybox'":                                                                                             true,
-				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'hab pkg exec core/busybox adduser -D -g \"\" hab'":                                                                     true,
-				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'rm -f install.sh'":                                                                                                     true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'curl --silent -L0 https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh > install.sh'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'bash ./install.sh -v 0.81.0'":                                                                                          true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'hab install core/busybox'":                                                                                             true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'hab pkg exec core/busybox adduser -D -g \"\" hab'":                                                                     true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'rm -f install.sh'":                                                                                                     true,
 			},
 		},
 	}
@@ -119,9 +119,9 @@ func TestLinuxProvisioner_linuxStartHabitat(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab install core/hab-sup/0.79.1'":                             true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'systemctl enable hab-sup && systemctl start hab-sup'":         true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'mv /tmp/hab-sup.service /etc/systemd/system/hab-sup.service'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab install core/hab-sup/0.79.1'":                             true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'systemctl enable hab-sup && systemctl start hab-sup'":         true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'mv /tmp/hab-sup.service /etc/systemd/system/hab-sup.service'": true,
 			},
 
 			Uploads: map[string]string{
@@ -138,8 +138,8 @@ func TestLinuxProvisioner_linuxStartHabitat(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"env HAB_NONINTERACTIVE=true /bin/bash -c 'hab install core/hab-sup/0.79.1'":                     true,
-				"env HAB_NONINTERACTIVE=true /bin/bash -c 'systemctl enable hab-sup && systemctl start hab-sup'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true /bin/bash -c 'hab install core/hab-sup/0.79.1'":                     true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true /bin/bash -c 'systemctl enable hab-sup && systemctl start hab-sup'": true,
 			},
 
 			Uploads: map[string]string{
@@ -157,9 +157,9 @@ func TestLinuxProvisioner_linuxStartHabitat(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'hab install core/hab-sup/0.81.0'":                                                                                                      true,
-				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'mkdir -p /hab/sup/default && chmod o+w /hab/sup/default'":                                                                              true,
-				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c '(env HAB_LICENSE=accept-no-persist  setsid hab sup run --peer 1.2.3.4 --auto-update > /hab/sup/default/sup.log 2>&1 <&1 &) ; sleep 1'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'hab install core/hab-sup/0.81.0'":                                                                                                      true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'mkdir -p /hab/sup/default && chmod o+w /hab/sup/default'":                                                                              true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c '(env HAB_LICENSE=accept-no-persist  setsid hab sup run --peer 1.2.3.4 --auto-update > /hab/sup/default/sup.log 2>&1 <&1 &) ; sleep 1'": true,
 			},
 
 			Uploads: map[string]string{
@@ -182,9 +182,9 @@ func TestLinuxProvisioner_linuxStartHabitat(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"env HAB_NONINTERACTIVE=true HAB_AUTH_TOKEN=dead-beef sudo -E /bin/bash -c 'hab install core/hab-sup/0.79.1'":                             true,
-				"env HAB_NONINTERACTIVE=true HAB_AUTH_TOKEN=dead-beef sudo -E /bin/bash -c 'systemctl enable hab-sup && systemctl start hab-sup'":         true,
-				"env HAB_NONINTERACTIVE=true HAB_AUTH_TOKEN=dead-beef sudo -E /bin/bash -c 'mv /tmp/hab-sup.service /etc/systemd/system/hab-sup.service'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_AUTH_TOKEN=dead-beef sudo -E /bin/bash -c 'hab install core/hab-sup/0.79.1'":                             true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_AUTH_TOKEN=dead-beef sudo -E /bin/bash -c 'systemctl enable hab-sup && systemctl start hab-sup'":         true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true HAB_AUTH_TOKEN=dead-beef sudo -E /bin/bash -c 'mv /tmp/hab-sup.service /etc/systemd/system/hab-sup.service'": true,
 			},
 
 			Uploads: map[string]string{
@@ -231,7 +231,7 @@ func TestLinuxProvisioner_linuxUploadRingKey(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'echo -e \"dead-beef\" | hab ring key import'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'echo -e \"dead-beef\" | hab ring key import'": true,
 			},
 		},
 	}
@@ -297,14 +297,14 @@ func TestLinuxProvisioner_linuxStartHabitatService(t *testing.T) {
 			},
 
 			Commands: map[string]bool{
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab pkg install core/foo  --channel stable'":                                                                        true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'mkdir -p /hab/user/foo/config'":                                                                                     true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'mv /tmp/user-a5b83ec1b302d109f41852ae17379f75c36dff9bc598aae76b6f7c9cd425fd76.toml /hab/user/foo/config/user.toml'": true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab svc load core/foo  --topology standalone --strategy none --channel stable --bind backend:bar.default'":          true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab pkg install core/bar  --channel staging'":                                                                       true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'mkdir -p /hab/user/bar/config'":                                                                                     true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'mv /tmp/user-6466ae3283ae1bd4737b00367bc676c6465b25682169ea5f7da222f3f078a5bf.toml /hab/user/bar/config/user.toml'": true,
-				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab svc load core/bar  --topology standalone --strategy rolling --channel staging'":                                 true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab pkg install core/foo  --channel stable'":                                                                        true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'mkdir -p /hab/user/foo/config'":                                                                                     true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'mv /tmp/user-a5b83ec1b302d109f41852ae17379f75c36dff9bc598aae76b6f7c9cd425fd76.toml /hab/user/foo/config/user.toml'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab svc load core/foo  --topology standalone --strategy none --channel stable --bind backend:bar.default'":          true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab pkg install core/bar  --channel staging'":                                                                       true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'mkdir -p /hab/user/bar/config'":                                                                                     true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'mv /tmp/user-6466ae3283ae1bd4737b00367bc676c6465b25682169ea5f7da222f3f078a5bf.toml /hab/user/bar/config/user.toml'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab svc load core/bar  --topology standalone --strategy rolling --channel staging'":                                 true,
 			},
 
 			Uploads: map[string]string{

--- a/builtin/provisioners/habitat/linux_provisioner_test.go
+++ b/builtin/provisioners/habitat/linux_provisioner_test.go
@@ -1,0 +1,346 @@
+package habitat
+
+import (
+	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+const linuxDefaultSystemdUnitFileContents = `[Unit]
+Description=Habitat Supervisor
+
+[Service]
+ExecStart=/bin/hab sup run --peer 1.2.3.4 --auto-update
+Restart=on-failure
+[Install]
+WantedBy=default.target`
+
+const linuxCustomSystemdUnitFileContents = `[Unit]
+Description=Habitat Supervisor
+
+[Service]
+ExecStart=/bin/hab sup run --listen-ctl 192.168.0.1:8443 --listen-gossip 192.168.10.1:9443 --listen-http 192.168.20.1:8080 --peer 1.2.3.4 --peer 5.6.7.8 --peer foo.example.com
+Restart=on-failure
+Environment="HAB_SUP_GATEWAY_AUTH_TOKEN=ea7-beef"
+Environment="HAB_AUTH_TOKEN=dead-beef"
+[Install]
+WantedBy=default.target`
+
+func TestLinuxProvisioner_linuxInstallHabitat(t *testing.T) {
+	cases := map[string]struct {
+		Config   map[string]interface{}
+		Commands map[string]bool
+	}{
+		"Installation with sudo": {
+			Config: map[string]interface{}{
+				"version":     "0.79.1",
+				"auto_update": true,
+				"use_sudo":    true,
+				"peers":       []string{"1.2.3.4"},
+			},
+
+			Commands: map[string]bool{
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'curl --silent -L0 https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh > install.sh'": true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'bash ./install.sh -v 0.79.1'":                                                                                          true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab install core/busybox'":                                                                                             true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab pkg exec core/busybox adduser -D -g \"\" hab'":                                                                     true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'rm -f install.sh'":                                                                                                     true,
+			},
+		},
+		"Installation without sudo": {
+			Config: map[string]interface{}{
+				"version":     "0.79.1",
+				"auto_update": true,
+				"use_sudo":    false,
+				"peers":       []string{"1.2.3.4"},
+			},
+
+			Commands: map[string]bool{
+				"env HAB_NONINTERACTIVE=true /bin/bash -c 'curl --silent -L0 https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh > install.sh'": true,
+				"env HAB_NONINTERACTIVE=true /bin/bash -c 'bash ./install.sh -v 0.79.1'":                                                                                          true,
+				"env HAB_NONINTERACTIVE=true /bin/bash -c 'hab install core/busybox'":                                                                                             true,
+				"env HAB_NONINTERACTIVE=true /bin/bash -c 'hab pkg exec core/busybox adduser -D -g \"\" hab'":                                                                     true,
+				"env HAB_NONINTERACTIVE=true /bin/bash -c 'rm -f install.sh'":                                                                                                     true,
+			},
+		},
+		"Installation with Habitat license acceptance": {
+			Config: map[string]interface{}{
+				"version":     "0.81.0",
+				"license":     "accept-no-persist",
+				"auto_update": true,
+				"use_sudo":    true,
+				"peers":       []string{"1.2.3.4"},
+			},
+
+			Commands: map[string]bool{
+				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'curl --silent -L0 https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh > install.sh'": true,
+				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'bash ./install.sh -v 0.81.0'":                                                                                          true,
+				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'hab install core/busybox'":                                                                                             true,
+				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'hab pkg exec core/busybox adduser -D -g \"\" hab'":                                                                     true,
+				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'rm -f install.sh'":                                                                                                     true,
+			},
+		},
+	}
+
+	o := new(terraform.MockUIOutput)
+	c := new(communicator.MockCommunicator)
+
+	for k, tc := range cases {
+		c.Commands = tc.Commands
+
+		p, err := decodeConfig(
+			schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, tc.Config),
+		)
+		if err != nil {
+			t.Fatalf("Error: %v", err)
+		}
+
+		err = p.linuxInstallHabitat(o, c)
+		if err != nil {
+			t.Fatalf("Test %q failed: %v", k, err)
+		}
+	}
+}
+
+func TestLinuxProvisioner_linuxStartHabitat(t *testing.T) {
+	cases := map[string]struct {
+		Config   map[string]interface{}
+		Commands map[string]bool
+		Uploads  map[string]string
+	}{
+		"Start systemd Habitat with sudo": {
+			Config: map[string]interface{}{
+				"version":      "0.79.1",
+				"auto_update":  true,
+				"use_sudo":     true,
+				"service_name": "hab-sup",
+				"peers":        []string{"1.2.3.4"},
+			},
+
+			Commands: map[string]bool{
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab install core/hab-sup/0.79.1'":                             true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'systemctl enable hab-sup && systemctl start hab-sup'":         true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'mv /tmp/hab-sup.service /etc/systemd/system/hab-sup.service'": true,
+			},
+
+			Uploads: map[string]string{
+				"/tmp/hab-sup.service": linuxDefaultSystemdUnitFileContents,
+			},
+		},
+		"Start systemd Habitat without sudo": {
+			Config: map[string]interface{}{
+				"version":      "0.79.1",
+				"auto_update":  true,
+				"use_sudo":     false,
+				"service_name": "hab-sup",
+				"peers":        []string{"1.2.3.4"},
+			},
+
+			Commands: map[string]bool{
+				"env HAB_NONINTERACTIVE=true /bin/bash -c 'hab install core/hab-sup/0.79.1'":                     true,
+				"env HAB_NONINTERACTIVE=true /bin/bash -c 'systemctl enable hab-sup && systemctl start hab-sup'": true,
+			},
+
+			Uploads: map[string]string{
+				"/etc/systemd/system/hab-sup.service": linuxDefaultSystemdUnitFileContents,
+			},
+		},
+		"Start unmanaged Habitat with sudo": {
+			Config: map[string]interface{}{
+				"version":      "0.81.0",
+				"license":      "accept-no-persist",
+				"auto_update":  true,
+				"use_sudo":     true,
+				"service_type": "unmanaged",
+				"peers":        []string{"1.2.3.4"},
+			},
+
+			Commands: map[string]bool{
+				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'hab install core/hab-sup/0.81.0'":                                                                                                      true,
+				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c 'mkdir -p /hab/sup/default && chmod o+w /hab/sup/default'":                                                                              true,
+				"env HAB_NONINTERACTIVE=true HAB_LICENSE=accept-no-persist sudo -E /bin/bash -c '(env HAB_LICENSE=accept-no-persist  setsid hab sup run --peer 1.2.3.4 --auto-update > /hab/sup/default/sup.log 2>&1 <&1 &) ; sleep 1'": true,
+			},
+
+			Uploads: map[string]string{
+				"/etc/systemd/system/hab-sup.service": linuxDefaultSystemdUnitFileContents,
+			},
+		},
+		"Start Habitat with custom config": {
+			Config: map[string]interface{}{
+				"version":            "0.79.1",
+				"auto_update":        false,
+				"use_sudo":           true,
+				"service_name":       "hab-sup",
+				"peers":              []string{"1.2.3.4", "5.6.7.8", "foo.example.com"},
+				"listen_ctl":         "192.168.0.1:8443",
+				"listen_gossip":      "192.168.10.1:9443",
+				"listen_http":        "192.168.20.1:8080",
+				"builder_auth_token": "dead-beef",
+				"gateway_auth_token": "ea7-beef",
+				"ctl_secret":         "bad-beef",
+			},
+
+			Commands: map[string]bool{
+				"env HAB_NONINTERACTIVE=true HAB_AUTH_TOKEN=dead-beef sudo -E /bin/bash -c 'hab install core/hab-sup/0.79.1'":                             true,
+				"env HAB_NONINTERACTIVE=true HAB_AUTH_TOKEN=dead-beef sudo -E /bin/bash -c 'systemctl enable hab-sup && systemctl start hab-sup'":         true,
+				"env HAB_NONINTERACTIVE=true HAB_AUTH_TOKEN=dead-beef sudo -E /bin/bash -c 'mv /tmp/hab-sup.service /etc/systemd/system/hab-sup.service'": true,
+			},
+
+			Uploads: map[string]string{
+				"/tmp/hab-sup.service": linuxCustomSystemdUnitFileContents,
+			},
+		},
+	}
+
+	o := new(terraform.MockUIOutput)
+	c := new(communicator.MockCommunicator)
+
+	for k, tc := range cases {
+		c.Commands = tc.Commands
+		c.Uploads = tc.Uploads
+
+		p, err := decodeConfig(
+			schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, tc.Config),
+		)
+		if err != nil {
+			t.Fatalf("Error: %v", err)
+		}
+
+		err = p.linuxStartHabitat(o, c)
+		if err != nil {
+			t.Fatalf("Test %q failed: %v", k, err)
+		}
+	}
+}
+
+func TestLinuxProvisioner_linuxUploadRingKey(t *testing.T) {
+	cases := map[string]struct {
+		Config   map[string]interface{}
+		Commands map[string]bool
+	}{
+		"Upload ring key": {
+			Config: map[string]interface{}{
+				"version":          "0.79.1",
+				"auto_update":      true,
+				"use_sudo":         true,
+				"service_name":     "hab-sup",
+				"peers":            []string{"1.2.3.4"},
+				"ring_key":         "test-ring",
+				"ring_key_content": "dead-beef",
+			},
+
+			Commands: map[string]bool{
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'echo -e \"dead-beef\" | hab ring key import'": true,
+			},
+		},
+	}
+
+	o := new(terraform.MockUIOutput)
+	c := new(communicator.MockCommunicator)
+
+	for k, tc := range cases {
+		c.Commands = tc.Commands
+
+		p, err := decodeConfig(
+			schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, tc.Config),
+		)
+		if err != nil {
+			t.Fatalf("Error: %v", err)
+		}
+
+		err = p.linuxUploadRingKey(o, c)
+		if err != nil {
+			t.Fatalf("Test %q failed: %v", k, err)
+		}
+	}
+}
+
+func TestLinuxProvisioner_linuxStartHabitatService(t *testing.T) {
+	cases := map[string]struct {
+		Config   map[string]interface{}
+		Commands map[string]bool
+		Uploads  map[string]string
+	}{
+		"Start Habitat service with sudo": {
+			Config: map[string]interface{}{
+				"version":          "0.79.1",
+				"auto_update":      false,
+				"use_sudo":         true,
+				"service_name":     "hab-sup",
+				"peers":            []string{"1.2.3.4"},
+				"ring_key":         "test-ring",
+				"ring_key_content": "dead-beef",
+				"service": []map[string]interface{}{
+					{
+						"name":      "core/foo",
+						"topology":  "standalone",
+						"strategy":  "none",
+						"channel":   "stable",
+						"user_toml": "[config]\nlisten = 0.0.0.0:8080",
+						"bind": []map[string]interface{}{
+							{
+								"alias":   "backend",
+								"service": "bar",
+								"group":   "default",
+							},
+						},
+					},
+					{
+						"name":      "core/bar",
+						"topology":  "standalone",
+						"strategy":  "rolling",
+						"channel":   "staging",
+						"user_toml": "[config]\nlisten = 0.0.0.0:443",
+					},
+				},
+			},
+
+			Commands: map[string]bool{
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab pkg install core/foo  --channel stable'":                                                                        true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'mkdir -p /hab/user/foo/config'":                                                                                     true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'mv /tmp/user-a5b83ec1b302d109f41852ae17379f75c36dff9bc598aae76b6f7c9cd425fd76.toml /hab/user/foo/config/user.toml'": true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab svc load core/foo  --topology standalone --strategy none --channel stable --bind backend:bar.default'":          true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab pkg install core/bar  --channel staging'":                                                                       true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'mkdir -p /hab/user/bar/config'":                                                                                     true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'mv /tmp/user-6466ae3283ae1bd4737b00367bc676c6465b25682169ea5f7da222f3f078a5bf.toml /hab/user/bar/config/user.toml'": true,
+				"env HAB_NONINTERACTIVE=true sudo -E /bin/bash -c 'hab svc load core/bar  --topology standalone --strategy rolling --channel staging'":                                 true,
+			},
+
+			Uploads: map[string]string{
+				"/tmp/user-a5b83ec1b302d109f41852ae17379f75c36dff9bc598aae76b6f7c9cd425fd76.toml": "[config]\nlisten = 0.0.0.0:8080",
+				"/tmp/user-6466ae3283ae1bd4737b00367bc676c6465b25682169ea5f7da222f3f078a5bf.toml": "[config]\nlisten = 0.0.0.0:443",
+			},
+		},
+	}
+
+	o := new(terraform.MockUIOutput)
+	c := new(communicator.MockCommunicator)
+
+	for k, tc := range cases {
+		c.Commands = tc.Commands
+		c.Uploads = tc.Uploads
+
+		p, err := decodeConfig(
+			schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, tc.Config),
+		)
+		if err != nil {
+			t.Fatalf("Error: %v", err)
+		}
+
+		var errs []error
+		for _, s := range p.Services {
+			err = p.linuxStartHabitatService(o, c, s)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		if len(errs) > 0 {
+			for _, e := range errs {
+				t.Logf("Test %q failed: %v", k, e)
+				t.Fail()
+			}
+		}
+	}
+}

--- a/builtin/provisioners/habitat/resource_provisioner.go
+++ b/builtin/provisioners/habitat/resource_provisioner.go
@@ -27,6 +27,7 @@ type provisioner struct {
 	ListenCtl        string
 	ListenGossip     string
 	ListenHTTP       string
+	Peer             string
 	Peers            []string
 	RingKey          string
 	RingKeyContent   string
@@ -75,6 +76,10 @@ func Provisioner() terraform.ResourceProvisioner {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+			},
+			"peer": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"peers": &schema.Schema{
 				Type:     schema.TypeList,
@@ -396,6 +401,7 @@ func decodeConfig(d *schema.ResourceData) (*provisioner, error) {
 		License:          d.Get("license").(string),
 		AutoUpdate:       d.Get("auto_update").(bool),
 		HttpDisable:      d.Get("http_disable").(bool),
+		Peer:             d.Get("peer").(string),
 		Peers:            getPeers(d.Get("peers").([]interface{})),
 		Services:         getServices(d.Get("service").(*schema.Set).List()),
 		UseSudo:          d.Get("use_sudo").(bool),

--- a/builtin/provisioners/habitat/resource_provisioner.go
+++ b/builtin/provisioners/habitat/resource_provisioner.go
@@ -132,11 +132,11 @@ func Provisioner() terraform.ResourceProvisioner {
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					u, err := url.Parse(val.(string))
 					if err != nil {
-						errs = append(errs, err)
+						errs = append(errs, fmt.Errorf("invalid URL specified for %q: %v", key, err))
 					}
 
 					if u.Scheme == "" {
-						errs = append(errs, fmt.Errorf("invalid URL specified for service (no scheme specified)"))
+						errs = append(errs, fmt.Errorf("invalid URL specified for %q (scheme must be specified)", key))
 					}
 
 					return warns, errs
@@ -223,11 +223,11 @@ func Provisioner() terraform.ResourceProvisioner {
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 								u, err := url.Parse(val.(string))
 								if err != nil {
-									errs = append(errs, err)
+									errs = append(errs, fmt.Errorf("invalid URL specified for %q: %v", key, err))
 								}
 
 								if u.Scheme == "" {
-									errs = append(errs, fmt.Errorf("invalid URL specified for service (no scheme specified)"))
+									errs = append(errs, fmt.Errorf("invalid URL specified for %q (scheme must be specified)", key))
 								}
 
 								return warns, errs

--- a/builtin/provisioners/habitat/resource_provisioner_test.go
+++ b/builtin/provisioners/habitat/resource_provisioner_test.go
@@ -20,7 +20,7 @@ func TestProvisioner(t *testing.T) {
 
 func TestResourceProvisioner_Validate_good(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
-		"peer":         "1.2.3.4",
+		"peers":        []string{"1.2.3.4"},
 		"version":      "0.32.0",
 		"service_type": "systemd",
 	})
@@ -37,14 +37,15 @@ func TestResourceProvisioner_Validate_good(t *testing.T) {
 func TestResourceProvisioner_Validate_bad(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"service_type": "invalidtype",
+		"url":          "badurl",
 	})
 
 	warn, errs := Provisioner().Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
 	}
-	if len(errs) != 1 {
-		t.Fatalf("Should have one error")
+	if len(errs) != 2 {
+		t.Fatalf("Should have two errors")
 	}
 }
 
@@ -60,7 +61,7 @@ func TestResourceProvisioner_Validate_bad_service_config(t *testing.T) {
 		t.Fatalf("Warnings: %v", warn)
 	}
 	if len(errs) != 3 {
-		t.Fatalf("Should have three errors")
+		t.Fatalf("Should have three errors: %v", errs)
 	}
 }
 

--- a/website/docs/provisioners/habitat.html.markdown
+++ b/website/docs/provisioners/habitat.html.markdown
@@ -47,7 +47,7 @@ There are 2 configuration levels, `supervisor` and `service`.  Configuration pla
 
 ### Supervisor Arguments
 * `version (string)` - (Optional) The Habitat version to install on the remote machine.  If not specified, the latest available version is used.
-* `license (string)` - (Optional) Sets the acceptance of Chef licensing: https://www.chef.io/end-user-license-agreement/
+* `license (string)` - (Optional) Sets the acceptance of Chef licensing (one of `accept-no-persist` or `accept`): https://www.chef.io/end-user-license-agreement/
 * `auto_update (bool)` - (Optional) If set to `true`, the supervisor will auto-update itself as soon as new releases are available on the specified `channel`.
 * `http_disable (bool)` - (Optional) If set to `true`, disables the supervisor HTTP listener entirely.
 * `peers (array)` - (Optional) A list of IP or FQDN's of other supervisor instance(s) to peer with. (Defaults to none)

--- a/website/docs/provisioners/habitat.html.markdown
+++ b/website/docs/provisioners/habitat.html.markdown
@@ -50,6 +50,7 @@ There are 2 configuration levels, `supervisor` and `service`.  Configuration pla
 * `license (string)` - (Optional) Sets the acceptance of Chef licensing (one of `accept-no-persist` or `accept`): https://www.chef.io/end-user-license-agreement/
 * `auto_update (bool)` - (Optional) If set to `true`, the supervisor will auto-update itself as soon as new releases are available on the specified `channel`.
 * `http_disable (bool)` - (Optional) If set to `true`, disables the supervisor HTTP listener entirely.
+* `peer (string)` - (Optional, deprecated) IP addresses or FQDN's for other Habitat supervisors to peer with, like: `--peer 1.2.3.4 --peer 5.6.7.8`. (Defaults to none)
 * `peers (array)` - (Optional) A list of IP or FQDN's of other supervisor instance(s) to peer with. (Defaults to none)
 * `service_type (string)` - (Optional) Method used to run the Habitat supervisor.  Valid options are `unmanaged` and `systemd`.  (Defaults to `systemd`)
 * `service_name (string)` - (Optional) The name of the Habitat supervisor service, if using an init system such as `systemd`. (Defaults to `hab-supervisor`)

--- a/website/docs/provisioners/habitat.html.markdown
+++ b/website/docs/provisioners/habitat.html.markdown
@@ -47,7 +47,7 @@ There are 2 configuration levels, `supervisor` and `service`.  Configuration pla
 
 ### Supervisor Arguments
 * `version (string)` - (Optional) The Habitat version to install on the remote machine.  If not specified, the latest available version is used.
-* `license (string)` - (Optional) Sets the acceptance of Habitat licensing.
+* `license (string)` - (Optional) Sets the acceptance of Chef licensing: https://www.chef.io/end-user-license-agreement/
 * `auto_update (bool)` - (Optional) If set to `true`, the supervisor will auto-update itself as soon as new releases are available on the specified `channel`.
 * `http_disable (bool)` - (Optional) If set to `true`, disables the supervisor HTTP listener entirely.
 * `peers (array)` - (Optional) A list of IP or FQDN's of other supervisor instance(s) to peer with. (Defaults to none)

--- a/website/docs/provisioners/habitat.html.markdown
+++ b/website/docs/provisioners/habitat.html.markdown
@@ -27,14 +27,14 @@ resource "aws_instance" "redis" {
   count = 3
 
   provisioner "habitat" {
-    peer = "${aws_instance.redis.0.private_ip}"
+    peers = [aws_instance.redis[0].private_ip]
     use_sudo = true
     service_type = "systemd"
 
     service {
       name = "core/redis"
       topology = "leader"
-      user_toml = "${file("conf/redis.toml")}"
+      user_toml = file("conf/redis.toml")
     }
   }
 }
@@ -47,20 +47,25 @@ There are 2 configuration levels, `supervisor` and `service`.  Configuration pla
 
 ### Supervisor Arguments
 * `version (string)` - (Optional) The Habitat version to install on the remote machine.  If not specified, the latest available version is used.
-* `use_sudo (bool)` - (Optional) Use `sudo` when executing remote commands.  Required when the user specified in the `connection` block is not `root`.  (Defaults to `true`)
+* `license (string)` - (Optional) Sets the acceptance of Habitat licensing.
+* `auto_update (bool)` - (Optional) If set to `true`, the supervisor will auto-update itself as soon as new releases are available on the specified `channel`.
+* `http_disable (bool)` - (Optional) If set to `true`, disables the supervisor HTTP listener entirely.
+* `peers (array)` - (Optional) A list of IP or FQDN's of other supervisor instance(s) to peer with. (Defaults to none)
 * `service_type (string)` - (Optional) Method used to run the Habitat supervisor.  Valid options are `unmanaged` and `systemd`.  (Defaults to `systemd`)
 * `service_name (string)` - (Optional) The name of the Habitat supervisor service, if using an init system such as `systemd`. (Defaults to `hab-supervisor`)
-* `peer (string)` - (Optional) IP or FQDN of a supervisor instance to peer with. (Defaults to none)
+* `use_sudo (bool)` - (Optional) Use `sudo` when executing remote commands.  Required when the user specified in the `connection` block is not `root`.  (Defaults to `true`)
 * `permanent_peer (bool)` - (Optional) Marks this supervisor as a permanent peer.  (Defaults to false)
+* `listen_ctl (string)` - (Optional) The listen address for the countrol gateway system (Defaults to 127.0.0.1:9632)
 * `listen_gossip (string)` - (Optional) The listen address for the gossip system (Defaults to 0.0.0.0:9638)
 * `listen_http (string)` - (Optional) The listen address for the HTTP gateway (Defaults to 0.0.0.0:9631)
 * `ring_key (string)` - (Optional) The name of the ring key for encrypting gossip ring communication (Defaults to no encryption)
 * `ring_key_content (string)` - (Optional) The key content.  Only needed if using ring encryption and want the provisioner to take care of uploading and importing it.  Easiest to source from a file (eg `ring_key_content = "${file("conf/foo-123456789.sym.key")}"`) (Defaults to none)
+* `ctl_secret (string)` - (Optional) Specify a secret to use (from `hab sup secret generate`) for control gateway communication between hab client(s) and the supervisor.  (Defaults to none)
 * `url (string)` - (Optional) The URL of a Builder service to download packages and receive updates from.  (Defaults to https://bldr.habitat.sh)
 * `channel (string)` - (Optional) The release channel in the Builder service to use. (Defaults to `stable`)
 * `events (string)` - (Optional) Name of the service group running a Habitat EventSrv to forward Supervisor and service event data to. (Defaults to none)
-* `override_name (string)` - (Optional) The name of the Supervisor (Defaults to `default`)
 * `organization (string)` - (Optional) The organization that the Supervisor and it's subsequent services are part of. (Defaults to `default`)
+* `gateway_auth_token (string)` - (Optional) The http gateway authorization token (Defaults to none)
 * `builder_auth_token (string)` - (Optional) The builder authorization token when using a private origin. (Defaults to none)
 
 ### Service Arguments
@@ -83,5 +88,4 @@ bind {
 * `url (string)` - (Optional) The URL of a Builder service to download packages and receive updates from.  (Defaults to https://bldr.habitat.sh)
 * `application (string)` - (Optional) The application name.  (Defaults to none)
 * `environment (string)` - (Optional) The environment name.  (Defaults to none)
-* `override_name (string)` - (Optional) The name for the state directory if there is more than one Supervisor running. (Defaults to `default`)
 * `service_key (string)` - (Optional) The key content of a service private key, if using service group encryption.  Easiest to source from a file (eg `service_key = "${file("conf/redis.default@org-123456789.box.key")}"`) (Defaults to none)


### PR DESCRIPTION
Update Habitat Provisioner (built-in) to support Chef license acceptance, ctl secret, remote ctl gateway, auto update, http disable, gateway auth token, peers, user.toml placement in correct directory, and disable colorized output for hab-sup.  Also avoids a race condition if multiple `service { }` blocks are defined and each have their own user.toml upload. Updated docs for provisioner as well, with a few new options.  Split out linux specific provisioner steps (I'd like to add Windows support eventually).  Unit tests for both the resource_provisioner and linux_provisioner.

I believe this falls under `Core BugFix/Enhancement`, and includes `Unit Tests`, `Documentation Updates`, and `Well Formed Code`, to the best of my knowledge.

I believe this PR also resolves the following tickets:
- #21350
- #20684
- #19394
- #18492 (maybe?)
- #17799