### PR TITLE
Habitat Provisioner Fixups

### DIFF
--- a/builtin/provisioners/habitat/linux_provisioner.go
+++ b/builtin/provisioners/habitat/linux_provisioner.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform/communicator"
-	"github.com/hashicorp/terraform/terraform"
 	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
-	"time"
+
+	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 const installURL = "https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh"
@@ -210,20 +210,7 @@ func (p *provisioner) linuxStartHabitatSystemd(o terraform.UIOutput, comm commun
 		return err
 	}
 
-	// Restart habitat service
-	err = p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("systemctl enable %s && systemctl start %s", p.ServiceName, p.ServiceName)))
-	if err != nil {
-		return err
-	}
-
-	// Wait for habitat service to start (hab svc status is zero return)
-	for habErr := p.runCommand(o, comm, p.linuxGetCommand("hab svc status >/dev/null 2>&1")); habErr != nil; {
-		o.Output("Waiting for habitat to start ...")
-		time.Sleep(time.Duration(1) * time.Second)
-		habErr = p.runCommand(o, comm, p.linuxGetCommand("hab svc status >/dev/null 2>&1"))
-	}
-
-	return nil
+	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("systemctl enable %s && systemctl start %s", p.ServiceName, p.ServiceName)))
 }
 
 func (p *provisioner) linuxUploadSystemdUnit(o terraform.UIOutput, comm communicator.Communicator, contents *bytes.Buffer) error {

--- a/builtin/provisioners/habitat/linux_provisioner.go
+++ b/builtin/provisioners/habitat/linux_provisioner.go
@@ -211,7 +211,7 @@ func (p *provisioner) linuxStartHabitatSystemd(o terraform.UIOutput, comm commun
 	}
 
 	// Restart habitat service
-	err = p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("systemctl enable %s && systemctl restart %s", p.ServiceName, p.ServiceName)))
+	err = p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("systemctl enable %s && systemctl start %s", p.ServiceName, p.ServiceName)))
 	if err != nil {
 		return err
 	}

--- a/builtin/provisioners/habitat/linux_provisioner_test.go
+++ b/builtin/provisioners/habitat/linux_provisioner_test.go
@@ -302,10 +302,12 @@ func TestLinuxProvisioner_linuxStartHabitatService(t *testing.T) {
 				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab pkg install core/foo  --channel stable'":                                                                        true,
 				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'mkdir -p /hab/user/foo/config'":                                                                                     true,
 				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'mv /tmp/user-a5b83ec1b302d109f41852ae17379f75c36dff9bc598aae76b6f7c9cd425fd76.toml /hab/user/foo/config/user.toml'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab svc status core/foo >/dev/null 2>&1'":                                                                           true,
 				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab svc load core/foo  --topology standalone --strategy none --channel stable --bind backend:bar.default'":          true,
 				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab pkg install core/bar  --channel staging'":                                                                       true,
 				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'mkdir -p /hab/user/bar/config'":                                                                                     true,
 				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'mv /tmp/user-6466ae3283ae1bd4737b00367bc676c6465b25682169ea5f7da222f3f078a5bf.toml /hab/user/bar/config/user.toml'": true,
+				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab svc status core/bar >/dev/null 2>&1'":                                                                           true,
 				"env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab svc load core/bar  --topology standalone --strategy rolling --channel staging'":                                 true,
 			},
 

--- a/builtin/provisioners/habitat/resource_provisioner.go
+++ b/builtin/provisioners/habitat/resource_provisioner.go
@@ -369,7 +369,7 @@ func validateFn(c *terraform.ResourceConfig) (ws []string, es []error) {
 	}
 
 	acceptLicense, ok := c.Get("accept_license")
-	if ok && !acceptLicense.(bool) {
+	if ok && acceptLicense != hcl2shim.UnknownVariableValue && !acceptLicense.(bool) {
 		if v != nil && strings.TrimSpace(v.(string)) != "" {
 			versionOld, _ := version.NewVersion("0.79.0")
 			versionRequired, _ := version.NewVersion(v.(string))


### PR DESCRIPTION
This partially resolves https://github.com/hashicorp/terraform/issues/23784, (at least for the failed-run):

- Do not fail the converge when attempting to load a Habitat service on to the supervisor but the service is already loaded/running.

Other crasher in `resource_provisioner.go:372` is still pending.