### PR TITLE
implement addrs.ConfigResource

### DIFF
--- a/addrs/parse_target_test.go
+++ b/addrs/parse_target_test.go
@@ -250,6 +250,51 @@ func TestParseTarget(t *testing.T) {
 			``,
 		},
 		{
+			`module.foo.module.bar[0].data.aws_instance.baz`,
+			&Target{
+				Subject: AbsResource{
+					Resource: Resource{
+						Mode: DataResourceMode,
+						Type: "aws_instance",
+						Name: "baz",
+					},
+					Module: ModuleInstance{
+						{Name: "foo", InstanceKey: NoKey},
+						{Name: "bar", InstanceKey: IntKey(0)},
+					},
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 47, Byte: 46},
+				},
+			},
+			``,
+		},
+		{
+			`module.foo.module.bar["a"].data.aws_instance.baz["hello"]`,
+			&Target{
+				Subject: AbsResourceInstance{
+					Resource: ResourceInstance{
+						Resource: Resource{
+							Mode: DataResourceMode,
+							Type: "aws_instance",
+							Name: "baz",
+						},
+						Key: StringKey("hello"),
+					},
+					Module: ModuleInstance{
+						{Name: "foo", InstanceKey: NoKey},
+						{Name: "bar", InstanceKey: StringKey("a")},
+					},
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 58, Byte: 57},
+				},
+			},
+			``,
+		},
+		{
 			`module.foo.module.bar.data.aws_instance.baz["hello"]`,
 			&Target{
 				Subject: AbsResourceInstance{

--- a/addrs/target_test.go
+++ b/addrs/target_test.go
@@ -1,0 +1,164 @@
+package addrs
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTargetContains(t *testing.T) {
+	for _, test := range []struct {
+		addr, other Targetable
+		expect      bool
+	}{
+		{
+			mustParseTarget("module.foo"),
+			mustParseTarget("module.bar"),
+			false,
+		},
+		{
+			mustParseTarget("module.foo"),
+			mustParseTarget("module.foo"),
+			true,
+		},
+		{
+			// module.foo is an unkeyed module instance here, so it cannot
+			// contain another instance
+			mustParseTarget("module.foo"),
+			mustParseTarget("module.foo[0]"),
+			false,
+		},
+		{
+			RootModuleInstance,
+			mustParseTarget("module.foo"),
+			true,
+		},
+		{
+			mustParseTarget("module.foo"),
+			RootModuleInstance,
+			false,
+		},
+		{
+			mustParseTarget("module.foo"),
+			mustParseTarget("module.foo.module.bar[0]"),
+			true,
+		},
+		{
+			mustParseTarget("module.foo"),
+			mustParseTarget("module.foo.module.bar[0]"),
+			true,
+		},
+		{
+			mustParseTarget("module.foo[2]"),
+			mustParseTarget("module.foo[2].module.bar[0]"),
+			true,
+		},
+		{
+			mustParseTarget("module.foo"),
+			mustParseTarget("module.foo.test_resource.bar"),
+			true,
+		},
+		{
+			mustParseTarget("module.foo"),
+			mustParseTarget("module.foo.test_resource.bar[0]"),
+			true,
+		},
+
+		// Resources
+		{
+			mustParseTarget("test_resource.foo"),
+			mustParseTarget("test_resource.foo[\"bar\"]"),
+			true,
+		},
+		{
+			mustParseTarget(`test_resource.foo["bar"]`),
+			mustParseTarget(`test_resource.foo["bar"]`),
+			true,
+		},
+		{
+			mustParseTarget("test_resource.foo"),
+			mustParseTarget("test_resource.foo[2]"),
+			true,
+		},
+		{
+			mustParseTarget("test_resource.foo"),
+			mustParseTarget("module.bar.test_resource.foo[2]"),
+			false,
+		},
+		{
+			mustParseTarget("module.bar.test_resource.foo"),
+			mustParseTarget("module.bar.test_resource.foo[2]"),
+			true,
+		},
+		{
+			mustParseTarget("module.bar.test_resource.foo"),
+			mustParseTarget("module.bar[0].test_resource.foo[2]"),
+			false,
+		},
+
+		// Config paths, while never returned from parsing a target, must still be targetable
+		{
+			ConfigResource{
+				Module: []string{"bar"},
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "test_resource",
+					Name: "foo",
+				},
+			},
+			mustParseTarget("module.bar.test_resource.foo[2]"),
+			true,
+		},
+		{
+			ConfigResource{
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "test_resource",
+					Name: "foo",
+				},
+			},
+			mustParseTarget("module.bar.test_resource.foo[2]"),
+			false,
+		},
+		{
+			ConfigResource{
+				Module: []string{"bar"},
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "test_resource",
+					Name: "foo",
+				},
+			},
+			mustParseTarget("module.bar[0].test_resource.foo"),
+			true,
+		},
+	} {
+		t.Run(fmt.Sprintf("%s-in-%s", test.other, test.addr), func(t *testing.T) {
+			got := test.addr.TargetContains(test.other)
+			if got != test.expect {
+				t.Fatalf("expected %q.TargetContains(%q) == %t", test.addr, test.other, test.expect)
+			}
+		})
+	}
+}
+
+func TestResourceContains(t *testing.T) {
+	for _, test := range []struct {
+		in, other Targetable
+		expect    bool
+	}{} {
+		t.Run(fmt.Sprintf("%s-in-%s", test.other, test.in), func(t *testing.T) {
+			got := test.in.TargetContains(test.other)
+			if got != test.expect {
+				t.Fatalf("expected %q.TargetContains(%q) == %t", test.in, test.other, test.expect)
+			}
+		})
+	}
+}
+
+func mustParseTarget(str string) Targetable {
+	t, diags := ParseTargetStr(str)
+	if diags != nil {
+		panic(fmt.Sprintf("%s: %s", str, diags.ErrWithWarnings()))
+	}
+	return t.Subject
+}

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -597,7 +597,7 @@ func TestContextImport_moduleDiff(t *testing.T) {
 					Mode: addrs.ManagedResourceMode,
 					Type: "aws_instance",
 					Name: "bar",
-				}.Instance(addrs.NoKey).Absolute(addrs.Module{"bar"}.UnkeyedInstanceShim()),
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance.Child("bar", addrs.NoKey)),
 				&states.ResourceInstanceObjectSrc{
 					AttrsFlat: map[string]string{
 						"id": "bar",
@@ -658,7 +658,7 @@ func TestContextImport_moduleExisting(t *testing.T) {
 					Mode: addrs.ManagedResourceMode,
 					Type: "aws_instance",
 					Name: "bar",
-				}.Instance(addrs.NoKey).Absolute(addrs.Module{"foo"}.UnkeyedInstanceShim()),
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance.Child("foo", addrs.NoKey)),
 				&states.ResourceInstanceObjectSrc{
 					AttrsFlat: map[string]string{
 						"id": "bar",

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -452,8 +452,7 @@ func (n *EvalMaybeRestoreDeposedObject) Eval(ctx EvalContext) (interface{}, erro
 // in that case, allowing expression evaluation to see it as a zero-element
 // list rather than as not set at all.
 type EvalWriteResourceState struct {
-	Addr         addrs.Resource
-	Module       addrs.Module
+	Addr         addrs.ConfigResource
 	Config       *configs.Resource
 	ProviderAddr addrs.AbsProviderConfig
 }
@@ -489,18 +488,18 @@ func (n *EvalWriteResourceState) Eval(ctx EvalContext) (interface{}, error) {
 	// can refer to it. Since this node represents the abstract module, we need
 	// to expand the module here to create all resources.
 	expander := ctx.InstanceExpander()
-	for _, module := range expander.ExpandModule(n.Module) {
+	for _, module := range expander.ExpandModule(n.Addr.Module) {
 		// This method takes care of all of the business logic of updating this
 		// while ensuring that any existing instances are preserved, etc.
 		state.SetResourceMeta(n.Addr.Absolute(module), eachMode, n.ProviderAddr)
 
 		switch eachMode {
 		case states.EachList:
-			expander.SetResourceCount(module, n.Addr, count)
+			expander.SetResourceCount(module, n.Addr.Resource, count)
 		case states.EachMap:
-			expander.SetResourceForEach(module, n.Addr, forEach)
+			expander.SetResourceForEach(module, n.Addr.Resource, forEach)
 		default:
-			expander.SetResourceSingle(module, n.Addr)
+			expander.SetResourceSingle(module, n.Addr.Resource)
 		}
 	}
 

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -209,7 +209,7 @@ func TestApplyGraphBuilder_doubleCBD(t *testing.T) {
 			continue
 		}
 
-		switch tv.Addr.Name {
+		switch tv.Addr.Resource.Name {
 		case "A":
 			destroyA = fmt.Sprintf("test_object.A (destroy deposed %s)", tv.DeposedKey)
 		case "B":

--- a/terraform/node_data_refresh.go
+++ b/terraform/node_data_refresh.go
@@ -59,7 +59,7 @@ func (n *NodeRefreshableDataResource) DynamicExpand(ctx EvalContext) (*Graph, er
 	// Inform our instance expander about our expansion results above,
 	// and then use it to calculate the instance addresses we'll expand for.
 	expander := ctx.InstanceExpander()
-	for _, path := range expander.ExpandModule(n.Module) {
+	for _, path := range expander.ExpandModule(n.Addr.Module) {
 		switch {
 		case count >= 0:
 			expander.SetResourceCount(path, n.ResourceAddr().Resource, count)

--- a/terraform/node_data_refresh_test.go
+++ b/terraform/node_data_refresh_test.go
@@ -40,12 +40,7 @@ func TestNodeRefreshableDataResourceDynamicExpand_scaleOut(t *testing.T) {
 
 	n := &NodeRefreshableDataResource{
 		NodeAbstractResource: &NodeAbstractResource{
-			Addr: addrs.Resource{
-				Mode: addrs.DataResourceMode,
-				Type: "aws_instance",
-				Name: "foo",
-			},
-			Module: addrs.RootModule,
+			Addr:   addrs.RootModule.Resource(addrs.DataResourceMode, "aws_instance", "foo"),
 			Config: m.Module.DataResources["data.aws_instance.foo"],
 		},
 	}
@@ -125,12 +120,7 @@ func TestNodeRefreshableDataResourceDynamicExpand_scaleIn(t *testing.T) {
 
 	n := &NodeRefreshableDataResource{
 		NodeAbstractResource: &NodeAbstractResource{
-			Addr: addrs.Resource{
-				Mode: addrs.DataResourceMode,
-				Type: "aws_instance",
-				Name: "foo",
-			},
-			Module: addrs.RootModule,
+			Addr:   addrs.RootModule.Resource(addrs.DataResourceMode, "aws_instance", "foo"),
 			Config: m.Module.DataResources["data.aws_instance.foo"],
 			ResolvedProvider: addrs.AbsProviderConfig{
 				Provider: addrs.NewLegacyProvider("aws"),

--- a/terraform/node_module_expand.go
+++ b/terraform/node_module_expand.go
@@ -110,8 +110,8 @@ func (n *evalPrepareModuleExpansion) Eval(ctx EvalContext) (interface{}, error) 
 		eachMode = states.EachMap
 	}
 
-	// nodeExpandModule itself does not have visibility into how it's ancestors
-	// were expended, so we use the expander here to provide all possible paths
+	// nodeExpandModule itself does not have visibility into how its ancestors
+	// were expanded, so we use the expander here to provide all possible paths
 	// to our module, and register module instances with each of them.
 	for _, path := range expander.ExpandModule(n.Addr.Parent()) {
 		switch eachMode {

--- a/terraform/node_module_removed.go
+++ b/terraform/node_module_removed.go
@@ -32,7 +32,7 @@ func (n *NodeModuleRemoved) Path() addrs.ModuleInstance {
 // GraphNodeModulePath implementation
 func (n *NodeModuleRemoved) ModulePath() addrs.Module {
 	// This node represents the module call within a module,
-	// so return the CallerAddr as the path as the module
+	// so return the CallerAddr as the path, as the module
 	// call may expand into multiple child instances
 	return n.Addr.Module()
 }

--- a/terraform/node_provider_abstract.go
+++ b/terraform/node_provider_abstract.go
@@ -41,6 +41,8 @@ func (n *NodeAbstractProvider) Name() string {
 
 // GraphNodeModuleInstance
 func (n *NodeAbstractProvider) Path() addrs.ModuleInstance {
+	// Providers cannot be contained inside an expanded module, so this shim
+	// converts our module path to the correct ModuleInstance.
 	return n.Addr.Module.UnkeyedInstanceShim()
 }
 

--- a/terraform/node_provider_disabled.go
+++ b/terraform/node_provider_disabled.go
@@ -14,7 +14,7 @@ type NodeDisabledProvider struct {
 }
 
 var (
-	_ GraphNodeModuleInstance = (*NodeDisabledProvider)(nil)
+	_ GraphNodeModulePath     = (*NodeDisabledProvider)(nil)
 	_ RemovableIfNotTargeted  = (*NodeDisabledProvider)(nil)
 	_ GraphNodeReferencer     = (*NodeDisabledProvider)(nil)
 	_ GraphNodeProvider       = (*NodeDisabledProvider)(nil)

--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -61,7 +61,6 @@ func (n *NodeApplyableResource) EvalTree() EvalNode {
 
 	return &EvalWriteResourceState{
 		Addr:         n.Addr,
-		Module:       n.Module,
 		Config:       n.Config,
 		ProviderAddr: n.ResolvedProvider,
 	}

--- a/terraform/node_resource_plan.go
+++ b/terraform/node_resource_plan.go
@@ -38,7 +38,6 @@ func (n *NodePlannableResource) EvalTree() EvalNode {
 	// this ensures we can reference the resource even if the count is 0
 	return &EvalWriteResourceState{
 		Addr:         n.Addr,
-		Module:       n.Module,
 		Config:       n.Config,
 		ProviderAddr: n.ResolvedProvider,
 	}

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -60,7 +60,7 @@ func (n *NodeRefreshableManagedResource) DynamicExpand(ctx EvalContext) (*Graph,
 	// Inform our instance expander about our expansion results above,
 	// and then use it to calculate the instance addresses we'll expand for.
 	expander := ctx.InstanceExpander()
-	for _, module := range expander.ExpandModule(n.Module) {
+	for _, module := range expander.ExpandModule(n.Addr.Module) {
 		switch {
 		case count >= 0:
 			expander.SetResourceCount(module, n.ResourceAddr().Resource, count)
@@ -70,7 +70,7 @@ func (n *NodeRefreshableManagedResource) DynamicExpand(ctx EvalContext) (*Graph,
 			expander.SetResourceSingle(module, n.ResourceAddr().Resource)
 		}
 	}
-	instanceAddrs := expander.ExpandResource(n.Module, n.ResourceAddr().Resource)
+	instanceAddrs := expander.ExpandResource(n.Addr.Module, n.ResourceAddr().Resource)
 
 	// Our graph transformers require access to the full state, so we'll
 	// temporarily lock it while we work on this.

--- a/terraform/node_resource_refresh_test.go
+++ b/terraform/node_resource_refresh_test.go
@@ -42,12 +42,7 @@ func TestNodeRefreshableManagedResourceDynamicExpand_scaleOut(t *testing.T) {
 
 	n := &NodeRefreshableManagedResource{
 		NodeAbstractResource: &NodeAbstractResource{
-			Addr: addrs.Resource{
-				Mode: addrs.ManagedResourceMode,
-				Type: "aws_instance",
-				Name: "foo",
-			},
-			Module: addrs.RootModule,
+			Addr:   addrs.RootModule.Resource(addrs.ManagedResourceMode, "aws_instance", "foo"),
 			Config: m.Module.ManagedResources["aws_instance.foo"],
 		},
 	}
@@ -127,12 +122,7 @@ func TestNodeRefreshableManagedResourceDynamicExpand_scaleIn(t *testing.T) {
 
 	n := &NodeRefreshableManagedResource{
 		NodeAbstractResource: &NodeAbstractResource{
-			Addr: addrs.Resource{
-				Mode: addrs.ManagedResourceMode,
-				Type: "aws_instance",
-				Name: "foo",
-			},
-			Module: addrs.RootModule,
+			Addr:   addrs.RootModule.Resource(addrs.ManagedResourceMode, "aws_instance", "foo"),
 			Config: m.Module.ManagedResources["aws_instance.foo"],
 		},
 	}
@@ -172,12 +162,7 @@ func TestNodeRefreshableManagedResourceEvalTree_scaleOut(t *testing.T) {
 	n := &NodeRefreshableManagedResourceInstance{
 		NodeAbstractResourceInstance: &NodeAbstractResourceInstance{
 			NodeAbstractResource: NodeAbstractResource{
-				Addr: addrs.Resource{
-					Mode: addrs.ManagedResourceMode,
-					Type: "aws_instance",
-					Name: "foo",
-				},
-				Module: addrs.RootModule,
+				Addr:   addrs.RootModule.Resource(addrs.ManagedResourceMode, "aws_instance", "foo"),
 				Config: m.Module.ManagedResources["aws_instance.foo"],
 			},
 			InstanceKey: addrs.IntKey(2),

--- a/terraform/transform_attach_config_provider.go
+++ b/terraform/transform_attach_config_provider.go
@@ -8,9 +8,6 @@ import (
 // GraphNodeAttachProvider is an interface that must be implemented by nodes
 // that want provider configurations attached.
 type GraphNodeAttachProvider interface {
-	// Must be implemented to determine the path for the configuration
-	GraphNodeModuleInstance
-
 	// ProviderName with no module prefix. Example: "aws".
 	ProviderAddr() addrs.AbsProviderConfig
 

--- a/terraform/transform_config.go
+++ b/terraform/transform_config.go
@@ -111,8 +111,10 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 		}
 
 		abstract := &NodeAbstractResource{
-			Addr:   relAddr,
-			Module: path,
+			Addr: addrs.ConfigResource{
+				Resource: relAddr,
+				Module:   path,
+			},
 		}
 
 		if _, ok := t.uniqueMap[abstract.Name()]; ok {


### PR DESCRIPTION
Core needs a way to address resources through unexpanded modules, as
they are present in the configuration. There are already some cases of
paring `addrs.Module` with `addrs.Resource` for this purpose, but it is
going to be helpful to have a single type to describe that pair, as
well as have the ability to use TargetContains.