### PR TITLE
Update copy for Exists

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -95,9 +95,10 @@ type Resource struct {
 	//
 	// Exists is a function that is called to check if a resource still
 	// exists. If this returns false, then this will affect the diff
-	// accordingly. If this function isn't set, it will not be called. It
-	// is highly recommended to set it. The *ResourceData passed to Exists
-	// should _not_ be modified.
+	// accordingly. If this function isn't set, it will not be called. You
+	// can also signal existence in the Read method by calling d.SetId("")
+	// if the Resource is not longer present and should be removed from state.
+	// The *ResourceData passed to Exists should _not_ be modified.
 	Create CreateFunc
 	Read   ReadFunc
 	Update UpdateFunc

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -97,7 +97,7 @@ type Resource struct {
 	// exists. If this returns false, then this will affect the diff
 	// accordingly. If this function isn't set, it will not be called. You
 	// can also signal existence in the Read method by calling d.SetId("")
-	// if the Resource is not longer present and should be removed from state.
+	// if the Resource is no longer present and should be removed from state.
 	// The *ResourceData passed to Exists should _not_ be modified.
 	Create CreateFunc
 	Read   ReadFunc


### PR DESCRIPTION
You can signal the same information in `Read` with an empty ID if the object does not exist, Implementing `Exists` is not the only way to do so and in some providers is also not the preferred way.