### PR TITLE
Always prune unused values

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -10521,7 +10521,6 @@ func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
 	}
 
 	ctxOpts.ProviderResolver = providerResolver
-	ctxOpts.Destroy = true
 	ctx, diags = NewContext(ctxOpts)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -175,16 +175,19 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// Reverse the edges from outputs and locals, so that
 		// interpolations don't fail during destroy.
 		// Create a destroy node for outputs to remove them from the state.
-		// Prune unreferenced values, which may have interpolations that can't
-		// be resolved.
 		GraphTransformIf(
 			func() bool { return b.Destroy },
 			GraphTransformMulti(
 				&DestroyValueReferenceTransformer{},
 				&DestroyOutputTransformer{},
-				&PruneUnusedValuesTransformer{},
 			),
 		),
+
+		// Prune unreferenced values, which may have interpolations that can't
+		// be resolved.
+		&PruneUnusedValuesTransformer{
+			Destroy: b.Destroy,
+		},
 
 		// Add the node to fix the state count boundaries
 		&CountBoundaryTransformer{

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -406,9 +406,7 @@ module.child:
 <no state>
 Outputs:
 
-aws_access_key = YYYYY
 aws_route53_zone_id = XXXX
-aws_secret_key = ZZZZ
 `
 
 const testTerraformApplyDependsCreateBeforeStr = `
@@ -693,11 +691,6 @@ foo = bar
 
 const testTerraformApplyOutputOrphanModuleStr = `
 <no state>
-module.child:
-  <no state>
-  Outputs:
-
-  foo = bar
 `
 
 const testTerraformApplyProvisionerStr = `

--- a/terraform/testdata/plan-destroy-interpolated-count/main.tf
+++ b/terraform/testdata/plan-destroy-interpolated-count/main.tf
@@ -3,9 +3,18 @@ variable "list" {
 }
 
 resource "aws_instance" "a" {
-  count = "${length(var.list)}"
+  count = length(var.list)
+}
+
+locals {
+  ids = aws_instance.a[*].id
+}
+
+module "empty" {
+  source = "./mod"
+  input = zipmap(var.list, local.ids)
 }
 
 output "out" {
-  value = "${aws_instance.a.*.id}"
+  value = aws_instance.a[*].id
 }

--- a/terraform/testdata/plan-destroy-interpolated-count/mod/main.tf
+++ b/terraform/testdata/plan-destroy-interpolated-count/mod/main.tf
@@ -1,0 +1,2 @@
+variable "input" {
+}


### PR DESCRIPTION
Since a planned destroy can no longer indicate it is a full destroy,
unused values were being left in the apply graph for evaluation. If
these values contains interpolations that can fail, (for example, a
zipmap with mismatched list sizes), it will cause the apply to abort.

The PruneUnusedValuesTransformer was only previously run during destroy,
more out of conservatism than for any other particular reason. Adapt it
to always remove unused values from the graph, with the exception being
the root module outputs, which must be retained when we don't have a
clear indication that a full destroy is being executed.