### PR TITLE
website: add yt video to /intro

### DIFF
--- a/website/intro/index.html.markdown
+++ b/website/intro/index.html.markdown
@@ -36,6 +36,8 @@ low-level components such as
 compute instances, storage, and networking, as well as high-level
 components such as DNS entries, SaaS features, etc.
 
+<iframe src="https://www.youtube.com/embed/h970ZBgKINg" frameborder="0" allowfullscreen="true"  width="560" height="315" ></iframe>
+
 Examples work best to showcase Terraform. Please see the
 [use cases](/intro/use-cases.html).
 


### PR DESCRIPTION
⚠️ this PR has a companion PR on the `terraform-website` repo that handles it's required CSS updates: https://github.com/hashicorp/terraform-website/pull/1036. It's important (although not entirely essential) that this PR be merged after it's companion is merged and deployed.

context: the impetus for adding this video comes from a request from Armon Dadgar...

> I do think it would be worth getting some of them onto the IO sites as well, like quick "what is TF" type videos - armon
