### PR TITLE
consistency in destroy message when coming from tf cli

### DIFF
--- a/backend/remote/backend_plan.go
+++ b/backend/remote/backend_plan.go
@@ -198,6 +198,12 @@ func (b *Remote) plan(stopCtx, cancelCtx context.Context, op *backend.Operation,
 		ConfigurationVersion: cv,
 		Workspace:            w,
 	}
+	
+	//Incident 16886: similar message (as TFE) when destroy is done via CLI
+	if *tfe.Bool(op.Destroy) {
+		rco := &runOptions
+		rco.Message = tfe.String("Queued manually using Terraform to destroy infrastructure")
+	}
 
 	r, err := b.client.Runs.Create(stopCtx, runOptions)
 	if err != nil {


### PR DESCRIPTION
This is for greater clarity - a destroy coming from the CLI via remote backend should show the same/similar output as a destroy done manually within TFE.