### PR TITLE
Remove testing dependecy from helper/schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb
+	github.com/mitchellh/go-testing-interface v1.0.0
 	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2

--- a/helper/schema/testing.go
+++ b/helper/schema/testing.go
@@ -1,14 +1,13 @@
 package schema
 
 import (
-	"testing"
-
 	"github.com/hashicorp/terraform/terraform"
+	testing "github.com/mitchellh/go-testing-interface"
 )
 
 // TestResourceDataRaw creates a ResourceData from a raw configuration map.
 func TestResourceDataRaw(
-	t *testing.T, schema map[string]*Schema, raw map[string]interface{}) *ResourceData {
+	t testing.T, schema map[string]*Schema, raw map[string]interface{}) *ResourceData {
 	t.Helper()
 
 	c := terraform.NewResourceConfigRaw(raw)


### PR DESCRIPTION
"testing" package dependency causes users of helper/schema to import testing flags in their apps as they are defined on static