### PR TITLE
Pin Dockerfile base image to match with .go-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # binary from releases.hashicorp.com; these are built instead from
 # scripts/docker-release/Dockerfile-release.
 
-FROM golang:alpine
+FROM golang:1.14-alpine3.11
 LABEL maintainer="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
 RUN apk add --no-cache git bash openssh


### PR DESCRIPTION
relates to https://github.com/hashicorp/terraform/pull/24270