### PR TITLE
rename provider-specific functions

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -463,11 +463,11 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 		return false, diags
 	}
 
-	configReqs := configDeps.AllPluginRequirements()
+	configReqs := configDeps.AllProviderRequirements()
 	// FIXME: This is weird because ConfigTreeDependencies was written before
 	// we switched over to using earlyConfig as the main source of dependencies.
 	// In future we should clean this up to be a more reasonable API.
-	stateReqs := terraform.ConfigTreeDependencies(nil, state).AllPluginRequirements()
+	stateReqs := terraform.ConfigTreeDependencies(nil, state).AllProviderRequirements()
 
 	requirements := configReqs.Merge(stateReqs)
 	if len(requirements) == 0 {

--- a/command/init.go
+++ b/command/init.go
@@ -479,7 +479,7 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 		"\n[reset][bold]Initializing provider plugins...",
 	))
 
-	missing := c.missingPlugins(available, requirements)
+	missing := c.missingProviders(available, requirements)
 
 	if c.getPlugins {
 		if len(missing) > 0 {

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -788,7 +788,7 @@ func TestInit_getProvider(t *testing.T) {
 			// looking for an exact version
 			"exact": []string{"1.2.3"},
 			// config requires >= 2.3.3
-			"greater_than": []string{"2.3.4", "2.3.3", "2.3.0"},
+			"greater-than": []string{"2.3.4", "2.3.3", "2.3.0"},
 			// config specifies
 			"between": []string{"3.4.5", "2.3.4", "1.2.3"},
 		},
@@ -817,9 +817,9 @@ func TestInit_getProvider(t *testing.T) {
 	if _, err := os.Stat(exactPath); os.IsNotExist(err) {
 		t.Fatal("provider 'exact' not downloaded")
 	}
-	greaterThanPath := filepath.Join(c.pluginDir(), installer.FileName("greater_than", "2.3.4"))
+	greaterThanPath := filepath.Join(c.pluginDir(), installer.FileName("greater-than", "2.3.4"))
 	if _, err := os.Stat(greaterThanPath); os.IsNotExist(err) {
-		t.Fatal("provider 'greater_than' not downloaded")
+		t.Fatal("provider 'greater-than' not downloaded")
 	}
 	betweenPath := filepath.Join(c.pluginDir(), installer.FileName("between", "2.3.4"))
 	if _, err := os.Stat(betweenPath); os.IsNotExist(err) {
@@ -893,7 +893,7 @@ func TestInit_findVendoredProviders(t *testing.T) {
 		t.Fatal(err)
 	}
 	// the vendor path
-	greaterThanPath := filepath.Join(DefaultPluginVendorDir, "terraform-provider-greater_than_v2.3.4_x4")
+	greaterThanPath := filepath.Join(DefaultPluginVendorDir, "terraform-provider-greater-than_v2.3.4_x4")
 	if err := ioutil.WriteFile(greaterThanPath, []byte("test bin"), 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -1020,7 +1020,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			// looking for an exact version
 			"exact": []string{"1.2.3"},
 			// config requires >= 2.3.3
-			"greater_than": []string{"2.3.4", "2.3.3", "2.3.0"},
+			"greater-than": []string{"2.3.4", "2.3.3", "2.3.0"},
 			// config specifies
 			"between": []string{"3.4.5", "2.3.4", "1.2.3"},
 		},
@@ -1037,7 +1037,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	greaterThanUnwanted := filepath.Join(m.pluginDir(), installer.FileName("greater_than", "2.3.3"))
+	greaterThanUnwanted := filepath.Join(m.pluginDir(), installer.FileName("greater-than", "2.3.3"))
 	err = ioutil.WriteFile(greaterThanUnwanted, []byte{}, os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
@@ -1084,8 +1084,8 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 		// includes both our old and new versions.
 		"terraform-provider-exact_v0.0.1_x4",
 		"terraform-provider-exact_v1.2.3_x4",
-		"terraform-provider-greater_than_v2.3.3_x4",
-		"terraform-provider-greater_than_v2.3.4_x4",
+		"terraform-provider-greater-than_v2.3.3_x4",
+		"terraform-provider-greater-than_v2.3.4_x4",
 	}
 
 	if !reflect.DeepEqual(gotFilenames, wantFilenames) {
@@ -1112,7 +1112,7 @@ func TestInit_getProviderMissing(t *testing.T) {
 			// looking for exact version 1.2.3
 			"exact": []string{"1.2.4"},
 			// config requires >= 2.3.3
-			"greater_than": []string{"2.3.4", "2.3.3", "2.3.0"},
+			"greater-than": []string{"2.3.4", "2.3.3", "2.3.0"},
 			// config specifies
 			"between": []string{"3.4.5", "2.3.4", "1.2.3"},
 		},
@@ -1331,7 +1331,7 @@ func TestInit_pluginDirProviders(t *testing.T) {
 	// add some dummy providers in our plugin dirs
 	for i, name := range []string{
 		"terraform-provider-exact_v1.2.3_x4",
-		"terraform-provider-greater_than_v2.3.4_x4",
+		"terraform-provider-greater-than_v2.3.4_x4",
 		"terraform-provider-between_v2.3.4_x4",
 	} {
 
@@ -1382,7 +1382,7 @@ func TestInit_pluginDirProvidersDoesNotGet(t *testing.T) {
 	// add some dummy providers in our plugin dirs
 	for i, name := range []string{
 		"terraform-provider-exact_v1.2.3_x4",
-		"terraform-provider-greater_than_v2.3.4_x4",
+		"terraform-provider-greater-than_v2.3.4_x4",
 	} {
 
 		if err := ioutil.WriteFile(filepath.Join(pluginPath[i], name), []byte("test bin"), 0755); err != nil {

--- a/command/plugins.go
+++ b/command/plugins.go
@@ -290,7 +290,7 @@ func (m *Meta) internalProviders() map[addrs.Provider]providers.Factory {
 }
 
 // filter the requirements returning only the providers that we can't resolve
-func (m *Meta) missingPlugins(avail discovery.PluginMetaSet, reqd discovery.PluginRequirements) discovery.PluginRequirements {
+func (m *Meta) missingProviders(avail discovery.PluginMetaSet, reqd discovery.PluginRequirements) discovery.PluginRequirements {
 	missing := make(discovery.PluginRequirements)
 
 	candidates := avail.ConstrainVersions(reqd)

--- a/command/testdata/init-get-providers/main.tf
+++ b/command/testdata/init-get-providers/main.tf
@@ -1,11 +1,11 @@
 provider "exact" {
-	version = "1.2.3"
+  version = "1.2.3"
 }
 
-provider "greater_than" {
-	version = ">= 2.3.3"
+provider "greater-than" {
+  version = ">= 2.3.3"
 }
 
 provider "between" {
-	version = "> 1.0.0 , < 3.0.0"
+  version = "> 1.0.0 , < 3.0.0"
 }

--- a/moduledeps/module.go
+++ b/moduledeps/module.go
@@ -97,7 +97,7 @@ func (s sortModules) Swap(i, j int) {
 	s.modules[i], s.modules[j] = s.modules[j], s.modules[i]
 }
 
-// PluginRequirements produces a PluginRequirements structure that can
+// ProviderRequirements produces a PluginRequirements structure that can
 // be used with discovery.PluginMetaSet.ConstrainVersions to identify
 // suitable plugins to satisfy the module's provider dependencies.
 //
@@ -107,16 +107,14 @@ func (s sortModules) Swap(i, j int) {
 //
 // Requirements returned by this method include only version constraints,
 // and apply no particular SHA256 hash constraint.
-func (m *Module) PluginRequirements() discovery.PluginRequirements {
+func (m *Module) ProviderRequirements() discovery.PluginRequirements {
 	ret := make(discovery.PluginRequirements)
 	for pFqn, dep := range m.Providers {
-		// TODO: discovery.PluginRequirements should be refactored and use
-		// addrs.Provider as the map keys
-		provider := pFqn.LegacyString()
-		if existing, exists := ret[provider]; exists {
-			ret[provider].Versions = existing.Versions.Append(dep.Constraints)
+		providerStr := pFqn.LegacyString()
+		if existing, exists := ret[providerStr]; exists {
+			ret[providerStr].Versions = existing.Versions.Append(dep.Constraints)
 		} else {
-			ret[provider] = &discovery.PluginConstraints{
+			ret[providerStr] = &discovery.PluginConstraints{
 				Versions: dep.Constraints,
 			}
 		}
@@ -124,16 +122,16 @@ func (m *Module) PluginRequirements() discovery.PluginRequirements {
 	return ret
 }
 
-// AllPluginRequirements calls PluginRequirements for the receiver and all
+// AllProviderRequirements calls ProviderRequirements for the receiver and all
 // of its descendents, and merges the result into a single PluginRequirements
 // structure that would satisfy all of the modules together.
 //
 // Requirements returned by this method include only version constraints,
 // and apply no particular SHA256 hash constraint.
-func (m *Module) AllPluginRequirements() discovery.PluginRequirements {
+func (m *Module) AllProviderRequirements() discovery.PluginRequirements {
 	var ret discovery.PluginRequirements
 	m.WalkTree(func(path []string, parent *Module, current *Module) error {
-		ret = ret.Merge(current.PluginRequirements())
+		ret = ret.Merge(current.ProviderRequirements())
 		return nil
 	})
 	return ret

--- a/moduledeps/module_test.go
+++ b/moduledeps/module_test.go
@@ -188,7 +188,7 @@ func TestModuleSortChildren(t *testing.T) {
 	}
 }
 
-func TestModulePluginRequirements(t *testing.T) {
+func TestModuleProviderRequirements(t *testing.T) {
 	m := &Module{
 		Name: "root",
 		Providers: Providers{
@@ -201,7 +201,7 @@ func TestModulePluginRequirements(t *testing.T) {
 		},
 	}
 
-	reqd := m.PluginRequirements()
+	reqd := m.ProviderRequirements()
 	if len(reqd) != 2 {
 		t.Errorf("wrong number of elements in %#v; want 2", reqd)
 	}

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -173,7 +173,7 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 	var providerFactories map[addrs.Provider]providers.Factory
 	if opts.ProviderResolver != nil {
 		deps := ConfigTreeDependencies(opts.Config, state)
-		reqd := deps.AllPluginRequirements()
+		reqd := deps.AllProviderRequirements()
 		if opts.ProviderSHA256s != nil && !opts.SkipProviderVerify {
 			reqd.LockExecutables(opts.ProviderSHA256s)
 		}


### PR DESCRIPTION
I've renamed a couple of functions that had `plugin` in the name but were hard-coded to only work with providers for clarity.

If it isn't obvious from the branch name, this started as a project to convert maps that use provider type name strings to fqns or fqn strings, but I kept getting caught up on functions that were, or appeared to be, generic to all plugins (provisioners + providers). 

I am probably blocked on map key changes until the remaining provider installer work lands (which is a-ok) but I figured I'd take this opportunity to make these function names unambiguous.