### PR TITLE
Add -ignore-empty-output flag

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -30,12 +30,10 @@ func (c *OutputCommand) Run(args []string) int {
 
 	var module, statePath string
 	var jsonOutput bool
-	var flagIgnoreEmptyOutput bool
 	cmdFlags := c.Meta.defaultFlagSet("output")
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "json")
 	cmdFlags.StringVar(&statePath, "state", "", "path")
 	cmdFlags.StringVar(&module, "module", "", "module")
-	cmdFlags.BoolVar(&flagIgnoreEmptyOutput, "ignore-empty-output", false, "ignore empty output")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
@@ -115,19 +113,14 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	if !jsonOutput && (state.Empty() || len(mod.OutputValues) == 0) {
-		emptyOutputString := "The state file either has no outputs defined, or all the defined\n" +
-			"outputs are empty. Please define an output in your configuration\n" +
-			"with the `output` keyword and run `terraform refresh` for it to\n" +
-			"become available. If you are using interpolation, please verify\n" +
-			"the interpolated value is not empty. You can use the \n" +
-			"`terraform console` command to assist."
-		if flagIgnoreEmptyOutput {
-			c.Ui.Output(emptyOutputString)
-			return 0
-		} else {
-			c.Ui.Error(emptyOutputString)
-			return 1
-		}
+		c.Ui.Error(
+			"The state file either has no outputs defined, or all the defined\n" +
+				"outputs are empty. Please define an output in your configuration\n" +
+				"with the `output` keyword and run `terraform refresh` for it to\n" +
+				"become available. If you are using interpolation, please verify\n" +
+				"the interpolated value is not empty. You can use the \n" +
+				"`terraform console` command to assist.")
+		return 0
 	}
 
 	if name == "" {
@@ -338,16 +331,13 @@ Usage: terraform output [options] [NAME]
 
 Options:
 
-  -state=path        Path to the state file to read. Defaults to
-                     "terraform.tfstate".
+  -state=path      Path to the state file to read. Defaults to
+                   "terraform.tfstate".
 
-  -no-color          If specified, output won't contain any color.
+  -no-color        If specified, output won't contain any color.
 
-  -json              If specified, machine readable output will be
-                     printed in JSON format
-
-  -ignore-no-output  If specified, empty or no output will still
-                     result in a sucessful command.
+  -json            If specified, machine readable output will be
+                   printed in JSON format
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/output.go
+++ b/command/output.go
@@ -30,10 +30,12 @@ func (c *OutputCommand) Run(args []string) int {
 
 	var module, statePath string
 	var jsonOutput bool
+	var flagIgnoreEmptyOutput bool
 	cmdFlags := c.Meta.defaultFlagSet("output")
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "json")
 	cmdFlags.StringVar(&statePath, "state", "", "path")
 	cmdFlags.StringVar(&module, "module", "", "module")
+	cmdFlags.BoolVar(&flagIgnoreEmptyOutput, "ignore-empty-output", false, "ignore empty output")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
@@ -113,14 +115,19 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	if !jsonOutput && (state.Empty() || len(mod.OutputValues) == 0) {
-		c.Ui.Error(
-			"The state file either has no outputs defined, or all the defined\n" +
-				"outputs are empty. Please define an output in your configuration\n" +
-				"with the `output` keyword and run `terraform refresh` for it to\n" +
-				"become available. If you are using interpolation, please verify\n" +
-				"the interpolated value is not empty. You can use the \n" +
-				"`terraform console` command to assist.")
-		return 1
+		emptyOutputString := "The state file either has no outputs defined, or all the defined\n" +
+			"outputs are empty. Please define an output in your configuration\n" +
+			"with the `output` keyword and run `terraform refresh` for it to\n" +
+			"become available. If you are using interpolation, please verify\n" +
+			"the interpolated value is not empty. You can use the \n" +
+			"`terraform console` command to assist."
+		if flagIgnoreEmptyOutput {
+			c.Ui.Output(emptyOutputString)
+			return 0
+		} else {
+			c.Ui.Error(emptyOutputString)
+			return 1
+		}
 	}
 
 	if name == "" {
@@ -331,13 +338,16 @@ Usage: terraform output [options] [NAME]
 
 Options:
 
-  -state=path      Path to the state file to read. Defaults to
-                   "terraform.tfstate".
+  -state=path        Path to the state file to read. Defaults to
+                     "terraform.tfstate".
 
-  -no-color        If specified, output won't contain any color.
+  -no-color          If specified, output won't contain any color.
 
-  -json            If specified, machine readable output will be
-                   printed in JSON format
+  -json              If specified, machine readable output will be
+                     printed in JSON format
+
+  -ignore-no-output  If specified, empty or no output will still
+                     result in a sucessful command.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/output_test.go
+++ b/command/output_test.go
@@ -136,29 +136,6 @@ func TestOutput_emptyOutputsErr(t *testing.T) {
 	args := []string{
 		"-state", statePath,
 	}
-	if code := c.Run(args); code != 1 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
-	}
-}
-
-func TestOutput_emptyOutputsIgnore(t *testing.T) {
-	originalState := states.NewState()
-	statePath := testStateFile(t, originalState)
-
-	p := testProvider()
-	ui := new(cli.MockUi)
-	c := &OutputCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			Ui:               ui,
-		},
-	}
-
-	args := []string{
-		"-state", statePath,
-		"-ignore-empty-output",
-	}
-
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
@@ -315,7 +292,7 @@ func TestOutput_noArgs(t *testing.T) {
 	}
 
 	args := []string{}
-	if code := c.Run(args); code != 1 {
+	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.OutputWriter.String())
 	}
 }
@@ -336,7 +313,7 @@ func TestOutput_noState(t *testing.T) {
 		"-state", statePath,
 		"foo",
 	}
-	if code := c.Run(args); code != 1 {
+	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
 }
@@ -358,7 +335,7 @@ func TestOutput_noVars(t *testing.T) {
 		"-state", statePath,
 		"bar",
 	}
-	if code := c.Run(args); code != 1 {
+	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
 }

--- a/command/output_test.go
+++ b/command/output_test.go
@@ -141,6 +141,29 @@ func TestOutput_emptyOutputsErr(t *testing.T) {
 	}
 }
 
+func TestOutput_emptyOutputsIgnore(t *testing.T) {
+	originalState := states.NewState()
+	statePath := testStateFile(t, originalState)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &OutputCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"-ignore-empty-output",
+	}
+
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+}
+
 func TestOutput_jsonEmptyOutputs(t *testing.T) {
 	originalState := states.NewState()
 	statePath := testStateFile(t, originalState)


### PR DESCRIPTION
This PR adds an `-ignore-empty-output` flag to the `terraform output` command.

With this flag, when `terraform output -ignore-empty-flag` is run against no state or empty state, the exit status is 0 and the output is not from Error().

Without this flag, when `terraform output` is run against no state or empty state, the exit status remains 1 and the output continues to be from Error().

When merged, resolves #18975