### PR TITLE
Resource value may be an object in self evaluation

### DIFF
--- a/lang/eval.go
+++ b/lang/eval.go
@@ -240,15 +240,19 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 			// Self is an exception in that it must always resolve to a
 			// particular instance. We will still insert the full resource into
 			// the context below.
+			var hclDiags hcl.Diagnostics
+			// We should always have a valid self index by this point, but in
+			// the case of an error, self may end up as a cty.DynamicValue.
 			switch k := subj.Key.(type) {
 			case addrs.IntKey:
-				self = val.Index(cty.NumberIntVal(int64(k)))
+				self, hclDiags = hcl.Index(val, cty.NumberIntVal(int64(k)), ref.SourceRange.ToHCL().Ptr())
+				diags.Append(hclDiags)
 			case addrs.StringKey:
-				self = val.Index(cty.StringVal(string(k)))
+				self, hclDiags = hcl.Index(val, cty.StringVal(string(k)), ref.SourceRange.ToHCL().Ptr())
+				diags.Append(hclDiags)
 			default:
 				self = val
 			}
-
 			continue
 		}
 

--- a/terraform/testdata/apply-provisioner-for-each-self/main.tf
+++ b/terraform/testdata/apply-provisioner-for-each-self/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "foo" {
+    for_each = toset(["a", "b", "c"])
+    foo = "number ${each.value}"
+
+    provisioner "shell" {
+        command = "${self.foo}"
+    }
+}


### PR DESCRIPTION
The fallback type for `GetResource` from an `EachMap` is a `cty.Object`,
because resource schemas may contain dynamically typed attributes.
Check for an Object type in the evaluation of self, to use the proper
`GetAttr` method when extracting the value.

Fixes #23194