### PR TITLE
[hashibot] configure issue locker

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -34,3 +34,16 @@ poll "label_issue_migrater" "provider_migrater" {
     EOF
     migrated_comment = "This issue has been automatically migrated to ${var.repository}#${var.issue_number} because it looks like an issue with that provider. If you believe this is _not_ an issue with the provider, please reply to ${var.repository}#${var.issue_number}."
 }
+
+poll "closed_issue_locker" "locker" {
+  schedule             = "0 50 1 * * *"
+  closed_for           = "720h" # 30 days
+  max_issues           = 500
+  sleep_between_issues = "5s"
+
+  message = <<-EOF
+    I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+
+    If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+  EOF
+}


### PR DESCRIPTION
We can tune the sleep between issues and the max amount to process per routine as desired. The cron schedule is just an arbitrary point in the day that is far from the other similar crons... that system in general needs some work.