### PR TITLE
Update filesystem unlock err

### DIFF
--- a/states/statemgr/filesystem.go
+++ b/states/statemgr/filesystem.go
@@ -336,7 +336,7 @@ func (s *Filesystem) Unlock(id string) error {
 		idErr := fmt.Errorf("invalid lock id: %q. current id: %q", id, s.lockID)
 		info, err := s.lockInfo()
 		if err != nil {
-			err = multierror.Append(idErr, err)
+			idErr = multierror.Append(idErr, err)
 		}
 
 		return &LockError{


### PR DESCRIPTION
Looks like `multierror.Append(idErr, err)` is assigned to the `err` variable which is not used/returned the so updated it to `idErr`.