### PR TITLE
update computed field error message more descriptive

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1362,7 +1362,7 @@ func (m schemaMap) validate(
 	if !schema.Required && !schema.Optional {
 		// This is a computed-only field
 		return nil, []error{fmt.Errorf(
-			"%q: this field cannot be set", k)}
+			"%q: computed field was not set", k)}
 	}
 
 	// If the value is unknown then we can't validate it yet.


### PR DESCRIPTION
This pr makes the error message for `computed field` errors to be more descriptive.

I ran into this error message earlier today. It took me a while to figure out the schema was using a computed field. Hopefully this rewording of the error message will mitigate that!