### PR TITLE
[Website] Add Signalfx provider links

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -108,6 +108,7 @@ down to see all providers.
 - [RunScope](/docs/providers/runscope/index.html)
 - [Scaleway](/docs/providers/scaleway/index.html)
 - [Selectel](/docs/providers/selectel/index.html)
+- [SignalFX](/docs/providers/signalfx/index.html)
 - [Skytap](/docs/providers/skytap/index.html)
 - [SoftLayer](/docs/providers/softlayer/index.html)
 - [Spotinst](/docs/providers/spotinst/index.html)

--- a/website/docs/providers/type/monitor-index.html.markdown
+++ b/website/docs/providers/type/monitor-index.html.markdown
@@ -31,4 +31,5 @@ HashiCorp, and are tested by HashiCorp.
 - [OpsGenie](/docs/providers/opsgenie/index.html)
 - [PagerDuty](/docs/providers/pagerduty/index.html)
 - [Runscope](/docs/providers/runscope/index.html)
+- [SignalFX)(/docs/providers/signalfx/index.html)
 - [StatusCake](/docs/providers/statuscake/index.html)


### PR DESCRIPTION
SignalFX provider has complete the TPDP, this PR will add the links pointing to the SignalFX provider docs. 