### PR TITLE
Fix negative parallelism and negative semaphore

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -138,9 +138,16 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 	// Determine parallelism, default to 10. We do this both to limit
 	// CPU pressure but also to have an extra guard against rate throttling
 	// from providers.
+	// We throw an error in case of negative parallelism or
+	// parallelism equal to 0.
 	par := opts.Parallelism
-	if par == 0 {
-		par = 10
+	if par <= 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid parallelism value",
+			fmt.Sprintf("The parallelism must be a positive value. Not %d.", par),
+		))
+		return nil, diags
 	}
 
 	// Set up the variables in the following sequence:

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -141,13 +141,17 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 	// We throw an error in case of negative parallelism or
 	// parallelism equal to 0.
 	par := opts.Parallelism
-	if par <= 0 {
+	if par < 0 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Invalid parallelism value",
 			fmt.Sprintf("The parallelism must be a positive value. Not %d.", par),
 		))
 		return nil, diags
+	}
+
+	if par == 0 {
+		par = 10
 	}
 
 	// Set up the variables in the following sequence:

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -138,8 +138,7 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 	// Determine parallelism, default to 10. We do this both to limit
 	// CPU pressure but also to have an extra guard against rate throttling
 	// from providers.
-	// We throw an error in case of negative parallelism or
-	// parallelism equal to 0.
+	// We throw an error in case of negative parallelism
 	par := opts.Parallelism
 	if par < 0 {
 		diags = diags.Append(tfdiags.Sourceless(

--- a/terraform/util.go
+++ b/terraform/util.go
@@ -12,8 +12,8 @@ type Semaphore chan struct{}
 // NewSemaphore creates a semaphore that allows up
 // to a given limit of simultaneous acquisitions
 func NewSemaphore(n int) Semaphore {
-	if n == 0 {
-		panic("semaphore with limit 0")
+	if n <= 0 {
+		panic("semaphore with limit <=0")
 	}
 	ch := make(chan struct{}, n)
 	return Semaphore(ch)


### PR DESCRIPTION
Linked to #23470 
Actually, terraform crash when putting a negative parallelism value. With this we throw a proper error when it happen.

I also updated the `NewSemaphore` to throw an error with negative value