### PR TITLE
website: In 0.12, terraform_remote_state syntax differs from backend config

### DIFF
--- a/website/docs/providers/terraform/d/remote_state.html.md
+++ b/website/docs/providers/terraform/d/remote_state.html.md
@@ -24,8 +24,12 @@ use interpolations when configuring them.
 ```hcl
 data "terraform_remote_state" "vpc" {
   backend = "remote"
+
   config = {
-    name = "hashicorp/vpc-prod"
+    organization = "hashicorp"
+    workspaces = {
+      name = "vpc-prod"
+    }
   }
 }
 
@@ -49,19 +53,26 @@ The following arguments are supported:
 * `backend` - (Required) The remote backend to use.
 * `workspace` - (Optional) The Terraform workspace to use, if the backend
   supports workspaces.
-* `config` - (Optional; block) The configuration of the remote backend. The
-  `config` block can use any arguments that would be valid in the equivalent
-  `terraform { backend "<TYPE>" { ... } }` block. See
-  [the documentation of your chosen backend](/docs/backends/types/index.html)
-  for details.
-* `defaults` - (Optional; block) Default values for outputs, in case the state
+* `config` - (Optional; object) The configuration of the remote backend.
+  Although this argument is listed as optional, most backends require
+  some configuration.
+
+    The `config` object can use any arguments that would be valid in the
+    equivalent `terraform { backend "<TYPE>" { ... } }` block. See
+    [the documentation of your chosen backend](/docs/backends/types/index.html)
+    for details.
+
+    -> **Note:** If the backend configuration requires a nested block, specify
+    it here as a normal attribute with an object value. (For example,
+    `workspaces = { ... }` instead of `workspaces { ... }`.)
+* `defaults` - (Optional; object) Default values for outputs, in case the state
   file is empty or lacks a required output.
 
 ## Attributes Reference
 
 In addition to the above, the following attributes are exported:
 
-* (v0.12+) `outputs` - An object containing every root-level 
+* (v0.12+) `outputs` - An object containing every root-level
   [output](/docs/configuration/outputs.html) in the remote state.
 * (<= v0.11) `<OUTPUT NAME>` - Each root-level [output](/docs/configuration/outputs.html)
   in the remote state appears as a top level attribute on the data source.

--- a/website/docs/providers/terraform/index.html.markdown
+++ b/website/docs/providers/terraform/index.html.markdown
@@ -18,10 +18,13 @@ Use the navigation to the left to read about the available data sources.
 ```hcl
 # Shared infrastructure state stored in Atlas
 data "terraform_remote_state" "vpc" {
-  backend = "atlas"
+  backend = "remote"
 
   config {
-    name = "hashicorp/vpc-prod"
+    organization = "hashicorp"
+    workspaces = {
+      name = "vpc-prod"
+    }
   }
 }
 


### PR DESCRIPTION
I was testing this with 0.12 to pin down some related TFC behavior, and if my data source tried specifying `workspaces` as a nested block (the way the backend config requires it), it blows up with a syntax error. 

I'm actually not sure whether this is an intentional change! 