### PR TITLE
small fix with command usage 'terraform workspace New'

### DIFF
--- a/command/workspace_command.go
+++ b/command/workspace_command.go
@@ -33,7 +33,7 @@ func (c *WorkspaceCommand) Help() string {
 	helpText := `
 Usage: terraform workspace
 
-  New, list, show, select and delete Terraform workspaces.
+  new, list, show, select and delete Terraform workspaces.
 
 `
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
The help documentation for "docker workspace" shows New with camel case N which is wrong. This commit fixes the doc error for following commands:

~/C/terraform ❯❯❯ docker run -i -t terraform workspace New                        
Usage: terraform workspace

  new, list, show, select and delete Terraform workspaces.
~/C/terraform ❯❯❯ docker run -i -t terraform workspace                                  
Usage: terraform workspace

  new, list, show, select and delete Terraform workspaces.
~/C/terraform ❯❯❯ docker run -i -t terraform workspace --usage                          
Usage: terraform workspace

  new, list, show, select and delete Terraform workspaces.