### PR TITLE
Mildwonkey/ps abs pc

### DIFF
--- a/addrs/provider_config.go
+++ b/addrs/provider_config.go
@@ -60,21 +60,6 @@ func NewDefaultLocalProviderConfig(LocalNameName string) LocalProviderConfig {
 // providerConfig Implements addrs.ProviderConfig.
 func (pc LocalProviderConfig) providerConfig() {}
 
-// Absolute returns an AbsProviderConfig from the receiver and the given module
-// instance address.
-//
-// TODO: This methold will become obsolete as part of supporting fully-qualified
-// provider names in AbsProviderConfig, requiring a lookup via the module
-// configuration instead. However, we continue to support it for now by
-// relying on the fact that only "legacy" provider addresses are currently
-// supported.
-func (pc LocalProviderConfig) Absolute(module ModuleInstance) AbsProviderConfig {
-	return AbsProviderConfig{
-		Module:         module,
-		ProviderConfig: pc,
-	}
-}
-
 func (pc LocalProviderConfig) String() string {
 	if pc.LocalName == "" {
 		// Should never happen; always indicates a bug
@@ -100,21 +85,9 @@ func (pc LocalProviderConfig) StringCompact() string {
 // AbsProviderConfig is the absolute address of a provider configuration
 // within a particular module instance.
 type AbsProviderConfig struct {
-	Module ModuleInstance
-
-	// TODO: In a future change, this will no longer be an embedded
-	// LocalProviderConfig and should instead be two separate fields
-	// to allow AbsProviderConfig to use provider FQN rather than
-	// local type name:
-	//
-	//     Provider Provider
-	//     Alias    string
-	//
-	// For now though, we continue to embed LocalProviderConfig until we're
-	// ready to teach the rest of Terraform Core about non-legacy provider
-	// FQNs, and update our ParseAbsProviderConfig and AbsProviderConfig.String
-	// methods to deal with FQNs.
-	ProviderConfig LocalProviderConfig
+	Module   ModuleInstance
+	Provider Provider
+	Alias    string
 }
 
 var _ ProviderConfig = AbsProviderConfig{}
@@ -123,11 +96,11 @@ var _ ProviderConfig = AbsProviderConfig{}
 // address. The following are examples of traversals that can be successfully
 // parsed as absolute provider configuration addresses:
 //
-//     provider.aws
-//     provider.aws.foo
-//     module.bar.provider.aws
-//     module.bar.module.baz.provider.aws.foo
-//     module.foo[1].provider.aws.foo
+//     provider.["registry.terraform.io/hashicorp/aws"]
+//     provider.["registry.terraform.io/hashicorp/aws"].foo
+//     module.bar.provider.["registry.terraform.io/hashicorp/aws"]
+//     module.bar.module.baz.provider.["registry.terraform.io/hashicorp/aws"].foo
+//     module.foo[1].provider.["registry.terraform.io/hashicorp/aws"].foo
 //
 // This type of address is used, for example, to record the relationships
 // between resources and provider configurations in the state structure.
@@ -157,8 +130,13 @@ func ParseAbsProviderConfig(traversal hcl.Traversal) (AbsProviderConfig, tfdiags
 		return ret, diags
 	}
 
-	if tt, ok := remain[1].(hcl.TraverseAttr); ok {
-		ret.ProviderConfig.LocalName = tt.Name
+	if tt, ok := remain[1].(hcl.TraverseIndex); ok {
+		p, sourceDiags := ParseProviderSourceString(tt.Key.AsString())
+		ret.Provider = p
+		if sourceDiags.HasErrors() {
+			diags = diags.Append(sourceDiags)
+			return ret, diags
+		}
 	} else {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
@@ -171,7 +149,7 @@ func ParseAbsProviderConfig(traversal hcl.Traversal) (AbsProviderConfig, tfdiags
 
 	if len(remain) == 3 {
 		if tt, ok := remain[2].(hcl.TraverseAttr); ok {
-			ret.ProviderConfig.Alias = tt.Name
+			ret.Alias = tt.Name
 		} else {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -215,6 +193,89 @@ func ParseAbsProviderConfigStr(str string) (AbsProviderConfig, tfdiags.Diagnosti
 	return addr, diags
 }
 
+func ParseLegacyAbsProviderConfigStr(str string) (AbsProviderConfig, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	traversal, parseDiags := hclsyntax.ParseTraversalAbs([]byte(str), "", hcl.Pos{Line: 1, Column: 1})
+	diags = diags.Append(parseDiags)
+	if parseDiags.HasErrors() {
+		return AbsProviderConfig{}, diags
+	}
+
+	addr, addrDiags := ParseLegacyAbsProviderConfig(traversal)
+	diags = diags.Append(addrDiags)
+	return addr, diags
+}
+
+// ParseLegacyAbsProviderConfig parses the given traversal as an absolute provider
+// address. The following are examples of traversals that can be successfully
+// parsed as absolute provider configuration addresses:
+//
+//     provider.aws
+//     provider.aws.foo
+//     module.bar.provider.aws
+//     module.bar.module.baz.provider.aws.foo
+//     module.foo[1].provider.aws.foo
+//
+// This type of address is used, for example, to record the relationships
+// between resources and provider configurations in the state structure.
+// This type of address is not generally used in the UI, except in error
+// messages that refer to provider configurations.
+func ParseLegacyAbsProviderConfig(traversal hcl.Traversal) (AbsProviderConfig, tfdiags.Diagnostics) {
+	modInst, remain, diags := parseModuleInstancePrefix(traversal)
+	ret := AbsProviderConfig{
+		Module: modInst,
+	}
+
+	if len(remain) < 2 || remain.RootName() != "provider" {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid provider configuration address",
+			Detail:   "Provider address must begin with \"provider.\", followed by a provider type name.",
+			Subject:  remain.SourceRange().Ptr(),
+		})
+		return ret, diags
+	}
+	if len(remain) > 3 {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid provider configuration address",
+			Detail:   "Extraneous operators after provider configuration alias.",
+			Subject:  hcl.Traversal(remain[3:]).SourceRange().Ptr(),
+		})
+		return ret, diags
+	}
+
+	// We always assume legacy-style providers in legacy state
+	if tt, ok := remain[1].(hcl.TraverseAttr); ok {
+		ret.Provider = NewLegacyProvider(tt.Name)
+	} else {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid provider configuration address",
+			Detail:   "The prefix \"provider.\" must be followed by a provider type name.",
+			Subject:  remain[1].SourceRange().Ptr(),
+		})
+		return ret, diags
+	}
+
+	if len(remain) == 3 {
+		if tt, ok := remain[2].(hcl.TraverseAttr); ok {
+			ret.Alias = tt.Name
+		} else {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid provider configuration address",
+				Detail:   "Provider type name must be followed by a configuration alias name.",
+				Subject:  remain[2].SourceRange().Ptr(),
+			})
+			return ret, diags
+		}
+	}
+
+	return ret, diags
+}
+
 // ProviderConfigDefault returns the address of the default provider config
 // of the given type inside the recieving module instance.
 //
@@ -223,10 +284,8 @@ func ParseAbsProviderConfigStr(str string) (AbsProviderConfig, tfdiags.Diagnosti
 // and Alias fields rather than embedding LocalProviderConfig.
 func (m ModuleInstance) ProviderConfigDefault(name string) AbsProviderConfig {
 	return AbsProviderConfig{
-		Module: m,
-		ProviderConfig: LocalProviderConfig{
-			LocalName: name,
-		},
+		Module:   m,
+		Provider: NewLegacyProvider(name),
 	}
 }
 
@@ -238,11 +297,9 @@ func (m ModuleInstance) ProviderConfigDefault(name string) AbsProviderConfig {
 // and Alias fields rather than embedding LocalProviderConfig.
 func (m ModuleInstance) ProviderConfigAliased(name, alias string) AbsProviderConfig {
 	return AbsProviderConfig{
-		Module: m,
-		ProviderConfig: LocalProviderConfig{
-			LocalName: name,
-			Alias:     alias,
-		},
+		Module:   m,
+		Provider: NewLegacyProvider(name),
+		Alias:    alias,
 	}
 }
 
@@ -267,19 +324,25 @@ func (pc AbsProviderConfig) Inherited() (AbsProviderConfig, bool) {
 	}
 
 	// Can't inherit if we have an alias.
-	if pc.ProviderConfig.Alias != "" {
+	if pc.Alias != "" {
 		return AbsProviderConfig{}, false
 	}
 
 	// Otherwise, we might inherit from a configuration with the same
-	// provider name in the parent module instance.
+	// provider type in the parent module instance.
 	parentMod := pc.Module.Parent()
-	return pc.ProviderConfig.Absolute(parentMod), true
+	return AbsProviderConfig{
+		Module:   parentMod,
+		Provider: pc.Provider,
+	}, true
+
 }
 
+// FIXME: we're only using legacy strings for now until all of terraform knows the difference
+// The original LocalProviderConfig strings included a leading "provider.", which is why its added here.
 func (pc AbsProviderConfig) String() string {
 	if len(pc.Module) == 0 {
-		return pc.ProviderConfig.String()
+		return fmt.Sprintf("%s.%s", "provider", pc.Provider.LegacyString())
 	}
-	return fmt.Sprintf("%s.%s", pc.Module.String(), pc.ProviderConfig.String())
+	return fmt.Sprintf("%s.%s.%s", pc.Module.String(), "provider", pc.Provider.LegacyString())
 }

--- a/addrs/provider_config.go
+++ b/addrs/provider_config.go
@@ -205,9 +205,9 @@ func ParseLegacyAbsProviderConfigStr(str string) (AbsProviderConfig, tfdiags.Dia
 	return addr, diags
 }
 
-// ParseLegacyAbsProviderConfig parses the given traversal as an absolute provider
-// address. The following are examples of traversals that can be successfully
-// parsed as absolute provider configuration addresses:
+// ParseLegacyAbsProviderConfig parses the given traversal as an absolute
+// provider address. The following are examples of traversals that can be
+// successfully parsed as legacy absolute provider configuration addresses:
 //
 //     provider.aws
 //     provider.aws.foo
@@ -215,10 +215,9 @@ func ParseLegacyAbsProviderConfigStr(str string) (AbsProviderConfig, tfdiags.Dia
 //     module.bar.module.baz.provider.aws.foo
 //     module.foo[1].provider.aws.foo
 //
-// This type of address is used, for example, to record the relationships
-// between resources and provider configurations in the state structure.
-// This type of address is not generally used in the UI, except in error
-// messages that refer to provider configurations.
+// This type of address is used in legacy state and may appear in state v4 if
+// the provider config addresses have not been normalized to include provider
+// FQN.
 func ParseLegacyAbsProviderConfig(traversal hcl.Traversal) (AbsProviderConfig, tfdiags.Diagnostics) {
 	modInst, remain, diags := parseModuleInstancePrefix(traversal)
 	ret := AbsProviderConfig{
@@ -336,8 +335,7 @@ func (pc AbsProviderConfig) Inherited() (AbsProviderConfig, bool) {
 
 }
 
-// This function returns a legagy-style AbsProviderConfig string and should only be used for legacy state shimming.
-
+// LegacyString() returns a legacy-style AbsProviderConfig string and should only be used for legacy state shimming.
 func (pc AbsProviderConfig) LegacyString() string {
 	if pc.Alias != "" {
 		if len(pc.Module) == 0 {
@@ -352,6 +350,12 @@ func (pc AbsProviderConfig) LegacyString() string {
 	return fmt.Sprintf("%s.%s.%s", pc.Module.String(), "provider", pc.Provider.LegacyString())
 }
 
+// String() returns a string representation of an AbsProviderConfig in the following format:
+//
+// 	provider["example.com/namespace/name"]
+// 	provider["example.com/namespace/name"].alias
+// 	module.module-name.provider["example.com/namespace/name"]
+// 	module.module-name.provider["example.com/namespace/name"].alias
 func (pc AbsProviderConfig) String() string {
 	if pc.Alias != "" {
 		if len(pc.Module) == 0 {

--- a/addrs/provider_config.go
+++ b/addrs/provider_config.go
@@ -336,13 +336,14 @@ func (pc AbsProviderConfig) Inherited() (AbsProviderConfig, bool) {
 
 }
 
-// FIXME: This will be removed once all of terraform understands FQNs
+// This function returns a legagy-style AbsProviderConfig string and should only be used for legacy state shimming.
+
 func (pc AbsProviderConfig) LegacyString() string {
 	if pc.Alias != "" {
 		if len(pc.Module) == 0 {
 			return fmt.Sprintf("%s.%s.%s", "provider", pc.Provider.LegacyString(), pc.Alias)
 		} else {
-			return fmt.Sprintf("%s.%s.%s", "provider", pc.Provider.LegacyString(), pc.Alias)
+			return fmt.Sprintf("%s.%s.%s.%s", pc.Module.String(), "provider", pc.Provider.LegacyString(), pc.Alias)
 		}
 	}
 	if len(pc.Module) == 0 {

--- a/addrs/provider_config_test.go
+++ b/addrs/provider_config_test.go
@@ -16,57 +16,65 @@ func TestParseAbsProviderConfig(t *testing.T) {
 		WantDiag string
 	}{
 		{
-			`provider.aws`,
+			`provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: RootModuleInstance,
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
 				},
 			},
 			``,
 		},
 		{
-			`provider.aws.foo`,
+			`provider["registry.terraform.io/hashicorp/aws"].foo`,
 			AbsProviderConfig{
 				Module: RootModuleInstance,
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
-					Alias:     "foo",
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
 				},
+				Alias: "foo",
 			},
 			``,
 		},
 		{
-			`module.baz.provider.aws`,
+			`module.baz.provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: ModuleInstance{
 					{
 						Name: "baz",
 					},
 				},
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
 				},
 			},
 			``,
 		},
 		{
-			`module.baz.provider.aws.foo`,
+			`module.baz.provider["registry.terraform.io/hashicorp/aws"].foo`,
 			AbsProviderConfig{
 				Module: ModuleInstance{
 					{
 						Name: "baz",
 					},
 				},
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
-					Alias:     "foo",
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
 				},
+				Alias: "foo",
 			},
 			``,
 		},
 		{
-			`module.baz["foo"].provider.aws`,
+			`module.baz["foo"].provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: ModuleInstance{
 					{
@@ -74,14 +82,16 @@ func TestParseAbsProviderConfig(t *testing.T) {
 						InstanceKey: StringKey("foo"),
 					},
 				},
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
 				},
 			},
 			``,
 		},
 		{
-			`module.baz[1].provider.aws`,
+			`module.baz[1].provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: ModuleInstance{
 					{
@@ -89,14 +99,16 @@ func TestParseAbsProviderConfig(t *testing.T) {
 						InstanceKey: IntKey(1),
 					},
 				},
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
 				},
 			},
 			``,
 		},
 		{
-			`module.baz[1].module.bar.provider.aws`,
+			`module.baz[1].module.bar.provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: ModuleInstance{
 					{
@@ -107,8 +119,10 @@ func TestParseAbsProviderConfig(t *testing.T) {
 						Name: "bar",
 					},
 				},
-				ProviderConfig: LocalProviderConfig{
-					LocalName: "aws",
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
 				},
 			},
 			``,
@@ -134,22 +148,12 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			`Extraneous operators after provider configuration alias.`,
 		},
 		{
-			`provider["aws"]`,
-			AbsProviderConfig{},
-			`The prefix "provider." must be followed by a provider type name.`,
-		},
-		{
-			`provider.aws["foo"]`,
+			`provider["aws"]["foo"]`,
 			AbsProviderConfig{},
 			`Provider type name must be followed by a configuration alias name.`,
 		},
 		{
 			`module.foo`,
-			AbsProviderConfig{},
-			`Provider address must begin with "provider.", followed by a provider type name.`,
-		},
-		{
-			`module.foo["provider"]`,
 			AbsProviderConfig{},
 			`Provider address must begin with "provider.", followed by a provider type name.`,
 		},

--- a/addrs/provider_config_test.go
+++ b/addrs/provider_config_test.go
@@ -193,3 +193,48 @@ func TestParseAbsProviderConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		Config AbsProviderConfig
+		Want   string
+	}{
+		{
+			AbsProviderConfig{
+				Module:   RootModuleInstance,
+				Provider: NewLegacyProvider("foo"),
+			},
+			`provider["registry.terraform.io/-/foo"]`,
+		},
+		{
+			AbsProviderConfig{
+				Module:   RootModuleInstance.Child("child_module", NoKey),
+				Provider: NewLegacyProvider("foo"),
+			},
+			`module.child_module.provider["registry.terraform.io/-/foo"]`,
+		},
+		{
+			AbsProviderConfig{
+				Module:   RootModuleInstance,
+				Alias:    "bar",
+				Provider: NewLegacyProvider("foo"),
+			},
+			`provider["registry.terraform.io/-/foo"].bar`,
+		},
+		{
+			AbsProviderConfig{
+				Module:   RootModuleInstance.Child("child_module", NoKey),
+				Alias:    "bar",
+				Provider: NewLegacyProvider("foo"),
+			},
+			`module.child_module.provider["registry.terraform.io/-/foo"].bar`,
+		},
+	}
+
+	for _, test := range tests {
+		got := test.Config.String()
+		if got != test.Want {
+			t.Errorf("wrong result. Got %s, want %s\n", got, test.Want)
+		}
+	}
+}

--- a/addrs/provider_config_test.go
+++ b/addrs/provider_config_test.go
@@ -194,7 +194,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 	}
 }
 
-func TestString(t *testing.T) {
+func TestAbsProviderConfigString(t *testing.T) {
 	tests := []struct {
 		Config AbsProviderConfig
 		Want   string
@@ -233,6 +233,51 @@ func TestString(t *testing.T) {
 
 	for _, test := range tests {
 		got := test.Config.String()
+		if got != test.Want {
+			t.Errorf("wrong result. Got %s, want %s\n", got, test.Want)
+		}
+	}
+}
+
+func TestAbsProviderConfigLegacyString(t *testing.T) {
+	tests := []struct {
+		Config AbsProviderConfig
+		Want   string
+	}{
+		{
+			AbsProviderConfig{
+				Module:   RootModuleInstance,
+				Provider: NewLegacyProvider("foo"),
+			},
+			`provider.foo`,
+		},
+		{
+			AbsProviderConfig{
+				Module:   RootModuleInstance.Child("child_module", NoKey),
+				Provider: NewLegacyProvider("foo"),
+			},
+			`module.child_module.provider.foo`,
+		},
+		{
+			AbsProviderConfig{
+				Module:   RootModuleInstance,
+				Alias:    "bar",
+				Provider: NewLegacyProvider("foo"),
+			},
+			`provider.foo.bar`,
+		},
+		{
+			AbsProviderConfig{
+				Module:   RootModuleInstance.Child("child_module", NoKey),
+				Alias:    "bar",
+				Provider: NewLegacyProvider("foo"),
+			},
+			`module.child_module.provider.foo.bar`,
+		},
+	}
+
+	for _, test := range tests {
+		got := test.Config.LegacyString()
 		if got != test.Want {
 			t.Errorf("wrong result. Got %s, want %s\n", got, test.Want)
 		}

--- a/backend/local/backend_apply_test.go
+++ b/backend/local/backend_apply_test.go
@@ -59,7 +59,7 @@ func TestLocal_applyBasic(t *testing.T) {
 	checkState(t, b.StateOutPath, `
 test_instance.foo:
   ID = yes
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   ami = bar
 `)
 }
@@ -176,7 +176,7 @@ func TestLocal_applyError(t *testing.T) {
 	checkState(t, b.StateOutPath, `
 test_instance.foo:
   ID = foo
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   ami = bar
 	`)
 }
@@ -226,7 +226,7 @@ func TestLocal_applyBackendFail(t *testing.T) {
 	checkState(t, "errored.tfstate", `
 test_instance.foo:
   ID = yes
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   ami = bar
 	`)
 }

--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -263,9 +263,7 @@ func RenderPlan(plan *plans.Plan, state *states.State, schemas *terraform.Schema
 			continue
 		}
 
-		// FIXME: update this once the provider fqn is available in the AbsProviderConfig
-		providerFqn := addrs.NewLegacyProvider(rcs.ProviderAddr.ProviderConfig.LocalName)
-		providerSchema := schemas.ProviderSchema(providerFqn)
+		providerSchema := schemas.ProviderSchema(rcs.ProviderAddr.Provider)
 		if providerSchema == nil {
 			// Should never happen
 			ui.Output(fmt.Sprintf("(schema missing for %s)\n", rcs.ProviderAddr))

--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -215,9 +215,10 @@ func TestLocal_planDeposedOnly(t *testing.T) {
 				}]
 			}`),
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "test",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	}))
 	b.CLI = cli.NewMockUi()
@@ -658,9 +659,10 @@ func testPlanState() *states.State {
 				}]
 			}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	return state
 }
@@ -684,9 +686,10 @@ func testPlanState_withDataSource() *states.State {
 				}]
 			}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	rootModule.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -700,9 +703,10 @@ func testPlanState_withDataSource() *states.State {
 				"filter": "foo"
 			}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	return state
 }
@@ -726,9 +730,10 @@ func testPlanState_tainted() *states.State {
 				}]
 			}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	return state
 }

--- a/backend/local/backend_refresh_test.go
+++ b/backend/local/backend_refresh_test.go
@@ -42,7 +42,7 @@ func TestLocal_refresh(t *testing.T) {
 	checkState(t, b.StateOutPath, `
 test_instance.foo:
   ID = yes
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`)
 }
 
@@ -72,7 +72,7 @@ func TestLocal_refreshNoConfig(t *testing.T) {
 	checkState(t, b.StateOutPath, `
 test_instance.foo:
   ID = yes
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`)
 }
 
@@ -105,7 +105,7 @@ func TestLocal_refreshNilModuleWithInput(t *testing.T) {
 	checkState(t, b.StateOutPath, `
 test_instance.foo:
   ID = yes
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`)
 }
 
@@ -163,7 +163,7 @@ func TestLocal_refreshInput(t *testing.T) {
 	checkState(t, b.StateOutPath, `
 test_instance.foo:
   ID = yes
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`)
 }
 
@@ -196,7 +196,7 @@ func TestLocal_refreshValidate(t *testing.T) {
 	checkState(t, b.StateOutPath, `
 test_instance.foo:
   ID = yes
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`)
 }
 

--- a/backend/testing.go
+++ b/backend/testing.go
@@ -150,9 +150,10 @@ func TestBackendStates(t *testing.T, b Backend) {
 				Status:        states.ObjectReady,
 				SchemaVersion: 0,
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "test",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 
 		// write a distinct known state to bar

--- a/command/apply_destroy_test.go
+++ b/command/apply_destroy_test.go
@@ -29,7 +29,10 @@ func TestApply_destroy(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -122,7 +125,10 @@ func TestApply_destroyLockedState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -194,7 +200,10 @@ func TestApply_destroyTargeted(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"i-ab123"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -206,7 +215,10 @@ func TestApply_destroyTargeted(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"i-abc123"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, originalState)

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -833,7 +833,10 @@ func TestApply_refresh(t *testing.T) {
 				AttrsJSON: []byte(`{"ami":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -987,7 +990,10 @@ func TestApply_state(t *testing.T) {
 				AttrsJSON: []byte(`{"ami":"foo"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -1351,7 +1357,10 @@ func TestApply_backup(t *testing.T) {
 				AttrsJSON: []byte("{\n            \"id\": \"bar\"\n          }"),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -1652,7 +1661,10 @@ func applyFixturePlanFile(t *testing.T) string {
 			Type: "test_instance",
 			Name: "foo",
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-		ProviderAddr: addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+		ProviderAddr: addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 		ChangeSrc: plans.ChangeSrc{
 			Action: plans.Create,
 			Before: priorValRaw,

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -271,9 +271,10 @@ func testState() *states.State {
 				Dependencies: []addrs.AbsResource{},
 				DependsOn:    []addrs.Referenceable{},
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "test",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		// DeepCopy is used here to ensure our synthetic state matches exactly
 		// with a state that will have been copied during the command

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3157,7 +3157,10 @@ func runTestCases(t *testing.T, testCases map[string]testCase) {
 					Type: "test_instance",
 					Name: "example",
 				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-				ProviderAddr: addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+				ProviderAddr: addrs.AbsProviderConfig{
+					Provider: addrs.NewLegacyProvider("test"),
+					Module:   addrs.RootModuleInstance,
+				},
 				ChangeSrc: plans.ChangeSrc{
 					Action: tc.Action,
 					Before: before,

--- a/command/format/state.go
+++ b/command/format/state.go
@@ -140,9 +140,7 @@ func formatStateModule(p blockBodyDiffPrinter, m *states.Module, schemas *terraf
 
 				var schema *configschema.Block
 
-				// TODO: Get the provider FQN when it is available from the AbsoluteProviderConfig, in state
-				// check if the resource has a configured provider, otherwise use the default provider
-				provider := addrs.NewLegacyProvider(m.Resources[key].ProviderConfig.ProviderConfig.LocalName)
+				provider := m.Resources[key].ProviderConfig.Provider
 				if _, exists := schemas.Providers[provider]; !exists {
 					// This should never happen in normal use because we should've
 					// loaded all of the schemas and checked things prior to this

--- a/command/format/state_test.go
+++ b/command/format/state_test.go
@@ -243,9 +243,10 @@ func basicState(t *testing.T) *states.State {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	rootModule.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -258,9 +259,10 @@ func basicState(t *testing.T) *states.State {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"compute":"sure"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	return state
 }
@@ -293,9 +295,10 @@ func stateWithMoreOutputs(t *testing.T) *states.State {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	return state
 }
@@ -319,9 +322,10 @@ func nestedState(t *testing.T) *states.State {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	return state
 }
@@ -341,9 +345,10 @@ func deposedState(t *testing.T) *states.State {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	return state
 }
@@ -369,9 +374,10 @@ func onlyDeposedState(t *testing.T) *states.State {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	rootModule.SetResourceInstanceDeposed(
 		addrs.Resource{
@@ -385,9 +391,10 @@ func onlyDeposedState(t *testing.T) *states.State {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	return state
 }

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -125,7 +125,10 @@ func TestGraph_plan(t *testing.T) {
 			Before: plans.DynamicValue(`{}`),
 			After:  plans.DynamicValue(`null`),
 		},
-		ProviderAddr: addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+		ProviderAddr: addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	})
 	emptyConfig, err := plans.NewDynamicValue(cty.EmptyObjectVal, cty.EmptyObject)
 	if err != nil {

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -33,7 +33,7 @@ func TestGraph(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "provider.test") {
+	if !strings.Contains(output, `provider["registry.terraform.io/-/test"]`) {
 		t.Fatalf("doesn't look like digraph: %s", output)
 	}
 }
@@ -80,7 +80,7 @@ func TestGraph_noArgs(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "provider.test") {
+	if !strings.Contains(output, `provider["registry.terraform.io/-/test"]`) {
 		t.Fatalf("doesn't look like digraph: %s", output)
 	}
 }
@@ -161,7 +161,7 @@ func TestGraph_plan(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "provider.test") {
+	if !strings.Contains(output, `provider["registry.terraform.io/-/test"]`) {
 		t.Fatalf("doesn't look like digraph: %s", output)
 	}
 }

--- a/command/import.go
+++ b/command/import.go
@@ -155,37 +155,9 @@ func (c *ImportCommand) Run(args []string) int {
 		return 1
 	}
 
-	if c.Meta.provider != "" {
-		traversal, travDiags := hclsyntax.ParseTraversalAbs([]byte(c.Meta.provider), `-provider=...`, hcl.Pos{Line: 1, Column: 1})
-		diags = diags.Append(travDiags)
-		if travDiags.HasErrors() {
-			c.showDiagnostics(diags)
-			c.Ui.Info(importCommandInvalidAddressReference)
-			return 1
-		}
-		relAddr, addrDiags := configs.ParseProviderConfigCompact(traversal)
-		diags = diags.Append(addrDiags)
-		if addrDiags.HasErrors() {
-			c.showDiagnostics(diags)
-			return 1
-		}
-		providerAddr = relAddr.Absolute(addrs.RootModuleInstance)
-
-	} else {
-		// Use a default address inferred from the resource type.
-		// We assume the same module as the resource address here, which
-		// may get resolved to an inherited provider when we construct the
-		// import graph inside ctx.Import, called below.
-		if rc != nil && rc.ProviderConfigRef != nil {
-			providerAddr = rc.ProviderConfigAddr().Absolute(addr.Module)
-		} else {
-			providerType := resourceRelAddr.DefaultProvider()
-			providerAddr = addrs.NewDefaultLocalProviderConfig(providerType.LegacyString()).Absolute(addr.Module)
-		}
-	}
-
 	// Check for user-supplied plugin path
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
 		return 1
 	}
 

--- a/command/import_test.go
+++ b/command/import_test.go
@@ -838,17 +838,17 @@ func TestImport_pluginDir(t *testing.T) {
 const testImportStr = `
 test_instance.foo:
   ID = yay
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 `
 
 const testImportCustomProviderStr = `
 test_instance.foo:
   ID = yay
-  provider = provider.test.alias
+  provider = provider["registry.terraform.io/-/test"].alias
 `
 
 const testImportProviderMismatchStr = `
 test_instance.foo:
   ID = yay
-  provider = provider.test-beta
+  provider = provider["registry.terraform.io/-/test-beta"]
 `

--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -177,10 +177,8 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 			continue
 		}
 
-		// FIXME: update this once the provider fqn is available in the AbsProviderConfig
-		providerFqn := addrs.NewLegacyProvider(rc.ProviderAddr.ProviderConfig.LocalName)
 		schema, _ := schemas.ResourceTypeConfig(
-			providerFqn,
+			rc.ProviderAddr.Provider,
 			addr.Resource.Resource.Mode,
 			addr.Resource.Resource.Type,
 		)
@@ -254,7 +252,7 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 		r.ModuleAddress = addr.Module.String()
 		r.Name = addr.Resource.Resource.Name
 		r.Type = addr.Resource.Resource.Type
-		r.ProviderName = rc.ProviderAddr.ProviderConfig.StringCompact()
+		r.ProviderName = rc.ProviderAddr.Provider.LegacyString()
 
 		p.ResourceChanges = append(p.ResourceChanges, r)
 

--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -164,7 +164,7 @@ func marshalPlanResources(changes *plans.Changes, ris []addrs.AbsResourceInstanc
 			Address:      r.Addr.String(),
 			Type:         r.Addr.Resource.Resource.Type,
 			Name:         r.Addr.Resource.Resource.Name,
-			ProviderName: r.ProviderAddr.ProviderConfig.StringCompact(),
+			ProviderName: r.ProviderAddr.Provider.LegacyString(),
 			Index:        r.Addr.Resource.Key,
 		}
 
@@ -180,10 +180,8 @@ func marshalPlanResources(changes *plans.Changes, ris []addrs.AbsResourceInstanc
 			)
 		}
 
-		// FIXME: update this once the provider fqn is available in the AbsProviderConfig
-		providerFqn := addrs.NewLegacyProvider(r.ProviderAddr.ProviderConfig.LocalName)
 		schema, schemaVer := schemas.ResourceTypeConfig(
-			providerFqn,
+			r.ProviderAddr.Provider,
 			r.Addr.Resource.Resource.Mode,
 			resource.Type,
 		)

--- a/command/jsonplan/values_test.go
+++ b/command/jsonplan/values_test.go
@@ -258,7 +258,10 @@ func TestMarshalPlanResources(t *testing.T) {
 							Type: "test_thing",
 							Name: "example",
 						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-						ProviderAddr: addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+						ProviderAddr: addrs.AbsProviderConfig{
+							Provider: addrs.NewLegacyProvider("test"),
+							Module:   addrs.RootModuleInstance,
+						},
 						ChangeSrc: plans.ChangeSrc{
 							Action: test.Action,
 							Before: before,

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -254,7 +254,7 @@ func marshalResources(resources map[string]*states.Resource, schemas *terraform.
 				Address:      r.Addr.String(),
 				Type:         r.Addr.Type,
 				Name:         r.Addr.Name,
-				ProviderName: r.ProviderConfig.ProviderConfig.StringCompact(),
+				ProviderName: r.ProviderConfig.Provider.LegacyString(),
 			}
 
 			switch r.Addr.Mode {
@@ -273,10 +273,8 @@ func marshalResources(resources map[string]*states.Resource, schemas *terraform.
 				current.Index = k
 			}
 
-			// FIXME: lookup providerFqn from state
-			providerFqn := addrs.NewLegacyProvider(r.ProviderConfig.ProviderConfig.LocalName)
 			schema, _ := schemas.ResourceTypeConfig(
-				providerFqn,
+				r.ProviderConfig.Provider,
 				r.Addr.Mode,
 				r.Addr.Type,
 			)

--- a/command/jsonstate/state_test.go
+++ b/command/jsonstate/state_test.go
@@ -201,9 +201,10 @@ func TestMarshalResources(t *testing.T) {
 							},
 						},
 					},
-					ProviderConfig: addrs.LocalProviderConfig{
-						LocalName: "test",
-					}.Absolute(addrs.RootModuleInstance),
+					ProviderConfig: addrs.AbsProviderConfig{
+						Provider: addrs.NewLegacyProvider("test"),
+						Module:   addrs.RootModuleInstance,
+					},
 				},
 			},
 			testSchemas(),
@@ -244,9 +245,10 @@ func TestMarshalResources(t *testing.T) {
 							},
 						},
 					},
-					ProviderConfig: addrs.LocalProviderConfig{
-						LocalName: "test",
-					}.Absolute(addrs.RootModuleInstance),
+					ProviderConfig: addrs.AbsProviderConfig{
+						Provider: addrs.NewLegacyProvider("test"),
+						Module:   addrs.RootModuleInstance,
+					},
 				},
 			},
 			testSchemas(),
@@ -292,9 +294,10 @@ func TestMarshalResources(t *testing.T) {
 							},
 						},
 					},
-					ProviderConfig: addrs.LocalProviderConfig{
-						LocalName: "test",
-					}.Absolute(addrs.RootModuleInstance),
+					ProviderConfig: addrs.AbsProviderConfig{
+						Provider: addrs.NewLegacyProvider("test"),
+						Module:   addrs.RootModuleInstance,
+					},
 				},
 			},
 			testSchemas(),

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -124,7 +124,10 @@ func TestPlan_destroy(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	outPath := testTempFile(t)
@@ -240,7 +243,10 @@ func TestPlan_outPathNoChange(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","ami":"bar","network_interface":[{"description":"Main network interface","device_index":"0"}]}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, originalState)

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -757,10 +757,10 @@ foo = "bar"
 const testRefreshStr = `
 test_instance.foo:
   ID = yes
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 `
 const testRefreshCwdStr = `
 test_instance.foo:
   ID = yes
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 `

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -489,7 +489,10 @@ func showFixturePlanFile(t *testing.T, action plans.Action) string {
 			Type: "test_instance",
 			Name: "foo",
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-		ProviderAddr: addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+		ProviderAddr: addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 		ChangeSrc: plans.ChangeSrc{
 			Action: action,
 			Before: priorValRaw,

--- a/command/state_mv_test.go
+++ b/command/state_mv_test.go
@@ -154,12 +154,12 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 	testStateOutput(t, statePath, `
 test_instance.bar.0:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.baz:
   ID = foo
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `)
@@ -231,12 +231,12 @@ func TestStateMv_instanceToResource(t *testing.T) {
 	testStateOutput(t, statePath, `
 test_instance.bar:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.baz:
   ID = foo
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `)
@@ -249,12 +249,12 @@ test_instance.baz:
 	testStateOutput(t, backups[0], `
 test_instance.baz:
   ID = foo
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.0:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `)
@@ -304,7 +304,7 @@ func TestStateMv_instanceToNewResource(t *testing.T) {
 	testStateOutput(t, statePath, `
 test_instance.bar["new"]:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `)
@@ -325,7 +325,7 @@ test_instance.bar["new"]:
 module.test:
   test_instance.baz["new"]:
     ID = bar
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
     bar = value
     foo = value
 `)
@@ -1133,7 +1133,7 @@ func TestStateMv_fromBackendToLocal(t *testing.T) {
 const testStateMvOutputOriginal = `
 test_instance.baz:
   ID = foo
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 
@@ -1141,7 +1141,7 @@ test_instance.baz:
     test_instance.foo
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1149,12 +1149,12 @@ test_instance.foo:
 const testStateMvOutput = `
 test_instance.bar:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.baz:
   ID = foo
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1162,12 +1162,12 @@ test_instance.baz:
 const testStateMvCount_stateOut = `
 test_instance.bar.0:
   ID = foo
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.bar.1:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1175,7 +1175,7 @@ test_instance.bar.1:
 const testStateMvCount_stateOutSrc = `
 test_instance.bar:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1183,17 +1183,17 @@ test_instance.bar:
 const testStateMvCount_stateOutOriginal = `
 test_instance.bar:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.0:
   ID = foo
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.1:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1201,57 +1201,57 @@ test_instance.foo.1:
 const testStateMvLargeCount_stateOut = `
 test_instance.bar.0:
   ID = foo0
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.bar.1:
   ID = foo1
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.bar.2:
   ID = foo2
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.bar.3:
   ID = foo3
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.bar.4:
   ID = foo4
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.bar.5:
   ID = foo5
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.bar.6:
   ID = foo6
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.bar.7:
   ID = foo7
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.bar.8:
   ID = foo8
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.bar.9:
   ID = foo9
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.bar.10:
   ID = foo10
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1259,7 +1259,7 @@ test_instance.bar.10:
 const testStateMvLargeCount_stateOutSrc = `
 test_instance.bar:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1267,62 +1267,62 @@ test_instance.bar:
 const testStateMvLargeCount_stateOutOriginal = `
 test_instance.bar:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.0:
   ID = foo0
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.1:
   ID = foo1
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.2:
   ID = foo2
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.3:
   ID = foo3
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.4:
   ID = foo4
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.5:
   ID = foo5
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.6:
   ID = foo6
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.7:
   ID = foo7
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.8:
   ID = foo8
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.9:
   ID = foo9
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo.10:
   ID = foo10
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1332,13 +1332,13 @@ const testStateMvNestedModule_stateOut = `
 module.bar.child1:
   test_instance.foo:
     ID = bar
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
     bar = value
     foo = value
 module.bar.child2:
   test_instance.foo:
     ID = bar
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
     bar = value
     foo = value
 `
@@ -1348,7 +1348,7 @@ const testStateMvNewModule_stateOut = `
 module.bar:
   test_instance.bar:
     ID = bar
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
     bar = value
     foo = value
 `
@@ -1358,7 +1358,7 @@ const testStateMvModuleNewModule_stateOut = `
 module.foo:
   test_instance.bar:
     ID = bar
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
     bar = value
     foo = value
 `
@@ -1366,7 +1366,7 @@ module.foo:
 const testStateMvNewModule_stateOutOriginal = `
 test_instance.bar:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1380,13 +1380,13 @@ const testStateMvNestedModule_stateOutOriginal = `
 module.foo.child1:
   test_instance.foo:
     ID = bar
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
     bar = value
     foo = value
 module.foo.child2:
   test_instance.foo:
     ID = bar
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
     bar = value
     foo = value
 `
@@ -1394,7 +1394,7 @@ module.foo.child2:
 const testStateMvOutput_stateOut = `
 test_instance.bar:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1406,7 +1406,7 @@ const testStateMvOutput_stateOutSrc = `
 const testStateMvOutput_stateOutOriginal = `
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1418,18 +1418,18 @@ const testStateMvExisting_stateSrc = `
 const testStateMvExisting_stateDst = `
 test_instance.bar:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.qux:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 `
 
 const testStateMvExisting_stateSrcOriginal = `
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -1437,13 +1437,13 @@ test_instance.foo:
 const testStateMvExisting_stateDstOriginal = `
 test_instance.qux:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 `
 
 const testStateMvOriginal_backend = `
 test_instance.baz:
   ID = foo
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `

--- a/command/state_mv_test.go
+++ b/command/state_mv_test.go
@@ -27,7 +27,10 @@ func TestStateMv(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -40,7 +43,10 @@ func TestStateMv(t *testing.T) {
 				Status:       states.ObjectReady,
 				Dependencies: []addrs.AbsResource{mustResourceAddr("test_instance.foo")},
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -88,7 +94,10 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -101,7 +110,10 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 				Status:       states.ObjectReady,
 				Dependencies: []addrs.AbsResource{mustResourceAddr("test_instance.foo")},
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceMeta(
 			addrs.Resource{
@@ -110,7 +122,10 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 				Name: "bar",
 			}.Absolute(addrs.RootModuleInstance),
 			states.EachList,
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -169,7 +184,10 @@ func TestStateMv_instanceToResource(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -181,7 +199,10 @@ func TestStateMv_instanceToResource(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -251,7 +272,10 @@ func TestStateMv_instanceToNewResource(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -319,7 +343,10 @@ func TestStateMv_differentResourceTypes(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -369,7 +396,10 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -381,7 +411,10 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -438,7 +471,10 @@ func TestStateMv_backupExplicit(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -451,7 +487,10 @@ func TestStateMv_backupExplicit(t *testing.T) {
 				Status:       states.ObjectReady,
 				Dependencies: []addrs.AbsResource{mustResourceAddr("test_instance.foo")},
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -497,7 +536,10 @@ func TestStateMv_stateOutNew(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -548,7 +590,10 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, stateSrc)
@@ -564,7 +609,10 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	stateOutPath := testStateFile(t, stateDst)
@@ -641,7 +689,10 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -653,7 +704,10 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -665,7 +719,10 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -720,7 +777,10 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 					AttrsJSON: []byte(fmt.Sprintf(`{"id":"foo%d","foo":"value","bar":"value"}`, i)),
 					Status:    states.ObjectReady,
 				},
-				addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewLegacyProvider("test"),
+					Module:   addrs.RootModuleInstance,
+				},
 			)
 		}
 		s.SetResourceInstanceCurrent(
@@ -733,7 +793,10 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -784,7 +847,10 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -796,7 +862,10 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 
@@ -848,7 +917,10 @@ func TestStateMv_toNewModule(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 
@@ -918,7 +990,10 @@ func TestStateMv_withinBackend(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -931,7 +1006,10 @@ func TestStateMv_withinBackend(t *testing.T) {
 				Status:       states.ObjectReady,
 				Dependencies: []addrs.AbsResource{mustResourceAddr("test_instance.foo")},
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 

--- a/command/state_rm_test.go
+++ b/command/state_rm_test.go
@@ -141,7 +141,7 @@ func TestStateRmNotChildModule(t *testing.T) {
 module.child:
   test_instance.foo:
     ID = foo
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
     bar = value
     foo = value
 `)
@@ -154,14 +154,14 @@ module.child:
 	testStateOutput(t, backups[0], `
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 
 module.child:
   test_instance.foo:
     ID = foo
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
     bar = value
     foo = value
 `)
@@ -479,12 +479,12 @@ func TestStateRm_backendState(t *testing.T) {
 const testStateRmOutputOriginal = `
 test_instance.bar:
   ID = foo
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `
@@ -492,7 +492,7 @@ test_instance.foo:
 const testStateRmOutput = `
 test_instance.bar:
   ID = foo
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   bar = value
   foo = value
 `

--- a/command/state_rm_test.go
+++ b/command/state_rm_test.go
@@ -25,7 +25,10 @@ func TestStateRm(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -37,7 +40,10 @@ func TestStateRm(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -84,7 +90,10 @@ func TestStateRmNotChildModule(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		// This second instance has the same local address as the first but
 		// is in a child module. Older versions of Terraform would incorrectly
@@ -99,7 +108,10 @@ func TestStateRmNotChildModule(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -167,7 +179,10 @@ func TestStateRmNoArgs(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -179,7 +194,10 @@ func TestStateRmNoArgs(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -220,7 +238,10 @@ func TestStateRmNonExist(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -232,7 +253,10 @@ func TestStateRmNonExist(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -274,7 +298,10 @@ func TestStateRm_backupExplicit(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -286,7 +313,10 @@ func TestStateRm_backupExplicit(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -384,7 +414,10 @@ func TestStateRm_backendState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -396,7 +429,10 @@ func TestStateRm_backendState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -117,8 +117,11 @@ func (c *StateShowCommand) Run(args []string) int {
 
 	// check if the resource has a configured provider, otherwise this will use the default provider
 	rs := state.Resource(addr.ContainingResource())
-	absPc := rs.ProviderConfig.ProviderConfig.Absolute(addrs.RootModuleInstance)
-
+	absPc := addrs.AbsProviderConfig{
+		Provider: rs.ProviderConfig.Provider,
+		Alias:    rs.ProviderConfig.Alias,
+		Module:   addrs.RootModuleInstance,
+	}
 	singleInstance := states.NewState()
 	singleInstance.EnsureModule(addr.Module).SetResourceInstanceCurrent(
 		addr.Resource,

--- a/command/state_show_test.go
+++ b/command/state_show_test.go
@@ -25,7 +25,10 @@ func TestStateShow(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -80,7 +83,10 @@ func TestStateShow_multi(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -92,7 +98,10 @@ func TestStateShow_multi(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"foo","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(submod),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   submod,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -195,7 +204,10 @@ func TestStateShow_configured_provider(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test-beta"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test-beta"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)

--- a/command/taint_test.go
+++ b/command/taint_test.go
@@ -410,22 +410,22 @@ func TestTaint_module(t *testing.T) {
 const testTaintStr = `
 test_instance.foo: (tainted)
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 `
 
 const testTaintDefaultStr = `
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 `
 
 const testTaintModuleStr = `
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 
 module.child:
   test_instance.blah: (tainted)
     ID = blah
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
 `

--- a/command/taint_test.go
+++ b/command/taint_test.go
@@ -24,7 +24,10 @@ func TestTaint(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -59,7 +62,10 @@ func TestTaint_lockedState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -245,7 +251,10 @@ func TestTaint_missing(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -278,7 +287,10 @@ func TestTaint_missingAllow(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -354,7 +366,10 @@ func TestTaint_module(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -366,7 +381,10 @@ func TestTaint_module(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"blah"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)

--- a/command/testdata/show-json/basic-delete/terraform.tfstate
+++ b/command/testdata/show-json/basic-delete/terraform.tfstate
@@ -9,7 +9,7 @@
       "mode": "managed",
       "type": "test_instance",
       "name": "test",
-      "provider": "provider.test",
+      "provider": "provider[\"registry.terraform.io/-/test\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -24,7 +24,7 @@
       "mode": "managed",
       "type": "test_instance",
       "name": "test-delete",
-      "provider": "provider.test",
+      "provider": "provider[\"registry.terraform.io/-/test\"]",
       "instances": [
         {
           "schema_version": 0,

--- a/command/testdata/show-json/basic-update/terraform.tfstate
+++ b/command/testdata/show-json/basic-update/terraform.tfstate
@@ -9,7 +9,7 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
-            "provider": "provider.test",
+            "provider": "provider[\"registry.terraform.io/-/test\"]",
             "instances": [
                 {
                     "schema_version": 0,

--- a/command/testdata/state-list-backend-custom/local-state.tfstate
+++ b/command/testdata/state-list-backend-custom/local-state.tfstate
@@ -9,7 +9,7 @@
       "mode": "managed",
       "type": "null_resource",
       "name": "a",
-      "provider": "provider.null",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
       "instances": [
         {
           "schema_version": 0,

--- a/command/testdata/state-list-backend-default/terraform.tfstate
+++ b/command/testdata/state-list-backend-default/terraform.tfstate
@@ -9,7 +9,7 @@
       "mode": "managed",
       "type": "null_resource",
       "name": "a",
-      "provider": "provider.null",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
       "instances": [
         {
           "schema_version": 0,

--- a/command/testdata/state-push-serial-newer/local-state.tfstate
+++ b/command/testdata/state-push-serial-newer/local-state.tfstate
@@ -8,7 +8,7 @@
       "mode": "managed",
       "type": "null_resource",
       "name": "a",
-      "provider": "provider.null",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
       "instances": [
         {
           "schema_version": 0,

--- a/command/testdata/state-push-serial-newer/replace.tfstate
+++ b/command/testdata/state-push-serial-newer/replace.tfstate
@@ -8,7 +8,7 @@
       "mode": "managed",
       "type": "null_resource",
       "name": "b",
-      "provider": "provider.null",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
       "instances": [
         {
           "schema_version": 0,

--- a/command/untaint_test.go
+++ b/command/untaint_test.go
@@ -49,7 +49,7 @@ func TestUntaint(t *testing.T) {
 	expected := strings.TrimSpace(`
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`)
 	testStateOutput(t, statePath, expected)
 }
@@ -142,14 +142,14 @@ func TestUntaint_backup(t *testing.T) {
 	testStateOutput(t, path+".backup", strings.TrimSpace(`
 test_instance.foo: (tainted)
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`))
 
 	// State is untainted
 	testStateOutput(t, path, strings.TrimSpace(`
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`))
 }
 
@@ -199,7 +199,7 @@ func TestUntaint_backupDisable(t *testing.T) {
 	testStateOutput(t, path, strings.TrimSpace(`
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`))
 }
 
@@ -261,7 +261,7 @@ func TestUntaint_defaultState(t *testing.T) {
 	testStateOutput(t, path, strings.TrimSpace(`
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`))
 }
 
@@ -380,12 +380,12 @@ func TestUntaint_stateOut(t *testing.T) {
 	testStateOutput(t, path, strings.TrimSpace(`
 test_instance.foo: (tainted)
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`))
 	testStateOutput(t, "foo", strings.TrimSpace(`
 test_instance.foo:
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 	`))
 }
 
@@ -442,11 +442,11 @@ func TestUntaint_module(t *testing.T) {
 	testStateOutput(t, statePath, strings.TrimSpace(`
 test_instance.foo: (tainted)
   ID = bar
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 
 module.child:
   test_instance.blah:
     ID = bar
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
 	`))
 }

--- a/command/untaint_test.go
+++ b/command/untaint_test.go
@@ -23,7 +23,10 @@ func TestUntaint(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -63,7 +66,10 @@ func TestUntaint_lockedState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -271,7 +277,10 @@ func TestUntaint_missing(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -304,7 +313,10 @@ func TestUntaint_missingAllow(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -389,7 +401,10 @@ func TestUntaint_module(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -401,7 +416,10 @@ func TestUntaint_module(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectTainted,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	statePath := testStateFile(t, state)

--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -241,7 +241,10 @@ func TestWorkspace_createWithState(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"bar"}`),
 				Status:    states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 

--- a/configs/config.go
+++ b/configs/config.go
@@ -247,17 +247,10 @@ func (c *Config) ResolveAbsProviderAddr(addr addrs.ProviderConfig, inModule addr
 			provider = addrs.NewLegacyProvider(addr.LocalName)
 		}
 
-		// FIXME: Once AbsProviderConfig starts using FQN rather than
-		// embedding LocalProviderConfig we will use "provider"
-		// properly here, but for now we'll require a legacy one because
-		// the rest of Terraform isn't ready to deal with non-legacy
-		// provider addresses yet.
 		return addrs.AbsProviderConfig{
-			Module: inModule,
-			ProviderConfig: addrs.LocalProviderConfig{
-				LocalName: provider.LegacyString(),
-				Alias:     addr.Alias,
-			},
+			Module:   inModule,
+			Provider: provider,
+			Alias:    addr.Alias,
 		}
 
 	default:
@@ -270,14 +263,5 @@ func (c *Config) ResolveAbsProviderAddr(addr addrs.ProviderConfig, inModule addr
 // by checking for the provider in module.ProviderRequirements and falling
 // back to addrs.NewLegacyProvider if it is not found.
 func (c *Config) ProviderForConfigAddr(addr addrs.LocalProviderConfig) addrs.Provider {
-	// FIXME: Once AbsProviderAddr itself includes an addrs.Provider we
-	// can just return that here.
-	return addrs.NewLegacyProvider(
-		// addrs.RootModuleInstance here looks weird, but it's okay because
-		// ProviderForConfigAddr looks up addresses in the module directly
-		// connected to the receiver (rather than a descendent, as with
-		// ResolveAbsProviderAddr) and we're going to discard the Module field
-		// of the ResolveAbsProviderAddr return value anyway.
-		c.ResolveAbsProviderAddr(addr, addrs.RootModuleInstance).ProviderConfig.LocalName,
-	)
+	return c.ResolveAbsProviderAddr(addr, addrs.RootModuleInstance).Provider
 }

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -43,11 +43,9 @@ func TestConfigResolveAbsProviderAddr(t *testing.T) {
 
 	t.Run("already absolute", func(t *testing.T) {
 		addr := addrs.AbsProviderConfig{
-			Module: addrs.RootModuleInstance,
-			ProviderConfig: addrs.LocalProviderConfig{
-				LocalName: "test",
-				Alias:     "boop",
-			},
+			Module:   addrs.RootModuleInstance,
+			Provider: addrs.NewLegacyProvider("test"),
+			Alias:    "boop",
 		}
 		got := cfg.ResolveAbsProviderAddr(addr, addrs.RootModuleInstance)
 		if got, want := got.String(), addr.String(); got != want {
@@ -68,10 +66,8 @@ func TestConfigResolveAbsProviderAddr(t *testing.T) {
 			// string here, at which point the correct result will be:
 			//    Provider as the addrs repr of "registry.terraform.io/hashicorp/implied"
 			//    Alias as "boop".
-			ProviderConfig: addrs.LocalProviderConfig{
-				LocalName: "implied",
-				Alias:     "boop",
-			},
+			Provider: addrs.NewLegacyProvider("implied"),
+			Alias:    "boop",
 		}
 		if got, want := got.String(), want.String(); got != want {
 			t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
@@ -91,10 +87,8 @@ func TestConfigResolveAbsProviderAddr(t *testing.T) {
 			// once we are fully supporting this we should expect to see
 			// the "registry.terraform.io/foo/test" FQN here, while still
 			// preserving the "boop" alias.
-			ProviderConfig: addrs.LocalProviderConfig{
-				LocalName: "foo_test",
-				Alias:     "boop",
-			},
+			Provider: addrs.NewLegacyProvider("foo_test"),
+			Alias:    "boop",
 		}
 		if got, want := got.String(), want.String(); got != want {
 			t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)

--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -48,7 +48,7 @@ func shimNewState(newState *states.State, providers map[string]terraform.Resourc
 
 		for _, res := range newMod.Resources {
 			resType := res.Addr.Type
-			providerType := res.ProviderConfig.ProviderConfig.LocalName
+			providerType := res.ProviderConfig.Provider.Type
 
 			resource := getResource(providers, providerType, res.Addr)
 

--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -55,7 +55,7 @@ func shimNewState(newState *states.State, providers map[string]terraform.Resourc
 			for key, i := range res.Instances {
 				resState := &terraform.ResourceState{
 					Type:     resType,
-					Provider: res.ProviderConfig.String(),
+					Provider: res.ProviderConfig.LegacyString(),
 				}
 
 				// We should always have a Current instance here, but be safe about checking.

--- a/helper/resource/state_shim_test.go
+++ b/helper/resource/state_shim_test.go
@@ -41,9 +41,10 @@ func TestStateShim(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	rootModule.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -56,9 +57,10 @@ func TestStateShim(t *testing.T) {
 			AttrsFlat: map[string]string{"id": "baz", "bazzle": "dazzle"},
 			DependsOn: []addrs.Referenceable{},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	childInstance := addrs.RootModuleInstance.Child("child", addrs.NoKey)
@@ -74,9 +76,10 @@ func TestStateShim(t *testing.T) {
 			AttrsJSON: []byte(`{"id": "bar", "fuzzle":"wuzzle"}`),
 			DependsOn: []addrs.Referenceable{},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(childInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   childInstance,
+		},
 	)
 	childModule.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -97,9 +100,10 @@ func TestStateShim(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(childInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   childInstance,
+		},
 	)
 
 	childModule.SetResourceInstanceDeposed(
@@ -122,9 +126,10 @@ func TestStateShim(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(childInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   childInstance,
+		},
 	)
 
 	childModule.SetResourceInstanceCurrent(
@@ -138,9 +143,10 @@ func TestStateShim(t *testing.T) {
 			AttrsFlat: map[string]string{"id": "0", "bazzle": "dazzle"},
 			DependsOn: []addrs.Referenceable{},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(childInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   childInstance,
+		},
 	)
 	childModule.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -153,9 +159,10 @@ func TestStateShim(t *testing.T) {
 			AttrsFlat: map[string]string{"id": "1", "bazzle": "dazzle"},
 			DependsOn: []addrs.Referenceable{},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(childInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   childInstance,
+		},
 	)
 
 	childModule.SetResourceInstanceCurrent(
@@ -169,9 +176,10 @@ func TestStateShim(t *testing.T) {
 			AttrsJSON: []byte(`{"id": "single", "bazzle":"dazzle"}`),
 			DependsOn: []addrs.Referenceable{},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(childInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   childInstance,
+		},
 	)
 
 	expected := &terraform.State{

--- a/helper/resource/state_shim_test.go
+++ b/helper/resource/state_shim_test.go
@@ -42,7 +42,7 @@ func TestStateShim(t *testing.T) {
 			},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewDefaultProvider("test"),
+			Provider: addrs.NewLegacyProvider("test"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -58,7 +58,7 @@ func TestStateShim(t *testing.T) {
 			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewDefaultProvider("test"),
+			Provider: addrs.NewLegacyProvider("test"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -77,7 +77,7 @@ func TestStateShim(t *testing.T) {
 			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewDefaultProvider("test"),
+			Provider: addrs.NewLegacyProvider("test"),
 			Module:   childInstance,
 		},
 	)
@@ -101,7 +101,7 @@ func TestStateShim(t *testing.T) {
 			},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewDefaultProvider("test"),
+			Provider: addrs.NewLegacyProvider("test"),
 			Module:   childInstance,
 		},
 	)
@@ -127,7 +127,7 @@ func TestStateShim(t *testing.T) {
 			},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewDefaultProvider("test"),
+			Provider: addrs.NewLegacyProvider("test"),
 			Module:   childInstance,
 		},
 	)
@@ -144,7 +144,7 @@ func TestStateShim(t *testing.T) {
 			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewDefaultProvider("test"),
+			Provider: addrs.NewLegacyProvider("test"),
 			Module:   childInstance,
 		},
 	)
@@ -160,7 +160,7 @@ func TestStateShim(t *testing.T) {
 			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewDefaultProvider("test"),
+			Provider: addrs.NewLegacyProvider("test"),
 			Module:   childInstance,
 		},
 	)
@@ -177,7 +177,7 @@ func TestStateShim(t *testing.T) {
 			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewDefaultProvider("test"),
+			Provider: addrs.NewLegacyProvider("test"),
 			Module:   childInstance,
 		},
 	)
@@ -329,6 +329,6 @@ func TestStateShim(t *testing.T) {
 	}
 
 	if !expected.Equal(shimmed) {
-		t.Fatalf("wrong result state\ngot:\n%s\n\nwant:\n%s", expected, shimmed)
+		t.Fatalf("wrong result state\ngot:\n%s\n\nwant:\n%s", shimmed, expected)
 	}
 }

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -727,7 +727,10 @@ func testIDOnlyRefresh(c TestCase, opts terraform.ContextOpts, step TestStep, r 
 			AttrsFlat: r.Primary.Attributes,
 			Status:    states.ObjectReady,
 		},
-		addrs.LocalProviderConfig{LocalName: "placeholder"}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("placeholder"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	// Create the config module. We use the full config because Refresh

--- a/helper/resource/testing_import_state.go
+++ b/helper/resource/testing_import_state.go
@@ -137,7 +137,8 @@ func testStepImportState(
 			// this shouldn't happen in any reasonable case.
 			var rsrcSchema *schema.Resource
 			if providerAddr, diags := addrs.ParseAbsProviderConfigStr(r.Provider); !diags.HasErrors() {
-				providerType := providerAddr.ProviderConfig.LocalName
+				// FIXME
+				providerType := providerAddr.Provider.Type
 				if provider, ok := step.providers[providerType]; ok {
 					if provider, ok := provider.(*schema.Provider); ok {
 						rsrcSchema = provider.ResourcesMap[r.Type]

--- a/plans/plan_test.go
+++ b/plans/plan_test.go
@@ -20,9 +20,10 @@ func TestProviderAddrs(t *testing.T) {
 						Type: "test_thing",
 						Name: "woot",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
-					ProviderAddr: addrs.LocalProviderConfig{
-						LocalName: "test",
-					}.Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Module:   addrs.RootModuleInstance,
+						Provider: addrs.NewLegacyProvider("test"),
+					},
 				},
 				{
 					Addr: addrs.Resource{
@@ -31,9 +32,10 @@ func TestProviderAddrs(t *testing.T) {
 						Name: "woot",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					DeposedKey: "foodface",
-					ProviderAddr: addrs.LocalProviderConfig{
-						LocalName: "test",
-					}.Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Module:   addrs.RootModuleInstance,
+						Provider: addrs.NewLegacyProvider("test"),
+					},
 				},
 				{
 					Addr: addrs.Resource{
@@ -41,9 +43,10 @@ func TestProviderAddrs(t *testing.T) {
 						Type: "test_thing",
 						Name: "what",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
-					ProviderAddr: addrs.LocalProviderConfig{
-						LocalName: "test",
-					}.Absolute(addrs.RootModuleInstance.Child("foo", addrs.NoKey)),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Module:   addrs.RootModuleInstance.Child("foo", addrs.NoKey),
+						Provider: addrs.NewLegacyProvider("test"),
+					},
 				},
 			},
 		},
@@ -51,12 +54,14 @@ func TestProviderAddrs(t *testing.T) {
 
 	got := plan.ProviderAddrs()
 	want := []addrs.AbsProviderConfig{
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance.Child("foo", addrs.NoKey)),
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Module:   addrs.RootModuleInstance.Child("foo", addrs.NoKey),
+			Provider: addrs.NewLegacyProvider("test"),
+		},
+		addrs.AbsProviderConfig{
+			Module:   addrs.RootModuleInstance,
+			Provider: addrs.NewLegacyProvider("test"),
+		},
 	}
 
 	for _, problem := range deep.Equal(got, want) {

--- a/plans/planfile/tfplan_test.go
+++ b/plans/planfile/tfplan_test.go
@@ -56,9 +56,10 @@ func TestTFPlanRoundTrip(t *testing.T) {
 						Type: "test_thing",
 						Name: "woot",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
-					ProviderAddr: addrs.LocalProviderConfig{
-						LocalName: "test",
-					}.Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+						Module:   addrs.RootModuleInstance,
+					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.DeleteThenCreate,
 						Before: mustNewDynamicValue(cty.ObjectVal(map[string]cty.Value{
@@ -76,9 +77,10 @@ func TestTFPlanRoundTrip(t *testing.T) {
 						Name: "woot",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					DeposedKey: "foodface",
-					ProviderAddr: addrs.LocalProviderConfig{
-						LocalName: "test",
-					}.Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+						Module:   addrs.RootModuleInstance,
+					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.Delete,
 						Before: mustNewDynamicValue(cty.ObjectVal(map[string]cty.Value{
@@ -194,9 +196,10 @@ func TestTFPlanRoundTripDestroy(t *testing.T) {
 						Type: "test_thing",
 						Name: "woot",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
-					ProviderAddr: addrs.LocalProviderConfig{
-						LocalName: "test",
-					}.Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+						Module:   addrs.RootModuleInstance,
+					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.Delete,
 						Before: mustNewDynamicValue(cty.ObjectVal(map[string]cty.Value{

--- a/providers/addressed_types.go
+++ b/providers/addressed_types.go
@@ -6,40 +6,6 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 )
 
-// // AddressedTypes is a helper that extracts all of the distinct provider
-// // types from the given list of relative provider configuration addresses.
-// //
-// // FIXME: This function is now incorrect, because we can't do a syntax-only
-// // mapping from a local provider configuration to a provider type. It
-// // works for now by assuming legacy provider addresses, but will need to be
-// // replaced by something configuration-aware as part of removing legacy
-// // provider address reliance.
-// func AddressedTypes(providerAddrs []addrs.LocalProviderConfig) []addrs.Provider {
-// 	if len(providerAddrs) == 0 {
-// 		return nil
-// 	}
-// 	m := map[string]addrs.Provider{}
-// 	for _, addr := range providerAddrs {
-// 		// FIXME: This will no longer work once we move away from legacy addresses.
-// 		legacyFQN := addrs.NewLegacyProvider(addr.LocalName)
-// 		m[legacyFQN.String()] = legacyFQN
-// 	}
-
-// 	names := make([]string, 0, len(m))
-// 	for typeName := range m {
-// 		names = append(names, typeName)
-// 	}
-
-// 	sort.Strings(names) // Stable result for tests
-
-// 	ret := make([]addrs.Provider, len(names))
-// 	for i, name := range names {
-// 		ret[i] = m[name]
-// 	}
-
-// 	return ret
-// }
-
 // AddressedTypesAbs is a helper that extracts all of the distinct provider
 // types from the given list of absolute provider configuration addresses.
 func AddressedTypesAbs(providerAddrs []addrs.AbsProviderConfig) []addrs.Provider {

--- a/providers/addressed_types.go
+++ b/providers/addressed_types.go
@@ -6,39 +6,39 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 )
 
-// AddressedTypes is a helper that extracts all of the distinct provider
-// types from the given list of relative provider configuration addresses.
-//
-// FIXME: This function is now incorrect, because we can't do a syntax-only
-// mapping from a local provider configuration to a provider type. It
-// works for now by assuming legacy provider addresses, but will need to be
-// replaced by something configuration-aware as part of removing legacy
-// provider address reliance.
-func AddressedTypes(providerAddrs []addrs.LocalProviderConfig) []addrs.Provider {
-	if len(providerAddrs) == 0 {
-		return nil
-	}
-	m := map[string]addrs.Provider{}
-	for _, addr := range providerAddrs {
-		// FIXME: This will no longer work once we move away from legacy addresses.
-		legacyFQN := addrs.NewLegacyProvider(addr.LocalName)
-		m[legacyFQN.String()] = legacyFQN
-	}
+// // AddressedTypes is a helper that extracts all of the distinct provider
+// // types from the given list of relative provider configuration addresses.
+// //
+// // FIXME: This function is now incorrect, because we can't do a syntax-only
+// // mapping from a local provider configuration to a provider type. It
+// // works for now by assuming legacy provider addresses, but will need to be
+// // replaced by something configuration-aware as part of removing legacy
+// // provider address reliance.
+// func AddressedTypes(providerAddrs []addrs.LocalProviderConfig) []addrs.Provider {
+// 	if len(providerAddrs) == 0 {
+// 		return nil
+// 	}
+// 	m := map[string]addrs.Provider{}
+// 	for _, addr := range providerAddrs {
+// 		// FIXME: This will no longer work once we move away from legacy addresses.
+// 		legacyFQN := addrs.NewLegacyProvider(addr.LocalName)
+// 		m[legacyFQN.String()] = legacyFQN
+// 	}
 
-	names := make([]string, 0, len(m))
-	for typeName := range m {
-		names = append(names, typeName)
-	}
+// 	names := make([]string, 0, len(m))
+// 	for typeName := range m {
+// 		names = append(names, typeName)
+// 	}
 
-	sort.Strings(names) // Stable result for tests
+// 	sort.Strings(names) // Stable result for tests
 
-	ret := make([]addrs.Provider, len(names))
-	for i, name := range names {
-		ret[i] = m[name]
-	}
+// 	ret := make([]addrs.Provider, len(names))
+// 	for i, name := range names {
+// 		ret[i] = m[name]
+// 	}
 
-	return ret
-}
+// 	return ret
+// }
 
 // AddressedTypesAbs is a helper that extracts all of the distinct provider
 // types from the given list of absolute provider configuration addresses.
@@ -48,10 +48,7 @@ func AddressedTypesAbs(providerAddrs []addrs.AbsProviderConfig) []addrs.Provider
 	}
 	m := map[string]addrs.Provider{}
 	for _, addr := range providerAddrs {
-		// FIXME: When changing AbsProviderConfig to include provider FQN,
-		// use that directly here instead.
-		legacyFQN := addrs.NewLegacyProvider(addr.ProviderConfig.LocalName)
-		m[legacyFQN.String()] = legacyFQN
+		m[addr.Provider.String()] = addr.Provider
 	}
 
 	names := make([]string, 0, len(m))

--- a/providers/addressed_types_test.go
+++ b/providers/addressed_types_test.go
@@ -8,26 +8,6 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 )
 
-// func TestAddressedTypes(t *testing.T) {
-// 	providerAddrs := []addrs.LocalProviderConfig{
-// 		{LocalName: "aws"},
-// 		{LocalName: "aws", Alias: "foo"},
-// 		{LocalName: "azure"},
-// 		{LocalName: "null"},
-// 		{LocalName: "null"},
-// 	}
-
-// 	got := AddressedTypes(providerAddrs)
-// 	want := []addrs.Provider{
-// 		addrs.NewLegacyProvider("aws"),
-// 		addrs.NewLegacyProvider("azure"),
-// 		addrs.NewLegacyProvider("null"),
-// 	}
-// 	for _, problem := range deep.Equal(got, want) {
-// 		t.Error(problem)
-// 	}
-// }
-
 func TestAddressedTypesAbs(t *testing.T) {
 	providerAddrs := []addrs.AbsProviderConfig{
 		addrs.AbsProviderConfig{

--- a/providers/addressed_types_test.go
+++ b/providers/addressed_types_test.go
@@ -8,33 +8,49 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 )
 
-func TestAddressedTypes(t *testing.T) {
-	providerAddrs := []addrs.LocalProviderConfig{
-		{LocalName: "aws"},
-		{LocalName: "aws", Alias: "foo"},
-		{LocalName: "azure"},
-		{LocalName: "null"},
-		{LocalName: "null"},
-	}
+// func TestAddressedTypes(t *testing.T) {
+// 	providerAddrs := []addrs.LocalProviderConfig{
+// 		{LocalName: "aws"},
+// 		{LocalName: "aws", Alias: "foo"},
+// 		{LocalName: "azure"},
+// 		{LocalName: "null"},
+// 		{LocalName: "null"},
+// 	}
 
-	got := AddressedTypes(providerAddrs)
-	want := []addrs.Provider{
-		addrs.NewLegacyProvider("aws"),
-		addrs.NewLegacyProvider("azure"),
-		addrs.NewLegacyProvider("null"),
-	}
-	for _, problem := range deep.Equal(got, want) {
-		t.Error(problem)
-	}
-}
+// 	got := AddressedTypes(providerAddrs)
+// 	want := []addrs.Provider{
+// 		addrs.NewLegacyProvider("aws"),
+// 		addrs.NewLegacyProvider("azure"),
+// 		addrs.NewLegacyProvider("null"),
+// 	}
+// 	for _, problem := range deep.Equal(got, want) {
+// 		t.Error(problem)
+// 	}
+// }
 
 func TestAddressedTypesAbs(t *testing.T) {
 	providerAddrs := []addrs.AbsProviderConfig{
-		addrs.LocalProviderConfig{LocalName: "aws"}.Absolute(addrs.RootModuleInstance),
-		addrs.LocalProviderConfig{LocalName: "aws", Alias: "foo"}.Absolute(addrs.RootModuleInstance),
-		addrs.LocalProviderConfig{LocalName: "azure"}.Absolute(addrs.RootModuleInstance),
-		addrs.LocalProviderConfig{LocalName: "null"}.Absolute(addrs.RootModuleInstance),
-		addrs.LocalProviderConfig{LocalName: "null"}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Module:   addrs.RootModuleInstance,
+			Provider: addrs.NewLegacyProvider("aws"),
+		},
+		addrs.AbsProviderConfig{
+			Module:   addrs.RootModuleInstance,
+			Provider: addrs.NewLegacyProvider("aws"),
+			Alias:    "foo",
+		},
+		addrs.AbsProviderConfig{
+			Module:   addrs.RootModuleInstance,
+			Provider: addrs.NewLegacyProvider("azure"),
+		},
+		addrs.AbsProviderConfig{
+			Module:   addrs.RootModuleInstance,
+			Provider: addrs.NewLegacyProvider("null"),
+		},
+		addrs.AbsProviderConfig{
+			Module:   addrs.RootModuleInstance,
+			Provider: addrs.NewLegacyProvider("null"),
+		},
 	}
 
 	got := AddressedTypesAbs(providerAddrs)

--- a/repl/session_test.go
+++ b/repl/session_test.go
@@ -45,9 +45,10 @@ func TestSession_basicState(t *testing.T) {
 				Status:    states.ObjectReady,
 				AttrsJSON: []byte(`{"id":"bar"}`),
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "test",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -59,9 +60,10 @@ func TestSession_basicState(t *testing.T) {
 				Status:    states.ObjectReady,
 				AttrsJSON: []byte(`{"id":"bar"}`),
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "test",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 

--- a/states/state_test.go
+++ b/states/state_test.go
@@ -35,9 +35,10 @@ func TestState(t *testing.T) {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	childModule := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
@@ -78,9 +79,10 @@ func TestState(t *testing.T) {
 								Deposed: map[DeposedKey]*ResourceInstanceObjectSrc{},
 							},
 						},
-						ProviderConfig: addrs.LocalProviderConfig{
-							LocalName: "test",
-						}.Absolute(addrs.RootModuleInstance),
+						ProviderConfig: addrs.AbsProviderConfig{
+							Provider: addrs.NewDefaultProvider("test"),
+							Module:   addrs.RootModuleInstance,
+						},
 					},
 				},
 			},
@@ -140,9 +142,10 @@ func TestStateDeepCopy(t *testing.T) {
 			Private:       []byte("private data"),
 			Dependencies:  []addrs.AbsResource{},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	rootModule.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -166,9 +169,10 @@ func TestStateDeepCopy(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	childModule := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))

--- a/states/statefile/read.go
+++ b/states/statefile/read.go
@@ -91,6 +91,7 @@ func readState(src []byte) (*File, tfdiags.Diagnostics) {
 	if versionDiags.HasErrors() {
 		return nil, diags
 	}
+
 	switch version {
 	case 0:
 		diags = diags.Append(tfdiags.Sourceless(

--- a/states/statefile/read.go
+++ b/states/statefile/read.go
@@ -91,7 +91,6 @@ func readState(src []byte) (*File, tfdiags.Diagnostics) {
 	if versionDiags.HasErrors() {
 		return nil, diags
 	}
-
 	switch version {
 	case 0:
 		diags = diags.Append(tfdiags.Sourceless(

--- a/states/statefile/testdata/roundtrip/v1-simple.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v1-simple.out.tfstate
@@ -14,7 +14,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "bar",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "instances": [
                 {
                     "schema_version": 0,
@@ -23,7 +23,9 @@
                         "triggers.%": "1",
                         "triggers.whaaat": "0,1"
                     },
-                    "depends_on": ["null_resource.foo"]
+                    "depends_on": [
+                        "null_resource.foo"
+                    ]
                 }
             ]
         },
@@ -31,7 +33,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "foo",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "each": "list",
             "instances": [
                 {

--- a/states/statefile/testdata/roundtrip/v3-bigint.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-bigint.out.tfstate
@@ -28,7 +28,7 @@
             "type": "null_resource",
             "name": "bar",
             "each": "list",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "instances": [
                 {
                     "attributes_flat": {
@@ -36,7 +36,9 @@
                         "triggers.%": "1",
                         "triggers.index": "0"
                     },
-                    "depends_on": ["null_resource.baz"],
+                    "depends_on": [
+                        "null_resource.baz"
+                    ],
                     "index_key": 0,
                     "schema_version": 1
                 },
@@ -46,7 +48,9 @@
                         "triggers.%": "1",
                         "triggers.index": "1"
                     },
-                    "depends_on": ["null_resource.baz"],
+                    "depends_on": [
+                        "null_resource.baz"
+                    ],
                     "index_key": 1,
                     "schema_version": 0
                 }
@@ -56,7 +60,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "baz",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "instances": [
                 {
                     "attributes_flat": {
@@ -82,7 +86,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "foo",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "instances": [
                 {
                     "attributes_flat": {

--- a/states/statefile/testdata/roundtrip/v3-grabbag.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-grabbag.out.tfstate
@@ -28,7 +28,7 @@
             "type": "null_resource",
             "name": "bar",
             "each": "list",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "instances": [
                 {
                     "attributes_flat": {
@@ -36,7 +36,9 @@
                         "triggers.%": "1",
                         "triggers.index": "0"
                     },
-                    "depends_on": ["null_resource.baz"],
+                    "depends_on": [
+                        "null_resource.baz"
+                    ],
                     "index_key": 0,
                     "schema_version": 1
                 },
@@ -46,7 +48,9 @@
                         "triggers.%": "1",
                         "triggers.index": "1"
                     },
-                    "depends_on": ["null_resource.baz"],
+                    "depends_on": [
+                        "null_resource.baz"
+                    ],
                     "index_key": 1,
                     "schema_version": 0
                 }
@@ -56,7 +60,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "baz",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "instances": [
                 {
                     "attributes_flat": {
@@ -82,7 +86,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "foo",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "instances": [
                 {
                     "attributes_flat": {

--- a/states/statefile/testdata/roundtrip/v3-invalid-depends.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-invalid-depends.out.tfstate
@@ -14,7 +14,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "bar",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "instances": [
                 {
                     "schema_version": 0,

--- a/states/statefile/testdata/roundtrip/v3-simple.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-simple.out.tfstate
@@ -14,7 +14,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "bar",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "instances": [
                 {
                     "schema_version": 0,
@@ -35,7 +35,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "foo",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "each": "list",
             "instances": [
                 {
@@ -62,7 +62,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "foobar",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "instances": [
                 {
                     "schema_version": 0,

--- a/states/statefile/testdata/roundtrip/v4-foreach.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-foreach.in.tfstate
@@ -15,7 +15,7 @@
       "mode": "managed",
       "type": "null_resource",
       "name": "resource",
-      "provider": "provider.null",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
       "instances": [
         {
           "schema_version": 0,

--- a/states/statefile/testdata/roundtrip/v4-legacy-foreach.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-legacy-foreach.in.tfstate
@@ -1,0 +1,36 @@
+{
+  "version": 4,
+  "serial": 0,
+  "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+  "terraform_version": "0.12.0",
+  "outputs": {
+    "numbers": {
+      "type": "string",
+      "value": "0,1"
+    }
+  },
+  "resources": [
+    {
+      "module": "module.modA",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "resource",
+      "provider": "provider.null",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4639265839606265182",
+            "triggers": {
+              "input": "test"
+            }
+          },
+          "private": "bnVsbA==",
+          "depends_on": [
+            "var.input"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/states/statefile/testdata/roundtrip/v4-legacy-foreach.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-legacy-foreach.out.tfstate
@@ -1,0 +1,36 @@
+{
+  "version": 4,
+  "serial": 0,
+  "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+  "terraform_version": "0.12.0",
+  "outputs": {
+    "numbers": {
+      "type": "string",
+      "value": "0,1"
+    }
+  },
+  "resources": [
+    {
+      "module": "module.modA",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "resource",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4639265839606265182",
+            "triggers": {
+              "input": "test"
+            }
+          },
+          "private": "bnVsbA==",
+          "depends_on": [
+            "var.input"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/states/statefile/testdata/roundtrip/v4-legacy-modules.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-legacy-modules.in.tfstate
@@ -1,0 +1,88 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.0",
+  "serial": 0,
+  "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+  "outputs": {
+    "numbers": {
+      "value": "0,1",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "bar",
+      "provider": "provider.null",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes_flat": {
+            "id": "5388490630832483079",
+            "triggers.%": "1",
+            "triggers.whaaat": "0,1"
+          },
+          "depends_on": [
+            "null_resource.foo"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.modB",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "bar",
+      "each": "map",
+      "provider": "provider. null",
+      "instances": [
+        {
+          "index_key": "a",
+          "schema_version": 0,
+          "attributes_flat": {
+            "id": "8212585058302700791"
+          },
+          "dependencies": [
+            "module.modA.null_resource.resource"
+          ]
+        },
+        {
+          "index_key": "b",
+          "schema_version": 0,
+          "attributes_flat": {
+            "id": "1523897709610803586"
+          },
+          "dependencies": [
+            "module.modA.null_resource.resource"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.modA",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "resource",
+      "provider": "provider.null",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4639265839606265182",
+            "triggers": {
+              "input": "test"
+            }
+          },
+          "private": "bnVsbA==",
+          "dependencies": [
+            "null_resource.bar"
+          ],
+          "depends_on": [
+            "var.input"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/states/statefile/testdata/roundtrip/v4-legacy-modules.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-legacy-modules.out.tfstate
@@ -1,0 +1,88 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.0",
+  "serial": 0,
+  "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+  "outputs": {
+    "numbers": {
+      "value": "0,1",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "bar",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes_flat": {
+            "id": "5388490630832483079",
+            "triggers.%": "1",
+            "triggers.whaaat": "0,1"
+          },
+          "depends_on": [
+            "null_resource.foo"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.modB",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "bar",
+      "each": "map",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
+      "instances": [
+        {
+          "index_key": "a",
+          "schema_version": 0,
+          "attributes_flat": {
+            "id": "8212585058302700791"
+          },
+          "dependencies": [
+            "module.modA.null_resource.resource"
+          ]
+        },
+        {
+          "index_key": "b",
+          "schema_version": 0,
+          "attributes_flat": {
+            "id": "1523897709610803586"
+          },
+          "dependencies": [
+            "module.modA.null_resource.resource"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.modA",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "resource",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4639265839606265182",
+            "triggers": {
+              "input": "test"
+            }
+          },
+          "private": "bnVsbA==",
+          "dependencies": [
+            "null_resource.bar"
+          ],
+          "depends_on": [
+            "var.input"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/states/statefile/testdata/roundtrip/v4-legacy-simple.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-legacy-simple.in.tfstate
@@ -1,0 +1,60 @@
+{
+    "version": 4,
+    "serial": 0,
+    "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+    "terraform_version": "0.12.0",
+    "outputs": {
+        "numbers": {
+            "type": "string",
+            "value": "0,1"
+        }
+    },
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "bar",
+            "provider": "provider.null",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "5388490630832483079",
+                        "triggers.%": "1",
+                        "triggers.whaaat": "0,1"
+                    },
+                    "depends_on": [
+                        "null_resource.foo"
+                    ]
+                }
+            ]
+        },
+        {
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "foo",
+            "provider": "provider.null",
+            "each": "list",
+            "instances": [
+                {
+                    "index_key": 0,
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "8212585058302700791",
+                        "triggers.%": "1",
+                        "triggers.what": "0"
+                    }
+                },
+                {
+                    "index_key": 1,
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "1523897709610803586",
+                        "triggers.%": "1",
+                        "triggers.what": "0"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/states/statefile/testdata/roundtrip/v4-legacy-simple.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-legacy-simple.out.tfstate
@@ -1,0 +1,60 @@
+{
+    "version": 4,
+    "serial": 0,
+    "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+    "terraform_version": "0.12.0",
+    "outputs": {
+        "numbers": {
+            "type": "string",
+            "value": "0,1"
+        }
+    },
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "bar",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "5388490630832483079",
+                        "triggers.%": "1",
+                        "triggers.whaaat": "0,1"
+                    },
+                    "depends_on": [
+                        "null_resource.foo"
+                    ]
+                }
+            ]
+        },
+        {
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "foo",
+            "provider": "provider.null",
+            "each": "list",
+            "instances": [
+                {
+                    "index_key": 0,
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "8212585058302700791",
+                        "triggers.%": "1",
+                        "triggers.what": "0"
+                    }
+                },
+                {
+                    "index_key": 1,
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "1523897709610803586",
+                        "triggers.%": "1",
+                        "triggers.what": "0"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/states/statefile/testdata/roundtrip/v4-modules.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-modules.in.tfstate
@@ -14,7 +14,7 @@
       "mode": "managed",
       "type": "null_resource",
       "name": "bar",
-      "provider": "provider.null",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -35,7 +35,7 @@
       "type": "null_resource",
       "name": "bar",
       "each": "map",
-      "provider": "provider.null",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
       "instances": [
         {
           "index_key": "a",
@@ -64,7 +64,7 @@
       "mode": "managed",
       "type": "null_resource",
       "name": "resource",
-      "provider": "provider.null",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
       "instances": [
         {
           "schema_version": 0,

--- a/states/statefile/testdata/roundtrip/v4-simple.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-simple.in.tfstate
@@ -14,7 +14,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "bar",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "instances": [
                 {
                     "schema_version": 0,
@@ -23,7 +23,9 @@
                         "triggers.%": "1",
                         "triggers.whaaat": "0,1"
                     },
-                    "depends_on": ["null_resource.foo"]
+                    "depends_on": [
+                        "null_resource.foo"
+                    ]
                 }
             ]
         },

--- a/states/statefile/version3_upgrade.go
+++ b/states/statefile/version3_upgrade.go
@@ -106,22 +106,16 @@ func upgradeStateV3ToV4(old *stateV3) (*stateV4, error) {
 				if strings.Contains(oldProviderAddr, "provider.") {
 					// Smells like a new-style provider address, but we'll test it.
 					var diags tfdiags.Diagnostics
-					// let's see if this is a legacy provider string, before provider source FQNs were included
 					providerAddr, diags = addrs.ParseLegacyAbsProviderConfigStr(oldProviderAddr)
-
 					if diags.HasErrors() {
-						providerAddr, diags = addrs.ParseAbsProviderConfigStr(oldProviderAddr)
-						if diags.HasErrors() {
-							if strings.Contains(oldProviderAddr, "${") {
-								// There seems to be a common misconception that
-								// interpolation was valid in provider aliases
-								// in 0.11, so we'll use a specialized error
-								// message for that case.
-								return nil, fmt.Errorf("invalid provider config reference %q for %s: this alias seems to contain a template interpolation sequence, which was not supported but also not error-checked in Terraform 0.11. To proceed, rename the associated provider alias to a valid identifier and apply the change with Terraform 0.11 before upgrading to Terraform 0.12", oldProviderAddr, instAddr)
-							}
-
-							return nil, fmt.Errorf("invalid provider config reference %q for %s: %s", oldProviderAddr, instAddr, diags.Err())
+						if strings.Contains(oldProviderAddr, "${") {
+							// There seems to be a common misconception that
+							// interpolation was valid in provider aliases
+							// in 0.11, so we'll use a specialized error
+							// message for that case.
+							return nil, fmt.Errorf("invalid provider config reference %q for %s: this alias seems to contain a template interpolation sequence, which was not supported but also not error-checked in Terraform 0.11. To proceed, rename the associated provider alias to a valid identifier and apply the change with Terraform 0.11 before upgrading to Terraform 0.12", oldProviderAddr, instAddr)
 						}
+						return nil, fmt.Errorf("invalid provider config reference %q for %s: %s", oldProviderAddr, instAddr, diags.Err())
 					}
 				} else {
 					// Smells like an old-style module-local provider address,

--- a/states/statefile/version4.go
+++ b/states/statefile/version4.go
@@ -84,7 +84,15 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 		providerAddr, addrDiags := addrs.ParseAbsProviderConfigStr(rsV4.ProviderConfig)
 		diags.Append(addrDiags)
 		if addrDiags.HasErrors() {
-			continue
+			// If ParseAbsProviderConfigStr returns an error, the state may have
+			// been written before Provider FQNs were introduced and the
+			// AbsProviderConfig string format will need normalization. If so,
+			// we assume it is a default (hashicorp) provider.
+			var legacyAddrDiags tfdiags.Diagnostics
+			providerAddr, legacyAddrDiags = addrs.ParseLegacyAbsProviderConfigStr(rsV4.ProviderConfig)
+			if legacyAddrDiags.HasErrors() {
+				continue
+			}
 		}
 
 		var eachMode states.EachMode

--- a/states/statemgr/testing.go
+++ b/states/statemgr/testing.go
@@ -150,6 +150,10 @@ func TestFullInitialState() *states.State {
 		Type: "null_resource",
 		Name: "foo",
 	}
-	childMod.SetResourceMeta(rAddr, states.EachList, addrs.NewDefaultLocalProviderConfig(rAddr.DefaultProvider().LegacyString()).Absolute(addrs.RootModuleInstance))
+	providerAddr := addrs.AbsProviderConfig{
+		Provider: rAddr.DefaultProvider(),
+		Module:   addrs.RootModuleInstance,
+	}
+	childMod.SetResourceMeta(rAddr, states.EachList, providerAddr)
 	return state
 }

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -156,7 +156,7 @@ func TestContext2Apply_escape(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = "bar"
   type = aws_instance
 `)
@@ -186,7 +186,7 @@ func TestContext2Apply_resourceCountOneList(t *testing.T) {
 	got := strings.TrimSpace(state.String())
 	want := strings.TrimSpace(`null_resource.foo.0:
   ID = foo
-  provider = provider.null
+  provider = provider["registry.terraform.io/-/null"]
 
 Outputs:
 
@@ -596,7 +596,7 @@ amis_from_module = {eu-west-1:ami-789012 eu-west-2:ami-989484 us-west-1:ami-1234
 module.test:
   null_resource.noop:
     ID = foo
-    provider = provider.null
+    provider = provider["registry.terraform.io/-/null"]
 
   Outputs:
 
@@ -764,7 +764,7 @@ func TestContext2Apply_providerWarning(t *testing.T) {
 	expected := strings.TrimSpace(`
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 	`)
 	if actual != expected {
 		t.Fatalf("got: \n%s\n\nexpected:\n%s", actual, expected)
@@ -978,7 +978,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   require_new = yes
   type = aws_instance
   value = foo
@@ -987,7 +987,7 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   require_new = yes
   type = aws_instance
 	`)
@@ -1132,12 +1132,12 @@ func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 	`)
@@ -1198,7 +1198,7 @@ func TestContext2Apply_createBeforeDestroy_deposedOnly(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 	`)
 }
 
@@ -2113,7 +2113,7 @@ func TestContext2Apply_cancelBlock(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
 	`)
 }
@@ -2248,7 +2248,7 @@ func TestContext2Apply_cancelProvisioner(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo: (tainted)
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 	`)
@@ -2594,12 +2594,12 @@ CREATE: aws_instance.foo[1]
 	want := strings.TrimSpace(`
 aws_instance.foo.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 `)
@@ -2931,7 +2931,7 @@ func TestContext2Apply_moduleInheritAlias(t *testing.T) {
 module.child:
   aws_instance.foo:
     ID = foo
-    provider = provider.aws.eu
+    provider = provider["registry.terraform.io/-/aws"].eu
 	`)
 }
 
@@ -3555,7 +3555,7 @@ func TestContext2Apply_moduleTarget(t *testing.T) {
 module.A:
   aws_instance.foo:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     foo = bar
     type = aws_instance
 
@@ -3565,7 +3565,7 @@ module.A:
 module.B:
   aws_instance.bar:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     foo = foo
     type = aws_instance
 
@@ -4486,7 +4486,7 @@ func TestContext2Apply_outputDependsOn(t *testing.T) {
 		checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 
 Outputs:
 
@@ -5197,7 +5197,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.web: (1 deposed)
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   require_new = yes
   Deposed ID 1 = foo
 	`)
@@ -5280,7 +5280,7 @@ aws_instance.web: (1 deposed)
 	checkStateString(t, state, `
 aws_instance.web: (1 deposed)
   ID = qux
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   require_new = yes
   Deposed ID 1 = bar
 	`)
@@ -5308,7 +5308,7 @@ aws_instance.web: (1 deposed)
 	checkStateString(t, state, `
 aws_instance.web:
   ID = quux
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   require_new = yes
 	`)
 }
@@ -5350,7 +5350,7 @@ func TestContext2Apply_provisionerFailContinue(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
   `)
@@ -5518,7 +5518,7 @@ func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 	`)
 
 	// Verify apply was invoked
@@ -5668,7 +5668,7 @@ func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   `)
 
 	// Verify apply was invoked
@@ -5748,7 +5748,7 @@ func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 	`)
@@ -7421,7 +7421,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 	expected := strings.TrimSpace(`
 test_thing.foo:
   ID = baz
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
 `) // test_thing.foo is still here, even though provider returned no new state along with its error
 	if actual != expected {
 		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, actual)
@@ -8216,7 +8216,7 @@ func TestContext2Apply_targeted(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 	`)
@@ -8253,13 +8253,13 @@ func TestContext2Apply_targetedCount(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.foo.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.foo.2:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 	`)
 }
 
@@ -8294,7 +8294,7 @@ func TestContext2Apply_targetedCountIndex(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 	`)
 }
 
@@ -8346,7 +8346,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar:
   ID = i-abc123
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 	`)
 }
 
@@ -8692,15 +8692,15 @@ func TestContext2Apply_targetedDestroyModule(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar:
   ID = i-abc123
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.foo:
   ID = i-bcd345
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 
 module.child:
   aws_instance.bar:
     ID = i-abc123
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
 	`)
 }
 
@@ -8754,16 +8754,16 @@ func TestContext2Apply_targetedDestroyCountIndex(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar.0:
   ID = i-abc123
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.bar.2:
   ID = i-abc123
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.foo.0:
   ID = i-bcd345
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.foo.1:
   ID = i-bcd345
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 	`)
 }
 
@@ -8806,12 +8806,12 @@ func TestContext2Apply_targetedModule(t *testing.T) {
 module.child:
   aws_instance.bar:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     num = 2
     type = aws_instance
   aws_instance.foo:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     num = 2
     type = aws_instance
 	`)
@@ -8851,7 +8851,7 @@ func TestContext2Apply_targetedModuleDep(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 
@@ -8861,7 +8861,7 @@ aws_instance.foo:
 module.child:
   aws_instance.mod:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
 
   Outputs:
 
@@ -8934,7 +8934,7 @@ child2_id = foo
 module.child2:
   aws_instance.foo:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
 
   Outputs:
 
@@ -8980,7 +8980,7 @@ func TestContext2Apply_targetedModuleResource(t *testing.T) {
 module.child:
   aws_instance.foo:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     num = 2
     type = aws_instance
 	`)
@@ -9529,7 +9529,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 	expected := strings.TrimSpace(`
 template_file.child:
   ID = foo
-  provider = provider.template
+  provider = provider["registry.terraform.io/-/template"]
   __template_requires_new = true
   template = Hi
   type = template_file
@@ -9538,7 +9538,7 @@ template_file.child:
     template_file.parent
 template_file.parent.0:
   ID = foo
-  provider = provider.template
+  provider = provider["registry.terraform.io/-/template"]
   template = Hi
   type = template_file
 `)
@@ -9612,10 +9612,10 @@ func TestContext2Apply_targetedWithTaintedInState(t *testing.T) {
 	expected := strings.TrimSpace(`
 aws_instance.iambeingadded:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.ifailedprovisioners: (tainted)
   ID = ifailedprovisioners
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 		`)
 	if actual != expected {
 		t.Fatalf("expected state: \n%s\ngot: \n%s", expected, actual)
@@ -9666,7 +9666,7 @@ func TestContext2Apply_ignoreChangesCreate(t *testing.T) {
 	expected := strings.TrimSpace(`
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   required_field = set
   type = aws_instance
 `)
@@ -9813,7 +9813,7 @@ func TestContext2Apply_ignoreChangesWildcard(t *testing.T) {
 	expected := strings.TrimSpace(`
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   required_field = set
   type = aws_instance
 `)
@@ -10064,7 +10064,7 @@ func TestContext2Apply_targetedModuleRecursive(t *testing.T) {
 module.child.subchild:
   aws_instance.foo:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     num = 2
     type = aws_instance
 	`)

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -1370,9 +1370,10 @@ func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"foo"}`),
 			Dependencies: []addrs.AbsResource{},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "aws",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("aws"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -1394,9 +1395,10 @@ func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "aws",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("aws"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	// It is possible for this to be racy, so we loop a number of times
@@ -1497,9 +1499,10 @@ func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"foo"}`),
 			Dependencies: []addrs.AbsResource{},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "aws",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("aws"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	child.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -1521,9 +1524,10 @@ func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "aws",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("aws"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	// It is possible for this to be racy, so we loop a number of times
@@ -2144,8 +2148,8 @@ func TestContext2Apply_provisionerDestroyForEach(t *testing.T) {
 							},
 						},
 						ProviderConfig: addrs.AbsProviderConfig{
-							Module:         addrs.ModuleInstance(nil),
-							ProviderConfig: addrs.LocalProviderConfig{LocalName: "aws", Alias: ""},
+							Module:   addrs.ModuleInstance(nil),
+							Provider: addrs.NewLegacyProvider("aws"),
 						},
 					},
 				},
@@ -2965,9 +2969,10 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 	// At this point both resources should be recorded in the state, along
 	// with the single instance associated with test_thing.one.
 	want := states.BuildState(func(s *states.SyncState) {
-		providerAddr := addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance)
+		providerAddr := addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		}
 		zeroAddr := addrs.Resource{
 			Mode: addrs.ManagedResourceMode,
 			Type: "test_thing",
@@ -7390,9 +7395,10 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 					Status:    states.ObjectReady,
 					AttrsJSON: []byte(`{"id":"baz"}`),
 				},
-				addrs.LocalProviderConfig{
-					LocalName: "test",
-				}.Absolute(addrs.RootModuleInstance),
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewLegacyProvider("test"),
+					Module:   addrs.RootModuleInstance,
+				},
 			)
 		}),
 		ProviderResolver: providers.ResolverFixed(
@@ -7529,9 +7535,10 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 					Status:    states.ObjectReady,
 					AttrsJSON: []byte(`{"value":"old"}`),
 				},
-				addrs.LocalProviderConfig{
-					LocalName: "aws",
-				}.Absolute(addrs.RootModuleInstance),
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewLegacyProvider("aws"),
+					Module:   addrs.RootModuleInstance,
+				},
 			)
 		}),
 		ProviderResolver: providers.ResolverFixed(
@@ -9192,9 +9199,10 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"bar","require_new":"ami-old"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "aws",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("aws"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	root.SetResourceInstanceCurrent(
@@ -9217,9 +9225,10 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "aws",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("aws"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -9323,9 +9332,10 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"bar","require_new":"ami-old"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "aws",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("aws"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	root.SetResourceInstanceCurrent(
@@ -9348,9 +9358,10 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "aws",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("aws"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -10266,10 +10277,11 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 	}
 
 	// correct the state
-	s.Modules["module.mod.module.removed"].Resources["aws_instance.child"].ProviderConfig = addrs.LocalProviderConfig{
-		LocalName: "aws",
-		Alias:     "bar",
-	}.Absolute(addrs.RootModuleInstance)
+	s.Modules["module.mod.module.removed"].Resources["aws_instance.child"].ProviderConfig = addrs.AbsProviderConfig{
+		Provider: addrs.NewLegacyProvider("aws"),
+		Module:   addrs.RootModuleInstance,
+		Alias:    "bar",
+	}
 
 	if _, diags := ctx.Plan(); diags.HasErrors() {
 		t.Fatal(diags.Err())
@@ -10690,9 +10702,10 @@ func TestContext2Apply_issue19908(t *testing.T) {
 					AttrsJSON: []byte(`{"baz":"old"}`),
 					Status:    states.ObjectReady,
 				},
-				addrs.LocalProviderConfig{
-					LocalName: "test",
-				}.Absolute(addrs.RootModuleInstance),
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewLegacyProvider("test"),
+					Module:   addrs.RootModuleInstance,
+				},
 			)
 		}),
 		ProviderResolver: providers.ResolverFixed(
@@ -10817,9 +10830,10 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 				Status:    states.ObjectReady,
 				AttrsJSON: []byte(`{"id":"a","require_new":"old"}`),
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 
 		modB := state.EnsureModule(addrs.RootModuleInstance.Child("b", addrs.NoKey))
@@ -10833,9 +10847,10 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 				Status:    states.ObjectReady,
 				AttrsJSON: []byte(`{"id":"b","require_new":"old"}`),
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 
 		aBefore, _ := plans.NewDynamicValue(
@@ -10875,9 +10890,10 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 						Type: "aws_instance",
 						Name: "a",
 					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance.Child("a", addrs.NoKey)),
-					ProviderAddr: addrs.LocalProviderConfig{
-						LocalName: "aws",
-					}.Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Provider: addrs.NewLegacyProvider("aws"),
+						Module:   addrs.RootModuleInstance,
+					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: aAction,
 						Before: aBefore,
@@ -10890,9 +10906,10 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 						Type: "aws_instance",
 						Name: "b",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance.Child("b", addrs.NoKey)),
-					ProviderAddr: addrs.LocalProviderConfig{
-						LocalName: "aws",
-					}.Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Provider: addrs.NewLegacyProvider("aws"),
+						Module:   addrs.RootModuleInstance,
+					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.DeleteThenCreate,
 						Before: bBefore,
@@ -10940,9 +10957,10 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"a"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "null",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("null"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -10954,9 +10972,10 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"data"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "null",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("null"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	providerResolver := providers.ResolverFixed(
@@ -11028,9 +11047,10 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			Status:    states.ObjectTainted,
 			AttrsJSON: []byte(`{"id":"a","foo":"a"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -11042,9 +11062,10 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			Status:    states.ObjectTainted,
 			AttrsJSON: []byte(`{"id":"b","foo":"b"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -11056,9 +11077,10 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			Status:    states.ObjectTainted,
 			AttrsJSON: []byte(`{"id":"c","foo":"old"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	providerResolver := providers.ResolverFixed(
@@ -11232,9 +11254,10 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -11256,9 +11279,10 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -11270,9 +11294,10 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"c","require_new":"old"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	providerResolver := providers.ResolverFixed(

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -147,7 +147,7 @@ func TestContextImport_collision(t *testing.T) {
 	actual := strings.TrimSpace(state.String())
 	expected := `aws_instance.foo:
   ID = bar
-  provider = provider.aws`
+  provider = provider["registry.terraform.io/-/aws"]`
 
 	if actual != expected {
 		t.Fatalf("bad: \n%s", actual)
@@ -918,13 +918,13 @@ func TestContextImport_customProvider(t *testing.T) {
 const testImportStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testImportCountIndexStr = `
 aws_instance.foo.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testImportModuleStr = `
@@ -932,7 +932,7 @@ const testImportModuleStr = `
 module.foo:
   aws_instance.foo:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testImportModuleDepth2Str = `
@@ -940,7 +940,7 @@ const testImportModuleDepth2Str = `
 module.a.b:
   aws_instance.foo:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testImportModuleDiffStr = `
@@ -948,11 +948,11 @@ const testImportModuleDiffStr = `
 module.bar:
   aws_instance.bar:
     ID = bar
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
 module.foo:
   aws_instance.foo:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testImportModuleExistingStr = `
@@ -960,42 +960,42 @@ const testImportModuleExistingStr = `
 module.foo:
   aws_instance.bar:
     ID = bar
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
   aws_instance.foo:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testImportMultiStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance_thing.foo:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testImportMultiSameStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance_thing.foo:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance_thing.foo-1:
   ID = qux
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testImportRefreshStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
 `
 
 const testImportCustomProviderStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws.alias
+  provider = provider["registry.terraform.io/-/aws"].alias
 `

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -115,7 +115,10 @@ func TestContextImport_collision(t *testing.T) {
 					},
 					Status: states.ObjectReady,
 				},
-				addrs.LocalProviderConfig{LocalName: "aws"}.Absolute(addrs.RootModuleInstance),
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewLegacyProvider("aws"),
+					Module:   addrs.RootModuleInstance,
+				},
 			)
 		}),
 	})
@@ -601,7 +604,10 @@ func TestContextImport_moduleDiff(t *testing.T) {
 					},
 					Status: states.ObjectReady,
 				},
-				addrs.LocalProviderConfig{LocalName: "aws"}.Absolute(addrs.RootModuleInstance),
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewLegacyProvider("aws"),
+					Module:   addrs.RootModuleInstance,
+				},
 			)
 		}),
 	})
@@ -659,7 +665,10 @@ func TestContextImport_moduleExisting(t *testing.T) {
 					},
 					Status: states.ObjectReady,
 				},
-				addrs.LocalProviderConfig{LocalName: "aws"}.Absolute(addrs.RootModuleInstance),
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewLegacyProvider("aws"),
+					Module:   addrs.RootModuleInstance,
+				},
 			)
 		}),
 	})

--- a/terraform/context_input.go
+++ b/terraform/context_input.go
@@ -167,7 +167,6 @@ func (c *Context) Input(mode InputMode) tfdiags.Diagnostics {
 				Alias:    pa.Alias,
 				Module:   c.Config().Path.UnkeyedInstanceShim(),
 			}
-			// FIXME: this could be keyed by absProviderConfigs instead of strings.
 			c.providerInputConfig[absConfigAddr.String()] = vals
 
 			log.Printf("[TRACE] Context.Input: Input for %s: %#v", pk, vals)

--- a/terraform/context_input.go
+++ b/terraform/context_input.go
@@ -162,7 +162,14 @@ func (c *Context) Input(mode InputMode) tfdiags.Diagnostics {
 				vals[key] = cty.StringVal(rawVal)
 			}
 
-			c.providerInputConfig[pk] = vals
+			absConfigAddr := addrs.AbsProviderConfig{
+				Provider: providerFqn,
+				Alias:    pa.Alias,
+				Module:   c.Config().Path.UnkeyedInstanceShim(),
+			}
+			// FIXME: this could be keyed by absProviderConfigs instead of strings.
+			c.providerInputConfig[absConfigAddr.String()] = vals
+
 			log.Printf("[TRACE] Context.Input: Input for %s: %#v", pk, vals)
 		}
 	}

--- a/terraform/context_input_test.go
+++ b/terraform/context_input_test.go
@@ -479,7 +479,7 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("aws"),
+				Provider: addrs.NewLegacyProvider("null"),
 				Module:   addrs.RootModuleInstance,
 			},
 		)

--- a/terraform/context_input_test.go
+++ b/terraform/context_input_test.go
@@ -478,7 +478,10 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{LocalName: "null"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -4975,9 +4975,10 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 				Status:    states.ObjectReady,
 				AttrsJSON: []byte(`{"tags":{"ignored":"from state","other":"from state"}}`),
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "test",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 	m := testModule(t, "plan-ignore-changes-in-map")

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -133,7 +133,7 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 	expectedState := strings.TrimSpace(`
  aws_instance.foo: (1 deposed)
   ID = baz
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   Deposed ID 1 = foo`)
 
 	if ctx.State().String() != expectedState {
@@ -863,7 +863,7 @@ func TestContext2Plan_moduleOrphans(t *testing.T) {
 module.child:
   aws_instance.foo:
     ID = baz
-    provider = provider.aws`
+    provider = provider["registry.terraform.io/-/aws"]`
 
 	if ctx.State().String() != expectedState {
 		t.Fatalf("\nexpected state: %q\n\ngot: %q", expectedState, ctx.State().String())
@@ -967,16 +967,16 @@ func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 
 	expectedState := `aws_instance.top:
   ID = top
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 
 module.parent.childone:
   aws_instance.foo:
     ID = baz
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
 module.parent.childtwo:
   aws_instance.foo:
     ID = baz
-    provider = provider.aws`
+    provider = provider["registry.terraform.io/-/aws"]`
 
 	if expectedState != ctx.State().String() {
 		t.Fatalf("\nexpect state: %q\ngot state:    %q\n", expectedState, ctx.State().String())
@@ -2923,15 +2923,15 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 
 	expectedState := `aws_instance.foo.0:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo.1:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.foo.2:
   ID = bar
-  provider = provider.aws`
+  provider = provider["registry.terraform.io/-/aws"]`
 
 	if ctx.State().String() != expectedState {
 		t.Fatalf("epected state:\n%q\n\ngot state:\n%q\n", expectedState, ctx.State().String())

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -103,9 +103,10 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 				Status:    states.ObjectReady,
 				AttrsJSON: []byte(`{"dynamic":{"type":"string","value":"hello"}}`),
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "test",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 
@@ -1739,7 +1740,10 @@ func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
 					"id": "foo",
 				},
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 
@@ -1822,7 +1826,10 @@ func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
 				SchemaVersion: 3,
 				AttrsJSON:     []byte(`{"id":"foo"}`),
 			},
-			addrs.LocalProviderConfig{LocalName: "test"}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("test"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 
@@ -1990,9 +1997,10 @@ func TestRefresh_updateDependencies(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "aws",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("aws"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -2004,9 +2012,10 @@ func TestRefresh_updateDependencies(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"bar","foo":"foo"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "aws",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("aws"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	m := testModuleInline(t, map[string]string{

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -1689,7 +1689,7 @@ func TestContext2Refresh_updateProviderInState(t *testing.T) {
 	expected := strings.TrimSpace(`
 aws_instance.bar:
   ID = foo
-  provider = provider.aws.foo`)
+  provider = provider["registry.terraform.io/-/aws"].foo`)
 
 	state, diags := ctx.Refresh()
 	if diags.HasErrors() {
@@ -1781,7 +1781,7 @@ func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
 		want := strings.TrimSpace(`
 test_thing.bar:
   ID = 
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   name = foo
 `)
 		if got != want {
@@ -1865,7 +1865,7 @@ func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
 		want := strings.TrimSpace(`
 test_thing.bar:
   ID = 
-  provider = provider.test
+  provider = provider["registry.terraform.io/-/test"]
   name = foo
 `)
 		if got != want {
@@ -2050,14 +2050,14 @@ resource "aws_instance" "foo" {
 	expect := strings.TrimSpace(`
 aws_instance.bar:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
 
   Dependencies:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 
   Dependencies:
     aws_instance.baz

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -1086,18 +1086,18 @@ root
 const testContextRefreshModuleStr = `
 aws_instance.web: (tainted)
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 
 module.child:
   aws_instance.web:
     ID = new
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testContextRefreshOutputStr = `
 aws_instance.web:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
 
 Outputs:
@@ -1112,5 +1112,5 @@ const testContextRefreshOutputPartialStr = `
 const testContextRefreshTaintedStr = `
 aws_instance.web: (tainted)
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 `

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -128,7 +128,7 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced invalid object",
 			fmt.Sprintf(
 				"Provider %q produced an invalid value after apply for %s. The result cannot not be saved in the Terraform state.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.ProviderConfig.LocalName, tfdiags.FormatErrorPrefixed(err, absAddr.String()),
+				n.ProviderAddr.Provider.LegacyString(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
 			),
 		))
 	}
@@ -198,7 +198,7 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 				// to notice in the logs if an inconsistency beyond the type system
 				// leads to a downstream provider failure.
 				var buf strings.Builder
-				fmt.Fprintf(&buf, "[WARN] Provider %q produced an unexpected new value for %s, but we are tolerating it because it is using the legacy plugin SDK.\n    The following problems may be the cause of any confusing errors from downstream operations:", n.ProviderAddr.ProviderConfig.LocalName, absAddr)
+				fmt.Fprintf(&buf, "[WARN] Provider %q produced an unexpected new value for %s, but we are tolerating it because it is using the legacy plugin SDK.\n    The following problems may be the cause of any confusing errors from downstream operations:", n.ProviderAddr.Provider.LegacyString(), absAddr)
 				for _, err := range errs {
 					fmt.Fprintf(&buf, "\n      - %s", tfdiags.FormatError(err))
 				}
@@ -218,7 +218,7 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 						"Provider produced inconsistent result after apply",
 						fmt.Sprintf(
 							"When applying changes to %s, provider %q produced an unexpected new value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-							absAddr, n.ProviderAddr.ProviderConfig.LocalName, tfdiags.FormatError(err),
+							absAddr, n.ProviderAddr.Provider.LegacyString(), tfdiags.FormatError(err),
 						),
 					))
 				}

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -149,7 +149,7 @@ func (ctx *BuiltinEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) *Pro
 
 	// FIXME: Once AbsProviderConfig starts containing an FQN, use that directly
 	// here instead of addr.ProviderConfig.LocalName.
-	return ctx.Schemas.ProviderSchema(addrs.NewLegacyProvider(addr.ProviderConfig.LocalName))
+	return ctx.Schemas.ProviderSchema(addr.Provider)
 }
 
 func (ctx *BuiltinEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error {

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -104,7 +104,6 @@ func (ctx *BuiltinEvalContext) Input() UIInput {
 }
 
 func (ctx *BuiltinEvalContext) InitProvider(typeName string, addr addrs.AbsProviderConfig) (providers.Interface, error) {
-
 	ctx.once.Do(ctx.init)
 	absAddr := addr
 	if !absAddr.Module.Equal(ctx.Path()) {

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -104,6 +104,7 @@ func (ctx *BuiltinEvalContext) Input() UIInput {
 }
 
 func (ctx *BuiltinEvalContext) InitProvider(typeName string, addr addrs.AbsProviderConfig) (providers.Interface, error) {
+
 	ctx.once.Do(ctx.init)
 	absAddr := addr
 	if !absAddr.Module.Equal(ctx.Path()) {

--- a/terraform/eval_context_builtin_test.go
+++ b/terraform/eval_context_builtin_test.go
@@ -25,16 +25,12 @@ func TestBuiltinEvalContextProviderInput(t *testing.T) {
 	ctx2.ProviderLock = &lock
 
 	providerAddr1 := addrs.AbsProviderConfig{
-		Module: addrs.RootModuleInstance,
-		ProviderConfig: addrs.LocalProviderConfig{
-			LocalName: "foo",
-		},
+		Module:   addrs.RootModuleInstance,
+		Provider: addrs.NewLegacyProvider("foo"),
 	}
 	providerAddr2 := addrs.AbsProviderConfig{
-		Module: addrs.RootModuleInstance.Child("child", addrs.NoKey),
-		ProviderConfig: addrs.LocalProviderConfig{
-			LocalName: "foo",
-		},
+		Module:   addrs.RootModuleInstance.Child("child", addrs.NoKey),
+		Provider: addrs.NewLegacyProvider("foo"),
 	}
 
 	expected1 := map[string]cty.Value{"value": cty.StringVal("foo")}
@@ -73,17 +69,13 @@ func TestBuildingEvalContextInitProvider(t *testing.T) {
 	// here depending on whether we've moved away from legacy provider
 	// addresses in general yet.
 	providerAddrDefault := addrs.AbsProviderConfig{
-		Module: addrs.RootModuleInstance,
-		ProviderConfig: addrs.LocalProviderConfig{
-			LocalName: "test",
-		},
+		Module:   addrs.RootModuleInstance,
+		Provider: addrs.NewLegacyProvider("test"),
 	}
 	providerAddrAlias := addrs.AbsProviderConfig{
-		Module: addrs.RootModuleInstance,
-		ProviderConfig: addrs.LocalProviderConfig{
-			LocalName: "test",
-			Alias:     "foo",
-		},
+		Module:   addrs.RootModuleInstance,
+		Provider: addrs.NewLegacyProvider("test"),
+		Alias:    "foo",
 	}
 
 	_, err := ctx.InitProvider("test", providerAddrDefault)

--- a/terraform/eval_provider.go
+++ b/terraform/eval_provider.go
@@ -125,7 +125,7 @@ type EvalGetProvider struct {
 }
 
 func (n *EvalGetProvider) Eval(ctx EvalContext) (interface{}, error) {
-	if n.Addr.ProviderConfig.LocalName == "" {
+	if n.Addr.Provider.Type == "" {
 		// Should never happen
 		panic("EvalGetProvider used with uninitialized provider configuration address")
 	}

--- a/terraform/eval_provider_test.go
+++ b/terraform/eval_provider_test.go
@@ -17,10 +17,8 @@ func TestBuildProviderConfig(t *testing.T) {
 		"set_in_config": cty.StringVal("config"),
 	})
 	providerAddr := addrs.AbsProviderConfig{
-		Module: addrs.RootModuleInstance,
-		ProviderConfig: addrs.LocalProviderConfig{
-			LocalName: "foo",
-		},
+		Module:   addrs.RootModuleInstance,
+		Provider: addrs.NewLegacyProvider("foo"),
 	}
 
 	ctx := &MockEvalContext{
@@ -71,10 +69,8 @@ func TestEvalConfigProvider(t *testing.T) {
 	provider := mockProviderWithConfigSchema(simpleTestSchema())
 	rp := providers.Interface(provider)
 	providerAddr := addrs.AbsProviderConfig{
-		Module: addrs.RootModuleInstance,
-		ProviderConfig: addrs.LocalProviderConfig{
-			LocalName: "foo",
-		},
+		Module:   addrs.RootModuleInstance,
+		Provider: addrs.NewLegacyProvider("foo"),
 	}
 	n := &EvalConfigProvider{
 		Addr:     providerAddr,
@@ -107,10 +103,8 @@ func TestEvalInitProvider_impl(t *testing.T) {
 
 func TestEvalInitProvider(t *testing.T) {
 	providerAddr := addrs.AbsProviderConfig{
-		Module: addrs.RootModuleInstance,
-		ProviderConfig: addrs.LocalProviderConfig{
-			LocalName: "foo",
-		},
+		Module:   addrs.RootModuleInstance,
+		Provider: addrs.NewLegacyProvider("foo"),
 	}
 	n := &EvalInitProvider{
 		Addr: providerAddr,
@@ -131,10 +125,8 @@ func TestEvalInitProvider(t *testing.T) {
 
 func TestEvalCloseProvider(t *testing.T) {
 	providerAddr := addrs.AbsProviderConfig{
-		Module: addrs.RootModuleInstance,
-		ProviderConfig: addrs.LocalProviderConfig{
-			LocalName: "foo",
-		},
+		Module:   addrs.RootModuleInstance,
+		Provider: addrs.NewLegacyProvider("foo"),
 	}
 	n := &EvalCloseProvider{
 		Addr: providerAddr,

--- a/terraform/eval_provider_test.go
+++ b/terraform/eval_provider_test.go
@@ -118,7 +118,7 @@ func TestEvalInitProvider(t *testing.T) {
 	if !ctx.InitProviderCalled {
 		t.Fatal("should be called")
 	}
-	if ctx.InitProviderAddr.String() != "provider.foo" {
+	if ctx.InitProviderAddr.String() != `provider["registry.terraform.io/-/foo"]` {
 		t.Fatalf("wrong provider address %s", ctx.InitProviderAddr)
 	}
 }
@@ -140,7 +140,7 @@ func TestEvalCloseProvider(t *testing.T) {
 	if !ctx.CloseProviderCalled {
 		t.Fatal("should be called")
 	}
-	if ctx.CloseProviderAddr.String() != "provider.foo" {
+	if ctx.CloseProviderAddr.String() != `provider["registry.terraform.io/-/foo"]` {
 		t.Fatalf("wrong provider address %s", ctx.CloseProviderAddr)
 	}
 }
@@ -167,7 +167,7 @@ func TestEvalGetProvider(t *testing.T) {
 	if !ctx.ProviderCalled {
 		t.Fatal("should be called")
 	}
-	if ctx.ProviderAddr.String() != "provider.foo" {
+	if ctx.ProviderAddr.String() != `provider["registry.terraform.io/-/foo"]` {
 		t.Fatalf("wrong provider address %s", ctx.ProviderAddr)
 	}
 }

--- a/terraform/eval_read_data.go
+++ b/terraform/eval_read_data.go
@@ -85,7 +85,7 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 	schema, _ := providerSchema.SchemaForResourceAddr(n.Addr.ContainingResource())
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
-		return nil, fmt.Errorf("provider %q does not support data source %q", n.ProviderAddr.ProviderConfig.LocalName, n.Addr.Resource.Type)
+		return nil, fmt.Errorf("provider %q does not support data source %q", n.ProviderAddr.Provider.LegacyString(), n.Addr.Resource.Type)
 	}
 
 	// We'll always start by evaluating the configuration. What we do after
@@ -223,7 +223,7 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced invalid object",
 			fmt.Sprintf(
 				"Provider %q produced an invalid value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.ProviderConfig.LocalName, tfdiags.FormatErrorPrefixed(err, absAddr.String()),
+				n.ProviderAddr.Provider.LegacyString(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
 			),
 		))
 	}
@@ -237,7 +237,7 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced null object",
 			fmt.Sprintf(
 				"Provider %q produced a null value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.ProviderConfig.LocalName, absAddr,
+				n.ProviderAddr.Provider.LegacyString(), absAddr,
 			),
 		))
 	}
@@ -247,7 +247,7 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced invalid object",
 			fmt.Sprintf(
 				"Provider %q produced a value for %s that is not wholly known.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.ProviderConfig.LocalName, absAddr,
+				n.ProviderAddr.Provider.LegacyString(), absAddr,
 			),
 		))
 
@@ -364,7 +364,7 @@ func (n *EvalReadDataApply) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced invalid object",
 			fmt.Sprintf(
 				"Provider %q planned an invalid value for %s. The result could not be saved.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.ProviderConfig.LocalName, tfdiags.FormatErrorPrefixed(err, absAddr.String()),
+				n.ProviderAddr.Provider.LegacyString(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
 			),
 		))
 	}

--- a/terraform/eval_refresh.go
+++ b/terraform/eval_refresh.go
@@ -78,7 +78,7 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced invalid object",
 			fmt.Sprintf(
 				"Provider %q planned an invalid value for %s during refresh: %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.ProviderConfig.LocalName, absAddr, tfdiags.FormatError(err),
+				n.ProviderAddr.Provider.LegacyString(), absAddr, tfdiags.FormatError(err),
 			),
 		))
 	}

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -218,7 +218,7 @@ func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
 	absAddr := n.Addr.Absolute(ctx.Path())
 	state := ctx.State()
 
-	if n.ProviderAddr.ProviderConfig.LocalName == "" {
+	if n.ProviderAddr.Provider.Type == "" {
 		return nil, fmt.Errorf("failed to write state for %s: missing provider type", absAddr)
 	}
 	obj := *n.State

--- a/terraform/eval_state_test.go
+++ b/terraform/eval_state_test.go
@@ -224,7 +224,7 @@ func TestEvalWriteState(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = i-abc123
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 	`)
 }
 
@@ -271,7 +271,7 @@ func TestEvalWriteStateDeposed(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo: (1 deposed)
   ID = <not created>
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   Deposed ID 1 = i-abc123
 	`)
 }

--- a/terraform/evaltree_provider.go
+++ b/terraform/evaltree_provider.go
@@ -15,7 +15,9 @@ func ProviderEvalTree(n *NodeApplyableProvider, config *configs.Provider) EvalNo
 
 	seq := make([]EvalNode, 0, 5)
 	seq = append(seq, &EvalInitProvider{
-		TypeName: addr.ProviderConfig.LocalName, // TODO: This should be an addrs.Provider
+		// FIXME: type is now in the AbsProviderConfig, EvalInitProvider doen't
+		// need this field anymore
+		TypeName: addr.Provider.Type,
 		Addr:     addr,
 	})
 

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -779,11 +779,8 @@ func (d *evaluationStateData) getResourceInstancesAll(addr addrs.Resource, rng t
 }
 
 func (d *evaluationStateData) getResourceSchema(addr addrs.Resource, providerAddr addrs.AbsProviderConfig) *configschema.Block {
-	// FIXME: Once AbsProviderConfig has an addrs.Provider in it, we should
-	// be looking schemas up using provider FQNs rather than legacy names.
-	providerFqn := addrs.NewLegacyProvider(providerAddr.ProviderConfig.LocalName)
 	schemas := d.Evaluator.Schemas
-	schema, _ := schemas.ResourceTypeConfig(providerFqn, addr.Mode, addr.Type)
+	schema, _ := schemas.ResourceTypeConfig(providerAddr.Provider, addr.Mode, addr.Type)
 	return schema
 }
 

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -97,7 +97,7 @@ func TestApplyGraphBuilder_depCbd(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -106,7 +106,7 @@ func TestApplyGraphBuilder_depCbd(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
 			Dependencies: []addrs.AbsResource{mustResourceAddr("test_object.A")},
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 
 	b := &ApplyGraphBuilder{
@@ -623,7 +623,7 @@ func TestApplyGraphBuilder_orphanedWithProvider(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
-		mustProviderConfig("provider.test.foo"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"].foo`),
 	)
 
 	b := &ApplyGraphBuilder{
@@ -651,15 +651,15 @@ meta.count-boundary (EachMode fixup)
 module.child.test_object.create
   module.child.test_object.create (prepare state)
 module.child.test_object.create (prepare state)
-  provider.test
+  provider["registry.terraform.io/-/test"]
   provisioner.test
 module.child.test_object.other
   module.child.test_object.create
   module.child.test_object.other (prepare state)
 module.child.test_object.other (prepare state)
-  provider.test
-provider.test
-provider.test (close)
+  provider["registry.terraform.io/-/test"]
+provider["registry.terraform.io/-/test"]
+provider["registry.terraform.io/-/test"] (close)
   module.child.test_object.other
   test_object.other
 provisioner.test
@@ -667,36 +667,36 @@ provisioner.test (close)
   module.child.test_object.create
 root
   meta.count-boundary (EachMode fixup)
-  provider.test (close)
+  provider["registry.terraform.io/-/test"] (close)
   provisioner.test (close)
 test_object.create
   test_object.create (prepare state)
 test_object.create (prepare state)
-  provider.test
+  provider["registry.terraform.io/-/test"]
 test_object.other
   test_object.create
   test_object.other (prepare state)
 test_object.other (prepare state)
-  provider.test
+  provider["registry.terraform.io/-/test"]
 `
 
 const testApplyGraphBuilderDestroyCountStr = `
 meta.count-boundary (EachMode fixup)
   test_object.B
-provider.test
-provider.test (close)
+provider["registry.terraform.io/-/test"]
+provider["registry.terraform.io/-/test"] (close)
   test_object.B
 root
   meta.count-boundary (EachMode fixup)
-  provider.test (close)
+  provider["registry.terraform.io/-/test"] (close)
 test_object.A (prepare state)
-  provider.test
+  provider["registry.terraform.io/-/test"]
 test_object.A[1] (destroy)
-  provider.test
+  provider["registry.terraform.io/-/test"]
 test_object.B
   test_object.A (prepare state)
   test_object.A[1] (destroy)
   test_object.B (prepare state)
 test_object.B (prepare state)
-  provider.test
+  provider["registry.terraform.io/-/test"]
 `

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -544,9 +544,10 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"a_id"}`),
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -568,9 +569,10 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 				},
 			},
 		},
-		addrs.LocalProviderConfig{
-			LocalName: "test",
-		}.Absolute(addrs.RootModuleInstance),
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider("test"),
+			Module:   addrs.RootModuleInstance,
+		},
 	)
 
 	b := &ApplyGraphBuilder{

--- a/terraform/graph_builder_plan_test.go
+++ b/terraform/graph_builder_plan_test.go
@@ -125,25 +125,25 @@ func TestPlanGraphBuilder_dynamicBlock(t *testing.T) {
 	actual := strings.TrimSpace(g.String())
 	expected := strings.TrimSpace(`
 meta.count-boundary (EachMode fixup)
-  provider.test
+  provider["registry.terraform.io/-/test"]
   test_thing.a
   test_thing.b
   test_thing.c
-provider.test
-provider.test (close)
-  provider.test
+provider["registry.terraform.io/-/test"]
+provider["registry.terraform.io/-/test"] (close)
+  provider["registry.terraform.io/-/test"]
   test_thing.a
   test_thing.b
   test_thing.c
 root
   meta.count-boundary (EachMode fixup)
-  provider.test (close)
+  provider["registry.terraform.io/-/test"] (close)
 test_thing.a
-  provider.test
+  provider["registry.terraform.io/-/test"]
 test_thing.b
-  provider.test
+  provider["registry.terraform.io/-/test"]
 test_thing.c
-  provider.test
+  provider["registry.terraform.io/-/test"]
   test_thing.a
   test_thing.b
 `)
@@ -204,21 +204,21 @@ func TestPlanGraphBuilder_attrAsBlocks(t *testing.T) {
 	actual := strings.TrimSpace(g.String())
 	expected := strings.TrimSpace(`
 meta.count-boundary (EachMode fixup)
-  provider.test
+  provider["registry.terraform.io/-/test"]
   test_thing.a
   test_thing.b
-provider.test
-provider.test (close)
-  provider.test
+provider["registry.terraform.io/-/test"]
+provider["registry.terraform.io/-/test"] (close)
+  provider["registry.terraform.io/-/test"]
   test_thing.a
   test_thing.b
 root
   meta.count-boundary (EachMode fixup)
-  provider.test (close)
+  provider["registry.terraform.io/-/test"] (close)
 test_thing.a
-  provider.test
+  provider["registry.terraform.io/-/test"]
 test_thing.b
-  provider.test
+  provider["registry.terraform.io/-/test"]
   test_thing.a
 `)
 	if actual != expected {
@@ -243,7 +243,7 @@ func TestPlanGraphBuilder_targetModule(t *testing.T) {
 
 	t.Logf("Graph: %s", g.String())
 
-	testGraphNotContains(t, g, "module.child1.provider.test")
+	testGraphNotContains(t, g, `module.child1.provider["registry.terraform.io/-/test"]`)
 	testGraphNotContains(t, g, "module.child1.test_object.foo")
 }
 
@@ -295,13 +295,13 @@ func TestPlanGraphBuilder_forEach(t *testing.T) {
 const testPlanGraphBuilderStr = `
 aws_instance.web
   aws_security_group.firewall
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
   var.foo
 aws_load_balancer.weblb
   aws_instance.web
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 aws_security_group.firewall
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 local.instance_id
   aws_instance.web
 meta.count-boundary (EachMode fixup)
@@ -311,44 +311,44 @@ meta.count-boundary (EachMode fixup)
   local.instance_id
   openstack_floating_ip.random
   output.instance_id
-  provider.aws
-  provider.openstack
+  provider["registry.terraform.io/-/aws"]
+  provider["registry.terraform.io/-/openstack"]
   var.foo
 openstack_floating_ip.random
-  provider.openstack
+  provider["registry.terraform.io/-/openstack"]
 output.instance_id
   local.instance_id
-provider.aws
+provider["registry.terraform.io/-/aws"]
   openstack_floating_ip.random
-provider.aws (close)
+provider["registry.terraform.io/-/aws"] (close)
   aws_instance.web
   aws_load_balancer.weblb
   aws_security_group.firewall
-  provider.aws
-provider.openstack
-provider.openstack (close)
+  provider["registry.terraform.io/-/aws"]
+provider["registry.terraform.io/-/openstack"]
+provider["registry.terraform.io/-/openstack"] (close)
   openstack_floating_ip.random
-  provider.openstack
+  provider["registry.terraform.io/-/openstack"]
 root
   meta.count-boundary (EachMode fixup)
-  provider.aws (close)
-  provider.openstack (close)
+  provider["registry.terraform.io/-/aws"] (close)
+  provider["registry.terraform.io/-/openstack"] (close)
 var.foo
 `
 const testPlanGraphBuilderForEachStr = `
 aws_instance.bar
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 aws_instance.bar2
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 aws_instance.bat
   aws_instance.boo
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 aws_instance.baz
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 aws_instance.boo
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 aws_instance.foo
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 meta.count-boundary (EachMode fixup)
   aws_instance.bar
   aws_instance.bar2
@@ -356,17 +356,17 @@ meta.count-boundary (EachMode fixup)
   aws_instance.baz
   aws_instance.boo
   aws_instance.foo
-  provider.aws
-provider.aws
-provider.aws (close)
+  provider["registry.terraform.io/-/aws"]
+provider["registry.terraform.io/-/aws"]
+provider["registry.terraform.io/-/aws"] (close)
   aws_instance.bar
   aws_instance.bar2
   aws_instance.bat
   aws_instance.baz
   aws_instance.boo
   aws_instance.foo
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 root
   meta.count-boundary (EachMode fixup)
-  provider.aws (close)
+  provider["registry.terraform.io/-/aws"] (close)
 `

--- a/terraform/graph_builder_refresh_test.go
+++ b/terraform/graph_builder_refresh_test.go
@@ -83,19 +83,19 @@ func TestRefreshGraphBuilder_configOrphans(t *testing.T) {
 	actual := strings.TrimSpace(g.StringWithNodeTypes())
 	expected := strings.TrimSpace(`
 data.test_object.foo[0] - *terraform.NodeRefreshableManagedResourceInstance
-  provider.test - *terraform.NodeApplyableProvider
+  provider["registry.terraform.io/-/test"] - *terraform.NodeApplyableProvider
 data.test_object.foo[0] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
-  provider.test - *terraform.NodeApplyableProvider
+  provider["registry.terraform.io/-/test"] - *terraform.NodeApplyableProvider
 data.test_object.foo[1] - *terraform.NodeRefreshableManagedResourceInstance
-  provider.test - *terraform.NodeApplyableProvider
+  provider["registry.terraform.io/-/test"] - *terraform.NodeApplyableProvider
 data.test_object.foo[1] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
-  provider.test - *terraform.NodeApplyableProvider
+  provider["registry.terraform.io/-/test"] - *terraform.NodeApplyableProvider
 data.test_object.foo[2] - *terraform.NodeRefreshableManagedResourceInstance
-  provider.test - *terraform.NodeApplyableProvider
+  provider["registry.terraform.io/-/test"] - *terraform.NodeApplyableProvider
 data.test_object.foo[2] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
-  provider.test - *terraform.NodeApplyableProvider
-provider.test - *terraform.NodeApplyableProvider
-provider.test (close) - *terraform.graphNodeCloseProvider
+  provider["registry.terraform.io/-/test"] - *terraform.NodeApplyableProvider
+provider["registry.terraform.io/-/test"] - *terraform.NodeApplyableProvider
+provider["registry.terraform.io/-/test"] (close) - *terraform.graphNodeCloseProvider
   data.test_object.foo[0] - *terraform.NodeRefreshableManagedResourceInstance
   data.test_object.foo[0] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
   data.test_object.foo[1] - *terraform.NodeRefreshableManagedResourceInstance
@@ -107,13 +107,13 @@ provider.test (close) - *terraform.graphNodeCloseProvider
   test_object.foo[1] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
   test_object.foo[2] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
 test_object.foo - *terraform.NodeRefreshableManagedResource
-  provider.test - *terraform.NodeApplyableProvider
+  provider["registry.terraform.io/-/test"] - *terraform.NodeApplyableProvider
 test_object.foo[0] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
-  provider.test - *terraform.NodeApplyableProvider
+  provider["registry.terraform.io/-/test"] - *terraform.NodeApplyableProvider
 test_object.foo[1] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
-  provider.test - *terraform.NodeApplyableProvider
+  provider["registry.terraform.io/-/test"] - *terraform.NodeApplyableProvider
 test_object.foo[2] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
-  provider.test - *terraform.NodeApplyableProvider
+  provider["registry.terraform.io/-/test"] - *terraform.NodeApplyableProvider
 `)
 	if expected != actual {
 		t.Fatalf("wrong result\n\ngot:\n%s\n\nwant:\n%s", actual, expected)

--- a/terraform/module_dependencies.go
+++ b/terraform/module_dependencies.go
@@ -215,7 +215,7 @@ func configTreeMergeStateDependencies(root *moduledeps.Module, state *states.Sta
 		for _, rs := range ms.Resources {
 			//FIXME: lookup the provider localname in the TBD map and see if
 			//there is an FQN associated
-			fqn := addrs.NewLegacyProvider(rs.ProviderConfig.ProviderConfig.LocalName)
+			fqn := rs.ProviderConfig.Provider
 			if _, exists := module.Providers[fqn]; !exists {
 				module.Providers[fqn] = moduledeps.ProviderDependency{
 					Constraints: discovery.AllVersions,

--- a/terraform/node_data_refresh_test.go
+++ b/terraform/node_data_refresh_test.go
@@ -129,9 +129,8 @@ func TestNodeRefreshableDataResourceDynamicExpand_scaleIn(t *testing.T) {
 			),
 			Config: m.Module.DataResources["data.aws_instance.foo"],
 			ResolvedProvider: addrs.AbsProviderConfig{
-				ProviderConfig: addrs.LocalProviderConfig{
-					LocalName: "aws",
-				},
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
 			},
 		},
 	}
@@ -174,7 +173,7 @@ root - terraform.graphNodeRoot
 		t.Fatal("failed to find a destroyableDataResource")
 	}
 
-	if destroyableDataResource.ResolvedProvider.ProviderConfig.LocalName == "" {
+	if destroyableDataResource.ResolvedProvider.Provider.Type == "" {
 		t.Fatal("NodeDestroyableDataResourceInstance missing provider config")
 	}
 }

--- a/terraform/node_provider_eval.go
+++ b/terraform/node_provider_eval.go
@@ -13,7 +13,9 @@ func (n *NodeEvalableProvider) EvalTree() EvalNode {
 	addr := n.Addr
 
 	return &EvalInitProvider{
-		TypeName: addr.ProviderConfig.LocalName, // FIXME: Should be an addrs.Provider
+		// FIXME: type is now in the AbsProviderConfig, EvalInitProvider doen't
+		// need this field anymore
+		TypeName: addr.Provider.Type,
 		Addr:     addr,
 	}
 }

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -321,7 +321,14 @@ func (n *NodeAbstractResource) ProvidedBy() (addrs.AbsProviderConfig, bool) {
 	// If we have a config we prefer that above all else
 	if n.Config != nil {
 		relAddr := n.Config.ProviderConfigAddr()
-		return relAddr.Absolute(n.Path()), false
+		// FIXME: this will need to lookup the provider and see if there's an
+		// FQN associated with the local config
+		fqn := addrs.NewLegacyProvider(relAddr.LocalName)
+		return addrs.AbsProviderConfig{
+			Provider: fqn,
+			Module:   n.Path(),
+			Alias:    relAddr.Alias,
+		}, false
 	}
 
 	// Use our type and containing module path to guess a provider configuration address.
@@ -330,7 +337,10 @@ func (n *NodeAbstractResource) ProvidedBy() (addrs.AbsProviderConfig, bool) {
 	// with the local name here, once we've done the work elsewhere to make
 	// that possible.
 	defaultFQN := n.Addr.Resource.DefaultProvider()
-	return addrs.NewDefaultLocalProviderConfig(defaultFQN.LegacyString()).Absolute(n.Addr.Module), false
+	return addrs.AbsProviderConfig{
+		Provider: defaultFQN,
+		Module:   n.Addr.Module,
+	}, false
 }
 
 // GraphNodeProviderConsumer
@@ -338,7 +348,16 @@ func (n *NodeAbstractResourceInstance) ProvidedBy() (addrs.AbsProviderConfig, bo
 	// If we have a config we prefer that above all else
 	if n.Config != nil {
 		relAddr := n.Config.ProviderConfigAddr()
-		return relAddr.Absolute(n.Path()), false
+		// Use our type and containing module path to guess a provider configuration address.
+		// FIXME: This is relying on the FQN-to-local matching true only of legacy
+		// addresses.
+		fqn := addrs.NewLegacyProvider(relAddr.LocalName)
+
+		return addrs.AbsProviderConfig{
+			Provider: fqn,
+			Module:   n.Path(),
+			Alias:    relAddr.Alias,
+		}, false
 	}
 
 	// If we have state, then we will use the provider from there
@@ -355,7 +374,10 @@ func (n *NodeAbstractResourceInstance) ProvidedBy() (addrs.AbsProviderConfig, bo
 	// with the local name here, once we've done the work elsewhere to make
 	// that possible.
 	defaultFQN := n.Addr.Resource.DefaultProvider()
-	return addrs.NewDefaultLocalProviderConfig(defaultFQN.LegacyString()).Absolute(n.Addr.Module), false
+	return addrs.AbsProviderConfig{
+		Provider: defaultFQN,
+		Module:   n.Addr.Module,
+	}, false
 }
 
 // GraphNodeProvisionerConsumer

--- a/terraform/node_resource_plan_destroy.go
+++ b/terraform/node_resource_plan_destroy.go
@@ -47,7 +47,7 @@ func (n *NodePlanDestroyableResourceInstance) EvalTree() EvalNode {
 	var change *plans.ResourceInstanceChange
 	var state *states.ResourceInstanceObject
 
-	if n.ResolvedProvider.ProviderConfig.LocalName == "" {
+	if n.ResolvedProvider.Provider.Type == "" {
 		// Should never happen; indicates that the graph was not constructed
 		// correctly since we didn't get our provider attached.
 		panic(fmt.Sprintf("%T %q was not assigned a resolved provider", n, dag.VertexName(n)))

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -283,13 +283,13 @@ func (h *HookRecordApplyOrder) PreApply(addr addrs.AbsResourceInstance, gen stat
 const testTerraformInputProviderStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   bar = override
   foo = us-east-1
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   bar = baz
   num = 2
   type = aws_instance
@@ -298,7 +298,7 @@ aws_instance.foo:
 const testTerraformInputProviderOnlyStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = us-west-2
   type = aws_instance
 `
@@ -306,7 +306,7 @@ aws_instance.foo:
 const testTerraformInputVarOnlyStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = us-east-1
   type = aws_instance
 `
@@ -314,7 +314,7 @@ aws_instance.foo:
 const testTerraformInputVarOnlyUnsetStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   bar = baz
   foo = foovalue
   type = aws_instance
@@ -323,13 +323,13 @@ aws_instance.foo:
 const testTerraformInputVarsStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   bar = override
   foo = us-east-1
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   bar = baz
   num = 2
   type = aws_instance
@@ -338,12 +338,12 @@ aws_instance.foo:
 const testTerraformApplyStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 `
@@ -351,13 +351,13 @@ aws_instance.foo:
 const testTerraformApplyDataBasicStr = `
 data.null_data_source.testing:
   ID = yo
-  provider = provider.null
+  provider = provider["registry.terraform.io/-/null"]
 `
 
 const testTerraformApplyRefCountStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = 3
   type = aws_instance
 
@@ -365,24 +365,24 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.foo.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.foo.2:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testTerraformApplyProviderAliasStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws.bar
+  provider = provider["registry.terraform.io/-/aws"].bar
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 `
@@ -390,10 +390,10 @@ aws_instance.foo:
 const testTerraformApplyProviderAliasConfigStr = `
 another_instance.bar:
   ID = foo
-  provider = provider.another.two
+  provider = provider["registry.terraform.io/-/another"].two
 another_instance.foo:
   ID = foo
-  provider = provider.another
+  provider = provider["registry.terraform.io/-/another"]
 `
 
 const testTerraformApplyEmptyModuleStr = `
@@ -412,7 +412,7 @@ aws_route53_zone_id = XXXX
 const testTerraformApplyDependsCreateBeforeStr = `
 aws_instance.lb:
   ID = baz
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   instance = foo
   type = aws_instance
 
@@ -420,7 +420,7 @@ aws_instance.lb:
     aws_instance.web
 aws_instance.web:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   require_new = ami-new
   type = aws_instance
 `
@@ -428,7 +428,7 @@ aws_instance.web:
 const testTerraformApplyCreateBeforeStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   require_new = xyz
   type = aws_instance
 `
@@ -436,7 +436,7 @@ aws_instance.bar:
 const testTerraformApplyCreateBeforeUpdateStr = `
 aws_instance.bar:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = baz
   type = aws_instance
 `
@@ -444,14 +444,14 @@ aws_instance.bar:
 const testTerraformApplyCancelStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   value = 2
 `
 
 const testTerraformApplyComputeStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = computed_value
   type = aws_instance
 
@@ -459,7 +459,7 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   compute = value
   compute_value = 1
   num = 2
@@ -470,17 +470,17 @@ aws_instance.foo:
 const testTerraformApplyCountDecStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo.0:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo.1:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 `
@@ -488,7 +488,7 @@ aws_instance.foo.1:
 const testTerraformApplyCountDecToOneStr = `
 aws_instance.foo:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 `
@@ -496,7 +496,7 @@ aws_instance.foo:
 const testTerraformApplyCountDecToOneCorruptedStr = `
 aws_instance.foo:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 `
@@ -514,24 +514,24 @@ STATE:
 
 aws_instance.foo:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo.0:
   ID = baz
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   type = aws_instance
 `
 
 const testTerraformApplyCountVariableStr = `
 aws_instance.foo.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 `
@@ -539,7 +539,7 @@ aws_instance.foo.1:
 const testTerraformApplyCountVariableRefStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = 2
   type = aws_instance
 
@@ -547,70 +547,70 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.foo.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 `
 const testTerraformApplyForEachVariableStr = `
 aws_instance.foo["b15c6d616d6143248c575900dff57325eb1de498"]:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo["c3de47d34b0a9f13918dd705c141d579dd6555fd"]:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo["e30a7edcc42a846684f2a4eea5f3cd261d33c46d"]:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   type = aws_instance
 aws_instance.one["a"]:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.one["b"]:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.two["a"]:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 
   Dependencies:
     aws_instance.one
 aws_instance.two["b"]:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 
   Dependencies:
     aws_instance.one`
 const testTerraformApplyMinimalStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testTerraformApplyModuleStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 
 module.child:
   aws_instance.baz:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     foo = bar
     type = aws_instance
 `
@@ -618,7 +618,7 @@ module.child:
 const testTerraformApplyModuleBoolStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = true
   type = aws_instance
 
@@ -636,12 +636,12 @@ const testTerraformApplyModuleDestroyOrderStr = `
 const testTerraformApplyMultiProviderStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 do_instance.foo:
   ID = foo
-  provider = provider.do
+  provider = provider["registry.terraform.io/-/do"]
   num = 2
   type = do_instance
 `
@@ -651,10 +651,10 @@ const testTerraformApplyModuleOnlyProviderStr = `
 module.child:
   aws_instance.foo:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
   test_instance.foo:
     ID = foo
-    provider = provider.test
+    provider = provider["registry.terraform.io/-/test"]
 `
 
 const testTerraformApplyModuleProviderAliasStr = `
@@ -662,19 +662,19 @@ const testTerraformApplyModuleProviderAliasStr = `
 module.child:
   aws_instance.foo:
     ID = foo
-    provider = module.child.provider.aws.eu
+    provider = module.child.provider["registry.terraform.io/-/aws"].eu
 `
 
 const testTerraformApplyModuleVarRefExistingStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
 
 module.child:
   aws_instance.foo:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     type = aws_instance
     value = bar
 
@@ -696,13 +696,13 @@ const testTerraformApplyOutputOrphanModuleStr = `
 const testTerraformApplyProvisionerStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 
   Dependencies:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   compute = value
   compute_value = 1
   num = 2
@@ -715,16 +715,16 @@ const testTerraformApplyProvisionerModuleStr = `
 module.child:
   aws_instance.bar:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testTerraformApplyProvisionerFailStr = `
 aws_instance.bar: (tainted)
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 `
@@ -732,7 +732,7 @@ aws_instance.foo:
 const testTerraformApplyProvisionerFailCreateStr = `
 aws_instance.bar: (tainted)
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 `
 
 const testTerraformApplyProvisionerFailCreateNoIdStr = `
@@ -742,7 +742,7 @@ const testTerraformApplyProvisionerFailCreateNoIdStr = `
 const testTerraformApplyProvisionerFailCreateBeforeDestroyStr = `
 aws_instance.bar: (tainted) (1 deposed)
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   require_new = xyz
   type = aws_instance
   Deposed ID 1 = bar
@@ -751,7 +751,7 @@ aws_instance.bar: (tainted) (1 deposed)
 const testTerraformApplyProvisionerResourceRefStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 `
@@ -759,7 +759,7 @@ aws_instance.bar:
 const testTerraformApplyProvisionerSelfRefStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 `
@@ -767,17 +767,17 @@ aws_instance.foo:
 const testTerraformApplyProvisionerMultiSelfRefStr = `
 aws_instance.foo.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = number 0
   type = aws_instance
 aws_instance.foo.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = number 1
   type = aws_instance
 aws_instance.foo.2:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = number 2
   type = aws_instance
 `
@@ -785,17 +785,17 @@ aws_instance.foo.2:
 const testTerraformApplyProvisionerMultiSelfRefSingleStr = `
 aws_instance.foo.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = number 0
   type = aws_instance
 aws_instance.foo.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = number 1
   type = aws_instance
 aws_instance.foo.2:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = number 2
   type = aws_instance
 `
@@ -803,7 +803,7 @@ aws_instance.foo.2:
 const testTerraformApplyProvisionerDiffStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 `
@@ -815,27 +815,27 @@ const testTerraformApplyDestroyStr = `
 const testTerraformApplyErrorStr = `
 aws_instance.bar: (tainted)
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 
   Dependencies:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   value = 2
 `
 
 const testTerraformApplyErrorCreateBeforeDestroyStr = `
 aws_instance.bar:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   require_new = abc
 `
 
 const testTerraformApplyErrorDestroyCreateBeforeDestroyStr = `
 aws_instance.bar: (1 deposed)
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   require_new = xyz
   type = aws_instance
   Deposed ID 1 = bar
@@ -844,20 +844,20 @@ aws_instance.bar: (1 deposed)
 const testTerraformApplyErrorPartialStr = `
 aws_instance.bar:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
 
   Dependencies:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   value = 2
 `
 
 const testTerraformApplyResourceDependsOnModuleStr = `
 aws_instance.a:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   ami = parent
   type = aws_instance
 
@@ -867,7 +867,7 @@ aws_instance.a:
 module.child:
   aws_instance.child:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     ami = child
     type = aws_instance
 `
@@ -875,7 +875,7 @@ module.child:
 const testTerraformApplyResourceDependsOnModuleDeepStr = `
 aws_instance.a:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   ami = parent
   type = aws_instance
 
@@ -885,7 +885,7 @@ aws_instance.a:
 module.child.grandchild:
   aws_instance.c:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     ami = grandchild
     type = aws_instance
 `
@@ -895,7 +895,7 @@ const testTerraformApplyResourceDependsOnModuleInModuleStr = `
 module.child:
   aws_instance.b:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     ami = child
     type = aws_instance
 
@@ -904,7 +904,7 @@ module.child:
 module.child.grandchild:
   aws_instance.c:
     ID = foo
-    provider = provider.aws
+    provider = provider["registry.terraform.io/-/aws"]
     ami = grandchild
     type = aws_instance
 `
@@ -912,7 +912,7 @@ module.child.grandchild:
 const testTerraformApplyTaintStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 `
@@ -920,7 +920,7 @@ aws_instance.bar:
 const testTerraformApplyTaintDepStr = `
 aws_instance.bar:
   ID = bar
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   num = 2
   type = aws_instance
@@ -929,7 +929,7 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 `
@@ -937,7 +937,7 @@ aws_instance.foo:
 const testTerraformApplyTaintDepRequireNewStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo
   require_new = yes
   type = aws_instance
@@ -946,7 +946,7 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 `
@@ -954,12 +954,12 @@ aws_instance.foo:
 const testTerraformApplyOutputStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 
@@ -971,12 +971,12 @@ foo_num = 2
 const testTerraformApplyOutputAddStr = `
 aws_instance.test.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo0
   type = aws_instance
 aws_instance.test.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = foo1
   type = aws_instance
 
@@ -989,22 +989,22 @@ secondOutput = foo1
 const testTerraformApplyOutputListStr = `
 aws_instance.bar.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.2:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 
@@ -1016,22 +1016,22 @@ foo_num = [bar,bar,bar]
 const testTerraformApplyOutputMultiStr = `
 aws_instance.bar.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.2:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 
@@ -1043,22 +1043,22 @@ foo_num = bar,bar,bar
 const testTerraformApplyOutputMultiIndexStr = `
 aws_instance.bar.0:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.1:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.2:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   num = 2
   type = aws_instance
 
@@ -1070,7 +1070,7 @@ foo_num = bar
 const testTerraformApplyUnknownAttrStr = `
 aws_instance.foo: (tainted)
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   compute = unknown
   num = 2
   type = aws_instance
@@ -1079,13 +1079,13 @@ aws_instance.foo: (tainted)
 const testTerraformApplyVarsStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   bar = override
   baz = override
   foo = us-east-1
 aws_instance.foo:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   bar = baz
   list.# = 2
   list.0 = Hello
@@ -1099,7 +1099,7 @@ aws_instance.foo:
 const testTerraformApplyVarsEnvStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider.aws
+  provider = provider["registry.terraform.io/-/aws"]
   list.# = 2
   list.0 = Hello
   list.1 = World
@@ -1294,7 +1294,7 @@ STATE:
 const testTerraformInputHCL = `
 hcl_instance.hcltest:
   ID = foo
-  provider = provider.hcl
+  provider = provider["registry.terraform.io/-/hcl"]
   bar.w = z
   bar.x = y
   foo.# = 2
@@ -1306,10 +1306,10 @@ hcl_instance.hcltest:
 const testTerraformRefreshDataRefDataStr = `
 data.null_data_source.bar:
   ID = foo
-  provider = provider.null
+  provider = provider["registry.terraform.io/-/null"]
   bar = yes
 data.null_data_source.foo:
   ID = foo
-  provider = provider.null
+  provider = provider["registry.terraform.io/-/null"]
   foo = yes
 `

--- a/terraform/transform_attach_schema.go
+++ b/terraform/transform_attach_schema.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/dag"
 )
@@ -61,10 +60,7 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 			typeName := addr.Resource.Type
 			providerAddr, _ := tv.ProvidedBy()
 
-			// TODO: get providerFQN directly from AbsProviderConfig
-			providerFqn := addrs.NewLegacyProvider(providerAddr.ProviderConfig.LocalName)
-
-			schema, version := t.Schemas.ResourceTypeConfig(providerFqn, mode, typeName)
+			schema, version := t.Schemas.ResourceTypeConfig(providerAddr.Provider, mode, typeName)
 			if schema == nil {
 				log.Printf("[ERROR] AttachSchemaTransformer: No resource schema available for %s", addr)
 				continue
@@ -75,9 +71,7 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 
 		if tv, ok := v.(GraphNodeAttachProviderConfigSchema); ok {
 			providerAddr := tv.ProviderAddr()
-			// TODO: get providerFQN directly from AbsProviderConfig
-			providerFqn := addrs.NewLegacyProvider(providerAddr.ProviderConfig.LocalName)
-			schema := t.Schemas.ProviderConfig(providerFqn)
+			schema := t.Schemas.ProviderConfig(providerAddr.Provider)
 
 			if schema == nil {
 				log.Printf("[ERROR] AttachSchemaTransformer: No provider config schema available for %s", providerAddr)

--- a/terraform/transform_destroy_cbd_test.go
+++ b/terraform/transform_destroy_cbd_test.go
@@ -87,7 +87,7 @@ func TestCBDEdgeTransformer(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -96,7 +96,7 @@ func TestCBDEdgeTransformer(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
 			Dependencies: []addrs.AbsResource{mustResourceAddr("test_object.A")},
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 
 	g := cbdTestGraph(t, "transform-destroy-cbd-edge-basic", changes, state)
@@ -149,7 +149,7 @@ func TestCBDEdgeTransformerMulti(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -157,7 +157,7 @@ func TestCBDEdgeTransformerMulti(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"B"}`),
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.C").Resource,
@@ -169,7 +169,7 @@ func TestCBDEdgeTransformerMulti(t *testing.T) {
 				mustResourceAddr("test_object.B"),
 			},
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 
 	g := cbdTestGraph(t, "transform-destroy-cbd-edge-multi", changes, state)
@@ -227,7 +227,7 @@ func TestCBDEdgeTransformer_depNonCBDCount(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B[0]").Resource,
@@ -236,7 +236,7 @@ func TestCBDEdgeTransformer_depNonCBDCount(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
 			Dependencies: []addrs.AbsResource{mustResourceAddr("test_object.A")},
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B[1]").Resource,
@@ -245,7 +245,7 @@ func TestCBDEdgeTransformer_depNonCBDCount(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
 			Dependencies: []addrs.AbsResource{mustResourceAddr("test_object.A")},
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 
 	g := cbdTestGraph(t, "transform-cbd-destroy-edge-count", changes, state)
@@ -305,7 +305,7 @@ func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.A[1]").Resource,
@@ -313,7 +313,7 @@ func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B[0]").Resource,
@@ -322,7 +322,7 @@ func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
 			Dependencies: []addrs.AbsResource{mustResourceAddr("test_object.A")},
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B[1]").Resource,
@@ -331,7 +331,7 @@ func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
 			Dependencies: []addrs.AbsResource{mustResourceAddr("test_object.A")},
 		},
-		mustProviderConfig("provider.test"),
+		mustProviderConfig(`provider["registry.terraform.io/-/test"]`),
 	)
 
 	g := cbdTestGraph(t, "transform-cbd-destroy-edge-both-count", changes, state)

--- a/terraform/transform_diff_test.go
+++ b/terraform/transform_diff_test.go
@@ -43,9 +43,10 @@ func TestDiffTransformer(t *testing.T) {
 						Type: "aws_instance",
 						Name: "foo",
 					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-					ProviderAddr: addrs.LocalProviderConfig{
-						LocalName: "aws",
-					}.Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Provider: addrs.NewLegacyProvider("aws"),
+						Module:   addrs.RootModuleInstance,
+					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.Update,
 						Before: beforeVal,

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -20,9 +20,12 @@ func (t *ImportStateTransformer) Transform(g *Graph) error {
 		// This will be populated if the targets come from the cli, but tests
 		// may not specify implied provider addresses.
 		providerAddr := target.ProviderAddr
-		if providerAddr.ProviderConfig.LocalName == "" {
+		if providerAddr.Provider.Type == "" {
 			defaultFQN := target.Addr.Resource.Resource.DefaultProvider()
-			providerAddr = addrs.NewDefaultLocalProviderConfig(defaultFQN.LegacyString()).Absolute(target.Addr.Module)
+			providerAddr = addrs.AbsProviderConfig{
+				Provider: defaultFQN,
+				Module:   target.Addr.Module,
+			}
 		}
 
 		node := &graphNodeImportState{

--- a/terraform/transform_orphan_count_test.go
+++ b/terraform/transform_orphan_count_test.go
@@ -352,9 +352,10 @@ func TestOrphanResourceCountTransformer_ForEachEdgesAdded(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 
 		// NoKey'd resource
@@ -370,9 +371,10 @@ func TestOrphanResourceCountTransformer_ForEachEdgesAdded(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 

--- a/terraform/transform_orphan_resource_test.go
+++ b/terraform/transform_orphan_resource_test.go
@@ -26,9 +26,10 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 
 		// The orphan
@@ -44,9 +45,10 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 
@@ -92,9 +94,10 @@ func TestOrphanResourceInstanceTransformer_countGood(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -108,9 +111,10 @@ func TestOrphanResourceInstanceTransformer_countGood(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 
@@ -155,9 +159,10 @@ func TestOrphanResourceInstanceTransformer_countBad(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -171,9 +176,10 @@ func TestOrphanResourceInstanceTransformer_countBad(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 
@@ -218,9 +224,10 @@ func TestOrphanResourceInstanceTransformer_modules(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -234,9 +241,10 @@ func TestOrphanResourceInstanceTransformer_modules(t *testing.T) {
 				},
 				Status: states.ObjectReady,
 			},
-			addrs.LocalProviderConfig{
-				LocalName: "aws",
-			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("aws"),
+				Module:   addrs.RootModuleInstance,
+			},
 		)
 	})
 

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -165,7 +165,10 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 			// stub it out with an init-only provider node, which will just
 			// start up the provider and fetch its schema.
 			if _, exists := needConfigured[key]; target == nil && !exists {
-				stubAddr := p.ProviderConfig.Absolute(addrs.RootModuleInstance)
+				stubAddr := addrs.AbsProviderConfig{
+					Module:   addrs.RootModuleInstance,
+					Provider: p.Provider,
+				}
 				stub := &NodeEvalableProvider{
 					&NodeAbstractProvider{
 						Addr: stubAddr,
@@ -300,7 +303,7 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 		// the later proper resolution of provider inheritance done by
 		// ProviderTransformer.
 		p, _ := pv.ProvidedBy()
-		if p.ProviderConfig.Alias != "" {
+		if p.Alias != "" {
 			// We do not create default aliased configurations.
 			log.Println("[TRACE] MissingProviderTransformer: skipping implication of aliased config", p)
 			continue
@@ -309,8 +312,8 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 		// We're going to create an implicit _default_ configuration for the
 		// referenced provider type in the _root_ module, ignoring all other
 		// aspects of the resource's declared provider address.
-		defaultAddr := addrs.RootModuleInstance.ProviderConfigDefault(p.ProviderConfig.LocalName)
-		key := defaultAddr.String()
+		defaultAddr := addrs.RootModuleInstance.ProviderConfigDefault(p.Provider.LegacyString())
+		key := fmt.Sprintf("%s.%s", "provider", defaultAddr.String())
 		provider := m[key]
 
 		if provider != nil {
@@ -585,7 +588,15 @@ func (t *ProviderConfigTransformer) transformSingle(g *Graph, c *configs.Config)
 	// add all providers from the configuration
 	for _, p := range mod.ProviderConfigs {
 		relAddr := p.Addr()
-		addr := relAddr.Absolute(path)
+
+		// FIXME: This relies on the assumption that all providers are
+		// LegacyProviders, and will instead need to lookup the FQN in the
+		// config from the provider local name when that is supported.
+		fqn := addrs.NewLegacyProvider(relAddr.LocalName)
+		addr := addrs.AbsProviderConfig{
+			Provider: fqn,
+			Module:   path,
+		}
 
 		abstract := &NodeAbstractProvider{
 			Addr: addr,
@@ -661,8 +672,23 @@ func (t *ProviderConfigTransformer) addProxyProviders(g *Graph, c *configs.Confi
 	// Go through all the providers the parent is passing in, and add proxies to
 	// the parent provider nodes.
 	for _, pair := range parentCfg.Providers {
-		fullAddr := pair.InChild.Addr().Absolute(instPath)
-		fullParentAddr := pair.InParent.Addr().Absolute(parentInstPath)
+
+		// FIXME: this is relying on assumptions that the only providers are
+		// legacy-style providers, and will instead need to lookup fqns from the
+		// config when that information is available.
+		//fullAddr := pair.InChild.Addr().Absolute(instPath)
+		fullAddr := addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider(pair.InChild.Addr().LocalName),
+			Module:   instPath,
+			Alias:    pair.InChild.Addr().Alias,
+		}
+
+		fullParentAddr := addrs.AbsProviderConfig{
+			Provider: addrs.NewLegacyProvider(pair.InParent.Addr().LocalName),
+			Module:   instPath,
+			Alias:    pair.InParent.Addr().Alias,
+		}
+
 		fullName := fullAddr.String()
 		fullParentName := fullParentAddr.String()
 
@@ -687,7 +713,7 @@ func (t *ProviderConfigTransformer) addProxyProviders(g *Graph, c *configs.Confi
 		}
 
 		// aliased configurations can't be implicitly passed in
-		if fullAddr.ProviderConfig.Alias != "" {
+		if fullAddr.Alias != "" {
 			continue
 		}
 
@@ -719,7 +745,7 @@ func (t *ProviderConfigTransformer) attachProviderConfigs(g *Graph) error {
 
 		// Go through the provider configs to find the matching config
 		for _, p := range mc.Module.ProviderConfigs {
-			if p.Name == addr.ProviderConfig.LocalName && p.Alias == addr.ProviderConfig.Alias {
+			if p.Name == addr.Provider.Type && p.Alias == addr.Alias {
 				log.Printf("[TRACE] ProviderConfigTransformer: attaching to %q provider configuration from %s", dag.VertexName(v), p.DeclRange)
 				apn.AttachProvider(p)
 				break

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -313,7 +313,7 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 		// referenced provider type in the _root_ module, ignoring all other
 		// aspects of the resource's declared provider address.
 		defaultAddr := addrs.RootModuleInstance.ProviderConfigDefault(p.Provider.LegacyString())
-		key := fmt.Sprintf("%s.%s", "provider", defaultAddr.String())
+		key := defaultAddr.String()
 		provider := m[key]
 
 		if provider != nil {
@@ -595,6 +595,7 @@ func (t *ProviderConfigTransformer) transformSingle(g *Graph, c *configs.Config)
 		fqn := addrs.NewLegacyProvider(relAddr.LocalName)
 		addr := addrs.AbsProviderConfig{
 			Provider: fqn,
+			Alias:    p.Alias,
 			Module:   path,
 		}
 
@@ -685,7 +686,7 @@ func (t *ProviderConfigTransformer) addProxyProviders(g *Graph, c *configs.Confi
 
 		fullParentAddr := addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider(pair.InParent.Addr().LocalName),
-			Module:   instPath,
+			Module:   parentInstPath,
 			Alias:    pair.InParent.Addr().Alias,
 		}
 

--- a/terraform/transform_provider_test.go
+++ b/terraform/transform_provider_test.go
@@ -598,8 +598,8 @@ func TestProviderConfigTransformer_implicitModule(t *testing.T) {
 
 	actual := strings.TrimSpace(g.String())
 	expected := strings.TrimSpace(`module.mod.aws_instance.bar
-  provider.aws.foo
-provider.aws.foo`)
+  provider["registry.terraform.io/-/aws"].foo
+provider["registry.terraform.io/-/aws"].foo`)
 	if actual != expected {
 		t.Fatalf("wrong result\n\nexpected:\n%s\n\ngot:\n%s", expected, actual)
 	}
@@ -629,118 +629,118 @@ func TestProviderConfigTransformer_invalidProvider(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected missing provider error")
 	}
-	if !strings.Contains(err.Error(), "provider.aws.foo") {
+	if !strings.Contains(err.Error(), `provider["registry.terraform.io/-/aws"].foo`) {
 		t.Fatalf("error should reference missing provider, got: %s", err)
 	}
 }
 
 const testTransformProviderBasicStr = `
 aws_instance.web
-  provider.aws
-provider.aws
+  provider["registry.terraform.io/-/aws"]
+provider["registry.terraform.io/-/aws"]
 `
 
 const testTransformCloseProviderBasicStr = `
 aws_instance.web
-  provider.aws
-provider.aws
-provider.aws (close)
+  provider["registry.terraform.io/-/aws"]
+provider["registry.terraform.io/-/aws"]
+provider["registry.terraform.io/-/aws"] (close)
   aws_instance.web
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 `
 
 const testTransformMissingProviderBasicStr = `
 aws_instance.web
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 foo_instance.web
-  provider.foo
-provider.aws
-provider.aws (close)
+  provider["registry.terraform.io/-/foo"]
+provider["registry.terraform.io/-/aws"]
+provider["registry.terraform.io/-/aws"] (close)
   aws_instance.web
-  provider.aws
-provider.foo
-provider.foo (close)
+  provider["registry.terraform.io/-/aws"]
+provider["registry.terraform.io/-/foo"]
+provider["registry.terraform.io/-/foo"] (close)
   foo_instance.web
-  provider.foo
+  provider["registry.terraform.io/-/foo"]
 `
 
 const testTransformMissingGrandchildProviderStr = `
 module.sub.module.subsub.bar_instance.two
-  provider.bar
+  provider["registry.terraform.io/-/bar"]
 module.sub.module.subsub.foo_instance.one
-  module.sub.provider.foo
-module.sub.provider.foo
-provider.bar
+  module.sub.provider["registry.terraform.io/-/foo"]
+module.sub.provider["registry.terraform.io/-/foo"]
+provider["registry.terraform.io/-/bar"]
 `
 
 const testTransformMissingProviderModuleChildStr = `
 module.moo.foo_instance.qux (import id "bar")
-provider.foo
+provider["registry.terraform.io/-/foo"]
 `
 
 const testTransformMissingProviderModuleGrandchildStr = `
 module.a.module.b.foo_instance.qux (import id "bar")
-provider.foo
+provider["registry.terraform.io/-/foo"]
 `
 
 const testTransformParentProviderStr = `
 module.moo.foo_instance.qux (import id "bar")
-provider.foo
+provider["registry.terraform.io/-/foo"]
 `
 
 const testTransformParentProviderModuleGrandchildStr = `
 module.a.module.b.foo_instance.qux (import id "bar")
-provider.foo
+provider["registry.terraform.io/-/foo"]
 `
 
 const testTransformProviderModuleChildStr = `
 module.moo.foo_instance.qux (import id "bar")
-  provider.foo
-provider.foo
+  provider["registry.terraform.io/-/foo"]
+provider["registry.terraform.io/-/foo"]
 `
 
 const testTransformPruneProviderBasicStr = `
 foo_instance.web
-  provider.foo
-provider.foo
-provider.foo (close)
+  provider["registry.terraform.io/-/foo"]
+provider["registry.terraform.io/-/foo"]
+provider["registry.terraform.io/-/foo"] (close)
   foo_instance.web
-  provider.foo
+  provider["registry.terraform.io/-/foo"]
 `
 
 const testTransformDisableProviderBasicStr = `
 module.child
-  provider.aws (disabled)
+  provider["registry.terraform.io/-/aws"] (disabled)
   var.foo
-provider.aws (close)
+provider["registry.terraform.io/-/aws"] (close)
   module.child
-  provider.aws (disabled)
-provider.aws (disabled)
+  provider["registry.terraform.io/-/aws"] (disabled)
+provider["registry.terraform.io/-/aws"] (disabled)
 var.foo
 `
 
 const testTransformDisableProviderKeepStr = `
 aws_instance.foo
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 module.child
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
   var.foo
-provider.aws
-provider.aws (close)
+provider["registry.terraform.io/-/aws"]
+provider["registry.terraform.io/-/aws"] (close)
   aws_instance.foo
   module.child
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 var.foo
 `
 
 const testTransformModuleProviderConfigStr = `
 module.child.aws_instance.thing
-  provider.aws.foo
-provider.aws.foo
+  provider["registry.terraform.io/-/aws"].foo
+provider["registry.terraform.io/-/aws"].foo
 `
 
 const testTransformModuleProviderGrandparentStr = `
 module.child.module.grandchild.aws_instance.baz
-  provider.aws.foo
-provider.aws.foo
+  provider["registry.terraform.io/-/aws"].foo
+provider["registry.terraform.io/-/aws"].foo
 `

--- a/terraform/transform_provisioner_test.go
+++ b/terraform/transform_provisioner_test.go
@@ -70,9 +70,10 @@ func TestMissingProvisionerTransformer_module(t *testing.T) {
 					},
 					Status: states.ObjectReady,
 				},
-				addrs.LocalProviderConfig{
-					LocalName: "aws",
-				}.Absolute(addrs.RootModuleInstance),
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewLegacyProvider("aws"),
+					Module:   addrs.RootModuleInstance,
+				},
 			)
 			s.SetResourceInstanceCurrent(
 				addrs.Resource{
@@ -86,9 +87,10 @@ func TestMissingProvisionerTransformer_module(t *testing.T) {
 					},
 					Status: states.ObjectReady,
 				},
-				addrs.LocalProviderConfig{
-					LocalName: "aws",
-				}.Absolute(addrs.RootModuleInstance),
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewLegacyProvider("aws"),
+					Module:   addrs.RootModuleInstance,
+				},
 			)
 		})
 

--- a/terraform/transform_root_test.go
+++ b/terraform/transform_root_test.go
@@ -58,11 +58,11 @@ func TestRootTransformer(t *testing.T) {
 
 const testTransformRootBasicStr = `
 aws_instance.foo
-  provider.aws
+  provider["registry.terraform.io/-/aws"]
 do_droplet.bar
-  provider.do
-provider.aws
-provider.do
+  provider["registry.terraform.io/-/do"]
+provider["registry.terraform.io/-/aws"]
+provider["registry.terraform.io/-/do"]
 root
   aws_instance.foo
   do_droplet.bar


### PR DESCRIPTION
This is the big one: a large refactor to `addrs.AbsProviderConfig`, embedding the `addrs.Provider` instead of a `Type string`. I've added and updated tests, added some `Legacy` functions to support older state formats and shims, and added a normalization step when reading v4 (current) state files (not the added tests under `states/statefile/roundtrip` which work with both current and legacy-style `AbsProviderConfig` strings).  

The remaining 'fixme' and 'todo' comments are mostly going to be addressed in a subsequent PR and involve looking up a given _local_ provider config's FQN. This is fine for now as we are only working with default assumption.  