### PR TITLE
Fix typo in Arithmetic Operators section

### DIFF
--- a/website/docs/configuration/expressions.html.md
+++ b/website/docs/configuration/expressions.html.md
@@ -382,7 +382,7 @@ as results:
 
 * `a + b` returns the result of adding `a` and `b` together.
 * `a - b` returns the result of subtracting `b` from `a`.
-* `a * b` returns the result of multiplying `b` and `b`.
+* `a * b` returns the result of multiplying `a` and `b`.
 * `a / b` returns the result of dividing `a` by `b`.
 * `a % b` returns the remainder of dividing `a` by `b`. This operator is
   generally useful only when used with whole numbers.


### PR DESCRIPTION
It looks like there was a typo in the **Arithmetic Operators** section, this PR just fixes that :)