### PR TITLE
Terraform Plan CLI Vars Format

### DIFF
--- a/website/docs/commands/plan.html.markdown
+++ b/website/docs/commands/plan.html.markdown
@@ -72,7 +72,7 @@ The command-line flags are all optional. The list of available flags are:
   Address](/docs/internals/resource-addressing.html) to target. This flag can
   be used multiple times. See below for more information.
 
-* `-var='foo=bar'` - Set a variable in the Terraform configuration. This flag
+* `-var=foo=bar` - Set a variable in the Terraform configuration. This flag
   can be set multiple times. Variable values are interpreted as
   [HCL](/docs/configuration/syntax.html#HCL), so list and map values can be
   specified via this flag.

--- a/website/docs/commands/plan.html.markdown
+++ b/website/docs/commands/plan.html.markdown
@@ -72,7 +72,7 @@ The command-line flags are all optional. The list of available flags are:
   Address](/docs/internals/resource-addressing.html) to target. This flag can
   be used multiple times. See below for more information.
 
-* `-var 'foo=bar'` - Set a variable in the Terraform configuration. This flag
+* `-var='foo=bar'` - Set a variable in the Terraform configuration. This flag
   can be set multiple times. Variable values are interpreted as
   [HCL](/docs/configuration/syntax.html#HCL), so list and map values can be
   specified via this flag.


### PR DESCRIPTION
Ran into an issue requiring `-var=foo=bar` over `-var 'foo=bar'`.  

Without the `=` the generic response came back:

```
Usage: terraform plan [options] [DIR]

Generates an execution plan for Terraform.

 This execution plan can be reviewed...
```

Terraform `0.12.2`