### PR TITLE
"modules" => "variables"

### DIFF
--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -182,7 +182,7 @@ assigned in the configuration of their parent module, as described in
 
 ### Variables on the Command Line
 
-To specify individual modules on the command line, use the `-var` option
+To specify individual variables on the command line, use the `-var` option
 when running the `terraform plan` and `terraform apply` commands:
 
 ```


### PR DESCRIPTION
I believe the use of "modules" in this case was a typo. Perhaps @apparentlymart can confirm?

Thanks 👍 