### PR TITLE
Improve remote backend missing token error

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -14,7 +14,7 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	version "github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-svchost"
+	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/disco"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/configs/configschema"
@@ -267,12 +267,17 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 
 	// Return an error if we still don't have a token at this point.
 	if token == "" {
+		loginCommand := "terraform login"
+		if b.hostname != defaultHostname {
+			loginCommand = loginCommand + " " + b.hostname
+		}
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Required token could not be found",
 			fmt.Sprintf(
-				"Make sure you configured a credentials block for %s in your CLI Config File.",
+				"Run the following command to generate a token for %s:\n    %s",
 				b.hostname,
+				loginCommand,
 			),
 		))
 		return diags

--- a/backend/remote/backend_test.go
+++ b/backend/remote/backend_test.go
@@ -64,6 +64,19 @@ func TestRemote_config(t *testing.T) {
 			}),
 			confErr: "Failed to request discovery document",
 		},
+		// localhost advertises TFE services, but has no token in the credentials
+		"without_a_token": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"hostname":     cty.StringVal("localhost"),
+				"organization": cty.StringVal("hashicorp"),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":   cty.StringVal("prod"),
+					"prefix": cty.NullVal(cty.String),
+				}),
+			}),
+			confErr: "terraform login localhost",
+		},
 		"with_a_name": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),


### PR DESCRIPTION
Prompt the user to run terraform login to generate and store a token for the configured remote backend.

## Example output

When using Terraform Cloud:

```
$ terraform init

Initializing the backend...

Error: Required token could not be found

Run the following command to generate a token for app.terraform.io:
    terraform login
```

When using another host (e.g. Terraform Enterprise):

```
$ terraform init

Initializing the backend...

Error: Required token could not be found

Run the following command to generate a token for tfe.acme.com:
    terraform login tfe.acme.com
```