### PR TITLE
ssh: Fix deadlock on agent forwarding error

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -206,7 +206,7 @@ func (c *Communicator) Connect(o terraform.UIOutput) (err error) {
 		}
 
 		log.Printf("[DEBUG] Setting up a session to request agent forwarding")
-		session, err := c.newSession()
+		session, err := c.client.NewSession()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If there is an error when opening the session for agent forwarding in
the process ssh connention, there is a deadlock when recursively
calling Connect on an internal reattempt. Avoid that, and let the
connection be reattempted externally.

Fixes: #23662