### PR TITLE
command/cliconfig: EmptyCredentialsSourceForTests

### DIFF
--- a/command/cliconfig/credentials.go
+++ b/command/cliconfig/credentials.go
@@ -64,6 +64,17 @@ func (c *Config) CredentialsSource(helperPlugins pluginDiscovery.PluginMetaSet) 
 	return c.credentialsSource(helperType, helper, credentialsFilePath), nil
 }
 
+// EmptyCredentialsSourceForTests constructs a CredentialsSource with
+// no credentials pre-loaded and which writes new credentials to a file
+// at the given path.
+//
+// As the name suggests, this function is here only for testing and should not
+// be used in normal application code.
+func EmptyCredentialsSourceForTests(credentialsFilePath string) *CredentialsSource {
+	cfg := &Config{}
+	return cfg.credentialsSource("", nil, credentialsFilePath)
+}
+
 // credentialsSource is an internal factory for the credentials source which
 // allows overriding the credentials file path, which allows setting it to
 // a temporary file location when testing.


### PR DESCRIPTION
A more convenient interface to get a throwaway empty credentials source for use in tests, which doesn't interact at all with the real CLI configuration directory.

(This is for the tests for `terraform login`, which we can't merge yet because the server behind it isn't present. For that reason, the caller of this function will follow in a later PR.)