### PR TITLE
lang/funcs: templatefile requires valid variable names

### DIFF
--- a/lang/funcs/filesystem_test.go
+++ b/lang/funcs/filesystem_test.go
@@ -88,6 +88,14 @@ func TestTemplateFile(t *testing.T) {
 		},
 		{
 			cty.StringVal("testdata/hello.tmpl"),
+			cty.MapVal(map[string]cty.Value{
+				"name!": cty.StringVal("Jodie"),
+			}),
+			cty.NilVal,
+			`invalid template variable name "name!": must start with a letter, followed by zero or more letters, digits, and underscores`,
+		},
+		{
+			cty.StringVal("testdata/hello.tmpl"),
 			cty.ObjectVal(map[string]cty.Value{
 				"name": cty.StringVal("Jimbo"),
 			}),

--- a/website/docs/configuration/functions/templatefile.html.md
+++ b/website/docs/configuration/functions/templatefile.html.md
@@ -29,7 +29,9 @@ into a separate file for readability.
 The "vars" argument must be a map. Within the template file, each of the keys
 in the map is available as a variable for interpolation. The template may
 also use any other function available in the Terraform language, except that
-recursive calls to `templatefile` are not permitted.
+recursive calls to `templatefile` are not permitted. Variable names must
+each start with a letter, followed by zero or more letters, digits, or
+underscores.
 
 Strings in the Terraform language are sequences of Unicode characters, so
 this function will interpret the file contents as UTF-8 encoded text and


### PR DESCRIPTION
Previously the `templatefile` function would permit any arbitrary string as a variable name, but due to the HCL template syntax it would be impossible to refer to one that isn't a valid HCL identifier without causing an HCL syntax error.

The HCL syntax errors are correct, but don't really point to the root cause of the problem. Instead, we'll pre-verify that the variable names are valid before we even try to render the template, and given a specialized error message that refers to the vars argument expression as the problematic part, which will hopefully make the resolution path clearer for a user encountering this situation.

```
invalid template variable name "<invalid>": must start with
a letter, followed by zero or more letters, digits, and
underscores.
```

The syntax error still remains for situations where all of the variable names are correct but e.g. the user made a typo referring to one, which makes sense because in that case the problem _is_ inside the template.

I've marked this as a breaking change because technically a user could previously have had a `templatefile` call with an invalid variable name as long as they didn't try to refer to that variable name in the template itself. While that situation seems unlikely, we will still call it out explicitly in the changelog once merged, and we must not backport this change to a Terraform 0.12 minor release.

This closes #23789.