### PR TITLE
build: Use the official Go module proxy for Travis-CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ go:
 # add TF_ETCDV3_TEST=1 to run etcdv3 tests
 # if added, TF_ETCDV3_ENDPOINTS must be set to a comma-separated list of (insecure) etcd endpoints against which to test
 env:
-  - CONSUL_VERSION=0.7.5 GOMAXPROCS=4 GO111MODULE=on
+  - CONSUL_VERSION=0.7.5 GOMAXPROCS=4 GO111MODULE=on GOPROXY=https://proxy.golang.org/
 
 # Fetch consul for the backend and provider tests
 before_install:


### PR DESCRIPTION
This gets us slightly faster test runtimes and also insulates us better from downtime of individual upstreams, in favor of being dependent only on one specific upstream (the Go module proxy itself, currently run by Google).

This affects only Travis-CI runs. While it's also a good idea for many developers working on Terraform to use the module proxy too, I didn't go so far as to _force_ that in the `Makefile` because some folks cannot reach the official module proxy from their development systems for one reason or another, and so we will allow everyone to make their own local policy decision about whether to use a proxy and which proxy to use.
