### PR TITLE
Fix diff of list of objects

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -1071,8 +1071,8 @@ func ctySequenceDiff(old, new []cty.Value) []*plans.Change {
 	var oldI, newI, lcsI int
 	for oldI < len(old) || newI < len(new) || lcsI < len(lcs) {
 		for oldI < len(old) && (lcsI >= len(lcs) || !old[oldI].RawEquals(lcs[lcsI])) {
-			isObjectDiff := old[oldI].Type().IsObjectType() && (newI >= len(new) || new[newI].Type().IsObjectType())
-			if isObjectDiff && newI < len(new) {
+			isObjectDiff := old[oldI].Type().IsObjectType() && newI < len(new) && new[newI].Type().IsObjectType() && (lcsI >= len(lcs) || !new[newI].RawEquals(lcs[lcsI]))
+			if isObjectDiff {
 				ret = append(ret, &plans.Change{
 					Action: plans.Update,
 					Before: old[oldI],

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -857,11 +857,11 @@ func TestResourceChange_JSON(t *testing.T) {
 			Mode:   addrs.ManagedResourceMode,
 			Before: cty.ObjectVal(map[string]cty.Value{
 				"id":         cty.StringVal("i-02ae66f368e8518a9"),
-				"json_field": cty.StringVal(`[{"one": "111"}, {"two": "222"}]`),
+				"json_field": cty.StringVal(`[{"one": "111"}, {"two": "222"}, {"three": "333"}]`),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":         cty.UnknownVal(cty.String),
-				"json_field": cty.StringVal(`[{"one": "111"}]`),
+				"json_field": cty.StringVal(`[{"one": "111"}, {"three": "333"}]`),
 			}),
 			Schema: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -881,6 +881,9 @@ func TestResourceChange_JSON(t *testing.T) {
                 },
               - {
                   - two = "222"
+                },
+                {
+                    three = "333"
                 },
             ]
         )


### PR DESCRIPTION
Fixes #21473

The previous code incorrectly compared the old value of the object with
a new value at the same index, even if the value was common to both
lists but occurs in old later. This caused confusing and wrong diffs if
you deleted an object in the middle of a list.