### PR TITLE
[WIP] #15389 use xdg basedir spec

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -25,7 +25,7 @@ func runCheckpoint(c *Config) {
 		return
 	}
 
-	configDir, err := ConfigDir()
+	cacheDir, err := CacheDir()
 	if err != nil {
 		log.Printf("[ERR] Checkpoint setup error: %s", err)
 		checkpointResult <- nil
@@ -37,7 +37,7 @@ func runCheckpoint(c *Config) {
 		version += fmt.Sprintf("-%s", VersionPrerelease)
 	}
 
-	signaturePath := filepath.Join(configDir, "checkpoint_signature")
+	signaturePath := filepath.Join(cacheDir, "checkpoint_signature")
 	if c.DisableCheckpointSignature {
 		log.Printf("[INFO] Checkpoint signature disabled")
 		signaturePath = ""
@@ -47,7 +47,7 @@ func runCheckpoint(c *Config) {
 		Product:       "terraform",
 		Version:       version,
 		SignatureFile: signaturePath,
-		CacheFile:     filepath.Join(configDir, "checkpoint_cache"),
+		CacheFile:     filepath.Join(cacheDir, "checkpoint_cache"),
 	})
 	if err != nil {
 		log.Printf("[ERR] Checkpoint error: %s", err)

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -27,7 +27,8 @@ func runCheckpoint(c *Config) {
 
 	cacheDir, err := CacheDir()
 	if err != nil {
-		log.Printf("[ERR] Checkpoint setup error: %s", err)
+		log.Printf("[ERROR] Error finding global cache directory: %s", err)
+		log.Printf("[ERROR] Checkpoint setup error")
 		checkpointResult <- nil
 		return
 	}
@@ -50,7 +51,7 @@ func runCheckpoint(c *Config) {
 		CacheFile:     filepath.Join(cacheDir, "checkpoint_cache"),
 	})
 	if err != nil {
-		log.Printf("[ERR] Checkpoint error: %s", err)
+		log.Printf("[ERROR] Checkpoint error: %s", err)
 		resp = nil
 	}
 

--- a/command/cliconfig/cliconfig.go
+++ b/command/cliconfig/cliconfig.go
@@ -75,6 +75,11 @@ func ConfigDir() (string, error) {
 	return configDir()
 }
 
+// CacheDir returns the cache directory for Terraform.
+func CacheDir() (string, error) {
+	return cacheDir()
+}
+
 // LoadConfig reads the CLI configuration from the various filesystem locations
 // and from the environment, returning a merged configuration along with any
 // diagnostics (errors and warnings) encountered along the way.

--- a/command/cliconfig/config_unix.go
+++ b/command/cliconfig/config_unix.go
@@ -32,9 +32,12 @@ func configFile() (string, error) {
 }
 
 func configDir() (string, error) {
+	log.Printf("[DEBUG] Getting config dir")
+
 	// First prefer the XDG_CONFIG_HOME environmental variable
 	configDirPath := os.Getenv("XDG_CONFIG_HOME")
 	if configDirPath != "" {
+		log.Printf("[DEBUG] Prefering XDG_CONFIG_HOME env variable")
 		return filepath.Join(configDirPath, "terraform"), nil
 	}
 
@@ -51,6 +54,7 @@ func configDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	log.Printf("[DEBUG] Falling back to XDG_CONFIG_HOME standard location $HOME/.config")
 	return filepath.Join(home, ".config", "terraform"), nil
 
 }
@@ -65,9 +69,12 @@ func legacyConfigDir() (string, error) {
 }
 
 func cacheDir() (string, error) {
+	log.Printf("[DEBUG] Getting cache dir")
+
 	// First prefer the XDG_CACHE_HOME environmental variable
 	cacheDirPath := os.Getenv("XDG_CACHE_HOME")
 	if cacheDirPath != "" {
+		log.Printf("[DEBUG] Prefering XDG_CACHE_HOME env variable")
 		return filepath.Join(cacheDirPath, "terraform"), nil
 	}
 
@@ -75,6 +82,7 @@ func cacheDir() (string, error) {
 	cacheDirPath, err := legacyConfigDir()
 	if err == nil {
 		if _, err := os.Stat(cacheDirPath); !os.IsNotExist(err) {
+			log.Printf("[DEBUG] Found .terraform.d directory in legacy location, continuing")
 			return cacheDirPath, nil
 		}
 	}
@@ -83,6 +91,7 @@ func cacheDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	log.Printf("[DEBUG] Falling back to XDG_CACHE_HOME standard location $HOME/.cache")
 	return filepath.Join(home, ".cache", "terraform"), nil
 }
 

--- a/command/cliconfig/config_unix.go
+++ b/command/cliconfig/config_unix.go
@@ -23,12 +23,19 @@ func configFile() (string, error) {
 		return file, nil
 	}
 
-	// else use configDir()'s result /.terraformrc
+	// else use configDir()'s result and attach terraformrc
 	dir, err := configDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, ".terraformrc"), nil
+
+	// With the legacy dir still keep the dot infront of terraformrc
+	legacyDir, err := legacyConfigDir()
+	if dir == legacyDir {
+		return filepath.Join(dir, ".terraformrc"), nil
+	}
+
+	return filepath.Join(dir, "terraformrc"), nil
 }
 
 func configDir() (string, error) {

--- a/command/cliconfig/config_unix.go
+++ b/command/cliconfig/config_unix.go
@@ -64,6 +64,28 @@ func legacyConfigDir() (string, error) {
 	return filepath.Join(home, ".terraform.d"), nil
 }
 
+func cacheDir() (string, error) {
+	// First prefer the XDG_CACHE_HOME environmental variable
+	cacheDirPath := os.Getenv("XDG_CACHE_HOME")
+	if cacheDirPath != "" {
+		return filepath.Join(cacheDirPath, "terraform"), nil
+	}
+
+	// If legacy ~/.terraform.d dir exists already, prefer that
+	cacheDirPath, err := legacyConfigDir()
+	if err == nil {
+		if _, err := os.Stat(cacheDirPath); !os.IsNotExist(err) {
+			return cacheDirPath, nil
+		}
+	}
+	// Else fall back to XDG_CACHE_HOME's standard location $HOME/.cache
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cache", "terraform"), nil
+}
+
 func homeDir() (string, error) {
 	// First prefer the HOME environmental variable
 	if home := os.Getenv("HOME"); home != "" {

--- a/command/cliconfig/config_windows.go
+++ b/command/cliconfig/config_windows.go
@@ -36,6 +36,10 @@ func configDir() (string, error) {
 	return filepath.Join(dir, "terraform.d"), nil
 }
 
+func cacheDir() (string, error) {
+	return configDir()
+}
+
 func homeDir() (string, error) {
 	b := make([]uint16, syscall.MAX_PATH)
 

--- a/config.go
+++ b/config.go
@@ -46,6 +46,11 @@ func ConfigDir() (string, error) {
 	return cliconfig.ConfigDir()
 }
 
+// CacheDir returns the cache directory for Terraform.
+func CacheDir() (string, error) {
+	return cliconfig.CacheDir()
+}
+
 // LoadConfig reads the CLI configuration from the various filesystem locations
 // and from the environment, returning a merged configuration along with any
 // diagnostics (errors and warnings) encountered along the way.

--- a/plugins.go
+++ b/plugins.go
@@ -15,14 +15,15 @@ import (
 // older versions where both satisfy the provider version constraints.
 func globalPluginDirs() []string {
 	var ret []string
-	// Look in ~/.terraform.d/plugins/ , or its equivalent on non-UNIX
-	dir, err := ConfigDir()
+	// Look in legacy ~/.terraform.d/plugins/ if it exists or
+	// $XDG_CACHE_HOME/terraform/plugins , or its equivalent on non-UNIX
+	cacheDir, err := CacheDir()
 	if err != nil {
-		log.Printf("[ERROR] Error finding global config directory: %s", err)
+		log.Printf("[ERROR] Error finding global cache directory: %s", err)
 	} else {
 		machineDir := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
-		ret = append(ret, filepath.Join(dir, "plugins"))
-		ret = append(ret, filepath.Join(dir, "plugins", machineDir))
+		ret = append(ret, filepath.Join(cacheDir, "plugins"))
+		ret = append(ret, filepath.Join(cacheDir, "plugins", machineDir))
 	}
 
 	return ret


### PR DESCRIPTION
This PR aims to resolve #15389 

This is my first PR to terraform, I've had a good read through the `README.md` and `CONTRIBUTING.md` but if I've missed anything please shout.
Also I haven't written too much golang so any and all feedback/criticism is welcome, please feel free to be picky/strict

*Note:* Bellow I will explain the flow of priorities for env variables and directory defaults etc. I'm generally happy with it, but I'm also not against swapping the `XDG_...` env variables to have less priority than the "legacy" locations, as some people may have `XDG_` env variables defined but still expect it to use their current `.terraform.d` `.terraformrc` files.

---

The existing flow for `cliConfigFile()` is:
`TF_CLI_CONFIG_FILE` then `TERRAFORM_CONFIG` then `ConfigFile()` where `ConfigFile()` results in `~/.terraformrc`

Now it is `TF_CLI_CONFIG_FILE` then `TERRAFORM_CONFIG` then `ConfigFile()` where `ConfigFile()` results in `~/.terraformrc` if it already exists but will use `$XDG_CONFIG_HOME/terraform/.terraformrc` or `~/config/terraform/.terraformrc` if it doesn't.
(I can change it to `~/config/terraform/` for `ConfigDir()` and `~/config/.terraformrc` for `ConfigFile()` if this may cause issues with some of the stuff around line 162 of `config.go`)
This allows for all previous setups to work just fine but default to XDG going forward (Although see the note in the first section). `~/.terraform.d` can also gradually be fazed out if we want.

---

The existing flow for `ConfigDir()` is:
Just results `~/.terraform.d/`

Now it is `~/.terraform.d/` if it already exists but will use `$XDG_CONFIG_HOME/terraform/` or `~/config/terraform/` if it doesn't.
(I can change it to `~/config/terraform/` for `ConfigDir()` and `~/config/.terraformrc` for `ConfigFile()` if this may cause issues with some of the stuff around line 162 of `config.go`)
This allows for all previous setups to work just fine going but default to XDG going forward (Although see the note in the first section). `~/.terraform.d` can also gradually be fazed out if we want.

---

`runCheckpoint()` uses currently uses `ConfigFile()` for `checkpoint_cache` & `checkpoint_signature` but it should be outputting to `XDG_CACHE_HOME`
As far as I can tell they're completely safe to delete with one being called `cache` and the other saying within the file "you can delete this file at any time". If `checkpoint_signature` should be put in `XDG_DATA_HOME` instead please let me know.

---

One case where these changes may cause issues is scripts that utilize terraform and allow it to create a `~/terraform.d` directory, then mess with it or whatever (e.g. maybe installing a plugin then the script doing something with `~/.terraform.d/plugins/PLUGIN-NAME-HERE` or any of the checkpoint files: `checkpoint_cache` & `checkpoint_signature`)

---

Along the way there was quite a bit of mess. As far as I can tell `.terraform.d` was called a config dir but it didn't actually hold any config, `~/.terraformrc` was the actual config file and only form of config.
Also there is XDG standard use in `install.go` for `fishConfigDir()`.

---

Still TODO:

* [ ] Update Docs references to `~/.terraform.d` including `PLUGIN_CACHE_DIR` config examples
* [ ] More thorough manual testing
* [ ] Probably write some extra tests
* [ ] Double check this doesn't break Windows