### PR TITLE
Add a backend-specific env var for the GCS backend.

### DIFF
--- a/backend/remote-state/gcs/backend.go
+++ b/backend/remote-state/gcs/backend.go
@@ -136,6 +136,8 @@ func (b *Backend) configure(ctx context.Context) error {
 		})
 	} else if v, ok := data.GetOk("credentials"); ok {
 		creds = v.(string)
+	} else if v := os.Getenv("GOOGLE_BACKEND_CREDENTIALS"); v != "" {
+		creds = v
 	} else {
 		creds = os.Getenv("GOOGLE_CREDENTIALS")
 	}

--- a/website/docs/backends/types/gcs.html.md
+++ b/website/docs/backends/types/gcs.html.md
@@ -52,15 +52,27 @@ resource "template_file" "bar" {
 
 The following configuration options are supported:
 
- *  `bucket` - (Required) The name of the GCS bucket.
-    This name must be globally unique.
-    For more information, see [Bucket Naming Guidelines](https://cloud.google.com/storage/docs/bucketnaming.html#requirements).
- *  `credentials` / `GOOGLE_CREDENTIALS` - (Optional) Local path to Google Cloud Platform account credentials in JSON format.
-    If unset, [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials) are used.
-    The provided credentials need to have the `devstorage.read_write` scope and `WRITER` permissions on the bucket.
- * `access_token` - (Optional) A temporary [OAuth 2.0 access token] obtained from
-    the Google Authorization server, i.e. the `Authorization: Bearer` token used to
-    authenticate HTTP requests to GCP APIs. This is an alternative to `credentials`. If both are specified, `access_token` will be used over the `credentials` field.
- *  `prefix` - (Optional) GCS prefix inside the bucket. Named states for workspaces are stored in an object called `<prefix>/<name>.tfstate`.
- *  `path` - (Deprecated) GCS path to the state file of the default state. For backwards compatibility only, use `prefix` instead.
- *  `encryption_key` / `GOOGLE_ENCRYPTION_KEY` - (Optional) A 32 byte base64 encoded 'customer supplied encryption key' used to encrypt all state. For more information see [Customer Supplied Encryption Keys](https://cloud.google.com/storage/docs/encryption#customer-supplied).
+ *  `bucket` - (Required) The name of the GCS bucket.  This name must be
+    globally unique.  For more information, see [Bucket Naming
+    Guidelines](https://cloud.google.com/storage/docs/bucketnaming.html#requirements).
+ *  `credentials` / `GOOGLE_BACKEND_CREDENTIALS` / `GOOGLE_CREDENTIALS` -
+    (Optional) Local path to Google Cloud Platform account credentials in JSON
+    format.  If unset, [Google Application Default
+    Credentials](https://developers.google.com/identity/protocols/application-default-credentials)
+    are used.  The provided credentials need to have the
+    `devstorage.read_write` scope and `WRITER` permissions on the bucket.
+    **Warning**: if using the Google Cloud Platform provider as well, it will
+    also pick up the `GOOGLE_CREDENTIALS` environment variable.
+ * `access_token` - (Optional) A temporary [OAuth 2.0 access token] obtained
+   from the Google Authorization server, i.e. the `Authorization: Bearer` token
+   used to authenticate HTTP requests to GCP APIs. This is an alternative to
+   `credentials`. If both are specified, `access_token` will be used over the
+   `credentials` field.
+ *  `prefix` - (Optional) GCS prefix inside the bucket. Named states for
+    workspaces are stored in an object called `<prefix>/<name>.tfstate`.
+ *  `path` - (Deprecated) GCS path to the state file of the default state. For
+    backwards compatibility only, use `prefix` instead.
+ *  `encryption_key` / `GOOGLE_ENCRYPTION_KEY` - (Optional) A 32 byte base64
+    encoded 'customer supplied encryption key' used to encrypt all state. For
+    more information see [Customer Supplied Encryption
+    Keys](https://cloud.google.com/storage/docs/encryption#customer-supplied).


### PR DESCRIPTION
Right now, the only environment variable available is the same
environment variable that will be picked up by the GCP provider. Users
would like to be able to store state in separate projects or accounts or
otherwise authenticate to the provider with a service account that
doesn't have access to the state. This seems like a reasonable enough
practice to me, and the solution seems straightforward--offer an
environment variable that doesn't mean anything to the provider to
configure the backend credentials. I've added GOOGLE_BACKEND_CREDENTIALS
to manage just the backend credentials, and documented it appropriately.

Fixes terraform-providers/terraform-provider-google#4209.