### PR TITLE
command/e2etest: Fix TestInitProviders

### DIFF
--- a/command/e2etest/init_test.go
+++ b/command/e2etest/init_test.go
@@ -39,7 +39,7 @@ func TestInitProviders(t *testing.T) {
 		t.Errorf("success message is missing from output:\n%s", stdout)
 	}
 
-	if !strings.Contains(stdout, "- Downloading plugin for provider \"template\" (terraform-providers/template)") {
+	if !strings.Contains(stdout, "- Downloading plugin for provider \"template\" (hashicorp/template)") {
 		t.Errorf("provider download message is missing from output:\n%s", stdout)
 		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
 	}


### PR DESCRIPTION
The canonical location of the `template` provider is now in the `hashicorp` namespace rather than the `terraform-providers` namespace, so the output has changed to reflect that.
