### PR TITLE
Continue pushing the Path calls out of the Resource and Provider types

### DIFF
--- a/addrs/provider_config_test.go
+++ b/addrs/provider_config_test.go
@@ -18,7 +18,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 		{
 			`provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
-				Module: RootModuleInstance,
+				Module: RootModule,
 				Provider: Provider{
 					Type:      "aws",
 					Namespace: "hashicorp",
@@ -30,7 +30,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 		{
 			`provider["registry.terraform.io/hashicorp/aws"].foo`,
 			AbsProviderConfig{
-				Module: RootModuleInstance,
+				Module: RootModule,
 				Provider: Provider{
 					Type:      "aws",
 					Namespace: "hashicorp",
@@ -43,11 +43,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 		{
 			`module.baz.provider["registry.terraform.io/hashicorp/aws"]`,
 			AbsProviderConfig{
-				Module: ModuleInstance{
-					{
-						Name: "baz",
-					},
-				},
+				Module: Module{"baz"},
 				Provider: Provider{
 					Type:      "aws",
 					Namespace: "hashicorp",
@@ -59,11 +55,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 		{
 			`module.baz.provider["registry.terraform.io/hashicorp/aws"].foo`,
 			AbsProviderConfig{
-				Module: ModuleInstance{
-					{
-						Name: "baz",
-					},
-				},
+				Module: Module{"baz"},
 				Provider: Provider{
 					Type:      "aws",
 					Namespace: "hashicorp",
@@ -75,57 +67,18 @@ func TestParseAbsProviderConfig(t *testing.T) {
 		},
 		{
 			`module.baz["foo"].provider["registry.terraform.io/hashicorp/aws"]`,
-			AbsProviderConfig{
-				Module: ModuleInstance{
-					{
-						Name:        "baz",
-						InstanceKey: StringKey("foo"),
-					},
-				},
-				Provider: Provider{
-					Type:      "aws",
-					Namespace: "hashicorp",
-					Hostname:  "registry.terraform.io",
-				},
-			},
-			``,
+			AbsProviderConfig{},
+			`Provider address cannot contain module indexes`,
 		},
 		{
 			`module.baz[1].provider["registry.terraform.io/hashicorp/aws"]`,
-			AbsProviderConfig{
-				Module: ModuleInstance{
-					{
-						Name:        "baz",
-						InstanceKey: IntKey(1),
-					},
-				},
-				Provider: Provider{
-					Type:      "aws",
-					Namespace: "hashicorp",
-					Hostname:  "registry.terraform.io",
-				},
-			},
-			``,
+			AbsProviderConfig{},
+			`Provider address cannot contain module indexes`,
 		},
 		{
 			`module.baz[1].module.bar.provider["registry.terraform.io/hashicorp/aws"]`,
-			AbsProviderConfig{
-				Module: ModuleInstance{
-					{
-						Name:        "baz",
-						InstanceKey: IntKey(1),
-					},
-					{
-						Name: "bar",
-					},
-				},
-				Provider: Provider{
-					Type:      "aws",
-					Namespace: "hashicorp",
-					Hostname:  "registry.terraform.io",
-				},
-			},
-			``,
+			AbsProviderConfig{},
+			`Provider address cannot contain module indexes`,
 		},
 		{
 			`aws`,
@@ -206,21 +159,21 @@ func TestAbsProviderConfigString(t *testing.T) {
 	}{
 		{
 			AbsProviderConfig{
-				Module:   RootModuleInstance,
+				Module:   RootModule,
 				Provider: NewLegacyProvider("foo"),
 			},
 			`provider["registry.terraform.io/-/foo"]`,
 		},
 		{
 			AbsProviderConfig{
-				Module:   RootModuleInstance.Child("child_module", NoKey),
+				Module:   RootModule.Child("child_module"),
 				Provider: NewLegacyProvider("foo"),
 			},
 			`module.child_module.provider["registry.terraform.io/-/foo"]`,
 		},
 		{
 			AbsProviderConfig{
-				Module:   RootModuleInstance,
+				Module:   RootModule,
 				Alias:    "bar",
 				Provider: NewLegacyProvider("foo"),
 			},
@@ -228,7 +181,7 @@ func TestAbsProviderConfigString(t *testing.T) {
 		},
 		{
 			AbsProviderConfig{
-				Module:   RootModuleInstance.Child("child_module", NoKey),
+				Module:   RootModule.Child("child_module"),
 				Alias:    "bar",
 				Provider: NewLegacyProvider("foo"),
 			},
@@ -251,21 +204,21 @@ func TestAbsProviderConfigLegacyString(t *testing.T) {
 	}{
 		{
 			AbsProviderConfig{
-				Module:   RootModuleInstance,
+				Module:   RootModule,
 				Provider: NewLegacyProvider("foo"),
 			},
 			`provider.foo`,
 		},
 		{
 			AbsProviderConfig{
-				Module:   RootModuleInstance.Child("child_module", NoKey),
+				Module:   RootModule.Child("child_module"),
 				Provider: NewLegacyProvider("foo"),
 			},
 			`module.child_module.provider.foo`,
 		},
 		{
 			AbsProviderConfig{
-				Module:   RootModuleInstance,
+				Module:   RootModule,
 				Alias:    "bar",
 				Provider: NewLegacyProvider("foo"),
 			},
@@ -273,7 +226,7 @@ func TestAbsProviderConfigLegacyString(t *testing.T) {
 		},
 		{
 			AbsProviderConfig{
-				Module:   RootModuleInstance.Child("child_module", NoKey),
+				Module:   RootModule.Child("child_module"),
 				Alias:    "bar",
 				Provider: NewLegacyProvider("foo"),
 			},

--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -217,7 +217,7 @@ func TestLocal_planDeposedOnly(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	}))
@@ -661,7 +661,7 @@ func testPlanState() *states.State {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	return state
@@ -688,7 +688,7 @@ func testPlanState_withDataSource() *states.State {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	rootModule.SetResourceInstanceCurrent(
@@ -705,7 +705,7 @@ func testPlanState_withDataSource() *states.State {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	return state
@@ -732,7 +732,7 @@ func testPlanState_tainted() *states.State {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	return state

--- a/backend/testing.go
+++ b/backend/testing.go
@@ -152,7 +152,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 

--- a/command/apply_destroy_test.go
+++ b/command/apply_destroy_test.go
@@ -31,7 +31,7 @@ func TestApply_destroy(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -127,7 +127,7 @@ func TestApply_destroyLockedState(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -202,7 +202,7 @@ func TestApply_destroyTargeted(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -218,7 +218,7 @@ func TestApply_destroyTargeted(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -835,7 +835,7 @@ func TestApply_refresh(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -992,7 +992,7 @@ func TestApply_state(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -1359,7 +1359,7 @@ func TestApply_backup(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -1663,7 +1663,7 @@ func applyFixturePlanFile(t *testing.T) string {
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 		ProviderAddr: addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 		ChangeSrc: plans.ChangeSrc{
 			Action: plans.Create,

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -273,7 +273,7 @@ func testState() *states.State {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		// DeepCopy is used here to ensure our synthetic state matches exactly

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3159,7 +3159,7 @@ func runTestCases(t *testing.T, testCases map[string]testCase) {
 				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 				ProviderAddr: addrs.AbsProviderConfig{
 					Provider: addrs.NewLegacyProvider("test"),
-					Module:   addrs.RootModuleInstance,
+					Module:   addrs.RootModule,
 				},
 				ChangeSrc: plans.ChangeSrc{
 					Action: tc.Action,

--- a/command/format/state_test.go
+++ b/command/format/state_test.go
@@ -245,7 +245,7 @@ func basicState(t *testing.T) *states.State {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	rootModule.SetResourceInstanceCurrent(
@@ -261,7 +261,7 @@ func basicState(t *testing.T) *states.State {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	return state
@@ -297,7 +297,7 @@ func stateWithMoreOutputs(t *testing.T) *states.State {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	return state
@@ -324,7 +324,7 @@ func nestedState(t *testing.T) *states.State {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	return state
@@ -347,7 +347,7 @@ func deposedState(t *testing.T) *states.State {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	return state
@@ -376,7 +376,7 @@ func onlyDeposedState(t *testing.T) *states.State {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	rootModule.SetResourceInstanceDeposed(
@@ -393,7 +393,7 @@ func onlyDeposedState(t *testing.T) *states.State {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	return state

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -127,7 +127,7 @@ func TestGraph_plan(t *testing.T) {
 		},
 		ProviderAddr: addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	})
 	emptyConfig, err := plans.NewDynamicValue(cty.EmptyObjectVal, cty.EmptyObject)

--- a/command/jsonplan/values_test.go
+++ b/command/jsonplan/values_test.go
@@ -260,7 +260,7 @@ func TestMarshalPlanResources(t *testing.T) {
 						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 						ProviderAddr: addrs.AbsProviderConfig{
 							Provider: addrs.NewLegacyProvider("test"),
-							Module:   addrs.RootModuleInstance,
+							Module:   addrs.RootModule,
 						},
 						ChangeSrc: plans.ChangeSrc{
 							Action: test.Action,

--- a/command/jsonstate/state_test.go
+++ b/command/jsonstate/state_test.go
@@ -203,7 +203,7 @@ func TestMarshalResources(t *testing.T) {
 					},
 					ProviderConfig: addrs.AbsProviderConfig{
 						Provider: addrs.NewLegacyProvider("test"),
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 					},
 				},
 			},
@@ -245,7 +245,7 @@ func TestMarshalResources(t *testing.T) {
 					},
 					ProviderConfig: addrs.AbsProviderConfig{
 						Provider: addrs.NewLegacyProvider("test"),
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 					},
 				},
 			},
@@ -287,7 +287,7 @@ func TestMarshalResources(t *testing.T) {
 					},
 					ProviderConfig: addrs.AbsProviderConfig{
 						Provider: addrs.NewLegacyProvider("test"),
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 					},
 				},
 			},
@@ -331,7 +331,7 @@ func TestMarshalResources(t *testing.T) {
 					},
 					ProviderConfig: addrs.AbsProviderConfig{
 						Provider: addrs.NewLegacyProvider("test"),
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 					},
 				},
 			},
@@ -380,7 +380,7 @@ func TestMarshalResources(t *testing.T) {
 					},
 					ProviderConfig: addrs.AbsProviderConfig{
 						Provider: addrs.NewLegacyProvider("test"),
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 					},
 				},
 			},
@@ -452,7 +452,7 @@ func TestMarshalModules_basic(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -467,7 +467,7 @@ func TestMarshalModules_basic(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   childModule,
+				Module:   childModule.Module(),
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -482,7 +482,7 @@ func TestMarshalModules_basic(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   subModule,
+				Module:   subModule.Module(),
 			},
 		)
 	})
@@ -521,7 +521,7 @@ func TestMarshalModules_nested(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -536,7 +536,7 @@ func TestMarshalModules_nested(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   childModule,
+				Module:   childModule.Module(),
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -551,7 +551,7 @@ func TestMarshalModules_nested(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   subModule,
+				Module:   subModule.Module(),
 			},
 		)
 	})

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -126,7 +126,7 @@ func TestPlan_destroy(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -245,7 +245,7 @@ func TestPlan_outPathNoChange(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -487,7 +487,7 @@ func showFixturePlanFile(t *testing.T, action plans.Action) string {
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 		ProviderAddr: addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 		ChangeSrc: plans.ChangeSrc{
 			Action: action,

--- a/command/state_mv_test.go
+++ b/command/state_mv_test.go
@@ -29,7 +29,7 @@ func TestStateMv(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -45,7 +45,7 @@ func TestStateMv(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -160,7 +160,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -176,7 +176,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceMeta(
@@ -188,7 +188,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 			states.EachList,
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -250,7 +250,7 @@ func TestStateMv_instanceToResource(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -265,7 +265,7 @@ func TestStateMv_instanceToResource(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -338,7 +338,7 @@ func TestStateMv_instanceToNewResource(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -409,7 +409,7 @@ func TestStateMv_differentResourceTypes(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -462,7 +462,7 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -477,7 +477,7 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -537,7 +537,7 @@ func TestStateMv_backupExplicit(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -553,7 +553,7 @@ func TestStateMv_backupExplicit(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -602,7 +602,7 @@ func TestStateMv_stateOutNew(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -656,7 +656,7 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -675,7 +675,7 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -755,7 +755,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -770,7 +770,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -785,7 +785,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -843,7 +843,7 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 				},
 				addrs.AbsProviderConfig{
 					Provider: addrs.NewLegacyProvider("test"),
-					Module:   addrs.RootModuleInstance,
+					Module:   addrs.RootModule,
 				},
 			)
 		}
@@ -859,7 +859,7 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -913,7 +913,7 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -928,7 +928,7 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -983,7 +983,7 @@ func TestStateMv_toNewModule(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -1056,7 +1056,7 @@ func TestStateMv_withinBackend(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -1072,7 +1072,7 @@ func TestStateMv_withinBackend(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/command/state_rm_test.go
+++ b/command/state_rm_test.go
@@ -27,7 +27,7 @@ func TestStateRm(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -42,7 +42,7 @@ func TestStateRm(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -92,7 +92,7 @@ func TestStateRmNotChildModule(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		// This second instance has the same local address as the first but
@@ -110,7 +110,7 @@ func TestStateRmNotChildModule(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -181,7 +181,7 @@ func TestStateRmNoArgs(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -196,7 +196,7 @@ func TestStateRmNoArgs(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -240,7 +240,7 @@ func TestStateRmNonExist(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -255,7 +255,7 @@ func TestStateRmNonExist(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -300,7 +300,7 @@ func TestStateRm_backupExplicit(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -315,7 +315,7 @@ func TestStateRm_backupExplicit(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -416,7 +416,7 @@ func TestStateRm_backendState(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -431,7 +431,7 @@ func TestStateRm_backendState(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -120,7 +120,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	absPc := addrs.AbsProviderConfig{
 		Provider: rs.ProviderConfig.Provider,
 		Alias:    rs.ProviderConfig.Alias,
-		Module:   addrs.RootModuleInstance,
+		Module:   addrs.RootModule,
 	}
 	singleInstance := states.NewState()
 	singleInstance.EnsureModule(addr.Module).SetResourceInstanceCurrent(

--- a/command/state_show_test.go
+++ b/command/state_show_test.go
@@ -27,7 +27,7 @@ func TestStateShow(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -85,7 +85,7 @@ func TestStateShow_multi(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -100,7 +100,7 @@ func TestStateShow_multi(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   submod,
+				Module:   submod.Module(),
 			},
 		)
 	})
@@ -206,7 +206,7 @@ func TestStateShow_configured_provider(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test-beta"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/command/taint_test.go
+++ b/command/taint_test.go
@@ -26,7 +26,7 @@ func TestTaint(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -64,7 +64,7 @@ func TestTaint_lockedState(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -253,7 +253,7 @@ func TestTaint_missing(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -289,7 +289,7 @@ func TestTaint_missingAllow(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -368,7 +368,7 @@ func TestTaint_module(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -383,7 +383,7 @@ func TestTaint_module(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/command/untaint_test.go
+++ b/command/untaint_test.go
@@ -25,7 +25,7 @@ func TestUntaint(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -68,7 +68,7 @@ func TestUntaint_lockedState(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -279,7 +279,7 @@ func TestUntaint_missing(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -315,7 +315,7 @@ func TestUntaint_missingAllow(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -403,7 +403,7 @@ func TestUntaint_module(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -418,7 +418,7 @@ func TestUntaint_module(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -243,7 +243,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/configs/config.go
+++ b/configs/config.go
@@ -222,7 +222,7 @@ func (c *Config) gatherProviderTypes(m map[addrs.Provider]struct{}) {
 // The module address to resolve local addresses in must be given in the second
 // argument, and must refer to a module that exists under the receiver or
 // else this method will panic.
-func (c *Config) ResolveAbsProviderAddr(addr addrs.ProviderConfig, inModule addrs.ModuleInstance) addrs.AbsProviderConfig {
+func (c *Config) ResolveAbsProviderAddr(addr addrs.ProviderConfig, inModule addrs.Module) addrs.AbsProviderConfig {
 	switch addr := addr.(type) {
 
 	case addrs.AbsProviderConfig:
@@ -231,7 +231,7 @@ func (c *Config) ResolveAbsProviderAddr(addr addrs.ProviderConfig, inModule addr
 	case addrs.LocalProviderConfig:
 		// Find the descendent Config that contains the module that this
 		// local config belongs to.
-		mc := c.DescendentForInstance(inModule)
+		mc := c.Descendent(inModule)
 		if mc == nil {
 			panic(fmt.Sprintf("ResolveAbsProviderAddr with non-existent module %s", inModule.String()))
 		}
@@ -265,5 +265,5 @@ func (c *Config) ProviderForConfigAddr(addr addrs.LocalProviderConfig) addrs.Pro
 	if provider, exists := c.Module.ProviderRequirements[addr.LocalName]; exists {
 		return provider.Type
 	}
-	return c.ResolveAbsProviderAddr(addr, addrs.RootModuleInstance).Provider
+	return c.ResolveAbsProviderAddr(addr, addrs.RootModule).Provider
 }

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -43,11 +43,11 @@ func TestConfigResolveAbsProviderAddr(t *testing.T) {
 
 	t.Run("already absolute", func(t *testing.T) {
 		addr := addrs.AbsProviderConfig{
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 			Provider: addrs.NewLegacyProvider("test"),
 			Alias:    "boop",
 		}
-		got := cfg.ResolveAbsProviderAddr(addr, addrs.RootModuleInstance)
+		got := cfg.ResolveAbsProviderAddr(addr, addrs.RootModule)
 		if got, want := got.String(), addr.String(); got != want {
 			t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
 		}
@@ -57,9 +57,9 @@ func TestConfigResolveAbsProviderAddr(t *testing.T) {
 			LocalName: "implied",
 			Alias:     "boop",
 		}
-		got := cfg.ResolveAbsProviderAddr(addr, addrs.RootModuleInstance)
+		got := cfg.ResolveAbsProviderAddr(addr, addrs.RootModule)
 		want := addrs.AbsProviderConfig{
-			Module: addrs.RootModuleInstance,
+			Module: addrs.RootModule,
 			// FIXME: At the time of writing we still have LocalProviderConfig
 			// nested inside AbsProviderConfig, but a future change will
 			// stop tis embedding and just have an addrs.Provider and an alias
@@ -78,9 +78,9 @@ func TestConfigResolveAbsProviderAddr(t *testing.T) {
 			LocalName: "foo-test", // this is explicitly set in the config
 			Alias:     "boop",
 		}
-		got := cfg.ResolveAbsProviderAddr(addr, addrs.RootModuleInstance)
+		got := cfg.ResolveAbsProviderAddr(addr, addrs.RootModule)
 		want := addrs.AbsProviderConfig{
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 			Provider: addrs.NewProvider(addrs.DefaultRegistryHost, "foo", "test"),
 			Alias:    "boop",
 		}

--- a/helper/resource/state_shim_test.go
+++ b/helper/resource/state_shim_test.go
@@ -43,7 +43,7 @@ func TestStateShim(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	rootModule.SetResourceInstanceCurrent(
@@ -59,7 +59,7 @@ func TestStateShim(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 
@@ -78,7 +78,7 @@ func TestStateShim(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   childInstance,
+			Module:   childInstance.Module(),
 		},
 	)
 	childModule.SetResourceInstanceCurrent(
@@ -102,7 +102,7 @@ func TestStateShim(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   childInstance,
+			Module:   childInstance.Module(),
 		},
 	)
 
@@ -128,7 +128,7 @@ func TestStateShim(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   childInstance,
+			Module:   childInstance.Module(),
 		},
 	)
 
@@ -145,7 +145,7 @@ func TestStateShim(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   childInstance,
+			Module:   childInstance.Module(),
 		},
 	)
 	childModule.SetResourceInstanceCurrent(
@@ -161,7 +161,7 @@ func TestStateShim(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   childInstance,
+			Module:   childInstance.Module(),
 		},
 	)
 
@@ -178,7 +178,7 @@ func TestStateShim(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   childInstance,
+			Module:   childInstance.Module(),
 		},
 	)
 

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -729,7 +729,7 @@ func testIDOnlyRefresh(c TestCase, opts terraform.ContextOpts, step TestStep, r 
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("placeholder"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 

--- a/plans/plan_test.go
+++ b/plans/plan_test.go
@@ -21,7 +21,7 @@ func TestProviderAddrs(t *testing.T) {
 						Name: "woot",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.AbsProviderConfig{
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 						Provider: addrs.NewLegacyProvider("test"),
 					},
 				},
@@ -33,7 +33,7 @@ func TestProviderAddrs(t *testing.T) {
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					DeposedKey: "foodface",
 					ProviderAddr: addrs.AbsProviderConfig{
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 						Provider: addrs.NewLegacyProvider("test"),
 					},
 				},
@@ -44,7 +44,7 @@ func TestProviderAddrs(t *testing.T) {
 						Name: "what",
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.AbsProviderConfig{
-						Module:   addrs.RootModuleInstance.Child("foo", addrs.NoKey),
+						Module:   addrs.RootModule.Child("foo"),
 						Provider: addrs.NewLegacyProvider("test"),
 					},
 				},
@@ -55,11 +55,11 @@ func TestProviderAddrs(t *testing.T) {
 	got := plan.ProviderAddrs()
 	want := []addrs.AbsProviderConfig{
 		addrs.AbsProviderConfig{
-			Module:   addrs.RootModuleInstance.Child("foo", addrs.NoKey),
+			Module:   addrs.RootModule.Child("foo"),
 			Provider: addrs.NewLegacyProvider("test"),
 		},
 		addrs.AbsProviderConfig{
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 			Provider: addrs.NewLegacyProvider("test"),
 		},
 	}

--- a/plans/planfile/tfplan_test.go
+++ b/plans/planfile/tfplan_test.go
@@ -58,7 +58,7 @@ func TestTFPlanRoundTrip(t *testing.T) {
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.AbsProviderConfig{
 						Provider: addrs.NewDefaultProvider("test"),
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.DeleteThenCreate,
@@ -79,7 +79,7 @@ func TestTFPlanRoundTrip(t *testing.T) {
 					DeposedKey: "foodface",
 					ProviderAddr: addrs.AbsProviderConfig{
 						Provider: addrs.NewDefaultProvider("test"),
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.Delete,
@@ -198,7 +198,7 @@ func TestTFPlanRoundTripDestroy(t *testing.T) {
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.AbsProviderConfig{
 						Provider: addrs.NewDefaultProvider("test"),
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.Delete,

--- a/providers/addressed_types_test.go
+++ b/providers/addressed_types_test.go
@@ -11,24 +11,24 @@ import (
 func TestAddressedTypesAbs(t *testing.T) {
 	providerAddrs := []addrs.AbsProviderConfig{
 		addrs.AbsProviderConfig{
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 			Provider: addrs.NewLegacyProvider("aws"),
 		},
 		addrs.AbsProviderConfig{
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 			Provider: addrs.NewLegacyProvider("aws"),
 			Alias:    "foo",
 		},
 		addrs.AbsProviderConfig{
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 			Provider: addrs.NewLegacyProvider("azure"),
 		},
 		addrs.AbsProviderConfig{
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 			Provider: addrs.NewLegacyProvider("null"),
 		},
 		addrs.AbsProviderConfig{
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 			Provider: addrs.NewLegacyProvider("null"),
 		},
 	}

--- a/repl/session_test.go
+++ b/repl/session_test.go
@@ -47,7 +47,7 @@ func TestSession_basicState(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -62,7 +62,7 @@ func TestSession_basicState(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/states/state_test.go
+++ b/states/state_test.go
@@ -37,7 +37,7 @@ func TestState(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 
@@ -81,7 +81,7 @@ func TestState(t *testing.T) {
 						},
 						ProviderConfig: addrs.AbsProviderConfig{
 							Provider: addrs.NewDefaultProvider("test"),
-							Module:   addrs.RootModuleInstance,
+							Module:   addrs.RootModule,
 						},
 					},
 				},
@@ -144,7 +144,7 @@ func TestStateDeepCopy(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	rootModule.SetResourceInstanceCurrent(
@@ -171,7 +171,7 @@ func TestStateDeepCopy(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 

--- a/states/statefile/version3_upgrade.go
+++ b/states/statefile/version3_upgrade.go
@@ -136,13 +136,13 @@ func upgradeStateV3ToV4(old *stateV3) (*stateV4, error) {
 							return nil, fmt.Errorf("invalid legacy provider config reference %q for %s: %s", oldProviderAddr, instAddr, diags.Err())
 						}
 						providerAddr = addrs.AbsProviderConfig{
-							Module:   moduleAddr,
+							Module:   moduleAddr.Module(),
 							Provider: addrs.NewLegacyProvider(localAddr.LocalName),
 							Alias:    localAddr.Alias,
 						}
 					} else {
 						providerAddr = addrs.AbsProviderConfig{
-							Module:   moduleAddr,
+							Module:   moduleAddr.Module(),
 							Provider: resAddr.DefaultProvider(),
 						}
 					}

--- a/states/statemgr/testing.go
+++ b/states/statemgr/testing.go
@@ -152,7 +152,7 @@ func TestFullInitialState() *states.State {
 	}
 	providerAddr := addrs.AbsProviderConfig{
 		Provider: rAddr.DefaultProvider(),
-		Module:   addrs.RootModuleInstance,
+		Module:   addrs.RootModule,
 	}
 	childMod.SetResourceMeta(rAddr, states.EachList, providerAddr)
 	return state

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -1333,7 +1333,7 @@ func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("aws"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	root.SetResourceInstanceCurrent(
@@ -1358,7 +1358,7 @@ func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("aws"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 
@@ -1431,7 +1431,7 @@ func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("aws"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	child.SetResourceInstanceCurrent(
@@ -1456,7 +1456,7 @@ func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("aws"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 
@@ -2828,7 +2828,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 	want := states.BuildState(func(s *states.SyncState) {
 		providerAddr := addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		}
 		zeroAddr := addrs.Resource{
 			Mode: addrs.ManagedResourceMode,
@@ -7051,7 +7051,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 				},
 				addrs.AbsProviderConfig{
 					Provider: addrs.NewLegacyProvider("test"),
-					Module:   addrs.RootModuleInstance,
+					Module:   addrs.RootModule,
 				},
 			)
 		}),
@@ -7191,7 +7191,7 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 				},
 				addrs.AbsProviderConfig{
 					Provider: addrs.NewLegacyProvider("aws"),
-					Module:   addrs.RootModuleInstance,
+					Module:   addrs.RootModule,
 				},
 			)
 		}),
@@ -8618,7 +8618,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("aws"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 
@@ -8644,7 +8644,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("aws"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 
@@ -8751,7 +8751,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("aws"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 
@@ -8777,7 +8777,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("aws"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 
@@ -9684,7 +9684,7 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 	state.Modules["module.mod.module.removed"].Resources["aws_instance.child"].ProviderConfig = addrs.AbsProviderConfig{
 		Provider: addrs.NewLegacyProvider("aws"),
 		Alias:    "bar",
-		Module:   addrs.RootModuleInstance,
+		Module:   addrs.RootModule,
 	}
 
 	if _, diags := ctx.Plan(); diags.HasErrors() {
@@ -10108,7 +10108,7 @@ func TestContext2Apply_issue19908(t *testing.T) {
 				},
 				addrs.AbsProviderConfig{
 					Provider: addrs.NewLegacyProvider("test"),
-					Module:   addrs.RootModuleInstance,
+					Module:   addrs.RootModule,
 				},
 			)
 		}),
@@ -10236,7 +10236,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 
@@ -10253,7 +10253,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 
@@ -10296,7 +10296,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance.Child("a", addrs.NoKey)),
 					ProviderAddr: addrs.AbsProviderConfig{
 						Provider: addrs.NewLegacyProvider("aws"),
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: aAction,
@@ -10312,7 +10312,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance.Child("b", addrs.NoKey)),
 					ProviderAddr: addrs.AbsProviderConfig{
 						Provider: addrs.NewLegacyProvider("aws"),
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.DeleteThenCreate,
@@ -10363,7 +10363,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("null"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	root.SetResourceInstanceCurrent(
@@ -10378,7 +10378,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("null"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 
@@ -10453,7 +10453,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	root.SetResourceInstanceCurrent(
@@ -10468,7 +10468,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	root.SetResourceInstanceCurrent(
@@ -10483,7 +10483,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 
@@ -10660,7 +10660,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	root.SetResourceInstanceCurrent(
@@ -10685,7 +10685,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	root.SetResourceInstanceCurrent(
@@ -10700,7 +10700,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -117,7 +117,7 @@ func TestContextImport_collision(t *testing.T) {
 				},
 				addrs.AbsProviderConfig{
 					Provider: addrs.NewLegacyProvider("aws"),
-					Module:   addrs.RootModuleInstance,
+					Module:   addrs.RootModule,
 				},
 			)
 		}),
@@ -606,7 +606,7 @@ func TestContextImport_moduleDiff(t *testing.T) {
 				},
 				addrs.AbsProviderConfig{
 					Provider: addrs.NewLegacyProvider("aws"),
-					Module:   addrs.RootModuleInstance,
+					Module:   addrs.RootModule,
 				},
 			)
 		}),
@@ -667,7 +667,7 @@ func TestContextImport_moduleExisting(t *testing.T) {
 				},
 				addrs.AbsProviderConfig{
 					Provider: addrs.NewLegacyProvider("aws"),
-					Module:   addrs.RootModuleInstance,
+					Module:   addrs.RootModule,
 				},
 			)
 		}),

--- a/terraform/context_input.go
+++ b/terraform/context_input.go
@@ -160,7 +160,7 @@ func (c *Context) Input(mode InputMode) tfdiags.Diagnostics {
 			absConfigAddr := addrs.AbsProviderConfig{
 				Provider: providerFqn,
 				Alias:    pa.Alias,
-				Module:   c.Config().Path.UnkeyedInstanceShim(),
+				Module:   c.Config().Path,
 			}
 			c.providerInputConfig[absConfigAddr.String()] = vals
 

--- a/terraform/context_input_test.go
+++ b/terraform/context_input_test.go
@@ -480,7 +480,7 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("null"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -5052,7 +5052,7 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -105,7 +105,7 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -1742,7 +1742,7 @@ func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -1828,7 +1828,7 @@ func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("test"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -1999,7 +1999,7 @@ func TestRefresh_updateDependencies(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("aws"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	root.SetResourceInstanceCurrent(
@@ -2014,7 +2014,7 @@ func TestRefresh_updateDependencies(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("aws"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -108,7 +108,7 @@ func (ctx *BuiltinEvalContext) Input() UIInput {
 func (ctx *BuiltinEvalContext) InitProvider(addr addrs.AbsProviderConfig) (providers.Interface, error) {
 	ctx.once.Do(ctx.init)
 	absAddr := addr
-	if !absAddr.Module.Equal(ctx.Path()) {
+	if !absAddr.Module.Equal(ctx.Path().Module()) {
 		// This indicates incorrect use of InitProvider: it should be used
 		// only from the module that the provider configuration belongs to.
 		panic(fmt.Sprintf("%s initialized by wrong module %s", absAddr, ctx.Path()))
@@ -153,7 +153,7 @@ func (ctx *BuiltinEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) *Pro
 
 func (ctx *BuiltinEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error {
 	ctx.once.Do(ctx.init)
-	if !addr.Module.Equal(ctx.Path()) {
+	if !addr.Module.Equal(ctx.Path().Module()) {
 		// This indicates incorrect use of CloseProvider: it should be used
 		// only from the module that the provider configuration belongs to.
 		panic(fmt.Sprintf("%s closed by wrong module %s", addr, ctx.Path()))
@@ -175,7 +175,7 @@ func (ctx *BuiltinEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error
 func (ctx *BuiltinEvalContext) ConfigureProvider(addr addrs.AbsProviderConfig, cfg cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	absAddr := addr
-	if !absAddr.Module.Equal(ctx.Path()) {
+	if !absAddr.Module.Equal(ctx.Path().Module()) {
 		// This indicates incorrect use of ConfigureProvider: it should be used
 		// only from the module that the provider configuration belongs to.
 		panic(fmt.Sprintf("%s configured by wrong module %s", absAddr, ctx.Path()))
@@ -206,7 +206,7 @@ func (ctx *BuiltinEvalContext) ProviderInput(pc addrs.AbsProviderConfig) map[str
 	ctx.ProviderLock.Lock()
 	defer ctx.ProviderLock.Unlock()
 
-	if !pc.Module.Equal(ctx.Path()) {
+	if !pc.Module.Equal(ctx.Path().Module()) {
 		// This indicates incorrect use of InitProvider: it should be used
 		// only from the module that the provider configuration belongs to.
 		panic(fmt.Sprintf("%s initialized by wrong module %s", pc, ctx.Path()))
@@ -222,7 +222,7 @@ func (ctx *BuiltinEvalContext) ProviderInput(pc addrs.AbsProviderConfig) map[str
 
 func (ctx *BuiltinEvalContext) SetProviderInput(pc addrs.AbsProviderConfig, c map[string]cty.Value) {
 	absProvider := pc
-	if !absProvider.Module.Equal(ctx.Path()) {
+	if !absProvider.Module.Equal(ctx.Path().Module()) {
 		// This indicates incorrect use of InitProvider: it should be used
 		// only from the module that the provider configuration belongs to.
 		panic(fmt.Sprintf("%s initialized by wrong module %s", absProvider, ctx.Path()))

--- a/terraform/eval_context_builtin_test.go
+++ b/terraform/eval_context_builtin_test.go
@@ -25,11 +25,11 @@ func TestBuiltinEvalContextProviderInput(t *testing.T) {
 	ctx2.ProviderLock = &lock
 
 	providerAddr1 := addrs.AbsProviderConfig{
-		Module:   addrs.RootModuleInstance,
+		Module:   addrs.RootModule,
 		Provider: addrs.NewLegacyProvider("foo"),
 	}
 	providerAddr2 := addrs.AbsProviderConfig{
-		Module:   addrs.RootModuleInstance.Child("child", addrs.NoKey),
+		Module:   addrs.RootModule.Child("child"),
 		Provider: addrs.NewLegacyProvider("foo"),
 	}
 
@@ -65,11 +65,11 @@ func TestBuildingEvalContextInitProvider(t *testing.T) {
 	}
 
 	providerAddrDefault := addrs.AbsProviderConfig{
-		Module:   addrs.RootModuleInstance,
+		Module:   addrs.RootModule,
 		Provider: addrs.NewLegacyProvider("test"),
 	}
 	providerAddrAlias := addrs.AbsProviderConfig{
-		Module:   addrs.RootModuleInstance,
+		Module:   addrs.RootModule,
 		Provider: addrs.NewLegacyProvider("test"),
 		Alias:    "foo",
 	}

--- a/terraform/eval_provider_test.go
+++ b/terraform/eval_provider_test.go
@@ -17,7 +17,7 @@ func TestBuildProviderConfig(t *testing.T) {
 		"set_in_config": cty.StringVal("config"),
 	})
 	providerAddr := addrs.AbsProviderConfig{
-		Module:   addrs.RootModuleInstance,
+		Module:   addrs.RootModule,
 		Provider: addrs.NewLegacyProvider("foo"),
 	}
 
@@ -69,7 +69,7 @@ func TestEvalConfigProvider(t *testing.T) {
 	provider := mockProviderWithConfigSchema(simpleTestSchema())
 	rp := providers.Interface(provider)
 	providerAddr := addrs.AbsProviderConfig{
-		Module:   addrs.RootModuleInstance,
+		Module:   addrs.RootModule,
 		Provider: addrs.NewLegacyProvider("foo"),
 	}
 	n := &EvalConfigProvider{
@@ -103,7 +103,7 @@ func TestEvalInitProvider_impl(t *testing.T) {
 
 func TestEvalInitProvider(t *testing.T) {
 	providerAddr := addrs.AbsProviderConfig{
-		Module:   addrs.RootModuleInstance,
+		Module:   addrs.RootModule,
 		Provider: addrs.NewLegacyProvider("foo"),
 	}
 	n := &EvalInitProvider{
@@ -125,7 +125,7 @@ func TestEvalInitProvider(t *testing.T) {
 
 func TestEvalCloseProvider(t *testing.T) {
 	providerAddr := addrs.AbsProviderConfig{
-		Module:   addrs.RootModuleInstance,
+		Module:   addrs.RootModule,
 		Provider: addrs.NewLegacyProvider("foo"),
 	}
 	n := &EvalCloseProvider{

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -554,7 +554,7 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 	root.SetResourceInstanceCurrent(
@@ -579,7 +579,7 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewLegacyProvider("test"),
-			Module:   addrs.RootModuleInstance,
+			Module:   addrs.RootModule,
 		},
 	)
 

--- a/terraform/node_data_refresh_test.go
+++ b/terraform/node_data_refresh_test.go
@@ -134,7 +134,7 @@ func TestNodeRefreshableDataResourceDynamicExpand_scaleIn(t *testing.T) {
 			Config: m.Module.DataResources["data.aws_instance.foo"],
 			ResolvedProvider: addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		},
 	}

--- a/terraform/node_provider_abstract.go
+++ b/terraform/node_provider_abstract.go
@@ -26,7 +26,7 @@ type NodeAbstractProvider struct {
 }
 
 var (
-	_ GraphNodeModuleInstance             = (*NodeAbstractProvider)(nil)
+	_ GraphNodeModulePath                 = (*NodeAbstractProvider)(nil)
 	_ RemovableIfNotTargeted              = (*NodeAbstractProvider)(nil)
 	_ GraphNodeReferencer                 = (*NodeAbstractProvider)(nil)
 	_ GraphNodeProvider                   = (*NodeAbstractProvider)(nil)
@@ -41,12 +41,12 @@ func (n *NodeAbstractProvider) Name() string {
 
 // GraphNodeModuleInstance
 func (n *NodeAbstractProvider) Path() addrs.ModuleInstance {
-	return n.Addr.Module
+	return n.Addr.Module.UnkeyedInstanceShim()
 }
 
 // GraphNodeModulePath
 func (n *NodeAbstractProvider) ModulePath() addrs.Module {
-	return n.Addr.Module.Module()
+	return n.Addr.Module
 }
 
 // RemovableIfNotTargeted

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -99,7 +99,8 @@ func NewNodeAbstractResource(addr addrs.AbsResource) *NodeAbstractResource {
 // the "count" or "for_each" arguments.
 type NodeAbstractResourceInstance struct {
 	NodeAbstractResource
-	InstanceKey addrs.InstanceKey
+	ModuleInstance addrs.ModuleInstance
+	InstanceKey    addrs.InstanceKey
 
 	// The fields below will be automatically set using the Attach
 	// interfaces if you're running those transforms, but also be explicitly
@@ -138,7 +139,8 @@ func NewNodeAbstractResourceInstance(addr addrs.AbsResourceInstance) *NodeAbstra
 			Addr:   addr.Resource.Resource,
 			Module: addr.Module.Module(),
 		},
-		InstanceKey: addr.Resource.Key,
+		ModuleInstance: addr.Module,
+		InstanceKey:    addr.Resource.Key,
 	}
 }
 
@@ -153,6 +155,10 @@ func (n *NodeAbstractResourceInstance) Name() string {
 // GraphNodeModuleInstance
 func (n *NodeAbstractResource) Path() addrs.ModuleInstance {
 	return n.Module.UnkeyedInstanceShim()
+}
+
+func (n *NodeAbstractResourceInstance) Path() addrs.ModuleInstance {
+	return n.ModuleInstance
 }
 
 // GraphNodeModulePath

--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -53,19 +53,16 @@ func (n *NodeApplyableResource) References() []*addrs.Reference {
 
 // GraphNodeEvalable
 func (n *NodeApplyableResource) EvalTree() EvalNode {
-	addr := n.ResourceAddr()
-	config := n.Config
-	providerAddr := n.ResolvedProvider
-
-	if config == nil {
+	if n.Config == nil {
 		// Nothing to do, then.
-		log.Printf("[TRACE] NodeApplyableResource: no configuration present for %s", addr)
+		log.Printf("[TRACE] NodeApplyableResource: no configuration present for %s", n.Name())
 		return &EvalNoop{}
 	}
 
 	return &EvalWriteResourceState{
-		Addr:         addr.Resource,
-		Config:       config,
-		ProviderAddr: providerAddr,
+		Addr:         n.Addr,
+		Module:       n.Module,
+		Config:       n.Config,
+		ProviderAddr: n.ResolvedProvider,
 	}
 }

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -288,6 +288,7 @@ func (n *NodeDestroyResourceInstance) EvalTree() EvalNode {
 // all been destroyed.
 type NodeDestroyResource struct {
 	*NodeAbstractResource
+	Addr addrs.AbsResource
 }
 
 var (
@@ -340,11 +341,6 @@ func (n *NodeDestroyResource) EvalTree() EvalNode {
 // GraphNodeResource
 func (n *NodeDestroyResource) ResourceAddr() addrs.AbsResource {
 	return n.NodeAbstractResource.ResourceAddr()
-}
-
-// GraphNodeSubpath
-func (n *NodeDestroyResource) Path() addrs.ModuleInstance {
-	return n.NodeAbstractResource.Path()
 }
 
 // GraphNodeNoProvider

--- a/terraform/node_resource_plan.go
+++ b/terraform/node_resource_plan.go
@@ -19,7 +19,6 @@ type NodePlannableResource struct {
 }
 
 var (
-	_ GraphNodeModuleInstance       = (*NodePlannableResource)(nil)
 	_ GraphNodeDestroyerCBD         = (*NodePlannableResource)(nil)
 	_ GraphNodeDynamicExpandable    = (*NodePlannableResource)(nil)
 	_ GraphNodeReferenceable        = (*NodePlannableResource)(nil)
@@ -30,19 +29,17 @@ var (
 
 // GraphNodeEvalable
 func (n *NodePlannableResource) EvalTree() EvalNode {
-	addr := n.ResourceAddr()
-	config := n.Config
-
-	if config == nil {
+	if n.Config == nil {
 		// Nothing to do, then.
-		log.Printf("[TRACE] NodeApplyableResource: no configuration present for %s", addr)
+		log.Printf("[TRACE] NodeApplyableResource: no configuration present for %s", n.Name())
 		return &EvalNoop{}
 	}
 
 	// this ensures we can reference the resource even if the count is 0
 	return &EvalWriteResourceState{
-		Addr:         addr.Resource,
-		Config:       config,
+		Addr:         n.Addr,
+		Module:       n.Module,
+		Config:       n.Config,
 		ProviderAddr: n.ResolvedProvider,
 	}
 }

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -25,7 +25,6 @@ type NodeRefreshableManagedResource struct {
 }
 
 var (
-	_ GraphNodeModuleInstance       = (*NodeRefreshableManagedResource)(nil)
 	_ GraphNodeDynamicExpandable    = (*NodeRefreshableManagedResource)(nil)
 	_ GraphNodeReferenceable        = (*NodeRefreshableManagedResource)(nil)
 	_ GraphNodeReferencer           = (*NodeRefreshableManagedResource)(nil)
@@ -61,8 +60,7 @@ func (n *NodeRefreshableManagedResource) DynamicExpand(ctx EvalContext) (*Graph,
 	// Inform our instance expander about our expansion results above,
 	// and then use it to calculate the instance addresses we'll expand for.
 	expander := ctx.InstanceExpander()
-
-	for _, module := range expander.ExpandModule(ctx.Path().Module()) {
+	for _, module := range expander.ExpandModule(n.Module) {
 		switch {
 		case count >= 0:
 			expander.SetResourceCount(module, n.ResourceAddr().Resource, count)
@@ -72,7 +70,7 @@ func (n *NodeRefreshableManagedResource) DynamicExpand(ctx EvalContext) (*Graph,
 			expander.SetResourceSingle(module, n.ResourceAddr().Resource)
 		}
 	}
-	instanceAddrs := expander.ExpandResource(ctx.Path().Module(), n.ResourceAddr().Resource)
+	instanceAddrs := expander.ExpandResource(n.Module, n.ResourceAddr().Resource)
 
 	// Our graph transformers require access to the full state, so we'll
 	// temporarily lock it while we work on this.
@@ -131,7 +129,7 @@ func (n *NodeRefreshableManagedResource) DynamicExpand(ctx EvalContext) (*Graph,
 		Name:     "NodeRefreshableManagedResource",
 	}
 
-	graph, diags := b.Build(ctx.Path())
+	graph, diags := b.Build(nil)
 	return graph, diags.ErrWithWarnings()
 }
 

--- a/terraform/node_resource_validate.go
+++ b/terraform/node_resource_validate.go
@@ -15,7 +15,6 @@ type NodeValidatableResource struct {
 }
 
 var (
-	_ GraphNodeModuleInstance            = (*NodeValidatableResource)(nil)
 	_ GraphNodeEvalable                  = (*NodeValidatableResource)(nil)
 	_ GraphNodeReferenceable             = (*NodeValidatableResource)(nil)
 	_ GraphNodeReferencer                = (*NodeValidatableResource)(nil)

--- a/terraform/transform_attach_schema.go
+++ b/terraform/transform_attach_schema.go
@@ -69,7 +69,7 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 				if t.Config == nil {
 					providerFqn = addrs.NewLegacyProvider(p.LocalName)
 				} else {
-					modConfig := t.Config.DescendentForInstance(tv.Path())
+					modConfig := t.Config.Descendent(tv.ModulePath())
 					if modConfig == nil {
 						providerFqn = addrs.NewLegacyProvider(p.LocalName)
 					} else {

--- a/terraform/transform_diff_test.go
+++ b/terraform/transform_diff_test.go
@@ -45,7 +45,7 @@ func TestDiffTransformer(t *testing.T) {
 					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.AbsProviderConfig{
 						Provider: addrs.NewLegacyProvider("aws"),
-						Module:   addrs.RootModuleInstance,
+						Module:   addrs.RootModule,
 					},
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.Update,

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -24,7 +24,7 @@ func (t *ImportStateTransformer) Transform(g *Graph) error {
 			defaultFQN := target.Addr.Resource.Resource.DefaultProvider()
 			providerAddr = addrs.AbsProviderConfig{
 				Provider: defaultFQN,
-				Module:   target.Addr.Module,
+				Module:   target.Addr.Module.Module(),
 			}
 		}
 
@@ -48,7 +48,7 @@ type graphNodeImportState struct {
 }
 
 var (
-	_ GraphNodeModuleInstance    = (*graphNodeImportState)(nil)
+	_ GraphNodeModulePath        = (*graphNodeImportState)(nil)
 	_ GraphNodeEvalable          = (*graphNodeImportState)(nil)
 	_ GraphNodeProviderConsumer  = (*graphNodeImportState)(nil)
 	_ GraphNodeDynamicExpandable = (*graphNodeImportState)(nil)
@@ -86,6 +86,11 @@ func (n *graphNodeImportState) SetProvider(addr addrs.AbsProviderConfig) {
 // GraphNodeModuleInstance
 func (n *graphNodeImportState) Path() addrs.ModuleInstance {
 	return n.Addr.Module
+}
+
+// GraphNodeModulePath
+func (n *graphNodeImportState) ModulePath() addrs.Module {
+	return n.Addr.Module.Module()
 }
 
 // GraphNodeEvalable impl.

--- a/terraform/transform_orphan_resource_test.go
+++ b/terraform/transform_orphan_resource_test.go
@@ -28,7 +28,7 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 
@@ -47,7 +47,7 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -96,7 +96,7 @@ func TestOrphanResourceInstanceTransformer_countGood(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -113,7 +113,7 @@ func TestOrphanResourceInstanceTransformer_countGood(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -161,7 +161,7 @@ func TestOrphanResourceInstanceTransformer_countBad(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -178,7 +178,7 @@ func TestOrphanResourceInstanceTransformer_countBad(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})
@@ -226,7 +226,7 @@ func TestOrphanResourceInstanceTransformer_modules(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 		s.SetResourceInstanceCurrent(
@@ -243,7 +243,7 @@ func TestOrphanResourceInstanceTransformer_modules(t *testing.T) {
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),
-				Module:   addrs.RootModuleInstance,
+				Module:   addrs.RootModule,
 			},
 		)
 	})

--- a/terraform/transform_provisioner_test.go
+++ b/terraform/transform_provisioner_test.go
@@ -72,7 +72,7 @@ func TestMissingProvisionerTransformer_module(t *testing.T) {
 				},
 				addrs.AbsProviderConfig{
 					Provider: addrs.NewLegacyProvider("aws"),
-					Module:   addrs.RootModuleInstance,
+					Module:   addrs.RootModule,
 				},
 			)
 			s.SetResourceInstanceCurrent(
@@ -89,7 +89,7 @@ func TestMissingProvisionerTransformer_module(t *testing.T) {
 				},
 				addrs.AbsProviderConfig{
 					Provider: addrs.NewLegacyProvider("aws"),
-					Module:   addrs.RootModuleInstance,
+					Module:   addrs.RootModule,
 				},
 			)
 		})


### PR DESCRIPTION
This starts with some more removal of the `Path` method from `*Resource` types, so we can work with them in an unexpanded context.

The majority of this PR is the conversion of the `addrs.AbsProviderConfig` to use a `Module` rather than a `ModuleInstance`.  The `Abs` prefix  in `AbsProviderConfig` is retained for now to reduce the size of the changes, and we can do a wholesale rename later when there is less work in-flight.