### PR TITLE
Allow typing the name of the workspace to confirm in addition to of "yes"

### DIFF
--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -133,7 +133,7 @@ func (b *Local) opApply(
 				b.ReportResult(runningOp, diags)
 				return
 			}
-			if v != "yes" && v != op.Workspace {
+			if v != "yes" && (v != op.Workspace || op.Workspace == "default") {
 				if op.Destroy {
 					b.CLI.Info("Destroy cancelled.")
 				} else {

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -129,7 +129,7 @@ func (b *Local) opApply(
 				b.ReportResult(runningOp, diags)
 				return
 			}
-			if v != "yes" {
+			if v != "yes" && v != op.Workspace {
 				if op.Destroy {
 					b.CLI.Info("Destroy cancelled.")
 				} else {

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -91,19 +91,23 @@ func (b *Local) opApply(
 			if op.Destroy {
 				if op.Workspace != "default" {
 					query = "Do you really want to destroy all resources in workspace \"" + op.Workspace + "\"?"
+					desc = "Terraform will destroy all your managed infrastructure, as shown above.\n" +
+						"There is no undo. Only 'yes' or '" + op.Workspace + "' will be accepted to confirm."
 				} else {
 					query = "Do you really want to destroy all resources?"
+					desc = "Terraform will destroy all your managed infrastructure, as shown above.\n" +
+						"There is no undo. Only 'yes' will be accepted to confirm."
 				}
-				desc = "Terraform will destroy all your managed infrastructure, as shown above.\n" +
-					"There is no undo. Only 'yes' will be accepted to confirm."
 			} else {
 				if op.Workspace != "default" {
 					query = "Do you want to perform these actions in workspace \"" + op.Workspace + "\"?"
+					desc = "Terraform will perform the actions described above.\n" +
+						"Only 'yes' or '" + op.Workspace + "' will be accepted to approve."
 				} else {
 					query = "Do you want to perform these actions?"
+					desc = "Terraform will perform the actions described above.\n" +
+						"Only 'yes' will be accepted to approve."
 				}
-				desc = "Terraform will perform the actions described above.\n" +
-					"Only 'yes' will be accepted to approve."
 			}
 
 			if !trivialPlan {


### PR DESCRIPTION
I often find myself accidentally typing the name of the active workspace instead of "yes" when confirming an operation.
This PR allows the name of the workspace to be used in addition to "yes".
This guarantees that the operation is being performed on the expected workspace as an added security measure against mistakes.