### PR TITLE
Enable login subcommand, add manual token support

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -184,15 +184,11 @@ func initCommands(config *cliconfig.Config, services *disco.Disco, providerSrc g
 			}, nil
 		},
 
-		// "terraform login" is disabled until Terraform Cloud is ready to
-		// support it.
-		/*
-			"login": func() (cli.Command, error) {
-				return &command.LoginCommand{
-					Meta: meta,
-				}, nil
-			},
-		*/
+		"login": func() (cli.Command, error) {
+			return &command.LoginCommand{
+				Meta: meta,
+			}, nil
+		},
 
 		"output": func() (cli.Command, error) {
 			return &command.OutputCommand{


### PR DESCRIPTION
![terraform-login](https://user-images.githubusercontent.com/68917/73461154-a8aefa00-4347-11ea-8c5e-3178a6002f13.gif)

_The token generated in the above screen capture has been invalidated_ 🤫

This is the first in a series of PRs implementing and improving the `terraform login` feature.

## Changes

- Enable the stubbed-out `terraform login` sub-command
- Add fallback detection of the `tfe.v2` API (to ensure that we're trying to authenticate against compatible Terraform Cloud/Terraform Enterprise)
- If `login.v1` is supported, use whichever OAuth grant flow is available (note: none of these are supported by TFC/TFE yet)
- Otherwise, if `tfe.v2` is supported, open a browser to the user's token settings page, and wait for a token to be pasted back