### PR TITLE
Fix expected output of statefile roundtrip tests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31 // indirect
 	github.com/dylanmei/iso8601 v0.1.0 // indirect
 	github.com/dylanmei/winrmtest v0.0.0-20190225150635-99b7fe2fddf1
-	github.com/go-test/deep v1.0.1
+	github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31
 	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 // indirect
 	github.com/golang/mock v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31 h1:28FVBuwkwowZMjbA7M0wXsI6t3PYulRTMio3SO+eKCM=
+github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/states/statefile/testdata/roundtrip/v1-simple.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v1-simple.out.tfstate
@@ -49,7 +49,7 @@
                     "attributes_flat": {
                         "id": "3214385801340650197",
                         "triggers.%": "1",
-                        "triggers.what": "0"
+                        "triggers.what": "1"
                     }
                 }
             ]

--- a/states/statefile/testdata/roundtrip/v3-bigint.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-bigint.out.tfstate
@@ -42,9 +42,9 @@
                 },
                 {
                     "attributes_flat": {
-                        "id": "604776346677326098",
+                        "id": "4776432143683449212",
                         "triggers.%": "1",
-                        "triggers.index": "0"
+                        "triggers.index": "1"
                     },
                     "depends_on": ["null_resource.baz"],
                     "index_key": 1,

--- a/states/statefile/testdata/roundtrip/v3-grabbag.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-grabbag.out.tfstate
@@ -42,9 +42,9 @@
                 },
                 {
                     "attributes_flat": {
-                        "id": "604776346677326098",
+                        "id": "4776432143683449212",
                         "triggers.%": "1",
-                        "triggers.index": "0"
+                        "triggers.index": "1"
                     },
                     "depends_on": ["null_resource.baz"],
                     "index_key": 1,

--- a/states/statefile/testdata/roundtrip/v3-simple.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-simple.out.tfstate
@@ -53,7 +53,7 @@
                     "attributes_flat": {
                         "id": "1523897709610803586",
                         "triggers.%": "1",
-                        "triggers.what": "0"
+                        "triggers.what": "1"
                     }
                 }
             ]

--- a/vendor/github.com/go-test/deep/.travis.yml
+++ b/vendor/github.com/go-test/deep/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 
 go:
-  - 1.7
-  - 1.8
-  - 1.9
+  - "1.9"
+  - "1.10"
+  - "1.11"
 
 before_install:
   - go get github.com/mattn/goveralls

--- a/vendor/github.com/go-test/deep/deep.go
+++ b/vendor/github.com/go-test/deep/deep.go
@@ -19,8 +19,9 @@ var (
 	// MaxDiff specifies the maximum number of differences to return.
 	MaxDiff = 10
 
-	// MaxDepth specifies the maximum levels of a struct to recurse into.
-	MaxDepth = 10
+	// MaxDepth specifies the maximum levels of a struct to recurse into,
+	// if greater than zero. If zero, there is no limit.
+	MaxDepth = 0
 
 	// LogErrors causes errors to be logged to STDERR when true.
 	LogErrors = false
@@ -50,8 +51,9 @@ type cmp struct {
 var errorType = reflect.TypeOf((*error)(nil)).Elem()
 
 // Equal compares variables a and b, recursing into their structure up to
-// MaxDepth levels deep, and returns a list of differences, or nil if there are
-// none. Some differences may not be found if an error is also returned.
+// MaxDepth levels deep (if greater than zero), and returns a list of differences,
+// or nil if there are none. Some differences may not be found if an error is
+// also returned.
 //
 // If a type has an Equal method, like time.Equal, it is called to check for
 // equality.
@@ -66,7 +68,7 @@ func Equal(a, b interface{}) []string {
 	if a == nil && b == nil {
 		return nil
 	} else if a == nil && b != nil {
-		c.saveDiff(b, "<nil pointer>")
+		c.saveDiff("<nil pointer>", b)
 	} else if a != nil && b == nil {
 		c.saveDiff(a, "<nil pointer>")
 	}
@@ -82,7 +84,7 @@ func Equal(a, b interface{}) []string {
 }
 
 func (c *cmp) equals(a, b reflect.Value, level int) {
-	if level > MaxDepth {
+	if MaxDepth > 0 && level > MaxDepth {
 		logError(ErrMaxRecursion)
 		return
 	}
@@ -140,16 +142,6 @@ func (c *cmp) equals(a, b reflect.Value, level int) {
 		return
 	}
 
-	// Types with an Equal(), like time.Time.
-	eqFunc := a.MethodByName("Equal")
-	if eqFunc.IsValid() {
-		retVals := eqFunc.Call([]reflect.Value{b})
-		if !retVals[0].Bool() {
-			c.saveDiff(a, b)
-		}
-		return
-	}
-
 	switch aKind {
 
 	/////////////////////////////////////////////////////////////////////
@@ -167,6 +159,29 @@ func (c *cmp) equals(a, b reflect.Value, level int) {
 
 			Iterate through the fields (FirstName, LastName), recurse into their values.
 		*/
+
+		// Types with an Equal() method, like time.Time, only if struct field
+		// is exported (CanInterface)
+		if eqFunc := a.MethodByName("Equal"); eqFunc.IsValid() && eqFunc.CanInterface() {
+			// Handle https://github.com/go-test/deep/issues/15:
+			// Don't call T.Equal if the method is from an embedded struct, like:
+			//   type Foo struct { time.Time }
+			// First, we'll encounter Equal(Ttime, time.Time) but if we pass b
+			// as the 2nd arg we'll panic: "Call using pkg.Foo as type time.Time"
+			// As far as I can tell, there's no way to see that the method is from
+			// time.Time not Foo. So we check the type of the 1st (0) arg and skip
+			// unless it's b type. Later, we'll encounter the time.Time anonymous/
+			// embedded field and then we'll have Equal(time.Time, time.Time).
+			funcType := eqFunc.Type()
+			if funcType.NumIn() == 1 && funcType.In(0) == bType {
+				retVals := eqFunc.Call([]reflect.Value{b})
+				if !retVals[0].Bool() {
+					c.saveDiff(a, b)
+				}
+				return
+			}
+		}
+
 		for i := 0; i < a.NumField(); i++ {
 			if aType.Field(i).PkgPath != "" && !CompareUnexportedFields {
 				continue // skip unexported field, e.g. s in type T struct {s string}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -156,7 +156,7 @@ github.com/dylanmei/iso8601
 github.com/dylanmei/winrmtest
 # github.com/fatih/color v1.7.0
 github.com/fatih/color
-# github.com/go-test/deep v1.0.1
+# github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31
 github.com/go-test/deep
 # github.com/gogo/protobuf v1.2.0
 github.com/gogo/protobuf/gogoproto


### PR DESCRIPTION
The vendored version of github.com/go-test/deep has a default recursion limit
of 10, cf. https://github.com/go-test/deep/issues/21, which is too low to catch
a diff between the actual and expected output.

Instead of setting deep.MaxDepth = 100 (or any other arbitrary value >= 12),
I think it's better to update to a newer version of github.com/go-test/deep,
which has no recursion limit by default, cf.
https://github.com/go-test/deep/commit/317d539aaa0b1ef900853c9537efa29491696e99.

I've adjusted the expected test output accordingly.