### PR TITLE
make diagnose on for_each argument more precise

### DIFF
--- a/terraform/eval_for_each.go
+++ b/terraform/eval_for_each.go
@@ -54,7 +54,7 @@ func evaluateResourceForEachExpressionKnown(expr hcl.Expression, ctx EvalContext
 		return map[string]cty.Value{}, false, diags
 	}
 
-	if !forEachVal.Type().IsMapType() && !forEachVal.Type().IsSetType() {
+	if !forEachVal.CanIterateElements() || forEachVal.Type().IsListType() || forEachVal.Type().IsTupleType() {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid for_each argument",

--- a/terraform/eval_for_each.go
+++ b/terraform/eval_for_each.go
@@ -54,7 +54,7 @@ func evaluateResourceForEachExpressionKnown(expr hcl.Expression, ctx EvalContext
 		return map[string]cty.Value{}, false, diags
 	}
 
-	if !forEachVal.CanIterateElements() || forEachVal.Type().IsListType() {
+	if !forEachVal.Type().IsMapType() && !forEachVal.Type().IsSetType() {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid for_each argument",


### PR DESCRIPTION
That condition would not diagnose [other iterables](https://github.com/zclconf/go-cty/blob/3ccef1ae92b0ac73b92d86f274f0ff781e2d9b3b/cty/element_iterator.go#L24-L39), such as `tuple` argument values, causing a [`panic: not a string`](https://github.com/zclconf/go-cty/blob/8c00057b05d70e7d4a4ab5c197ae8871d2b3ec69/cty/value_ops.go#L1026) later on.