### PR TITLE
make: Add check for protobuf dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ generate: tools
 # If you are working on changes to protobuf interfaces you may either use
 # this target or run the individual scripts below directly.
 protobuf:
+	bash scripts/protobuf-check.sh
 	bash internal/tfplugin5/generate.sh
 	bash plans/internal/planproto/generate.sh
 

--- a/scripts/protobuf-check.sh
+++ b/scripts/protobuf-check.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Check whether protobuf & go plugin are installed
+PROTOC_HELP_URL="http://google.github.io/proto-lens/installing-protoc.html"
+PROTOC_GEN_GO_HELP_URL="https://github.com/golang/protobuf/tree/v1.3.2#installation"
+
+EXIT_CODE=0
+
+which protoc >/dev/null
+if [ $? -ne 0 ]; then
+	echo "Protocol Buffers not found."
+	echo "Please install Protocol Buffers and ensure 'protoc' is available in your PATH."
+	echo "See ${PROTOC_HELP_URL} for more."
+	echo
+	EXIT_CODE=1
+fi
+
+which protoc-gen-go >/dev/null
+if [ $? -ne 0 ]; then
+	echo "Protocol Buffers Go plugin not found."
+	echo "Please install the plugin and ensure 'protoc-gen-go' is available in your PATH."
+	echo "See ${PROTOC_GEN_GO_HELP_URL} for more."
+	echo
+	EXIT_CODE=1
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
I originally thought I could document this but then I realized since the Makefile seems to be (realistically) the most likely entrypoint, this may be better than any documentation.
