### PR TITLE
Add info on dynamodb locking multiple state files as per issue #15303

### DIFF
--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -15,6 +15,7 @@ Stores the state as a given key in a given bucket on
 This backend also supports state locking and consistency checking via
 [Dynamo DB](https://aws.amazon.com/dynamodb/), which can be enabled by setting
 the `dynamodb_table` field to an existing DynamoDB table name.
+A single DynamoDB table can be used to lock multiple remote state files. Terraform generates key names that include the values of the `bucket` and `key` variables.
 
 ~> **Warning!** It is highly recommended that you enable
 [Bucket Versioning](http://docs.aws.amazon.com/AmazonS3/latest/UG/enable-bucket-versioning.html)


### PR DESCRIPTION
Doc improvement by adding short info on a single dynamodb table being usable to lock multiple state files as requested per issue #15303. 