### PR TITLE
terrafrom: remove GraphNodeProviderConsumer and instead embed funcs i…

### DIFF
--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -23,7 +23,6 @@ type NodeApplyableResource struct {
 var (
 	_ GraphNodeResource             = (*NodeApplyableResource)(nil)
 	_ GraphNodeEvalable             = (*NodeApplyableResource)(nil)
-	_ GraphNodeProviderConsumer     = (*NodeApplyableResource)(nil)
 	_ GraphNodeAttachResourceConfig = (*NodeApplyableResource)(nil)
 	_ GraphNodeReferencer           = (*NodeApplyableResource)(nil)
 )

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -33,7 +33,6 @@ var (
 	_ GraphNodeReferenceable       = (*NodeDestroyResourceInstance)(nil)
 	_ GraphNodeReferencer          = (*NodeDestroyResourceInstance)(nil)
 	_ GraphNodeEvalable            = (*NodeDestroyResourceInstance)(nil)
-	_ GraphNodeProviderConsumer    = (*NodeDestroyResourceInstance)(nil)
 	_ GraphNodeProvisionerConsumer = (*NodeDestroyResourceInstance)(nil)
 )
 
@@ -286,12 +285,8 @@ var (
 	_ GraphNodeReferencer    = (*NodeDestroyResource)(nil)
 	_ GraphNodeEvalable      = (*NodeDestroyResource)(nil)
 
-	// FIXME: this is here to document that this node is both
-	// GraphNodeProviderConsumer by virtue of the embedded
-	// NodeAbstractResource, but that behavior is not desired and we skip it by
-	// checking for GraphNodeNoProvider.
-	_ GraphNodeProviderConsumer = (*NodeDestroyResource)(nil)
-	_ GraphNodeNoProvider       = (*NodeDestroyResource)(nil)
+	// FIXME: fix this comment
+	_ GraphNodeNoProvider = (*NodeDestroyResource)(nil)
 )
 
 func (n *NodeDestroyResource) Name() string {

--- a/terraform/node_resource_destroy_deposed.go
+++ b/terraform/node_resource_destroy_deposed.go
@@ -38,7 +38,6 @@ var (
 	_ GraphNodeReferenceable                 = (*NodePlanDeposedResourceInstanceObject)(nil)
 	_ GraphNodeReferencer                    = (*NodePlanDeposedResourceInstanceObject)(nil)
 	_ GraphNodeEvalable                      = (*NodePlanDeposedResourceInstanceObject)(nil)
-	_ GraphNodeProviderConsumer              = (*NodePlanDeposedResourceInstanceObject)(nil)
 	_ GraphNodeProvisionerConsumer           = (*NodePlanDeposedResourceInstanceObject)(nil)
 )
 
@@ -173,7 +172,6 @@ var (
 	_ GraphNodeReferenceable                 = (*NodeDestroyDeposedResourceInstanceObject)(nil)
 	_ GraphNodeReferencer                    = (*NodeDestroyDeposedResourceInstanceObject)(nil)
 	_ GraphNodeEvalable                      = (*NodeDestroyDeposedResourceInstanceObject)(nil)
-	_ GraphNodeProviderConsumer              = (*NodeDestroyDeposedResourceInstanceObject)(nil)
 	_ GraphNodeProvisionerConsumer           = (*NodeDestroyDeposedResourceInstanceObject)(nil)
 )
 

--- a/terraform/node_resource_plan_destroy.go
+++ b/terraform/node_resource_plan_destroy.go
@@ -26,7 +26,6 @@ var (
 	_ GraphNodeAttachResourceConfig = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeAttachResourceState  = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeEvalable             = (*NodePlanDestroyableResourceInstance)(nil)
-	_ GraphNodeProviderConsumer     = (*NodePlanDestroyableResourceInstance)(nil)
 )
 
 // GraphNodeDestroyer

--- a/terraform/transform_attach_config_resource.go
+++ b/terraform/transform_attach_config_resource.go
@@ -42,7 +42,8 @@ func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
 		// Get the configuration.
 		config := t.Config.DescendentForInstance(addr.Module)
 		if config == nil {
-			log.Printf("[TRACE] AttachResourceConfigTransformer: %q (%T) has no configuration available", dag.VertexName(v), v)
+			log.Printf("[TRACE] AttachResourceConfigTransformer: %q (%T) has no configuration available",
+				dag.VertexName(v), v)
 			continue
 		}
 
@@ -54,7 +55,8 @@ func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
 				continue
 			}
 
-			log.Printf("[TRACE] AttachResourceConfigTransformer: attaching to %q (%T) config from %s", dag.VertexName(v), v, r.DeclRange)
+			log.Printf("[TRACE] AttachResourceConfigTransformer: attaching to %q (%T) config from %s",
+				dag.VertexName(v), v, r.DeclRange)
 			arn.AttachResourceConfig(r)
 		}
 		for _, r := range config.Module.DataResources {
@@ -65,7 +67,8 @@ func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
 				continue
 			}
 
-			log.Printf("[TRACE] AttachResourceConfigTransformer: attaching to %q (%T) config from %#v", dag.VertexName(v), v, r.DeclRange)
+			log.Printf("[TRACE] AttachResourceConfigTransformer: attaching to %q (%T) config from %#v",
+				dag.VertexName(v), v, r.DeclRange)
 			arn.AttachResourceConfig(r)
 		}
 	}

--- a/terraform/transform_attach_schema.go
+++ b/terraform/transform_attach_schema.go
@@ -12,8 +12,6 @@ import (
 // that need a resource schema attached.
 type GraphNodeAttachResourceSchema interface {
 	GraphNodeResource
-	GraphNodeProviderConsumer
-
 	AttachResourceSchema(schema *configschema.Block, version uint64)
 }
 

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -50,7 +50,6 @@ type graphNodeImportState struct {
 var (
 	_ GraphNodeSubPath           = (*graphNodeImportState)(nil)
 	_ GraphNodeEvalable          = (*graphNodeImportState)(nil)
-	_ GraphNodeProviderConsumer  = (*graphNodeImportState)(nil)
 	_ GraphNodeDynamicExpandable = (*graphNodeImportState)(nil)
 )
 


### PR DESCRIPTION
and instead embed funcs into GraphNodeResource

@apparentlymart and I were talking through a problem and he commented that the GraphNodeProviderConsumer was redundant - all resources are provider consumers - and could be absorbed by the GraphNodeResource. We weren't sure if it was the right thing to do, or if it was the right thing to do _right now_, but (after bashing my head on a tangential problem for awhile) I thought I'd try it.

