### PR TITLE
[Website] Add MetalCloud provider links

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -88,6 +88,7 @@ down to see all providers.
 - [Logentries](/docs/providers/logentries/index.html)
 - [LogicMonitor](/docs/providers/logicmonitor/index.html)
 - [Mailgun](/docs/providers/mailgun/index.html)
+- [MetalCloud](/docs/providers/metalcloud/index.html)
 - [MongoDB Atlas](/docs/providers/mongodbatlas/index.html)
 - [MySQL](/docs/providers/mysql/index.html)
 - [Naver Cloud](/docs/providers/ncloud/index.html)

--- a/website/docs/providers/type/cloud-index.html.markdown
+++ b/website/docs/providers/type/cloud-index.html.markdown
@@ -36,6 +36,7 @@ vendor in close collaboration with HashiCorp, and are tested by HashiCorp.
 - [HuaweiCloudStack](/docs/providers/huaweicloudstack/index.html)
 - [JDCloud](/docs/providers/jdcloud/index.html)
 - [Linode](/docs/providers/linode/index.html)
+- [MetalCloud](/docs/providers/metalcloud/index.html)
 - [Naver Cloud](/docs/providers/ncloud/index.html)
 - [Nutanix](/docs/providers/nutanix/index.html)
 - [OpenNebula](/docs/providers/opennebula/index.html)


### PR DESCRIPTION
Adding two links to point to the new metalcloud provider docs