### PR TITLE
Always evaluate resources in their entirety

### DIFF
--- a/addrs/parse_ref.go
+++ b/addrs/parse_ref.go
@@ -290,7 +290,7 @@ func parseResourceRef(mode ResourceMode, startRange hcl.Range, traversal hcl.Tra
 		// of the resource, but we don't have enough context here to decide
 		// so we'll let the caller resolve that ambiguity.
 		return &Reference{
-			Subject:     resourceInstAddr,
+			Subject:     resourceAddr,
 			SourceRange: tfdiags.SourceRangeFromHCL(rng),
 		}, diags
 	}

--- a/addrs/parse_ref_test.go
+++ b/addrs/parse_ref_test.go
@@ -114,12 +114,10 @@ func TestParseRef(t *testing.T) {
 		{
 			`data.external.foo`,
 			&Reference{
-				Subject: ResourceInstance{
-					Resource: Resource{
-						Mode: DataResourceMode,
-						Type: "external",
-						Name: "foo",
-					},
+				Subject: Resource{
+					Mode: DataResourceMode,
+					Type: "external",
+					Name: "foo",
 				},
 				SourceRange: tfdiags.SourceRange{
 					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
@@ -592,12 +590,10 @@ func TestParseRef(t *testing.T) {
 		{
 			`boop_instance.foo`,
 			&Reference{
-				Subject: ResourceInstance{
-					Resource: Resource{
-						Mode: ManagedResourceMode,
-						Type: "boop_instance",
-						Name: "foo",
-					},
+				Subject: Resource{
+					Mode: ManagedResourceMode,
+					Type: "boop_instance",
+					Name: "foo",
 				},
 				SourceRange: tfdiags.SourceRange{
 					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},

--- a/configs/configupgrade/analysis_expr.go
+++ b/configs/configupgrade/analysis_expr.go
@@ -75,28 +75,27 @@ func (d analysisData) GetForEachAttr(addr addrs.ForEachAttr, rng tfdiags.SourceR
 	return cty.DynamicVal, nil
 }
 
-func (d analysisData) GetResourceInstance(instAddr addrs.ResourceInstance, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
-	log.Printf("[TRACE] configupgrade: Determining type for %s", instAddr)
-	addr := instAddr.Resource
+func (d analysisData) GetResource(addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	log.Printf("[TRACE] configupgrade: Determining type for %s", addr)
 
 	// Our analysis pass should've found a suitable schema for every resource
 	// type in the module.
 	providerType, ok := d.an.ResourceProviderType[addr]
 	if !ok {
 		// Should not be possible, since analysis visits every resource block.
-		log.Printf("[TRACE] configupgrade: analysis.GetResourceInstance doesn't have a provider type for %s", addr)
+		log.Printf("[TRACE] configupgrade: analysis.GetResource doesn't have a provider type for %s", addr)
 		return cty.DynamicVal, nil
 	}
 	providerSchema, ok := d.an.ProviderSchemas[providerType]
 	if !ok {
 		// Should not be possible, since analysis loads schema for every provider.
-		log.Printf("[TRACE] configupgrade: analysis.GetResourceInstance doesn't have a provider schema for for %q", providerType)
+		log.Printf("[TRACE] configupgrade: analysis.GetResource doesn't have a provider schema for for %q", providerType)
 		return cty.DynamicVal, nil
 	}
 	schema, _ := providerSchema.SchemaForResourceAddr(addr)
 	if schema == nil {
 		// Should not be possible, since analysis loads schema for every provider.
-		log.Printf("[TRACE] configupgrade: analysis.GetResourceInstance doesn't have a schema for for %s", addr)
+		log.Printf("[TRACE] configupgrade: analysis.GetResource doesn't have a schema for for %s", addr)
 		return cty.DynamicVal, nil
 	}
 
@@ -106,19 +105,11 @@ func (d analysisData) GetResourceInstance(instAddr addrs.ResourceInstance, rng t
 	// return a list or a single object type depending on whether count is
 	// set and whether an instance key is given in the address.
 	if d.an.ResourceHasCount[addr] {
-		if instAddr.Key == addrs.NoKey {
-			log.Printf("[TRACE] configupgrade: %s refers to counted instance without a key, so result is a list of %#v", instAddr, objTy)
-			return cty.UnknownVal(cty.List(objTy)), nil
-		}
-		log.Printf("[TRACE] configupgrade: %s refers to counted instance with a key, so result is single object", instAddr)
-		return cty.UnknownVal(objTy), nil
+		log.Printf("[TRACE] configupgrade: %s refers to counted instance, so result is a list of %#v", addr, objTy)
+		return cty.UnknownVal(cty.List(objTy)), nil
 	}
 
-	if instAddr.Key != addrs.NoKey {
-		log.Printf("[TRACE] configupgrade: %s refers to non-counted instance with a key, which is invalid", instAddr)
-		return cty.DynamicVal, nil
-	}
-	log.Printf("[TRACE] configupgrade: %s refers to non-counted instance without a key, so result is single object", instAddr)
+	log.Printf("[TRACE] configupgrade: %s refers to non-counted instance, so result is single object", addr)
 	return cty.UnknownVal(objTy), nil
 }
 

--- a/lang/data.go
+++ b/lang/data.go
@@ -24,7 +24,7 @@ type Data interface {
 
 	GetCountAttr(addrs.CountAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetForEachAttr(addrs.ForEachAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetResourceInstance(addrs.ResourceInstance, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetResource(addrs.Resource, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetLocalValue(addrs.LocalValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetModuleInstance(addrs.ModuleCallInstance, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetModuleInstanceOutput(addrs.ModuleCallOutput, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)

--- a/lang/data_test.go
+++ b/lang/data_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 type dataForTests struct {
-	CountAttrs        map[string]cty.Value
-	ForEachAttrs      map[string]cty.Value
-	ResourceInstances map[string]cty.Value
-	LocalValues       map[string]cty.Value
-	Modules           map[string]cty.Value
-	PathAttrs         map[string]cty.Value
-	TerraformAttrs    map[string]cty.Value
-	InputVariables    map[string]cty.Value
+	CountAttrs     map[string]cty.Value
+	ForEachAttrs   map[string]cty.Value
+	Resources      map[string]cty.Value
+	LocalValues    map[string]cty.Value
+	Modules        map[string]cty.Value
+	PathAttrs      map[string]cty.Value
+	TerraformAttrs map[string]cty.Value
+	InputVariables map[string]cty.Value
 }
 
 var _ Data = &dataForTests{}
@@ -31,8 +31,8 @@ func (d *dataForTests) GetForEachAttr(addr addrs.ForEachAttr, rng tfdiags.Source
 	return d.ForEachAttrs[addr.Name], nil
 }
 
-func (d *dataForTests) GetResourceInstance(addr addrs.ResourceInstance, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
-	return d.ResourceInstances[addr.String()], nil
+func (d *dataForTests) GetResource(addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.Resources[addr.String()], nil
 }
 
 func (d *dataForTests) GetInputVariable(addr addrs.InputVariable, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {

--- a/lang/eval.go
+++ b/lang/eval.go
@@ -261,8 +261,6 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 		// in package addrs.
 		switch subj := rawSubj.(type) {
 		case addrs.Resource:
-			panic("RESOURCE REFERENCES DON'T HIT THIS")
-
 			var into map[string]map[string]cty.Value
 			switch subj.Mode {
 			case addrs.ManagedResourceMode:

--- a/lang/eval_test.go
+++ b/lang/eval_test.go
@@ -24,7 +24,7 @@ func TestScopeEvalContext(t *testing.T) {
 			"key":   cty.StringVal("a"),
 			"value": cty.NumberIntVal(1),
 		},
-		ResourceInstances: map[string]cty.Value{
+		Resources: map[string]cty.Value{
 			"null_resource.foo": cty.ObjectVal(map[string]cty.Value{
 				"attr": cty.StringVal("bar"),
 			}),
@@ -37,6 +37,14 @@ func TestScopeEvalContext(t *testing.T) {
 				}),
 				cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("multi1"),
+				}),
+			}),
+			"null_resource.each": cty.ObjectVal(map[string]cty.Value{
+				"each0": cty.ObjectVal(map[string]cty.Value{
+					"attr": cty.StringVal("each0"),
+				}),
+				"each1": cty.ObjectVal(map[string]cty.Value{
+					"attr": cty.StringVal("each1"),
 				}),
 			}),
 			"null_resource.multi[1]": cty.ObjectVal(map[string]cty.Value{
@@ -139,13 +147,32 @@ func TestScopeEvalContext(t *testing.T) {
 			},
 		},
 		{
+			// at this level, all instance references return the entire resource
 			`null_resource.multi[1]`,
 			map[string]cty.Value{
 				"null_resource": cty.ObjectVal(map[string]cty.Value{
 					"multi": cty.TupleVal([]cty.Value{
-						cty.DynamicVal,
+						cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("multi0"),
+						}),
 						cty.ObjectVal(map[string]cty.Value{
 							"attr": cty.StringVal("multi1"),
+						}),
+					}),
+				}),
+			},
+		},
+		{
+			// at this level, all instance references return the entire resource
+			`null_resource.each["each1"]`,
+			map[string]cty.Value{
+				"null_resource": cty.ObjectVal(map[string]cty.Value{
+					"each": cty.ObjectVal(map[string]cty.Value{
+						"each0": cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("each0"),
+						}),
+						"each1": cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("each1"),
 						}),
 					}),
 				}),
@@ -215,7 +242,9 @@ func TestScopeEvalContext(t *testing.T) {
 				// expanded here and then copied into "self".
 				"null_resource": cty.ObjectVal(map[string]cty.Value{
 					"multi": cty.TupleVal([]cty.Value{
-						cty.DynamicVal,
+						cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("multi0"),
+						}),
 						cty.ObjectVal(map[string]cty.Value{
 							"attr": cty.StringVal("multi1"),
 						}),

--- a/lang/eval_test.go
+++ b/lang/eval_test.go
@@ -237,19 +237,6 @@ func TestScopeEvalContext(t *testing.T) {
 		{
 			`self.baz`,
 			map[string]cty.Value{
-				// In the test function below we set "SelfAddr" to be
-				// one of the resources in our dataset, causing it to get
-				// expanded here and then copied into "self".
-				"null_resource": cty.ObjectVal(map[string]cty.Value{
-					"multi": cty.TupleVal([]cty.Value{
-						cty.ObjectVal(map[string]cty.Value{
-							"attr": cty.StringVal("multi0"),
-						}),
-						cty.ObjectVal(map[string]cty.Value{
-							"attr": cty.StringVal("multi1"),
-						}),
-					}),
-				}),
 				"self": cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("multi1"),
 				}),

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -10527,3 +10527,44 @@ func TestContext2Apply_issue19908(t *testing.T) {
 		t.Errorf("test.foo attributes JSON doesn't contain %s after apply\ngot: %s", want, got)
 	}
 }
+
+func TestContext2Apply_invalidIndexRef(t *testing.T) {
+	p := testProvider("test")
+	p.GetSchemaReturn = &ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_instance": {
+				Attributes: map[string]*configschema.Attribute{
+					"value": {Type: cty.String, Optional: true, Computed: true},
+				},
+			},
+		},
+	}
+	p.DiffFn = testDiffFn
+
+	m := testModule(t, "apply-invalid-index")
+	c := testContext2(t, &ContextOpts{
+		Config: m,
+		ProviderResolver: providers.ResolverFixed(
+			map[string]providers.Factory{
+				"test": testProviderFuncFixed(p),
+			},
+		),
+	})
+
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("unexpected validation failure: %s", diags.Err())
+	}
+
+	wantErr := `The given key does not identify an element in this collection value`
+	_, diags = c.Plan()
+
+	if !diags.HasErrors() {
+		t.Fatalf("plan succeeded; want error")
+	}
+	gotErr := diags.Err().Error()
+
+	if !strings.Contains(gotErr, wantErr) {
+		t.Fatalf("missing expected error\ngot: %s\n\nwant: error containing %q", gotErr, wantErr)
+	}
+}

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -70,6 +70,13 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 		}
 	}
 
+	if !configVal.IsWhollyKnown() {
+		return nil, fmt.Errorf(
+			"configuration for %s still contains unknown values during apply (this is a bug in Terraform; please report it!)",
+			absAddr,
+		)
+	}
+
 	log.Printf("[DEBUG] %s: applying the planned %s change", n.Addr.Absolute(ctx.Path()), change.Action)
 	resp := provider.ApplyResourceChange(providers.ApplyResourceChangeRequest{
 		TypeName:       n.Addr.Resource.Type,

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -507,14 +507,8 @@ func (d *evaluationStateData) GetPathAttr(addr addrs.PathAttr, rng tfdiags.Sourc
 	}
 }
 
-func (d *evaluationStateData) GetResourceInstance(addr addrs.ResourceInstance, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-
-	// Although we are giving a ResourceInstance address here, if it has
-	// a key of addrs.NoKey then it might actually be a request for all of
-	// the instances of a particular resource. The reference resolver can't
-	// resolve the ambiguity itself, so we must do it in here.
-
 	// First we'll consult the configuration to see if an resource of this
 	// name is declared at all.
 	moduleAddr := d.ModulePath
@@ -525,36 +519,21 @@ func (d *evaluationStateData) GetResourceInstance(addr addrs.ResourceInstance, r
 		panic(fmt.Sprintf("resource value read from %s, which has no configuration", moduleAddr))
 	}
 
-	config := moduleConfig.Module.ResourceByAddr(addr.ContainingResource())
+	config := moduleConfig.Module.ResourceByAddr(addr)
 	if config == nil {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  `Reference to undeclared resource`,
-			Detail:   fmt.Sprintf(`A resource %q %q has not been declared in %s`, addr.Resource.Type, addr.Resource.Name, moduleDisplayAddr(moduleAddr)),
+			Detail:   fmt.Sprintf(`A resource %q %q has not been declared in %s`, addr.Type, addr.Name, moduleDisplayAddr(moduleAddr)),
 			Subject:  rng.ToHCL().Ptr(),
 		})
 		return cty.DynamicVal, diags
 	}
 
-	// First we'll find the state for the resource as a whole, and decide
-	// from there whether we're going to interpret the given address as a
-	// resource or a resource instance address.
-	rs := d.Evaluator.State.Resource(addr.ContainingResource().Absolute(d.ModulePath))
+	rs := d.Evaluator.State.Resource(addr.Absolute(d.ModulePath))
 
 	if rs == nil {
-		schema := d.getResourceSchema(addr.ContainingResource(), config.ProviderConfigAddr().Absolute(d.ModulePath))
-
-		// If it doesn't exist at all then we can't reliably determine whether
-		// single-instance or whole-resource interpretation was intended, but
-		// we can decide this partially...
-		if addr.Key != addrs.NoKey {
-			// If there's an instance key then the user must be intending
-			// single-instance interpretation, and so we can return a
-			// properly-typed unknown value to help with type checking.
-			return cty.UnknownVal(schema.ImpliedType()), diags
-		}
-
-		// otherwise we must return DynamicVal so that both interpretations
+		// we must return DynamicVal so that both interpretations
 		// can proceed without generating errors, and we'll deal with this
 		// in a later step where more information is gathered.
 		// (In practice we should only end up here during the validate walk,
@@ -569,69 +548,25 @@ func (d *evaluationStateData) GetResourceInstance(addr addrs.ResourceInstance, r
 		return cty.DynamicVal, diags
 	}
 
-	schema := d.getResourceSchema(addr.ContainingResource(), rs.ProviderConfig)
-
-	// If we are able to automatically convert to the "right" type of instance
-	// key for this each mode then we'll do so, to match with how we generally
-	// treat values elsewhere in the language. This allows code below to
-	// assume that any possible conversions have already been dealt with and
-	// just worry about validation.
-	key := d.coerceInstanceKey(addr.Key, rs.EachMode)
-
-	multi := false
-
 	switch rs.EachMode {
 	case states.NoEach:
-		if key != addrs.NoKey {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid resource index",
-				Detail:   fmt.Sprintf("Resource %s does not have either \"count\" or \"for_each\" set, so it cannot be indexed.", addr.ContainingResource()),
-				Subject:  rng.ToHCL().Ptr(),
-			})
-			return cty.DynamicVal, diags
-		}
-	case states.EachList:
-		multi = key == addrs.NoKey
-		if _, ok := addr.Key.(addrs.IntKey); !multi && !ok {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid resource index",
-				Detail:   fmt.Sprintf("Resource %s must be indexed with a number value.", addr.ContainingResource()),
-				Subject:  rng.ToHCL().Ptr(),
-			})
-			return cty.DynamicVal, diags
-		}
-	case states.EachMap:
-		multi = key == addrs.NoKey
-		if _, ok := addr.Key.(addrs.StringKey); !multi && !ok {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid resource index",
-				Detail:   fmt.Sprintf("Resource %s must be indexed with a string value.", addr.ContainingResource()),
-				Subject:  rng.ToHCL().Ptr(),
-			})
-			return cty.DynamicVal, diags
-		}
+		log.Printf("[TRACE] GetResource: %s is a single instance", addr)
+		return d.getResourceInstanceSingle(addr, rng, rs, config, rs.ProviderConfig)
+	case states.EachList, states.EachMap:
+		log.Printf("[TRACE] GetResource: %s has multiple keyed instances", addr)
+		return d.getResourceInstancesAll(addr, rng, config, rs, rs.ProviderConfig)
+	default:
+		panic("invalid EachMode")
 	}
-
-	if !multi {
-		log.Printf("[TRACE] GetResourceInstance: %s is a single instance", addr)
-		is := rs.Instance(key)
-		if is == nil {
-			return cty.UnknownVal(schema.ImpliedType()), diags
-		}
-		return d.getResourceInstanceSingle(addr, rng, is, config, rs.ProviderConfig)
-	}
-
-	log.Printf("[TRACE] GetResourceInstance: %s has multiple keyed instances", addr)
-	return d.getResourceInstancesAll(addr.ContainingResource(), rng, config, rs, rs.ProviderConfig)
 }
 
-func (d *evaluationStateData) getResourceInstanceSingle(addr addrs.ResourceInstance, rng tfdiags.SourceRange, is *states.ResourceInstance, config *configs.Resource, providerAddr addrs.AbsProviderConfig) (cty.Value, tfdiags.Diagnostics) {
+func (d *evaluationStateData) getResourceInstanceSingle(addr addrs.Resource, rng tfdiags.SourceRange, rs *states.Resource, config *configs.Resource, providerAddr addrs.AbsProviderConfig) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	schema := d.getResourceSchema(addr.ContainingResource(), providerAddr)
+	instAddr := addrs.ResourceInstance{Resource: addr, Key: addrs.NoKey}
+	is := rs.Instances[addrs.NoKey]
+
+	schema := d.getResourceSchema(addr, providerAddr)
 	if schema == nil {
 		// This shouldn't happen, since validation before we get here should've
 		// taken care of it, but we'll show a reasonable error message anyway.
@@ -654,7 +589,7 @@ func (d *evaluationStateData) getResourceInstanceSingle(addr addrs.ResourceInsta
 		// If there's a pending change for this instance in our plan, we'll prefer
 		// that. This is important because the state can't represent unknown values
 		// and so its data is inaccurate when changes are pending.
-		if change := d.Evaluator.Changes.GetResourceInstanceChange(addr.Absolute(d.ModulePath), states.CurrentGen); change != nil {
+		if change := d.Evaluator.Changes.GetResourceInstanceChange(instAddr.Absolute(d.ModulePath), states.CurrentGen); change != nil {
 			val, err := change.After.Decode(ty)
 			if err != nil {
 				diags = diags.Append(&hcl.Diagnostic{

--- a/terraform/testdata/apply-invalid-index/main.tf
+++ b/terraform/testdata/apply-invalid-index/main.tf
@@ -1,0 +1,7 @@
+resource "test_instance" "a" {
+  count = 0
+}
+
+resource "test_instance" "b" {
+  value = test_instance.a[0].value
+}


### PR DESCRIPTION
The primary goal of this PR is to always return entire resources to be evaluated, rather than individual instances. This allows us to push the evaluation of resource indexes down into expression evaluation. 

Invalid indexed references to other resources were silently returning unknown values when the instance didn't exist. These were only caught by extra validation in data sources when the config still contained unknown values during `ReadDataSource`. This now will catch invalid indexes, and adds an `IsWhollyKnown` validation to the config during apply, preventing config values from being silently dropped.

Only data sources caught this previously, but returned a rather unhelpful error of

```
configuration for data.null_data_source.foo[0].id still contains unknown values during apply (this is a bug in Terraform; please report it!)
```

Now that indexes are handled during expression evaluation, we can get a full diagnostic output:

```
Error: Invalid index

  on main.tf line 7, in resource "null_resource" "b":
   7:     a = null_resource.foo[0].id
    |----------------
    | null_resource.foo is empty tuple

The given key does not identify an element in this collection value.
```

