### PR TITLE
Failing test for nested computed map

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -34,6 +34,7 @@ func Provider() terraform.ResourceProvider {
 			"test_resource_list_set":         testResourceListSet(),
 			"test_resource_map":              testResourceMap(),
 			"test_resource_computed_set":     testResourceComputedSet(),
+			"test_resource_computed_map":     testResourceComputedMap(),
 			"test_resource_config_mode":      testResourceConfigMode(),
 			"test_resource_nested_id":        testResourceNestedId(),
 			"test_undeleteable":              testResourceUndeleteable(),

--- a/builtin/providers/test/resource_computed_map.go
+++ b/builtin/providers/test/resource_computed_map.go
@@ -1,0 +1,82 @@
+package test
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceComputedMap() *schema.Resource {
+	return &schema.Resource{
+		Create: testResourceComputedMapCreate,
+		Read:   testResourceComputedMapRead,
+		Delete: testResourceComputedMapDelete,
+		Update: testResourceComputedMapUpdate,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"nested_resources": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"limits": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"computed_map": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"optional_map": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func testResourceComputedMapCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(fmt.Sprintf("%x", rand.Int63()))
+	return testResourceComputedMapRead(d, meta)
+}
+
+func testResourceComputedMapRead(d *schema.ResourceData, meta interface{}) error {
+
+	computedMap := map[string]interface{}{
+		"computed_key": "value",
+	}
+	d.Set("computed_map", computedMap)
+
+	resources := []map[string]interface{}{
+		{
+			"limits": map[string]interface{}{
+				"cpu": "100",
+			},
+		},
+	}
+	d.Set("nested_resources", resources)
+
+	return nil
+}
+
+func testResourceComputedMapUpdate(d *schema.ResourceData, meta interface{}) error {
+	return testResourceComputedMapRead(d, meta)
+}
+
+func testResourceComputedMapDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/test/resource_computed_map_test.go
+++ b/builtin/providers/test/resource_computed_map_test.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestResourceComputedMap_basic(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource_computed_map" "foo" {
+}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"test_resource_computed_map.foo", "nested_resources.#", "1",
+					),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
I would expect this test to pass, however it fails because the plan was not empty after apply.

output:
```
go test ./builtin/providers/... -run=TestResourceComputedMap
ok  	github.com/hashicorp/terraform/builtin/providers/terraform	(cached) [no tests to run]
--- FAIL: TestResourceComputedMap_basic (0.03s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: test_resource_computed_map.foo
          computed_map.computed_key:     "value" => "value"
          id:                            "4d65822107fcfd52" => "4d65822107fcfd52"
          nested_resources.#:            "1" => "0"
          nested_resources.0.limits.cpu: "100" => ""



        STATE:

        test_resource_computed_map.foo:
          ID = 4d65822107fcfd52
          provider = provider.test
          computed_map.computed_key = value
          nested_resources.# = 1
          nested_resources.0.limits.cpu = 100
FAIL
FAIL	github.com/hashicorp/terraform/builtin/providers/test	0.250s
FAIL
```