### PR TITLE
Properly end code block in upgrade docs

### DIFF
--- a/website/upgrade-guides/0-12.html.markdown
+++ b/website/upgrade-guides/0-12.html.markdown
@@ -717,7 +717,7 @@ the upgrade tool will not change it to a number, so take care to inspect your co
 locals {
   some_count = "3" # will not be changed to a number after config upgrade
 }
-
+```
 
 ## Upgrades for reusable modules
 


### PR DESCRIPTION
The unterminated code block effectively breaks rendering in the latter half of this section https://www.terraform.io/upgrade-guides/0-12.html#equality-operations-must-be-valid-on-value-and-type