### PR TITLE
allow operation without state for templating purposes

### DIFF
--- a/backend/init/init.go
+++ b/backend/init/init.go
@@ -48,6 +48,9 @@ func Init(services *disco.Disco) {
 	defer backendsLock.Unlock()
 
 	backends = map[string]backend.InitFn{
+		// No state storage.
+		"nil": func() backend.Backend { return new(backend.Nil) },
+
 		// Enhanced backends.
 		"local":  func() backend.Backend { return backendLocal.New() },
 		"remote": func() backend.Backend { return backendRemote.New(services) },

--- a/website/docs/backends/types/index.html.md
+++ b/website/docs/backends/types/index.html.md
@@ -22,4 +22,7 @@ must implement **standard** functionality. These are defined below:
   * **Enhanced**: Everything in standard plus
     [remote operations](/docs/backends/operations.html).
 
+  * **Nil**: Discard state after each run.
+    [nil](/docs/backends/nil.html).
+
 The backends are separated in the left by standard and enhanced.

--- a/website/docs/backends/types/nil.html.md
+++ b/website/docs/backends/types/nil.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # nil
 
-**Kind: Standard**
+**Kind: Nil**
 
 Discards state after every run. Advanced usage for local operations only (e.g.
 using Terraform to scaffold template terraform files).

--- a/website/docs/backends/types/nil.html.md
+++ b/website/docs/backends/types/nil.html.md
@@ -1,0 +1,22 @@
+---
+layout: "backend-types"
+page_title: "Backend Type: nil"
+sidebar_current: "docs-backends-types-standard-nil"
+description: |-
+  Terraform can be run with a backend that does not record state at all.
+---
+
+# nil
+
+**Kind: Standard**
+
+Discards state after every run. Advanced usage for local operations only (e.g.
+using Terraform to scaffold template terraform files).
+
+## Example Usage
+
+```hcl
+terraform {
+  backend "nil" {}
+}
+```


### PR DESCRIPTION
I am using terraform to scaffold terraform projects using terraform's templating functionality. I have no need for the state produced during this work. I currently `.gitignore` the tfstate file for the "bootstrap" project.

...but since this is just sitting in tree right here... what do ya'll think? Too weird?