### PR TITLE
registry: Fix panic when server is unreachable

### DIFF
--- a/registry/test/mock_registry.go
+++ b/registry/test/mock_registry.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	version "github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-svchost"
+	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/auth"
 	"github.com/hashicorp/terraform-svchost/disco"
 	"github.com/hashicorp/terraform/httpclient"


### PR DESCRIPTION
Non-HTTP errors previously resulted in a panic due to dereferencing the `resp` pointer while it was `nil`, as part of rendering the error message. This commit changes the error message formatting to cope with a `nil` response, and extends test coverage.

Fixes #24384