### PR TITLE
Update destroy provisioner warnings

### DIFF
--- a/command/meta_config.go
+++ b/command/meta_config.go
@@ -173,10 +173,13 @@ func (m *Meta) dirIsConfigPath(dir string) bool {
 // directory even if loadBackendConfig succeeded.)
 func (m *Meta) loadBackendConfig(rootDir string) (*configs.Backend, tfdiags.Diagnostics) {
 	mod, diags := m.loadSingleModule(rootDir)
+
+	// Only return error diagnostics at this point. Any warnings will be caught
+	// again later and duplicated in the output.
 	if diags.HasErrors() {
 		return nil, diags
 	}
-	return mod.Backend, diags
+	return mod.Backend, nil
 }
 
 // loadValuesFile loads a file that defines a single map of key/value pairs.

--- a/configs/provisioner.go
+++ b/configs/provisioner.go
@@ -149,8 +149,11 @@ func onlySelfRefs(body hcl.Body) hcl.Diagnostics {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagWarning,
 					Summary:  "External references from destroy provisioners are deprecated",
-					Detail:   "Destroy time provisioners and their connections may only reference values stored in the instance state, which include 'self', 'count.index', or 'each.key'.",
-					Subject:  attr.Expr.Range().Ptr(),
+					Detail: "Destroy-time provisioners and their connection configurations may only " +
+						"reference attributes of the related resource, via 'self', 'count.index', " +
+						"or 'each.key'.\n\nReferences to other resources during the destroy phase " +
+						"can cause dependency cycles and interact poorly with create_before_destroy.",
+					Subject: attr.Expr.Range().Ptr(),
 				})
 			}
 		}


### PR DESCRIPTION
This updates the text to be more user-oriented:

```
Warning: External references from destroy provisioners are deprecated

  on main.tf line 12, in resource "null_resource" "new":
  12:     command = local.command

Destroy-time provisioners and their connection configurations may only
reference attributes of the related resource, via 'self', 'count.index', or
'each.key'.

References to other resources during the destroy phase can cause dependency
cycles and interact poorly with create_before_destroy.
```

Suppress warnings from loading the backend config. 
These will be caught again later when the entire config is loaded, and would be duplicated in the output.

Cosmetic updates for #23559