### PR TITLE
configs: extend module.ProviderRequirements to include an addrs.Provider instead of just version constraints.

### DIFF
--- a/configs/module_merge.go
+++ b/configs/module_merge.go
@@ -35,7 +35,7 @@ func (p *Provider) merge(op *Provider) hcl.Diagnostics {
 	return diags
 }
 
-func mergeProviderVersionConstraints(recv map[string][]VersionConstraint, ovrd []*ProviderRequirement) {
+func mergeProviderVersionConstraints(recv map[string]ProviderRequirements, ovrd []*RequiredProvider) {
 	// Any provider name that's mentioned in the override gets nilled out in
 	// our map so that we'll rebuild it below. Any provider not mentioned is
 	// left unchanged.
@@ -43,7 +43,8 @@ func mergeProviderVersionConstraints(recv map[string][]VersionConstraint, ovrd [
 		delete(recv, reqd.Name)
 	}
 	for _, reqd := range ovrd {
-		recv[reqd.Name] = append(recv[reqd.Name], reqd.Requirement)
+		fqn := addrs.NewLegacyProvider(reqd.Name)
+		recv[reqd.Name] = ProviderRequirements{Type: fqn, VersionConstraints: []VersionConstraint{reqd.Requirement}}
 	}
 }
 

--- a/configs/parser_config.go
+++ b/configs/parser_config.go
@@ -75,7 +75,7 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 				case "required_providers":
 					reqs, reqsDiags := decodeRequiredProvidersBlock(innerBlock)
 					diags = append(diags, reqsDiags...)
-					file.ProviderRequirements = append(file.ProviderRequirements, reqs...)
+					file.RequiredProviders = append(file.RequiredProviders, reqs...)
 
 				default:
 					// Should never happen because the above cases should be exhaustive

--- a/terraform/module_dependencies.go
+++ b/terraform/module_dependencies.go
@@ -58,9 +58,8 @@ func configTreeConfigDependencies(root *configs.Config, inheritProviders map[str
 		// The main way to declare a provider dependency is explicitly inside
 		// the "terraform" block, which allows declaring a requirement without
 		// also creating a configuration.
-		for fullName, constraints := range module.ProviderRequirements {
+		for fullName, req := range module.ProviderRequirements {
 			inst := moduledeps.ProviderInstance(fullName)
-
 			// The handling here is a bit fiddly because the moduledeps package
 			// was designed around the legacy (pre-0.12) configuration model
 			// and hasn't yet been revised to handle the new model. As a result,
@@ -69,7 +68,7 @@ func configTreeConfigDependencies(root *configs.Config, inheritProviders map[str
 			// can also retain the source location of each constraint, for
 			// more informative output from the "terraform providers" command.
 			var rawConstraints version.Constraints
-			for _, constraint := range constraints {
+			for _, constraint := range req.VersionConstraints {
 				rawConstraints = append(rawConstraints, constraint.Required...)
 			}
 			discoConstraints := discovery.NewConstraints(rawConstraints)

--- a/terraform/module_dependencies_test.go
+++ b/terraform/module_dependencies_test.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/moduledeps"
@@ -46,6 +46,20 @@ func TestModuleTreeDependencies(t *testing.T) {
 					},
 					"foo.bar": moduledeps.ProviderDependency{
 						Constraints: discovery.ConstraintStr(">=2.0.0").MustParse(),
+						Reason:      moduledeps.ProviderDependencyExplicit,
+					},
+				},
+				Children: nil,
+			},
+		},
+		"required_providers block": {
+			"module-deps-required-providers",
+			nil,
+			&moduledeps.Module{
+				Name: "root",
+				Providers: moduledeps.Providers{
+					"foo": moduledeps.ProviderDependency{
+						Constraints: discovery.ConstraintStr(">=1.0.0").MustParse(),
 						Reason:      moduledeps.ProviderDependencyExplicit,
 					},
 				},
@@ -251,8 +265,8 @@ func TestModuleTreeDependencies(t *testing.T) {
 			}
 
 			got := ConfigTreeDependencies(root, MustShimLegacyState(test.State))
-			for _, problem := range deep.Equal(got, test.Want) {
-				t.Error(problem)
+			if !cmp.Equal(got, test.Want) {
+				t.Error(cmp.Diff(got, test.Want))
 			}
 		})
 	}

--- a/terraform/testdata/module-deps-required-providers/main.tf
+++ b/terraform/testdata/module-deps-required-providers/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    foo = {
+      version = ">=1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
Renamed `file.ProviderRequirements` to` file.RequiredProviders` to match the
name of the block in the configuration. `file.RequiredProviders` contains
the contents of the file(s); `module.ProviderRequirements` contains the
parsed and merged provider requirements.

Extended `decodeRequiredProvidersBlock` to parse the new provider source
syntax (version only, it will ignore any other attributes).

Added some tests; swapped `deep.Equal` with `cmp.Equal` in
`terraform/module_dependencies_test.go` because deep was not catching
incorrect constraints.

