### PR TITLE
command/format: multi-line rendering for unchanged strings

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -520,6 +520,21 @@ func (p *blockBodyDiffPrinter) writeValue(val cty.Value, action plans.Action, in
 					}
 				}
 			}
+
+			if strings.Contains(val.AsString(), "\n") {
+				// It's a multi-line string, so we want to use the multi-line
+				// rendering so it'll be readable. Rather than re-implement
+				// that here, we'll just re-use the multi-line string diff
+				// printer with no changes, which ends up producing the
+				// result we want here.
+				// The path argument is nil because we don't track path
+				// information into strings and we know that a string can't
+				// have any indices or attributes that might need to be marked
+				// as (requires replacement), which is what that argument is for.
+				p.writeValueDiff(val, val, indent, nil)
+				break
+			}
+
 			fmt.Fprintf(p.buf, "%q", val.AsString())
 		case cty.Bool:
 			if val.True() {

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -209,6 +209,37 @@ new line
     }
 `,
 		},
+		"addition of multi-line string field": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.StringVal("i-02ae66f368e8518a9"),
+				"more_lines": cty.NullVal(cty.String),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.UnknownVal(cty.String),
+				"more_lines": cty.StringVal(`original
+new line
+`),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":         {Type: cty.String, Optional: true, Computed: true},
+					"more_lines": {Type: cty.String, Optional: true},
+				},
+			},
+			RequiredReplace: cty.NewPathSet(),
+			Tainted:         false,
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
+      + more_lines = <<~EOT
+            original
+            new line
+        EOT
+    }
+`,
+		},
 		"force-new update of multi-line string field": {
 			Action: plans.DeleteThenCreate,
 			Mode:   addrs.ManagedResourceMode,


### PR DESCRIPTION
We have a special treatment for multi-line strings that are being updated in-place where we show them across multiple lines in the plan output, but we didn't use that same treatment for rendering multi-line strings in isolation such as when they are being added for the first time.

Here we detect when we're rendering a multi-line string in a no-change situation and render it using the diff renderer instead, using the same value for old and new and thus producing a multi-line result without any diff markers at all.

This improves consistency between the change and no-change cases, and makes multi-line strings (such as YAML in block mode) readable in all cases.

Before:

```
  # null_resource.foo will be created
  + resource "null_resource" "foo" {
      + id       = (known after apply)
      + triggers = {
          + "a" = "foo\nbar\nbaz\n"
        }
    }
```

After:

```
  # null_resource.foo will be created
  + resource "null_resource" "foo" {
      + id       = (known after apply)
      + triggers = {
          + "a" = <<~EOT
                foo
                bar
                baz
            EOT
        }
    }
```

This fixes #21817 as closely as we can within our existing diff heuristics. Specifically, the new treatment of the list-of-multiline-strings case is improved but still not ideal because the list diffing algorithm only ever produces additions and removals and never in-place updates, so a list like the `values` in that issue's example would use the above multi-line rendering for both the old and new values but would not interleave them into a single line-oriented diff because it doesn't understand that the new element zero is intended as an in-place edit to the old element zero, rather than a replacement. Maybe we'll improve on that further someday, but for now just showing the lines of the string in full should hopefully be a reasonable compromise.


