### PR TITLE
website: Remove links to the getting started guide's old location

### DIFF
--- a/website/docs/configuration-0-11/outputs.html.md
+++ b/website/docs/configuration-0-11/outputs.html.md
@@ -14,10 +14,7 @@ and later, see
 
 Outputs define values that will be highlighted to the user
 when Terraform applies, and can be queried easily using the
-[output command](/docs/commands/output.html). Output usage
-is covered in more detail in the
-[getting started guide](/intro/getting-started/outputs.html).
-This page covers configuration syntax for outputs.
+[output command](/docs/commands/output.html).
 
 Terraform knows a lot about the infrastructure it manages.
 Most resources have attributes associated with them, and

--- a/website/docs/configuration-0-11/variables.html.md
+++ b/website/docs/configuration-0-11/variables.html.md
@@ -19,9 +19,6 @@ When used in the root module of a configuration, variables can be set from CLI
 arguments and environment variables. For [_child_ modules](./modules.html),
 they allow values to pass from parent to child.
 
-Input variable usage is introduced in the Getting Started guide section
-[_Input Variables_](/intro/getting-started/variables.html).
-
 This page assumes you're familiar with the
 [configuration syntax](./syntax.html)
 already.


### PR DESCRIPTION
Since these links were in the soon-to-be-deprecated 0.11 language section, I
think we can just remove them without needing to find an equivalent link.