### PR TITLE
remove dotfile exclusion in copyDir

### DIFF
--- a/configs/configload/copy_dir.go
+++ b/configs/configload/copy_dir.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // copyDir copies the src directory contents into dst. Both directories
@@ -22,15 +21,6 @@ func copyDir(dst, src string) error {
 
 		if path == src {
 			return nil
-		}
-
-		if strings.HasPrefix(filepath.Base(path), ".") {
-			// Skip any dot files
-			if info.IsDir() {
-				return filepath.SkipDir
-			} else {
-				return nil
-			}
 		}
 
 		// The "path" has the src prefixed to it. We need to join our


### PR DESCRIPTION
fixes #22844 

This is a question, really: do we need to exclude dotfiles in `copyDir`?

`copyDir` is used in `configload/getter.go` to copy previously downloaded modules instead of using the go-getter client every time. The go-getter client downloads dotfiles, but `copyDir` did not copy dotfiles, leading to inconsistent behaviour when reusing the same module source.