### PR TITLE
command: Fix dropped errors

### DIFF
--- a/command/show.go
+++ b/command/show.go
@@ -133,8 +133,8 @@ func (c *ShowCommand) Run(args []string) int {
 	} else {
 		env := c.Workspace()
 		stateFile, stateErr = getStateFromEnv(b, env)
-		if err != nil {
-			c.Ui.Error(err.Error())
+		if stateErr != nil {
+			c.Ui.Error(stateErr.Error())
 			return 1
 		}
 	}
@@ -215,7 +215,7 @@ func getPlanFromPath(path string) (*plans.Plan, *statefile.File, error) {
 	}
 
 	stateFile, err := pr.ReadStateFile()
-	return plan, stateFile, nil
+	return plan, stateFile, err
 }
 
 // getStateFromPath returns a statefile if the user-supplied path points to a statefile.


### PR DESCRIPTION
Fix two dropped error variables from the `command` package.