### PR TITLE
Fix bug where ids were not showing in 'Still applying...' type states

### DIFF
--- a/command/format/object_id.go
+++ b/command/format/object_id.go
@@ -116,8 +116,8 @@ func ObjectValueName(obj cty.Value) (k, v string) {
 func ObjectValueIDOrName(obj cty.Value) (k, v string) {
 	k, v = ObjectValueID(obj)
 	if k != "" {
-		return
+		return k, v
 	}
 	k, v = ObjectValueName(obj)
-	return
+	return k, v
 }


### PR DESCRIPTION
This function was using the naked return approach, but this somehow led to the values being unpopulated in the PreApply function, which creates the uiState used by the "Still applying... [or destroying, etc.]" display