### PR TITLE
store absolute addresses for resource dependencies in the state

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -260,8 +260,10 @@ func testState() *states.State {
 				// The weird whitespace here is reflective of how this would
 				// get written out in a real state file, due to the indentation
 				// of all of the containing wrapping objects and arrays.
-				AttrsJSON: []byte("{\n            \"id\": \"bar\"\n          }"),
-				Status:    states.ObjectReady,
+				AttrsJSON:    []byte("{\n            \"id\": \"bar\"\n          }"),
+				Status:       states.ObjectReady,
+				Dependencies: []addrs.AbsResource{},
+				DependsOn:    []addrs.Referenceable{},
 			},
 			addrs.ProviderConfig{
 				Type: "test",

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -275,7 +275,8 @@ func TestRefresh_defaultState(t *testing.T) {
 	expected := &states.ResourceInstanceObjectSrc{
 		Status:       states.ObjectReady,
 		AttrsJSON:    []byte("{\n            \"ami\": null,\n            \"id\": \"yes\"\n          }"),
-		Dependencies: []addrs.Referenceable{},
+		Dependencies: []addrs.AbsResource{},
+		DependsOn:    []addrs.Referenceable{},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("wrong new object\ngot:  %swant: %s", spew.Sdump(actual), spew.Sdump(expected))
@@ -339,7 +340,8 @@ func TestRefresh_outPath(t *testing.T) {
 	expected := &states.ResourceInstanceObjectSrc{
 		Status:       states.ObjectReady,
 		AttrsJSON:    []byte("{\n            \"ami\": null,\n            \"id\": \"yes\"\n          }"),
-		Dependencies: []addrs.Referenceable{},
+		Dependencies: []addrs.AbsResource{},
+		DependsOn:    []addrs.Referenceable{},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("wrong new object\ngot:  %swant: %s", spew.Sdump(actual), spew.Sdump(expected))
@@ -568,7 +570,8 @@ func TestRefresh_backup(t *testing.T) {
 	expected := &states.ResourceInstanceObjectSrc{
 		Status:       states.ObjectReady,
 		AttrsJSON:    []byte("{\n            \"ami\": null,\n            \"id\": \"changed\"\n          }"),
-		Dependencies: []addrs.Referenceable{},
+		Dependencies: []addrs.AbsResource{},
+		DependsOn:    []addrs.Referenceable{},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("wrong new object\ngot:  %swant: %s", spew.Sdump(actual), spew.Sdump(expected))
@@ -632,7 +635,8 @@ func TestRefresh_disableBackup(t *testing.T) {
 	expected := &states.ResourceInstanceObjectSrc{
 		Status:       states.ObjectReady,
 		AttrsJSON:    []byte("{\n            \"ami\": null,\n            \"id\": \"yes\"\n          }"),
-		Dependencies: []addrs.Referenceable{},
+		Dependencies: []addrs.AbsResource{},
+		DependsOn:    []addrs.Referenceable{},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("wrong new object\ngot:  %swant: %s", spew.Sdump(actual), spew.Sdump(expected))

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+var equateEmpty = cmpopts.EquateEmpty()
+
 func TestRefresh(t *testing.T) {
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -626,8 +628,10 @@ func TestRefresh_disableBackup(t *testing.T) {
 	}
 
 	newState := testStateRead(t, statePath)
-	if !reflect.DeepEqual(newState, state) {
-		t.Fatalf("bad: %#v", newState)
+	if !cmp.Equal(state, newState, equateEmpty) {
+		spew.Config.DisableMethods = true
+		fmt.Println(cmp.Diff(state, newState, equateEmpty))
+		t.Fatalf("bad: %s", newState)
 	}
 
 	newState = testStateRead(t, outPath)

--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -87,7 +87,7 @@ func shimNewState(newState *states.State, providers map[string]terraform.Resourc
 						resState.Primary.Meta["schema_version"] = i.Current.SchemaVersion
 					}
 
-					for _, dep := range i.Current.Dependencies {
+					for _, dep := range i.Current.DependsOn {
 						resState.Dependencies = append(resState.Dependencies, dep.String())
 					}
 

--- a/helper/resource/state_shim_test.go
+++ b/helper/resource/state_shim_test.go
@@ -31,7 +31,7 @@ func TestStateShim(t *testing.T) {
 			Status:        states.ObjectReady,
 			AttrsFlat:     map[string]string{"id": "foo", "bazzle": "dazzle"},
 			SchemaVersion: 7,
-			Dependencies: []addrs.Referenceable{
+			DependsOn: []addrs.Referenceable{
 				addrs.ResourceInstance{
 					Resource: addrs.Resource{
 						Mode: 'M',
@@ -52,9 +52,9 @@ func TestStateShim(t *testing.T) {
 			Name: "baz",
 		}.Instance(addrs.NoKey),
 		&states.ResourceInstanceObjectSrc{
-			Status:       states.ObjectReady,
-			AttrsFlat:    map[string]string{"id": "baz", "bazzle": "dazzle"},
-			Dependencies: []addrs.Referenceable{},
+			Status:    states.ObjectReady,
+			AttrsFlat: map[string]string{"id": "baz", "bazzle": "dazzle"},
+			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.ProviderConfig{
 			Type: "test",
@@ -70,9 +70,9 @@ func TestStateShim(t *testing.T) {
 			Name: "foo",
 		}.Instance(addrs.NoKey),
 		&states.ResourceInstanceObjectSrc{
-			Status:       states.ObjectReady,
-			AttrsJSON:    []byte(`{"id": "bar", "fuzzle":"wuzzle"}`),
-			Dependencies: []addrs.Referenceable{},
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id": "bar", "fuzzle":"wuzzle"}`),
+			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.ProviderConfig{
 			Type: "test",
@@ -87,7 +87,7 @@ func TestStateShim(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id": "bar", "fizzle":"wizzle"}`),
-			Dependencies: []addrs.Referenceable{
+			DependsOn: []addrs.Referenceable{
 				addrs.ResourceInstance{
 					Resource: addrs.Resource{
 						Mode: 'D',
@@ -112,7 +112,7 @@ func TestStateShim(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsFlat: map[string]string{"id": "old", "fizzle": "wizzle"},
-			Dependencies: []addrs.Referenceable{
+			DependsOn: []addrs.Referenceable{
 				addrs.ResourceInstance{
 					Resource: addrs.Resource{
 						Mode: 'D',
@@ -134,9 +134,9 @@ func TestStateShim(t *testing.T) {
 			Name: "lots",
 		}.Instance(addrs.IntKey(0)),
 		&states.ResourceInstanceObjectSrc{
-			Status:       states.ObjectReady,
-			AttrsFlat:    map[string]string{"id": "0", "bazzle": "dazzle"},
-			Dependencies: []addrs.Referenceable{},
+			Status:    states.ObjectReady,
+			AttrsFlat: map[string]string{"id": "0", "bazzle": "dazzle"},
+			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.ProviderConfig{
 			Type: "test",
@@ -149,9 +149,9 @@ func TestStateShim(t *testing.T) {
 			Name: "lots",
 		}.Instance(addrs.IntKey(1)),
 		&states.ResourceInstanceObjectSrc{
-			Status:       states.ObjectTainted,
-			AttrsFlat:    map[string]string{"id": "1", "bazzle": "dazzle"},
-			Dependencies: []addrs.Referenceable{},
+			Status:    states.ObjectTainted,
+			AttrsFlat: map[string]string{"id": "1", "bazzle": "dazzle"},
+			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.ProviderConfig{
 			Type: "test",
@@ -165,9 +165,9 @@ func TestStateShim(t *testing.T) {
 			Name: "single_count",
 		}.Instance(addrs.IntKey(0)),
 		&states.ResourceInstanceObjectSrc{
-			Status:       states.ObjectReady,
-			AttrsJSON:    []byte(`{"id": "single", "bazzle":"dazzle"}`),
-			Dependencies: []addrs.Referenceable{},
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id": "single", "bazzle":"dazzle"}`),
+			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.ProviderConfig{
 			Type: "test",

--- a/states/instance_object.go
+++ b/states/instance_object.go
@@ -29,12 +29,17 @@ type ResourceInstanceObject struct {
 	// it was updated.
 	Status ObjectStatus
 
-	// Dependencies is a set of other addresses in the same module which
-	// this instance depended on when the given attributes were evaluated.
-	// This is used to construct the dependency relationships for an object
-	// whose configuration is no longer available, such as if it has been
-	// removed from configuration altogether, or is now deposed.
-	Dependencies []addrs.Referenceable
+	// Dependencies is a set of absolute address to other resources this
+	// instance dependeded on when it was applied. This is used to construct
+	// the dependency relationships for an object whose configuration is no
+	// longer available, such as if it has been removed from configuration
+	// altogether, or is now deposed.
+	Dependencies []addrs.AbsResource
+
+	// DependsOn corresponds to the deprecated `depends_on` field in the state.
+	// This field contained the configuration `depends_on` values, and some of
+	// the references from within a single module.
+	DependsOn []addrs.Referenceable
 }
 
 // ObjectStatus represents the status of a RemoteObject.

--- a/states/instance_object_src.go
+++ b/states/instance_object_src.go
@@ -53,7 +53,9 @@ type ResourceInstanceObjectSrc struct {
 	// ResourceInstanceObject.
 	Private      []byte
 	Status       ObjectStatus
-	Dependencies []addrs.Referenceable
+	Dependencies []addrs.AbsResource
+	// deprecated
+	DependsOn []addrs.Referenceable
 }
 
 // Decode unmarshals the raw representation of the object attributes. Pass the

--- a/states/instance_object_src.go
+++ b/states/instance_object_src.go
@@ -88,6 +88,7 @@ func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObjec
 		Value:        val,
 		Status:       os.Status,
 		Dependencies: os.Dependencies,
+		DependsOn:    os.DependsOn,
 		Private:      os.Private,
 	}, nil
 }

--- a/states/state_deepcopy.go
+++ b/states/state_deepcopy.go
@@ -153,8 +153,17 @@ func (obj *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 
 	// Some addrs.Referencable implementations are technically mutable, but
 	// we treat them as immutable by convention and so we don't deep-copy here.
-	dependencies := make([]addrs.Referenceable, len(obj.Dependencies))
-	copy(dependencies, obj.Dependencies)
+	var dependencies []addrs.AbsResource
+	if obj.Dependencies != nil {
+		dependencies = make([]addrs.AbsResource, len(obj.Dependencies))
+		copy(dependencies, obj.Dependencies)
+	}
+
+	var dependsOn []addrs.Referenceable
+	if obj.DependsOn != nil {
+		dependsOn = make([]addrs.Referenceable, len(obj.DependsOn))
+		copy(dependsOn, obj.DependsOn)
+	}
 
 	return &ResourceInstanceObjectSrc{
 		Status:        obj.Status,
@@ -187,9 +196,9 @@ func (obj *ResourceInstanceObject) DeepCopy() *ResourceInstanceObject {
 
 	// Some addrs.Referenceable implementations are technically mutable, but
 	// we treat them as immutable by convention and so we don't deep-copy here.
-	var dependencies []addrs.Referenceable
+	var dependencies []addrs.AbsResource
 	if obj.Dependencies != nil {
-		dependencies = make([]addrs.Referenceable, len(obj.Dependencies))
+		dependencies = make([]addrs.AbsResource, len(obj.Dependencies))
 		copy(dependencies, obj.Dependencies)
 	}
 

--- a/states/state_deepcopy.go
+++ b/states/state_deepcopy.go
@@ -172,6 +172,7 @@ func (obj *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		AttrsFlat:     attrsFlat,
 		AttrsJSON:     attrsJSON,
 		Dependencies:  dependencies,
+		DependsOn:     dependsOn,
 	}
 }
 

--- a/states/state_test.go
+++ b/states/state_test.go
@@ -138,7 +138,7 @@ func TestStateDeepCopy(t *testing.T) {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 			Private:       []byte("private data"),
-			Dependencies:  []addrs.Referenceable{},
+			Dependencies:  []addrs.AbsResource{},
 		},
 		addrs.ProviderConfig{
 			Type: "test",
@@ -155,11 +155,16 @@ func TestStateDeepCopy(t *testing.T) {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 			Private:       []byte("private data"),
-			Dependencies: []addrs.Referenceable{addrs.Resource{
-				Mode: addrs.ManagedResourceMode,
-				Type: "test_thing",
-				Name: "baz",
-			}},
+			Dependencies: []addrs.AbsResource{
+				{
+					Module: addrs.RootModuleInstance,
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "test_thing",
+						Name: "baz",
+					},
+				},
+			},
 		},
 		addrs.ProviderConfig{
 			Type: "test",

--- a/states/statefile/testdata/roundtrip/v4-foreach.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-foreach.in.tfstate
@@ -1,0 +1,36 @@
+{
+  "version": 4,
+  "serial": 0,
+  "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+  "terraform_version": "0.12.0",
+  "outputs": {
+    "numbers": {
+      "type": "string",
+      "value": "0,1"
+    }
+  },
+  "resources": [
+    {
+      "module": "module.modA",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "resource",
+      "provider": "provider.null",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4639265839606265182",
+            "triggers": {
+              "input": "test"
+            }
+          },
+          "private": "bnVsbA==",
+          "depends_on": [
+            "var.input"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/states/statefile/testdata/roundtrip/v4-foreach.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-foreach.out.tfstate
@@ -1,0 +1,1 @@
+v4-foreach.in.tfstate

--- a/states/statefile/testdata/roundtrip/v4-modules.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-modules.in.tfstate
@@ -1,0 +1,88 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.0",
+  "serial": 0,
+  "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+  "outputs": {
+    "numbers": {
+      "value": "0,1",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "bar",
+      "provider": "provider.null",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes_flat": {
+            "id": "5388490630832483079",
+            "triggers.%": "1",
+            "triggers.whaaat": "0,1"
+          },
+          "depends_on": [
+            "null_resource.foo"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.modB",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "bar",
+      "each": "map",
+      "provider": "provider.null",
+      "instances": [
+        {
+          "index_key": "a",
+          "schema_version": 0,
+          "attributes_flat": {
+            "id": "8212585058302700791"
+          },
+          "dependencies": [
+            "module.modA.null_resource.resource"
+          ]
+        },
+        {
+          "index_key": "b",
+          "schema_version": 0,
+          "attributes_flat": {
+            "id": "1523897709610803586"
+          },
+          "dependencies": [
+            "module.modA.null_resource.resource"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.modA",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "resource",
+      "provider": "provider.null",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4639265839606265182",
+            "triggers": {
+              "input": "test"
+            }
+          },
+          "private": "bnVsbA==",
+          "dependencies": [
+            "null_resource.bar"
+          ],
+          "depends_on": [
+            "var.input"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/states/statefile/testdata/roundtrip/v4-modules.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-modules.out.tfstate
@@ -1,0 +1,1 @@
+v4-modules.in.tfstate

--- a/states/statefile/version3_upgrade.go
+++ b/states/statefile/version3_upgrade.go
@@ -313,7 +313,7 @@ func upgradeInstanceObjectV3ToV4(rsOld *resourceStateV2, isOld *instanceStateV2,
 		Status:         status,
 		Deposed:        string(deposedKey),
 		AttributesFlat: attributes,
-		Dependencies:   dependencies,
+		DependsOn:      dependencies,
 		SchemaVersion:  schemaVersion,
 		PrivateRaw:     privateJSON,
 	}, nil

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -2885,8 +2885,9 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 		s.SetResourceMeta(zeroAddr, states.EachList, providerAddr)
 		s.SetResourceMeta(oneAddr, states.EachList, providerAddr)
 		s.SetResourceInstanceCurrent(oneAddr.Instance(addrs.IntKey(0)), &states.ResourceInstanceObjectSrc{
-			Status:    states.ObjectReady,
-			AttrsJSON: []byte(`{}`),
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{}`),
+			Dependencies: []addrs.AbsResource{},
 		}, providerAddr)
 	})
 	if !cmp.Equal(state, want) {

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/provisioners"
 	"github.com/hashicorp/terraform/states"
+	"github.com/hashicorp/terraform/states/statefile"
 	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -2984,7 +2985,9 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 			AttrsJSON: []byte(`{}`),
 		}, providerAddr)
 	})
-	if !cmp.Equal(state, want) {
+
+	// compare the marshaled form to easily remove empty and nil slices
+	if !statefile.StatesMarshalEqual(state, want) {
 		t.Fatalf("wrong state after step 1\n%s", cmp.Diff(want, state))
 	}
 

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -2980,9 +2980,8 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 		s.SetResourceMeta(zeroAddr, states.EachList, providerAddr)
 		s.SetResourceMeta(oneAddr, states.EachList, providerAddr)
 		s.SetResourceInstanceCurrent(oneAddr.Instance(addrs.IntKey(0)), &states.ResourceInstanceObjectSrc{
-			Status:       states.ObjectReady,
-			AttrsJSON:    []byte(`{}`),
-			Dependencies: []addrs.AbsResource{},
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{}`),
 		}, providerAddr)
 	})
 	if !cmp.Equal(state, want) {

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -1964,3 +1964,81 @@ func TestContext2Refresh_dataResourceDependsOn(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 }
+
+// verify that dependencies are updated in the state during refresh
+func TestRefresh_updateDependencies(t *testing.T) {
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "foo",
+		}.Instance(addrs.NoKey),
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"foo"}`),
+		},
+		addrs.ProviderConfig{
+			Type: "aws",
+		}.Absolute(addrs.RootModuleInstance),
+	)
+	root.SetResourceInstanceCurrent(
+		addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "bar",
+		}.Instance(addrs.NoKey),
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"bar","foo":"foo"}`),
+		},
+		addrs.ProviderConfig{
+			Type: "aws",
+		}.Absolute(addrs.RootModuleInstance),
+	)
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "aws_instance" "bar" {
+  foo = aws_instance.foo.id
+}
+
+resource "aws_instance" "foo" {
+}`,
+	})
+
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		ProviderResolver: providers.ResolverFixed(
+			map[string]providers.Factory{
+				"aws": testProviderFuncFixed(p),
+			},
+		),
+		State: state,
+	})
+
+	result, diags := ctx.Refresh()
+	if diags.HasErrors() {
+		t.Fatalf("plan errors: %s", diags.Err())
+	}
+
+	expect := strings.TrimSpace(`
+aws_instance.bar:
+  ID = bar
+  provider = provider.aws
+  foo = foo
+
+  Dependencies:
+    aws_instance.foo
+aws_instance.foo:
+  ID = foo
+  provider = provider.aws
+`)
+
+	checkStateString(t, result, expect)
+}

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -1992,6 +1992,17 @@ func TestRefresh_updateDependencies(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"bar","foo":"foo"}`),
+			Dependencies: []addrs.AbsResource{
+				// Existing dependencies should not be removed during refresh
+				{
+					Module: addrs.RootModuleInstance,
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "aws_instance",
+						Name: "baz",
+					},
+				},
+			},
 		},
 		addrs.ProviderConfig{
 			Type: "aws",
@@ -2034,6 +2045,7 @@ aws_instance.bar:
   foo = foo
 
   Dependencies:
+    aws_instance.baz
     aws_instance.foo
 aws_instance.foo:
   ID = foo

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -24,7 +24,6 @@ import (
 type EvalApply struct {
 	Addr           addrs.ResourceInstance
 	Config         *configs.Resource
-	Dependencies   []addrs.Referenceable
 	State          **states.ResourceInstanceObject
 	Change         **plans.ResourceInstanceChange
 	ProviderAddr   addrs.AbsProviderConfig
@@ -271,10 +270,9 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 	var newState *states.ResourceInstanceObject
 	if !newVal.IsNull() { // null value indicates that the object is deleted, so we won't set a new state in that case
 		newState = &states.ResourceInstanceObject{
-			Status:       states.ObjectReady,
-			Value:        newVal,
-			Private:      resp.Private,
-			Dependencies: n.Dependencies, // Should be populated by the caller from the StateDependencies method on the resource instance node
+			Status:  states.ObjectReady,
+			Value:   newVal,
+			Private: resp.Private,
 		}
 	}
 

--- a/terraform/eval_read_data.go
+++ b/terraform/eval_read_data.go
@@ -21,7 +21,6 @@ import (
 type EvalReadData struct {
 	Addr           addrs.ResourceInstance
 	Config         *configs.Resource
-	Dependencies   []addrs.Referenceable
 	Provider       *providers.Interface
 	ProviderAddr   addrs.AbsProviderConfig
 	ProviderSchema **ProviderSchema
@@ -161,9 +160,8 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 		}
 		if n.OutputState != nil {
 			state := &states.ResourceInstanceObject{
-				Value:        change.After,
-				Status:       states.ObjectPlanned, // because the partial value in the plan must be used for now
-				Dependencies: n.Dependencies,
+				Value:  change.After,
+				Status: states.ObjectPlanned, // because the partial value in the plan must be used for now
 			}
 			*n.OutputState = state
 		}
@@ -275,9 +273,8 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 		},
 	}
 	state := &states.ResourceInstanceObject{
-		Value:        change.After,
-		Status:       states.ObjectReady, // because we completed the read from the provider
-		Dependencies: n.Dependencies,
+		Value:  change.After,
+		Status: states.ObjectReady, // because we completed the read from the provider
 	}
 
 	err = ctx.Hook(func(h Hook) (HookAction, error) {
@@ -306,14 +303,13 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 // EvalReadDataApply is an EvalNode implementation that executes a data
 // resource's ReadDataApply method to read data from the data source.
 type EvalReadDataApply struct {
-	Addr            addrs.ResourceInstance
-	Provider        *providers.Interface
-	ProviderAddr    addrs.AbsProviderConfig
-	ProviderSchema  **ProviderSchema
-	Output          **states.ResourceInstanceObject
-	Config          *configs.Resource
-	Change          **plans.ResourceInstanceChange
-	StateReferences []addrs.Referenceable
+	Addr           addrs.ResourceInstance
+	Provider       *providers.Interface
+	ProviderAddr   addrs.AbsProviderConfig
+	ProviderSchema **ProviderSchema
+	Output         **states.ResourceInstanceObject
+	Config         *configs.Resource
+	Change         **plans.ResourceInstanceChange
 }
 
 func (n *EvalReadDataApply) Eval(ctx EvalContext) (interface{}, error) {
@@ -385,9 +381,8 @@ func (n *EvalReadDataApply) Eval(ctx EvalContext) (interface{}, error) {
 
 	if n.Output != nil {
 		*n.Output = &states.ResourceInstanceObject{
-			Value:        newVal,
-			Status:       states.ObjectReady,
-			Dependencies: n.StateReferences,
+			Value:  newVal,
+			Status: states.ObjectReady,
 		}
 	}
 

--- a/terraform/eval_refresh.go
+++ b/terraform/eval_refresh.go
@@ -89,6 +89,7 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 	newState := state.DeepCopy()
 	newState.Value = resp.NewState
 	newState.Private = resp.Private
+	newState.Dependencies = state.Dependencies
 
 	// Call post-refresh hook
 	err = ctx.Hook(func(h Hook) (HookAction, error) {

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"fmt"
 	"log"
+	"sort"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"
@@ -203,7 +204,7 @@ type EvalWriteState struct {
 
 	// Dependencies are the inter-resource dependencies to be stored in the
 	// state.
-	Dependencies []addrs.AbsResource
+	Dependencies *[]addrs.AbsResource
 }
 
 func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
@@ -228,7 +229,10 @@ func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	// store the new deps in the state
-	obj.Dependencies = n.Dependencies
+	if n.Dependencies != nil {
+		log.Printf("[TRACE] EvalWriteState: recording %d dependencies for %s", len(*n.Dependencies), absAddr)
+		obj.Dependencies = *n.Dependencies
+	}
 
 	if n.ProviderSchema == nil || *n.ProviderSchema == nil {
 		// Should never happen, unless our state object is nil
@@ -477,6 +481,47 @@ func (n *EvalForgetResourceState) Eval(ctx EvalContext) (interface{}, error) {
 		return nil, fmt.Errorf("orphan resource %s still has a non-empty state after apply; this is a bug in Terraform", absAddr)
 	}
 	log.Printf("[TRACE] EvalForgetResourceState: Pruned husk of %s from state", absAddr)
+
+	return nil, nil
+}
+
+// EvalRefreshDependencies is an EvalNode implementation that appends any newly
+// found dependencies to those saved in the state. The existing dependencies
+// are retained, as they may be missing from the config, and will be required
+// for the updates and destroys during the next apply.
+type EvalRefreshDependencies struct {
+	// Prior State
+	State **states.ResourceInstanceObject
+	// Dependencies to write to the new state
+	Dependencies *[]addrs.AbsResource
+}
+
+func (n *EvalRefreshDependencies) Eval(ctx EvalContext) (interface{}, error) {
+	state := *n.State
+	if state == nil {
+		// no existing state to append
+		return nil, nil
+	}
+
+	depMap := make(map[string]addrs.AbsResource)
+	for _, d := range *n.Dependencies {
+		depMap[d.String()] = d
+	}
+
+	for _, d := range state.Dependencies {
+		depMap[d.String()] = d
+	}
+
+	deps := make([]addrs.AbsResource, 0, len(depMap))
+	for _, d := range depMap {
+		deps = append(deps, d)
+	}
+
+	sort.Slice(deps, func(i, j int) bool {
+		return deps[i].String() < deps[j].String()
+	})
+
+	*n.Dependencies = deps
 
 	return nil, nil
 }

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -200,6 +200,10 @@ type EvalWriteState struct {
 	// ProviderAddr is the address of the provider configuration that
 	// produced the given object.
 	ProviderAddr addrs.AbsProviderConfig
+
+	// Dependencies are the inter-resource dependencies to be stored in the
+	// state.
+	Dependencies []addrs.AbsResource
 }
 
 func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
@@ -215,7 +219,6 @@ func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
 	if n.ProviderAddr.ProviderConfig.Type == "" {
 		return nil, fmt.Errorf("failed to write state for %s, missing provider type", absAddr)
 	}
-
 	obj := *n.State
 	if obj == nil || obj.Value.IsNull() {
 		// No need to encode anything: we'll just write it directly.
@@ -223,6 +226,10 @@ func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
 		log.Printf("[TRACE] EvalWriteState: removing state object for %s", absAddr)
 		return nil, nil
 	}
+
+	// store the new deps in the state
+	obj.Dependencies = n.Dependencies
+
 	if n.ProviderSchema == nil || *n.ProviderSchema == nil {
 		// Should never happen, unless our state object is nil
 		panic("EvalWriteState used with pointer to nil ProviderSchema object")

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -155,6 +155,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 
 		// Connect references so ordering is correct
 		&ReferenceTransformer{},
+		&AttachDependenciesTransformer{},
 
 		// Destruction ordering
 		&DestroyEdgeTransformer{

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -572,8 +572,10 @@ test_object.b
 `)
 
 	instanceGraph := filterInstances(g)
-	if instanceGraph.String() != expected {
-		t.Fatalf("expected:\n%s\ngot:\n%s", expected, instanceGraph)
+	got := strings.TrimSpace(instanceGraph.String())
+
+	if got != expected {
+		t.Fatalf("expected:\n%s\ngot:\n%s", expected, got)
 	}
 }
 

--- a/terraform/graph_builder_refresh.go
+++ b/terraform/graph_builder_refresh.go
@@ -165,6 +165,7 @@ func (b *RefreshGraphBuilder) Steps() []GraphTransformer {
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.
 		&ReferenceTransformer{},
+		&AttachDependenciesTransformer{},
 
 		// Target
 		&TargetsTransformer{

--- a/terraform/node_data_refresh.go
+++ b/terraform/node_data_refresh.go
@@ -169,7 +169,6 @@ func (n *NodeRefreshableDataResourceInstance) EvalTree() EvalNode {
 			&EvalReadData{
 				Addr:              addr.Resource,
 				Config:            n.Config,
-				Dependencies:      n.StateReferences(),
 				Provider:          &provider,
 				ProviderAddr:      n.ResolvedProvider,
 				ProviderSchema:    &providerSchema,

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -34,6 +34,10 @@ type ConcreteResourceInstanceNodeFunc func(*NodeAbstractResourceInstance) dag.Ve
 // configuration.
 type GraphNodeResourceInstance interface {
 	ResourceInstanceAddr() addrs.AbsResourceInstance
+
+	// StateDependencies returns any inter-resource dependencies that are
+	// stored in the state.
+	StateDependencies() []addrs.AbsResource
 }
 
 // NodeAbstractResource represents a resource that has no associated

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -28,12 +28,13 @@ type NodeApplyableResourceInstance struct {
 }
 
 var (
-	_ GraphNodeResource         = (*NodeApplyableResourceInstance)(nil)
-	_ GraphNodeResourceInstance = (*NodeApplyableResourceInstance)(nil)
-	_ GraphNodeCreator          = (*NodeApplyableResourceInstance)(nil)
-	_ GraphNodeReferencer       = (*NodeApplyableResourceInstance)(nil)
-	_ GraphNodeDeposer          = (*NodeApplyableResourceInstance)(nil)
-	_ GraphNodeEvalable         = (*NodeApplyableResourceInstance)(nil)
+	_ GraphNodeResource           = (*NodeApplyableResourceInstance)(nil)
+	_ GraphNodeResourceInstance   = (*NodeApplyableResourceInstance)(nil)
+	_ GraphNodeCreator            = (*NodeApplyableResourceInstance)(nil)
+	_ GraphNodeReferencer         = (*NodeApplyableResourceInstance)(nil)
+	_ GraphNodeDeposer            = (*NodeApplyableResourceInstance)(nil)
+	_ GraphNodeEvalable           = (*NodeApplyableResourceInstance)(nil)
+	_ GraphNodeAttachDependencies = (*NodeApplyableResourceInstance)(nil)
 )
 
 // GraphNodeAttachDestroyer
@@ -95,6 +96,11 @@ func (n *NodeApplyableResourceInstance) References() []*addrs.Reference {
 	}
 
 	return ret
+}
+
+// GraphNodeAttachDependencies
+func (n *NodeApplyableResourceInstance) AttachDependencies(deps []addrs.AbsResource) {
+	n.Dependencies = deps
 }
 
 // GraphNodeEvalable
@@ -171,7 +177,6 @@ func (n *NodeApplyableResourceInstance) evalTreeDataResource(addr addrs.AbsResou
 			&EvalReadData{
 				Addr:           addr.Resource,
 				Config:         n.Config,
-				Dependencies:   n.StateReferences(),
 				Planned:        &change, // setting this indicates that the result must be complete
 				Provider:       &provider,
 				ProviderAddr:   n.ResolvedProvider,
@@ -341,7 +346,6 @@ func (n *NodeApplyableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 			&EvalApply{
 				Addr:           addr.Resource,
 				Config:         n.Config,
-				Dependencies:   n.StateReferences(),
 				State:          &state,
 				Change:         &diffApply,
 				Provider:       &provider,
@@ -363,6 +367,7 @@ func (n *NodeApplyableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 				ProviderAddr:   n.ResolvedProvider,
 				ProviderSchema: &providerSchema,
 				State:          &state,
+				Dependencies:   n.Dependencies,
 			},
 			&EvalApplyProvisioners{
 				Addr:           addr.Resource,
@@ -384,6 +389,7 @@ func (n *NodeApplyableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 				ProviderAddr:   n.ResolvedProvider,
 				ProviderSchema: &providerSchema,
 				State:          &state,
+				Dependencies:   n.Dependencies,
 			},
 			&EvalIf{
 				If: func(ctx EvalContext) (bool, error) {

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -367,7 +367,7 @@ func (n *NodeApplyableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 				ProviderAddr:   n.ResolvedProvider,
 				ProviderSchema: &providerSchema,
 				State:          &state,
-				Dependencies:   n.Dependencies,
+				Dependencies:   &n.Dependencies,
 			},
 			&EvalApplyProvisioners{
 				Addr:           addr.Resource,
@@ -389,7 +389,7 @@ func (n *NodeApplyableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 				ProviderAddr:   n.ResolvedProvider,
 				ProviderSchema: &providerSchema,
 				State:          &state,
-				Dependencies:   n.Dependencies,
+				Dependencies:   &n.Dependencies,
 			},
 			&EvalIf{
 				If: func(ctx EvalContext) (bool, error) {

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -78,8 +78,8 @@ func (n *NodePlannableResourceInstance) evalTreeDataResource(addr addrs.AbsResou
 
 					// Check and see if any of our dependencies have changes.
 					changes := ctx.Changes()
-					for _, d := range n.StateReferences() {
-						ri, ok := d.(addrs.ResourceInstance)
+					for _, d := range n.References() {
+						ri, ok := d.Subject.(addrs.ResourceInstance)
 						if !ok {
 							continue
 						}
@@ -114,7 +114,6 @@ func (n *NodePlannableResourceInstance) evalTreeDataResource(addr addrs.AbsResou
 			&EvalReadData{
 				Addr:           addr.Resource,
 				Config:         n.Config,
-				Dependencies:   n.StateReferences(),
 				Provider:       &provider,
 				ProviderAddr:   n.ResolvedProvider,
 				ProviderSchema: &providerSchema,

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -214,6 +214,11 @@ func (n *NodeRefreshableManagedResourceInstance) evalTreeManagedResource() EvalN
 				Output: &state,
 			},
 
+			&EvalRefreshDependencies{
+				State:        &state,
+				Dependencies: &n.Dependencies,
+			},
+
 			&EvalRefresh{
 				Addr:           addr.Resource,
 				ProviderAddr:   n.ResolvedProvider,
@@ -228,6 +233,7 @@ func (n *NodeRefreshableManagedResourceInstance) evalTreeManagedResource() EvalN
 				ProviderAddr:   n.ResolvedProvider,
 				ProviderSchema: &providerSchema,
 				State:          &state,
+				Dependencies:   &n.Dependencies,
 			},
 		},
 	}
@@ -287,6 +293,7 @@ func (n *NodeRefreshableManagedResourceInstance) evalTreeManagedResourceNoState(
 				ProviderAddr:   n.ResolvedProvider,
 				ProviderSchema: &providerSchema,
 				State:          &state,
+				Dependencies:   &n.Dependencies,
 			},
 
 			// We must also save the planned change, so that expressions in

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -18,6 +18,10 @@ import (
 // NodeRefreshableManagedResourceInstance. Resource count orphans are also added.
 type NodeRefreshableManagedResource struct {
 	*NodeAbstractResource
+
+	// We attach dependencies to the Resource during refresh, since the
+	// instances are instantiated during DynamicExpand.
+	Dependencies []addrs.AbsResource
 }
 
 var (
@@ -27,7 +31,13 @@ var (
 	_ GraphNodeReferencer           = (*NodeRefreshableManagedResource)(nil)
 	_ GraphNodeResource             = (*NodeRefreshableManagedResource)(nil)
 	_ GraphNodeAttachResourceConfig = (*NodeRefreshableManagedResource)(nil)
+	_ GraphNodeAttachDependencies   = (*NodeRefreshableManagedResource)(nil)
 )
+
+// GraphNodeAttachDependencies
+func (n *NodeRefreshableManagedResource) AttachDependencies(deps []addrs.AbsResource) {
+	n.Dependencies = deps
+}
 
 // GraphNodeDynamicExpandable
 func (n *NodeRefreshableManagedResource) DynamicExpand(ctx EvalContext) (*Graph, error) {
@@ -58,6 +68,7 @@ func (n *NodeRefreshableManagedResource) DynamicExpand(ctx EvalContext) (*Graph,
 		// Add the config and state since we don't do that via transforms
 		a.Config = n.Config
 		a.ResolvedProvider = n.ResolvedProvider
+		a.Dependencies = n.Dependencies
 
 		return &NodeRefreshableManagedResourceInstance{
 			NodeAbstractResourceInstance: a,

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -608,9 +608,6 @@ aws_instance.bar:
   foo = true
   type = aws_instance
 
-  Dependencies:
-    module.child
-
 module.child:
   <no state>
   Outputs:
@@ -666,6 +663,9 @@ module.child:
     provider = provider.aws
     type = aws_instance
     value = bar
+
+    Dependencies:
+      aws_instance.foo
 `
 
 const testTerraformApplyOutputOrphanStr = `
@@ -784,17 +784,11 @@ aws_instance.foo.1:
   provider = provider.aws
   foo = number 1
   type = aws_instance
-
-  Dependencies:
-    aws_instance.foo[0]
 aws_instance.foo.2:
   ID = foo
   provider = provider.aws
   foo = number 2
   type = aws_instance
-
-  Dependencies:
-    aws_instance.foo[0]
 `
 
 const testTerraformApplyProvisionerDiffStr = `
@@ -859,7 +853,7 @@ aws_instance.a:
   type = aws_instance
 
   Dependencies:
-    module.child
+    module.child.aws_instance.child
 
 module.child:
   aws_instance.child:
@@ -877,7 +871,7 @@ aws_instance.a:
   type = aws_instance
 
   Dependencies:
-    module.child
+    module.child.module.grandchild.aws_instance.c
 
 module.child.grandchild:
   aws_instance.c:
@@ -897,7 +891,7 @@ module.child:
     type = aws_instance
 
     Dependencies:
-      module.grandchild
+      module.child.module.grandchild.aws_instance.c
 module.child.grandchild:
   aws_instance.c:
     ID = foo
@@ -1305,9 +1299,6 @@ data.null_data_source.bar:
   ID = foo
   provider = provider.null
   bar = yes
-
-  Dependencies:
-    data.null_data_source.foo
 data.null_data_source.foo:
   ID = foo
   provider = provider.null

--- a/terraform/testdata/graph-builder-apply-orphan-update/main.tf
+++ b/terraform/testdata/graph-builder-apply-orphan-update/main.tf
@@ -1,0 +1,3 @@
+resource "test_object" "b" {
+  test_string = "changed"
+}

--- a/terraform/transform_reference.go
+++ b/terraform/transform_reference.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"fmt"
 	"log"
+	"sort"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/addrs"
@@ -158,11 +159,14 @@ func (t AttachDependenciesTransformer) Transform(g *Graph) error {
 		for _, d := range depMap {
 			deps = append(deps, d)
 		}
+		sort.Slice(deps, func(i, j int) bool {
+			return deps[i].String() < deps[j].String()
+		})
 
 		log.Printf("[TRACE] AttachDependenciesTransformer: %s depends on %s", attacher.ResourceAddr(), deps)
 		attacher.AttachDependencies(deps)
-
 	}
+
 	return nil
 }
 

--- a/terraform/transform_reference.go
+++ b/terraform/transform_reference.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/dag"
 	"github.com/hashicorp/terraform/lang"
+	"github.com/hashicorp/terraform/states"
 )
 
 // GraphNodeReferenceable must be implemented by any node that represents
@@ -35,6 +37,11 @@ type GraphNodeReferencer interface {
 	// include both a referenced address and source location information for
 	// the reference.
 	References() []*addrs.Reference
+}
+
+type GraphNodeAttachDependencies interface {
+	GraphNodeResource
+	AttachDependencies([]addrs.AbsResource)
 }
 
 // GraphNodeReferenceOutside is an interface that can optionally be implemented.
@@ -84,8 +91,78 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 		for _, parent := range parents {
 			g.Connect(dag.BasicEdge(v, parent))
 		}
+
+		if len(parents) > 0 {
+			continue
+		}
 	}
 
+	return nil
+}
+
+// AttachDependenciesTransformer records all resource dependencies for each
+// instance, and attaches the addresses to the node itself. Managed resource
+// will record these in the state for proper ordering of destroy operations.
+type AttachDependenciesTransformer struct {
+	Config  *configs.Config
+	State   *states.State
+	Schemas *Schemas
+}
+
+func (t AttachDependenciesTransformer) Transform(g *Graph) error {
+	for _, v := range g.Vertices() {
+		attacher, ok := v.(GraphNodeAttachDependencies)
+		if !ok {
+			continue
+		}
+		selfAddr := attacher.ResourceAddr()
+
+		// Data sources don't need to track destroy dependencies
+		if selfAddr.Resource.Mode == addrs.DataResourceMode {
+			continue
+		}
+
+		ans, err := g.Ancestors(v)
+		if err != nil {
+			return err
+		}
+
+		// dedupe addrs when there's multiple instances involved, or
+		// multiple paths in the un-reduced graph
+		depMap := map[string]addrs.AbsResource{}
+		for _, d := range ans.List() {
+			var addr addrs.AbsResource
+
+			switch d := d.(type) {
+			case GraphNodeResourceInstance:
+				instAddr := d.ResourceInstanceAddr()
+				addr = instAddr.Resource.Resource.Absolute(instAddr.Module)
+			case GraphNodeResource:
+				addr = d.ResourceAddr()
+			default:
+				continue
+			}
+
+			// Data sources don't need to track destroy dependencies
+			if addr.Resource.Mode == addrs.DataResourceMode {
+				continue
+			}
+
+			if addr.Equal(selfAddr) {
+				continue
+			}
+			depMap[addr.String()] = addr
+		}
+
+		deps := make([]addrs.AbsResource, 0, len(depMap))
+		for _, d := range depMap {
+			deps = append(deps, d)
+		}
+
+		log.Printf("[TRACE] AttachDependenciesTransformer: %s depends on %s", attacher.ResourceAddr(), deps)
+		attacher.AttachDependencies(deps)
+
+	}
 	return nil
 }
 


### PR DESCRIPTION
We need to be able to reference all possible dependencies for ordering
when the configuration is no longer present, which means that absolute
addresses must be used. Since this is only to recreate the proper
ordering for instance destruction, only resources addresses need to be
listed rather than individual instance addresses.

The state version remains the same with this change, since it's only
adding a field, provides an easier upgrade path for users, and
provides the ability for refresh/apply to handle the "upgrade" by
reading the old depends_on field and writing out the new
dependencies .

The inter-instance dependencies will be determined from the complete
reference graph, so that absolute addresses can be stored, rather than
just references within a module. The Dependencies are added to the node
in the same manner as state, i.e. via an "attacher" interface and
transformer. This is because dependencies must be calculated from the
graph itself, and not from the config.

The new StateDependencies are used in the DestroyEdgeTransformer
to connect both dependent destroyers, as well as creators depending on
another instance's destroyer.

The old code in DestroyEdgeTransformer may no longer be needed in the
long run, but that can be determined separately, since too many of the
tests start with an incomplete state and rely on the Dependencies being
determined from the configuration alone.

Fixes #18408
Fixes #20196
Fixes #21497
Fixes #21630
Fixes #23169
Fixes #22928
Closes #8617 (fixes the remaining issue described in the comments)
Might take care of #20823 (The linked issue sounds like a 0.11 bug. If it's still broken in 0.12 it would probably fall into this same category)

