### PR TITLE
Mildwonkey/ps schema

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -195,15 +195,18 @@ func (c *Config) gatherProviderTypes(m map[addrs.Provider]struct{}) {
 	// the true provider addresses via the local-to-FQN mapping table
 	// stored inside c.Module.
 	for _, pc := range c.Module.ProviderConfigs {
-		m[addrs.NewLegacyProvider(pc.Name)] = struct{}{}
+		fqn := c.Module.ProviderForLocalConfig(addrs.LocalProviderConfig{LocalName: pc.Name})
+		m[fqn] = struct{}{}
 	}
 	for _, rc := range c.Module.ManagedResources {
 		providerAddr := rc.ProviderConfigAddr()
-		m[addrs.NewLegacyProvider(providerAddr.LocalName)] = struct{}{}
+		fqn := c.Module.ProviderForLocalConfig(providerAddr)
+		m[fqn] = struct{}{}
 	}
 	for _, rc := range c.Module.DataResources {
 		providerAddr := rc.ProviderConfigAddr()
-		m[addrs.NewLegacyProvider(providerAddr.LocalName)] = struct{}{}
+		fqn := c.Module.ProviderForLocalConfig(providerAddr)
+		m[fqn] = struct{}{}
 	}
 
 	// Must also visit our child modules, recursively.
@@ -263,5 +266,8 @@ func (c *Config) ResolveAbsProviderAddr(addr addrs.ProviderConfig, inModule addr
 // by checking for the provider in module.ProviderRequirements and falling
 // back to addrs.NewLegacyProvider if it is not found.
 func (c *Config) ProviderForConfigAddr(addr addrs.LocalProviderConfig) addrs.Provider {
+	if provider, exists := c.Module.ProviderRequirements[addr.LocalName]; exists {
+		return provider.Type
+	}
 	return c.ResolveAbsProviderAddr(addr, addrs.RootModuleInstance).Provider
 }

--- a/configs/config.go
+++ b/configs/config.go
@@ -190,10 +190,6 @@ func (c *Config) gatherProviderTypes(m map[addrs.Provider]struct{}) {
 		return
 	}
 
-	// FIXME: These are currently all assuming legacy provider addresses.
-	// As part of phasing those out we'll need to change this to look up
-	// the true provider addresses via the local-to-FQN mapping table
-	// stored inside c.Module.
 	for _, pc := range c.Module.ProviderConfigs {
 		fqn := c.Module.ProviderForLocalConfig(addrs.LocalProviderConfig{LocalName: pc.Name})
 		m[fqn] = struct{}{}

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -80,14 +80,8 @@ func TestConfigResolveAbsProviderAddr(t *testing.T) {
 		}
 		got := cfg.ResolveAbsProviderAddr(addr, addrs.RootModuleInstance)
 		want := addrs.AbsProviderConfig{
-			Module: addrs.RootModuleInstance,
-			// FIXME: At the time of writing we're not actually supporting
-			// the explicit mapping to FQNs because we're still in
-			// legacy-only mode, so this is temporarily correct. However,
-			// once we are fully supporting this we should expect to see
-			// the "registry.terraform.io/foo/test" FQN here, while still
-			// preserving the "boop" alias.
-			Provider: addrs.NewLegacyProvider("foo-test"),
+			Module:   addrs.RootModuleInstance,
+			Provider: addrs.NewProvider(addrs.DefaultRegistryHost, "foo", "test"),
 			Alias:    "boop",
 		}
 		if got, want := got.String(), want.String(); got != want {

--- a/configs/module_test.go
+++ b/configs/module_test.go
@@ -13,11 +13,7 @@ func TestNewModule_provider_local_name(t *testing.T) {
 		t.Fatal(diags.Error())
 	}
 
-	// FIXME: while the provider source is set to "foo/test", terraform
-	// currently assumes everything is a legacy provider and the localname and
-	// type match. This test will be updated when provider source is fully
-	// implemented.
-	p := addrs.NewLegacyProvider("foo-test")
+	p := addrs.NewProvider(addrs.DefaultRegistryHost, "foo", "test")
 	if name, exists := mod.ProviderLocalNames[p]; !exists {
 		t.Fatal("provider FQN foo/test not found")
 	} else {

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -151,7 +151,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 
 		// Must attach schemas before ReferenceTransformer so that we can
 		// analyze the configuration to find references.
-		&AttachSchemaTransformer{Schemas: b.Schemas},
+		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
 		// Create expansion nodes for all of the module calls. This must
 		// come after all other transformers that create nodes representing

--- a/terraform/graph_builder_eval.go
+++ b/terraform/graph_builder_eval.go
@@ -87,7 +87,7 @@ func (b *EvalGraphBuilder) Steps() []GraphTransformer {
 
 		// Must attach schemas before ReferenceTransformer so that we can
 		// analyze the configuration to find references.
-		&AttachSchemaTransformer{Schemas: b.Schemas},
+		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.

--- a/terraform/graph_builder_import.go
+++ b/terraform/graph_builder_import.go
@@ -77,7 +77,7 @@ func (b *ImportGraphBuilder) Steps() []GraphTransformer {
 
 		// Must attach schemas before ReferenceTransformer so that we can
 		// analyze the configuration to find references.
-		&AttachSchemaTransformer{Schemas: b.Schemas},
+		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -135,7 +135,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 
 		// Must attach schemas before ReferenceTransformer so that we can
 		// analyze the configuration to find references.
-		&AttachSchemaTransformer{Schemas: b.Schemas},
+		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
 		// Create expansion nodes for all of the module calls. This must
 		// come after all other transformers that create nodes representing

--- a/terraform/graph_builder_refresh.go
+++ b/terraform/graph_builder_refresh.go
@@ -160,7 +160,7 @@ func (b *RefreshGraphBuilder) Steps() []GraphTransformer {
 
 		// Must attach schemas before ReferenceTransformer so that we can
 		// analyze the configuration to find references.
-		&AttachSchemaTransformer{Schemas: b.Schemas},
+		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
 		// Create expansion nodes for all of the module calls. This must
 		// come after all other transformers that create nodes representing

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -300,7 +300,7 @@ func (n *NodeAbstractResource) ProvidedBy() (addrs.ProviderConfig, bool) {
 }
 
 // GraphNodeProviderConsumer
-func (n *NodeAbstractResource) DefaultProvider() addrs.Provider {
+func (n *NodeAbstractResource) ImpliedProvider() addrs.Provider {
 	return n.Addr.Resource.DefaultProvider()
 }
 
@@ -328,7 +328,7 @@ func (n *NodeAbstractResourceInstance) ProvidedBy() (addrs.ProviderConfig, bool)
 }
 
 // GraphNodeProviderConsumer
-func (n *NodeAbstractResourceInstance) DefaultProvider() addrs.Provider {
+func (n *NodeAbstractResourceInstance) ImpliedProvider() addrs.Provider {
 	return n.Addr.Resource.DefaultProvider()
 }
 

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -295,12 +295,13 @@ func (n *NodeAbstractResource) ProvidedBy() (addrs.ProviderConfig, bool) {
 		}, false
 	}
 
-	// Use our type and containing module path to guess a provider configuration address.
-	defaultFQN := n.Addr.Resource.DefaultProvider()
-	return addrs.AbsProviderConfig{
-		Provider: defaultFQN,
-		Module:   n.Addr.Module,
-	}, false
+	// No provider configuration found
+	return nil, false
+}
+
+// GraphNodeProviderConsumer
+func (n *NodeAbstractResource) DefaultProvider() addrs.Provider {
+	return n.Addr.Resource.DefaultProvider()
 }
 
 // GraphNodeProviderConsumer
@@ -322,12 +323,13 @@ func (n *NodeAbstractResourceInstance) ProvidedBy() (addrs.ProviderConfig, bool)
 		return n.ResourceState.ProviderConfig, true
 	}
 
-	// Use our type and containing module path to guess a provider configuration address
-	defaultFQN := n.Addr.Resource.DefaultProvider()
-	return addrs.AbsProviderConfig{
-		Provider: defaultFQN,
-		Module:   n.Addr.Module,
-	}, false
+	// No provider configuration found
+	return nil, false
+}
+
+// GraphNodeProviderConsumer
+func (n *NodeAbstractResourceInstance) DefaultProvider() addrs.Provider {
+	return n.Addr.Resource.DefaultProvider()
 }
 
 // GraphNodeProvisionerConsumer

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -69,7 +69,7 @@ func (n *graphNodeImportState) ProvidedBy() (addrs.ProviderConfig, bool) {
 }
 
 // GraphNodeProviderConsumer
-func (n *graphNodeImportState) DefaultProvider() addrs.Provider {
+func (n *graphNodeImportState) ImpliedProvider() addrs.Provider {
 	// We assume that n.ProviderAddr has been properly populated here.
 	// It's the responsibility of the code creating a graphNodeImportState
 	// to populate this, possibly by calling DefaultProviderConfig() on the

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -69,6 +69,16 @@ func (n *graphNodeImportState) ProvidedBy() (addrs.ProviderConfig, bool) {
 }
 
 // GraphNodeProviderConsumer
+func (n *graphNodeImportState) DefaultProvider() addrs.Provider {
+	// We assume that n.ProviderAddr has been properly populated here.
+	// It's the responsibility of the code creating a graphNodeImportState
+	// to populate this, possibly by calling DefaultProviderConfig() on the
+	// resource address to infer an implied provider from the resource type
+	// name.
+	return n.ProviderAddr.Provider
+}
+
+// GraphNodeProviderConsumer
 func (n *graphNodeImportState) SetProvider(addr addrs.AbsProviderConfig) {
 	n.ResolvedProvider = addr
 }


### PR DESCRIPTION
This PR tackles the last "big" provider source related FIXMEs in the `terraform` package 🎉 

* the full `configs.Config` is now included in  `AttachSchemaTransformer` and `MissingProviderTransformer`. This change allows those transformers to properly look up the FQN for a given resource
*  I refactored `ProvidedBy()` to return nil if a provider config (in config or state) is not found and added an `ImpliedProvider()` function that would return the assumed provider based on the resource type name (ie, "null" for a "null_resource"). This change was primarily for readability; the whole thing was non-intuitive (it's not perfect now, but I think it's at least easier to reason about).
* `configs` now parses the provider source attribute! 