### PR TITLE
command/console: support root module output

### DIFF
--- a/addrs/output_value.go
+++ b/addrs/output_value.go
@@ -13,6 +13,7 @@ import (
 // OutputValue is not Referenceable, while ModuleCallOutput is.
 type OutputValue struct {
 	Name string
+	referenceable
 }
 
 func (v OutputValue) String() string {

--- a/addrs/parse_ref.go
+++ b/addrs/parse_ref.go
@@ -219,6 +219,17 @@ func parseRef(traversal hcl.Traversal) (*Reference, tfdiags.Diagnostics) {
 			Remaining:   remain,
 		}, diags
 
+	case "output":
+		name, rng, remain, diags := parseSingleAttrRef(traversal)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		return &Reference{
+			Subject:     OutputValue{Name: name},
+			SourceRange: tfdiags.SourceRangeFromHCL(rng),
+			Remaining:   remain,
+		}, diags
+
 	default:
 		return parseResourceRef(ManagedResourceMode, rootRange, traversal)
 	}

--- a/configs/configupgrade/analysis_expr.go
+++ b/configs/configupgrade/analysis_expr.go
@@ -128,6 +128,11 @@ func (d analysisData) GetModuleInstance(addrs.ModuleCallInstance, tfdiags.Source
 }
 
 func (d analysisData) GetModuleInstanceOutput(addrs.ModuleCallOutput, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// This implementation doesn't use this.
+	return cty.DynamicVal, nil
+}
+
+func (d analysisData) GetRootModuleOutput(addrs.OutputValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	// We only work on one module at a time during upgrading, so we have no
 	// information about the outputs of a child module.
 	return cty.DynamicVal, nil

--- a/lang/data.go
+++ b/lang/data.go
@@ -28,6 +28,7 @@ type Data interface {
 	GetLocalValue(addrs.LocalValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetModuleInstance(addrs.ModuleCallInstance, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetModuleInstanceOutput(addrs.ModuleCallOutput, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetRootModuleOutput(addrs.OutputValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetPathAttr(addrs.PathAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetTerraformAttr(addrs.TerraformAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetInputVariable(addrs.InputVariable, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)

--- a/lang/data_test.go
+++ b/lang/data_test.go
@@ -15,6 +15,7 @@ type dataForTests struct {
 	PathAttrs      map[string]cty.Value
 	TerraformAttrs map[string]cty.Value
 	InputVariables map[string]cty.Value
+	Outputs        map[string]cty.Value
 }
 
 var _ Data = &dataForTests{}
@@ -51,6 +52,10 @@ func (d *dataForTests) GetModuleInstanceOutput(addr addrs.ModuleCallOutput, rng 
 	// This will panic if the module object does not have the requested attribute
 	obj := d.Modules[addr.Call.String()]
 	return obj.GetAttr(addr.Name), nil
+}
+
+func (d *dataForTests) GetRootModuleOutput(addr addrs.OutputValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.Outputs[addr.Name], nil
 }
 
 func (d *dataForTests) GetPathAttr(addr addrs.PathAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {

--- a/lang/eval.go
+++ b/lang/eval.go
@@ -198,6 +198,7 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 	managedResources := map[string]map[string]cty.Value{}
 	wholeModules := map[string]map[addrs.InstanceKey]cty.Value{}
 	moduleOutputs := map[string]map[addrs.InstanceKey]map[string]cty.Value{}
+	rootModuleOutputs := map[string]cty.Value{}
 	inputVariables := map[string]cty.Value{}
 	localValues := map[string]cty.Value{}
 	pathAttrs := map[string]cty.Value{}
@@ -307,6 +308,11 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 			}
 			moduleOutputs[callName][callKey][subj.Name] = val
 
+		case addrs.OutputValue:
+			val, valDiags := normalizeRefValue(s.Data.GetRootModuleOutput(subj, rng))
+			diags = diags.Append(valDiags)
+			rootModuleOutputs[subj.Name] = val
+
 		case addrs.InputVariable:
 			val, valDiags := normalizeRefValue(s.Data.GetInputVariable(subj, rng))
 			diags = diags.Append(valDiags)
@@ -354,6 +360,7 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 	vals["terraform"] = cty.ObjectVal(terraformAttrs)
 	vals["count"] = cty.ObjectVal(countAttrs)
 	vals["each"] = cty.ObjectVal(forEachAttrs)
+	vals["output"] = cty.ObjectVal(rootModuleOutputs)
 	if self != cty.NilVal {
 		vals["self"] = self
 	}

--- a/lang/eval_test.go
+++ b/lang/eval_test.go
@@ -69,6 +69,10 @@ func TestScopeEvalContext(t *testing.T) {
 		InputVariables: map[string]cty.Value{
 			"baz": cty.StringVal("boop"),
 		},
+		Outputs: map[string]cty.Value{
+			"output0": cty.StringVal("foo0"),
+			"output1": cty.StringVal("foo1"),
+		},
 	}
 
 	tests := []struct {
@@ -255,6 +259,14 @@ func TestScopeEvalContext(t *testing.T) {
 			map[string]cty.Value{
 				"var": cty.ObjectVal(map[string]cty.Value{
 					"baz": cty.StringVal("boop"),
+				}),
+			},
+		},
+		{
+			`output.output0`,
+			map[string]cty.Value{
+				"output": cty.ObjectVal(map[string]cty.Value{
+					"output0": cty.StringVal("foo0"),
 				}),
 			},
 		},


### PR DESCRIPTION
The `terraform console` command was unable to print root module outputs, instead only supporting module output (which I suspect won't work in 0.12 at all, since only root module outputs are stored in state).

Addresses some of the concerns in 21516, but possibly not all - as implemented this still requires an initial apply, even if the value is hard-coded in the module. 

From a *MODIFIED* example in [this comment](https://github.com/hashicorp/terraform/issues/21516#issuecomment-564409664):

```bash
echo output.stuff | terraform console
{
  "house" = {
    "foo" = "bar"
  }
}
```
I had to add the output to the root module for the above to work:
```hcl
output "stuff" {
  value = module.stuff
}
```
Note that (as currently implemented) this only works after an apply; the value must be in state. If it's intended/expected to work without apply there's more to be done, but I hope this is a sufficient first step.


This works too!
```bash
echo output.stuff.house | terraform console
{
  "foo" = "bar"
}
```