### PR TITLE
terraform: use addrs.Provider as map keys for provider schemas

### DIFF
--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -262,7 +262,10 @@ func RenderPlan(plan *plans.Plan, state *states.State, schemas *terraform.Schema
 		if rcs.Action == plans.NoOp {
 			continue
 		}
-		providerSchema := schemas.ProviderSchema(rcs.ProviderAddr.ProviderConfig.LocalName)
+
+		// FIXME: update this once the provider fqn is available in the AbsProviderConfig
+		providerFqn := addrs.NewLegacyProvider(rcs.ProviderAddr.ProviderConfig.LocalName)
+		providerSchema := schemas.ProviderSchema(providerFqn)
 		if providerSchema == nil {
 			// Should never happen
 			ui.Output(fmt.Sprintf("(schema missing for %s)\n", rcs.ProviderAddr))

--- a/command/format/state.go
+++ b/command/format/state.go
@@ -139,7 +139,9 @@ func formatStateModule(p blockBodyDiffPrinter, m *states.Module, schemas *terraf
 				}
 
 				var schema *configschema.Block
-				provider := addrs.NewDefaultLocalProviderConfig(addr.DefaultProvider().LegacyString()).Absolute(m.Addr).ProviderConfig.StringCompact()
+
+				// TODO: Get the provider FQN when it is available from the AbsoluteProviderConfig, in state
+				provider := addr.DefaultProvider()
 				if _, exists := schemas.Providers[provider]; !exists {
 					// This should never happen in normal use because we should've
 					// loaded all of the schemas and checked things prior to this

--- a/command/format/state_test.go
+++ b/command/format/state_test.go
@@ -138,8 +138,8 @@ func testProviderSchema() *terraform.ProviderSchema {
 func testSchemas() *terraform.Schemas {
 	provider := testProvider()
 	return &terraform.Schemas{
-		Providers: map[string]*terraform.ProviderSchema{
-			"test": provider.GetSchemaReturn,
+		Providers: map[addrs.Provider]*terraform.ProviderSchema{
+			addrs.NewLegacyProvider("test"): provider.GetSchemaReturn,
 		},
 	}
 }

--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -139,7 +139,9 @@ func marshalProviderConfigs(
 	}
 
 	for k, pc := range c.Module.ProviderConfigs {
-		schema := schemas.ProviderConfig(pc.Name)
+		// FIXME: lookup providerFqn from config
+		providerFqn := addrs.NewLegacyProvider(pc.Name)
+		schema := schemas.ProviderConfig(providerFqn)
 		p := providerConfig{
 			Name:              pc.Name,
 			Alias:             pc.Alias,
@@ -301,8 +303,10 @@ func marshalResources(resources map[string]*configs.Resource, schemas *terraform
 			}
 		}
 
+		// TODO: get actual providerFqn
+		providerFqn := addrs.NewLegacyProvider(v.ProviderConfigAddr().LocalName)
 		schema, schemaVer := schemas.ResourceTypeConfig(
-			v.ProviderConfigAddr().LocalName,
+			providerFqn,
 			v.Mode,
 			v.Type,
 		)

--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -177,8 +177,10 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 			continue
 		}
 
+		// FIXME: update this once the provider fqn is available in the AbsProviderConfig
+		providerFqn := addrs.NewLegacyProvider(rc.ProviderAddr.ProviderConfig.LocalName)
 		schema, _ := schemas.ResourceTypeConfig(
-			rc.ProviderAddr.ProviderConfig.LocalName,
+			providerFqn,
 			addr.Resource.Resource.Mode,
 			addr.Resource.Resource.Type,
 		)

--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -180,8 +180,10 @@ func marshalPlanResources(changes *plans.Changes, ris []addrs.AbsResourceInstanc
 			)
 		}
 
+		// FIXME: update this once the provider fqn is available in the AbsProviderConfig
+		providerFqn := addrs.NewLegacyProvider(r.ProviderAddr.ProviderConfig.LocalName)
 		schema, schemaVer := schemas.ResourceTypeConfig(
-			r.ProviderAddr.ProviderConfig.LocalName,
+			providerFqn,
 			r.Addr.Resource.Resource.Mode,
 			resource.Type,
 		)

--- a/command/jsonplan/values_test.go
+++ b/command/jsonplan/values_test.go
@@ -290,8 +290,8 @@ func TestMarshalPlanResources(t *testing.T) {
 
 func testSchemas() *terraform.Schemas {
 	return &terraform.Schemas{
-		Providers: map[string]*terraform.ProviderSchema{
-			"test": &terraform.ProviderSchema{
+		Providers: map[addrs.Provider]*terraform.ProviderSchema{
+			addrs.NewLegacyProvider("test"): &terraform.ProviderSchema{
 				ResourceTypes: map[string]*configschema.Block{
 					"test_thing": {
 						Attributes: map[string]*configschema.Attribute{

--- a/command/jsonprovider/provider.go
+++ b/command/jsonprovider/provider.go
@@ -35,7 +35,7 @@ func Marshal(s *terraform.Schemas) ([]byte, error) {
 	providers := newProviders()
 
 	for k, v := range s.Providers {
-		providers.Schemas[k] = marshalProvider(v)
+		providers.Schemas[k.LegacyString()] = marshalProvider(v)
 	}
 
 	ret, err := json.Marshal(providers)

--- a/command/jsonprovider/provider_test.go
+++ b/command/jsonprovider/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -117,8 +118,8 @@ func TestMarshalProvider(t *testing.T) {
 
 func testProviders() *terraform.Schemas {
 	return &terraform.Schemas{
-		Providers: map[string]*terraform.ProviderSchema{
-			"test": testProvider(),
+		Providers: map[addrs.Provider]*terraform.ProviderSchema{
+			addrs.NewLegacyProvider("test"): testProvider(),
 		},
 	}
 }

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -273,8 +273,10 @@ func marshalResources(resources map[string]*states.Resource, schemas *terraform.
 				current.Index = k
 			}
 
+			// FIXME: lookup providerFqn from state
+			providerFqn := addrs.NewLegacyProvider(r.ProviderConfig.ProviderConfig.LocalName)
 			schema, _ := schemas.ResourceTypeConfig(
-				r.ProviderConfig.ProviderConfig.LocalName,
+				providerFqn,
 				r.Addr.Mode,
 				r.Addr.Type,
 			)

--- a/command/jsonstate/state_test.go
+++ b/command/jsonstate/state_test.go
@@ -351,8 +351,8 @@ func TestMarshalResources(t *testing.T) {
 
 func testSchemas() *terraform.Schemas {
 	return &terraform.Schemas{
-		Providers: map[string]*terraform.ProviderSchema{
-			"test": &terraform.ProviderSchema{
+		Providers: map[addrs.Provider]*terraform.ProviderSchema{
+			addrs.NewLegacyProvider("test"): &terraform.ProviderSchema{
 				ResourceTypes: map[string]*configschema.Block{
 					"test_thing": {
 						Attributes: map[string]*configschema.Attribute{

--- a/configs/config.go
+++ b/configs/config.go
@@ -163,7 +163,7 @@ func (c *Config) DescendentForInstance(path addrs.ModuleInstance) *Config {
 	return current
 }
 
-// ProviderTypes returns the names of each distinct provider type referenced
+// ProviderTypes returns the FQNs of each distinct provider type referenced
 // in the receiving configuration.
 //
 // This is a helper for easily determining which provider types are required

--- a/terraform/context_input.go
+++ b/terraform/context_input.go
@@ -96,7 +96,9 @@ func (c *Context) Input(mode InputMode) tfdiags.Diagnostics {
 				UIInput:     c.uiInput,
 			}
 
-			schema := c.schemas.ProviderConfig(pa.LocalName)
+			// TODO: get provider FQN
+			providerFqn := addrs.NewLegacyProvider(pa.LocalName)
+			schema := c.schemas.ProviderConfig(providerFqn)
 			if schema == nil {
 				// Could either be an incorrect config or just an incomplete
 				// mock in tests. We'll let a later pass decide, and just

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -149,7 +149,7 @@ func (ctx *BuiltinEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) *Pro
 
 	// FIXME: Once AbsProviderConfig starts containing an FQN, use that directly
 	// here instead of addr.ProviderConfig.LocalName.
-	return ctx.Schemas.ProviderSchema(addr.ProviderConfig.LocalName)
+	return ctx.Schemas.ProviderSchema(addrs.NewLegacyProvider(addr.ProviderConfig.LocalName))
 }
 
 func (ctx *BuiltinEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error {

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -781,9 +781,9 @@ func (d *evaluationStateData) getResourceInstancesAll(addr addrs.Resource, rng t
 func (d *evaluationStateData) getResourceSchema(addr addrs.Resource, providerAddr addrs.AbsProviderConfig) *configschema.Block {
 	// FIXME: Once AbsProviderConfig has an addrs.Provider in it, we should
 	// be looking schemas up using provider FQNs rather than legacy names.
-	providerType := providerAddr.ProviderConfig.LocalName
+	providerFqn := addrs.NewLegacyProvider(providerAddr.ProviderConfig.LocalName)
 	schemas := d.Evaluator.Schemas
-	schema, _ := schemas.ResourceTypeConfig(providerType, addr.Mode, addr.Type)
+	schema, _ := schemas.ResourceTypeConfig(providerFqn, addr.Mode, addr.Type)
 	return schema
 }
 

--- a/terraform/evaluate_valid.go
+++ b/terraform/evaluate_valid.go
@@ -217,8 +217,8 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 	// legacy addresses. d.Evaluator.Schemas.ResourceTypeConfig below ought to
 	// change to take an addrs.Provider, and then that's what we should be
 	// passing in here.
-	providerType := cfg.ProviderConfigAddr().LocalName
-	schema, _ := d.Evaluator.Schemas.ResourceTypeConfig(providerType, addr.Mode, addr.Type)
+	providerFqn := addrs.NewLegacyProvider(cfg.ProviderConfigAddr().LocalName)
+	schema, _ := d.Evaluator.Schemas.ResourceTypeConfig(providerFqn, addr.Mode, addr.Type)
 
 	if schema == nil {
 		// Prior validation should've taken care of a resource block with an
@@ -227,7 +227,7 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  `Invalid resource type`,
-			Detail:   fmt.Sprintf(`A %s resource type %q is not supported by provider %q.`, modeAdjective, addr.Type, providerType),
+			Detail:   fmt.Sprintf(`A %s resource type %q is not supported by provider %q.`, modeAdjective, addr.Type, providerFqn.LegacyString()),
 			Subject:  rng.ToHCL().Ptr(),
 		})
 		return diags

--- a/terraform/evaluate_valid_test.go
+++ b/terraform/evaluate_valid_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 
+	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/lang"
 )
@@ -55,8 +56,8 @@ For example, to correlate with indices of a referring resource, use:
 	evaluator := &Evaluator{
 		Config: cfg,
 		Schemas: &Schemas{
-			Providers: map[string]*ProviderSchema{
-				"aws": {
+			Providers: map[addrs.Provider]*ProviderSchema{
+				addrs.NewLegacyProvider("aws"): {
 					ResourceTypes: map[string]*configschema.Block{
 						"aws_instance": {},
 					},

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -500,7 +500,7 @@ func TestApplyGraphBuilder_targetModule(t *testing.T) {
 // that resource is destroyed.
 func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 	schemas := simpleTestSchemas()
-	instanceSchema := schemas.Providers["test"].ResourceTypes["test_object"]
+	instanceSchema := schemas.Providers[addrs.NewLegacyProvider("test")].ResourceTypes["test_object"]
 
 	bBefore, _ := plans.NewDynamicValue(
 		cty.ObjectVal(map[string]cty.Value{

--- a/terraform/graph_builder_plan_test.go
+++ b/terraform/graph_builder_plan_test.go
@@ -44,9 +44,9 @@ func TestPlanGraphBuilder(t *testing.T) {
 		Config:     testModule(t, "graph-builder-plan-basic"),
 		Components: components,
 		Schemas: &Schemas{
-			Providers: map[string]*ProviderSchema{
-				"aws":       awsProvider.GetSchemaReturn,
-				"openstack": openstackProvider.GetSchemaReturn,
+			Providers: map[addrs.Provider]*ProviderSchema{
+				addrs.NewLegacyProvider("aws"):       awsProvider.GetSchemaReturn,
+				addrs.NewLegacyProvider("openstack"): openstackProvider.GetSchemaReturn,
 			},
 		},
 		DisableReduce: true,
@@ -101,8 +101,8 @@ func TestPlanGraphBuilder_dynamicBlock(t *testing.T) {
 		Config:     testModule(t, "graph-builder-plan-dynblock"),
 		Components: components,
 		Schemas: &Schemas{
-			Providers: map[string]*ProviderSchema{
-				"test": provider.GetSchemaReturn,
+			Providers: map[addrs.Provider]*ProviderSchema{
+				addrs.NewLegacyProvider("test"): provider.GetSchemaReturn,
 			},
 		},
 		DisableReduce: true,
@@ -180,8 +180,8 @@ func TestPlanGraphBuilder_attrAsBlocks(t *testing.T) {
 		Config:     testModule(t, "graph-builder-plan-attr-as-blocks"),
 		Components: components,
 		Schemas: &Schemas{
-			Providers: map[string]*ProviderSchema{
-				"test": provider.GetSchemaReturn,
+			Providers: map[addrs.Provider]*ProviderSchema{
+				addrs.NewLegacyProvider("test"): provider.GetSchemaReturn,
 			},
 		},
 		DisableReduce: true,
@@ -267,8 +267,8 @@ func TestPlanGraphBuilder_forEach(t *testing.T) {
 		Config:     testModule(t, "plan-for-each"),
 		Components: components,
 		Schemas: &Schemas{
-			Providers: map[string]*ProviderSchema{
-				"aws": awsProvider.GetSchemaReturn,
+			Providers: map[addrs.Provider]*ProviderSchema{
+				addrs.NewLegacyProvider("aws"): awsProvider.GetSchemaReturn,
 			},
 		},
 		DisableReduce: true,

--- a/terraform/schemas_test.go
+++ b/terraform/schemas_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
 )
 
@@ -8,8 +9,8 @@ func simpleTestSchemas() *Schemas {
 	provider := simpleMockProvider()
 	provisioner := simpleMockProvisioner()
 	return &Schemas{
-		Providers: map[string]*ProviderSchema{
-			"test": provider.GetSchemaReturn,
+		Providers: map[addrs.Provider]*ProviderSchema{
+			addrs.NewLegacyProvider("test"): provider.GetSchemaReturn,
 		},
 		Provisioners: map[string]*configschema.Block{
 			"test": provisioner.GetSchemaResponse.Provisioner,

--- a/terraform/transform_transitive_reduction_test.go
+++ b/terraform/transform_transitive_reduction_test.go
@@ -31,8 +31,8 @@ func TestTransitiveReductionTransformer(t *testing.T) {
 	{
 		transform := &AttachSchemaTransformer{
 			Schemas: &Schemas{
-				Providers: map[string]*ProviderSchema{
-					"aws": {
+				Providers: map[addrs.Provider]*ProviderSchema{
+					addrs.NewLegacyProvider("aws"): {
 						ResourceTypes: map[string]*configschema.Block{
 							"aws_instance": &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{


### PR DESCRIPTION
This is a stepping-stone PR for the provider source project. In this PR
"legcay-stype" FQNs are created from the provider name string. Future
work involves encoding the FQN directly in the AbsProviderConfig and
removing the calls to addrs.NewLegacyProvider().