### PR TITLE
invlaid use of dynamic with attrs should not panic

### DIFF
--- a/lang/blocktoattr/variables.go
+++ b/lang/blocktoattr/variables.go
@@ -33,7 +33,7 @@ func walkVariables(node dynblock.WalkVariablesNode, body hcl.Body, schema *confi
 	for _, child := range children {
 		if blockS, exists := schema.BlockTypes[child.BlockTypeName]; exists {
 			vars = append(vars, walkVariables(child.Node, child.Body(), &blockS.Block)...)
-		} else if attrS, exists := schema.Attributes[child.BlockTypeName]; exists {
+		} else if attrS, exists := schema.Attributes[child.BlockTypeName]; exists && attrS.Type.ElementType().IsObjectType() {
 			synthSchema := SchemaForCtyElementType(attrS.Type.ElementType())
 			vars = append(vars, walkVariables(child.Node, child.Body(), synthSchema)...)
 		}

--- a/lang/blocktoattr/variables_test.go
+++ b/lang/blocktoattr/variables_test.go
@@ -21,6 +21,10 @@ func TestExpandedVariables(t *testing.T) {
 				})),
 				Optional: true,
 			},
+			"bar": {
+				Type:     cty.Map(cty.String),
+				Optional: true,
+			},
 		},
 	}
 
@@ -138,6 +142,29 @@ dynamic "foo" {
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 5, Column: 11, Byte: 57},
 							End:      hcl.Pos{Line: 5, Column: 14, Byte: 60},
+						},
+					},
+				},
+			},
+		},
+		"misplaced dynamic block": {
+			src: `
+dynamic "bar" {
+  for_each = beep
+  content {
+    key = val
+  }
+}
+`,
+			schema: fooSchema,
+			want: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{
+						Name: "beep",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 14, Byte: 30},
+							End:      hcl.Pos{Line: 3, Column: 18, Byte: 34},
 						},
 					},
 				},


### PR DESCRIPTION
Mistakenly using dynamic on an attribute will lead to a panic when
attempting to resolve variable references with a partial body, because
the dynamic blocks have yet to be expanded and validated. Check that the
block element type is actually an object before generating a schema.

Fixes #22043
Fixes #21619