### PR TITLE
fix, use extended flags for terraform console

### DIFF
--- a/command/console.go
+++ b/command/console.go
@@ -25,7 +25,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := c.Meta.defaultFlagSet("console")
+	cmdFlags := c.Meta.extendedFlagSet("console")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {


### PR DESCRIPTION
Allows -var and -var-file flags as expected

Fixes https://github.com/hashicorp/terraform/issues/21483
Fixes #22682