### PR TITLE
Add edge when calculating for_each orphans

### DIFF
--- a/states/sync.go
+++ b/states/sync.go
@@ -283,7 +283,7 @@ func (s *SyncState) MaybeFixUpResourceInstanceAddressForCount(addr addrs.AbsReso
 }
 
 // SetResourceInstanceCurrent saves the given instance object as the current
-// generation of the resource instance with the given address, simulataneously
+// generation of the resource instance with the given address, simultaneously
 // updating the recorded provider configuration address, dependencies, and
 // resource EachMode.
 //

--- a/terraform/transform_orphan_count.go
+++ b/terraform/transform_orphan_count.go
@@ -56,8 +56,14 @@ func (t *OrphanResourceCountTransformer) transformForEach(haveKeys map[addrs.Ins
 	// so if this (non-deterministically) happens to end up as the last one,
 	// that will change the resource's EachMode and our addressing for our instances
 	// will not work as expected
-	noKeyNode, hasNoKeyNode := haveKeys[addrs.NoKey]
+	_, hasNoKeyNode := haveKeys[addrs.NoKey]
+	var noKeyNode dag.Vertex
 	if hasNoKeyNode {
+		abstract := NewNodeAbstractResourceInstance(t.Addr.Instance(addrs.NoKey))
+		noKeyNode = abstract
+		if f := t.Concrete; f != nil {
+			noKeyNode = f(abstract)
+		}
 		g.Add(noKeyNode)
 	}
 

--- a/terraform/transform_orphan_count.go
+++ b/terraform/transform_orphan_count.go
@@ -51,7 +51,8 @@ func (t *OrphanResourceCountTransformer) Transform(g *Graph) error {
 
 func (t *OrphanResourceCountTransformer) transformForEach(haveKeys map[addrs.InstanceKey]struct{}, g *Graph) error {
 	// If there is a no-key node, add this to the graph first,
-	// because the last item determines the resource mode for the whole resource,
+	// so that we can create edges to it in subsequent (StringKey) nodes.
+	// This is because the last item determines the resource mode for the whole resource,
 	// so if this (non-deterministically) happens to end up as the last one,
 	// that will change the resource's EachMode and our addressing for our instances
 	// will not work as expected
@@ -79,6 +80,11 @@ func (t *OrphanResourceCountTransformer) transformForEach(haveKeys map[addrs.Ins
 		}
 		log.Printf("[TRACE] OrphanResourceCount(non-zero): adding %s as %T", t.Addr, node)
 		g.Add(node)
+
+		// Add edge to noKeyNode if it exists
+		if hasNoKeyNode {
+			g.Connect(dag.BasicEdge(node, noKeyNode))
+		}
 	}
 	return nil
 }

--- a/terraform/transform_orphan_count.go
+++ b/terraform/transform_orphan_count.go
@@ -50,12 +50,12 @@ func (t *OrphanResourceCountTransformer) Transform(g *Graph) error {
 }
 
 func (t *OrphanResourceCountTransformer) transformForEach(haveKeys map[addrs.InstanceKey]struct{}, g *Graph) error {
-	// If there is a no-key node, add this to the graph first,
+	// If there is a NoKey node, add this to the graph first,
 	// so that we can create edges to it in subsequent (StringKey) nodes.
 	// This is because the last item determines the resource mode for the whole resource,
-	// so if this (non-deterministically) happens to end up as the last one,
-	// that will change the resource's EachMode and our addressing for our instances
-	// will not work as expected
+	// (see SetResourceInstanceCurrent for more information) and we need to evaluate
+	// an orphaned (NoKey) resource before the in-memory state is updated
+	// to deal with a new for_each resource
 	_, hasNoKeyNode := haveKeys[addrs.NoKey]
 	var noKeyNode dag.Vertex
 	if hasNoKeyNode {
@@ -68,14 +68,14 @@ func (t *OrphanResourceCountTransformer) transformForEach(haveKeys map[addrs.Ins
 	}
 
 	for key := range haveKeys {
-		s, _ := key.(addrs.StringKey)
-		// If the key is present in our current for_each, carry on
-		if _, ok := t.ForEach[string(s)]; ok {
+		// If the key is no-key, we have already added it, so skip
+		if key == addrs.NoKey {
 			continue
 		}
 
-		// If the key is no-key, we have already added it, so skip
-		if key == addrs.NoKey {
+		s, _ := key.(addrs.StringKey)
+		// If the key is present in our current for_each, carry on
+		if _, ok := t.ForEach[string(s)]; ok {
 			continue
 		}
 


### PR DESCRIPTION
In the scenario when a resource is orphaned by the addition of for_each, in the evaluation of orphans, it is possible for the EachMode of the resource to be set incorrectly, because the last evaluated resource sets the EachMode for the whole resource. As such, adding an edge when evaluating the movement between NoKey and StringKey resources will ensure order is maintained, and an instance with StringKey will "win".

Fixes #22407 