### PR TITLE
website: Add missing fmt -recursive flag

### DIFF
--- a/website/docs/commands/fmt.html.markdown
+++ b/website/docs/commands/fmt.html.markdown
@@ -38,3 +38,5 @@ The command-line flags are all optional. The list of available flags are:
 * `-diff` - Display diffs of formatting changes
 * `-check` - Check if the input is formatted. Exit status will be 0 if
     all input is properly formatted and non-zero otherwise.
+* `-recursive` - Also process files in subdirectories.
+    By default, only the given directory (or current directory) is processed.


### PR DESCRIPTION
In Terraform v0.12, the `fmt` command does not format recursively by default, and the `-recursive` flag has been added. https://github.com/hashicorp/terraform/commit/dc7f793be9f263de29b5220d9d7664fdca734659

However, it is not documented. We should add it to doc.

```
$ terraform --version
Terraform v0.12.2

$ terraform fmt --help
Usage: terraform fmt [options] [DIR]

        Rewrites all Terraform configuration files to a canonical format. Both
        configuration files (.tf) and variables files (.tfvars) are updated.
        JSON files (.tf.json or .tfvars.json) are not modified.

        If DIR is not specified then the current working directory will be used.
        If DIR is "-" then content will be read from STDIN. The given content must
        be in the Terraform language native syntax; JSON is not supported.

Options:

  -list=false    Don't list files whose formatting differs
                 (always disabled if using STDIN)

  -write=false   Don't write to source files
                 (always disabled if using STDIN or -check)

  -diff          Display diffs of formatting changes

  -check         Check if the input is formatted. Exit status will be 0 if all
                 input is properly formatted and non-zero otherwise.

  -recursive     Also process files in subdirectories. By default, only the
                 given directory (or current directory) is processed.

```