### PR TITLE
make the merge function more precise

### DIFF
--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -2119,9 +2119,7 @@ func TestMerge(t *testing.T) {
 					"a": cty.List(cty.String),
 				})),
 			},
-			cty.MapVal(map[string]cty.Value{
-				"c": cty.StringVal("d"),
-			}),
+			cty.NullVal(cty.EmptyObject),
 			false,
 		},
 		{ // handle null object

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -2079,7 +2079,7 @@ func TestMerge(t *testing.T) {
 					"c": cty.StringVal("d"),
 				}),
 			},
-			cty.ObjectVal(map[string]cty.Value{
+			cty.MapVal(map[string]cty.Value{
 				"a": cty.StringVal("b"),
 				"c": cty.StringVal("d"),
 			}),
@@ -2090,6 +2090,67 @@ func TestMerge(t *testing.T) {
 				cty.MapVal(map[string]cty.Value{
 					"a": cty.UnknownVal(cty.String),
 				}),
+				cty.MapVal(map[string]cty.Value{
+					"c": cty.StringVal("d"),
+				}),
+			},
+			cty.MapVal(map[string]cty.Value{
+				"a": cty.UnknownVal(cty.String),
+				"c": cty.StringVal("d"),
+			}),
+			false,
+		},
+		{ // handle null map
+			[]cty.Value{
+				cty.NullVal(cty.Map(cty.String)),
+				cty.MapVal(map[string]cty.Value{
+					"c": cty.StringVal("d"),
+				}),
+			},
+			cty.MapVal(map[string]cty.Value{
+				"c": cty.StringVal("d"),
+			}),
+			false,
+		},
+		{ // handle null map
+			[]cty.Value{
+				cty.NullVal(cty.Map(cty.String)),
+				cty.NullVal(cty.Object(map[string]cty.Type{
+					"a": cty.List(cty.String),
+				})),
+			},
+			cty.MapVal(map[string]cty.Value{
+				"c": cty.StringVal("d"),
+			}),
+			false,
+		},
+		{ // handle null object
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"c": cty.StringVal("d"),
+				}),
+				cty.NullVal(cty.Object(map[string]cty.Type{
+					"a": cty.List(cty.String),
+				})),
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"c": cty.StringVal("d"),
+			}),
+			false,
+		},
+		{ // handle unknowns
+			[]cty.Value{
+				cty.UnknownVal(cty.Map(cty.String)),
+				cty.MapVal(map[string]cty.Value{
+					"c": cty.StringVal("d"),
+				}),
+			},
+			cty.UnknownVal(cty.Map(cty.String)),
+			false,
+		},
+		{ // handle dynamic unknown
+			[]cty.Value{
+				cty.UnknownVal(cty.DynamicPseudoType),
 				cty.MapVal(map[string]cty.Value{
 					"c": cty.StringVal("d"),
 				}),
@@ -2107,7 +2168,7 @@ func TestMerge(t *testing.T) {
 					"a": cty.StringVal("x"),
 				}),
 			},
-			cty.ObjectVal(map[string]cty.Value{
+			cty.MapVal(map[string]cty.Value{
 				"a": cty.StringVal("x"),
 				"c": cty.StringVal("d"),
 			}),
@@ -2151,7 +2212,7 @@ func TestMerge(t *testing.T) {
 					}),
 				}),
 			},
-			cty.ObjectVal(map[string]cty.Value{
+			cty.MapVal(map[string]cty.Value{
 				"a": cty.MapVal(map[string]cty.Value{
 					"b": cty.StringVal("c"),
 				}),
@@ -2176,7 +2237,7 @@ func TestMerge(t *testing.T) {
 					}),
 				}),
 			},
-			cty.ObjectVal(map[string]cty.Value{
+			cty.MapVal(map[string]cty.Value{
 				"a": cty.ListVal([]cty.Value{
 					cty.StringVal("b"),
 					cty.StringVal("c"),
@@ -2210,6 +2271,66 @@ func TestMerge(t *testing.T) {
 				"d": cty.MapVal(map[string]cty.Value{
 					"e": cty.StringVal("f"),
 				}),
+			}),
+			false,
+		},
+		{ // merge objects of various shapes
+			[]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.ListVal([]cty.Value{
+						cty.StringVal("b"),
+					}),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"d": cty.DynamicVal,
+				}),
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.ListVal([]cty.Value{
+					cty.StringVal("b"),
+				}),
+				"d": cty.DynamicVal,
+			}),
+			false,
+		},
+		{ // merge maps and objects
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.ListVal([]cty.Value{
+						cty.StringVal("b"),
+					}),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"d": cty.NumberIntVal(2),
+				}),
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.ListVal([]cty.Value{
+					cty.StringVal("b"),
+				}),
+				"d": cty.NumberIntVal(2),
+			}),
+			false,
+		},
+		{ // attr a type and value is overridden
+			[]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.ListVal([]cty.Value{
+						cty.StringVal("b"),
+					}),
+					"b": cty.StringVal("b"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"e": cty.StringVal("f"),
+					}),
+				}),
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.ObjectVal(map[string]cty.Value{
+					"e": cty.StringVal("f"),
+				}),
+				"b": cty.StringVal("b"),
 			}),
 			false,
 		},

--- a/website/docs/configuration/functions/merge.html.md
+++ b/website/docs/configuration/functions/merge.html.md
@@ -3,8 +3,9 @@ layout: "functions"
 page_title: "merge - Functions - Configuration Language"
 sidebar_current: "docs-funcs-collection-merge"
 description: |-
-  The merge function takes an arbitrary number of maps and returns a single
-  map after merging the keys from each argument.
+  The merge function takes an arbitrary number maps or objects, and returns a
+  single map or object that contains a merged set of elements from all
+  arguments.
 ---
 
 # `merge` Function
@@ -13,19 +14,33 @@ description: |-
 earlier, see
 [0.11 Configuration Language: Interpolation Syntax](../../configuration-0-11/interpolation.html).
 
-`merge` takes an arbitrary number of maps and returns a single map that
-contains a merged set of elements from all of the maps.
+`merge` takes an arbitrary number of maps or objects, and returns a single map
+pr object that contains a merged set of elements from all arguments. 
 
-If more than one given map defines the same key then the one that is later
-in the argument sequence takes precedence.
+If more than one given map or object defines the same key or attribute, then
+the one that is later in the argument sequence takes precedence. If the
+argument types do not match, the resulting type will be an object matching the
+type structure of the attributes after the merging rules have been applied.
 
 ## Examples
 
 ```
-> merge({"a"="b", "c"="d"}, {"e"="f", "c"="z"})
+> merge({a="b", c="d"}, {e="f", c="z"})
 {
   "a" = "b"
   "c" = "z"
   "e" = "f"
+}
+```
+
+```
+> merge({a="b"}, {a=[1,2], c="z"}, {d=3})
+{
+  "a" = [
+    1,
+    2,
+  ]
+  "c" = "z"
+  "d" = 3
 }
 ```


### PR DESCRIPTION
This PR implements 2 changes to the merge function.
 - Rather than always defining the merge return type as dynamic, return
 a precise type when all argument types match, or all possible object
 attributes are known.
 - Always return a value containing all keys when the keys are known.
 This allows the use of merge output in for_each, even when keys are yet
 to be determined.

Fixes #24024

This also handles the bulk of the concerns from #23052 and comments in #22735. While those had other confounding factors that led us astray, the common thread is that users expect `merge` to return what known keys it has, which is what a for expression would be able to do.