### PR TITLE
etcdv3: Add discovery_srv configuration variable

### DIFF
--- a/website/docs/backends/types/etcdv3.html.md
+++ b/website/docs/backends/types/etcdv3.html.md
@@ -47,6 +47,7 @@ data "terraform_remote_state" "foo" {
 The following configuration options / environment variables are supported:
 
  * `endpoints` - (Required) The list of 'etcd' endpoints which to connect to.
+ * `discovery_srv` / `ETCD_DISCOVERY_SRV` - (Optional) Specifies the domain name to query for SRV records describing cluster endpoints. Mutually exclusive with `endpoints`.
  * `username` / `ETCDV3_USERNAME` - (Optional) Username used to connect to the etcd cluster.
  * `password` / `ETCDV3_PASSWORD` - (Optional) Password used to connect to the etcd  cluster.
  * `prefix` - (Optional) An optional prefix to be added to keys when to storing state in etcd. Defaults to `""`.


### PR DESCRIPTION
Adds the option to the etcdv3 backend to discover cluster endpoints via
[DNS discovery][1].
Implemented via the etcd SRV package to perform discovery.
This new option is mutually exclusive with providing a static list of
endpoints.

In a dynamic environment, the hostname/IPs of the etcd cluster can change and it's a burden to constantly have to keep all your clients in sync so DNS discovery is advantageous as clients only need know the domain they are running in and the etcd client does the rest of the work for us.

[1]: https://etcd.io/docs/v3.3.12/op-guide/clustering/#dns-discovery