### PR TITLE
Add "leading zeros" for the sake of SEO

### DIFF
--- a/website/docs/configuration/functions/format.html.md
+++ b/website/docs/configuration/functions/format.html.md
@@ -105,7 +105,7 @@ to set additoinal flags:
 | space  | Leave a space where the sign would be if a number is positive. |
 | `+`    | Show the sign of a number even if it is positive.              |
 | `-`    | Pad the width with spaces on the left rather than the right.   |
-| `0`    | Pad the width with zeros rather than spaces.                   |
+| `0`    | Pad the width with leading zeros rather than spaces.           |
 
 By default, `%` sequences consume successive arguments starting with the first.
 Introducing a `[n]` sequence immediately before the verb letter, where `n` is a


### PR DESCRIPTION
The search "terraform leading zero" does not find the `format()`
function, which is perfectly capable of adding leading zeros.
Thus I have added this one word to help people find `format()`.

I tried using "%-03" and "%0-3" and found that '-' overrides '0',
always padding with trailing _spaces_. Therefore there is no
need to mention trailing zeros. 