### PR TITLE
[Website] Vultr provider links

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -137,7 +137,7 @@ down to see all providers.
 - [VMware vCloud Director](/docs/providers/vcd/index.html)
 - [VMware vRA7](/docs/providers/vra7/index.html)
 - [VMware vSphere](/docs/providers/vsphere/index.html)
-- [Vultr](/docs/providers/vultr/index/html)
+- [Vultr](/docs/providers/vultr/index.html)
 - [Yandex](/docs/providers/yandex/index.html)
 
 

--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -137,6 +137,7 @@ down to see all providers.
 - [VMware vCloud Director](/docs/providers/vcd/index.html)
 - [VMware vRA7](/docs/providers/vra7/index.html)
 - [VMware vSphere](/docs/providers/vsphere/index.html)
+- [Vultr](/docs/providers/vultr/index/html)
 - [Yandex](/docs/providers/yandex/index.html)
 
 

--- a/website/docs/providers/type/cloud-index.html.markdown
+++ b/website/docs/providers/type/cloud-index.html.markdown
@@ -49,5 +49,6 @@ vendor in close collaboration with HashiCorp, and are tested by HashiCorp.
 - [TencentCloud](/docs/providers/tencentcloud/index.html)
 - [Triton](/docs/providers/triton/index.html)
 - [UCloud](/docs/providers/ucloud/index.html)
+- [Vultr](/docs/providers/vultr/index.html)
 - [Yandex](/docs/providers/yandex/index.html)
 - [1&1](/docs/providers/oneandone/index.html)


### PR DESCRIPTION
Adding the links to navigate to the Vultr provider docs