### PR TITLE
command: Don't treat config warnings as errors

### DIFF
--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -346,9 +346,10 @@ func (m *Meta) backendConfig(opts *BackendOpts) (*configs.Backend, int, tfdiags.
 
 	if opts.Config == nil {
 		// check if the config was missing, or just not required
-		conf, err := m.loadBackendConfig(".")
-		if err != nil {
-			return nil, 0, err
+		conf, moreDiags := m.loadBackendConfig(".")
+		diags = diags.Append(moreDiags)
+		if moreDiags.HasErrors() {
+			return nil, 0, diags
 		}
 
 		if conf == nil {


### PR DESCRIPTION
`Meta.backendConfig` was incorrectly treating the second return value from `loadBackendConfig` as if it were go `error` rather than `tfdiags.Diagnostics`, which in turn meant that it would treat warnings like
errors.

This had confusing results because it still returned that `tfdiags.Diagnostics` value in its own diagnostics return value, causing the caller to see warnings even though the `backendConfig` function had taken
the error codepath.

In particular, this fixes #23370.
