### PR TITLE
to e2e, or not e2e, that is the question

### DIFF
--- a/backend/remote-state/etcdv3/backend_test.go
+++ b/backend/remote-state/etcdv3/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -44,6 +45,9 @@ func prepareEtcdv3(t *testing.T) {
 	if skip {
 		t.Log("etcd server tests require setting TF_ACC or TF_ETCDV3_TEST")
 		t.Skip()
+	}
+	if reflect.DeepEqual(etcdv3Endpoints, []string{""}) {
+		t.Fatal("etcd server tests require setting TF_ETCDV3_ENDPOINTS")
 	}
 	cleanupEtcdv3(t)
 }

--- a/backend/remote-state/manta/backend.go
+++ b/backend/remote-state/manta/backend.go
@@ -53,7 +53,7 @@ func New() backend.Backend {
 			"insecure_skip_tls_verify": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TRITON_SKIP_TLS_VERIFY", ""),
+				DefaultFunc: schema.EnvDefaultFunc("TRITON_SKIP_TLS_VERIFY", false),
 			},
 
 			"path": {
@@ -127,6 +127,9 @@ func (b *Backend) configure(ctx context.Context) error {
 
 	if data.Get("account").(string) == "" {
 		validationError = multierror.Append(validationError, errors.New("`Account` must be configured for the Triton provider"))
+	}
+	if data.Get("key_id").(string) == "" {
+		validationError = multierror.Append(validationError, errors.New("`Key ID` must be configured for the Triton provider"))
 	}
 	if data.Get("key_id").(string) == "" {
 		validationError = multierror.Append(validationError, errors.New("`Key ID` must be configured for the Triton provider"))

--- a/backend/remote-state/manta/backend.go
+++ b/backend/remote-state/manta/backend.go
@@ -131,9 +131,6 @@ func (b *Backend) configure(ctx context.Context) error {
 	if data.Get("key_id").(string) == "" {
 		validationError = multierror.Append(validationError, errors.New("`Key ID` must be configured for the Triton provider"))
 	}
-	if data.Get("key_id").(string) == "" {
-		validationError = multierror.Append(validationError, errors.New("`Key ID` must be configured for the Triton provider"))
-	}
 	if b.path == "" {
 		validationError = multierror.Append(validationError, errors.New("`Path` must be configured for the Triton provider"))
 	}

--- a/backend/remote-state/manta/backend_test.go
+++ b/backend/remote-state/manta/backend_test.go
@@ -18,6 +18,14 @@ func testACC(t *testing.T) {
 		t.Log("Manta backend tests require setting TF_ACC or TF_MANTA_TEST")
 		t.Skip()
 	}
+	skip = os.Getenv("TRITON_ACCOUNT") == "" && os.Getenv("SDC_ACCOUNT") == ""
+	if skip {
+		t.Fatal("Manta backend tests require setting TRITON_ACCOUNT or SDC_ACCOUNT")
+	}
+	skip = os.Getenv("TRITON_KEY_ID") == "" && os.Getenv("SDC_KEY_ID") == ""
+	if skip {
+		t.Fatal("Manta backend tests require setting TRITON_KEY_ID or SDC_KEY_ID")
+	}
 }
 
 func TestBackend_impl(t *testing.T) {

--- a/backend/remote-state/oss/backend_test.go
+++ b/backend/remote-state/oss/backend_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"strings"
+
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/configs/hcl2shim"
-	"strings"
 )
 
 // verify that we are doing ACC tests or the OSS tests specifically
@@ -19,6 +20,9 @@ func testACC(t *testing.T) {
 	if skip {
 		t.Log("oss backend tests require setting TF_ACC or TF_OSS_TEST")
 		t.Skip()
+	}
+	if skip {
+		t.Fatal("oss backend tests require setting ALICLOUD_ACCESS_KEY or ALICLOUD_ACCESS_KEY_ID")
 	}
 	if os.Getenv("ALICLOUD_REGION") == "" {
 		os.Setenv("ALICLOUD_REGION", "cn-beijing")

--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -20,6 +20,11 @@ func TestDirFromModule_registry(t *testing.T) {
 
 	fixtureDir := filepath.Clean("testdata/empty")
 	tmpDir, done := tempChdir(t, fixtureDir)
+
+	// the module installer runs filepath.EvalSymlinks() on the destination
+	// directory before copying files, and the resultant directory is what is
+	// returned by the install hooks. Without this, tests could fail on machines
+	// where the default temp dir was a symlink.
 	dir, err := filepath.EvalSymlinks(tmpDir)
 	if err != nil {
 		t.Error(err)

--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -19,7 +19,11 @@ func TestDirFromModule_registry(t *testing.T) {
 	}
 
 	fixtureDir := filepath.Clean("testdata/empty")
-	dir, done := tempChdir(t, fixtureDir)
+	tmpDir, done := tempChdir(t, fixtureDir)
+	dir, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Error(err)
+	}
 	modsDir := filepath.Join(dir, ".terraform/modules")
 	defer done()
 

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -233,6 +233,10 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 
 	fixtureDir := filepath.Clean("testdata/registry-modules")
 	tmpDir, done := tempChdir(t, fixtureDir)
+	// the module installer runs filepath.EvalSymlinks() on the destination
+	// directory before copying files, and the resultant directory is what is
+	// returned by the install hooks. Without this, tests could fail on machines
+	// where the default temp dir was a symlink.
 	dir, err := filepath.EvalSymlinks(tmpDir)
 	if err != nil {
 		t.Error(err)
@@ -365,6 +369,10 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 
 	fixtureDir := filepath.Clean("testdata/go-getter-modules")
 	tmpDir, done := tempChdir(t, fixtureDir)
+	// the module installer runs filepath.EvalSymlinks() on the destination
+	// directory before copying files, and the resultant directory is what is
+	// returned by the install hooks. Without this, tests could fail on machines
+	// where the default temp dir was a symlink.
 	dir, err := filepath.EvalSymlinks(tmpDir)
 	if err != nil {
 		t.Error(err)

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -232,7 +232,12 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 	}
 
 	fixtureDir := filepath.Clean("testdata/registry-modules")
-	dir, done := tempChdir(t, fixtureDir)
+	tmpDir, done := tempChdir(t, fixtureDir)
+	dir, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Error(err)
+	}
+
 	defer done()
 
 	hooks := &testInstallHooks{}
@@ -359,7 +364,11 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 	}
 
 	fixtureDir := filepath.Clean("testdata/go-getter-modules")
-	dir, done := tempChdir(t, fixtureDir)
+	tmpDir, done := tempChdir(t, fixtureDir)
+	dir, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Error(err)
+	}
 	defer done()
 
 	hooks := &testInstallHooks{}

--- a/tools/terraform-bundle/e2etest/package_test.go
+++ b/tools/terraform-bundle/e2etest/package_test.go
@@ -31,10 +31,10 @@ func TestPackage_empty(t *testing.T) {
 		t.Errorf("unexpected stderr output:\n%s", stderr)
 	}
 
-	if !strings.Contains(stdout, "Fetching Terraform 0.10.1 core package...") {
+	if !strings.Contains(stdout, "Fetching Terraform 0.12.0 core package...") {
 		t.Errorf("success message is missing from output:\n%s", stdout)
 	}
-	if !strings.Contains(stdout, "Creating terraform_0.10.1-bundle") {
+	if !strings.Contains(stdout, "Creating terraform_0.12.0-bundle") {
 		t.Errorf("success message is missing from output:\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "All done!") {
@@ -65,36 +65,37 @@ func TestPackage_manyProviders(t *testing.T) {
 		t.Errorf("unexpected stderr output:\n%s", stderr)
 	}
 
-	if !strings.Contains(stdout, "Checking for available provider plugins on ") {
-		t.Errorf("success message is missing from output:\n%s", stdout)
-	}
-
 	// Here we have to check each provider separately
 	// because it's internally held in a map (i.e. not guaranteed order)
 
-	if !strings.Contains(stdout, `- Resolving "aws" provider (~> 0.1)...
-- Downloading plugin for provider "aws" (0.1.4)...`) {
+	if !strings.Contains(stdout, `- Resolving "aws" provider (~> 2.26.0)...
+- Checking for provider plugin on https://releases.hashicorp.com...
+- Downloading plugin for provider "aws" (hashicorp/aws) 2.26.0...`) {
 		t.Errorf("success message is missing from output:\n%s", stdout)
 	}
 
-	if !strings.Contains(stdout, `- Resolving "kubernetes" provider (0.1.0)...
-- Downloading plugin for provider "kubernetes" (0.1.0)...
-- Resolving "kubernetes" provider (0.1.1)...
-- Downloading plugin for provider "kubernetes" (0.1.1)...
-- Resolving "kubernetes" provider (0.1.2)...
-- Downloading plugin for provider "kubernetes" (0.1.2)...`) {
+	if !strings.Contains(stdout, `- Resolving "kubernetes" provider (1.8.0)...
+- Checking for provider plugin on https://releases.hashicorp.com...
+- Downloading plugin for provider "kubernetes" (hashicorp/kubernetes) 1.8.0...
+- Resolving "kubernetes" provider (1.8.1)...
+- Checking for provider plugin on https://releases.hashicorp.com...
+- Downloading plugin for provider "kubernetes" (hashicorp/kubernetes) 1.8.1...
+- Resolving "kubernetes" provider (1.9.0)...
+- Checking for provider plugin on https://releases.hashicorp.com...
+- Downloading plugin for provider "kubernetes" (hashicorp/kubernetes) 1.9.0...`) {
 		t.Errorf("success message is missing from output:\n%s", stdout)
 	}
 
-	if !strings.Contains(stdout, `- Resolving "null" provider (0.1.0)...
-- Downloading plugin for provider "null" (0.1.0)...`) {
+	if !strings.Contains(stdout, `- Resolving "null" provider (2.1.0)...
+- Checking for provider plugin on https://releases.hashicorp.com...
+- Downloading plugin for provider "null" (hashicorp/null) 2.1.0...`) {
 		t.Errorf("success message is missing from output:\n%s", stdout)
 	}
 
-	if !strings.Contains(stdout, "Fetching Terraform 0.10.1 core package...") {
+	if !strings.Contains(stdout, "Fetching Terraform 0.12.0 core package...") {
 		t.Errorf("success message is missing from output:\n%s", stdout)
 	}
-	if !strings.Contains(stdout, "Creating terraform_0.10.1-bundle") {
+	if !strings.Contains(stdout, "Creating terraform_0.12.0-bundle") {
 		t.Errorf("success message is missing from output:\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "All done!") {

--- a/tools/terraform-bundle/e2etest/testdata/empty/terraform-bundle.hcl
+++ b/tools/terraform-bundle/e2etest/testdata/empty/terraform-bundle.hcl
@@ -1,3 +1,3 @@
 terraform {
-  version = "0.10.1"
+  version = "0.12.0"
 }

--- a/tools/terraform-bundle/e2etest/testdata/many-providers/terraform-bundle.hcl
+++ b/tools/terraform-bundle/e2etest/testdata/many-providers/terraform-bundle.hcl
@@ -1,9 +1,9 @@
 terraform {
-  version = "0.10.1"
+  version = "0.12.0"
 }
 
 providers {
-  aws = ["~> 0.1"]
-  kubernetes = ["0.1.0", "0.1.1", "0.1.2"]
-  null = ["0.1.0"]
+  aws        = ["~> 2.26.0"]
+  kubernetes = ["1.8.0", "1.8.1", "1.9.0"]
+  null       = ["2.1.0"]
 }


### PR DESCRIPTION
While working on a new feature I found that certain e2e tests had not been updated for 0.12. This sent me down a bit of a rabbit trail getting the e2e tests to either pass _or_ (in the case of backends) fail cleanly. (The first two commits represent tests I needed to get working for my feature while the latter two were fixed merely because the messiness of the failures annoyed me). 

Some of these backend failures might represent bugs in the backend themselves (such as [etcv3](https://github.com/hashicorp/terraform/issues/21181)] but overall it seemed that the tests were simply making assumptions about env vars being set, then failing in weird ways when that was not the case. 

I did find one clear bug in the `manta` backend: a bool attribute was defaulting to `""` and causing a panic, so I updated it to `false` (matching the [documented default](https://www.terraform.io/docs/backends/types/manta.html#insecure_skip_tls_verify)). 