### PR TITLE
ensure data sources are always written to state

### DIFF
--- a/terraform/testdata/plan-data-depends-on/main.tf
+++ b/terraform/testdata/plan-data-depends-on/main.tf
@@ -1,0 +1,14 @@
+resource "test_resource" "a" {
+}
+
+data "test_data" "d" {
+  count = 1
+  depends_on = [
+    test_resource.a
+  ]
+}
+
+resource "test_resource" "b" {
+  count = 1
+  foo = data.test_data.d[count.index].compute
+}


### PR DESCRIPTION
The old logic for `depends_on` was to short-circuit evaluation of the
data source, but that prevented a plan and state from being recorded.
Use the (currently unused) ForcePlanRead to ensure that the plan is
recorded when the config contains `depends_on`.

This does not fix the fact that `depends_on` does not work with data
sources, and will still produce a perpetual diff. This is only to fix
evaluation errors when an indexed data source is evaluated during
refresh.

Fixes #21917