### PR TITLE
Update the gcs backend docs' remote state example

### DIFF
--- a/website/docs/backends/types/gcs.html.md
+++ b/website/docs/backends/types/gcs.html.md
@@ -43,7 +43,7 @@ resource "template_file" "bar" {
   template = "${greeting}"
 
   vars {
-    greeting = "${data.terraform_remote_state.foo.greeting}"
+    greeting = "${data.terraform_remote_state.foo.outputs.greeting}"
   }
 }
 ```


### PR DESCRIPTION
As of Terraform 0.12 remote state outputs reside in the `outputs` object.