### PR TITLE
ifset function

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -504,6 +504,34 @@ func flattener(flattenList cty.Value) ([]cty.Value, bool) {
 	return out, true
 }
 
+// IfSetFunc returns the value of the field in a map or the dafult if the variable is not defined
+var IfSetFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name:         "m",
+			Type:         cty.DynamicPseudoType,
+			AllowUnknown: true,
+		},
+		{
+			Name: "f",
+			Type: cty.String,
+		},
+		{
+			Name: "d",
+			Type: cty.DynamicPseudoType,
+		},
+	},
+	Type: function.StaticReturnType(cty.DynamicPseudoType),
+	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
+		m := args[0].AsValueMap()
+		f := args[1].AsString()
+		if _, ok := m[f]; ok {
+			return m[f], nil
+		}
+		return args[2], nil
+	},
+})
+
 // KeysFunc constructs a function that takes a map and returns a sorted list of the map keys.
 var KeysFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
@@ -1447,6 +1475,11 @@ func Chunklist(list, size cty.Value) (cty.Value, error) {
 // sequence of the list contents.
 func Flatten(list cty.Value) (cty.Value, error) {
 	return FlattenFunc.Call([]cty.Value{list})
+}
+
+// IfSet returns the value of the field in a map or the dafult if the variable is not defined
+func IfSet(m, f, d cty.Value) (cty.Value, error) {
+	return IfSetFunc.Call([]cty.Value{m, f, d})
 }
 
 // Keys takes a map and returns a sorted list of the map keys.

--- a/lang/functions.go
+++ b/lang/functions.go
@@ -72,6 +72,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"format":           stdlib.FormatFunc,
 			"formatdate":       stdlib.FormatDateFunc,
 			"formatlist":       stdlib.FormatListFunc,
+			"ifset":            funcs.IfSetFunc,
 			"indent":           funcs.IndentFunc,
 			"index":            funcs.IndexFunc,
 			"join":             funcs.JoinFunc,

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -451,6 +451,13 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"ifset": {
+			{
+				`ifset({ a: "a", b: "b"}, "a", "z"])`,
+				cty.StringVal("a"),
+			},
+		},
+
 		"join": {
 			{
 				`join(" ", ["Hello", "World"])`,

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -453,8 +453,8 @@ func TestFunctions(t *testing.T) {
 
 		"ifset": {
 			{
-				`ifset({ a: "a", b: "b"}, "a", "z"])`,
-				cty.StringVal("a"),
+				`ifset({ "a" = "a", "b" = "b"}, "c", "z" )`,
+				cty.StringVal("z"),
 			},
 		},
 

--- a/website/docs/configuration/functions/ifset.md
+++ b/website/docs/configuration/functions/ifset.md
@@ -1,0 +1,33 @@
+---
+layout: "functions"
+page_title: "ifset - Functions - Configuration Language"
+sidebar_current: "docs-funcs-numeric-ifset"
+description: |-
+  The ifset function returns the specified value or the default if the key is not defined.
+---
+
+# `ifset` Function
+
+-> **Note:** This page is about Terraform 0.12 and later
+
+`ifset` takes a map, a key as string and a default value and returns the value of the key in the map or the default value if the key does not exist.
+
+## Examples
+
+```
+> ifset({ a="1", b="2"},"a","3")
+1
+> ifset({ a="1", b="2"},"d","3")
+3
+```
+
+```
+> ifset({ a= { x = "1" },b= { y = "2" }},"a",{ z = "3"} )
+{
+  "x" = "1"
+}
+> ifset({ a= { x = "1" },b= { y = "2" }},"c",{ z = "3"} )
+{
+  "z" = "1"
+}
+```


### PR DESCRIPTION
`ifset` takes a map, a key as string and a default value and returns the value of the key in the map or the default value if the key does not exist.

I needed a cleaner way of retrieving a key value from a map.
I have used contains(keys(map),key) ? map.key : default value but that can become hard to maintain.

Use-cases
I have a list maps and I want to add some fields (with values based on the same map) to each map. The added field value may be undefined in the map
```

Input

a = [
    { one=1, two=2, three=3},
    { two=2, three=3},
    { one=1, three=3},
]
b = "zzz"

locals {
    r = [for i, c in var.a : merge(c, {
        field1 = contains(keys(c), "one") ? c.one : "not defined"
        field2 = contains(keys(c), "two") ? c.two : "not defined"
        field3 = contains(keys(c), "three") ? c.three : var.b
    })]
}

```
Code will become
```

locals {
    r = [for i, c in var.a : merge(c, {
        field1 = ifset(c, "one", "not defined" )
        field2 = ifset(c, "two", "not defined" )
        field3 = ifset(c, "three", var.b )
    })]
}
```

This would simplify the code, and reduces the amount of typing
