### PR TITLE
don't lose track of private data in the ACC tests

### DIFF
--- a/builtin/providers/test/resource_nested_set_test.go
+++ b/builtin/providers/test/resource_nested_set_test.go
@@ -646,12 +646,7 @@ resource "test_resource_nested_set" "foo" {
   }
 }
 				`),
-				Check: resource.ComposeTestCheckFunc(
-					func(s *terraform.State) error {
-						fmt.Println(s)
-						return nil
-					},
-				),
+				Check: resource.ComposeTestCheckFunc(),
 			},
 		},
 	})

--- a/builtin/providers/test/resource_timeout.go
+++ b/builtin/providers/test/resource_timeout.go
@@ -14,6 +14,11 @@ func testResourceTimeout() *schema.Resource {
 		Update: testResourceTimeoutUpdate,
 		Delete: testResourceTimeoutDelete,
 
+		// Due to the schema version also being stashed in the private/meta
+		// data, we need to ensure that it does not overwrite the map
+		// containing the timeouts.
+		SchemaVersion: 1,
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(time.Second),
 			Update: schema.DefaultTimeout(time.Second),

--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -81,9 +81,10 @@ func shimNewState(newState *states.State, providers map[string]terraform.Resourc
 					}
 
 					if i.Current.SchemaVersion != 0 {
-						resState.Primary.Meta = map[string]interface{}{
-							"schema_version": i.Current.SchemaVersion,
+						if resState.Primary.Meta == nil {
+							resState.Primary.Meta = map[string]interface{}{}
 						}
+						resState.Primary.Meta["schema_version"] = i.Current.SchemaVersion
 					}
 
 					for _, dep := range i.Current.Dependencies {


### PR DESCRIPTION
If the resource schema version is > 0, the metadata containing the
timeout values was overwritten during acceptance tests.

Closes #22810