### PR TITLE
Fixes #21907

### DIFF
--- a/command/format/plan.go
+++ b/command/format/plan.go
@@ -83,6 +83,10 @@ func NewPlan(changes *plans.Changes) *Plan {
 			continue
 		}
 
+		if rc.Action == plans.NoOp {
+			continue
+		}
+
 		// For now we'll shim this to work with our old types.
 		// TODO: Update for the new plan types, ideally also switching over to
 		// a structural diff renderer instead of a flat renderer.


### PR DESCRIPTION
Don't show no-ops in `terraform show`, since it's not something that will change any state.