### PR TITLE
Improve travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
-dist: trusty
-sudo: required
+dist: bionic
 services:
   - docker
 language: go
 go:
-- "1.14"
+  - "1.14.x"
 
 # add TF_CONSUL_TEST=1 to run consul tests
 # they were causing timouts in travis


### PR DESCRIPTION
- `dist` upgrade (`trusty` to `bionic`)
- remove `sudo` flag (https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
> If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon.
- "1.14.x" (this would capture all go1.14 releases)