### PR TITLE
lang/funcs: Add fileset function

### DIFF
--- a/lang/functions.go
+++ b/lang/functions.go
@@ -56,6 +56,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"chunklist":        funcs.ChunklistFunc,
 			"file":             funcs.MakeFileFunc(s.BaseDir, false),
 			"fileexists":       funcs.MakeFileExistsFunc(s.BaseDir),
+			"fileset":          funcs.MakeFileSetFunc(s.BaseDir),
 			"filebase64":       funcs.MakeFileFunc(s.BaseDir, true),
 			"filebase64sha256": funcs.MakeFileBase64Sha256Func(s.BaseDir),
 			"filebase64sha512": funcs.MakeFileBase64Sha512Func(s.BaseDir),

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -279,6 +279,16 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"fileset": {
+			{
+				`fileset("hello.*")`,
+				cty.SetVal([]cty.Value{
+					cty.StringVal("testdata/functions-test/hello.tmpl"),
+					cty.StringVal("testdata/functions-test/hello.txt"),
+				}),
+			},
+		},
+
 		"filebase64": {
 			{
 				`filebase64("hello.txt")`,

--- a/website/docs/configuration/functions/fileset.html.md
+++ b/website/docs/configuration/functions/fileset.html.md
@@ -1,0 +1,48 @@
+---
+layout: "functions"
+page_title: "fileset - Functions - Configuration Language"
+sidebar_current: "docs-funcs-file-file-set"
+description: |-
+  The fileset function enumerates a set of regular file names given a pattern.
+---
+
+# `fileset` Function
+
+-> **Note:** This page is about Terraform 0.12 and later. For Terraform 0.11 and
+earlier, see
+[0.11 Configuration Language: Interpolation Syntax](../../configuration-0-11/interpolation.html).
+
+`fileset` enumerates a set of regular file names given a pattern.
+
+```hcl
+fileset(pattern)
+```
+
+Supported pattern matches:
+
+- `*` - matches any sequence of non-separator characters
+- `?` - matches any single non-separator character
+- `[RANGE]` - matches a range of characters
+- `[^RANGE]` - matches outside the range of characters
+
+Functions are evaluated during configuration parsing rather than at apply time,
+so this function can only be used with files that are already present on disk
+before Terraform takes any actions.
+
+## Examples
+
+```
+> fileset("${path.module}/*.txt")
+[
+  "path/to/module/hello.txt",
+  "path/to/module/world.txt",
+]
+```
+
+```hcl
+resource "example_thing" "example" {
+  for_each = fileset("${path.module}/files/*")
+
+  # other configuration using each.value
+}
+```

--- a/website/layouts/functions.erb
+++ b/website/layouts/functions.erb
@@ -305,6 +305,10 @@
               </li>
 
               <li>
+                <a href="/docs/configuration/functions/fileset.html">fileset</a>
+              </li>
+
+              <li>
                 <a href="/docs/configuration/functions/filebase64.html">filebase64</a>
               </li>
 


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform/issues/16697

Enumerates a set of regular file names from a given glob pattern.

Example Usage:

```hcl
> fileset("${path.module}/*.txt")
[
  "path/to/module/hello.txt",
  "path/to/module/world.txt",
]
```

```hcl
resource "aws_s3_bucket_object" "example" {
  for_each = fileset("${path.module}/*.txt")

  bucket = aws_s3_bucket.example.bucket
  key    = replace(each.value, "${path.module}", "example-prefix")
  source = each.value
}
```

Potential Caveats:

- Implemented via the Go stdlib `path/filepath.Glob()` functionality. Notably, stdlib does not support `**` or `{}` extended patterns. See also: https://github.com/golang/go/issues/11862 To support the extended glob patterns, it will require adding a dependency on a third party library (e.g. https://github.com/bmatcuk/doublestar) or adding our own matching code
- Implemented as `fileset` using `cty.Set(cty.String)` for easier usage with `for_each`, but could just as easily be `filelist` using `cty.List(cty.String)` type
- Includes relative path information from base directory in each result by default