### PR TITLE
website: update publishing modules documentation

### DIFF
--- a/website/docs/registry/modules/publish.html.md
+++ b/website/docs/registry/modules/publish.html.md
@@ -89,7 +89,7 @@ The webhook will notify the registry of the new version and it will appear
 on the registry usually in less than a minute.
 
 If your version doesn't appear properly, you may force a sync with GitHub
-by viewing your module on the registry and clicking "Force GitHub Sync"
+by viewing your module on the registry and clicking "Resync Module"
 under the "Manage Module" dropdown. This process may take a few minutes.
 Please only do this if you do not see the version appear, since it will
 cause the registry to resync _all versions_ of your module.


### PR DESCRIPTION
This is a minor change on the [Publishing Modules](https://www.terraform.io/docs/registry/modules/publish.html) page of the Terraform documentation.

The **Force GitHub Sync** option of the dropdown menu has been renamed to **Resync Module**.