### PR TITLE
fix default state file path for refresh command

### DIFF
--- a/command/refresh.go
+++ b/command/refresh.go
@@ -18,7 +18,7 @@ type RefreshCommand struct {
 func (c *RefreshCommand) Run(args []string) int {
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.extendedFlagSet("refresh")
-	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
+	cmdFlags.StringVar(&statePath, "state", "", "path")
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
@@ -33,6 +33,10 @@ func (c *RefreshCommand) Run(args []string) int {
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
+	}
+
+	if statePath != "" {
+		c.Meta.statePath = statePath
 	}
 
 	var diags tfdiags.Diagnostics

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -18,7 +18,7 @@ type RefreshCommand struct {
 func (c *RefreshCommand) Run(args []string) int {
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.extendedFlagSet("refresh")
-	cmdFlags.StringVar(&statePath, "state", "", "path")
+	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
@@ -33,10 +33,6 @@ func (c *RefreshCommand) Run(args []string) int {
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
-	}
-
-	if statePath != "" {
-		c.Meta.statePath = statePath
 	}
 
 	var diags tfdiags.Diagnostics


### PR DESCRIPTION
This patch will fix `terraform refresh` command default state file path.

`refresh` command forcibly updates state path to `DefaultStateFilename` when state argument is not present.
DefaultStateFilename = terraform.tfstate, but when using workspace, it is a mistake.

So, I changed to refers correct state path.
\*) I refered output.go

Related Issue: #22842

