### PR TITLE
Correct identifier validation error message

### DIFF
--- a/configs/named_values.go
+++ b/configs/named_values.go
@@ -14,7 +14,7 @@ import (
 )
 
 // A consistent detail message for all "not a valid identifier" diagnostics.
-const badIdentifierDetail = "A name must start with a letter and may contain only letters, digits, underscores, and dashes."
+const badIdentifierDetail = "A name must start with a letter or underscore and may contain only letters, digits, underscores, and dashes."
 
 // Variable represents a "variable" block in a module or file.
 type Variable struct {


### PR DESCRIPTION
The error message when an identifier begins with a digit or other invalid first character says that identifiers must start with a letter. However, underscores are also acceptable, as stated in the docs:

https://github.com/hashicorp/terraform/blob/6eb40f846b5984ea64339c30e934f87952db1835/website/docs/configuration/resources.html.md#L49-L50

This PR fixes the error message.