### PR TITLE
(docs) Update docs to reflect current behavior for module-depth

### DIFF
--- a/command/graph.go
+++ b/command/graph.go
@@ -191,12 +191,11 @@ Options:
   -draw-cycles     Highlight any cycles in the graph with colored edges.
                    This helps when diagnosing cycle errors.
 
-  -module-depth=n  Specifies the depth of modules to show in the output.	
-                   By default this is -1, which will expand all.
-
   -type=plan       Type of graph to output. Can be: plan, plan-destroy, apply,
                    validate, input, refresh.
 
+  -module-depth=n  (deprecated) In prior versions of Terraform, specified the
+				   depth of modules to show in the output.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/website/docs/commands/graph.html.markdown
+++ b/website/docs/commands/graph.html.markdown
@@ -36,11 +36,11 @@ Options:
 * `-draw-cycles`    - Highlight any cycles in the graph with colored edges.
                       This helps when diagnosing cycle errors.
 
-* `-module-depth=n` - Specifies the depth of modules to show in the output.
-                      By default this is `-1`, which will expand all.
-
 * `-type=plan`      - Type of graph to output. Can be: `plan`, `plan-destroy`, `apply`,
                       `validate`, `input`, `refresh`.
+
+* `-module-depth=n` - (deprecated) In prior versions of Terraform, specified the
+                      depth of modules to show in the output.
 
 ## Generating Images
 


### PR DESCRIPTION
Update docs to reflect that `-module-depth` won't change output in current versions of Terraform

Fixes https://github.com/hashicorp/terraform/issues/23750