### PR TITLE
command/state show: use configured provider

### DIFF
--- a/command/format/state.go
+++ b/command/format/state.go
@@ -141,13 +141,14 @@ func formatStateModule(p blockBodyDiffPrinter, m *states.Module, schemas *terraf
 				var schema *configschema.Block
 
 				// TODO: Get the provider FQN when it is available from the AbsoluteProviderConfig, in state
-				provider := addr.DefaultProvider()
+				// check if the resource has a configured provider, otherwise use the default provider
+				provider := addrs.NewLegacyProvider(m.Resources[key].ProviderConfig.ProviderConfig.LocalName)
 				if _, exists := schemas.Providers[provider]; !exists {
 					// This should never happen in normal use because we should've
 					// loaded all of the schemas and checked things prior to this
 					// point. We can't return errors here, but since this is UI code
 					// we will try to do _something_ reasonable.
-					p.buf.WriteString(fmt.Sprintf("# missing schema for provider %q\n\n", provider))
+					p.buf.WriteString(fmt.Sprintf("# missing schema for provider %q\n\n", provider.LegacyString()))
 					continue
 				}
 

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -115,11 +115,15 @@ func (c *StateShowCommand) Run(args []string) int {
 		return 1
 	}
 
+	// check if the resource has a configured provider, otherwise this will use the default provider
+	rs := state.Resource(addr.ContainingResource())
+	absPc := rs.ProviderConfig.ProviderConfig.Absolute(addrs.RootModuleInstance)
+
 	singleInstance := states.NewState()
 	singleInstance.EnsureModule(addr.Module).SetResourceInstanceCurrent(
 		addr.Resource,
 		is.Current,
-		addrs.NewDefaultLocalProviderConfig(addr.Resource.Resource.DefaultProvider().LegacyString()).Absolute(addr.Module),
+		absPc,
 	)
 
 	output := format.State(&format.StateOpts{

--- a/command/state_show_test.go
+++ b/command/state_show_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
@@ -179,6 +180,66 @@ func TestStateShow_emptyState(t *testing.T) {
 	}
 	if !strings.Contains(ui.ErrorWriter.String(), "No instance found for the given address!") {
 		t.Fatalf("expected a no instance found error, got: %s", ui.ErrorWriter.String())
+	}
+}
+
+func TestStateShow_configured_provider(t *testing.T) {
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_instance",
+				Name: "foo",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
+				Status:    states.ObjectReady,
+			},
+			addrs.LocalProviderConfig{LocalName: "test-beta"}.Absolute(addrs.RootModuleInstance),
+		)
+	})
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	p.GetSchemaReturn = &terraform.ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_instance": {
+				Attributes: map[string]*configschema.Attribute{
+					"id":  {Type: cty.String, Optional: true, Computed: true},
+					"foo": {Type: cty.String, Optional: true},
+					"bar": {Type: cty.String, Optional: true},
+				},
+			},
+		},
+	}
+
+	ui := new(cli.MockUi)
+	c := &StateShowCommand{
+		Meta: Meta{
+			testingOverrides: &testingOverrides{
+				ProviderResolver: providers.ResolverFixed(
+					map[addrs.Provider]providers.Factory{
+						addrs.NewLegacyProvider("test-beta"): providers.FactoryFixed(p),
+					},
+				),
+			},
+			Ui: ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"test_instance.foo",
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Test that outputs were displayed
+	expected := strings.TrimSpace(testStateShowOutput) + "\n"
+	actual := ui.OutputWriter.String()
+	if actual != expected {
+		t.Fatalf("Expected:\n%q\n\nTo equal:\n%q", actual, expected)
 	}
 }
 


### PR DESCRIPTION
The `state show`  command was not checking if a given resource had a
configured provider, and instead was only using the default provider
config. This PR checks for a configured provider, using the default
provider if one is not set.

Fixes #22010

Test results _before_ this fix (I'm including this because more than once I've added a test only to notice that is was passing _before_ I fixed the problem and needed re-writing to 'successfully fail'):
```
--- FAIL: TestStateShow_configured_provider (0.00s)
    state_show_test.go:242: Expected:
        "# test_instance.foo:\n# missing schema for provider \"test\"\n"

        To equal:
        "# test_instance.foo:\nresource \"test_instance\" \"foo\" {\n    bar = \"value\"\n    foo = \"value\"\n    id  = \"bar\"\n}\n"
FAIL
FAIL	github.com/hashicorp/terraform/command	3.400s
```