### PR TITLE
support OSS backend credentials that start as an STS token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 0.12.13 (Unreleased)
+
+ENHANCEMENTS:
+
+* backend/oss: Support `role_arn` in combination with a set of credentials issued from the Aliyun STS service.
+
 ## 0.12.12 (October 18, 2019)
 
 BUG FIXES:


### PR DESCRIPTION
The AliCloud provider was updated to support this flow in
terraform-providers/terraform-provider-alicloud#1639, but the
OSS backend was never updated with the same code.