### PR TITLE
S3 Backend : Bucket key should not contain trailing slash

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -37,6 +37,11 @@ func New() backend.Backend {
 					if strings.HasPrefix(v.(string), "/") {
 						return nil, []error{errors.New("key must not start with '/'")}
 					}
+					// s3 will recognize objects with a trailing slash as a directory
+					// so they should not be valid keys
+					if strings.HasSuffix(v.(string), "/") {
+						return nil, []error{errors.New("key must not end with '/'")}
+					}
 					return nil, nil
 				},
 			},

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -326,6 +326,19 @@ func TestBackendConfig_invalidKey(t *testing.T) {
 	if !diags.HasErrors() {
 		t.Fatal("expected config validation error")
 	}
+
+	cfg = hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{
+		"region":         "us-west-1",
+		"bucket":         "tf-test",
+		"key":            "trailing-slash/",
+		"encrypt":        true,
+		"dynamodb_table": "dynamoTable",
+	})
+
+	_, diags = New().PrepareConfig(cfg)
+	if !diags.HasErrors() {
+		t.Fatal("expected config validation error")
+	}
 }
 
 func TestBackendConfig_invalidSSECustomerKeyLength(t *testing.T) {


### PR DESCRIPTION
This PR closes #23385 [S3 Backend allows key ending with '/'](https://github.com/hashicorp/terraform/issues/23385).

Currently, the core issue is that a bucket 'key' with a trailing slash will be treated as an S3 folder, and while no error is displayed to the user, no `.tfstate` files are uploaded.

The proposed fix is quite simple fix; when instantiating an s3 `Backend` using `New()`, a new check is added, this time for trailing slashes. A relevant testcase has been added as well.

### Notes
I'm not very familiar with Terraform, so I apologize if I've missed anything obvious.    
If any more actions would be required or recommended, let me know so I can fix it. 😄 