### PR TITLE
jsonstate: sort child modules by address for consistency

### DIFF
--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -241,6 +241,11 @@ func marshalModules(
 		ret = append(ret, cm)
 	}
 
+	// sort the child modules by address for consistency.
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Address < ret[j].Address
+	})
+
 	return ret, nil
 }
 

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -212,8 +212,8 @@ func marshalRootModule(s *states.State, schemas *terraform.Schemas) (module, err
 	return ret, err
 }
 
-// marshalModules is an ungainly recursive function to build a module
-// structure out of a teraform state.
+// marshalModules is an ungainly recursive function to build a module structure
+// out of terraform state.
 func marshalModules(
 	s *states.State,
 	schemas *terraform.Schemas,

--- a/command/testdata/show-json-state/modules/output.json
+++ b/command/testdata/show-json-state/modules/output.json
@@ -13,6 +13,23 @@
                 {
                     "resources": [
                         {
+                            "address": "module.module_test_bar.test_instance.example",
+                            "mode": "managed",
+                            "type": "test_instance",
+                            "name": "example",
+                            "provider_name": "test",
+                            "schema_version": 0,
+                            "values": {
+                                "ami": "bar-var",
+                                "id": null
+                            }
+                        }
+                    ],
+                    "address": "module.module_test_bar"
+                },
+                {
+                    "resources": [
+                        {
                             "address": "module.module_test_foo.test_instance.example[0]",
                             "mode": "managed",
                             "type": "test_instance",
@@ -27,23 +44,6 @@
                         }
                     ],
                     "address": "module.module_test_foo"
-                },
-                {
-                    "resources": [
-                        {
-                            "address": "module.module_test_bar.test_instance.example",
-                            "mode": "managed",
-                            "type": "test_instance",
-                            "name": "example",
-                            "provider_name": "test",
-                            "schema_version": 0,
-                            "values": {
-                                "ami": "bar-var",
-                                "id": null
-                            }
-                        }
-                    ],
-                    "address": "module.module_test_bar"
                 }
             ]
         }


### PR DESCRIPTION
inconsistent ordering of child modules in the json output from `terraform show` was causing flapping tests. HARRUMPH