### PR TITLE
helper/schema: don't skip deprecation check during validation

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1371,6 +1371,9 @@ func (m schemaMap) validate(
 	// The SDK has to allow the unknown value through initially, so that
 	// Required fields set via an interpolated value are accepted.
 	if !isWhollyKnown(raw) {
+		if schema.Deprecated != "" {
+			return []string{fmt.Sprintf("%q: [DEPRECATED] %s", k, schema.Deprecated)}, nil
+		}
 		return nil, nil
 	}
 

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -4510,6 +4510,24 @@ func TestSchemaMap_Validate(t *testing.T) {
 			Err: false,
 		},
 
+		"Unknown + Deprecation": {
+			Schema: map[string]*Schema{
+				"old_news": &Schema{
+					Type:       TypeString,
+					Optional:   true,
+					Deprecated: "please use 'new_news' instead",
+				},
+			},
+
+			Config: map[string]interface{}{
+				"old_news": hcl2shim.UnknownVariableValue,
+			},
+
+			Warnings: []string{
+				"\"old_news\": [DEPRECATED] please use 'new_news' instead",
+			},
+		},
+
 		"Required sub-resource field": {
 			Schema: map[string]*Schema{
 				"ingress": &Schema{


### PR DESCRIPTION
If an attribute was not wholly known, helper/schema was skipping the
`validateType` function which (among other things) returned deprecation
messages. This PR checks for deprecation before returning when skipping
validateType.

Fixes #22255