### PR TITLE
Fix & improve state locking of OSS backend

### DIFF
--- a/backend/remote-state/oss/backend.go
+++ b/backend/remote-state/oss/backend.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"strings"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/sts"
@@ -12,10 +17,11 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/jmespath/go-jmespath"
-	"io/ioutil"
-	"os"
-	"runtime"
-	"strings"
+
+	"log"
+	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
@@ -24,10 +30,6 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform/version"
 	"github.com/mitchellh/go-homedir"
-	"log"
-	"net/http"
-	"strconv"
-	"time"
 )
 
 // New creates a new backend for OSS remote state.

--- a/backend/remote-state/oss/backend_state.go
+++ b/backend/remote-state/oss/backend_state.go
@@ -12,9 +12,10 @@ import (
 	"github.com/hashicorp/terraform/state/remote"
 	"github.com/hashicorp/terraform/states"
 
-	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
 	"log"
 	"path"
+
+	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
 )
 
 const (

--- a/backend/remote-state/oss/backend_state.go
+++ b/backend/remote-state/oss/backend_state.go
@@ -39,27 +39,11 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 		otsClient:            b.otsClient,
 	}
 	if b.otsEndpoint != "" && b.otsTable != "" {
-		table, err := b.otsClient.DescribeTable(&tablestore.DescribeTableRequest{
+		_, err := b.otsClient.DescribeTable(&tablestore.DescribeTableRequest{
 			TableName: b.otsTable,
 		})
 		if err != nil {
 			return client, fmt.Errorf("Error describing table store %s: %#v", b.otsTable, err)
-		}
-		for _, t := range table.TableMeta.SchemaEntry {
-			pkMeta := TableStorePrimaryKeyMeta{
-				PKName: *t.Name,
-			}
-			if *t.Type == tablestore.PrimaryKeyType_INTEGER {
-				pkMeta.PKType = "Integer"
-			} else if *t.Type == tablestore.PrimaryKeyType_STRING {
-				pkMeta.PKType = "String"
-			} else if *t.Type == tablestore.PrimaryKeyType_BINARY {
-				pkMeta.PKType = "Binary"
-			} else {
-				return client, fmt.Errorf("Unsupported PrimaryKey type: %d.", *t.Type)
-			}
-			client.otsTabkePK = pkMeta
-			break
 		}
 	}
 

--- a/backend/remote-state/oss/backend_test.go
+++ b/backend/remote-state/oss/backend_test.go
@@ -181,7 +181,7 @@ func deleteOSSBucket(t *testing.T, ossClient *oss.Client, bucketName string) {
 func createTablestoreTable(t *testing.T, otsClient *tablestore.TableStoreClient, tableName string) {
 	tableMeta := new(tablestore.TableMeta)
 	tableMeta.TableName = tableName
-	tableMeta.AddPrimaryKeyColumn("LockID", tablestore.PrimaryKeyType_STRING)
+	tableMeta.AddPrimaryKeyColumn(pkName, tablestore.PrimaryKeyType_STRING)
 
 	tableOption := new(tablestore.TableOption)
 	tableOption.TimeToAlive = -1

--- a/backend/remote-state/oss/backend_test.go
+++ b/backend/remote-state/oss/backend_test.go
@@ -177,11 +177,11 @@ func deleteOSSBucket(t *testing.T, ossClient *oss.Client, bucketName string) {
 	}
 }
 
-// create the dynamoDB table, and wait until we can query it.
+// create the tablestore table, and wait until we can query it.
 func createTablestoreTable(t *testing.T, otsClient *tablestore.TableStoreClient, tableName string) {
 	tableMeta := new(tablestore.TableMeta)
 	tableMeta.TableName = tableName
-	tableMeta.AddPrimaryKeyColumn("testbackend", tablestore.PrimaryKeyType_STRING)
+	tableMeta.AddPrimaryKeyColumn("LockID", tablestore.PrimaryKeyType_STRING)
 
 	tableOption := new(tablestore.TableOption)
 	tableOption.TimeToAlive = -1

--- a/backend/remote-state/oss/client.go
+++ b/backend/remote-state/oss/client.go
@@ -181,7 +181,7 @@ func (c *RemoteClient) Lock(info *state.LockInfo) (string, error) {
 		Columns: []tablestore.AttributeColumn{
 			{
 				ColumnName: "LockID",
-				Value:      c.lockFile,
+				Value:      c.lockPath(),
 			},
 			{
 				ColumnName: "Info",

--- a/backend/remote-state/oss/client.go
+++ b/backend/remote-state/oss/client.go
@@ -21,9 +21,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Store the last saved serial in tablestore with this suffix for consistency checks.
 const (
+	// Store the last saved serial in tablestore with this suffix for consistency checks.
 	stateIDSuffix = "-md5"
+
+	pkName = "LockID"
 )
 
 var (
@@ -165,7 +167,7 @@ func (c *RemoteClient) Lock(info *state.LockInfo) (string, error) {
 		PrimaryKey: &tablestore.PrimaryKey{
 			PrimaryKeys: []*tablestore.PrimaryKeyColumn{
 				{
-					ColumnName: "LockID",
+					ColumnName: pkName,
 					Value:      c.lockPath(),
 				},
 			},
@@ -214,12 +216,12 @@ func (c *RemoteClient) getMD5() ([]byte, error) {
 		PrimaryKey: &tablestore.PrimaryKey{
 			PrimaryKeys: []*tablestore.PrimaryKeyColumn{
 				{
-					ColumnName: "LockID",
+					ColumnName: pkName,
 					Value:      c.lockPath() + stateIDSuffix,
 				},
 			},
 		},
-		ColumnsToGet: []string{"LockID", "Digest"},
+		ColumnsToGet: []string{pkName, "Digest"},
 		MaxVersion:   1,
 	}
 
@@ -261,7 +263,7 @@ func (c *RemoteClient) putMD5(sum []byte) error {
 		PrimaryKey: &tablestore.PrimaryKey{
 			PrimaryKeys: []*tablestore.PrimaryKeyColumn{
 				{
-					ColumnName: "LockID",
+					ColumnName: pkName,
 					Value:      c.lockPath() + stateIDSuffix,
 				},
 			},
@@ -302,7 +304,7 @@ func (c *RemoteClient) deleteMD5() error {
 			PrimaryKey: &tablestore.PrimaryKey{
 				PrimaryKeys: []*tablestore.PrimaryKeyColumn{
 					{
-						ColumnName: "LockID",
+						ColumnName: pkName,
 						Value:      c.lockPath() + stateIDSuffix,
 					},
 				},
@@ -328,12 +330,12 @@ func (c *RemoteClient) getLockInfo() (*state.LockInfo, error) {
 		PrimaryKey: &tablestore.PrimaryKey{
 			PrimaryKeys: []*tablestore.PrimaryKeyColumn{
 				{
-					ColumnName: "LockID",
+					ColumnName: pkName,
 					Value:      c.lockPath(),
 				},
 			},
 		},
-		ColumnsToGet: []string{"LockID", "Info"},
+		ColumnsToGet: []string{pkName, "Info"},
 		MaxVersion:   1,
 	}
 
@@ -381,7 +383,7 @@ func (c *RemoteClient) Unlock(id string) error {
 			PrimaryKey: &tablestore.PrimaryKey{
 				PrimaryKeys: []*tablestore.PrimaryKeyColumn{
 					{
-						ColumnName: "LockID",
+						ColumnName: pkName,
 						Value:      c.lockPath(),
 					},
 				},

--- a/backend/remote-state/oss/client.go
+++ b/backend/remote-state/oss/client.go
@@ -8,6 +8,10 @@ import (
 	"io"
 
 	"encoding/hex"
+	"log"
+	"sync"
+	"time"
+
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
 	"github.com/hashicorp/go-multierror"
@@ -16,9 +20,6 @@ import (
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/state/remote"
 	"github.com/pkg/errors"
-	"log"
-	"sync"
-	"time"
 )
 
 // Store the last saved serial in tablestore with this suffix for consistency checks.

--- a/backend/remote-state/oss/client.go
+++ b/backend/remote-state/oss/client.go
@@ -158,6 +158,8 @@ func (c *RemoteClient) Lock(info *state.LockInfo) (string, error) {
 		return "", nil
 	}
 
+	info.Path = c.lockPath()
+
 	if info.ID == "" {
 		lockID, err := uuid.GenerateUUID()
 		if err != nil {

--- a/backend/remote-state/oss/client_test.go
+++ b/backend/remote-state/oss/client_test.go
@@ -85,6 +85,52 @@ func TestRemoteClientLocks(t *testing.T) {
 	remote.TestRemoteLocks(t, s1.(*remote.State).Client, s2.(*remote.State).Client)
 }
 
+// verify that the backend can handle more than one state in the same table
+func TestRemoteClientLocks_multipleStates(t *testing.T) {
+	testACC(t)
+	bucketName := fmt.Sprintf("tf-remote-oss-test-force-%x", time.Now().Unix())
+	tableName := fmt.Sprintf("tfRemoteTestForce%x", time.Now().Unix())
+	path := "testState"
+
+	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
+		"bucket":              bucketName,
+		"prefix":              path,
+		"encrypt":             true,
+		"tablestore_table":    tableName,
+		"tablestore_endpoint": RemoteTestUsedOTSEndpoint,
+	})).(*Backend)
+
+	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
+		"bucket":              bucketName,
+		"prefix":              path,
+		"encrypt":             true,
+		"tablestore_table":    tableName,
+		"tablestore_endpoint": RemoteTestUsedOTSEndpoint,
+	})).(*Backend)
+
+	createOSSBucket(t, b1.ossClient, bucketName)
+	defer deleteOSSBucket(t, b1.ossClient, bucketName)
+	createTablestoreTable(t, b1.otsClient, tableName)
+	defer deleteTablestoreTable(t, b1.otsClient, tableName)
+
+	s1, err := b1.StateMgr("s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s1.Lock(state.NewLockInfo()); err != nil {
+		t.Fatal("failed to get lock for s1:", err)
+	}
+
+	// s1 is now locked, s2 should not be locked as it's a different state file
+	s2, err := b2.StateMgr("s2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s2.Lock(state.NewLockInfo()); err != nil {
+		t.Fatal("failed to get lock for s2:", err)
+	}
+}
+
 // verify that we can unlock a state with an existing lock
 func TestRemoteForceUnlock(t *testing.T) {
 	testACC(t)

--- a/backend/remote-state/oss/client_test.go
+++ b/backend/remote-state/oss/client_test.go
@@ -8,6 +8,7 @@ import (
 
 	"bytes"
 	"crypto/md5"
+
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/state/remote"

--- a/website/docs/backends/types/oss.html.md
+++ b/website/docs/backends/types/oss.html.md
@@ -18,9 +18,6 @@ the `tablestore_table` field to an existing TableStore table name.
 
 -> **Note:** The OSS backend is available from terraform version 0.12.2.
 
-!> **Warning:** If you set `tablestore_table`, please ensure the table does not contain primary key named
-`LockID`, `Info` and `Digest`. Otherwise, there will throw an error `OTSParameterInvalid Duplicated attribute column ...`.
-
 ## Example Configuration
 
 ```hcl
@@ -39,7 +36,7 @@ terraform {
 This assumes we have a [OSS Bucket](https://www.terraform.io/docs/providers/alicloud/r/oss_bucket.html) created called `bucket-for-terraform-state`,
 a [OTS Instance](https://www.terraform.io/docs/providers/alicloud/r/ots_instance.html) called `terraform-remote` and
 a [OTS TableStore](https://www.terraform.io/docs/providers/alicloud/r/ots_table.html) called `statelock`. The
-Terraform state will be written into the file `path/mystate/version-1.tfstate`. The `TableStore` must have a primary key of type `string`.
+Terraform state will be written into the file `path/mystate/version-1.tfstate`. The `TableStore` must have a primary key named `LockID` of type `String`.
 
 
 ## Using the OSS remote state
@@ -90,7 +87,7 @@ The following configuration options or environment variables are supported:
  * `prefix` - (Opeional) The path directory of the state file will be stored. Default to "env:".
  * `key` - (Optional) The name of the state file. Defaults to `terraform.tfstate`.
  * `tablestore_endpoint` / `ALICLOUD_TABLESTORE_ENDPOINT` - (Optional) A custom endpoint for the TableStore API.
- * `tablestore_table` - (Optional) A TableStore table for state locking and consistency.
+ * `tablestore_table` - (Optional) A TableStore table for state locking and consistency. The table must have a primary key named `LockID` of type `String`.
  * `encrypt` - (Optional) Whether to enable server side
    encryption of the state file. If it is true, OSS will use 'AES256' encryption algorithm to encrypt state file.
  * `acl` - (Optional) [Object
@@ -113,4 +110,3 @@ The nested `assume_role` block supports the following:
 * `session_expiration` - (Optional) The time after which the established session for assuming role expires. Valid value range: [900-3600] seconds. Default to 3600 (in this case Alibaba Cloud use own default value). It supports environment variable `ALICLOUD_ASSUME_ROLE_SESSION_EXPIRATION`.
 
 -> **Note:** If you want to store state in the custom OSS endpoint, you can specify a environment variable `OSS_ENDPOINT`, like "oss-cn-beijing-internal.aliyuncs.com"
-


### PR DESCRIPTION
While using the OSS backend with Terragrunt, which can execute many Terraform modules in parallel, I found multiple bugs in the way the backend handles state locking via Tablestore.

## Current behavior

Currently, the locking works as follows:

- User creates a Tablestore table with some arbitrary primary key
- The backend discovers this primary key and *always* writes the fixed string "terraform-remote-state-lock" to it
- The backend then tries to update/delete rows based on this primary key alone, ignoring any other attributes

| Something (PK) | Digest | Info |
|-------------|--------|-----|
| terraform-remote-state-lock | (empty) | {ID: ...} |
| terraform-remote-state-lock-md5 | \<hash\> | (empty) |

This won't work when having more than one lock in the table at a time. What the backend actually does is provide *a global lock* for Terraform, not per-module locking.

For the same reason, MD5 hashing is broken as there can only be one hash at a time.

## New behavior

This PR changes the logic to follow the more obvious data model of DynamoDB, which requires users to create a Tablestore table with a primary key named `LockID`:

| LockID (PK) | Digest | Info |
|-------------|--------|-----|
| \<statefile-path\> | (empty) | {ID: ...} |
| \<statefile-path\>-md5 | \<hash\> | (empty) |

**Note that this breaks backward compatibility since the schema of the Tablestore table is different.** I tried to fix the backend without having to change the schema, but couldn't make it work, even with additional row conditions/filters.

Tests are passing too:

```
$ TF_ACC=1 go test ./backend/remote-state/oss/
ok      github.com/hashicorp/terraform/backend/remote-state/oss 24.788s
```

cc @arafato @xiaozhu36