### PR TITLE
command/init: new error message for signature verification failure

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/hashicorp/terraform/version"
 )
 
 // InitCommand is a Command implementation that takes a Terraform
@@ -568,7 +569,7 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 					// Generic version incompatible msg
 					c.Ui.Error(fmt.Sprintf(errProviderIncompatible, provider, constraint))
 				case err == discovery.ErrorSignatureVerification:
-					c.Ui.Error(fmt.Sprintf(errSignatureVerification, provider))
+					c.Ui.Error(fmt.Sprintf(errSignatureVerification, provider, version.SemVer))
 				case err == discovery.ErrorChecksumVerification,
 					err == discovery.ErrorMissingChecksumVerification:
 					c.Ui.Error(fmt.Sprintf(errChecksumVerification, provider))
@@ -1020,9 +1021,12 @@ were changed after this version was released to the Registry.
 `
 
 const errSignatureVerification = `
-[reset][bold][red]Error verifying GPG signature for provider %[1]q[reset][red]
-Terraform was unable to verify the GPG signature of the downloaded provider
-files using the keys downloaded from the Terraform Registry. This may mean that
-the publisher of the provider removed the key it was signed with, or that the
-distributed files were changed after this version was released.
+[reset][bold][red]Error:[reset][bold] Untrusted signing key for provider %[1]q[reset]
+
+This provider package is not signed with the HashiCorp signing key, and is
+therefore incompatible with Terraform v%[2]s.
+
+A later version of Terraform may have introduced other signing keys that would
+accept this provider. Alternatively, an earlier version of this provider may
+be compatible with Terraform v%[2]s.
 `


### PR DESCRIPTION
Our initial Terraform 0.13.0 release is expected to continue to support only the hard-coded official HashiCorp signing key, with support for other keys to follow in a later release once the trust infrastructure is in place to support that.

This change is intended to (marginally) improve the UX for a possible future situation where a HashiCorp-distributed provider makes a released signed with a new key and a prior version of Terraform ends up trying to install it due to incorrect version constraints. With this new text we
hope to give the user a better prompt for onward troubleshooting, but in a sort of hedging way because we have not yet finalized the details of how new keys might roll out in practice.

```
Error: Untrusted signing key for provider "null"

This provider package is not signed with the HashiCorp signing key, and is
therefore incompatible with Terraform v0.13.0.

A later version of Terraform may have introduced other signing keys that would
accept this provider. Alternatively, an earlier version of this provider may
be compatible with Terraform v0.13.0.
```

Hopefully a user seeing this message would consult the release notes for Terraform itself and for the provider in question and find some as-yet-undetermined information about how to proceed. This message is not ideal by any means, but is at least more actionable than the one it's replacing, which included some suggested causes that cannot arise in the current process in practice. (The old text is talking about situations that would arise only in the distributed trust model expected to come in later commits.)

If the decentralized trust model design comes together before the v0.13.0 release then we may make further amendments here to give more explicit guidance based on that design, but that work should not block the v0.13.0 release if other work concludes first.
