### PR TITLE
Clarification for type of primary key

### DIFF
--- a/website/docs/backends/types/oss.html.md
+++ b/website/docs/backends/types/oss.html.md
@@ -34,7 +34,7 @@ terraform {
 This assumes we have a [OSS Bucket](https://www.terraform.io/docs/providers/alicloud/r/oss_bucket.html) created called `bucket-for-terraform-state`,
 a [OTS Instance](https://www.terraform.io/docs/providers/alicloud/r/ots_instance.html) called `terraform-remote` and
 a [OTS TableStore](https://www.terraform.io/docs/providers/alicloud/r/ots_table.html) called `statelock`. The
-Terraform state will be written into the file `path/mystate/version-1.tfstate`.
+Terraform state will be written into the file `path/mystate/version-1.tfstate`. The `TableStore` must have a primary key of type `string`.
 
 
 ## Using the OSS remote state


### PR DESCRIPTION
I tried with integer, it crashed.

```
Initializing the backend...

Successfully configured the backend "oss"! Terraform will automatically
use this backend unless the backend configuration changes.
panic: [tablestore] invalid input

goroutine 1 [running]:
github.com/aliyun/aliyun-tablestore-go-sdk/tablestore.NewPrimaryKeyColumn(0xc0001e0fb0, 0x2, 0x8, 0x19efe40, 0xc0001e0f30, 0x0, 0x0)
	/opt/teamcity-agent/work/9e329aa031982669/pkg/mod/github.com/aliyun/aliyun-tablestore-go-sdk@v4.1.2+incompatible/tablestore/util.go:279 +0x338
github.com/aliyun/aliyun-tablestore-go-sdk/tablestore.(*PrimaryKey).Build(0xc0001fabe0, 0xc00069f200, 0x0, 0x0, 0x200)
	/opt/teamcity-agent/work/9e329aa031982669/pkg/mod/github.com/aliyun/aliyun-tablestore-go-sdk@v4.1.2+incompatible/tablestore/util.go:388 +0x200
github.com/aliyun/aliyun-tablestore-go-sdk/tablestore.(*TableStoreClient).GetRow(0xc0001982a0, 0xc00061f6e0, 0xc00061f6e8, 0x1, 0x1)
	/opt/teamcity-agent/work/9e329aa031982669/pkg/mod/github.com/aliyun/aliyun-tablestore-go-sdk@v4.1.2+incompatible/tablestore/api.go:610 +0x107
github.com/hashicorp/terraform/backend/remote-state/oss.(*RemoteClient).getMD5(0xc000352280, 0x0, 0x0, 0x0, 0xbf50fe2c800680c9, 0x332561bda)
	/opt/teamcity-agent/work/9e329aa031982669/src/github.com/hashicorp/terraform/backend/remote-state/oss/client.go:237 +0x254
github.com/hashicorp/terraform/backend/remote-state/oss.(*RemoteClient).Get(0xc000352280, 0x0, 0xc00061f838, 0x42af3f)
	/opt/teamcity-agent/work/9e329aa031982669/src/github.com/hashicorp/terraform/backend/remote-state/oss/client.go:81 +0x129
github.com/hashicorp/terraform/state/remote.(*State).refreshState(0xc0000199a0, 0x1e55c68, 0xc0000199a0)
	/opt/teamcity-agent/work/9e329aa031982669/src/github.com/hashicorp/terraform/state/remote/state.go:95 +0x38
github.com/hashicorp/terraform/state/remote.(*State).RefreshState(0xc0000199a0, 0x0, 0x0)
	/opt/teamcity-agent/work/9e329aa031982669/src/github.com/hashicorp/terraform/state/remote/state.go:88 +0x6d
github.com/hashicorp/terraform/command.(*InitCommand).Run(0xc0004411e0, 0xc00000c090, 0x0, 0x0, 0xc0003dcfa0)
	/opt/teamcity-agent/work/9e329aa031982669/src/github.com/hashicorp/terraform/command/init.go:324 +0x171c
github.com/mitchellh/cli.(*CLI).Run(0xc0003c77c0, 0xc0003c77c0, 0xc000225d90, 0x1)
	/opt/teamcity-agent/work/9e329aa031982669/pkg/mod/github.com/mitchellh/cli@v1.0.0/cli.go:255 +0x1f1
main.wrappedMain(0x0)
	/opt/teamcity-agent/work/9e329aa031982669/src/github.com/hashicorp/terraform/main.go:223 +0xaff
main.realMain(0x0)
	/opt/teamcity-agent/work/9e329aa031982669/src/github.com/hashicorp/terraform/main.go:100 +0xb4
main.main()
	/opt/teamcity-agent/work/9e329aa031982669/src/github.com/hashicorp/terraform/main.go:36 +0x3b



!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

Terraform crashed! This is always indicative of a bug within Terraform.
A crash log has been placed at "crash.log" relative to your current
working directory. It would be immensely helpful if you could please
report the crash with Terraform[1] so that we can fix this.

When reporting bugs, please include your terraform version. That
information is available on the first line of crash.log. You can also
get it by running 'terraform --version' on the command line.

[1]: https://github.com/hashicorp/terraform/issues

!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
```