### PR TITLE
Add concise flag to plan and apply.

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -224,6 +224,10 @@ type Operation struct {
 	// Workspace is the name of the workspace that this operation should run
 	// in, which controls which named state is used.
 	Workspace string
+
+	// If Concise is true, then only the modified attributes (ie. NoOp's are ignored)
+	// are rendered in plan diff.
+	Concise bool
 }
 
 // HasConfig returns true if and only if the operation has a ConfigDir value

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -108,7 +108,7 @@ func (b *Local) opApply(
 
 			if !trivialPlan {
 				// Display the plan of what we are going to apply/destroy.
-				b.renderPlan(plan, runningOp.State, tfCtx.Schemas())
+				b.renderPlan(plan, runningOp.State, tfCtx.Schemas(), op.Concise)
 				b.CLI.Output("")
 			}
 

--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -165,7 +165,7 @@ func (b *Local) opPlan(
 			return
 		}
 
-		b.renderPlan(plan, baseState, schemas)
+		b.renderPlan(plan, baseState, schemas, op.Concise)
 
 		// If we've accumulated any warnings along the way then we'll show them
 		// here just before we show the summary and next steps. If we encountered
@@ -192,8 +192,8 @@ func (b *Local) opPlan(
 	}
 }
 
-func (b *Local) renderPlan(plan *plans.Plan, state *states.State, schemas *terraform.Schemas) {
-	RenderPlan(plan, state, schemas, b.CLI, b.Colorize())
+func (b *Local) renderPlan(plan *plans.Plan, state *states.State, schemas *terraform.Schemas, concise bool) {
+	RenderPlan(plan, state, schemas, b.CLI, b.Colorize(), concise)
 }
 
 // RenderPlan renders the given plan to the given UI.
@@ -207,7 +207,7 @@ func (b *Local) renderPlan(plan *plans.Plan, state *states.State, schemas *terra
 // please consider whether it's time to do the more disruptive refactoring
 // so that something other than the local backend package is offering this
 // functionality.
-func RenderPlan(plan *plans.Plan, state *states.State, schemas *terraform.Schemas, ui cli.Ui, colorize *colorstring.Colorize) {
+func RenderPlan(plan *plans.Plan, state *states.State, schemas *terraform.Schemas, ui cli.Ui, colorize *colorstring.Colorize, concise bool) {
 	counts := map[plans.Action]int{}
 	var rChanges []*plans.ResourceInstanceChangeSrc
 	for _, change := range plan.Changes.Resources {
@@ -293,6 +293,7 @@ func RenderPlan(plan *plans.Plan, state *states.State, schemas *terraform.Schema
 			tainted,
 			rSchema,
 			colorize,
+			concise,
 		))
 	}
 

--- a/command/apply.go
+++ b/command/apply.go
@@ -27,7 +27,7 @@ type ApplyCommand struct {
 }
 
 func (c *ApplyCommand) Run(args []string) int {
-	var destroyForce, refresh, autoApprove bool
+	var destroyForce, refresh, autoApprove, concise bool
 	args, err := c.Meta.process(args, true)
 	if err != nil {
 		return 1
@@ -50,6 +50,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
+	cmdFlags.BoolVar(&concise, "concise", false, "concise")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -182,6 +183,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	opReq.DestroyForce = destroyForce
 	opReq.PlanFile = planFile
 	opReq.PlanRefresh = refresh
+	opReq.Concise = concise
 	opReq.Type = backend.OperationTypeApply
 
 	opReq.ConfigLoader, err = c.initConfigLoader()
@@ -257,6 +259,9 @@ Options:
   -compact-warnings      If Terraform produces any warnings that are not
                          accompanied by errors, show them in a more compact
                          form that includes only the summary messages.
+
+  -concise               If set, a concise diff of only the changed attributes
+                         will be generated.
 
   -lock=true             Lock the state file when locking is supported.
 

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -139,6 +139,11 @@ func TestResourceChange_primitiveTypes(t *testing.T) {
         id  = "i-02ae66f368e8518a9"
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+    }
+`,
 		},
 		"string force-new update": {
 			Action: plans.DeleteThenCreate,
@@ -165,6 +170,11 @@ func TestResourceChange_primitiveTypes(t *testing.T) {
 -/+ resource "test_instance" "example" {
       ~ ami = "ami-BEFORE" -> "ami-AFTER" # forces replacement
         id  = "i-02ae66f368e8518a9"
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER" # forces replacement
     }
 `,
 		},
@@ -194,6 +204,11 @@ func TestResourceChange_primitiveTypes(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ ami = "ami-BEFORE" -> "ami-AFTER"
         id  = "i-02ae66f368e8518a9"
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
     }
 `,
 		},
@@ -349,6 +364,12 @@ new line
       ~ str      = "before" -> "after"
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id       = "blah" -> (known after apply)
+      ~ str      = "before" -> "after"
+    }
+`,
 		},
 
 		// tainted resources
@@ -407,6 +428,11 @@ new line
         name   = "name"
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      + forced = "example" # forces replacement
+    }
+`,
 		},
 		"force replacement with empty before value legacy": {
 			Action: plans.DeleteThenCreate,
@@ -433,6 +459,11 @@ new line
 -/+ resource "test_instance" "example" {
       + forced = "example" # forces replacement
         name   = "name"
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      + forced = "example" # forces replacement
     }
 `,
 		},
@@ -508,6 +539,16 @@ func TestResourceChange_JSON(t *testing.T) {
       ~ json_field = jsonencode(
           ~ {
                 aaa = "value"
+              + bbb = "new_value"
+            }
+        )
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ {
               + bbb = "new_value"
             }
         )
@@ -613,6 +654,20 @@ func TestResourceChange_JSON(t *testing.T) {
         )
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ {
+              ~ aaa = [
+                  ~ {
+                      ~ foo = "bar" -> "baz"
+                    },
+                ]
+            }
+        )
+    }
+`,
 		},
 		"force-new update": {
 			Action: plans.DeleteThenCreate,
@@ -641,6 +696,16 @@ func TestResourceChange_JSON(t *testing.T) {
       ~ json_field = jsonencode(
           ~ {
                 aaa = "value"
+              + bbb = "new_value"
+            } # forces replacement
+        )
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ {
               + bbb = "new_value"
             } # forces replacement
         )
@@ -767,6 +832,16 @@ func TestResourceChange_JSON(t *testing.T) {
         )
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ [
+              - "third",
+            ]
+        )
+    }
+`,
 		},
 		"JSON list item addition": {
 			Action: plans.Update,
@@ -799,6 +874,16 @@ func TestResourceChange_JSON(t *testing.T) {
         )
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ [
+              + "third",
+            ]
+        )
+    }
+`,
 		},
 		"JSON list object addition": {
 			Action: plans.Update,
@@ -825,6 +910,16 @@ func TestResourceChange_JSON(t *testing.T) {
       ~ json_field = jsonencode(
           ~ {
                 first  = "111"
+              + second = "222"
+            }
+        )
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ {
               + second = "222"
             }
         )
@@ -867,6 +962,18 @@ func TestResourceChange_JSON(t *testing.T) {
         )
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ {
+              ~ Statement = [
+                  + "second",
+                ]
+            }
+        )
+    }
+`,
 		},
 		"JSON list of objects - adding item": {
 			Action: plans.Update,
@@ -895,6 +1002,18 @@ func TestResourceChange_JSON(t *testing.T) {
                 {
                     one = "111"
                 },
+              + {
+                  + two = "222"
+                },
+            ]
+        )
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ [
               + {
                   + two = "222"
                 },
@@ -940,6 +1059,18 @@ func TestResourceChange_JSON(t *testing.T) {
         )
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ [
+              - {
+                  - two = "222"
+                },
+            ]
+        )
+    }
+`,
 		},
 		"JSON object with list of objects": {
 			Action: plans.Update,
@@ -977,6 +1108,20 @@ func TestResourceChange_JSON(t *testing.T) {
         )
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ {
+              ~ parent = [
+                  + {
+                      + two = "222"
+                    },
+                ]
+            }
+        )
+    }
+`,
 		},
 		"JSON object double nested lists": {
 			Action: plans.Update,
@@ -1006,6 +1151,22 @@ func TestResourceChange_JSON(t *testing.T) {
                   ~ {
                       ~ another_list = [
                             "111",
+                          + "222",
+                        ]
+                    },
+                ]
+            }
+        )
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ json_field = jsonencode(
+          ~ {
+              ~ parent = [
+                  ~ {
+                      ~ another_list = [
                           + "222",
                         ]
                     },
@@ -1094,6 +1255,14 @@ func TestResourceChange_primitiveList(t *testing.T) {
         ]
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      + list_field = [
+          + "new-element",
+        ]
+    }
+`,
 		},
 		"in-place update - first addition": {
 			Action: plans.Update,
@@ -1122,6 +1291,14 @@ func TestResourceChange_primitiveList(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
         ami        = "ami-STATIC"
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ list_field = [
+          + "new-element",
+        ]
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
       ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
       ~ list_field = [
           + "new-element",
@@ -1169,6 +1346,14 @@ func TestResourceChange_primitiveList(t *testing.T) {
         ]
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ list_field = [
+          + "bbbb",
+        ]
+    }
+`,
 		},
 		"force-new update - insertion": {
 			Action: plans.DeleteThenCreate,
@@ -1212,6 +1397,14 @@ func TestResourceChange_primitiveList(t *testing.T) {
         ]
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ list_field = [ # forces replacement
+          + "bbbb",
+        ]
+    }
+`,
 		},
 		"in-place update - deletion": {
 			Action: plans.Update,
@@ -1248,6 +1441,15 @@ func TestResourceChange_primitiveList(t *testing.T) {
       ~ list_field = [
           - "aaaa",
             "bbbb",
+          - "cccc",
+        ]
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ list_field = [
+          - "aaaa",
           - "cccc",
         ]
     }
@@ -1316,6 +1518,16 @@ func TestResourceChange_primitiveList(t *testing.T) {
         ]
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ list_field = [
+          - "aaaa",
+          - "bbbb",
+          - "cccc",
+        ]
+    }
+`,
 		},
 		"in-place update - null to empty": {
 			Action: plans.Update,
@@ -1342,6 +1554,12 @@ func TestResourceChange_primitiveList(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
         ami        = "ami-STATIC"
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      + list_field = []
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
       ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
       + list_field = []
     }
@@ -1386,6 +1604,15 @@ func TestResourceChange_primitiveList(t *testing.T) {
           - "bbbb",
           + (known after apply),
             "cccc",
+        ]
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ list_field = [
+          - "bbbb",
+          + (known after apply),
         ]
     }
 `,
@@ -1434,6 +1661,16 @@ func TestResourceChange_primitiveList(t *testing.T) {
         ]
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ list_field = [
+          - "bbbb",
+          + (known after apply),
+          + (known after apply),
+        ]
+    }
+`,
 		},
 	}
 	runTestCases(t, testCases)
@@ -1474,6 +1711,14 @@ func TestResourceChange_primitiveSet(t *testing.T) {
         ]
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      + set_field = [
+          + "new-element",
+        ]
+    }
+`,
 		},
 		"in-place update - first insertion": {
 			Action: plans.Update,
@@ -1502,6 +1747,14 @@ func TestResourceChange_primitiveSet(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
         ami       = "ami-STATIC"
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ set_field = [
+          + "new-element",
+        ]
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       ~ set_field = [
           + "new-element",
@@ -1549,6 +1802,14 @@ func TestResourceChange_primitiveSet(t *testing.T) {
         ]
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ set_field = [
+          + "bbbb",
+        ]
+    }
+`,
 		},
 		"force-new update - insertion": {
 			Action: plans.DeleteThenCreate,
@@ -1592,6 +1853,14 @@ func TestResourceChange_primitiveSet(t *testing.T) {
         ]
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ set_field = [ # forces replacement
+          + "bbbb",
+        ]
+    }
+`,
 		},
 		"in-place update - deletion": {
 			Action: plans.Update,
@@ -1628,6 +1897,15 @@ func TestResourceChange_primitiveSet(t *testing.T) {
       ~ set_field = [
           - "aaaa",
             "bbbb",
+          - "cccc",
+        ]
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ set_field = [
+          - "aaaa",
           - "cccc",
         ]
     }
@@ -1693,6 +1971,15 @@ func TestResourceChange_primitiveSet(t *testing.T) {
         ]
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ set_field = [
+          - "aaaa",
+          - "bbbb",
+        ]
+    }
+`,
 		},
 		"in-place update - null to empty set": {
 			Action: plans.Update,
@@ -1719,6 +2006,12 @@ func TestResourceChange_primitiveSet(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
         ami       = "ami-STATIC"
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      + set_field = []
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       + set_field = []
     }
@@ -1752,6 +2045,15 @@ func TestResourceChange_primitiveSet(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
         ami       = "ami-STATIC"
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ set_field = [
+          - "aaaa",
+          - "bbbb",
+        ] -> (known after apply)
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       ~ set_field = [
           - "aaaa",
@@ -1799,6 +2101,15 @@ func TestResourceChange_primitiveSet(t *testing.T) {
         ]
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ set_field = [
+          - "bbbb",
+          ~ (known after apply),
+        ]
+    }
+`,
 		},
 	}
 	runTestCases(t, testCases)
@@ -1839,6 +2150,14 @@ func TestResourceChange_map(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      + map_field = {
+          + "new-key" = "new-element"
+        }
+    }
+`,
 		},
 		"in-place update - first insertion": {
 			Action: plans.Update,
@@ -1867,6 +2186,14 @@ func TestResourceChange_map(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
         ami       = "ami-STATIC"
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ map_field = {
+          + "new-key" = "new-element"
+        }
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       ~ map_field = {
           + "new-key" = "new-element"
@@ -1914,6 +2241,14 @@ func TestResourceChange_map(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ map_field = {
+          + "b" = "bbbb"
+        }
+    }
+`,
 		},
 		"force-new update - insertion": {
 			Action: plans.DeleteThenCreate,
@@ -1957,6 +2292,14 @@ func TestResourceChange_map(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ map_field = { # forces replacement
+          + "b" = "bbbb"
+        }
+    }
+`,
 		},
 		"in-place update - deletion": {
 			Action: plans.Update,
@@ -1993,6 +2336,15 @@ func TestResourceChange_map(t *testing.T) {
       ~ map_field = {
           - "a" = "aaaa" -> null
             "b" = "bbbb"
+          - "c" = "cccc" -> null
+        }
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ map_field = {
+          - "a" = "aaaa" -> null
           - "c" = "cccc" -> null
         }
     }
@@ -2065,6 +2417,14 @@ func TestResourceChange_map(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
+      ~ map_field = {
+          ~ "b" = "bbbb" -> (known after apply)
+        }
+    }
+`,
 		},
 	}
 	runTestCases(t, testCases)
@@ -2125,6 +2485,11 @@ func TestResourceChange_nestedList(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+    }
+`,
 		},
 		"in-place update - creation": {
 			Action: plans.Update,
@@ -2175,6 +2540,13 @@ func TestResourceChange_nestedList(t *testing.T) {
       + root_block_device {}
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+
+      + root_block_device {}
+    }
+`,
 		},
 		"in-place update - first insertion": {
 			Action: plans.Update,
@@ -2221,6 +2593,15 @@ func TestResourceChange_nestedList(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ ami = "ami-BEFORE" -> "ami-AFTER"
         id  = "i-02ae66f368e8518a9"
+
+      + root_block_device {
+          + volume_type = "gp2"
+        }
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
 
       + root_block_device {
           + volume_type = "gp2"
@@ -2289,6 +2670,15 @@ func TestResourceChange_nestedList(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+
+      ~ root_block_device {
+          + new_field   = "new_value"
+        }
+    }
+`,
 		},
 		"force-new update (inside block)": {
 			Action: plans.DeleteThenCreate,
@@ -2341,6 +2731,15 @@ func TestResourceChange_nestedList(t *testing.T) {
 -/+ resource "test_instance" "example" {
       ~ ami = "ami-BEFORE" -> "ami-AFTER"
         id  = "i-02ae66f368e8518a9"
+
+      ~ root_block_device {
+          ~ volume_type = "gp2" -> "different" # forces replacement
+        }
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
 
       ~ root_block_device {
           ~ volume_type = "gp2" -> "different" # forces replacement
@@ -2403,6 +2802,15 @@ func TestResourceChange_nestedList(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+
+      ~ root_block_device { # forces replacement
+          ~ volume_type = "gp2" -> "different"
+        }
+    }
+`,
 		},
 		"in-place update - deletion": {
 			Action: plans.Update,
@@ -2456,6 +2864,16 @@ func TestResourceChange_nestedList(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ ami = "ami-BEFORE" -> "ami-AFTER"
         id  = "i-02ae66f368e8518a9"
+
+      - root_block_device {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp2" -> null
+        }
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
 
       - root_block_device {
           - new_field   = "new_value" -> null
@@ -2562,6 +2980,15 @@ func TestResourceChange_nestedSet(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+
+      + root_block_device {
+          + volume_type = "gp2"
+        }
+    }
+`,
 		},
 		"in-place update - insertion": {
 			Action: plans.Update,
@@ -2617,6 +3044,19 @@ func TestResourceChange_nestedSet(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ ami = "ami-BEFORE" -> "ami-AFTER"
         id  = "i-02ae66f368e8518a9"
+
+      + root_block_device {
+          + new_field   = "new_value"
+          + volume_type = "gp2"
+        }
+      - root_block_device {
+          - volume_type = "gp2" -> null
+        }
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
 
       + root_block_device {
           + new_field   = "new_value"
@@ -2686,6 +3126,18 @@ func TestResourceChange_nestedSet(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+
+      + root_block_device { # forces replacement
+          + volume_type = "different"
+        }
+      - root_block_device { # forces replacement
+          - volume_type = "gp2" -> null
+        }
+    }
+`,
 		},
 		"in-place update - deletion": {
 			Action: plans.Update,
@@ -2739,6 +3191,16 @@ func TestResourceChange_nestedSet(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ ami = "ami-BEFORE" -> "ami-AFTER"
         id  = "i-02ae66f368e8518a9"
+
+      - root_block_device {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp2" -> null
+        }
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
 
       - root_block_device {
           - new_field   = "new_value" -> null
@@ -2804,6 +3266,15 @@ func TestResourceChange_nestedMap(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+
+      + root_block_device "a" {
+          + volume_type = "gp2"
+        }
+    }
+`,
 		},
 		"in-place update - change attr": {
 			Action: plans.Update,
@@ -2863,6 +3334,15 @@ func TestResourceChange_nestedMap(t *testing.T) {
       ~ root_block_device "a" {
           + new_field   = "new_value"
             volume_type = "gp2"
+        }
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+
+      ~ root_block_device "a" {
+          + new_field   = "new_value"
         }
     }
 `,
@@ -2935,6 +3415,16 @@ func TestResourceChange_nestedMap(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+
+      + root_block_device "b" {
+          + new_field   = "new_value"
+          + volume_type = "gp2"
+        }
+    }
+`,
 		},
 		"force-new update (whole block)": {
 			Action: plans.DeleteThenCreate,
@@ -3001,6 +3491,15 @@ func TestResourceChange_nestedMap(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example must be replaced
+-/+ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+
+      ~ root_block_device "a" { # forces replacement
+          ~ volume_type = "gp2" -> "different"
+        }
+    }
+`,
 		},
 		"in-place update - deletion": {
 			Action: plans.Update,
@@ -3061,6 +3560,16 @@ func TestResourceChange_nestedMap(t *testing.T) {
         }
     }
 `,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER"
+
+      - root_block_device "a" {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp2" -> null
+        }
+    }
+`,
 		},
 		"in-place sequence update - deletion": {
 			Action: plans.Update,
@@ -3110,66 +3619,78 @@ func TestResourceChange_nestedMap(t *testing.T) {
 }
 
 type testCase struct {
-	Action          plans.Action
-	Mode            addrs.ResourceMode
-	Before          cty.Value
-	After           cty.Value
-	Schema          *configschema.Block
-	RequiredReplace cty.PathSet
-	Tainted         bool
-	ExpectedOutput  string
+	Action                plans.Action
+	Mode                  addrs.ResourceMode
+	Before                cty.Value
+	After                 cty.Value
+	Schema                *configschema.Block
+	RequiredReplace       cty.PathSet
+	Tainted               bool
+	ExpectedOutput        string
+	ExpectedConciseOutput string
 }
 
 func runTestCases(t *testing.T, testCases map[string]testCase) {
 	color := &colorstring.Colorize{Colors: colorstring.DefaultColors, Disable: true}
-
 	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			ty := tc.Schema.ImpliedType()
-
-			beforeVal := tc.Before
-			switch { // Some fixups to make the test cases a little easier to write
-			case beforeVal.IsNull():
-				beforeVal = cty.NullVal(ty) // allow mistyped nulls
-			case !beforeVal.IsKnown():
-				beforeVal = cty.UnknownVal(ty) // allow mistyped unknowns
-			}
-			before, err := plans.NewDynamicValue(beforeVal, ty)
-			if err != nil {
-				t.Fatal(err)
+		for _, concise := range []bool{false, true} {
+			testName := name
+			if concise {
+				testName = name + " (concise)"
 			}
 
-			afterVal := tc.After
-			switch { // Some fixups to make the test cases a little easier to write
-			case afterVal.IsNull():
-				afterVal = cty.NullVal(ty) // allow mistyped nulls
-			case !afterVal.IsKnown():
-				afterVal = cty.UnknownVal(ty) // allow mistyped unknowns
-			}
-			after, err := plans.NewDynamicValue(afterVal, ty)
-			if err != nil {
-				t.Fatal(err)
-			}
+			t.Run(testName, func(t *testing.T) {
+				ty := tc.Schema.ImpliedType()
 
-			change := &plans.ResourceInstanceChangeSrc{
-				Addr: addrs.Resource{
-					Mode: tc.Mode,
-					Type: "test_instance",
-					Name: "example",
-				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-				ProviderAddr: addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
-				ChangeSrc: plans.ChangeSrc{
-					Action: tc.Action,
-					Before: before,
-					After:  after,
-				},
-				RequiredReplace: tc.RequiredReplace,
-			}
+				beforeVal := tc.Before
+				switch { // Some fixups to make the test cases a little easier to write
+				case beforeVal.IsNull():
+					beforeVal = cty.NullVal(ty) // allow mistyped nulls
+				case !beforeVal.IsKnown():
+					beforeVal = cty.UnknownVal(ty) // allow mistyped unknowns
+				}
+				before, err := plans.NewDynamicValue(beforeVal, ty)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-			output := ResourceChange(change, tc.Tainted, tc.Schema, color)
-			if output != tc.ExpectedOutput {
-				t.Fatalf("Unexpected diff.\ngot:\n%s\nwant:\n%s\n", output, tc.ExpectedOutput)
-			}
-		})
+				afterVal := tc.After
+				switch { // Some fixups to make the test cases a little easier to write
+				case afterVal.IsNull():
+					afterVal = cty.NullVal(ty) // allow mistyped nulls
+				case !afterVal.IsKnown():
+					afterVal = cty.UnknownVal(ty) // allow mistyped unknowns
+				}
+				after, err := plans.NewDynamicValue(afterVal, ty)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				change := &plans.ResourceInstanceChangeSrc{
+					Addr: addrs.Resource{
+						Mode: tc.Mode,
+						Type: "test_instance",
+						Name: "example",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+					ChangeSrc: plans.ChangeSrc{
+						Action: tc.Action,
+						Before: before,
+						After:  after,
+					},
+					RequiredReplace: tc.RequiredReplace,
+				}
+
+				expectedOutput := tc.ExpectedOutput
+				if concise && tc.ExpectedConciseOutput != "" {
+					expectedOutput = tc.ExpectedConciseOutput
+				}
+
+				output := ResourceChange(change, tc.Tainted, tc.Schema, color, concise)
+				if output != expectedOutput {
+					t.Fatalf("Unexpected diff.\ngot:\n%s\nwant:\n%s\n", output, expectedOutput)
+				}
+			})
+		}
 	}
 }

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -550,6 +550,7 @@ func TestResourceChange_JSON(t *testing.T) {
       ~ json_field = jsonencode(
           ~ {
               + bbb = "new_value"
+                ... = ...
             }
         )
     }
@@ -663,6 +664,7 @@ func TestResourceChange_JSON(t *testing.T) {
                   ~ {
                       ~ foo = "bar" -> "baz"
                     },
+                    ...
                 ]
             }
         )
@@ -707,6 +709,7 @@ func TestResourceChange_JSON(t *testing.T) {
       ~ json_field = jsonencode(
           ~ {
               + bbb = "new_value"
+                ... = ...
             } # forces replacement
         )
     }
@@ -838,6 +841,7 @@ func TestResourceChange_JSON(t *testing.T) {
       ~ json_field = jsonencode(
           ~ [
               - "third",
+                ...
             ]
         )
     }
@@ -880,6 +884,7 @@ func TestResourceChange_JSON(t *testing.T) {
       ~ json_field = jsonencode(
           ~ [
               + "third",
+                ...
             ]
         )
     }
@@ -921,6 +926,7 @@ func TestResourceChange_JSON(t *testing.T) {
       ~ json_field = jsonencode(
           ~ {
               + second = "222"
+                ...    = ...
             }
         )
     }
@@ -969,6 +975,7 @@ func TestResourceChange_JSON(t *testing.T) {
           ~ {
               ~ Statement = [
                   + "second",
+                    ...
                 ]
             }
         )
@@ -1017,6 +1024,7 @@ func TestResourceChange_JSON(t *testing.T) {
               + {
                   + two = "222"
                 },
+                ...
             ]
         )
     }
@@ -1067,6 +1075,7 @@ func TestResourceChange_JSON(t *testing.T) {
               - {
                   - two = "222"
                 },
+                ...
             ]
         )
     }
@@ -1117,6 +1126,7 @@ func TestResourceChange_JSON(t *testing.T) {
                   + {
                       + two = "222"
                     },
+                    ...
                 ]
             }
         )
@@ -1168,6 +1178,7 @@ func TestResourceChange_JSON(t *testing.T) {
                   ~ {
                       ~ another_list = [
                           + "222",
+                            ...
                         ]
                     },
                 ]
@@ -1351,6 +1362,7 @@ func TestResourceChange_primitiveList(t *testing.T) {
       ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
       ~ list_field = [
           + "bbbb",
+            ...
         ]
     }
 `,
@@ -1402,6 +1414,7 @@ func TestResourceChange_primitiveList(t *testing.T) {
       ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
       ~ list_field = [ # forces replacement
           + "bbbb",
+            ...
         ]
     }
 `,
@@ -1451,6 +1464,7 @@ func TestResourceChange_primitiveList(t *testing.T) {
       ~ list_field = [
           - "aaaa",
           - "cccc",
+            ...
         ]
     }
 `,
@@ -1613,6 +1627,7 @@ func TestResourceChange_primitiveList(t *testing.T) {
       ~ list_field = [
           - "bbbb",
           + (known after apply),
+            ...
         ]
     }
 `,
@@ -1668,6 +1683,7 @@ func TestResourceChange_primitiveList(t *testing.T) {
           - "bbbb",
           + (known after apply),
           + (known after apply),
+            ...
         ]
     }
 `,
@@ -1807,6 +1823,7 @@ func TestResourceChange_primitiveSet(t *testing.T) {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       ~ set_field = [
           + "bbbb",
+            ...
         ]
     }
 `,
@@ -1858,6 +1875,7 @@ func TestResourceChange_primitiveSet(t *testing.T) {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       ~ set_field = [ # forces replacement
           + "bbbb",
+            ...
         ]
     }
 `,
@@ -1907,6 +1925,7 @@ func TestResourceChange_primitiveSet(t *testing.T) {
       ~ set_field = [
           - "aaaa",
           - "cccc",
+            ...
         ]
     }
 `,
@@ -2107,6 +2126,7 @@ func TestResourceChange_primitiveSet(t *testing.T) {
       ~ set_field = [
           - "bbbb",
           ~ (known after apply),
+            ...
         ]
     }
 `,
@@ -2246,6 +2266,7 @@ func TestResourceChange_map(t *testing.T) {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       ~ map_field = {
           + "b" = "bbbb"
+            ... = ...
         }
     }
 `,
@@ -2297,6 +2318,7 @@ func TestResourceChange_map(t *testing.T) {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       ~ map_field = { # forces replacement
           + "b" = "bbbb"
+            ... = ...
         }
     }
 `,
@@ -2346,6 +2368,7 @@ func TestResourceChange_map(t *testing.T) {
       ~ map_field = {
           - "a" = "aaaa" -> null
           - "c" = "cccc" -> null
+            ... = ...
         }
     }
 `,
@@ -2422,6 +2445,7 @@ func TestResourceChange_map(t *testing.T) {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       ~ map_field = {
           ~ "b" = "bbbb" -> (known after apply)
+            ... = ...
         }
     }
 `,
@@ -3611,6 +3635,113 @@ func TestResourceChange_nestedMap(t *testing.T) {
       ~ list {
           ~ attr = "y" -> "z"
         }
+    }
+`,
+		},
+	}
+	runTestCases(t, testCases)
+}
+
+func TestResourceChange_complex(t *testing.T) {
+	testCases := map[string]testCase{
+		"complex diff with suppressed elements": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.StringVal("i-02ae66f368e8518a9"),
+				"ami":        cty.StringVal("ami-BEFORE"),
+				"json_field": cty.StringVal(`[{"one": "111", "two": "222", "three": "333"}, {"key": "val", "foo": "bar"}, {"letters": ["a", "b", "c"]}, [1, 2, 3], "foo"]`),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.StringVal("i-02ae66f368e8518a9"),
+				"ami":        cty.StringVal("ami-AFTER"),
+				"json_field": cty.StringVal(`[{"two": "2", "three": "333", "four": "444"}, {"key": "new", "foo": "foobar"}, {"letters": ["a", "c", "d"]}, [4, 5, 6], "foo", "bar"]`),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":         {Type: cty.String, Optional: true},
+					"ami":        {Type: cty.String, Optional: true},
+					"json_field": {Type: cty.String, Optional: true},
+				},
+			},
+			RequiredReplace: cty.NewPathSet(),
+			Tainted:         false,
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami        = "ami-BEFORE" -> "ami-AFTER"
+        id         = "i-02ae66f368e8518a9"
+      ~ json_field = jsonencode(
+          ~ [
+              ~ {
+                  + four  = "444"
+                  - one   = "111" -> null
+                    three = "333"
+                  ~ two   = "222" -> "2"
+                },
+              ~ {
+                  ~ foo = "bar" -> "foobar"
+                  ~ key = "val" -> "new"
+                },
+              ~ {
+                  ~ letters = [
+                        "a",
+                      - "b",
+                        "c",
+                      + "d",
+                    ]
+                },
+              - [
+                  - 1,
+                  - 2,
+                  - 3,
+                ],
+              + [
+                  + 4,
+                  + 5,
+                  + 6,
+                ],
+                "foo",
+              + "bar",
+            ]
+        )
+    }
+`,
+			ExpectedConciseOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami        = "ami-BEFORE" -> "ami-AFTER"
+      ~ json_field = jsonencode(
+          ~ [
+              ~ {
+                  + four  = "444"
+                  - one   = "111" -> null
+                  ~ two   = "222" -> "2"
+                    ...   = ...
+                },
+              ~ {
+                  ~ foo = "bar" -> "foobar"
+                  ~ key = "val" -> "new"
+                },
+              ~ {
+                  ~ letters = [
+                      - "b",
+                      + "d",
+                        ...
+                    ]
+                },
+              - [
+                  - 1,
+                  - 2,
+                  - 3,
+                ],
+              + [
+                  + 4,
+                  + 5,
+                  + 6,
+                ],
+              + "bar",
+                ...
+            ]
+        )
     }
 `,
 		},

--- a/command/plan.go
+++ b/command/plan.go
@@ -17,7 +17,7 @@ type PlanCommand struct {
 }
 
 func (c *PlanCommand) Run(args []string) int {
-	var destroy, refresh, detailed bool
+	var destroy, refresh, detailed, concise bool
 	var outPath string
 
 	args, err := c.Meta.process(args, true)
@@ -34,6 +34,7 @@ func (c *PlanCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&detailed, "detailed-exitcode", false, "detailed-exitcode")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
+	cmdFlags.BoolVar(&concise, "concise", false, "concise")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -98,6 +99,7 @@ func (c *PlanCommand) Run(args []string) int {
 	opReq.Destroy = destroy
 	opReq.PlanOutPath = outPath
 	opReq.PlanRefresh = refresh
+	opReq.Concise = concise
 	opReq.Type = backend.OperationTypePlan
 
 	opReq.ConfigLoader, err = c.initConfigLoader()
@@ -204,6 +206,9 @@ Options:
   -compact-warnings   If Terraform produces any warnings that are not
                       accompanied by errors, show them in a more compact form
                       that includes only the summary messages.
+
+  -concise            If set, a concise diff of only the changed attributes
+                      will be generated.
 
   -destroy            If set, a plan will be generated to destroy all resources
                       managed by the given configuration and state.

--- a/command/show.go
+++ b/command/show.go
@@ -162,7 +162,7 @@ func (c *ShowCommand) Run(args []string) int {
 		// package rather than in the backends themselves, but for now we're
 		// accepting this oddity because "terraform show" is a less commonly
 		// used way to render a plan than "terraform plan" is.
-		localBackend.RenderPlan(plan, stateFile.State, schemas, c.Ui, c.Colorize())
+		localBackend.RenderPlan(plan, stateFile.State, schemas, c.Ui, c.Colorize(), false)
 		return 0
 	}
 


### PR DESCRIPTION
As per https://github.com/hashicorp/terraform/issues/21639, `terraform plan` outputs in 0.12 are extremely verbose and difficult to review (I personally had almost 10k lines of output for what amounted to about 50 actual changed attributes all up).

This is a first pass attempt at adding a `-concise` flag to `terraform plan` and `terraform apply`.

It simply ignores `NoOp` attributes and values when producing the diff. 

eg. formerly for a simple metadata change on a GCP instance:
```
# module.db.module.masters.google_compute_instance.instance[1] will be updated in-place
  ~ resource "google_compute_instance" "instance" {
        allow_stopping_for_update = false
        can_ip_forward            = false
        cpu_platform              = "Intel Haswell"
        deletion_protection       = false
        guest_accelerator         = []
        id                        = "<redacted>"
        instance_id               = "<redacted>"
        label_fingerprint         = "<redacted>"
        labels                    = {
            "cluster"   = "<redacted>"
            "node_type" = "<redacted>"
        }
        machine_type              = "custom-48-212992"
        metadata                  = {
            "cluster"                   = "<redacted>"
            "data_disk_snapshot_policy" = ""
            "disk_setup"                = jsonencode(
                {
                    mysql = {
                        device = "data"
                        mount  = "/mnt/data/"
                        size   = "75%"
                    }
                }
            )
            "node_type"                 = "<redacted>"
        }
        metadata_fingerprint      = "<redacted>
      + min_cpu_platform          = "Intel Haswell"
        name                      = "<redacted>"
        project                   = "<redacted>"
        self_link                 = "https://www.googleapis.com/compute/v1/projects/<redacted>/zones/us-central1-b/instances/<redacted>"
        tags                      = ["<redacted>"]
        tags_fingerprint          = "<redacted>"
        zone                      = "us-central1-b"

        attached_disk {
            device_name = "data"
            mode        = "READ_WRITE"
            source      = "https://www.googleapis.com/compute/v1/projects/<redacted>/zones/us-central1-b/disks/<redacted>-data"
        }

        boot_disk {
            auto_delete = true
            device_name = "persistent-disk-0"
            source      = "https://www.googleapis.com/compute/v1/projects/<redacted>/zones/us-central1-b/disks/<redacted>"

            initialize_params {
                image  = "<redacted>"
                labels = {}
                size   = 150
                type   = "pd-standard"
            }
        }

        network_interface {
            name               = "nic0"
            network            = "https://www.googleapis.com/compute/v1/projects/<redacted>/global/networks/platform"
            network_ip         = "<redacted>"
            subnetwork         = "https://www.googleapis.com/compute/v1/projects/<redacted>/regions/us-central1/subnetworks/private"
            subnetwork_project = "<redacted>"
        }

        scheduling {
            automatic_restart   = true
            on_host_maintenance = "MIGRATE"
            preemptible         = false
        }

        service_account {
            email  = "<redacted>@<redacted>.iam.gserviceaccount.com"
            scopes = [
                "https://www.googleapis.com/auth/cloud-platform",
            ]
        }

        timeouts {}
    }
```

now:
```
  # module.db.module.masters.google_compute_instance.instance[1] will be updated in-place
  ~ resource "google_compute_instance" "instance" {
      + min_cpu_platform          = "Intel Haswell"
    }
```

