### PR TITLE
Fix for crash #21896

### DIFF
--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -696,7 +696,7 @@ func (d *evaluationStateData) getResourceInstancesAll(addr addrs.Resource, rng t
 			ty := schema.ImpliedType()
 			key := addrs.IntKey(i)
 			is, exists := rs.Instances[key]
-			if exists {
+			if exists && is.Current != nil {
 				instAddr := addr.Instance(key).Absolute(d.ModulePath)
 
 				// Prefer pending value in plan if present. See getResourceInstanceSingle


### PR DESCRIPTION
Fix for a crash during terraform plan: If there is a multi-instance
resource (count > 1) where one of the instances was deleted in the
deployment but was still present in the terraform state,
getResourceInstancesAll crashed.

Check not only for rs.Instances[key] to exist, but also to have a
valid Current pointer.