### PR TITLE
configs: use local set of go-getter detectors

### DIFF
--- a/configs/configload/getter.go
+++ b/configs/configload/getter.go
@@ -19,6 +19,7 @@ import (
 
 var goGetterDetectors = []getter.Detector{
 	new(getter.GitHubDetector),
+	new(getter.GitDetector),
 	new(getter.BitBucketDetector),
 	new(getter.GCSDetector),
 	new(getter.S3Detector),
@@ -84,7 +85,7 @@ func (g reusingGetter) getWithGoGetter(instPath, addr string) (string, error) {
 
 	log.Printf("[DEBUG] will download %q to %s", packageAddr, instPath)
 
-	realAddr, err := getter.Detect(packageAddr, instPath, getter.Detectors)
+	realAddr, err := getter.Detect(packageAddr, instPath, goGetterDetectors)
 	if err != nil {
 		return "", err
 	}

--- a/internal/initwd/getter.go
+++ b/internal/initwd/getter.go
@@ -21,6 +21,7 @@ import (
 
 var goGetterDetectors = []getter.Detector{
 	new(getter.GitHubDetector),
+	new(getter.GitDetector),
 	new(getter.BitBucketDetector),
 	new(getter.GCSDetector),
 	new(getter.S3Detector),
@@ -86,7 +87,7 @@ func (g reusingGetter) getWithGoGetter(instPath, addr string) (string, error) {
 
 	log.Printf("[DEBUG] will download %q to %s", packageAddr, instPath)
 
-	realAddr, err := getter.Detect(packageAddr, instPath, getter.Detectors)
+	realAddr, err := getter.Detect(packageAddr, instPath, goGetterDetectors)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
In an earlier change we switched to defining our own sets of detectors, getters, etc for `go-getter` in order to insulate us from upstream changes to those sets that might otherwise change the user-visible behavior of Terraform's module installer. We want these to change only intentionally on our part so that we can be sure to also update the relevant documentation and mention it in the changelog, rather than inadvertently introducing new functionality as part of bringing in upstream bug fixes.

However, we apparently neglected to actually refer to our local set of detectors, and continued to refer to the upstream set. Here we catch up with the latest detectors from upstream (taken from the version of `go-getter` we currently have vendored) and start using that fixed set.

Currently we are maintaining these custom `go-getter` sets in two places due to the `configload` vs. `initwd` distinction. That was already true for `goGetterGetters` and `goGetterDecompressors`, and so I've preserved that for now just to keep this change relatively simple; in later change it would
be nice to factor these "get with `go-getter`" functions out into a shared location which we can call from both `configload` and `initwd`.

This bug was surfaced by the dead code analysis in #23682. The analyzer correctly spotted that `goGetterDetectors` was dead code, but it being dead code was unintentional.
