### PR TITLE
lang: fileexists should not error if evaluating a directory

### DIFF
--- a/lang/funcs/filesystem.go
+++ b/lang/funcs/filesystem.go
@@ -201,6 +201,10 @@ func MakeFileExistsFunc(baseDir string) function.Function {
 				return cty.True, nil
 			}
 
+			if fi.Mode().IsDir() {
+				return cty.False, nil
+			}
+
 			return cty.False, fmt.Errorf("%s is not a regular file, but %q",
 				path, fi.Mode().String())
 		},

--- a/lang/funcs/filesystem_test.go
+++ b/lang/funcs/filesystem_test.go
@@ -193,9 +193,9 @@ func TestFileExists(t *testing.T) {
 			false,
 		},
 		{
-			cty.StringVal(""), // empty path
+			cty.StringVal(""), // empty path is the local directory
 			cty.BoolVal(false),
-			true,
+			false,
 		},
 		{
 			cty.StringVal("testdata/missing"),


### PR DESCRIPTION
fileexists currently throws an error when given a directory. Instead, it should return false

Resolves #22260