### PR TITLE
Address some problems with state upgrade from 0.11 to 0.12

### DIFF
--- a/states/statefile/testdata/roundtrip/v3-invalid-depends.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-invalid-depends.in.tfstate
@@ -1,0 +1,42 @@
+{
+    "version": 3,
+    "terraform_version": "0.7.13",
+    "serial": 0,
+    "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {
+                "numbers": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "0,1"
+                }
+            },
+            "resources": {
+                "null_resource.bar": {
+                    "type": "null_resource",
+                    "depends_on": [
+                        "null_resource.valid",
+                        "null_resource.1invalid"
+                    ],
+                    "primary": {
+                        "id": "5388490630832483079",
+                        "attributes": {
+                            "id": "5388490630832483079",
+                            "triggers.%": "1",
+                            "triggers.whaaat": "0,1"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                }
+            },
+            "depends_on": []
+        }
+    ]
+}

--- a/states/statefile/testdata/roundtrip/v3-invalid-depends.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-invalid-depends.out.tfstate
@@ -1,0 +1,33 @@
+{
+    "version": 4,
+    "serial": 0,
+    "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+    "terraform_version": "0.7.13",
+    "outputs": {
+        "numbers": {
+            "type": "string",
+            "value": "0,1"
+        }
+    },
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "bar",
+            "provider": "provider.null",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "5388490630832483079",
+                        "triggers.%": "1",
+                        "triggers.whaaat": "0,1"
+                    },
+                    "depends_on": [
+                        "null_resource.valid"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/website/upgrade-guides/0-12.html.markdown
+++ b/website/upgrade-guides/0-12.html.markdown
@@ -106,6 +106,31 @@ After all of the tasks are complete, run `terraform 0.12checklist` one more time
 to verify that everything is complete. If so, continue reading the following
 sections to complete the upgrade!
 
+### Addendum: Invalid module names
+
+There is one additional pre-upgrade checklist item that the Terraform team did
+not become aware of until after the release of Terraform v0.11.14, and thus
+cannot be detected automatically by the checklist tool: renaming modules which
+have names that start with digits.
+
+Terraform 0.11 inadvertently tolerated leading-digit names for modules as a
+result of a validation bug, but Terraform 0.12 has corrected that bug and will
+reject such module names. Unfortunately, module names are also recorded in
+state snapshots and so a state snapshot created for a configuration with an
+invalid module name will itself be invalid as far as Terraform 0.12 is
+concerned.
+
+You can address this in a similar way to what the checklist tool suggests for
+invalid resource names and provider aliases:
+
+* Rename the module in your configuration.
+* Use `terraform state mv module.old module.new` _in Terraform 0.11.14_ to
+  update the state to use the new name instead of the old name.
+
+As with all of the pre-upgrade checklist items, be sure to run `terraform apply`
+once more before upgrading in order to ensure that the latest state snapshot is
+synchronized with the latest configuration.
+
 ## Upgrading to Terraform 0.12
 
 Before switching to Terraform 0.12, we recommend using Terraform v0.11.14 (or


### PR DESCRIPTION
In #21435 we can see three different specific issues arising from the state format upgrade codepath moving between Terraform 0.11 and Terraform 0.12:

1. Terraform 0.11 had a habit of leaving behind old entries in `depends_on` in state snapshots after various operations, including the `terraform state mv` command we recommended for fixing invalid resource names (starting with digits) in `terraform 0.12checklist`. The state upgrade would then choke on these and refuse to proceed, even though in practice such invalid references are generally ignored completely by Terraform 0.11 after `terraform state mv` has orphaned them.

2. Terraform 0.11 treated the resource `provider` argument as a literal string always, and allowed it to include all sorts of weird and wonderful punctuation characters. In particular, it would accept a string like `"aws.${var.foo}"` as literally that string without producing an error, giving folks the incorrect impression that Terraform was in fact evaluating that interpolation syntax.

    The `terraform 0.12checklist` tool _does_ catch this problem, but the error message there doesn't specifically address the fact that interpolations were not valid in 0.11 and are now explicitly checked in 0.12, causing folks to think this is a bug in the checklist tool.

3. Terraform 0.11 tolerated non-identifier names for modules. We didn't catch this in our survey of missing validation rules in Terraform 0.11 prior to releasing `terraform 0.12checklist`, so this one isn't flagged as a checklist item. In this particular case, the state upgrade was just silently tolerating it too, causing the resulting Terraform 0.12-oriented state snapshot to be invalid.

This PR addresses the first of these by discarding invalid dependency entries, mimicking how Terraform 0.11 itself treats dependency references in the state that refer to objects that don't actually exist. Although there is a very edge-y edge case where this might cause an incorrect operating ordering on the first operation after upgrading, it requires a very unlikely set of coincidences. For most users, this will be fixed up automatically by the refresh phase on the first plan they run after upgrading.

The other two cannot be fixed automatically during state upgrading, so instead I've improved the error messages for them to be more specific that this is something that must be resolved on Terraform 0.11 before upgrading to Terraform 0.12. For problem 3 above with the module names, I also added an addendum section to the 0.12 upgrade guide to compensate for the fact that `terraform 0.12checklist` doesn't know how to detect and propose a fix for that one.

This fixes #21435 to the extent that it is possible to fix it, as long as users are able to take the proposed pre-upgrade checklist steps on Terraform 0.11.14 before upgrading. The `depends_on` issue seems to have been the most common one, and this will at least offer an automatic fix for _that_.


