### PR TITLE
website: Link to hashicorp/subnets/cidr for cidrsubnets docs

### DIFF
--- a/website/docs/configuration/functions/cidrsubnets.html.md
+++ b/website/docs/configuration/functions/cidrsubnets.html.md
@@ -43,6 +43,12 @@ existing calls safely, as long as there is sufficient address space available.
 This function accepts both IPv6 and IPv4 prefixes, and the result always uses
 the same addressing scheme as the given prefix.
 
+-> **Note:** [The Terraform module `hashicorp/subnets/cidr`](https://registry.terraform.io/modules/hashicorp/subnets/cidr)
+wraps `cidrsubnets` to provide additional functionality for assigning symbolic
+names to your networks and skipping prefixes for obsolete allocations. Its
+documentation includes usage examples for several popular cloud virtual network
+platforms.
+
 ## Examples
 
 ```


### PR DESCRIPTION
The `cidrsubnets` function signature is intentionally very low-level and focused on the core requirement of generating addresses. This registry module then wraps it with some additional functionality to make it more convenient to generate and use subnet address ranges.

This module won't work until Terraform 0.12.10 is released, but this documentation change won't be released until then either so this link will become useful at approximately the time it is published.
