### PR TITLE
docs: terraform state show is not machine-readable

### DIFF
--- a/website/docs/commands/state/show.html.md
+++ b/website/docs/commands/state/show.html.md
@@ -19,10 +19,6 @@ Usage: `terraform state show [options] ADDRESS`
 The command will show the attributes of a single resource in the
 state file that matches the given address.
 
-The attributes are listed in alphabetical order (with the except of "id"
-which is always at the top). They are outputted in a way that is easy
-to parse on the command-line.
-
 This command requires an address that points to a single resource in the
 state. Addresses are
 in [resource addressing format](/docs/commands/state/addressing.html).
@@ -31,6 +27,11 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
   Ignored when [remote state](/docs/state/remote.html) is used.
+
+The output of `terraform state show` is intended for human consumption, not
+programmatic consumption. To extract state data for use in other software, use
+[`terraform show -json`](../show.html#json-output) and decode the result
+using the documented structure.
 
 ## Example: Show a Resource
 


### PR DESCRIPTION
In earlier versions of Terraform the result of terraform state show was in the pre-0.12 "flatmap" structure that was unable to reflect nested data structures. That was fixed in Terraform 0.12, but as a consequence this statement about the output being machine-parseable (which was debateable even in older versions) is incorrect.

Fortunately, we now have `terraform show -json` to get output that is _explicitly_ machine-parseable, so we'll recommend to use that instead here. The JSON output of that command is a superset of what's produced by `terraform state show`, so should be usable to meet any use-case that might previously have been met by parsing the `terraform state show` output.
