### PR TITLE
plugin: Pass TerraformVersion from ConfigureRequest

### DIFF
--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -12,7 +12,6 @@ import (
 	proto "github.com/hashicorp/terraform/internal/tfplugin5"
 	"github.com/hashicorp/terraform/plugin/convert"
 	"github.com/hashicorp/terraform/providers"
-	"github.com/hashicorp/terraform/version"
 	"github.com/zclconf/go-cty/cty/msgpack"
 	"google.golang.org/grpc"
 )
@@ -287,7 +286,7 @@ func (p *GRPCProvider) Configure(r providers.ConfigureRequest) (resp providers.C
 	}
 
 	protoReq := &proto.Configure_Request{
-		TerraformVersion: version.Version,
+		TerraformVersion: r.TerraformVersion,
 		Config: &proto.DynamicValue{
 			Msgpack: mp,
 		},


### PR DESCRIPTION
As I was reading through the code and trying to understand where does the testing framework get Terraform version from I found that there are two places which are sourcing version, one of which seems redundant.

https://github.com/hashicorp/terraform/blob/75d3f1e62ef0d607da3d85a3222ed24a42a3958d/terraform/eval_context_builtin.go#L179-L182

I believe that this is just oversight and not a safeguard against callers of `GRPCProvider.Configure` which wouldn't declare Terraform version, but I'm happy to be corrected! 😄 

A side effect of this change is that we'll now report pre-released versions too, i.e. custom built `0.12.7` from master will be reported as `0.12.7-dev`, rather than simple `0.12.7`.