### PR TITLE
httpclient: Create trace logging for outgoing HTTP requests

### DIFF
--- a/httpclient/useragent.go
+++ b/httpclient/useragent.go
@@ -36,5 +36,6 @@ func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	if _, ok := req.Header["User-Agent"]; !ok {
 		req.Header.Set("User-Agent", rt.userAgent)
 	}
+	log.Printf("[TRACE] HTTP client %s request to %s", req.Method, req.URL.String())
 	return rt.inner.RoundTrip(req)
 }


### PR DESCRIPTION
Sometimes HTTP requests are buried inside third-party libraries where we can't otherwise access their request method/URL, so this ensures we'll more often have at least a record of the fact that a request happened, even if there's no other logging for why it did.

We only include the method and URL here under the assumption that secret keys and other particularly sensitive information will not appear there, in line with usual best-practices.

This covers anything in the main Terraform CLI process that makes HTTP requests through our `httpclient` package, which is not 100% comprehensive but has good coverage of a number of interesting requests Terraform does, such as calling to a module registry, etc. When we use third-party libraries that make HTTP requests we generally provide our own client to them where possible to make sure they send our user-agent string and so that they don't pick up any `init`-time customizations made to the Go global HTTP client; this will include requests made in those cases too.

I'm submitting this now just because I seem to be repeatedly adding variants of this locally while debugging various things, and it seems general enough and useful enough to be default behavior. 