### PR TITLE
Expander.ExpandResource should use AbsResource

### DIFF
--- a/instances/expander_test.go
+++ b/instances/expander_test.go
@@ -130,7 +130,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("resource single", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			addrs.RootModule,
 			singleResourceAddr,
 		)
@@ -142,7 +142,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("resource count2", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			addrs.RootModule,
 			count2ResourceAddr,
 		)
@@ -155,7 +155,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("resource count0", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			addrs.RootModule,
 			count0ResourceAddr,
 		)
@@ -165,7 +165,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("resource for_each", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			addrs.RootModule,
 			forEachResourceAddr,
 		)
@@ -187,7 +187,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module single resource single", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			mustModuleAddr("single"),
 			singleResourceAddr,
 		)
@@ -199,7 +199,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module single resource count2", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			mustModuleAddr(`single`),
 			count2ResourceAddr,
 		)
@@ -222,7 +222,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module count2 resource single", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			mustModuleAddr(`count2`),
 			singleResourceAddr,
 		)
@@ -235,7 +235,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module count2 resource count2", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			mustModuleAddr(`count2`),
 			count2ResourceAddr,
 		)
@@ -262,7 +262,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module count2 resource count2 resource count2", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			mustModuleAddr(`count2.count2`),
 			count2ResourceAddr,
 		)
@@ -280,6 +280,18 @@ func TestExpander(t *testing.T) {
 			t.Errorf("wrong result\n%s", diff)
 		}
 	})
+	t.Run("module count2 resource count2 resource count2", func(t *testing.T) {
+		got := ex.ExpandResource(
+			count2ResourceAddr.Absolute(mustModuleInstanceAddr(`module.count2[0].module.count2[1]`)),
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`module.count2[0].module.count2[1].test.count2[0]`),
+			mustAbsResourceInstanceAddr(`module.count2[0].module.count2[1].test.count2[1]`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
 	t.Run("module count0", func(t *testing.T) {
 		got := ex.ExpandModule(mustModuleAddr(`count0`))
 		want := []addrs.ModuleInstance(nil)
@@ -288,7 +300,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module count0 resource single", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			mustModuleAddr(`count0`),
 			singleResourceAddr,
 		)
@@ -311,7 +323,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module for_each resource single", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			mustModuleAddr(`for_each`),
 			singleResourceAddr,
 		)
@@ -324,7 +336,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module for_each resource count2", func(t *testing.T) {
-		got := ex.ExpandResource(
+		got := ex.ExpandModuleResource(
 			mustModuleAddr(`for_each`),
 			count2ResourceAddr,
 		)
@@ -333,6 +345,18 @@ func TestExpander(t *testing.T) {
 			mustAbsResourceInstanceAddr(`module.for_each["a"].test.count2[1]`),
 			mustAbsResourceInstanceAddr(`module.for_each["b"].test.count2[0]`),
 			mustAbsResourceInstanceAddr(`module.for_each["b"].test.count2[1]`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module for_each resource count2", func(t *testing.T) {
+		got := ex.ExpandResource(
+			count2ResourceAddr.Absolute(mustModuleInstanceAddr(`module.for_each["a"]`)),
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`module.for_each["a"].test.count2[0]`),
+			mustAbsResourceInstanceAddr(`module.for_each["a"].test.count2[1]`),
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("wrong result\n%s", diff)

--- a/terraform/node_data_refresh.go
+++ b/terraform/node_data_refresh.go
@@ -68,7 +68,7 @@ func (n *NodeRefreshableDataResource) DynamicExpand(ctx EvalContext) (*Graph, er
 		default:
 			expander.SetResourceSingle(path, n.ResourceAddr().Resource)
 		}
-		instanceAddrs = append(instanceAddrs, expander.ExpandResource(path.Module(), n.ResourceAddr().Resource)...)
+		instanceAddrs = append(instanceAddrs, expander.ExpandResource(n.ResourceAddr().Absolute(path))...)
 	}
 
 	// Our graph transformers require access to the full state, so we'll

--- a/terraform/node_resource_plan.go
+++ b/terraform/node_resource_plan.go
@@ -70,9 +70,8 @@ func (n *NodePlannableResource) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	// Our instance expander should already have been informed about the
 	// expansion of this resource and of all of its containing modules, so
 	// it can tell us which instance addresses we need to process.
-	module := ctx.Path().Module()
 	expander := ctx.InstanceExpander()
-	instanceAddrs := expander.ExpandResource(module, n.ResourceAddr().Resource)
+	instanceAddrs := expander.ExpandResource(n.ResourceAddr().Absolute(ctx.Path()))
 
 	// We need to potentially rename an instance address in the state
 	// if we're transitioning whether "count" is set at all.

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -75,7 +75,7 @@ func (n *NodeRefreshableManagedResource) DynamicExpand(ctx EvalContext) (*Graph,
 			expander.SetResourceSingle(module, n.ResourceAddr().Resource)
 		}
 	}
-	instanceAddrs := expander.ExpandResource(n.Addr.Module, n.ResourceAddr().Resource)
+	instanceAddrs := expander.ExpandModuleResource(n.Addr.Module, n.ResourceAddr().Resource)
 
 	// Our graph transformers require access to the full state, so we'll
 	// temporarily lock it while we work on this.


### PR DESCRIPTION
It turns out that within terraform resource expansion will normally
happen with an absolute address. This is because in order to evaluate
the expansion expression, we need to already have the context within a
module instance.

This leaves the existing ExpandResource logic in place as
ExpandModuleResource since it's working, and in case we do find a
location where it's useful to get a full expansion (which may be needed
for instance dependency tracking)

Reword some of the resource related arguments and comments, as they were
copied from the module methods and not entirely accurate.