### PR TITLE
Let helper/logging/transport extend http.RoundTripper

### DIFF
--- a/helper/logging/transport.go
+++ b/helper/logging/transport.go
@@ -10,8 +10,8 @@ import (
 )
 
 type transport struct {
-	name      string
-	transport http.RoundTripper
+	http.RoundTripper
+	name string
 }
 
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -24,7 +24,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 
-	resp, err := t.transport.RoundTrip(req)
+	resp, err := t.RoundTripper.RoundTrip(req)
 	if err != nil {
 		return resp, err
 	}
@@ -42,7 +42,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func NewTransport(name string, t http.RoundTripper) *transport {
-	return &transport{name, t}
+	return &transport{t, name}
 }
 
 // prettyPrintJsonLines iterates through a []byte line-by-line,


### PR DESCRIPTION
Using a custom transport in the context of the kubernetes SDK fails when TLS is enabled with the following error:

```
using a custom transport with TLS certificate options or the insecure flag is not allowed
```

See https://github.com/kubernetes/client-go/blob/v10.0.0/transport/transport.go#L32
and https://github.com/kubernetes/client-go/issues/452#issuecomment-413881709

Letting the `helper/logging/transport` struct extend `http.RoundTripper` makes it usable with the kubernetes SDK `Config.WrapTransport`: https://github.com/kubernetes/client-go/blob/v10.0.0/rest/config.go#L99

This PR allows enabling HTTP requests/responses tracing in debug mode with the terraform kubernetes provider: https://github.com/terraform-providers/terraform-provider-kubernetes/pull/630

I've tested compatibility with the terraform google provider and did not notice any regression.

If this change is accepted, I guess I'll need to submit the same change to the SDK: https://github.com/hashicorp/terraform-plugin-sdk/blob/v1.1.0/helper/logging/transport.go#L13