### PR TITLE
svchost/disco: Tolerate unpopulated OAuth endpoints

### DIFF
--- a/svchost/disco/oauth_client.go
+++ b/svchost/disco/oauth_client.go
@@ -51,15 +51,21 @@ type OAuthClient struct {
 // Endpoint returns an oauth2.Endpoint value ready to be used with the oauth2
 // library, representing the URLs from the receiver.
 func (c *OAuthClient) Endpoint() oauth2.Endpoint {
-	return oauth2.Endpoint{
-		AuthURL:  c.AuthorizationURL.String(),
-		TokenURL: c.TokenURL.String(),
-
+	ep := oauth2.Endpoint{
 		// We don't actually auth because we're not a server-based OAuth client,
 		// so this instead just means that we include client_id as an argument
 		// in our requests.
 		AuthStyle: oauth2.AuthStyleInParams,
 	}
+
+	if c.AuthorizationURL != nil {
+		ep.AuthURL = c.AuthorizationURL.String()
+	}
+	if c.TokenURL != nil {
+		ep.TokenURL = c.TokenURL.String()
+	}
+
+	return ep
 }
 
 // OAuthGrantType is an enumeration of grant type strings that a host can


### PR DESCRIPTION
A server is allowed to omit `AuthorizationURL` if it's using the "password" grant type, and other future grant type implementations may have similar accommodations.

Doing this conditionally is required because this would otherwise panic if either of these were `nil`.