### PR TITLE
Remove -check-variables flag from the docs

### DIFF
--- a/website/docs/commands/validate.html.markdown
+++ b/website/docs/commands/validate.html.markdown
@@ -37,9 +37,6 @@ for the configurations.
 
 The command-line flags are all optional. The available flags are:
 
-* `-check-variables=true` - If set to true (default), the command will check
-  whether all required variables have been specified.
-
 * `-no-color` - Disables output with coloring.
 
 * `-var 'foo=bar'` - Set a variable in the Terraform configuration. This flag


### PR DESCRIPTION
`-check-variables` is not present in v0.12 of `terraform validate`.

```
$ terraform --version
Terraform v0.12.9

$ terraform validate --help
Usage: terraform validate [options] [dir]

  Validate the configuration files in a directory, referring only to the
  configuration and not accessing any remote services such as remote state,
  provider APIs, etc.

  Validate runs checks that verify whether a configuration is
  internally-consistent, regardless of any provided variables or existing
  state. It is thus primarily useful for general verification of reusable
  modules, including correctness of attribute names and value types.

  It is safe to run this command automatically, for example as a post-save
  check in a text editor or as a test step for a re-usable module in a CI
  system.

  Validation requires an initialized working directory with any referenced
  plugins and modules installed. To initialize a working directory for
  validation without accessing any configured remote backend, use:
      terraform init -backend=false

  If dir is not specified, then the current directory will be used.

  To verify configuration in the context of a particular run (a particular
  target workspace, operation variables, etc), use the terraform plan
  subcommand instead, which includes an implied validation check.

Options:

  -json        Produce output in a machine-readable JSON format, suitable for
               use in e.g. text editor integrations.

$ terraform validate -check-variables=true
Usage: terraform validate [options] [dir]

  Validate the configuration files in a directory, referring only to the
  configuration and not accessing any remote services such as remote state,
  provider APIs, etc.

  Validate runs checks that verify whether a configuration is
  internally-consistent, regardless of any provided variables or existing
  state. It is thus primarily useful for general verification of reusable
  modules, including correctness of attribute names and value types.

  It is safe to run this command automatically, for example as a post-save
  check in a text editor or as a test step for a re-usable module in a CI
  system.

  Validation requires an initialized working directory with any referenced
  plugins and modules installed. To initialize a working directory for
  validation without accessing any configured remote backend, use:
      terraform init -backend=false

  If dir is not specified, then the current directory will be used.

  To verify configuration in the context of a particular run (a particular
  target workspace, operation variables, etc), use the terraform plan
  subcommand instead, which includes an implied validation check.

Options:

  -json        Produce output in a machine-readable JSON format, suitable for
               use in e.g. text editor integrations.
Error parsing command-line flags: flag provided but not defined: -check-variables
```