### PR TITLE
Updated usage examples

### DIFF
--- a/website/docs/backends/types/remote.html.md
+++ b/website/docs/backends/types/remote.html.md
@@ -107,16 +107,41 @@ terraform {
 ## Example Reference
 
 ```hcl
+# Terraform <= 0.11
 data "terraform_remote_state" "foo" {
   backend = "remote"
 
   config = {
+    hostname     = "app.terraform.io"
     organization = "company"
 
     workspaces {
       name = "workspace"
     }
   }
+}
+
+resource "aws_instance" "foo" {
+  # ...
+  subnet_id = "${data.terraform_remote_state.foo.subnet_id}"
+}
+
+# Terraform >= 0.12
+data "terraform_remote_state" "foo" {
+  backend = "remote"
+
+  config = {
+    organization = "company"
+
+    workspaces = {
+      name = "workspace"
+    }
+  }
+}
+
+resource "aws_instance" "foo" {
+  # ...
+  subnet_id = data.terraform_remote_state.foo.outputs.subnet_id
 }
 ```
 


### PR DESCRIPTION
Originally discovered that for v0.12, the example was missing the "=" assignment for workspaces block. Also added a usage example showing the new "outputs" attribute reference for root-level ouputs in the data object.