### PR TITLE
make plan-diff format a bit more dry

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -70,22 +70,7 @@ func ResourceChange(
 	}
 	buf.WriteString(color.Color("[reset]\n"))
 
-	switch change.Action {
-	case plans.Create:
-		buf.WriteString(color.Color("[green]  +[reset] "))
-	case plans.Read:
-		buf.WriteString(color.Color("[cyan] <=[reset] "))
-	case plans.Update:
-		buf.WriteString(color.Color("[yellow]  ~[reset] "))
-	case plans.DeleteThenCreate:
-		buf.WriteString(color.Color("[red]-[reset]/[green]+[reset] "))
-	case plans.CreateThenDelete:
-		buf.WriteString(color.Color("[green]+[reset]/[red]-[reset] "))
-	case plans.Delete:
-		buf.WriteString(color.Color("[red]  -[reset] "))
-	default:
-		buf.WriteString(color.Color("??? "))
-	}
+	buf.WriteString(color.Color(DiffActionSymbol(change.Action)) + " ")
 
 	switch addr.Resource.Resource.Mode {
 	case addrs.ManagedResourceMode:


### PR DESCRIPTION
On formatting plan result, prefixes (indicators) before resource name and prefixes before the description are generated by different code.

```
  ~ update in-place
...
  ~ resource "aws_security_group" "..." {
  ↑
  them
```

<img width="202" alt="ss-2019-12-03 19 17 38" src="https://user-images.githubusercontent.com/3760893/70042262-e9b5b700-1601-11ea-96e5-a3da3c052add.png">

This is so tiny point, but should deserve to be fixed.

By this change,

- whitespaces before sign go out of color codes (e.g.: `[green]__+[reset]` → `__[green]+[reset]`)
- unknown action shows `__?` rather than `???`

but these changes can be affordable.