### PR TITLE
Force TLS 1.2 for windows puppet provisioner

### DIFF
--- a/builtin/provisioners/puppet/windows_provisioner.go
+++ b/builtin/provisioners/puppet/windows_provisioner.go
@@ -44,7 +44,8 @@ func (p *provisioner) windowsDefaultCertname() (string, error) {
 
 func (p *provisioner) windowsInstallPuppetAgent() error {
 	_, err := p.runCommand(fmt.Sprintf(
-		`powershell -Command "& {[Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; `+
+		`powershell -Command "& {[System.Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `+
+			`[Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; `+
 			`(New-Object System.Net.WebClient).DownloadFile('https://%s:8140/packages/current/install.ps1', `+
 			`'install.ps1')}"`,
 		p.Server,

--- a/builtin/provisioners/puppet/windows_provisioner_test.go
+++ b/builtin/provisioners/puppet/windows_provisioner_test.go
@@ -16,7 +16,7 @@ import (
 const (
 	getHostByNameCmd     = `powershell -Command "& {([System.Net.Dns]::GetHostByName(($env:computerName))).Hostname}"`
 	domainQueryCmd       = `powershell -Command "& {(Get-WmiObject -Query 'select DNSDomain from Win32_NetworkAdapterConfiguration where IPEnabled = True').DNSDomain}"`
-	downloadInstallerCmd = `powershell -Command "& {[Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; (New-Object System.Net.WebClient).DownloadFile('https://puppet.test.com:8140/packages/current/install.ps1', 'install.ps1')}"`
+	downloadInstallerCmd = `powershell -Command "& {[System.Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; [Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; (New-Object System.Net.WebClient).DownloadFile('https://puppet.test.com:8140/packages/current/install.ps1', 'install.ps1')}"`
 	runInstallerCmd      = `powershell -Command "& .\install.ps1 -PuppetServiceEnsure stopped"`
 	runPuppetCmd         = "puppet agent --test --server puppet.test.com --environment production"
 )


### PR DESCRIPTION
fixes the error 'The request was aborted: Could not create SSL/TLS secure channel'.

possible solution for #23693 