### PR TITLE
Remove some destroy cycles

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -10672,3 +10672,80 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 		})
 	}
 }
+
+func TestContext2Apply_destroyDataCycle(t *testing.T) {
+	m, snap := testModuleWithSnapshot(t, "apply-destroy-data-cycle")
+	p := testProvider("null")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "null_resource",
+			Name: "a",
+		}.Instance(addrs.IntKey(0)),
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"a"}`),
+		},
+		addrs.ProviderConfig{
+			Type: "null",
+		}.Absolute(addrs.RootModuleInstance),
+	)
+	root.SetResourceInstanceCurrent(
+		addrs.Resource{
+			Mode: addrs.DataResourceMode,
+			Type: "null_data_source",
+			Name: "d",
+		}.Instance(addrs.NoKey),
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"data"}`),
+		},
+		addrs.ProviderConfig{
+			Type: "null",
+		}.Absolute(addrs.RootModuleInstance),
+	)
+
+	providerResolver := providers.ResolverFixed(
+		map[string]providers.Factory{
+			"null": testProviderFuncFixed(p),
+		},
+	)
+
+	hook := &testHook{}
+	ctx := testContext2(t, &ContextOpts{
+		Config:           m,
+		ProviderResolver: providerResolver,
+		State:            state,
+		Destroy:          true,
+		Hooks:            []Hook{hook},
+	})
+
+	plan, diags := ctx.Plan()
+	diags.HasErrors()
+	if diags.HasErrors() {
+		t.Fatalf("diags: %s", diags.Err())
+	}
+
+	// We'll marshal and unmarshal the plan here, to ensure that we have
+	// a clean new context as would be created if we separately ran
+	// terraform plan -out=tfplan && terraform apply tfplan
+	ctxOpts, err := contextOptsForPlanViaFile(snap, state, plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctxOpts.ProviderResolver = providerResolver
+	ctx, diags = NewContext(ctxOpts)
+	if diags.HasErrors() {
+		t.Fatalf("failed to create context for plan: %s", diags.Err())
+	}
+
+	_, diags = ctx.Apply()
+	if diags.HasErrors() {
+		t.Fatalf("diags: %s", diags.Err())
+	}
+}

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -10527,3 +10527,148 @@ func TestContext2Apply_issue19908(t *testing.T) {
 		t.Errorf("test.foo attributes JSON doesn't contain %s after apply\ngot: %s", want, got)
 	}
 }
+
+func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
+	for _, mode := range []string{"normal", "cbd"} {
+		var m *configs.Config
+
+		switch mode {
+		case "normal":
+			m = testModule(t, "apply-module-replace-cycle")
+		case "cbd":
+			m = testModule(t, "apply-module-replace-cycle-cbd")
+		}
+
+		p := testProvider("aws")
+		p.DiffFn = testDiffFn
+		p.ApplyFn = testApplyFn
+
+		instanceSchema := &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"id":          {Type: cty.String, Computed: true},
+				"require_new": {Type: cty.String, Optional: true},
+			},
+		}
+
+		p.GetSchemaReturn = &ProviderSchema{
+			ResourceTypes: map[string]*configschema.Block{
+				"aws_instance": instanceSchema,
+			},
+		}
+
+		state := states.NewState()
+		modA := state.EnsureModule(addrs.RootModuleInstance.Child("a", addrs.NoKey))
+		modA.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "aws_instance",
+				Name: "a",
+			}.Instance(addrs.NoKey),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"a","require_new":"old"}`),
+			},
+			addrs.ProviderConfig{
+				Type: "aws",
+			}.Absolute(addrs.RootModuleInstance),
+		)
+
+		modB := state.EnsureModule(addrs.RootModuleInstance.Child("b", addrs.NoKey))
+		modB.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "aws_instance",
+				Name: "b",
+			}.Instance(addrs.IntKey(0)),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"b","require_new":"old"}`),
+			},
+			addrs.ProviderConfig{
+				Type: "aws",
+			}.Absolute(addrs.RootModuleInstance),
+		)
+
+		aBefore, _ := plans.NewDynamicValue(
+			cty.ObjectVal(map[string]cty.Value{
+				"id":          cty.StringVal("a"),
+				"require_new": cty.StringVal("old"),
+			}), instanceSchema.ImpliedType())
+		aAfter, _ := plans.NewDynamicValue(
+			cty.ObjectVal(map[string]cty.Value{
+				"id":          cty.UnknownVal(cty.String),
+				"require_new": cty.StringVal("new"),
+			}), instanceSchema.ImpliedType())
+		bBefore, _ := plans.NewDynamicValue(
+			cty.ObjectVal(map[string]cty.Value{
+				"id":          cty.StringVal("b"),
+				"require_new": cty.StringVal("old"),
+			}), instanceSchema.ImpliedType())
+		bAfter, _ := plans.NewDynamicValue(
+			cty.ObjectVal(map[string]cty.Value{
+				"id":          cty.UnknownVal(cty.String),
+				"require_new": cty.UnknownVal(cty.String),
+			}), instanceSchema.ImpliedType())
+
+		var aAction plans.Action
+		switch mode {
+		case "normal":
+			aAction = plans.DeleteThenCreate
+		case "cbd":
+			aAction = plans.CreateThenDelete
+		}
+
+		changes := &plans.Changes{
+			Resources: []*plans.ResourceInstanceChangeSrc{
+				{
+					Addr: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "aws_instance",
+						Name: "a",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance.Child("a", addrs.NoKey)),
+					ProviderAddr: addrs.ProviderConfig{
+						Type: "aws",
+					}.Absolute(addrs.RootModuleInstance),
+					ChangeSrc: plans.ChangeSrc{
+						Action: aAction,
+						Before: aBefore,
+						After:  aAfter,
+					},
+				},
+				{
+					Addr: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "aws_instance",
+						Name: "b",
+					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance.Child("b", addrs.NoKey)),
+					ProviderAddr: addrs.ProviderConfig{
+						Type: "aws",
+					}.Absolute(addrs.RootModuleInstance),
+					ChangeSrc: plans.ChangeSrc{
+						Action: plans.DeleteThenCreate,
+						Before: bBefore,
+						After:  bAfter,
+					},
+				},
+			},
+		}
+
+		ctx := testContext2(t, &ContextOpts{
+			Config: m,
+			ProviderResolver: providers.ResolverFixed(
+				map[string]providers.Factory{
+					"aws": testProviderFuncFixed(p),
+				},
+			),
+			State:   state,
+			Changes: changes,
+		})
+
+		t.Run(mode, func(t *testing.T) {
+			_, diags := ctx.Apply()
+			if diags.HasErrors() {
+				t.Fatal(diags.Err())
+			}
+		})
+	}
+}

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -522,8 +522,9 @@ root
 test_object.A (prepare state)
   provider.test
 test_object.A[1] (destroy)
-  test_object.A (prepare state)
+  provider.test
 test_object.B
+  test_object.A (prepare state)
   test_object.A[1] (destroy)
   test_object.B (prepare state)
 test_object.B (prepare state)

--- a/terraform/testdata/apply-destroy-data-cycle/main.tf
+++ b/terraform/testdata/apply-destroy-data-cycle/main.tf
@@ -1,0 +1,10 @@
+locals {
+    l = data.null_data_source.d.id
+}
+
+data "null_data_source" "d" {
+}
+
+resource "null_resource" "a" {
+    count = local.l == "NONE" ? 1 : 0
+}

--- a/terraform/testdata/apply-module-replace-cycle-cbd/main.tf
+++ b/terraform/testdata/apply-module-replace-cycle-cbd/main.tf
@@ -1,0 +1,8 @@
+module "a" {
+  source = "./mod1"
+}
+
+module "b" {
+  source = "./mod2"
+  ids = module.a.ids
+}

--- a/terraform/testdata/apply-module-replace-cycle-cbd/mod1/main.tf
+++ b/terraform/testdata/apply-module-replace-cycle-cbd/mod1/main.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "a" {
+  require_new = "new"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "ids" {
+  value = [aws_instance.a.id]
+}

--- a/terraform/testdata/apply-module-replace-cycle-cbd/mod2/main.tf
+++ b/terraform/testdata/apply-module-replace-cycle-cbd/mod2/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "b" {
+  count    = length(var.ids)
+  require_new = var.ids[count.index]
+}
+
+variable "ids" {
+  type = list(string)
+}

--- a/terraform/testdata/apply-module-replace-cycle/main.tf
+++ b/terraform/testdata/apply-module-replace-cycle/main.tf
@@ -1,0 +1,8 @@
+module "a" {
+  source = "./mod1"
+}
+
+module "b" {
+  source = "./mod2"
+  ids = module.a.ids
+}

--- a/terraform/testdata/apply-module-replace-cycle/mod1/main.tf
+++ b/terraform/testdata/apply-module-replace-cycle/mod1/main.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "a" {
+  require_new = "new"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "ids" {
+  value = [aws_instance.a.id]
+}

--- a/terraform/testdata/apply-module-replace-cycle/mod2/main.tf
+++ b/terraform/testdata/apply-module-replace-cycle/mod2/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "b" {
+  count    = length(var.ids)
+  require_new = var.ids[count.index]
+}
+
+variable "ids" {
+  type = list(string)
+}

--- a/terraform/transform_diff.go
+++ b/terraform/transform_diff.go
@@ -174,14 +174,6 @@ func (t *DiffTransformer) Transform(g *Graph) error {
 				log.Printf("[TRACE] DiffTransformer: %s deposed object %s will be represented for destruction by %s", addr, dk, dag.VertexName(node))
 			}
 			g.Add(node)
-			rsrcAddr := addr.ContainingResource().String()
-			for _, rsrcNode := range resourceNodes[rsrcAddr] {
-				// We connect this edge "forwards" (even though destroy dependencies
-				// are often inverted) because evaluating the resource node
-				// after the destroy node could cause an unnecessary husk of
-				// a resource state to be re-added.
-				g.Connect(dag.BasicEdge(node, rsrcNode))
-			}
 		}
 
 	}


### PR DESCRIPTION
This PR removes extra connections from the graph which are unneeded, however only cause problems in certain destroy scenarios. This solves a number of common cycles issues, while simplifying the graph itself. It does not solve all cycles, as destroy nodes still need their references evaluated in order for destroy-provisioners to function. 

---

Destroy nodes do not need to be connected to the resource (prepare
state) node when adding them to the graph. Destroy nodes already have a
complete state in the graph (which is being destroyed), any references
will be added in the ReferenceTransformer, and the proper
connection to the create node will be added in the
DestroyEdgeTransformer.

Under normal circumstances this makes no difference, as create and
destroy nodes always have a direct dependency, so having the 
prepare state handled before both only linearizes the operation slightly
in the normal destroy-then-create scenario.
However if there is a dependency on a resource being replaced in another
module, there will be a dependency between the destroy nodes in each
module (to complete the destroy ordering), while the resource node will
depend on the variable->output->resource chain. If both the destroy and
create nodes depend on the resource node, there will be a cycle.

---

If a resource is only destroying instances, there is no reason to
prepare the state and we can remove the Resource (prepare state) nodes.
They normally have pose no issue, but if the instances are being
destroyed along with their dependencies, the resource node may fail to
evaluate due to the missing dependencies (since destroy happens in the
reverse order).

These failures were previously blocked by there being a cycle when the
destroy nodes were directly attached to the resource nodes.

---

This depends on jbardin/cbd-modules, and can be merged into that first, or re-targeted to later to master.

Fixes #22502
Does not close #21662, but does fix some of the in-line examples that have been provided.