### PR TITLE
website: Use canonical URLs for learn.hashicorp.com links

### DIFF
--- a/website/docs/cli-index.html.md
+++ b/website/docs/cli-index.html.md
@@ -30,7 +30,7 @@ _intermediate and advanced users,_ who need to find complete and detailed
 information quickly.
 
 - **New user?** Try the
-  [Getting Started guide](https://learn.hashicorp.com/terraform/getting-started/install.html)
+  [Getting Started guide](https://learn.hashicorp.com/terraform/getting-started/install)
   at [Learn Terraform](https://learn.hashicorp.com/terraform), then return
   here once you've used Terraform to manage some simple resources.
 - **Curious about Terraform?** See [Introduction to Terraform](/intro/index.html)


### PR DESCRIPTION
The .html suffix redirects correctly, but it's not the 'real' path and thus
can throw off analytics. Cf. https://github.com/hashicorp/terraform-website/pull/1062