### PR TITLE
Fix taint and untaint commands when in a workspace

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	backendInit "github.com/hashicorp/terraform/backend/init"
+	backendLocal "github.com/hashicorp/terraform/backend/local"
 )
 
 // These are the directories for our test data and fixtures.
@@ -386,6 +387,31 @@ func testStateFileDefault(t *testing.T, s *terraform.State) string {
 	}
 
 	return DefaultStateFilename
+}
+
+// testStateFileWorkspaceDefault writes the state out to the default workspace statefile
+// in the cwd. Use `testCwd` to change into a temp cwd.
+func testStateFileWorkspaceDefault(t *testing.T, workspace string, s *terraform.State) string {
+	t.Helper()
+
+	workspaceDir := filepath.Join(backendLocal.DefaultWorkspaceDir, workspace)
+	err := os.MkdirAll(workspaceDir, os.ModePerm)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	workspaceDefault := filepath.Join(workspaceDir, DefaultStateFilename)
+	f, err := os.Create(workspaceDefault)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer f.Close()
+
+	if err := terraform.WriteState(s, f); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	return workspaceDefault
 }
 
 // testStateFileRemote writes the state out to the remote statefile

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -389,9 +389,9 @@ func testStateFileDefault(t *testing.T, s *terraform.State) string {
 	return DefaultStateFilename
 }
 
-// testStateFileWorkspaceDefault writes the state out to the default workspace statefile
-// in the cwd. Use `testCwd` to change into a temp cwd.
-func testStateFileWorkspaceDefault(t *testing.T, workspace string, s *terraform.State) string {
+// testStateFileWorkspaceDefault writes the state out to the default statefile
+// for the given workspace in the cwd. Use `testCwd` to change into a temp cwd.
+func testStateFileWorkspaceDefault(t *testing.T, workspace string, s *states.State) string {
 	t.Helper()
 
 	workspaceDir := filepath.Join(backendLocal.DefaultWorkspaceDir, workspace)
@@ -400,18 +400,18 @@ func testStateFileWorkspaceDefault(t *testing.T, workspace string, s *terraform.
 		t.Fatalf("err: %s", err)
 	}
 
-	workspaceDefault := filepath.Join(workspaceDir, DefaultStateFilename)
-	f, err := os.Create(workspaceDefault)
+	path := filepath.Join(workspaceDir, DefaultStateFilename)
+	f, err := os.Create(path)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	defer f.Close()
 
-	if err := terraform.WriteState(s, f); err != nil {
+	if err := writeStateForTesting(s, f); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	return workspaceDefault
+	return path
 }
 
 // testStateFileRemote writes the state out to the remote statefile

--- a/command/taint.go
+++ b/command/taint.go
@@ -29,7 +29,7 @@ func (c *TaintCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
 	cmdFlags.StringVar(&module, "module", "", "module")
-	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
+	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -27,7 +27,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
 	cmdFlags.StringVar(&module, "module", "", "module")
-	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
+	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {

--- a/command/untaint_test.go
+++ b/command/untaint_test.go
@@ -271,23 +271,23 @@ func TestUntaint_defaultWorkspaceState(t *testing.T) {
 	defer testFixCwd(t, tmp, cwd)
 
 	// Write the temp state
-	state := &terraform.State{
-		Modules: []*terraform.ModuleState{
-			&terraform.ModuleState{
-				Path: []string{"root"},
-				Resources: map[string]*terraform.ResourceState{
-					"test_instance.foo": &terraform.ResourceState{
-						Type: "test_instance",
-						Primary: &terraform.InstanceState{
-							ID:      "bar",
-							Tainted: true,
-						},
-					},
-				},
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_instance",
+				Name: "foo",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"id":"bar"}`),
+				Status:    states.ObjectTainted,
 			},
-		},
-	}
-
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModule,
+			},
+		)
+	})
 	testWorkspace := "development"
 	path := testStateFileWorkspaceDefault(t, testWorkspace, state)
 
@@ -308,7 +308,7 @@ func TestUntaint_defaultWorkspaceState(t *testing.T) {
 	testStateOutput(t, path, strings.TrimSpace(`
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`))
 }
 


### PR DESCRIPTION
Fixes #22157. Removes DefaultStateFilepath as the default for the
-state flag, allowing workspaces to be used properly.