### PR TITLE
Add a special error when each.value is nil in for_each resources

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -2079,7 +2079,7 @@ func TestContext2Apply_provisionerDestroyForEach(t *testing.T) {
 	if diags == nil {
 		t.Fatal("should error")
 	}
-	if !strings.Contains(diags.Err().Error(), `Reference to "each" in context without for_each`) {
+	if !strings.Contains(diags.Err().Error(), "each.value is unknown and cannot be used in this context") {
 		t.Fatal("unexpected error:", diags.Err())
 	}
 }

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -185,6 +185,16 @@ func (d *evaluationStateData) GetForEachAttr(addr addrs.ForEachAttr, rng tfdiags
 		returnVal = d.InstanceKeyData.EachKey
 	case "value":
 		returnVal = d.InstanceKeyData.EachValue
+
+		if returnVal == cty.NilVal {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  `each.value is unknown and cannot be used in this context`,
+				Detail:   fmt.Sprintf(`A reference to "each.value" has been used in a context in which it unavailable, such as after the config no longer contains the value in its "for_each" expression. Remove this reference to each.value in your config to work around this error.`),
+				Subject:  rng.ToHCL().Ptr(),
+			})
+			return cty.UnknownVal(cty.DynamicPseudoType), diags
+		}
 	default:
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -189,8 +189,8 @@ func (d *evaluationStateData) GetForEachAttr(addr addrs.ForEachAttr, rng tfdiags
 		if returnVal == cty.NilVal {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  `each.value is unknown and cannot be used in this context`,
-				Detail:   fmt.Sprintf(`A reference to "each.value" has been used in a context in which it unavailable, such as after the config no longer contains the value in its "for_each" expression. Remove this reference to each.value in your config to work around this error.`),
+				Summary:  `each.value cannot be used in this context`,
+				Detail:   fmt.Sprintf(`A reference to "each.value" has been used in a context in which it unavailable, such as when the configuration no longer contains the value in its "for_each" expression. Remove this reference to each.value in your configuration to work around this error.`),
 				Subject:  rng.ToHCL().Ptr(),
 			})
 			return cty.UnknownVal(cty.DynamicPseudoType), diags


### PR DESCRIPTION
Again, doesn't fix the root cause, but builds on https://github.com/hashicorp/terraform/pull/22729 to help a bit as far as improving the error context to show users that `each.value` is the source of their error, versus the ambiguous error otherwise.

Related to https://github.com/hashicorp/terraform/issues/22700