### PR TITLE
Chef provisioner: fix rpc UTF8 related issues #22856

### DIFF
--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"text/template"
+	"unicode/utf8"
 
 	"github.com/hashicorp/terraform/communicator"
 	"github.com/hashicorp/terraform/communicator/remote"
@@ -710,9 +711,16 @@ func (p *provisioner) runCommand(o terraform.UIOutput, comm communicator.Communi
 }
 
 func (p *provisioner) copyOutput(o terraform.UIOutput, r io.Reader) {
+	utf8mapF := func(r rune) rune {
+		if r == utf8.RuneError {
+			return -1
+		}
+		return r
+	}
 	lr := linereader.New(r)
 	for line := range lr.Ch {
-		o.Output(strings.ToValidUTF8(line, ""))
+		// o.Output(strings.ToValidUTF8(line, "")) // with golang 1.13
+		o.Output(strings.Map(utf8mapF, line))
 	}
 }
 

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -712,7 +712,7 @@ func (p *provisioner) runCommand(o terraform.UIOutput, comm communicator.Communi
 func (p *provisioner) copyOutput(o terraform.UIOutput, r io.Reader) {
 	lr := linereader.New(r)
 	for line := range lr.Ch {
-		o.Output(line)
+		o.Output(strings.ToValidUTF8(line, ""))
 	}
 }
 


### PR DESCRIPTION
Hey maintainers, @donovanmuller has reported exactly the same problem in my Ansible provisoner: https://github.com/radekg/terraform-provisioner-ansible/issues/139.

Assuming that you are building with golang 1.13, this should be sufficient to fix the problem reported in https://github.com/hashicorp/terraform/issues/22856.