### PR TITLE
Adding type boolean syntax for reference.

### DIFF
--- a/website/docs/configuration-0-11/variables.html.md
+++ b/website/docs/configuration-0-11/variables.html.md
@@ -164,6 +164,7 @@ For a configuration such as the following:
 ```hcl
 variable "active" {
   default = false
+  type    = bool
 }
 ```
 


### PR DESCRIPTION
It would help Terraform users to easily see how to define type boolean for their variables, without referring to Terraform repo.