### PR TITLE
return an error with an invalid resource index

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -10407,3 +10407,48 @@ func TestContext2Apply_issue19908(t *testing.T) {
 		t.Errorf("test.foo attributes JSON doesn't contain %s after apply\ngot: %s", want, got)
 	}
 }
+
+func TestContext2Apply_invalidIndexRef(t *testing.T) {
+	p := testProvider("test")
+	p.GetSchemaReturn = &ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_instance": {
+				Attributes: map[string]*configschema.Attribute{
+					"value": {Type: cty.String, Optional: true, Computed: true},
+				},
+			},
+		},
+	}
+	p.DiffFn = testDiffFn
+
+	m := testModule(t, "apply-invalid-index")
+	c := testContext2(t, &ContextOpts{
+		Config: m,
+		ProviderResolver: providers.ResolverFixed(
+			map[string]providers.Factory{
+				"test": testProviderFuncFixed(p),
+			},
+		),
+	})
+
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("unexpected validation failure: %s", diags.Err())
+	}
+
+	if _, diags := c.Plan(); diags.HasErrors() {
+		t.Fatalf("plan errors: %s", diags.Err())
+	}
+
+	_, diags = c.Apply()
+	if !diags.HasErrors() {
+		t.Fatalf("apply succeeded; want error")
+	}
+
+	gotErrStr := diags.Err().Error()
+
+	wantErrStr := "test_instance.a has no index [0]"
+	if !strings.Contains(gotErrStr, wantErrStr) {
+		t.Fatalf("missing expected error\ngot: %s\n\nwant: error containing %q", gotErrStr, wantErrStr)
+	}
+}

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -68,6 +68,13 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 		if configDiags.HasErrors() {
 			return nil, diags.Err()
 		}
+
+		if !configVal.IsWhollyKnown() {
+			return nil, fmt.Errorf(
+				"configuration for %s still contains unknown values during apply (this is a bug in Terraform; please report it!)",
+				absAddr,
+			)
+		}
 	}
 
 	log.Printf("[DEBUG] %s: applying the planned %s change", n.Addr.Absolute(ctx.Path()), change.Action)

--- a/terraform/testdata/apply-invalid-index/main.tf
+++ b/terraform/testdata/apply-invalid-index/main.tf
@@ -1,0 +1,7 @@
+resource "test_instance" "a" {
+  count = 0
+}
+
+resource "test_instance" "b" {
+  value = test_instance.a[0].value
+}


### PR DESCRIPTION
Invalid indexed references to other resources were silently returning
unknown values when the resource didn't exist. These were only caught by
extra validation in data sources when the config still contained unknown
values during ReadDataSource.

Also add a check for unknown values when applying managed resources to
prevent sending unknown values.

Have GetResourceInstance return full diagnostics pointing to the invalid
reference in the config to help users troubleshoot the issue. This is
currently only done during Apply, as there is some uncertainly about
all instances being resolved in time for plan evaluation. This will
still catch errors for both resources and data sources and report
diagnostic errors, but unfortunately that won't happen until the apply
phase.

The original output for a datasource with this error would only be

```
configuration for data.null_data_source.foo[0].id still contains unknown values during apply (this is a bug in Terraform; please report it!)
```

And now will report

```
Error: Invalid resource index

  on main.tf line 7, in data "null_data_source" "bar":
   7:     a = data.null_data_source.foo[0].id

Resource data.null_data_source.foo has no index [0].
```

Fixes #22424