### PR TITLE
configs: check for errors after LoadHCLFile

### DIFF
--- a/configs/parser_config.go
+++ b/configs/parser_config.go
@@ -32,7 +32,7 @@ func (p *Parser) LoadConfigFileOverride(path string) (*File, hcl.Diagnostics) {
 func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnostics) {
 
 	body, diags := p.LoadHCLFile(path)
-	if body == nil || diags.HasErrors() {
+	if body == nil {
 		return nil, diags
 	}
 

--- a/configs/parser_config.go
+++ b/configs/parser_config.go
@@ -32,7 +32,7 @@ func (p *Parser) LoadConfigFileOverride(path string) (*File, hcl.Diagnostics) {
 func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnostics) {
 
 	body, diags := p.LoadHCLFile(path)
-	if body == nil {
+	if body == nil || diags.HasErrors() {
 		return nil, diags
 	}
 

--- a/configs/test-fixtures/invalid-files/provider-syntax.tf
+++ b/configs/test-fixtures/invalid-files/provider-syntax.tf
@@ -1,0 +1,3 @@
+provider "template" {
+  version = 
+}

--- a/configs/version_constraint.go
+++ b/configs/version_constraint.go
@@ -45,6 +45,13 @@ func decodeVersionConstraint(attr *hcl.Attribute) (VersionConstraint, hcl.Diagno
 		return ret, diags
 	}
 
+	if !val.IsWhollyKnown() {
+		// If there is a syntax error, HCL sets the value of the given attribute
+		// to cty.DynamicVal. A diagnostic for the syntax error will already
+		// bubble up, so we will move forward gracefully here.
+		return ret, diags
+	}
+
 	constraintStr := val.AsString()
 	constraints, err := version.NewConstraint(constraintStr)
 	if err != nil {


### PR DESCRIPTION
The `configs` package was not checking the diagnostics for errors after loading files as HCL, which lead to panics in `init` and `validate` when terraform encountered invalid HCL.

The following config would produce an error out of `terraform fmt`, which explicitly validates the syntax first, but cause a panic in `init` or `validate`:

```hcl
provider "aws" {
  region = var.aws_region
  version =
}
```

I think a follow-up HCL issue to improve the output in this instance is warranted:

```
$ terraform validate

Error: Invalid expression

  on main.tf line 3, in provider "aws":
   3:
   4:

Expected the start of an expression, but found an invalid expression token.
```

Fixes #21518