### PR TITLE
states: Fix coverage blips in statemgr/filesystem

### DIFF
--- a/states/statemgr/filesystem_test.go
+++ b/states/statemgr/filesystem_test.go
@@ -298,6 +298,41 @@ func TestFilesystem_nonExist(t *testing.T) {
 	}
 }
 
+func TestFilesystem_lockUnlockWithoutWrite(t *testing.T) {
+	info := NewLockInfo()
+	info.Operation = "test"
+
+	ls := testFilesystem(t)
+
+	// Delete the just-created tempfile so that Lock recreates it
+	os.Remove(ls.path)
+
+	// Lock the state, and in doing so recreate the tempfile
+	lockID, err := ls.Lock(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !ls.created {
+		t.Fatal("should have marked state as created")
+	}
+
+	if err := ls.Unlock(lockID); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat(ls.path)
+	if os.IsNotExist(err) {
+		// Success! Unlocking the state successfully deleted the tempfile
+		return
+	} else if err != nil {
+		t.Fatalf("unexpected error from os.Stat: %s", err)
+	} else {
+		os.Remove(ls.readPath)
+		t.Fatal("should have removed path, but exists")
+	}
+}
+
 func TestFilesystem_impl(t *testing.T) {
 	defer testOverrideVersion(t, "1.2.3")()
 	var _ Reader = new(Filesystem)


### PR DESCRIPTION
Something non-deterministic in the test suite is causing a coverage blip in a line in the filesystem state manager. This commit adds a test which specifically covers that line, which hopefully pleases the Codecov robot.