### PR TITLE
initwd: cache registry responses for module versions and download URL

### DIFF
--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -14,18 +14,32 @@ import (
 	"github.com/hashicorp/terraform/internal/modsdir"
 	"github.com/hashicorp/terraform/registry"
 	"github.com/hashicorp/terraform/registry/regsrc"
+	"github.com/hashicorp/terraform/registry/response"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
 type ModuleInstaller struct {
 	modsDir string
 	reg     *registry.Client
+
+	// The keys in moduleVersions are resolved and trimmed registry source
+	// addresses and the values are the download URLs.
+	moduleVersions map[string]*response.ModuleVersions
+
+	moduleVersionsUrl map[moduleVersion]string
+}
+
+type moduleVersion struct {
+	module  string
+	version string
 }
 
 func NewModuleInstaller(modsDir string, reg *registry.Client) *ModuleInstaller {
 	return &ModuleInstaller{
-		modsDir: modsDir,
-		reg:     reg,
+		modsDir:           modsDir,
+		reg:               reg,
+		moduleVersions:    make(map[string]*response.ModuleVersions),
+		moduleVersionsUrl: make(map[moduleVersion]string),
 	}
 }
 
@@ -309,24 +323,32 @@ func (i *ModuleInstaller) installRegistryModule(req *earlyconfig.ModuleRequest, 
 	}
 
 	reg := i.reg
+	var resp *response.ModuleVersions
+	var exists bool
 
-	log.Printf("[DEBUG] %s listing available versions of %s at %s", key, addr, hostname)
-	resp, err := reg.ModuleVersions(addr)
-	if err != nil {
-		if registry.IsModuleNotFound(err) {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Module not found",
-				fmt.Sprintf("Module %q (from %s:%d) cannot be found in the module registry at %s.", req.Name, req.CallPos.Filename, req.CallPos.Line, hostname),
-			))
-		} else {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Error accessing remote module registry",
-				fmt.Sprintf("Failed to retrieve available versions for module %q (%s:%d) from %s: %s.", req.Name, req.CallPos.Filename, req.CallPos.Line, hostname, err),
-			))
+	// check if we've already looked up this module from the registry
+	if resp, exists = i.moduleVersions[addr.String()]; exists {
+		log.Printf("[TRACE] %s using already found available versions of %s at %s", key, addr, hostname)
+	} else {
+		log.Printf("[DEBUG] %s listing available versions of %s at %s", key, addr, hostname)
+		resp, err = reg.ModuleVersions(addr)
+		if err != nil {
+			if registry.IsModuleNotFound(err) {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Module not found",
+					fmt.Sprintf("Module %q (from %s:%d) cannot be found in the module registry at %s.", req.Name, req.CallPos.Filename, req.CallPos.Line, hostname),
+				))
+			} else {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Error accessing remote module registry",
+					fmt.Sprintf("Failed to retrieve available versions for module %q (%s:%d) from %s: %s.", req.Name, req.CallPos.Filename, req.CallPos.Line, hostname, err),
+				))
+			}
+			return nil, nil, diags
 		}
-		return nil, nil, diags
+		i.moduleVersions[addr.String()] = resp
 	}
 
 	// The response might contain information about dependencies to allow us
@@ -405,15 +427,23 @@ func (i *ModuleInstaller) installRegistryModule(req *earlyconfig.ModuleRequest, 
 	// If we manage to get down here then we've found a suitable version to
 	// install, so we need to ask the registry where we should download it from.
 	// The response to this is a go-getter-style address string.
-	dlAddr, err := reg.ModuleLocation(addr, latestMatch.String())
-	if err != nil {
-		log.Printf("[ERROR] %s from %s %s: %s", key, addr, latestMatch, err)
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid response from remote module registry",
-			fmt.Sprintf("The remote registry at %s failed to return a download URL for %s %s.", hostname, addr, latestMatch),
-		))
-		return nil, nil, diags
+	var dlAddr string
+
+	// check if we've already looked up the module download URL
+	if dlAddr, exists = i.moduleVersionsUrl[moduleVersion{module: addr.String(), version: latestMatch.String()}]; exists {
+		log.Printf("[TRACE] %s using previously-found download URL for %s %s", key, addr, latestMatch)
+	} else {
+		dlAddr, err = reg.ModuleLocation(addr, latestMatch.String())
+		if err != nil {
+			log.Printf("[ERROR] %s from %s %s: %s", key, addr, latestMatch, err)
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid response from remote module registry",
+				fmt.Sprintf("The remote registry at %s failed to return a download URL for %s %s.", hostname, addr, latestMatch),
+			))
+			return nil, nil, diags
+		}
+		i.moduleVersionsUrl[moduleVersion{module: addr.String(), version: latestMatch.String()}] = dlAddr
 	}
 
 	log.Printf("[TRACE] ModuleInstaller: %s %s %s is available at %q", key, addr, latestMatch, dlAddr)

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -327,6 +327,14 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 		return
 	}
 
+	//check that the registry reponses were cached
+	if _, ok := inst.moduleVersions["hashicorp/module-installer-acctest/aws"]; !ok {
+		t.Fatal("module versions cache was not populated")
+	}
+	if _, ok := inst.moduleVersionsUrl[moduleVersion{module: "hashicorp/module-installer-acctest/aws", version: "0.0.1"}]; !ok {
+		t.Fatal("module download url cache was not populated")
+	}
+
 	loader, err := configload.NewLoader(&configload.Config{
 		ModulesDir: modulesDir,
 	})


### PR DESCRIPTION
Closes #23544

Suggestions for tests that specifically exercise this feature appreciated - the ideas I had felt more complicated (and fragile) than was worthwhile so I'd love to hear better ones. 

Some relevant trace output (using the example from #23544 ):

```
2019/12/19 11:16:04 [DEBUG] Module installer: security-group-reg-1 installed at .terraform/modules/security-group-reg-1/terraform-aws-modules-terraform-aws-security-group-57856b3
2019/12/19 11:16:04 [DEBUG] Module installer: begin security-group-reg-2
2019/12/19 11:16:05 [TRACE] ModuleInstaller: security-group-reg-2 is not yet installed
2019/12/19 11:16:05 [TRACE] ModuleInstaller: cleaning directory .terraform/modules/security-group-reg-2 prior to install of security-group-reg-2
- security-group-reg-1 in .terraform/modules/security-group-reg-1/terraform-aws-modules-terraform-aws-security-group-57856b3
2019/12/19 11:16:05 [TRACE] ModuleInstaller: security-group-reg-2 is a registry module at terraform-aws-modules/security-group/aws
2019/12/19 11:16:05 [TRACE] security-group-reg-2 using already found available versions of terraform-aws-modules/security-group/aws at registry.terraform.io
2019/12/19 11:16:05 [TRACE] security-group-reg-2 using previously-found download URL for terraform-aws-modules/security-group/aws 3.2.0
```