### PR TITLE
lang: Fix non-string key panics in map function

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -346,12 +346,14 @@ var MapFunc = function.New(&function.Spec{
 
 		for i := 0; i < len(args); i += 2 {
 
-			key := args[i].AsString()
-
-			err := gocty.FromCtyValue(args[i], &key)
+			keyVal, err := convert.Convert(args[i], cty.String)
 			if err != nil {
 				return cty.NilVal, err
 			}
+			if keyVal.IsNull() {
+				return cty.NilVal, fmt.Errorf("argument %d is a null key", i+1)
+			}
+			key := keyVal.AsString()
 
 			val := args[i+1]
 


### PR DESCRIPTION
The map function assumed that the key arguments were strings, and would panic if they were not.

After this commit, calling `map(1, 2)` will result in a map `{"1" = 2}`, and calling `map(null, 1)` will result in a syntax error.

```
$ terraform console
> map(1, 2)
{
  "1" = 2
}
> map(null, 1)

>
Error: Error in function call

  on <console-input> line 1:
  (source code not available)

Call to function "map" failed: argument 1 is a null key.
```

Fixes #23346, fixes #23043