### PR TITLE
backend/remote: Filter environment variables when loading context

### DIFF
--- a/backend/remote/backend_context.go
+++ b/backend/remote/backend_context.go
@@ -116,8 +116,10 @@ func (b *Remote) Context(op *backend.Operation) (*terraform.Context, statemgr.Fu
 				op.Variables = make(map[string]backend.UnparsedVariableValue)
 			}
 			for _, v := range tfeVariables.Items {
-				op.Variables[v.Key] = &remoteStoredVariableValue{
-					definition: v,
+				if v.Category == tfe.CategoryTerraform {
+					op.Variables[v.Key] = &remoteStoredVariableValue{
+						definition: v,
+					}
 				}
 			}
 		}

--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -981,7 +981,6 @@ func (m *mockVariables) Create(ctx context.Context, options tfe.VariableCreateOp
 	}
 
 	workspace := options.Workspace.Name
-	fmt.Printf("WS Name: %s\n", workspace)
 
 	if m.workspaces[workspace] == nil {
 		m.workspaces[workspace] = &tfe.VariableList{}

--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -27,6 +27,7 @@ type mockClient struct {
 	PolicyChecks          *mockPolicyChecks
 	Runs                  *mockRuns
 	StateVersions         *mockStateVersions
+	Variables             *mockVariables
 	Workspaces            *mockWorkspaces
 }
 
@@ -40,6 +41,7 @@ func newMockClient() *mockClient {
 	c.PolicyChecks = newMockPolicyChecks(c)
 	c.Runs = newMockRuns(c)
 	c.StateVersions = newMockStateVersions(c)
+	c.Variables = newMockVariables(c)
 	c.Workspaces = newMockWorkspaces(c)
 	return c
 }
@@ -943,6 +945,64 @@ func (m *mockStateVersions) Download(ctx context.Context, url string) ([]byte, e
 		return nil, tfe.ErrResourceNotFound
 	}
 	return state, nil
+}
+
+type mockVariables struct {
+	client     *mockClient
+	workspaces map[string]*tfe.VariableList
+}
+
+func newMockVariables(client *mockClient) *mockVariables {
+	return &mockVariables{
+		client:     client,
+		workspaces: make(map[string]*tfe.VariableList),
+	}
+}
+
+func (m *mockVariables) List(ctx context.Context, options tfe.VariableListOptions) (*tfe.VariableList, error) {
+	vl := m.workspaces[*options.Workspace]
+	return vl, nil
+}
+
+func (m *mockVariables) Create(ctx context.Context, options tfe.VariableCreateOptions) (*tfe.Variable, error) {
+	v := &tfe.Variable{
+		ID:       generateID("var-"),
+		Key:      *options.Key,
+		Category: *options.Category,
+	}
+	if options.Value != nil {
+		v.Value = *options.Value
+	}
+	if options.HCL != nil {
+		v.HCL = *options.HCL
+	}
+	if options.Sensitive != nil {
+		v.Sensitive = *options.Sensitive
+	}
+
+	workspace := options.Workspace.Name
+	fmt.Printf("WS Name: %s\n", workspace)
+
+	if m.workspaces[workspace] == nil {
+		m.workspaces[workspace] = &tfe.VariableList{}
+	}
+
+	vl := m.workspaces[workspace]
+	vl.Items = append(vl.Items, v)
+
+	return v, nil
+}
+
+func (m *mockVariables) Read(ctx context.Context, variableID string) (*tfe.Variable, error) {
+	panic("not implemented")
+}
+
+func (m *mockVariables) Update(ctx context.Context, variableID string, options tfe.VariableUpdateOptions) (*tfe.Variable, error) {
+	panic("not implemented")
+}
+
+func (m *mockVariables) Delete(ctx context.Context, variableID string) error {
+	panic("not implemented")
 }
 
 type mockWorkspaces struct {

--- a/backend/remote/testing.go
+++ b/backend/remote/testing.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	tfe "github.com/hashicorp/go-tfe"
-	"github.com/hashicorp/terraform-svchost"
+	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/auth"
 	"github.com/hashicorp/terraform-svchost/disco"
 	"github.com/hashicorp/terraform/backend"
@@ -123,6 +123,7 @@ func testBackend(t *testing.T, obj cty.Value) (*Remote, func()) {
 	b.client.PolicyChecks = mc.PolicyChecks
 	b.client.Runs = mc.Runs
 	b.client.StateVersions = mc.StateVersions
+	b.client.Variables = mc.Variables
 	b.client.Workspaces = mc.Workspaces
 
 	b.ShowDiagnostics = func(vals ...interface{}) {


### PR DESCRIPTION
Following up on #23122, the remote system (Terraform Cloud or Enterprise) serves environment and Terraform variables using a single type of object. We only should load Terraform variables into the Terraform context.

Fixes https://github.com/hashicorp/terraform/issues/23283.