### PR TITLE
don't allow nil, typed or untyped from get

### DIFF
--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -228,7 +228,7 @@ func (r *ConfigFieldReader) readMap(k string, schema *Schema) (FieldReadResult, 
 		return FieldReadResult{}, nil
 	}
 
-	var value interface{}
+	var value map[string]interface{}
 	if !computed {
 		value = result
 	}

--- a/helper/schema/field_reader_diff.go
+++ b/helper/schema/field_reader_diff.go
@@ -128,7 +128,7 @@ func (r *DiffFieldReader) readMap(
 		return FieldReadResult{}, nil
 	}
 
-	var resultVal interface{}
+	var resultVal map[string]interface{}
 	if resultSet {
 		resultVal = result
 	}

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -438,7 +438,7 @@ func (c *ResourceConfig) get(
 	var current interface{} = raw
 	var previous interface{} = nil
 	for i, part := range parts {
-		if current == nil {
+		if reallyNil(current) {
 			return nil, false
 		}
 
@@ -500,7 +500,25 @@ func (c *ResourceConfig) get(
 		}
 	}
 
+	if reallyNil(current) {
+		return nil, false
+	}
 	return current, true
+}
+
+func reallyNil(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(i)
+	switch v.Kind() {
+	case reflect.Map, reflect.Slice, reflect.Ptr:
+		if v.IsNil() {
+			return true
+		}
+	}
+	return false
 }
 
 // interpolateForce is a temporary thing. We want to get rid of interpolate

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -87,6 +87,28 @@ func TestResourceConfigGet(t *testing.T) {
 
 		{
 			Config: map[string]interface{}{
+				"foo": nil,
+			},
+			Key:   "foo",
+			Value: nil,
+		},
+		{
+			Config: map[string]interface{}{
+				"foo": ([]interface{})(nil),
+			},
+			Key:   "foo",
+			Value: nil,
+		},
+		{
+			Config: map[string]interface{}{
+				"foo": ([]map[string]interface{})(nil),
+			},
+			Key:   "foo",
+			Value: nil,
+		},
+
+		{
+			Config: map[string]interface{}{
 				"foo": "bar",
 			},
 			Key:   "foo",


### PR DESCRIPTION
The ResourceConfig.get method contains typed nils assigned to an
interface, so double check that the interfaces dynamic value is actually
nil before returning. The actual behavior here seem questionable, since
it will return false for values that exist if they are nil, but
ResourceConfig is part of the legacy code used by helper/schema, and the
overall behavior cannot be changed.

Similarly, the schema field readers also hid a typed nil interface in
the readMap methods, which can cause unexpected panics.

Fixes #15442,#19978,#21866