### PR TITLE
hcl native syntax spec link led to 404

### DIFF
--- a/website/docs/configuration/syntax.html.md
+++ b/website/docs/configuration/syntax.html.md
@@ -30,9 +30,8 @@ syntax called _HCL_, which is also used by configuration languages in
 other applications, and in particular other HashiCorp products.
 It is not necessary to know all of the details of HCL syntax in
 order to use Terraform, and so this page summarizes the most important
-details. If you are interested, you can find a full definition of HCL
-syntax in
-[the HCL native syntax specification](https://github.com/hashicorp/hcl/blob/hcl2/hclsyntax/spec.md).
+details. If you are interested, you can find a high-level overview of the syntax and grammar in
+[the HCL native syntax specification](https://github.com/hashicorp/hcl#syntax).
 
 ## Arguments and Blocks
 


### PR DESCRIPTION
I didn't see a full syntax .md file in the repo, and the README suggests reading the parser for a full description of the syntax. I thought the summary was the next best thing to a full syntax .md.

The didn't change the link text, if someone has a better description that would be good.