### PR TITLE
tests: Normalize in the fmt -check test

### DIFF
--- a/command/fmt_test.go
+++ b/command/fmt_test.go
@@ -245,6 +245,10 @@ func TestFmt_check(t *testing.T) {
 		t.Fatalf("wrong exit code. expected 3")
 	}
 
+	// Given that we give relative paths back to the user, normalize this temp
+	// dir so that we're comparing against a relative-ized (normalized) path
+	tempDir = c.normalizePath(tempDir)
+
 	if actual := ui.OutputWriter.String(); !strings.Contains(actual, tempDir) {
 		t.Fatalf("expected:\n%s\n\nto include: %q", actual, tempDir)
 	}


### PR DESCRIPTION
When running in CI, where the system puts the temp directory can be impacted by Terraform's desire to normalize paths, as such, in the TestFmt_check test, when it is comparing the actual and expected directories, the temp directory should be normalized for this check to succeed consistently across systems.