### PR TITLE
copy client pointer for keep-alive loop

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -236,7 +236,7 @@ func (c *Communicator) Connect(o terraform.UIOutput) (err error) {
 	// long-running commands.
 	log.Printf("[DEBUG] starting ssh KeepAlives")
 
-	// We wont a local copy of the ssh client pointer, so that a reconnect
+	// We want a local copy of the ssh client pointer, so that a reconnect
 	// doesn't race with the running keep-alive loop.
 	sshClient := c.client
 	go func() {


### PR DESCRIPTION
If a connection fails and attempts to reconnect after the keep-alive
loop started, the client will be pulled out from under the keep-alive
requests. Close over a local copy of the client, so that reconnecting
doesn't race with the keepalive loop terminating.

Fixes #22943