### PR TITLE
Bugfix for #23004

### DIFF
--- a/builtin/provisioners/puppet/resource_provisioner.go
+++ b/builtin/provisioners/puppet/resource_provisioner.go
@@ -259,6 +259,7 @@ func (p *provisioner) generateAutosignToken(certname string) (string, error) {
 }
 
 func (p *provisioner) installPuppetAgentOpenSource() error {
+	task := "puppet_agent::install"
 
 	connType := p.instanceState.Ephemeral.ConnInfo["type"]
 	if connType == "" {
@@ -276,12 +277,12 @@ func (p *provisioner) installPuppetAgentOpenSource() error {
 		agentConnInfo,
 		p.BoltTimeout,
 		p.UseSudo,
-		"puppet_agent::install",
+		task,
 		nil,
 	)
 
 	if err != nil || result.Items[0].Status != "success" {
-		return fmt.Errorf("puppet_agent::install failed: %s\n%+v", err, result)
+		return fmt.Errorf("%s failed: %s\n%+v", task, err, result)
 	}
 
 	return nil

--- a/builtin/provisioners/puppet/resource_provisioner.go
+++ b/builtin/provisioners/puppet/resource_provisioner.go
@@ -128,7 +128,7 @@ func applyFn(ctx context.Context) error {
 
 	if p.OSType == "" {
 		switch connType := state.Ephemeral.ConnInfo["type"]; connType {
-		case "ssh", "":
+		case "ssh", "": // The default connection type is ssh, so if the type is empty assume ssh
 			p.OSType = "linux"
 		case "winrm":
 			p.OSType = "windows"

--- a/builtin/provisioners/puppet/resource_provisioner.go
+++ b/builtin/provisioners/puppet/resource_provisioner.go
@@ -259,8 +259,21 @@ func (p *provisioner) generateAutosignToken(certname string) (string, error) {
 }
 
 func (p *provisioner) installPuppetAgentOpenSource() error {
+
+	connType := p.instanceState.Ephemeral.ConnInfo["type"]
+	if connType == "" {
+		connType = "ssh"
+	}
+
+	agentConnInfo := map[string]string{
+		"type":     connType,
+		"host":     p.instanceState.Ephemeral.ConnInfo["host"],
+		"user":     p.instanceState.Ephemeral.ConnInfo["user"],
+		"password": p.instanceState.Ephemeral.ConnInfo["password"], // Required on Windows only
+	}
+
 	result, err := bolt.Task(
-		p.instanceState.Ephemeral.ConnInfo,
+		agentConnInfo,
 		p.BoltTimeout,
 		p.UseSudo,
 		"puppet_agent::install",


### PR DESCRIPTION
    
    Before this, the Terraform Puppet provisioner would error out in a
    confusing way if the type attribute in a connection block was not given.
    
    Apparently an omitted type leads to type having a value "" which must be
    then assumed to mean "ssh".