### PR TITLE
command/state_show: Infer missing quotes with for_each resource addressing

### DIFF
--- a/addrs/infer_target.go
+++ b/addrs/infer_target.go
@@ -1,0 +1,60 @@
+package addrs
+
+import (
+	"strconv"
+
+	"github.com/hashicorp/terraform/tfdiags"
+)
+
+// InferAbsResourceInstanceStr Attempts to infer a resource instance address with invalid syntax
+// The current implementation will only quote any invalid resource index values
+// as shell environments can easily strip quotes (e.g. type.name["quoted"]
+// becoming type.name[quoted]). This function is currently only intended for
+// CLI command handling.
+func InferAbsResourceInstanceStr(originalStr string) (AbsResourceInstance, tfdiags.Diagnostics) {
+	addr, addrDiags := ParseAbsResourceInstanceStr(originalStr)
+
+	if !addrDiags.HasErrors() {
+		return addr, addrDiags
+	}
+
+	previousStr := originalStr
+	currentStr := originalStr
+
+	for {
+		for _, diag := range addrDiags {
+			if diag.Description().Summary != "Index value required" {
+				continue
+			}
+
+			indexValueStart := diag.Source().Subject.Start.Column - 1
+			indexValueEnd := diag.Source().Subject.End.Column - 1
+			indexValue := currentStr[indexValueStart:indexValueEnd]
+
+			// If the index value is numeric, skip handling
+			if _, err := strconv.Atoi(indexValue); err == nil {
+				break
+			}
+
+			// Add quotes around index value
+			currentStr = currentStr[:indexValueStart] + `"` + indexValue + `"` + currentStr[indexValueEnd:]
+
+			addr, addrDiags = ParseAbsResourceInstanceStr(currentStr)
+
+			break
+		}
+
+		if !addrDiags.HasErrors() {
+			break
+		}
+
+		// Prevent infinite looping on unresolveable conditions
+		if currentStr == previousStr {
+			break
+		}
+
+		previousStr = currentStr
+	}
+
+	return addr, addrDiags
+}

--- a/addrs/infer_target_test.go
+++ b/addrs/infer_target_test.go
@@ -1,0 +1,286 @@
+package addrs
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestInferAbsResourceInstanceStr(t *testing.T) {
+	tests := []struct {
+		Input   string
+		Want    AbsResourceInstance
+		WantErr string
+	}{
+		{
+			`test_resource.foo`,
+			AbsResourceInstance{
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "foo",
+					},
+					Key: NoKey,
+				},
+			},
+			``,
+		},
+		{
+			`test_resource.foo[1]`,
+			AbsResourceInstance{
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "foo",
+					},
+					Key: IntKey(1),
+				},
+			},
+			``,
+		},
+		{
+			`test_resource.foo[bar]`,
+			AbsResourceInstance{
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "foo",
+					},
+					Key: StringKey("bar"),
+				},
+			},
+			``,
+		},
+		{
+			`test_resource.foo["bar"]`,
+			AbsResourceInstance{
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "foo",
+					},
+					Key: StringKey("bar"),
+				},
+			},
+			``,
+		},
+		{
+			`module.foo.test_resource.bar`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					{
+						Name: "foo",
+					},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "bar",
+					},
+				},
+			},
+			``,
+		},
+		{
+			`module.foo.test_resource.bar[1]`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					{
+						Name: "foo",
+					},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "bar",
+					},
+					Key: IntKey(1),
+				},
+			},
+			``,
+		},
+		{
+			`module.foo.test_resource.bar[baz]`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					{
+						Name: "foo",
+					},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "bar",
+					},
+					Key: StringKey("baz"),
+				},
+			},
+			``,
+		},
+		{
+			`module.foo.test_resource.bar["baz"]`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					{
+						Name: "foo",
+					},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "bar",
+					},
+					Key: StringKey("baz"),
+				},
+			},
+			``,
+		},
+		{
+			`module.foo[1].test_resource.bar`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					{
+						Name:        "foo",
+						InstanceKey: IntKey(1),
+					},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "bar",
+					},
+				},
+			},
+			``,
+		},
+		{
+			`module.foo[1].test_resource.bar[2]`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					{
+						Name:        "foo",
+						InstanceKey: IntKey(1),
+					},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "bar",
+					},
+					Key: IntKey(2),
+				},
+			},
+			``,
+		},
+		{
+			`module.foo[1].test_resource.bar[baz]`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					{
+						Name:        "foo",
+						InstanceKey: IntKey(1),
+					},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "bar",
+					},
+					Key: StringKey("baz"),
+				},
+			},
+			``,
+		},
+		{
+			`module.foo[1].test_resource.bar["baz"]`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					{
+						Name:        "foo",
+						InstanceKey: IntKey(1),
+					},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "test_resource",
+						Name: "bar",
+					},
+					Key: StringKey("baz"),
+				},
+			},
+			``,
+		},
+		{
+			`aws_instance`,
+			AbsResourceInstance{},
+			`Resource specification must include a resource type and name.`,
+		},
+		{
+			`module`,
+			AbsResourceInstance{},
+			`Prefix "module." must be followed by a module name.`,
+		},
+		{
+			`module["baz"]`,
+			AbsResourceInstance{},
+			`Prefix "module." must be followed by a module name.`,
+		},
+		{
+			`module.baz.bar`,
+			AbsResourceInstance{},
+			`Resource specification must include a resource type and name.`,
+		},
+		{
+			`aws_instance.foo.bar`,
+			AbsResourceInstance{},
+			`Resource instance key must be given in square brackets.`,
+		},
+		{
+			`aws_instance.foo[1].baz`,
+			AbsResourceInstance{},
+			`Unexpected extra operators after address.`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			addr, addrDiags := InferAbsResourceInstanceStr(test.Input)
+
+			switch len(addrDiags) {
+			case 0:
+				if test.WantErr != "" {
+					t.Fatalf("succeeded; want error: %s", test.WantErr)
+				}
+			case 1:
+				if test.WantErr == "" {
+					t.Fatalf("unexpected diagnostics: %s", addrDiags.Err())
+				}
+				if got, want := addrDiags[0].Description().Detail, test.WantErr; got != want {
+					t.Fatalf("wrong error\ngot:  %s\nwant: %s", got, want)
+				}
+			default:
+				t.Fatalf("too many diagnostics: %s", addrDiags.Err())
+			}
+
+			if addrDiags.HasErrors() {
+				return
+			}
+
+			for _, problem := range deep.Equal(addr, test.Want) {
+				t.Errorf(problem)
+			}
+		})
+	}
+}

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -56,7 +56,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	}
 
 	// Check if the address can be parsed
-	addr, addrDiags := addrs.ParseAbsResourceInstanceStr(args[0])
+	addr, addrDiags := addrs.InferAbsResourceInstanceStr(args[0])
 	if addrDiags.HasErrors() {
 		c.Ui.Error(fmt.Sprintf(errParsingAddress, args[0]))
 		return 1


### PR DESCRIPTION
Many shells will preprocess quote characters when executing a command and the new `for_each` resource addressing support requires surrounding quotes for index values. The error when missing those quotes on index values currently bubbles up as a syntax error from HCL itself, which supports only numeric or quote characters following the opening brace character.

A brief example of the current behavior:

```console
bash-3.2$ terraform state show null_resource.direct_for_each_map_alphanumeric["key1"]
Error parsing instance address: null_resource.direct_for_each_map_alphanumeric[key1]

This command requires that the address references one specific instance.
To view the available instances, use "terraform state list". Please modify
the address to reference a specific instance.

bash-3.2$ terraform state show null_resource.direct_for_each_map_alphanumeric[\"key1\"]
# null_resource.direct_for_each_map_alphanumeric["key1"]:
resource "null_resource" "direct_for_each_map_alphanumeric" {
    id = "1673079759258687264"
}
```

To allow commands to be more operator friendly in this situation, we can introduce a variant function of `ParseAbsResourceInstanceStr()`, which can detect this syntax error and progressively (for potential module `for_each` support in the future) attempt to implement the missing quoting for resource index values. Its only intended use should be for CLI command handling as we likely do not want to introduce any ambiguity about resource index value quoting inside the rest of Terraform itself.

This pull request is submitted with only `state show` but the same concept can be applied to other commands as well.