### PR TITLE
website: Label backend data source examples as "data source configuration"

### DIFF
--- a/website/docs/backends/types/artifactory.html.md
+++ b/website/docs/backends/types/artifactory.html.md
@@ -33,7 +33,7 @@ terraform {
 }
 ```
 
-## Example Referencing
+## Data Source Configuration
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/backends/types/azurerm.html.md
+++ b/website/docs/backends/types/azurerm.html.md
@@ -77,7 +77,7 @@ terraform {
 
 -> **NOTE:** When using a Service Principal or an Access Key - we recommend using a [Partial Configuration](/docs/backends/config.html) for the credentials.
 
-## Example Referencing
+## Data Source Configuration
 
 When authenticating using a Service Principal:
 

--- a/website/docs/backends/types/consul.html.md
+++ b/website/docs/backends/types/consul.html.md
@@ -29,7 +29,7 @@ terraform {
 Note that for the access credentials we recommend using a
 [partial configuration](/docs/backends/config.html).
 
-## Example Referencing
+## Data Source Configuration
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/backends/types/cos.html.md
+++ b/website/docs/backends/types/cos.html.md
@@ -31,9 +31,9 @@ terraform {
 This assumes we have a [COS Bucket](https://www.terraform.io/docs/providers/tencentcloud/r/cos_bucket.html) created named `bucket-for-terraform-state-1258798060`,
 Terraform state will be written into the file `terraform/state/terraform.tfstate`.
 
-## Using the COS remote state
+## Data Source Configuration
 
-To make use of the COS remote state we can use the [`terraform_remote_state` data source](/docs/providers/terraform/d/remote_state.html).
+To make use of the COS remote state in another configuration, use the [`terraform_remote_state` data source](/docs/providers/terraform/d/remote_state.html).
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/backends/types/etcd.html.md
+++ b/website/docs/backends/types/etcd.html.md
@@ -23,7 +23,7 @@ terraform {
 }
 ```
 
-## Example Referencing
+## Data Source Configuration
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/backends/types/etcdv3.html.md
+++ b/website/docs/backends/types/etcdv3.html.md
@@ -29,7 +29,7 @@ terraform {
 Note that for the access credentials we recommend using a
 [partial configuration](/docs/backends/config.html).
 
-## Example Referencing
+## Data Source Configuration
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/backends/types/gcs.html.md
+++ b/website/docs/backends/types/gcs.html.md
@@ -28,7 +28,7 @@ terraform {
 }
 ```
 
-## Example Referencing
+## Data Source Configuration
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/backends/types/http.html.md
+++ b/website/docs/backends/types/http.html.md
@@ -30,7 +30,7 @@ terraform {
 }
 ```
 
-## Example Referencing
+## Data Source Configuration
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/backends/types/local.html.md
+++ b/website/docs/backends/types/local.html.md
@@ -23,7 +23,7 @@ terraform {
 }
 ```
 
-## Example Reference
+## Data Source Configuration
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/backends/types/manta.html.md
+++ b/website/docs/backends/types/manta.html.md
@@ -26,7 +26,7 @@ terraform {
 Note that for the access credentials we recommend using a
 [partial configuration](/docs/backends/config.html).
 
-## Example Referencing
+## Data Source Configuration
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/backends/types/oss.html.md
+++ b/website/docs/backends/types/oss.html.md
@@ -42,9 +42,9 @@ a [OTS TableStore](https://www.terraform.io/docs/providers/alicloud/r/ots_table.
 Terraform state will be written into the file `path/mystate/version-1.tfstate`. The `TableStore` must have a primary key of type `string`.
 
 
-## Using the OSS remote state
+## Data Source Configuration
 
-To make use of the OSS remote state we can use the
+To make use of the OSS remote state in another configuration, use the
 [`terraform_remote_state` data
 source](/docs/providers/terraform/d/remote_state.html).
 

--- a/website/docs/backends/types/pg.html.md
+++ b/website/docs/backends/types/pg.html.md
@@ -52,9 +52,9 @@ To use a Postgres server running on the same machine as Terraform, configure loc
 terraform init -backend-config="conn_str=postgres://localhost/terraform_backend?sslmode=disable"
 ```
 
-## Example Referencing
+## Data Source Configuration
 
-To make use of the pg remote state we can use the [`terraform_remote_state` data source](/docs/providers/terraform/d/remote_state.html).
+To make use of the pg remote state in another configuration, use the [`terraform_remote_state` data source](/docs/providers/terraform/d/remote_state.html).
 
 ```hcl
 data "terraform_remote_state" "network" {

--- a/website/docs/backends/types/remote.html.md
+++ b/website/docs/backends/types/remote.html.md
@@ -91,7 +91,7 @@ set or requires a specific version of Terraform for remote operations, we
 recommend that you create your remote workspaces on Terraform Cloud before
 running any remote operations against them.
 
-## Example Configurations and References
+## Example Configurations
 
 ->  **Note:** We recommend omitting the token from the configuration, and instead using
   [`terraform login`](/docs/commands/login.html) or manually configuring
@@ -151,7 +151,7 @@ Running `terraform init` with the backend file:
 terraform init -backend-config=backend.hcl
 ```
 
-### Example Reference
+### Data Source Configuration
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -102,9 +102,9 @@ This is seen in the following AWS IAM Statement:
 }
 ```
 
-## Using the S3 remote state
+## Data Source Configuration
 
-To make use of the S3 remote state we can use the
+To make use of the S3 remote state in another configuration, use the
 [`terraform_remote_state` data
 source](/docs/providers/terraform/d/remote_state.html).
 

--- a/website/docs/backends/types/swift.html.md
+++ b/website/docs/backends/types/swift.html.md
@@ -29,7 +29,7 @@ This will create a container called `terraform-state` and an object within that 
 For the access credentials we recommend using a
 [partial configuration](/docs/backends/config.html).
 
-## Example Referencing
+## Data Source Configuration
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/backends/types/terraform-enterprise.html.md
+++ b/website/docs/backends/types/terraform-enterprise.html.md
@@ -42,7 +42,7 @@ terraform {
 We recommend using a [partial configuration](/docs/backends/config.html) and
 omitting the access token, which can be provided as an environment variable.
 
-## Example Referencing
+## Data Source Configuration
 
 ```hcl
 data "terraform_remote_state" "foo" {


### PR DESCRIPTION
"Example referencing" was ambiguous and confusing, especially since these
sections don't show how to reference an output in an expression.