### PR TITLE
bug: fix terraform trying to clean up orphan modules on target

### DIFF
--- a/terraform/node_module_removed.go
+++ b/terraform/node_module_removed.go
@@ -14,6 +14,7 @@ type NodeModuleRemoved struct {
 
 var (
 	_ GraphNodeSubPath          = (*NodeModuleRemoved)(nil)
+	_ RemovableIfNotTargeted    = (*NodeModuleRemoved)(nil)
 	_ GraphNodeEvalable         = (*NodeModuleRemoved)(nil)
 	_ GraphNodeReferencer       = (*NodeModuleRemoved)(nil)
 	_ GraphNodeReferenceOutside = (*NodeModuleRemoved)(nil)
@@ -61,6 +62,13 @@ func (n *NodeModuleRemoved) References() []*addrs.Reference {
 			// us to return.
 		},
 	}
+}
+
+// RemovableIfNotTargeted
+func (n *NodeModuleRemoved) RemoveIfNotTargeted() bool {
+	// We need to add this so that this node will be removed if
+	// it isn't targeted or a dependency of a target.
+	return true
 }
 
 // EvalCheckModuleRemoved is an EvalNode implementation that verifies that

--- a/terraform/testdata/apply-targeted-resource-orphan-module/child/main.tf
+++ b/terraform/testdata/apply-targeted-resource-orphan-module/child/main.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "bar" {}

--- a/terraform/testdata/apply-targeted-resource-orphan-module/main.tf
+++ b/terraform/testdata/apply-targeted-resource-orphan-module/main.tf
@@ -1,0 +1,5 @@
+//module "child" {
+//  source = "./child"
+//}
+
+resource "aws_instance" "foo" {}


### PR DESCRIPTION
Fixes issue #21313.

The purpose of this PR is to implement `RemovableIfNotTargeted` for `NodeModuleRemoved`. During `TargetsTransformer.Transform` graph vertices are checked for `RemovableIfNotTargeted`

If config diff exists between state and the targeted apply graph, receive following error: `leftover module module.child in state that should have been removed`.

Added a test that contains a commented out module which exists in state, with target existing against a separate resource.