### PR TITLE
terraform import bulk

### DIFF
--- a/command/testdata/import-provider-implicit/main.tf
+++ b/command/testdata/import-provider-implicit/main.tf
@@ -2,3 +2,6 @@
 # "test" provider, making it available for import.
 resource "test_instance" "foo" {
 }
+
+resource "test_instance" "morefoo" {
+}


### PR DESCRIPTION
Allow to import many different terraform resources in one command, by
supplying a list of addr,id pairs.

Basically, importing hundreds of resources takes a few hours before this
change, and a few mintues after it.

To make implementation somewhat easier I have taken out a chunk of the
mapping from args to targets into a smaller function, but the rest stays
almost the same. Some error messages change a bit.

Fixes #22219