### PR TITLE
Mildwonkey/ps limiter

### DIFF
--- a/addrs/provider.go
+++ b/addrs/provider.go
@@ -126,6 +126,25 @@ func (pt Provider) LessThan(other Provider) bool {
 	}
 }
 
+// IsLegacy returns true if the provider is a legacy-style provider
+func (pt Provider) IsLegacy() bool {
+	if pt.IsZero() {
+		panic("called IsLegacy() on zero-value addrs.Provider")
+	}
+
+	return pt.Hostname == DefaultRegistryHost && pt.Namespace == LegacyProviderNamespace
+
+}
+
+// IsDefault returns true if the provider is a default hashicorp provider
+func (pt Provider) IsDefault() bool {
+	if pt.IsZero() {
+		panic("called IsDefault() on zero-value addrs.Provider")
+	}
+
+	return pt.Hostname == DefaultRegistryHost && pt.Namespace == "hashicorp"
+}
+
 // Equals returns true if the receiver and other provider have the same attributes.
 func (pt Provider) Equals(other Provider) bool {
 	return pt == other

--- a/addrs/provider_config.go
+++ b/addrs/provider_config.go
@@ -360,7 +360,6 @@ func (pc AbsProviderConfig) Inherited() (AbsProviderConfig, bool) {
 		Module:   parentMod,
 		Provider: pc.Provider,
 	}, true
-
 }
 
 // LegacyString() returns a legacy-style AbsProviderConfig string and should only be used for legacy state shimming.

--- a/addrs/provider_test.go
+++ b/addrs/provider_test.go
@@ -7,6 +7,84 @@ import (
 	svchost "github.com/hashicorp/terraform-svchost"
 )
 
+func TestProviderIsDefault(t *testing.T) {
+	tests := []struct {
+		Input Provider
+		Want  bool
+	}{
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  DefaultRegistryHost,
+				Namespace: "hashicorp",
+			},
+			true,
+		},
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  "registry.terraform.com",
+				Namespace: "hashicorp",
+			},
+			false,
+		},
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  DefaultRegistryHost,
+				Namespace: "othercorp",
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		got := test.Input.IsDefault()
+		if got != test.Want {
+			t.Errorf("wrong result for %s\n", test.Input.String())
+		}
+	}
+}
+
+func TestProviderIsLegacy(t *testing.T) {
+	tests := []struct {
+		Input Provider
+		Want  bool
+	}{
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  DefaultRegistryHost,
+				Namespace: LegacyProviderNamespace,
+			},
+			true,
+		},
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  "registry.terraform.com",
+				Namespace: LegacyProviderNamespace,
+			},
+			false,
+		},
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  DefaultRegistryHost,
+				Namespace: "hashicorp",
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		got := test.Input.IsLegacy()
+		if got != test.Want {
+			t.Errorf("wrong result for %s\n", test.Input.String())
+		}
+	}
+}
+
 func TestParseProviderSourceStr(t *testing.T) {
 	tests := map[string]struct {
 		Want Provider

--- a/command/format/state.go
+++ b/command/format/state.go
@@ -147,7 +147,7 @@ func formatStateModule(p blockBodyDiffPrinter, m *states.Module, schemas *terraf
 					// loaded all of the schemas and checked things prior to this
 					// point. We can't return errors here, but since this is UI code
 					// we will try to do _something_ reasonable.
-					p.buf.WriteString(fmt.Sprintf("# missing schema for provider %q\n\n", provider.LegacyString()))
+					p.buf.WriteString(fmt.Sprintf("# missing schema for provider %q\n\n", provider.String()))
 					continue
 				}
 

--- a/command/init.go
+++ b/command/init.go
@@ -487,6 +487,7 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 		}
 
 		for provider, reqd := range missing {
+			// FIXME
 			pty := addrs.NewLegacyProvider(provider)
 			_, providerDiags, err := c.providerInstaller.Get(pty, reqd.Versions)
 			diags = diags.Append(providerDiags)

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -986,6 +986,10 @@ func TestInit_providerSource(t *testing.T) {
 	if err := ioutil.WriteFile(testPath, []byte("test bin"), 0755); err != nil {
 		t.Fatal(err)
 	}
+	randomPath := filepath.Join(c.pluginDir(), "terraform-provider-random_v1.2.3_x4")
+	if err := ioutil.WriteFile(randomPath, []byte("test bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
 	// the vendor path
 	sourcePath := filepath.Join(DefaultPluginVendorDir, "terraform-provider-source_v1.2.3_x4")
 	if err := ioutil.WriteFile(sourcePath, []byte("test bin"), 0755); err != nil {

--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -252,7 +252,7 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 		r.ModuleAddress = addr.Module.String()
 		r.Name = addr.Resource.Resource.Name
 		r.Type = addr.Resource.Resource.Type
-		r.ProviderName = rc.ProviderAddr.Provider.LegacyString()
+		r.ProviderName = rc.ProviderAddr.Provider.String()
 
 		p.ResourceChanges = append(p.ResourceChanges, r)
 

--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -164,7 +164,7 @@ func marshalPlanResources(changes *plans.Changes, ris []addrs.AbsResourceInstanc
 			Address:      r.Addr.String(),
 			Type:         r.Addr.Resource.Resource.Type,
 			Name:         r.Addr.Resource.Resource.Name,
-			ProviderName: r.ProviderAddr.Provider.LegacyString(),
+			ProviderName: r.ProviderAddr.Provider.String(),
 			Index:        r.Addr.Resource.Key,
 		}
 

--- a/command/jsonplan/values_test.go
+++ b/command/jsonplan/values_test.go
@@ -198,7 +198,7 @@ func TestMarshalPlanResources(t *testing.T) {
 				Type:            "test_thing",
 				Name:            "example",
 				Index:           addrs.InstanceKey(nil),
-				ProviderName:    "test",
+				ProviderName:    "registry.terraform.io/-/test",
 				SchemaVersion:   1,
 				AttributeValues: attributeValues{},
 			}},
@@ -227,7 +227,7 @@ func TestMarshalPlanResources(t *testing.T) {
 				Type:          "test_thing",
 				Name:          "example",
 				Index:         addrs.InstanceKey(nil),
-				ProviderName:  "test",
+				ProviderName:  "registry.terraform.io/-/test",
 				SchemaVersion: 1,
 				AttributeValues: attributeValues{
 

--- a/command/jsonprovider/provider.go
+++ b/command/jsonprovider/provider.go
@@ -35,7 +35,7 @@ func Marshal(s *terraform.Schemas) ([]byte, error) {
 	providers := newProviders()
 
 	for k, v := range s.Providers {
-		providers.Schemas[k.LegacyString()] = marshalProvider(v)
+		providers.Schemas[k.String()] = marshalProvider(v)
 	}
 
 	ret, err := json.Marshal(providers)

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -261,7 +261,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 				Address:      r.Addr.Instance(k).String(),
 				Type:         resAddr.Type,
 				Name:         resAddr.Name,
-				ProviderName: r.ProviderConfig.Provider.LegacyString(),
+				ProviderName: r.ProviderConfig.Provider.String(),
 			}
 
 			switch resAddr.Mode {

--- a/command/jsonstate/state_test.go
+++ b/command/jsonstate/state_test.go
@@ -217,7 +217,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:          "test_thing",
 					Name:          "bar",
 					Index:         addrs.InstanceKey(nil),
-					ProviderName:  "test",
+					ProviderName:  "registry.terraform.io/-/test",
 					SchemaVersion: 1,
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),
@@ -261,7 +261,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:          "test_thing",
 					Name:          "bar",
 					Index:         addrs.IntKey(0),
-					ProviderName:  "test",
+					ProviderName:  "registry.terraform.io/-/test",
 					SchemaVersion: 1,
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),
@@ -305,7 +305,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:          "test_thing",
 					Name:          "bar",
 					Index:         addrs.StringKey("rockhopper"),
-					ProviderName:  "test",
+					ProviderName:  "registry.terraform.io/-/test",
 					SchemaVersion: 1,
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),
@@ -351,7 +351,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:         "test_thing",
 					Name:         "bar",
 					Index:        addrs.InstanceKey(nil),
-					ProviderName: "test",
+					ProviderName: "registry.terraform.io/-/test",
 					DeposedKey:   deposedKey.String(),
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),
@@ -402,7 +402,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:          "test_thing",
 					Name:          "bar",
 					Index:         addrs.InstanceKey(nil),
-					ProviderName:  "test",
+					ProviderName:  "registry.terraform.io/-/test",
 					SchemaVersion: 1,
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),
@@ -415,7 +415,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:         "test_thing",
 					Name:         "bar",
 					Index:        addrs.InstanceKey(nil),
-					ProviderName: "test",
+					ProviderName: "registry.terraform.io/-/test",
 					DeposedKey:   deposedKey.String(),
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),

--- a/command/providers.go
+++ b/command/providers.go
@@ -136,7 +136,7 @@ func providersCommandPopulateTreeNode(node treeprint.Tree, deps *moduledeps.Modu
 		case moduledeps.ProviderDependencyFromState:
 			reasonStr = " (from state)"
 		}
-		node.AddNode(fmt.Sprintf("provider.%s%s%s", fqn.LegacyString(), versionsStr, reasonStr))
+		node.AddNode(fmt.Sprintf("provider[%s]%s%s", fqn.String(), versionsStr, reasonStr))
 	}
 
 	for _, child := range deps.Children {

--- a/command/providers_test.go
+++ b/command/providers_test.go
@@ -31,14 +31,14 @@ func TestProviders(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "provider.foo") {
-		t.Errorf("output missing provider.foo\n\n%s", output)
+	if !strings.Contains(output, "provider[registry.terraform.io/-/foo]") {
+		t.Errorf("output missing provider[registry.terraform.io/-/foo]\n\n%s", output)
 	}
-	if !strings.Contains(output, "provider.bar") {
-		t.Errorf("output missing provider.bar\n\n%s", output)
+	if !strings.Contains(output, "provider[registry.terraform.io/-/bar]") {
+		t.Errorf("output missing provider[registry.terraform.io/-/bar]\n\n%s", output)
 	}
-	if !strings.Contains(output, "provider.baz") {
-		t.Errorf("output missing provider.baz\n\n%s", output)
+	if !strings.Contains(output, "provider[registry.terraform.io/-/baz]") {
+		t.Errorf("output missing provider[registry.terraform.io/-/baz]\n\n%s", output)
 	}
 }
 

--- a/command/testdata/init-required-providers/main.tf
+++ b/command/testdata/init-required-providers/main.tf
@@ -1,8 +1,15 @@
 terraform {
   required_providers {
+    // legacy syntax
     test = "1.2.3"
+
+    // 0.13 syntax
     source = {
       version = "1.2.3"
+    }
+
+    default = {
+      source = "registry.terraform.io/hashicorp/random"
     }
   }
 }

--- a/command/testdata/providers-schema/basic/output.json
+++ b/command/testdata/providers-schema/basic/output.json
@@ -1,7 +1,7 @@
 {
     "format_version": "0.1",
     "provider_schemas": {
-        "test": {
+        "registry.terraform.io/-/test": {
             "resource_schemas": {
                 "test_instance": {
                     "version": 0,

--- a/command/testdata/show-json-state/basic/output.json
+++ b/command/testdata/show-json-state/basic/output.json
@@ -10,7 +10,7 @@
                     "type": "test_instance",
                     "name": "example",
                     "index": 0,
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/-/test",
                     "schema_version": 0,
                     "values": {
                         "ami": null,
@@ -23,7 +23,7 @@
                     "type": "test_instance",
                     "name": "example",
                     "index": 1,
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/-/test",
                     "schema_version": 0,
                     "values": {
                         "ami": null,

--- a/command/testdata/show-json-state/modules/output.json
+++ b/command/testdata/show-json-state/modules/output.json
@@ -17,7 +17,7 @@
                             "mode": "managed",
                             "type": "test_instance",
                             "name": "example",
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/-/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "bar-var",
@@ -35,7 +35,7 @@
                             "type": "test_instance",
                             "name": "example",
                             "index": 0,
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/-/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "foo-var",

--- a/command/testdata/show-json/basic-create/output.json
+++ b/command/testdata/show-json/basic-create/output.json
@@ -20,7 +20,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/-/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar"
@@ -32,7 +32,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/-/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar"
@@ -44,7 +44,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/-/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar"
@@ -71,7 +71,7 @@
             "index": 0,
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "name": "test",
             "change": {
                 "actions": [
@@ -91,7 +91,7 @@
             "index": 1,
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "name": "test",
             "change": {
                 "actions": [
@@ -111,7 +111,7 @@
             "index": 2,
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "name": "test",
             "change": {
                 "actions": [

--- a/command/testdata/show-json/basic-delete/output.json
+++ b/command/testdata/show-json/basic-delete/output.json
@@ -19,7 +19,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/-/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar",
@@ -34,7 +34,7 @@
             "address": "test_instance.test",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "name": "test",
             "change": {
                 "actions": [
@@ -55,7 +55,7 @@
             "address": "test_instance.test-delete",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "name": "test-delete",
             "change": {
                 "actions": [
@@ -97,7 +97,7 @@
                         "mode": "managed",
                         "type": "test_instance",
                         "name": "test",
-                        "provider_name": "test",
+                        "provider_name": "registry.terraform.io/-/test",
                         "values": {
                             "ami": "foo",
                             "id": "placeholder"
@@ -109,7 +109,7 @@
                         "mode": "managed",
                         "type": "test_instance",
                         "name": "test-delete",
-                        "provider_name": "test",
+                        "provider_name": "registry.terraform.io/-/test",
                         "values": {
                             "ami": "foo",
                             "id": "placeholder"

--- a/command/testdata/show-json/basic-update/output.json
+++ b/command/testdata/show-json/basic-update/output.json
@@ -19,7 +19,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/-/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar",
@@ -34,7 +34,7 @@
             "address": "test_instance.test",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "name": "test",
             "change": {
                 "actions": [
@@ -79,7 +79,7 @@
                         "type": "test_instance",
                         "name": "test",
                         "schema_version": 0,
-                        "provider_name": "test",
+                        "provider_name": "registry.terraform.io/-/test",
                         "values": {
                             "ami": "bar",
                             "id": "placeholder"

--- a/command/testdata/show-json/modules/output.json
+++ b/command/testdata/show-json/modules/output.json
@@ -16,7 +16,7 @@
                             "mode": "managed",
                             "type": "test_instance",
                             "name": "test",
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/-/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "bar-var"
@@ -33,7 +33,7 @@
                             "type": "test_instance",
                             "name": "test",
                             "index": 0,
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/-/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "baz"
@@ -45,7 +45,7 @@
                             "type": "test_instance",
                             "name": "test",
                             "index": 1,
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/-/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "baz"
@@ -57,7 +57,7 @@
                             "type": "test_instance",
                             "name": "test",
                             "index": 2,
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/-/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "baz"
@@ -88,7 +88,7 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "change": {
                 "actions": [
                     "create"
@@ -107,7 +107,7 @@
             "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "name": "test",
             "index": 0,
             "change": {
@@ -128,7 +128,7 @@
             "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "name": "test",
             "index": 1,
             "change": {
@@ -149,7 +149,7 @@
             "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "name": "test",
             "index": 2,
             "change": {

--- a/command/testdata/show-json/multi-resource-update/output.json
+++ b/command/testdata/show-json/multi-resource-update/output.json
@@ -21,7 +21,7 @@
                     "type": "test_instance",
                     "name": "test",
                     "index": 0,
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/-/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar",
@@ -34,7 +34,7 @@
                     "type": "test_instance",
                     "name": "test",
                     "index": 1,
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/-/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar"
@@ -50,7 +50,7 @@
             "type": "test_instance",
             "name": "test",
             "index": 0,
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "change": {
                 "actions": [
                     "no-op"
@@ -72,7 +72,7 @@
             "type": "test_instance",
             "name": "test",
             "index": 1,
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/-/test",
             "change": {
                 "actions": [
                     "create"
@@ -115,7 +115,7 @@
                         "type": "test_instance",
                         "name": "test",
                         "index": 0,
-                        "provider_name": "test",
+                        "provider_name": "registry.terraform.io/-/test",
                         "schema_version": 0,
                         "values": {
                             "ami": "bar",

--- a/command/testdata/show-json/nested-modules/output.json
+++ b/command/testdata/show-json/nested-modules/output.json
@@ -13,7 +13,7 @@
                   "mode": "managed",
                   "type": "test_instance",
                   "name": "test",
-                  "provider_name": "test",
+                  "provider_name": "registry.terraform.io/-/test",
                   "schema_version": 0,
                   "values": {
                     "ami": "bar-var"
@@ -34,7 +34,7 @@
       "mode": "managed",
       "type": "test_instance",
       "name": "test",
-      "provider_name": "test",
+      "provider_name": "registry.terraform.io/-/test",
       "change": {
         "actions": [
           "create"

--- a/configs/module.go
+++ b/configs/module.go
@@ -201,7 +201,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid provider source",
-				Detail:   fmt.Sprintf("%s is an invalid source. Provider source may only be used with Hashicorp providers.", fqn.String()),
+				Detail:   fmt.Sprintf("%s is an invalid source. Provider source may only be used with HashiCorp providers.", fqn.String()),
 				Subject:  reqd.Source.DeclRange.Ptr(),
 			})
 			continue

--- a/configs/module_merge_test.go
+++ b/configs/module_merge_test.go
@@ -207,7 +207,7 @@ func TestModuleOverrideResourceFQNs(t *testing.T) {
 	assertNoDiagnostics(t, diags)
 
 	got := mod.ManagedResources["test_instance.explicit"]
-	wantProvider := addrs.NewProvider(addrs.DefaultRegistryHost, "bar", "test")
+	wantProvider := addrs.NewLegacyProvider("bar")
 	wantProviderCfg := &ProviderConfigRef{
 		Name: "bar-test",
 		NameRange: hcl.Range{

--- a/configs/module_test.go
+++ b/configs/module_test.go
@@ -1,7 +1,6 @@
 package configs
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/addrs"
@@ -16,7 +15,6 @@ func TestNewModule_provider_local_name(t *testing.T) {
 
 	p := addrs.NewLegacyProvider("foo")
 	if name, exists := mod.ProviderLocalNames[p]; !exists {
-		fmt.Printf("%#v\n", mod.ProviderLocalNames)
 		t.Fatal("provider FQN foo/test not found")
 	} else {
 		if name != "foo-test" {
@@ -28,6 +26,12 @@ func TestNewModule_provider_local_name(t *testing.T) {
 	localName := mod.LocalNameForProvider(p)
 	if localName != "foo-test" {
 		t.Fatal("provider local name not found")
+	}
+
+	// if the provider is not found, it should return the type name
+	localName = mod.LocalNameForProvider(addrs.NewLegacyProvider("nonexist"))
+	if localName != "nonexist" {
+		t.Error("wrong local name returned for a non-local provider")
 	}
 }
 

--- a/configs/module_test.go
+++ b/configs/module_test.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/addrs"
@@ -13,8 +14,9 @@ func TestNewModule_provider_local_name(t *testing.T) {
 		t.Fatal(diags.Error())
 	}
 
-	p := addrs.NewProvider(addrs.DefaultRegistryHost, "foo", "test")
+	p := addrs.NewLegacyProvider("foo")
 	if name, exists := mod.ProviderLocalNames[p]; !exists {
+		fmt.Printf("%#v\n", mod.ProviderLocalNames)
 		t.Fatal("provider FQN foo/test not found")
 	} else {
 		if name != "foo-test" {
@@ -40,8 +42,8 @@ func TestNewModule_resource_providers(t *testing.T) {
 	// the default implied provider and one explicitly using a provider set in
 	// required_providers
 	wantImplicit := addrs.NewLegacyProvider("test")
-	wantFoo := addrs.NewProvider(addrs.DefaultRegistryHost, "foo", "test")
-	wantBar := addrs.NewProvider(addrs.DefaultRegistryHost, "bar", "test")
+	wantFoo := addrs.NewLegacyProvider("foo")
+	wantBar := addrs.NewLegacyProvider("bar")
 
 	// root module
 	if !cfg.Module.ManagedResources["test_instance.explicit"].Provider.Equals(wantFoo) {
@@ -88,7 +90,7 @@ func TestProviderForLocalConfig(t *testing.T) {
 	}
 	lc := addrs.LocalProviderConfig{LocalName: "foo-test"}
 	got := mod.ProviderForLocalConfig(lc)
-	want := addrs.NewProvider(addrs.DefaultRegistryHost, "foo", "test")
+	want := addrs.NewLegacyProvider("foo")
 	if !got.Equals(want) {
 		t.Fatalf("wrong result! got %#v, want %#v\n", got, want)
 	}

--- a/configs/testdata/invalid-files/provider-source-duplicate.tf
+++ b/configs/testdata/invalid-files/provider-source-duplicate.tf
@@ -1,0 +1,12 @@
+terraform {
+    required_providers {
+        foo-test = {
+            version = "1.0"
+            source = "foo"
+        }
+        foo-test = {
+            version = "1.0"
+            source = "bar"
+        }
+    }
+}

--- a/configs/testdata/providers-explicit-fqn/root.tf
+++ b/configs/testdata/providers-explicit-fqn/root.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     foo-test = {
-      source = "foo/test"
+      source = "-/foo"
     }
   }
 }

--- a/configs/testdata/valid-modules/nested-providers-fqns/child/main.tf
+++ b/configs/testdata/valid-modules/nested-providers-fqns/child/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     bar-test = {
-      source = "bar/test"
+      source = "bar"
     }
   }
 }

--- a/configs/testdata/valid-modules/nested-providers-fqns/main.tf
+++ b/configs/testdata/valid-modules/nested-providers-fqns/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     foo-test = {
-      source = "foo/test"
+      source = "foo"
     }
   }
 }

--- a/configs/testdata/valid-modules/override-resource-provider/base.tf
+++ b/configs/testdata/valid-modules/override-resource-provider/base.tf
@@ -1,10 +1,10 @@
 terraform {
   required_providers {
     foo-test = {
-      source = "foo/test"
+      source = "-/foo"
     }
     bar-test = {
-      source = "bar/test"
+      source = "-/bar"
     }
   }
 }

--- a/configs/testdata/valid-modules/providers-fqns/main.tf
+++ b/configs/testdata/valid-modules/providers-fqns/main.tf
@@ -1,7 +1,10 @@
 terraform {
   required_providers {
     foo-test = {
-      source = "foo/test"
+      // This is depending on the current behavior which allows legacy-style
+      // provider sources. When provider source is fully implemented this can be
+      // update to use any namespace. 
+      source = "-/test"
     }
   }
 }

--- a/moduledeps/module.go
+++ b/moduledeps/module.go
@@ -110,7 +110,9 @@ func (s sortModules) Swap(i, j int) {
 func (m *Module) ProviderRequirements() discovery.PluginRequirements {
 	ret := make(discovery.PluginRequirements)
 	for pFqn, dep := range m.Providers {
-		providerStr := pFqn.LegacyString()
+		// FIXME: when provider source is fully implemented the map keys will be
+		// addrs.Provider instead of strings.
+		providerStr := pFqn.Type
 		if existing, exists := ret[providerStr]; exists {
 			ret[providerStr].Versions = existing.Versions.Append(dep.Constraints)
 		} else {

--- a/terraform/context_components.go
+++ b/terraform/context_components.go
@@ -32,7 +32,7 @@ type basicComponentFactory struct {
 func (c *basicComponentFactory) ResourceProviders() []string {
 	var result []string
 	for k := range c.providers {
-		result = append(result, k.LegacyString())
+		result = append(result, k.String())
 	}
 	return result
 }
@@ -49,7 +49,7 @@ func (c *basicComponentFactory) ResourceProvisioners() []string {
 func (c *basicComponentFactory) ResourceProvider(typ addrs.Provider) (providers.Interface, error) {
 	f, ok := c.providers[typ]
 	if !ok {
-		return nil, fmt.Errorf("unknown provider %q", typ.LegacyString())
+		return nil, fmt.Errorf("unknown provider %q", typ.String())
 	}
 
 	return f()

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -155,7 +155,7 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced invalid object",
 			fmt.Sprintf(
 				"Provider %q produced an invalid value after apply for %s. The result cannot not be saved in the Terraform state.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.Provider.LegacyString(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
+				n.ProviderAddr.Provider.String(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
 			),
 		))
 	}
@@ -225,7 +225,7 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 				// to notice in the logs if an inconsistency beyond the type system
 				// leads to a downstream provider failure.
 				var buf strings.Builder
-				fmt.Fprintf(&buf, "[WARN] Provider %q produced an unexpected new value for %s, but we are tolerating it because it is using the legacy plugin SDK.\n    The following problems may be the cause of any confusing errors from downstream operations:", n.ProviderAddr.Provider.LegacyString(), absAddr)
+				fmt.Fprintf(&buf, "[WARN] Provider %q produced an unexpected new value for %s, but we are tolerating it because it is using the legacy plugin SDK.\n    The following problems may be the cause of any confusing errors from downstream operations:", n.ProviderAddr.Provider.String(), absAddr)
 				for _, err := range errs {
 					fmt.Fprintf(&buf, "\n      - %s", tfdiags.FormatError(err))
 				}
@@ -245,7 +245,7 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 						"Provider produced inconsistent result after apply",
 						fmt.Sprintf(
 							"When applying changes to %s, provider %q produced an unexpected new value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-							absAddr, n.ProviderAddr.Provider.LegacyString(), tfdiags.FormatError(err),
+							absAddr, n.ProviderAddr.Provider.String(), tfdiags.FormatError(err),
 						),
 					))
 				}

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -127,7 +127,7 @@ func (ctx *BuiltinEvalContext) InitProvider(addr addrs.AbsProviderConfig) (provi
 		return nil, err
 	}
 
-	log.Printf("[TRACE] BuiltinEvalContext: Initialized %q provider for %s", addr.LegacyString(), addr)
+	log.Printf("[TRACE] BuiltinEvalContext: Initialized %q provider for %s", addr.String(), addr)
 	ctx.ProviderCache[key] = p
 
 	return p, nil

--- a/terraform/eval_context_mock.go
+++ b/terraform/eval_context_mock.go
@@ -156,7 +156,7 @@ func (c *MockEvalContext) Input() UIInput {
 
 func (c *MockEvalContext) InitProvider(addr addrs.AbsProviderConfig) (providers.Interface, error) {
 	c.InitProviderCalled = true
-	c.InitProviderType = addr.LegacyString()
+	c.InitProviderType = addr.Provider.String()
 	c.InitProviderAddr = addr
 	return c.InitProviderProvider, c.InitProviderError
 }

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -65,7 +65,7 @@ func (n *EvalCheckPlannedChange) Eval(ctx EvalContext) (interface{}, error) {
 				"Provider produced inconsistent final plan",
 				fmt.Sprintf(
 					"When expanding the plan for %s to include new values learned so far during apply, provider %q changed the planned action from %s to %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-					absAddr, n.ProviderAddr.Provider.LegacyString(),
+					absAddr, n.ProviderAddr.Provider.String(),
 					plannedChange.Action, actualChange.Action,
 				),
 			))
@@ -79,7 +79,7 @@ func (n *EvalCheckPlannedChange) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced inconsistent final plan",
 			fmt.Sprintf(
 				"When expanding the plan for %s to include new values learned so far during apply, provider %q produced an invalid new value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				absAddr, n.ProviderAddr.Provider.LegacyString(), tfdiags.FormatError(err),
+				absAddr, n.ProviderAddr.Provider.String(), tfdiags.FormatError(err),
 			),
 		))
 	}
@@ -254,7 +254,7 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced invalid plan",
 			fmt.Sprintf(
 				"Provider %q planned an invalid value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.Provider.LegacyString(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
+				n.ProviderAddr.Provider.String(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
 			),
 		))
 	}
@@ -272,7 +272,7 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 			var buf strings.Builder
 			fmt.Fprintf(&buf,
 				"[WARN] Provider %q produced an invalid plan for %s, but we are tolerating it because it is using the legacy plugin SDK.\n    The following problems may be the cause of any confusing errors from downstream operations:",
-				n.ProviderAddr.Provider.LegacyString(), absAddr,
+				n.ProviderAddr.Provider.String(), absAddr,
 			)
 			for _, err := range errs {
 				fmt.Fprintf(&buf, "\n      - %s", tfdiags.FormatError(err))
@@ -285,7 +285,7 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 					"Provider produced invalid plan",
 					fmt.Sprintf(
 						"Provider %q planned an invalid value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-						n.ProviderAddr.Provider.LegacyString(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
+						n.ProviderAddr.Provider.String(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
 					),
 				))
 			}
@@ -328,7 +328,7 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 					"Provider produced invalid plan",
 					fmt.Sprintf(
 						"Provider %q has indicated \"requires replacement\" on %s for a non-existent attribute path %#v.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-						n.ProviderAddr.Provider.LegacyString(), absAddr, path,
+						n.ProviderAddr.Provider.String(), absAddr, path,
 					),
 				))
 				continue
@@ -425,7 +425,7 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 				"Provider produced invalid plan",
 				fmt.Sprintf(
 					"Provider %q planned an invalid value for %s%s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-					n.ProviderAddr.Provider.LegacyString(), absAddr, tfdiags.FormatError(err),
+					n.ProviderAddr.Provider.String(), absAddr, tfdiags.FormatError(err),
 				),
 			))
 		}

--- a/terraform/eval_read_data.go
+++ b/terraform/eval_read_data.go
@@ -87,7 +87,7 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 	schema, _ := providerSchema.SchemaForResourceAddr(n.Addr.ContainingResource())
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
-		return nil, fmt.Errorf("provider %q does not support data source %q", n.ProviderAddr.Provider.LegacyString(), n.Addr.Resource.Type)
+		return nil, fmt.Errorf("provider %q does not support data source %q", n.ProviderAddr.Provider.String(), n.Addr.Resource.Type)
 	}
 
 	// We'll always start by evaluating the configuration. What we do after
@@ -248,7 +248,7 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced invalid object",
 			fmt.Sprintf(
 				"Provider %q produced an invalid value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.Provider.LegacyString(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
+				n.ProviderAddr.Provider.String(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
 			),
 		))
 	}
@@ -262,7 +262,7 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced null object",
 			fmt.Sprintf(
 				"Provider %q produced a null value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.Provider.LegacyString(), absAddr,
+				n.ProviderAddr.Provider.String(), absAddr,
 			),
 		))
 	}
@@ -272,7 +272,7 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced invalid object",
 			fmt.Sprintf(
 				"Provider %q produced a value for %s that is not wholly known.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.Provider.LegacyString(), absAddr,
+				n.ProviderAddr.Provider.String(), absAddr,
 			),
 		))
 
@@ -411,7 +411,7 @@ func (n *EvalReadDataApply) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced invalid object",
 			fmt.Sprintf(
 				"Provider %q planned an invalid value for %s. The result could not be saved.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.Provider.LegacyString(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
+				n.ProviderAddr.Provider.String(), tfdiags.FormatErrorPrefixed(err, absAddr.String()),
 			),
 		))
 	}

--- a/terraform/eval_refresh.go
+++ b/terraform/eval_refresh.go
@@ -107,7 +107,7 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 			"Provider produced invalid object",
 			fmt.Sprintf(
 				"Provider %q planned an invalid value for %s during refresh: %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ProviderAddr.Provider.LegacyString(), absAddr, tfdiags.FormatError(err),
+				n.ProviderAddr.Provider.String(), absAddr, tfdiags.FormatError(err),
 			),
 		))
 	}

--- a/terraform/evaluate_valid.go
+++ b/terraform/evaluate_valid.go
@@ -222,7 +222,7 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  `Invalid resource type`,
-			Detail:   fmt.Sprintf(`A %s resource type %q is not supported by provider %q.`, modeAdjective, addr.Type, providerFqn.LegacyString()),
+			Detail:   fmt.Sprintf(`A %s resource type %q is not supported by provider %q.`, modeAdjective, addr.Type, providerFqn.String()),
 			Subject:  rng.ToHCL().Ptr(),
 		})
 		return diags

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -93,21 +93,18 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 	var diags tfdiags.Diagnostics
 
 	ensure := func(fqn addrs.Provider) {
-		// TODO: LegacyString() will be removed in an upcoming release
-		typeName := fqn.LegacyString()
-
 		if _, exists := schemas[fqn]; exists {
 			return
 		}
 
-		log.Printf("[TRACE] LoadSchemas: retrieving schema for provider type %q", fqn.LegacyString())
+		log.Printf("[TRACE] LoadSchemas: retrieving schema for provider type %q", fqn.String())
 		provider, err := components.ResourceProvider(fqn)
 		if err != nil {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to instantiate provider %q to obtain schema: %s", typeName, err),
+				fmt.Errorf("Failed to instantiate provider %q to obtain schema: %s", fqn.String(), err),
 			)
 			return
 		}
@@ -121,7 +118,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to retrieve schema from provider %q: %s", typeName, resp.Diagnostics.Err()),
+				fmt.Errorf("Failed to retrieve schema from provider %q: %s", fqn.String(), resp.Diagnostics.Err()),
 			)
 			return
 		}
@@ -138,7 +135,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// We're not using the version numbers here yet, but we'll check
 			// for validity anyway in case we start using them in future.
 			diags = diags.Append(
-				fmt.Errorf("invalid negative schema version provider configuration for provider %q", typeName),
+				fmt.Errorf("invalid negative schema version provider configuration for provider %q", fqn.String()),
 			)
 		}
 
@@ -147,7 +144,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			s.ResourceTypeSchemaVersions[t] = uint64(r.Version)
 			if r.Version < 0 {
 				diags = diags.Append(
-					fmt.Errorf("invalid negative schema version for resource type %s in provider %q", t, typeName),
+					fmt.Errorf("invalid negative schema version for resource type %s in provider %q", t, fqn.String()),
 				)
 			}
 		}
@@ -158,7 +155,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 				// We're not using the version numbers here yet, but we'll check
 				// for validity anyway in case we start using them in future.
 				diags = diags.Append(
-					fmt.Errorf("invalid negative schema version for data source %s in provider %q", t, typeName),
+					fmt.Errorf("invalid negative schema version for data source %s in provider %q", t, fqn.String()),
 				)
 			}
 		}


### PR DESCRIPTION
The goal of this PR is beta-readiness: Given the restriction (added in this PR) where only default and legacy sources are allowed, you could build terraform from this branch, use the new `source` attribute in `terraform.required_providers` and everything will _just work_ (at least as a **beta release** not in production please).

My biggest concern is this holding back local testing, which is most relevant for @justincampbell, @apparentlymart and @alisdair. If this ends up being too much of a problem I can hold off for awhile.

With that said, the actual changes:

* Added `IsLegacy` and `IsDefault` functions to check if a provider is a legacy or default provider. I expect that these functions can be removed when we lift the restriction on provider sources.
* replaced `LegacyString()` with `String()` and updated tests to expect provider fqn strings
* Added a check in `configs.NewModule` which will verify if a given provider source is a legacy or default provider
* bonus: replace an outdated `panic` in the same code as above with an actual error message (and also added a test) 

There are a few holdouts that will be addressed in future prs: the `plugins/discovery` package and related provider installer code still only understands legacy provider type names. Those packages are actively being worked on (either refactored or replaced, depending on the package) so I left in the last-minute shims to work with the legacy plugin installer. 
