### PR TITLE
Fix error message for unassigned variable

### DIFF
--- a/terraform/variables.go
+++ b/terraform/variables.go
@@ -244,7 +244,7 @@ func checkInputVariables(vcs map[string]*configs.Variable, vs InputValues) tfdia
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Unassigned variable",
-				fmt.Sprintf("The input variable %q has not been assigned a value. This is a bug in Terraform; please report it in a GitHub issue.", name),
+				fmt.Sprintf("The input variable %q has not been assigned a value.", name),
 			))
 			continue
 		}


### PR DESCRIPTION
> The input variable "abc" has not been assigned a value. This is a bug in Terraform; please report it in a GitHub issue.

I don't think it's a bug in Terraform. Maybe it's just very meta ("this error message is a bug in Terraform").