### PR TITLE
Prevent unknowns in provider config

### DIFF
--- a/terraform/eval_provider.go
+++ b/terraform/eval_provider.go
@@ -78,6 +78,10 @@ func (n *EvalConfigProvider) Eval(ctx EvalContext) (interface{}, error) {
 		return nil, diags.NonFatalErr()
 	}
 
+	if !configVal.IsWhollyKnown() {
+		return nil, fmt.Errorf("EvalConfigProvider %s configuration contains unknown values", n.Addr)
+	}
+
 	configDiags := ctx.ConfigureProvider(n.Addr, configVal)
 	configDiags = configDiags.InConfigBody(configBody)
 


### PR DESCRIPTION
Providers cannot be configured with unknown value, but we lost the check preventing these from being applied. Most providers will ignores these values and apply defaults, which leads to resources possibly be applied through an incorrectly configured provider.

Since we do allow referencing resources from provider configurations, either directly or indirectly through module inputs, we can't statically check for unknowns in the config. Instead, we need to catch them immediately before `ConfigureProvider`.

Fixes #24131