### PR TITLE
Mildwonkey/ps schema

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -195,15 +195,18 @@ func (c *Config) gatherProviderTypes(m map[addrs.Provider]struct{}) {
 	// the true provider addresses via the local-to-FQN mapping table
 	// stored inside c.Module.
 	for _, pc := range c.Module.ProviderConfigs {
-		m[addrs.NewLegacyProvider(pc.Name)] = struct{}{}
+		fqn := c.Module.ProviderForLocalConfig(addrs.LocalProviderConfig{LocalName: pc.Name})
+		m[fqn] = struct{}{}
 	}
 	for _, rc := range c.Module.ManagedResources {
 		providerAddr := rc.ProviderConfigAddr()
-		m[addrs.NewLegacyProvider(providerAddr.LocalName)] = struct{}{}
+		fqn := c.Module.ProviderForLocalConfig(providerAddr)
+		m[fqn] = struct{}{}
 	}
 	for _, rc := range c.Module.DataResources {
 		providerAddr := rc.ProviderConfigAddr()
-		m[addrs.NewLegacyProvider(providerAddr.LocalName)] = struct{}{}
+		fqn := c.Module.ProviderForLocalConfig(providerAddr)
+		m[fqn] = struct{}{}
 	}
 
 	// Must also visit our child modules, recursively.
@@ -263,5 +266,8 @@ func (c *Config) ResolveAbsProviderAddr(addr addrs.ProviderConfig, inModule addr
 // by checking for the provider in module.ProviderRequirements and falling
 // back to addrs.NewLegacyProvider if it is not found.
 func (c *Config) ProviderForConfigAddr(addr addrs.LocalProviderConfig) addrs.Provider {
+	if provider, exists := c.Module.ProviderRequirements[addr.LocalName]; exists {
+		return provider.Type
+	}
 	return c.ResolveAbsProviderAddr(addr, addrs.RootModuleInstance).Provider
 }

--- a/configs/module_merge.go
+++ b/configs/module_merge.go
@@ -44,6 +44,7 @@ func mergeProviderVersionConstraints(recv map[string]ProviderRequirements, ovrd 
 	}
 	for _, reqd := range ovrd {
 		fqn := addrs.NewLegacyProvider(reqd.Name)
+		fmt.Printf("reqd: %#v\n", reqd)
 		recv[reqd.Name] = ProviderRequirements{Type: fqn, VersionConstraints: []VersionConstraint{reqd.Requirement}}
 	}
 }

--- a/moduledeps/module.go
+++ b/moduledeps/module.go
@@ -112,7 +112,7 @@ func (m *Module) PluginRequirements() discovery.PluginRequirements {
 	for pFqn, dep := range m.Providers {
 		// TODO: discovery.PluginRequirements should be refactored and use
 		// addrs.Provider as the map keys
-		provider := pFqn.LegacyString()
+		provider := pFqn.String()
 		if existing, exists := ret[provider]; exists {
 			ret[provider].Versions = existing.Versions.Append(dep.Constraints)
 		} else {

--- a/providers/resolver.go
+++ b/providers/resolver.go
@@ -40,7 +40,7 @@ func ResolverFixed(factories map[addrs.Provider]Factory) Resolver {
 		ret := make(map[addrs.Provider]Factory, len(reqd))
 		var errs []error
 		for name := range reqd {
-			fqn := addrs.NewLegacyProvider(name)
+			fqn, _ := addrs.ParseProviderSourceString(name)
 			if factory, exists := factories[fqn]; exists {
 				ret[fqn] = factory
 			} else {

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -41,7 +41,7 @@ func TestContext2Apply_basic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -84,7 +84,7 @@ func TestContext2Apply_unstable(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -140,7 +140,7 @@ func TestContext2Apply_escape(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -157,7 +157,7 @@ func TestContext2Apply_escape(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = "bar"
   type = aws_instance
 `)
@@ -172,7 +172,7 @@ func TestContext2Apply_resourceCountOneList(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("null"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("null"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -187,7 +187,7 @@ func TestContext2Apply_resourceCountOneList(t *testing.T) {
 	got := strings.TrimSpace(state.String())
 	want := strings.TrimSpace(`null_resource.foo.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/null"]
+  provider = provider["registry.terraform.io/hashicorp/null"]
 
 Outputs:
 
@@ -205,7 +205,7 @@ func TestContext2Apply_resourceCountZeroList(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("null"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("null"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -263,7 +263,7 @@ func TestContext2Apply_resourceDependsOnModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -300,7 +300,7 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"parent"}`),
 			Dependencies: []addrs.AbsResource{mustResourceAddr("module.child.aws_instance.child")},
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
 	child.SetResourceInstanceCurrent(
@@ -309,7 +309,7 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"child"}`),
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 
 	{
@@ -342,7 +342,7 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 			State: state,
@@ -375,7 +375,7 @@ func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -422,7 +422,7 @@ func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 			State:   globalState,
@@ -481,7 +481,7 @@ func TestContext2Apply_resourceDependsOnModuleGrandchild(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -534,7 +534,7 @@ func TestContext2Apply_resourceDependsOnModuleInModule(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -565,7 +565,7 @@ func TestContext2Apply_mapVarBetweenModules(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("null"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("null"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -588,7 +588,7 @@ amis_from_module = {eu-west-1:ami-789012 eu-west-2:ami-989484 us-west-1:ami-1234
 module.test:
   null_resource.noop:
     ID = foo
-    provider = provider["registry.terraform.io/-/null"]
+    provider = provider["registry.terraform.io/hashicorp/null"]
 
   Outputs:
 
@@ -607,7 +607,7 @@ func TestContext2Apply_refCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -642,7 +642,7 @@ func TestContext2Apply_providerAlias(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -680,7 +680,7 @@ func TestContext2Apply_providerAliasConfigure(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("another"): testProviderFuncFixed(p2),
+				addrs.NewDefaultProvider("another"): testProviderFuncFixed(p2),
 			},
 		),
 	})
@@ -738,7 +738,7 @@ func TestContext2Apply_providerWarning(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -756,7 +756,7 @@ func TestContext2Apply_providerWarning(t *testing.T) {
 	expected := strings.TrimSpace(`
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 	`)
 	if actual != expected {
 		t.Fatalf("got: \n%s\n\nexpected:\n%s", actual, expected)
@@ -777,7 +777,7 @@ func TestContext2Apply_emptyModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -826,7 +826,7 @@ func TestContext2Apply_createBeforeDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -883,7 +883,7 @@ func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -951,7 +951,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -971,7 +971,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   require_new = yes
   type = aws_instance
   value = foo
@@ -980,7 +980,7 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   require_new = yes
   type = aws_instance
 	`)
@@ -1027,7 +1027,7 @@ func TestContext2Apply_createBeforeDestroy_hook(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1105,7 +1105,7 @@ func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1125,12 +1125,12 @@ func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 	`)
@@ -1171,7 +1171,7 @@ func TestContext2Apply_createBeforeDestroy_deposedOnly(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -1191,7 +1191,7 @@ func TestContext2Apply_createBeforeDestroy_deposedOnly(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 	`)
 }
 
@@ -1223,7 +1223,7 @@ func TestContext2Apply_destroyComputed(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -1266,7 +1266,7 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo").Resource,
@@ -1275,7 +1275,7 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"foo"}`),
 			Dependencies: []addrs.AbsResource{mustResourceAddr("aws_instance.bar")},
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 
 	// Record the order we see Apply
@@ -1293,7 +1293,7 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State:       state,
@@ -1332,7 +1332,7 @@ func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
 			Dependencies: []addrs.AbsResource{},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("aws"),
+			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -1357,7 +1357,7 @@ func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
 			},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("aws"),
+			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -1391,7 +1391,7 @@ func testContext2Apply_destroyDependsOnStateOnly(t *testing.T, state *states.Sta
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State:       state,
@@ -1430,7 +1430,7 @@ func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
 			Dependencies: []addrs.AbsResource{},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("aws"),
+			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -1455,7 +1455,7 @@ func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
 			},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("aws"),
+			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -1490,7 +1490,7 @@ func testContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T, state *stat
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State:       state,
@@ -1528,7 +1528,7 @@ func TestContext2Apply_dataBasic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("null"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("null"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1578,7 +1578,7 @@ func TestContext2Apply_destroyData(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("null"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("null"): testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -1649,7 +1649,7 @@ func TestContext2Apply_destroySkipsCBD(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -1691,7 +1691,7 @@ func TestContext2Apply_destroyModuleVarProviderConfig(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -1737,7 +1737,7 @@ func TestContext2Apply_destroyCrossProviders(t *testing.T) {
 	}
 
 	providers := map[addrs.Provider]providers.Factory{
-		addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p_aws),
+		addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p_aws),
 	}
 
 	// Bug only appears from time to time,
@@ -1814,7 +1814,7 @@ func TestContext2Apply_minimal(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1844,7 +1844,7 @@ func TestContext2Apply_badDiff(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1879,7 +1879,7 @@ func TestContext2Apply_cancel(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -1958,7 +1958,7 @@ func TestContext2Apply_cancelBlock(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2040,7 +2040,7 @@ func TestContext2Apply_cancelBlock(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
 	`)
 }
@@ -2067,7 +2067,7 @@ func TestContext2Apply_cancelProvisioner(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -2109,7 +2109,7 @@ func TestContext2Apply_cancelProvisioner(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo: (tainted)
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 	`)
@@ -2165,7 +2165,7 @@ func TestContext2Apply_compute(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2241,7 +2241,7 @@ func TestContext2Apply_countDecrease(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -2302,7 +2302,7 @@ func TestContext2Apply_countDecreaseToOneX(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -2366,7 +2366,7 @@ func TestContext2Apply_countDecreaseToOneCorrupted(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -2423,7 +2423,7 @@ func TestContext2Apply_countTainted(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -2455,12 +2455,12 @@ CREATE: aws_instance.foo[1]
 	want := strings.TrimSpace(`
 aws_instance.foo.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 `)
@@ -2478,7 +2478,7 @@ func TestContext2Apply_countVariable(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2508,7 +2508,7 @@ func TestContext2Apply_countVariableRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2544,7 +2544,7 @@ func TestContext2Apply_provisionerInterpCount(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 		},
 	)
 	provisioners := map[string]ProvisionerFactory{
@@ -2598,7 +2598,7 @@ func TestContext2Apply_foreachVariable(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -2633,7 +2633,7 @@ func TestContext2Apply_moduleBasic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2700,7 +2700,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"a"}`),
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 	root := state.EnsureModule(addrs.RootModuleInstance)
 	root.SetResourceInstanceCurrent(
@@ -2710,14 +2710,14 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"b"}`),
 			Dependencies: []addrs.AbsResource{mustResourceAddr("module.child.aws_instance.a")},
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -2769,7 +2769,7 @@ func TestContext2Apply_moduleInheritAlias(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2788,7 +2788,7 @@ func TestContext2Apply_moduleInheritAlias(t *testing.T) {
 module.child:
   aws_instance.foo:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"].eu
+    provider = provider["registry.terraform.io/hashicorp/aws"].eu
 	`)
 }
 
@@ -2814,7 +2814,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2827,7 +2827,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 	// with the single instance associated with test_thing.one.
 	want := states.BuildState(func(s *states.SyncState) {
 		providerAddr := addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModuleInstance,
 		}
 		zeroAddr := addrs.Resource{
@@ -2860,7 +2860,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2922,7 +2922,7 @@ func TestContext2Apply_moduleOrphanInheritAlias(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -2980,7 +2980,7 @@ func TestContext2Apply_moduleOrphanProvider(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3031,7 +3031,7 @@ func TestContext2Apply_moduleOrphanGrandchildProvider(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3068,7 +3068,7 @@ func TestContext2Apply_moduleGrandchildProvider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3105,8 +3105,8 @@ func TestContext2Apply_moduleOnlyProvider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"):  testProviderFuncFixed(p),
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(pTest),
+				addrs.NewDefaultProvider("aws"):  testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(pTest),
 			},
 		),
 	})
@@ -3136,7 +3136,7 @@ func TestContext2Apply_moduleProviderAlias(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3166,7 +3166,7 @@ func TestContext2Apply_moduleProviderAliasTargets(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -3208,7 +3208,7 @@ func TestContext2Apply_moduleProviderCloseNested(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -3273,7 +3273,7 @@ func TestContext2Apply_moduleVarRefExisting(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -3304,7 +3304,7 @@ func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -3328,7 +3328,7 @@ func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -3358,7 +3358,7 @@ func TestContext2Apply_moduleBool(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -3390,7 +3390,7 @@ func TestContext2Apply_moduleTarget(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -3412,7 +3412,7 @@ func TestContext2Apply_moduleTarget(t *testing.T) {
 module.A:
   aws_instance.foo:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     foo = bar
     type = aws_instance
 
@@ -3422,7 +3422,7 @@ module.A:
 module.B:
   aws_instance.bar:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     foo = foo
     type = aws_instance
 
@@ -3445,8 +3445,8 @@ func TestContext2Apply_multiProvider(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
-				addrs.NewLegacyProvider("do"):  testProviderFuncFixed(pDO),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("do"):  testProviderFuncFixed(pDO),
 			},
 		),
 	})
@@ -3513,8 +3513,8 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"):   testProviderFuncFixed(p),
-					addrs.NewLegacyProvider("vault"): testProviderFuncFixed(p2),
+					addrs.NewDefaultProvider("aws"):   testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("vault"): testProviderFuncFixed(p2),
 				},
 			),
 		})
@@ -3570,8 +3570,8 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 			Config:  m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"):   testProviderFuncFixed(p),
-					addrs.NewLegacyProvider("vault"): testProviderFuncFixed(p2),
+					addrs.NewDefaultProvider("aws"):   testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("vault"): testProviderFuncFixed(p2),
 				},
 			),
 		})
@@ -3640,8 +3640,8 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"):   testProviderFuncFixed(p),
-					addrs.NewLegacyProvider("vault"): testProviderFuncFixed(p2),
+					addrs.NewDefaultProvider("aws"):   testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("vault"): testProviderFuncFixed(p2),
 				},
 			),
 		})
@@ -3697,8 +3697,8 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 			Config:  m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"):   testProviderFuncFixed(p),
-					addrs.NewLegacyProvider("vault"): testProviderFuncFixed(p2),
+					addrs.NewDefaultProvider("aws"):   testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("vault"): testProviderFuncFixed(p2),
 				},
 			),
 		})
@@ -3735,7 +3735,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -3770,7 +3770,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 			State:  state,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 			Variables: InputValues{
@@ -3878,7 +3878,7 @@ func TestContext2Apply_multiVarComprehensive(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 		Variables: InputValues{
@@ -4031,7 +4031,7 @@ func TestContext2Apply_multiVarOrder(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4067,7 +4067,7 @@ func TestContext2Apply_multiVarOrderInterp(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4105,7 +4105,7 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 			Variables: InputValues{
@@ -4173,7 +4173,7 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 			Variables: InputValues{
@@ -4233,7 +4233,7 @@ func TestContext2Apply_multiVarMissingState(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4259,7 +4259,7 @@ func TestContext2Apply_nilDiff(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4301,7 +4301,7 @@ func TestContext2Apply_outputDependsOn(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -4326,7 +4326,7 @@ func TestContext2Apply_outputDependsOn(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -4343,7 +4343,7 @@ func TestContext2Apply_outputDependsOn(t *testing.T) {
 		checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 
 Outputs:
 
@@ -4382,7 +4382,7 @@ func TestContext2Apply_outputOrphan(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -4432,7 +4432,7 @@ func TestContext2Apply_outputOrphanModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state.DeepCopy(),
@@ -4459,7 +4459,7 @@ func TestContext2Apply_outputOrphanModule(t *testing.T) {
 		Config: configs.NewEmptyConfig(),
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state.DeepCopy(),
@@ -4493,8 +4493,8 @@ func TestContext2Apply_providerComputedVar(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"):  testProviderFuncFixed(p),
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(pTest),
+				addrs.NewDefaultProvider("aws"):  testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(pTest),
 			},
 		),
 	})
@@ -4545,7 +4545,7 @@ func TestContext2Apply_providerConfigureDisabled(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -4583,7 +4583,7 @@ func TestContext2Apply_provisionerModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -4630,7 +4630,7 @@ func TestContext2Apply_Provisioner_compute(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -4680,7 +4680,7 @@ func TestContext2Apply_provisionerCreateFail(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -4721,7 +4721,7 @@ func TestContext2Apply_provisionerCreateFailNoId(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -4760,7 +4760,7 @@ func TestContext2Apply_provisionerFail(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -4816,7 +4816,7 @@ func TestContext2Apply_provisionerFail_createBeforeDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -4866,7 +4866,7 @@ func TestContext2Apply_error_createBeforeDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -4922,7 +4922,7 @@ func TestContext2Apply_errorDestroy_createBeforeDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -4974,7 +4974,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 			},
 		},
 	}
-	ps := map[addrs.Provider]providers.Factory{addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p)}
+	ps := map[addrs.Provider]providers.Factory{addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p)}
 	state := MustShimLegacyState(&State{
 		Modules: []*ModuleState{
 			&ModuleState{
@@ -5054,7 +5054,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.web: (1 deposed)
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   require_new = yes
   Deposed ID 1 = foo
 	`)
@@ -5137,7 +5137,7 @@ aws_instance.web: (1 deposed)
 	checkStateString(t, state, `
 aws_instance.web: (1 deposed)
   ID = qux
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   require_new = yes
   Deposed ID 1 = bar
 	`)
@@ -5165,7 +5165,7 @@ aws_instance.web: (1 deposed)
 	checkStateString(t, state, `
 aws_instance.web:
   ID = quux
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   require_new = yes
 	`)
 }
@@ -5187,7 +5187,7 @@ func TestContext2Apply_provisionerFailContinue(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5207,7 +5207,7 @@ func TestContext2Apply_provisionerFailContinue(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
   `)
@@ -5236,7 +5236,7 @@ func TestContext2Apply_provisionerFailContinueHook(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5283,7 +5283,7 @@ func TestContext2Apply_provisionerDestroy(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5292,7 +5292,7 @@ func TestContext2Apply_provisionerDestroy(t *testing.T) {
 		Destroy: true,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5336,7 +5336,7 @@ func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5345,7 +5345,7 @@ func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 		Destroy: true,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5365,7 +5365,7 @@ func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo["a"]:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 	`)
 
 	// Verify apply was invoked
@@ -5405,7 +5405,7 @@ func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5414,7 +5414,7 @@ func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
 		Destroy: true,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5490,7 +5490,7 @@ func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
 		Destroy: true,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5510,7 +5510,7 @@ func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   `)
 
 	// Verify apply was invoked
@@ -5556,7 +5556,7 @@ func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
 			Status:    states.ObjectTainted,
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5564,7 +5564,7 @@ func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5592,7 +5592,7 @@ func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo["a"]:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 	`)
@@ -5627,7 +5627,7 @@ func TestContext2Apply_provisionerResourceRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5675,7 +5675,7 @@ func TestContext2Apply_provisionerSelfRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5730,7 +5730,7 @@ func TestContext2Apply_provisionerMultiSelfRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5792,7 +5792,7 @@ func TestContext2Apply_provisionerMultiSelfRefSingle(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5849,7 +5849,7 @@ func TestContext2Apply_provisionerExplicitSelfRef(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 			Provisioners: map[string]ProvisionerFactory{
@@ -5880,7 +5880,7 @@ func TestContext2Apply_provisionerExplicitSelfRef(t *testing.T) {
 			State:   state,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 			Provisioners: map[string]ProvisionerFactory{
@@ -5922,7 +5922,7 @@ func TestContext2Apply_provisionerForEachSelfRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -5954,7 +5954,7 @@ func TestContext2Apply_Provisioner_Diff(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -6004,7 +6004,7 @@ func TestContext2Apply_Provisioner_Diff(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -6057,7 +6057,7 @@ func TestContext2Apply_outputDiffVars(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -6120,7 +6120,7 @@ func TestContext2Apply_destroyX(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6144,7 +6144,7 @@ func TestContext2Apply_destroyX(t *testing.T) {
 		Hooks:   []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6184,7 +6184,7 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6210,7 +6210,7 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 		Hooks:   []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6251,7 +6251,7 @@ func TestContext2Apply_destroyModulePrefix(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6280,7 +6280,7 @@ func TestContext2Apply_destroyModulePrefix(t *testing.T) {
 		Hooks:   []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6327,7 +6327,7 @@ func TestContext2Apply_destroyNestedModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -6377,7 +6377,7 @@ func TestContext2Apply_destroyDeeplyNestedModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -6412,7 +6412,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6444,7 +6444,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 			Hooks:   []Hook{h},
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6464,7 +6464,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 
 		ctxOpts.ProviderResolver = providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		)
 		ctx, diags = NewContext(ctxOpts)
@@ -6501,7 +6501,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6528,7 +6528,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 			Hooks:   []Hook{h},
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6546,7 +6546,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 
 		ctxOpts.ProviderResolver = providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		)
 		ctx, diags = NewContext(ctxOpts)
@@ -6584,7 +6584,7 @@ func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6607,7 +6607,7 @@ func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
 			State:   state,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 			Targets: []addrs.Targetable{
@@ -6667,7 +6667,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6694,7 +6694,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 			Hooks:   []Hook{h},
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -6712,7 +6712,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 
 		ctxOpts.ProviderResolver = providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		)
 		ctx, diags = NewContext(ctxOpts)
@@ -6746,7 +6746,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6769,7 +6769,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 		Config:  m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6795,7 +6795,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 		Config:  m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -6830,7 +6830,7 @@ func TestContext2Apply_destroyOrphan(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -6914,7 +6914,7 @@ func TestContext2Apply_destroyTaintedProvisioner(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Provisioners: map[string]ProvisionerFactory{
@@ -6953,7 +6953,7 @@ func TestContext2Apply_error(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7050,14 +7050,14 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 					AttrsJSON: []byte(`{"id":"baz"}`),
 				},
 				addrs.AbsProviderConfig{
-					Provider: addrs.NewLegacyProvider("test"),
+					Provider: addrs.NewDefaultProvider("test"),
 					Module:   addrs.RootModuleInstance,
 				},
 			)
 		}),
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7075,7 +7075,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 	expected := strings.TrimSpace(`
 test_thing.foo:
   ID = baz
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
 `) // test_thing.foo is still here, even though provider returned no new state along with its error
 	if actual != expected {
 		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, actual)
@@ -7118,7 +7118,7 @@ func TestContext2Apply_errorCreateInvalidNew(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7190,14 +7190,14 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 					AttrsJSON: []byte(`{"value":"old"}`),
 				},
 				addrs.AbsProviderConfig{
-					Provider: addrs.NewLegacyProvider("aws"),
+					Provider: addrs.NewDefaultProvider("aws"),
 					Module:   addrs.RootModuleInstance,
 				},
 			)
 		}),
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7260,7 +7260,7 @@ func TestContext2Apply_errorPartial(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -7328,7 +7328,7 @@ func TestContext2Apply_hook(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7382,7 +7382,7 @@ func TestContext2Apply_hookOrphan(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7413,7 +7413,7 @@ func TestContext2Apply_idAttr(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7471,7 +7471,7 @@ func TestContext2Apply_outputBasic(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7501,7 +7501,7 @@ func TestContext2Apply_outputAdd(t *testing.T) {
 		Config: m1,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p1),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p1),
 			},
 		),
 	})
@@ -7523,7 +7523,7 @@ func TestContext2Apply_outputAdd(t *testing.T) {
 		Config: m2,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p2),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p2),
 			},
 		),
 		State: state1,
@@ -7554,7 +7554,7 @@ func TestContext2Apply_outputList(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7584,7 +7584,7 @@ func TestContext2Apply_outputMulti(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7614,7 +7614,7 @@ func TestContext2Apply_outputMultiIndex(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -7678,7 +7678,7 @@ func TestContext2Apply_taintX(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -7746,7 +7746,7 @@ func TestContext2Apply_taintDep(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -7810,7 +7810,7 @@ func TestContext2Apply_taintDepRequiresNew(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -7843,7 +7843,7 @@ func TestContext2Apply_targeted(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -7870,7 +7870,7 @@ func TestContext2Apply_targeted(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 	`)
@@ -7885,7 +7885,7 @@ func TestContext2Apply_targetedCount(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -7907,13 +7907,13 @@ func TestContext2Apply_targetedCount(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.foo.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.foo.2:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 	`)
 }
 
@@ -7926,7 +7926,7 @@ func TestContext2Apply_targetedCountIndex(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -7948,7 +7948,7 @@ func TestContext2Apply_targetedCountIndex(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 	`)
 }
 
@@ -7961,7 +7961,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -8000,7 +8000,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar:
   ID = i-abc123
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 	`)
 }
 
@@ -8018,7 +8018,7 @@ func TestContext2Apply_targetedDestroyCountDeps(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"i-bcd345"}`),
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar").Resource,
@@ -8027,14 +8027,14 @@ func TestContext2Apply_targetedDestroyCountDeps(t *testing.T) {
 			AttrsJSON:    []byte(`{"id":"i-abc123"}`),
 			Dependencies: []addrs.AbsResource{mustResourceAddr("aws_instance.foo")},
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"]`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -8068,7 +8068,7 @@ func TestContext2Apply_targetedDestroyModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -8109,15 +8109,15 @@ func TestContext2Apply_targetedDestroyModule(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar:
   ID = i-abc123
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.foo:
   ID = i-bcd345
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 
 module.child:
   aws_instance.bar:
     ID = i-abc123
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
 	`)
 }
 
@@ -8130,7 +8130,7 @@ func TestContext2Apply_targetedDestroyCountIndex(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: MustShimLegacyState(&State{
@@ -8171,16 +8171,16 @@ func TestContext2Apply_targetedDestroyCountIndex(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.bar.0:
   ID = i-abc123
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.bar.2:
   ID = i-abc123
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.foo.0:
   ID = i-bcd345
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.foo.1:
   ID = i-bcd345
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 	`)
 }
 
@@ -8193,7 +8193,7 @@ func TestContext2Apply_targetedModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -8223,12 +8223,12 @@ func TestContext2Apply_targetedModule(t *testing.T) {
 module.child:
   aws_instance.bar:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     num = 2
     type = aws_instance
   aws_instance.foo:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     num = 2
     type = aws_instance
 	`)
@@ -8244,7 +8244,7 @@ func TestContext2Apply_targetedModuleDep(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -8268,7 +8268,7 @@ func TestContext2Apply_targetedModuleDep(t *testing.T) {
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 
@@ -8278,7 +8278,7 @@ aws_instance.foo:
 module.child:
   aws_instance.mod:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
 
   Outputs:
 
@@ -8297,7 +8297,7 @@ func TestContext2Apply_targetedModuleUnrelatedOutputs(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -8351,7 +8351,7 @@ child2_id = foo
 module.child2:
   aws_instance.foo:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
 
   Outputs:
 
@@ -8368,7 +8368,7 @@ func TestContext2Apply_targetedModuleResource(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -8397,7 +8397,7 @@ func TestContext2Apply_targetedModuleResource(t *testing.T) {
 module.child:
   aws_instance.foo:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     num = 2
     type = aws_instance
 	`)
@@ -8429,7 +8429,7 @@ func TestContext2Apply_targetedResourceOrphanModule(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -8458,7 +8458,7 @@ func TestContext2Apply_unknownAttribute(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -8488,7 +8488,7 @@ func TestContext2Apply_unknownAttributeInterpolate(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -8617,7 +8617,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","require_new":"ami-old"}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("aws"),
+			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -8643,7 +8643,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 			},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("aws"),
+			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -8653,7 +8653,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -8750,7 +8750,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","require_new":"ami-old"}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("aws"),
+			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -8776,7 +8776,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 			},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("aws"),
+			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -8786,7 +8786,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 		Hooks:  []Hook{h},
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: state,
@@ -8830,7 +8830,7 @@ func TestContext2Apply_issue7824(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("template"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("template"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -8848,7 +8848,7 @@ func TestContext2Apply_issue7824(t *testing.T) {
 
 	ctxOpts.ProviderResolver = providers.ResolverFixed(
 		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider("template"): testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("template"): testProviderFuncFixed(p),
 		},
 	)
 	ctx, diags = NewContext(ctxOpts)
@@ -8888,7 +8888,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 		Config: testModule(t, "issue-5254/step-0"),
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("template"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("template"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -8911,7 +8911,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 		State:  state,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("template"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("template"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -8929,7 +8929,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 
 	ctxOpts.ProviderResolver = providers.ResolverFixed(
 		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider("template"): testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("template"): testProviderFuncFixed(p),
 		},
 	)
 	ctx, diags = NewContext(ctxOpts)
@@ -8946,7 +8946,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 	expected := strings.TrimSpace(`
 template_file.child:
   ID = foo
-  provider = provider["registry.terraform.io/-/template"]
+  provider = provider["registry.terraform.io/hashicorp/template"]
   __template_requires_new = true
   template = Hi
   type = template_file
@@ -8955,7 +8955,7 @@ template_file.child:
     template_file.parent
 template_file.parent.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/template"]
+  provider = provider["registry.terraform.io/hashicorp/template"]
   template = Hi
   type = template_file
 `)
@@ -8973,7 +8973,7 @@ func TestContext2Apply_targetedWithTaintedInState(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -9012,7 +9012,7 @@ func TestContext2Apply_targetedWithTaintedInState(t *testing.T) {
 
 	ctxOpts.ProviderResolver = providers.ResolverFixed(
 		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 		},
 	)
 	ctx, diags = NewContext(ctxOpts)
@@ -9029,10 +9029,10 @@ func TestContext2Apply_targetedWithTaintedInState(t *testing.T) {
 	expected := strings.TrimSpace(`
 aws_instance.iambeingadded:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.ifailedprovisioners: (tainted)
   ID = ifailedprovisioners
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 		`)
 	if actual != expected {
 		t.Fatalf("expected state: \n%s\ngot: \n%s", expected, actual)
@@ -9057,7 +9057,7 @@ func TestContext2Apply_ignoreChangesCreate(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9083,7 +9083,7 @@ func TestContext2Apply_ignoreChangesCreate(t *testing.T) {
 	expected := strings.TrimSpace(`
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   required_field = set
   type = aws_instance
 `)
@@ -9170,7 +9170,7 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State: s,
@@ -9205,7 +9205,7 @@ func TestContext2Apply_ignoreChangesWildcard(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9230,7 +9230,7 @@ func TestContext2Apply_ignoreChangesWildcard(t *testing.T) {
 	expected := strings.TrimSpace(`
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   required_field = set
   type = aws_instance
 `)
@@ -9253,7 +9253,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("null"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("null"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -9276,7 +9276,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 			State:   state,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("null"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("null"): testProviderFuncFixed(p),
 				},
 			),
 		})
@@ -9293,7 +9293,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 
 		ctxOpts.ProviderResolver = providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("null"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("null"): testProviderFuncFixed(p),
 			},
 		)
 		ctx, diags = NewContext(ctxOpts)
@@ -9322,7 +9322,7 @@ func TestContext2Apply_dataDependsOn(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("null"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("null"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9389,7 +9389,7 @@ func TestContext2Apply_terraformWorkspace(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9420,7 +9420,7 @@ func TestContext2Apply_multiRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9449,7 +9449,7 @@ func TestContext2Apply_targetedModuleRecursive(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		Targets: []addrs.Targetable{
@@ -9481,7 +9481,7 @@ func TestContext2Apply_targetedModuleRecursive(t *testing.T) {
 module.child.subchild:
   aws_instance.foo:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     num = 2
     type = aws_instance
 	`)
@@ -9563,7 +9563,7 @@ func TestContext2Apply_destroyWithLocals(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State:   s,
@@ -9604,7 +9604,7 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -9622,7 +9622,7 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -9661,14 +9661,14 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
-		mustProviderConfig(`provider["registry.terraform.io/-/aws"].baz`),
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"].baz`),
 	)
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
 		),
 		State:   state,
@@ -9682,7 +9682,7 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 
 	// correct the state
 	state.Modules["module.mod.module.removed"].Resources["aws_instance.child"].ProviderConfig = addrs.AbsProviderConfig{
-		Provider: addrs.NewLegacyProvider("aws"),
+		Provider: addrs.NewDefaultProvider("aws"),
 		Alias:    "bar",
 		Module:   addrs.RootModuleInstance,
 	}
@@ -9787,7 +9787,7 @@ func TestContext2Apply_providersFromState(t *testing.T) {
 				Config: m,
 				ProviderResolver: providers.ResolverFixed(
 					map[addrs.Provider]providers.Factory{
-						addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+						addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 					},
 				),
 				State: tc.state,
@@ -9825,7 +9825,7 @@ func TestContext2Apply_plannedInterpolatedCount(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 		},
 	)
 
@@ -9887,7 +9887,7 @@ func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 		},
 	)
 
@@ -9963,7 +9963,7 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 		},
 	)
 
@@ -10046,7 +10046,7 @@ func TestContext2Apply_inconsistentWithPlan(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -10107,14 +10107,14 @@ func TestContext2Apply_issue19908(t *testing.T) {
 					Status:    states.ObjectReady,
 				},
 				addrs.AbsProviderConfig{
-					Provider: addrs.NewLegacyProvider("test"),
+					Provider: addrs.NewDefaultProvider("test"),
 					Module:   addrs.RootModuleInstance,
 				},
 			)
 		}),
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -10171,7 +10171,7 @@ func TestContext2Apply_invalidIndexRef(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -10234,7 +10234,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"a","require_new":"old"}`),
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("aws"),
+				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModuleInstance,
 			},
 		)
@@ -10251,7 +10251,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"b","require_new":"old"}`),
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("aws"),
+				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModuleInstance,
 			},
 		)
@@ -10294,7 +10294,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 						Name: "a",
 					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance.Child("a", addrs.NoKey)),
 					ProviderAddr: addrs.AbsProviderConfig{
-						Provider: addrs.NewLegacyProvider("aws"),
+						Provider: addrs.NewDefaultProvider("aws"),
 						Module:   addrs.RootModuleInstance,
 					},
 					ChangeSrc: plans.ChangeSrc{
@@ -10310,7 +10310,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 						Name: "b",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance.Child("b", addrs.NoKey)),
 					ProviderAddr: addrs.AbsProviderConfig{
-						Provider: addrs.NewLegacyProvider("aws"),
+						Provider: addrs.NewDefaultProvider("aws"),
 						Module:   addrs.RootModuleInstance,
 					},
 					ChangeSrc: plans.ChangeSrc{
@@ -10326,7 +10326,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 			Config: m,
 			ProviderResolver: providers.ResolverFixed(
 				map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+					addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 				},
 			),
 			State:   state,
@@ -10361,7 +10361,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"a"}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("null"),
+			Provider: addrs.NewDefaultProvider("null"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -10376,14 +10376,14 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"data"}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("null"),
+			Provider: addrs.NewDefaultProvider("null"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
 
 	providerResolver := providers.ResolverFixed(
 		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider("null"): testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("null"): testProviderFuncFixed(p),
 		},
 	)
 
@@ -10451,7 +10451,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"a","foo":"a"}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -10466,7 +10466,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"b","foo":"b"}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -10481,14 +10481,14 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"c","foo":"old"}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
 
 	providerResolver := providers.ResolverFixed(
 		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	)
 
@@ -10593,7 +10593,7 @@ func TestContext2Apply_plannedConnectionRefs(t *testing.T) {
 
 	providerResolver := providers.ResolverFixed(
 		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	)
 
@@ -10658,7 +10658,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 			},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -10683,7 +10683,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 			},
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
@@ -10698,14 +10698,14 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"c","require_new":"old"}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModuleInstance,
 		},
 	)
 
 	providerResolver := providers.ResolverFixed(
 		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	)
 
@@ -10769,7 +10769,7 @@ func TestContext2Apply_ProviderMeta_apply_set(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -10845,7 +10845,7 @@ func TestContext2Apply_ProviderMeta_apply_unset(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -10898,7 +10898,7 @@ func TestContext2Apply_ProviderMeta_plan_set(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -10969,7 +10969,7 @@ func TestContext2Apply_ProviderMeta_plan_unset(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -11003,7 +11003,7 @@ func TestContext2Apply_ProviderMeta_plan_setNoSchema(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -11016,7 +11016,7 @@ func TestContext2Apply_ProviderMeta_plan_setNoSchema(t *testing.T) {
 	var rootErr, subErr bool
 	errorSummary := "The resource test_%s.bar belongs to a provider that doesn't support provider_meta blocks"
 	for _, diag := range diags {
-		if diag.Description().Summary != "Provider registry.terraform.io/-/test doesn't support provider_meta" {
+		if diag.Description().Summary != "Provider registry.terraform.io/hashicorp/test doesn't support provider_meta" {
 			t.Errorf("Unexpected error: %+v", diag.Description())
 		}
 		switch diag.Description().Detail {
@@ -11055,7 +11055,7 @@ func TestContext2Apply_ProviderMeta_plan_setInvalid(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -11122,7 +11122,7 @@ func TestContext2Apply_ProviderMeta_refresh_set(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -11193,7 +11193,7 @@ func TestContext2Apply_ProviderMeta_refresh_unset(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -11236,7 +11236,7 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -11254,7 +11254,7 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 		State: ctx.State(),
@@ -11268,7 +11268,7 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 	var rootErr, subErr bool
 	errorSummary := "The resource test_%s.bar belongs to a provider that doesn't support provider_meta blocks"
 	for _, diag := range diags {
-		if diag.Description().Summary != "Provider registry.terraform.io/-/test doesn't support provider_meta" {
+		if diag.Description().Summary != "Provider registry.terraform.io/hashicorp/test doesn't support provider_meta" {
 			t.Errorf("Unexpected error: %+v", diag.Description())
 		}
 		switch diag.Description().Detail {
@@ -11309,7 +11309,7 @@ func TestContext2Apply_ProviderMeta_refresh_setInvalid(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -11334,7 +11334,7 @@ func TestContext2Apply_ProviderMeta_refresh_setInvalid(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 		State: ctx.State(),
@@ -11391,7 +11391,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_set(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -11489,7 +11489,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_unset(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -11553,7 +11553,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setNoSchema(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})
@@ -11572,7 +11572,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setNoSchema(t *testing.T) {
 	var rootErr, subErr bool
 	errorSummary := "The resource data.test_%s.foo belongs to a provider that doesn't support provider_meta blocks"
 	for _, diag := range diags {
-		if diag.Description().Summary != "Provider registry.terraform.io/-/test doesn't support provider_meta" {
+		if diag.Description().Summary != "Provider registry.terraform.io/hashicorp/test doesn't support provider_meta" {
 			t.Errorf("Unexpected error: %+v", diag.Description())
 		}
 		switch diag.Description().Detail {
@@ -11611,7 +11611,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setInvalid(t *testing.T) {
 		Config: m,
 		ProviderResolver: providers.ResolverFixed(
 			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): testProviderFuncFixed(p),
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		),
 	})

--- a/terraform/context_components.go
+++ b/terraform/context_components.go
@@ -32,7 +32,7 @@ type basicComponentFactory struct {
 func (c *basicComponentFactory) ResourceProviders() []string {
 	var result []string
 	for k := range c.providers {
-		result = append(result, k.LegacyString())
+		result = append(result, k.String())
 	}
 	return result
 }
@@ -49,7 +49,7 @@ func (c *basicComponentFactory) ResourceProvisioners() []string {
 func (c *basicComponentFactory) ResourceProvider(typ addrs.Provider) (providers.Interface, error) {
 	f, ok := c.providers[typ]
 	if !ok {
-		return nil, fmt.Errorf("unknown provider %q", typ.LegacyString())
+		return nil, fmt.Errorf("unknown provider %q", typ.String())
 	}
 
 	return f()

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -131,7 +131,7 @@ func (ctx *BuiltinEvalContext) InitProvider(addr addrs.AbsProviderConfig) (provi
 		return nil, err
 	}
 
-	log.Printf("[TRACE] BuiltinEvalContext: Initialized %q provider for %s", addr.LegacyString(), absAddr)
+	log.Printf("[TRACE] BuiltinEvalContext: Initialized %q provider for %s", addr.String(), absAddr)
 	ctx.ProviderCache[key] = p
 
 	return p, nil

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -151,7 +151,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 
 		// Must attach schemas before ReferenceTransformer so that we can
 		// analyze the configuration to find references.
-		&AttachSchemaTransformer{Schemas: b.Schemas},
+		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
 		// Create expansion nodes for all of the module calls. This must
 		// come after all other transformers that create nodes representing

--- a/terraform/graph_builder_eval.go
+++ b/terraform/graph_builder_eval.go
@@ -87,7 +87,7 @@ func (b *EvalGraphBuilder) Steps() []GraphTransformer {
 
 		// Must attach schemas before ReferenceTransformer so that we can
 		// analyze the configuration to find references.
-		&AttachSchemaTransformer{Schemas: b.Schemas},
+		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.

--- a/terraform/graph_builder_import.go
+++ b/terraform/graph_builder_import.go
@@ -77,7 +77,7 @@ func (b *ImportGraphBuilder) Steps() []GraphTransformer {
 
 		// Must attach schemas before ReferenceTransformer so that we can
 		// analyze the configuration to find references.
-		&AttachSchemaTransformer{Schemas: b.Schemas},
+		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -135,7 +135,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 
 		// Must attach schemas before ReferenceTransformer so that we can
 		// analyze the configuration to find references.
-		&AttachSchemaTransformer{Schemas: b.Schemas},
+		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
 		// Create expansion nodes for all of the module calls. This must
 		// come after all other transformers that create nodes representing

--- a/terraform/graph_builder_refresh.go
+++ b/terraform/graph_builder_refresh.go
@@ -160,7 +160,7 @@ func (b *RefreshGraphBuilder) Steps() []GraphTransformer {
 
 		// Must attach schemas before ReferenceTransformer so that we can
 		// analyze the configuration to find references.
-		&AttachSchemaTransformer{Schemas: b.Schemas},
+		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
 		// Create expansion nodes for all of the module calls. This must
 		// come after all other transformers that create nodes representing

--- a/terraform/module_dependencies.go
+++ b/terraform/module_dependencies.go
@@ -73,7 +73,7 @@ func configTreeConfigDependencies(root *configs.Config, inheritProviders map[str
 			discoConstraints := discovery.NewConstraints(rawConstraints)
 			fqn := req.Type
 			if fqn.IsZero() {
-				fqn = addrs.NewLegacyProvider(localName)
+				fqn = addrs.NewDefaultProvider(localName)
 			}
 
 			providers[req.Type] = moduledeps.ProviderDependency{

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -295,12 +295,13 @@ func (n *NodeAbstractResource) ProvidedBy() (addrs.ProviderConfig, bool) {
 		}, false
 	}
 
-	// Use our type and containing module path to guess a provider configuration address.
-	defaultFQN := n.Addr.Resource.DefaultProvider()
-	return addrs.AbsProviderConfig{
-		Provider: defaultFQN,
-		Module:   n.Addr.Module,
-	}, false
+	// No provider configuration found
+	return nil, false
+}
+
+// GraphNodeProviderConsumer
+func (n *NodeAbstractResource) DefaultProvider() addrs.Provider {
+	return n.Addr.Resource.DefaultProvider()
 }
 
 // GraphNodeProviderConsumer
@@ -322,12 +323,13 @@ func (n *NodeAbstractResourceInstance) ProvidedBy() (addrs.ProviderConfig, bool)
 		return n.ResourceState.ProviderConfig, true
 	}
 
-	// Use our type and containing module path to guess a provider configuration address
-	defaultFQN := n.Addr.Resource.DefaultProvider()
-	return addrs.AbsProviderConfig{
-		Provider: defaultFQN,
-		Module:   n.Addr.Module,
-	}, false
+	// No provider configuration found
+	return nil, false
+}
+
+// GraphNodeProviderConsumer
+func (n *NodeAbstractResourceInstance) DefaultProvider() addrs.Provider {
+	return n.Addr.Resource.DefaultProvider()
 }
 
 // GraphNodeProvisionerConsumer

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -239,7 +239,7 @@ func ResourceProviderResolverFixed(factories map[addrs.Provider]ResourceProvider
 		for name := range reqd {
 			// FIXME: discovery.PluginRequirements should use addrs.Provider as
 			// the map keys instead of a string
-			fqn := addrs.NewLegacyProvider(name)
+			fqn := addrs.NewDefaultProvider(name)
 			if factory, exists := factories[fqn]; exists {
 				ret[fqn] = factory
 			} else {

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -93,21 +93,18 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 	var diags tfdiags.Diagnostics
 
 	ensure := func(fqn addrs.Provider) {
-		// TODO: LegacyString() will be removed in an upcoming release
-		typeName := fqn.LegacyString()
-
 		if _, exists := schemas[fqn]; exists {
 			return
 		}
 
-		log.Printf("[TRACE] LoadSchemas: retrieving schema for provider type %q", fqn.LegacyString())
+		log.Printf("[TRACE] LoadSchemas: retrieving schema for provider type %q", fqn.String())
 		provider, err := components.ResourceProvider(fqn)
 		if err != nil {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to instantiate provider %q to obtain schema: %s", typeName, err),
+				fmt.Errorf("Failed to instantiate provider %q to obtain schema: %s", fqn.String(), err),
 			)
 			return
 		}
@@ -121,7 +118,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to retrieve schema from provider %q: %s", typeName, resp.Diagnostics.Err()),
+				fmt.Errorf("Failed to retrieve schema from provider %q: %s", fqn.String(), resp.Diagnostics.Err()),
 			)
 			return
 		}
@@ -138,7 +135,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// We're not using the version numbers here yet, but we'll check
 			// for validity anyway in case we start using them in future.
 			diags = diags.Append(
-				fmt.Errorf("invalid negative schema version provider configuration for provider %q", typeName),
+				fmt.Errorf("invalid negative schema version provider configuration for provider %q", fqn.String()),
 			)
 		}
 
@@ -147,7 +144,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			s.ResourceTypeSchemaVersions[t] = uint64(r.Version)
 			if r.Version < 0 {
 				diags = diags.Append(
-					fmt.Errorf("invalid negative schema version for resource type %s in provider %q", t, typeName),
+					fmt.Errorf("invalid negative schema version for resource type %s in provider %q", t, fqn.String()),
 				)
 			}
 		}
@@ -158,7 +155,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 				// We're not using the version numbers here yet, but we'll check
 				// for validity anyway in case we start using them in future.
 				diags = diags.Append(
-					fmt.Errorf("invalid negative schema version for data source %s in provider %q", t, typeName),
+					fmt.Errorf("invalid negative schema version for data source %s in provider %q", t, fqn.String()),
 				)
 			}
 		}

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -283,13 +283,13 @@ func (h *HookRecordApplyOrder) PreApply(addr addrs.AbsResourceInstance, gen stat
 const testTerraformInputProviderStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   bar = override
   foo = us-east-1
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   bar = baz
   num = 2
   type = aws_instance
@@ -298,7 +298,7 @@ aws_instance.foo:
 const testTerraformInputProviderOnlyStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = us-west-2
   type = aws_instance
 `
@@ -306,7 +306,7 @@ aws_instance.foo:
 const testTerraformInputVarOnlyStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = us-east-1
   type = aws_instance
 `
@@ -314,7 +314,7 @@ aws_instance.foo:
 const testTerraformInputVarOnlyUnsetStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   bar = baz
   foo = foovalue
   type = aws_instance
@@ -323,13 +323,13 @@ aws_instance.foo:
 const testTerraformInputVarsStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   bar = override
   foo = us-east-1
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   bar = baz
   num = 2
   type = aws_instance
@@ -338,12 +338,12 @@ aws_instance.foo:
 const testTerraformApplyStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 `
@@ -351,13 +351,13 @@ aws_instance.foo:
 const testTerraformApplyDataBasicStr = `
 data.null_data_source.testing:
   ID = yo
-  provider = provider["registry.terraform.io/-/null"]
+  provider = provider["registry.terraform.io/hashicorp/null"]
 `
 
 const testTerraformApplyRefCountStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = 3
   type = aws_instance
 
@@ -365,24 +365,24 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.foo.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.foo.2:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 `
 
 const testTerraformApplyProviderAliasStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"].bar
+  provider = provider["registry.terraform.io/hashicorp/aws"].bar
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 `
@@ -390,10 +390,10 @@ aws_instance.foo:
 const testTerraformApplyProviderAliasConfigStr = `
 another_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/another"].two
+  provider = provider["registry.terraform.io/hashicorp/another"].two
 another_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/another"]
+  provider = provider["registry.terraform.io/hashicorp/another"]
 `
 
 const testTerraformApplyEmptyModuleStr = `
@@ -412,7 +412,7 @@ aws_route53_zone_id = XXXX
 const testTerraformApplyDependsCreateBeforeStr = `
 aws_instance.lb:
   ID = baz
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   instance = foo
   type = aws_instance
 
@@ -420,7 +420,7 @@ aws_instance.lb:
     aws_instance.web
 aws_instance.web:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   require_new = ami-new
   type = aws_instance
 `
@@ -428,7 +428,7 @@ aws_instance.web:
 const testTerraformApplyCreateBeforeStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   require_new = xyz
   type = aws_instance
 `
@@ -436,7 +436,7 @@ aws_instance.bar:
 const testTerraformApplyCreateBeforeUpdateStr = `
 aws_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = baz
   type = aws_instance
 `
@@ -444,14 +444,14 @@ aws_instance.bar:
 const testTerraformApplyCancelStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   value = 2
 `
 
 const testTerraformApplyComputeStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = computed_value
   type = aws_instance
 
@@ -459,7 +459,7 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   compute = value
   compute_value = 1
   num = 2
@@ -470,17 +470,17 @@ aws_instance.foo:
 const testTerraformApplyCountDecStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo.0:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo.1:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 `
@@ -488,7 +488,7 @@ aws_instance.foo.1:
 const testTerraformApplyCountDecToOneStr = `
 aws_instance.foo:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 `
@@ -496,7 +496,7 @@ aws_instance.foo:
 const testTerraformApplyCountDecToOneCorruptedStr = `
 aws_instance.foo:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 `
@@ -514,24 +514,24 @@ STATE:
 
 aws_instance.foo:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo.0:
   ID = baz
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   type = aws_instance
 `
 
 const testTerraformApplyCountVariableStr = `
 aws_instance.foo.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 `
@@ -539,7 +539,7 @@ aws_instance.foo.1:
 const testTerraformApplyCountVariableRefStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = 2
   type = aws_instance
 
@@ -547,70 +547,70 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.foo.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 `
 const testTerraformApplyForEachVariableStr = `
 aws_instance.foo["b15c6d616d6143248c575900dff57325eb1de498"]:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo["c3de47d34b0a9f13918dd705c141d579dd6555fd"]:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 aws_instance.foo["e30a7edcc42a846684f2a4eea5f3cd261d33c46d"]:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   type = aws_instance
 aws_instance.one["a"]:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.one["b"]:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.two["a"]:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 
   Dependencies:
     aws_instance.one
 aws_instance.two["b"]:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 
   Dependencies:
     aws_instance.one`
 const testTerraformApplyMinimalStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 `
 
 const testTerraformApplyModuleStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 
 module.child:
   aws_instance.baz:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     foo = bar
     type = aws_instance
 `
@@ -618,7 +618,7 @@ module.child:
 const testTerraformApplyModuleBoolStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = true
   type = aws_instance
 
@@ -636,12 +636,12 @@ const testTerraformApplyModuleDestroyOrderStr = `
 const testTerraformApplyMultiProviderStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 do_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/do"]
+  provider = provider["registry.terraform.io/hashicorp/do"]
   num = 2
   type = do_instance
 `
@@ -651,10 +651,10 @@ const testTerraformApplyModuleOnlyProviderStr = `
 module.child:
   aws_instance.foo:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
   test_instance.foo:
     ID = foo
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
 `
 
 const testTerraformApplyModuleProviderAliasStr = `
@@ -662,19 +662,19 @@ const testTerraformApplyModuleProviderAliasStr = `
 module.child:
   aws_instance.foo:
     ID = foo
-    provider = module.child.provider["registry.terraform.io/-/aws"].eu
+    provider = module.child.provider["registry.terraform.io/hashicorp/aws"].eu
 `
 
 const testTerraformApplyModuleVarRefExistingStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
 
 module.child:
   aws_instance.foo:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     type = aws_instance
     value = bar
 
@@ -696,13 +696,13 @@ const testTerraformApplyOutputOrphanModuleStr = `
 const testTerraformApplyProvisionerStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 
   Dependencies:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   compute = value
   compute_value = 1
   num = 2
@@ -715,16 +715,16 @@ const testTerraformApplyProvisionerModuleStr = `
 module.child:
   aws_instance.bar:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
 `
 
 const testTerraformApplyProvisionerFailStr = `
 aws_instance.bar: (tainted)
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 `
@@ -732,7 +732,7 @@ aws_instance.foo:
 const testTerraformApplyProvisionerFailCreateStr = `
 aws_instance.bar: (tainted)
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 `
 
 const testTerraformApplyProvisionerFailCreateNoIdStr = `
@@ -742,7 +742,7 @@ const testTerraformApplyProvisionerFailCreateNoIdStr = `
 const testTerraformApplyProvisionerFailCreateBeforeDestroyStr = `
 aws_instance.bar: (tainted) (1 deposed)
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   require_new = xyz
   type = aws_instance
   Deposed ID 1 = bar
@@ -751,7 +751,7 @@ aws_instance.bar: (tainted) (1 deposed)
 const testTerraformApplyProvisionerResourceRefStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 `
@@ -759,7 +759,7 @@ aws_instance.bar:
 const testTerraformApplyProvisionerSelfRefStr = `
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 `
@@ -767,17 +767,17 @@ aws_instance.foo:
 const testTerraformApplyProvisionerMultiSelfRefStr = `
 aws_instance.foo.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = number 0
   type = aws_instance
 aws_instance.foo.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = number 1
   type = aws_instance
 aws_instance.foo.2:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = number 2
   type = aws_instance
 `
@@ -785,17 +785,17 @@ aws_instance.foo.2:
 const testTerraformApplyProvisionerMultiSelfRefSingleStr = `
 aws_instance.foo.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = number 0
   type = aws_instance
 aws_instance.foo.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = number 1
   type = aws_instance
 aws_instance.foo.2:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = number 2
   type = aws_instance
 `
@@ -803,7 +803,7 @@ aws_instance.foo.2:
 const testTerraformApplyProvisionerDiffStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 `
@@ -815,27 +815,27 @@ const testTerraformApplyDestroyStr = `
 const testTerraformApplyErrorStr = `
 aws_instance.bar: (tainted)
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 
   Dependencies:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   value = 2
 `
 
 const testTerraformApplyErrorCreateBeforeDestroyStr = `
 aws_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   require_new = abc
 `
 
 const testTerraformApplyErrorDestroyCreateBeforeDestroyStr = `
 aws_instance.bar: (1 deposed)
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   require_new = xyz
   type = aws_instance
   Deposed ID 1 = bar
@@ -844,20 +844,20 @@ aws_instance.bar: (1 deposed)
 const testTerraformApplyErrorPartialStr = `
 aws_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
 
   Dependencies:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   value = 2
 `
 
 const testTerraformApplyResourceDependsOnModuleStr = `
 aws_instance.a:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   ami = parent
   type = aws_instance
 
@@ -867,7 +867,7 @@ aws_instance.a:
 module.child:
   aws_instance.child:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     ami = child
     type = aws_instance
 `
@@ -875,7 +875,7 @@ module.child:
 const testTerraformApplyResourceDependsOnModuleDeepStr = `
 aws_instance.a:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   ami = parent
   type = aws_instance
 
@@ -885,7 +885,7 @@ aws_instance.a:
 module.child.grandchild:
   aws_instance.c:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     ami = grandchild
     type = aws_instance
 `
@@ -895,7 +895,7 @@ const testTerraformApplyResourceDependsOnModuleInModuleStr = `
 module.child:
   aws_instance.b:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     ami = child
     type = aws_instance
 
@@ -904,7 +904,7 @@ module.child:
 module.child.grandchild:
   aws_instance.c:
     ID = foo
-    provider = provider["registry.terraform.io/-/aws"]
+    provider = provider["registry.terraform.io/hashicorp/aws"]
     ami = grandchild
     type = aws_instance
 `
@@ -912,7 +912,7 @@ module.child.grandchild:
 const testTerraformApplyTaintStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 `
@@ -920,7 +920,7 @@ aws_instance.bar:
 const testTerraformApplyTaintDepStr = `
 aws_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   num = 2
   type = aws_instance
@@ -929,7 +929,7 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 `
@@ -937,7 +937,7 @@ aws_instance.foo:
 const testTerraformApplyTaintDepRequireNewStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
   require_new = yes
   type = aws_instance
@@ -946,7 +946,7 @@ aws_instance.bar:
     aws_instance.foo
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 `
@@ -954,12 +954,12 @@ aws_instance.foo:
 const testTerraformApplyOutputStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 
@@ -971,12 +971,12 @@ foo_num = 2
 const testTerraformApplyOutputAddStr = `
 aws_instance.test.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo0
   type = aws_instance
 aws_instance.test.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo1
   type = aws_instance
 
@@ -989,22 +989,22 @@ secondOutput = foo1
 const testTerraformApplyOutputListStr = `
 aws_instance.bar.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.2:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 
@@ -1016,22 +1016,22 @@ foo_num = [bar,bar,bar]
 const testTerraformApplyOutputMultiStr = `
 aws_instance.bar.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.2:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 
@@ -1043,22 +1043,22 @@ foo_num = bar,bar,bar
 const testTerraformApplyOutputMultiIndexStr = `
 aws_instance.bar.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.1:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.bar.2:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = bar
   type = aws_instance
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   num = 2
   type = aws_instance
 
@@ -1070,7 +1070,7 @@ foo_num = bar
 const testTerraformApplyUnknownAttrStr = `
 aws_instance.foo: (tainted)
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   compute = unknown
   num = 2
   type = aws_instance
@@ -1079,13 +1079,13 @@ aws_instance.foo: (tainted)
 const testTerraformApplyVarsStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   bar = override
   baz = override
   foo = us-east-1
 aws_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   bar = baz
   list.# = 2
   list.0 = Hello
@@ -1099,7 +1099,7 @@ aws_instance.foo:
 const testTerraformApplyVarsEnvStr = `
 aws_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/aws"]
+  provider = provider["registry.terraform.io/hashicorp/aws"]
   list.# = 2
   list.0 = Hello
   list.1 = World
@@ -1294,7 +1294,7 @@ STATE:
 const testTerraformInputHCL = `
 hcl_instance.hcltest:
   ID = foo
-  provider = provider["registry.terraform.io/-/hcl"]
+  provider = provider["registry.terraform.io/hashicorp/hcl"]
   bar.w = z
   bar.x = y
   foo.# = 2
@@ -1306,10 +1306,10 @@ hcl_instance.hcltest:
 const testTerraformRefreshDataRefDataStr = `
 data.null_data_source.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/null"]
+  provider = provider["registry.terraform.io/hashicorp/null"]
   bar = yes
 data.null_data_source.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/null"]
+  provider = provider["registry.terraform.io/hashicorp/null"]
   foo = yes
 `

--- a/terraform/testdata/transform-provider-fqns/main.tf
+++ b/terraform/testdata/transform-provider-fqns/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    my_aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+resource "aws_instance" "web" {
+  provider = "my_aws"
+}

--- a/terraform/transform_attach_schema.go
+++ b/terraform/transform_attach_schema.go
@@ -73,11 +73,11 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 
 			var providerFqn addrs.Provider
 			if t.Config == nil {
-				providerFqn = addrs.NewLegacyProvider(providerTypeName)
+				providerFqn = addrs.NewDefaultProvider(providerTypeName)
 			} else {
 				modConfig := t.Config.DescendentForInstance(tv.Path())
 				if modConfig == nil {
-					providerFqn = addrs.NewLegacyProvider(providerTypeName)
+					providerFqn = addrs.NewDefaultProvider(providerTypeName)
 				} else {
 					providerFqn = modConfig.Module.ProviderForLocalConfig(addrs.LocalProviderConfig{LocalName: providerTypeName})
 				}

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -69,6 +69,16 @@ func (n *graphNodeImportState) ProvidedBy() (addrs.ProviderConfig, bool) {
 }
 
 // GraphNodeProviderConsumer
+func (n *graphNodeImportState) DefaultProvider() addrs.Provider {
+	// We assume that n.ProviderAddr has been properly populated here.
+	// It's the responsibility of the code creating a graphNodeImportState
+	// to populate this, possibly by calling DefaultProviderConfig() on the
+	// resource address to infer an implied provider from the resource type
+	// name.
+	return n.ProviderAddr.Provider
+}
+
+// GraphNodeProviderConsumer
 func (n *graphNodeImportState) SetProvider(addr addrs.AbsProviderConfig) {
 	n.ResolvedProvider = addr
 }


### PR DESCRIPTION
This PR will make the most sense if you look at the first two commits and ignore the last one for now - I tried to start writing actual tests exercising the provider source attribute but that required much more busywork than I wanted to do before discussing the changes in this PR. 

The highlights are:
* refactor ProvidedBy() to return `nil` when provider configuration was not set (in config or state)
- this required the addition of a DefaultProvider() function to the interface, so the provider transformer could determine the correct provider FQN

* adding `*configs.Config` to `AttachSchemaTransformer` and `MissingProviderTransformer` so those nodes could also properly determine the FQN. 

I'm (very) open to rethinking this PR: I really wasn't sure if adding the full config to the aforementioned transformers was appropriate, but I'm not sure how else to lookup the FQNs without a bigger refactor.

If this implementation looks reasonable, I will to reopen this PR with *just* the changes to the terraform package, minus the additional test (and all the related changes to tests). Then I can follow that up with a giant PR that adds tests and removes use of `LegacyProvider`. 