### PR TITLE
terraform: look up provider fqns from the `configs.Module`

### DIFF
--- a/terraform/context_components.go
+++ b/terraform/context_components.go
@@ -13,16 +13,13 @@ import (
 // This factory gets more information than the raw maps using to initialize
 // a Context. This information is used for debugging.
 type contextComponentFactory interface {
-	// ResourceProvider creates a new ResourceProvider with the given
-	// type. The "uid" is a unique identifier for this provider being
-	// initialized that can be used for internal tracking.
-	ResourceProvider(typ, uid string) (providers.Interface, error)
+	// ResourceProvider creates a new ResourceProvider with the given type.
+	ResourceProvider(typ string) (providers.Interface, error)
 	ResourceProviders() []string
 
-	// ResourceProvisioner creates a new ResourceProvisioner with the
-	// given type. The "uid" is a unique identifier for this provisioner
-	// being initialized that can be used for internal tracking.
-	ResourceProvisioner(typ, uid string) (provisioners.Interface, error)
+	// ResourceProvisioner creates a new ResourceProvisioner with the given
+	// type.
+	ResourceProvisioner(typ string) (provisioners.Interface, error)
 	ResourceProvisioners() []string
 }
 
@@ -49,7 +46,7 @@ func (c *basicComponentFactory) ResourceProvisioners() []string {
 	return result
 }
 
-func (c *basicComponentFactory) ResourceProvider(typ, uid string) (providers.Interface, error) {
+func (c *basicComponentFactory) ResourceProvider(typ string) (providers.Interface, error) {
 	f, ok := c.providers[addrs.NewLegacyProvider(typ)]
 	if !ok {
 		return nil, fmt.Errorf("unknown provider %q", typ)
@@ -58,7 +55,7 @@ func (c *basicComponentFactory) ResourceProvider(typ, uid string) (providers.Int
 	return f()
 }
 
-func (c *basicComponentFactory) ResourceProvisioner(typ, uid string) (provisioners.Interface, error) {
+func (c *basicComponentFactory) ResourceProvisioner(typ string) (provisioners.Interface, error) {
 	f, ok := c.provisioners[typ]
 	if !ok {
 		return nil, fmt.Errorf("unknown provisioner %q", typ)

--- a/terraform/context_input.go
+++ b/terraform/context_input.go
@@ -96,8 +96,12 @@ func (c *Context) Input(mode InputMode) tfdiags.Diagnostics {
 				UIInput:     c.uiInput,
 			}
 
-			// TODO: get provider FQN
-			providerFqn := addrs.NewLegacyProvider(pa.LocalName)
+			var providerFqn addrs.Provider
+			if existing, exists := c.config.Module.ProviderRequirements[pa.LocalName]; exists {
+				providerFqn = existing.Type
+			} else {
+				providerFqn = addrs.NewLegacyProvider(pa.LocalName)
+			}
 			schema := c.schemas.ProviderConfig(providerFqn)
 			if schema == nil {
 				// Could either be an incorrect config or just an incomplete

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -124,7 +124,7 @@ func (ctx *BuiltinEvalContext) InitProvider(typeName string, addr addrs.AbsProvi
 
 	key := absAddr.String()
 
-	p, err := ctx.Components.ResourceProvider(typeName, key)
+	p, err := ctx.Components.ResourceProvider(typeName)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (ctx *BuiltinEvalContext) InitProvisioner(n string) (provisioners.Interface
 	ctx.ProvisionerLock.Lock()
 	defer ctx.ProvisionerLock.Unlock()
 
-	p, err := ctx.Components.ResourceProvisioner(n, "")
+	p, err := ctx.Components.ResourceProvisioner(n)
 	if err != nil {
 		return nil, err
 	}

--- a/terraform/evaluate_valid.go
+++ b/terraform/evaluate_valid.go
@@ -212,12 +212,12 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 		return diags
 	}
 
-	// FIXME: This is wrong: it's assuming that the local type is the same
-	// as the type from the provider FQN, which will not hold once we eliminate
-	// legacy addresses. d.Evaluator.Schemas.ResourceTypeConfig below ought to
-	// change to take an addrs.Provider, and then that's what we should be
-	// passing in here.
-	providerFqn := addrs.NewLegacyProvider(cfg.ProviderConfigAddr().LocalName)
+	var providerFqn addrs.Provider
+	if existing, exists := modCfg.Module.ProviderRequirements[cfg.ProviderConfigAddr().LocalName]; exists {
+		providerFqn = existing.Type
+	} else {
+		providerFqn = addrs.NewLegacyProvider(cfg.ProviderConfigAddr().LocalName)
+	}
 	schema, _ := d.Evaluator.Schemas.ResourceTypeConfig(providerFqn, addr.Mode, addr.Type)
 
 	if schema == nil {

--- a/terraform/module_dependencies.go
+++ b/terraform/module_dependencies.go
@@ -82,9 +82,12 @@ func configTreeConfigDependencies(root *configs.Config, inheritProviders map[str
 		// allowing for more terse declaration in situations where both a
 		// configuration and a constraint are defined in the same module.
 		for _, pCfg := range module.ProviderConfigs {
-			//FIXME: lookup the provider localname in the TBD map and see if
-			//there is an FQN associated
-			fqn := addrs.NewLegacyProvider(pCfg.Name)
+			var fqn addrs.Provider
+			if existing, exists := module.ProviderRequirements[pCfg.Name]; exists {
+				fqn = existing.Type
+			} else {
+				fqn = addrs.NewLegacyProvider(pCfg.Name)
+			}
 
 			discoConstraints := discovery.AllVersions
 			if pCfg.Version.Required != nil {
@@ -105,9 +108,15 @@ func configTreeConfigDependencies(root *configs.Config, inheritProviders map[str
 		// an explicit dependency on the same provider.
 		for _, rc := range module.ManagedResources {
 			addr := rc.ProviderConfigAddr()
-			//FIXME: lookup the provider localname in the TBD map and see if
-			//there is an FQN associated
-			fqn := addrs.NewLegacyProvider(addr.LocalName)
+			//look up the provider localname in the provider requirements map and see if
+			//there is a non-default FQN associated
+			var fqn addrs.Provider
+			if existing, exists := module.ProviderRequirements[addr.LocalName]; exists {
+				fqn = existing.Type
+			} else {
+				fqn = addrs.NewLegacyProvider(addr.LocalName)
+			}
+
 			if _, exists := providers[fqn]; exists {
 				// Explicit dependency already present
 				continue
@@ -125,9 +134,14 @@ func configTreeConfigDependencies(root *configs.Config, inheritProviders map[str
 		}
 		for _, rc := range module.DataResources {
 			addr := rc.ProviderConfigAddr()
-			//FIXME: lookup the provider localname in the TBD map and see if
-			//there is an FQN associated
-			fqn := addrs.NewLegacyProvider(addr.LocalName)
+			//look up the provider localname in the provider requirements map and see if
+			//there is a non-default FQN associated
+			var fqn addrs.Provider
+			if existing, exists := module.ProviderRequirements[addr.LocalName]; exists {
+				fqn = existing.Type
+			} else {
+				fqn = addrs.NewLegacyProvider(addr.LocalName)
+			}
 			if _, exists := providers[fqn]; exists {
 				// Explicit dependency already present
 				continue

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -101,7 +101,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 		}
 
 		log.Printf("[TRACE] LoadSchemas: retrieving schema for provider type %q", typeName)
-		provider, err := components.ResourceProvider(typeName, "early/"+typeName)
+		provider, err := components.ResourceProvider(typeName)
 		if err != nil {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls.
@@ -191,7 +191,7 @@ func loadProvisionerSchemas(schemas map[string]*configschema.Block, config *conf
 		}
 
 		log.Printf("[TRACE] LoadSchemas: retrieving schema for provisioner %q", name)
-		provisioner, err := components.ResourceProvisioner(name, "early/"+name)
+		provisioner, err := components.ResourceProvisioner(name)
 		if err != nil {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls.


### PR DESCRIPTION
This is close to a no-op  change: we aren't accepting the provider source
attribute yet, so the only entires in the ProviderRequirements will
already be legacy provider addrs.

This PR also removes the unused `uid` field from `ResourceProvider` and
`ResourceProvisioner.` It is even less likely to be useful now that we have a specific addrs.Provider type.

The overall goal of this block of work was to remove the immediate assumptions that all providers are legacy providers whenever the caller had access to the `configs.Module`. The remaining calls to addrs.NewLegacyProvider in the terraform package (those that do not first check the map in the module) will be replaced at a later date, when the `addrs.AbsProviderConfig` is refactored to include `addrs.Provider`.