### PR TITLE
helper/schema: remove outdated ValidateFunc restrictions

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -828,13 +828,6 @@ func (m schemaMap) internalValidate(topSchemaMap schemaMap, attrsOnly bool) erro
 			}
 		}
 
-		if v.ValidateFunc != nil {
-			switch v.Type {
-			case TypeList, TypeSet:
-				return fmt.Errorf("%s: ValidateFunc is not yet supported on lists or sets.", k)
-			}
-		}
-
 		if v.Deprecated == "" && v.Removed == "" {
 			if !isValidFieldName(k) {
 				return fmt.Errorf("%s: Field name may only contain lowercase alphanumeric characters & underscores.", k)

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3763,9 +3763,10 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 					ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 						return
 					},
+					Elem: &Schema{Type: TypeString},
 				},
 			},
-			true,
+			false,
 		},
 
 		"computed-only field with validateFunc": {


### PR DESCRIPTION
Validation on non-primitives has possibly worked for several years -
see initial commit in 2a179d1, and subsequent blames associated with
respective lines in functions validateType, validateList, and
validatePrimitive.

For some reason though, we've never removed the restriction from
internalValidate.

This commit removes it, in addition to fixing the specific test case,
which was giving a false positive on the validation error as it was
missing the Elem attribute for TypeSet.