### PR TITLE
fix a flapping test involving CreateBeforeDestroy

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -10230,8 +10230,9 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 				Name: "a",
 			}.Instance(addrs.NoKey),
 			&states.ResourceInstanceObjectSrc{
-				Status:    states.ObjectReady,
-				AttrsJSON: []byte(`{"id":"a","require_new":"old"}`),
+				Status:              states.ObjectReady,
+				AttrsJSON:           []byte(`{"id":"a","require_new":"old"}`),
+				CreateBeforeDestroy: mode == "cbd",
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),

--- a/terraform/testdata/apply-module-replace-cycle/mod1/main.tf
+++ b/terraform/testdata/apply-module-replace-cycle/mod1/main.tf
@@ -1,8 +1,5 @@
 resource "aws_instance" "a" {
   require_new = "new"
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 output "ids" {


### PR DESCRIPTION
A typo in the config caused it to disagree with the plan on whether a
resource should be CreateBeforeDestroy, preventing it from being ordered
properly. Add the new CreateBeforeDestroy field to the test fixture
state as well for completeness.