### PR TITLE
command/import: when '-provider' is included, do not evaluate the implied provider

### DIFF
--- a/command/testdata/import-provider-mismatch/main.tf
+++ b/command/testdata/import-provider-mismatch/main.tf
@@ -1,0 +1,7 @@
+provider "test-beta" {
+  foo = "baz"
+}
+
+resource "test_instance" "foo" {
+  provider = "test-beta"
+}

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -363,6 +363,10 @@ func (n *NodeAbstractResource) ProvidedBy() (addrs.AbsProviderConfig, bool) {
 		return relAddr.Absolute(n.Path()), false
 	}
 
+	if n.ResolvedProvider.ProviderConfig.Type != "" {
+		return n.ResolvedProvider.ProviderConfig.Absolute(n.Path()), false
+	}
+
 	// Use our type and containing module path to guess a provider configuration address
 	return n.Addr.Resource.DefaultProviderConfig().Absolute(n.Addr.Module), false
 }

--- a/terraform/transform_config.go
+++ b/terraform/transform_config.go
@@ -120,7 +120,15 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 			continue
 		}
 
-		abstract := &NodeAbstractResource{Addr: addr}
+		abstract := &NodeAbstractResource{
+			Addr: addr,
+		}
+		provider := r.ProviderConfigAddr()
+		absProvider := provider.Absolute(instPath)
+		if absProvider.String() != "" {
+			abstract.ResolvedProvider = absProvider
+		}
+
 		var node dag.Vertex = abstract
 		if f := t.Concrete; f != nil {
 			node = f(abstract)


### PR DESCRIPTION
A NodeAbstractResource can have a 'provider' specified in two places:
the attached `Config` `(*configs.Resource)` or the `ResolvedProvider`, which
wasn't being set (more accurately, it was set to the zero value) during `Import`. 

This PR sets the `ResolvedProvider` and modifies `ProvidedBy()` to return the `ResolvedProvider` if it is supplied.

I am not fully confident that this is the correct solution - I expected the change to happen somewhere in the import-specific nodes/functions, instead of `transform_config` and `node_resource_abstract`, but was unable to find a better solution. 

I should have saved some commits from the things I tried that did not work; I can say that setting the `ResolvedProvider` in `(t *ImportStateTransformer) Transform(...)` (below) was insufficient, but again I suspect I am missing some details:

https://github.com/hashicorp/terraform/blob/39f61a07955b57c0a4afeb183259ca1697677148/terraform/transform_import_state.go#L27-L30


---
This isn't necessarily the relevant part of the graph, but you can see that terraform is no longer attaching the implied `test` provider to the `test_instance` with this change (during the newly-added import test).

Graph snippet BEFORE this pr:
```
019/09/17 15:59:42 [TRACE] ProviderTransformer: test_instance.foo (import id "bar") is provided by provider.test-beta or inherited equivalent
2019/09/17 15:59:42 [TRACE] ProviderTransformer: test_instance.foo is provided by provider.test or inherited equivalent
2019/09/17 15:59:42 [TRACE] ProviderTransformer: exact match for provider.test-beta serving test_instance.foo (import id "bar")
2019/09/17 15:59:42 [TRACE] ProviderTransformer: exact match for provider.test serving test_instance.foo
```

Graph snippet AFTER this pr:
```
2019/09/18 14:18:29 [TRACE] ProviderTransformer: test_instance.foo is provided by provider.test-beta or inherited equivalent
2019/09/18 14:18:29 [TRACE] ProviderTransformer: test_instance.foo (import id "bar") is provided by provider.test-beta or inherited equivalent
2019/09/18 14:18:29 [TRACE] ProviderTransformer: exact match for provider.test-beta serving test_instance.foo
2019/09/18 14:18:29 [TRACE] ProviderTransformer: exact match for provider.test-beta serving test_instance.foo (import id "bar")
```