### PR TITLE
Improve error messages typically involved in the Terraform 0.12 upgrade

### DIFF
--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/parser_traversal.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/parser_traversal.go
@@ -53,10 +53,19 @@ func (p *parser) ParseTraversalAbs() (hcl.Traversal, hcl.Diagnostics) {
 						Context:  hcl.RangeBetween(varTok.Range, nameTok.Range).Ptr(),
 					})
 				} else {
+					diagnosticDetail := "Dot must be followed by attribute name (found: \"" + string(nameTok.Bytes)
+
+					nextTok := p.Peek()
+					if nextTok.Type != TokenEOF {
+						diagnosticDetail += string(nextTok.Bytes)
+					}
+
+					diagnosticDetail += "\")."
+
 					diags = append(diags, &hcl.Diagnostic{
 						Severity: hcl.DiagError,
 						Summary:  "Attribute name required",
-						Detail:   "Dot must be followed by attribute name.",
+						Detail:   diagnosticDetail,
 						Subject:  &nameTok.Range,
 						Context:  hcl.RangeBetween(varTok.Range, nameTok.Range).Ptr(),
 					})

--- a/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/token.go
+++ b/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax/token.go
@@ -297,7 +297,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid character",
-				Detail:   "This character is not used within the language.",
+				Detail:   "The character \"" + string(tok.Bytes) + "\" is not used within the language.",
 				Subject:  &tok.Range,
 			})
 		}


### PR DESCRIPTION
Two messages that typically happen when upgrading Terraform configurations to 0.12 are invalid character, and invalid attribute name.

Since the messages don't include any reference to the problematic tokens, the devs need to perform a manual search, with the additional problem that in some cases it can't be pinpointed if the issue lies in the configuration or if it's a Terraform bug.

This commit improves the error messages, printing the related token(s).

Examples:

- `Attribute name required: Dot must be followed by attribute name (found: "1module").`
- `The character "¹" is not used within the language.`

Mitigates #21435.