### PR TITLE
update deps to match the aws provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/aws/aws-sdk-go v1.21.7
+	github.com/aws/aws-sdk-go v1.22.0
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/boltdb/bolt v1.3.1 // indirect
@@ -42,7 +42,7 @@ require (
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
-	github.com/hashicorp/aws-sdk-go-base v0.2.0
+	github.com/hashicorp/aws-sdk-go-base v0.3.0
 	github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-azure-helpers v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/aws/aws-sdk-go v1.16.36 h1:POeH34ZME++pr7GBGh+ZO6Y5kOwSMQpqp5BGUgooJ6
 github.com/aws/aws-sdk-go v1.16.36/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.21.7 h1:ml+k7szyVaq4YD+3LhqOGl9tgMTqgMbpnuUSkB6UJvQ=
 github.com/aws/aws-sdk-go v1.21.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.22.0 h1:e88V6+dSEyBibUy0ekOydtTfNWzqG3hrtCR8SF6UqqY=
+github.com/aws/aws-sdk-go v1.22.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f h1:ZNv7On9kyUzm7fvRZumSyy/IUiSC7AzL0I1jKKtwooA=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
@@ -204,6 +206,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.8.5 h1:2+KSC78XiO6Qy0hIjfc1OD9H+hsaJdJ
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/aws-sdk-go-base v0.2.0 h1:5bjZnWCvQg9Im5CHZr9t90IaFC4uvVlMl2fTh23IoCk=
 github.com/hashicorp/aws-sdk-go-base v0.2.0/go.mod h1:ZIWACGGi0N7a4DZbf15yuE1JQORmWLtBcVM6F5SXNFU=
+github.com/hashicorp/aws-sdk-go-base v0.3.0 h1:CPWKWCuOwpIFNsy8FUI9IT2QI7mGwgVPc4hrXW9I4L4=
+github.com/hashicorp/aws-sdk-go-base v0.3.0/go.mod h1:ZIWACGGi0N7a4DZbf15yuE1JQORmWLtBcVM6F5SXNFU=
 github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089 h1:1eDpXAxTh0iPv+1kc9/gfSI2pxRERDsTk/lNGolwHn8=
 github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+sfyn/OOI=
 github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -83,7 +83,7 @@ var awsPartition = partition{
 	DNSSuffix: "amazonaws.com",
 	RegionRegex: regionRegex{
 		Regexp: func() *regexp.Regexp {
-			reg, _ := regexp.Compile("^(us|eu|ap|sa|ca)\\-\\w+\\-\\d+$")
+			reg, _ := regexp.Compile("^(us|eu|ap|sa|ca|me)\\-\\w+\\-\\d+$")
 			return reg
 		}(),
 	},
@@ -775,6 +775,7 @@ var awsPartition = partition{
 		"codebuild": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -786,6 +787,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-1-fips": endpoint{
@@ -827,6 +829,7 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -1891,6 +1894,8 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
@@ -2178,6 +2183,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -2470,6 +2476,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1": endpoint{
 					SSLCommonName: "{service}.{dnsSuffix}",
@@ -2927,6 +2934,7 @@ var awsPartition = partition{
 		"securityhub": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -4545,6 +4553,7 @@ var awsusgovPartition = partition{
 				},
 			},
 			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
 		},

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
@@ -170,9 +170,12 @@ func PartitionForRegion(ps []Partition, regionID string) (Partition, bool) {
 // A Partition provides the ability to enumerate the partition's regions
 // and services.
 type Partition struct {
-	id string
-	p  *partition
+	id, dnsSuffix string
+	p             *partition
 }
+
+// DNSSuffix returns the base domain name of the partition.
+func (p Partition) DNSSuffix() string { return p.dnsSuffix }
 
 // ID returns the identifier of the partition.
 func (p Partition) ID() string { return p.id }

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/v3model.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/v3model.go
@@ -54,8 +54,9 @@ type partition struct {
 
 func (p partition) Partition() Partition {
 	return Partition{
-		id: p.ID,
-		p:  &p,
+		dnsSuffix: p.DNSSuffix,
+		id:        p.ID,
+		p:         &p,
 	}
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/credentials.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/credentials.go
@@ -21,9 +21,10 @@ func resolveCredentials(cfg *aws.Config,
 ) (*credentials.Credentials, error) {
 
 	switch {
-	case len(envCfg.Profile) != 0:
-		// User explicitly provided an Profile, so load from shared config
-		// first.
+	case len(sessOpts.Profile) != 0:
+		// User explicitly provided an Profile in the session's configuration
+		// so load that profile from shared config first.
+		// Github(aws/aws-sdk-go#2727)
 		return resolveCredsFromProfile(cfg, envCfg, sharedCfg, handlers, sessOpts)
 
 	case envCfg.Creds.HasKeys():

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/doc.go
@@ -1,97 +1,93 @@
 /*
-Package session provides configuration for the SDK's service clients.
-
-Sessions can be shared across all service clients that share the same base
-configuration.  The Session is built from the SDK's default configuration and
-request handlers.
-
-Sessions should be cached when possible, because creating a new Session will
-load all configuration values from the environment, and config files each time
-the Session is created. Sharing the Session value across all of your service
-clients will ensure the configuration is loaded the fewest number of times possible.
-
-Concurrency
+Package session provides configuration for the SDK's service clients. Sessions
+can be shared across service clients that share the same base configuration.
 
 Sessions are safe to use concurrently as long as the Session is not being
-modified. The SDK will not modify the Session once the Session has been created.
-Creating service clients concurrently from a shared Session is safe.
+modified. Sessions should be cached when possible, because creating a new
+Session will load all configuration values from the environment, and config
+files each time the Session is created. Sharing the Session value across all of
+your service clients will ensure the configuration is loaded the fewest number
+of times possible.
 
-Sessions from Shared Config
-
-Sessions can be created using the method above that will only load the
-additional config if the AWS_SDK_LOAD_CONFIG environment variable is set.
-Alternatively you can explicitly create a Session with shared config enabled.
-To do this you can use NewSessionWithOptions to configure how the Session will
-be created. Using the NewSessionWithOptions with SharedConfigState set to
-SharedConfigEnable will create the session as if the AWS_SDK_LOAD_CONFIG
-environment variable was set.
-
-Creating Sessions
-
-When creating Sessions optional aws.Config values can be passed in that will
-override the default, or loaded config values the Session is being created
-with. This allows you to provide additional, or case based, configuration
-as needed.
+Sessions options from Shared Config
 
 By default NewSession will only load credentials from the shared credentials
 file (~/.aws/credentials). If the AWS_SDK_LOAD_CONFIG environment variable is
 set to a truthy value the Session will be created from the configuration
 values from the shared config (~/.aws/config) and shared credentials
-(~/.aws/credentials) files. See the section Sessions from Shared Config for
-more information.
+(~/.aws/credentials) files. Using the NewSessionWithOptions with
+SharedConfigState set to SharedConfigEnable will create the session as if the
+AWS_SDK_LOAD_CONFIG environment variable was set.
 
-Create a Session with the default config and request handlers. With credentials
-region, and profile loaded from the environment and shared config automatically.
-Requires the AWS_PROFILE to be set, or "default" is used.
+Credential and config loading order
+
+The Session will attempt to load configuration and credentials from the
+environment, configuration files, and other credential sources. The order
+configuration is loaded in is:
+
+  * Environment Variables
+  * Shared Credentials file
+  * Shared Configuration file (if SharedConfig is enabled)
+  * EC2 Instance Metadata (credentials only)
+
+The Environment variables for credentials will have precedence over shared
+config even if SharedConfig is enabled. To override this behavior, and use
+shared config credentials instead specify the session.Options.Profile, (e.g.
+when using credential_source=Environment to assume a role).
+
+  sess, err := session.NewSessionWithOptions(session.Options{
+	  Profile: "myProfile",
+  })
+
+Creating Sessions
+
+Creating a Session without additional options will load credentials region, and
+profile loaded from the environment and shared config automatically. See,
+"Environment Variables" section for information on environment variables used
+by Session.
 
 	// Create Session
-	sess := session.Must(session.NewSession())
+	sess, err := session.NewSession()
+
+
+When creating Sessions optional aws.Config values can be passed in that will
+override the default, or loaded, config values the Session is being created
+with. This allows you to provide additional, or case based, configuration
+as needed.
 
 	// Create a Session with a custom region
-	sess := session.Must(session.NewSession(&aws.Config{
-		Region: aws.String("us-east-1"),
-	}))
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-west-2"),
+	})
 
-	// Create a S3 client instance from a session
-	sess := session.Must(session.NewSession())
-
-	svc := s3.New(sess)
-
-Create Session With Option Overrides
-
-In addition to NewSession, Sessions can be created using NewSessionWithOptions.
-This func allows you to control and override how the Session will be created
-through code instead of being driven by environment variables only.
-
-Use NewSessionWithOptions when you want to provide the config profile, or
-override the shared config state (AWS_SDK_LOAD_CONFIG).
+Use NewSessionWithOptions to provide additional configuration driving how the
+Session's configuration will be loaded. Such as, specifying shared config
+profile, or override the shared config state,  (AWS_SDK_LOAD_CONFIG).
 
 	// Equivalent to session.NewSession()
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
+	sess, err := session.NewSessionWithOptions(session.Options{
 		// Options
-	}))
+	})
 
-	// Specify profile to load for the session's config
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		 Profile: "profile_name",
-	}))
+	sess, err := session.NewSessionWithOptions(session.Options{
+		// Specify profile to load for the session's config
+		Profile: "profile_name",
 
-	// Specify profile for config and region for requests
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		 Config: aws.Config{Region: aws.String("us-east-1")},
-		 Profile: "profile_name",
-	}))
+		// Provide SDK Config options, such as Region.
+		Config: aws.Config{
+			Region: aws.String("us-west-2"),
+		},
 
-	// Force enable Shared Config support
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		// Force enable Shared Config support
 		SharedConfigState: session.SharedConfigEnable,
-	}))
+	})
 
 Adding Handlers
 
-You can add handlers to a session for processing HTTP requests. All service
-clients that use the session inherit the handlers. For example, the following
-handler logs every request and its payload made by a service client:
+You can add handlers to a session to decorate API operation, (e.g. adding HTTP
+headers). All clients that use the Session receive a copy of the Session's
+handlers. For example, the following request handler added to the Session logs
+every requests made.
 
 	// Create a session, and add additional handlers for all service
 	// clients created with the Session to inherit. Adds logging handler.
@@ -99,22 +95,15 @@ handler logs every request and its payload made by a service client:
 
 	sess.Handlers.Send.PushFront(func(r *request.Request) {
 		// Log every request made and its payload
-		logger.Printf("Request: %s/%s, Payload: %s",
+		logger.Printf("Request: %s/%s, Params: %s",
 			r.ClientInfo.ServiceName, r.Operation, r.Params)
 	})
 
-Deprecated "New" function
-
-The New session function has been deprecated because it does not provide good
-way to return errors that occur when loading the configuration files and values.
-Because of this, NewSession was created so errors can be retrieved when
-creating a session fails.
-
 Shared Config Fields
 
-By default the SDK will only load the shared credentials file's (~/.aws/credentials)
-credentials values, and all other config is provided by the environment variables,
-SDK defaults, and user provided aws.Config values.
+By default the SDK will only load the shared credentials file's
+(~/.aws/credentials) credentials values, and all other config is provided by
+the environment variables, SDK defaults, and user provided aws.Config values.
 
 If the AWS_SDK_LOAD_CONFIG environment variable is set, or SharedConfigEnable
 option is used to create the Session the full shared config values will be
@@ -125,24 +114,31 @@ files have the same format.
 
 If both config files are present the configuration from both files will be
 read. The Session will be created from configuration values from the shared
-credentials file (~/.aws/credentials) over those in the shared config file (~/.aws/config).
+credentials file (~/.aws/credentials) over those in the shared config file
+(~/.aws/config).
 
-Credentials are the values the SDK should use for authenticating requests with
-AWS Services. They are from a configuration file will need to include both
-aws_access_key_id and aws_secret_access_key must be provided together in the
-same file to be considered valid. The values will be ignored if not a complete
-group. aws_session_token is an optional field that can be provided if both of
-the other two fields are also provided.
+Credentials are the values the SDK uses to authenticating requests with AWS
+Services. When specified in a file, both aws_access_key_id and
+aws_secret_access_key must be provided together in the same file to be
+considered valid. They will be ignored if both are not present.
+aws_session_token is an optional field that can be provided in addition to the
+other two fields.
 
 	aws_access_key_id = AKID
 	aws_secret_access_key = SECRET
 	aws_session_token = TOKEN
 
-Assume Role values allow you to configure the SDK to assume an IAM role using
-a set of credentials provided in a config file via the source_profile field.
-Both "role_arn" and "source_profile" are required. The SDK supports assuming
-a role with MFA token if the session option AssumeRoleTokenProvider
-is set.
+	; region only supported if SharedConfigEnabled.
+	region = us-east-1
+
+Assume Role configuration
+
+The role_arn field allows you to configure the SDK to assume an IAM role using
+a set of credentials from another source. Such as when paired with static
+credentials, "profile_source", "credential_process", or "credential_source"
+fields. If "role_arn" is provided, a source of credentials must also be
+specified, such as "source_profile", "credential_source", or
+"credential_process".
 
 	role_arn = arn:aws:iam::<account_number>:role/<role_name>
 	source_profile = profile_with_creds
@@ -150,40 +146,16 @@ is set.
 	mfa_serial = <serial or mfa arn>
 	role_session_name = session_name
 
-Region is the region the SDK should use for looking up AWS service endpoints
-and signing requests.
 
-	region = us-east-1
-
-Assume Role with MFA token
-
-To create a session with support for assuming an IAM role with MFA set the
-session option AssumeRoleTokenProvider to a function that will prompt for the
-MFA token code when the SDK assumes the role and refreshes the role's credentials.
-This allows you to configure the SDK via the shared config to assumea role
-with MFA tokens.
-
-In order for the SDK to assume a role with MFA the SharedConfigState
-session option must be set to SharedConfigEnable, or AWS_SDK_LOAD_CONFIG
-environment variable set.
-
-The shared configuration instructs the SDK to assume an IAM role with MFA
-when the mfa_serial configuration field is set in the shared config
-(~/.aws/config) or shared credentials (~/.aws/credentials) file.
-
-If mfa_serial is set in the configuration, the SDK will assume the role, and
-the AssumeRoleTokenProvider session option is not set an an error will
-be returned when creating the session.
+The SDK supports assuming a role with MFA token. If "mfa_serial" is set, you
+must also set the Session Option.AssumeRoleTokenProvider. The Session will fail
+to load if the AssumeRoleTokenProvider is not specified.
 
     sess := session.Must(session.NewSessionWithOptions(session.Options{
         AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
     }))
 
-    // Create service client value configured for credentials
-    // from assumed role.
-    svc := s3.New(sess)
-
-To setup assume role outside of a session see the stscreds.AssumeRoleProvider
+To setup Assume Role outside of a session see the stscreds.AssumeRoleProvider
 documentation.
 
 Environment Variables

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
@@ -281,7 +281,7 @@ func NewSessionWithOptions(opts Options) (*Session, error) {
 		envCfg = loadEnvConfig()
 	}
 
-	if len(opts.Profile) > 0 {
+	if len(opts.Profile) != 0 {
 		envCfg.Profile = opts.Profile
 	}
 

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.21.7"
+const SDKVersion = "1.22.0"

--- a/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
@@ -760,15 +760,15 @@ func (c *STS) GetAccessKeyInfoRequest(input *GetAccessKeyInfoInput) (req *reques
 // key IDs beginning with ASIA are temporary credentials that are created using
 // STS operations. If the account in the response belongs to you, you can sign
 // in as the root user and review your root user access keys. Then, you can
-// pull a credentials report (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_getting-report)
+// pull a credentials report (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_getting-report.html)
 // to learn which IAM user owns the keys. To learn who requested the temporary
 // credentials for an ASIA access key, view the STS events in your CloudTrail
-// logs (https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration).
+// logs (https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html).
 //
 // This operation does not indicate the state of the access key. The key might
 // be active, inactive, or deleted. Active keys might not have permissions to
-// perform an operation. Providing a deleted keys might return an error that
-// the key doesn't exist.
+// perform an operation. Providing a deleted access key might return an error
+// that the key doesn't exist.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -842,8 +842,15 @@ func (c *STS) GetCallerIdentityRequest(input *GetCallerIdentityInput) (req *requ
 
 // GetCallerIdentity API operation for AWS Security Token Service.
 //
-// Returns details about the IAM identity whose credentials are used to call
-// the API.
+// Returns details about the IAM user or role whose credentials are used to
+// call the operation.
+//
+// No permissions are required to perform this operation. If an administrator
+// adds a policy to your IAM user or role that explicitly denies access to the
+// sts:GetCallerIdentity action, you can still perform this operation. Permissions
+// are not required because the same information is returned when an IAM user
+// or role is denied access. To view an example response, see I Am Not Authorized
+// to Perform: iam:DeleteVirtualMFADevice (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_access-denied-delete-mfa).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2447,7 +2454,7 @@ type GetFederationTokenInput struct {
 	// use as managed session policies. The plain text that you use for both inline
 	// and managed session policies shouldn't exceed 2048 characters. You can provide
 	// up to 10 managed policy ARNs. For more information about ARNs, see Amazon
-	// Resource Names (ARNs) and AWS Service Namespaces (general/latest/gr/aws-arns-and-namespaces.html)
+	// Resource Names (ARNs) and AWS Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	//
 	// This parameter is optional. However, if you do not pass any session policies,

--- a/vendor/github.com/hashicorp/aws-sdk-go-base/CHANGELOG.md
+++ b/vendor/github.com/hashicorp/aws-sdk-go-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.3.0 (February 26, 2019)
+
+BUG FIXES
+
+* session: Return error instead of logging with AWS Account ID lookup failure [GH-3]
+
 # v0.2.0 (February 20, 2019)
 
 ENHANCEMENTS

--- a/vendor/github.com/hashicorp/aws-sdk-go-base/session.go
+++ b/vendor/github.com/hashicorp/aws-sdk-go-base/session.go
@@ -185,13 +185,10 @@ func GetSessionWithAccountIDAndPartition(c *Config) (*session.Session, string, s
 			return sess, accountID, partition, nil
 		}
 
-		// DEPRECATED: Next major version of the provider should return the error instead of logging
-		//             if skip_request_account_id is not enabled.
-		log.Printf("[WARN] %s", fmt.Sprintf(
+		return nil, "", "", fmt.Errorf(
 			"AWS account ID not previously found and failed retrieving via all available methods. "+
-				"This will return an error in the next major version of the AWS provider. "+
 				"See https://www.terraform.io/docs/providers/aws/index.html#skip_requesting_account_id for workaround and implications. "+
-				"Errors: %s", err))
+				"Errors: %s", err)
 	}
 
 	var partition string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -89,7 +89,7 @@ github.com/apparentlymart/go-textseg/textseg
 github.com/armon/circbuf
 # github.com/armon/go-radix v1.0.0
 github.com/armon/go-radix
-# github.com/aws/aws-sdk-go v1.21.7
+# github.com/aws/aws-sdk-go v1.22.0
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/awserr
 github.com/aws/aws-sdk-go/service/dynamodb
@@ -303,7 +303,7 @@ github.com/gophercloud/utils/openstack/clientconfig
 github.com/grpc-ecosystem/grpc-gateway/runtime
 github.com/grpc-ecosystem/grpc-gateway/utilities
 github.com/grpc-ecosystem/grpc-gateway/internal
-# github.com/hashicorp/aws-sdk-go-base v0.2.0
+# github.com/hashicorp/aws-sdk-go-base v0.3.0
 github.com/hashicorp/aws-sdk-go-base
 # github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089
 github.com/hashicorp/consul/api


### PR DESCRIPTION
Update the aws-sdk-go-base and aws-sdk-go packages to ensure the same
client behavior as the aws provider.