### PR TITLE
Quote differently so render works on taint docs

### DIFF
--- a/website/docs/commands/taint.html.markdown
+++ b/website/docs/commands/taint.html.markdown
@@ -41,7 +41,7 @@ the output from other commands, such as:
 
  * `aws_instance.foo`
  * `aws_instance.bar[1]`
- * `aws_instance.baz[\"key\"]` (quotes in resource addresses must be escaped on the command line, so that they are not interpreted by your shell)
+ * `aws_instance.baz``[\"key\"]` (quotes in resource addresses must be escaped on the command line, so that they are not interpreted by your shell)
  * `module.foo.module.bar.aws_instance.qux`
 
 The command-line flags are all optional. The list of available flags are:


### PR DESCRIPTION
https://www.terraform.io/docs/commands/taint.html#aws_instance-baz-quot-key-quot- has weird things happening on render. Separating the two causes the render to work correctly, at least when built locally (`make website`)

Related to https://github.com/hashicorp/terraform/pull/23185