### PR TITLE
Make sure a failed destroy is marked as tainted

### DIFF
--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -356,11 +356,10 @@ func (n *NodeApplyableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 				CreateNew:      &createNew,
 			},
 			&EvalMaybeTainted{
-				Addr:        addr.Resource,
-				State:       &state,
-				Change:      &diffApply,
-				Error:       &err,
-				StateOutput: &state,
+				Addr:   addr.Resource,
+				State:  &state,
+				Change: &diffApply,
+				Error:  &err,
 			},
 			&EvalWriteState{
 				Addr:           addr.Resource,
@@ -378,11 +377,10 @@ func (n *NodeApplyableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 				When:           configs.ProvisionerWhenCreate,
 			},
 			&EvalMaybeTainted{
-				Addr:        addr.Resource,
-				State:       &state,
-				Change:      &diffApply,
-				Error:       &err,
-				StateOutput: &state,
+				Addr:   addr.Resource,
+				State:  &state,
+				Change: &diffApply,
+				Error:  &err,
 			},
 			&EvalWriteState{
 				Addr:           addr.Resource,

--- a/terraform/testdata/apply-destroy-tainted/main.tf
+++ b/terraform/testdata/apply-destroy-tainted/main.tf
@@ -1,0 +1,17 @@
+resource "test_instance" "a" {
+  foo = "a"
+}
+
+resource "test_instance" "b" {
+  foo = "b"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "test_instance" "c" {
+  foo = "c"
+  lifecycle {
+    create_before_destroy = true
+  }
+}


### PR DESCRIPTION
If there are errors while deleting an instance, mark the instance as
tainted. This ensures the instance remains queued for deletion, as it
may have been tainted in the first place.

Fixes #22011