### PR TITLE
Private data and timeouts were lost in empty plans

### DIFF
--- a/builtin/providers/test/resource_timeout_test.go
+++ b/builtin/providers/test/resource_timeout_test.go
@@ -28,6 +28,52 @@ resource "test_resource_timeout" "foo" {
 	})
 }
 
+// start with the default, then modify it
+func TestResourceTimeout_defaults(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_timeout" "foo" {
+	update_delay = "1ms"
+}
+				`),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_timeout" "foo" {
+	update_delay = "2ms"
+	timeouts {
+		update = "3s"
+	}
+}
+				`),
+			},
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_timeout" "foo" {
+	update_delay = "2s"
+	delete_delay = "2s"
+	timeouts {
+		delete = "3s"
+		update = "3s"
+	}
+}
+				`),
+			},
+			// delete "foo"
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_timeout" "bar" {
+}
+				`),
+			},
+		},
+	})
+}
+
 func TestResourceTimeout_delete(t *testing.T) {
 	// If the delete timeout isn't saved until destroy, the cleanup here will
 	// fail because the default is only 20m.

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -329,21 +329,13 @@ func (r *Resource) simpleDiff(
 	c *terraform.ResourceConfig,
 	meta interface{}) (*terraform.InstanceDiff, error) {
 
-	t := &ResourceTimeout{}
-	err := t.ConfigDecode(r, c)
-
-	if err != nil {
-		return nil, fmt.Errorf("[ERR] Error decoding timeout: %s", err)
-	}
-
 	instanceDiff, err := schemaMap(r.Schema).Diff(s, c, r.CustomizeDiff, meta, false)
 	if err != nil {
 		return instanceDiff, err
 	}
 
 	if instanceDiff == nil {
-		log.Printf("[DEBUG] Instance Diff is nil in SimpleDiff()")
-		return nil, err
+		instanceDiff = terraform.NewInstanceDiff()
 	}
 
 	// Make sure the old value is set in each of the instance diffs.
@@ -357,10 +349,7 @@ func (r *Resource) simpleDiff(
 		}
 	}
 
-	if err := t.DiffEncode(instanceDiff); err != nil {
-		log.Printf("[ERR] Error encoding timeout to instance diff: %s", err)
-	}
-	return instanceDiff, err
+	return instanceDiff, nil
 }
 
 // Validate validates the resource configuration against the schema.


### PR DESCRIPTION
Timeouts needs to always exist in the private data with the new protocol, since not all helper/schema operations load the combined config+defaults at the correct time. The private data was lost in PlanResourceChange when there was no diff, which means there was no `diff.Meta` to encode them into. The `read` timeouts were also not decoded during `ReadResource`, so make sure to insert them from the private data.