### PR TITLE
Adding 'folder' directive for structuring module content on disk

### DIFF
--- a/config/import_tree.go
+++ b/config/import_tree.go
@@ -13,6 +13,7 @@ import (
 // formats of Terraform in order to return a *Config.
 type configurable interface {
 	Config() (*Config, error)
+	FolderIncludes() ([]string, error)
 }
 
 // importTree is the result of the first-pass load of the configuration
@@ -148,4 +149,10 @@ func (t *importTree) ConfigTree() (*configTree, error) {
 	}
 
 	return result, nil
+}
+
+// FolderIncludes returns the folders referenced for inclusion
+// within a configuration
+func (t *importTree) FolderIncludes() ([]string, error) {
+	return t.Raw.FolderIncludes()
 }

--- a/config/loader_hcl2.go
+++ b/config/loader_hcl2.go
@@ -65,6 +65,10 @@ func (l hcl2Loader) loadFile(filename string) (configurable, []string, error) {
 	}, nil, nil
 }
 
+func (t *hcl2Configurable) FolderIncludes() ([]string, error) {
+	return nil, fmt.Errorf("Not implemented")
+}
+
 func (t *hcl2Configurable) Config() (*Config, error) {
 	config := &Config{}
 

--- a/config/testdata/folder-include-basic/child-folder-1/main.tf
+++ b/config/testdata/folder-include-basic/child-folder-1/main.tf
@@ -1,0 +1,3 @@
+variable "a" {
+  default = "1"
+}

--- a/config/testdata/folder-include-basic/child-folder-2/main.tf
+++ b/config/testdata/folder-include-basic/child-folder-2/main.tf
@@ -1,0 +1,3 @@
+variable "b" {
+  default = "2"
+}

--- a/config/testdata/folder-include-basic/main.tf
+++ b/config/testdata/folder-include-basic/main.tf
@@ -1,0 +1,15 @@
+folder {
+  source = "./child-folder-1"
+}
+
+folder {
+  source = "./child-folder-2"
+}
+
+output "a" {
+  value = "${var.a}"
+}
+
+output "b" {
+  value = "${var.b}"
+}

--- a/config/testdata/folder-include-collision/child-folder-1/main.tf
+++ b/config/testdata/folder-include-collision/child-folder-1/main.tf
@@ -1,0 +1,3 @@
+variable "a" {
+  default = "1"
+}

--- a/config/testdata/folder-include-collision/child-folder-2/main.tf
+++ b/config/testdata/folder-include-collision/child-folder-2/main.tf
@@ -1,0 +1,7 @@
+variable "b" {
+  default = "2"
+}
+
+variable "a" { // collision
+  default = "3"
+}

--- a/config/testdata/folder-include-collision/main.tf
+++ b/config/testdata/folder-include-collision/main.tf
@@ -1,0 +1,15 @@
+folder {
+  source = "./child-folder-1"
+}
+
+folder {
+  source = "./child-folder-2"
+}
+
+output "a" {
+  value = "${var.a}"
+}
+
+output "b" {
+  value = "${var.b}"
+}

--- a/website/docs/configuration/folders.html.md
+++ b/website/docs/configuration/folders.html.md
@@ -1,0 +1,40 @@
+---
+layout: "docs"
+page_title: "Folder includes - Configuration Language"
+sidebar_current: "docs-config-folders"
+description: |-
+  Folder includes allow Terraform configuration content to be split across multiple
+  file system folders with no side effects.
+---
+
+# Folder includes
+
+-> **Note:** This page is about Terraform 0.12 and later. Folder includes are
+not supported in earlier versions.
+
+A folder include specifies an additional file system folder to be incorporated
+into a Terraform configuration. Unlike a [module](./modules.html), a folder
+include does not represent a configuration boundary and does not change the
+way that resources are addressed in interpolations.
+
+-> **Note:** Path-based interpolations are relative to the module root, not
+the included folder.
+
+## Declaring a Folder Include
+
+A folder include is declared using a `folder` block:
+
+```hcl
+folder {
+  source = "./security-group-rules"
+}
+```
+
+Each referenced folder is merged entirely with the referencing module. Folder
+includes may be nested.
+
+## When To Use Folder Includes
+
+Modules allow for creating reusable configurations and for representing more
+abstract resources. Folder includes in contrast provide a way for managing
+large modules where it does not make sense to use modules.


### PR DESCRIPTION
This PR adds a new Terraform directive, `folder`, that allows multiple on-disk folders to contribute Terraform HCL configuration content to a single Terraform module.

At present, the changes add support for the directive and merge content but do not change the behaviour of resources inside the module, such as when referencing paths. This is a complexity but has an obvious workaround of including the full relative path to content if needed. I'm not sure if there is a good alternative solution to this in the existing code (I've already played with some ideas but would want to know if the maintainers thought this desirable before proceeding).

In my experience it is not uncommon for a single Terraform root module to have more than 50 or even a hundred distinct files, with some resources having multiple resources. Splitting these into modules is not always desirable. AWS IAM policies, security group rules, S3 and Lambda content, and a host of other configurations do not always split nicely along loosely-coupled boundaries.

Currently, there is no direct issue using a single large folder but it does create difficulty for team members to absorb the design of a large module.

Putting code into Terraform for this solves bigger problems of how to combine content using a build step and ensures that the CLI remains an effective way of developing with larger codebases, even if just to see plans and not actually apply them (which is done by a build/deployment system).

I'm happy to work on this further if there's an implementation that would be acceptable to the Terraform maintainers.