### PR TITLE
github: Make link to vulnerability reports more visible

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,3 @@ contact_links:
   - name: Terraform Language or Workflow Questions
     url: https://discuss.hashicorp.com/c/terraform-core
     about: Please ask and answer language or workflow related questions through the Terraform Core Community Forum.
-  - name: Security Vulnerability
-    url: https://www.hashicorp.com/security.html
-    about: Please report security vulnerabilities responsibly.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,4 @@
+# Vulnerability Reporting
+
+Please disclose security vulnerabilities responsibly by following procedure
+described at https://www.hashicorp.com/security#vulnerability-reporting

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,4 +1,4 @@
 # Vulnerability Reporting
 
-Please disclose security vulnerabilities responsibly by following procedure
+Please disclose security vulnerabilities responsibly by following the procedure
 described at https://www.hashicorp.com/security#vulnerability-reporting


### PR DESCRIPTION
As I discovered, GitHub can prioritize link to a security policy, if that is defined under the right file - see https://github.com/hashicorp/terraform-plugin-sdk/pull/267 for example.

I'm therefore proposing replacement of a custom link with policy in this repo too as that will make the (critical) link much more visible.