### PR TITLE
Added regex details to replace() docs

### DIFF
--- a/website/docs/configuration/functions/replace.html.md
+++ b/website/docs/configuration/functions/replace.html.md
@@ -20,9 +20,19 @@ each occurrence with a given replacement string.
 replace(string, substring, replacement)
 ```
 
+If `substring` is wrapped in forward slashes, it is treated as a regular
+expression; the syntax conforms to the [re2 regular expression
+syntax](https://github.com/google/re2/wiki/Syntax) syntax. If using a regular
+expression for the substring argument, the `replacement` string can incorporate
+captured strings from the input by using an `$n` sequence, where `n` is the
+index or name of a capture group.
+
 ## Examples
 
 ```
 > replace("1 + 2 + 3", "+", "-")
 1 - 2 - 3
+
+> replace("hello world", "/w.*d/", "everybody")
+hello everybody
 ```


### PR DESCRIPTION
Noted that the helpful details around regular expressions in `replace()` that are in the 0.11 documentation aren't present in the 0.12 documentation.