### PR TITLE
[Website] remove okta link

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -93,7 +93,6 @@ down to see all providers.
 - [Null](/docs/providers/null/index.html)
 - [Nutanix](/docs/providers/nutanix/index.html)
 - [1&1](/docs/providers/oneandone/index.html)
-- [Okta](/docs/providers/okta/index.html)
 - [OpenStack](/docs/providers/openstack/index.html)
 - [OpenTelekomCloud](/docs/providers/opentelekomcloud/index.html)
 - [OpsGenie](/docs/providers/opsgenie/index.html)

--- a/website/docs/providers/type/infra-index.html.markdown
+++ b/website/docs/providers/type/infra-index.html.markdown
@@ -24,7 +24,6 @@ and are tested by HashiCorp.
 - [Kubernetes](/docs/providers/kubernetes/index.html)
 - [Mailgun](/docs/providers/mailgun/index.html)
 - [Nomad](/docs/providers/nomad/index.html)
-- [Okta](/docs/providers/okta/index.html)
 - [RabbitMQ](/docs/providers/rabbitmq/index.html)
 - [Rancher](/docs/providers/rancher/index.html)
 - [Rancher2](/docs/providers/rancher2/index.html)


### PR DESCRIPTION
Okta has requested that we remove their recently certified provider. 