### PR TITLE
Use new endpoints for Google authentication

### DIFF
--- a/backend/remote-state/gcs/backend.go
+++ b/backend/remote-state/gcs/backend.go
@@ -138,7 +138,7 @@ func (b *Backend) configure(ctx context.Context) error {
 			Email:      account.ClientEmail,
 			PrivateKey: []byte(account.PrivateKey),
 			Scopes:     []string{storage.ScopeReadWrite},
-			TokenURL:   "https://accounts.google.com/o/oauth2/token",
+			TokenURL:   "https://oauth2.googleapis.com/token",
 		}
 
 		opts = append(opts, option.WithHTTPClient(conf.Client(ctx)))


### PR DESCRIPTION
Fixes hashicorp/terraform#22451.

See golang/oauth2#310 for more details.