### PR TITLE
[Website] vmc provider links

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -146,6 +146,7 @@ down to see all providers.
 - [UltraDNS](/docs/providers/ultradns/index.html)
 - [Vault](/docs/providers/vault/index.html)
 - [Venafi](/docs/providers/venafi/index.html)
+- [VMware Cloud](/docs/providers/vmc/index.html)
 - [VMware NSX-T](/docs/providers/nsxt/index.html)
 - [VMware vCloud Director](/docs/providers/vcd/index.html)
 - [VMware vRA7](/docs/providers/vra7/index.html)

--- a/website/docs/providers/type/major-index.html.markdown
+++ b/website/docs/providers/type/major-index.html.markdown
@@ -27,6 +27,7 @@ tested by HashiCorp.
 - [Oracle Cloud Infrastructure](/docs/providers/oci/index.html)
 - [Oracle Cloud Platform](/docs/providers/oraclepaas/index.html)
 - [Oracle Public Cloud](/docs/providers/opc/index.html)
+- [VMware Cloud](/docs/providers/vmc/index.html)
 - [VMware NSX-T](/docs/providers/nsxt/index.html)
 - [vCloud Director](/docs/providers/vcd/index.html)
 - [VMware vRA7](/docs/providers/vra7/index.html)


### PR DESCRIPTION
Adding vmc provider link to documentation

Tests should fail because changes must be made to terraform-website after this PR is merged