### PR TITLE
instances.Expander: A utility for encapsulating "count" and "for_each" concerns

### DIFF
--- a/addrs/module_instance.go
+++ b/addrs/module_instance.go
@@ -410,6 +410,19 @@ func (m ModuleInstance) TargetContains(other Targetable) bool {
 	}
 }
 
+// Module returns the address of the module that this instance is an instance
+// of.
+func (m ModuleInstance) Module() Module {
+	if len(m) == 0 {
+		return nil
+	}
+	ret := make(Module, len(m))
+	for i, step := range m {
+		ret[i] = step.Name
+	}
+	return ret
+}
+
 func (m ModuleInstance) targetableSigil() {
 	// ModuleInstance is targetable
 }

--- a/addrs/module_instance.go
+++ b/addrs/module_instance.go
@@ -413,3 +413,10 @@ func (m ModuleInstance) TargetContains(other Targetable) bool {
 func (m ModuleInstance) targetableSigil() {
 	// ModuleInstance is targetable
 }
+
+func (s ModuleInstanceStep) String() string {
+	if s.InstanceKey != NoKey {
+		return s.Name + s.InstanceKey.String()
+	}
+	return s.Name
+}

--- a/instances/expander.go
+++ b/instances/expander.go
@@ -1,0 +1,319 @@
+package instances
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Expander instances serve as a coordination point for gathering object
+// repetition values (count and for_each in configuration) and then later
+// making use of them to fully enumerate all of the instances of an object.
+//
+// The two repeatable object types in Terraform are modules and resources.
+// Because resources belong to modules and modules can nest inside other
+// modules, module expansion in particular has a recursive effect that can
+// cause deep objects to expand exponentially. Expander assumes that all
+// instances of a module have the same static objects inside, and that they
+// differ only in the repetition count for some of those objects.
+//
+// Expander is a synchronized object whose methods can be safely called
+// from concurrent threads of execution. However, it does expect a certain
+// sequence of operations which is normally obtained by the caller traversing
+// a dependency graph: each object must have its repetition mode set exactly
+// once, and this must be done before any calls that depend on the repetition
+// mode. In other words, the count or for_each expression value for a module
+// must be provided before any object nested directly or indirectly inside
+// that module can be expanded. If this ordering is violated, the methods
+// will panic to enforce internal consistency.
+//
+// The Expand* methods of Expander only work directly with modules and with
+// resources. Addresses for other objects that nest within modules but
+// do not themselves support repetition can be obtained by calling ExpandModule
+// with the containing module path and then producing one absolute instance
+// address per module instance address returned.
+type Expander struct {
+	mu   sync.RWMutex
+	exps *expanderModule
+}
+
+// NewExpander initializes and returns a new Expander, empty and ready to use.
+func NewExpander() *Expander {
+	return &Expander{
+		exps: newExpanderModule(),
+	}
+}
+
+// SetModuleSingle records that the given module call inside the given parent
+// module does not use any repetition arguments and is therefore a singleton.
+func (e *Expander) SetModuleSingle(parentAddr addrs.ModuleInstance, callAddr addrs.ModuleCall) {
+	e.setModuleExpansion(parentAddr, callAddr, expansionSingleVal)
+}
+
+// SetModuleCount records that the given module call inside the given parent
+// module instance uses the "count" repetition argument, with the given value.
+func (e *Expander) SetModuleCount(parentAddr addrs.ModuleInstance, callAddr addrs.ModuleCall, count int) {
+	e.setModuleExpansion(parentAddr, callAddr, expansionCount(count))
+}
+
+// SetModuleForEach records that the given module call inside the given parent
+// module instance uses the "for_each" repetition argument, with the given
+// map value.
+//
+// In the configuration language the for_each argument can also accept a set.
+// It's the caller's responsibility to convert that into an identity map before
+// calling this method.
+func (e *Expander) SetModuleForEach(parentAddr addrs.ModuleInstance, callAddr addrs.ModuleCall, mapping map[string]cty.Value) {
+	e.setModuleExpansion(parentAddr, callAddr, expansionForEach(mapping))
+}
+
+// SetResourceSingle records that the given module inside the given parent
+// module does not use any repetition arguments and is therefore a singleton.
+func (e *Expander) SetResourceSingle(parentAddr addrs.ModuleInstance, resourceAddr addrs.Resource) {
+	e.setResourceExpansion(parentAddr, resourceAddr, expansionSingleVal)
+}
+
+// SetResourceCount records that the given module inside the given parent
+// module uses the "count" repetition argument, with the given value.
+func (e *Expander) SetResourceCount(parentAddr addrs.ModuleInstance, resourceAddr addrs.Resource, count int) {
+	e.setResourceExpansion(parentAddr, resourceAddr, expansionCount(count))
+}
+
+// SetResourceForEach records that the given module inside the given parent
+// module uses the "for_each" repetition argument, with the given map value.
+//
+// In the configuration language the for_each argument can also accept a set.
+// It's the caller's responsibility to convert that into an identity map before
+// calling this method.
+func (e *Expander) SetResourceForEach(parentAddr addrs.ModuleInstance, resourceAddr addrs.Resource, mapping map[string]cty.Value) {
+	e.setResourceExpansion(parentAddr, resourceAddr, expansionForEach(mapping))
+}
+
+// ExpandModule finds the exhaustive set of module instances resulting from
+// the expansion of the given module and all of its ancestor modules.
+//
+// All of the modules on the path to the identified module must already have
+// had their expansion registered using one of the SetModule* methods before
+// calling, or this method will panic.
+func (e *Expander) ExpandModule(addr addrs.Module) []addrs.ModuleInstance {
+	if len(addr) == 0 {
+		// Root module is always a singleton.
+		return singletonRootModule
+	}
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	// We're going to be dynamically growing ModuleInstance addresses, so
+	// we'll preallocate some space to do it so that for typical shallow
+	// module trees we won't need to reallocate this.
+	// (moduleInstances does plenty of allocations itself, so the benefit of
+	// pre-allocating this is marginal but it's not hard to do.)
+	parentAddr := make(addrs.ModuleInstance, 0, 4)
+	ret := e.exps.moduleInstances(addr, parentAddr)
+	sort.SliceStable(ret, func(i, j int) bool {
+		return ret[i].Less(ret[j])
+	})
+	return ret
+}
+
+// ExpandResource finds the exhaustive set of resource instances resulting from
+// the expansion of the given resource and all of its containing modules.
+//
+// All of the modules on the path to the identified resource and the resource
+// itself must already have had their expansion registered using one of the
+// SetModule*/SetResource* methods before calling, or this method will panic.
+func (e *Expander) ExpandResource(parentAddr addrs.Module, resourceAddr addrs.Resource) []addrs.AbsResourceInstance {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	// We're going to be dynamically growing ModuleInstance addresses, so
+	// we'll preallocate some space to do it so that for typical shallow
+	// module trees we won't need to reallocate this.
+	// (moduleInstances does plenty of allocations itself, so the benefit of
+	// pre-allocating this is marginal but it's not hard to do.)
+	moduleInstanceAddr := make(addrs.ModuleInstance, 0, 4)
+	ret := e.exps.resourceInstances(parentAddr, resourceAddr, moduleInstanceAddr)
+	sort.SliceStable(ret, func(i, j int) bool {
+		return ret[i].Less(ret[j])
+	})
+	return ret
+}
+
+// GetModuleInstanceRepetitionData returns an object describing the values
+// that should be available for each.key, each.value, and count.index within
+// the call block for the given module instance.
+func (e *Expander) GetModuleInstanceRepetitionData(addr addrs.ModuleInstance) RepetitionData {
+	if len(addr) == 0 {
+		// The root module is always a singleton, so it has no repetition data.
+		return RepetitionData{}
+	}
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	parentMod := e.findModule(addr[:len(addr)-1])
+	lastStep := addr[len(addr)-1]
+	exp, ok := parentMod.moduleCalls[addrs.ModuleCall{Name: lastStep.Name}]
+	if !ok {
+		panic(fmt.Sprintf("no expansion has been registered for %s", addr))
+	}
+	return exp.repetitionData(lastStep.InstanceKey)
+}
+
+// GetResourceInstanceRepetitionData returns an object describing the values
+// that should be available for each.key, each.value, and count.index within
+// the definition block for the given resource instance.
+func (e *Expander) GetResourceInstanceRepetitionData(addr addrs.AbsResourceInstance) RepetitionData {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	parentMod := e.findModule(addr.Module)
+	exp, ok := parentMod.resources[addr.Resource.Resource]
+	if !ok {
+		panic(fmt.Sprintf("no expansion has been registered for %s", addr.ContainingResource()))
+	}
+	return exp.repetitionData(addr.Resource.Key)
+}
+
+func (e *Expander) findModule(moduleInstAddr addrs.ModuleInstance) *expanderModule {
+	// We expect that all of the modules on the path to our module instance
+	// should already have expansions registered.
+	mod := e.exps
+	for i, step := range moduleInstAddr {
+		next, ok := mod.childInstances[step]
+		if !ok {
+			// Top-down ordering of registration is part of the contract of
+			// Expander, so this is always indicative of a bug in the caller.
+			panic(fmt.Sprintf("no expansion has been registered for ancestor module %s", moduleInstAddr[:i+1]))
+		}
+		mod = next
+	}
+	return mod
+}
+
+func (e *Expander) setModuleExpansion(parentAddr addrs.ModuleInstance, callAddr addrs.ModuleCall, exp expansion) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	mod := e.findModule(parentAddr)
+	if _, exists := mod.moduleCalls[callAddr]; exists {
+		panic(fmt.Sprintf("expansion already registered for %s", parentAddr.Child(callAddr.Name, addrs.NoKey)))
+	}
+	// We'll also pre-register the child instances so that later calls can
+	// populate them as the caller traverses the configuration tree.
+	for _, key := range exp.instanceKeys() {
+		step := addrs.ModuleInstanceStep{Name: callAddr.Name, InstanceKey: key}
+		mod.childInstances[step] = newExpanderModule()
+	}
+	mod.moduleCalls[callAddr] = exp
+}
+
+func (e *Expander) setResourceExpansion(parentAddr addrs.ModuleInstance, resourceAddr addrs.Resource, exp expansion) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	mod := e.findModule(parentAddr)
+	if _, exists := mod.resources[resourceAddr]; exists {
+		panic(fmt.Sprintf("expansion already registered for %s", resourceAddr.Absolute(parentAddr)))
+	}
+	mod.resources[resourceAddr] = exp
+}
+
+type expanderModule struct {
+	moduleCalls    map[addrs.ModuleCall]expansion
+	resources      map[addrs.Resource]expansion
+	childInstances map[addrs.ModuleInstanceStep]*expanderModule
+}
+
+func newExpanderModule() *expanderModule {
+	return &expanderModule{
+		moduleCalls:    make(map[addrs.ModuleCall]expansion),
+		resources:      make(map[addrs.Resource]expansion),
+		childInstances: make(map[addrs.ModuleInstanceStep]*expanderModule),
+	}
+}
+
+var singletonRootModule = []addrs.ModuleInstance{addrs.RootModuleInstance}
+
+func (m *expanderModule) moduleInstances(addr addrs.Module, parentAddr addrs.ModuleInstance) []addrs.ModuleInstance {
+	callName := addr[0]
+	exp, ok := m.moduleCalls[addrs.ModuleCall{Name: callName}]
+	if !ok {
+		// This is a bug in the caller, because it should always register
+		// expansions for an object and all of its ancestors before requesting
+		// expansion of it.
+		panic(fmt.Sprintf("no expansion has been registered for %s", parentAddr.Child(callName, addrs.NoKey)))
+	}
+
+	var ret []addrs.ModuleInstance
+
+	// If there's more than one step remaining then we need to traverse deeper.
+	if len(addr) > 1 {
+		for step, inst := range m.childInstances {
+			if step.Name != callName {
+				continue
+			}
+			instAddr := append(parentAddr, step)
+			ret = append(ret, inst.moduleInstances(addr[1:], instAddr)...)
+		}
+		return ret
+	}
+
+	// Otherwise, we'll use the expansion from the final step to produce
+	// a sequence of addresses under this prefix.
+	for _, k := range exp.instanceKeys() {
+		// We're reusing the buffer under parentAddr as we recurse through
+		// the structure, so we need to copy it here to produce a final
+		// immutable slice to return.
+		full := make(addrs.ModuleInstance, 0, len(parentAddr)+1)
+		full = append(full, parentAddr...)
+		full = full.Child(callName, k)
+		ret = append(ret, full)
+	}
+	return ret
+}
+
+func (m *expanderModule) resourceInstances(moduleAddr addrs.Module, resourceAddr addrs.Resource, parentAddr addrs.ModuleInstance) []addrs.AbsResourceInstance {
+	var ret []addrs.AbsResourceInstance
+
+	if len(moduleAddr) > 0 {
+		// We need to traverse through the module levels first, so we can
+		// then iterate resource expansions in the context of each module
+		// path leading to them.
+		callName := moduleAddr[0]
+		if _, ok := m.moduleCalls[addrs.ModuleCall{Name: callName}]; !ok {
+			// This is a bug in the caller, because it should always register
+			// expansions for an object and all of its ancestors before requesting
+			// expansion of it.
+			panic(fmt.Sprintf("no expansion has been registered for %s", parentAddr.Child(callName, addrs.NoKey)))
+		}
+
+		for step, inst := range m.childInstances {
+			if step.Name != callName {
+				continue
+			}
+			moduleInstAddr := append(parentAddr, step)
+			ret = append(ret, inst.resourceInstances(moduleAddr[1:], resourceAddr, moduleInstAddr)...)
+		}
+		return ret
+	}
+
+	exp, ok := m.resources[resourceAddr]
+	if !ok {
+		panic(fmt.Sprintf("no expansion has been registered for %s", resourceAddr.Absolute(parentAddr)))
+	}
+
+	for _, k := range exp.instanceKeys() {
+		// We're reusing the buffer under parentAddr as we recurse through
+		// the structure, so we need to copy it here to produce a final
+		// immutable slice to return.
+		moduleAddr := make(addrs.ModuleInstance, len(parentAddr))
+		copy(moduleAddr, parentAddr)
+		ret = append(ret, resourceAddr.Instance(k).Absolute(moduleAddr))
+	}
+	return ret
+}

--- a/instances/expander_test.go
+++ b/instances/expander_test.go
@@ -1,0 +1,458 @@
+package instances
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/addrs"
+)
+
+func TestExpander(t *testing.T) {
+	// Some module and resource addresses and values we'll use repeatedly below.
+	singleModuleAddr := addrs.ModuleCall{Name: "single"}
+	count2ModuleAddr := addrs.ModuleCall{Name: "count2"}
+	count0ModuleAddr := addrs.ModuleCall{Name: "count0"}
+	forEachModuleAddr := addrs.ModuleCall{Name: "for_each"}
+	singleResourceAddr := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "test",
+		Name: "single",
+	}
+	count2ResourceAddr := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "test",
+		Name: "count2",
+	}
+	count0ResourceAddr := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "test",
+		Name: "count0",
+	}
+	forEachResourceAddr := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "test",
+		Name: "for_each",
+	}
+	eachMap := map[string]cty.Value{
+		"a": cty.NumberIntVal(1),
+		"b": cty.NumberIntVal(2),
+	}
+
+	// In normal use, Expander would be called in the context of a graph
+	// traversal to ensure that information is registered/requested in the
+	// correct sequence, but to keep this test self-contained we'll just
+	// manually write out the steps here.
+	//
+	// The steps below are assuming a configuration tree like the following:
+	// - root module
+	//   - resource test.single with no count or for_each
+	//   - resource test.count2 with count = 2
+	//   - resource test.count0 with count = 0
+	//   - resource test.for_each with for_each = { a = 1, b = 2 }
+	//   - child module "single" with no count or for_each
+	//     - resource test.single with no count or for_each
+	//     - resource test.count2 with count = 2
+	//   - child module "count2" with count = 2
+	//     - resource test.single with no count or for_each
+	//     - resource test.count2 with count = 2
+	//     - child module "count2" with count = 2
+	//       - resource test.count2 with count = 2
+	//   - child module "count0" with count = 0
+	//     - resource test.single with no count or for_each
+	//   - child module for_each with for_each = { a = 1, b = 2 }
+	//     - resource test.single with no count or for_each
+	//     - resource test.count2 with count = 2
+
+	ex := NewExpander()
+
+	// We don't register the root module, because it's always implied to exist.
+	//
+	// Below we're going to use braces and indentation just to help visually
+	// reflect the tree structure from the tree in the above comment, in the
+	// hope that the following is easier to follow.
+	//
+	// The Expander API requires that we register containing modules before
+	// registering anything inside them, so we'll work through the above
+	// in a depth-first order in the registration steps that follow.
+	{
+		ex.SetResourceSingle(addrs.RootModuleInstance, singleResourceAddr)
+		ex.SetResourceCount(addrs.RootModuleInstance, count2ResourceAddr, 2)
+		ex.SetResourceCount(addrs.RootModuleInstance, count0ResourceAddr, 0)
+		ex.SetResourceForEach(addrs.RootModuleInstance, forEachResourceAddr, eachMap)
+
+		ex.SetModuleSingle(addrs.RootModuleInstance, singleModuleAddr)
+		{
+			// The single instance of the module
+			moduleInstanceAddr := addrs.RootModuleInstance.Child("single", addrs.NoKey)
+			ex.SetResourceSingle(moduleInstanceAddr, singleResourceAddr)
+			ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
+		}
+
+		ex.SetModuleCount(addrs.RootModuleInstance, count2ModuleAddr, 2)
+		for i1 := 0; i1 < 2; i1++ {
+			moduleInstanceAddr := addrs.RootModuleInstance.Child("count2", addrs.IntKey(i1))
+			ex.SetResourceSingle(moduleInstanceAddr, singleResourceAddr)
+			ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
+			ex.SetModuleCount(moduleInstanceAddr, count2ModuleAddr, 2)
+			for i2 := 0; i2 < 2; i2++ {
+				moduleInstanceAddr := moduleInstanceAddr.Child("count2", addrs.IntKey(i2))
+				ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
+			}
+		}
+
+		ex.SetModuleCount(addrs.RootModuleInstance, count0ModuleAddr, 0)
+		{
+			// There are no instances of module "count0", so our nested module
+			// would never actually get registered here: the expansion node
+			// for the resource would see that its containing module has no
+			// instances and so do nothing.
+		}
+
+		ex.SetModuleForEach(addrs.RootModuleInstance, forEachModuleAddr, eachMap)
+		for k := range eachMap {
+			moduleInstanceAddr := addrs.RootModuleInstance.Child("for_each", addrs.StringKey(k))
+			ex.SetResourceSingle(moduleInstanceAddr, singleResourceAddr)
+			ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
+		}
+	}
+
+	t.Run("root module", func(t *testing.T) {
+		// Requesting expansion of the root module doesn't really mean anything
+		// since it's always a singleton, but for consistency it should work.
+		got := ex.ExpandModule(addrs.RootModule)
+		want := []addrs.ModuleInstance{addrs.RootModuleInstance}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("resource single", func(t *testing.T) {
+		got := ex.ExpandResource(
+			addrs.RootModule,
+			singleResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`test.single`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("resource count2", func(t *testing.T) {
+		got := ex.ExpandResource(
+			addrs.RootModule,
+			count2ResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`test.count2[0]`),
+			mustAbsResourceInstanceAddr(`test.count2[1]`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("resource count0", func(t *testing.T) {
+		got := ex.ExpandResource(
+			addrs.RootModule,
+			count0ResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance(nil)
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("resource for_each", func(t *testing.T) {
+		got := ex.ExpandResource(
+			addrs.RootModule,
+			forEachResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`test.for_each["a"]`),
+			mustAbsResourceInstanceAddr(`test.for_each["b"]`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module single", func(t *testing.T) {
+		got := ex.ExpandModule(addrs.RootModule.Child("single"))
+		want := []addrs.ModuleInstance{
+			mustModuleInstanceAddr(`module.single`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module single resource single", func(t *testing.T) {
+		got := ex.ExpandResource(
+			mustModuleAddr("single"),
+			singleResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr("module.single.test.single"),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module single resource count2", func(t *testing.T) {
+		got := ex.ExpandResource(
+			mustModuleAddr(`single`),
+			count2ResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`module.single.test.count2[0]`),
+			mustAbsResourceInstanceAddr(`module.single.test.count2[1]`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module count2", func(t *testing.T) {
+		got := ex.ExpandModule(mustModuleAddr(`count2`))
+		want := []addrs.ModuleInstance{
+			mustModuleInstanceAddr(`module.count2[0]`),
+			mustModuleInstanceAddr(`module.count2[1]`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module count2 resource single", func(t *testing.T) {
+		got := ex.ExpandResource(
+			mustModuleAddr(`count2`),
+			singleResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`module.count2[0].test.single`),
+			mustAbsResourceInstanceAddr(`module.count2[1].test.single`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module count2 resource count2", func(t *testing.T) {
+		got := ex.ExpandResource(
+			mustModuleAddr(`count2`),
+			count2ResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`module.count2[0].test.count2[0]`),
+			mustAbsResourceInstanceAddr(`module.count2[0].test.count2[1]`),
+			mustAbsResourceInstanceAddr(`module.count2[1].test.count2[0]`),
+			mustAbsResourceInstanceAddr(`module.count2[1].test.count2[1]`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module count2 module count2", func(t *testing.T) {
+		got := ex.ExpandModule(mustModuleAddr(`count2.count2`))
+		want := []addrs.ModuleInstance{
+			mustModuleInstanceAddr(`module.count2[0].module.count2[0]`),
+			mustModuleInstanceAddr(`module.count2[0].module.count2[1]`),
+			mustModuleInstanceAddr(`module.count2[1].module.count2[0]`),
+			mustModuleInstanceAddr(`module.count2[1].module.count2[1]`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module count2 resource count2 resource count2", func(t *testing.T) {
+		got := ex.ExpandResource(
+			mustModuleAddr(`count2.count2`),
+			count2ResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`module.count2[0].module.count2[0].test.count2[0]`),
+			mustAbsResourceInstanceAddr(`module.count2[0].module.count2[0].test.count2[1]`),
+			mustAbsResourceInstanceAddr(`module.count2[0].module.count2[1].test.count2[0]`),
+			mustAbsResourceInstanceAddr(`module.count2[0].module.count2[1].test.count2[1]`),
+			mustAbsResourceInstanceAddr(`module.count2[1].module.count2[0].test.count2[0]`),
+			mustAbsResourceInstanceAddr(`module.count2[1].module.count2[0].test.count2[1]`),
+			mustAbsResourceInstanceAddr(`module.count2[1].module.count2[1].test.count2[0]`),
+			mustAbsResourceInstanceAddr(`module.count2[1].module.count2[1].test.count2[1]`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module count0", func(t *testing.T) {
+		got := ex.ExpandModule(mustModuleAddr(`count0`))
+		want := []addrs.ModuleInstance(nil)
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module count0 resource single", func(t *testing.T) {
+		got := ex.ExpandResource(
+			mustModuleAddr(`count0`),
+			singleResourceAddr,
+		)
+		// The containing module has zero instances, so therefore there
+		// are zero instances of this resource even though it doesn't have
+		// count = 0 set itself.
+		want := []addrs.AbsResourceInstance(nil)
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module for_each", func(t *testing.T) {
+		got := ex.ExpandModule(mustModuleAddr(`for_each`))
+		want := []addrs.ModuleInstance{
+			mustModuleInstanceAddr(`module.for_each["a"]`),
+			mustModuleInstanceAddr(`module.for_each["b"]`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module for_each resource single", func(t *testing.T) {
+		got := ex.ExpandResource(
+			mustModuleAddr(`for_each`),
+			singleResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`module.for_each["a"].test.single`),
+			mustAbsResourceInstanceAddr(`module.for_each["b"].test.single`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module for_each resource count2", func(t *testing.T) {
+		got := ex.ExpandResource(
+			mustModuleAddr(`for_each`),
+			count2ResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`module.for_each["a"].test.count2[0]`),
+			mustAbsResourceInstanceAddr(`module.for_each["a"].test.count2[1]`),
+			mustAbsResourceInstanceAddr(`module.for_each["b"].test.count2[0]`),
+			mustAbsResourceInstanceAddr(`module.for_each["b"].test.count2[1]`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+
+	t.Run(`module.for_each["b"] repetitiondata`, func(t *testing.T) {
+		got := ex.GetModuleInstanceRepetitionData(
+			mustModuleInstanceAddr(`module.for_each["b"]`),
+		)
+		want := RepetitionData{
+			EachKey:   cty.StringVal("b"),
+			EachValue: cty.NumberIntVal(2),
+		}
+		if diff := cmp.Diff(want, got, cmp.Comparer(valueEquals)); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run(`module.count2[0].module.count2[1] repetitiondata`, func(t *testing.T) {
+		got := ex.GetModuleInstanceRepetitionData(
+			mustModuleInstanceAddr(`module.count2[0].module.count2[1]`),
+		)
+		want := RepetitionData{
+			CountIndex: cty.NumberIntVal(1),
+		}
+		if diff := cmp.Diff(want, got, cmp.Comparer(valueEquals)); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run(`module.for_each["a"] repetitiondata`, func(t *testing.T) {
+		got := ex.GetModuleInstanceRepetitionData(
+			mustModuleInstanceAddr(`module.for_each["a"]`),
+		)
+		want := RepetitionData{
+			EachKey:   cty.StringVal("a"),
+			EachValue: cty.NumberIntVal(1),
+		}
+		if diff := cmp.Diff(want, got, cmp.Comparer(valueEquals)); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+
+	t.Run(`test.for_each["a"] repetitiondata`, func(t *testing.T) {
+		got := ex.GetResourceInstanceRepetitionData(
+			mustAbsResourceInstanceAddr(`test.for_each["a"]`),
+		)
+		want := RepetitionData{
+			EachKey:   cty.StringVal("a"),
+			EachValue: cty.NumberIntVal(1),
+		}
+		if diff := cmp.Diff(want, got, cmp.Comparer(valueEquals)); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run(`module.for_each["a"].test.single repetitiondata`, func(t *testing.T) {
+		got := ex.GetResourceInstanceRepetitionData(
+			mustAbsResourceInstanceAddr(`module.for_each["a"].test.single`),
+		)
+		want := RepetitionData{}
+		if diff := cmp.Diff(want, got, cmp.Comparer(valueEquals)); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run(`module.for_each["a"].test.count2[1] repetitiondata`, func(t *testing.T) {
+		got := ex.GetResourceInstanceRepetitionData(
+			mustAbsResourceInstanceAddr(`module.for_each["a"].test.count2[1]`),
+		)
+		want := RepetitionData{
+			CountIndex: cty.NumberIntVal(1),
+		}
+		if diff := cmp.Diff(want, got, cmp.Comparer(valueEquals)); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+}
+
+func mustResourceAddr(str string) addrs.Resource {
+	addr, diags := addrs.ParseAbsResourceStr(str)
+	if diags.HasErrors() {
+		panic(fmt.Sprintf("invalid resource address: %s", diags.Err()))
+	}
+	if !addr.Module.IsRoot() {
+		panic("invalid resource address: includes module path")
+	}
+	return addr.Resource
+}
+
+func mustAbsResourceInstanceAddr(str string) addrs.AbsResourceInstance {
+	addr, diags := addrs.ParseAbsResourceInstanceStr(str)
+	if diags.HasErrors() {
+		panic(fmt.Sprintf("invalid absolute resource instance address: %s", diags.Err()))
+	}
+	return addr
+}
+
+func mustModuleAddr(str string) addrs.Module {
+	if len(str) == 0 {
+		return addrs.RootModule
+	}
+	// We don't have a real parser for these because they don't appear in the
+	// language anywhere, but this interpretation mimics the format we
+	// produce from the String method on addrs.Module.
+	parts := strings.Split(str, ".")
+	return addrs.Module(parts)
+}
+
+func mustModuleInstanceAddr(str string) addrs.ModuleInstance {
+	if len(str) == 0 {
+		return addrs.RootModuleInstance
+	}
+	addr, diags := addrs.ParseModuleInstanceStr(str)
+	if diags.HasErrors() {
+		panic(fmt.Sprintf("invalid module instance address: %s", diags.Err()))
+	}
+	return addr
+}
+
+func valueEquals(a, b cty.Value) bool {
+	if a == cty.NilVal || b == cty.NilVal {
+		return a == b
+	}
+	return a.RawEquals(b)
+}

--- a/instances/expansion_mode.go
+++ b/instances/expansion_mode.go
@@ -1,0 +1,85 @@
+package instances
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/addrs"
+)
+
+// expansion is an internal interface used to represent the different
+// ways expansion can operate depending on how repetition is configured for
+// an object.
+type expansion interface {
+	instanceKeys() []addrs.InstanceKey
+	repetitionData(addrs.InstanceKey) RepetitionData
+}
+
+// expansionSingle is the expansion corresponding to no repetition arguments
+// at all, producing a single object with no key.
+//
+// expansionSingleVal is the only valid value of this type.
+type expansionSingle uintptr
+
+var singleKeys = []addrs.InstanceKey{addrs.NoKey}
+var expansionSingleVal expansionSingle
+
+func (e expansionSingle) instanceKeys() []addrs.InstanceKey {
+	return singleKeys
+}
+
+func (e expansionSingle) repetitionData(key addrs.InstanceKey) RepetitionData {
+	if key != addrs.NoKey {
+		panic("cannot use instance key with non-repeating object")
+	}
+	return RepetitionData{}
+}
+
+// expansionCount is the expansion corresponding to the "count" argument.
+type expansionCount int
+
+func (e expansionCount) instanceKeys() []addrs.InstanceKey {
+	ret := make([]addrs.InstanceKey, int(e))
+	for i := range ret {
+		ret[i] = addrs.IntKey(i)
+	}
+	return ret
+}
+
+func (e expansionCount) repetitionData(key addrs.InstanceKey) RepetitionData {
+	i := int(key.(addrs.IntKey))
+	if i < 0 || i >= int(e) {
+		panic(fmt.Sprintf("instance key %d out of range for count %d", i, e))
+	}
+	return RepetitionData{
+		CountIndex: cty.NumberIntVal(int64(i)),
+	}
+}
+
+// expansionForEach is the expansion corresponding to the "for_each" argument.
+type expansionForEach map[string]cty.Value
+
+func (e expansionForEach) instanceKeys() []addrs.InstanceKey {
+	ret := make([]addrs.InstanceKey, 0, len(e))
+	for k := range e {
+		ret = append(ret, addrs.StringKey(k))
+	}
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].(addrs.StringKey) < ret[j].(addrs.StringKey)
+	})
+	return ret
+}
+
+func (e expansionForEach) repetitionData(key addrs.InstanceKey) RepetitionData {
+	k := string(key.(addrs.StringKey))
+	v, ok := e[k]
+	if !ok {
+		panic(fmt.Sprintf("instance key %q does not match any instance", k))
+	}
+	return RepetitionData{
+		EachKey:   cty.StringVal(k),
+		EachValue: v,
+	}
+}

--- a/instances/instance_key_data.go
+++ b/instances/instance_key_data.go
@@ -1,0 +1,28 @@
+package instances
+
+import (
+	"github.com/zclconf/go-cty/cty"
+)
+
+// RepetitionData represents the values available to identify individual
+// repetitions of a particular object.
+//
+// This corresponds to the each.key, each.value, and count.index symbols in
+// the configuration language.
+type RepetitionData struct {
+	// CountIndex is the value for count.index, or cty.NilVal if evaluating
+	// in a context where the "count" argument is not active.
+	//
+	// For correct operation, this should always be of type cty.Number if not
+	// nil.
+	CountIndex cty.Value
+
+	// EachKey and EachValue are the values for each.key and each.value
+	// respectively, or cty.NilVal if evaluating in a context where the
+	// "for_each" argument is not active. These must either both be set
+	// or neither set.
+	//
+	// For correct operation, EachKey must always be either of type cty.String
+	// or cty.Number if not nil.
+	EachKey, EachValue cty.Value
+}

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/instances"
 	"github.com/hashicorp/terraform/lang"
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/providers"
@@ -788,6 +789,7 @@ func (c *Context) graphWalker(operation walkOperation) *ContextGraphWalker {
 		Context:            c,
 		State:              c.state.SyncWrapper(),
 		Changes:            c.changes.SyncWrapper(),
+		InstanceExpander:   instances.NewExpander(),
 		Operation:          operation,
 		StopContext:        c.runContext,
 		RootVariableValues: c.variables,

--- a/terraform/eval_context.go
+++ b/terraform/eval_context.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/instances"
 	"github.com/hashicorp/terraform/lang"
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/providers"
@@ -152,4 +153,12 @@ type EvalContext interface {
 	// State returns a wrapper object that provides safe concurrent access to
 	// the global state.
 	State() *states.SyncState
+
+	// InstanceExpander returns a helper object for tracking the expansion of
+	// graph nodes during the plan phase in response to "count" and "for_each"
+	// arguments.
+	//
+	// The InstanceExpander is a global object that is shared across all of the
+	// EvalContext objects for a given configuration.
+	InstanceExpander() *instances.Expander
 }

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"sync"
 
+	"github.com/hashicorp/terraform/instances"
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/provisioners"
@@ -53,16 +54,17 @@ type BuiltinEvalContext struct {
 	VariableValues     map[string]map[string]cty.Value
 	VariableValuesLock *sync.Mutex
 
-	Components          contextComponentFactory
-	Hooks               []Hook
-	InputValue          UIInput
-	ProviderCache       map[string]providers.Interface
-	ProviderInputConfig map[string]map[string]cty.Value
-	ProviderLock        *sync.Mutex
-	ProvisionerCache    map[string]provisioners.Interface
-	ProvisionerLock     *sync.Mutex
-	ChangesValue        *plans.ChangesSync
-	StateValue          *states.SyncState
+	Components            contextComponentFactory
+	Hooks                 []Hook
+	InputValue            UIInput
+	ProviderCache         map[string]providers.Interface
+	ProviderInputConfig   map[string]map[string]cty.Value
+	ProviderLock          *sync.Mutex
+	ProvisionerCache      map[string]provisioners.Interface
+	ProvisionerLock       *sync.Mutex
+	ChangesValue          *plans.ChangesSync
+	StateValue            *states.SyncState
+	InstanceExpanderValue *instances.Expander
 
 	once sync.Once
 }
@@ -357,6 +359,10 @@ func (ctx *BuiltinEvalContext) Changes() *plans.ChangesSync {
 
 func (ctx *BuiltinEvalContext) State() *states.SyncState {
 	return ctx.StateValue
+}
+
+func (ctx *BuiltinEvalContext) InstanceExpander() *instances.Expander {
+	return ctx.InstanceExpanderValue
 }
 
 func (ctx *BuiltinEvalContext) init() {

--- a/terraform/eval_context_mock.go
+++ b/terraform/eval_context_mock.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/instances"
 	"github.com/hashicorp/terraform/lang"
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/providers"
@@ -124,6 +125,9 @@ type MockEvalContext struct {
 
 	StateCalled bool
 	StateState  *states.SyncState
+
+	InstanceExpanderCalled   bool
+	InstanceExpanderExpander *instances.Expander
 }
 
 // MockEvalContext implements EvalContext
@@ -326,4 +330,9 @@ func (c *MockEvalContext) Changes() *plans.ChangesSync {
 func (c *MockEvalContext) State() *states.SyncState {
 	c.StateCalled = true
 	return c.StateState
+}
+
+func (c *MockEvalContext) InstanceExpander() *instances.Expander {
+	c.InstanceExpanderCalled = true
+	return c.InstanceExpanderExpander
 }

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -488,6 +488,19 @@ func (n *EvalWriteResourceState) Eval(ctx EvalContext) (interface{}, error) {
 	// while ensuring that any existing instances are preserved, etc.
 	state.SetResourceMeta(absAddr, eachMode, n.ProviderAddr)
 
+	// We'll record our expansion decision in the shared "expander" object
+	// so that later operations (i.e. DynamicExpand and expression evaluation)
+	// can refer to it.
+	expander := ctx.InstanceExpander()
+	switch eachMode {
+	case states.EachList:
+		expander.SetResourceCount(ctx.Path(), n.Addr, count)
+	case states.EachMap:
+		expander.SetResourceForEach(ctx.Path(), n.Addr, forEach)
+	default:
+		expander.SetResourceSingle(ctx.Path(), n.Addr)
+	}
+
 	return nil, nil
 }
 

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/instances"
 	"github.com/hashicorp/terraform/lang"
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/states"
@@ -97,25 +98,9 @@ type evaluationStateData struct {
 	Operation walkOperation
 }
 
-// InstanceKeyEvalData is used during evaluation to specify which values,
-// if any, should be produced for count.index, each.key, and each.value.
-type InstanceKeyEvalData struct {
-	// CountIndex is the value for count.index, or cty.NilVal if evaluating
-	// in a context where the "count" argument is not active.
-	//
-	// For correct operation, this should always be of type cty.Number if not
-	// nil.
-	CountIndex cty.Value
-
-	// EachKey and EachValue are the values for each.key and each.value
-	// respectively, or cty.NilVal if evaluating in a context where the
-	// "for_each" argument is not active. These must either both be set
-	// or neither set.
-	//
-	// For correct operation, EachKey must always be either of type cty.String
-	// or cty.Number if not nil.
-	EachKey, EachValue cty.Value
-}
+// InstanceKeyEvalData is the old name for instances.RepetitionData, aliased
+// here for compatibility. In new code, use instances.RepetitionData instead.
+type InstanceKeyEvalData = instances.RepetitionData
 
 // EvalDataForInstanceKey constructs a suitable InstanceKeyEvalData for
 // evaluating in a context that has the given instance key.

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -153,6 +153,11 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// analyze the configuration to find references.
 		&AttachSchemaTransformer{Schemas: b.Schemas},
 
+		// Create expansion nodes for all of the module calls. This must
+		// come after all other transformers that create nodes representing
+		// objects that can belong to modules.
+		&ModuleExpansionTransformer{Config: b.Config},
+
 		// Connect references so ordering is correct
 		&ReferenceTransformer{},
 		&AttachDependenciesTransformer{},

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -656,15 +656,18 @@ const testApplyGraphBuilderStr = `
 meta.count-boundary (EachMode fixup)
   module.child.test_object.other
   test_object.other
+module.child
 module.child.test_object.create
   module.child.test_object.create (prepare state)
 module.child.test_object.create (prepare state)
+  module.child
   provider["registry.terraform.io/-/test"]
   provisioner.test
 module.child.test_object.other
   module.child.test_object.create
   module.child.test_object.other (prepare state)
 module.child.test_object.other (prepare state)
+  module.child
   provider["registry.terraform.io/-/test"]
 provider["registry.terraform.io/-/test"]
 provider["registry.terraform.io/-/test"] (close)

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -137,6 +137,11 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// analyze the configuration to find references.
 		&AttachSchemaTransformer{Schemas: b.Schemas},
 
+		// Create expansion nodes for all of the module calls. This must
+		// come after all other transformers that create nodes representing
+		// objects that can belong to modules.
+		&ModuleExpansionTransformer{Config: b.Config},
+
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.
 		&ReferenceTransformer{},

--- a/terraform/graph_builder_refresh.go
+++ b/terraform/graph_builder_refresh.go
@@ -162,6 +162,11 @@ func (b *RefreshGraphBuilder) Steps() []GraphTransformer {
 		// analyze the configuration to find references.
 		&AttachSchemaTransformer{Schemas: b.Schemas},
 
+		// Create expansion nodes for all of the module calls. This must
+		// come after all other transformers that create nodes representing
+		// objects that can belong to modules.
+		&ModuleExpansionTransformer{Config: b.Config},
+
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.
 		&ReferenceTransformer{},

--- a/terraform/node_data_refresh_test.go
+++ b/terraform/node_data_refresh_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/instances"
 )
 
 func TestNodeRefreshableDataResourceDynamicExpand_scaleOut(t *testing.T) {
@@ -49,8 +50,9 @@ func TestNodeRefreshableDataResourceDynamicExpand_scaleOut(t *testing.T) {
 	}
 
 	g, err := n.DynamicExpand(&MockEvalContext{
-		PathPath:   addrs.RootModuleInstance,
-		StateState: state.SyncWrapper(),
+		PathPath:                 addrs.RootModuleInstance,
+		StateState:               state.SyncWrapper(),
+		InstanceExpanderExpander: instances.NewExpander(),
 
 		// DynamicExpand will call EvaluateExpr to evaluate the "count"
 		// expression, which is just a literal number 3 in the fixture config
@@ -136,8 +138,9 @@ func TestNodeRefreshableDataResourceDynamicExpand_scaleIn(t *testing.T) {
 	}
 
 	g, err := n.DynamicExpand(&MockEvalContext{
-		PathPath:   addrs.RootModuleInstance,
-		StateState: state.SyncWrapper(),
+		PathPath:                 addrs.RootModuleInstance,
+		StateState:               state.SyncWrapper(),
+		InstanceExpanderExpander: instances.NewExpander(),
 
 		// DynamicExpand will call EvaluateExpr to evaluate the "count"
 		// expression, which is just a literal number 3 in the fixture config

--- a/terraform/node_module_expand.go
+++ b/terraform/node_module_expand.go
@@ -1,0 +1,96 @@
+package terraform
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/configs"
+)
+
+// nodeExpandModule represents a module call in the configuration that
+// might expand into multiple module instances depending on how it is
+// configured.
+type nodeExpandModule struct {
+	CallerAddr addrs.ModuleInstance
+	Call       addrs.ModuleCall
+	Config     *configs.Module
+}
+
+var (
+	_ GraphNodeSubPath       = (*nodeExpandModule)(nil)
+	_ RemovableIfNotTargeted = (*nodeExpandModule)(nil)
+	_ GraphNodeEvalable      = (*nodeExpandModule)(nil)
+	_ GraphNodeReferencer    = (*nodeExpandModule)(nil)
+)
+
+func (n *nodeExpandModule) Name() string {
+	return n.CallerAddr.Child(n.Call.Name, addrs.NoKey).String()
+}
+
+// GraphNodeSubPath implementation
+func (n *nodeExpandModule) Path() addrs.ModuleInstance {
+	// Notice that the node represents the module call and so we report
+	// the parent module as the path. The module call we're representing
+	// might expand into multiple child module instances during our work here.
+	return n.CallerAddr
+}
+
+// GraphNodeReferencer implementation
+func (n *nodeExpandModule) References() []*addrs.Reference {
+	// Expansion only uses the count and for_each expressions, so this
+	// particular graph node only refers to those.
+	// Individual variable values in the module call definition might also
+	// refer to other objects, but that's handled by
+	// NodeApplyableModuleVariable.
+	//
+	// Because our Path method returns the module instance that contains
+	// our call, these references will be correctly interpreted as being
+	// in the calling module's namespace, not the namespaces of any of the
+	// child module instances we might expand to during our evaluation.
+	var ret []*addrs.Reference
+	// TODO: Once count and for_each are actually supported, analyze their
+	// expressions for references here.
+	/*
+		if n.Config.Count != nil {
+			ret = append(ret, n.Config.Count.References()...)
+		}
+		if n.Config.ForEach != nil {
+			ret = append(ret, n.Config.ForEach.References()...)
+		}
+	*/
+	return ret
+}
+
+// RemovableIfNotTargeted implementation
+func (n *nodeExpandModule) RemoveIfNotTargeted() bool {
+	// We need to add this so that this node will be removed if
+	// it isn't targeted or a dependency of a target.
+	return true
+}
+
+// GraphNodeEvalable
+func (n *nodeExpandModule) EvalTree() EvalNode {
+	return &evalPrepareModuleExpansion{
+		CallerAddr: n.CallerAddr,
+		Call:       n.Call,
+		Config:     n.Config,
+	}
+}
+
+type evalPrepareModuleExpansion struct {
+	CallerAddr addrs.ModuleInstance
+	Call       addrs.ModuleCall
+	Config     *configs.Module
+}
+
+func (n *evalPrepareModuleExpansion) Eval(ctx EvalContext) (interface{}, error) {
+	// Modules don't support any of the repetition arguments yet, so their
+	// expansion type is always "single". We just record this here to make
+	// the expander data structure consistent for now.
+	// FIXME: Once the rest of Terraform Core is ready to support expanding
+	// modules, evaluate the "count" and "for_each" arguments here in a
+	// similar way as in EvalWriteResourceState.
+	log.Printf("[TRACE] evalPrepareModuleExpansion: %s is a singleton", n.CallerAddr.Child(n.Call.Name, addrs.NoKey))
+	ctx.InstanceExpander().SetModuleSingle(n.CallerAddr, n.Call)
+	return nil, nil
+}

--- a/terraform/node_resource_refresh_test.go
+++ b/terraform/node_resource_refresh_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/instances"
 )
 
 func TestNodeRefreshableManagedResourceDynamicExpand_scaleOut(t *testing.T) {
@@ -49,8 +50,9 @@ func TestNodeRefreshableManagedResourceDynamicExpand_scaleOut(t *testing.T) {
 	}
 
 	g, err := n.DynamicExpand(&MockEvalContext{
-		PathPath:   addrs.RootModuleInstance,
-		StateState: state,
+		PathPath:                 addrs.RootModuleInstance,
+		StateState:               state,
+		InstanceExpanderExpander: instances.NewExpander(),
 
 		// DynamicExpand will call EvaluateExpr to evaluate the "count"
 		// expression, which is just a literal number 3 in the fixture config
@@ -130,8 +132,9 @@ func TestNodeRefreshableManagedResourceDynamicExpand_scaleIn(t *testing.T) {
 	}
 
 	g, err := n.DynamicExpand(&MockEvalContext{
-		PathPath:   addrs.RootModuleInstance,
-		StateState: state,
+		PathPath:                 addrs.RootModuleInstance,
+		StateState:               state,
+		InstanceExpanderExpander: instances.NewExpander(),
 
 		// DynamicExpand will call EvaluateExpr to evaluate the "count"
 		// expression, which is just a literal number 3 in the fixture config

--- a/terraform/transform_module_expansion.go
+++ b/terraform/transform_module_expansion.go
@@ -1,0 +1,82 @@
+package terraform
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/dag"
+)
+
+// ModuleExpansionTransformer is a GraphTransformer that adds graph nodes
+// representing the possible expansion of each module call in the configuration,
+// and ensures that any nodes representing objects declared within a module
+// are dependent on the expansion node so that they will be visited only
+// after the module expansion has been decided.
+//
+// This transform must be applied only after all nodes representing objects
+// that can be contained within modules have already been added.
+type ModuleExpansionTransformer struct {
+	Config *configs.Config
+}
+
+func (t *ModuleExpansionTransformer) Transform(g *Graph) error {
+	// The root module is always a singleton and so does not need expansion
+	// processing, but any descendent modules do. We'll process them
+	// recursively using t.transform.
+	for _, cfg := range t.Config.Children {
+		err := t.transform(g, cfg, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *ModuleExpansionTransformer) transform(g *Graph, c *configs.Config, parentNode dag.Vertex) error {
+	// FIXME: We're using addrs.ModuleInstance to represent the paths here
+	// because the rest of Terraform Core is expecting that, but in practice
+	// thus is representing a path through the static module instances (not
+	// expanded yet), and so as we weave in support for repetition of module
+	// calls we'll need to make the plan processing actually use addrs.Module
+	// to represent that our graph nodes are actually representing unexpanded
+	// static configuration objects, not instances.
+	fullAddr := c.Path.UnkeyedInstanceShim()
+	callerAddr, callAddr := fullAddr.Call()
+
+	v := &nodeExpandModule{
+		CallerAddr: callerAddr,
+		Call:       callAddr,
+		Config:     c.Module,
+	}
+	g.Add(v)
+	log.Printf("[TRACE] ModuleExpansionTransformer: Added %s as %T", fullAddr, v)
+
+	if parentNode != nil {
+		log.Printf("[TRACE] ModuleExpansionTransformer: %s must wait for expansion of %s", dag.VertexName(v), dag.VertexName(parentNode))
+		g.Connect(dag.BasicEdge(v, parentNode))
+	}
+
+	// Connect any node that reports this module as its Path to ensure that
+	// the module expansion will be handled before that node.
+	// FIXME: Again, there is some Module vs. ModuleInstance muddling here
+	// for legacy reasons, which we'll need to clean up as part of further
+	// work to properly support "count" and "for_each" for modules. Nodes
+	// in the plan graph actually belong to modules, not to module instances.
+	for _, childV := range g.Vertices() {
+		pather, ok := childV.(GraphNodeSubPath)
+		if !ok {
+			continue
+		}
+		if pather.Path().Equal(fullAddr) {
+			log.Printf("[TRACE] ModuleExpansionTransformer: %s must wait for expansion of %s", dag.VertexName(childV), fullAddr)
+			g.Connect(dag.BasicEdge(childV, v))
+		}
+	}
+
+	// Also visit child modules, recursively.
+	for _, cc := range c.Children {
+		return t.transform(g, cc, v)
+	}
+
+	return nil
+}

--- a/terraform/transform_orphan_count.go
+++ b/terraform/transform_orphan_count.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/dag"
 	"github.com/hashicorp/terraform/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // OrphanResourceCountTransformer is a GraphTransformer that adds orphans
@@ -19,155 +18,43 @@ import (
 type OrphanResourceCountTransformer struct {
 	Concrete ConcreteResourceInstanceNodeFunc
 
-	Count   int                  // Actual count of the resource, or -1 if count is not set at all
-	ForEach map[string]cty.Value // The ForEach map on the resource
-	Addr    addrs.AbsResource    // Addr of the resource to look for orphans
-	State   *states.State        // Full global state
+	Addr          addrs.AbsResource           // Addr of the resource to look for orphans
+	InstanceAddrs []addrs.AbsResourceInstance // Addresses that currently exist in config
+	State         *states.State               // Full global state
 }
 
 func (t *OrphanResourceCountTransformer) Transform(g *Graph) error {
+	// FIXME: This is currently assuming that all of the instances of
+	// this resource belong to a single module instance, which is true
+	// at the time of writing this because Terraform Core doesn't support
+	// repetition of module calls yet, but this will need to be corrected
+	// in order to support count and for_each on module calls, where
+	// our t.InstanceAddrs may contain resource instances from many different
+	// module instances.
 	rs := t.State.Resource(t.Addr)
 	if rs == nil {
 		return nil // Resource doesn't exist in state, so nothing to do!
 	}
 
-	haveKeys := make(map[addrs.InstanceKey]struct{})
+	// This is an O(n*m) analysis, which we accept for now because the
+	// number of instances of a single resource ought to always be small in any
+	// reasonable Terraform configuration.
+Have:
 	for key := range rs.Instances {
-		haveKeys[key] = struct{}{}
-	}
-
-	// if for_each is set, use that transformer
-	if t.ForEach != nil {
-		return t.transformForEach(haveKeys, g)
-	}
-	if t.Count < 0 {
-		return t.transformNoCount(haveKeys, g)
-	}
-	if t.Count == 0 {
-		return t.transformZeroCount(haveKeys, g)
-	}
-	return t.transformCount(haveKeys, g)
-}
-
-func (t *OrphanResourceCountTransformer) transformForEach(haveKeys map[addrs.InstanceKey]struct{}, g *Graph) error {
-	// If there is a NoKey node, add this to the graph first,
-	// so that we can create edges to it in subsequent (StringKey) nodes.
-	// This is because the last item determines the resource mode for the whole resource,
-	// (see SetResourceInstanceCurrent for more information) and we need to evaluate
-	// an orphaned (NoKey) resource before the in-memory state is updated
-	// to deal with a new for_each resource
-	_, hasNoKeyNode := haveKeys[addrs.NoKey]
-	var noKeyNode dag.Vertex
-	if hasNoKeyNode {
-		abstract := NewNodeAbstractResourceInstance(t.Addr.Instance(addrs.NoKey))
-		noKeyNode = abstract
-		if f := t.Concrete; f != nil {
-			noKeyNode = f(abstract)
+		thisAddr := t.Addr.Instance(key)
+		for _, wantAddr := range t.InstanceAddrs {
+			if wantAddr.Equal(thisAddr) {
+				continue Have
+			}
 		}
-		g.Add(noKeyNode)
-	}
+		// If thisAddr is not in t.InstanceAddrs then we've found an "orphan"
 
-	for key := range haveKeys {
-		// If the key is no-key, we have already added it, so skip
-		if key == addrs.NoKey {
-			continue
-		}
-
-		s, _ := key.(addrs.StringKey)
-		// If the key is present in our current for_each, carry on
-		if _, ok := t.ForEach[string(s)]; ok {
-			continue
-		}
-
-		abstract := NewNodeAbstractResourceInstance(t.Addr.Instance(key))
+		abstract := NewNodeAbstractResourceInstance(thisAddr)
 		var node dag.Vertex = abstract
 		if f := t.Concrete; f != nil {
 			node = f(abstract)
 		}
-		log.Printf("[TRACE] OrphanResourceCount(non-zero): adding %s as %T", t.Addr, node)
-		g.Add(node)
-
-		// Add edge to noKeyNode if it exists
-		if hasNoKeyNode {
-			g.Connect(dag.BasicEdge(node, noKeyNode))
-		}
-	}
-	return nil
-}
-
-func (t *OrphanResourceCountTransformer) transformCount(haveKeys map[addrs.InstanceKey]struct{}, g *Graph) error {
-	// Due to the logic in Transform, we only get in here if our count is
-	// at least one.
-
-	_, have0Key := haveKeys[addrs.IntKey(0)]
-
-	for key := range haveKeys {
-		if key == addrs.NoKey && !have0Key {
-			// If we have no 0-key then we will accept a no-key instance
-			// as an alias for it.
-			continue
-		}
-
-		i, isInt := key.(addrs.IntKey)
-		if isInt && int(i) < t.Count {
-			continue
-		}
-
-		abstract := NewNodeAbstractResourceInstance(t.Addr.Instance(key))
-		var node dag.Vertex = abstract
-		if f := t.Concrete; f != nil {
-			node = f(abstract)
-		}
-		log.Printf("[TRACE] OrphanResourceCount(non-zero): adding %s as %T", t.Addr, node)
-		g.Add(node)
-	}
-
-	return nil
-}
-
-func (t *OrphanResourceCountTransformer) transformZeroCount(haveKeys map[addrs.InstanceKey]struct{}, g *Graph) error {
-	// This case is easy: we need to orphan any keys we have at all.
-
-	for key := range haveKeys {
-		abstract := NewNodeAbstractResourceInstance(t.Addr.Instance(key))
-		var node dag.Vertex = abstract
-		if f := t.Concrete; f != nil {
-			node = f(abstract)
-		}
-		log.Printf("[TRACE] OrphanResourceCount(zero): adding %s as %T", t.Addr, node)
-		g.Add(node)
-	}
-
-	return nil
-}
-
-func (t *OrphanResourceCountTransformer) transformNoCount(haveKeys map[addrs.InstanceKey]struct{}, g *Graph) error {
-	// Negative count indicates that count is not set at all, in which
-	// case we expect to have a single instance with no key set at all.
-	// However, we'll also accept an instance with key 0 set as an alias
-	// for it, in case the user has just deleted the "count" argument and
-	// so wants to keep the first instance in the set.
-
-	_, haveNoKey := haveKeys[addrs.NoKey]
-	_, have0Key := haveKeys[addrs.IntKey(0)]
-	keepKey := addrs.NoKey
-	if have0Key && !haveNoKey {
-		// If we don't have a no-key instance then we can use the 0-key instance
-		// instead.
-		keepKey = addrs.IntKey(0)
-	}
-
-	for key := range haveKeys {
-		if key == keepKey {
-			continue
-		}
-
-		abstract := NewNodeAbstractResourceInstance(t.Addr.Instance(key))
-		var node dag.Vertex = abstract
-		if f := t.Concrete; f != nil {
-			node = f(abstract)
-		}
-		log.Printf("[TRACE] OrphanResourceCount(no-count): adding %s as %T", t.Addr, node)
+		log.Printf("[TRACE] OrphanResourceCountTransformer: adding %s as %T", thisAddr, node)
 		g.Add(node)
 	}
 

--- a/terraform/transform_orphan_count_test.go
+++ b/terraform/transform_orphan_count_test.go
@@ -1,5 +1,10 @@
 package terraform
 
+// FIXME: Update these tests for the new OrphanResourceCountTransformer
+// interface that expects to be given a list of instance addresses that
+// exist in config.
+
+/*
 import (
 	"strings"
 	"testing"
@@ -433,3 +438,4 @@ aws_instance.foo (orphan)
 aws_instance.foo["bar"] (orphan)
   aws_instance.foo (orphan)
 `
+*/

--- a/terraform/transform_resource_count.go
+++ b/terraform/transform_resource_count.go
@@ -1,10 +1,11 @@
 package terraform
 
 import (
+	"log"
+
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/dag"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // ResourceCountTransformer is a GraphTransformer that expands the count
@@ -15,19 +16,12 @@ type ResourceCountTransformer struct {
 	Concrete ConcreteResourceInstanceNodeFunc
 	Schema   *configschema.Block
 
-	// Count is either the number of indexed instances to create, or -1 to
-	// indicate that count is not set at all and thus a no-key instance should
-	// be created.
-	Count   int
-	ForEach map[string]cty.Value
-	Addr    addrs.AbsResource
+	Addr          addrs.AbsResource
+	InstanceAddrs []addrs.AbsResourceInstance
 }
 
 func (t *ResourceCountTransformer) Transform(g *Graph) error {
-	if t.Count < 0 && t.ForEach == nil {
-		// Negative count indicates that count is not set at all.
-		addr := t.Addr.Instance(addrs.NoKey)
-
+	for _, addr := range t.InstanceAddrs {
 		abstract := NewNodeAbstractResourceInstance(addr)
 		abstract.Schema = t.Schema
 		var node dag.Vertex = abstract
@@ -35,37 +29,8 @@ func (t *ResourceCountTransformer) Transform(g *Graph) error {
 			node = f(abstract)
 		}
 
-		g.Add(node)
-		return nil
-	}
-
-	// Add nodes related to the for_each expression
-	for key := range t.ForEach {
-		addr := t.Addr.Instance(addrs.StringKey(key))
-		abstract := NewNodeAbstractResourceInstance(addr)
-		abstract.Schema = t.Schema
-		var node dag.Vertex = abstract
-		if f := t.Concrete; f != nil {
-			node = f(abstract)
-		}
-
+		log.Printf("[TRACE] ResourceCountTransformer: adding %s as %T", addr, node)
 		g.Add(node)
 	}
-
-	// For each count, build and add the node
-	for i := 0; i < t.Count; i++ {
-		key := addrs.IntKey(i)
-		addr := t.Addr.Instance(key)
-
-		abstract := NewNodeAbstractResourceInstance(addr)
-		abstract.Schema = t.Schema
-		var node dag.Vertex = abstract
-		if f := t.Concrete; f != nil {
-			node = f(abstract)
-		}
-
-		g.Add(node)
-	}
-
 	return nil
 }


### PR DESCRIPTION
Our existing handling of `count` and `for_each` for resources is rather scattered across different parts of Terraform.

This PR represents some initial experimentation towards centralizing the expansion logic for resources and for modules (looking forward to future module `count` and `for_each`) to help the different parts of Terraform Core that deal with the repetition constructs to coordinate with each other in a more organized way.

The `Expander` type includes three different families of methods:

* `Set*` methods (`SetResourceSingle`, `SetResourceCount`, `SetResourceForEach`, `SetModuleCount`) are used to record the results of evaluating the `count` and `for_each` expressions in the configuration for later use by the `Expand*` family.
* `Expand*` methods (`ExpandResource` and `ExpandModule`) take the addresses of static (unexpanded) objects in the configuration and return all of the instance addresses that result from the expansions that were recorded by earlier calls to the `Set*` methods.

    Because modules can nest inside other modules, the `Expand*` methods fully expand all levels of the tree and so the number of instances for a particular object can grow exponentially for objects in deeper modules.
* `Get*RepetitionData` methods (`GetResourceInstanceRepetitionData` and `GetModuleInstanceRepetitionData`) take the absolute address of a particular module instance or resource instance identified by the `Expand*` family and return a decision about what values should appear for `each.key`, `each.value`, and `count.index` when evaluating the configuration for the identified instance.

Each family feeds into the next, so they must be called in a particular order for correct operation. The graph walk can take care of ensuring the correct ordering of calls so that data is always available before it is needed.

---

As an initial proof-of-concept I integrated `instances.Expander` in a rough way to replace some -- but not all -- of the scattered `count` and `for_each` logic for resources. This now explicitly registers that every module in the configuration is a singleton (`count` and `for_each` aren't supported there yet) and then registers the repetition mode of each resource, which then allows the `DynamicExpand` logic to just ask the expander what instances it ought to be creating.

---

This `Expander` thing is also intended to be responsible for deciding what goes in `each.key`, `each.value`, and `count.index` for expressions, but I wasn't able to wire that up just yet because the apply graph (which is pre-expanded with nodes representing resource instances, not resources) isn't interacting with expander quite right yet, and the codepaths that do expression evaluation all run in both the plan and apply phases.

In principle though, if the `Expander` is being populated properly on all walks, we would be able to get the values representing the current repetition using the `GetResourceInstanceRepetitionData` method, which takes an absolute resource address and returns an object giving the `cty.Value` to use for `each.key`, `each.value` and `count.index`.

---

If this were to be taken forward as the basis for module `count` and `for_each`, that would require us to do some rework on the way Terraform Core implements the plan walk so that it's clear that the nodes in the main plan graph represent configuration constructs belonging to unexpanded modules only (not to module instances), and add `DynamicExpand` to _all_ of the nodes representing configuration constructs which calls into the `Expander` instance in order to find all of the module instances that the configuration construct is instantiated in. That would be a far more disruptive change, so I've not attempted that yet, but the new `DynamicExpand` implementation for _resources_ is ready to deal with `count` and `for_each` on modules once the rest of the plan graph catches up.

---

This does appear to work and pass all the existing context tests without modification, but for the moment it's mainly intended as a conversation starter for whether this particular direction -- `DynamicExpand` on _everything_ -- feels good for module `count` and `for_each`.
