### PR TITLE
website: Fix inpage link in docs

### DIFF
--- a/website/docs/configuration/syntax-json.html.md
+++ b/website/docs/configuration/syntax-json.html.md
@@ -93,7 +93,7 @@ resource "aws_instance" "example" {
 ```
 
 Within each top-level block type the rules for mapping to JSON are slightly
-different (see [Block-type-specific Exceptions][inpage-exceptions] below), but the following general rules apply in most cases:
+different (see [the block-type-specific exceptions](#block-type-specific-exceptions) below), but the following general rules apply in most cases:
 
 * The JSON object representing the block body contains properties that
   correspond either to argument names or to nested block type names.


### PR DESCRIPTION
Fixes a little markup misuse.

[Here's how it was before](https://www.terraform.io/docs/configuration/syntax-json.html):
![image](https://user-images.githubusercontent.com/924977/70910028-e964e500-201f-11ea-9ee5-7eb8d107f11e.png)