### PR TITLE
check for missing Current instance in EachMap

### DIFF
--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -648,60 +648,59 @@ func (d *evaluationStateData) getResourceInstancesAll(addr addrs.Resource, rng t
 		for i := 0; i < length; i++ {
 			ty := schema.ImpliedType()
 			key := addrs.IntKey(i)
-			is, exists := rs.Instances[key]
-			if exists && is.Current != nil {
-				instAddr := addr.Instance(key).Absolute(d.ModulePath)
-
-				// Prefer pending value in plan if present. See getResourceInstanceSingle
-				// comment for the rationale.
-				if is.Current.Status == states.ObjectPlanned {
-					if change := d.Evaluator.Changes.GetResourceInstanceChange(instAddr, states.CurrentGen); change != nil {
-						val, err := change.After.Decode(ty)
-						if err != nil {
-							diags = diags.Append(&hcl.Diagnostic{
-								Severity: hcl.DiagError,
-								Summary:  "Invalid resource instance data in plan",
-								Detail:   fmt.Sprintf("Instance %s data could not be decoded from the plan: %s.", instAddr, err),
-								Subject:  &config.DeclRange,
-							})
-							continue
-						}
-						vals[i] = val
-						continue
-					} else {
-						// If the object is in planned status then we should not
-						// get here, since we should've found a pending value
-						// in the plan above instead.
-						diags = diags.Append(&hcl.Diagnostic{
-							Severity: hcl.DiagError,
-							Summary:  "Missing pending object in plan",
-							Detail:   fmt.Sprintf("Instance %s is marked as having a change pending but that change is not recorded in the plan. This is a bug in Terraform; please report it.", instAddr),
-							Subject:  &config.DeclRange,
-						})
-						continue
-					}
-				}
-
-				ios, err := is.Current.Decode(ty)
-				if err != nil {
-					// This shouldn't happen, since by the time we get here
-					// we should've upgraded the state data already.
-					diags = diags.Append(&hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  "Invalid resource instance data in state",
-						Detail:   fmt.Sprintf("Instance %s data could not be decoded from the state: %s.", instAddr, err),
-						Subject:  &config.DeclRange,
-					})
-					continue
-				}
-				vals[i] = ios.Value
-			} else {
+			is := rs.Instances[key]
+			if is == nil || is.Current == nil {
 				// There shouldn't normally be "gaps" in our list but we'll
 				// allow it under the assumption that we're in a weird situation
 				// where e.g. someone has run "terraform state mv" to reorder
 				// a list and left a hole behind.
 				vals[i] = cty.UnknownVal(schema.ImpliedType())
+				continue
 			}
+
+			instAddr := addr.Instance(key).Absolute(d.ModulePath)
+
+			if is.Current.Status == states.ObjectPlanned {
+				if change := d.Evaluator.Changes.GetResourceInstanceChange(instAddr, states.CurrentGen); change != nil {
+					val, err := change.After.Decode(ty)
+					if err != nil {
+						diags = diags.Append(&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "Invalid resource instance data in plan",
+							Detail:   fmt.Sprintf("Instance %s data could not be decoded from the plan: %s.", instAddr, err),
+							Subject:  &config.DeclRange,
+						})
+						continue
+					}
+					vals[i] = val
+					continue
+				} else {
+					// If the object is in planned status then we should not
+					// get here, since we should've found a pending value
+					// in the plan above instead.
+					diags = diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Missing pending object in plan",
+						Detail:   fmt.Sprintf("Instance %s is marked as having a change pending but that change is not recorded in the plan. This is a bug in Terraform; please report it.", instAddr),
+						Subject:  &config.DeclRange,
+					})
+					continue
+				}
+			}
+
+			ios, err := is.Current.Decode(ty)
+			if err != nil {
+				// This shouldn't happen, since by the time we get here
+				// we should've upgraded the state data already.
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid resource instance data in state",
+					Detail:   fmt.Sprintf("Instance %s data could not be decoded from the state: %s.", instAddr, err),
+					Subject:  &config.DeclRange,
+				})
+				continue
+			}
+			vals[i] = ios.Value
 		}
 
 		// We use a tuple rather than a list here because resource schemas may
@@ -715,12 +714,14 @@ func (d *evaluationStateData) getResourceInstancesAll(addr addrs.Resource, rng t
 		vals := make(map[string]cty.Value, len(rs.Instances))
 		for k, is := range rs.Instances {
 			if sk, ok := k.(addrs.StringKey); ok {
+				if is == nil || is.Current == nil {
+					// Assume we're dealing with an instance that hasn't been created yet.
+					vals[string(sk)] = cty.UnknownVal(schema.ImpliedType())
+					continue
+				}
+
 				instAddr := addr.Instance(k).Absolute(d.ModulePath)
 
-				// Prefer pending value in plan if present. See getResourceInstanceSingle
-				// comment for the rationale.
-				// Prefer pending value in plan if present. See getResourceInstanceSingle
-				// comment for the rationale.
 				if is.Current.Status == states.ObjectPlanned {
 					if change := d.Evaluator.Changes.GetResourceInstanceChange(instAddr, states.CurrentGen); change != nil {
 						val, err := change.After.Decode(ty)


### PR DESCRIPTION
NoEach and Each list both have this check, but it was missing in
EachMap. Refactor the EachList check to remove a level of indentation,
and make the check consistently near the start of the block.

This fixes #23522 by preventing the panic, but the mechanism that removes the Current instance is still not fully understood. It may be due to unexpected behavior of the provider, which we can better observe once the panic is caught.