### PR TITLE
[WIP] Indicate empty workspaces in workspace list command output

### DIFF
--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -101,7 +101,7 @@ func TestWorkspace_createAndList(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(ui.OutputWriter.String())
-	expected := "default\n  test_a\n  test_b\n* test_c"
+	expected := "default (empty)\n  test_a (empty)\n  test_b (empty)\n* test_c (empty)"
 
 	if actual != expected {
 		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)
@@ -207,7 +207,7 @@ func TestWorkspace_createInvalid(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(ui.OutputWriter.String())
-	expected := "* default"
+	expected := "* default (empty)"
 
 	if actual != expected {
 		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -68,7 +68,26 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 		} else {
 			out.WriteString("  ")
 		}
-		out.WriteString(s + "\n")
+
+		m, err := b.StateMgr(s)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+
+		err = m.RefreshState()
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+
+		state := m.State()
+
+		out.WriteString(s)
+		if state.Empty() {
+			out.WriteString(" (empty)")
+		}
+		out.WriteString("\n")
 	}
 
 	c.Ui.Output(out.String())

--- a/website/docs/commands/workspace/list.html.md
+++ b/website/docs/commands/workspace/list.html.md
@@ -15,7 +15,8 @@ The `terraform workspace list` command is used to list all existing workspaces.
 Usage: `terraform workspace list`
 
 The command will list all existing workspaces. The current workspace is
-indicated using an asterisk (`*`) marker.
+indicated using an asterisk (`*`) marker. Workspaces with empty states
+are indicated by `(empty)` markers. 
 
 ## Example
 
@@ -23,5 +24,5 @@ indicated using an asterisk (`*`) marker.
 $ terraform workspace list
   default
 * development
-  jsmith-test
+  jsmith-test (empty)
 ```


### PR DESCRIPTION
Include markers in `workspace list` command output to indicate workspaces that do not contain any resources.

**Reason for PR**: currently there is no quick way to get an overview of workspaces that have been `applied` and which have been `destroyed`. This enhancement provides that by marking workspaces with no resources as `(empty)`.

All tests pass; running `make` and `make bin` terminates without error. However, I am new to the go programming language and would be very glad if You could review this PR and provide some feedback.