### PR TITLE
Destroy provisioner each.key

### DIFF
--- a/addrs/instance_key.go
+++ b/addrs/instance_key.go
@@ -18,6 +18,10 @@ import (
 type InstanceKey interface {
 	instanceKeySigil()
 	String() string
+
+	// Value returns the cty.Value of the appropriate type for the InstanceKey
+	// value.
+	Value() cty.Value
 }
 
 // ParseInstanceKey returns the instance key corresponding to the given value,
@@ -56,6 +60,10 @@ func (k IntKey) String() string {
 	return fmt.Sprintf("[%d]", int(k))
 }
 
+func (k IntKey) Value() cty.Value {
+	return cty.NumberIntVal(int64(k))
+}
+
 // StringKey is the InstanceKey representation representing string indices, as
 // used when the "for_each" argument is specified with a map or object type.
 type StringKey string
@@ -67,6 +75,10 @@ func (k StringKey) String() string {
 	// FIXME: This isn't _quite_ right because Go's quoted string syntax is
 	// slightly different than HCL's, but we'll accept it for now.
 	return fmt.Sprintf("[%q]", string(k))
+}
+
+func (k StringKey) Value() cty.Value {
+	return cty.StringVal(string(k))
 }
 
 // InstanceKeyLess returns true if the first given instance key i should sort

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -563,7 +563,10 @@ func (n *EvalApplyProvisioners) apply(ctx EvalContext, provs []*configs.Provisio
 
 		var forEach map[string]cty.Value
 
-		// We can't evaluate the for_each expression during a destroy
+		// For a destroy-time provisioner forEach is intentionally nil here,
+		// which EvalDataForInstanceKey responds to by not populating EachValue
+		// in its result. That's okay because each.value is prohibited for
+		// destroy-time provisioners.
 		if n.When != configs.ProvisionerWhenDestroy {
 			m, forEachDiags := evaluateResourceForEachExpression(n.ResourceConfig.ForEach, ctx)
 			diags = diags.Append(forEachDiags)

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -104,6 +104,11 @@ type InstanceKeyEvalData = instances.RepetitionData
 
 // EvalDataForInstanceKey constructs a suitable InstanceKeyEvalData for
 // evaluating in a context that has the given instance key.
+//
+// The forEachMap argument can be nil when preparing for evaluation
+// in a context where each.value is prohibited, such as a destroy-time
+// provisioner. In that case, the returned EachValue will always be
+// cty.NilVal.
 func EvalDataForInstanceKey(key addrs.InstanceKey, forEachMap map[string]cty.Value) InstanceKeyEvalData {
 	var evalData InstanceKeyEvalData
 	if key == nil {

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -105,24 +105,20 @@ type InstanceKeyEvalData = instances.RepetitionData
 // EvalDataForInstanceKey constructs a suitable InstanceKeyEvalData for
 // evaluating in a context that has the given instance key.
 func EvalDataForInstanceKey(key addrs.InstanceKey, forEachMap map[string]cty.Value) InstanceKeyEvalData {
-	var countIdx cty.Value
-	var eachKey cty.Value
-	var eachVal cty.Value
-
-	if intKey, ok := key.(addrs.IntKey); ok {
-		countIdx = cty.NumberIntVal(int64(intKey))
+	var evalData InstanceKeyEvalData
+	if key == nil {
+		return evalData
 	}
 
-	if stringKey, ok := key.(addrs.StringKey); ok {
-		eachKey = cty.StringVal(string(stringKey))
-		eachVal = forEachMap[string(stringKey)]
+	keyValue := key.Value()
+	switch keyValue.Type() {
+	case cty.String:
+		evalData.EachKey = keyValue
+		evalData.EachValue = forEachMap[keyValue.AsString()]
+	case cty.Number:
+		evalData.CountIndex = keyValue
 	}
-
-	return InstanceKeyEvalData{
-		CountIndex: countIdx,
-		EachKey:    eachKey,
-		EachValue:  eachVal,
-	}
+	return evalData
 }
 
 // EvalDataForNoInstanceKey is a value of InstanceKeyData that sets no instance

--- a/terraform/testdata/apply-provisioner-destroy/main.tf
+++ b/terraform/testdata/apply-provisioner-destroy/main.tf
@@ -1,12 +1,18 @@
 resource "aws_instance" "foo" {
+    for_each = var.input
     foo = "bar"
 
     provisioner "shell" {
-        command = "create"
+        command = "create ${each.key} ${each.value}"
     }
 
     provisioner "shell" {
-        command  = "destroy"
         when = "destroy"
+        command  = "destroy ${each.key}"
     }
+}
+
+variable "input" {
+  type = map(string)
+  default = {}
 }


### PR DESCRIPTION
Destroy provisioners have access to the `each.key` value, but they cannot access it by evaluating the `for_each` expressions and must extract it from the instance address.

Fixes #24139