### PR TITLE
discovery: use `addrs.ProviderConfig` in place of a `typeName` string

### DIFF
--- a/addrs/provider_type.go
+++ b/addrs/provider_type.go
@@ -1,0 +1,7 @@
+package addrs
+
+// ProviderType encapsulates a single provider type. In the future this will be
+// extended to include additional fields including Namespace and SourceHost
+type ProviderType struct {
+	Name string
+}

--- a/command/init.go
+++ b/command/init.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/backend"
 	backendInit "github.com/hashicorp/terraform/backend/init"
 	"github.com/hashicorp/terraform/configs"
@@ -516,7 +517,8 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 		}
 
 		for provider, reqd := range missing {
-			_, providerDiags, err := c.providerInstaller.Get(provider, reqd.Versions)
+			pty := addrs.ProviderType{Name: provider}
+			_, providerDiags, err := c.providerInstaller.Get(pty, reqd.Versions)
 			diags = diags.Append(providerDiags)
 
 			if err != nil {

--- a/command/plugins_test.go
+++ b/command/plugins_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/hashicorp/terraform/providers"
@@ -147,10 +148,10 @@ func (i *mockProviderInstaller) FileName(provider, version string) string {
 	return fmt.Sprintf("terraform-provider-%s_v%s_x4", provider, version)
 }
 
-func (i *mockProviderInstaller) Get(provider string, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error) {
+func (i *mockProviderInstaller) Get(provider addrs.ProviderType, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error) {
 	var diags tfdiags.Diagnostics
 	noMeta := discovery.PluginMeta{}
-	versions := i.Providers[provider]
+	versions := i.Providers[provider.Name]
 	if len(versions) == 0 {
 		return noMeta, diags, fmt.Errorf("provider %q not found", provider)
 	}
@@ -168,7 +169,7 @@ func (i *mockProviderInstaller) Get(provider string, req discovery.Constraints) 
 
 		if req.Allows(version) {
 			// provider filename
-			name := i.FileName(provider, v)
+			name := i.FileName(provider.Name, v)
 			path := filepath.Join(i.Dir, name)
 			f, err := os.Create(path)
 			if err != nil {
@@ -176,7 +177,7 @@ func (i *mockProviderInstaller) Get(provider string, req discovery.Constraints) 
 			}
 			f.Close()
 			return discovery.PluginMeta{
-				Name:    provider,
+				Name:    provider.Name,
 				Version: discovery.VersionStr(v),
 				Path:    path,
 			}, diags, nil
@@ -199,8 +200,8 @@ func (i *mockProviderInstaller) PurgeUnused(map[string]discovery.PluginMeta) (di
 
 type callbackPluginInstaller func(provider string, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error)
 
-func (cb callbackPluginInstaller) Get(provider string, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error) {
-	return cb(provider, req)
+func (cb callbackPluginInstaller) Get(provider addrs.ProviderType, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error) {
+	return cb(provider.Name, req)
 }
 
 func (cb callbackPluginInstaller) PurgeUnused(map[string]discovery.PluginMeta) (discovery.PluginMetaSet, error) {

--- a/plugin/discovery/get_test.go
+++ b/plugin/discovery/get_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/registry"
 	"github.com/hashicorp/terraform/registry/response"
 	"github.com/hashicorp/terraform/svchost"
@@ -149,7 +150,7 @@ func TestVersionListing(t *testing.T) {
 
 	i := newProviderInstaller(server)
 
-	allVersions, err := i.listProviderVersions("test")
+	allVersions, err := i.listProviderVersions(addrs.ProviderType{Name: "test"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -415,7 +416,8 @@ func TestProviderInstallerGet(t *testing.T) {
 		Ui:                    cli.NewMockUi(),
 		registry:              registry.NewClient(Disco(server), nil),
 	}
-	_, _, err = i.Get("test", AllVersions)
+
+	_, _, err = i.Get(addrs.ProviderType{Name: "test"}, AllVersions)
 
 	if err != ErrorNoVersionCompatibleWithPlatform {
 		t.Fatal("want error for incompatible version")
@@ -432,20 +434,21 @@ func TestProviderInstallerGet(t *testing.T) {
 	}
 
 	{
-		_, _, err := i.Get("test", ConstraintStr(">9.0.0").MustParse())
+		_, _, err := i.Get(addrs.ProviderType{Name: "test"}, ConstraintStr(">9.0.0").MustParse())
 		if err != ErrorNoSuitableVersion {
 			t.Fatal("want error for mismatching constraints")
 		}
 	}
 
 	{
-		_, _, err := i.Get("nonexist", AllVersions)
+		provider := addrs.ProviderType{Name: "nonexist"}
+		_, _, err := i.Get(provider, AllVersions)
 		if err != ErrorNoSuchProvider {
 			t.Fatal("want error for no such provider")
 		}
 	}
 
-	gotMeta, _, err := i.Get("test", AllVersions)
+	gotMeta, _, err := i.Get(addrs.ProviderType{Name: "test"}, AllVersions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -503,7 +506,7 @@ func TestProviderInstallerGet_cache(t *testing.T) {
 		Arch:                  "mockarch",
 	}
 
-	gotMeta, _, err := i.Get("test", AllVersions)
+	gotMeta, _, err := i.Get(addrs.ProviderType{Name: "test"}, AllVersions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -14,6 +14,7 @@ import (
 	"io"
 
 	getter "github.com/hashicorp/go-getter"
+	"github.com/hashicorp/terraform/addrs"
 	discovery "github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/mitchellh/cli"
 )
@@ -181,7 +182,7 @@ func (c *PackageCommand) Run(args []string) int {
 			} else { //attempt to get from the public registry if not found locally
 				c.ui.Output(fmt.Sprintf("- Checking for provider plugin on %s...",
 					releaseHost))
-				_, _, err := installer.Get(name, constraint)
+				_, _, err := installer.Get(addrs.ProviderType{Name: name}, constraint)
 				if err != nil {
 					c.ui.Error(fmt.Sprintf("- Failed to resolve %s provider %s: %s", name, constraint, err))
 					return 1


### PR DESCRIPTION
This is a relatively small change meant to lay the foundation for
future enhancements to providers' address.