### PR TITLE
command/json{state,plan}: check for null values

### DIFF
--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -26,7 +26,7 @@ type stateValues struct {
 type attributeValues map[string]interface{}
 
 func marshalAttributeValues(value cty.Value, schema *configschema.Block) attributeValues {
-	if value == cty.NilVal {
+	if value == cty.NilVal || value.IsNull() {
 		return nil
 	}
 	ret := make(attributeValues)

--- a/command/jsonplan/values_test.go
+++ b/command/jsonplan/values_test.go
@@ -31,6 +31,18 @@ func TestMarshalAttributeValues(t *testing.T) {
 			nil,
 		},
 		{
+			cty.NullVal(cty.String),
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {
+						Type:     cty.String,
+						Optional: true,
+					},
+				},
+			},
+			nil,
+		},
+		{
 			cty.ObjectVal(map[string]cty.Value{
 				"foo": cty.StringVal("bar"),
 			}),

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -101,9 +101,10 @@ type resource struct {
 type attributeValues map[string]interface{}
 
 func marshalAttributeValues(value cty.Value, schema *configschema.Block) attributeValues {
-	if value == cty.NilVal {
+	if value == cty.NilVal || value.IsNull() {
 		return nil
 	}
+
 	ret := make(attributeValues)
 
 	it := value.ElementIterator()

--- a/command/jsonstate/state_test.go
+++ b/command/jsonstate/state_test.go
@@ -92,6 +92,18 @@ func TestMarshalAttributeValues(t *testing.T) {
 			nil,
 		},
 		{
+			cty.NullVal(cty.String),
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {
+						Type:     cty.String,
+						Optional: true,
+					},
+				},
+			},
+			nil,
+		},
+		{
 			cty.ObjectVal(map[string]cty.Value{
 				"foo": cty.StringVal("bar"),
 			}),


### PR DESCRIPTION
The code responsible for marshalling attribute values was checking for
nil values, but not null.

Fixes #23485, #23274