### PR TITLE
vendor: go get github.com/hashicorp/hcl/v2@v2.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl/v2 v2.0.0
+	github.com/hashicorp/hcl/v2 v2.2.0
 	github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590
 	github.com/hashicorp/memberlist v0.1.0 // indirect
 	github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb // indirect
@@ -119,7 +119,7 @@ require (
 	github.com/xanzy/ssh-agent v0.2.1
 	github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 // indirect
 	github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
-	github.com/zclconf/go-cty v1.1.0
+	github.com/zclconf/go-cty v1.1.1
 	github.com/zclconf/go-cty-yaml v1.0.1
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
-github.com/hashicorp/hcl/v2 v2.0.0 h1:efQznTz+ydmQXq3BOnRa3AXzvCeTq1P4dKj/z5GLlY8=
-github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
+github.com/hashicorp/hcl/v2 v2.2.0 h1:ZQ1eNLggMfTyFBhV8swxT081mlaRjr4EG85NEjjLB84=
+github.com/hashicorp/hcl/v2 v2.2.0/go.mod h1:MD4q2LOluJ5pRwTVkCXmJOY7ODWDXVXGVB8LY0t7wig=
 github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6 h1:JImQpEeUQ+0DPFMaWzLA0GdUNPaUlCXLpfiqkSZBUfc=
 github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6/go.mod h1:Cxv+IJLuBiEhQ7pBYGEuORa0nr4U994pE8mYLuFd7v0=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 h1:2yzhWGdgQUWZUCNK+AoO35V+HTsgEmcM4J9IkArh7PI=
@@ -418,6 +418,8 @@ github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6Ut
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+github.com/zclconf/go-cty v1.1.1 h1:Shl2p9Dat0cqJfXu0DZa+cOTRPhXQjK8IYWD6GVfiqo=
+github.com/zclconf/go-cty v1.1.1/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty-yaml v1.0.1 h1:up11wlgAaDvlAGENcFDnZgkn0qUJurso7k6EpURKNF8=
 github.com/zclconf/go-cty-yaml v1.0.1/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/vendor/github.com/hashicorp/hcl/v2/CHANGELOG.md
+++ b/vendor/github.com/hashicorp/hcl/v2/CHANGELOG.md
@@ -1,5 +1,28 @@
 # HCL Changelog
 
+## v2.2.0 (Dec 11, 2019)
+
+### Enhancements
+
+* hcldec: Attribute evaluation (as part of `AttrSpec` or `BlockAttrsSpec`) now captures expression evaluation metadata in any errors it produces during type conversions, allowing for better feedback in calling applications that are able to make use of this metadata when printing diagnostic messages. ([#329](https://github.com/hashicorp/hcl/pull/329))
+
+### Bugs Fixed
+
+* hclsyntax: `IndexExpr`, `SplatExpr`, and `RelativeTraversalExpr` will now report a source range that covers all of their child expression  nodes. Previously they would report only the operator part, such as `["foo"]`, `[*]`, or `.foo`, which was problematic for callers using source ranges for code analysis. ([#328](https://github.com/hashicorp/hcl/pull/328))
+* hclwrite: Parser will no longer panic when the input includes index, splat, or relative traversal syntax.  ([#328](https://github.com/hashicorp/hcl/pull/328))
+
+## v2.1.0 (Nov 19, 2019)
+
+### Enhancements
+
+* gohcl: When decoding into a struct value with some fields already populated, those values will be retained if not explicitly overwritten in the given HCL body, with similar overriding/merging behavior as `json.Unmarshal` in the Go standard library.
+* hclwrite: New interface to set the expression for an attribute to be a raw token sequence, with no special processing. This has some caveats, so if you intend to use it please refer to the godoc comments. ([#320](https://github.com/hashicorp/hcl/pull/320))
+
+### Bugs Fixed
+
+* hclwrite: The `Body.Blocks` method was returing the blocks in an indefined order, rather than preserving the order of declaration in the source input. ([#313](https://github.com/hashicorp/hcl/pull/313))
+* hclwrite: The `TokensForTraversal` function (and thus in turn the `Body.SetAttributeTraversal` method) was not correctly handling index steps in traversals, and thus producing invalid results. ([#319](https://github.com/hashicorp/hcl/pull/319))
+
 ## v2.0.0 (Oct 2, 2019)
 
 Initial release of HCL 2, which is a new implementating combining the HCL 1

--- a/vendor/github.com/hashicorp/hcl/v2/README.md
+++ b/vendor/github.com/hashicorp/hcl/v2/README.md
@@ -8,7 +8,7 @@ towards devops tools, servers, etc.
 > **NOTE:** This is major version 2 of HCL, whose Go API is incompatible with
 > major version 1. Both versions are available for selection in Go Modules
 > projects. HCL 2 _cannot_ be imported from Go projects that are not using Go Modules. For more information, see
-> [our version selection guide](https://github.com/golang/go/wiki/Version-Selection).
+> [our version selection guide](https://github.com/hashicorp/hcl/wiki/Version-Selection).
 
 HCL has both a _native syntax_, intended to be pleasant to read and write for
 humans, and a JSON-based variant that is easier for machines to generate
@@ -51,7 +51,8 @@ func main() {
 ```
 
 A lower-level API is available for applications that need more control over
-the parsing, decoding, and evaluation of configuration.
+the parsing, decoding, and evaluation of configuration. For more information,
+see [the package documentation](https://pkg.go.dev/github.com/hashicorp/hcl/v2).
 
 ## Why?
 
@@ -156,9 +157,9 @@ syntax allows use of arbitrary expressions within JSON strings:
 
 For more information, see the detailed specifications:
 
-* [Syntax-agnostic Information Model](hcl/spec.md)
-* [HCL Native Syntax](hcl/hclsyntax/spec.md)
-* [JSON Representation](hcl/json/spec.md)
+* [Syntax-agnostic Information Model](spec.md)
+* [HCL Native Syntax](hclsyntax/spec.md)
+* [JSON Representation](json/spec.md)
 
 ## Changes in 2.0
 

--- a/vendor/github.com/hashicorp/hcl/v2/appveyor.yml
+++ b/vendor/github.com/hashicorp/hcl/v2/appveyor.yml
@@ -1,0 +1,13 @@
+build: off
+
+clone_folder: c:\gopath\src\github.com\hashicorp\hcl
+
+environment:
+  GOPATH: c:\gopath
+  GO111MODULE: on
+  GOPROXY: https://goproxy.io
+
+stack: go 1.12
+
+test_script:
+  - go test ./...

--- a/vendor/github.com/hashicorp/hcl/v2/go.mod
+++ b/vendor/github.com/hashicorp/hcl/v2/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/sergi/go-diff v1.0.0
 	github.com/spf13/pflag v1.0.2
 	github.com/stretchr/testify v1.2.2 // indirect
-	github.com/zclconf/go-cty v1.1.0
+	github.com/zclconf/go-cty v1.1.1
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 	golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82 // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/vendor/github.com/hashicorp/hcl/v2/go.sum
+++ b/vendor/github.com/hashicorp/hcl/v2/go.sum
@@ -29,8 +29,8 @@ github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
-github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+github.com/zclconf/go-cty v1.1.1 h1:Shl2p9Dat0cqJfXu0DZa+cOTRPhXQjK8IYWD6GVfiqo=
+github.com/zclconf/go-cty v1.1.1/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/vendor/github.com/hashicorp/hcl/v2/hcldec/spec.go
+++ b/vendor/github.com/hashicorp/hcl/v2/hcldec/spec.go
@@ -204,8 +204,10 @@ func (s *AttrSpec) decode(content *hcl.BodyContent, blockLabels []blockLabel, ct
 				"Inappropriate value for attribute %q: %s.",
 				s.Name, err.Error(),
 			),
-			Subject: attr.Expr.StartRange().Ptr(),
-			Context: hcl.RangeBetween(attr.NameRange, attr.Expr.StartRange()).Ptr(),
+			Subject:     attr.Expr.Range().Ptr(),
+			Context:     hcl.RangeBetween(attr.NameRange, attr.Expr.Range()).Ptr(),
+			Expression:  attr.Expr,
+			EvalContext: ctx,
 		})
 		// We'll return an unknown value of the _correct_ type so that the
 		// incomplete result can still be used for some analysis use-cases.
@@ -1227,10 +1229,13 @@ func (s *BlockAttrsSpec) decode(content *hcl.BodyContent, blockLabels []blockLab
 		attrVal, err := convert.Convert(attrVal, s.ElementType)
 		if err != nil {
 			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid attribute value",
-				Detail:   fmt.Sprintf("Invalid value for attribute of %q block: %s.", s.TypeName, err),
-				Subject:  attr.Expr.Range().Ptr(),
+				Severity:    hcl.DiagError,
+				Summary:     "Invalid attribute value",
+				Detail:      fmt.Sprintf("Invalid value for attribute of %q block: %s.", s.TypeName, err),
+				Subject:     attr.Expr.Range().Ptr(),
+				Context:     hcl.RangeBetween(attr.NameRange, attr.Expr.Range()).Ptr(),
+				Expression:  attr.Expr,
+				EvalContext: ctx,
 			})
 			attrVal = cty.UnknownVal(s.ElementType)
 		}

--- a/vendor/github.com/hashicorp/hcl/v2/hclsyntax/expression.go
+++ b/vendor/github.com/hashicorp/hcl/v2/hclsyntax/expression.go
@@ -615,8 +615,9 @@ type IndexExpr struct {
 	Collection Expression
 	Key        Expression
 
-	SrcRange  hcl.Range
-	OpenRange hcl.Range
+	SrcRange     hcl.Range
+	OpenRange    hcl.Range
+	BracketRange hcl.Range
 }
 
 func (e *IndexExpr) walkChildNodes(w internalWalkFunc) {
@@ -631,7 +632,7 @@ func (e *IndexExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	diags = append(diags, collDiags...)
 	diags = append(diags, keyDiags...)
 
-	val, indexDiags := hcl.Index(coll, key, &e.SrcRange)
+	val, indexDiags := hcl.Index(coll, key, &e.BracketRange)
 	setDiagEvalContext(indexDiags, e, ctx)
 	diags = append(diags, indexDiags...)
 	return val, diags

--- a/vendor/github.com/hashicorp/hcl/v2/hclsyntax/parser.go
+++ b/vendor/github.com/hashicorp/hcl/v2/hclsyntax/parser.go
@@ -760,7 +760,7 @@ Traversal:
 					Each:   travExpr,
 					Item:   itemExpr,
 
-					SrcRange:    hcl.RangeBetween(dot.Range, lastRange),
+					SrcRange:    hcl.RangeBetween(from.Range(), lastRange),
 					MarkerRange: hcl.RangeBetween(dot.Range, marker.Range),
 				}
 
@@ -819,7 +819,7 @@ Traversal:
 					Each:   travExpr,
 					Item:   itemExpr,
 
-					SrcRange:    hcl.RangeBetween(open.Range, travExpr.Range()),
+					SrcRange:    hcl.RangeBetween(from.Range(), travExpr.Range()),
 					MarkerRange: hcl.RangeBetween(open.Range, close.Range),
 				}
 
@@ -867,8 +867,9 @@ Traversal:
 						Collection: ret,
 						Key:        keyExpr,
 
-						SrcRange:  rng,
-						OpenRange: open.Range,
+						SrcRange:     hcl.RangeBetween(from.Range(), rng),
+						OpenRange:    open.Range,
+						BracketRange: rng,
 					}
 				}
 			}
@@ -899,7 +900,7 @@ func makeRelativeTraversal(expr Expression, next hcl.Traverser, rng hcl.Range) E
 		return &RelativeTraversalExpr{
 			Source:    expr,
 			Traversal: hcl.Traversal{next},
-			SrcRange:  rng,
+			SrcRange:  hcl.RangeBetween(expr.Range(), rng),
 		}
 	}
 }

--- a/vendor/github.com/hashicorp/hcl/v2/hclwrite/ast_body.go
+++ b/vendor/github.com/hashicorp/hcl/v2/hclwrite/ast_body.go
@@ -60,7 +60,7 @@ func (b *Body) Attributes() map[string]*Attribute {
 // Blocks returns a new slice of all the blocks in the body.
 func (b *Body) Blocks() []*Block {
 	ret := make([]*Block, 0, len(b.items))
-	for n := range b.items {
+	for _, n := range b.items.List() {
 		if block, isBlock := n.content.(*Block); isBlock {
 			ret = append(ret, block)
 		}
@@ -132,6 +132,26 @@ func (b *Body) RemoveBlock(block *Block) bool {
 		}
 	}
 	return false
+}
+
+// SetAttributeRaw either replaces the expression of an existing attribute
+// of the given name or adds a new attribute definition to the end of the block,
+// using the given tokens verbatim as the expression.
+//
+// The same caveats apply to this function as for NewExpressionRaw on which
+// it is based. If possible, prefer to use SetAttributeValue or
+// SetAttributeTraversal.
+func (b *Body) SetAttributeRaw(name string, tokens Tokens) *Attribute {
+	attr := b.GetAttribute(name)
+	expr := NewExpressionRaw(tokens)
+	if attr != nil {
+		attr.expr = attr.expr.ReplaceWith(expr)
+	} else {
+		attr := newAttribute()
+		attr.init(name, expr)
+		b.appendItem(attr)
+	}
+	return attr
 }
 
 // SetAttributeValue either replaces the expression of an existing attribute

--- a/vendor/github.com/hashicorp/hcl/v2/hclwrite/ast_expression.go
+++ b/vendor/github.com/hashicorp/hcl/v2/hclwrite/ast_expression.go
@@ -21,6 +21,29 @@ func newExpression() *Expression {
 	}
 }
 
+// NewExpressionRaw constructs an expression containing the given raw tokens.
+//
+// There is no automatic validation that the given tokens produce a valid
+// expression. Callers of thus function must take care to produce invalid
+// expression tokens. Where possible, use the higher-level functions
+// NewExpressionLiteral or NewExpressionAbsTraversal instead.
+//
+// Because NewExpressionRaw does not interpret the given tokens in any way,
+// an expression created by NewExpressionRaw will produce an empty result
+// for calls to its method Variables, even if the given token sequence
+// contains a subslice that would normally be interpreted as a traversal under
+// parsing.
+func NewExpressionRaw(tokens Tokens) *Expression {
+	expr := newExpression()
+	// We copy the tokens here in order to make sure that later mutations
+	// by the caller don't inadvertently cause our expression to become
+	// invalid.
+	copyTokens := make(Tokens, len(tokens))
+	copy(copyTokens, tokens)
+	expr.children.AppendUnstructuredTokens(copyTokens)
+	return expr
+}
+
 // NewExpressionLiteral constructs an an expression that represents the given
 // literal value.
 //

--- a/vendor/github.com/hashicorp/hcl/v2/hclwrite/generate.go
+++ b/vendor/github.com/hashicorp/hcl/v2/hclwrite/generate.go
@@ -159,12 +159,12 @@ func appendTokensForValue(val cty.Value, toks Tokens) Tokens {
 
 func appendTokensForTraversal(traversal hcl.Traversal, toks Tokens) Tokens {
 	for _, step := range traversal {
-		appendTokensForTraversalStep(step, toks)
+		toks = appendTokensForTraversalStep(step, toks)
 	}
 	return toks
 }
 
-func appendTokensForTraversalStep(step hcl.Traverser, toks Tokens) {
+func appendTokensForTraversalStep(step hcl.Traverser, toks Tokens) Tokens {
 	switch ts := step.(type) {
 	case hcl.TraverseRoot:
 		toks = append(toks, &Token{
@@ -188,7 +188,7 @@ func appendTokensForTraversalStep(step hcl.Traverser, toks Tokens) {
 			Type:  hclsyntax.TokenOBrack,
 			Bytes: []byte{'['},
 		})
-		appendTokensForValue(ts.Key, toks)
+		toks = appendTokensForValue(ts.Key, toks)
 		toks = append(toks, &Token{
 			Type:  hclsyntax.TokenCBrack,
 			Bytes: []byte{']'},
@@ -196,6 +196,8 @@ func appendTokensForTraversalStep(step hcl.Traverser, toks Tokens) {
 	default:
 		panic(fmt.Sprintf("unsupported traversal step type %T", step))
 	}
+
+	return toks
 }
 
 func escapeQuotedStringLit(s string) []byte {

--- a/vendor/github.com/zclconf/go-cty/cty/convert/conversion_primitive.go
+++ b/vendor/github.com/zclconf/go-cty/cty/convert/conversion_primitive.go
@@ -1,6 +1,8 @@
 package convert
 
 import (
+	"strings"
+
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -41,7 +43,14 @@ var primitiveConversionsUnsafe = map[cty.Type]map[cty.Type]conversion{
 			case "false", "0":
 				return cty.False, nil
 			default:
-				return cty.NilVal, path.NewErrorf("a bool is required")
+				switch strings.ToLower(val.AsString()) {
+				case "true":
+					return cty.NilVal, path.NewErrorf("a bool is required; to convert from string, use lowercase \"true\"")
+				case "false":
+					return cty.NilVal, path.NewErrorf("a bool is required; to convert from string, use lowercase \"false\"")
+				default:
+					return cty.NilVal, path.NewErrorf("a bool is required")
+				}
 			}
 		},
 	},

--- a/vendor/github.com/zclconf/go-cty/cty/gob.go
+++ b/vendor/github.com/zclconf/go-cty/cty/gob.go
@@ -5,6 +5,8 @@ import (
 	"encoding/gob"
 	"fmt"
 	"math/big"
+
+	"github.com/zclconf/go-cty/cty/set"
 )
 
 // GobEncode is an implementation of the gob.GobEncoder interface, which
@@ -46,11 +48,12 @@ func (val *Value) GobDecode(buf []byte) error {
 		return fmt.Errorf("unsupported cty.Value encoding version %d; only 0 is supported", gv.Version)
 	}
 
-	// big.Float seems to, for some reason, lose its "pointerness" when we
-	// round-trip it, so we'll fix that here.
-	if bf, ok := gv.V.(big.Float); ok {
-		gv.V = &bf
-	}
+	// Because big.Float.GobEncode is implemented with a pointer reciever,
+	// gob encoding of an interface{} containing a *big.Float value does not
+	// round-trip correctly, emerging instead as a non-pointer big.Float.
+	// The rest of cty expects all number values to be represented by
+	// *big.Float, so we'll fix that up here.
+	gv.V = gobDecodeFixNumberPtr(gv.V, gv.Ty)
 
 	val.ty = gv.Ty
 	val.v = gv.V
@@ -122,4 +125,75 @@ type gobType struct {
 }
 
 type gobCapsuleTypeImpl struct {
+}
+
+// goDecodeFixNumberPtr fixes an unfortunate quirk of round-tripping cty.Number
+// values through gob: the big.Float.GobEncode method is implemented on a
+// pointer receiver, and so it loses the "pointer-ness" of the value on
+// encode, causing the values to emerge the other end as big.Float rather than
+// *big.Float as we expect elsewhere in cty.
+//
+// The implementation of gobDecodeFixNumberPtr mutates the given raw value
+// during its work, and may either return the same value mutated or a new
+// value. Callers must no longer use whatever value they pass as "raw" after
+// this function is called.
+func gobDecodeFixNumberPtr(raw interface{}, ty Type) interface{} {
+	// Unfortunately we need to work recursively here because number values
+	// might be embedded in structural or collection type values.
+
+	switch {
+	case ty.Equals(Number):
+		if bf, ok := raw.(big.Float); ok {
+			return &bf // wrap in pointer
+		}
+	case ty.IsMapType() && ty.ElementType().Equals(Number):
+		if m, ok := raw.(map[string]interface{}); ok {
+			for k, v := range m {
+				m[k] = gobDecodeFixNumberPtr(v, ty.ElementType())
+			}
+		}
+	case ty.IsListType() && ty.ElementType().Equals(Number):
+		if s, ok := raw.([]interface{}); ok {
+			for i, v := range s {
+				s[i] = gobDecodeFixNumberPtr(v, ty.ElementType())
+			}
+		}
+	case ty.IsSetType() && ty.ElementType().Equals(Number):
+		if s, ok := raw.(set.Set); ok {
+			newS := set.NewSet(s.Rules())
+			for it := s.Iterator(); it.Next(); {
+				newV := gobDecodeFixNumberPtr(it.Value(), ty.ElementType())
+				newS.Add(newV)
+			}
+			return newS
+		}
+	case ty.IsObjectType():
+		if m, ok := raw.(map[string]interface{}); ok {
+			for k, v := range m {
+				aty := ty.AttributeType(k)
+				m[k] = gobDecodeFixNumberPtr(v, aty)
+			}
+		}
+	case ty.IsTupleType():
+		if s, ok := raw.([]interface{}); ok {
+			for i, v := range s {
+				ety := ty.TupleElementType(i)
+				s[i] = gobDecodeFixNumberPtr(v, ety)
+			}
+		}
+	}
+
+	return raw
+}
+
+// gobDecodeFixNumberPtrVal is a helper wrapper around gobDecodeFixNumberPtr
+// that works with already-constructed values. This is primarily for testing,
+// to fix up intentionally-invalid number values for the parts of the test
+// code that need them to be valid, such as calling GoString on them.
+func gobDecodeFixNumberPtrVal(v Value) Value {
+	raw := gobDecodeFixNumberPtr(v.v, v.ty)
+	return Value{
+		v:  raw,
+		ty: v.ty,
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -346,7 +346,7 @@ github.com/hashicorp/hcl/hcl/scanner
 github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl/v2 v2.0.0
+# github.com/hashicorp/hcl/v2 v2.2.0
 github.com/hashicorp/hcl/v2
 github.com/hashicorp/hcl/v2/hclsyntax
 github.com/hashicorp/hcl/v2/hcldec
@@ -488,7 +488,7 @@ github.com/vmihailenco/msgpack/codes
 github.com/xanzy/ssh-agent
 # github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
 github.com/xlab/treeprint
-# github.com/zclconf/go-cty v1.1.0
+# github.com/zclconf/go-cty v1.1.1
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/convert


### PR DESCRIPTION
This also includes an upgrade to cty v1.1.1 because HCL calls for it.

The changes in these two libraries are mainly to codepaths that don't directly affect Terraform, but including this upgrade will cause some small improvements to Terraform's error messages for type conversion problems.