### PR TITLE
Create a dedicated schema Validation method

### DIFF
--- a/builtin/providers/test/resource_nested_set_test.go
+++ b/builtin/providers/test/resource_nested_set_test.go
@@ -646,12 +646,7 @@ resource "test_resource_nested_set" "foo" {
   }
 }
 				`),
-				Check: resource.ComposeTestCheckFunc(
-					func(s *terraform.State) error {
-						fmt.Println(s)
-						return nil
-					},
-				),
+				Check: resource.ComposeTestCheckFunc(),
 			},
 		},
 	})

--- a/builtin/providers/test/resource_required_min_test.go
+++ b/builtin/providers/test/resource_required_min_test.go
@@ -18,7 +18,7 @@ func TestResource_dynamicRequiredMinItems(t *testing.T) {
 resource "test_resource_required_min" "a" {
 }
 `,
-				ExpectError: regexp.MustCompile(`"required_min_items" blocks are required`),
+				ExpectError: regexp.MustCompile(`"required_min_items": required field is not set`),
 			},
 			resource.TestStep{
 				Config: strings.TrimSpace(`
@@ -37,7 +37,7 @@ resource "test_resource_required_min" "b" {
 	}
 }
 				`),
-				ExpectError: regexp.MustCompile(`required_min_items: attribute supports 2 item as a minimum`),
+				ExpectError: regexp.MustCompile(`attribute supports 2 item as a minimum, config has 1 declared`),
 			},
 			resource.TestStep{
 				Config: strings.TrimSpace(`

--- a/configs/configschema/coerce_value.go
+++ b/configs/configschema/coerce_value.go
@@ -8,9 +8,7 @@ import (
 )
 
 // CoerceValue attempts to force the given value to conform to the type
-// implied by the receiever, while also applying the same validation and
-// transformation rules that would be applied by the decoder specification
-// returned by method DecoderSpec.
+// implied by the receiever.
 //
 // This is useful in situations where a configuration must be derived from
 // an already-decoded value. It is always better to decode directly from
@@ -83,16 +81,6 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 				if err != nil {
 					return cty.UnknownVal(b.ImpliedType()), err
 				}
-			case blockS.MinItems != 1 && blockS.MaxItems != 1:
-				if blockS.Nesting == NestingGroup {
-					attrs[typeName] = blockS.EmptyValue()
-				} else {
-					attrs[typeName] = cty.NullVal(blockS.ImpliedType())
-				}
-			default:
-				// We use the word "attribute" here because we're talking about
-				// the cty sense of that word rather than the HCL sense.
-				return cty.UnknownVal(b.ImpliedType()), path.NewErrorf("attribute %q is required", typeName)
 			}
 
 		case NestingList:
@@ -132,8 +120,6 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 					}
 				}
 				attrs[typeName] = cty.ListVal(elems)
-			default:
-				attrs[typeName] = cty.ListValEmpty(blockS.ImpliedType())
 			}
 
 		case NestingSet:
@@ -173,8 +159,6 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 					}
 				}
 				attrs[typeName] = cty.SetVal(elems)
-			default:
-				attrs[typeName] = cty.SetValEmpty(blockS.ImpliedType())
 			}
 
 		case NestingMap:
@@ -238,8 +222,6 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 				} else {
 					attrs[typeName] = cty.MapVal(elems)
 				}
-			default:
-				attrs[typeName] = cty.MapValEmpty(blockS.ImpliedType())
 			}
 
 		default:

--- a/configs/configschema/decoder_spec_test.go
+++ b/configs/configschema/decoder_spec_test.go
@@ -354,7 +354,7 @@ func TestBlockDecoderSpec(t *testing.T) {
 					cty.EmptyObjectVal,
 				}),
 			}),
-			1, // too many "foo" blocks
+			0, // this should pass during decoding, as the blocks may be dynamic
 		},
 		// dynamic blocks may fulfill MinItems, but there is only one block to
 		// decode.

--- a/configs/configschema/internal_validate_test.go
+++ b/configs/configschema/internal_validate_test.go
@@ -243,6 +243,43 @@ func TestBlockInternalValidate(t *testing.T) {
 			},
 			1, // block schema is nil
 		},
+		"required nesting group": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"bad": &NestedBlock{
+						Nesting: NestingGroup,
+						Block: Block{
+							Attributes: map[string]*Attribute{
+								"nested_bad": &Attribute{
+									Type:     cty.DynamicPseudoType,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			1,
+		},
+		"required nesting group min items": {
+			&Block{
+				BlockTypes: map[string]*NestedBlock{
+					"good": &NestedBlock{
+						Nesting:  NestingGroup,
+						MinItems: 1,
+						Block: Block{
+							Attributes: map[string]*Attribute{
+								"nested_bad": &Attribute{
+									Type:     cty.DynamicPseudoType,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			0,
+		},
 	}
 
 	for name, test := range tests {

--- a/configs/configschema/schema.go
+++ b/configs/configschema/schema.go
@@ -97,10 +97,11 @@ const (
 	// single instance of a given block type with no labels, but it additonally
 	// guarantees that its result will never be null, even if the block is
 	// absent, and instead the nested attributes and blocks will be treated
-	// as absent in that case. (Any required attributes or blocks within the
-	// nested block are not enforced unless the block is explicitly present
-	// in the configuration, so they are all effectively optional when the
-	// block is not present.)
+	// as absent in that case. (Due to the automatic instantiation of a missing
+	// NestingGroup block, any required attributes or blocks within the nested
+	// block effectively make the block itself required. Setting MinItems of 1
+	// is required to be set in this case to better communicate this
+	// requirement.)
 	//
 	// This is useful for the situation where a remote API has a feature that
 	// is always enabled but has a group of settings related to that feature

--- a/configs/configschema/validate.go
+++ b/configs/configschema/validate.go
@@ -1,0 +1,151 @@
+package configschema
+
+import (
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Validate ensures a cty.Value conforms to the schema precisely.
+func (b Block) Validate(val cty.Value) error {
+	if err := b.validate(val); err != nil {
+		return fmt.Errorf("validate error: %s", err)
+	}
+	return nil
+}
+func (b Block) validate(val cty.Value) error {
+	if !val.IsKnown() {
+		return nil
+	}
+
+	if !val.Type().IsObjectType() {
+		return fmt.Errorf("value must be an object, got %#v", val.Type())
+	}
+
+	// get a list of all allowed object attributes
+	allowedNames := map[string]struct{}{}
+	for name := range b.Attributes {
+		allowedNames[name] = struct{}{}
+	}
+	for name := range b.BlockTypes {
+		allowedNames[name] = struct{}{}
+	}
+
+	valMap := map[string]cty.Value{}
+	if !val.IsNull() {
+		valMap = val.AsValueMap()
+	}
+
+	// verify that we don't have any unexpected attributes
+	for name, attrVal := range valMap {
+		if _, ok := allowedNames[name]; !ok {
+			return fmt.Errorf("unexpected attribute %q: %#v", name, attrVal)
+		}
+	}
+
+	for name, attr := range b.Attributes {
+		attrVal, exists := valMap[name]
+		// attrVal may be unknown, but we don't actually compare the value here
+
+		if attr.Required {
+			if !exists || attrVal.IsNull() {
+				return fmt.Errorf("attribute %q is required", name)
+			}
+		}
+
+		if !exists || attrVal.IsNull() {
+			continue
+		}
+
+		if !attrVal.Type().Equals(attr.Type) {
+			// the types must be exact, unless the schema allows any type
+			if attr.Type != cty.DynamicPseudoType {
+				return fmt.Errorf("attribute %q expected type %#v, got %#v", name, attr.Type, attrVal.Type())
+			}
+		}
+	}
+
+	for name, nested := range b.BlockTypes {
+		blockVal := valMap[name]
+		// NestingGroup cannot be null
+		if nested.Nesting == NestingGroup && blockVal.IsNull() {
+			return fmt.Errorf("block %q cannot be null", name)
+		}
+
+		// wait until the value is known to complete validation
+		if !blockVal.IsKnown() {
+			continue
+		}
+
+		// and only validate length once the value is wholly known
+		if blockVal.IsWhollyKnown() {
+			switch nested.Nesting {
+			case NestingSingle:
+				if blockVal.IsNull() && nested.MinItems == 1 {
+					return fmt.Errorf("insufficient items for attribute %q; must have at least %d", name, nested.MinItems)
+				}
+
+			case NestingGroup:
+				// Nested group isn't required during decode, but by this point it must have a value
+				if blockVal.IsNull() {
+					return fmt.Errorf("missing value for NestedGroup %q", name)
+				}
+
+			case NestingList, NestingSet, NestingMap:
+				items := 0
+				if !blockVal.IsNull() {
+					items = blockVal.LengthInt()
+				}
+
+				if items < nested.MinItems {
+					return fmt.Errorf("insufficient items for attribute %q; must have at least %d", name, nested.MinItems)
+				}
+
+				if nested.MaxItems > 0 && items > nested.MaxItems {
+					return fmt.Errorf("too many items for attribute %q; cannot have more than %d", name, nested.MaxItems)
+				}
+			}
+		}
+
+		switch nested.Nesting {
+		case NestingSingle, NestingGroup:
+			if err := nested.Block.validate(blockVal); err != nil {
+				return fmt.Errorf("%q: %s", name, err)
+			}
+		case NestingList:
+			if !blockVal.Type().IsListType() {
+				return fmt.Errorf("expected list for block %q, got %#v", name, blockVal)
+			}
+
+			for _, val := range blockVal.AsValueSlice() {
+				if err := nested.Block.validate(val); err != nil {
+					// add the block name to the error context
+					return fmt.Errorf("%q: %s", name, err)
+				}
+			}
+		case NestingSet:
+			if !blockVal.Type().IsSetType() {
+				return fmt.Errorf("expected set for block %q, got %#v", name, blockVal)
+			}
+			for _, val := range blockVal.AsValueSlice() {
+				if err := nested.Block.validate(val); err != nil {
+					// add the block name to the error context
+					return fmt.Errorf("%q: %s", name, err)
+				}
+			}
+		case NestingMap:
+			if !blockVal.Type().IsMapType() && !blockVal.Type().IsObjectType() {
+				return fmt.Errorf("expected map or object for block %q, got %#v", name, blockVal)
+			}
+			for key, val := range blockVal.AsValueMap() {
+				if err := nested.Block.validate(val); err != nil {
+					// add the block name and map key to the error context
+					return fmt.Errorf("%s[%q]: %s", name, key, err)
+				}
+			}
+		default:
+			panic(fmt.Sprintf("invalid nesting mode: %s", nested.Nesting))
+		}
+	}
+	return nil
+}

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -1771,7 +1771,7 @@ func TestContext2Plan_blockNestingGroup(t *testing.T) {
 						Nesting: configschema.NestingGroup,
 						Block: configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
-								"baz": {Type: cty.String, Required: true},
+								"baz": {Type: cty.String, Optional: true},
 							},
 						},
 					},


### PR DESCRIPTION
Due to both the nature of dynamic blocks, and the need for resources to
sometimes communicate incomplete values, we cannot validate `MinItems` and
`MaxItems` during decoding or in `CoerceValue`.

Since we're reducing the early automatic validation, add a
`Block.Validate` method to precisely validate values. The number of items in the
block will be validated once the values is wholly known.

If a `NestingGroup` block has any `RequiredAttributes`, automatically
instantiating that would create a block missing those required
attributes, which will fail with the new validation. This means that the
block itself is essentially required, which we can enforce early in `InternalValidate`.
Since nothing currently makes use of `NestingGroup`, we can change the
semantics slightly to better align with the validation rules already present.

This also turns on `InternalValidate` for the schema. While the generated configschema
for existing providers should follow the expectations of `InternalValidate`, this will
only return warnings for the time being to avoid breaking any existing providers.

Fixes #22414