### PR TITLE
command/validate: warn if unused flags are set on the command line

### DIFF
--- a/command/validate.go
+++ b/command/validate.go
@@ -25,17 +25,9 @@ func (c *ValidateCommand) Run(args []string) int {
 		return 1
 	}
 
-	if c.Meta.variableArgs.items == nil {
-		c.Meta.variableArgs = newRawFlags("-var")
-	}
-	varValues := c.Meta.variableArgs.Alias("-var")
-	varFiles := c.Meta.variableArgs.Alias("-var-file")
-
 	var jsonOutput bool
 	cmdFlags := c.Meta.defaultFlagSet("validate")
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "produce JSON output")
-	cmdFlags.Var(varValues, "var", "variables")
-	cmdFlags.Var(varFiles, "var-file", "variable file")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))


### PR DESCRIPTION
This PR removes the unused flags in the `validate` command.
 The `-var` and `-var-file` command line options are unused (and in the case of any `var`s given on the command line, overwritten).

#22938 was recently opened to reconcile the `validate` documentation with actual behavior.