### PR TITLE
Fix compatibility issue between Windows CLI and remote plan and apply

### DIFF
--- a/internal/modsdir/manifest.go
+++ b/internal/modsdir/manifest.go
@@ -82,11 +82,9 @@ func ReadManifestSnapshot(r io.Reader) (Manifest, error) {
 			}
 		}
 
-		// Ensure Windows is using the proper modules directory format after
-		// reading the modules manifest
-		if string(filepath.Separator) != "/" {
-			record.Dir = filepath.FromSlash(record.Dir)
-		}
+		// Ensure Windows is using the proper modules path format after
+		// reading the modules manifest Dir records
+		record.Dir = filepath.FromSlash(record.Dir)
 
 		if _, exists := new[record.Key]; exists {
 			// This should never happen in any valid file, so we'll catch it
@@ -124,10 +122,8 @@ func (m Manifest) WriteSnapshot(w io.Writer) error {
 		}
 
 		// Ensure Dir is written in a format that can be read by Linux and
-		// Windows nodes
-		if string(filepath.Separator) != "/" {
-			record.Dir = filepath.ToSlash(record.Dir)
-		}
+		// Windows nodes for remote and apply compatibility
+		record.Dir = filepath.ToSlash(record.Dir)
 		write.Records = append(write.Records, record)
 	}
 

--- a/internal/modsdir/manifest.go
+++ b/internal/modsdir/manifest.go
@@ -115,6 +115,12 @@ func (m Manifest) WriteSnapshot(w io.Writer) error {
 		} else {
 			record.VersionStr = ""
 		}
+
+		// Ensure Dir is written in a format that can be read by Linux and
+		// Windows nodes
+		if record.Dir != "" {
+			record.Dir = filepath.ToSlash(record.Dir)
+		}
 		write.Records = append(write.Records, record)
 	}
 

--- a/internal/modsdir/manifest.go
+++ b/internal/modsdir/manifest.go
@@ -81,6 +81,13 @@ func ReadManifestSnapshot(r io.Reader) (Manifest, error) {
 				return nil, fmt.Errorf("invalid version %q for %s: %s", record.VersionStr, record.Key, err)
 			}
 		}
+
+		// Ensure Windows is using the proper modules directory format after
+		// reading the modules manifest
+		if string(filepath.Separator) != "/" {
+			record.Dir = filepath.FromSlash(record.Dir)
+		}
+
 		if _, exists := new[record.Key]; exists {
 			// This should never happen in any valid file, so we'll catch it
 			// and report it to avoid confusing/undefined behavior if the

--- a/internal/modsdir/manifest.go
+++ b/internal/modsdir/manifest.go
@@ -125,7 +125,7 @@ func (m Manifest) WriteSnapshot(w io.Writer) error {
 
 		// Ensure Dir is written in a format that can be read by Linux and
 		// Windows nodes
-		if record.Dir != "" {
+		if string(filepath.Separator) != "/" {
 			record.Dir = filepath.ToSlash(record.Dir)
 		}
 		write.Records = append(write.Records, record)


### PR DESCRIPTION
Fixes an issue related to #22234 

In order to maintain compatibility between Windows CLI and remote plan and apply, the remote system, Terraform Cloud in this case, needs to be able to properly utilize the module path in the module manifest within the .terraform directory.

Windows writes the module path with its standard file path separator `\` as provided by the `filepath.Separator` function. Terraform Cloud, being Linux based, requires a different path separator `/`.

To appease both platforms without causing issue to how the functions operate, I have written a condition to always write the Linux-style path structure in to the module manifest file. To ensure there are no issues in Windows, I have added a condition that while reading the module manifest, the path is read in to memory using the Windows-style path structure.