### PR TITLE
Escape alternate in regex function docs

### DIFF
--- a/website/docs/configuration/functions/regex.html.md
+++ b/website/docs/configuration/functions/regex.html.md
@@ -77,7 +77,7 @@ of the pattern must be escaped as `\\`.
 | `\PN`          | The opposite of `\pN`                                                            |
 | `\P{Greek}`    | The opposite of `\p{Greek}`                                                      |
 | `xy`           | `x` followed immediately by `y`                                                  |
-| `x|y`          | either `x` or `y`, preferring `x`                                                |
+| `x\|y`         | either `x` or `y`, preferring `x`                                                |
 | `x*`           | zero or more `x`, preferring more                                                |
 | `x*?`          | zero or more `x`, preferring fewer                                               |
 | `x+`           | one or more `x`, preferring more                                                 |


### PR DESCRIPTION
Regex function docs had an unescaped table separator. Fix that.