### PR TITLE
registry: configurable client timeout

### DIFF
--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-svchost/disco"
@@ -47,6 +48,43 @@ func TestConfigureDiscoveryRetry(t *testing.T) {
 		if rc.client.RetryMax != expected {
 			t.Fatalf("expected client retry %q, got %q",
 				expected, rc.client.RetryMax)
+		}
+	})
+}
+
+func TestConfigureRegistryClientTimeout(t *testing.T) {
+	t.Run("default timeout", func(t *testing.T) {
+		if requestTimeout != defaultRequestTimeout {
+			t.Fatalf("expected timeout %q, got %q",
+				defaultRequestTimeout.String(), requestTimeout.String())
+		}
+
+		rc := NewClient(nil, nil)
+		if rc.client.HTTPClient.Timeout != defaultRequestTimeout {
+			t.Fatalf("expected client timeout %q, got %q",
+				defaultRequestTimeout.String(), rc.client.HTTPClient.Timeout.String())
+		}
+	})
+
+	t.Run("configured timeout", func(t *testing.T) {
+		defer func() {
+			os.Setenv(registryClientTimeoutEnvName,
+				os.Getenv(registryClientTimeoutEnvName))
+			requestTimeout = defaultRequestTimeout
+		}()
+		os.Setenv(registryClientTimeoutEnvName, "20")
+
+		configureRequestTimeout()
+		expected := 20 * time.Second
+		if requestTimeout != expected {
+			t.Fatalf("expected timeout %q, got %q",
+				expected, requestTimeout.String())
+		}
+
+		rc := NewClient(nil, nil)
+		if rc.client.HTTPClient.Timeout != expected {
+			t.Fatalf("expected client timeout %q, got %q",
+				expected, rc.client.HTTPClient.Timeout.String())
 		}
 	})
 }

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -67,11 +67,10 @@ func TestConfigureRegistryClientTimeout(t *testing.T) {
 	})
 
 	t.Run("configured timeout", func(t *testing.T) {
-		defer func() {
-			os.Setenv(registryClientTimeoutEnvName,
-				os.Getenv(registryClientTimeoutEnvName))
+		defer func(timeoutEnv string) {
+			os.Setenv(registryClientTimeoutEnvName, timeoutEnv)
 			requestTimeout = defaultRequestTimeout
-		}()
+		}(os.Getenv(registryClientTimeoutEnvName))
 		os.Setenv(registryClientTimeoutEnvName, "20")
 
 		configureRequestTimeout()

--- a/website/docs/commands/environment-variables.html.md
+++ b/website/docs/commands/environment-variables.html.md
@@ -120,6 +120,14 @@ Set `TF_REGISTRY_DISCOVERY_RETRY` to configure the max number of request retries
 the remote registry client will attempt for client connection errors or
 500-range responses that are safe to retry.
 
+## TF_REGISTRY_CLIENT_TIMEOUT
+
+The default client timeout for requests to the remote registry is 10s. `TF_REGISTRY_CLIENT_TIMEOUT` can be configured and increased during extraneous circumstances.
+
+```shell
+export TF_REGISTRY_CLIENT_TIMEOUT=15
+```
+
 ## TF_CLI_CONFIG_FILE
 
 The location of the [Terraform CLI configuration file](/docs/commands/cli-config.html).


### PR DESCRIPTION
This PR introduces no breaking changes. It adds the option to configure the remote registry client timeout duration with the environment variable `TF_REGISTRY_CLIENT_TIMEOUT`. This may be useful during extraneous circumstances to mediate server issues with the remote registry.