### PR TITLE
[Website] Add links to provider documentation

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -130,6 +130,7 @@ down to see all providers.
 - [UCloud](/docs/providers/ucloud/index.html)
 - [UltraDNS](/docs/providers/ultradns/index.html)
 - [Vault](/docs/providers/vault/index.html)
+- [Venafi](/docs/providers/venafi/index.html)
 - [VMware NSX-T](/docs/providers/nsxt/index.html)
 - [VMware vCloud Director](/docs/providers/vcd/index.html)
 - [VMware vRA7](/docs/providers/vra7/index.html)

--- a/website/docs/providers/type/monitor-index.html.markdown
+++ b/website/docs/providers/type/monitor-index.html.markdown
@@ -33,3 +33,4 @@ HashiCorp, and are tested by HashiCorp.
 - [Runscope](/docs/providers/runscope/index.html)
 - [SignalFx](/docs/providers/signalfx/index.html)
 - [StatusCake](/docs/providers/statuscake/index.html)
+- [Venafi](/docs/providers/venafi/index.html)


### PR DESCRIPTION
Adding two links that will point to the provider documentation for the new certified Venafi provider