### PR TITLE
lang/funcs: lookup() can work with maps of lists, maps and objects

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -660,6 +660,12 @@ var LookupFunc = function.New(&function.Spec{
 			}
 			return cty.DynamicPseudoType, function.NewArgErrorf(0, "the given object has no attribute %q", key)
 		case ty.IsMapType():
+			if len(args) == 3 {
+				_, err = convert.Convert(args[2], ty.ElementType())
+				if err != nil {
+					return cty.NilType, function.NewArgErrorf(0, "the default value and map elements must have the same type")
+				}
+			}
 			return ty.ElementType(), nil
 		default:
 			return cty.NilType, function.NewArgErrorf(0, "lookup() requires a map as the first argument")

--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -695,8 +695,10 @@ var LookupFunc = function.New(&function.Spec{
 					return cty.NumberVal(v.AsBigFloat()), nil
 				case ty.Equals(cty.Bool):
 					return cty.BoolVal(v.True()), nil
+				case ty.IsObjectType() || ty.IsListType() || ty.IsMapType():
+					return v, nil
 				default:
-					return cty.NilVal, errors.New("lookup() can only be used with maps of primitive types")
+					return cty.NilVal, fmt.Errorf("lookup() cannot be used with type %s", ty.FriendlyName())
 				}
 			}
 		}

--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -663,7 +663,7 @@ var LookupFunc = function.New(&function.Spec{
 			if len(args) == 3 {
 				_, err = convert.Convert(args[2], ty.ElementType())
 				if err != nil {
-					return cty.NilType, function.NewArgErrorf(0, "the default value and map elements must have the same type")
+					return cty.NilType, function.NewArgErrorf(2, "the default value must have the same type as the map elements")
 				}
 			}
 			return ty.ElementType(), nil
@@ -692,21 +692,7 @@ var LookupFunc = function.New(&function.Spec{
 				return mapVar.GetAttr(lookupKey), nil
 			}
 		} else if mapVar.HasIndex(cty.StringVal(lookupKey)) == cty.True {
-			v := mapVar.Index(cty.StringVal(lookupKey))
-			if ty := v.Type(); !ty.Equals(cty.NilType) {
-				switch {
-				case ty.Equals(cty.String):
-					return cty.StringVal(v.AsString()), nil
-				case ty.Equals(cty.Number):
-					return cty.NumberVal(v.AsBigFloat()), nil
-				case ty.Equals(cty.Bool):
-					return cty.BoolVal(v.True()), nil
-				case ty.IsObjectType() || ty.IsListType() || ty.IsMapType():
-					return v, nil
-				default:
-					return cty.NilVal, fmt.Errorf("lookup() cannot be used with type %s", ty.FriendlyName())
-				}
-			}
+			return mapVar.Index(cty.StringVal(lookupKey)), nil
 		}
 
 		if defaultValueSet {

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -1577,6 +1577,15 @@ func TestLookup(t *testing.T) {
 			cty.StringVal("bar"),
 			false,
 		},
+		{ // Supplied default with valid (int) key
+			[]cty.Value{
+				simpleMap,
+				cty.StringVal("foobar"),
+				cty.NumberIntVal(-1),
+			},
+			cty.StringVal("-1"),
+			false,
+		},
 		{ // Supplied default with valid key
 			[]cty.Value{
 				mapWithObjects,
@@ -1594,6 +1603,15 @@ func TestLookup(t *testing.T) {
 			},
 			cty.StringVal(""),
 			false,
+		},
+		{ // Supplied default with type mismatch: expects a map return
+			[]cty.Value{
+				mapOfMaps,
+				cty.StringVal("foo"),
+				cty.StringVal(""),
+			},
+			cty.NilVal,
+			true,
 		},
 		{ // Supplied non-empty default with invalid key
 			[]cty.Value{

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -1469,6 +1469,22 @@ func TestLookup(t *testing.T) {
 			cty.StringVal("baz"),
 		}),
 	})
+	mapOfMaps := cty.MapVal(map[string]cty.Value{
+		"foo": cty.MapVal(map[string]cty.Value{
+			"a": cty.StringVal("bar"),
+		}),
+		"baz": cty.MapVal(map[string]cty.Value{
+			"b": cty.StringVal("bat"),
+		}),
+	})
+	mapOfObjects := cty.ObjectVal(map[string]cty.Value{
+		"foo": cty.MapVal(map[string]cty.Value{
+			"a": cty.StringVal("bar"),
+		}),
+		"baz": cty.MapVal(map[string]cty.Value{
+			"b": cty.StringVal("bat"),
+		}),
+	})
 	mapWithUnknowns := cty.MapVal(map[string]cty.Value{
 		"foo": cty.StringVal("bar"),
 		"baz": cty.UnknownVal(cty.String),
@@ -1505,6 +1521,26 @@ func TestLookup(t *testing.T) {
 				cty.StringVal("foo"),
 			},
 			cty.NumberIntVal(42),
+			false,
+		},
+		{
+			[]cty.Value{
+				mapOfMaps,
+				cty.StringVal("foo"),
+			},
+			cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("bar"),
+			}),
+			false,
+		},
+		{
+			[]cty.Value{
+				mapOfObjects,
+				cty.StringVal("foo"),
+			},
+			cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("bar"),
+			}),
 			false,
 		},
 		{ // Invalid key

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -1477,7 +1477,11 @@ func TestLookup(t *testing.T) {
 			"b": cty.StringVal("bat"),
 		}),
 	})
-	mapOfObjects := cty.ObjectVal(map[string]cty.Value{
+	mapOfTuples := cty.MapVal(map[string]cty.Value{
+		"foo": cty.TupleVal([]cty.Value{cty.StringVal("bar")}),
+		"baz": cty.TupleVal([]cty.Value{cty.StringVal("bat")}),
+	})
+	objectOfMaps := cty.ObjectVal(map[string]cty.Value{
 		"foo": cty.MapVal(map[string]cty.Value{
 			"a": cty.StringVal("bar"),
 		}),
@@ -1535,12 +1539,20 @@ func TestLookup(t *testing.T) {
 		},
 		{
 			[]cty.Value{
-				mapOfObjects,
+				objectOfMaps,
 				cty.StringVal("foo"),
 			},
 			cty.MapVal(map[string]cty.Value{
 				"a": cty.StringVal("bar"),
 			}),
+			false,
+		},
+		{
+			[]cty.Value{
+				mapOfTuples,
+				cty.StringVal("foo"),
+			},
+			cty.TupleVal([]cty.Value{cty.StringVal("bar")}),
 			false,
 		},
 		{ // Invalid key


### PR DESCRIPTION
lookup() can already handle arbitrary objects of (whatever) and should
handle maps of (whatever) similarly.

[The documentation](https://www.terraform.io/docs/configuration/functions/lookup.html) does _not_ mention any limitation to the types returned, which was inconsistent with the error message when a map of objects, lists or maps was used.

Fixes #22267