### PR TITLE
command/jsonplan: fix bug with nested modules output

### DIFF
--- a/command/testdata/show-json/nested-modules/modules/more-modules/main.tf
+++ b/command/testdata/show-json/nested-modules/modules/more-modules/main.tf
@@ -1,4 +1,7 @@
-variable "ok" {
-  default     = "something"
-  description = "description"
+variable "test_var" {
+  default = "bar-var"
+}
+
+resource "test_instance" "test" {
+  ami = var.test_var
 }

--- a/command/testdata/show-json/nested-modules/output.json
+++ b/command/testdata/show-json/nested-modules/output.json
@@ -1,9 +1,54 @@
 {
   "format_version": "0.1",
-  "terraform_version": "0.12.1-dev",
   "planned_values": {
-    "root_module": {}
+    "root_module": {
+      "child_modules": [
+        {
+          "address": "module.my_module",
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.my_module.module.more.test_instance.test",
+                  "mode": "managed",
+                  "type": "test_instance",
+                  "name": "test",
+                  "provider_name": "test",
+                  "schema_version": 0,
+                  "values": {
+                    "ami": "bar-var"
+                  }
+                }
+              ],
+              "address": "module.my_module.module.more"
+            }
+          ]
+        }
+      ]
+    }
   },
+  "resource_changes": [
+    {
+      "address": "module.my_module.module.more.test_instance.test",
+      "module_address": "module.my_module.module.more",
+      "mode": "managed",
+      "type": "test_instance",
+      "name": "test",
+      "provider_name": "test",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "ami": "bar-var"
+        },
+        "after_unknown": {
+          "id": true
+        }
+      }
+    }
+  ],
   "configuration": {
     "root_module": {
       "module_calls": {
@@ -12,15 +57,31 @@
           "module": {
             "module_calls": {
               "more": {
+                "source": "./more-modules",
                 "module": {
+                  "resources": [
+                    {
+                      "address": "test_instance.test",
+                      "mode": "managed",
+                      "type": "test_instance",
+                      "name": "test",
+                      "provider_config_key": "more:test",
+                      "expressions": {
+                        "ami": {
+                          "references": [
+                            "var.test_var"
+                          ]
+                        }
+                      },
+                      "schema_version": 0
+                    }
+                  ],
                   "variables": {
-                    "ok": {
-                      "default": "something",
-                      "description": "description"
+                    "test_var": {
+                      "default": "bar-var"
                     }
                   }
-                },
-                "source": "./more-modules"
+                }
               }
             }
           }


### PR DESCRIPTION
`marshalPlannedValues` builds a map of modules to their children in
order to output the resource changes in a tree. The map was built from
the list of resource changes. However if the parent module had no resources
itself , that module would not get added to the map causing none of its children to be
output in `planned_values`.

This PR adds a walk up through a given module's ancestors to ensure that
each module, even those without resources, get added.

I spent much longer than I should have on this logic, and I mostly blame it on confusing naming (which I tried to improve, and added comments). While it now makes (enough) sense to me, I enthusiastically welcome variable name/comment suggestions if anything jumps out at you!  

