### PR TITLE
[Website] Add Exoscale provider links

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -52,6 +52,7 @@ down to see all providers.
 - [DNSMadeEasy](/docs/providers/dme/index.html)
 - [Docker](/docs/providers/docker/index.html)
 - [Dyn](/docs/providers/dyn/index.html)
+- [Exoscale](/docs/providers/exoscale/index.html)
 - [External](/docs/providers/external/index.html)
 - [F5 BIG-IP](/docs/providers/bigip/index.html)
 - [Fastly](/docs/providers/fastly/index.html)

--- a/website/docs/providers/type/cloud-index.html.markdown
+++ b/website/docs/providers/type/cloud-index.html.markdown
@@ -24,6 +24,7 @@ vendor in close collaboration with HashiCorp, and are tested by HashiCorp.
 - [CloudScale.ch](/docs/providers/cloudscale/index.html)
 - [CloudStack](/docs/providers/cloudstack/index.html)
 - [DigitalOcean](/docs/providers/do/index.html)
+- [Exoscale](/docs/providers/exoscale/index.html)
 - [Fastly](/docs/providers/fastly/index.html)
 - [FlexibleEngine](/docs/providers/flexibleengine/index.html)
 - [Gridscale](/docs/providers/gridscale/index.html)


### PR DESCRIPTION
Exoscale has completed the TPDP and this PR will add two links that ill point to the providers documentation pages. 