### PR TITLE
backend/oss: added support for profile config

### DIFF
--- a/backend/remote-state/oss/backend_test.go
+++ b/backend/remote-state/oss/backend_test.go
@@ -63,6 +63,41 @@ func TestBackendConfig(t *testing.T) {
 	}
 }
 
+func TestBackendConfigProfile(t *testing.T) {
+	testACC(t)
+	config := map[string]interface{}{
+		"region":              "cn-beijing",
+		"bucket":              "terraform-backend-oss-test",
+		"prefix":              "mystate",
+		"key":                 "first.tfstate",
+		"tablestore_endpoint": "https://terraformstate.cn-beijing.ots.aliyuncs.com",
+		"tablestore_table":    "TableStore",
+		"profile":             "default",
+	}
+
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
+
+	if !strings.HasPrefix(b.ossClient.Config.Endpoint, "https://oss-cn-beijing") {
+		t.Fatalf("Incorrect region was provided")
+	}
+	if b.bucketName != "terraform-backend-oss-test" {
+		t.Fatalf("Incorrect bucketName was provided")
+	}
+	if b.statePrefix != "mystate" {
+		t.Fatalf("Incorrect state file path was provided")
+	}
+	if b.stateKey != "first.tfstate" {
+		t.Fatalf("Incorrect keyName was provided")
+	}
+
+	if b.ossClient.Config.AccessKeyID == "" {
+		t.Fatalf("No Access Key Id was provided")
+	}
+	if b.ossClient.Config.AccessKeySecret == "" {
+		t.Fatalf("No Secret Access Key was provided")
+	}
+}
+
 func TestBackendConfig_invalidKey(t *testing.T) {
 	testACC(t)
 	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{

--- a/website/docs/backends/types/oss.html.md
+++ b/website/docs/backends/types/oss.html.md
@@ -90,9 +90,12 @@ The following configuration options or environment variables are supported:
  * `acl` - (Optional) [Object
    ACL](https://www.alibabacloud.com/help/doc-detail/52284.htm)
    to be applied to the state file.
- * `assume_role` - (Optional) If provided with a role ARN, will attempt to assume this role using the supplied credentials.
- 
+ * `shared_credentials_file` - (Optional, Available in 0.12.8+) This is the path to the shared credentials file. If this is not set and a profile is specified, `~/.aliyun/config.json` will be used.
+ * `profile` - (Optional, Available in 0.12.8+)  This is the Alibaba Cloud profile name as set in the shared credentials file. It can also be sourced from the `ALICLOUD_PROFILE` environment variable.
+ * `assume_role` - (Optional, Available in 0.12.6+) If provided with a role ARN, will attempt to assume this role using the supplied credentials.
+
 The nested `assume_role` block supports the following:
+
 * `role_arn` - (Required) The ARN of the role to assume. If ARN is set to an empty string, it does not perform role switching. It supports environment variable `ALICLOUD_ASSUME_ROLE_ARN`.
   Terraform executes configuration on account with provided credentials.
 

--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -13,7 +13,7 @@ as physical machines, VMs, network switches, containers, and more. Almost any
 infrastructure type can be represented as a resource in Terraform.
 
 A provider is responsible for understanding API interactions and exposing
-resources. Providers generally are an IaaS (e.g. AWS, GCP, Microsoft Azure,
+resources. Providers generally are an IaaS (e.g. Alibaba Cloud, AWS, GCP, Microsoft Azure,
 OpenStack), PaaS (e.g. Heroku), or SaaS services (e.g. Terraform Cloud,
 DNSimple, CloudFlare).
 

--- a/website/docs/providers/type/major-index.html.markdown
+++ b/website/docs/providers/type/major-index.html.markdown
@@ -19,7 +19,7 @@ tested by HashiCorp.
 ---
 
 
-- [AliCloud](/docs/providers/alicloud/index.html)
+- [Alibaba Cloud](/docs/providers/alicloud/index.html)
 - [AWS](/docs/providers/aws/index.html)
 - [Azure](/docs/providers/azurerm/index.html)
 - [Azure Stack](/docs/providers/azurestack/index.html)


### PR DESCRIPTION
This PR aims to support profile config in the Alibaba Cloud backend. The profile will help users to get config from credential file. Currently, the terraform-provider-alicloud has supported it and the backend also need to do it.