### PR TITLE
command/console: add support for -var and -var-file as documented

### DIFF
--- a/command/console.go
+++ b/command/console.go
@@ -26,7 +26,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 		return 1
 	}
 
-	cmdFlags := c.Meta.defaultFlagSet("console")
+	cmdFlags := c.Meta.extendedFlagSet("console")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {


### PR DESCRIPTION
`terraform console` was not supporting documented flags, including -var
and -var-file. I've modified the command so it uses the
`c.Meta.extendedFlagSet` instead of the defaultFlagSet.

Fixes #22682