### PR TITLE
website: Document behavior of `self` object for provisioners

### DIFF
--- a/website/docs/configuration/expressions.html.md
+++ b/website/docs/configuration/expressions.html.md
@@ -201,6 +201,25 @@ you cannot use square-bracket notation to replace the dot-separated paths, and
 you cannot iterate over the "parent object" of a named entity (for example, you
 cannot use `aws_instance` in a `for` expression).
 
+### Local Named Values
+
+Within the bodies of certain expressions, or in some other specific contexts,
+there are other named values available beyond the global values listed above.
+These local names are described in the documentation for the specific contexts
+where they appear. Some of most common local names are:
+
+- `count.index`, in resources that use
+  [the `count` meta-argument](./resources.html#count-multiple-resource-instances-by-count).
+- `each.key` / `each.value`, in resources that use
+  [the `for_each` meta-argument](./resources.html#for_each-multiple-resource-instances-defined-by-a-map-or-set-of-strings).
+- `self`, in [provisioner](../provisioners/index.html) and
+  [connection](../provisioners/connection.html) blocks.
+
+-> **Note:** Local names are often referred to as _variables_ or
+_temporary variables_ in their documentation. These are not [input
+variables](./variables.html); they are just arbitrary names
+that temporarily represent a value.
+
 ### Named Values and Dependencies
 
 Constructs like resources and module calls often use references to named values
@@ -283,19 +302,6 @@ either [splat expressions](#splat-expressions) or index syntax:
 * `aws_instance.example[*].id` returns a list of all of the ids of each of the
   instances.
 * `aws_instance.example[0].id` returns just the id of the first instance.
-
-### Local Named Values
-
-Within the bodies of certain expressions, or in some other specific contexts,
-there are other named values available beyond the global values listed above.
-(For example, the body of a resource block where `count` is set can use a
-special `count.index` value.) These local names are described in the
-documentation for the specific contexts where they appear.
-
--> **Note:** Local named values are often referred to as _variables_ or
-_temporary variables_ in their documentation. These are not [input
-variables](./variables.html); they are just arbitrary names
-that temporarily represent a value.
 
 ### Values Not Yet Known
 

--- a/website/docs/configuration/resources.html.md
+++ b/website/docs/configuration/resources.html.md
@@ -274,6 +274,10 @@ identified by an index number, starting with `0`.
 This is different from resources without `count` or `for_each`, which can be
 referenced without an index or key.
 
+-> **Note:** Within nested `provisioner` or `connection` blocks, the special
+`self` object refers to the current _resource instance,_ not the resource block
+as a whole.
+
 #### Using Expressions in `count`
 
 The `count` meta-argument accepts numeric [expressions](./expressions.html).
@@ -369,6 +373,10 @@ identified by a map key (or set member) from the value provided to `for_each`.
 
 This is different from resources without `count` or `for_each`, which can be
 referenced without an index or key.
+
+-> **Note:** Within nested `provisioner` or `connection` blocks, the special
+`self` object refers to the current _resource instance,_ not the resource block
+as a whole.
 
 #### Using Sets
 

--- a/website/docs/provisioners/index.html.markdown
+++ b/website/docs/provisioners/index.html.markdown
@@ -142,7 +142,7 @@ the sections above.
 
 If you are certain that provisioners are the best way to solve your problem
 after considering the advice in the sections above, you can add a
-`provisioner` block inside the `resource` block for your compute instance.
+`provisioner` block inside the `resource` block of a compute instance.
 
 ```hcl
 resource "aws_instance" "web" {
@@ -156,8 +156,29 @@ resource "aws_instance" "web" {
 
 The `local-exec` provisioner requires no other configuration, but most other
 provisioners must connect to the remote system using SSH or WinRM.
-You must write [a `connection` block](./connection.html) so that Terraform
+You must include [a `connection` block](./connection.html) so that Terraform
 will know how to communicate with the server.
+
+Terraform includes several built-in provisioners; use the navigation sidebar to
+view their documentation. You can also install third-party provisioners in
+[the user plugins directory](../configuration/providers.html#third-party-plugins).
+
+All provisioners support the `when` and `on_failure` meta-arguments, which
+are described below (see [Destroy-Time Provisioners](#destroy-time-provisioners)
+and [Failure Behavior](#failure-behavior)).
+
+### The `self` Object
+
+Expressions in `provisioner` blocks cannot refer to their parent resource by
+name. Instead, they can use the special `self` object.
+
+The `self` object represents the provisioner's parent resource, and has all of
+that resource's attributes. For example, use `self.public_ip` to reference an
+`aws_instance`'s `public_ip` attribute.
+
+-> **Technical note:** Resource references are restricted here because
+references create dependencies. Referring to a resource by name within its own
+block would create a dependency cycle.
 
 ## Creation-Time Provisioners
 
@@ -243,12 +264,12 @@ resource "aws_instance" "web" {
 ## Failure Behavior
 
 By default, provisioners that fail will also cause the Terraform apply
-itself to error. The `on_failure` setting can be used to change this. The
+itself to fail. The `on_failure` setting can be used to change this. The
 allowed values are:
 
 - `"continue"` - Ignore the error and continue with creation or destruction.
 
-- `"fail"` - Error (the default behavior). If this is a creation provisioner,
+- `"fail"` - Raise an error and stop applying (the default behavior). If this is a creation provisioner,
     taint the resource.
 
 Example:

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -331,33 +331,39 @@
             <a href="/docs/provisioners/null_resource.html">Provisioners Without a Resource</a>
           </li>
 
-          <li<%= sidebar_current("docs-provisioners-chef") %>>
-            <a href="/docs/provisioners/chef.html">chef Provisioner</a>
+          <li>
+            <a href="#">Built-in Provisioners</a>
+            <ul class="nav nav-auto-expand">
+              <li<%= sidebar_current("docs-provisioners-chef") %>>
+                <a href="/docs/provisioners/chef.html">chef Provisioner</a>
+              </li>
+
+              <li<%= sidebar_current("docs-provisioners-file") %>>
+                <a href="/docs/provisioners/file.html">file Provisioner</a>
+              </li>
+
+              <li<%= sidebar_current("docs-provisioners-habitat") %>>
+                <a href="/docs/provisioners/habitat.html">habitat Provisioner</a>
+              </li>
+
+              <li<%= sidebar_current("docs-provisioners-local") %>>
+                <a href="/docs/provisioners/local-exec.html">local-exec Provisioner</a>
+              </li>
+
+              <li<%= sidebar_current("docs-provisioners-puppet") %>>
+                <a href="/docs/provisioners/puppet.html">puppet Provisioner</a>
+              </li>
+
+              <li<%= sidebar_current("docs-provisioners-remote") %>>
+                <a href="/docs/provisioners/remote-exec.html">remote-exec Provisioner</a>
+              </li>
+
+              <li<%= sidebar_current("docs-provisioners-salt-masterless") %>>
+                <a href="/docs/provisioners/salt-masterless.html">salt-masterless Provisioner</a>
+              </li>
+            </ul>
           </li>
 
-          <li<%= sidebar_current("docs-provisioners-file") %>>
-            <a href="/docs/provisioners/file.html">file Provisioner</a>
-          </li>
-
-          <li<%= sidebar_current("docs-provisioners-habitat") %>>
-            <a href="/docs/provisioners/habitat.html">habitat Provisioner</a>
-          </li>
-
-          <li<%= sidebar_current("docs-provisioners-local") %>>
-            <a href="/docs/provisioners/local-exec.html">local-exec Provisioner</a>
-          </li>
-
-          <li<%= sidebar_current("docs-provisioners-puppet") %>>
-            <a href="/docs/provisioners/puppet.html">puppet Provisioner</a>
-          </li>
-
-          <li<%= sidebar_current("docs-provisioners-remote") %>>
-            <a href="/docs/provisioners/remote-exec.html">remote-exec Provisioner</a>
-          </li>
-
-          <li<%= sidebar_current("docs-provisioners-salt-masterless") %>>
-            <a href="/docs/provisioners/salt-masterless.html">salt-masterless Provisioner</a>
-          </li>
         </ul>
       </li>
 


### PR DESCRIPTION
Tried to be comprehensive about this: 

- As far as we know, connection and provisioner are the only places `self` is valid. 
- Robin's problem came from trying to use `count.index` within a connection block, so I added notes next to the count and each objects too. 
- The thing about local variables also benefited from just listing what are probably the three most common local values, since at least some readers are gonna check the info about variable names first before delving down into the stuff about meta-arguments or provisioners. 
- While I was messing with this, I was reminded that connection defaults went away in 0.12, so some language needed to be updated there. 
- Here's the result of that sidebar fiddling, which wasn't strictly necessary but which made that section a little more legible. 

    ![image](https://user-images.githubusercontent.com/484309/63306623-3cac6e00-c2a0-11e9-86d3-fe565eb778f7.png)
