### PR TITLE
Retry lock acquisition with configurable duration for OSS backend

### DIFF
--- a/backend/remote-state/oss/backend.go
+++ b/backend/remote-state/oss/backend.go
@@ -159,6 +159,14 @@ func New() backend.Backend {
 				Description: "This is the Alibaba Cloud profile name as set in the shared credentials file. It can also be sourced from the `ALICLOUD_PROFILE` environment variable.",
 				DefaultFunc: schema.EnvDefaultFunc("ALICLOUD_PROFILE", ""),
 			},
+
+			"lock_timeout_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Description:  "Number of seconds to wait and retry when acquiring a lock",
+				Default:      0,
+				ValidateFunc: validation.IntBetween(0, 600),
+			},
 		},
 	}
 
@@ -217,6 +225,7 @@ type Backend struct {
 	endpoint             string
 	otsEndpoint          string
 	otsTable             string
+	lockTimeout          time.Duration
 }
 
 func (b *Backend) configure(ctx context.Context) error {
@@ -344,6 +353,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		b.otsClient = tablestore.NewClientWithConfig(otsEndpoint, parts[0], accessKey, secretKey, securityToken, tablestore.NewDefaultTableStoreConfig())
 	}
 	b.otsTable = d.Get("tablestore_table").(string)
+	b.lockTimeout = time.Duration(d.Get("lock_timeout_seconds").(int)) * time.Second
 
 	return err
 }

--- a/backend/remote-state/oss/backend_state.go
+++ b/backend/remote-state/oss/backend_state.go
@@ -36,6 +36,7 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 		acl:                  b.acl,
 		otsTable:             b.otsTable,
 		otsClient:            b.otsClient,
+		lockTimeout:          b.lockTimeout,
 	}
 	if b.otsEndpoint != "" && b.otsTable != "" {
 		table, err := b.otsClient.DescribeTable(&tablestore.DescribeTableRequest{


### PR DESCRIPTION
Adds a `lock_timeout_seconds` parameter to the Alibaba Cloud OSS backend. This will be used to retry lock acquisitions for the configured number of seconds. If set to 0 (the default value), lock retries are disabled. This keeps the current behaviour as-is and makes this an opt-in feature.

Retries are scheduled once per second, this is currently not configurable.