### PR TITLE
don't refresh resources that have no state

### DIFF
--- a/terraform/transform_config.go
+++ b/terraform/transform_config.go
@@ -29,9 +29,7 @@ type ConfigTransformer struct {
 	// Unique will only add resources that aren't already present in the graph.
 	Unique bool
 
-	// Mode will only add resources that match the given mode
-	ModeFilter bool
-	Mode       addrs.ResourceMode
+	ResourceFilter func(addrs.AbsResource) bool
 
 	l         sync.Mutex
 	uniqueMap map[string]struct{}
@@ -108,8 +106,7 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 	for _, r := range allResources {
 		relAddr := r.Addr()
 
-		if t.ModeFilter && relAddr.Mode != t.Mode {
-			// Skip non-matching modes
+		if t.ResourceFilter != nil && !t.ResourceFilter(relAddr.Absolute(instPath)) {
 			continue
 		}
 

--- a/terraform/transform_config_test.go
+++ b/terraform/transform_config_test.go
@@ -36,9 +36,10 @@ func TestConfigTransformer(t *testing.T) {
 func TestConfigTransformer_mode(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	tf := &ConfigTransformer{
-		Config:     testModule(t, "transform-config-mode-data"),
-		ModeFilter: true,
-		Mode:       addrs.DataResourceMode,
+		Config: testModule(t, "transform-config-mode-data"),
+		ResourceFilter: func(addr addrs.AbsResource) bool {
+			return addr.Resource.Mode == addrs.DataResourceMode
+		},
 	}
 	if err := tf.Transform(&g); err != nil {
 		t.Fatalf("err: %s", err)


### PR DESCRIPTION
Managed Resources that have no state cannot be refreshed, because
their config may have references that cannot be evaluated.

Add a ResourceFilter function to the ConfigTransformer, which can
customize how resources are filtered, and also use it to replace the
existing mode and filter options leaving one clear way to do the task.

This is a more precise version of what the refresh graph builder was
trying to do by checking if the state has any resources at all. While
that caught the case where the state was empty, it could not account for
the case where only some resources were missing, or some would be
removed by ReadResource.