### PR TITLE
deprecation warning for destroy provisioner refs

### DIFF
--- a/configs/provisioner.go
+++ b/configs/provisioner.go
@@ -50,6 +50,11 @@ func decodeProvisionerBlock(block *hcl.Block) (*Provisioner, hcl.Diagnostics) {
 		}
 	}
 
+	// destroy provisioners can only refer to self
+	if pv.When == ProvisionerWhenDestroy {
+		diags = append(diags, onlySelfRefs(config)...)
+	}
+
 	if attr, exists := content.Attributes["on_failure"]; exists {
 		expr, shimDiags := shimTraversalInString(attr.Expr, true)
 		diags = append(diags, shimDiags...)
@@ -85,8 +90,11 @@ func decodeProvisionerBlock(block *hcl.Block) (*Provisioner, hcl.Diagnostics) {
 			}
 			seenConnection = block
 
-			//conn, connDiags := decodeConnectionBlock(block)
-			//diags = append(diags, connDiags...)
+			// destroy provisioners can only refer to self
+			if pv.When == ProvisionerWhenDestroy {
+				diags = append(diags, onlySelfRefs(block.Body)...)
+			}
+
 			pv.Connection = &Connection{
 				Config:    block.Body,
 				DeclRange: block.DefRange,
@@ -105,6 +113,49 @@ func decodeProvisionerBlock(block *hcl.Block) (*Provisioner, hcl.Diagnostics) {
 	}
 
 	return pv, diags
+}
+
+func onlySelfRefs(body hcl.Body) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	// Provisioners currently do not use any blocks in their configuration.
+	// Blocks are likely to remain solely for meta parameters, but in the case
+	// that blocks are supported for provisioners, we will want to extend this
+	// to find variables in nested blocks.
+	attrs, _ := body.JustAttributes()
+	for _, attr := range attrs {
+		for _, v := range attr.Expr.Variables() {
+			valid := false
+			switch v.RootName() {
+			case "self":
+				valid = true
+			case "count":
+				// count must use "index"
+				if len(v) == 2 {
+					if t, ok := v[1].(hcl.TraverseAttr); ok && t.Name == "index" {
+						valid = true
+					}
+				}
+
+			case "each":
+				if len(v) == 2 {
+					if t, ok := v[1].(hcl.TraverseAttr); ok && t.Name == "key" {
+						valid = true
+					}
+				}
+			}
+
+			if !valid {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  "External references from destroy provisioners are deprecated",
+					Detail:   "Destroy time provisioners and their connections may only reference values stored in the instance state, which include 'self', 'count.index', or 'each.key'.",
+					Subject:  attr.Expr.Range().Ptr(),
+				})
+			}
+		}
+	}
+	return diags
 }
 
 // Connection represents a "connection" block when used within either a

--- a/configs/resource.go
+++ b/configs/resource.go
@@ -273,6 +273,17 @@ func decodeResourceBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 		}
 	}
 
+	// Now we can validate the connection block references if there are any destroy provisioners.
+	// TODO: should we eliminate standalone connection blocks?
+	if r.Managed.Connection != nil {
+		for _, p := range r.Managed.Provisioners {
+			if p.When == ProvisionerWhenDestroy {
+				diags = append(diags, onlySelfRefs(r.Managed.Connection.Config)...)
+				break
+			}
+		}
+	}
+
 	return r, diags
 }
 

--- a/configs/testdata/warning-files/destroy-provisioners.tf
+++ b/configs/testdata/warning-files/destroy-provisioners.tf
@@ -1,0 +1,40 @@
+locals {
+  user = "name"
+}
+
+resource "null_resource" "a" {
+  connection {
+    host = self.hostname
+    user = local.user # WARNING: External references from destroy provisioners are deprecated
+  }
+
+  provisioner "remote-exec" {
+    when = destroy
+    index = count.index
+    key = each.key
+
+  }
+}
+
+resource "null_resource" "b" {
+  connection {
+    host = self.hostname
+    # this is OK since there is no destroy provisioner
+    user = local.user
+  }
+
+  provisioner "remote-exec" {
+  }
+}
+
+resource "null_resource" "b" {
+  provisioner "remote-exec" {
+    when = destroy
+    connection {
+      host = self.hostname
+      user = local.user # WARNING: External references from destroy provisioners are deprecated
+    }
+
+    command = "echo ${local.name}" # WARNING: External references from destroy provisioners are deprecated
+  }
+}


### PR DESCRIPTION
Add deprecation warning for references from destroy provisioners or
their connections to external resources or values. In order to ensure
resource destruction can be completed correctly, destroy nodes must be
able to evaluate with only their instance state.

We have sufficient information to validate destroy-time provisioners
early on during the config loading process. Later on these can be
converted to hard errors, and only allow self, count.index, and each.key
in destroy provisioners. Limiting the provisioner and block evaluation
scope later on is tricky, but if the references can never be loaded,
then they will never be encountered during evaluation.

## Background for the upcoming change

Destroy provisioner were added way back in the 0.9.0 release. The initial concept was simple, but the implications of the added dependencies of evaluating provisioners during destroy was not fully thought out. It turns out that it is very easy to inadvertently introduce dependency cycles, yet hard to detect when they might happen, since it requires a certain combination of updates to trigger. For example, the image below shows a simplified graph of 2 resources being replaced, with `a_destroy` containing a provisioner that references resource `b`. These resource may even be spread across modules, and updated due to unrelated events. 

![cycle](https://user-images.githubusercontent.com/35067/70173941-effb7000-16a1-11ea-8d3b-0862471d671e.png)

In the releases since 0.9.0, these cycles have both become easier to create and much harder to detect and reason about due to the increased use of modules. Modules themselves also lose some of their intended composability, because the inputs and outputs may have unexpected restrictions on which resources can be used with them to ensure there could be no cycles.

Since adding more heuristics and workarounds to detect and break these cycles won't ever be able to solve them all within Terraform's current operating model, we're proposing to deprecate the possibility of evaluating anything but a resource's own state during destroy. This results in a destroy subgraph that will only ever involve dependent resources, and `create_before_destroy` will only need to take into account the edges between the create and destroy nodes (notice in the graph above, `create_before_destroy` would remove the cycle, but in other cases it is just as likely to introduce one). In short, this means that any updates involving resource destruction are more reliable and easier to reason about. 
