### PR TITLE
backend/remote: remove milseading contents from error message

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -657,11 +657,7 @@ func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend
 			)
 		default:
 			return nil, fmt.Errorf(
-				"%s\n\n"+
-					"The configured \"remote\" backend encountered an unexpected error. Sometimes\n"+
-					"this is caused by network connection problems, in which case you could retr\n"+
-					"the command. If the issue persists please open a support ticket to get help\n"+
-					"resolving the problem.",
+				"The configured \"remote\" backend encountered an unexpected error:\n\n%s",
 				err,
 			)
 		}

--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -948,6 +948,11 @@ func (m *mockWorkspaces) Create(ctx context.Context, organization string, option
 }
 
 func (m *mockWorkspaces) Read(ctx context.Context, organization, workspace string) (*tfe.Workspace, error) {
+	// custom error for TestRemote_plan500 in backend_plan_test.go
+	if workspace == "network-error" {
+		return nil, errors.New("I'm a little teacup")
+	}
+
 	w, ok := m.workspaceNames[workspace]
 	if !ok {
 		return nil, tfe.ErrResourceNotFound

--- a/backend/remote/backend_plan_test.go
+++ b/backend/remote/backend_plan_test.go
@@ -855,3 +855,23 @@ func TestRemote_planWithRemoteError(t *testing.T) {
 		t.Fatalf("expected plan error in output: %s", output)
 	}
 }
+
+func TestRemote_planOtherError(t *testing.T) {
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
+
+	op, configCleanup := testOperationPlan(t, "./testdata/plan")
+	defer configCleanup()
+
+	op.Workspace = "network-error" // custom error response in backend_mock.go
+
+	_, err := b.Operation(context.Background(), op)
+	if err == nil {
+		t.Errorf("expected error, got success")
+	}
+
+	if !strings.Contains(err.Error(),
+		"The configured \"remote\" backend encountered an unexpected error:\n\nI'm a little teacup") {
+		t.Fatalf("expected error message, got: %s", err.Error())
+	}
+}


### PR DESCRIPTION
Previously, terraform was returning a potentially-misleading error
message in response to anything other than a 404 from the
b.client.Workspaces.Read operation. This PR simplifies Terraform's error
message with the intent of encouraging those who encounter it to focus
on the error message returned from the tfe client.

The added test is odd, and a bit hacky, and possibly overkill. I am
willing (and even eager) to remove it altogether.