### PR TITLE
addrs: ProviderConfig fixups

### DIFF
--- a/addrs/provider_config_test.go
+++ b/addrs/provider_config_test.go
@@ -157,6 +157,11 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			AbsProviderConfig{},
 			`Provider address must begin with "provider.", followed by a provider type name.`,
 		},
+		{
+			`provider[0]`,
+			AbsProviderConfig{},
+			`The prefix "provider." must be followed by a provider type name.`,
+		},
 	}
 
 	for _, test := range tests {

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -85,7 +85,7 @@ func TestShow_aliasedProvider(t *testing.T) {
 				Dependencies: []addrs.AbsResource{},
 				DependsOn:    []addrs.Referenceable{},
 			},
-			addrs.RootModuleInstance.ProviderConfigAliased("test", "alias"),
+			addrs.RootModuleInstance.ProviderConfigAliased(addrs.NewLegacyProvider("test"), "alias"),
 		)
 	})
 

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -392,7 +392,7 @@ func TestContextImport_providerNonVarConfig(t *testing.T) {
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("aws")),
 			},
 		},
 	})
@@ -436,7 +436,7 @@ func TestContextImport_refresh(t *testing.T) {
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("aws")),
 			},
 		},
 	})
@@ -483,7 +483,7 @@ func TestContextImport_refreshNil(t *testing.T) {
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("aws")),
 			},
 		},
 	})
@@ -524,7 +524,7 @@ func TestContextImport_module(t *testing.T) {
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("aws")),
 			},
 		},
 	})
@@ -565,7 +565,7 @@ func TestContextImport_moduleDepth2(t *testing.T) {
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("aws")),
 			},
 		},
 	})
@@ -626,7 +626,7 @@ func TestContextImport_moduleDiff(t *testing.T) {
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("aws")),
 			},
 		},
 	})
@@ -687,7 +687,7 @@ func TestContextImport_moduleExisting(t *testing.T) {
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("aws")),
 			},
 		},
 	})
@@ -753,7 +753,7 @@ func TestContextImport_multiState(t *testing.T) {
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("aws")),
 			},
 		},
 	})
@@ -823,7 +823,7 @@ func TestContextImport_multiStateSame(t *testing.T) {
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+				ProviderAddr: addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("aws")),
 			},
 		},
 	})
@@ -865,7 +865,7 @@ func TestContextImport_customProviderMissing(t *testing.T) {
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigAliased("aws", "alias"),
+				ProviderAddr: addrs.RootModuleInstance.ProviderConfigAliased(addrs.NewLegacyProvider("aws"), "alias"),
 			},
 		},
 	})
@@ -900,7 +900,7 @@ func TestContextImport_customProvider(t *testing.T) {
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID:           "bar",
-				ProviderAddr: addrs.RootModuleInstance.ProviderConfigAliased("aws", "alias"),
+				ProviderAddr: addrs.RootModuleInstance.ProviderConfigAliased(addrs.NewLegacyProvider("aws"), "alias"),
 			},
 		},
 	})

--- a/terraform/eval_provider_test.go
+++ b/terraform/eval_provider_test.go
@@ -152,7 +152,7 @@ func TestEvalGetProvider_impl(t *testing.T) {
 func TestEvalGetProvider(t *testing.T) {
 	var actual providers.Interface
 	n := &EvalGetProvider{
-		Addr:   addrs.RootModuleInstance.ProviderConfigDefault("foo"),
+		Addr:   addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("foo")),
 		Output: &actual,
 	}
 	provider := &MockProvider{}

--- a/terraform/eval_state_test.go
+++ b/terraform/eval_state_test.go
@@ -214,7 +214,7 @@ func TestEvalWriteState(t *testing.T) {
 		State: &obj,
 
 		ProviderSchema: &providerSchema,
-		ProviderAddr:   addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+		ProviderAddr:   addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("aws")),
 	}
 	_, err := node.Eval(ctx)
 	if err != nil {
@@ -261,7 +261,7 @@ func TestEvalWriteStateDeposed(t *testing.T) {
 		State: &obj,
 
 		ProviderSchema: &providerSchema,
-		ProviderAddr:   addrs.RootModuleInstance.ProviderConfigDefault("aws"),
+		ProviderAddr:   addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewLegacyProvider("aws")),
 	}
 	_, err := node.Eval(ctx)
 	if err != nil {

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -312,7 +312,7 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 		// We're going to create an implicit _default_ configuration for the
 		// referenced provider type in the _root_ module, ignoring all other
 		// aspects of the resource's declared provider address.
-		defaultAddr := addrs.RootModuleInstance.ProviderConfigDefault(p.Provider.LegacyString())
+		defaultAddr := addrs.RootModuleInstance.ProviderConfigDefault(p.Provider)
 		key := defaultAddr.String()
 		provider := m[key]
 

--- a/terraform/transform_provider_test.go
+++ b/terraform/transform_provider_test.go
@@ -62,7 +62,7 @@ func TestProviderTransformer_moduleChild(t *testing.T) {
 						),
 					ProviderAddr: addrs.RootModuleInstance.
 						Child("moo", addrs.NoKey).
-						ProviderConfigDefault("foo"),
+						ProviderConfigDefault(addrs.NewLegacyProvider("foo")),
 					ID: "bar",
 				},
 			},
@@ -279,7 +279,7 @@ func TestMissingProviderTransformer_moduleChild(t *testing.T) {
 						),
 					ProviderAddr: addrs.RootModuleInstance.
 						Child("moo", addrs.NoKey).
-						ProviderConfigDefault("foo"),
+						ProviderConfigDefault(addrs.NewLegacyProvider("foo")),
 					ID: "bar",
 				},
 			},
@@ -324,7 +324,7 @@ func TestMissingProviderTransformer_moduleGrandchild(t *testing.T) {
 						),
 					ProviderAddr: addrs.RootModuleInstance.
 						Child("moo", addrs.NoKey).
-						ProviderConfigDefault("foo"),
+						ProviderConfigDefault(addrs.NewLegacyProvider("foo")),
 					ID: "bar",
 				},
 			},
@@ -366,7 +366,7 @@ func TestParentProviderTransformer(t *testing.T) {
 						),
 					ProviderAddr: addrs.RootModuleInstance.
 						Child("moo", addrs.NoKey).
-						ProviderConfigDefault("foo"),
+						ProviderConfigDefault(addrs.NewLegacyProvider("foo")),
 					ID: "bar",
 				},
 			},
@@ -420,7 +420,7 @@ func TestParentProviderTransformer_moduleGrandchild(t *testing.T) {
 						),
 					ProviderAddr: addrs.RootModuleInstance.
 						Child("moo", addrs.NoKey).
-						ProviderConfigDefault("foo"),
+						ProviderConfigDefault(addrs.NewLegacyProvider("foo")),
 					ID: "bar",
 				},
 			},


### PR DESCRIPTION
* fix outdated syntax in comments
* test for non-strings in ParseAbsProviderConfig
* ProviderConfigDefault and ProviderConfigAliased now take Providers instead of strings
