### PR TITLE
terraform: large refactor to use Provider from configs.Resource

### DIFF
--- a/addrs/resource.go
+++ b/addrs/resource.go
@@ -50,6 +50,8 @@ func (r Resource) Absolute(module ModuleInstance) AbsResource {
 	}
 }
 
+// ImpliedProvider returns the implied provider type name, for e.g. the "aws" in
+// "aws_instance"
 func (r Resource) ImpliedProvider() string {
 	typeName := r.Type
 	if under := strings.Index(typeName, "_"); under != -1 {

--- a/addrs/resource.go
+++ b/addrs/resource.go
@@ -50,28 +50,13 @@ func (r Resource) Absolute(module ModuleInstance) AbsResource {
 	}
 }
 
-// DefaultProvider returns the address of the provider whose default
-// configuration shouldbe used for the resource identified by the reciever if
-// it does not have a provider configuration address explicitly set in
-// configuration.
-//
-// This method is not able to verify that such a configuration exists, nor
-// represent the behavior of automatically inheriting certain provider
-// configurations from parent modules. It just does a static analysis of the
-// receiving address and returns an address to start from, relative to the
-// same module that contains the resource.
-func (r Resource) DefaultProvider() Provider {
+func (r Resource) ImpliedProvider() string {
 	typeName := r.Type
 	if under := strings.Index(typeName, "_"); under != -1 {
 		typeName = typeName[:under]
 	}
 
-	// TODO: For now we're returning a _legacy_ provider address here
-	// because the rest of Terraform isn't yet prepared to deal with
-	// non-legacy ones. Once we phase out legacy addresses this should
-	// switch to being a _default_ provider address, i.e. one in the
-	// releases.hashicorp.com/hashicorp/... namespace.
-	return NewLegacyProvider(typeName)
+	return typeName
 }
 
 // ResourceInstance is an address for a specific instance of a resource.

--- a/configs/configupgrade/analysis.go
+++ b/configs/configupgrade/analysis.go
@@ -177,7 +177,7 @@ func (u *Upgrader) analyze(ms ModuleSources) (*analysis, error) {
 
 				var fqn addrs.Provider
 				if providerKey == "" {
-					fqn = rAddr.DefaultProvider()
+					fqn = addrs.NewLegacyProvider(rAddr.ImpliedProvider())
 				} else {
 					// ProviderDependencies only need to know the provider FQN
 					// strip any alias from the providerKey

--- a/configs/configupgrade/analysis.go
+++ b/configs/configupgrade/analysis.go
@@ -177,6 +177,8 @@ func (u *Upgrader) analyze(ms ModuleSources) (*analysis, error) {
 
 				var fqn addrs.Provider
 				if providerKey == "" {
+					// we are assuming a default, legacy provider for 012
+					// configurations
 					fqn = addrs.NewLegacyProvider(rAddr.ImpliedProvider())
 				} else {
 					// ProviderDependencies only need to know the provider FQN

--- a/configs/module.go
+++ b/configs/module.go
@@ -293,8 +293,9 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			r.Provider = provider
 			continue
 		}
-		// FIXME: r.Addr().DefaultProvider() will be refactored to return a string
-		r.Provider = r.Addr().DefaultProvider()
+		// FIXME: this will replaced with NewDefaultProvider when provider
+		// source is fully implemented.
+		r.Provider = addrs.NewLegacyProvider(r.Addr().ImpliedProvider())
 	}
 
 	for _, r := range file.DataResources {
@@ -322,8 +323,9 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			r.Provider = provider
 			continue
 		}
-		// FIXME: r.Addr().DefaultProvider() will be refactored to return a string
-		r.Provider = r.Addr().DefaultProvider()
+		// FIXME: this will replaced with NewDefaultProvider when provider
+		// source is fully implemented.
+		r.Provider = addrs.NewLegacyProvider(r.Addr().ImpliedProvider())
 	}
 
 	return diags

--- a/configs/module_test.go
+++ b/configs/module_test.go
@@ -57,6 +57,14 @@ func TestNewModule_resource_providers(t *testing.T) {
 		)
 	}
 
+	// a data source
+	if !cfg.Module.DataResources["data.test_resource.explicit"].Provider.Equals(wantFoo) {
+		t.Fatalf("wrong provider for \"module.child.test_instance.explicit\"\ngot:  %s\nwant: %s",
+			cfg.Module.ManagedResources["test_instance.explicit"].Provider,
+			wantBar,
+		)
+	}
+
 	// child module
 	cm := cfg.Children["child"].Module
 	if !cm.ManagedResources["test_instance.explicit"].Provider.Equals(wantBar) {
@@ -84,5 +92,4 @@ func TestProviderForLocalConfig(t *testing.T) {
 	if !got.Equals(want) {
 		t.Fatalf("wrong result! got %#v, want %#v\n", got, want)
 	}
-
 }

--- a/configs/resource.go
+++ b/configs/resource.go
@@ -61,22 +61,13 @@ func (r *Resource) Addr() addrs.Resource {
 	}
 }
 
-// ProviderConfigAddr returns the address for the provider configuration
-// that should be used for this resource. This function implements the
-// default behavior of extracting the type from the resource type name if
-// an explicit "provider" argument was not provided.
+// ProviderConfigAddr returns the address for the provider configuration that
+// should be used for this resource. This function returns a default provider
+// config addr if an explicit "provider" argument was not provided.
 func (r *Resource) ProviderConfigAddr() addrs.LocalProviderConfig {
 	if r.ProviderConfigRef == nil {
-		// TODO: This will become incorrect once we move away from legacy
-		// provider addresses, and we'll need to refactor here so that
-		// this lookup is on the Module type rather than the Resource
-		// type and can thus look at the local-to-FQN mapping table
-		// to find a suitable local name to use here.
-		fqn := r.Addr().DefaultProvider()
 		return addrs.LocalProviderConfig{
-			// This will panic once non-legacy addresses are in play.
-			// See the TODO comment above ^^
-			LocalName: fqn.LegacyString(),
+			LocalName: r.Provider.Type,
 		}
 	}
 

--- a/configs/testdata/valid-modules/nested-providers-fqns/main.tf
+++ b/configs/testdata/valid-modules/nested-providers-fqns/main.tf
@@ -16,6 +16,10 @@ resource "test_instance" "explicit" {
   provider = foo-test
 }
 
+data "test_resource" "explicit" {
+  provider = foo-test
+}
+
 resource "test_instance" "implicit" {
   // since the provider type name "test" does not match an entry in
   // required_providers, the default provider "test" should be used

--- a/states/statefile/version3_upgrade.go
+++ b/states/statefile/version3_upgrade.go
@@ -143,7 +143,7 @@ func upgradeStateV3ToV4(old *stateV3) (*stateV4, error) {
 					} else {
 						providerAddr = addrs.AbsProviderConfig{
 							Module:   moduleAddr.Module(),
-							Provider: resAddr.DefaultProvider(),
+							Provider: addrs.NewLegacyProvider(resAddr.ImpliedProvider()),
 						}
 					}
 				}

--- a/states/statemgr/testing.go
+++ b/states/statemgr/testing.go
@@ -151,7 +151,7 @@ func TestFullInitialState() *states.State {
 		Name: "foo",
 	}
 	providerAddr := addrs.AbsProviderConfig{
-		Provider: rAddr.DefaultProvider(),
+		Provider: addrs.NewLegacyProvider(rAddr.ImpliedProvider()),
 		Module:   addrs.RootModule,
 	}
 	childMod.SetResourceMeta(rAddr, states.EachList, providerAddr)

--- a/terraform/eval_state_upgrade.go
+++ b/terraform/eval_state_upgrade.go
@@ -27,7 +27,7 @@ func UpgradeResourceState(addr addrs.AbsResourceInstance, provider providers.Int
 	stateIsFlatmap := len(src.AttrsJSON) == 0
 
 	// TODO: This should eventually use a proper FQN.
-	providerType := addr.Resource.Resource.DefaultProvider().LegacyString()
+	providerType := addr.Resource.Resource.ImpliedProvider()
 	if src.SchemaVersion > currentVersion {
 		log.Printf("[TRACE] UpgradeResourceState: can't downgrade state for %s from version %d to %d", addr, src.SchemaVersion, currentVersion)
 		var diags tfdiags.Diagnostics

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -312,13 +312,20 @@ func (n *NodeAbstractResource) ProvidedBy() (addrs.ProviderConfig, bool) {
 		}, false
 	}
 
-	// No provider configuration found
-	return nil, false
+	// No provider configuration found; return a default address
+	return addrs.AbsProviderConfig{
+		Provider: n.Provider(),
+		Module:   n.ModulePath(),
+	}, false
 }
 
 // GraphNodeProviderConsumer
-func (n *NodeAbstractResource) ImpliedProvider() addrs.Provider {
-	return n.Addr.Resource.DefaultProvider()
+func (n *NodeAbstractResource) Provider() addrs.Provider {
+	if n.Config != nil {
+		return n.Config.Provider
+	}
+	// FIXME: this will be a default provider
+	return addrs.NewLegacyProvider(n.Addr.Resource.ImpliedProvider())
 }
 
 // GraphNodeProviderConsumer
@@ -340,13 +347,20 @@ func (n *NodeAbstractResourceInstance) ProvidedBy() (addrs.ProviderConfig, bool)
 		return n.ResourceState.ProviderConfig, true
 	}
 
-	// No provider configuration found
-	return nil, false
+	// No provider configuration found; return a default address
+	return addrs.AbsProviderConfig{
+		Provider: n.Provider(),
+		Module:   n.ModulePath(),
+	}, false
 }
 
 // GraphNodeProviderConsumer
-func (n *NodeAbstractResourceInstance) ImpliedProvider() addrs.Provider {
-	return n.Addr.Resource.DefaultProvider()
+func (n *NodeAbstractResourceInstance) Provider() addrs.Provider {
+	if n.Config != nil {
+		return n.Config.Provider
+	}
+	// FIXME: this will be a default provider
+	return addrs.NewLegacyProvider(n.Addr.Resource.ImpliedProvider())
 }
 
 // GraphNodeProvisionerConsumer

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -21,7 +21,7 @@ func (t *ImportStateTransformer) Transform(g *Graph) error {
 		// may not specify implied provider addresses.
 		providerAddr := target.ProviderAddr
 		if providerAddr.Provider.Type == "" {
-			defaultFQN := target.Addr.Resource.Resource.DefaultProvider()
+			defaultFQN := addrs.NewLegacyProvider(target.Addr.Resource.Resource.ImpliedProvider())
 			providerAddr = addrs.AbsProviderConfig{
 				Provider: defaultFQN,
 				Module:   target.Addr.Module.Module(),
@@ -69,7 +69,7 @@ func (n *graphNodeImportState) ProvidedBy() (addrs.ProviderConfig, bool) {
 }
 
 // GraphNodeProviderConsumer
-func (n *graphNodeImportState) ImpliedProvider() addrs.Provider {
+func (n *graphNodeImportState) Provider() addrs.Provider {
 	// We assume that n.ProviderAddr has been properly populated here.
 	// It's the responsibility of the code creating a graphNodeImportState
 	// to populate this, possibly by calling DefaultProviderConfig() on the


### PR DESCRIPTION
configs.Resource.ImpliedProvider() now returns a string; it is the
callers' responsibility to turn that into an addrs.Provider if needed.

GraphNodeProviderConsumer ProvidedBy() no longer returns nil (reverting
to earlier, pre-provider-fqn behavior): it will return either the
provider set in config, provider set in state, or the default provider.