### PR TITLE
Add a missing `=`

### DIFF
--- a/website/docs/configuration-0-11/interpolation.html.md
+++ b/website/docs/configuration-0-11/interpolation.html.md
@@ -465,7 +465,7 @@ ${hello} ${world}!
 ```hcl
 data "template_file" "example" {
   template = "${file("templates/greeting.tpl")}"
-  vars {
+  vars = {
     hello = "goodnight"
     world = "moon"
   }


### PR DESCRIPTION
Fix the error

```
Blocks of type "vars" are not expected here. Did you mean to define argument
"vars"? If so, use the equals sign to assign it a value.
```