### PR TITLE
Cover empty sets in for_each

### DIFF
--- a/terraform/eval_for_each.go
+++ b/terraform/eval_for_each.go
@@ -64,6 +64,12 @@ func evaluateResourceForEachExpressionKnown(expr hcl.Expression, ctx EvalContext
 		return nil, true, diags
 	}
 
+	// If the map is empty ({}), return an empty map, because cty will return nil when representing {} AsValueMap
+	// This also covers an empty set (toset([]))
+	if forEachVal.LengthInt() == 0 {
+		return map[string]cty.Value{}, true, diags
+	}
+
 	if forEachVal.Type().IsSetType() {
 		if forEachVal.Type().ElementType() != cty.String {
 			diags = diags.Append(&hcl.Diagnostic{
@@ -82,11 +88,6 @@ func evaluateResourceForEachExpressionKnown(expr hcl.Expression, ctx EvalContext
 		if !forEachVal.IsWhollyKnown() {
 			return map[string]cty.Value{}, false, diags
 		}
-	}
-
-	// If the map is empty ({}), return an empty map, because cty will return nil when representing {} AsValueMap
-	if forEachVal.LengthInt() == 0 {
-		return map[string]cty.Value{}, true, diags
 	}
 
 	return forEachVal.AsValueMap(), true, nil

--- a/terraform/graph_builder_plan_test.go
+++ b/terraform/graph_builder_plan_test.go
@@ -338,6 +338,8 @@ var.foo
 const testPlanGraphBuilderForEachStr = `
 aws_instance.bar
   provider.aws
+aws_instance.bar2
+  provider.aws
 aws_instance.bat
   aws_instance.boo
   provider.aws
@@ -349,6 +351,7 @@ aws_instance.foo
   provider.aws
 meta.count-boundary (EachMode fixup)
   aws_instance.bar
+  aws_instance.bar2
   aws_instance.bat
   aws_instance.baz
   aws_instance.boo
@@ -357,6 +360,7 @@ meta.count-boundary (EachMode fixup)
 provider.aws
 provider.aws (close)
   aws_instance.bar
+  aws_instance.bar2
   aws_instance.bat
   aws_instance.baz
   aws_instance.boo

--- a/terraform/testdata/plan-for-each/main.tf
+++ b/terraform/testdata/plan-for-each/main.tf
@@ -10,6 +10,9 @@ resource "aws_instance" "foo" {
 
 # sets
 resource "aws_instance" "bar" {
+    for_each = toset([])
+}
+resource "aws_instance" "bar2" {
     for_each = toset(list("z", "y", "x"))
 }
 


### PR DESCRIPTION
We should check earlier for empty lists -- having it after set-specific checking meant we were missing empty lists/empty sets, and users would get an error they shouldn't get.

Fixes #22281