### PR TITLE
it's safe for destroy provisioners to access path

### DIFF
--- a/configs/provisioner.go
+++ b/configs/provisioner.go
@@ -127,7 +127,7 @@ func onlySelfRefs(body hcl.Body) hcl.Diagnostics {
 		for _, v := range attr.Expr.Variables() {
 			valid := false
 			switch v.RootName() {
-			case "self", "path":
+			case "self", "path", "terraform":
 				valid = true
 			case "count":
 				// count must use "index"

--- a/configs/provisioner.go
+++ b/configs/provisioner.go
@@ -127,7 +127,7 @@ func onlySelfRefs(body hcl.Body) hcl.Diagnostics {
 		for _, v := range attr.Expr.Variables() {
 			valid := false
 			switch v.RootName() {
-			case "self":
+			case "self", "path":
 				valid = true
 			case "count":
 				// count must use "index"

--- a/configs/testdata/warning-files/destroy-provisioners.tf
+++ b/configs/testdata/warning-files/destroy-provisioners.tf
@@ -12,7 +12,7 @@ resource "null_resource" "a" {
     when = destroy
     index = count.index
     key = each.key
-
+    dir = path.module
   }
 }
 

--- a/configs/testdata/warning-files/destroy-provisioners.tf
+++ b/configs/testdata/warning-files/destroy-provisioners.tf
@@ -12,7 +12,11 @@ resource "null_resource" "a" {
     when = destroy
     index = count.index
     key = each.key
+
+    // path and terraform values are static, and do not create any
+    // dependencies.
     dir = path.module
+    workspace = terraform.workspace
   }
 }
 


### PR DESCRIPTION
The path values are statically loaded, and do not create any
dependencies that could cause problems with destroy provisioners.

closes #23675