### PR TITLE
prevent panics when encountering nil diffs

### DIFF
--- a/builtin/providers/test/diff_apply_test.go
+++ b/builtin/providers/test/diff_apply_test.go
@@ -47,6 +47,8 @@ func TestDiffApply_set(t *testing.T) {
 			"egress.746197026.security_groups.#":   {Old: "", New: "0", NewComputed: false, NewRemoved: false},
 			"egress.746197026.self":                {Old: "", New: "false", NewComputed: false, NewRemoved: false},
 			"egress.746197026.to_port":             {Old: "", New: "8000", NewComputed: false, NewRemoved: false},
+			// an erroneous nil diff should do nothing
+			"egress.111111111.to_port": nil,
 		},
 	}
 

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -513,6 +513,12 @@ func (d *InstanceDiff) applyBlockDiff(path []string, attrs map[string]string, sc
 		}
 
 		for k, diff := range d.Attributes {
+			// helper/schema should not insert nil diff values, but don't panic
+			// if it does.
+			if diff == nil {
+				continue
+			}
+
 			if strings.HasPrefix(k, blockKey) {
 				nextDot := strings.Index(k[len(blockKey):], ".")
 				if nextDot < 0 {
@@ -539,6 +545,12 @@ func (d *InstanceDiff) applyBlockDiff(path []string, attrs map[string]string, sc
 				// that we're dropping. Since we're only applying the "New"
 				// portion of the set, we can ignore diffs that only contain "Old"
 				for attr, diff := range d.Attributes {
+					// helper/schema should not insert nil diff values, but don't panic
+					// if it does.
+					if diff == nil {
+						continue
+					}
+
 					if !strings.HasPrefix(attr, indexPrefix) {
 						continue
 					}


### PR DESCRIPTION
While we can't change the behavior of helper/schema at this point, we
can protect against panics in the case of unexpected nils in the
instance diff.

Fixes the panic in #22196
It's likely caused by a combination of diff suppress funcs and/or customize diff, but given that helper/schema is frozen there's not much that can be done. The new 0.12 code here is in the diff.Apply method, which is the last piece that still needs to handle the instance diff. 