### PR TITLE
Fix backend remote state dropped test errors

### DIFF
--- a/backend/remote-state/http/client_test.go
+++ b/backend/remote-state/http/client_test.go
@@ -26,7 +26,7 @@ func TestHTTPClient(t *testing.T) {
 
 	url, err := url.Parse(ts.URL)
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("Parse: %s", err)
 	}
 
 	// Test basic get/update
@@ -73,6 +73,10 @@ func TestHTTPClient(t *testing.T) {
 		UpdateMethod: "PUT",
 		Client:       retryablehttp.NewClient(),
 	}
+	if err != nil {
+		t.Fatalf("Parse: %s", err)
+	}
+
 	remote.TestClient(t, client) // first time through: 201
 	remote.TestClient(t, client) // second time, with identical data: 204
 
@@ -83,6 +87,9 @@ func TestHTTPClient(t *testing.T) {
 	defer ts.Close()
 
 	url, err = url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Parse: %s", err)
+	}
 	client = &httpClient{URL: url, Client: retryablehttp.NewClient()}
 	remote.TestClient(t, client)
 }

--- a/backend/remote-state/http/client_test.go
+++ b/backend/remote-state/http/client_test.go
@@ -87,14 +87,6 @@ func TestHTTPClient(t *testing.T) {
 	remote.TestClient(t, client)
 }
 
-func assertError(t *testing.T, err error, expected string) {
-	if err == nil {
-		t.Fatalf("Expected empty config to err")
-	} else if err.Error() != expected {
-		t.Fatalf("Expected err.Error() to be \"%s\", got \"%s\"", expected, err.Error())
-	}
-}
-
 type testHTTPHandler struct {
 	Data   []byte
 	Locked bool


### PR DESCRIPTION
This fixes two dropped errors in `backend/remote-state/http`, and removes the unused test function `assertError()`.