### PR TITLE
ssh: return error if host is empty

### DIFF
--- a/communicator/communicator_test.go
+++ b/communicator/communicator_test.go
@@ -16,6 +16,7 @@ func TestCommunicator_new(t *testing.T) {
 		Ephemeral: terraform.EphemeralState{
 			ConnInfo: map[string]string{
 				"type": "telnet",
+				"host": "127.0.0.1",
 			},
 		},
 	}

--- a/communicator/ssh/communicator_test.go
+++ b/communicator/ssh/communicator_test.go
@@ -149,6 +149,25 @@ func TestNew_Invalid(t *testing.T) {
 	}
 }
 
+func TestNew_InvalidHost(t *testing.T) {
+	r := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: map[string]string{
+				"type":     "ssh",
+				"user":     "user",
+				"password": "i-am-invalid",
+				"port":     "22",
+				"timeout":  "30s",
+			},
+		},
+	}
+
+	_, err := New(r)
+	if err == nil {
+		t.Fatal("should have had an error creating communicator")
+	}
+}
+
 func TestStart(t *testing.T) {
 	address := newMockLineServer(t, nil, testClientPublicKey)
 	parts := strings.Split(address, ":")

--- a/communicator/ssh/communicator_test.go
+++ b/communicator/ssh/communicator_test.go
@@ -691,6 +691,7 @@ func TestScriptPath(t *testing.T) {
 			Ephemeral: terraform.EphemeralState{
 				ConnInfo: map[string]string{
 					"type":        "ssh",
+					"host":        "127.0.0.1",
 					"script_path": tc.Input,
 				},
 			},
@@ -715,7 +716,14 @@ func TestScriptPath_randSeed(t *testing.T) {
 	// Pre GH-4186 fix, this value was the deterministic start the pseudorandom
 	// chain of unseeded math/rand values for Int31().
 	staticSeedPath := "/tmp/terraform_1298498081.sh"
-	c, err := New(&terraform.InstanceState{})
+	c, err := New(&terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: map[string]string{
+				"type": "ssh",
+				"host": "127.0.0.1",
+			},
+		},
+	})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform/communicator/shared"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/mapstructure"
-	"github.com/xanzy/ssh-agent"
+	sshagent "github.com/xanzy/ssh-agent"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -91,6 +91,12 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 
 	if connInfo.User == "" {
 		connInfo.User = DefaultUser
+	}
+
+	// Check if host is empty.
+	// Otherwise return error.
+	if connInfo.Host == "" {
+		return nil, fmt.Errorf("host for provisioner cannot be empty")
 	}
 
 	// Format the host if needed.

--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -131,3 +131,24 @@ func TestProvisioner_connInfoHostname(t *testing.T) {
 		t.Fatalf("bad %v", conf)
 	}
 }
+
+func TestProvisioner_connInfoEmptyHostname(t *testing.T) {
+	r := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: map[string]string{
+				"type":        "ssh",
+				"user":        "root",
+				"password":    "supersecret",
+				"private_key": "someprivatekeycontents",
+				"host":        "",
+				"port":        "22",
+				"timeout":     "30s",
+			},
+		},
+	}
+
+	_, err := parseConnectionInfo(r)
+	if err == nil {
+		t.Fatalf("bad: should not allow empty host")
+	}
+}


### PR DESCRIPTION
Validate if the SSH host is empty in provisioner connection configuration.

This will avoid the behavior of terraform trying to connect to the provisioner remote-exec that has no connection configured.

Fixes #21690