### PR TITLE
httpclient: Introduce composable UserAgent()

### DIFF
--- a/httpclient/useragent.go
+++ b/httpclient/useragent.go
@@ -13,6 +13,7 @@ import (
 const userAgentFormat = "Terraform/%s"
 const uaEnvVar = "TF_APPEND_USER_AGENT"
 
+// Deprecated: Use UserAgent(version) instead
 func UserAgentString() string {
 	ua := fmt.Sprintf(userAgentFormat, version.Version)
 
@@ -37,4 +38,18 @@ func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 		req.Header.Set("User-Agent", rt.userAgent)
 	}
 	return rt.inner.RoundTrip(req)
+}
+
+func TerraformUserAgent(version string) string {
+	ua := fmt.Sprintf("HashiCorp Terraform/%s (+https://www.terraform.io)", version)
+
+	if add := os.Getenv(uaEnvVar); add != "" {
+		add = strings.TrimSpace(add)
+		if len(add) > 0 {
+			ua += " " + add
+			log.Printf("[DEBUG] Using modified User-Agent: %s", ua)
+		}
+	}
+
+	return ua
 }

--- a/httpclient/useragent_test.go
+++ b/httpclient/useragent_test.go
@@ -43,5 +43,36 @@ func TestUserAgentString_env(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestUserAgentAppendViaEnvVar(t *testing.T) {
+	if oldenv, isSet := os.LookupEnv(uaEnvVar); isSet {
+		defer os.Setenv(uaEnvVar, oldenv)
+	} else {
+		defer os.Unsetenv(uaEnvVar)
+	}
+
+	expectedBase := "HashiCorp Terraform/0.0.0 (+https://www.terraform.io)"
+
+	testCases := []struct {
+		envVarValue string
+		expected    string
+	}{
+		{"", expectedBase},
+		{" ", expectedBase},
+		{" \n", expectedBase},
+		{"test/1", expectedBase + " test/1"},
+		{"test/1 (comment)", expectedBase + " test/1 (comment)"},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			os.Unsetenv(uaEnvVar)
+			os.Setenv(uaEnvVar, tc.envVarValue)
+			givenUA := TerraformUserAgent("0.0.0")
+			if givenUA != tc.expected {
+				t.Fatalf("Expected User-Agent '%s' does not match '%s'", tc.expected, givenUA)
+			}
+		})
+	}
 }

--- a/terraform/user_agent.go
+++ b/terraform/user_agent.go
@@ -6,8 +6,7 @@ import (
 
 // Generate a UserAgent string
 //
-// Deprecated: Use httpclient.UserAgentString if you are setting your
-// own User-Agent header.
+// Deprecated: Use httpclient.UserAgent(version) instead
 func UserAgentString() string {
 	return httpclient.UserAgentString()
 }

--- a/terraform/version.go
+++ b/terraform/version.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform/version"
 )
 
-// TODO: update providers to use the version package directly
+// Deprecated: Providers should use schema.Provider.TerraformVersion instead
 func VersionString() string {
 	return version.String()
 }


### PR DESCRIPTION
## Context

Providers need to know version of Terraform that is calling them, so they can report this via `User-Agent` header to upstream APIs. Currently providers do this basically by leveraging Terraform's `version` package as Terraform provides the SDK for interacting with core and is therefore imported to providers.

Such version is inaccurate and https://github.com/hashicorp/terraform/commit/bb9ae50279a8b27a8456b6952a674b34306747b4 already introduced a way for providers to source real version of Terraform (the binary that is talking to provider's gRPC server).

## Proposal

This new interface reflects recent changes to the protocol in 0.12 and proposes standard `User-Agent` format for providers to use. It will also allow providers to avoid depending on the `version` package which will not be available in the extracted SDK v1.

It is meant to replace the following ones (in use by some providers):

 - `httpclient.UserAgentString()` (e.g. AzureRM, Google)
 - `terraform.UserAgentString()` (e.g. OpenStack, ProfitBricks)
 - `terraform.VersionString()` (e.g. AWS, AzureStack, DigitalOcean, Kubernetes)

This also proposes the initial UA string to be set to

    HashiCorp Terraform/X.Y.Z (+https://www.terraform.io)

and some providers already defined this convention for encoding provider version

    terraform-provider-name/X.Y.Z

## Compatibility

Since the `TerraformVersion` field was introduced in the gRPC protocol of 0.12, it is worth noting that 0.10 and 0.11 do not send any version and it is up to the provider to decide what to do in such case. If this is not "special-case'd", UA will be constructed with empty version string, i.e.

    HashiCorp Terraform/ (+https://www.terraform.io)
