### PR TITLE
Update to 0.13 version for master

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // The main version number that is being run at the moment.
-var Version = "0.12.21"
+var Version = "0.13.0"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
Update the building version to 0.13 to reflect `master` being the next major version.