### PR TITLE
Mildwonkey/ps transform provider

### DIFF
--- a/configs/module.go
+++ b/configs/module.go
@@ -457,3 +457,11 @@ func (m *Module) LocalNameForProvider(p addrs.Provider) string {
 		return p.Type
 	}
 }
+
+// ProviderForLocalConfig returns the provider FQN for a given LocalProviderConfig
+func (m *Module) ProviderForLocalConfig(pc addrs.LocalProviderConfig) addrs.Provider {
+	if provider, exists := m.ProviderRequirements[pc.String()]; exists {
+		return provider.Type
+	}
+	return addrs.NewLegacyProvider(pc.LocalName)
+}

--- a/terraform/context_components.go
+++ b/terraform/context_components.go
@@ -14,7 +14,7 @@ import (
 // a Context. This information is used for debugging.
 type contextComponentFactory interface {
 	// ResourceProvider creates a new ResourceProvider with the given type.
-	ResourceProvider(typ string) (providers.Interface, error)
+	ResourceProvider(typ addrs.Provider) (providers.Interface, error)
 	ResourceProviders() []string
 
 	// ResourceProvisioner creates a new ResourceProvisioner with the given
@@ -46,10 +46,10 @@ func (c *basicComponentFactory) ResourceProvisioners() []string {
 	return result
 }
 
-func (c *basicComponentFactory) ResourceProvider(typ string) (providers.Interface, error) {
-	f, ok := c.providers[addrs.NewLegacyProvider(typ)]
+func (c *basicComponentFactory) ResourceProvider(typ addrs.Provider) (providers.Interface, error) {
+	f, ok := c.providers[typ]
 	if !ok {
-		return nil, fmt.Errorf("unknown provider %q", typ)
+		return nil, fmt.Errorf("unknown provider %q", typ.LegacyString())
 	}
 
 	return f()

--- a/terraform/context_input.go
+++ b/terraform/context_input.go
@@ -96,12 +96,7 @@ func (c *Context) Input(mode InputMode) tfdiags.Diagnostics {
 				UIInput:     c.uiInput,
 			}
 
-			var providerFqn addrs.Provider
-			if existing, exists := c.config.Module.ProviderRequirements[pa.LocalName]; exists {
-				providerFqn = existing.Type
-			} else {
-				providerFqn = addrs.NewLegacyProvider(pa.LocalName)
-			}
+			providerFqn := c.config.Module.ProviderForLocalConfig(pa)
 			schema := c.schemas.ProviderConfig(providerFqn)
 			if schema == nil {
 				// Could either be an incorrect config or just an incomplete

--- a/terraform/eval_context.go
+++ b/terraform/eval_context.go
@@ -29,13 +29,13 @@ type EvalContext interface {
 	// Input is the UIInput object for interacting with the UI.
 	Input() UIInput
 
-	// InitProvider initializes the provider with the given type and address, and
-	// returns the implementation of the resource provider or an error.
+	// InitProvider initializes the provider with the given address, and returns
+	// the implementation of the resource provider or an error.
 	//
 	// It is an error to initialize the same provider more than once. This
 	// method will panic if the module instance address of the given provider
 	// configuration does not match the Path() of the EvalContext.
-	InitProvider(typ string, addr addrs.AbsProviderConfig) (providers.Interface, error)
+	InitProvider(addr addrs.AbsProviderConfig) (providers.Interface, error)
 
 	// Provider gets the provider instance with the given address (already
 	// initialized) or returns nil if the provider isn't initialized.

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -146,9 +146,6 @@ func (ctx *BuiltinEvalContext) Provider(addr addrs.AbsProviderConfig) providers.
 
 func (ctx *BuiltinEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) *ProviderSchema {
 	ctx.once.Do(ctx.init)
-
-	// FIXME: Once AbsProviderConfig starts containing an FQN, use that directly
-	// here instead of addr.ProviderConfig.LocalName.
 	return ctx.Schemas.ProviderSchema(addr.Provider)
 }
 

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -103,7 +103,7 @@ func (ctx *BuiltinEvalContext) Input() UIInput {
 	return ctx.InputValue
 }
 
-func (ctx *BuiltinEvalContext) InitProvider(typeName string, addr addrs.AbsProviderConfig) (providers.Interface, error) {
+func (ctx *BuiltinEvalContext) InitProvider(addr addrs.AbsProviderConfig) (providers.Interface, error) {
 	ctx.once.Do(ctx.init)
 	absAddr := addr
 	if !absAddr.Module.Equal(ctx.Path()) {
@@ -124,12 +124,12 @@ func (ctx *BuiltinEvalContext) InitProvider(typeName string, addr addrs.AbsProvi
 
 	key := absAddr.String()
 
-	p, err := ctx.Components.ResourceProvider(typeName)
+	p, err := ctx.Components.ResourceProvider(addr.Provider)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Printf("[TRACE] BuiltinEvalContext: Initialized %q provider for %s", typeName, absAddr)
+	log.Printf("[TRACE] BuiltinEvalContext: Initialized %q provider for %s", addr.LegacyString(), absAddr)
 	ctx.ProviderCache[key] = p
 
 	return p, nil

--- a/terraform/eval_context_builtin_test.go
+++ b/terraform/eval_context_builtin_test.go
@@ -78,11 +78,11 @@ func TestBuildingEvalContextInitProvider(t *testing.T) {
 		Alias:    "foo",
 	}
 
-	_, err := ctx.InitProvider("test", providerAddrDefault)
+	_, err := ctx.InitProvider(providerAddrDefault)
 	if err != nil {
 		t.Fatalf("error initializing provider test: %s", err)
 	}
-	_, err = ctx.InitProvider("test", providerAddrAlias)
+	_, err = ctx.InitProvider(providerAddrAlias)
 	if err != nil {
 		t.Fatalf("error initializing provider test.foo: %s", err)
 	}

--- a/terraform/eval_context_builtin_test.go
+++ b/terraform/eval_context_builtin_test.go
@@ -64,10 +64,6 @@ func TestBuildingEvalContextInitProvider(t *testing.T) {
 		},
 	}
 
-	// FIXME: Once AbsProviderConfig has a provider FQN instead of an
-	// embedded LocalProviderConfig, use a legacy or default provider address
-	// here depending on whether we've moved away from legacy provider
-	// addresses in general yet.
 	providerAddrDefault := addrs.AbsProviderConfig{
 		Module:   addrs.RootModuleInstance,
 		Provider: addrs.NewLegacyProvider("test"),

--- a/terraform/eval_context_mock.go
+++ b/terraform/eval_context_mock.go
@@ -150,9 +150,9 @@ func (c *MockEvalContext) Input() UIInput {
 	return c.InputInput
 }
 
-func (c *MockEvalContext) InitProvider(t string, addr addrs.AbsProviderConfig) (providers.Interface, error) {
+func (c *MockEvalContext) InitProvider(addr addrs.AbsProviderConfig) (providers.Interface, error) {
 	c.InitProviderCalled = true
-	c.InitProviderType = t
+	c.InitProviderType = addr.LegacyString()
 	c.InitProviderAddr = addr
 	return c.InitProviderProvider, c.InitProviderError
 }

--- a/terraform/eval_provider.go
+++ b/terraform/eval_provider.go
@@ -88,12 +88,11 @@ func (n *EvalConfigProvider) Eval(ctx EvalContext) (interface{}, error) {
 // and returns nothing. The provider can be retrieved again with the
 // EvalGetProvider node.
 type EvalInitProvider struct {
-	TypeName string
-	Addr     addrs.AbsProviderConfig
+	Addr addrs.AbsProviderConfig
 }
 
 func (n *EvalInitProvider) Eval(ctx EvalContext) (interface{}, error) {
-	return ctx.InitProvider(n.TypeName, n.Addr)
+	return ctx.InitProvider(n.Addr)
 }
 
 // EvalCloseProvider is an EvalNode implementation that closes provider

--- a/terraform/evaltree_provider.go
+++ b/terraform/evaltree_provider.go
@@ -15,10 +15,7 @@ func ProviderEvalTree(n *NodeApplyableProvider, config *configs.Provider) EvalNo
 
 	seq := make([]EvalNode, 0, 5)
 	seq = append(seq, &EvalInitProvider{
-		// FIXME: type is now in the AbsProviderConfig, EvalInitProvider doen't
-		// need this field anymore
-		TypeName: addr.Provider.Type,
-		Addr:     addr,
+		Addr: addr,
 	})
 
 	// Input stuff

--- a/terraform/evaluate_valid.go
+++ b/terraform/evaluate_valid.go
@@ -212,12 +212,7 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 		return diags
 	}
 
-	var providerFqn addrs.Provider
-	if existing, exists := modCfg.Module.ProviderRequirements[cfg.ProviderConfigAddr().LocalName]; exists {
-		providerFqn = existing.Type
-	} else {
-		providerFqn = addrs.NewLegacyProvider(cfg.ProviderConfigAddr().LocalName)
-	}
+	providerFqn := modCfg.Module.ProviderForLocalConfig(cfg.ProviderConfigAddr())
 	schema, _ := d.Evaluator.Schemas.ResourceTypeConfig(providerFqn, addr.Mode, addr.Type)
 
 	if schema == nil {

--- a/terraform/module_dependencies.go
+++ b/terraform/module_dependencies.go
@@ -82,13 +82,7 @@ func configTreeConfigDependencies(root *configs.Config, inheritProviders map[str
 		// allowing for more terse declaration in situations where both a
 		// configuration and a constraint are defined in the same module.
 		for _, pCfg := range module.ProviderConfigs {
-			var fqn addrs.Provider
-			if existing, exists := module.ProviderRequirements[pCfg.Name]; exists {
-				fqn = existing.Type
-			} else {
-				fqn = addrs.NewLegacyProvider(pCfg.Name)
-			}
-
+			fqn := module.ProviderForLocalConfig(pCfg.Addr())
 			discoConstraints := discovery.AllVersions
 			if pCfg.Version.Required != nil {
 				discoConstraints = discovery.NewConstraints(pCfg.Version.Required)
@@ -112,15 +106,7 @@ func configTreeConfigDependencies(root *configs.Config, inheritProviders map[str
 		// an explicit dependency on the same provider.
 		for _, rc := range module.ManagedResources {
 			addr := rc.ProviderConfigAddr()
-			//look up the provider localname in the provider requirements map and see if
-			//there is a non-default FQN associated
-			var fqn addrs.Provider
-			if existing, exists := module.ProviderRequirements[addr.LocalName]; exists {
-				fqn = existing.Type
-			} else {
-				fqn = addrs.NewLegacyProvider(addr.LocalName)
-			}
-
+			fqn := module.ProviderForLocalConfig(addr)
 			if _, exists := providers[fqn]; exists {
 				// Explicit dependency already present
 				continue
@@ -138,14 +124,7 @@ func configTreeConfigDependencies(root *configs.Config, inheritProviders map[str
 		}
 		for _, rc := range module.DataResources {
 			addr := rc.ProviderConfigAddr()
-			//look up the provider localname in the provider requirements map and see if
-			//there is a non-default FQN associated
-			var fqn addrs.Provider
-			if existing, exists := module.ProviderRequirements[addr.LocalName]; exists {
-				fqn = existing.Type
-			} else {
-				fqn = addrs.NewLegacyProvider(addr.LocalName)
-			}
+			fqn := module.ProviderForLocalConfig(addr)
 			if _, exists := providers[fqn]; exists {
 				// Explicit dependency already present
 				continue

--- a/terraform/module_dependencies.go
+++ b/terraform/module_dependencies.go
@@ -192,8 +192,6 @@ func configTreeMergeStateDependencies(root *moduledeps.Module, state *states.Sta
 		module := findModule(ms.Addr)
 
 		for _, rs := range ms.Resources {
-			//FIXME: lookup the provider localname in the TBD map and see if
-			//there is an FQN associated
 			fqn := rs.ProviderConfig.Provider
 			if _, exists := module.Providers[fqn]; !exists {
 				module.Providers[fqn] = moduledeps.ProviderDependency{

--- a/terraform/node_provider_eval.go
+++ b/terraform/node_provider_eval.go
@@ -13,9 +13,6 @@ func (n *NodeEvalableProvider) EvalTree() EvalNode {
 	addr := n.Addr
 
 	return &EvalInitProvider{
-		// FIXME: type is now in the AbsProviderConfig, EvalInitProvider doen't
-		// need this field anymore
-		TypeName: addr.Provider.Type,
-		Addr:     addr,
+		Addr: addr,
 	}
 }

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -237,7 +237,8 @@ func ResourceProviderResolverFixed(factories map[addrs.Provider]ResourceProvider
 		ret := make(map[addrs.Provider]ResourceProviderFactory, len(reqd))
 		var errs []error
 		for name := range reqd {
-			// Provider Source Readiness!
+			// FIXME: discovery.PluginRequirements should use addrs.Provider as
+			// the map keys instead of a string
 			fqn := addrs.NewLegacyProvider(name)
 			if factory, exists := factories[fqn]; exists {
 				ret[fqn] = factory

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -100,8 +100,8 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			return
 		}
 
-		log.Printf("[TRACE] LoadSchemas: retrieving schema for provider type %q", typeName)
-		provider, err := components.ResourceProvider(typeName)
+		log.Printf("[TRACE] LoadSchemas: retrieving schema for provider type %q", fqn.LegacyString())
+		provider, err := components.ResourceProvider(fqn)
 		if err != nil {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls.

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -587,12 +587,7 @@ func (t *ProviderConfigTransformer) transformSingle(g *Graph, c *configs.Config)
 
 	// add all providers from the configuration
 	for _, p := range mod.ProviderConfigs {
-		relAddr := p.Addr()
-
-		// FIXME: This relies on the assumption that all providers are
-		// LegacyProviders, and will instead need to lookup the FQN in the
-		// config from the provider local name when that is supported.
-		fqn := addrs.NewLegacyProvider(relAddr.LocalName)
+		fqn := mod.ProviderForLocalConfig(p.Addr())
 		addr := addrs.AbsProviderConfig{
 			Provider: fqn,
 			Alias:    p.Alias,

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -673,14 +673,15 @@ func (t *ProviderConfigTransformer) addProxyProviders(g *Graph, c *configs.Confi
 		// legacy-style providers, and will instead need to lookup fqns from the
 		// config when that information is available.
 		//fullAddr := pair.InChild.Addr().Absolute(instPath)
+		fqn := c.Module.ProviderForLocalConfig(pair.InChild.Addr())
 		fullAddr := addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider(pair.InChild.Addr().LocalName),
+			Provider: fqn,
 			Module:   instPath,
 			Alias:    pair.InChild.Addr().Alias,
 		}
 
 		fullParentAddr := addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider(pair.InParent.Addr().LocalName),
+			Provider: fqn,
 			Module:   parentInstPath,
 			Alias:    pair.InParent.Addr().Alias,
 		}

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -668,11 +668,6 @@ func (t *ProviderConfigTransformer) addProxyProviders(g *Graph, c *configs.Confi
 	// Go through all the providers the parent is passing in, and add proxies to
 	// the parent provider nodes.
 	for _, pair := range parentCfg.Providers {
-
-		// FIXME: this is relying on assumptions that the only providers are
-		// legacy-style providers, and will instead need to lookup fqns from the
-		// config when that information is available.
-		//fullAddr := pair.InChild.Addr().Absolute(instPath)
 		fqn := c.Module.ProviderForLocalConfig(pair.InChild.Addr())
 		fullAddr := addrs.AbsProviderConfig{
 			Provider: fqn,


### PR DESCRIPTION
These commits continue the work of replacing legacy provider strings and calls to `addrs.NewLegacyProvider()` with addrs.Providers. 

This leaves 2 main provider source FIXMEs in the `terraform` package: the `NodeAbstractResource` does not have access to the `addrs.Provider` with only the `configs.Resource`,  and discovery.PluginRequirements (used in resource_provider.go) needs to use `addrs.Provider` as the map keys in place of the type name string.