### PR TITLE
Update in terraform output documentation

### DIFF
--- a/website/docs/commands/output.html.markdown
+++ b/website/docs/commands/output.html.markdown
@@ -24,13 +24,9 @@ The command-line flags are all optional. The list of available flags are:
 * `-json` - If specified, the outputs are formatted as a JSON object, with
     a key per output. If `NAME` is specified, only the output specified will be
     returned. This can be piped into tools such as `jq` for further processing.
+* `-no-color` - If specified, output won't contain any color.
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
     Ignored when [remote state](/docs/state/remote.html) is used.
-* `-module=module_name` - The module path which has needed output.
-    By default this is the root path. Other modules can be specified by
-    a period-separated list. Example: "foo" would reference the module
-    "foo" but "foo.bar" would reference the "bar" module in the "foo"
-    module.
 
 ## Examples
 


### PR DESCRIPTION
This PR will update documentation for `terraform output` options (please also see #21799).

- Removing deprecated `-module=` option

```
$ terraform output -module=network

Error: Unsupported option

The -module option is no longer supported since Terraform 0.12, because now
only root outputs are persisted in the state.
```

- Add documentation for missing `-no-color` option

```
$ terraform output -h
Options:
  -state=path      Path to the state file to read. Defaults to
                   "terraform.tfstate".
  -no-color        If specified, output won't contain any color.
  -json            If specified, machine readable output will be
                   printed in JSON format
```