### PR TITLE
make v0.11 tests green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ script:
 - make test
 - make e2etest
 - GOOS=windows go build
-- make website-test
 
 branches:
   only:

--- a/command/e2etest/init_test.go
+++ b/command/e2etest/init_test.go
@@ -144,7 +144,7 @@ func TestInit_fromModule(t *testing.T) {
 	tf := e2e.NewBinary(terraformBin, fixturePath)
 	defer tf.Close()
 
-	cmd := tf.Cmd("init", "-from-module=hashicorp/vault/aws")
+	cmd := tf.Cmd("init", "-from-module=./init-from-module")
 	cmd.Stdin = nil
 	cmd.Stderr = &bytes.Buffer{}
 
@@ -162,7 +162,7 @@ func TestInit_fromModule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read main.tf: %s", err)
 	}
-	if !bytes.Contains(content, []byte("vault")) {
-		t.Fatalf("main.tf doesn't appear to be a vault configuration: \n%s", content)
+	if !bytes.Contains(content, []byte("null_resource")) {
+		t.Fatalf("main.tf doesn't appear to be a null_resource configuration: \n%s", content)
 	}
 }

--- a/command/e2etest/test-fixtures/empty/init-from-module/main.tf
+++ b/command/e2etest/test-fixtures/empty/init-from-module/main.tf
@@ -1,0 +1,6 @@
+resource "null_resource" "test" {
+}
+
+output "output" {
+  value = "${null_resource.test.id}"
+}


### PR DESCRIPTION
Public modules aren't likely to stay compatible with 0.11 syntax. Keep
the init test rather than disable it, but change it to use a local
module.

Disable the website tests since this isn't on the master branch