### PR TITLE
don't allow nil in config values

### DIFF
--- a/config/hcl2shim/values.go
+++ b/config/hcl2shim/values.go
@@ -167,7 +167,13 @@ func ConfigValueFromHCL2(v cty.Value) interface{} {
 		it := v.ElementIterator()
 		for it.Next() {
 			_, ev := it.Element()
-			l = append(l, ConfigValueFromHCL2(ev))
+			cv := ConfigValueFromHCL2(ev)
+			// hcl could not have nils here, but we may see them from hcl2.
+			// Since we generally want to associate a null value as unset, it's
+			// safest here to drop nil values from the list.
+			if cv != nil {
+				l = append(l, cv)
+			}
 		}
 		return l
 	}

--- a/config/hcl2shim/values_test.go
+++ b/config/hcl2shim/values_test.go
@@ -292,6 +292,16 @@ func TestConfigValueFromHCL2(t *testing.T) {
 			},
 		},
 		{
+			cty.ObjectVal(map[string]cty.Value{
+				"strings": cty.ListVal([]cty.Value{
+					cty.NullVal(cty.String),
+				}),
+			}),
+			map[string]interface{}{
+				"strings": []interface{}{},
+			},
+		},
+		{
 			cty.MapVal(map[string]cty.Value{
 				"foo": cty.StringVal("bar"),
 				"bar": cty.StringVal("baz"),
@@ -321,8 +331,8 @@ func TestConfigValueFromHCL2(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%#v", test.Input), func(t *testing.T) {
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d-%#v", i, test.Input), func(t *testing.T) {
 			got := ConfigValueFromHCL2(test.Input)
 			if !reflect.DeepEqual(got, test.Want) {
 				t.Errorf("wrong result\ninput: %#v\ngot:   %#v\nwant:  %#v", test.Input, got, test.Want)


### PR DESCRIPTION
Nil values didn't exist in hcl, and we can't allow them through in the
shimmed config. The map and object shims already check for nil, but
lists and sets did not.

Fixes #22216
Fixes #22147