### PR TITLE
readme : remove references to vagrant file

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -22,24 +22,11 @@ The guide below outlines the steps HashiCorp takes to build the official release
 binaries for Terraform. This process will generate a set of binaries for each supported
 platform, using the [gox](https://github.com/mitchellh/gox) tool.
 
-A Vagrant virtual machine is used to provide a consistent environment with
-the pre-requisite tools in place. The specifics of this VM are defined in the 
-[Vagrantfile](Vagrantfile).
-
 
 ```sh
 # clone the repository if needed
 git clone https://github.com/hashicorp/terraform.git
 cd terraform
-
-# Spin up a fresh build VM
-vagrant destroy -f
-vagrant up
-vagrant ssh
-
-# The Vagrantfile installs Go and configures the $GOPATH at /opt/gopath
-# The current "terraform" directory is then sync'd into the gopath
-cd /opt/gopath/src/github.com/hashicorp/terraform/
 
 # Verify unit tests pass
 make test

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All documentation is available on the [Terraform website](http://www.terraform.i
 Developing Terraform
 --------------------
 
-If you wish to work on Terraform itself or any of its built-in providers, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). Alternatively, you can use the Vagrantfile in the root of this repo to stand up a virtual machine with the appropriate dev tooling already set up for you.
+If you wish to work on Terraform itself or any of its built-in providers, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*).
 
 This repository contains only Terraform core, which includes the command line interface and the main graph engine. Providers are implemented as plugins that each have their own repository in [the `terraform-providers` organization](https://github.com/terraform-providers) on GitHub. Instructions for developing each provider are in the associated README file. For more information, see [the provider development overview](https://www.terraform.io/docs/plugins/provider.html).
 


### PR DESCRIPTION
* Remove references to vagrant file as it is no longer is used in building 