### PR TITLE
config: Add new functions to build config without reading files

### DIFF
--- a/configs/parser.go
+++ b/configs/parser.go
@@ -59,6 +59,16 @@ func (p *Parser) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 		}
 	}
 
+	return p.parseHCLFile(src, path)
+}
+
+// ParseHCLFile is a low-level method that parses the given code without reading the file.
+// It is useful when the code can be obtained other than reading files, such as LSP.
+func (p *Parser) ParseHCLFile(src []byte, path string) (hcl.Body, hcl.Diagnostics) {
+	return p.parseHCLFile(src, path)
+}
+
+func (p *Parser) parseHCLFile(src []byte, path string) (hcl.Body, hcl.Diagnostics) {
 	var file *hcl.File
 	var diags hcl.Diagnostics
 	switch {

--- a/configs/parser_values.go
+++ b/configs/parser_values.go
@@ -26,6 +26,21 @@ func (p *Parser) LoadValuesFile(path string) (map[string]cty.Value, hcl.Diagnost
 		return nil, diags
 	}
 
+	vals, buildDiags := buildValuesFile(body)
+	diags = append(diags, buildDiags...)
+
+	return vals, diags
+}
+
+// BuildValuesFile builds the cty.Value's key-value pairs from the given hcl.Body.
+// The difference with LoadValuesFile is whether to read the file directly.
+// It is useful when the code can be obtained other than reading files, such as LSP.
+func BuildValuesFile(body hcl.Body) (map[string]cty.Value, hcl.Diagnostics) {
+	return buildValuesFile(body)
+}
+
+func buildValuesFile(body hcl.Body) (map[string]cty.Value, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
 	vals := make(map[string]cty.Value)
 	attrs, attrDiags := body.JustAttributes()
 	diags = append(diags, attrDiags...)


### PR DESCRIPTION
Fixes #22369

This pull request adds new public functions that are not used in the Terraform core. See the issue for details. Note that these do not change the existing behavior.