### PR TITLE
Minor dependency handling fixups

### DIFF
--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -89,11 +89,32 @@ func TestApplyGraphBuilder_depCbd(t *testing.T) {
 		},
 	}
 
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_object.A").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"A"}`),
+		},
+		mustProviderConfig("provider.test"),
+	)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_object.B").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
+			Dependencies: []addrs.AbsResource{mustResourceAddr("test_object.A")},
+		},
+		mustProviderConfig("provider.test"),
+	)
+
 	b := &ApplyGraphBuilder{
 		Config:     testModule(t, "graph-builder-apply-dep-cbd"),
 		Changes:    changes,
 		Components: simpleMockComponentFactory(),
 		Schemas:    simpleTestSchemas(),
+		State:      state,
 	}
 
 	g, err := b.Build(addrs.RootModuleInstance)

--- a/terraform/node_resource_destroy_deposed.go
+++ b/terraform/node_resource_destroy_deposed.go
@@ -178,7 +178,7 @@ var (
 )
 
 func (n *NodeDestroyDeposedResourceInstanceObject) Name() string {
-	return fmt.Sprintf("%s (destroy deposed %s)", n.Addr.String(), n.DeposedKey)
+	return fmt.Sprintf("%s (destroy deposed %s)", n.ResourceInstanceAddr(), n.DeposedKey)
 }
 
 func (n *NodeDestroyDeposedResourceInstanceObject) DeposedInstanceObjectKey() states.DeposedKey {

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -210,6 +210,22 @@ func mustResourceInstanceAddr(s string) addrs.AbsResourceInstance {
 	return addr
 }
 
+func mustResourceAddr(s string) addrs.AbsResource {
+	addr, diags := addrs.ParseAbsResourceStr(s)
+	if diags.HasErrors() {
+		panic(diags.Err())
+	}
+	return addr
+}
+
+func mustProviderConfig(s string) addrs.AbsProviderConfig {
+	p, diags := addrs.ParseAbsProviderConfigStr(s)
+	if diags.HasErrors() {
+		panic(diags.Err())
+	}
+	return p
+}
+
 func instanceObjectIdForTests(obj *states.ResourceInstanceObject) string {
 	v := obj.Value
 	if v.IsNull() || !v.IsKnown() {

--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -81,7 +81,7 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 			destroyers[key] = append(destroyers[key], n)
 			destroyerAddrs[key] = addr
 
-			resAddr := addr.Resource.Absolute(addr.Module).String()
+			resAddr := addr.Resource.Resource.Absolute(addr.Module).String()
 			destroyersByResource[resAddr] = append(destroyersByResource[resAddr], n)
 		case GraphNodeCreator:
 			addr := n.CreateAddr()

--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -122,12 +122,6 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 
 		for _, resAddr := range ri.StateDependencies() {
 			for _, desDep := range destroyersByResource[resAddr.String()] {
-				// TODO: don't connect this if c is CreateBeforeDestroy.
-				//       This will require getting the actual change action at
-				//       this point, since the lifecycle may have been forced
-				//       by a dependent. This should prevent needing to prune
-				//       the edge back out in CBDEdgeTransformer, and allow
-				//       non-CBD nodes to depend on CBD destroys directly.
 				log.Printf("[TRACE] DestroyEdgeTransformer: %s has stored dependency of %s\n", dag.VertexName(c), dag.VertexName(desDep))
 				g.Connect(dag.BasicEdge(c, desDep))
 


### PR DESCRIPTION
Pulls the most critical changes from #23426

- Node string format was missing deposed key
- The CBD transformation uses state information, but the tests didn't include any state.
- Dependencies connections were referencing the instance address when they should have been using the resource address.
- The dependency connection is correct (the CBD transformation is what needed to be fixed), so remove TODO about changing it. 