### PR TITLE
Support passthrough of system env for local-exec provisioner

### DIFF
--- a/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -204,7 +204,7 @@ func TestResourceProvider_ApplySystemEnv(t *testing.T) {
 	os.Setenv("BAM", "SystemBAM")
 
 	c := testConfig(t, map[string]interface{}{
-		"command": "echo $FOO $BAR $BAZ $BAM",
+		"command":    "echo $FOO $BAR $BAZ $BAM",
 		"system_env": true,
 		"environment": map[string]interface{}{
 			"FOO": "BAR",

--- a/website/docs/provisioners/local-exec.html.markdown
+++ b/website/docs/provisioners/local-exec.html.markdown
@@ -58,6 +58,11 @@ The following arguments are supported:
 * `environment` - (Optional) block of key value pairs representing the
   environment of the executed command. inherits the current process environment.
 
+* `system_environment` - (Optional) If true, the environment of the terraform 
+   process will be passed through to the executed command. Variables explicitly specified
+   in `environment` will take precedence over any variables inherited from the system
+   environment. 
+   
 ### Interpreter Examples
 
 ```hcl


### PR DESCRIPTION
Allows the environment of the parent terraform process to be passed through to commands being invoked by the `local-exec` provisioner. Any variables explicitly specified in an `environment` block take precedence over those imported from the system.

I'm open to suggestions for a better argument name than `system_environment`.

The specific use case I'm after is passing AWS credentials down through to a `local-exec` provisioner. In my workflow, those (temporary) credentials are supplied as environment variables when terraform itself is invoked, so this will allow them to pass through. A solution to #8242 or #21983 would be better for a more general use case, but those don't seem likely to be implemented any time soon.
