### PR TITLE
Allow disabling plugin AutoMTLS with TF_DISABLE_AUTOMTLS env var

### DIFF
--- a/plugin/client.go
+++ b/plugin/client.go
@@ -9,6 +9,11 @@ import (
 	"github.com/hashicorp/terraform/plugin/discovery"
 )
 
+// The TF_DISABLE_PLUGIN_TLS environment variable is intended only for use by
+// the plugin SDK test framework. We do not recommend Terraform CLI end-users
+// set this variable.
+var enableAutoMTLS = os.Getenv("TF_DISABLE_PLUGIN_TLS") == ""
+
 // ClientConfig returns a configuration object that can be used to instantiate
 // a client for the plugin described by the given metadata.
 func ClientConfig(m discovery.PluginMeta) *plugin.ClientConfig {
@@ -25,7 +30,7 @@ func ClientConfig(m discovery.PluginMeta) *plugin.ClientConfig {
 		Managed:          true,
 		Logger:           logger,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
-		AutoMTLS:         true,
+		AutoMTLS:         enableAutoMTLS,
 	}
 }
 


### PR DESCRIPTION
When using the new provider binary acceptance testing framework, disabling AutoMTLS for Core-provider gRPC communication leads to test run speed improvements of between 10% (for a typical provider) and 70% (for an in-memory provider such as `random`).

This PR allows AutoMTLS to be disabled at runtime with the `TF_DISABLE_AUTOMTLS` env var. The binary testing framework would set this env var when running `terraform` commands.

@apparentlymart , requesting review as you have some context on this from previous discussion.