### PR TITLE
[Website] MongoDB Atlas provider links

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -80,6 +80,7 @@ down to see all providers.
 - [Logentries](/docs/providers/logentries/index.html)
 - [LogicMonitor](/docs/providers/logicmonitor/index.html)
 - [Mailgun](/docs/providers/mailgun/index.html)
+- [MongoDB Atlas](/docs/providers/mongodbatlas/index.html)
 - [MySQL](/docs/providers/mysql/index.html)
 - [Naver Cloud](/docs/providers/ncloud/index.html)
 - [Netlify](/docs/providers/netlify/index.html)

--- a/website/docs/providers/type/database-index.html.markdown
+++ b/website/docs/providers/type/database-index.html.markdown
@@ -18,5 +18,6 @@ collaboration with HashiCorp, and are tested by HashiCorp.
 
 
 - [InfluxDB](/docs/providers/influxdb/index.html)
+- [MongoDB Atlas](/docs/providers/mongodbatlas/index.html)
 - [MySQL](/docs/providers/mysql/index.html)
 - [PostgreSQL](/docs/providers/postgresql/index.html)


### PR DESCRIPTION
Add two links that will point to the MongoDB Atlas provider documentation. 