### PR TITLE
Fix #23100: Panic in plan output when string contains "null" with whitespace

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -502,7 +502,7 @@ func (p *blockBodyDiffPrinter) writeValue(val cty.Value, action plans.Action, in
 				ty, err := ctyjson.ImpliedType(src)
 				// check for the special case of "null", which decodes to nil,
 				// and just allow it to be printed out directly
-				if err == nil && !ty.IsPrimitiveType() && val.AsString() != "null" {
+				if err == nil && !ty.IsPrimitiveType() && strings.TrimSpace(val.AsString()) != "null" {
 					jv, err := ctyjson.Unmarshal(src, ty)
 					if err == nil {
 						p.buf.WriteString("jsonencode(")

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -52,6 +52,26 @@ func TestResourceChange_primitiveTypes(t *testing.T) {
     }
 `,
 		},
+		"creation (null string with extra whitespace)": {
+			Action: plans.Create,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.NullVal(cty.EmptyObject),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"string": cty.StringVal("null "),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"string": {Type: cty.String, Optional: true},
+				},
+			},
+			RequiredReplace: cty.NewPathSet(),
+			Tainted:         false,
+			ExpectedOutput: `  # test_instance.example will be created
+  + resource "test_instance" "example" {
+      + string = "null "
+    }
+`,
+		},
 		"deletion": {
 			Action: plans.Delete,
 			Mode:   addrs.ManagedResourceMode,
@@ -205,6 +225,37 @@ new line
       ~ more_lines = <<~EOT
             original
           + new line
+        EOT
+    }
+`,
+		},
+		"addition of multi-line string field": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.StringVal("i-02ae66f368e8518a9"),
+				"more_lines": cty.NullVal(cty.String),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.UnknownVal(cty.String),
+				"more_lines": cty.StringVal(`original
+new line
+`),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":         {Type: cty.String, Optional: true, Computed: true},
+					"more_lines": {Type: cty.String, Optional: true},
+				},
+			},
+			RequiredReplace: cty.NewPathSet(),
+			Tainted:         false,
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      + more_lines = <<~EOT
+            original
+            new line
         EOT
     }
 `,
@@ -857,11 +908,11 @@ func TestResourceChange_JSON(t *testing.T) {
 			Mode:   addrs.ManagedResourceMode,
 			Before: cty.ObjectVal(map[string]cty.Value{
 				"id":         cty.StringVal("i-02ae66f368e8518a9"),
-				"json_field": cty.StringVal(`[{"one": "111"}, {"two": "222"}]`),
+				"json_field": cty.StringVal(`[{"one": "111"}, {"two": "222"}, {"three": "333"}]`),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":         cty.UnknownVal(cty.String),
-				"json_field": cty.StringVal(`[{"one": "111"}]`),
+				"json_field": cty.StringVal(`[{"one": "111"}, {"three": "333"}]`),
 			}),
 			Schema: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -881,6 +932,9 @@ func TestResourceChange_JSON(t *testing.T) {
                 },
               - {
                   - two = "222"
+                },
+                {
+                    three = "333"
                 },
             ]
         )


### PR DESCRIPTION
Fix for #23100 where `terraform plan` panics instead of decoding the string "null" with whitespace. Underlying cause is that `json.Decoder` tokenises "null" with any amount of whitespace around it as a `nil` value ([demonstration](https://gist.github.com/simonbrady/6e15f76faead23c58ee7abc60b2fcad7)), but the code only checks for literal `"null"`.