### PR TITLE
command/import: attach references before validating provider

### DIFF
--- a/command/import_test.go
+++ b/command/import_test.go
@@ -332,6 +332,63 @@ func TestImport_providerConfigWithVar(t *testing.T) {
 	testStateOutput(t, statePath, testImportStr)
 }
 
+func TestImport_providerConfigWithDataSource(t *testing.T) {
+	defer testChdir(t, testFixturePath("import-provider-datasource"))()
+
+	statePath := testTempFile(t)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &ImportCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+		},
+	}
+
+	p.ImportResourceStateFn = nil
+	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "test_instance",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("yay"),
+				}),
+			},
+		},
+	}
+	p.GetSchemaReturn = &terraform.ProviderSchema{
+		Provider: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"foo": {Type: cty.String, Optional: true},
+			},
+		},
+		ResourceTypes: map[string]*configschema.Block{
+			"test_instance": {
+				Attributes: map[string]*configschema.Attribute{
+					"id": {Type: cty.String, Optional: true, Computed: true},
+				},
+			},
+		},
+		DataSources: map[string]*configschema.Block{
+			"test_data": {
+				Attributes: map[string]*configschema.Attribute{
+					"id": {Type: cty.String, Optional: true, Computed: true},
+				},
+			},
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"test_instance.foo",
+		"bar",
+	}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad, wanted error: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}
+
 func TestImport_providerConfigWithVarDefault(t *testing.T) {
 	defer testChdir(t, testFixturePath("import-provider-var-default"))()
 

--- a/command/testdata/import-provider-datasource/main.tf
+++ b/command/testdata/import-provider-datasource/main.tf
@@ -1,0 +1,13 @@
+provider "test" {
+  foo = data.test_data.key.id
+}
+
+provider "test" {
+  alias = "credentials"
+}
+
+data "test_data" "key" {
+  provider = test.credentials
+}
+
+resource "test_instance" "foo" {}

--- a/terraform/graph_builder_import.go
+++ b/terraform/graph_builder_import.go
@@ -66,9 +66,6 @@ func (b *ImportGraphBuilder) Steps() []GraphTransformer {
 
 		TransformProviders(b.Components.ResourceProviders(), concreteProvider, config),
 
-		// This validates that the providers only depend on variables
-		&ImportProviderValidateTransformer{},
-
 		// Add the local values
 		&LocalTransformer{Config: b.Config},
 
@@ -85,6 +82,9 @@ func (b *ImportGraphBuilder) Steps() []GraphTransformer {
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.
 		&ReferenceTransformer{},
+
+		// This validates that the providers only depend on variables
+		&ImportProviderValidateTransformer{},
 
 		// Close opened plugin connections
 		&CloseProviderTransformer{},


### PR DESCRIPTION
There was an order-of-operations bug where the import graph builder was
validating that the provider did not have any resource references before
references were actually being attached. This PR fixes the order of
operations and adds a test (in the command package).

Fixes #22804