### PR TITLE
Fix typo in environment variable

### DIFF
--- a/website/docs/backends/types/consul.html.md
+++ b/website/docs/backends/types/consul.html.md
@@ -56,6 +56,6 @@ The following configuration options / environment variables are supported:
    communicating with Consul, in the format of either `user` or `user:pass`.
  * `gzip` - (Optional) `true` to compress the state data using gzip, or `false` (the default) to leave it uncompressed.
  * `lock` - (Optional) `false` to disable locking. This defaults to true, but will require session permissions with Consul and at least kv write permissions on `$path/.lock` to perform locking. 
- * `ca_file` / `CONSUL_CAFILE` - (Optional) A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.
+ * `ca_file` / `CONSUL_CACERT` - (Optional) A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.
  * `cert_file` / `CONSUL_CLIENT_CERT` - (Optional) A path to a PEM-encoded certificate provided to the remote agent; requires use of `key_file`.
  * `key_file` / `CONSUL_CLIENT_KEY` - (Optional) A path to a PEM-encoded private key, required if `cert_file` is specified.


### PR DESCRIPTION
The correct environment variable corresponding to the `ca_file` variable is `CONSUL_CACERT` and not `CONSUL_CAFILE`.

See `backend/remote-state/consul/backend.go` line 77.