### PR TITLE
core: Don't panic if EvalMaybeResourceDeposedObject has no DeposedKey

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -5010,7 +5010,7 @@ func TestContext2Apply_error_createBeforeDestroy(t *testing.T) {
 		State: state,
 	})
 	p.ApplyFn = func(info *InstanceInfo, is *InstanceState, id *InstanceDiff) (*InstanceState, error) {
-		return nil, fmt.Errorf("error")
+		return nil, fmt.Errorf("placeholder error from ApplyFn")
 	}
 	p.DiffFn = testDiffFn
 
@@ -5021,6 +5021,11 @@ func TestContext2Apply_error_createBeforeDestroy(t *testing.T) {
 	state, diags := ctx.Apply()
 	if diags == nil {
 		t.Fatal("should have error")
+	}
+	if got, want := diags.Err().Error(), "placeholder error from ApplyFn"; got != want {
+		// We're looking for our artificial error from ApplyFn above, whose
+		// message is literally "placeholder error from ApplyFn".
+		t.Fatalf("wrong error\ngot:  %s\nwant: %s", got, want)
 	}
 
 	actual := strings.TrimSpace(state.String())
@@ -11117,6 +11122,10 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 		Type: "test_instance",
 		Name: "c",
 	}.Instance(addrs.NoKey))
+
+	if c.Current == nil {
+		t.Fatal("test_instance.c has no current instance, but it should")
+	}
 
 	if c.Current.Status != states.ObjectTainted {
 		t.Fatal("test_instance.c should be tainted")

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -394,8 +394,9 @@ func (n *NodeApplyableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 					return createBeforeDestroyEnabled && err != nil, nil
 				},
 				Then: &EvalMaybeRestoreDeposedObject{
-					Addr: addr.Resource,
-					Key:  &deposedKey,
+					Addr:          addr.Resource,
+					PlannedChange: &diffApply,
+					Key:           &deposedKey,
 				},
 			},
 


### PR DESCRIPTION
This is a "should never happen" case, but we have reports of it actually happening. In order to try to collect a bit more data about what's going on here, we're changing what was previously a hard panic into a normal error message that can include the address of the instance we were working on and the action we were trying to do to it at the time.

The hope is to narrow down what situations can trigger this in order to find a reliable reproduction case in order to debug further. This also means that for those who _do_ encounter this problem in the meantime Terraform will have a chance to shut down cleanly and therefore be more likely to be able to recover on a subsequent plan/apply cycle.

Further investigation of this will follow once we see a report or two of this updated error message.

This closes #23709, and is aiming to contribute to _eventually_ figuring out #22974 in a later change.

---

This also includes some tweaks to some tests that are not directly related to this change but that behaved in unfortunate ways when I faked an occurrence of this problem in order to test the error messages. Neither of those changes affects the outcome of the change I've made here, but both of these tests will now behave better when receiving an error other than the one they are expecting.
