### PR TITLE
backend/remote: Report invalid variables only remotely

### DIFF
--- a/backend/remote/backend_apply.go
+++ b/backend/remote/backend_apply.go
@@ -75,10 +75,7 @@ func (b *Remote) opApply(stopCtx, cancelCtx context.Context, op *backend.Operati
 		))
 	}
 
-	variables, parseDiags := b.parseVariableValues(op)
-	diags = diags.Append(parseDiags)
-
-	if len(variables) > 0 {
+	if b.hasExplicitVariableValues(op) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Run variables are currently not supported",

--- a/backend/remote/backend_plan.go
+++ b/backend/remote/backend_plan.go
@@ -78,10 +78,7 @@ func (b *Remote) opPlan(stopCtx, cancelCtx context.Context, op *backend.Operatio
 		))
 	}
 
-	variables, parseDiags := b.parseVariableValues(op)
-	diags = diags.Append(parseDiags)
-
-	if len(variables) > 0 {
+	if b.hasExplicitVariableValues(op) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Run variables are currently not supported",

--- a/backend/unparsed_value.go
+++ b/backend/unparsed_value.go
@@ -37,7 +37,10 @@ type UnparsedVariableValue interface {
 //
 // If this function returns without any errors in the diagnostics, the
 // resulting input values map is guaranteed to be valid and ready to pass
-// to terraform.NewContext.
+// to terraform.NewContext. If the diagnostics contains errors, the returned
+// InputValues may be incomplete but will include the subset of variables
+// that were successfully processed, allowing for careful analysis of the
+// partial result.
 func ParseVariableValues(vv map[string]UnparsedVariableValue, decls map[string]*configs.Variable) (terraform.InputValues, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	ret := make(terraform.InputValues, len(vv))


### PR DESCRIPTION
The remote backend uses `backend.ParseVariableValues` locally only to decide if the user seems to be trying to use -var or -var-file options locally, since those are not supported for the remote backend.

Other than detecting those, we don't actually have any need to use the results of `backend.ParseVariableValues` locally, and so it's better for us to ignore any errors it produces itself and prefer to just send a potentially-invalid request to the remote system and let the remote system
be responsible for validating it.

This then avoids issues caused by the fact that when remote operations are in use the local system does not have all of the required context: it can't see which environment variables will be set in the remote execution context nor which variables the remote system will set using its own generated `-var-file` based on the workspace stored variables. This fixes #23115.

This _does_ have a minor drawback in that it won't produce the error about variables not being supported if the only `-var` argument provided by the user produces a parse error, because we can't currently distinguish that particular error type from other error types. We may wish to revisit this in a later release to improve the precision of this hint, but for the moment the priority is to avoid the incorrect validation messages.
