### PR TITLE
Mildwonkey/f provider config

### DIFF
--- a/addrs/provider.go
+++ b/addrs/provider.go
@@ -1,6 +1,8 @@
 package addrs
 
-import svchost "github.com/hashicorp/terraform-svchost"
+import (
+	svchost "github.com/hashicorp/terraform-svchost"
+)
 
 // Provider encapsulates a single provider type. In the future this will be
 // extended to include additional fields including Namespace and SourceHost

--- a/addrs/provider_config.go
+++ b/addrs/provider_config.go
@@ -11,7 +11,7 @@ import (
 
 // ProviderConfig is the address of a provider configuration.
 type ProviderConfig struct {
-	Type string
+	Type Provider
 
 	// If not empty, Alias identifies which non-default (aliased) provider
 	// configuration this address refers to.
@@ -22,7 +22,7 @@ type ProviderConfig struct {
 // configuration for the provider with the given type name.
 func NewDefaultProviderConfig(typeName string) ProviderConfig {
 	return ProviderConfig{
-		Type: typeName,
+		Type: NewLegacyProvider(typeName),
 	}
 }
 
@@ -41,7 +41,7 @@ func NewDefaultProviderConfig(typeName string) ProviderConfig {
 func ParseProviderConfigCompact(traversal hcl.Traversal) (ProviderConfig, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	ret := ProviderConfig{
-		Type: traversal.RootName(),
+		Type: NewLegacyProvider(traversal.RootName()),
 	}
 
 	if len(traversal) < 2 {
@@ -114,25 +114,25 @@ func (pc ProviderConfig) Absolute(module ModuleInstance) AbsProviderConfig {
 }
 
 func (pc ProviderConfig) String() string {
-	if pc.Type == "" {
+	if pc.Type.LegacyString() == "" {
 		// Should never happen; always indicates a bug
 		return "provider.<invalid>"
 	}
 
 	if pc.Alias != "" {
-		return fmt.Sprintf("provider.%s.%s", pc.Type, pc.Alias)
+		return fmt.Sprintf("provider.%s.%s", pc.Type.LegacyString(), pc.Alias)
 	}
 
-	return "provider." + pc.Type
+	return "provider." + pc.Type.LegacyString()
 }
 
 // StringCompact is an alternative to String that returns the form that can
 // be parsed by ParseProviderConfigCompact, without the "provider." prefix.
 func (pc ProviderConfig) StringCompact() string {
 	if pc.Alias != "" {
-		return fmt.Sprintf("%s.%s", pc.Type, pc.Alias)
+		return fmt.Sprintf("%s.%s", pc.Type.LegacyString(), pc.Alias)
 	}
-	return pc.Type
+	return pc.Type.LegacyString()
 }
 
 // AbsProviderConfig is the absolute address of a provider configuration
@@ -181,7 +181,7 @@ func ParseAbsProviderConfig(traversal hcl.Traversal) (AbsProviderConfig, tfdiags
 	}
 
 	if tt, ok := remain[1].(hcl.TraverseAttr); ok {
-		ret.ProviderConfig.Type = tt.Name
+		ret.ProviderConfig.Type = NewLegacyProvider(tt.Name)
 	} else {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
@@ -244,7 +244,7 @@ func (m ModuleInstance) ProviderConfigDefault(name string) AbsProviderConfig {
 	return AbsProviderConfig{
 		Module: m,
 		ProviderConfig: ProviderConfig{
-			Type: name,
+			Type: NewLegacyProvider(name),
 		},
 	}
 }
@@ -255,7 +255,7 @@ func (m ModuleInstance) ProviderConfigAliased(name, alias string) AbsProviderCon
 	return AbsProviderConfig{
 		Module: m,
 		ProviderConfig: ProviderConfig{
-			Type:  name,
+			Type:  NewLegacyProvider(name),
 			Alias: alias,
 		},
 	}

--- a/addrs/provider_config_test.go
+++ b/addrs/provider_config_test.go
@@ -18,14 +18,14 @@ func TestParseProviderConfigCompact(t *testing.T) {
 		{
 			`aws`,
 			ProviderConfig{
-				Type: "aws",
+				Type: NewLegacyProvider("aws"),
 			},
 			``,
 		},
 		{
 			`aws.foo`,
 			ProviderConfig{
-				Type:  "aws",
+				Type:  NewLegacyProvider("aws"),
 				Alias: "foo",
 			},
 			``,
@@ -82,7 +82,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			AbsProviderConfig{
 				Module: RootModuleInstance,
 				ProviderConfig: ProviderConfig{
-					Type: "aws",
+					Type: NewLegacyProvider("aws"),
 				},
 			},
 			``,
@@ -92,7 +92,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			AbsProviderConfig{
 				Module: RootModuleInstance,
 				ProviderConfig: ProviderConfig{
-					Type:  "aws",
+					Type:  NewLegacyProvider("aws"),
 					Alias: "foo",
 				},
 			},
@@ -107,7 +107,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 					},
 				},
 				ProviderConfig: ProviderConfig{
-					Type: "aws",
+					Type: NewLegacyProvider("aws"),
 				},
 			},
 			``,
@@ -121,7 +121,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 					},
 				},
 				ProviderConfig: ProviderConfig{
-					Type:  "aws",
+					Type:  NewLegacyProvider("aws"),
 					Alias: "foo",
 				},
 			},
@@ -137,7 +137,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 					},
 				},
 				ProviderConfig: ProviderConfig{
-					Type: "aws",
+					Type: NewLegacyProvider("aws"),
 				},
 			},
 			``,
@@ -152,7 +152,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 					},
 				},
 				ProviderConfig: ProviderConfig{
-					Type: "aws",
+					Type: NewLegacyProvider("aws"),
 				},
 			},
 			``,
@@ -170,7 +170,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 					},
 				},
 				ProviderConfig: ProviderConfig{
-					Type: "aws",
+					Type: NewLegacyProvider("aws"),
 				},
 			},
 			``,

--- a/addrs/resource.go
+++ b/addrs/resource.go
@@ -65,8 +65,9 @@ func (r Resource) DefaultProviderConfig() ProviderConfig {
 	if under := strings.Index(typeName, "_"); under != -1 {
 		typeName = typeName[:under]
 	}
+
 	return ProviderConfig{
-		Type: typeName,
+		Type: NewLegacyProvider(typeName),
 	}
 }
 

--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -262,7 +262,7 @@ func RenderPlan(plan *plans.Plan, state *states.State, schemas *terraform.Schema
 		if rcs.Action == plans.NoOp {
 			continue
 		}
-		providerSchema := schemas.ProviderSchema(rcs.ProviderAddr.ProviderConfig.Type)
+		providerSchema := schemas.ProviderSchema(rcs.ProviderAddr.ProviderConfig.Type.LegacyString())
 		if providerSchema == nil {
 			// Should never happen
 			ui.Output(fmt.Sprintf("(schema missing for %s)\n", rcs.ProviderAddr))

--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -216,7 +216,7 @@ func TestLocal_planDeposedOnly(t *testing.T) {
 			}`),
 			},
 			addrs.ProviderConfig{
-				Type: "test",
+				Type: addrs.NewLegacyProvider("test"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 	}))
@@ -659,7 +659,7 @@ func testPlanState() *states.State {
 			}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	return state
@@ -685,7 +685,7 @@ func testPlanState_withDataSource() *states.State {
 			}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	rootModule.SetResourceInstanceCurrent(
@@ -701,7 +701,7 @@ func testPlanState_withDataSource() *states.State {
 			}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	return state
@@ -727,7 +727,7 @@ func testPlanState_tainted() *states.State {
 			}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	return state

--- a/backend/testing.go
+++ b/backend/testing.go
@@ -151,7 +151,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 				SchemaVersion: 0,
 			},
 			addrs.ProviderConfig{
-				Type: "test",
+				Type: addrs.NewLegacyProvider("test"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 

--- a/command/apply_destroy_test.go
+++ b/command/apply_destroy_test.go
@@ -29,7 +29,7 @@ func TestApply_destroy(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -122,7 +122,7 @@ func TestApply_destroyLockedState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -194,7 +194,7 @@ func TestApply_destroyTargeted(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"i-ab123"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -206,7 +206,7 @@ func TestApply_destroyTargeted(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"i-abc123"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, originalState)

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -833,7 +833,7 @@ func TestApply_refresh(t *testing.T) {
 				AttrsJSON: []byte(`{"ami":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -987,7 +987,7 @@ func TestApply_state(t *testing.T) {
 				AttrsJSON: []byte(`{"ami":"foo"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -1351,7 +1351,7 @@ func TestApply_backup(t *testing.T) {
 				AttrsJSON: []byte("{\n            \"id\": \"bar\"\n          }"),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -1652,7 +1652,7 @@ func applyFixturePlanFile(t *testing.T) string {
 			Type: "test_instance",
 			Name: "foo",
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-		ProviderAddr: addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+		ProviderAddr: addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		ChangeSrc: plans.ChangeSrc{
 			Action: plans.Create,
 			Before: priorValRaw,

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -266,7 +266,7 @@ func testState() *states.State {
 				DependsOn:    []addrs.Referenceable{},
 			},
 			addrs.ProviderConfig{
-				Type: "test",
+				Type: addrs.NewLegacyProvider("test"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 		// DeepCopy is used here to ensure our synthetic state matches exactly

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3157,7 +3157,7 @@ func runTestCases(t *testing.T, testCases map[string]testCase) {
 					Type: "test_instance",
 					Name: "example",
 				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-				ProviderAddr: addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+				ProviderAddr: addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 				ChangeSrc: plans.ChangeSrc{
 					Action: tc.Action,
 					Before: before,

--- a/command/format/state_test.go
+++ b/command/format/state_test.go
@@ -244,7 +244,7 @@ func basicState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	rootModule.SetResourceInstanceCurrent(
@@ -259,7 +259,7 @@ func basicState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"compute":"sure"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	return state
@@ -294,7 +294,7 @@ func stateWithMoreOutputs(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	return state
@@ -320,7 +320,7 @@ func nestedState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	return state
@@ -342,7 +342,7 @@ func deposedState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	return state
@@ -370,7 +370,7 @@ func onlyDeposedState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	rootModule.SetResourceInstanceDeposed(
@@ -386,7 +386,7 @@ func onlyDeposedState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	return state

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -125,7 +125,7 @@ func TestGraph_plan(t *testing.T) {
 			Before: plans.DynamicValue(`{}`),
 			After:  plans.DynamicValue(`null`),
 		},
-		ProviderAddr: addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+		ProviderAddr: addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 	})
 	emptyConfig, err := plans.NewDynamicValue(cty.EmptyObjectVal, cty.EmptyObject)
 	if err != nil {

--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -302,7 +302,7 @@ func marshalResources(resources map[string]*configs.Resource, schemas *terraform
 		}
 
 		schema, schemaVer := schemas.ResourceTypeConfig(
-			v.ProviderConfigAddr().Type,
+			v.ProviderConfigAddr().Type.LegacyString(),
 			v.Mode,
 			v.Type,
 		)

--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -178,7 +178,7 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 		}
 
 		schema, _ := schemas.ResourceTypeConfig(
-			rc.ProviderAddr.ProviderConfig.Type,
+			rc.ProviderAddr.ProviderConfig.Type.LegacyString(),
 			addr.Resource.Resource.Mode,
 			addr.Resource.Resource.Type,
 		)

--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -181,7 +181,7 @@ func marshalPlanResources(changes *plans.Changes, ris []addrs.AbsResourceInstanc
 		}
 
 		schema, schemaVer := schemas.ResourceTypeConfig(
-			r.ProviderAddr.ProviderConfig.Type,
+			r.ProviderAddr.ProviderConfig.Type.LegacyString(),
 			r.Addr.Resource.Resource.Mode,
 			resource.Type,
 		)

--- a/command/jsonplan/values_test.go
+++ b/command/jsonplan/values_test.go
@@ -258,7 +258,7 @@ func TestMarshalPlanResources(t *testing.T) {
 							Type: "test_thing",
 							Name: "example",
 						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-						ProviderAddr: addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+						ProviderAddr: addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 						ChangeSrc: plans.ChangeSrc{
 							Action: test.Action,
 							Before: before,

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -274,7 +274,7 @@ func marshalResources(resources map[string]*states.Resource, schemas *terraform.
 			}
 
 			schema, _ := schemas.ResourceTypeConfig(
-				r.ProviderConfig.ProviderConfig.Type,
+				r.ProviderConfig.ProviderConfig.Type.LegacyString(),
 				r.Addr.Mode,
 				r.Addr.Type,
 			)

--- a/command/jsonstate/state_test.go
+++ b/command/jsonstate/state_test.go
@@ -202,7 +202,7 @@ func TestMarshalResources(t *testing.T) {
 						},
 					},
 					ProviderConfig: addrs.ProviderConfig{
-						Type: "test",
+						Type: addrs.NewLegacyProvider("test"),
 					}.Absolute(addrs.RootModuleInstance),
 				},
 			},
@@ -245,7 +245,7 @@ func TestMarshalResources(t *testing.T) {
 						},
 					},
 					ProviderConfig: addrs.ProviderConfig{
-						Type: "test",
+						Type: addrs.NewLegacyProvider("test"),
 					}.Absolute(addrs.RootModuleInstance),
 				},
 			},
@@ -293,7 +293,7 @@ func TestMarshalResources(t *testing.T) {
 						},
 					},
 					ProviderConfig: addrs.ProviderConfig{
-						Type: "test",
+						Type: addrs.NewLegacyProvider("test"),
 					}.Absolute(addrs.RootModuleInstance),
 				},
 			},

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -124,7 +124,7 @@ func TestPlan_destroy(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	outPath := testTempFile(t)
@@ -240,7 +240,7 @@ func TestPlan_outPathNoChange(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","ami":"bar","network_interface":[{"description":"Main network interface","device_index":"0"}]}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, originalState)

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -400,7 +400,7 @@ func showFixturePlanFile(t *testing.T) string {
 			Type: "test_instance",
 			Name: "foo",
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-		ProviderAddr: addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+		ProviderAddr: addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		ChangeSrc: plans.ChangeSrc{
 			Action: plans.Create,
 			Before: priorValRaw,

--- a/command/state_mv_test.go
+++ b/command/state_mv_test.go
@@ -27,7 +27,7 @@ func TestStateMv(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -39,7 +39,7 @@ func TestStateMv(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -87,7 +87,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -99,7 +99,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceMeta(
 			addrs.Resource{
@@ -108,7 +108,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 				Name: "bar",
 			}.Absolute(addrs.RootModuleInstance),
 			states.EachList,
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -167,7 +167,7 @@ func TestStateMv_instanceToResource(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -179,7 +179,7 @@ func TestStateMv_instanceToResource(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -249,7 +249,7 @@ func TestStateMv_differentResourceTypes(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -299,7 +299,7 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -311,7 +311,7 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -368,7 +368,7 @@ func TestStateMv_backupExplicit(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -380,7 +380,7 @@ func TestStateMv_backupExplicit(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -426,7 +426,7 @@ func TestStateMv_stateOutNew(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -477,7 +477,7 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, stateSrc)
@@ -493,7 +493,7 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	stateOutPath := testStateFile(t, stateDst)
@@ -570,7 +570,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -582,7 +582,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -594,7 +594,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -649,7 +649,7 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 					AttrsJSON: []byte(fmt.Sprintf(`{"id":"foo%d","foo":"value","bar":"value"}`, i)),
 					Status:    states.ObjectReady,
 				},
-				addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+				addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 			)
 		}
 		s.SetResourceInstanceCurrent(
@@ -662,7 +662,7 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -713,7 +713,7 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -725,7 +725,7 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 
@@ -777,7 +777,7 @@ func TestStateMv_toNewModule(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 

--- a/command/state_rm_test.go
+++ b/command/state_rm_test.go
@@ -25,7 +25,7 @@ func TestStateRm(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -37,7 +37,7 @@ func TestStateRm(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -84,7 +84,7 @@ func TestStateRmNotChildModule(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		// This second instance has the same local address as the first but
 		// is in a child module. Older versions of Terraform would incorrectly
@@ -99,7 +99,7 @@ func TestStateRmNotChildModule(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -167,7 +167,7 @@ func TestStateRmNoArgs(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -179,7 +179,7 @@ func TestStateRmNoArgs(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -220,7 +220,7 @@ func TestStateRmNonExist(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -232,7 +232,7 @@ func TestStateRmNonExist(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -274,7 +274,7 @@ func TestStateRm_backupExplicit(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -286,7 +286,7 @@ func TestStateRm_backupExplicit(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -384,7 +384,7 @@ func TestStateRm_backendState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -396,7 +396,7 @@ func TestStateRm_backendState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 

--- a/command/state_show_test.go
+++ b/command/state_show_test.go
@@ -24,7 +24,7 @@ func TestStateShow(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -79,7 +79,7 @@ func TestStateShow_multi(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -91,7 +91,7 @@ func TestStateShow_multi(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(submod),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(submod),
 		)
 	})
 	statePath := testStateFile(t, state)

--- a/command/taint_test.go
+++ b/command/taint_test.go
@@ -24,7 +24,7 @@ func TestTaint(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -59,7 +59,7 @@ func TestTaint_lockedState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -245,7 +245,7 @@ func TestTaint_missing(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -278,7 +278,7 @@ func TestTaint_missingAllow(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -354,7 +354,7 @@ func TestTaint_module(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -366,7 +366,7 @@ func TestTaint_module(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"blah"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)

--- a/command/untaint_test.go
+++ b/command/untaint_test.go
@@ -23,7 +23,7 @@ func TestUntaint(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -63,7 +63,7 @@ func TestUntaint_lockedState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -271,7 +271,7 @@ func TestUntaint_missing(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -304,7 +304,7 @@ func TestUntaint_missingAllow(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -389,7 +389,7 @@ func TestUntaint_module(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -401,7 +401,7 @@ func TestUntaint_module(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 	statePath := testStateFile(t, state)

--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -241,7 +241,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 

--- a/configs/config.go
+++ b/configs/config.go
@@ -191,11 +191,11 @@ func (c *Config) gatherProviderTypes(m map[string]struct{}) {
 	}
 	for _, rc := range c.Module.ManagedResources {
 		providerAddr := rc.ProviderConfigAddr()
-		m[providerAddr.Type] = struct{}{}
+		m[providerAddr.Type.LegacyString()] = struct{}{}
 	}
 	for _, rc := range c.Module.DataResources {
 		providerAddr := rc.ProviderConfigAddr()
-		m[providerAddr.Type] = struct{}{}
+		m[providerAddr.Type.LegacyString()] = struct{}{}
 	}
 
 	// Must also visit our child modules, recursively.

--- a/configs/provider.go
+++ b/configs/provider.go
@@ -95,7 +95,7 @@ func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
 // to its containing module.
 func (p *Provider) Addr() addrs.ProviderConfig {
 	return addrs.ProviderConfig{
-		Type:  p.Name,
+		Type:  addrs.NewLegacyProvider(p.Name),
 		Alias: p.Alias,
 	}
 }

--- a/configs/resource.go
+++ b/configs/resource.go
@@ -70,7 +70,7 @@ func (r *Resource) ProviderConfigAddr() addrs.ProviderConfig {
 	}
 
 	return addrs.ProviderConfig{
-		Type:  r.ProviderConfigRef.Name,
+		Type:  addrs.NewLegacyProvider(r.ProviderConfigRef.Name),
 		Alias: r.ProviderConfigRef.Alias,
 	}
 }
@@ -436,7 +436,7 @@ func decodeProviderConfigRef(expr hcl.Expression, argName string) (*ProviderConf
 // location information and keeping just the addressing information.
 func (r *ProviderConfigRef) Addr() addrs.ProviderConfig {
 	return addrs.ProviderConfig{
-		Type:  r.Name,
+		Type:  addrs.NewLegacyProvider(r.Name),
 		Alias: r.Alias,
 	}
 }

--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -50,7 +50,7 @@ func shimNewState(newState *states.State, providers map[string]terraform.Resourc
 			resType := res.Addr.Type
 			providerType := res.ProviderConfig.ProviderConfig.Type
 
-			resource := getResource(providers, providerType, res.Addr)
+			resource := getResource(providers, providerType.LegacyString(), res.Addr)
 
 			for key, i := range res.Instances {
 				resState := &terraform.ResourceState{

--- a/helper/resource/state_shim_test.go
+++ b/helper/resource/state_shim_test.go
@@ -42,7 +42,7 @@ func TestStateShim(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	rootModule.SetResourceInstanceCurrent(
@@ -57,7 +57,7 @@ func TestStateShim(t *testing.T) {
 			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 
@@ -75,7 +75,7 @@ func TestStateShim(t *testing.T) {
 			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(childInstance),
 	)
 	childModule.SetResourceInstanceCurrent(
@@ -98,7 +98,7 @@ func TestStateShim(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(childInstance),
 	)
 
@@ -123,7 +123,7 @@ func TestStateShim(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(childInstance),
 	)
 
@@ -139,7 +139,7 @@ func TestStateShim(t *testing.T) {
 			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(childInstance),
 	)
 	childModule.SetResourceInstanceCurrent(
@@ -154,7 +154,7 @@ func TestStateShim(t *testing.T) {
 			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(childInstance),
 	)
 
@@ -170,7 +170,7 @@ func TestStateShim(t *testing.T) {
 			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(childInstance),
 	)
 

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -728,7 +728,7 @@ func testIDOnlyRefresh(c TestCase, opts terraform.ContextOpts, step TestStep, r 
 			AttrsFlat: r.Primary.Attributes,
 			Status:    states.ObjectReady,
 		},
-		addrs.ProviderConfig{Type: "placeholder"}.Absolute(addrs.RootModuleInstance),
+		addrs.ProviderConfig{Type: addrs.NewLegacyProvider("placeholder")}.Absolute(addrs.RootModuleInstance),
 	)
 
 	// Create the config module. We use the full config because Refresh

--- a/helper/resource/testing_import_state.go
+++ b/helper/resource/testing_import_state.go
@@ -137,7 +137,7 @@ func testStepImportState(
 			// this shouldn't happen in any reasonable case.
 			var rsrcSchema *schema.Resource
 			if providerAddr, diags := addrs.ParseAbsProviderConfigStr(r.Provider); !diags.HasErrors() {
-				providerType := providerAddr.ProviderConfig.Type
+				providerType := providerAddr.ProviderConfig.Type.LegacyString()
 				if provider, ok := step.providers[providerType]; ok {
 					if provider, ok := provider.(*schema.Provider); ok {
 						rsrcSchema = provider.ResourcesMap[r.Type]

--- a/plans/plan_test.go
+++ b/plans/plan_test.go
@@ -21,7 +21,7 @@ func TestProviderAddrs(t *testing.T) {
 						Name: "woot",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.ProviderConfig{
-						Type: "test",
+						Type: addrs.NewLegacyProvider("test"),
 					}.Absolute(addrs.RootModuleInstance),
 				},
 				{
@@ -32,7 +32,7 @@ func TestProviderAddrs(t *testing.T) {
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					DeposedKey: "foodface",
 					ProviderAddr: addrs.ProviderConfig{
-						Type: "test",
+						Type: addrs.NewLegacyProvider("test"),
 					}.Absolute(addrs.RootModuleInstance),
 				},
 				{
@@ -42,7 +42,7 @@ func TestProviderAddrs(t *testing.T) {
 						Name: "what",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.ProviderConfig{
-						Type: "test",
+						Type: addrs.NewLegacyProvider("test"),
 					}.Absolute(addrs.RootModuleInstance.Child("foo", addrs.NoKey)),
 				},
 			},
@@ -52,10 +52,10 @@ func TestProviderAddrs(t *testing.T) {
 	got := plan.ProviderAddrs()
 	want := []addrs.AbsProviderConfig{
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance.Child("foo", addrs.NoKey)),
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	}
 

--- a/plans/planfile/tfplan_test.go
+++ b/plans/planfile/tfplan_test.go
@@ -57,7 +57,7 @@ func TestTFPlanRoundTrip(t *testing.T) {
 						Name: "woot",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.ProviderConfig{
-						Type: "test",
+						Type: addrs.NewLegacyProvider("test"),
 					}.Absolute(addrs.RootModuleInstance),
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.DeleteThenCreate,
@@ -77,7 +77,7 @@ func TestTFPlanRoundTrip(t *testing.T) {
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					DeposedKey: "foodface",
 					ProviderAddr: addrs.ProviderConfig{
-						Type: "test",
+						Type: addrs.NewLegacyProvider("test"),
 					}.Absolute(addrs.RootModuleInstance),
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.Delete,
@@ -195,7 +195,7 @@ func TestTFPlanRoundTripDestroy(t *testing.T) {
 						Name: "woot",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.ProviderConfig{
-						Type: "test",
+						Type: addrs.NewLegacyProvider("test"),
 					}.Absolute(addrs.RootModuleInstance),
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.Delete,

--- a/providers/addressed_types.go
+++ b/providers/addressed_types.go
@@ -14,7 +14,7 @@ func AddressedTypes(providerAddrs []addrs.ProviderConfig) []string {
 	}
 	m := map[string]struct{}{}
 	for _, addr := range providerAddrs {
-		m[addr.Type] = struct{}{}
+		m[addr.Type.LegacyString()] = struct{}{}
 	}
 
 	names := make([]string, 0, len(m))
@@ -34,7 +34,7 @@ func AddressedTypesAbs(providerAddrs []addrs.AbsProviderConfig) []string {
 	}
 	m := map[string]struct{}{}
 	for _, addr := range providerAddrs {
-		m[addr.ProviderConfig.Type] = struct{}{}
+		m[addr.ProviderConfig.Type.LegacyString()] = struct{}{}
 	}
 
 	names := make([]string, 0, len(m))

--- a/providers/addressed_types_test.go
+++ b/providers/addressed_types_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestAddressedTypes(t *testing.T) {
 	providerAddrs := []addrs.ProviderConfig{
-		{Type: "aws"},
-		{Type: "aws", Alias: "foo"},
-		{Type: "azure"},
-		{Type: "null"},
-		{Type: "null"},
+		{Type: addrs.NewLegacyProvider("aws")},
+		{Type: addrs.NewLegacyProvider("aws"), Alias: "foo"},
+		{Type: addrs.NewLegacyProvider("azure")},
+		{Type: addrs.NewLegacyProvider("null")},
+		{Type: addrs.NewLegacyProvider("null")},
 	}
 
 	got := AddressedTypes(providerAddrs)
@@ -30,11 +30,11 @@ func TestAddressedTypes(t *testing.T) {
 
 func TestAddressedTypesAbs(t *testing.T) {
 	providerAddrs := []addrs.AbsProviderConfig{
-		addrs.ProviderConfig{Type: "aws"}.Absolute(addrs.RootModuleInstance),
-		addrs.ProviderConfig{Type: "aws", Alias: "foo"}.Absolute(addrs.RootModuleInstance),
-		addrs.ProviderConfig{Type: "azure"}.Absolute(addrs.RootModuleInstance),
-		addrs.ProviderConfig{Type: "null"}.Absolute(addrs.RootModuleInstance),
-		addrs.ProviderConfig{Type: "null"}.Absolute(addrs.RootModuleInstance),
+		addrs.ProviderConfig{Type: addrs.NewLegacyProvider("aws")}.Absolute(addrs.RootModuleInstance),
+		addrs.ProviderConfig{Type: addrs.NewLegacyProvider("aws"), Alias: "foo"}.Absolute(addrs.RootModuleInstance),
+		addrs.ProviderConfig{Type: addrs.NewLegacyProvider("azure")}.Absolute(addrs.RootModuleInstance),
+		addrs.ProviderConfig{Type: addrs.NewLegacyProvider("null")}.Absolute(addrs.RootModuleInstance),
+		addrs.ProviderConfig{Type: addrs.NewLegacyProvider("null")}.Absolute(addrs.RootModuleInstance),
 	}
 
 	got := AddressedTypesAbs(providerAddrs)

--- a/repl/session_test.go
+++ b/repl/session_test.go
@@ -46,7 +46,7 @@ func TestSession_basicState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 			},
 			addrs.ProviderConfig{
-				Type: "test",
+				Type: addrs.NewLegacyProvider("test"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
@@ -60,7 +60,7 @@ func TestSession_basicState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 			},
 			addrs.ProviderConfig{
-				Type: "test",
+				Type: addrs.NewLegacyProvider("test"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 	})

--- a/states/state_test.go
+++ b/states/state_test.go
@@ -36,7 +36,7 @@ func TestState(t *testing.T) {
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 
@@ -79,7 +79,7 @@ func TestState(t *testing.T) {
 							},
 						},
 						ProviderConfig: addrs.ProviderConfig{
-							Type: "test",
+							Type: addrs.NewLegacyProvider("test"),
 						}.Absolute(addrs.RootModuleInstance),
 					},
 				},
@@ -141,7 +141,7 @@ func TestStateDeepCopy(t *testing.T) {
 			Dependencies:  []addrs.AbsResource{},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	rootModule.SetResourceInstanceCurrent(
@@ -167,7 +167,7 @@ func TestStateDeepCopy(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -1371,7 +1371,7 @@ func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
 			Dependencies: []addrs.AbsResource{},
 		},
 		addrs.ProviderConfig{
-			Type: "aws",
+			Type: addrs.NewLegacyProvider("aws"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	root.SetResourceInstanceCurrent(
@@ -1395,7 +1395,7 @@ func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "aws",
+			Type: addrs.NewLegacyProvider("aws"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 
@@ -1498,7 +1498,7 @@ func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
 			Dependencies: []addrs.AbsResource{},
 		},
 		addrs.ProviderConfig{
-			Type: "aws",
+			Type: addrs.NewLegacyProvider("aws"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	child.SetResourceInstanceCurrent(
@@ -1522,7 +1522,7 @@ func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "aws",
+			Type: addrs.NewLegacyProvider("aws"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 
@@ -2145,7 +2145,7 @@ func TestContext2Apply_provisionerDestroyForEach(t *testing.T) {
 						},
 						ProviderConfig: addrs.AbsProviderConfig{
 							Module:         addrs.ModuleInstance(nil),
-							ProviderConfig: addrs.ProviderConfig{Type: "aws", Alias: ""},
+							ProviderConfig: addrs.ProviderConfig{Type: addrs.NewLegacyProvider("aws"), Alias: ""},
 						},
 					},
 				},
@@ -2966,7 +2966,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 	// with the single instance associated with test_thing.one.
 	want := states.BuildState(func(s *states.SyncState) {
 		providerAddr := addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance)
 		zeroAddr := addrs.Resource{
 			Mode: addrs.ManagedResourceMode,
@@ -7386,7 +7386,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 					AttrsJSON: []byte(`{"id":"baz"}`),
 				},
 				addrs.ProviderConfig{
-					Type: "test",
+					Type: addrs.NewLegacyProvider("test"),
 				}.Absolute(addrs.RootModuleInstance),
 			)
 		}),
@@ -7525,7 +7525,7 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 					AttrsJSON: []byte(`{"value":"old"}`),
 				},
 				addrs.ProviderConfig{
-					Type: "aws",
+					Type: addrs.NewLegacyProvider("aws"),
 				}.Absolute(addrs.RootModuleInstance),
 			)
 		}),
@@ -9188,7 +9188,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","require_new":"ami-old"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "aws",
+			Type: addrs.NewLegacyProvider("aws"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 
@@ -9213,7 +9213,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "aws",
+			Type: addrs.NewLegacyProvider("aws"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 
@@ -9319,7 +9319,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","require_new":"ami-old"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "aws",
+			Type: addrs.NewLegacyProvider("aws"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 
@@ -9344,7 +9344,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "aws",
+			Type: addrs.NewLegacyProvider("aws"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 
@@ -10262,7 +10262,7 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 
 	// correct the state
 	s.Modules["module.mod.module.removed"].Resources["aws_instance.child"].ProviderConfig = addrs.ProviderConfig{
-		Type:  "aws",
+		Type:  addrs.NewLegacyProvider("aws"),
 		Alias: "bar",
 	}.Absolute(addrs.RootModuleInstance)
 
@@ -10687,7 +10687,7 @@ func TestContext2Apply_issue19908(t *testing.T) {
 					Status:    states.ObjectReady,
 				},
 				addrs.ProviderConfig{
-					Type: "test",
+					Type: addrs.NewLegacyProvider("test"),
 				}.Absolute(addrs.RootModuleInstance),
 			)
 		}),
@@ -10814,7 +10814,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"a","require_new":"old"}`),
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 
@@ -10830,7 +10830,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"b","require_new":"old"}`),
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 
@@ -10872,7 +10872,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 						Name: "a",
 					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance.Child("a", addrs.NoKey)),
 					ProviderAddr: addrs.ProviderConfig{
-						Type: "aws",
+						Type: addrs.NewLegacyProvider("aws"),
 					}.Absolute(addrs.RootModuleInstance),
 					ChangeSrc: plans.ChangeSrc{
 						Action: aAction,
@@ -10887,7 +10887,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 						Name: "b",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance.Child("b", addrs.NoKey)),
 					ProviderAddr: addrs.ProviderConfig{
-						Type: "aws",
+						Type: addrs.NewLegacyProvider("aws"),
 					}.Absolute(addrs.RootModuleInstance),
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.DeleteThenCreate,
@@ -10937,7 +10937,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"a"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "null",
+			Type: addrs.NewLegacyProvider("null"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	root.SetResourceInstanceCurrent(
@@ -10951,7 +10951,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"data"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "null",
+			Type: addrs.NewLegacyProvider("null"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 
@@ -11025,7 +11025,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"a","foo":"a"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	root.SetResourceInstanceCurrent(
@@ -11039,7 +11039,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"b","foo":"b"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	root.SetResourceInstanceCurrent(
@@ -11053,7 +11053,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"c","foo":"old"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 
@@ -11168,7 +11168,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	root.SetResourceInstanceCurrent(
@@ -11192,7 +11192,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	root.SetResourceInstanceCurrent(
@@ -11206,7 +11206,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"c","require_new":"old"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 

--- a/terraform/context_components.go
+++ b/terraform/context_components.go
@@ -33,16 +33,15 @@ type basicComponentFactory struct {
 }
 
 func (c *basicComponentFactory) ResourceProviders() []string {
-	result := make([]string, len(c.providers))
+	var result []string
 	for k := range c.providers {
 		result = append(result, k.LegacyString())
 	}
-
 	return result
 }
 
 func (c *basicComponentFactory) ResourceProvisioners() []string {
-	result := make([]string, len(c.provisioners))
+	var result []string
 	for k := range c.provisioners {
 		result = append(result, k)
 	}

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -115,7 +115,7 @@ func TestContextImport_collision(t *testing.T) {
 					},
 					Status: states.ObjectReady,
 				},
-				addrs.ProviderConfig{Type: "aws"}.Absolute(addrs.RootModuleInstance),
+				addrs.ProviderConfig{Type: addrs.NewLegacyProvider("aws")}.Absolute(addrs.RootModuleInstance),
 			)
 		}),
 	})
@@ -601,7 +601,7 @@ func TestContextImport_moduleDiff(t *testing.T) {
 					},
 					Status: states.ObjectReady,
 				},
-				addrs.ProviderConfig{Type: "aws"}.Absolute(addrs.RootModuleInstance),
+				addrs.ProviderConfig{Type: addrs.NewLegacyProvider("aws")}.Absolute(addrs.RootModuleInstance),
 			)
 		}),
 	})
@@ -659,7 +659,7 @@ func TestContextImport_moduleExisting(t *testing.T) {
 					},
 					Status: states.ObjectReady,
 				},
-				addrs.ProviderConfig{Type: "aws"}.Absolute(addrs.RootModuleInstance),
+				addrs.ProviderConfig{Type: addrs.NewLegacyProvider("aws")}.Absolute(addrs.RootModuleInstance),
 			)
 		}),
 	})

--- a/terraform/context_input.go
+++ b/terraform/context_input.go
@@ -96,7 +96,7 @@ func (c *Context) Input(mode InputMode) tfdiags.Diagnostics {
 				UIInput:     c.uiInput,
 			}
 
-			schema := c.schemas.ProviderConfig(pa.Type)
+			schema := c.schemas.ProviderConfig(pa.Type.LegacyString())
 			if schema == nil {
 				// Could either be an incorrect config or just an incomplete
 				// mock in tests. We'll let a later pass decide, and just

--- a/terraform/context_input_test.go
+++ b/terraform/context_input_test.go
@@ -478,7 +478,7 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.ProviderConfig{Type: "null"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("null")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -4976,7 +4976,7 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 				AttrsJSON: []byte(`{"tags":{"ignored":"from state","other":"from state"}}`),
 			},
 			addrs.ProviderConfig{
-				Type: "test",
+				Type: addrs.NewLegacyProvider("test"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 	})

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -104,7 +104,7 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 				AttrsJSON: []byte(`{"dynamic":{"type":"string","value":"hello"}}`),
 			},
 			addrs.ProviderConfig{
-				Type: "test",
+				Type: addrs.NewLegacyProvider("test"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 	})
@@ -1739,7 +1739,7 @@ func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
 					"id": "foo",
 				},
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 
@@ -1822,7 +1822,7 @@ func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
 				SchemaVersion: 3,
 				AttrsJSON:     []byte(`{"id":"foo"}`),
 			},
-			addrs.ProviderConfig{Type: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}.Absolute(addrs.RootModuleInstance),
 		)
 	})
 
@@ -1991,7 +1991,7 @@ func TestRefresh_updateDependencies(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "aws",
+			Type: addrs.NewLegacyProvider("aws"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	root.SetResourceInstanceCurrent(
@@ -2005,7 +2005,7 @@ func TestRefresh_updateDependencies(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo":"foo"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "aws",
+			Type: addrs.NewLegacyProvider("aws"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -142,7 +142,7 @@ func (ctx *BuiltinEvalContext) Provider(addr addrs.AbsProviderConfig) providers.
 func (ctx *BuiltinEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) *ProviderSchema {
 	ctx.once.Do(ctx.init)
 
-	return ctx.Schemas.ProviderSchema(addr.ProviderConfig.Type)
+	return ctx.Schemas.ProviderSchema(addr.ProviderConfig.Type.LegacyString())
 }
 
 func (ctx *BuiltinEvalContext) CloseProvider(addr addrs.ProviderConfig) error {

--- a/terraform/eval_context_builtin_test.go
+++ b/terraform/eval_context_builtin_test.go
@@ -24,7 +24,7 @@ func TestBuiltinEvalContextProviderInput(t *testing.T) {
 	ctx2.ProviderInputConfig = cache
 	ctx2.ProviderLock = &lock
 
-	providerAddr := addrs.ProviderConfig{Type: "foo"}
+	providerAddr := addrs.ProviderConfig{Type: addrs.NewLegacyProvider("foo")}
 
 	expected1 := map[string]cty.Value{"value": cty.StringVal("foo")}
 	ctx1.SetProviderInput(providerAddr, expected1)
@@ -57,8 +57,8 @@ func TestBuildingEvalContextInitProvider(t *testing.T) {
 		},
 	}
 
-	providerAddrDefault := addrs.ProviderConfig{Type: "test"}
-	providerAddrAlias := addrs.ProviderConfig{Type: "test", Alias: "foo"}
+	providerAddrDefault := addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test")}
+	providerAddrAlias := addrs.ProviderConfig{Type: addrs.NewLegacyProvider("test"), Alias: "foo"}
 
 	_, err := ctx.InitProvider("test", providerAddrDefault)
 	if err != nil {

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -120,7 +120,7 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 	if providerSchema == nil {
 		return nil, fmt.Errorf("provider schema is unavailable for %s", n.Addr)
 	}
-	if n.ProviderAddr.ProviderConfig.Type == "" {
+	if n.ProviderAddr.ProviderConfig.Type.LegacyString() == "" {
 		panic(fmt.Sprintf("EvalDiff for %s does not have ProviderAddr set", n.Addr.Absolute(ctx.Path())))
 	}
 
@@ -603,7 +603,7 @@ func (n *EvalDiffDestroy) Eval(ctx EvalContext) (interface{}, error) {
 	absAddr := n.Addr.Absolute(ctx.Path())
 	state := *n.State
 
-	if n.ProviderAddr.ProviderConfig.Type == "" {
+	if n.ProviderAddr.ProviderConfig.Type.LegacyString() == "" {
 		if n.DeposedKey == "" {
 			panic(fmt.Sprintf("EvalDiffDestroy for %s does not have ProviderAddr set", absAddr))
 		} else {

--- a/terraform/eval_provider.go
+++ b/terraform/eval_provider.go
@@ -125,7 +125,7 @@ type EvalGetProvider struct {
 }
 
 func (n *EvalGetProvider) Eval(ctx EvalContext) (interface{}, error) {
-	if n.Addr.ProviderConfig.Type == "" {
+	if n.Addr.ProviderConfig.Type.LegacyString() == "" {
 		// Should never happen
 		panic("EvalGetProvider used with uninitialized provider configuration address")
 	}

--- a/terraform/eval_provider_test.go
+++ b/terraform/eval_provider_test.go
@@ -17,7 +17,7 @@ func TestBuildProviderConfig(t *testing.T) {
 		"set_in_config": cty.StringVal("config"),
 	})
 	providerAddr := addrs.ProviderConfig{
-		Type: "foo",
+		Type: addrs.NewLegacyProvider("foo"),
 	}
 
 	ctx := &MockEvalContext{
@@ -68,7 +68,7 @@ func TestEvalConfigProvider(t *testing.T) {
 	provider := mockProviderWithConfigSchema(simpleTestSchema())
 	rp := providers.Interface(provider)
 	n := &EvalConfigProvider{
-		Addr:     addrs.ProviderConfig{Type: "foo"},
+		Addr:     addrs.ProviderConfig{Type: addrs.NewLegacyProvider("foo")},
 		Config:   config,
 		Provider: &rp,
 	}
@@ -98,7 +98,7 @@ func TestEvalInitProvider_impl(t *testing.T) {
 
 func TestEvalInitProvider(t *testing.T) {
 	n := &EvalInitProvider{
-		Addr: addrs.ProviderConfig{Type: "foo"},
+		Addr: addrs.ProviderConfig{Type: addrs.NewLegacyProvider("foo")},
 	}
 	provider := &MockProvider{}
 	ctx := &MockEvalContext{InitProviderProvider: provider}
@@ -116,7 +116,7 @@ func TestEvalInitProvider(t *testing.T) {
 
 func TestEvalCloseProvider(t *testing.T) {
 	n := &EvalCloseProvider{
-		Addr: addrs.ProviderConfig{Type: "foo"},
+		Addr: addrs.ProviderConfig{Type: addrs.NewLegacyProvider("foo")},
 	}
 	provider := &MockProvider{}
 	ctx := &MockEvalContext{CloseProviderProvider: provider}

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -217,7 +217,7 @@ func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
 	absAddr := n.Addr.Absolute(ctx.Path())
 	state := ctx.State()
 
-	if n.ProviderAddr.ProviderConfig.Type == "" {
+	if n.ProviderAddr.ProviderConfig.Type.LegacyString() == "" {
 		return nil, fmt.Errorf("failed to write state for %s, missing provider type", absAddr)
 	}
 	obj := *n.State

--- a/terraform/evaltree_provider.go
+++ b/terraform/evaltree_provider.go
@@ -16,7 +16,7 @@ func ProviderEvalTree(n *NodeApplyableProvider, config *configs.Provider) EvalNo
 
 	seq := make([]EvalNode, 0, 5)
 	seq = append(seq, &EvalInitProvider{
-		TypeName: relAddr.Type,
+		TypeName: relAddr.Type.LegacyString(),
 		Addr:     addr.ProviderConfig,
 	})
 

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -779,7 +779,7 @@ func (d *evaluationStateData) getResourceInstancesAll(addr addrs.Resource, rng t
 }
 
 func (d *evaluationStateData) getResourceSchema(addr addrs.Resource, providerAddr addrs.AbsProviderConfig) *configschema.Block {
-	providerType := providerAddr.ProviderConfig.Type
+	providerType := providerAddr.ProviderConfig.Type.LegacyString()
 	schemas := d.Evaluator.Schemas
 	schema, _ := schemas.ResourceTypeConfig(providerType, addr.Mode, addr.Type)
 	return schema

--- a/terraform/evaluate_valid.go
+++ b/terraform/evaluate_valid.go
@@ -215,7 +215,7 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 	// Normally accessing this directly is wrong because it doesn't take into
 	// account provider inheritance, etc but it's okay here because we're only
 	// paying attention to the type anyway.
-	providerType := cfg.ProviderConfigAddr().Type
+	providerType := cfg.ProviderConfigAddr().Type.LegacyString()
 	schema, _ := d.Evaluator.Schemas.ResourceTypeConfig(providerType, addr.Mode, addr.Type)
 
 	if schema == nil {

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -545,7 +545,7 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"a_id"}`),
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 	root.SetResourceInstanceCurrent(
@@ -569,7 +569,7 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 			},
 		},
 		addrs.ProviderConfig{
-			Type: "test",
+			Type: addrs.NewLegacyProvider("test"),
 		}.Absolute(addrs.RootModuleInstance),
 	)
 

--- a/terraform/node_data_refresh_test.go
+++ b/terraform/node_data_refresh_test.go
@@ -130,7 +130,7 @@ func TestNodeRefreshableDataResourceDynamicExpand_scaleIn(t *testing.T) {
 			Config: m.Module.DataResources["data.aws_instance.foo"],
 			ResolvedProvider: addrs.AbsProviderConfig{
 				ProviderConfig: addrs.ProviderConfig{
-					Type: "aws",
+					Type: addrs.NewLegacyProvider("aws"),
 				},
 			},
 		},
@@ -174,7 +174,7 @@ root - terraform.graphNodeRoot
 		t.Fatal("failed to find a destroyableDataResource")
 	}
 
-	if destroyableDataResource.ResolvedProvider.ProviderConfig.Type == "" {
+	if destroyableDataResource.ResolvedProvider.ProviderConfig.Type.LegacyString() == "" {
 		t.Fatal("NodeDestroyableDataResourceInstance missing provider config")
 	}
 }

--- a/terraform/node_provider_eval.go
+++ b/terraform/node_provider_eval.go
@@ -14,7 +14,7 @@ func (n *NodeEvalableProvider) EvalTree() EvalNode {
 	relAddr := addr.ProviderConfig
 
 	return &EvalInitProvider{
-		TypeName: relAddr.Type,
+		TypeName: relAddr.Type.LegacyString(),
 		Addr:     addr.ProviderConfig,
 	}
 }

--- a/terraform/node_resource_plan_destroy.go
+++ b/terraform/node_resource_plan_destroy.go
@@ -47,7 +47,7 @@ func (n *NodePlanDestroyableResourceInstance) EvalTree() EvalNode {
 	var change *plans.ResourceInstanceChange
 	var state *states.ResourceInstanceObject
 
-	if n.ResolvedProvider.ProviderConfig.Type == "" {
+	if n.ResolvedProvider.ProviderConfig.Type.String() == "" {
 		// Should never happen; indicates that the graph was not constructed
 		// correctly since we didn't get our provider attached.
 		panic(fmt.Sprintf("%T %q was not assigned a resolved provider", n, dag.VertexName(n)))

--- a/terraform/transform_attach_schema.go
+++ b/terraform/transform_attach_schema.go
@@ -59,7 +59,7 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 			mode := addr.Resource.Mode
 			typeName := addr.Resource.Type
 			providerAddr, _ := tv.ProvidedBy()
-			providerType := providerAddr.ProviderConfig.Type
+			providerType := providerAddr.ProviderConfig.Type.LegacyString()
 
 			schema, version := t.Schemas.ResourceTypeConfig(providerType, mode, typeName)
 			if schema == nil {
@@ -72,7 +72,7 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 
 		if tv, ok := v.(GraphNodeAttachProviderConfigSchema); ok {
 			providerAddr := tv.ProviderAddr()
-			schema := t.Schemas.ProviderConfig(providerAddr.ProviderConfig.Type)
+			schema := t.Schemas.ProviderConfig(providerAddr.ProviderConfig.Type.LegacyString())
 			if schema == nil {
 				log.Printf("[ERROR] AttachSchemaTransformer: No provider config schema available for %s", providerAddr)
 				continue

--- a/terraform/transform_diff_test.go
+++ b/terraform/transform_diff_test.go
@@ -44,7 +44,7 @@ func TestDiffTransformer(t *testing.T) {
 						Name: "foo",
 					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.ProviderConfig{
-						Type: "aws",
+						Type: addrs.NewLegacyProvider("aws"),
 					}.Absolute(addrs.RootModuleInstance),
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.Update,

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -20,7 +20,7 @@ func (t *ImportStateTransformer) Transform(g *Graph) error {
 		// This will be populated if the targets come from the cli, but tests
 		// may not specify implied provider addresses.
 		providerAddr := target.ProviderAddr
-		if providerAddr.ProviderConfig.Type == "" {
+		if providerAddr.ProviderConfig.Type.Type == "" {
 			providerAddr = target.Addr.Resource.Resource.DefaultProviderConfig().Absolute(target.Addr.Module)
 		}
 

--- a/terraform/transform_orphan_count_test.go
+++ b/terraform/transform_orphan_count_test.go
@@ -353,7 +353,7 @@ func TestOrphanResourceCountTransformer_ForEachEdgesAdded(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 
@@ -371,7 +371,7 @@ func TestOrphanResourceCountTransformer_ForEachEdgesAdded(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 	})

--- a/terraform/transform_orphan_resource_test.go
+++ b/terraform/transform_orphan_resource_test.go
@@ -27,7 +27,7 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 
@@ -45,7 +45,7 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 	})
@@ -93,7 +93,7 @@ func TestOrphanResourceInstanceTransformer_countGood(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
@@ -109,7 +109,7 @@ func TestOrphanResourceInstanceTransformer_countGood(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 	})
@@ -156,7 +156,7 @@ func TestOrphanResourceInstanceTransformer_countBad(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
@@ -172,7 +172,7 @@ func TestOrphanResourceInstanceTransformer_countBad(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 	})
@@ -219,7 +219,7 @@ func TestOrphanResourceInstanceTransformer_modules(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 		s.SetResourceInstanceCurrent(
@@ -235,7 +235,7 @@ func TestOrphanResourceInstanceTransformer_modules(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			addrs.ProviderConfig{
-				Type: "aws",
+				Type: addrs.NewLegacyProvider("aws"),
 			}.Absolute(addrs.RootModuleInstance),
 		)
 	})

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -295,7 +295,7 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 		// We're going to create an implicit _default_ configuration for the
 		// referenced provider type in the _root_ module, ignoring all other
 		// aspects of the resource's declared provider address.
-		defaultAddr := addrs.RootModuleInstance.ProviderConfigDefault(p.ProviderConfig.Type)
+		defaultAddr := addrs.RootModuleInstance.ProviderConfigDefault(p.ProviderConfig.Type.LegacyString())
 		key := defaultAddr.String()
 		provider := m[key]
 
@@ -705,7 +705,7 @@ func (t *ProviderConfigTransformer) attachProviderConfigs(g *Graph) error {
 
 		// Go through the provider configs to find the matching config
 		for _, p := range mc.Module.ProviderConfigs {
-			if p.Name == addr.ProviderConfig.Type && p.Alias == addr.ProviderConfig.Alias {
+			if p.Name == addr.ProviderConfig.Type.LegacyString() && p.Alias == addr.ProviderConfig.Alias {
 				log.Printf("[TRACE] ProviderConfigTransformer: attaching to %q provider configuration from %s", dag.VertexName(v), p.DeclRange)
 				apn.AttachProvider(p)
 				break

--- a/terraform/transform_provisioner_test.go
+++ b/terraform/transform_provisioner_test.go
@@ -71,7 +71,7 @@ func TestMissingProvisionerTransformer_module(t *testing.T) {
 					Status: states.ObjectReady,
 				},
 				addrs.ProviderConfig{
-					Type: "aws",
+					Type: addrs.NewLegacyProvider("aws"),
 				}.Absolute(addrs.RootModuleInstance),
 			)
 			s.SetResourceInstanceCurrent(
@@ -87,7 +87,7 @@ func TestMissingProvisionerTransformer_module(t *testing.T) {
 					Status: states.ObjectReady,
 				},
 				addrs.ProviderConfig{
-					Type: "aws",
+					Type: addrs.NewLegacyProvider("aws"),
 				}.Absolute(addrs.RootModuleInstance),
 			)
 		})


### PR DESCRIPTION
The next big change! Weaving `addrs.Provider` into `addrs.ProviderConfig`

There are two commits; the first involves a small bug I happened across while battling tests. Tt was not what was causing my test error, so I left it as a separate commit. 