### PR TITLE
[NOT TO BE MERGED] configs: replace `resource.ProviderConfigAddr()` with `module.ProviderForResource()`

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -527,7 +527,11 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 		}
 
 		for provider, reqd := range missing {
-			pty := addrs.NewLegacyProvider(provider)
+			pty, diags := addrs.ParseProviderSourceString(provider)
+
+			if diags.HasErrors() {
+				panic(diags.Err().Error())
+			}
 			_, providerDiags, err := c.providerInstaller.Get(pty, reqd.Versions)
 			diags = diags.Append(providerDiags)
 

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -788,7 +788,7 @@ func TestInit_getProvider(t *testing.T) {
 			// looking for an exact version
 			"exact": []string{"1.2.3"},
 			// config requires >= 2.3.3
-			"greater_than": []string{"2.3.4", "2.3.3", "2.3.0"},
+			"greater-than": []string{"2.3.4", "2.3.3", "2.3.0"},
 			// config specifies
 			"between": []string{"3.4.5", "2.3.4", "1.2.3"},
 		},
@@ -817,9 +817,9 @@ func TestInit_getProvider(t *testing.T) {
 	if _, err := os.Stat(exactPath); os.IsNotExist(err) {
 		t.Fatal("provider 'exact' not downloaded")
 	}
-	greaterThanPath := filepath.Join(c.pluginDir(), installer.FileName("greater_than", "2.3.4"))
+	greaterThanPath := filepath.Join(c.pluginDir(), installer.FileName("greater-than", "2.3.4"))
 	if _, err := os.Stat(greaterThanPath); os.IsNotExist(err) {
-		t.Fatal("provider 'greater_than' not downloaded")
+		t.Fatal("provider 'greater-than' not downloaded")
 	}
 	betweenPath := filepath.Join(c.pluginDir(), installer.FileName("between", "2.3.4"))
 	if _, err := os.Stat(betweenPath); os.IsNotExist(err) {
@@ -893,7 +893,7 @@ func TestInit_findVendoredProviders(t *testing.T) {
 		t.Fatal(err)
 	}
 	// the vendor path
-	greaterThanPath := filepath.Join(DefaultPluginVendorDir, "terraform-provider-greater_than_v2.3.4_x4")
+	greaterThanPath := filepath.Join(DefaultPluginVendorDir, "terraform-provider-greater-than_v2.3.4_x4")
 	if err := ioutil.WriteFile(greaterThanPath, []byte("test bin"), 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -1020,7 +1020,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			// looking for an exact version
 			"exact": []string{"1.2.3"},
 			// config requires >= 2.3.3
-			"greater_than": []string{"2.3.4", "2.3.3", "2.3.0"},
+			"greater-than": []string{"2.3.4", "2.3.3", "2.3.0"},
 			// config specifies
 			"between": []string{"3.4.5", "2.3.4", "1.2.3"},
 		},
@@ -1037,7 +1037,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	greaterThanUnwanted := filepath.Join(m.pluginDir(), installer.FileName("greater_than", "2.3.3"))
+	greaterThanUnwanted := filepath.Join(m.pluginDir(), installer.FileName("greater-than", "2.3.3"))
 	err = ioutil.WriteFile(greaterThanUnwanted, []byte{}, os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
@@ -1084,8 +1084,8 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 		// includes both our old and new versions.
 		"terraform-provider-exact_v0.0.1_x4",
 		"terraform-provider-exact_v1.2.3_x4",
-		"terraform-provider-greater_than_v2.3.3_x4",
-		"terraform-provider-greater_than_v2.3.4_x4",
+		"terraform-provider-greater-than_v2.3.3_x4",
+		"terraform-provider-greater-than_v2.3.4_x4",
 	}
 
 	if !reflect.DeepEqual(gotFilenames, wantFilenames) {
@@ -1112,7 +1112,7 @@ func TestInit_getProviderMissing(t *testing.T) {
 			// looking for exact version 1.2.3
 			"exact": []string{"1.2.4"},
 			// config requires >= 2.3.3
-			"greater_than": []string{"2.3.4", "2.3.3", "2.3.0"},
+			"greater-than": []string{"2.3.4", "2.3.3", "2.3.0"},
 			// config specifies
 			"between": []string{"3.4.5", "2.3.4", "1.2.3"},
 		},
@@ -1331,7 +1331,7 @@ func TestInit_pluginDirProviders(t *testing.T) {
 	// add some dummy providers in our plugin dirs
 	for i, name := range []string{
 		"terraform-provider-exact_v1.2.3_x4",
-		"terraform-provider-greater_than_v2.3.4_x4",
+		"terraform-provider-greater-than_v2.3.4_x4",
 		"terraform-provider-between_v2.3.4_x4",
 	} {
 
@@ -1382,7 +1382,7 @@ func TestInit_pluginDirProvidersDoesNotGet(t *testing.T) {
 	// add some dummy providers in our plugin dirs
 	for i, name := range []string{
 		"terraform-provider-exact_v1.2.3_x4",
-		"terraform-provider-greater_than_v2.3.4_x4",
+		"terraform-provider-greater-than_v2.3.4_x4",
 	} {
 
 		if err := ioutil.WriteFile(filepath.Join(pluginPath[i], name), []byte("test bin"), 0755); err != nil {

--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -277,11 +277,19 @@ func marshalModuleCall(c *configs.Config, mc *configs.ModuleCall, schemas *terra
 func marshalResources(resources map[string]*configs.Resource, schemas *terraform.Schemas, moduleAddr string) ([]resource, error) {
 	var rs []resource
 	for _, v := range resources {
+
+		var providerConfig string
+
+		if v.ProviderConfigRef != nil {
+			providerConfig = v.ProviderConfigRef.String()
+		} else {
+			providerConfig = addrs.LocalProviderConfig{LocalName: v.Type}.StringCompact()
+		}
 		r := resource{
 			Address:           v.Addr().String(),
 			Type:              v.Type,
 			Name:              v.Name,
-			ProviderConfigKey: opaqueProviderKey(v.ProviderConfigAddr().StringCompact(), moduleAddr),
+			ProviderConfigKey: opaqueProviderKey(providerConfig, moduleAddr),
 		}
 
 		switch v.Mode {
@@ -304,7 +312,7 @@ func marshalResources(resources map[string]*configs.Resource, schemas *terraform
 		}
 
 		// TODO: get actual providerFqn
-		providerFqn := addrs.NewLegacyProvider(v.ProviderConfigAddr().LocalName)
+		providerFqn := addrs.NewLegacyProvider(v.Type)
 		schema, schemaVer := schemas.ResourceTypeConfig(
 			providerFqn,
 			v.Mode,

--- a/command/testdata/init-get-providers/main.tf
+++ b/command/testdata/init-get-providers/main.tf
@@ -1,11 +1,11 @@
 provider "exact" {
-	version = "1.2.3"
+  version = "1.2.3"
 }
 
-provider "greater_than" {
-	version = ">= 2.3.3"
+provider "greater-than" {
+  version = ">= 2.3.3"
 }
 
 provider "between" {
-	version = "> 1.0.0 , < 3.0.0"
+  version = "> 1.0.0 , < 3.0.0"
 }

--- a/configs/config.go
+++ b/configs/config.go
@@ -195,12 +195,12 @@ func (c *Config) gatherProviderTypes(m map[addrs.Provider]struct{}) {
 		m[fqn] = struct{}{}
 	}
 	for _, rc := range c.Module.ManagedResources {
-		providerAddr := rc.ProviderConfigAddr()
+		providerAddr := c.Module.ProviderForResource(rc)
 		fqn := c.Module.ProviderForLocalConfig(providerAddr)
 		m[fqn] = struct{}{}
 	}
 	for _, rc := range c.Module.DataResources {
-		providerAddr := rc.ProviderConfigAddr()
+		providerAddr := c.Module.ProviderForResource(rc)
 		fqn := c.Module.ProviderForLocalConfig(providerAddr)
 		m[fqn] = struct{}{}
 	}

--- a/configs/configupgrade/analysis.go
+++ b/configs/configupgrade/analysis.go
@@ -234,7 +234,7 @@ func (u *Upgrader) analyze(ms ModuleSources) (*analysis, error) {
 		}
 	}
 
-	providerFactories, errs := u.Providers.ResolveProviders(m.PluginRequirements())
+	providerFactories, errs := u.Providers.ResolveProviders(m.ProviderRequirements())
 	if len(errs) > 0 {
 		var errorsMsg string
 		for _, err := range errs {

--- a/configs/module.go
+++ b/configs/module.go
@@ -491,3 +491,16 @@ func (m *Module) ProviderForLocalConfig(pc addrs.LocalProviderConfig) addrs.Prov
 	}
 	return addrs.NewLegacyProvider(pc.LocalName)
 }
+
+func (m *Module) ProviderForResource(r *Resource) addrs.LocalProviderConfig {
+	if r.ProviderConfigRef == nil {
+		return addrs.LocalProviderConfig{
+			LocalName: m.LocalNameForProvider(r.Addr().DefaultProvider()),
+		}
+	}
+
+	return addrs.LocalProviderConfig{
+		LocalName: r.ProviderConfigRef.Name,
+		Alias:     r.ProviderConfigRef.Alias,
+	}
+}

--- a/configs/module_merge.go
+++ b/configs/module_merge.go
@@ -48,7 +48,7 @@ func mergeProviderVersionConstraints(recv map[string]ProviderRequirements, ovrd 
 			// any errors parsing the source string will have already been captured.
 			fqn, _ = addrs.ParseProviderSourceString(reqd.Source.SourceStr)
 		} else {
-			fqn = addrs.NewLegacyProvider(reqd.Name)
+			fqn = addrs.NewDefaultProvider(reqd.Name)
 		}
 		recv[reqd.Name] = ProviderRequirements{Type: fqn, VersionConstraints: []VersionConstraint{reqd.Requirement}}
 	}

--- a/configs/resource.go
+++ b/configs/resource.go
@@ -60,31 +60,6 @@ func (r *Resource) Addr() addrs.Resource {
 	}
 }
 
-// ProviderConfigAddr returns the address for the provider configuration
-// that should be used for this resource. This function implements the
-// default behavior of extracting the type from the resource type name if
-// an explicit "provider" argument was not provided.
-func (r *Resource) ProviderConfigAddr() addrs.LocalProviderConfig {
-	if r.ProviderConfigRef == nil {
-		// TODO: This will become incorrect once we move away from legacy
-		// provider addresses, and we'll need to refactor here so that
-		// this lookup is on the Module type rather than the Resource
-		// type and can thus look at the local-to-FQN mapping table
-		// to find a suitable local name to use here.
-		fqn := r.Addr().DefaultProvider()
-		return addrs.LocalProviderConfig{
-			// This will panic once non-legacy addresses are in play.
-			// See the TODO comment above ^^
-			LocalName: fqn.LegacyString(),
-		}
-	}
-
-	return addrs.LocalProviderConfig{
-		LocalName: r.ProviderConfigRef.Name,
-		Alias:     r.ProviderConfigRef.Alias,
-	}
-}
-
 func decodeResourceBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	r := &Resource{

--- a/moduledeps/module.go
+++ b/moduledeps/module.go
@@ -97,7 +97,7 @@ func (s sortModules) Swap(i, j int) {
 	s.modules[i], s.modules[j] = s.modules[j], s.modules[i]
 }
 
-// PluginRequirements produces a PluginRequirements structure that can
+// ProviderRequirements produces a ProviderRequirements structure that can
 // be used with discovery.PluginMetaSet.ConstrainVersions to identify
 // suitable plugins to satisfy the module's provider dependencies.
 //
@@ -107,16 +107,13 @@ func (s sortModules) Swap(i, j int) {
 //
 // Requirements returned by this method include only version constraints,
 // and apply no particular SHA256 hash constraint.
-func (m *Module) PluginRequirements() discovery.PluginRequirements {
+func (m *Module) ProviderRequirements() discovery.PluginRequirements {
 	ret := make(discovery.PluginRequirements)
 	for pFqn, dep := range m.Providers {
-		// TODO: discovery.PluginRequirements should be refactored and use
-		// addrs.Provider as the map keys
-		provider := pFqn.LegacyString()
-		if existing, exists := ret[provider]; exists {
-			ret[provider].Versions = existing.Versions.Append(dep.Constraints)
+		if existing, exists := ret[pFqn.String()]; exists {
+			ret[pFqn.String()].Versions = existing.Versions.Append(dep.Constraints)
 		} else {
-			ret[provider] = &discovery.PluginConstraints{
+			ret[pFqn.String()] = &discovery.PluginConstraints{
 				Versions: dep.Constraints,
 			}
 		}
@@ -133,7 +130,7 @@ func (m *Module) PluginRequirements() discovery.PluginRequirements {
 func (m *Module) AllPluginRequirements() discovery.PluginRequirements {
 	var ret discovery.PluginRequirements
 	m.WalkTree(func(path []string, parent *Module, current *Module) error {
-		ret = ret.Merge(current.PluginRequirements())
+		ret = ret.Merge(current.ProviderRequirements())
 		return nil
 	})
 	return ret

--- a/moduledeps/module_test.go
+++ b/moduledeps/module_test.go
@@ -201,14 +201,14 @@ func TestModulePluginRequirements(t *testing.T) {
 		},
 	}
 
-	reqd := m.PluginRequirements()
+	reqd := m.ProviderRequirements()
 	if len(reqd) != 2 {
 		t.Errorf("wrong number of elements in %#v; want 2", reqd)
 	}
-	if got, want := reqd["foo"].Versions.String(), ">=1.0.0"; got != want {
+	if got, want := reqd[addrs.NewLegacyProvider("foo").String()].Versions.String(), ">=1.0.0"; got != want {
 		t.Errorf("wrong combination of versions for 'foo' %q; want %q", got, want)
 	}
-	if got, want := reqd["baz"].Versions.String(), ">=3.0.0"; got != want {
+	if got, want := reqd[addrs.NewLegacyProvider("baz").String()].Versions.String(), ">=3.0.0"; got != want {
 		t.Errorf("wrong combination of versions for 'baz' %q; want %q", got, want)
 	}
 }

--- a/providers/resolver.go
+++ b/providers/resolver.go
@@ -40,11 +40,11 @@ func ResolverFixed(factories map[addrs.Provider]Factory) Resolver {
 		ret := make(map[addrs.Provider]Factory, len(reqd))
 		var errs []error
 		for name := range reqd {
-			fqn := addrs.NewLegacyProvider(name)
+			fqn, _ := addrs.ParseProviderSourceString(name)
 			if factory, exists := factories[fqn]; exists {
 				ret[fqn] = factory
 			} else {
-				errs = append(errs, fmt.Errorf("provider %q is not available", name))
+				errs = append(errs, fmt.Errorf("provider %q is not available", fqn.String()))
 			}
 		}
 		return ret, errs

--- a/terraform/context_input.go
+++ b/terraform/context_input.go
@@ -64,7 +64,7 @@ func (c *Context) Input(mode InputMode) tfdiags.Diagnostics {
 		// These won't have *configs.Provider objects, but they will still
 		// exist in the map and we'll just treat them as empty below.
 		for _, rc := range c.config.Module.ManagedResources {
-			pa := rc.ProviderConfigAddr()
+			pa := c.config.Module.ProviderForResource(rc)
 			if pa.Alias != "" {
 				continue // alias configurations cannot be implied
 			}
@@ -75,7 +75,7 @@ func (c *Context) Input(mode InputMode) tfdiags.Diagnostics {
 			}
 		}
 		for _, rc := range c.config.Module.DataResources {
-			pa := rc.ProviderConfigAddr()
+			pa := c.config.Module.ProviderForResource(rc)
 			if pa.Alias != "" {
 				continue // alias configurations cannot be implied
 			}

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -468,7 +468,7 @@ func (n *EvalValidateResource) Eval(ctx EvalContext) (interface{}, error) {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid resource type",
-				Detail:   fmt.Sprintf("The provider %s does not support resource type %q.", cfg.ProviderConfigAddr(), cfg.Type),
+				Detail:   fmt.Sprintf("The provider %s does not support resource type %q.", provider, cfg.Type),
 				Subject:  &cfg.TypeRange,
 			})
 			return nil, diags.Err()
@@ -505,7 +505,7 @@ func (n *EvalValidateResource) Eval(ctx EvalContext) (interface{}, error) {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid data source",
-				Detail:   fmt.Sprintf("The provider %s does not support data source %q.", cfg.ProviderConfigAddr(), cfg.Type),
+				Detail:   fmt.Sprintf("The provider %s does not support data source %q.", provider, cfg.Type),
 				Subject:  &cfg.TypeRange,
 			})
 			return nil, diags.Err()

--- a/terraform/evaluate_valid.go
+++ b/terraform/evaluate_valid.go
@@ -212,7 +212,9 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 		return diags
 	}
 
-	providerFqn := modCfg.Module.ProviderForLocalConfig(cfg.ProviderConfigAddr())
+	lc := modCfg.Module.ProviderForResource(cfg)
+	providerFqn := modCfg.Module.ProviderForLocalConfig(lc)
+
 	schema, _ := d.Evaluator.Schemas.ResourceTypeConfig(providerFqn, addr.Mode, addr.Type)
 
 	if schema == nil {

--- a/terraform/module_dependencies.go
+++ b/terraform/module_dependencies.go
@@ -110,7 +110,7 @@ func configTreeConfigDependencies(root *configs.Config, inheritProviders map[str
 		// dependency, though we'll only record it if there isn't already
 		// an explicit dependency on the same provider.
 		for _, rc := range module.ManagedResources {
-			addr := rc.ProviderConfigAddr()
+			addr := module.ProviderForResource(rc)
 			fqn := module.ProviderForLocalConfig(addr)
 
 			if _, exists := providers[fqn]; exists {
@@ -129,7 +129,7 @@ func configTreeConfigDependencies(root *configs.Config, inheritProviders map[str
 			}
 		}
 		for _, rc := range module.DataResources {
-			addr := rc.ProviderConfigAddr()
+			addr := module.ProviderForResource(rc)
 			fqn := module.ProviderForLocalConfig(addr)
 
 			if _, exists := providers[fqn]; exists {

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -301,11 +301,13 @@ func (n *NodeAbstractResource) SetProvider(p addrs.AbsProviderConfig) {
 func (n *NodeAbstractResource) ProvidedBy() (addrs.ProviderConfig, bool) {
 	// If we have a config we prefer that above all else
 	if n.Config != nil {
-		relAddr := n.Config.ProviderConfigAddr()
-		return addrs.LocalProviderConfig{
-			LocalName: relAddr.LocalName,
-			Alias:     relAddr.Alias,
-		}, false
+		relAddr := n.Config.ProviderConfigRef
+		if relAddr != nil {
+			return addrs.LocalProviderConfig{
+				LocalName: relAddr.Name,
+				Alias:     relAddr.Alias,
+			}, false
+		}
 	}
 
 	// No provider configuration found
@@ -321,11 +323,17 @@ func (n *NodeAbstractResource) ImpliedProvider() addrs.Provider {
 func (n *NodeAbstractResourceInstance) ProvidedBy() (addrs.ProviderConfig, bool) {
 	// If we have a config we prefer that above all else
 	if n.Config != nil {
-		relAddr := n.Config.ProviderConfigAddr()
-		return addrs.LocalProviderConfig{
-			LocalName: relAddr.LocalName,
-			Alias:     relAddr.Alias,
-		}, false
+		relAddr := n.Config.ProviderConfigRef
+		if relAddr != nil {
+			return addrs.LocalProviderConfig{
+				LocalName: relAddr.Name,
+				Alias:     relAddr.Alias,
+			}, false
+		} else {
+			return addrs.LocalProviderConfig{
+				LocalName: n.ImpliedProvider().Type,
+			}, false
+		}
 	}
 
 	// If we have state, then we will use the provider from there

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -237,13 +237,11 @@ func ResourceProviderResolverFixed(factories map[addrs.Provider]ResourceProvider
 		ret := make(map[addrs.Provider]ResourceProviderFactory, len(reqd))
 		var errs []error
 		for name := range reqd {
-			// FIXME: discovery.PluginRequirements should use addrs.Provider as
-			// the map keys instead of a string
-			fqn := addrs.NewLegacyProvider(name)
+			fqn, _ := addrs.ParseProviderSourceString(name)
 			if factory, exists := factories[fqn]; exists {
 				ret[fqn] = factory
 			} else {
-				errs = append(errs, fmt.Errorf("provider %q is not available", name))
+				errs = append(errs, fmt.Errorf("provider %q is not available", fqn.String()))
 			}
 		}
 		return ret, errs


### PR DESCRIPTION
This is a WIP; there's a lot here but it's *mostly* all fallout from
removing `resource.ProviderConfigAddr()` and I would like to talk about
the implementation before I spend any more time chasing down test
failures (most of which are coming from codepaths that are being
changed, and are expected to handle provider fqns)

I'm opening this as a real PR so I can request review, but I will close this PR after our discussion. I will comment on the individual files that I think are the most relevant. 

