### PR TITLE
fix CreateBeforeDestroy de-duplication

### DIFF
--- a/terraform/testdata/transform-destroy-cbd-edge-multi/main.tf
+++ b/terraform/testdata/transform-destroy-cbd-edge-multi/main.tf
@@ -1,0 +1,15 @@
+resource "test_object" "A" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "test_object" "B" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "test_object" "C" {
+  test_string = "${test_object.A.id}-${test_object.B.id}"
+}


### PR DESCRIPTION
An earlier change to eliminate the large amount of duplicate edges being
added by the original CreateBeforeDestroy dependency mapper mistakingly
prevented adding edges when there are multiple CBD dependencies.

This updates the algorithm to use a map to collect all possible edges
and de-deplucating them before processing.

Possible alternative to #23426
Also fixes #23422