### PR TITLE
command/init: omit a warning if -backend-config is used with no backend

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -438,6 +438,27 @@ func (c *InitCommand) initBackend(root *configs.Module, extraConfig rawFlags) (b
 		if overrideDiags.HasErrors() {
 			return nil, true, diags
 		}
+	} else {
+		// If the user supplied a -backend-config on the CLI but no backend
+		// block was found in the configuration, return an error.
+		if !extraConfig.Empty() {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "missing backend block",
+				Detail: fmt.Sprintf(`
+-backend-config was used without a "backend" block in the configuration.
+
+If you intended to override the default local backend configuration,
+add an explicit backend block to your configuration first:
+
+terraform {
+	backend "local" {}
+  }
+`,
+				),
+			})
+			return nil, true, diags
+		}
 	}
 
 	opts := &BackendOpts{

--- a/command/init.go
+++ b/command/init.go
@@ -444,7 +444,7 @@ func (c *InitCommand) initBackend(root *configs.Module, extraConfig rawFlags) (b
 		if !extraConfig.Empty() {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "missing backend block",
+				Summary:  "Missing backend block",
 				Detail: fmt.Sprintf(`
 -backend-config was used without a "backend" block in the configuration.
 
@@ -453,7 +453,7 @@ add an explicit backend block to your configuration first:
 
 terraform {
 	backend "local" {}
-  }
+}
 `,
 				),
 			})

--- a/command/init.go
+++ b/command/init.go
@@ -440,24 +440,26 @@ func (c *InitCommand) initBackend(root *configs.Module, extraConfig rawFlags) (b
 		}
 	} else {
 		// If the user supplied a -backend-config on the CLI but no backend
-		// block was found in the configuration, return an error.
+		// block was found in the configuration, it's likely - but not
+		// necessarily - a mistake. Return a warning.
 		if !extraConfig.Empty() {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Missing backend block",
-				Detail: fmt.Sprintf(`
--backend-config was used without a "backend" block in the configuration.
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				"Missing backend configuration",
+				`-backend-config was used without a "backend" block in the configuration.
 
 If you intended to override the default local backend configuration,
-add an explicit backend block to your configuration first:
+no action is required, but you may add an explicit backend block to your
+configuration to clear this warning:
 
 terraform {
-	backend "local" {}
+  backend "local" {}
 }
+
+However, if you intended to override a defined backend, please verify that
+the backend configuration is present and valid.
 `,
-				),
-			})
-			return nil, true, diags
+			))
 		}
 	}
 

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -539,7 +539,7 @@ func TestInit_backendCli_no_config_block(t *testing.T) {
 	}
 
 	errMsg := ui.ErrorWriter.String()
-	if !strings.Contains(errMsg, "Error: missing backend block") {
+	if !strings.Contains(errMsg, "Error: Missing backend block") {
 		t.Fatal("expected missing backend block error, got", errMsg)
 	}
 }

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -518,6 +518,32 @@ func TestInit_backendConfigKVReInitWithConfigDiff(t *testing.T) {
 	}
 }
 
+func TestInit_backendCli_no_config_block(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	copy.CopyDir(testFixturePath("init"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	ui := new(cli.MockUi)
+	c := &InitCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			Ui:               ui,
+		},
+	}
+
+	args := []string{"-backend-config", "path=test"}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("got exit status %d; want 1\nstderr:\n%s\n\nstdout:\n%s", code, ui.ErrorWriter.String(), ui.OutputWriter.String())
+	}
+
+	errMsg := ui.ErrorWriter.String()
+	if !strings.Contains(errMsg, "Error: missing backend block") {
+		t.Fatal("expected missing backend block error, got", errMsg)
+	}
+}
+
 func TestInit_targetSubdir(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := tempDir(t)

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -534,13 +534,13 @@ func TestInit_backendCli_no_config_block(t *testing.T) {
 	}
 
 	args := []string{"-backend-config", "path=test"}
-	if code := c.Run(args); code != 1 {
-		t.Fatalf("got exit status %d; want 1\nstderr:\n%s\n\nstdout:\n%s", code, ui.ErrorWriter.String(), ui.OutputWriter.String())
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("got exit status %d; want 0\nstderr:\n%s\n\nstdout:\n%s", code, ui.ErrorWriter.String(), ui.OutputWriter.String())
 	}
 
 	errMsg := ui.ErrorWriter.String()
-	if !strings.Contains(errMsg, "Error: Missing backend block") {
-		t.Fatal("expected missing backend block error, got", errMsg)
+	if !strings.Contains(errMsg, "Warning: Missing backend configuration") {
+		t.Fatal("expected missing backend block warning, got", errMsg)
 	}
 }
 


### PR DESCRIPTION
Terraform would silently accept - and swallow - `-backend-config` on the
CLI when there was no `backend` block. Since it is mostly expected to
override existing backend configuration, ~it is reasonable that terraform
should return an error if there is no backend configuration to
override.~ EDIT: on second thought, let's print a warning! 

If the user intended to override the default (local) backend
configuration, they can first add a `backend` block to the `terraform` block to silence the warning:

```hcl
terraform {
  backend "local" {}
}
```
Fixes #21023