### PR TITLE
check resource-level connections block for references

### DIFF
--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -195,6 +195,11 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 		refs, _ = lang.ReferencesInBlock(c.Config, n.Schema)
 		result = append(result, refs...)
 		if c.Managed != nil {
+			if c.Managed.Connection != nil {
+				refs, _ = lang.ReferencesInBlock(c.Managed.Connection.Config, connectionBlockSupersetSchema)
+				result = append(result, refs...)
+			}
+
 			for _, p := range c.Managed.Provisioners {
 				if p.When != configs.ProvisionerWhenCreate {
 					continue

--- a/terraform/provisioner_mock.go
+++ b/terraform/provisioner_mock.go
@@ -120,7 +120,6 @@ func (p *MockProvisioner) ProvisionResource(r provisioners.ProvisionResourceRequ
 	}
 	if p.ProvisionResourceFn != nil {
 		fn := p.ProvisionResourceFn
-		p.Unlock()
 		return fn(r)
 	}
 

--- a/terraform/testdata/apply-plan-connection-refs/main.tf
+++ b/terraform/testdata/apply-plan-connection-refs/main.tf
@@ -1,0 +1,18 @@
+variable "msg" {
+  default = "ok"
+}
+
+resource "test_instance" "a" {
+  foo = "a"
+}
+
+
+resource "test_instance" "b" {
+  foo = "b"
+  provisioner "shell" {
+   command = "echo ${var.msg}"
+  }
+  connection {
+   host = test_instance.a.id
+  }
+}


### PR DESCRIPTION
References from a resource-level connection blocks were not returned from
`NodeAbstractResource.References`, causing the provisioner connection
attributes to sometimes be evaluated too early.

Fixes #23201