### PR TITLE
backend/plan: Show warnings even if no changes are needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ IMPROVEMENTS:
 * backend/http: New options for retries on outgoing requests. [GH-19702]
 * communicator/ssh: Keepalive support [GH-20437]
 
+BUG FIXES: 
+
+* cli: The `terraform plan` command (and the implied plan run by `terraform apply` with no arguments) will now print any warnings that were generated even if there are no changes to be made. [GH-24095]
+
 ## 0.11.14 (May 16, 2019)
 
 NEW FEATURES:

--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -129,6 +129,8 @@ func (b *Local) opPlan(
 		dispPlan := format.NewPlan(plan)
 		if dispPlan.Empty() {
 			b.CLI.Output("\n" + b.Colorize().Color(strings.TrimSpace(planNoChanges)))
+			// Even if there are no changes, there still could be some warnings
+			b.ShowDiagnostics(diags)
 			return
 		}
 


### PR DESCRIPTION
Backport of https://github.com/hashicorp/terraform/pull/24095
Fixes https://github.com/hashicorp/terraform/issues/22541 for v0.11