### PR TITLE
helper/validation: Add nullable int range validation

### DIFF
--- a/helper/validation/validation.go
+++ b/helper/validation/validation.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -58,6 +59,35 @@ func IntBetween(min, max int) schema.SchemaValidateFunc {
 
 		if v < min || v > max {
 			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// TypeStringNullableIntBetween returns a SchemaValidateFunc which tests if the provided value
+// is an empty string, or converts to an int and is between min and max (inclusive)
+func TypeStringNullableIntBetween(min, max int64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if v == "" {
+			return
+		}
+
+		vInt, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			es = append(es, fmt.Errorf("%s: cannot parse '%s' as integer: %s", k, v, err))
+			return
+		}
+
+		if vInt < min || vInt > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, vInt))
 			return
 		}
 

--- a/helper/validation/validation_test.go
+++ b/helper/validation/validation_test.go
@@ -99,6 +99,33 @@ func TestValidationIntBetween(t *testing.T) {
 	})
 }
 
+func TestValidationTypeStringNullableIntBetween(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "1",
+			f:   TypeStringNullableIntBetween(1, 1),
+		},
+		{
+			val: "1",
+			f:   TypeStringNullableIntBetween(0, 2),
+		},
+		{
+			val:         "1",
+			f:           TypeStringNullableIntBetween(2, 3),
+			expectedErr: regexp.MustCompile("expected [\\w]+ to be in the range \\(2 - 3\\), got 1"),
+		},
+		{
+			val: "",
+			f:   TypeStringNullableIntBetween(2, 3),
+		},
+		{
+			val:         1,
+			f:           TypeStringNullableIntBetween(2, 3),
+			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be string"),
+		},
+	})
+}
+
 func TestValidationIntAtLeast(t *testing.T) {
 	runTestCases(t, []testCase{
 		{


### PR DESCRIPTION
This PR is to complement a terraform-provider-aws PR: https://github.com/terraform-providers/terraform-provider-aws/pull/8845

The ability to add a range to a "nullable"/"string to int" type is valuable in that case!

I added some tests and the unit tests all pass, let me know if there is anything else I can do!