### PR TITLE
terraform-bundle bundle filename with `minutes` added

### DIFF
--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -259,9 +259,9 @@ func (c *PackageCommand) Run(args []string) int {
 func (c *PackageCommand) bundleFilename(version discovery.VersionStr, time time.Time, osName, archName string) string {
 	time = time.UTC()
 	return fmt.Sprintf(
-		"terraform_%s-bundle%04d%02d%02d%02d_%s_%s.zip",
+		"terraform_%s-bundle%04d%02d%02d%02d%02d_%s_%s.zip",
 		version,
-		time.Year(), time.Month(), time.Day(), time.Hour(),
+		time.Year(), time.Month(), time.Day(), time.Hour(), time.Minute(),
 		osName, archName,
 	)
 }


### PR DESCRIPTION
### Problem
When using `terraform-bundle` to generate a `bundle` x times in the same hour a bundle with the same name is created, creating collision. 

### Solution
Add `time.Minute` to bundle name. 

It is still not perfect as there is a chance for a collision in minutes but not sure if its worth it to make it down to `milliseconds`. This solutions seems like a `good enough` one.