### PR TITLE
Include puppet provisioner in docs sidebar

### DIFF
--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -346,6 +346,10 @@
           <li<%= sidebar_current("docs-provisioners-local") %>>
             <a href="/docs/provisioners/local-exec.html">local-exec Provisioner</a>
           </li>
+          
+          <li<%= sidebar_current("docs-provisioners-puppet") %>>
+            <a href="/docs/provisioners/puppet.html">puppet Provisioner</a>
+          </li>
 
           <li<%= sidebar_current("docs-provisioners-remote") %>>
             <a href="/docs/provisioners/remote-exec.html">remote-exec Provisioner</a>


### PR DESCRIPTION
Sidebar needs to link to https://www.terraform.io/docs/provisioners/puppet.html