### PR TITLE
docs: Update example remote_state to use remote backend

### DIFF
--- a/website/docs/providers/terraform/d/remote_state.html.md
+++ b/website/docs/providers/terraform/d/remote_state.html.md
@@ -23,7 +23,7 @@ use interpolations when configuring them.
 
 ```hcl
 data "terraform_remote_state" "vpc" {
-  backend = "atlas"
+  backend = "remote"
   config = {
     name = "hashicorp/vpc-prod"
   }


### PR DESCRIPTION
The "remote" backend supersedes the "atlas" backend so this is the one we should use in the example.