### PR TITLE
Fix example reference for remote backend

### DIFF
--- a/website/docs/backends/types/remote.html.md
+++ b/website/docs/backends/types/remote.html.md
@@ -130,7 +130,7 @@ data "terraform_remote_state" "foo" {
   config = {
     organization = "company"
 
-    workspaces {
+    workspaces = {
       name = "workspace"
     }
   }


### PR DESCRIPTION
Example reference had a missing `=` sign on line 133; this causes the workspace reference not to parse properly