### PR TITLE
addrs: rename Provider Name to more accurate Provider Type

### DIFF
--- a/addrs/provider_type.go
+++ b/addrs/provider_type.go
@@ -3,5 +3,5 @@ package addrs
 // ProviderType encapsulates a single provider type. In the future this will be
 // extended to include additional fields including Namespace and SourceHost
 type ProviderType struct {
-	Name string
+	Type string
 }

--- a/command/init.go
+++ b/command/init.go
@@ -517,7 +517,7 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 		}
 
 		for provider, reqd := range missing {
-			pty := addrs.ProviderType{Name: provider}
+			pty := addrs.ProviderType{Type: provider}
 			_, providerDiags, err := c.providerInstaller.Get(pty, reqd.Versions)
 			diags = diags.Append(providerDiags)
 

--- a/command/plugins_test.go
+++ b/command/plugins_test.go
@@ -151,7 +151,7 @@ func (i *mockProviderInstaller) FileName(provider, version string) string {
 func (i *mockProviderInstaller) Get(provider addrs.ProviderType, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error) {
 	var diags tfdiags.Diagnostics
 	noMeta := discovery.PluginMeta{}
-	versions := i.Providers[provider.Name]
+	versions := i.Providers[provider.Type]
 	if len(versions) == 0 {
 		return noMeta, diags, fmt.Errorf("provider %q not found", provider)
 	}
@@ -169,7 +169,7 @@ func (i *mockProviderInstaller) Get(provider addrs.ProviderType, req discovery.C
 
 		if req.Allows(version) {
 			// provider filename
-			name := i.FileName(provider.Name, v)
+			name := i.FileName(provider.Type, v)
 			path := filepath.Join(i.Dir, name)
 			f, err := os.Create(path)
 			if err != nil {
@@ -177,7 +177,7 @@ func (i *mockProviderInstaller) Get(provider addrs.ProviderType, req discovery.C
 			}
 			f.Close()
 			return discovery.PluginMeta{
-				Name:    provider.Name,
+				Name:    provider.Type,
 				Version: discovery.VersionStr(v),
 				Path:    path,
 			}, diags, nil
@@ -201,7 +201,7 @@ func (i *mockProviderInstaller) PurgeUnused(map[string]discovery.PluginMeta) (di
 type callbackPluginInstaller func(provider string, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error)
 
 func (cb callbackPluginInstaller) Get(provider addrs.ProviderType, req discovery.Constraints) (discovery.PluginMeta, tfdiags.Diagnostics, error) {
-	return cb(provider.Name, req)
+	return cb(provider.Type, req)
 }
 
 func (cb callbackPluginInstaller) PurgeUnused(map[string]discovery.PluginMeta) (discovery.PluginMetaSet, error) {

--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -232,7 +232,7 @@ func (i *ProviderInstaller) Get(provider addrs.ProviderType, req Constraints) (P
 		}
 	}
 
-	printedProviderName := fmt.Sprintf("%q (%s)", provider.Name, providerSource)
+	printedProviderName := fmt.Sprintf("%q (%s)", provider.Type, providerSource)
 	i.Ui.Info(fmt.Sprintf("- Downloading plugin for provider %s %s...", printedProviderName, versionMeta.Version))
 	log.Printf("[DEBUG] getting provider %s version %q", printedProviderName, versionMeta.Version)
 	err = i.install(provider, v, providerURL)
@@ -244,11 +244,11 @@ func (i *ProviderInstaller) Get(provider addrs.ProviderType, req Constraints) (P
 	// (This is weird, because go-getter doesn't directly return
 	//  information about what was extracted, and we just extracted
 	//  the archive directly into a shared dir here.)
-	log.Printf("[DEBUG] looking for the %s %s plugin we just installed", provider.Name, versionMeta.Version)
+	log.Printf("[DEBUG] looking for the %s %s plugin we just installed", provider.Type, versionMeta.Version)
 	metas := FindPlugins("provider", []string{i.Dir})
 	log.Printf("[DEBUG] all plugins found %#v", metas)
 	metas, _ = metas.ValidateVersions()
-	metas = metas.WithName(provider.Name).WithVersion(v)
+	metas = metas.WithName(provider.Type).WithVersion(v)
 	log.Printf("[DEBUG] filtered plugins %#v", metas)
 	if metas.Count() == 0 {
 		// This should never happen. Suggests that the release archive
@@ -278,16 +278,16 @@ func (i *ProviderInstaller) Get(provider addrs.ProviderType, req Constraints) (P
 
 func (i *ProviderInstaller) install(provider addrs.ProviderType, version Version, url string) error {
 	if i.Cache != nil {
-		log.Printf("[DEBUG] looking for provider %s %s in plugin cache", provider.Name, version)
-		cached := i.Cache.CachedPluginPath("provider", provider.Name, version)
+		log.Printf("[DEBUG] looking for provider %s %s in plugin cache", provider.Type, version)
+		cached := i.Cache.CachedPluginPath("provider", provider.Type, version)
 		if cached == "" {
-			log.Printf("[DEBUG] %s %s not yet in cache, so downloading %s", provider.Name, version, url)
+			log.Printf("[DEBUG] %s %s not yet in cache, so downloading %s", provider.Type, version, url)
 			err := getter.Get(i.Cache.InstallDir(), url)
 			if err != nil {
 				return err
 			}
 			// should now be in cache
-			cached = i.Cache.CachedPluginPath("provider", provider.Name, version)
+			cached = i.Cache.CachedPluginPath("provider", provider.Type, version)
 			if cached == "" {
 				// should never happen if the getter is behaving properly
 				// and the plugins are packaged properly.
@@ -308,7 +308,7 @@ func (i *ProviderInstaller) install(provider addrs.ProviderType, version Version
 			return err
 		}
 
-		log.Printf("[DEBUG] installing %s %s to %s from local cache %s", provider.Name, version, targetPath, cached)
+		log.Printf("[DEBUG] installing %s %s to %s from local cache %s", provider.Type, version, targetPath, cached)
 
 		// Delete if we can. If there's nothing there already then no harm done.
 		// This is important because we can't create a link if there's
@@ -366,7 +366,7 @@ func (i *ProviderInstaller) install(provider addrs.ProviderType, version Version
 		// One way or another, by the time we get here we should have either
 		// a link or a copy of the cached plugin within i.Dir, as expected.
 	} else {
-		log.Printf("[DEBUG] plugin cache is disabled, so downloading %s %s from %s", provider.Name, version, url)
+		log.Printf("[DEBUG] plugin cache is disabled, so downloading %s %s from %s", provider.Type, version, url)
 		err := getter.Get(i.Dir, url)
 		if err != nil {
 			return err
@@ -473,7 +473,7 @@ func (i *ProviderInstaller) hostname() (string, error) {
 
 // list all versions available for the named provider
 func (i *ProviderInstaller) listProviderVersions(provider addrs.ProviderType) (*response.TerraformProviderVersions, error) {
-	req := regsrc.NewTerraformProvider(provider.Name, i.OS, i.Arch)
+	req := regsrc.NewTerraformProvider(provider.Type, i.OS, i.Arch)
 	versions, err := i.registry.TerraformProviderVersions(req)
 	return versions, err
 }

--- a/plugin/discovery/get_test.go
+++ b/plugin/discovery/get_test.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-svchost"
+	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/disco"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/httpclient"
@@ -152,7 +152,7 @@ func TestVersionListing(t *testing.T) {
 
 	i := newProviderInstaller(server)
 
-	allVersions, err := i.listProviderVersions(addrs.ProviderType{Name: "test"})
+	allVersions, err := i.listProviderVersions(addrs.ProviderType{Type: "test"})
 
 	if err != nil {
 		t.Fatal(err)
@@ -419,7 +419,7 @@ func TestProviderInstallerGet(t *testing.T) {
 		registry:              registry.NewClient(Disco(server), nil),
 	}
 
-	_, _, err = i.Get(addrs.ProviderType{Name: "test"}, AllVersions)
+	_, _, err = i.Get(addrs.ProviderType{Type: "test"}, AllVersions)
 
 	if err != ErrorNoVersionCompatibleWithPlatform {
 		t.Fatal("want error for incompatible version")
@@ -436,21 +436,21 @@ func TestProviderInstallerGet(t *testing.T) {
 	}
 
 	{
-		_, _, err := i.Get(addrs.ProviderType{Name: "test"}, ConstraintStr(">9.0.0").MustParse())
+		_, _, err := i.Get(addrs.ProviderType{Type: "test"}, ConstraintStr(">9.0.0").MustParse())
 		if err != ErrorNoSuitableVersion {
 			t.Fatal("want error for mismatching constraints")
 		}
 	}
 
 	{
-		provider := addrs.ProviderType{Name: "nonexist"}
+		provider := addrs.ProviderType{Type: "nonexist"}
 		_, _, err := i.Get(provider, AllVersions)
 		if err != ErrorNoSuchProvider {
 			t.Fatal("want error for no such provider")
 		}
 	}
 
-	gotMeta, _, err := i.Get(addrs.ProviderType{Name: "test"}, AllVersions)
+	gotMeta, _, err := i.Get(addrs.ProviderType{Type: "test"}, AllVersions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -508,7 +508,7 @@ func TestProviderInstallerGet_cache(t *testing.T) {
 		Arch:                  "mockarch",
 	}
 
-	gotMeta, _, err := i.Get(addrs.ProviderType{Name: "test"}, AllVersions)
+	gotMeta, _, err := i.Get(addrs.ProviderType{Type: "test"}, AllVersions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -182,7 +182,7 @@ func (c *PackageCommand) Run(args []string) int {
 			} else { //attempt to get from the public registry if not found locally
 				c.ui.Output(fmt.Sprintf("- Checking for provider plugin on %s...",
 					releaseHost))
-				_, _, err := installer.Get(addrs.ProviderType{Name: name}, constraint)
+				_, _, err := installer.Get(addrs.ProviderType{Type: name}, constraint)
 				if err != nil {
 					c.ui.Error(fmt.Sprintf("- Failed to resolve %s provider %s: %s", name, constraint, err))
 					return 1


### PR DESCRIPTION
`addrs.ProviderType{Name}` should have been `{Type}`. 

A `ProviderType` may have multiple names, and may end up with a field like `Name []string` (or some other associative mechanism). The existing `name` field was intended as `Type` 

As an example: the type should be `google`, while the name might be `google-beta` or `google.alias`.