### PR TITLE
remove duplicate statement

### DIFF
--- a/command/plan.go
+++ b/command/plan.go
@@ -96,7 +96,6 @@ func (c *PlanCommand) Run(args []string) int {
 	opReq := c.Operation(b)
 	opReq.ConfigDir = configPath
 	opReq.Destroy = destroy
-	opReq.PlanRefresh = refresh
 	opReq.PlanOutPath = outPath
 	opReq.PlanRefresh = refresh
 	opReq.Type = backend.OperationTypePlan


### PR DESCRIPTION
This removes a duplicate statement, so `opReq.PlanRefresh` is set only once (as per `command/apply.go`)