### PR TITLE
Allow null values in Compact function

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -246,7 +246,7 @@ var CompactFunc = function.New(&function.Spec{
 
 		for it := listVal.ElementIterator(); it.Next(); {
 			_, v := it.Element()
-			if v.AsString() == "" {
+			if v.IsNull() || v.AsString() == "" {
 				continue
 			}
 			outputList = append(outputList, v)

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -572,6 +572,7 @@ func TestCompact(t *testing.T) {
 				cty.StringVal("test"),
 				cty.StringVal(""),
 				cty.StringVal("test"),
+				cty.NullVal(cty.String),
 			}),
 			cty.ListVal([]cty.Value{
 				cty.StringVal("test"),
@@ -584,6 +585,14 @@ func TestCompact(t *testing.T) {
 				cty.StringVal(""),
 				cty.StringVal(""),
 				cty.StringVal(""),
+			}),
+			cty.ListValEmpty(cty.String),
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{
+				cty.NullVal(cty.String),
+				cty.NullVal(cty.String),
 			}),
 			cty.ListValEmpty(cty.String),
 			false,
@@ -610,6 +619,7 @@ func TestCompact(t *testing.T) {
 				cty.StringVal("test"),
 				cty.UnknownVal(cty.String),
 				cty.StringVal(""),
+				cty.NullVal(cty.String),
 			}),
 			cty.UnknownVal(cty.List(cty.String)),
 			false,


### PR DESCRIPTION
The function would previously panic when one or more null values were among the arguments.

The new behavior treats nulls as empty strings, therefore, it removes them.

Closes https://github.com/hashicorp/terraform/issues/22026.