### PR TITLE
command: New -compact-warnings option

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -248,11 +248,15 @@ Usage: terraform apply [options] [DIR-OR-PLAN]
 
 Options:
 
+  -auto-approve          Skip interactive approval of plan before applying.
+
   -backup=path           Path to backup the existing state file before
                          modifying. Defaults to the "-state-out" path with
                          ".backup" extension. Set to "-" to disable backup.
 
-  -auto-approve          Skip interactive approval of plan before applying.
+  -compact-warnings      If Terraform produces any warnings that are not
+                         accompanied by errors, show them in a more compact
+                         form that includes only the summary messages.
 
   -lock=true             Lock the state file when locking is supported.
 

--- a/command/format/diagnostic.go
+++ b/command/format/diagnostic.go
@@ -177,6 +177,51 @@ func Diagnostic(diag tfdiags.Diagnostic, sources map[string][]byte, color *color
 	return buf.String()
 }
 
+// DiagnosticWarningsCompact is an alternative to Diagnostic for when all of
+// the given diagnostics are warnings and we want to show them compactly,
+// with only two lines per warning and excluding all of the detail information.
+//
+// The caller may optionally pre-process the given diagnostics with
+// ConsolidateWarnings, in which case this function will recognize consolidated
+// messages and include an indication that they are consolidated.
+//
+// Do not pass non-warning diagnostics to this function, or the result will
+// be nonsense.
+func DiagnosticWarningsCompact(diags tfdiags.Diagnostics, color *colorstring.Colorize) string {
+	var b strings.Builder
+	b.WriteString(color.Color("[bold][yellow]Warnings:[reset]\n\n"))
+	for _, diag := range diags {
+		sources := tfdiags.WarningGroupSourceRanges(diag)
+		b.WriteString(fmt.Sprintf("- %s\n", diag.Description().Summary))
+		if len(sources) > 0 {
+			mainSource := sources[0]
+			if mainSource.Subject != nil {
+				if len(sources) > 1 {
+					b.WriteString(fmt.Sprintf(
+						"  on %s line %d (and %d more)\n",
+						mainSource.Subject.Filename,
+						mainSource.Subject.Start.Line,
+						len(sources)-1,
+					))
+				} else {
+					b.WriteString(fmt.Sprintf(
+						"  on %s line %d\n",
+						mainSource.Subject.Filename,
+						mainSource.Subject.Start.Line,
+					))
+				}
+			} else if len(sources) > 1 {
+				b.WriteString(fmt.Sprintf(
+					"  (%d occurences of this warning)\n",
+					len(sources),
+				))
+			}
+		}
+	}
+
+	return b.String()
+}
+
 func parseRange(src []byte, rng hcl.Range) (*hcl.File, int) {
 	filename := rng.Filename
 	offset := rng.Start.Byte

--- a/command/format/diagnostic_test.go
+++ b/command/format/diagnostic_test.go
@@ -1,0 +1,73 @@
+package format
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/mitchellh/colorstring"
+
+	"github.com/hashicorp/terraform/tfdiags"
+)
+
+func TestDiagnosticWarningsCompact(t *testing.T) {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.SimpleWarning("foo"))
+	diags = diags.Append(tfdiags.SimpleWarning("foo"))
+	diags = diags.Append(tfdiags.SimpleWarning("bar"))
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Summary:  "source foo",
+		Detail:   "...",
+		Subject: &hcl.Range{
+			Filename: "source.tf",
+			Start:    hcl.Pos{Line: 2, Column: 1, Byte: 5},
+			End:      hcl.Pos{Line: 2, Column: 1, Byte: 5},
+		},
+	})
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Summary:  "source foo",
+		Detail:   "...",
+		Subject: &hcl.Range{
+			Filename: "source.tf",
+			Start:    hcl.Pos{Line: 3, Column: 1, Byte: 7},
+			End:      hcl.Pos{Line: 3, Column: 1, Byte: 7},
+		},
+	})
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Summary:  "source bar",
+		Detail:   "...",
+		Subject: &hcl.Range{
+			Filename: "source2.tf",
+			Start:    hcl.Pos{Line: 1, Column: 1, Byte: 1},
+			End:      hcl.Pos{Line: 1, Column: 1, Byte: 1},
+		},
+	})
+
+	// ConsolidateWarnings groups together the ones
+	// that have source location information and that
+	// have the same summary text.
+	diags = diags.ConsolidateWarnings(1)
+
+	// A zero-value Colorize just passes all the formatting
+	// codes back to us, so we can test them literally.
+	got := DiagnosticWarningsCompact(diags, &colorstring.Colorize{})
+	want := `[bold][yellow]Warnings:[reset]
+
+- foo
+- foo
+- bar
+- source foo
+  on source.tf line 2 (and 1 more)
+- source bar
+  on source2.tf line 1
+`
+	if got != want {
+		t.Errorf(
+			"wrong result\ngot:\n%s\n\nwant:\n%s\n\ndiff:\n%s",
+			got, want, cmp.Diff(want, got),
+		)
+	}
+}

--- a/command/plan.go
+++ b/command/plan.go
@@ -201,6 +201,10 @@ Usage: terraform plan [options] [DIR]
 
 Options:
 
+  -compact-warnings   If Terraform produces any warnings that are not
+                      accompanied by errors, show them in a more compact form
+                      that includes only the summary messages.
+
   -destroy            If set, a plan will be generated to destroy all resources
                       managed by the given configuration and state.
 

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -124,6 +124,10 @@ Options:
                       modifying. Defaults to the "-state-out" path with
                       ".backup" extension. Set to "-" to disable backup.
 
+  -compact-warnings   If Terraform produces any warnings that are not
+                      accompanied by errors, show them in a more compact form
+                      that includes only the summary messages.
+
   -input=true         Ask for input for variables if not directly set.
 
   -lock=true          Lock the state file when locking is supported.

--- a/tfdiags/consolidate_warnings_test.go
+++ b/tfdiags/consolidate_warnings_test.go
@@ -53,7 +53,7 @@ func TestConsolidateWarnings(t *testing.T) {
 
 	// We're using ForRPC here to force the diagnostics to be of a consistent
 	// type that we can easily assert against below.
-	got := diags.ConsolidateWarnings().ForRPC()
+	got := diags.ConsolidateWarnings(2).ForRPC()
 	want := Diagnostics{
 		// First set
 		&rpcFriendlyDiag{

--- a/website/docs/commands/apply.html.markdown
+++ b/website/docs/commands/apply.html.markdown
@@ -27,6 +27,10 @@ The command-line flags are all optional. The list of available flags are:
 * `-backup=path` - Path to the backup file. Defaults to `-state-out` with
   the ".backup" extension. Disabled by setting to "-".
 
+* `-compact-warnings` - If Terraform produces any warnings that are not
+  accompanied by errors, show them in a more compact form that includes only
+  the summary messages.
+
 * `-lock=true` - Lock the state file when locking is supported.
 
 * `-lock-timeout=0s` - Duration to retry a state lock.

--- a/website/docs/commands/plan.html.markdown
+++ b/website/docs/commands/plan.html.markdown
@@ -37,6 +37,10 @@ inspect a planfile.
 
 The command-line flags are all optional. The list of available flags are:
 
+* `-compact-warnings` - If Terraform produces any warnings that are not
+  accompanied by errors, show them in a more compact form that includes only
+  the summary messages.
+
 * `-destroy` - If set, generates a plan to destroy all the known resources.
 
 * `-detailed-exitcode` - Return a detailed exit code when the command exits.

--- a/website/docs/commands/refresh.html.markdown
+++ b/website/docs/commands/refresh.html.markdown
@@ -29,6 +29,10 @@ The command-line flags are all optional. The list of available flags are:
 * `-backup=path` - Path to the backup file. Defaults to `-state-out` with
   the ".backup" extension. Disabled by setting to "-".
 
+* `-compact-warnings` - If Terraform produces any warnings that are not
+  accompanied by errors, show them in a more compact form that includes only
+  the summary messages.
+
 * `-input=true` - Ask for input for variables if not directly set.
 
 * `-lock=true` - Lock the state file when locking is supported.


### PR DESCRIPTION
When warnings appear in isolation (not accompanied by an error) it's reasonable to want to defer resolving them for a while because they are not actually blocking immediate work.

However, our warning messages tend to be long by default in order to include all of the necessary context to understand the implications of the warning, and that can make them overwhelming when combined with other output.

As a compromise, this adds a new CLI option `-compact-warnings` which is supported for all the main operation commands and which uses a more compact format to print out warnings as long as they aren't also accompanied by errors. This is mainly intended for use in automation scenarios where work is being sent to production, as opposed local development scenarios while working on changes to a module, but it can be used in either context. The intent is to ensure that the warnings still stay visible (or else the warning mechanism would become useless) while minimizing their weight in the overall output.

This also includes a change to the default behavior to consolidate warnings further so that there's only one instance of each distinct summary in the output. Aside from that additional consolidation, the default behavior is unchanged so that the warning messages can be presented with contextual information initially.

Full warning messages are always shown if there's at least one error included in the diagnostic set too, because in that case the warning message could contain additional context to help understand the error.

---

![](https://user-images.githubusercontent.com/20180/70562016-6f74bd80-1b40-11ea-808b-54e174e01d7c.png)

```
Warnings:

- Quoted type constraints are deprecated
  on deprecated-interp.tf line 3 (and 2 more)
- Interpolation-only expressions are deprecated
  on deprecated-interp.tf line 18

To see the full warning notes, run Terraform without -compact-warnings.
```
