### PR TITLE
command: Fix stale lock when exiting early

### DIFF
--- a/command/console.go
+++ b/command/console.go
@@ -96,11 +96,6 @@ func (c *ConsoleCommand) Run(args []string) int {
 
 	// Get the context
 	ctx, _, ctxDiags := local.Context(opReq)
-	diags = diags.Append(ctxDiags)
-	if ctxDiags.HasErrors() {
-		c.showDiagnostics(diags)
-		return 1
-	}
 
 	defer func() {
 		err := opReq.StateLocker.Unlock(nil)
@@ -108,6 +103,12 @@ func (c *ConsoleCommand) Run(args []string) int {
 			c.Ui.Error(err.Error())
 		}
 	}()
+
+	diags = diags.Append(ctxDiags)
+	if ctxDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
 
 	// Setup the UI so we can output directly to stdout
 	ui := &cli.BasicUi{

--- a/command/graph.go
+++ b/command/graph.go
@@ -111,13 +111,6 @@ func (c *GraphCommand) Run(args []string) int {
 		return 1
 	}
 
-	defer func() {
-		err := opReq.StateLocker.Unlock(nil)
-		if err != nil {
-			c.Ui.Error(err.Error())
-		}
-	}()
-
 	// Determine the graph type
 	graphType := terraform.GraphTypePlan
 	if plan != nil {

--- a/command/import.go
+++ b/command/import.go
@@ -203,19 +203,19 @@ func (c *ImportCommand) Run(args []string) int {
 
 	// Get the context
 	ctx, state, ctxDiags := local.Context(opReq)
-	diags = diags.Append(ctxDiags)
-	if ctxDiags.HasErrors() {
-		c.showDiagnostics(diags)
-		return 1
-	}
 
-	// Make sure to unlock the state
 	defer func() {
 		err := opReq.StateLocker.Unlock(nil)
 		if err != nil {
 			c.Ui.Error(err.Error())
 		}
 	}()
+
+	diags = diags.Append(ctxDiags)
+	if ctxDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
 
 	// Perform the import. Note that as you can see it is possible for this
 	// API to import more than one resource at once. For now, we only allow

--- a/command/testdata/import-provider-invalid/main.tf
+++ b/command/testdata/import-provider-invalid/main.tf
@@ -1,0 +1,15 @@
+terraform {
+	backend "local" {
+		path = "imported.tfstate"
+	}
+}
+
+provider "test" {
+    foo = "bar"
+}
+
+resource "test_instance" "foo" {
+}
+
+resource "unknown_instance" "baz" {
+}

--- a/command/testdata/import-provider-mismatch/main.tf
+++ b/command/testdata/import-provider-mismatch/main.tf
@@ -1,7 +1,0 @@
-provider "test-beta" {
-  foo = "baz"
-}
-
-resource "test_instance" "foo" {
-  provider = "test-beta"
-}


### PR DESCRIPTION
If an error occurs on creating the context for console or import, we would fail to unlock the state. Fix this by unlocking slightly earlier. Affects console and import commands.

Fixes #23318.

Also, while I was making these changes:

- Remove the no-op unlock from the graph command, which followed the same code pattern. graph never actually acquires a lock, so rather than applying the same fix, I thought it best to remove the code.
- Remove a now-unused test fixture which was almost reusable for this change, but not quite.