### PR TITLE
add versioning / snapshot for azure backend state file

### DIFF
--- a/backend/remote-state/azure/backend.go
+++ b/backend/remote-state/azure/backend.go
@@ -51,6 +51,13 @@ func New() backend.Backend {
 				DefaultFunc: schema.EnvDefaultFunc("ARM_SAS_TOKEN", ""),
 			},
 
+			"versioning": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Enable/Disable automatic blob snapshotting",
+				DefaultFunc: schema.EnvDefaultFunc("ARM_VERSIONING", false),
+			},
+
 			"resource_group_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -149,6 +156,7 @@ type Backend struct {
 	armClient     *ArmClient
 	containerName string
 	keyName       string
+	versioning    bool
 }
 
 type BackendConfig struct {
@@ -178,6 +186,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	data := schema.FromContextBackendConfig(ctx)
 	b.containerName = data.Get("container_name").(string)
 	b.keyName = data.Get("key").(string)
+	b.versioning = data.Get("versioning").(bool)
 
 	// support for previously deprecated fields
 	clientId := valueFromDeprecatedField(data, "client_id", "arm_client_id")

--- a/backend/remote-state/azure/backend_state.go
+++ b/backend/remote-state/azure/backend_state.go
@@ -86,6 +86,7 @@ func (b *Backend) StateMgr(name string) (state.State, error) {
 	client := &RemoteClient{
 		blobClient:    *blobClient,
 		containerName: b.containerName,
+		versioning:    b.versioning,
 		keyName:       b.path(name),
 	}
 

--- a/backend/remote-state/azure/backend_test.go
+++ b/backend/remote-state/azure/backend_test.go
@@ -21,6 +21,7 @@ func TestBackendConfig(t *testing.T) {
 		"storage_account_name": "tfaccount",
 		"container_name":       "tfcontainer",
 		"key":                  "state",
+		"versioning":           false,
 		// Access Key must be Base64
 		"access_key": "QUNDRVNTX0tFWQ0K",
 	}
@@ -32,6 +33,9 @@ func TestBackendConfig(t *testing.T) {
 	}
 	if b.keyName != "state" {
 		t.Fatalf("Incorrect keyName was populated")
+	}
+	if b.versioning != false {
+		t.Fatalf("Incorrect versioning was populated")
 	}
 }
 
@@ -52,6 +56,7 @@ func TestBackendAccessKeyBasic(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
+		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
@@ -77,6 +82,7 @@ func TestBackendManagedServiceIdentityBasic(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
+		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"resource_group_name":  res.resourceGroup,
 		"use_msi":              true,
@@ -110,6 +116,7 @@ func TestBackendSASTokenBasic(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
+		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"sas_token":            *sasToken,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
@@ -135,6 +142,7 @@ func TestBackendServicePrincipalBasic(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
+		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"resource_group_name":  res.resourceGroup,
 		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
@@ -171,6 +179,7 @@ func TestBackendServicePrincipalCustomEndpoint(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
+		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"resource_group_name":  res.resourceGroup,
 		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
@@ -200,6 +209,7 @@ func TestBackendAccessKeyLocked(t *testing.T) {
 	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
+		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
@@ -209,6 +219,7 @@ func TestBackendAccessKeyLocked(t *testing.T) {
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
+		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
@@ -235,6 +246,7 @@ func TestBackendServicePrincipalLocked(t *testing.T) {
 	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
+		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
@@ -248,6 +260,7 @@ func TestBackendServicePrincipalLocked(t *testing.T) {
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
+		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),

--- a/backend/remote-state/azure/backend_test.go
+++ b/backend/remote-state/azure/backend_test.go
@@ -56,7 +56,6 @@ func TestBackendAccessKeyBasic(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
-		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
@@ -82,7 +81,6 @@ func TestBackendManagedServiceIdentityBasic(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
-		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"resource_group_name":  res.resourceGroup,
 		"use_msi":              true,
@@ -116,7 +114,6 @@ func TestBackendSASTokenBasic(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
-		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"sas_token":            *sasToken,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
@@ -142,7 +139,6 @@ func TestBackendServicePrincipalBasic(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
-		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"resource_group_name":  res.resourceGroup,
 		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
@@ -179,7 +175,6 @@ func TestBackendServicePrincipalCustomEndpoint(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
-		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"resource_group_name":  res.resourceGroup,
 		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
@@ -209,7 +204,6 @@ func TestBackendAccessKeyLocked(t *testing.T) {
 	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
-		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
@@ -219,7 +213,6 @@ func TestBackendAccessKeyLocked(t *testing.T) {
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
-		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"environment":          os.Getenv("ARM_ENVIRONMENT"),
@@ -246,7 +239,6 @@ func TestBackendServicePrincipalLocked(t *testing.T) {
 	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
-		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
@@ -260,7 +252,6 @@ func TestBackendServicePrincipalLocked(t *testing.T) {
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
-		"versioning":           res.storageVersioning,
 		"key":                  res.storageKeyName,
 		"access_key":           res.storageAccountAccessKey,
 		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),

--- a/backend/remote-state/azure/client.go
+++ b/backend/remote-state/azure/client.go
@@ -27,6 +27,7 @@ type RemoteClient struct {
 	containerName string
 	keyName       string
 	leaseID       string
+	versioning    bool
 }
 
 func (c *RemoteClient) Get() (*remote.Payload, error) {
@@ -74,6 +75,10 @@ func (c *RemoteClient) Put(data []byte) error {
 
 	containerReference := c.blobClient.GetContainerReference(c.containerName)
 	blobReference := containerReference.GetBlobReference(c.keyName)
+
+	if c.versioning {
+		blobReference.CreateSnapshot(nil)
+	}
 
 	blobReference.Properties.ContentType = "application/json"
 	blobReference.Properties.ContentLength = int64(len(data))

--- a/website/docs/backends/types/azurerm.html.md
+++ b/website/docs/backends/types/azurerm.html.md
@@ -153,6 +153,8 @@ The following configuration options are supported:
 
 * `environment` - (Optional) The Azure Environment which should be used. This can also be sourced from the `ARM_ENVIRONMENT` environment variable. Possible values are `public`, `china`, `german`, `stack` and `usgovernment`. Defaults to `public`.
 
+* `versioning` - (Optional) Should versioning for state file be used - default `false`.
+
 * `endpoint` - (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the `ARM_ENDPOINT` environment variable.
 
 ~> **NOTE:** An `endpoint` should only be configured when using Azure Stack.


### PR DESCRIPTION
Based on @pmarques [PR](https://github.com/hashicorp/terraform/pull/18512)
I've used it and it's a life saver.

Somehow I had an issue where helm_release disappeared ... there is no import yet ...
Snapshot of the remote state file would have been great last night :)