### PR TITLE
command/workspace_select: discard flag package output in favor of

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -354,6 +354,11 @@ func (m *Meta) contextOpts() *terraform.ContextOpts {
 func (m *Meta) defaultFlagSet(n string) *flag.FlagSet {
 	f := flag.NewFlagSet(n, flag.ContinueOnError)
 
+	// TODO: we should instead discard the flag package's output and print any
+	// errors ourselves. Sporadically the commands exited before the output got
+	// written. See the 'workspace select' command for an example - this should
+	// be copied to all other commands using the defaultFlagSet.
+
 	// Create an io.Writer that writes to our Ui properly for errors.
 	// This is kind of a hack, but it does the job. Basically: create
 	// a pipe, use a scanner to break it into lines, and output each line

--- a/command/workspace_select.go
+++ b/command/workspace_select.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/hashicorp/terraform/tfdiags"
@@ -24,7 +25,13 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 
 	cmdFlags := c.Meta.defaultFlagSet("workspace select")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
+
+	// TODO: This change should be applied to meta.defaultFlagSet and other
+	// commands refactored to print the error from the flags package, instead of
+	// counting on the flag package's output writer.
+	cmdFlags.SetOutput(ioutil.Discard)
 	if err := cmdFlags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 

--- a/command/workspace_select.go
+++ b/command/workspace_select.go
@@ -31,7 +31,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	// counting on the flag package's output writer.
 	cmdFlags.SetOutput(ioutil.Discard)
 	if err := cmdFlags.Parse(args); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
+		c.Ui.Error(fmt.Sprintf("Error parsing command line flags: %s\n", err.Error()))
 		return 1
 	}
 


### PR DESCRIPTION
returning an error

Sporadically, the `workspace select` command would exit 1 before the
flag package output got written. This commit discards the flag package
stdout in favor of directly returning the error.

Fixes #21913; this change should be moved into meta.defaultFlagSet and
applied to all commands.