### PR TITLE
Escape double quotes in alphanumerical indexing

### DIFF
--- a/website/docs/internals/resource-addressing.html.markdown
+++ b/website/docs/internals/resource-addressing.html.markdown
@@ -101,7 +101,7 @@ resource "aws_instance" "web" {
 An address like this:
 
 ```
-aws_instance.web["example"]
+aws_instance.web[\"example\"]
 ```
 
 Refers to only the "example" instance in the config.


### PR DESCRIPTION
This is just a minor fix for the documentation.