### PR TITLE
fixed testing about git.apache.org and TestInitProviders

### DIFF
--- a/command/e2etest/init_test.go
+++ b/command/e2etest/init_test.go
@@ -39,7 +39,7 @@ func TestInitProviders(t *testing.T) {
 		t.Errorf("success message is missing from output:\n%s", stdout)
 	}
 
-	if !strings.Contains(stdout, "- Downloading plugin for provider \"template\" (terraform-providers/template)") {
+	if !strings.Contains(stdout, "- Downloading plugin for provider \"template\" (hashicorp/template)") {
 		t.Errorf("provider download message is missing from output:\n%s", stdout)
 		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
 	}

--- a/go.mod
+++ b/go.mod
@@ -127,3 +127,5 @@ require (
 	gopkg.in/ini.v1 v1.42.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0


### PR DESCRIPTION
fixed testing:
 - git.apache.org is down, replace to github.com/apache in go.mod
 - changed assert string terraform-providers/template to hashicorp/template in TestInitProviders