### PR TITLE
Update codeowners file with real handles

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,6 @@
 # Each line is a file pattern followed by one or more owners.
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-# Terraform Core default ownership
-*                               @hashicorp/terraform-core
-
 # Remote-state backends
 /backend/remote-state/azure     @hashicorp/terraform-azure
 /backend/remote-state/gcs       @hashicorp/terraform-google

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,10 @@
-# remote-state backends.
-/backend/remote-state/azure   @terraform-azure
-/backend/remote-state/gcs     @terraform-google
-/backend/remote-state/s3      @terraform-aws
+# Each line is a file pattern followed by one or more owners.
+# More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Terraform Core default ownership
+*                               @hashicorp/terraform-core
+
+# Remote-state backends
+/backend/remote-state/azure     @hashicorp/terraform-azure
+/backend/remote-state/gcs       @hashicorp/terraform-google
+/backend/remote-state/s3        @hashicorp/terraform-aws


### PR DESCRIPTION
This updates the CODEOWNERS file with real GitHub handles so that PRs would actually get targeted towards these groups for the backends.

I did not update `*` to be `@hashicorp/terraform-core` because that would auto-request review on all PRs to the core team, and so glob should wait until more ownership is established codebase-wide.