### PR TITLE
terraform-bundle: fix panic with addrs.Provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,12 @@ testacc: fmtcheck generate
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -mod=vendor -timeout 120m
 
 # e2etest runs the end-to-end tests against a generated Terraform binary
+# and a generated terraform-bundle binary.
 # The TF_ACC here allows network access, but does not require any special
-# credentials since the e2etests use local-only providers such as "null".
+# credentials.
 e2etest: generate
 	TF_ACC=1 go test -mod=vendor -v ./command/e2etest
+	TF_ACC=1 go test -mod=vendor -v ./tools/terraform-bundle/e2etest
 
 test-compile: fmtcheck generate
 	@if [ "$(TEST)" = "./..." ]; then \

--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -182,7 +182,7 @@ func (c *PackageCommand) Run(args []string) int {
 			} else { //attempt to get from the public registry if not found locally
 				c.ui.Output(fmt.Sprintf("- Checking for provider plugin on %s...",
 					releaseHost))
-				_, _, err := installer.Get(addrs.Provider{Type: name}, constraint)
+				_, _, err := installer.Get(addrs.NewLegacyProvider(name), constraint)
 				if err != nil {
 					c.ui.Error(fmt.Sprintf("- Failed to resolve %s provider %s: %s", name, constraint, err))
 					return 1


### PR DESCRIPTION
We must use the `addrs.NewLegacyProvider()` func when creating a new `addrs.Provider`

Fixes #23652