### PR TITLE
backend/remote: Support HCL variable values in local operations

### DIFF
--- a/backend/remote/backend_context.go
+++ b/backend/remote/backend_context.go
@@ -2,11 +2,14 @@ package remote
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/errwrap"
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/command/clistate"
 	"github.com/hashicorp/terraform/configs"
@@ -113,12 +116,8 @@ func (b *Remote) Context(op *backend.Operation) (*terraform.Context, statemgr.Fu
 				op.Variables = make(map[string]backend.UnparsedVariableValue)
 			}
 			for _, v := range tfeVariables.Items {
-				if v.Sensitive {
-					v.Value = "<sensitive>"
-				}
-				op.Variables[v.Key] = &unparsedVariableValue{
-					value:  v.Value,
-					source: terraform.ValueFromEnvVar,
+				op.Variables[v.Key] = &remoteStoredVariableValue{
+					definition: v,
 				}
 			}
 		}
@@ -166,4 +165,77 @@ func stubAllVariables(vv map[string]backend.UnparsedVariableValue, decls map[str
 	}
 
 	return ret
+}
+
+type remoteStoredVariableValue struct {
+	definition *tfe.Variable
+}
+
+func (v *remoteStoredVariableValue) ParseVariableValue(mode configs.VariableParsingMode) (*terraform.InputValue, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	var val cty.Value
+
+	switch {
+	case v.definition.Sensitive:
+		// If it's marked as sensitive then it's not available for use in
+		// local operations. We'll use an unknown value as a placeholder for
+		// it so that operations that don't need it might still work, but
+		// we'll also produce a warning about it to add context for any
+		// errors that might result here.
+		val = cty.DynamicVal
+		if !v.definition.HCL {
+			// If it's not marked as HCL then we at least know that the
+			// value must be a string, so we'll set that in case it allows
+			// us to do some more precise type checking.
+			val = cty.UnknownVal(cty.String)
+		}
+
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			fmt.Sprintf("Value for var.%s unavailable", v.definition.Key),
+			fmt.Sprintf("The value of variable %q is marked as sensitive in the remote workspace. This operation always runs locally, so the value for that variable is not available.", v.definition.Key),
+		))
+
+	case v.definition.HCL:
+		// If the variable value is marked as being in HCL syntax, we need to
+		// parse it the same way as it would be interpreted in a .tfvars
+		// file because that is how it would get passed to Terraform CLI for
+		// a remote operation and we want to mimic that result as closely as
+		// possible.
+		var exprDiags hcl.Diagnostics
+		expr, exprDiags := hclsyntax.ParseExpression([]byte(v.definition.Value), "<remote workspace>", hcl.Pos{Line: 1, Column: 1})
+		if expr != nil {
+			var moreDiags hcl.Diagnostics
+			val, moreDiags = expr.Value(nil)
+			exprDiags = append(exprDiags, moreDiags...)
+		} else {
+			// We'll have already put some errors in exprDiags above, so we'll
+			// just stub out the value here.
+			val = cty.DynamicVal
+		}
+
+		// We don't have sufficient context to return decent error messages
+		// for syntax errors in the remote values, so we'll just return a
+		// generic message instead for now.
+		// (More complete error messages will still result from true remote
+		// operations, because they'll run on the remote system where we've
+		// materialized the values into a tfvars file we can report from.)
+		if exprDiags.HasErrors() {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				fmt.Sprintf("Invalid expression for var.%s", v.definition.Key),
+				fmt.Sprintf("The value of variable %q is marked in the remote workspace as being specified in HCL syntax, but the given value is not valid HCL. Stored variable values must be valid literal expressions and may not contain references to other variables or calls to functions.", v.definition.Key),
+			))
+		}
+
+	default:
+		// A variable value _not_ marked as HCL is always be a string, given
+		// literally.
+		val = cty.StringVal(v.definition.Value)
+	}
+
+	return &terraform.InputValue{
+		Value:      val,
+		SourceType: terraform.ValueFromInput,
+	}, diags
 }

--- a/backend/remote/backend_context_test.go
+++ b/backend/remote/backend_context_test.go
@@ -1,0 +1,143 @@
+package remote
+
+import (
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestRemoteStoredVariableValue(t *testing.T) {
+	tests := map[string]struct {
+		Def       *tfe.Variable
+		Want      cty.Value
+		WantError string
+	}{
+		"string literal": {
+			&tfe.Variable{
+				Key:       "test",
+				Value:     "foo",
+				HCL:       false,
+				Sensitive: false,
+			},
+			cty.StringVal("foo"),
+			``,
+		},
+		"string HCL": {
+			&tfe.Variable{
+				Key:       "test",
+				Value:     `"foo"`,
+				HCL:       true,
+				Sensitive: false,
+			},
+			cty.StringVal("foo"),
+			``,
+		},
+		"list HCL": {
+			&tfe.Variable{
+				Key:       "test",
+				Value:     `[]`,
+				HCL:       true,
+				Sensitive: false,
+			},
+			cty.EmptyTupleVal,
+			``,
+		},
+		"null HCL": {
+			&tfe.Variable{
+				Key:       "test",
+				Value:     `null`,
+				HCL:       true,
+				Sensitive: false,
+			},
+			cty.NullVal(cty.DynamicPseudoType),
+			``,
+		},
+		"literal sensitive": {
+			&tfe.Variable{
+				Key:       "test",
+				HCL:       false,
+				Sensitive: true,
+			},
+			cty.UnknownVal(cty.String),
+			``,
+		},
+		"HCL sensitive": {
+			&tfe.Variable{
+				Key:       "test",
+				HCL:       true,
+				Sensitive: true,
+			},
+			cty.DynamicVal,
+			``,
+		},
+		"HCL computation": {
+			// This (stored expressions containing computation) is not a case
+			// we intentionally supported, but it became possible for remote
+			// operations in Terraform 0.12 (due to Terraform Cloud/Enterprise
+			// just writing the HCL verbatim into generated `.tfvars` files).
+			// We support it here for consistency, and we continue to support
+			// it in both places for backward-compatibility. In practice,
+			// there's little reason to do computation in a stored variable
+			// value because references are not supported.
+			&tfe.Variable{
+				Key:       "test",
+				Value:     `[for v in ["a"] : v]`,
+				HCL:       true,
+				Sensitive: false,
+			},
+			cty.TupleVal([]cty.Value{cty.StringVal("a")}),
+			``,
+		},
+		"HCL syntax error": {
+			&tfe.Variable{
+				Key:       "test",
+				Value:     `[`,
+				HCL:       true,
+				Sensitive: false,
+			},
+			cty.DynamicVal,
+			`Invalid expression for var.test: The value of variable "test" is marked in the remote workspace as being specified in HCL syntax, but the given value is not valid HCL. Stored variable values must be valid literal expressions and may not contain references to other variables or calls to functions.`,
+		},
+		"HCL with references": {
+			&tfe.Variable{
+				Key:       "test",
+				Value:     `foo.bar`,
+				HCL:       true,
+				Sensitive: false,
+			},
+			cty.DynamicVal,
+			`Invalid expression for var.test: The value of variable "test" is marked in the remote workspace as being specified in HCL syntax, but the given value is not valid HCL. Stored variable values must be valid literal expressions and may not contain references to other variables or calls to functions.`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			v := &remoteStoredVariableValue{
+				definition: test.Def,
+			}
+			// This ParseVariableValue implementation ignores the parsing mode,
+			// so we'll just always parse literal here. (The parsing mode is
+			// selected by the remote server, not by our local configuration.)
+			gotIV, diags := v.ParseVariableValue(configs.VariableParseLiteral)
+			if test.WantError != "" {
+				if !diags.HasErrors() {
+					t.Fatalf("missing expected error\ngot:  <no error>\nwant: %s", test.WantError)
+				}
+				errStr := diags.Err().Error()
+				if errStr != test.WantError {
+					t.Fatalf("wrong error\ngot:  %s\nwant: %s", errStr, test.WantError)
+				}
+			} else {
+				if diags.HasErrors() {
+					t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())
+				}
+				got := gotIV.Value
+				if !test.Want.RawEquals(got) {
+					t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
For remote operations, the remote system (Terraform Cloud or Enterprise) writes the stored variable values into a .tfvars file before running the remote copy of Terraform CLI.

By contrast, for operations that only run locally (like `terraform import`), we fetch the stored variable values from the remote API and add them into the set of available variables directly as part
of creating the local execution context.

Previously in the local-only case we were assuming that all stored variables are strings, which isn't true: the Terraform Cloud/Enterprise UI allows users to specify that a particular variable is given as an HCL expression, in which case the correct behavior is to parse and evaluate the expression to obtain the final value.

This also addresses a related issue whereby previously we were forcing all sensitive values to be represented as a special string `"<sensitive>"`. That leads to type checking errors for any variable specified as having a type other than string, so instead here we use an unknown value as a placeholder so that type checking can pass.

Unpopulated sensitive values may cause errors downstream though, so we'll also produce a warning for each of them to let the user know that those variables are not available for local-only operations. It's a warning rather than an error so that operations that don't rely on known values for those variables can potentially complete successfully.

---

This can potentially produce errors in situations that would've been silently ignored before: if a remote variable is marked as being HCL syntax but is not valid HCL then it will now fail parsing at this early
stage, whereas previously it would've just passed through as a string and failed only if the operation tried to interpret it as a non-string.

However, in situations like these the remote operations like
"terraform plan" would already have been failing with an equivalent error message anyway, so it's unlikely that any existing workspace that is being used for routine operations would have such a broken configuration.

---

This fixes #23228.