### PR TITLE
Update dynamic block docs to use a better example

### DIFF
--- a/website/docs/configuration/expressions.html.md
+++ b/website/docs/configuration/expressions.html.md
@@ -664,28 +664,31 @@ form. This covers many uses, but some resource types include repeatable _nested
 blocks_ in their arguments, which do not accept expressions:
 
 ```hcl
-resource "sample_resource" "example" {
-  name = "example" # can use expressions here
+resource "aws_elastic_beanstalk_environment" "tfenvtest" {
+  name = "tf-test-name" # can use expressions here
 
-  repeatable_block {
-    # but the "repeatable_block" block is always a literal block
+  setting {
+    # but the "setting" block is always a literal block
   }
 }
 ```
 
-You can dynamically construct repeatable nested blocks like `repeatable_block` using a
+You can dynamically construct repeatable nested blocks like `setting` using a
 special `dynamic` block type, which is supported inside `resource`, `data`,
 `provider`, and `provisioner` blocks:
 
 ```hcl
-resource "sample_resource" "example" {
-  name = "example" # can use expressions here
+resource "aws_elastic_beanstalk_environment" "tfenvtest" {
+  name                = "tf-test-name"
+  application         = "${aws_elastic_beanstalk_application.tftest.name}"
+  solution_stack_name = "64bit Amazon Linux 2018.03 v2.11.4 running Go 1.12.6"
 
-  dynamic "repeatable_block" {
-    for_each = var.things
+  dynamic "setting" {
+    for_each = var.settings
     content {
-      val1 = repeatable_block.value
-      val2   = repeatable_block.value
+      namespace = setting.value["namespace"]
+      name = setting.value["name"]
+      value = setting.value["value"]
     }
   }
 }
@@ -695,12 +698,12 @@ A `dynamic` block acts much like a `for` expression, but produces nested blocks
 instead of a complex typed value. It iterates over a given complex value, and
 generates a nested block for each element of that complex value.
 
-- The label of the dynamic block (`"repeatable_block"` in the example above) specifies
+- The label of the dynamic block (`"setting"` in the example above) specifies
   what kind of nested block to generate.
 - The `for_each` argument provides the complex value to iterate over.
 - The `iterator` argument (optional) sets the name of a temporary variable
   that represents the current element of the complex value. If omitted, the name
-  of the variable defaults to the label of the `dynamic` block (`"repeatable_block"` in
+  of the variable defaults to the label of the `dynamic` block (`"setting"` in
   the example above).
 - The `labels` argument (optional) is a list of strings that specifies the block
   labels, in order, to use for each generated block. You can use the temporary
@@ -712,7 +715,7 @@ Since the `for_each` argument accepts any collection or structural value,
 you can use a `for` expression or splat expression to transform an existing
 collection.
 
-The iterator object (`repeatable_block` in the example above) has two attributes:
+The iterator object (`setting` in the example above) has two attributes:
 
 * `key` is the map key or list element index for the current element. If the
   `for_each` expression produces a _set_ value then `key` is identical to

--- a/website/docs/configuration/expressions.html.md
+++ b/website/docs/configuration/expressions.html.md
@@ -664,29 +664,28 @@ form. This covers many uses, but some resource types include repeatable _nested
 blocks_ in their arguments, which do not accept expressions:
 
 ```hcl
-resource "aws_security_group" "example" {
+resource "sample_resource" "example" {
   name = "example" # can use expressions here
 
-  ingress {
-    # but the "ingress" block is always a literal block
+  repeatable_block {
+    # but the "repeatable_block" block is always a literal block
   }
 }
 ```
 
-You can dynamically construct repeatable nested blocks like `ingress` using a
+You can dynamically construct repeatable nested blocks like `repeatable_block` using a
 special `dynamic` block type, which is supported inside `resource`, `data`,
 `provider`, and `provisioner` blocks:
 
 ```hcl
-resource "aws_security_group" "example" {
+resource "sample_resource" "example" {
   name = "example" # can use expressions here
 
-  dynamic "ingress" {
-    for_each = var.service_ports
+  dynamic "repeatable_block" {
+    for_each = var.things
     content {
-      from_port = ingress.value
-      to_port   = ingress.value
-      protocol  = "tcp"
+      val1 = repeatable_block.value
+      val2   = repeatable_block.value
     }
   }
 }
@@ -696,12 +695,12 @@ A `dynamic` block acts much like a `for` expression, but produces nested blocks
 instead of a complex typed value. It iterates over a given complex value, and
 generates a nested block for each element of that complex value.
 
-- The label of the dynamic block (`"ingress"` in the example above) specifies
+- The label of the dynamic block (`"repeatable_block"` in the example above) specifies
   what kind of nested block to generate.
 - The `for_each` argument provides the complex value to iterate over.
 - The `iterator` argument (optional) sets the name of a temporary variable
   that represents the current element of the complex value. If omitted, the name
-  of the variable defaults to the label of the `dynamic` block (`"ingress"` in
+  of the variable defaults to the label of the `dynamic` block (`"repeatable_block"` in
   the example above).
 - The `labels` argument (optional) is a list of strings that specifies the block
   labels, in order, to use for each generated block. You can use the temporary
@@ -713,7 +712,7 @@ Since the `for_each` argument accepts any collection or structural value,
 you can use a `for` expression or splat expression to transform an existing
 collection.
 
-The iterator object (`ingress` in the example above) has two attributes:
+The iterator object (`repeatable_block` in the example above) has two attributes:
 
 * `key` is the map key or list element index for the current element. If the
   `for_each` expression produces a _set_ value then `key` is identical to


### PR DESCRIPTION
The current docs use `aws_security_group`, which is a resource where the referenced attribute in the example is in attributes-as-blocks mode, and thus, should not be used with dynamic blocks (because setting the `for_each` iterator to `[]` will result in "unset" versus "set to none" behavior).

This updates to use the `aws_elastic_beanstalk_environment` resource, whose `setting` attribute does not have the same issues (it is _not_ attributes as blocks mode)