### PR TITLE
[WIP] Add abandon_on_destroy lifecycle attribute

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -116,6 +116,7 @@ type ResourceLifecycle struct {
 	CreateBeforeDestroy bool     `mapstructure:"create_before_destroy"`
 	PreventDestroy      bool     `mapstructure:"prevent_destroy"`
 	IgnoreChanges       []string `mapstructure:"ignore_changes"`
+	AbandonOnDestroy    bool     `mapstructure:"abandon_on_destroy"`
 }
 
 // Copy returns a copy of this ResourceLifecycle
@@ -124,6 +125,7 @@ func (r *ResourceLifecycle) Copy() *ResourceLifecycle {
 		CreateBeforeDestroy: r.CreateBeforeDestroy,
 		PreventDestroy:      r.PreventDestroy,
 		IgnoreChanges:       make([]string, len(r.IgnoreChanges)),
+		AbandonOnDestroy:    r.AbandonOnDestroy,
 	}
 	copy(n.IgnoreChanges, r.IgnoreChanges)
 	return n

--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -1012,7 +1012,7 @@ func loadManagedResourcesHcl(list *ast.ObjectList) ([]*Resource, error) {
 			}
 
 			// Check for invalid keys
-			valid := []string{"create_before_destroy", "ignore_changes", "prevent_destroy"}
+			valid := []string{"create_before_destroy", "ignore_changes", "prevent_destroy", "abandon_on_destroy"}
 			if err := checkHCLKeys(o.Items[0].Val, valid); err != nil {
 				return nil, multierror.Prefix(err, fmt.Sprintf(
 					"%s[%s]:", t, k))

--- a/config/loader_hcl2.go
+++ b/config/loader_hcl2.go
@@ -92,6 +92,7 @@ func (t *hcl2Configurable) Config() (*Config, error) {
 		CreateBeforeDestroy *bool     `hcl:"create_before_destroy,attr"`
 		PreventDestroy      *bool     `hcl:"prevent_destroy,attr"`
 		IgnoreChanges       *[]string `hcl:"ignore_changes,attr"`
+		AbandonOnDestroy    *bool     `hcl:"abandon_on_destroy,attr"`
 	}
 	type connection struct {
 		Config hcl2.Body `hcl:",remain"`
@@ -320,6 +321,14 @@ func (t *hcl2Configurable) Config() (*Config, error) {
 			}
 			if rawR.Lifecycle.IgnoreChanges != nil {
 				l.IgnoreChanges = *rawR.Lifecycle.IgnoreChanges
+			}
+			if rawR.Lifecycle.AbandonOnDestroy != nil {
+				diags = append(diags, &hcl2.Diagnostic{
+					Severity: hcl2.DiagWarning,
+					Summary:  "Ooooh, enabled abandon_on_destroy have we?",
+					Detail:   "Nice one",
+				})
+				l.AbandonOnDestroy = *rawR.Lifecycle.AbandonOnDestroy
 			}
 			r.Lifecycle = l
 		}

--- a/config/testdata/abandon-on-destroy.tf
+++ b/config/testdata/abandon-on-destroy.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "abandon" {
+  ami = "foo"
+  lifecycle {
+    abandon_on_destroy = true
+  }
+}
+
+resource "aws_instance" "no_lifecycle" {
+  ami = "foo"
+}

--- a/configs/configupgrade/upgrade_body.go
+++ b/configs/configupgrade/upgrade_body.go
@@ -536,6 +536,7 @@ func lifecycleBlockBodyRules(filename string, an *analysis) bodyContentRules {
 	return bodyContentRules{
 		"create_before_destroy": noInterpAttributeRule(filename, cty.Bool, an),
 		"prevent_destroy":       noInterpAttributeRule(filename, cty.Bool, an),
+		"abandon_on_destroy":    noInterpAttributeRule(filename, cty.Bool, an),
 		"ignore_changes": func(buf *bytes.Buffer, blockAddr string, item *hcl1ast.ObjectItem) tfdiags.Diagnostics {
 			var diags tfdiags.Diagnostics
 			val, ok := item.Val.(*hcl1ast.ListType)

--- a/configs/module_merge.go
+++ b/configs/module_merge.go
@@ -225,6 +225,10 @@ func (r *Resource) merge(or *Resource) hcl.Diagnostics {
 			r.Managed.PreventDestroy = or.Managed.PreventDestroy
 			r.Managed.PreventDestroySet = or.Managed.PreventDestroySet
 		}
+		if or.Managed.AbandonOnDestroySet {
+			r.Managed.AbandonOnDestroy = or.Managed.AbandonOnDestroy
+			r.Managed.AbandonOnDestroySet = or.Managed.AbandonOnDestroySet
+		}
 		if len(or.Managed.Provisioners) != 0 {
 			r.Managed.Provisioners = or.Managed.Provisioners
 		}

--- a/configs/resource.go
+++ b/configs/resource.go
@@ -41,9 +41,11 @@ type ManagedResource struct {
 	PreventDestroy      bool
 	IgnoreChanges       []hcl.Traversal
 	IgnoreAllChanges    bool
+	AbandonOnDestroy    bool
 
 	CreateBeforeDestroySet bool
 	PreventDestroySet      bool
+	AbandonOnDestroySet    bool
 }
 
 func (r *Resource) moduleUniqueKey() string {
@@ -163,6 +165,12 @@ func decodeResourceBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &r.Managed.PreventDestroy)
 				diags = append(diags, valDiags...)
 				r.Managed.PreventDestroySet = true
+			}
+
+			if attr, exists := lcContent.Attributes["abandon_on_destroy"]; exists {
+				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &r.Managed.AbandonOnDestroy)
+				diags = append(diags, valDiags...)
+				r.Managed.AbandonOnDestroySet = true
 			}
 
 			if attr, exists := lcContent.Attributes["ignore_changes"]; exists {
@@ -485,6 +493,9 @@ var resourceLifecycleBlockSchema = &hcl.BodySchema{
 		},
 		{
 			Name: "ignore_changes",
+		},
+		{
+			Name: "abandon_on_destroy",
 		},
 	},
 }

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -278,16 +278,17 @@ func (n *NodeApplyableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 			// Make a new diff, in case we've learned new values in the state
 			// during apply which we can now incorporate.
 			&EvalDiff{
-				Addr:           addr.Resource,
-				Config:         n.Config,
-				Provider:       &provider,
-				ProviderAddr:   n.ResolvedProvider,
-				ProviderSchema: &providerSchema,
-				State:          &state,
-				PreviousDiff:   &diff,
-				OutputChange:   &diffApply,
-				OutputValue:    &configVal,
-				OutputState:    &state,
+				Addr:             addr.Resource,
+				Config:           n.Config,
+				AbandonOnDestroy: n.Config.Managed.AbandonOnDestroy,
+				Provider:         &provider,
+				ProviderAddr:     n.ResolvedProvider,
+				ProviderSchema:   &providerSchema,
+				State:            &state,
+				PreviousDiff:     &diff,
+				OutputChange:     &diffApply,
+				OutputValue:      &configVal,
+				OutputState:      &state,
 			},
 
 			// Compare the diffs

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -173,6 +173,7 @@ func (n *NodePlannableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 				Addr:                addr.Resource,
 				Config:              n.Config,
 				CreateBeforeDestroy: n.ForceCreateBeforeDestroy,
+				AbandonOnDestroy:    n.Config.Managed.AbandonOnDestroy,
 				Provider:            &provider,
 				ProviderAddr:        n.ResolvedProvider,
 				ProviderSchema:      &providerSchema,

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -260,15 +260,16 @@ func (n *NodeRefreshableManagedResourceInstance) evalTreeManagedResourceNoState(
 			},
 
 			&EvalDiff{
-				Addr:           addr.Resource,
-				Config:         n.Config,
-				Provider:       &provider,
-				ProviderAddr:   n.ResolvedProvider,
-				ProviderSchema: &providerSchema,
-				State:          &state,
-				OutputChange:   &change,
-				OutputState:    &state,
-				Stub:           true,
+				Addr:             addr.Resource,
+				Config:           n.Config,
+				AbandonOnDestroy: n.Config.Managed.AbandonOnDestroy,
+				Provider:         &provider,
+				ProviderAddr:     n.ResolvedProvider,
+				ProviderSchema:   &providerSchema,
+				State:            &state,
+				OutputChange:     &change,
+				OutputState:      &state,
+				Stub:             true,
 			},
 
 			&EvalWriteState{


### PR DESCRIPTION
Experimenting with implementing https://github.com/hashicorp/terraform/issues/15485. I felt confident that there were valid use cases for having Terraform simply forget existing resources, but I wanted to actually play with it and see if it worked for me.

For now, the lifecycle rule only has an effect on resources that would otherwise be destroyed and re-created, updates to an existing resource are still made in place. There may also be a use case for having the resource entirely immutable, but that felt like it missed the point of the use cases described in https://github.com/hashicorp/terraform/issues/15485.

Right now I've only really played with the `plan` and `apply` commands. I haven't had a good think about the blast radius of this change and whether any other commands would be impacted.

Also, the diffing is pretty rubbish. The plan shows that a resource impacted by this lifecycle rule will be created and makes no mention of the fact that the resource is already present in state. That should be improved.

## Tasks:

- [x] Prototype the `abandon_on_destroy` lifecycle rule
- [ ] Gather feedback on semantics
- [ ] Improve diffing behaviour.
- [ ] Add new acceptance test for new lifecycle rule
- [ ] Documentation updates

Let me know any thoughts / feelings / questions / life stories ✌️ 