### PR TITLE
backend/remote: notify users when uploading something other than cwd

### DIFF
--- a/backend/remote/backend_plan.go
+++ b/backend/remote/backend_plan.go
@@ -152,6 +152,25 @@ func (b *Remote) plan(stopCtx, cancelCtx context.Context, op *backend.Operation,
 			filepath.Clean(configDir),
 			filepath.Clean(w.WorkingDirectory),
 		))
+
+		// If the workspace has a subdirectory as its working directory then
+		// our configDir will be some parent directory of the current working
+		// directory. Users are likely to find that surprising, so we'll
+		// produce an explicit message about it to be transparent about what
+		// we are doing and why.
+		if w.WorkingDirectory != "" && filepath.Base(configDir) != w.WorkingDirectory {
+			if b.CLI != nil {
+				b.CLI.Output(fmt.Sprintf(strings.TrimSpace(`
+The remote workspace is configured to work with configuration at
+%s relative to the target repository.
+
+Therefore Terraform will upload the full contents of the following directory
+to capture the filesystem context the remote workspace expects:
+    %s
+`), w.WorkingDirectory, configDir) + "\n")
+			}
+		}
+
 	} else {
 		// We did a check earlier to make sure we either have a config dir,
 		// or the plan is run with -destroy. So this else clause will only

--- a/backend/remote/backend_plan_test.go
+++ b/backend/remote/backend_plan_test.go
@@ -647,6 +647,9 @@ func TestRemote_planWithWorkingDirectory(t *testing.T) {
 	}
 
 	output := b.CLI.(*cli.MockUi).OutputWriter.String()
+	if !strings.Contains(output, "The remote workspace is configured to work with configuration") {
+		t.Fatalf("expected working directory warning: %s", output)
+	}
 	if !strings.Contains(output, "Running plan in the remote backend") {
 		t.Fatalf("expected remote backend header in output: %s", output)
 	}


### PR DESCRIPTION
When a TFC workspace is configured with a working directory (and not with a VCS root), and a user is running `terraform init` locally from that same directory, TFC uploads the
entire configuration directory, not only the user's cwd. This is not
obvious to the user, so we are adding a descriptive message explaining
what is being uploaded, and why.

No VCS root, WD configured, init from directory other than VCS root:
 
<img width="550" alt="Screen Shot 2019-07-18 at 10 18 03 AM" src="https://user-images.githubusercontent.com/6210214/61465746-aefafd00-a946-11e9-9b63-6b2810830f7e.png">

