### PR TITLE
Enhance link click-ability

### DIFF
--- a/command/version.go
+++ b/command/version.go
@@ -108,7 +108,7 @@ func (c *VersionCommand) Run(args []string) int {
 		if info.Outdated {
 			c.Ui.Output(fmt.Sprintf(
 				"\nYour version of Terraform is out of date! The latest version\n"+
-				"is %s. You can update by downloading from https://www.terraform.io/downloads.html",
+					"is %s. You can update by downloading from https://www.terraform.io/downloads.html",
 				info.Latest))
 		}
 	}

--- a/command/version.go
+++ b/command/version.go
@@ -108,7 +108,7 @@ func (c *VersionCommand) Run(args []string) int {
 		if info.Outdated {
 			c.Ui.Output(fmt.Sprintf(
 				"\nYour version of Terraform is out of date! The latest version\n"+
-					"is %s. You can update by downloading from www.terraform.io/downloads.html",
+				"is %s. You can update by downloading from https://www.terraform.io/downloads.html",
 				info.Latest))
 		}
 	}


### PR DESCRIPTION
Adding a protocol segment to the download link discourages parsers from interpreting the link as a filesystem link. For example in a terminal this does not currently work,
```
~$ open www.terraform.io/downloads.html 
The file ~/www.terraform.io/downloads.html does not exist.
```
But this does:
```
~$ open https://www.terraform.io/downloads.html 
```
