### PR TITLE
command/login: Fix browser launcher for WSL users

### DIFF
--- a/command/webbrowser/native.go
+++ b/command/webbrowser/native.go
@@ -2,6 +2,8 @@ package webbrowser
 
 import (
 	"github.com/pkg/browser"
+	"os/exec"
+	"strings"
 )
 
 // NewNativeLauncher creates and returns a Launcher that will attempt to interact
@@ -13,6 +15,18 @@ func NewNativeLauncher() Launcher {
 
 type nativeLauncher struct{}
 
+func hasProgram(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
 func (l nativeLauncher) OpenURL(url string) error {
+	// Windows Subsystem for Linux (bash for Windows) doesn't have xdg-open available
+	// but you can execute cmd.exe from there; try to identify it
+	if !hasProgram("xdg-open") && hasProgram("cmd.exe") {
+		r := strings.NewReplacer("&", "^&")
+		exec.Command("cmd.exe", "/c", "start", r.Replace(url)).Run()
+	}
+
 	return browser.OpenURL(url)
 }


### PR DESCRIPTION
With the current implementation of `terraform login`, Windows Subsystem for Linux fails to open a browser due to lack of support for xdg-open. This commit reuses a fix from https://github.com/pkg/browser/pull/8 which detects a WSL environment and uses `cmd.exe` to open the URL instead.

I'm a little uncertain that this fix is the right thing to do, for the same reasons the above PR hasn't been merged, but I thought it was worth a discussion. Tested manually on WSL (and Mac OS X).