### PR TITLE
terraform: use provider FQN as map key in provider factories

### DIFF
--- a/backend/local/testing.go
+++ b/backend/local/testing.go
@@ -112,9 +112,10 @@ func TestLocalProvider(t *testing.T, b *Local, name string, schema *terraform.Pr
 	}
 
 	// Setup our provider
+	fqn := shimProviderFqn(name)
 	b.ContextOpts.ProviderResolver = providers.ResolverFixed(
 		map[string]providers.Factory{
-			name: providers.FactoryFixed(p),
+			fqn: providers.FactoryFixed(p),
 		},
 	)
 
@@ -210,4 +211,9 @@ func testTempDir(t *testing.T) string {
 func testStateFile(t *testing.T, path string, s *states.State) {
 	stateFile := statemgr.NewFilesystem(path)
 	stateFile.WriteState(s)
+}
+
+// Provider Source readiness helper function!
+func shimProviderFqn(typeName string) string {
+	return "registry.terraform.io/hashicorp/" + typeName
 }

--- a/builtin/providers/terraform/provider_test.go
+++ b/builtin/providers/terraform/provider_test.go
@@ -17,7 +17,7 @@ func init() {
 
 	testAccProvider = NewProvider()
 	testAccProviders = map[string]*Provider{
-		"terraform": testAccProvider,
+		"registry.terraform.io/hashicorp/terraform": testAccProvider,
 	}
 }
 

--- a/builtin/providers/test/provider_test.go
+++ b/builtin/providers/test/provider_test.go
@@ -19,6 +19,6 @@ func TestProvider(t *testing.T) {
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
-		"test": testAccProvider,
+		"registry.terraform.io/hashicorp/test": testAccProvider,
 	}
 }

--- a/builtin/providers/test/resource_import_other_test.go
+++ b/builtin/providers/test/resource_import_other_test.go
@@ -23,7 +23,6 @@ resource "test_resource_import_other" "foo" {
 			{
 				ImportState:  true,
 				ResourceName: "test_resource_import_other.foo",
-
 				ImportStateCheck: func(iss []*terraform.InstanceState) error {
 					if got, want := len(iss), 2; got != want {
 						return fmt.Errorf("wrong number of resources %d; want %d", got, want)

--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -784,7 +784,7 @@ resource "test_resource" "foo" {
 }
 
 func TestResource_setDrift(t *testing.T) {
-	testProvider := testAccProviders["test"]
+	testProvider := testAccProviders["registry.terraform.io/hashicorp/test"]
 	res := testProvider.(*schema.Provider).ResourcesMap["test_resource"]
 
 	// reset the Read function after the test

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -203,7 +203,7 @@ func TestApply_parallelism(t *testing.T) {
 				NewState: cty.EmptyObjectVal,
 			}
 		}
-		providerFactories[name] = providers.FactoryFixed(provider)
+		providerFactories[shimProviderFqn(name)] = providers.FactoryFixed(provider)
 	}
 	testingOverrides := &testingOverrides{
 		ProviderResolver: providers.ResolverFixed(providerFactories),

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -115,7 +115,7 @@ func metaOverridesForProvider(p providers.Interface) *testingOverrides {
 	return &testingOverrides{
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": providers.FactoryFixed(p),
+				"registry.terraform.io/hashicorp/test": providers.FactoryFixed(p),
 			},
 		),
 	}
@@ -125,7 +125,7 @@ func metaOverridesForProviderAndProvisioner(p providers.Interface, pr provisione
 	return &testingOverrides{
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": providers.FactoryFixed(p),
+				"registry.terraform.io/hashicorp/test": providers.FactoryFixed(p),
 			},
 		),
 		Provisioners: map[string]provisioners.Factory{

--- a/command/import_test.go
+++ b/command/import_test.go
@@ -550,7 +550,7 @@ func TestImport_providerNameMismatch(t *testing.T) {
 			testingOverrides: &testingOverrides{
 				ProviderResolver: providers.ResolverFixed(
 					map[string]providers.Factory{
-						"test-beta": providers.FactoryFixed(p),
+						"registry.terraform.io/hashicorp/test-beta": providers.FactoryFixed(p),
 					},
 				),
 			},

--- a/command/plugins.go
+++ b/command/plugins.go
@@ -64,12 +64,13 @@ func (r *multiVersionProviderResolver) ResolveProviders(
 
 	chosen := choosePlugins(r.Available, r.Internal, reqd)
 	for name, req := range reqd {
+		fqn := shimProviderFqn(name)
 		if factory, isInternal := r.Internal[name]; isInternal {
 			if !req.Versions.Unconstrained() {
 				errs = append(errs, fmt.Errorf("provider.%s: this provider is built in to Terraform and so it does not support version constraints", name))
 				continue
 			}
-			factories[name] = factory
+			factories[fqn] = factory
 			continue
 		}
 
@@ -84,7 +85,7 @@ func (r *multiVersionProviderResolver) ResolveProviders(
 				continue
 			}
 
-			factories[name] = providerFactory(newest)
+			factories[fqn] = providerFactory(newest)
 		} else {
 			msg := fmt.Sprintf("provider.%s: no suitable version installed", name)
 
@@ -419,4 +420,9 @@ func newProvisionerClient(client *plugin.Client) (provisioners.Interface, error)
 	p := raw.(*tfplugin.GRPCProvisioner)
 	p.PluginClient = client
 	return p, nil
+}
+
+// Provider Source readiness helper function
+func shimProviderFqn(typeName string) string {
+	return "registry.terraform.io/hashicorp/" + typeName
 }

--- a/command/plugins_test.go
+++ b/command/plugins_test.go
@@ -51,7 +51,8 @@ func TestMultiVersionProviderResolver(t *testing.T) {
 		if ct := len(got); ct != 1 {
 			t.Errorf("wrong number of results %d; want 1", ct)
 		}
-		if _, exists := got["plugin"]; !exists {
+		fqn := shimProviderFqn("plugin")
+		if _, exists := got[fqn]; !exists {
 			t.Errorf("provider \"plugin\" not in result")
 		}
 	})
@@ -79,7 +80,8 @@ func TestMultiVersionProviderResolver(t *testing.T) {
 		if ct := len(got); ct != 1 {
 			t.Errorf("wrong number of results %d; want 1", ct)
 		}
-		if _, exists := got["internal"]; !exists {
+		fqn := shimProviderFqn("internal")
+		if _, exists := got[fqn]; !exists {
 			t.Errorf("provider \"internal\" not in result")
 		}
 	})

--- a/configs/config.go
+++ b/configs/config.go
@@ -2,6 +2,7 @@ package configs
 
 import (
 	"sort"
+	"strings"
 
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -187,7 +188,8 @@ func (c *Config) gatherProviderTypes(m map[string]struct{}) {
 	}
 
 	for _, pc := range c.Module.ProviderConfigs {
-		m[pc.Name] = struct{}{}
+		typeName := shimProviderNameFromFqn(pc.Name)
+		m[typeName] = struct{}{}
 	}
 	for _, rc := range c.Module.ManagedResources {
 		providerAddr := rc.ProviderConfigAddr()
@@ -201,5 +203,16 @@ func (c *Config) gatherProviderTypes(m map[string]struct{}) {
 	// Must also visit our child modules, recursively.
 	for _, cc := range c.Children {
 		cc.gatherProviderTypes(m)
+	}
+}
+
+// provider source readiness helper function
+// only relevant for tests.
+func shimProviderNameFromFqn(str string) string {
+	if strings.Contains(str, "registry.terraform.io") {
+		parts := strings.Split(str, "/")
+		return parts[len(parts)-1]
+	} else {
+		return str
 	}
 }

--- a/configs/configupgrade/analysis.go
+++ b/configs/configupgrade/analysis.go
@@ -241,7 +241,8 @@ func (u *Upgrader) analyze(ms ModuleSources) (*analysis, error) {
 		return nil, fmt.Errorf("error resolving providers:\n%s", errorsMsg)
 	}
 
-	for name, fn := range providerFactories {
+	for fqn, fn := range providerFactories {
+		name := shimProviderNameFromFqn(fqn)
 		log.Printf("[TRACE] Fetching schema from provider %q", name)
 		provider, err := fn()
 		if err != nil {
@@ -264,7 +265,7 @@ func (u *Upgrader) analyze(ms ModuleSources) (*analysis, error) {
 		for t, s := range resp.DataSources {
 			schema.DataSources[t] = s.Block
 		}
-		ret.ProviderSchemas[name] = schema
+		ret.ProviderSchemas[fqn] = schema
 	}
 
 	for name, fn := range u.Provisioners {

--- a/configs/configupgrade/analysis_expr.go
+++ b/configs/configupgrade/analysis_expr.go
@@ -86,7 +86,7 @@ func (d analysisData) GetResource(addr addrs.Resource, rng tfdiags.SourceRange) 
 		log.Printf("[TRACE] configupgrade: analysis.GetResource doesn't have a provider type for %s", addr)
 		return cty.DynamicVal, nil
 	}
-	providerSchema, ok := d.an.ProviderSchemas[providerType]
+	providerSchema, ok := d.an.ProviderSchemas[shimProviderFqn(providerType)]
 	if !ok {
 		// Should not be possible, since analysis loads schema for every provider.
 		log.Printf("[TRACE] configupgrade: analysis.GetResource doesn't have a provider schema for for %q", providerType)

--- a/configs/configupgrade/upgrade_expr.go
+++ b/configs/configupgrade/upgrade_expr.go
@@ -923,7 +923,7 @@ func upgradeTerraformRemoteStateTraversalParts(parts []string, an *analysis) []s
 	// the user intended this to be an output, or whether it's one of the real
 	// attributes of this data source.
 	var schema *configschema.Block
-	if providerSchema := an.ProviderSchemas["terraform"]; providerSchema != nil {
+	if providerSchema := an.ProviderSchemas["registry.terraform.io/hashicorp/terraform"]; providerSchema != nil {
 		schema, _ = providerSchema.SchemaForResourceType(addrs.DataResourceMode, "terraform_remote_state")
 	}
 	// Schema should be available in all reasonable cases, but might be nil

--- a/configs/configupgrade/upgrade_native.go
+++ b/configs/configupgrade/upgrade_native.go
@@ -304,7 +304,8 @@ func (u *Upgrader) upgradeNativeSyntaxResource(filename string, buf *bytes.Buffe
 	if !ok {
 		panic(fmt.Sprintf("unknown provider type for %s", addr.String()))
 	}
-	providerSchema, ok := an.ProviderSchemas[providerType]
+
+	providerSchema, ok := an.ProviderSchemas[shimProviderFqn(providerType)]
 	if !ok {
 		panic(fmt.Sprintf("missing schema for provider type %q", providerType))
 	}
@@ -357,7 +358,7 @@ func (u *Upgrader) upgradeNativeSyntaxProvider(filename string, buf *bytes.Buffe
 
 	// We should always have a schema for each provider in our analysis
 	// object. If not, it's a bug in the analyzer.
-	providerSchema, ok := an.ProviderSchemas[typeName]
+	providerSchema, ok := an.ProviderSchemas[shimProviderFqn(typeName)]
 	if !ok {
 		panic(fmt.Sprintf("missing schema for provider type %q", typeName))
 	}
@@ -793,4 +794,14 @@ func printLabelTodo(buf *bytes.Buffer, label string) {
 		"# state. Detailed information on the `state move` command can be found in the\n" +
 		"# documentation online: https://www.terraform.io/docs/commands/state/mv.html\n",
 	)
+}
+
+// provider source helper functions
+func shimProviderFqn(typeName string) string {
+	return "registry.terraform.io/hashicorp/" + typeName
+}
+
+func shimProviderNameFromFqn(fqn string) string {
+	parts := strings.Split(fqn, "/")
+	return parts[len(parts)-1]
 }

--- a/configs/configupgrade/upgrade_test.go
+++ b/configs/configupgrade/upgrade_test.go
@@ -187,7 +187,7 @@ func diffSourceFilesFallback(got, want []byte) []byte {
 }
 
 var testProviders = map[string]providers.Factory{
-	"test": providers.Factory(func() (providers.Interface, error) {
+	"registry.terraform.io/hashicorp/test": providers.Factory(func() (providers.Interface, error) {
 		p := &terraform.MockProvider{}
 		p.GetSchemaReturn = &terraform.ProviderSchema{
 			ResourceTypes: map[string]*configschema.Block{
@@ -236,7 +236,7 @@ var testProviders = map[string]providers.Factory{
 		}
 		return p, nil
 	}),
-	"terraform": providers.Factory(func() (providers.Interface, error) {
+	"registry.terraform.io/hashicorp/terraform": providers.Factory(func() (providers.Interface, error) {
 		p := &terraform.MockProvider{}
 		p.GetSchemaReturn = &terraform.ProviderSchema{
 			DataSources: map[string]*configschema.Block{
@@ -252,7 +252,7 @@ var testProviders = map[string]providers.Factory{
 		}
 		return p, nil
 	}),
-	"aws": providers.Factory(func() (providers.Interface, error) {
+	"registry.terraform.io/hashicorp/aws": providers.Factory(func() (providers.Interface, error) {
 		// This is here only so we can test the provisioner connection info
 		// migration behavior, which is resource-type specific. Do not use
 		// it in any other tests.

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -485,11 +485,12 @@ func Test(t TestT, c TestCase) {
 	// get instances of all providers, so we can use the individual
 	// resources to shim the state during the tests.
 	providers := make(map[string]terraform.ResourceProvider)
-	for name, pf := range testProviderFactories(c) {
+	for fqn, pf := range testProviderFactories(c) {
 		p, err := pf()
 		if err != nil {
 			t.Fatal(err)
 		}
+		name := shimProviderNameFromFqn(fqn)
 		providers[name] = p
 	}
 
@@ -1317,5 +1318,25 @@ func detailedErrorMessage(err error) string {
 		return tErr.ErrorDetail()
 	default:
 		return err.Error()
+	}
+}
+
+// provider source readiness helper function
+// only relevant for tests.
+func shimProviderNameFromFqn(str string) string {
+	if strings.Contains(str, "registry.terraform.io") {
+		parts := strings.Split(str, "/")
+		return parts[len(parts)-1]
+	} else {
+		return str
+	}
+}
+
+// Provider Source readiness helper function!
+func shimProviderFqn(str string) string {
+	if strings.Contains(str, "registry.terraform.io/hashicorp") {
+		return str
+	} else {
+		return "registry.terraform.io/hashicorp/" + str
 	}
 }

--- a/helper/resource/testing_import_state.go
+++ b/helper/resource/testing_import_state.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-// testStepImportState runs an imort state test step
+// testStepImportState runs an import state test step
 func testStepImportState(
 	opts terraform.ContextOpts,
 	state *terraform.State,
@@ -54,10 +54,8 @@ func testStepImportState(
 	}
 
 	opts.Config = cfg
-
 	// import tests start with empty state
 	opts.State = states.NewState()
-
 	ctx, stepDiags := terraform.NewContext(&opts)
 	if stepDiags.HasErrors() {
 		return state, stepDiags.Err()
@@ -74,7 +72,6 @@ func testStepImportState(
 	if stepDiags.HasErrors() {
 		return nil, stepDiags.Err()
 	}
-
 	// Do the import
 	importedState, stepDiags := ctx.Import(&terraform.ImportOpts{
 		// Set the module so that any provider config is loaded
@@ -87,6 +84,7 @@ func testStepImportState(
 			},
 		},
 	})
+
 	if stepDiags.HasErrors() {
 		log.Printf("[ERROR] Test: ImportState failure: %s", stepDiags.Err())
 		return state, stepDiags.Err()
@@ -96,7 +94,6 @@ func testStepImportState(
 	if err != nil {
 		return nil, err
 	}
-
 	// Go through the new state and verify
 	if step.ImportStateCheck != nil {
 		var states []*terraform.InstanceState
@@ -111,7 +108,6 @@ func testStepImportState(
 			return state, err
 		}
 	}
-
 	// Verify that all the states match
 	if step.ImportStateVerify {
 		new := newState.RootModule().Resources

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -1049,12 +1049,12 @@ func TestTestProviderResolver(t *testing.T) {
 
 	c := TestCase{
 		ProviderFactories: map[string]terraform.ResourceProviderFactory{
-			"foo": terraform.ResourceProviderFactoryFixed(stubProvider("foo")),
-			"bar": terraform.ResourceProviderFactoryFixed(stubProvider("bar")),
+			"registry.terraform.io/hashicorp/foo": terraform.ResourceProviderFactoryFixed(stubProvider("foo")),
+			"registry.terraform.io/hashicorp/bar": terraform.ResourceProviderFactoryFixed(stubProvider("bar")),
 		},
 		Providers: map[string]terraform.ResourceProvider{
-			"baz": stubProvider("baz"),
-			"bop": stubProvider("bop"),
+			"registry.terraform.io/hashicorp/baz": stubProvider("baz"),
+			"registry.terraform.io/hashicorp/bop": stubProvider("bop"),
 		},
 	}
 
@@ -1080,7 +1080,7 @@ func TestTestProviderResolver(t *testing.T) {
 
 	for name := range reqd {
 		t.Run(name, func(t *testing.T) {
-			pf, ok := factories[name]
+			pf, ok := factories[shimProviderFqn(name)]
 			if !ok {
 				t.Fatalf("no factory for %q", name)
 			}

--- a/moduledeps/provider.go
+++ b/moduledeps/provider.go
@@ -11,7 +11,12 @@ type ProviderInstance string
 // Type returns the provider type of this instance. For example, for an instance
 // named "aws.foo" the type is "aws".
 func (p ProviderInstance) Type() string {
-	t := string(p)
+
+	// strip FQN
+	parts := strings.Split(string(p), "/")
+	// TODO mid-step: fail if p is not an FQN
+	t := parts[len(parts)-1]
+
 	if dotPos := strings.Index(t, "."); dotPos != -1 {
 		t = t[:dotPos]
 	}
@@ -22,7 +27,11 @@ func (p ProviderInstance) Type() string {
 // has the alias "foo", while an instance named just "docker" has no alias,
 // so the empty string would be returned.
 func (p ProviderInstance) Alias() string {
-	t := string(p)
+	// strip FQN
+	parts := strings.Split(string(p), "/")
+	// TODO mid-step: fail if p is not an FQN
+	t := parts[len(parts)-1]
+
 	if dotPos := strings.Index(t, "."); dotPos != -1 {
 		return t[dotPos+1:]
 	}

--- a/providers/resolver.go
+++ b/providers/resolver.go
@@ -39,8 +39,9 @@ func ResolverFixed(factories map[string]Factory) Resolver {
 		ret := make(map[string]Factory, len(reqd))
 		var errs []error
 		for name := range reqd {
-			if factory, exists := factories[name]; exists {
-				ret[name] = factory
+			fqn := shimProviderFqn(name)
+			if factory, exists := factories[fqn]; exists {
+				ret[fqn] = factory
 			} else {
 				errs = append(errs, fmt.Errorf("provider %q is not available", name))
 			}
@@ -109,4 +110,9 @@ func ProviderHasDataSource(provider Interface, dataSourceName string) bool {
 
 	_, exists := resp.DataSources[dataSourceName]
 	return exists
+}
+
+// Provider Source readiness helper function!
+func shimProviderFqn(typeName string) string {
+	return "registry.terraform.io/hashicorp/" + typeName
 }

--- a/repl/session_test.go
+++ b/repl/session_test.go
@@ -212,7 +212,7 @@ func testSession(t *testing.T, test testSessionTest) {
 	ctx, diags := terraform.NewContext(&terraform.ContextOpts{
 		State: test.State,
 		ProviderResolver: providers.ResolverFixed(map[string]providers.Factory{
-			"test": providers.FactoryFixed(p),
+			"registry.terraform.io/hashicorp/test": providers.FactoryFixed(p),
 		}),
 		Config: config,
 	})

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -167,7 +167,6 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 			reqd.LockExecutables(opts.ProviderSHA256s)
 		}
 		log.Printf("[TRACE] terraform.NewContext: resolving provider version selections")
-
 		var providerDiags tfdiags.Diagnostics
 		providerFactories, providerDiags = resourceProviderFactories(opts.ProviderResolver, reqd)
 		diags = diags.Append(providerDiags)

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -40,7 +40,7 @@ func TestContext2Apply_basic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -83,7 +83,7 @@ func TestContext2Apply_unstable(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -139,7 +139,7 @@ func TestContext2Apply_escape(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -171,7 +171,7 @@ func TestContext2Apply_resourceCountOneList(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -204,7 +204,7 @@ func TestContext2Apply_resourceCountZeroList(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -262,7 +262,7 @@ func TestContext2Apply_resourceDependsOnModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -350,7 +350,7 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 			State: state,
@@ -383,7 +383,7 @@ func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -430,7 +430,7 @@ func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 			State:   globalState,
@@ -489,7 +489,7 @@ func TestContext2Apply_resourceDependsOnModuleGrandchild(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -542,7 +542,7 @@ func TestContext2Apply_resourceDependsOnModuleInModule(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -573,7 +573,7 @@ func TestContext2Apply_mapVarBetweenModules(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -615,7 +615,7 @@ func TestContext2Apply_refCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -650,7 +650,7 @@ func TestContext2Apply_providerAlias(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -688,7 +688,7 @@ func TestContext2Apply_providerAliasConfigure(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"another": testProviderFuncFixed(p2),
+				"registry.terraform.io/hashicorp/another": testProviderFuncFixed(p2),
 			},
 		),
 	})
@@ -746,7 +746,7 @@ func TestContext2Apply_providerWarning(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -784,7 +784,7 @@ func TestContext2Apply_emptyModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -833,7 +833,7 @@ func TestContext2Apply_createBeforeDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -890,7 +890,7 @@ func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -958,7 +958,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1034,7 +1034,7 @@ func TestContext2Apply_createBeforeDestroy_hook(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1112,7 +1112,7 @@ func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1178,7 +1178,7 @@ func TestContext2Apply_createBeforeDestroy_deposedOnly(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1230,7 +1230,7 @@ func TestContext2Apply_destroyComputed(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -1304,7 +1304,7 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:       state,
@@ -1431,7 +1431,7 @@ func testContext2Apply_destroyDependsOnStateOnly(t *testing.T, state *states.Sta
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:       state,
@@ -1559,7 +1559,7 @@ func testContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T, state *stat
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:       state,
@@ -1597,7 +1597,7 @@ func TestContext2Apply_dataBasic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1647,7 +1647,7 @@ func TestContext2Apply_destroyData(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -1718,7 +1718,7 @@ func TestContext2Apply_destroySkipsCBD(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -1760,7 +1760,7 @@ func TestContext2Apply_destroyModuleVarProviderConfig(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -1806,7 +1806,7 @@ func TestContext2Apply_destroyCrossProviders(t *testing.T) {
 	}
 
 	providers := map[string]providers.Factory{
-		"aws": testProviderFuncFixed(p_aws),
+		"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p_aws),
 	}
 
 	// Bug only appears from time to time,
@@ -1883,7 +1883,7 @@ func TestContext2Apply_minimal(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1913,7 +1913,7 @@ func TestContext2Apply_badDiff(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1948,7 +1948,7 @@ func TestContext2Apply_cancel(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2027,7 +2027,7 @@ func TestContext2Apply_cancelBlock(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2157,7 +2157,7 @@ func TestContext2Apply_provisionerDestroyForEach(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -2202,7 +2202,7 @@ func TestContext2Apply_cancelProvisioner(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -2300,7 +2300,7 @@ func TestContext2Apply_compute(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2376,7 +2376,7 @@ func TestContext2Apply_countDecrease(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -2437,7 +2437,7 @@ func TestContext2Apply_countDecreaseToOneX(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -2501,7 +2501,7 @@ func TestContext2Apply_countDecreaseToOneCorrupted(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -2558,7 +2558,7 @@ func TestContext2Apply_countTainted(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -2613,7 +2613,7 @@ func TestContext2Apply_countVariable(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2643,7 +2643,7 @@ func TestContext2Apply_countVariableRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2679,7 +2679,7 @@ func TestContext2Apply_provisionerInterpCount(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[string]providers.Factory{
-			"aws": testProviderFuncFixed(p),
+			"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 		},
 	)
 	provisioners := map[string]ProvisionerFactory{
@@ -2733,7 +2733,7 @@ func TestContext2Apply_foreachVariable(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -2768,7 +2768,7 @@ func TestContext2Apply_moduleBasic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2856,7 +2856,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -2908,7 +2908,7 @@ func TestContext2Apply_moduleInheritAlias(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2953,7 +2953,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2998,7 +2998,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3060,7 +3060,7 @@ func TestContext2Apply_moduleOrphanInheritAlias(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3118,7 +3118,7 @@ func TestContext2Apply_moduleOrphanProvider(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3169,7 +3169,7 @@ func TestContext2Apply_moduleOrphanGrandchildProvider(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3206,7 +3206,7 @@ func TestContext2Apply_moduleGrandchildProvider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3243,8 +3243,8 @@ func TestContext2Apply_moduleOnlyProvider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws":  testProviderFuncFixed(p),
-				"test": testProviderFuncFixed(pTest),
+				"registry.terraform.io/hashicorp/aws":  testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(pTest),
 			},
 		),
 	})
@@ -3274,7 +3274,7 @@ func TestContext2Apply_moduleProviderAlias(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3304,7 +3304,7 @@ func TestContext2Apply_moduleProviderAliasTargets(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -3346,7 +3346,7 @@ func TestContext2Apply_moduleProviderCloseNested(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -3411,7 +3411,7 @@ func TestContext2Apply_moduleVarRefExisting(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -3442,7 +3442,7 @@ func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -3466,7 +3466,7 @@ func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -3496,7 +3496,7 @@ func TestContext2Apply_moduleBool(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3528,7 +3528,7 @@ func TestContext2Apply_moduleTarget(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -3583,8 +3583,8 @@ func TestContext2Apply_multiProvider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
-				"do":  testProviderFuncFixed(pDO),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/do":  testProviderFuncFixed(pDO),
 			},
 		),
 	})
@@ -3651,8 +3651,8 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws":   testProviderFuncFixed(p),
-					"vault": testProviderFuncFixed(p2),
+					"registry.terraform.io/hashicorp/aws":   testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/vault": testProviderFuncFixed(p2),
 				},
 			),
 		})
@@ -3708,8 +3708,8 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 			Config:  m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws":   testProviderFuncFixed(p),
-					"vault": testProviderFuncFixed(p2),
+					"registry.terraform.io/hashicorp/aws":   testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/vault": testProviderFuncFixed(p2),
 				},
 			),
 		})
@@ -3778,8 +3778,8 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws":   testProviderFuncFixed(p),
-					"vault": testProviderFuncFixed(p2),
+					"registry.terraform.io/hashicorp/aws":   testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/vault": testProviderFuncFixed(p2),
 				},
 			),
 		})
@@ -3835,8 +3835,8 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 			Config:  m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws":   testProviderFuncFixed(p),
-					"vault": testProviderFuncFixed(p2),
+					"registry.terraform.io/hashicorp/aws":   testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/vault": testProviderFuncFixed(p2),
 				},
 			),
 		})
@@ -3873,7 +3873,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -3908,7 +3908,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 			State:  state,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 			Variables: InputValues{
@@ -4016,7 +4016,7 @@ func TestContext2Apply_multiVarComprehensive(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -4169,7 +4169,7 @@ func TestContext2Apply_multiVarOrder(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4205,7 +4205,7 @@ func TestContext2Apply_multiVarOrderInterp(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4243,7 +4243,7 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 			Variables: InputValues{
@@ -4311,7 +4311,7 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 			Variables: InputValues{
@@ -4371,7 +4371,7 @@ func TestContext2Apply_multiVarMissingState(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4397,7 +4397,7 @@ func TestContext2Apply_nilDiff(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4439,7 +4439,7 @@ func TestContext2Apply_outputDependsOn(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -4464,7 +4464,7 @@ func TestContext2Apply_outputDependsOn(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -4520,7 +4520,7 @@ func TestContext2Apply_outputOrphan(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -4570,7 +4570,7 @@ func TestContext2Apply_outputOrphanModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state.DeepCopy(),
@@ -4597,7 +4597,7 @@ func TestContext2Apply_outputOrphanModule(t *testing.T) {
 		Config: configs.NewEmptyConfig(),
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state.DeepCopy(),
@@ -4631,8 +4631,8 @@ func TestContext2Apply_providerComputedVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws":  testProviderFuncFixed(p),
-				"test": testProviderFuncFixed(pTest),
+				"registry.terraform.io/hashicorp/aws":  testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(pTest),
 			},
 		),
 	})
@@ -4683,7 +4683,7 @@ func TestContext2Apply_providerConfigureDisabled(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4721,7 +4721,7 @@ func TestContext2Apply_provisionerModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -4768,7 +4768,7 @@ func TestContext2Apply_Provisioner_compute(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -4818,7 +4818,7 @@ func TestContext2Apply_provisionerCreateFail(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -4859,7 +4859,7 @@ func TestContext2Apply_provisionerCreateFailNoId(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -4898,7 +4898,7 @@ func TestContext2Apply_provisionerFail(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -4954,7 +4954,7 @@ func TestContext2Apply_provisionerFail_createBeforeDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5004,7 +5004,7 @@ func TestContext2Apply_error_createBeforeDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -5055,7 +5055,7 @@ func TestContext2Apply_errorDestroy_createBeforeDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -5107,7 +5107,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 			},
 		},
 	}
-	ps := map[string]providers.Factory{"aws": testProviderFuncFixed(p)}
+	ps := map[string]providers.Factory{"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p)}
 	state := MustShimLegacyState(&State{
 		Modules: []*ModuleState{
 			&ModuleState{
@@ -5320,7 +5320,7 @@ func TestContext2Apply_provisionerFailContinue(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5369,7 +5369,7 @@ func TestContext2Apply_provisionerFailContinueHook(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5430,7 +5430,7 @@ func TestContext2Apply_provisionerDestroy(t *testing.T) {
 		Destroy: true,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5488,7 +5488,7 @@ func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 		Destroy: true,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5562,7 +5562,7 @@ func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
 		Destroy: true,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5638,7 +5638,7 @@ func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
 		Destroy: true,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5718,7 +5718,7 @@ func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5790,7 +5790,7 @@ func TestContext2Apply_provisionerDestroyModule(t *testing.T) {
 		Destroy: true,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5864,7 +5864,7 @@ func TestContext2Apply_provisionerDestroyRef(t *testing.T) {
 		Destroy: true,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5929,7 +5929,7 @@ func TestContext2Apply_provisionerDestroyRefInvalid(t *testing.T) {
 		Destroy: true,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5963,7 +5963,7 @@ func TestContext2Apply_provisionerResourceRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -6011,7 +6011,7 @@ func TestContext2Apply_provisionerSelfRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -6066,7 +6066,7 @@ func TestContext2Apply_provisionerMultiSelfRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -6128,7 +6128,7 @@ func TestContext2Apply_provisionerMultiSelfRefSingle(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -6185,7 +6185,7 @@ func TestContext2Apply_provisionerExplicitSelfRef(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 			Provisioners: map[string]ProvisionerFactory{
@@ -6216,7 +6216,7 @@ func TestContext2Apply_provisionerExplicitSelfRef(t *testing.T) {
 			State:   state,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 			Provisioners: map[string]ProvisionerFactory{
@@ -6258,7 +6258,7 @@ func TestContext2Apply_provisionerForEachSelfRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -6290,7 +6290,7 @@ func TestContext2Apply_Provisioner_Diff(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -6340,7 +6340,7 @@ func TestContext2Apply_Provisioner_Diff(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -6393,7 +6393,7 @@ func TestContext2Apply_outputDiffVars(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -6456,7 +6456,7 @@ func TestContext2Apply_destroyX(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6480,7 +6480,7 @@ func TestContext2Apply_destroyX(t *testing.T) {
 		Hooks:   []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6520,7 +6520,7 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6546,7 +6546,7 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 		Hooks:   []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6587,7 +6587,7 @@ func TestContext2Apply_destroyModulePrefix(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6616,7 +6616,7 @@ func TestContext2Apply_destroyModulePrefix(t *testing.T) {
 		Hooks:   []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6663,7 +6663,7 @@ func TestContext2Apply_destroyNestedModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -6713,7 +6713,7 @@ func TestContext2Apply_destroyDeeplyNestedModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -6748,7 +6748,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6780,7 +6780,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 			Hooks:   []Hook{h},
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6800,7 +6800,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 
 		ctxOpts.ProviderResolver = providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		)
 		ctx, diags = NewContext(ctxOpts)
@@ -6837,7 +6837,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6864,7 +6864,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 			Hooks:   []Hook{h},
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6882,7 +6882,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 
 		ctxOpts.ProviderResolver = providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		)
 		ctx, diags = NewContext(ctxOpts)
@@ -6920,7 +6920,7 @@ func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6943,7 +6943,7 @@ func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
 			State:   state,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 			Targets: []addrs.Targetable{
@@ -7003,7 +7003,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -7030,7 +7030,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 			Hooks:   []Hook{h},
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -7048,7 +7048,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 
 		ctxOpts.ProviderResolver = providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		)
 		ctx, diags = NewContext(ctxOpts)
@@ -7082,7 +7082,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7105,7 +7105,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 		Config:  m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7131,7 +7131,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 		Config:  m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7166,7 +7166,7 @@ func TestContext2Apply_destroyOrphan(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -7250,7 +7250,7 @@ func TestContext2Apply_destroyTaintedProvisioner(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -7289,7 +7289,7 @@ func TestContext2Apply_error(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7392,7 +7392,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 		}),
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7453,7 +7453,7 @@ func TestContext2Apply_errorCreateInvalidNew(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7531,7 +7531,7 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 		}),
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7594,7 +7594,7 @@ func TestContext2Apply_errorPartial(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -7662,7 +7662,7 @@ func TestContext2Apply_hook(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7716,7 +7716,7 @@ func TestContext2Apply_hookOrphan(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7747,7 +7747,7 @@ func TestContext2Apply_idAttr(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7805,7 +7805,7 @@ func TestContext2Apply_outputBasic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7835,7 +7835,7 @@ func TestContext2Apply_outputAdd(t *testing.T) {
 		Config: m1,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p1),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p1),
 			},
 		),
 	})
@@ -7857,7 +7857,7 @@ func TestContext2Apply_outputAdd(t *testing.T) {
 		Config: m2,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p2),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p2),
 			},
 		),
 		State: state1,
@@ -7888,7 +7888,7 @@ func TestContext2Apply_outputList(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7918,7 +7918,7 @@ func TestContext2Apply_outputMulti(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7948,7 +7948,7 @@ func TestContext2Apply_outputMultiIndex(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -8012,7 +8012,7 @@ func TestContext2Apply_taintX(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -8080,7 +8080,7 @@ func TestContext2Apply_taintDep(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -8144,7 +8144,7 @@ func TestContext2Apply_taintDepRequiresNew(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -8177,7 +8177,7 @@ func TestContext2Apply_targeted(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -8219,7 +8219,7 @@ func TestContext2Apply_targetedCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -8260,7 +8260,7 @@ func TestContext2Apply_targetedCountIndex(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -8295,7 +8295,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -8371,7 +8371,7 @@ func TestContext2Apply_destroyProvisionerWithLocals(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -8468,7 +8468,7 @@ func TestContext2Apply_destroyProvisionerWithMultipleLocals(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -8519,7 +8519,7 @@ func TestContext2Apply_destroyProvisionerWithOutput(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -8595,7 +8595,7 @@ func TestContext2Apply_targetedDestroyCountDeps(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -8639,7 +8639,7 @@ func TestContext2Apply_targetedDestroyModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -8701,7 +8701,7 @@ func TestContext2Apply_targetedDestroyCountIndex(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -8764,7 +8764,7 @@ func TestContext2Apply_targetedModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -8815,7 +8815,7 @@ func TestContext2Apply_targetedModuleDep(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -8868,7 +8868,7 @@ func TestContext2Apply_targetedModuleUnrelatedOutputs(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -8939,7 +8939,7 @@ func TestContext2Apply_targetedModuleResource(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -9000,7 +9000,7 @@ func TestContext2Apply_targetedResourceOrphanModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -9029,7 +9029,7 @@ func TestContext2Apply_unknownAttribute(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9059,7 +9059,7 @@ func TestContext2Apply_unknownAttributeInterpolate(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9222,7 +9222,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -9353,7 +9353,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -9397,7 +9397,7 @@ func TestContext2Apply_issue7824(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"template": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/template": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9415,7 +9415,7 @@ func TestContext2Apply_issue7824(t *testing.T) {
 
 	ctxOpts.ProviderResolver = providers.ResolverFixed(
 		map[string]providers.Factory{
-			"template": testProviderFuncFixed(p),
+			"registry.terraform.io/hashicorp/template": testProviderFuncFixed(p),
 		},
 	)
 	ctx, diags = NewContext(ctxOpts)
@@ -9455,7 +9455,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 		Config: testModule(t, "issue-5254/step-0"),
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"template": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/template": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9478,7 +9478,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"template": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/template": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9496,7 +9496,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 
 	ctxOpts.ProviderResolver = providers.ResolverFixed(
 		map[string]providers.Factory{
-			"template": testProviderFuncFixed(p),
+			"registry.terraform.io/hashicorp/template": testProviderFuncFixed(p),
 		},
 	)
 	ctx, diags = NewContext(ctxOpts)
@@ -9540,7 +9540,7 @@ func TestContext2Apply_targetedWithTaintedInState(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -9579,7 +9579,7 @@ func TestContext2Apply_targetedWithTaintedInState(t *testing.T) {
 
 	ctxOpts.ProviderResolver = providers.ResolverFixed(
 		map[string]providers.Factory{
-			"aws": testProviderFuncFixed(p),
+			"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 		},
 	)
 	ctx, diags = NewContext(ctxOpts)
@@ -9624,7 +9624,7 @@ func TestContext2Apply_ignoreChangesCreate(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9737,7 +9737,7 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -9772,7 +9772,7 @@ func TestContext2Apply_ignoreChangesWildcard(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9820,7 +9820,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"null": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -9843,7 +9843,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 			State:   state,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"null": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -9860,7 +9860,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 
 		ctxOpts.ProviderResolver = providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		)
 		ctx, diags = NewContext(ctxOpts)
@@ -9889,7 +9889,7 @@ func TestContext2Apply_dataDependsOn(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9956,7 +9956,7 @@ func TestContext2Apply_terraformWorkspace(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9987,7 +9987,7 @@ func TestContext2Apply_multiRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -10016,7 +10016,7 @@ func TestContext2Apply_targetedModuleRecursive(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -10130,7 +10130,7 @@ func TestContext2Apply_destroyWithLocals(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:   s,
@@ -10171,7 +10171,7 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -10189,7 +10189,7 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -10248,7 +10248,7 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:   s,
@@ -10366,7 +10366,7 @@ func TestContext2Apply_providersFromState(t *testing.T) {
 				Config: m,
 				ProviderResolver: providers.ResolverFixed(
 					map[string]providers.Factory{
-						"aws": testProviderFuncFixed(p),
+						"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 					},
 				),
 				State: tc.state,
@@ -10404,7 +10404,7 @@ func TestContext2Apply_plannedInterpolatedCount(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[string]providers.Factory{
-			"aws": testProviderFuncFixed(p),
+			"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 		},
 	)
 
@@ -10466,7 +10466,7 @@ func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[string]providers.Factory{
-			"aws": testProviderFuncFixed(p),
+			"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 		},
 	)
 
@@ -10543,7 +10543,7 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[string]providers.Factory{
-			"aws": testProviderFuncFixed(p),
+			"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 		},
 	)
 
@@ -10626,7 +10626,7 @@ func TestContext2Apply_inconsistentWithPlan(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -10693,7 +10693,7 @@ func TestContext2Apply_issue19908(t *testing.T) {
 		}),
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -10750,7 +10750,7 @@ func TestContext2Apply_invalidIndexRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -10902,7 +10902,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 			State:   state,
@@ -10957,7 +10957,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[string]providers.Factory{
-			"null": testProviderFuncFixed(p),
+			"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 		},
 	)
 
@@ -11059,7 +11059,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[string]providers.Factory{
-			"test": testProviderFuncFixed(p),
+			"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 		},
 	)
 
@@ -11212,7 +11212,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[string]providers.Factory{
-			"test": testProviderFuncFixed(p),
+			"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 		},
 	)
 

--- a/terraform/context_components.go
+++ b/terraform/context_components.go
@@ -34,7 +34,8 @@ type basicComponentFactory struct {
 func (c *basicComponentFactory) ResourceProviders() []string {
 	result := make([]string, len(c.providers))
 	for k := range c.providers {
-		result = append(result, k)
+		typeName := shimProviderFqn(k)
+		result = append(result, typeName)
 	}
 
 	return result

--- a/terraform/context_components.go
+++ b/terraform/context_components.go
@@ -50,7 +50,8 @@ func (c *basicComponentFactory) ResourceProvisioners() []string {
 }
 
 func (c *basicComponentFactory) ResourceProvider(typ, uid string) (providers.Interface, error) {
-	f, ok := c.providers[typ]
+	fqn := shimProviderFqn(typ)
+	f, ok := c.providers[fqn]
 	if !ok {
 		return nil, fmt.Errorf("unknown provider %q", typ)
 	}

--- a/terraform/context_fixtures_test.go
+++ b/terraform/context_fixtures_test.go
@@ -53,7 +53,7 @@ func contextFixtureApplyVars(t *testing.T) *contextTestFixture {
 		Config: c,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	}
@@ -81,7 +81,7 @@ func contextFixtureApplyVarsEnv(t *testing.T) *contextTestFixture {
 		Config: c,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	}

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -19,7 +19,7 @@ func TestContextImport_basic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -58,7 +58,7 @@ func TestContextImport_countIndex(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -98,7 +98,7 @@ func TestContextImport_collision(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 
@@ -165,7 +165,7 @@ func TestContextImport_missingType(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -217,7 +217,7 @@ func TestContextImport_moduleProvider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -256,7 +256,7 @@ func TestContextImport_providerModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -308,7 +308,7 @@ func TestContextImport_providerVarConfig(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -370,7 +370,7 @@ func TestContextImport_providerNonVarConfig(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -405,7 +405,7 @@ func TestContextImport_refresh(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -455,7 +455,7 @@ func TestContextImport_refreshNil(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -502,7 +502,7 @@ func TestContextImport_module(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -543,7 +543,7 @@ func TestContextImport_moduleDepth2(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -584,7 +584,7 @@ func TestContextImport_moduleDiff(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 
@@ -642,7 +642,7 @@ func TestContextImport_moduleExisting(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 
@@ -732,7 +732,7 @@ func TestContextImport_multiState(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -802,7 +802,7 @@ func TestContextImport_multiStateSame(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -837,7 +837,7 @@ func TestContextImport_customProviderMissing(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -872,7 +872,7 @@ func TestContextImport_customProvider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})

--- a/terraform/context_input_test.go
+++ b/terraform/context_input_test.go
@@ -44,7 +44,7 @@ func TestContext2Input_provider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		UIInput: inp,
@@ -115,7 +115,7 @@ func TestContext2Input_providerMulti(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		UIInput: inp,
@@ -160,7 +160,7 @@ func TestContext2Input_providerOnce(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -216,7 +216,7 @@ func TestContext2Input_providerId(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		UIInput: input,
@@ -281,7 +281,7 @@ func TestContext2Input_providerOnly(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -337,7 +337,7 @@ func TestContext2Input_providerVars(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -390,7 +390,7 @@ func TestContext2Input_providerVarsModuleInherit(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		UIInput: input,
@@ -422,7 +422,7 @@ func TestContext2Input_submoduleTriggersInvalidCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		UIInput: input,
@@ -486,7 +486,7 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 		State:   state,

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -32,7 +32,7 @@ func TestContext2Plan_basic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		ProviderSHA256s: map[string][]byte{
@@ -118,7 +118,7 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -210,7 +210,7 @@ func TestContext2Plan_createBefore_maintainRoot(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -250,7 +250,7 @@ func TestContext2Plan_emptyDiff(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -291,7 +291,7 @@ func TestContext2Plan_escapedVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -335,7 +335,7 @@ func TestContext2Plan_minimal(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -376,7 +376,7 @@ func TestContext2Plan_modules(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -451,7 +451,7 @@ func TestContext2Plan_moduleCycle(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -507,7 +507,7 @@ func TestContext2Plan_moduleDeadlock(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -553,7 +553,7 @@ func TestContext2Plan_moduleInput(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -610,7 +610,7 @@ func TestContext2Plan_moduleInputComputed(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -664,7 +664,7 @@ func TestContext2Plan_moduleInputFromVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -735,7 +735,7 @@ func TestContext2Plan_moduleMultiVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -816,7 +816,7 @@ func TestContext2Plan_moduleOrphans(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -919,7 +919,7 @@ func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -992,7 +992,7 @@ func TestContext2Plan_moduleProviderInherit(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": func() (providers.Interface, error) {
+				"registry.terraform.io/hashicorp/aws": func() (providers.Interface, error) {
 					l.Lock()
 					defer l.Unlock()
 
@@ -1058,7 +1058,7 @@ func TestContext2Plan_moduleProviderInheritDeep(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": func() (providers.Interface, error) {
+				"registry.terraform.io/hashicorp/aws": func() (providers.Interface, error) {
 					l.Lock()
 					defer l.Unlock()
 
@@ -1119,7 +1119,7 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": func() (providers.Interface, error) {
+				"registry.terraform.io/hashicorp/aws": func() (providers.Interface, error) {
 					l.Lock()
 					defer l.Unlock()
 
@@ -1204,7 +1204,7 @@ func TestContext2Plan_moduleProviderVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1249,7 +1249,7 @@ func TestContext2Plan_moduleVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1306,7 +1306,7 @@ func TestContext2Plan_moduleVarWrongTypeBasic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1325,7 +1325,7 @@ func TestContext2Plan_moduleVarWrongTypeNested(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1344,7 +1344,7 @@ func TestContext2Plan_moduleVarWithDefaultValue(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1363,7 +1363,7 @@ func TestContext2Plan_moduleVarComputed(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1416,7 +1416,7 @@ func TestContext2Plan_preventDestroy_bad(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -1455,7 +1455,7 @@ func TestContext2Plan_preventDestroy_good(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -1493,7 +1493,7 @@ func TestContext2Plan_preventDestroy_countBad(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -1548,7 +1548,7 @@ func TestContext2Plan_preventDestroy_countGood(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -1602,7 +1602,7 @@ func TestContext2Plan_preventDestroy_countGoodNoChange(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -1644,7 +1644,7 @@ func TestContext2Plan_preventDestroy_destroyPlan(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -1685,7 +1685,7 @@ func TestContext2Plan_provisionerCycle(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -1707,7 +1707,7 @@ func TestContext2Plan_computed(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1782,7 +1782,7 @@ func TestContext2Plan_blockNestingGroup(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1855,7 +1855,7 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1924,7 +1924,7 @@ func TestContext2Plan_computedInFunction(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1978,7 +1978,7 @@ func TestContext2Plan_computedDataCountResource(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2010,7 +2010,7 @@ func TestContext2Plan_localValueCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2080,7 +2080,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -2210,7 +2210,7 @@ func TestContext2Plan_computedList(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2322,7 +2322,7 @@ func TestContext2Plan_computedMultiIndex(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2380,7 +2380,7 @@ func TestContext2Plan_count(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2457,7 +2457,7 @@ func TestContext2Plan_countComputed(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2476,7 +2476,7 @@ func TestContext2Plan_countComputedModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2498,7 +2498,7 @@ func TestContext2Plan_countModuleStatic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2551,7 +2551,7 @@ func TestContext2Plan_countModuleStaticGrandchild(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2604,7 +2604,7 @@ func TestContext2Plan_countIndex(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2657,7 +2657,7 @@ func TestContext2Plan_countVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -2743,7 +2743,7 @@ func TestContext2Plan_countZero(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2786,7 +2786,7 @@ func TestContext2Plan_countOneIndex(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2870,7 +2870,7 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -2965,7 +2965,7 @@ func TestContext2Plan_countIncreaseFromNotSet(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -3054,7 +3054,7 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -3158,7 +3158,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -3296,7 +3296,7 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -3353,7 +3353,7 @@ func TestContext2Plan_forEach(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3391,7 +3391,7 @@ func TestContext2Plan_forEachUnknownValue(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -3445,7 +3445,7 @@ func TestContext2Plan_destroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:   s,
@@ -3516,7 +3516,7 @@ func TestContext2Plan_moduleDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:   s,
@@ -3587,7 +3587,7 @@ func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:   s,
@@ -3657,7 +3657,7 @@ func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State:   s,
@@ -3719,7 +3719,7 @@ func TestContext2Plan_pathVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3783,7 +3783,7 @@ func TestContext2Plan_diffVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -3863,7 +3863,7 @@ func TestContext2Plan_hook(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3892,7 +3892,7 @@ func TestContext2Plan_closeProvider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3930,7 +3930,7 @@ func TestContext2Plan_orphan(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -3984,7 +3984,7 @@ func TestContext2Plan_shadowUuid(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4018,7 +4018,7 @@ func TestContext2Plan_state(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -4106,7 +4106,7 @@ func TestContext2Plan_taint(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -4191,7 +4191,7 @@ func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -4271,7 +4271,7 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[string]providers.Factory{
-					"aws": testProviderFuncFixed(p),
+					"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 				},
 			),
 			State: s,
@@ -4325,7 +4325,7 @@ func TestContext2Plan_targeted(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -4378,7 +4378,7 @@ func TestContext2Plan_targetedCrossModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -4445,7 +4445,7 @@ func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -4484,7 +4484,7 @@ func TestContext2Plan_targetedOrphan(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -4554,7 +4554,7 @@ func TestContext2Plan_targetedModuleOrphan(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -4622,7 +4622,7 @@ func TestContext2Plan_targetedModuleUntargetedVariable(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -4680,7 +4680,7 @@ func TestContext2Plan_outputContainsTargetedResource(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -4727,7 +4727,7 @@ func TestContext2Plan_targetedOverTen(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -4779,7 +4779,7 @@ func TestContext2Plan_provider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -4806,7 +4806,7 @@ func TestContext2Plan_varListErr(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4844,7 +4844,7 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -4916,7 +4916,7 @@ func TestContext2Plan_ignoreChangesWildcard(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -4986,7 +4986,7 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -5066,7 +5066,7 @@ func TestContext2Plan_moduleMapLiteral(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5113,7 +5113,7 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5172,7 +5172,7 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5255,7 +5255,7 @@ func TestContext2Plan_createBeforeDestroy_depends_datasource(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5368,7 +5368,7 @@ func TestContext2Plan_listOrder(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5449,7 +5449,7 @@ func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -5585,7 +5585,7 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -5667,7 +5667,7 @@ func TestContext2Plan_computedAttrRefTypeMismatch(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5700,7 +5700,7 @@ func TestContext2Plan_selfRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5739,7 +5739,7 @@ func TestContext2Plan_selfRefMulti(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5778,7 +5778,7 @@ func TestContext2Plan_selfRefMultiAll(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5819,7 +5819,7 @@ output "out" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5861,7 +5861,7 @@ resource "aws_instance" "foo" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5910,7 +5910,7 @@ resource "aws_instance" "foo" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -5960,7 +5960,7 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6027,7 +6027,7 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -46,7 +46,7 @@ func TestContext2Refresh(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: startingState,
@@ -133,7 +133,7 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 		State: startingState,
@@ -169,7 +169,7 @@ func TestContext2Refresh_dataComputedModuleVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -260,7 +260,7 @@ func TestContext2Refresh_targeted(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -343,7 +343,7 @@ func TestContext2Refresh_targetedCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -436,7 +436,7 @@ func TestContext2Refresh_targetedCountIndex(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -505,7 +505,7 @@ func TestContext2Refresh_moduleComputedVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -524,7 +524,7 @@ func TestContext2Refresh_delete(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -567,7 +567,7 @@ func TestContext2Refresh_ignoreUncreated(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: nil,
@@ -598,7 +598,7 @@ func TestContext2Refresh_hook(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -664,7 +664,7 @@ func TestContext2Refresh_modules(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -726,7 +726,7 @@ func TestContext2Refresh_moduleInputComputedOutput(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -744,7 +744,7 @@ func TestContext2Refresh_moduleVarModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -762,7 +762,7 @@ func TestContext2Refresh_noState(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -804,7 +804,7 @@ func TestContext2Refresh_output(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -880,7 +880,7 @@ func TestContext2Refresh_outputPartial(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -935,7 +935,7 @@ func TestContext2Refresh_stateBasic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1010,7 +1010,7 @@ func TestContext2Refresh_dataCount(t *testing.T) {
 	ctx := testContext2(t, &ContextOpts{
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 		Config: m,
@@ -1056,7 +1056,7 @@ func TestContext2Refresh_dataOrphan(t *testing.T) {
 	ctx := testContext2(t, &ContextOpts{
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1106,7 +1106,7 @@ func TestContext2Refresh_dataState(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1213,7 +1213,7 @@ func TestContext2Refresh_dataStateRefData(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"null": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/null": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1264,7 +1264,7 @@ func TestContext2Refresh_tainted(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1361,7 +1361,7 @@ func TestContext2Refresh_vars(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -1523,7 +1523,7 @@ func TestContext2Refresh_orphanModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1568,7 +1568,7 @@ func TestContext2Validate(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1631,7 +1631,7 @@ func TestContext2Refresh_noDiffHookOnScaleOut(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1679,7 +1679,7 @@ func TestContext2Refresh_updateProviderInState(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -1747,7 +1747,7 @@ func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -1830,7 +1830,7 @@ func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -1890,7 +1890,7 @@ data "aws_data_source" "foo" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1953,7 +1953,7 @@ func TestContext2Refresh_dataResourceDependsOn(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -2027,7 +2027,7 @@ resource "aws_instance" "foo" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -31,7 +31,7 @@ func TestContext2Validate_badCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -60,7 +60,7 @@ func TestContext2Validate_badVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -91,7 +91,7 @@ func TestContext2Validate_varMapOverrideOld(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{},
@@ -143,8 +143,8 @@ func TestContext2Validate_computedVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws":  testProviderFuncFixed(p),
-				"test": testProviderFuncFixed(pt),
+				"registry.terraform.io/hashicorp/aws":  testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(pt),
 			},
 		),
 	})
@@ -192,7 +192,7 @@ func TestContext2Validate_computedInFunction(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -229,7 +229,7 @@ func TestContext2Validate_countComputed(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -255,7 +255,7 @@ func TestContext2Validate_countNegative(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -283,7 +283,7 @@ func TestContext2Validate_countVariable(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -311,7 +311,7 @@ func TestContext2Validate_countVariableNoDefault(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -338,7 +338,7 @@ func TestContext2Validate_moduleBadOutput(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -366,7 +366,7 @@ func TestContext2Validate_moduleGood(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -392,7 +392,7 @@ func TestContext2Validate_moduleBadResource(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -424,7 +424,7 @@ func TestContext2Validate_moduleDepsShouldNotCycle(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -457,7 +457,7 @@ func TestContext2Validate_moduleProviderVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -500,7 +500,7 @@ func TestContext2Validate_moduleProviderInheritUnused(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -548,7 +548,7 @@ func TestContext2Validate_orphans(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -590,7 +590,7 @@ func TestContext2Validate_providerConfig_bad(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -628,7 +628,7 @@ func TestContext2Validate_providerConfig_badEmpty(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -663,7 +663,7 @@ func TestContext2Validate_providerConfig_good(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -693,7 +693,7 @@ func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -730,7 +730,7 @@ func TestContext2Validate_badResourceConnection(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -764,7 +764,7 @@ func TestContext2Validate_badProvisionerConnection(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -812,7 +812,7 @@ func TestContext2Validate_provisionerConfig_good(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -843,7 +843,7 @@ func TestContext2Validate_requiredVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -870,7 +870,7 @@ func TestContext2Validate_resourceConfig_bad(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -902,7 +902,7 @@ func TestContext2Validate_resourceConfig_good(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -947,7 +947,7 @@ func TestContext2Validate_tainted(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -990,7 +990,7 @@ func TestContext2Validate_targetedDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -1037,7 +1037,7 @@ func TestContext2Validate_varRefUnknown(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -1087,7 +1087,7 @@ func TestContext2Validate_interpolateVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"template": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/template": testProviderFuncFixed(p),
 			},
 		),
 		UIInput: input,
@@ -1122,7 +1122,7 @@ func TestContext2Validate_interpolateComputedModuleVarDef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 		UIInput: input,
@@ -1147,7 +1147,7 @@ func TestContext2Validate_interpolateMap(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"template": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/template": testProviderFuncFixed(p),
 			},
 		),
 		UIInput: input,
@@ -1227,7 +1227,7 @@ output "out" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1266,7 +1266,7 @@ resource "aws_instance" "foo" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1297,7 +1297,7 @@ output "out" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1330,7 +1330,7 @@ output "out" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1363,7 +1363,7 @@ output "out" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"aws": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/aws": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1395,7 +1395,7 @@ resource "test_instance" "bar" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1430,7 +1430,7 @@ resource "test_instance" "bar" {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[string]providers.Factory{
-				"test": testProviderFuncFixed(p),
+				"registry.terraform.io/hashicorp/test": testProviderFuncFixed(p),
 			},
 		),
 	})

--- a/terraform/eval_context_builtin_test.go
+++ b/terraform/eval_context_builtin_test.go
@@ -53,7 +53,7 @@ func TestBuildingEvalContextInitProvider(t *testing.T) {
 	ctx.ProviderCache = make(map[string]providers.Interface)
 	ctx.Components = &basicComponentFactory{
 		providers: map[string]providers.Factory{
-			"test": providers.FactoryFixed(testP),
+			"registry.terraform.io/hashicorp/test": providers.FactoryFixed(testP),
 		},
 	}
 

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/tfdiags"
 
@@ -322,4 +323,9 @@ requirements and constraints from each module, run "terraform providers".
 
 func shimProviderFqn(typeName string) string {
 	return "registry.terraform.io/hashicorp/" + typeName
+}
+
+func shimProviderNameFromFqn(fqn string) string {
+	parts := strings.Split(fqn, "/")
+	return parts[len(parts)-1]
 }

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -236,8 +236,10 @@ func ResourceProviderResolverFixed(factories map[string]ResourceProviderFactory)
 		ret := make(map[string]ResourceProviderFactory, len(reqd))
 		var errs []error
 		for name := range reqd {
-			if factory, exists := factories[name]; exists {
-				ret[name] = factory
+			// Provider Source Readiness!
+			fqn := shimProviderFqn(name)
+			if factory, exists := factories[fqn]; exists {
+				ret[fqn] = factory
 			} else {
 				errs = append(errs, fmt.Errorf("provider %q is not available", name))
 			}
@@ -317,3 +319,7 @@ Terraform automatically discovers provider requirements from your
 configuration, including providers used in child modules. To see the
 requirements and constraints from each module, run "terraform providers".
 `
+
+func shimProviderFqn(typeName string) string {
+	return "registry.terraform.io/hashicorp/" + typeName
+}


### PR DESCRIPTION
This represents the absolute minimum entry to provider source!

Not a 'real' PR, I just want to see all the tests run. 