### PR TITLE
[docs] Add string key example to taint docs

### DIFF
--- a/website/docs/commands/taint.html.markdown
+++ b/website/docs/commands/taint.html.markdown
@@ -41,7 +41,8 @@ the output from other commands, such as:
 
  * `aws_instance.foo`
  * `aws_instance.bar[1]`
- * `module.foo.module.bar.aws_instance.baz`
+ * `aws_instance.baz[\"key\"]`
+ * `module.foo.module.bar.aws_instance.qux`
 
 The command-line flags are all optional. The list of available flags are:
 

--- a/website/docs/commands/taint.html.markdown
+++ b/website/docs/commands/taint.html.markdown
@@ -41,7 +41,7 @@ the output from other commands, such as:
 
  * `aws_instance.foo`
  * `aws_instance.bar[1]`
- * `aws_instance.baz[\"key\"]`
+ * `aws_instance.baz[\"key\"]` (quotes in resource addresses must be escaped on the command line, so that they are not interpreted by your shell)
  * `module.foo.module.bar.aws_instance.qux`
 
 The command-line flags are all optional. The list of available flags are:


### PR DESCRIPTION
Adds a string key example to the `taint` docs, as this is a gotcha when dealing with resources created with `for_each`