### PR TITLE
add hexadecimal support for tonumber()

### DIFF
--- a/lang/funcs/conversion_test.go
+++ b/lang/funcs/conversion_test.go
@@ -15,6 +15,12 @@ func TestTo(t *testing.T) {
 		Err      string
 	}{
 		{
+			cty.StringVal("0x99"),
+			cty.Number,
+			cty.NumberIntVal(153),
+			``,
+		},
+		{
 			cty.StringVal("a"),
 			cty.String,
 			cty.StringVal("a"),


### PR DESCRIPTION
fixes #22584 

add ability for `tonumber()` to support 0x prefixed hexadecimal strings

e.g.

```hcl
variable "v1" {
    default = "0x99"
}
output "input-v1" {
    value = tonumber(var.v1)
}
```

will return:
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

input-v1 = 153
```