### PR TITLE
POC: new traversal parsing

### DIFF
--- a/addrs/provider_config.go
+++ b/addrs/provider_config.go
@@ -60,21 +60,6 @@ func NewDefaultLocalProviderConfig(LocalNameName string) LocalProviderConfig {
 // providerConfig Implements addrs.ProviderConfig.
 func (pc LocalProviderConfig) providerConfig() {}
 
-// Absolute returns an AbsProviderConfig from the receiver and the given module
-// instance address.
-//
-// TODO: This methold will become obsolete as part of supporting fully-qualified
-// provider names in AbsProviderConfig, requiring a lookup via the module
-// configuration instead. However, we continue to support it for now by
-// relying on the fact that only "legacy" provider addresses are currently
-// supported.
-// func (pc LocalProviderConfig) Absolute(module ModuleInstance) AbsProviderConfig {
-// 	return AbsProviderConfig{
-// 		Module:         module,
-// 		ProviderConfig: pc,
-// 	}
-// }
-
 func (pc LocalProviderConfig) String() string {
 	if pc.LocalName == "" {
 		// Should never happen; always indicates a bug
@@ -111,11 +96,11 @@ var _ ProviderConfig = AbsProviderConfig{}
 // address. The following are examples of traversals that can be successfully
 // parsed as absolute provider configuration addresses:
 //
-//     provider.aws
-//     provider.aws.foo
-//     module.bar.provider.aws
-//     module.bar.module.baz.provider.aws.foo
-//     module.foo[1].provider.aws.foo
+//     provider.["registry.terraform.io/hashicorp/aws"]
+//     provider.["registry.terraform.io/hashicorp/aws"].foo
+//     module.bar.provider.["registry.terraform.io/hashicorp/aws"]
+//     module.bar.module.baz.provider.["registry.terraform.io/hashicorp/aws"].foo
+//     module.foo[1].provider.["registry.terraform.io/hashicorp/aws"].foo
 //
 // This type of address is used, for example, to record the relationships
 // between resources and provider configurations in the state structure.

--- a/addrs/provider_config_test.go
+++ b/addrs/provider_config_test.go
@@ -16,143 +16,145 @@ func TestParseAbsProviderConfig(t *testing.T) {
 		WantDiag string
 	}{
 		{
-			`provider.aws`,
+			`provider.["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: RootModuleInstance,
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
 				},
 			},
 			``,
 		},
-		{
-			`provider.aws.foo`,
-			AbsProviderConfig{
-				Module: RootModuleInstance,
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
-					Alias:     "foo",
-				},
-			},
-			``,
-		},
-		{
-			`module.baz.provider.aws`,
-			AbsProviderConfig{
-				Module: ModuleInstance{
-					{
-						Name: "baz",
-					},
-				},
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
-				},
-			},
-			``,
-		},
-		{
-			`module.baz.provider.aws.foo`,
-			AbsProviderConfig{
-				Module: ModuleInstance{
-					{
-						Name: "baz",
-					},
-				},
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
-					Alias:     "foo",
-				},
-			},
-			``,
-		},
-		{
-			`module.baz["foo"].provider.aws`,
-			AbsProviderConfig{
-				Module: ModuleInstance{
-					{
-						Name:        "baz",
-						InstanceKey: StringKey("foo"),
-					},
-				},
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
-				},
-			},
-			``,
-		},
-		{
-			`module.baz[1].provider.aws`,
-			AbsProviderConfig{
-				Module: ModuleInstance{
-					{
-						Name:        "baz",
-						InstanceKey: IntKey(1),
-					},
-				},
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
-				},
-			},
-			``,
-		},
-		{
-			`module.baz[1].module.bar.provider.aws`,
-			AbsProviderConfig{
-				Module: ModuleInstance{
-					{
-						Name:        "baz",
-						InstanceKey: IntKey(1),
-					},
-					{
-						Name: "bar",
-					},
-				},
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
-				},
-			},
-			``,
-		},
-		{
-			`aws`,
-			AbsProviderConfig{},
-			`Provider address must begin with "provider.", followed by a provider type name.`,
-		},
-		{
-			`aws.foo`,
-			AbsProviderConfig{},
-			`Provider address must begin with "provider.", followed by a provider type name.`,
-		},
-		{
-			`provider`,
-			AbsProviderConfig{},
-			`Provider address must begin with "provider.", followed by a provider type name.`,
-		},
-		{
-			`provider.aws.foo.bar`,
-			AbsProviderConfig{},
-			`Extraneous operators after provider configuration alias.`,
-		},
-		{
-			`provider["aws"]`,
-			AbsProviderConfig{},
-			`The prefix "provider." must be followed by a provider type name.`,
-		},
-		{
-			`provider.aws["foo"]`,
-			AbsProviderConfig{},
-			`Provider type name must be followed by a configuration alias name.`,
-		},
-		{
-			`module.foo`,
-			AbsProviderConfig{},
-			`Provider address must begin with "provider.", followed by a provider type name.`,
-		},
-		{
-			`module.foo["provider"]`,
-			AbsProviderConfig{},
-			`Provider address must begin with "provider.", followed by a provider type name.`,
-		},
+		// {
+		// 	`provider.aws.foo`,
+		// 	AbsProviderConfig{
+		// 		Module: RootModuleInstance,
+		// 		ProviderConfig: LocalProviderConfig{
+		// 			LocalName: "aws",
+		// 			Alias:     "foo",
+		// 		},
+		// 	},
+		// 	``,
+		// },
+		// {
+		// 	`module.baz.provider.aws`,
+		// 	AbsProviderConfig{
+		// 		Module: ModuleInstance{
+		// 			{
+		// 				Name: "baz",
+		// 			},
+		// 		},
+		// 		ProviderConfig: LocalProviderConfig{
+		// 			LocalName: "aws",
+		// 		},
+		// 	},
+		// 	``,
+		// },
+		// {
+		// 	`module.baz.provider.aws.foo`,
+		// 	AbsProviderConfig{
+		// 		Module: ModuleInstance{
+		// 			{
+		// 				Name: "baz",
+		// 			},
+		// 		},
+		// 		ProviderConfig: LocalProviderConfig{
+		// 			LocalName: "aws",
+		// 			Alias:     "foo",
+		// 		},
+		// 	},
+		// 	``,
+		// },
+		// {
+		// 	`module.baz["foo"].provider.aws`,
+		// 	AbsProviderConfig{
+		// 		Module: ModuleInstance{
+		// 			{
+		// 				Name:        "baz",
+		// 				InstanceKey: StringKey("foo"),
+		// 			},
+		// 		},
+		// 		ProviderConfig: LocalProviderConfig{
+		// 			LocalName: "aws",
+		// 		},
+		// 	},
+		// 	``,
+		// },
+		// {
+		// 	`module.baz[1].provider.aws`,
+		// 	AbsProviderConfig{
+		// 		Module: ModuleInstance{
+		// 			{
+		// 				Name:        "baz",
+		// 				InstanceKey: IntKey(1),
+		// 			},
+		// 		},
+		// 		ProviderConfig: LocalProviderConfig{
+		// 			LocalName: "aws",
+		// 		},
+		// 	},
+		// 	``,
+		// },
+		// {
+		// 	`module.baz[1].module.bar.provider.aws`,
+		// 	AbsProviderConfig{
+		// 		Module: ModuleInstance{
+		// 			{
+		// 				Name:        "baz",
+		// 				InstanceKey: IntKey(1),
+		// 			},
+		// 			{
+		// 				Name: "bar",
+		// 			},
+		// 		},
+		// 		ProviderConfig: LocalProviderConfig{
+		// 			LocalName: "aws",
+		// 		},
+		// 	},
+		// 	``,
+		// },
+		// {
+		// 	`aws`,
+		// 	AbsProviderConfig{},
+		// 	`Provider address must begin with "provider.", followed by a provider type name.`,
+		// },
+		// {
+		// 	`aws.foo`,
+		// 	AbsProviderConfig{},
+		// 	`Provider address must begin with "provider.", followed by a provider type name.`,
+		// },
+		// {
+		// 	`provider`,
+		// 	AbsProviderConfig{},
+		// 	`Provider address must begin with "provider.", followed by a provider type name.`,
+		// },
+		// {
+		// 	`provider.aws.foo.bar`,
+		// 	AbsProviderConfig{},
+		// 	`Extraneous operators after provider configuration alias.`,
+		// },
+		// {
+		// 	`provider["aws"]`,
+		// 	AbsProviderConfig{},
+		// 	`The prefix "provider." must be followed by a provider type name.`,
+		// },
+		// {
+		// 	`provider.aws["foo"]`,
+		// 	AbsProviderConfig{},
+		// 	`Provider type name must be followed by a configuration alias name.`,
+		// },
+		// {
+		// 	`module.foo`,
+		// 	AbsProviderConfig{},
+		// 	`Provider address must begin with "provider.", followed by a provider type name.`,
+		// },
+		// {
+		// 	`module.foo["provider"]`,
+		// 	AbsProviderConfig{},
+		// 	`Provider address must begin with "provider.", followed by a provider type name.`,
+		// },
 	}
 
 	for _, test := range tests {

--- a/addrs/provider_config_test.go
+++ b/addrs/provider_config_test.go
@@ -17,7 +17,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 		WantDiag string
 	}{
 		{
-			`provider.["registry.terraform.io/hashicorp/aws"]`,
+			`provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: RootModuleInstance,
 				Provider: Provider{
@@ -29,7 +29,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			``,
 		},
 		{
-			`provider.["registry.terraform.io/hashicorp/aws"].foo`,
+			`provider["registry.terraform.io/hashicorp/aws"].foo`,
 			AbsProviderConfig{
 				Module: RootModuleInstance,
 				Provider: Provider{
@@ -42,7 +42,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			``,
 		},
 		{
-			`module.baz.provider.["registry.terraform.io/hashicorp/aws"]`,
+			`module.baz.provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: ModuleInstance{
 					{
@@ -58,7 +58,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			``,
 		},
 		{
-			`module.baz.provider.["registry.terraform.io/hashicorp/aws"].foo`,
+			`module.baz.provider["registry.terraform.io/hashicorp/aws"].foo`,
 			AbsProviderConfig{
 				Module: ModuleInstance{
 					{
@@ -75,7 +75,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			``,
 		},
 		{
-			`module.baz["foo"].provider.["registry.terraform.io/hashicorp/aws"]`,
+			`module.baz["foo"].provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: ModuleInstance{
 					{
@@ -92,7 +92,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			``,
 		},
 		{
-			`module.baz[1].provider.["registry.terraform.io/hashicorp/aws"]`,
+			`module.baz[1].provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: ModuleInstance{
 					{
@@ -109,7 +109,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			``,
 		},
 		{
-			`module.baz[1].module.bar.provider.["registry.terraform.io/hashicorp/aws"]`,
+			`module.baz[1].module.bar.provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: ModuleInstance{
 					{
@@ -147,19 +147,6 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			`provider.aws.foo.bar`,
 			AbsProviderConfig{},
 			`Extraneous operators after provider configuration alias.`,
-		},
-		// This used to generate an error, but now the syntax is ok.
-		// When NewLegacyProvider() is deprecated this will change.
-		{
-			`provider["aws"]`,
-			AbsProviderConfig{
-				Provider: Provider{
-					Type:      "aws",
-					Namespace: "-",
-					Hostname:  "registry.terraform.io",
-				},
-			},
-			``,
 		},
 		{
 			`provider["aws"]["foo"]`,

--- a/addrs/provider_config_test.go
+++ b/addrs/provider_config_test.go
@@ -1,6 +1,7 @@
 package addrs
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -40,123 +41,136 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			},
 			``,
 		},
-		// {
-		// 	`module.baz.provider.aws`,
-		// 	AbsProviderConfig{
-		// 		Module: ModuleInstance{
-		// 			{
-		// 				Name: "baz",
-		// 			},
-		// 		},
-		// 		ProviderConfig: LocalProviderConfig{
-		// 			LocalName: "aws",
-		// 		},
-		// 	},
-		// 	``,
-		// },
-		// {
-		// 	`module.baz.provider.aws.foo`,
-		// 	AbsProviderConfig{
-		// 		Module: ModuleInstance{
-		// 			{
-		// 				Name: "baz",
-		// 			},
-		// 		},
-		// 		ProviderConfig: LocalProviderConfig{
-		// 			LocalName: "aws",
-		// 			Alias:     "foo",
-		// 		},
-		// 	},
-		// 	``,
-		// },
-		// {
-		// 	`module.baz["foo"].provider.aws`,
-		// 	AbsProviderConfig{
-		// 		Module: ModuleInstance{
-		// 			{
-		// 				Name:        "baz",
-		// 				InstanceKey: StringKey("foo"),
-		// 			},
-		// 		},
-		// 		ProviderConfig: LocalProviderConfig{
-		// 			LocalName: "aws",
-		// 		},
-		// 	},
-		// 	``,
-		// },
-		// {
-		// 	`module.baz[1].provider.aws`,
-		// 	AbsProviderConfig{
-		// 		Module: ModuleInstance{
-		// 			{
-		// 				Name:        "baz",
-		// 				InstanceKey: IntKey(1),
-		// 			},
-		// 		},
-		// 		ProviderConfig: LocalProviderConfig{
-		// 			LocalName: "aws",
-		// 		},
-		// 	},
-		// 	``,
-		// },
-		// {
-		// 	`module.baz[1].module.bar.provider.aws`,
-		// 	AbsProviderConfig{
-		// 		Module: ModuleInstance{
-		// 			{
-		// 				Name:        "baz",
-		// 				InstanceKey: IntKey(1),
-		// 			},
-		// 			{
-		// 				Name: "bar",
-		// 			},
-		// 		},
-		// 		ProviderConfig: LocalProviderConfig{
-		// 			LocalName: "aws",
-		// 		},
-		// 	},
-		// 	``,
-		// },
-		// {
-		// 	`aws`,
-		// 	AbsProviderConfig{},
-		// 	`Provider address must begin with "provider.", followed by a provider type name.`,
-		// },
-		// {
-		// 	`aws.foo`,
-		// 	AbsProviderConfig{},
-		// 	`Provider address must begin with "provider.", followed by a provider type name.`,
-		// },
-		// {
-		// 	`provider`,
-		// 	AbsProviderConfig{},
-		// 	`Provider address must begin with "provider.", followed by a provider type name.`,
-		// },
-		// {
-		// 	`provider.aws.foo.bar`,
-		// 	AbsProviderConfig{},
-		// 	`Extraneous operators after provider configuration alias.`,
-		// },
-		// {
-		// 	`provider["aws"]`,
-		// 	AbsProviderConfig{},
-		// 	`The prefix "provider." must be followed by a provider type name.`,
-		// },
-		// {
-		// 	`provider.aws["foo"]`,
-		// 	AbsProviderConfig{},
-		// 	`Provider type name must be followed by a configuration alias name.`,
-		// },
-		// {
-		// 	`module.foo`,
-		// 	AbsProviderConfig{},
-		// 	`Provider address must begin with "provider.", followed by a provider type name.`,
-		// },
-		// {
-		// 	`module.foo["provider"]`,
-		// 	AbsProviderConfig{},
-		// 	`Provider address must begin with "provider.", followed by a provider type name.`,
-		// },
+		{
+			`module.baz.provider.["registry.terraform.io/hashicorp/aws"]`,
+			AbsProviderConfig{
+				Module: ModuleInstance{
+					{
+						Name: "baz",
+					},
+				},
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				},
+			},
+			``,
+		},
+		{
+			`module.baz.provider.["registry.terraform.io/hashicorp/aws"].foo`,
+			AbsProviderConfig{
+				Module: ModuleInstance{
+					{
+						Name: "baz",
+					},
+				},
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				},
+				Alias: "foo",
+			},
+			``,
+		},
+		{
+			`module.baz["foo"].provider.["registry.terraform.io/hashicorp/aws"]`,
+			AbsProviderConfig{
+				Module: ModuleInstance{
+					{
+						Name:        "baz",
+						InstanceKey: StringKey("foo"),
+					},
+				},
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				},
+			},
+			``,
+		},
+		{
+			`module.baz[1].provider.["registry.terraform.io/hashicorp/aws"]`,
+			AbsProviderConfig{
+				Module: ModuleInstance{
+					{
+						Name:        "baz",
+						InstanceKey: IntKey(1),
+					},
+				},
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				},
+			},
+			``,
+		},
+		{
+			`module.baz[1].module.bar.provider.["registry.terraform.io/hashicorp/aws"]`,
+			AbsProviderConfig{
+				Module: ModuleInstance{
+					{
+						Name:        "baz",
+						InstanceKey: IntKey(1),
+					},
+					{
+						Name: "bar",
+					},
+				},
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				},
+			},
+			``,
+		},
+		{
+			`aws`,
+			AbsProviderConfig{},
+			`Provider address must begin with "provider.", followed by a provider type name.`,
+		},
+		{
+			`aws.foo`,
+			AbsProviderConfig{},
+			`Provider address must begin with "provider.", followed by a provider type name.`,
+		},
+		{
+			`provider`,
+			AbsProviderConfig{},
+			`Provider address must begin with "provider.", followed by a provider type name.`,
+		},
+		{
+			`provider.aws.foo.bar`,
+			AbsProviderConfig{},
+			`Extraneous operators after provider configuration alias.`,
+		},
+		// This used to generate an error, but now the syntax is ok.
+		// When NewLegacyProvider() is deprecated this will change.
+		{
+			`provider["aws"]`,
+			AbsProviderConfig{
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "-",
+					Hostname:  "registry.terraform.io",
+				},
+			},
+			``,
+		},
+		{
+			`provider["aws"]["foo"]`,
+			AbsProviderConfig{},
+			`Provider type name must be followed by a configuration alias name.`,
+		},
+		{
+			`module.foo`,
+			AbsProviderConfig{},
+			`Provider address must begin with "provider.", followed by a provider type name.`,
+		},
 	}
 
 	for _, test := range tests {
@@ -188,6 +202,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			}
 
 			for _, problem := range deep.Equal(got, test.Want) {
+				fmt.Printf("%#v\n", got)
 				t.Error(problem)
 			}
 		})

--- a/addrs/provider_config_test.go
+++ b/addrs/provider_config_test.go
@@ -27,17 +27,19 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			},
 			``,
 		},
-		// {
-		// 	`provider.aws.foo`,
-		// 	AbsProviderConfig{
-		// 		Module: RootModuleInstance,
-		// 		ProviderConfig: LocalProviderConfig{
-		// 			LocalName: "aws",
-		// 			Alias:     "foo",
-		// 		},
-		// 	},
-		// 	``,
-		// },
+		{
+			`provider.["registry.terraform.io/hashicorp/aws"].foo`,
+			AbsProviderConfig{
+				Module: RootModuleInstance,
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				},
+				Alias: "foo",
+			},
+			``,
+		},
 		// {
 		// 	`module.baz.provider.aws`,
 		// 	AbsProviderConfig{

--- a/vendor/github.com/hashicorp/hcl/v2/hclsyntax/parser_traversal.go
+++ b/vendor/github.com/hashicorp/hcl/v2/hclsyntax/parser_traversal.go
@@ -43,7 +43,7 @@ func (p *parser) ParseTraversalAbs() (hcl.Traversal, hcl.Diagnostics) {
 			// Attribute access
 			dot := p.Read() // eat dot
 			nameTok := p.Read()
-			if nameTok.Type != TokenIdent {
+			if nameTok.Type != TokenIdent && nameTok.Type != TokenOBrack {
 				if nameTok.Type == TokenStar {
 					diags = append(diags, &hcl.Diagnostic{
 						Severity: hcl.DiagError,
@@ -64,11 +64,56 @@ func (p *parser) ParseTraversalAbs() (hcl.Traversal, hcl.Diagnostics) {
 				return ret, diags
 			}
 
-			attrName := string(nameTok.Bytes)
-			ret = append(ret, hcl.TraverseAttr{
-				Name:     attrName,
-				SrcRange: hcl.RangeBetween(dot.Range, nameTok.Range),
-			})
+			if nameTok.Type == TokenIdent {
+				attrName := string(nameTok.Bytes)
+				ret = append(ret, hcl.TraverseAttr{
+					Name:     attrName,
+					SrcRange: hcl.RangeBetween(dot.Range, nameTok.Range),
+				})
+			} else { // nameTok.Type == TokenOBrack
+				open := p.Read() // eat open bracket
+				next := p.Peek()
+				switch next.Type {
+				case TokenQuotedLit:
+					tok := p.Read() // eat string
+					str, strDiags := ParseStringLiteralToken(tok)
+					diags = append(diags, strDiags...)
+
+					close := p.Read()
+					if close.Type != TokenCQuote {
+						diags = append(diags, &hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "Unclosed quoted string",
+							Detail:   "String missing closing quote.",
+							Subject:  &close.Range,
+							Context:  hcl.RangeBetween(open.Range, close.Range).Ptr(),
+						})
+					}
+					ret = append(ret, hcl.TraverseIndex{
+						Key:      cty.StringVal(str),
+						SrcRange: hcl.RangeBetween(open.Range, close.Range),
+					})
+				default:
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "String required",
+						Detail:   "Bracket must be followed by a valid string.",
+						Subject:  &nameTok.Range,
+						Context:  hcl.RangeBetween(varTok.Range, nameTok.Range).Ptr(),
+					})
+				}
+				// close brackets
+				close := p.Read()
+				if close.Type != TokenCBrack {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Unclosed index brackets",
+						Detail:   "Index key must be followed by a closing bracket.",
+						Subject:  &close.Range,
+						Context:  hcl.RangeBetween(open.Range, close.Range).Ptr(),
+					})
+				}
+			}
 		case TokenOBrack:
 			// Index
 			open := p.Read() // eat open bracket


### PR DESCRIPTION
Here's a POC parsing a new ParseAbsProviderConfig string which include the full provider FQN in a new-to-hcl format:

```
provider.["registry.terraform.io/hashicorp/random"]
provider.["registry.terraform.io/hashicorp/random"].alias
```

This requires upstream changes to `hcl` (vendored in this PR so you can see one option); I am opening this draft PR to collect opinions and alternate ideas.

