### PR TITLE
Fix Dropped Error in statemgr Test Goroutine

### DIFF
--- a/states/statemgr/statemgr_test.go
+++ b/states/statemgr/statemgr_test.go
@@ -60,23 +60,13 @@ func TestLockWithContext(t *testing.T) {
 		t.Fatal("lock should have failed immediately")
 	}
 
-	// block until LockwithContext has made a first attempt
-	attempted := make(chan struct{})
-	postLockHook = func() {
-		close(attempted)
-		postLockHook = nil
-	}
-
 	// testing.T does not do much inside a goroutine
 	// create an error channel to collect error condition
 	errCh := make(chan error)
 	defer close(errCh)
 
 	// unlock the state during LockWithContext
-	unlocked := make(chan struct{})
 	go func() {
-		defer close(unlocked)
-		<-attempted
 		errCh <- s.Unlock(id)
 	}()
 
@@ -93,9 +83,6 @@ func TestLockWithContext(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// ensure the goruotine completes
-	<-unlocked
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
This PR fixes a test in `statemgr` where some an error condition could never be recorded, because it was happening inside a goroutine. It replaces the `unlocked` channel, and removes the `attempted` channel that didn't appear to do anything.

`T.Fatal()` is a convenience function that combines `T.Log()` and `T.FailNow()`. 

From the godoc of `T.FailNow()`: 

> FailNow must be called from the goroutine running the test or benchmark function, not from other goroutines created during the test. Calling FailNow does not stop those other goroutines.

To see this in action, take a look at `main_test.go` in my [example repo](https://github.com/alrs/fatalfail/).

Fixes https://github.com/hashicorp/terraform/issues/23626