### PR TITLE
backend/obs: Add HuaweiCloud OBS backend with locking

### DIFF
--- a/backend/init/init.go
+++ b/backend/init/init.go
@@ -23,6 +23,7 @@ import (
 	backendHTTP "github.com/hashicorp/terraform/backend/remote-state/http"
 	backendInmem "github.com/hashicorp/terraform/backend/remote-state/inmem"
 	backendManta "github.com/hashicorp/terraform/backend/remote-state/manta"
+	backendOBS "github.com/hashicorp/terraform/backend/remote-state/obs"
 	backendOSS "github.com/hashicorp/terraform/backend/remote-state/oss"
 	backendPg "github.com/hashicorp/terraform/backend/remote-state/pg"
 	backendS3 "github.com/hashicorp/terraform/backend/remote-state/s3"
@@ -65,6 +66,7 @@ func Init(services *disco.Disco) {
 		"http":        func() backend.Backend { return backendHTTP.New() },
 		"inmem":       func() backend.Backend { return backendInmem.New() },
 		"manta":       func() backend.Backend { return backendManta.New() },
+		"obs":         func() backend.Backend { return backendOBS.New() },
 		"oss":         func() backend.Backend { return backendOSS.New() },
 		"pg":          func() backend.Backend { return backendPg.New() },
 		"s3":          func() backend.Backend { return backendS3.New() },

--- a/backend/init/init_test.go
+++ b/backend/init/init_test.go
@@ -23,6 +23,7 @@ func TestInit_backend(t *testing.T) {
 		{"gcs", "*gcs.Backend"},
 		{"inmem", "*inmem.Backend"},
 		{"manta", "*manta.Backend"},
+		{"obs", "*obs.Backend"},
 		{"pg", "*pg.Backend"},
 		{"s3", "*s3.Backend"},
 		{"swift", "*swift.Backend"},

--- a/backend/remote-state/obs/backend.go
+++ b/backend/remote-state/obs/backend.go
@@ -1,0 +1,167 @@
+package obs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/obs"
+)
+
+// New creates a new backend for obs remote state.
+func New() backend.Backend {
+	s := &schema.Backend{
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The region of the obs bucket",
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+			},
+
+			"bucket": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the obs bucket",
+			},
+
+			"key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The path to the state file inside the bucket",
+				Default:     "terraform.tfstate",
+				ValidateFunc: func(v interface{}, s string) ([]string, []error) {
+					if strings.HasPrefix(v.(string), "/") || strings.HasSuffix(v.(string), "/") {
+						return nil, []error{fmt.Errorf("key can not start and end with '/'")}
+					}
+					return nil, nil
+				},
+			},
+
+			"prefix": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The directory for saving the state file in bucket",
+				ValidateFunc: func(v interface{}, s string) ([]string, []error) {
+					prefix := v.(string)
+					if strings.HasPrefix(prefix, "/") || strings.HasPrefix(prefix, "./") {
+						return nil, []error{fmt.Errorf("prefix must not start with '/' or './'")}
+					}
+					return nil, nil
+				},
+			},
+
+			"endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "An endpoint for the obs API",
+			},
+
+			"access_key_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "HuaweiCloud access key",
+				DefaultFunc: schema.EnvDefaultFunc("OS_ACCESS_KEY", ""),
+			},
+
+			"secret_key_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "HuaweiCloud secret key",
+				DefaultFunc: schema.EnvDefaultFunc("OS_SECRET_KEY", ""),
+			},
+
+			"acl": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Canned ACL to be applied to the state file",
+				Default:     "private",
+			},
+
+			"encrypt": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to enable server side encryption of the state file",
+				Default:     false,
+			},
+
+			"kms_key_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The KMS Key to use for encrypting the state",
+				Default:     "",
+			},
+		},
+	}
+
+	result := &Backend{Backend: s}
+	result.Backend.ConfigureFunc = result.configure
+	return result
+}
+
+// Backend implements backend.Backend for obs
+type Backend struct {
+	*schema.Backend
+
+	// The fields below are set from configure
+	obsClient *obs.ObsClient
+
+	bucketName string
+	keyName    string
+	prefix     string
+	acl        string
+	encryption bool
+	kmsKeyID   string
+}
+
+func (b *Backend) configure(ctx context.Context) error {
+	if b.obsClient != nil {
+		return nil
+	}
+
+	// Grab the resource data
+	data := schema.FromContextBackendConfig(ctx)
+
+	b.bucketName = data.Get("bucket").(string)
+	b.keyName = data.Get("key").(string)
+	b.prefix = data.Get("prefix").(string)
+	b.acl = data.Get("acl").(string)
+	b.encryption = data.Get("encrypt").(bool)
+	b.kmsKeyID = data.Get("kms_key_id").(string)
+
+	accessKey := data.Get("access_key_id").(string)
+	secretKey := data.Get("secret_key_id").(string)
+	region := data.Get("region").(string)
+	endpoint := data.Get("endpoint").(string)
+
+	if accessKey == "" {
+		return fmt.Errorf("Error: access_key_id or env OS_ACCESS_KEY must be set")
+	}
+
+	if secretKey == "" {
+		return fmt.Errorf("Error: secret_key_id or env OS_SECRET_KEY must be set")
+	}
+
+	if endpoint == "" {
+		endpoint = b.getDefaultOBSEndpoint(region)
+	}
+	if !strings.HasPrefix(endpoint, "http") {
+		endpoint = fmt.Sprintf("https://%s", endpoint)
+	}
+
+	obsclient, err := obs.New(accessKey, secretKey, endpoint)
+	if err != nil {
+		return err
+	}
+	b.obsClient = obsclient
+
+	return nil
+}
+
+func (b *Backend) getDefaultOBSEndpoint(region string) (endpoint string) {
+	endpoint = fmt.Sprintf("https://obs.%s.myhuaweicloud.com", region)
+
+	return endpoint
+}

--- a/backend/remote-state/obs/backend_state.go
+++ b/backend/remote-state/obs/backend_state.go
@@ -1,0 +1,160 @@
+package obs
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/state"
+	"github.com/hashicorp/terraform/state/remote"
+	"github.com/hashicorp/terraform/states"
+	"github.com/huaweicloud/golangsdk/openstack/obs"
+)
+
+// Define file suffix
+const (
+	stateFileSuffix = ".tfstate"
+	lockFileSuffix  = ".tflock"
+)
+
+// Workspaces returns a list of names for the workspaces
+func (b *Backend) Workspaces() ([]string, error) {
+	const maxKeys = 1000
+
+	params := &obs.ListObjectsInput{}
+	params.Bucket = b.bucketName
+	params.Prefix = b.prefix
+	params.MaxKeys = maxKeys
+
+	Objects, err := b.obsClient.ListObjects(params)
+	if obsErr, ok := err.(obs.ObsError); ok {
+		log.Printf("[ERROR] failed to list obs objects: %s", err)
+		if obsErr.Code == ErrCodeNoSuchBucket {
+			return nil, fmt.Errorf(errNoSuchBucket, err)
+		}
+		return nil, err
+	}
+
+	// Grab the Contents
+	wss := []string{backend.DefaultStateName}
+	for _, obj := range Objects.Contents {
+		// skip <name>.tfstate
+		if !strings.HasSuffix(obj.Key, stateFileSuffix) {
+			continue
+		}
+		// skip default worksapce
+		if path.Join(b.prefix, b.keyName) == obj.Key {
+			continue
+		}
+		// <prefix>/<worksapce>/<key>
+		prefix := strings.TrimRight(b.prefix, "/") + "/"
+		parts := strings.Split(strings.TrimPrefix(obj.Key, prefix), "/")
+		if len(parts) > 0 && parts[0] != "" {
+			wss = append(wss, parts[0])
+		}
+	}
+
+	sort.Strings(wss[1:])
+	log.Printf("[DEBUG] workspaces in bucket %s: %v", b.bucketName, wss)
+
+	return wss, nil
+}
+
+// DeleteWorkspace deletes the named workspaces. The "default" state cannot be deleted
+func (b *Backend) DeleteWorkspace(name string) error {
+	if name == backend.DefaultStateName || name == "" {
+		return fmt.Errorf("can't delete default state")
+	}
+
+	client, err := b.remoteClient(name)
+	if err != nil {
+		return err
+	}
+
+	return client.Delete()
+}
+
+// StateMgr manage the state, if the named state not exists, a new file will created
+func (b *Backend) StateMgr(name string) (state.State, error) {
+	client, err := b.remoteClient(name)
+	if err != nil {
+		return nil, err
+	}
+
+	stateMgr := &remote.State{Client: client}
+	// Check to see if this state already exists.
+	// If the state doesn't exist, we have to assume this is a normal create operation.
+	existing, err := b.Workspaces()
+	if err != nil {
+		return nil, err
+	}
+
+	exists := false
+	for _, s := range existing {
+		if s == name {
+			exists = true
+			break
+		}
+	}
+
+	// We need to create the object so it's listed by States.
+	if !exists {
+		log.Printf("[DEBUG] object %s does not exist in the workspace", name)
+		// Grab the value
+		if err := stateMgr.RefreshState(); err != nil {
+			log.Printf("[ERROR] failed to refresh the state file: %s", err)
+			return nil, err
+		}
+
+		// If we have no state, we have to create an empty state
+		if v := stateMgr.State(); v == nil {
+			if err := stateMgr.WriteState(states.NewState()); err != nil {
+				log.Printf("[ERROR] failed to write the state file: %s", err)
+				return nil, err
+			}
+			if err := stateMgr.PersistState(); err != nil {
+				log.Printf("[ERROR] failed to persist the state file: %s", err)
+				return nil, err
+			}
+		}
+	}
+
+	return stateMgr, nil
+}
+
+// get a remote client configured for this state
+func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
+	if name == "" {
+		return nil, errors.New("missing state name")
+	}
+
+	client := &RemoteClient{
+		obsClient:  b.obsClient,
+		bucketName: b.bucketName,
+		stateFile:  b.statePath(name),
+		lockFile:   b.lockPath(name),
+		acl:        b.acl,
+		encryption: b.encryption,
+		kmsKeyID:   b.kmsKeyID,
+	}
+
+	return client, nil
+}
+
+// statePath returns state file path by name
+func (b *Backend) statePath(name string) string {
+	if name == backend.DefaultStateName {
+		return path.Join(b.prefix, b.keyName)
+	}
+
+	return path.Join(b.prefix, name, b.keyName)
+}
+
+// lockPath returns lock file path by name
+func (b *Backend) lockPath(name string) string {
+	return b.statePath(name) + lockFileSuffix
+}

--- a/backend/remote-state/obs/backend_test.go
+++ b/backend/remote-state/obs/backend_test.go
@@ -1,0 +1,310 @@
+package obs
+
+import (
+	"crypto/md5"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/state/remote"
+	"github.com/huaweicloud/golangsdk/openstack/obs"
+)
+
+const (
+	defaultPrefix = ""
+	defaultKey    = "terraform.tfstate"
+)
+
+// verify that we are doing ACC tests or the OBS tests specifically
+func testACC(t *testing.T) {
+	skip := os.Getenv("TF_ACC") == "" && os.Getenv("TF_OBS_TEST") == ""
+	if skip {
+		t.Skip("obs backend tests require setting TF_ACC or TF_OBS_TEST")
+	}
+
+	skip = os.Getenv("OS_ACCESS_KEY") == "" || os.Getenv("OS_SECRET_KEY") == ""
+	if skip {
+		t.Skip("obs backend tests require setting OS_ACCESS_KEY and OS_SECRET_KEY")
+	}
+
+	if os.Getenv("OS_REGION_NAME") == "" {
+		os.Setenv("OS_REGION_NAME", "cn-north-1")
+	}
+}
+
+// Testing Thanks to GCS
+
+func TestStateFile(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		prefix        string
+		stateName     string
+		key           string
+		wantStateFile string
+		wantLockFile  string
+	}{
+		{"", "", "terraform.tfstate", "terraform.tfstate", "terraform.tfstate.tflock"},
+		{"", "default", "test.tfstate", "test.tfstate", "test.tfstate.tflock"},
+		{"", "dev", "test.tfstate", "dev/test.tfstate", "dev/test.tfstate.tflock"},
+		{"terraform", "default", "terraform.tfstate", "terraform/terraform.tfstate", "terraform/terraform.tfstate.tflock"},
+		{"terraform/test", "default", "test.tfstate", "terraform/test/test.tfstate", "terraform/test/test.tfstate.tflock"},
+		{"terraform/test", "dev", "test.tfstate", "terraform/test/dev/test.tfstate", "terraform/test/dev/test.tfstate.tflock"},
+	}
+
+	for i, c := range cases {
+		b := &Backend{
+			prefix:  c.prefix,
+			keyName: c.key,
+		}
+
+		if got := b.statePath(c.stateName); got != c.wantStateFile {
+			t.Errorf("case %d: stateFile(%q) = %q, want %q", i, c.stateName, got, c.wantStateFile)
+		}
+
+		if got := b.lockPath(c.stateName); got != c.wantLockFile {
+			t.Errorf("case %d: lockFile(%q) = %q, want %q", i, c.stateName, got, c.wantLockFile)
+		}
+	}
+}
+
+func TestRemoteClient(t *testing.T) {
+	testACC(t)
+	t.Parallel()
+
+	bucket := bucketName(t)
+	be := setupBackend(t, bucket, defaultPrefix, defaultKey, false)
+
+	createOBSBucket(t, be, bucket)
+	defer deleteOBSBucket(t, be, bucket)
+
+	ss, err := be.StateMgr(backend.DefaultStateName)
+	if err != nil {
+		t.Fatalf("be.StateMgr(%q) = %v", backend.DefaultStateName, err)
+	}
+
+	rs, ok := ss.(*remote.State)
+	if !ok {
+		t.Fatalf("be.StateMgr(): got a %T, want a *remote.State", ss)
+	}
+
+	remote.TestClient(t, rs.Client)
+}
+
+func TestRemoteClientWithPrefix(t *testing.T) {
+	testACC(t)
+	t.Parallel()
+
+	prefix := "prefix/test"
+	bucket := bucketName(t)
+	be := setupBackend(t, bucket, prefix, defaultKey, false)
+
+	createOBSBucket(t, be, bucket)
+	defer deleteOBSBucket(t, be, bucket)
+
+	ss, err := be.StateMgr(backend.DefaultStateName)
+	if err != nil {
+		t.Fatalf("be.StateMgr(%q) = %v", backend.DefaultStateName, err)
+	}
+
+	rs, ok := ss.(*remote.State)
+	if !ok {
+		t.Fatalf("be.StateMgr(): got a %T, want a *remote.State", ss)
+	}
+
+	remote.TestClient(t, rs.Client)
+}
+
+func TestRemoteClientWithEncryption(t *testing.T) {
+	testACC(t)
+	t.Parallel()
+
+	bucket := bucketName(t)
+	be := setupBackend(t, bucket, defaultPrefix, defaultKey, true)
+
+	createOBSBucket(t, be, bucket)
+	defer deleteOBSBucket(t, be, bucket)
+
+	ss, err := be.StateMgr(backend.DefaultStateName)
+	if err != nil {
+		t.Fatalf("be.StateMgr(%q) = %v", backend.DefaultStateName, err)
+	}
+
+	rs, ok := ss.(*remote.State)
+	if !ok {
+		t.Fatalf("be.StateMgr(): got a %T, want a *remote.State", ss)
+	}
+
+	remote.TestClient(t, rs.Client)
+}
+
+func TestRemoteLocks(t *testing.T) {
+	testACC(t)
+	t.Parallel()
+
+	bucket := bucketName(t)
+	be := setupBackend(t, bucket, defaultPrefix, defaultKey, false)
+
+	createOBSBucket(t, be, bucket)
+	defer deleteOBSBucket(t, be, bucket)
+
+	remoteClient := func() (remote.Client, error) {
+		ss, err := be.StateMgr(backend.DefaultStateName)
+		if err != nil {
+			return nil, err
+		}
+
+		rs, ok := ss.(*remote.State)
+		if !ok {
+			return nil, fmt.Errorf("be.StateMgr(): got a %T, want a *remote.State", ss)
+		}
+
+		return rs.Client, nil
+	}
+
+	c0, err := remoteClient()
+	if err != nil {
+		t.Fatalf("remoteClient(0) = %v", err)
+	}
+	c1, err := remoteClient()
+	if err != nil {
+		t.Fatalf("remoteClient(1) = %v", err)
+	}
+
+	remote.TestRemoteLocks(t, c0, c1)
+}
+
+func TestBackend(t *testing.T) {
+	testACC(t)
+	t.Parallel()
+
+	bucket := bucketName(t)
+	be0 := setupBackend(t, bucket, defaultPrefix, defaultKey, false)
+	be1 := setupBackend(t, bucket, defaultPrefix, defaultKey, false)
+
+	createOBSBucket(t, be0, bucket)
+	defer deleteOBSBucket(t, be0, bucket)
+
+	backend.TestBackendStates(t, be0)
+	backend.TestBackendStateLocks(t, be0, be1)
+	backend.TestBackendStateForceUnlock(t, be0, be1)
+}
+
+func TestBackendWithPrefix(t *testing.T) {
+	testACC(t)
+	t.Parallel()
+
+	prefix := "prefix/test"
+	bucket := bucketName(t)
+	be0 := setupBackend(t, bucket, prefix, defaultKey, false)
+	be1 := setupBackend(t, bucket, prefix, defaultKey, false)
+
+	createOBSBucket(t, be0, bucket)
+	defer deleteOBSBucket(t, be0, bucket)
+
+	backend.TestBackendStates(t, be0)
+	backend.TestBackendStateLocks(t, be0, be1)
+}
+
+func TestBackendWithEncryption(t *testing.T) {
+	testACC(t)
+	t.Parallel()
+
+	bucket := bucketName(t)
+	be0 := setupBackend(t, bucket, defaultPrefix, defaultKey, true)
+	be1 := setupBackend(t, bucket, defaultPrefix, defaultKey, true)
+
+	createOBSBucket(t, be0, bucket)
+	defer deleteOBSBucket(t, be0, bucket)
+
+	backend.TestBackendStates(t, be0)
+	backend.TestBackendStateLocks(t, be0, be1)
+}
+
+func bucketName(t *testing.T) string {
+	unique := fmt.Sprintf("%s-%x", t.Name(), time.Now().UnixNano())
+	return fmt.Sprintf("terraform-test-%s", fmt.Sprintf("%x", md5.Sum([]byte(unique)))[:10])
+}
+
+func setupBackend(t *testing.T, bucket, prefix, key string, encrypt bool) backend.Backend {
+	region := os.Getenv("OS_REGION_NAME")
+	config := map[string]interface{}{
+		"region":  region,
+		"bucket":  bucket,
+		"prefix":  prefix,
+		"key":     key,
+		"encrypt": encrypt,
+	}
+
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config))
+
+	return b
+}
+
+func createOBSBucket(t *testing.T, be backend.Backend, bucketName string) {
+	backend, ok := be.(*Backend)
+	if !ok {
+		t.Fatalf("be is a %T, want a *obs.Backend", be)
+	}
+	client := backend.obsClient
+
+	// Be clear about what we're doing in case the user needs to clean this up later.
+	region := os.Getenv("OS_REGION_NAME")
+
+	opts := &obs.CreateBucketInput{}
+	opts.Bucket = bucketName
+	opts.Location = region
+
+	if _, err := client.CreateBucket(opts); err != nil {
+		t.Fatal("failed to create test OBS bucket:", err)
+	}
+}
+
+func deleteOBSBucket(t *testing.T, be backend.Backend, bucketName string) {
+	backend, ok := be.(*Backend)
+	if !ok {
+		t.Fatalf("be is a %T, want a *obs.Backend", be)
+	}
+	client := backend.obsClient
+
+	warning := "WARNING: Failed to delete the test OBS bucket. " +
+		"It may have been left in your Cloud account and may incur storage charges. (error was %s)"
+
+	// first we have to delete objects in the bucket
+	listOpts := &obs.ListObjectsInput{
+		Bucket: bucketName,
+	}
+	resp, err := client.ListObjects(listOpts)
+	if err != nil {
+		t.Logf(warning, err)
+		return
+	}
+
+	if len(resp.Contents) > 0 {
+		objects := make([]obs.ObjectToDelete, len(resp.Contents))
+		for i, content := range resp.Contents {
+			objects[i].Key = content.Key
+		}
+
+		deleteOpts := &obs.DeleteObjectsInput{
+			Bucket:  bucketName,
+			Objects: objects,
+		}
+
+		output, err := client.DeleteObjects(deleteOpts)
+		if err != nil {
+			t.Logf("failed to delete objects of OBS bucket %s, %s", bucketName, err)
+		} else {
+			if len(output.Errors) > 0 {
+				t.Logf("some objects are still residual in bucket %s: %v", bucketName, output.Errors)
+			}
+		}
+	}
+
+	// Delete the bucket itself
+	if _, err = client.DeleteBucket(bucketName); err != nil {
+		t.Errorf(warning, err)
+	}
+}

--- a/backend/remote-state/obs/client.go
+++ b/backend/remote-state/obs/client.go
@@ -1,0 +1,262 @@
+package obs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform/state"
+	"github.com/hashicorp/terraform/state/remote"
+	"github.com/huaweicloud/golangsdk/openstack/obs"
+)
+
+// ErrCode
+const (
+	// Access OBS client denied
+	ErrCodeAccessDenied = "AccessDenied"
+
+	// The specified bucket does not exist.
+	ErrCodeNoSuchBucket = "NoSuchBucket"
+
+	// The specified key does not exist.
+	ErrCodeNoSuchKey = "NoSuchKey"
+)
+
+// RemoteClient implements the client of remote state
+type RemoteClient struct {
+	obsClient  *obs.ObsClient
+	bucketName string
+	stateFile  string
+	lockFile   string
+	acl        string
+	encryption bool
+	kmsKeyID   string
+}
+
+// Get remote state file
+func (c *RemoteClient) Get() (*remote.Payload, error) {
+	output, err := c.getObject(c.stateFile)
+	if err != nil || output == nil {
+		return nil, err
+	}
+
+	defer output.Body.Close()
+
+	buf := bytes.NewBuffer(nil)
+	if _, err := io.Copy(buf, output.Body); err != nil {
+		return nil, fmt.Errorf("Failed to read remote state: %s", err)
+	}
+
+	payload := &remote.Payload{
+		Data: buf.Bytes(),
+	}
+
+	// If there was no data, then return nil
+	if len(payload.Data) == 0 {
+		return nil, nil
+	}
+
+	return payload, nil
+}
+
+// Put state file to remote
+func (c *RemoteClient) Put(data []byte) error {
+	return c.putObject(c.stateFile, data)
+}
+
+// Delete remote state file
+func (c *RemoteClient) Delete() error {
+	return c.deleteObject(c.stateFile)
+}
+
+// Lock lock remote state file for writing
+func (c *RemoteClient) Lock(info *state.LockInfo) (string, error) {
+	log.Printf("[DEBUG] lock remote state file %s", c.lockFile)
+
+	//firstly we want to check that a lock doesn't already exist
+	lockErr := &state.LockError{}
+	lockInfo, err := c.getLockInfo()
+	if err != nil {
+		lockErr.Err = fmt.Errorf("failed to retrieve lock info: %s", err)
+		return "", lockErr
+	}
+
+	if lockInfo != nil {
+		lockErr := &state.LockError{
+			Err:  fmt.Errorf("A lock is already acquired"),
+			Info: lockInfo,
+		}
+		return "", lockErr
+	}
+
+	// get the lock
+	info.Path = c.lockFile
+	if info.ID == "" {
+		lockID, err := uuid.GenerateUUID()
+		if err != nil {
+			return "", err
+		}
+
+		info.ID = lockID
+	}
+
+	data, err := json.Marshal(info)
+	if err != nil {
+		return "", c.lockError(err)
+	}
+
+	err = c.putObject(c.lockFile, data)
+	if err != nil {
+		return "", c.lockError(err)
+	}
+
+	return info.ID, nil
+}
+
+// Unlock unlock remote state file
+func (c *RemoteClient) Unlock(check string) error {
+	log.Printf("[DEBUG] unlock remote state file %s", c.lockFile)
+
+	info, err := c.getLockInfo()
+	if err != nil {
+		return c.lockError(err)
+	}
+
+	if info.ID != check {
+		return c.lockError(fmt.Errorf("lock id mismatch, %v != %v", info.ID, check))
+	}
+
+	err = c.deleteObject(c.lockFile)
+	if err != nil {
+		return c.lockError(err)
+	}
+
+	return nil
+}
+
+// lockError returns state.LockError
+func (c *RemoteClient) lockError(err error) *state.LockError {
+	log.Printf("[WARN] failed to lock or unlock %s: %v", c.lockFile, err)
+
+	lockErr := &state.LockError{
+		Err: err,
+	}
+
+	info, infoErr := c.getLockInfo()
+	if infoErr != nil {
+		lockErr.Err = multierror.Append(lockErr.Err, infoErr)
+	} else {
+		lockErr.Info = info
+	}
+
+	return lockErr
+}
+
+// getLockInfo returns LockInfo from lock file
+func (c *RemoteClient) getLockInfo() (*state.LockInfo, error) {
+	output, err := c.getObject(c.lockFile)
+	if err != nil || output == nil {
+		return nil, err
+	}
+
+	defer output.Body.Close()
+
+	buf := bytes.NewBuffer(nil)
+	if _, err := io.Copy(buf, output.Body); err != nil {
+		return nil, fmt.Errorf("Failed to read remote lock info: %s", err)
+	}
+
+	lockInfo := &state.LockInfo{}
+	err = json.Unmarshal(buf.Bytes(), lockInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return lockInfo, nil
+}
+
+// getObject get remote object
+func (c *RemoteClient) getObject(object string) (*obs.GetObjectOutput, error) {
+	var output *obs.GetObjectOutput
+	var err error
+
+	input := &obs.GetObjectInput{}
+	input.Bucket = c.bucketName
+	input.Key = object
+
+	log.Printf("[DEBUG] get remote object: %s in bucket: %s", object, c.bucketName)
+	output, err = c.obsClient.GetObject(input)
+	if err != nil {
+		if obserr, ok := err.(obs.ObsError); ok {
+			switch obserr.Code {
+			case ErrCodeNoSuchBucket:
+				return nil, fmt.Errorf(errNoSuchBucket, obserr)
+			case ErrCodeNoSuchKey:
+				return nil, nil
+			}
+		}
+		return nil, err
+	}
+
+	return output, nil
+}
+
+// Put object to remote bucket
+func (c *RemoteClient) putObject(object string, data []byte) error {
+	i := &obs.PutObjectInput{}
+	i.ContentType = "application/json"
+	i.ContentLength = int64(len(data))
+	i.Body = bytes.NewReader(data)
+	i.Bucket = c.bucketName
+	i.Key = object
+
+	if c.encryption {
+		sseKmsHeader := obs.SseKmsHeader{
+			Encryption: obs.DEFAULT_SSE_KMS_ENCRYPTION,
+		}
+		if c.kmsKeyID != "" {
+			sseKmsHeader.Key = c.kmsKeyID
+		}
+		i.SseHeader = sseKmsHeader
+	}
+
+	if c.acl != "" {
+		i.ACL = obs.AclType(c.acl)
+	}
+
+	log.Printf("[DEBUG] upload object: %s to bucket: %s", object, c.bucketName)
+	_, err := c.obsClient.PutObject(i)
+	if err != nil {
+		return fmt.Errorf("failed to upload object: %s", err)
+	}
+
+	return nil
+}
+
+// delete remote object
+func (c *RemoteClient) deleteObject(object string) error {
+	log.Printf("[DEBUG] delete remote state:%s in bucket:%s", object, c.bucketName)
+
+	_, err := c.obsClient.DeleteObject(&obs.DeleteObjectInput{
+		Bucket: c.bucketName,
+		Key:    object,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const errNoSuchBucket = `bucket does not exist.
+
+The referenced bucket must have been previously created. If the bucket was
+created within the last minute, please wait for a minute or two and try again.
+
+Error: %s
+`

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7
 	github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596
 	github.com/hashicorp/vault v0.10.4
+	github.com/huaweicloud/golangsdk v0.0.0-20200323070305-98b64a3f37ba
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/joyent/triton-go v0.0.0-20180313100802-d8f9c0314926

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/hashicorp/vault v0.10.4 h1:4x0lHxui/ZRp/B3E0Auv1QNBJpzETqHR2kQD3mHSBJ
 github.com/hashicorp/vault v0.10.4/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/huaweicloud/golangsdk v0.0.0-20200323070305-98b64a3f37ba h1:eTQZkCooySmxShTy8boiZ69ueUNNNRxBWjt9T35sp8c=
+github.com/huaweicloud/golangsdk v0.0.0-20200323070305-98b64a3f37ba/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/vendor/github.com/huaweicloud/golangsdk/LICENSE
+++ b/vendor/github.com/huaweicloud/golangsdk/LICENSE
@@ -1,0 +1,207 @@
+Copyright 2012-2013 Rackspace, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.  You may obtain a copy of the
+License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations under the License.                                
+
+------
+ 
+				Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+Copyright 2018 Huawei Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.  You may obtain a copy of the
+License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations under the License.
+

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/CHANGELOG
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/CHANGELOG
@@ -1,0 +1,51 @@
+Version 3.19.11
+Updated the version ID format. The new version ID is named in the following format: Main version ID.Year ID.Month ID.
+
+New Features:
+
+Documentation & Demo:
+1. Added the description of WithMaxRedirectCount and WithSecurityToken in section "ObsClient Initialization" in the API Reference.
+2. Added descriptions about WithMaxRedirectCount and WithSecurityToken in section "Configuring an Instance of OBSClient" in the Developer Guide.
+3. Added methods for handling HTTP status code 405 in section "FAQs" in the Developer Guide.
+
+Resolved Issues:
+1. Fixed the issue that error code 400 is returned when DisplayName is carried in some circumstances.
+2. Fixed the issue that error code 400 is returned when the SetBucketNotification API is called.
+3. Fixed the issue that the SetObjectAcl API does not support the specified Delivered parameter.
+4. Fixed the issue that the SetBucketLoggingConfiguration API is incompatible with the Agency field in different protocols.
+5. Fixed the issue that the SetBucketLoggingConfiguration API incorrectly processes the Delivered field.
+6. Fixed the issue that the ContentMD5 configuration does not take effect when the UploadPart API is called.
+7. Fixed the issue that the SetBucketStoragePolicy API processes incorrect storage classes inconsistently in different protocols.
+8. Fixed the issue that error code 400 is returned because the CreateBucket API does not distinguish protocols.
+9. Fixed the syntax issue of the getBucketAclObs API.
+10. Rectified the error of the SetBucketWebsiteConfiguration API.
+11. Fixed the compatibility issue of the temporary authentication API in different protocols.
+12. Fixed the issue that the authentication information header is added when redirection is performed upon a 302 response returned for a GET request.
+13. Fixed the issue that the content-type cannot be obtained based on the file name extension if the extension is in uppercase.
+14. Changed the content-type of files with the .svg extension to image/svg+xml.
+15. Fixed the issue that an incorrect API is called in the sample code for deleting a bucket in examples/bucket_operations_sample.go.
+16. Fixed the issue in calculating the authentication value during the access using temporary access keys.
+17. Fixed the issue that some response fields are empty in anonymous access.
+
+-----------------------------------------------------------------------------------
+
+Version 3.1.2
+
+New Features:
+
+Documentation & Demo:
+
+Resolved Issues:
+1. Fixed the issue that the configuration of ContentType does not take effect when Obs.InitiateMultipartUpload is called.
+
+-----------------------------------------------------------------------------------
+
+Version 3.1.1
+
+New Features:
+1. Supports access to OBS using a user-defined domain name (obs.WithCustomDomainName).
+2. The API for object upload (ObsClient.PutObject) can automatically identify a wider MIME type.
+
+Resolved Issues:
+1. Fixed the issue that a null pointer error is reported when ObsClient.GetBucketStoragePolicy is called.
+2. Fixed the 400 error reported by ObsClient.SetBucketStoragePolicy.

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/README.MD
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/README.MD
@@ -1,0 +1,4 @@
+Version:3.19.11
+
+You can get the latest source code from [here](https://obssdk.obs.cn-north-1.myhuaweicloud.com/current/go/go.zip),
+then unzip the file.

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/auth.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/auth.go
@@ -1,0 +1,418 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+func (obsClient ObsClient) doAuthTemporary(method, bucketName, objectKey string, params map[string]string,
+	headers map[string][]string, expires int64) (requestUrl string, err error) {
+	isAkSkEmpty := obsClient.conf.securityProvider == nil || obsClient.conf.securityProvider.ak == "" || obsClient.conf.securityProvider.sk == ""
+	if isAkSkEmpty == false && obsClient.conf.securityProvider.securityToken != "" {
+		if obsClient.conf.signature == SignatureObs {
+			params[HEADER_STS_TOKEN_OBS] = obsClient.conf.securityProvider.securityToken
+		} else {
+			params[HEADER_STS_TOKEN_AMZ] = obsClient.conf.securityProvider.securityToken
+		}
+	}
+	requestUrl, canonicalizedUrl := obsClient.conf.formatUrls(bucketName, objectKey, params, true)
+	parsedRequestUrl, err := url.Parse(requestUrl)
+	if err != nil {
+		return "", err
+	}
+	encodeHeaders(headers)
+	hostName := parsedRequestUrl.Host
+
+	isV4 := obsClient.conf.signature == SignatureV4
+	prepareHostAndDate(headers, hostName, isV4)
+
+	if isAkSkEmpty {
+		doLog(LEVEL_WARN, "No ak/sk provided, skip to construct authorization")
+	} else {
+		if isV4 {
+			date, parseDateErr := time.Parse(RFC1123_FORMAT, headers[HEADER_DATE_CAMEL][0])
+			if parseDateErr != nil {
+				doLog(LEVEL_WARN, "Failed to parse date with reason: %v", parseDateErr)
+				return "", parseDateErr
+			}
+			delete(headers, HEADER_DATE_CAMEL)
+			shortDate := date.Format(SHORT_DATE_FORMAT)
+			longDate := date.Format(LONG_DATE_FORMAT)
+			if len(headers[HEADER_HOST_CAMEL]) != 0 {
+				index := strings.LastIndex(headers[HEADER_HOST_CAMEL][0], ":")
+				if index != -1 {
+					port := headers[HEADER_HOST_CAMEL][0][index+1:]
+					if port == "80" || port == "443" {
+						headers[HEADER_HOST_CAMEL] = []string{headers[HEADER_HOST_CAMEL][0][:index]}
+					}
+				}
+
+			}
+
+			signedHeaders, _headers := getSignedHeaders(headers)
+
+			credential, scope := getCredential(obsClient.conf.securityProvider.ak, obsClient.conf.region, shortDate)
+			params[PARAM_ALGORITHM_AMZ_CAMEL] = V4_HASH_PREFIX
+			params[PARAM_CREDENTIAL_AMZ_CAMEL] = credential
+			params[PARAM_DATE_AMZ_CAMEL] = longDate
+			params[PARAM_EXPIRES_AMZ_CAMEL] = Int64ToString(expires)
+			params[PARAM_SIGNEDHEADERS_AMZ_CAMEL] = strings.Join(signedHeaders, ";")
+
+			requestUrl, canonicalizedUrl = obsClient.conf.formatUrls(bucketName, objectKey, params, true)
+			parsedRequestUrl, _err := url.Parse(requestUrl)
+			if _err != nil {
+				doLog(LEVEL_WARN, "Failed to parse requestUrl with reason: %v", _err)
+				return "", _err
+			}
+
+			stringToSign := getV4StringToSign(method, canonicalizedUrl, parsedRequestUrl.RawQuery, scope, longDate, UNSIGNED_PAYLOAD, signedHeaders, _headers)
+			signature := getSignature(stringToSign, obsClient.conf.securityProvider.sk, obsClient.conf.region, shortDate)
+
+			requestUrl += fmt.Sprintf("&%s=%s", PARAM_SIGNATURE_AMZ_CAMEL, UrlEncode(signature, false))
+
+		} else {
+			originDate := headers[HEADER_DATE_CAMEL][0]
+			date, parseDateErr := time.Parse(RFC1123_FORMAT, originDate)
+			if parseDateErr != nil {
+				doLog(LEVEL_WARN, "Failed to parse date with reason: %v", parseDateErr)
+				return "", parseDateErr
+			}
+			expires += date.Unix()
+			headers[HEADER_DATE_CAMEL] = []string{Int64ToString(expires)}
+
+			stringToSign := getV2StringToSign(method, canonicalizedUrl, headers, obsClient.conf.signature == SignatureObs)
+			signature := UrlEncode(Base64Encode(HmacSha1([]byte(obsClient.conf.securityProvider.sk), []byte(stringToSign))), false)
+			if strings.Index(requestUrl, "?") < 0 {
+				requestUrl += "?"
+			} else {
+				requestUrl += "&"
+			}
+			delete(headers, HEADER_DATE_CAMEL)
+
+			if obsClient.conf.signature != SignatureObs {
+				requestUrl += "AWS"
+			}
+			requestUrl += fmt.Sprintf("AccessKeyId=%s&Expires=%d&Signature=%s", UrlEncode(obsClient.conf.securityProvider.ak, false), expires, signature)
+		}
+	}
+
+	return
+}
+
+func (obsClient ObsClient) doAuth(method, bucketName, objectKey string, params map[string]string,
+	headers map[string][]string, hostName string) (requestUrl string, err error) {
+	isAkSkEmpty := obsClient.conf.securityProvider == nil || obsClient.conf.securityProvider.ak == "" || obsClient.conf.securityProvider.sk == ""
+	if isAkSkEmpty == false && obsClient.conf.securityProvider.securityToken != "" {
+		if obsClient.conf.signature == SignatureObs {
+			headers[HEADER_STS_TOKEN_OBS] = []string{obsClient.conf.securityProvider.securityToken}
+		} else {
+			headers[HEADER_STS_TOKEN_AMZ] = []string{obsClient.conf.securityProvider.securityToken}
+		}
+	}
+	isObs := obsClient.conf.signature == SignatureObs
+	requestUrl, canonicalizedUrl := obsClient.conf.formatUrls(bucketName, objectKey, params, true)
+	parsedRequestUrl, err := url.Parse(requestUrl)
+	if err != nil {
+		return "", err
+	}
+	encodeHeaders(headers)
+
+	if hostName == "" {
+		hostName = parsedRequestUrl.Host
+	}
+
+	isV4 := obsClient.conf.signature == SignatureV4
+	prepareHostAndDate(headers, hostName, isV4)
+
+	if isAkSkEmpty {
+		doLog(LEVEL_WARN, "No ak/sk provided, skip to construct authorization")
+	} else {
+		ak := obsClient.conf.securityProvider.ak
+		sk := obsClient.conf.securityProvider.sk
+		var authorization string
+		if isV4 {
+			headers[HEADER_CONTENT_SHA256_AMZ] = []string{EMPTY_CONTENT_SHA256}
+			ret := v4Auth(ak, sk, obsClient.conf.region, method, canonicalizedUrl, parsedRequestUrl.RawQuery, headers)
+			authorization = fmt.Sprintf("%s Credential=%s,SignedHeaders=%s,Signature=%s", V4_HASH_PREFIX, ret["Credential"], ret["SignedHeaders"], ret["Signature"])
+		} else {
+			ret := v2Auth(ak, sk, method, canonicalizedUrl, headers, isObs)
+			hashPrefix := V2_HASH_PREFIX
+			if isObs {
+				hashPrefix = OBS_HASH_PREFIX
+			}
+			authorization = fmt.Sprintf("%s %s:%s", hashPrefix, ak, ret["Signature"])
+		}
+		headers[HEADER_AUTH_CAMEL] = []string{authorization}
+	}
+	return
+}
+
+func prepareHostAndDate(headers map[string][]string, hostName string, isV4 bool) {
+	headers[HEADER_HOST_CAMEL] = []string{hostName}
+	if date, ok := headers[HEADER_DATE_AMZ]; ok {
+		flag := false
+		if len(date) == 1 {
+			if isV4 {
+				if t, err := time.Parse(LONG_DATE_FORMAT, date[0]); err == nil {
+					headers[HEADER_DATE_CAMEL] = []string{FormatUtcToRfc1123(t)}
+					flag = true
+				}
+			} else {
+				if strings.HasSuffix(date[0], "GMT") {
+					headers[HEADER_DATE_CAMEL] = []string{date[0]}
+					flag = true
+				}
+			}
+		}
+		if !flag {
+			delete(headers, HEADER_DATE_AMZ)
+		}
+	}
+	if _, ok := headers[HEADER_DATE_CAMEL]; !ok {
+		headers[HEADER_DATE_CAMEL] = []string{FormatUtcToRfc1123(time.Now().UTC())}
+	}
+}
+
+func encodeHeaders(headers map[string][]string) {
+	for key, values := range headers {
+		for index, value := range values {
+			values[index] = UrlEncode(value, true)
+		}
+		headers[key] = values
+	}
+}
+
+func attachHeaders(headers map[string][]string, isObs bool) string {
+	length := len(headers)
+	_headers := make(map[string][]string, length)
+	keys := make([]string, 0, length)
+
+	for key, value := range headers {
+		_key := strings.ToLower(strings.TrimSpace(key))
+		if _key != "" {
+			prefixheader := HEADER_PREFIX
+			if isObs {
+				prefixheader = HEADER_PREFIX_OBS
+			}
+			if _key == "content-md5" || _key == "content-type" || _key == "date" || strings.HasPrefix(_key, prefixheader) {
+				keys = append(keys, _key)
+				_headers[_key] = value
+			}
+		} else {
+			delete(headers, key)
+		}
+	}
+
+	for _, interestedHeader := range interested_headers {
+		if _, ok := _headers[interestedHeader]; !ok {
+			_headers[interestedHeader] = []string{""}
+			keys = append(keys, interestedHeader)
+		}
+	}
+	dateCamelHeader := PARAM_DATE_AMZ_CAMEL
+	dataHeader := HEADER_DATE_AMZ
+	if isObs {
+		dateCamelHeader = PARAM_DATE_OBS_CAMEL
+		dataHeader = HEADER_DATE_OBS
+	}
+	if _, ok := _headers[HEADER_DATE_CAMEL]; ok {
+		if _, ok := _headers[dataHeader]; ok {
+			_headers[HEADER_DATE_CAMEL] = []string{""}
+		} else if _, ok := headers[dateCamelHeader]; ok {
+			_headers[HEADER_DATE_CAMEL] = []string{""}
+		}
+	} else if _, ok := _headers[strings.ToLower(HEADER_DATE_CAMEL)]; ok {
+		if _, ok := _headers[dataHeader]; ok {
+			_headers[HEADER_DATE_CAMEL] = []string{""}
+		} else if _, ok := headers[dateCamelHeader]; ok {
+			_headers[HEADER_DATE_CAMEL] = []string{""}
+		}
+	}
+
+	sort.Strings(keys)
+
+	stringToSign := make([]string, 0, len(keys))
+	for _, key := range keys {
+		var value string
+		prefixHeader := HEADER_PREFIX
+		prefixMetaHeader := HEADER_PREFIX_META
+		if isObs {
+			prefixHeader = HEADER_PREFIX_OBS
+			prefixMetaHeader = HEADER_PREFIX_META_OBS
+		}
+		if strings.HasPrefix(key, prefixHeader) {
+			if strings.HasPrefix(key, prefixMetaHeader) {
+				for index, v := range _headers[key] {
+					value += strings.TrimSpace(v)
+					if index != len(_headers[key])-1 {
+						value += ","
+					}
+				}
+			} else {
+				value = strings.Join(_headers[key], ",")
+			}
+			value = fmt.Sprintf("%s:%s", key, value)
+		} else {
+			value = strings.Join(_headers[key], ",")
+		}
+		stringToSign = append(stringToSign, value)
+	}
+	return strings.Join(stringToSign, "\n")
+}
+
+func getV2StringToSign(method, canonicalizedUrl string, headers map[string][]string, isObs bool) string {
+	stringToSign := strings.Join([]string{method, "\n", attachHeaders(headers, isObs), "\n", canonicalizedUrl}, "")
+	doLog(LEVEL_DEBUG, "The v2 auth stringToSign:\n%s", stringToSign)
+	return stringToSign
+}
+
+func v2Auth(ak, sk, method, canonicalizedUrl string, headers map[string][]string, isObs bool) map[string]string {
+	stringToSign := getV2StringToSign(method, canonicalizedUrl, headers, isObs)
+	return map[string]string{"Signature": Base64Encode(HmacSha1([]byte(sk), []byte(stringToSign)))}
+}
+
+func getScope(region, shortDate string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", shortDate, region, V4_SERVICE_NAME, V4_SERVICE_SUFFIX)
+}
+
+func getCredential(ak, region, shortDate string) (string, string) {
+	scope := getScope(region, shortDate)
+	return fmt.Sprintf("%s/%s", ak, scope), scope
+}
+
+func getV4StringToSign(method, canonicalizedUrl, queryUrl, scope, longDate, payload string, signedHeaders []string, headers map[string][]string) string {
+	canonicalRequest := make([]string, 0, 10+len(signedHeaders)*4)
+	canonicalRequest = append(canonicalRequest, method)
+	canonicalRequest = append(canonicalRequest, "\n")
+	canonicalRequest = append(canonicalRequest, canonicalizedUrl)
+	canonicalRequest = append(canonicalRequest, "\n")
+	canonicalRequest = append(canonicalRequest, queryUrl)
+	canonicalRequest = append(canonicalRequest, "\n")
+
+	for _, signedHeader := range signedHeaders {
+		values, _ := headers[signedHeader]
+		for _, value := range values {
+			canonicalRequest = append(canonicalRequest, signedHeader)
+			canonicalRequest = append(canonicalRequest, ":")
+			canonicalRequest = append(canonicalRequest, value)
+			canonicalRequest = append(canonicalRequest, "\n")
+		}
+	}
+	canonicalRequest = append(canonicalRequest, "\n")
+	canonicalRequest = append(canonicalRequest, strings.Join(signedHeaders, ";"))
+	canonicalRequest = append(canonicalRequest, "\n")
+	canonicalRequest = append(canonicalRequest, payload)
+
+	_canonicalRequest := strings.Join(canonicalRequest, "")
+
+	doLog(LEVEL_DEBUG, "The v4 auth canonicalRequest:\n%s", _canonicalRequest)
+
+	stringToSign := make([]string, 0, 7)
+	stringToSign = append(stringToSign, V4_HASH_PREFIX)
+	stringToSign = append(stringToSign, "\n")
+	stringToSign = append(stringToSign, longDate)
+	stringToSign = append(stringToSign, "\n")
+	stringToSign = append(stringToSign, scope)
+	stringToSign = append(stringToSign, "\n")
+	stringToSign = append(stringToSign, HexSha256([]byte(_canonicalRequest)))
+
+	_stringToSign := strings.Join(stringToSign, "")
+
+	doLog(LEVEL_DEBUG, "The v4 auth stringToSign:\n%s", _stringToSign)
+	return _stringToSign
+}
+
+func getSignedHeaders(headers map[string][]string) ([]string, map[string][]string) {
+	length := len(headers)
+	_headers := make(map[string][]string, length)
+	signedHeaders := make([]string, 0, length)
+	for key, value := range headers {
+		_key := strings.ToLower(strings.TrimSpace(key))
+		if _key != "" {
+			signedHeaders = append(signedHeaders, _key)
+			_headers[_key] = value
+		} else {
+			delete(headers, key)
+		}
+	}
+	sort.Strings(signedHeaders)
+	return signedHeaders, _headers
+}
+
+func getSignature(stringToSign, sk, region, shortDate string) string {
+	key := HmacSha256([]byte(V4_HASH_PRE+sk), []byte(shortDate))
+	key = HmacSha256(key, []byte(region))
+	key = HmacSha256(key, []byte(V4_SERVICE_NAME))
+	key = HmacSha256(key, []byte(V4_SERVICE_SUFFIX))
+	return Hex(HmacSha256(key, []byte(stringToSign)))
+}
+
+func V4Auth(ak, sk, region, method, canonicalizedUrl, queryUrl string, headers map[string][]string) map[string]string {
+	return v4Auth(ak, sk, region, method, canonicalizedUrl, queryUrl, headers)
+}
+
+func v4Auth(ak, sk, region, method, canonicalizedUrl, queryUrl string, headers map[string][]string) map[string]string {
+	var t time.Time
+	if val, ok := headers[HEADER_DATE_AMZ]; ok {
+		var err error
+		t, err = time.Parse(LONG_DATE_FORMAT, val[0])
+		if err != nil {
+			t = time.Now().UTC()
+		}
+	} else if val, ok := headers[PARAM_DATE_AMZ_CAMEL]; ok {
+		var err error
+		t, err = time.Parse(LONG_DATE_FORMAT, val[0])
+		if err != nil {
+			t = time.Now().UTC()
+		}
+	} else if val, ok := headers[HEADER_DATE_CAMEL]; ok {
+		var err error
+		t, err = time.Parse(RFC1123_FORMAT, val[0])
+		if err != nil {
+			t = time.Now().UTC()
+		}
+	} else if val, ok := headers[strings.ToLower(HEADER_DATE_CAMEL)]; ok {
+		var err error
+		t, err = time.Parse(RFC1123_FORMAT, val[0])
+		if err != nil {
+			t = time.Now().UTC()
+		}
+	} else {
+		t = time.Now().UTC()
+	}
+	shortDate := t.Format(SHORT_DATE_FORMAT)
+	longDate := t.Format(LONG_DATE_FORMAT)
+
+	signedHeaders, _headers := getSignedHeaders(headers)
+
+	credential, scope := getCredential(ak, region, shortDate)
+
+	payload := EMPTY_CONTENT_SHA256
+	if val, ok := headers[HEADER_CONTENT_SHA256_AMZ]; ok {
+		payload = val[0]
+	}
+	stringToSign := getV4StringToSign(method, canonicalizedUrl, queryUrl, scope, longDate, payload, signedHeaders, _headers)
+
+	signature := getSignature(stringToSign, sk, region, shortDate)
+
+	ret := make(map[string]string, 3)
+	ret["Credential"] = credential
+	ret["SignedHeaders"] = strings.Join(signedHeaders, ";")
+	ret["Signature"] = signature
+	return ret
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/client.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/client.go
@@ -1,0 +1,949 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+)
+
+type ObsClient struct {
+	conf       *config
+	httpClient *http.Client
+}
+
+func New(ak, sk, endpoint string, configurers ...configurer) (*ObsClient, error) {
+	conf := &config{securityProvider: &securityProvider{ak: ak, sk: sk}, endpoint: endpoint}
+	conf.maxRetryCount = -1
+	conf.maxRedirectCount = -1
+	for _, configurer := range configurers {
+		configurer(conf)
+	}
+
+	if err := conf.initConfigWithDefault(); err != nil {
+		return nil, err
+	}
+	err := conf.getTransport()
+	if err != nil {
+		return nil, err
+	}
+
+	if isWarnLogEnabled() {
+		info := make([]string, 3)
+		info[0] = fmt.Sprintf("[OBS SDK Version=%s", obs_sdk_version)
+		info[1] = fmt.Sprintf("Endpoint=%s", conf.endpoint)
+		accessMode := "Virtual Hosting"
+		if conf.pathStyle {
+			accessMode = "Path"
+		}
+		info[2] = fmt.Sprintf("Access Mode=%s]", accessMode)
+		doLog(LEVEL_WARN, strings.Join(info, "];["))
+	}
+	doLog(LEVEL_DEBUG, "Create obsclient with config:\n%s\n", conf)
+	obsClient := &ObsClient{conf: conf, httpClient: &http.Client{Transport: conf.transport, CheckRedirect: checkRedirectFunc}}
+	return obsClient, nil
+}
+
+func (obsClient ObsClient) Refresh(ak, sk, securityToken string) {
+	sp := &securityProvider{ak: strings.TrimSpace(ak), sk: strings.TrimSpace(sk), securityToken: strings.TrimSpace(securityToken)}
+	obsClient.conf.securityProvider = sp
+}
+
+func (obsClient ObsClient) Close() {
+	obsClient.httpClient = nil
+	obsClient.conf.transport.CloseIdleConnections()
+	obsClient.conf = nil
+	SyncLog()
+}
+
+func (obsClient ObsClient) ListBuckets(input *ListBucketsInput) (output *ListBucketsOutput, err error) {
+	if input == nil {
+		input = &ListBucketsInput{}
+	}
+	output = &ListBucketsOutput{}
+	err = obsClient.doActionWithoutBucket("ListBuckets", HTTP_GET, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) CreateBucket(input *CreateBucketInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("CreateBucketInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("CreateBucket", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucket(bucketName string) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("DeleteBucket", HTTP_DELETE, bucketName, defaultSerializable, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketStoragePolicy(input *SetBucketStoragePolicyInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketStoragePolicyInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketStoragePolicy", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+func (obsClient ObsClient) getBucketStoragePolicyS3(bucketName string) (output *GetBucketStoragePolicyOutput, err error) {
+	output = &GetBucketStoragePolicyOutput{}
+	var outputS3 *getBucketStoragePolicyOutputS3
+	outputS3 = &getBucketStoragePolicyOutputS3{}
+	err = obsClient.doActionWithBucket("GetBucketStoragePolicy", HTTP_GET, bucketName, newSubResourceSerial(SubResourceStoragePolicy), outputS3)
+	if err != nil {
+		output = nil
+		return
+	}
+	output.BaseModel = outputS3.BaseModel
+	output.StorageClass = fmt.Sprintf("%s", outputS3.StorageClass)
+	return
+}
+
+func (obsClient ObsClient) getBucketStoragePolicyObs(bucketName string) (output *GetBucketStoragePolicyOutput, err error) {
+	output = &GetBucketStoragePolicyOutput{}
+	var outputObs *getBucketStoragePolicyOutputObs
+	outputObs = &getBucketStoragePolicyOutputObs{}
+	err = obsClient.doActionWithBucket("GetBucketStoragePolicy", HTTP_GET, bucketName, newSubResourceSerial(SubResourceStorageClass), outputObs)
+	if err != nil {
+		output = nil
+		return
+	}
+	output.BaseModel = outputObs.BaseModel
+	output.StorageClass = outputObs.StorageClass
+	return
+}
+func (obsClient ObsClient) GetBucketStoragePolicy(bucketName string) (output *GetBucketStoragePolicyOutput, err error) {
+	if obsClient.conf.signature == SignatureObs {
+		return obsClient.getBucketStoragePolicyObs(bucketName)
+	}
+	return obsClient.getBucketStoragePolicyS3(bucketName)
+}
+
+func (obsClient ObsClient) ListObjects(input *ListObjectsInput) (output *ListObjectsOutput, err error) {
+	if input == nil {
+		return nil, errors.New("ListObjectsInput is nil")
+	}
+	output = &ListObjectsOutput{}
+	err = obsClient.doActionWithBucket("ListObjects", HTTP_GET, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		if location, ok := output.ResponseHeaders[HEADER_BUCKET_REGION]; ok {
+			output.Location = location[0]
+		}
+	}
+	return
+}
+
+func (obsClient ObsClient) ListVersions(input *ListVersionsInput) (output *ListVersionsOutput, err error) {
+	if input == nil {
+		return nil, errors.New("ListVersionsInput is nil")
+	}
+	output = &ListVersionsOutput{}
+	err = obsClient.doActionWithBucket("ListVersions", HTTP_GET, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		if location, ok := output.ResponseHeaders[HEADER_BUCKET_REGION]; ok {
+			output.Location = location[0]
+		}
+	}
+	return
+}
+
+func (obsClient ObsClient) ListMultipartUploads(input *ListMultipartUploadsInput) (output *ListMultipartUploadsOutput, err error) {
+	if input == nil {
+		return nil, errors.New("ListMultipartUploadsInput is nil")
+	}
+	output = &ListMultipartUploadsOutput{}
+	err = obsClient.doActionWithBucket("ListMultipartUploads", HTTP_GET, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketQuota(input *SetBucketQuotaInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketQuotaInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketQuota", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketQuota(bucketName string) (output *GetBucketQuotaOutput, err error) {
+	output = &GetBucketQuotaOutput{}
+	err = obsClient.doActionWithBucket("GetBucketQuota", HTTP_GET, bucketName, newSubResourceSerial(SubResourceQuota), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) HeadBucket(bucketName string) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("HeadBucket", HTTP_HEAD, bucketName, defaultSerializable, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketMetadata(input *GetBucketMetadataInput) (output *GetBucketMetadataOutput, err error) {
+	output = &GetBucketMetadataOutput{}
+	err = obsClient.doActionWithBucket("GetBucketMetadata", HTTP_HEAD, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		ParseGetBucketMetadataOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) SetObjectMetadata(input *SetObjectMetadataInput) (output *SetObjectMetadataOutput, err error) {
+	output = &SetObjectMetadataOutput{}
+	err = obsClient.doActionWithBucketAndKey("SetObjectMetadata", HTTP_PUT, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		ParseSetObjectMetadataOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketStorageInfo(bucketName string) (output *GetBucketStorageInfoOutput, err error) {
+	output = &GetBucketStorageInfoOutput{}
+	err = obsClient.doActionWithBucket("GetBucketStorageInfo", HTTP_GET, bucketName, newSubResourceSerial(SubResourceStorageInfo), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) getBucketLocationS3(bucketName string) (output *GetBucketLocationOutput, err error) {
+	output = &GetBucketLocationOutput{}
+	var outputS3 *getBucketLocationOutputS3
+	outputS3 = &getBucketLocationOutputS3{}
+	err = obsClient.doActionWithBucket("GetBucketLocation", HTTP_GET, bucketName, newSubResourceSerial(SubResourceLocation), outputS3)
+	if err != nil {
+		output = nil
+	} else {
+		output.BaseModel = outputS3.BaseModel
+		output.Location = outputS3.Location
+	}
+	return
+}
+func (obsClient ObsClient) getBucketLocationObs(bucketName string) (output *GetBucketLocationOutput, err error) {
+	output = &GetBucketLocationOutput{}
+	var outputObs *getBucketLocationOutputObs
+	outputObs = &getBucketLocationOutputObs{}
+	err = obsClient.doActionWithBucket("GetBucketLocation", HTTP_GET, bucketName, newSubResourceSerial(SubResourceLocation), outputObs)
+	if err != nil {
+		output = nil
+	} else {
+		output.BaseModel = outputObs.BaseModel
+		output.Location = outputObs.Location
+	}
+	return
+}
+func (obsClient ObsClient) GetBucketLocation(bucketName string) (output *GetBucketLocationOutput, err error) {
+	if obsClient.conf.signature == SignatureObs {
+		return obsClient.getBucketLocationObs(bucketName)
+	}
+	return obsClient.getBucketLocationS3(bucketName)
+}
+
+func (obsClient ObsClient) SetBucketAcl(input *SetBucketAclInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketAclInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketAcl", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+func (obsClient ObsClient) getBucketAclObs(bucketName string) (output *GetBucketAclOutput, err error) {
+	output = &GetBucketAclOutput{}
+	var outputObs *getBucketAclOutputObs
+	outputObs = &getBucketAclOutputObs{}
+	err = obsClient.doActionWithBucket("GetBucketAcl", HTTP_GET, bucketName, newSubResourceSerial(SubResourceAcl), outputObs)
+	if err != nil {
+		output = nil
+	} else {
+		output.BaseModel = outputObs.BaseModel
+		output.Owner = outputObs.Owner
+		output.Grants = make([]Grant, 0, len(outputObs.Grants))
+		for _, valGrant := range outputObs.Grants {
+			tempOutput := Grant{}
+			tempOutput.Delivered = valGrant.Delivered
+			tempOutput.Permission = valGrant.Permission
+			tempOutput.Grantee.DisplayName = valGrant.Grantee.DisplayName
+			tempOutput.Grantee.ID = valGrant.Grantee.ID
+			tempOutput.Grantee.Type = valGrant.Grantee.Type
+			tempOutput.Grantee.URI = GroupAllUsers
+
+			output.Grants = append(output.Grants, tempOutput)
+		}
+	}
+	return
+}
+func (obsClient ObsClient) GetBucketAcl(bucketName string) (output *GetBucketAclOutput, err error) {
+	output = &GetBucketAclOutput{}
+	if obsClient.conf.signature == SignatureObs {
+		return obsClient.getBucketAclObs(bucketName)
+	}
+	err = obsClient.doActionWithBucket("GetBucketAcl", HTTP_GET, bucketName, newSubResourceSerial(SubResourceAcl), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketPolicy(input *SetBucketPolicyInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketPolicy is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketPolicy", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketPolicy(bucketName string) (output *GetBucketPolicyOutput, err error) {
+	output = &GetBucketPolicyOutput{}
+	err = obsClient.doActionWithBucketV2("GetBucketPolicy", HTTP_GET, bucketName, newSubResourceSerial(SubResourcePolicy), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucketPolicy(bucketName string) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("DeleteBucketPolicy", HTTP_DELETE, bucketName, newSubResourceSerial(SubResourcePolicy), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketCors(input *SetBucketCorsInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketCorsInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketCors", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketCors(bucketName string) (output *GetBucketCorsOutput, err error) {
+	output = &GetBucketCorsOutput{}
+	err = obsClient.doActionWithBucket("GetBucketCors", HTTP_GET, bucketName, newSubResourceSerial(SubResourceCors), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucketCors(bucketName string) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("DeleteBucketCors", HTTP_DELETE, bucketName, newSubResourceSerial(SubResourceCors), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketVersioning(input *SetBucketVersioningInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketVersioningInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketVersioning", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketVersioning(bucketName string) (output *GetBucketVersioningOutput, err error) {
+	output = &GetBucketVersioningOutput{}
+	err = obsClient.doActionWithBucket("GetBucketVersioning", HTTP_GET, bucketName, newSubResourceSerial(SubResourceVersioning), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketWebsiteConfiguration(input *SetBucketWebsiteConfigurationInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketWebsiteConfigurationInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketWebsiteConfiguration", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketWebsiteConfiguration(bucketName string) (output *GetBucketWebsiteConfigurationOutput, err error) {
+	output = &GetBucketWebsiteConfigurationOutput{}
+	err = obsClient.doActionWithBucket("GetBucketWebsiteConfiguration", HTTP_GET, bucketName, newSubResourceSerial(SubResourceWebsite), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucketWebsiteConfiguration(bucketName string) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("DeleteBucketWebsiteConfiguration", HTTP_DELETE, bucketName, newSubResourceSerial(SubResourceWebsite), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketLoggingConfiguration(input *SetBucketLoggingConfigurationInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketLoggingConfigurationInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketLoggingConfiguration", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketLoggingConfiguration(bucketName string) (output *GetBucketLoggingConfigurationOutput, err error) {
+	output = &GetBucketLoggingConfigurationOutput{}
+	err = obsClient.doActionWithBucket("GetBucketLoggingConfiguration", HTTP_GET, bucketName, newSubResourceSerial(SubResourceLogging), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketLifecycleConfiguration(input *SetBucketLifecycleConfigurationInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketLifecycleConfigurationInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketLifecycleConfiguration", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketLifecycleConfiguration(bucketName string) (output *GetBucketLifecycleConfigurationOutput, err error) {
+	output = &GetBucketLifecycleConfigurationOutput{}
+	err = obsClient.doActionWithBucket("GetBucketLifecycleConfiguration", HTTP_GET, bucketName, newSubResourceSerial(SubResourceLifecycle), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucketLifecycleConfiguration(bucketName string) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("DeleteBucketLifecycleConfiguration", HTTP_DELETE, bucketName, newSubResourceSerial(SubResourceLifecycle), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketTagging(input *SetBucketTaggingInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketTaggingInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketTagging", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketTagging(bucketName string) (output *GetBucketTaggingOutput, err error) {
+	output = &GetBucketTaggingOutput{}
+	err = obsClient.doActionWithBucket("GetBucketTagging", HTTP_GET, bucketName, newSubResourceSerial(SubResourceTagging), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucketTagging(bucketName string) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("DeleteBucketTagging", HTTP_DELETE, bucketName, newSubResourceSerial(SubResourceTagging), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketNotification(input *SetBucketNotificationInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketNotificationInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketNotification", HTTP_PUT, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketNotification(bucketName string) (output *GetBucketNotificationOutput, err error) {
+	if obsClient.conf.signature != SignatureObs {
+		return obsClient.getBucketNotificationS3(bucketName)
+	}
+	output = &GetBucketNotificationOutput{}
+	err = obsClient.doActionWithBucket("GetBucketNotification", HTTP_GET, bucketName, newSubResourceSerial(SubResourceNotification), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) getBucketNotificationS3(bucketName string) (output *GetBucketNotificationOutput, err error) {
+	outputS3 := &getBucketNotificationOutputS3{}
+	err = obsClient.doActionWithBucket("GetBucketNotification", HTTP_GET, bucketName, newSubResourceSerial(SubResourceNotification), outputS3)
+	if err != nil {
+		return nil, err
+	}
+
+	output = &GetBucketNotificationOutput{}
+	output.BaseModel = outputS3.BaseModel
+	topicConfigurations := make([]TopicConfiguration, 0, len(outputS3.TopicConfigurations))
+	for _, topicConfigurationS3 := range outputS3.TopicConfigurations {
+		topicConfiguration := TopicConfiguration{}
+		topicConfiguration.ID = topicConfigurationS3.ID
+		topicConfiguration.Topic = topicConfigurationS3.Topic
+		topicConfiguration.FilterRules = topicConfigurationS3.FilterRules
+
+		events := make([]EventType, 0, len(topicConfigurationS3.Events))
+		for _, event := range topicConfigurationS3.Events {
+			events = append(events, ParseStringToEventType(event))
+		}
+		topicConfiguration.Events = events
+		topicConfigurations = append(topicConfigurations, topicConfiguration)
+	}
+	output.TopicConfigurations = topicConfigurations
+	return
+}
+
+func (obsClient ObsClient) DeleteObject(input *DeleteObjectInput) (output *DeleteObjectOutput, err error) {
+	if input == nil {
+		return nil, errors.New("DeleteObjectInput is nil")
+	}
+	output = &DeleteObjectOutput{}
+	err = obsClient.doActionWithBucketAndKey("DeleteObject", HTTP_DELETE, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		ParseDeleteObjectOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteObjects(input *DeleteObjectsInput) (output *DeleteObjectsOutput, err error) {
+	if input == nil {
+		return nil, errors.New("DeleteObjectsInput is nil")
+	}
+	output = &DeleteObjectsOutput{}
+	err = obsClient.doActionWithBucket("DeleteObjects", HTTP_POST, input.Bucket, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetObjectAcl(input *SetObjectAclInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetObjectAclInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucketAndKey("SetObjectAcl", HTTP_PUT, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetObjectAcl(input *GetObjectAclInput) (output *GetObjectAclOutput, err error) {
+	if input == nil {
+		return nil, errors.New("GetObjectAclInput is nil")
+	}
+	output = &GetObjectAclOutput{}
+	err = obsClient.doActionWithBucketAndKey("GetObjectAcl", HTTP_GET, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		if versionId, ok := output.ResponseHeaders[HEADER_VERSION_ID]; ok {
+			output.VersionId = versionId[0]
+		}
+	}
+	return
+}
+
+func (obsClient ObsClient) RestoreObject(input *RestoreObjectInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("RestoreObjectInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucketAndKey("RestoreObject", HTTP_POST, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetObjectMetadata(input *GetObjectMetadataInput) (output *GetObjectMetadataOutput, err error) {
+	if input == nil {
+		return nil, errors.New("GetObjectMetadataInput is nil")
+	}
+	output = &GetObjectMetadataOutput{}
+	err = obsClient.doActionWithBucketAndKey("GetObjectMetadata", HTTP_HEAD, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		ParseGetObjectMetadataOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) GetObject(input *GetObjectInput) (output *GetObjectOutput, err error) {
+	if input == nil {
+		return nil, errors.New("GetObjectInput is nil")
+	}
+	output = &GetObjectOutput{}
+	err = obsClient.doActionWithBucketAndKey("GetObject", HTTP_GET, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		ParseGetObjectOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) PutObject(input *PutObjectInput) (output *PutObjectOutput, err error) {
+	if input == nil {
+		return nil, errors.New("PutObjectInput is nil")
+	}
+
+	if input.ContentType == "" && input.Key != "" {
+		if contentType, ok := mime_types[strings.ToLower(input.Key[strings.LastIndex(input.Key, ".")+1:])]; ok {
+			input.ContentType = contentType
+		}
+	}
+
+	output = &PutObjectOutput{}
+	var repeatable bool
+	if input.Body != nil {
+		_, repeatable = input.Body.(*strings.Reader)
+		if input.ContentLength > 0 {
+			input.Body = &readerWrapper{reader: input.Body, totalCount: input.ContentLength}
+		}
+	}
+	if repeatable {
+		err = obsClient.doActionWithBucketAndKey("PutObject", HTTP_PUT, input.Bucket, input.Key, input, output)
+	} else {
+		err = obsClient.doActionWithBucketAndKeyUnRepeatable("PutObject", HTTP_PUT, input.Bucket, input.Key, input, output)
+	}
+	if err != nil {
+		output = nil
+	} else {
+		ParsePutObjectOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) PutFile(input *PutFileInput) (output *PutObjectOutput, err error) {
+	if input == nil {
+		return nil, errors.New("PutFileInput is nil")
+	}
+
+	var body io.Reader
+	sourceFile := strings.TrimSpace(input.SourceFile)
+	if sourceFile != "" {
+		fd, err := os.Open(sourceFile)
+		if err != nil {
+			return nil, err
+		}
+		defer fd.Close()
+
+		stat, err := fd.Stat()
+		if err != nil {
+			return nil, err
+		}
+		fileReaderWrapper := &fileReaderWrapper{filePath: sourceFile}
+		fileReaderWrapper.reader = fd
+		if input.ContentLength > 0 {
+			if input.ContentLength > stat.Size() {
+				input.ContentLength = stat.Size()
+			}
+			fileReaderWrapper.totalCount = input.ContentLength
+		} else {
+			fileReaderWrapper.totalCount = stat.Size()
+		}
+		body = fileReaderWrapper
+	}
+
+	_input := &PutObjectInput{}
+	_input.PutObjectBasicInput = input.PutObjectBasicInput
+	_input.Body = body
+
+	if _input.ContentType == "" && _input.Key != "" {
+		if contentType, ok := mime_types[strings.ToLower(_input.Key[strings.LastIndex(_input.Key, ".")+1:])]; ok {
+			_input.ContentType = contentType
+		} else if contentType, ok := mime_types[strings.ToLower(sourceFile[strings.LastIndex(sourceFile, ".")+1:])]; ok {
+			_input.ContentType = contentType
+		}
+	}
+
+	output = &PutObjectOutput{}
+	err = obsClient.doActionWithBucketAndKey("PutFile", HTTP_PUT, _input.Bucket, _input.Key, _input, output)
+	if err != nil {
+		output = nil
+	} else {
+		ParsePutObjectOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) CopyObject(input *CopyObjectInput) (output *CopyObjectOutput, err error) {
+	if input == nil {
+		return nil, errors.New("CopyObjectInput is nil")
+	}
+
+	if strings.TrimSpace(input.CopySourceBucket) == "" {
+		return nil, errors.New("Source bucket is empty")
+	}
+	if strings.TrimSpace(input.CopySourceKey) == "" {
+		return nil, errors.New("Source key is empty")
+	}
+
+	output = &CopyObjectOutput{}
+	err = obsClient.doActionWithBucketAndKey("CopyObject", HTTP_PUT, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		ParseCopyObjectOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) AbortMultipartUpload(input *AbortMultipartUploadInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("AbortMultipartUploadInput is nil")
+	}
+	if input.UploadId == "" {
+		return nil, errors.New("UploadId is empty")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucketAndKey("AbortMultipartUpload", HTTP_DELETE, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) InitiateMultipartUpload(input *InitiateMultipartUploadInput) (output *InitiateMultipartUploadOutput, err error) {
+	if input == nil {
+		return nil, errors.New("InitiateMultipartUploadInput is nil")
+	}
+
+	if input.ContentType == "" && input.Key != "" {
+		if contentType, ok := mime_types[strings.ToLower(input.Key[strings.LastIndex(input.Key, ".")+1:])]; ok {
+			input.ContentType = contentType
+		}
+	}
+
+	output = &InitiateMultipartUploadOutput{}
+	err = obsClient.doActionWithBucketAndKey("InitiateMultipartUpload", HTTP_POST, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		ParseInitiateMultipartUploadOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) UploadPart(_input *UploadPartInput) (output *UploadPartOutput, err error) {
+	if _input == nil {
+		return nil, errors.New("UploadPartInput is nil")
+	}
+
+	if _input.UploadId == "" {
+		return nil, errors.New("UploadId is empty")
+	}
+
+	input := &UploadPartInput{}
+	input.Bucket = _input.Bucket
+	input.Key = _input.Key
+	input.PartNumber = _input.PartNumber
+	input.UploadId = _input.UploadId
+	input.ContentMD5 = _input.ContentMD5
+	input.SourceFile = _input.SourceFile
+	input.Offset = _input.Offset
+	input.PartSize = _input.PartSize
+	input.SseHeader = _input.SseHeader
+	input.Body = _input.Body
+
+	output = &UploadPartOutput{}
+	var repeatable bool
+	if input.Body != nil {
+		_, repeatable = input.Body.(*strings.Reader)
+		if _, ok := input.Body.(*readerWrapper); !ok && input.PartSize > 0 {
+			input.Body = &readerWrapper{reader: input.Body, totalCount: input.PartSize}
+		}
+	} else if sourceFile := strings.TrimSpace(input.SourceFile); sourceFile != "" {
+		fd, err := os.Open(sourceFile)
+		if err != nil {
+			return nil, err
+		}
+		defer fd.Close()
+
+		stat, err := fd.Stat()
+		if err != nil {
+			return nil, err
+		}
+		fileSize := stat.Size()
+		fileReaderWrapper := &fileReaderWrapper{filePath: sourceFile}
+		fileReaderWrapper.reader = fd
+
+		if input.Offset < 0 || input.Offset > fileSize {
+			input.Offset = 0
+		}
+
+		if input.PartSize <= 0 || input.PartSize > (fileSize-input.Offset) {
+			input.PartSize = fileSize - input.Offset
+		}
+		fileReaderWrapper.totalCount = input.PartSize
+		if _, err = fd.Seek(input.Offset, io.SeekStart); err != nil {
+			return nil, err
+		}
+		input.Body = fileReaderWrapper
+		repeatable = true
+	}
+	if repeatable {
+		err = obsClient.doActionWithBucketAndKey("UploadPart", HTTP_PUT, input.Bucket, input.Key, input, output)
+	} else {
+		err = obsClient.doActionWithBucketAndKeyUnRepeatable("UploadPart", HTTP_PUT, input.Bucket, input.Key, input, output)
+	}
+	if err != nil {
+		output = nil
+	} else {
+		ParseUploadPartOutput(output)
+		output.PartNumber = input.PartNumber
+	}
+	return
+}
+
+func (obsClient ObsClient) CompleteMultipartUpload(input *CompleteMultipartUploadInput) (output *CompleteMultipartUploadOutput, err error) {
+	if input == nil {
+		return nil, errors.New("CompleteMultipartUploadInput is nil")
+	}
+
+	if input.UploadId == "" {
+		return nil, errors.New("UploadId is empty")
+	}
+
+	var parts partSlice = input.Parts
+	sort.Sort(parts)
+
+	output = &CompleteMultipartUploadOutput{}
+	err = obsClient.doActionWithBucketAndKey("CompleteMultipartUpload", HTTP_POST, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		ParseCompleteMultipartUploadOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) ListParts(input *ListPartsInput) (output *ListPartsOutput, err error) {
+	if input == nil {
+		return nil, errors.New("ListPartsInput is nil")
+	}
+	if input.UploadId == "" {
+		return nil, errors.New("UploadId is empty")
+	}
+	output = &ListPartsOutput{}
+	err = obsClient.doActionWithBucketAndKey("ListParts", HTTP_GET, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) CopyPart(input *CopyPartInput) (output *CopyPartOutput, err error) {
+	if input == nil {
+		return nil, errors.New("CopyPartInput is nil")
+	}
+	if input.UploadId == "" {
+		return nil, errors.New("UploadId is empty")
+	}
+	if strings.TrimSpace(input.CopySourceBucket) == "" {
+		return nil, errors.New("Source bucket is empty")
+	}
+	if strings.TrimSpace(input.CopySourceKey) == "" {
+		return nil, errors.New("Source key is empty")
+	}
+
+	output = &CopyPartOutput{}
+	err = obsClient.doActionWithBucketAndKey("CopyPart", HTTP_PUT, input.Bucket, input.Key, input, output)
+	if err != nil {
+		output = nil
+	} else {
+		ParseCopyPartOutput(output)
+		output.PartNumber = input.PartNumber
+	}
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/conf.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/conf.go
@@ -1,0 +1,428 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type securityProvider struct {
+	ak            string
+	sk            string
+	securityToken string
+}
+
+type urlHolder struct {
+	scheme string
+	host   string
+	port   int
+}
+
+type config struct {
+	securityProvider *securityProvider
+	urlHolder        *urlHolder
+	endpoint         string
+	signature        SignatureType
+	pathStyle        bool
+	region           string
+	connectTimeout   int
+	socketTimeout    int
+	headerTimeout    int
+	idleConnTimeout  int
+	finalTimeout     int
+	maxRetryCount    int
+	proxyUrl         string
+	maxConnsPerHost  int
+	sslVerify        bool
+	pemCerts         []byte
+	transport        *http.Transport
+	ctx              context.Context
+	cname            bool
+	maxRedirectCount int
+}
+
+func (conf config) String() string {
+	return fmt.Sprintf("[endpoint:%s, signature:%s, pathStyle:%v, region:%s"+
+		"\nconnectTimeout:%d, socketTimeout:%dheaderTimeout:%d, idleConnTimeout:%d"+
+		"\nmaxRetryCount:%d, maxConnsPerHost:%d, sslVerify:%v, proxyUrl:%s, maxRedirectCount:%d]",
+		conf.endpoint, conf.signature, conf.pathStyle, conf.region,
+		conf.connectTimeout, conf.socketTimeout, conf.headerTimeout, conf.idleConnTimeout,
+		conf.maxRetryCount, conf.maxConnsPerHost, conf.sslVerify, conf.proxyUrl, conf.maxRedirectCount,
+	)
+}
+
+type configurer func(conf *config)
+
+func WithSslVerify(sslVerify bool) configurer {
+	return WithSslVerifyAndPemCerts(sslVerify, nil)
+}
+
+func WithSslVerifyAndPemCerts(sslVerify bool, pemCerts []byte) configurer {
+	return func(conf *config) {
+		conf.sslVerify = sslVerify
+		conf.pemCerts = pemCerts
+	}
+}
+
+func WithHeaderTimeout(headerTimeout int) configurer {
+	return func(conf *config) {
+		conf.headerTimeout = headerTimeout
+	}
+}
+
+func WithProxyUrl(proxyUrl string) configurer {
+	return func(conf *config) {
+		conf.proxyUrl = proxyUrl
+	}
+}
+
+func WithMaxConnections(maxConnsPerHost int) configurer {
+	return func(conf *config) {
+		conf.maxConnsPerHost = maxConnsPerHost
+	}
+}
+
+func WithPathStyle(pathStyle bool) configurer {
+	return func(conf *config) {
+		conf.pathStyle = pathStyle
+	}
+}
+
+func WithSignature(signature SignatureType) configurer {
+	return func(conf *config) {
+		conf.signature = signature
+	}
+}
+
+func WithRegion(region string) configurer {
+	return func(conf *config) {
+		conf.region = region
+	}
+}
+
+func WithConnectTimeout(connectTimeout int) configurer {
+	return func(conf *config) {
+		conf.connectTimeout = connectTimeout
+	}
+}
+
+func WithSocketTimeout(socketTimeout int) configurer {
+	return func(conf *config) {
+		conf.socketTimeout = socketTimeout
+	}
+}
+
+func WithIdleConnTimeout(idleConnTimeout int) configurer {
+	return func(conf *config) {
+		conf.idleConnTimeout = idleConnTimeout
+	}
+}
+
+func WithMaxRetryCount(maxRetryCount int) configurer {
+	return func(conf *config) {
+		conf.maxRetryCount = maxRetryCount
+	}
+}
+
+func WithSecurityToken(securityToken string) configurer {
+	return func(conf *config) {
+		conf.securityProvider.securityToken = securityToken
+	}
+}
+
+func WithHttpTransport(transport *http.Transport) configurer {
+	return func(conf *config) {
+		conf.transport = transport
+	}
+}
+
+func WithRequestContext(ctx context.Context) configurer {
+	return func(conf *config) {
+		conf.ctx = ctx
+	}
+}
+
+func WithCustomDomainName(cname bool) configurer {
+	return func(conf *config) {
+		conf.cname = cname
+	}
+}
+
+func WithMaxRedirectCount(maxRedirectCount int) configurer {
+	return func(conf *config) {
+		conf.maxRedirectCount = maxRedirectCount
+	}
+}
+
+func (conf *config) initConfigWithDefault() error {
+	conf.securityProvider.ak = strings.TrimSpace(conf.securityProvider.ak)
+	conf.securityProvider.sk = strings.TrimSpace(conf.securityProvider.sk)
+	conf.securityProvider.securityToken = strings.TrimSpace(conf.securityProvider.securityToken)
+	conf.endpoint = strings.TrimSpace(conf.endpoint)
+	if conf.endpoint == "" {
+		return errors.New("endpoint is not set")
+	}
+
+	if index := strings.Index(conf.endpoint, "?"); index > 0 {
+		conf.endpoint = conf.endpoint[:index]
+	}
+
+	for strings.LastIndex(conf.endpoint, "/") == len(conf.endpoint)-1 {
+		conf.endpoint = conf.endpoint[:len(conf.endpoint)-1]
+	}
+
+	if conf.signature == "" {
+		conf.signature = DEFAULT_SIGNATURE
+	}
+
+	urlHolder := &urlHolder{}
+	var address string
+	if strings.HasPrefix(conf.endpoint, "https://") {
+		urlHolder.scheme = "https"
+		address = conf.endpoint[len("https://"):]
+	} else if strings.HasPrefix(conf.endpoint, "http://") {
+		urlHolder.scheme = "http"
+		address = conf.endpoint[len("http://"):]
+	} else {
+		urlHolder.scheme = "http"
+		address = conf.endpoint
+	}
+
+	addr := strings.Split(address, ":")
+	if len(addr) == 2 {
+		if port, err := strconv.Atoi(addr[1]); err == nil {
+			urlHolder.port = port
+		}
+	}
+	urlHolder.host = addr[0]
+	if urlHolder.port == 0 {
+		if urlHolder.scheme == "https" {
+			urlHolder.port = 443
+		} else {
+			urlHolder.port = 80
+		}
+	}
+
+	if IsIP(urlHolder.host) {
+		conf.pathStyle = true
+	}
+
+	conf.urlHolder = urlHolder
+
+	conf.region = strings.TrimSpace(conf.region)
+	if conf.region == "" {
+		conf.region = DEFAULT_REGION
+	}
+
+	if conf.connectTimeout <= 0 {
+		conf.connectTimeout = DEFAULT_CONNECT_TIMEOUT
+	}
+
+	if conf.socketTimeout <= 0 {
+		conf.socketTimeout = DEFAULT_SOCKET_TIMEOUT
+	}
+
+	conf.finalTimeout = conf.socketTimeout * 10
+
+	if conf.headerTimeout <= 0 {
+		conf.headerTimeout = DEFAULT_HEADER_TIMEOUT
+	}
+
+	if conf.idleConnTimeout < 0 {
+		conf.idleConnTimeout = DEFAULT_IDLE_CONN_TIMEOUT
+	}
+
+	if conf.maxRetryCount < 0 {
+		conf.maxRetryCount = DEFAULT_MAX_RETRY_COUNT
+	}
+
+	if conf.maxConnsPerHost <= 0 {
+		conf.maxConnsPerHost = DEFAULT_MAX_CONN_PER_HOST
+	}
+
+	if conf.maxRedirectCount < 0 {
+		conf.maxRedirectCount = DEFAULT_MAX_REDIRECT_COUNT
+	}
+
+	conf.proxyUrl = strings.TrimSpace(conf.proxyUrl)
+	return nil
+}
+
+func (conf *config) getTransport() error {
+	if conf.transport == nil {
+		conf.transport = &http.Transport{
+			Dial: func(network, addr string) (net.Conn, error) {
+				conn, err := net.DialTimeout(network, addr, time.Second*time.Duration(conf.connectTimeout))
+				if err != nil {
+					return nil, err
+				}
+				return getConnDelegate(conn, conf.socketTimeout, conf.finalTimeout), nil
+			},
+			MaxIdleConns:          conf.maxConnsPerHost,
+			MaxIdleConnsPerHost:   conf.maxConnsPerHost,
+			ResponseHeaderTimeout: time.Second * time.Duration(conf.headerTimeout),
+			IdleConnTimeout:       time.Second * time.Duration(conf.idleConnTimeout),
+		}
+
+		if conf.proxyUrl != "" {
+			proxyUrl, err := url.Parse(conf.proxyUrl)
+			if err != nil {
+				return err
+			}
+			conf.transport.Proxy = http.ProxyURL(proxyUrl)
+		}
+
+		tlsConfig := &tls.Config{InsecureSkipVerify: !conf.sslVerify}
+		if conf.sslVerify && conf.pemCerts != nil {
+			pool := x509.NewCertPool()
+			pool.AppendCertsFromPEM(conf.pemCerts)
+			tlsConfig.RootCAs = pool
+		}
+
+		conf.transport.TLSClientConfig = tlsConfig
+	}
+
+	return nil
+}
+
+func checkRedirectFunc(req *http.Request, via []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+func DummyQueryEscape(s string) string {
+	return s
+}
+
+func (conf *config) formatUrls(bucketName, objectKey string, params map[string]string, escape bool) (requestUrl string, canonicalizedUrl string) {
+
+	urlHolder := conf.urlHolder
+	if conf.cname {
+		requestUrl = fmt.Sprintf("%s://%s:%d", urlHolder.scheme, urlHolder.host, urlHolder.port)
+		if conf.signature == "v4" {
+			canonicalizedUrl = "/"
+		} else {
+			canonicalizedUrl = "/" + urlHolder.host + "/"
+		}
+	} else {
+		if bucketName == "" {
+			requestUrl = fmt.Sprintf("%s://%s:%d", urlHolder.scheme, urlHolder.host, urlHolder.port)
+			canonicalizedUrl = "/"
+		} else {
+			if conf.pathStyle {
+				requestUrl = fmt.Sprintf("%s://%s:%d/%s", urlHolder.scheme, urlHolder.host, urlHolder.port, bucketName)
+				canonicalizedUrl = "/" + bucketName
+			} else {
+				requestUrl = fmt.Sprintf("%s://%s.%s:%d", urlHolder.scheme, bucketName, urlHolder.host, urlHolder.port)
+				if conf.signature == "v2" || conf.signature == "OBS" {
+					canonicalizedUrl = "/" + bucketName + "/"
+				} else {
+					canonicalizedUrl = "/"
+				}
+			}
+		}
+	}
+	var escapeFunc func(s string) string
+	if escape {
+		escapeFunc = url.QueryEscape
+	} else {
+		escapeFunc = DummyQueryEscape
+	}
+
+	if objectKey != "" {
+		var encodeObjectKey string
+		if escape {
+			tempKey := []rune(objectKey)
+			result := make([]string, 0, len(tempKey))
+			for _, value := range tempKey {
+				if string(value) == "/" {
+					result = append(result, string(value))
+				} else {
+					result = append(result, url.QueryEscape(string(value)))
+				}
+			}
+			encodeObjectKey = strings.Join(result, "")
+		} else {
+			encodeObjectKey = escapeFunc(objectKey)
+		}
+		requestUrl += "/" + encodeObjectKey
+		if !strings.HasSuffix(canonicalizedUrl, "/") {
+			canonicalizedUrl += "/"
+		}
+		canonicalizedUrl += encodeObjectKey
+	}
+
+	keys := make([]string, 0, len(params))
+	for key, _ := range params {
+		keys = append(keys, strings.TrimSpace(key))
+	}
+	sort.Strings(keys)
+	i := 0
+
+	for index, key := range keys {
+		if index == 0 {
+			requestUrl += "?"
+		} else {
+			requestUrl += "&"
+		}
+		_key := url.QueryEscape(key)
+		requestUrl += _key
+
+		_value := params[key]
+		if conf.signature == "v4" {
+			requestUrl += "=" + url.QueryEscape(_value)
+		} else {
+			if _value != "" {
+				requestUrl += "=" + url.QueryEscape(_value)
+				_value = "=" + _value
+			} else {
+				_value = ""
+			}
+			lowerKey := strings.ToLower(key)
+			_, ok := allowed_resource_parameter_names[lowerKey]
+			prefixHeader := HEADER_PREFIX
+			isObs := conf.signature == SignatureObs
+			if isObs {
+				prefixHeader = HEADER_PREFIX_OBS
+			}
+			ok = ok || strings.HasPrefix(lowerKey, prefixHeader)
+			if ok {
+				if i == 0 {
+					canonicalizedUrl += "?"
+				} else {
+					canonicalizedUrl += "&"
+				}
+				canonicalizedUrl += getQueryUrl(_key, _value)
+				i++
+			}
+		}
+	}
+	return
+}
+
+func getQueryUrl(key, value string) string {
+	queryUrl := ""
+	queryUrl += key
+	queryUrl += value
+	return queryUrl
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/const.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/const.go
@@ -1,0 +1,795 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+const (
+	obs_sdk_version        = "3.19.11"
+	USER_AGENT             = "obs-sdk-go/" + obs_sdk_version
+	HEADER_PREFIX          = "x-amz-"
+	HEADER_PREFIX_META     = "x-amz-meta-"
+	HEADER_PREFIX_OBS      = "x-obs-"
+	HEADER_PREFIX_META_OBS = "x-obs-meta-"
+	HEADER_DATE_AMZ        = "x-amz-date"
+	HEADER_DATE_OBS        = "x-obs-date"
+	HEADER_STS_TOKEN_AMZ   = "x-amz-security-token"
+	HEADER_STS_TOKEN_OBS   = "x-obs-security-token"
+	HEADER_ACCESSS_KEY_AMZ = "AWSAccessKeyId"
+	PREFIX_META            = "meta-"
+
+	HEADER_CONTENT_SHA256_AMZ               = "x-amz-content-sha256"
+	HEADER_ACL_AMZ                          = "x-amz-acl"
+	HEADER_ACL_OBS                          = "x-obs-acl"
+	HEADER_ACL                              = "acl"
+	HEADER_LOCATION_AMZ                     = "location"
+	HEADER_BUCKET_LOCATION_OBS              = "bucket-location"
+	HEADER_COPY_SOURCE                      = "copy-source"
+	HEADER_COPY_SOURCE_RANGE                = "copy-source-range"
+	HEADER_RANGE                            = "Range"
+	HEADER_STORAGE_CLASS                    = "x-default-storage-class"
+	HEADER_STORAGE_CLASS_OBS                = "x-obs-storage-class"
+	HEADER_VERSION_OBS                      = "version"
+	HEADER_GRANT_READ_OBS                   = "grant-read"
+	HEADER_GRANT_WRITE_OBS                  = "grant-write"
+	HEADER_GRANT_READ_ACP_OBS               = "grant-read-acp"
+	HEADER_GRANT_WRITE_ACP_OBS              = "grant-write-acp"
+	HEADER_GRANT_FULL_CONTROL_OBS           = "grant-full-control"
+	HEADER_GRANT_READ_DELIVERED_OBS         = "grant-read-delivered"
+	HEADER_GRANT_FULL_CONTROL_DELIVERED_OBS = "grant-full-control-delivered"
+	HEADER_REQUEST_ID                       = "request-id"
+	HEADER_BUCKET_REGION                    = "bucket-region"
+	HEADER_ACCESS_CONRTOL_ALLOW_ORIGIN      = "access-control-allow-origin"
+	HEADER_ACCESS_CONRTOL_ALLOW_HEADERS     = "access-control-allow-headers"
+	HEADER_ACCESS_CONRTOL_MAX_AGE           = "access-control-max-age"
+	HEADER_ACCESS_CONRTOL_ALLOW_METHODS     = "access-control-allow-methods"
+	HEADER_ACCESS_CONRTOL_EXPOSE_HEADERS    = "access-control-expose-headers"
+	HEADER_EPID_HEADERS                     = "epid"
+	HEADER_VERSION_ID                       = "version-id"
+	HEADER_COPY_SOURCE_VERSION_ID           = "copy-source-version-id"
+	HEADER_DELETE_MARKER                    = "delete-marker"
+	HEADER_WEBSITE_REDIRECT_LOCATION        = "website-redirect-location"
+	HEADER_METADATA_DIRECTIVE               = "metadata-directive"
+	HEADER_EXPIRATION                       = "expiration"
+	HEADER_EXPIRES_OBS                      = "x-obs-expires"
+	HEADER_RESTORE                          = "restore"
+	HEADER_OBJECT_TYPE                      = "object-type"
+	HEADER_NEXT_APPEND_POSITION             = "next-append-position"
+	HEADER_STORAGE_CLASS2                   = "storage-class"
+	HEADER_CONTENT_LENGTH                   = "content-length"
+	HEADER_CONTENT_TYPE                     = "content-type"
+	HEADER_CONTENT_LANGUAGE                 = "content-language"
+	HEADER_EXPIRES                          = "expires"
+	HEADER_CACHE_CONTROL                    = "cache-control"
+	HEADER_CONTENT_DISPOSITION              = "content-disposition"
+	HEADER_CONTENT_ENCODING                 = "content-encoding"
+
+	HEADER_ETAG         = "etag"
+	HEADER_LASTMODIFIED = "last-modified"
+
+	HEADER_COPY_SOURCE_IF_MATCH            = "copy-source-if-match"
+	HEADER_COPY_SOURCE_IF_NONE_MATCH       = "copy-source-if-none-match"
+	HEADER_COPY_SOURCE_IF_MODIFIED_SINCE   = "copy-source-if-modified-since"
+	HEADER_COPY_SOURCE_IF_UNMODIFIED_SINCE = "copy-source-if-unmodified-since"
+
+	HEADER_IF_MATCH            = "If-Match"
+	HEADER_IF_NONE_MATCH       = "If-None-Match"
+	HEADER_IF_MODIFIED_SINCE   = "If-Modified-Since"
+	HEADER_IF_UNMODIFIED_SINCE = "If-Unmodified-Since"
+
+	HEADER_SSEC_ENCRYPTION = "server-side-encryption-customer-algorithm"
+	HEADER_SSEC_KEY        = "server-side-encryption-customer-key"
+	HEADER_SSEC_KEY_MD5    = "server-side-encryption-customer-key-MD5"
+
+	HEADER_SSEKMS_ENCRYPTION      = "server-side-encryption"
+	HEADER_SSEKMS_KEY             = "server-side-encryption-aws-kms-key-id"
+	HEADER_SSEKMS_ENCRYPT_KEY_OBS = "server-side-encryption-kms-key-id"
+
+	HEADER_SSEC_COPY_SOURCE_ENCRYPTION = "copy-source-server-side-encryption-customer-algorithm"
+	HEADER_SSEC_COPY_SOURCE_KEY        = "copy-source-server-side-encryption-customer-key"
+	HEADER_SSEC_COPY_SOURCE_KEY_MD5    = "copy-source-server-side-encryption-customer-key-MD5"
+
+	HEADER_SSEKMS_KEY_AMZ = "x-amz-server-side-encryption-aws-kms-key-id"
+
+	HEADER_SSEKMS_KEY_OBS = "x-obs-server-side-encryption-kms-key-id"
+
+	HEADER_SUCCESS_ACTION_REDIRECT = "success_action_redirect"
+
+	HEADER_DATE_CAMEL                          = "Date"
+	HEADER_HOST_CAMEL                          = "Host"
+	HEADER_HOST                                = "host"
+	HEADER_AUTH_CAMEL                          = "Authorization"
+	HEADER_MD5_CAMEL                           = "Content-MD5"
+	HEADER_LOCATION_CAMEL                      = "Location"
+	HEADER_CONTENT_LENGTH_CAMEL                = "Content-Length"
+	HEADER_CONTENT_TYPE_CAML                   = "Content-Type"
+	HEADER_USER_AGENT_CAMEL                    = "User-Agent"
+	HEADER_ORIGIN_CAMEL                        = "Origin"
+	HEADER_ACCESS_CONTROL_REQUEST_HEADER_CAMEL = "Access-Control-Request-Headers"
+	HEADER_CACHE_CONTROL_CAMEL                 = "Cache-Control"
+	HEADER_CONTENT_DISPOSITION_CAMEL           = "Content-Disposition"
+	HEADER_CONTENT_ENCODING_CAMEL              = "Content-Encoding"
+	HEADER_CONTENT_LANGUAGE_CAMEL              = "Content-Language"
+	HEADER_EXPIRES_CAMEL                       = "Expires"
+
+	PARAM_VERSION_ID                   = "versionId"
+	PARAM_RESPONSE_CONTENT_TYPE        = "response-content-type"
+	PARAM_RESPONSE_CONTENT_LANGUAGE    = "response-content-language"
+	PARAM_RESPONSE_EXPIRES             = "response-expires"
+	PARAM_RESPONSE_CACHE_CONTROL       = "response-cache-control"
+	PARAM_RESPONSE_CONTENT_DISPOSITION = "response-content-disposition"
+	PARAM_RESPONSE_CONTENT_ENCODING    = "response-content-encoding"
+	PARAM_IMAGE_PROCESS                = "x-image-process"
+
+	PARAM_ALGORITHM_AMZ_CAMEL     = "X-Amz-Algorithm"
+	PARAM_CREDENTIAL_AMZ_CAMEL    = "X-Amz-Credential"
+	PARAM_DATE_AMZ_CAMEL          = "X-Amz-Date"
+	PARAM_DATE_OBS_CAMEL          = "X-Obs-Date"
+	PARAM_EXPIRES_AMZ_CAMEL       = "X-Amz-Expires"
+	PARAM_SIGNEDHEADERS_AMZ_CAMEL = "X-Amz-SignedHeaders"
+	PARAM_SIGNATURE_AMZ_CAMEL     = "X-Amz-Signature"
+
+	DEFAULT_SIGNATURE            = SignatureV2
+	DEFAULT_REGION               = "region"
+	DEFAULT_CONNECT_TIMEOUT      = 60
+	DEFAULT_SOCKET_TIMEOUT       = 60
+	DEFAULT_HEADER_TIMEOUT       = 60
+	DEFAULT_IDLE_CONN_TIMEOUT    = 30
+	DEFAULT_MAX_RETRY_COUNT      = 3
+	DEFAULT_MAX_REDIRECT_COUNT   = 3
+	DEFAULT_MAX_CONN_PER_HOST    = 1000
+	EMPTY_CONTENT_SHA256         = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	UNSIGNED_PAYLOAD             = "UNSIGNED-PAYLOAD"
+	LONG_DATE_FORMAT             = "20060102T150405Z"
+	SHORT_DATE_FORMAT            = "20060102"
+	ISO8601_DATE_FORMAT          = "2006-01-02T15:04:05Z"
+	ISO8601_MIDNIGHT_DATE_FORMAT = "2006-01-02T00:00:00Z"
+	RFC1123_FORMAT               = "Mon, 02 Jan 2006 15:04:05 GMT"
+
+	V4_SERVICE_NAME   = "s3"
+	V4_SERVICE_SUFFIX = "aws4_request"
+
+	V2_HASH_PREFIX  = "AWS"
+	OBS_HASH_PREFIX = "OBS"
+
+	V4_HASH_PREFIX = "AWS4-HMAC-SHA256"
+	V4_HASH_PRE    = "AWS4"
+
+	DEFAULT_SSE_KMS_ENCRYPTION     = "aws:kms"
+	DEFAULT_SSE_KMS_ENCRYPTION_OBS = "kms"
+
+	DEFAULT_SSE_C_ENCRYPTION = "AES256"
+
+	HTTP_GET     = "GET"
+	HTTP_POST    = "POST"
+	HTTP_PUT     = "PUT"
+	HTTP_DELETE  = "DELETE"
+	HTTP_HEAD    = "HEAD"
+	HTTP_OPTIONS = "OPTIONS"
+)
+
+type SignatureType string
+
+const (
+	SignatureV2  SignatureType = "v2"
+	SignatureV4  SignatureType = "v4"
+	SignatureObs SignatureType = "OBS"
+)
+
+var (
+	interested_headers = []string{"content-md5", "content-type", "date"}
+
+	allowed_response_http_header_metadata_names = map[string]bool{
+		"content-type":                  true,
+		"content-md5":                   true,
+		"content-length":                true,
+		"content-language":              true,
+		"expires":                       true,
+		"origin":                        true,
+		"cache-control":                 true,
+		"content-disposition":           true,
+		"content-encoding":              true,
+		"x-default-storage-class":       true,
+		"location":                      true,
+		"date":                          true,
+		"etag":                          true,
+		"host":                          true,
+		"last-modified":                 true,
+		"content-range":                 true,
+		"x-reserved":                    true,
+		"x-reserved-indicator":          true,
+		"access-control-allow-origin":   true,
+		"access-control-allow-headers":  true,
+		"access-control-max-age":        true,
+		"access-control-allow-methods":  true,
+		"access-control-expose-headers": true,
+		"connection":                    true,
+	}
+
+	allowed_request_http_header_metadata_names = map[string]bool{
+		"content-type":                   true,
+		"content-md5":                    true,
+		"content-length":                 true,
+		"content-language":               true,
+		"expires":                        true,
+		"origin":                         true,
+		"cache-control":                  true,
+		"content-disposition":            true,
+		"content-encoding":               true,
+		"access-control-request-method":  true,
+		"access-control-request-headers": true,
+		"x-default-storage-class":        true,
+		"location":                       true,
+		"date":                           true,
+		"etag":                           true,
+		"range":                          true,
+		"host":                           true,
+		"if-modified-since":              true,
+		"if-unmodified-since":            true,
+		"if-match":                       true,
+		"if-none-match":                  true,
+		"last-modified":                  true,
+		"content-range":                  true,
+	}
+
+	allowed_resource_parameter_names = map[string]bool{
+		"acl":                          true,
+		"backtosource":                 true,
+		"policy":                       true,
+		"torrent":                      true,
+		"logging":                      true,
+		"location":                     true,
+		"storageinfo":                  true,
+		"quota":                        true,
+		"storageclass":                 true,
+		"storagepolicy":                true,
+		"requestpayment":               true,
+		"versions":                     true,
+		"versioning":                   true,
+		"versionid":                    true,
+		"uploads":                      true,
+		"uploadid":                     true,
+		"partnumber":                   true,
+		"website":                      true,
+		"notification":                 true,
+		"lifecycle":                    true,
+		"deletebucket":                 true,
+		"delete":                       true,
+		"cors":                         true,
+		"restore":                      true,
+		"tagging":                      true,
+		"append":                       true,
+		"position":                     true,
+		"replication":                  true,
+		"response-content-type":        true,
+		"response-content-language":    true,
+		"response-expires":             true,
+		"response-cache-control":       true,
+		"response-content-disposition": true,
+		"response-content-encoding":    true,
+		"x-image-process":              true,
+		"x-oss-process":                true,
+		"x-image-save-bucket":          true,
+		"x-image-save-object":          true,
+	}
+
+	mime_types = map[string]string{
+		"001":     "application/x-001",
+		"301":     "application/x-301",
+		"323":     "text/h323",
+		"7z":      "application/x-7z-compressed",
+		"906":     "application/x-906",
+		"907":     "drawing/907",
+		"IVF":     "video/x-ivf",
+		"a11":     "application/x-a11",
+		"aac":     "audio/x-aac",
+		"acp":     "audio/x-mei-aac",
+		"ai":      "application/postscript",
+		"aif":     "audio/aiff",
+		"aifc":    "audio/aiff",
+		"aiff":    "audio/aiff",
+		"anv":     "application/x-anv",
+		"apk":     "application/vnd.android.package-archive",
+		"asa":     "text/asa",
+		"asf":     "video/x-ms-asf",
+		"asp":     "text/asp",
+		"asx":     "video/x-ms-asf",
+		"atom":    "application/atom+xml",
+		"au":      "audio/basic",
+		"avi":     "video/avi",
+		"awf":     "application/vnd.adobe.workflow",
+		"biz":     "text/xml",
+		"bmp":     "application/x-bmp",
+		"bot":     "application/x-bot",
+		"bz2":     "application/x-bzip2",
+		"c4t":     "application/x-c4t",
+		"c90":     "application/x-c90",
+		"cal":     "application/x-cals",
+		"cat":     "application/vnd.ms-pki.seccat",
+		"cdf":     "application/x-netcdf",
+		"cdr":     "application/x-cdr",
+		"cel":     "application/x-cel",
+		"cer":     "application/x-x509-ca-cert",
+		"cg4":     "application/x-g4",
+		"cgm":     "application/x-cgm",
+		"cit":     "application/x-cit",
+		"class":   "java/*",
+		"cml":     "text/xml",
+		"cmp":     "application/x-cmp",
+		"cmx":     "application/x-cmx",
+		"cot":     "application/x-cot",
+		"crl":     "application/pkix-crl",
+		"crt":     "application/x-x509-ca-cert",
+		"csi":     "application/x-csi",
+		"css":     "text/css",
+		"csv":     "text/csv",
+		"cu":      "application/cu-seeme",
+		"cut":     "application/x-cut",
+		"dbf":     "application/x-dbf",
+		"dbm":     "application/x-dbm",
+		"dbx":     "application/x-dbx",
+		"dcd":     "text/xml",
+		"dcx":     "application/x-dcx",
+		"deb":     "application/x-debian-package",
+		"der":     "application/x-x509-ca-cert",
+		"dgn":     "application/x-dgn",
+		"dib":     "application/x-dib",
+		"dll":     "application/x-msdownload",
+		"doc":     "application/msword",
+		"docx":    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"dot":     "application/msword",
+		"drw":     "application/x-drw",
+		"dtd":     "text/xml",
+		"dvi":     "application/x-dvi",
+		"dwf":     "application/x-dwf",
+		"dwg":     "application/x-dwg",
+		"dxb":     "application/x-dxb",
+		"dxf":     "application/x-dxf",
+		"edn":     "application/vnd.adobe.edn",
+		"emf":     "application/x-emf",
+		"eml":     "message/rfc822",
+		"ent":     "text/xml",
+		"eot":     "application/vnd.ms-fontobject",
+		"epi":     "application/x-epi",
+		"eps":     "application/postscript",
+		"epub":    "application/epub+zip",
+		"etd":     "application/x-ebx",
+		"etx":     "text/x-setext",
+		"exe":     "application/x-msdownload",
+		"fax":     "image/fax",
+		"fdf":     "application/vnd.fdf",
+		"fif":     "application/fractals",
+		"flac":    "audio/flac",
+		"flv":     "video/x-flv",
+		"fo":      "text/xml",
+		"frm":     "application/x-frm",
+		"g4":      "application/x-g4",
+		"gbr":     "application/x-gbr",
+		"gif":     "image/gif",
+		"gl2":     "application/x-gl2",
+		"gp4":     "application/x-gp4",
+		"gz":      "application/gzip",
+		"hgl":     "application/x-hgl",
+		"hmr":     "application/x-hmr",
+		"hpg":     "application/x-hpgl",
+		"hpl":     "application/x-hpl",
+		"hqx":     "application/mac-binhex40",
+		"hrf":     "application/x-hrf",
+		"hta":     "application/hta",
+		"htc":     "text/x-component",
+		"htm":     "text/html",
+		"html":    "text/html",
+		"htt":     "text/webviewhtml",
+		"htx":     "text/html",
+		"icb":     "application/x-icb",
+		"ico":     "application/x-ico",
+		"ics":     "text/calendar",
+		"iff":     "application/x-iff",
+		"ig4":     "application/x-g4",
+		"igs":     "application/x-igs",
+		"iii":     "application/x-iphone",
+		"img":     "application/x-img",
+		"ini":     "text/plain",
+		"ins":     "application/x-internet-signup",
+		"ipa":     "application/vnd.iphone",
+		"iso":     "application/x-iso9660-image",
+		"isp":     "application/x-internet-signup",
+		"jar":     "application/java-archive",
+		"java":    "java/*",
+		"jfif":    "image/jpeg",
+		"jpe":     "image/jpeg",
+		"jpeg":    "image/jpeg",
+		"jpg":     "image/jpeg",
+		"js":      "application/x-javascript",
+		"json":    "application/json",
+		"jsp":     "text/html",
+		"la1":     "audio/x-liquid-file",
+		"lar":     "application/x-laplayer-reg",
+		"latex":   "application/x-latex",
+		"lavs":    "audio/x-liquid-secure",
+		"lbm":     "application/x-lbm",
+		"lmsff":   "audio/x-la-lms",
+		"log":     "text/plain",
+		"ls":      "application/x-javascript",
+		"ltr":     "application/x-ltr",
+		"m1v":     "video/x-mpeg",
+		"m2v":     "video/x-mpeg",
+		"m3u":     "audio/mpegurl",
+		"m4a":     "audio/mp4",
+		"m4e":     "video/mpeg4",
+		"m4v":     "video/mp4",
+		"mac":     "application/x-mac",
+		"man":     "application/x-troff-man",
+		"math":    "text/xml",
+		"mdb":     "application/msaccess",
+		"mfp":     "application/x-shockwave-flash",
+		"mht":     "message/rfc822",
+		"mhtml":   "message/rfc822",
+		"mi":      "application/x-mi",
+		"mid":     "audio/mid",
+		"midi":    "audio/mid",
+		"mil":     "application/x-mil",
+		"mml":     "text/xml",
+		"mnd":     "audio/x-musicnet-download",
+		"mns":     "audio/x-musicnet-stream",
+		"mocha":   "application/x-javascript",
+		"mov":     "video/quicktime",
+		"movie":   "video/x-sgi-movie",
+		"mp1":     "audio/mp1",
+		"mp2":     "audio/mp2",
+		"mp2v":    "video/mpeg",
+		"mp3":     "audio/mp3",
+		"mp4":     "video/mpeg4",
+		"mp4a":    "audio/mp4",
+		"mp4v":    "video/mp4",
+		"mpa":     "video/x-mpg",
+		"mpd":     "application/vnd.ms-project",
+		"mpe":     "video/x-mpeg",
+		"mpeg":    "video/mpg",
+		"mpg":     "video/mpg",
+		"mpg4":    "video/mp4",
+		"mpga":    "audio/rn-mpeg",
+		"mpp":     "application/vnd.ms-project",
+		"mps":     "video/x-mpeg",
+		"mpt":     "application/vnd.ms-project",
+		"mpv":     "video/mpg",
+		"mpv2":    "video/mpeg",
+		"mpw":     "application/vnd.ms-project",
+		"mpx":     "application/vnd.ms-project",
+		"mtx":     "text/xml",
+		"mxp":     "application/x-mmxp",
+		"net":     "image/pnetvue",
+		"nrf":     "application/x-nrf",
+		"nws":     "message/rfc822",
+		"odc":     "text/x-ms-odc",
+		"oga":     "audio/ogg",
+		"ogg":     "audio/ogg",
+		"ogv":     "video/ogg",
+		"ogx":     "application/ogg",
+		"out":     "application/x-out",
+		"p10":     "application/pkcs10",
+		"p12":     "application/x-pkcs12",
+		"p7b":     "application/x-pkcs7-certificates",
+		"p7c":     "application/pkcs7-mime",
+		"p7m":     "application/pkcs7-mime",
+		"p7r":     "application/x-pkcs7-certreqresp",
+		"p7s":     "application/pkcs7-signature",
+		"pbm":     "image/x-portable-bitmap",
+		"pc5":     "application/x-pc5",
+		"pci":     "application/x-pci",
+		"pcl":     "application/x-pcl",
+		"pcx":     "application/x-pcx",
+		"pdf":     "application/pdf",
+		"pdx":     "application/vnd.adobe.pdx",
+		"pfx":     "application/x-pkcs12",
+		"pgl":     "application/x-pgl",
+		"pgm":     "image/x-portable-graymap",
+		"pic":     "application/x-pic",
+		"pko":     "application/vnd.ms-pki.pko",
+		"pl":      "application/x-perl",
+		"plg":     "text/html",
+		"pls":     "audio/scpls",
+		"plt":     "application/x-plt",
+		"png":     "image/png",
+		"pnm":     "image/x-portable-anymap",
+		"pot":     "application/vnd.ms-powerpoint",
+		"ppa":     "application/vnd.ms-powerpoint",
+		"ppm":     "application/x-ppm",
+		"pps":     "application/vnd.ms-powerpoint",
+		"ppt":     "application/vnd.ms-powerpoint",
+		"pptx":    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		"pr":      "application/x-pr",
+		"prf":     "application/pics-rules",
+		"prn":     "application/x-prn",
+		"prt":     "application/x-prt",
+		"ps":      "application/postscript",
+		"ptn":     "application/x-ptn",
+		"pwz":     "application/vnd.ms-powerpoint",
+		"qt":      "video/quicktime",
+		"r3t":     "text/vnd.rn-realtext3d",
+		"ra":      "audio/vnd.rn-realaudio",
+		"ram":     "audio/x-pn-realaudio",
+		"rar":     "application/x-rar-compressed",
+		"ras":     "application/x-ras",
+		"rat":     "application/rat-file",
+		"rdf":     "text/xml",
+		"rec":     "application/vnd.rn-recording",
+		"red":     "application/x-red",
+		"rgb":     "application/x-rgb",
+		"rjs":     "application/vnd.rn-realsystem-rjs",
+		"rjt":     "application/vnd.rn-realsystem-rjt",
+		"rlc":     "application/x-rlc",
+		"rle":     "application/x-rle",
+		"rm":      "application/vnd.rn-realmedia",
+		"rmf":     "application/vnd.adobe.rmf",
+		"rmi":     "audio/mid",
+		"rmj":     "application/vnd.rn-realsystem-rmj",
+		"rmm":     "audio/x-pn-realaudio",
+		"rmp":     "application/vnd.rn-rn_music_package",
+		"rms":     "application/vnd.rn-realmedia-secure",
+		"rmvb":    "application/vnd.rn-realmedia-vbr",
+		"rmx":     "application/vnd.rn-realsystem-rmx",
+		"rnx":     "application/vnd.rn-realplayer",
+		"rp":      "image/vnd.rn-realpix",
+		"rpm":     "audio/x-pn-realaudio-plugin",
+		"rsml":    "application/vnd.rn-rsml",
+		"rss":     "application/rss+xml",
+		"rt":      "text/vnd.rn-realtext",
+		"rtf":     "application/x-rtf",
+		"rv":      "video/vnd.rn-realvideo",
+		"sam":     "application/x-sam",
+		"sat":     "application/x-sat",
+		"sdp":     "application/sdp",
+		"sdw":     "application/x-sdw",
+		"sgm":     "text/sgml",
+		"sgml":    "text/sgml",
+		"sis":     "application/vnd.symbian.install",
+		"sisx":    "application/vnd.symbian.install",
+		"sit":     "application/x-stuffit",
+		"slb":     "application/x-slb",
+		"sld":     "application/x-sld",
+		"slk":     "drawing/x-slk",
+		"smi":     "application/smil",
+		"smil":    "application/smil",
+		"smk":     "application/x-smk",
+		"snd":     "audio/basic",
+		"sol":     "text/plain",
+		"sor":     "text/plain",
+		"spc":     "application/x-pkcs7-certificates",
+		"spl":     "application/futuresplash",
+		"spp":     "text/xml",
+		"ssm":     "application/streamingmedia",
+		"sst":     "application/vnd.ms-pki.certstore",
+		"stl":     "application/vnd.ms-pki.stl",
+		"stm":     "text/html",
+		"sty":     "application/x-sty",
+		"svg":     "image/svg+xml",
+		"swf":     "application/x-shockwave-flash",
+		"tar":     "application/x-tar",
+		"tdf":     "application/x-tdf",
+		"tg4":     "application/x-tg4",
+		"tga":     "application/x-tga",
+		"tif":     "image/tiff",
+		"tiff":    "image/tiff",
+		"tld":     "text/xml",
+		"top":     "drawing/x-top",
+		"torrent": "application/x-bittorrent",
+		"tsd":     "text/xml",
+		"ttf":     "application/x-font-ttf",
+		"txt":     "text/plain",
+		"uin":     "application/x-icq",
+		"uls":     "text/iuls",
+		"vcf":     "text/x-vcard",
+		"vda":     "application/x-vda",
+		"vdx":     "application/vnd.visio",
+		"vml":     "text/xml",
+		"vpg":     "application/x-vpeg005",
+		"vsd":     "application/vnd.visio",
+		"vss":     "application/vnd.visio",
+		"vst":     "application/x-vst",
+		"vsw":     "application/vnd.visio",
+		"vsx":     "application/vnd.visio",
+		"vtx":     "application/vnd.visio",
+		"vxml":    "text/xml",
+		"wav":     "audio/wav",
+		"wax":     "audio/x-ms-wax",
+		"wb1":     "application/x-wb1",
+		"wb2":     "application/x-wb2",
+		"wb3":     "application/x-wb3",
+		"wbmp":    "image/vnd.wap.wbmp",
+		"webm":    "video/webm",
+		"wiz":     "application/msword",
+		"wk3":     "application/x-wk3",
+		"wk4":     "application/x-wk4",
+		"wkq":     "application/x-wkq",
+		"wks":     "application/x-wks",
+		"wm":      "video/x-ms-wm",
+		"wma":     "audio/x-ms-wma",
+		"wmd":     "application/x-ms-wmd",
+		"wmf":     "application/x-wmf",
+		"wml":     "text/vnd.wap.wml",
+		"wmv":     "video/x-ms-wmv",
+		"wmx":     "video/x-ms-wmx",
+		"wmz":     "application/x-ms-wmz",
+		"woff":    "application/x-font-woff",
+		"wp6":     "application/x-wp6",
+		"wpd":     "application/x-wpd",
+		"wpg":     "application/x-wpg",
+		"wpl":     "application/vnd.ms-wpl",
+		"wq1":     "application/x-wq1",
+		"wr1":     "application/x-wr1",
+		"wri":     "application/x-wri",
+		"wrk":     "application/x-wrk",
+		"ws":      "application/x-ws",
+		"ws2":     "application/x-ws",
+		"wsc":     "text/scriptlet",
+		"wsdl":    "text/xml",
+		"wvx":     "video/x-ms-wvx",
+		"x_b":     "application/x-x_b",
+		"x_t":     "application/x-x_t",
+		"xap":     "application/x-silverlight-app",
+		"xbm":     "image/x-xbitmap",
+		"xdp":     "application/vnd.adobe.xdp",
+		"xdr":     "text/xml",
+		"xfd":     "application/vnd.adobe.xfd",
+		"xfdf":    "application/vnd.adobe.xfdf",
+		"xhtml":   "text/html",
+		"xls":     "application/vnd.ms-excel",
+		"xlsx":    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"xlw":     "application/x-xlw",
+		"xml":     "text/xml",
+		"xpl":     "audio/scpls",
+		"xpm":     "image/x-xpixmap",
+		"xq":      "text/xml",
+		"xql":     "text/xml",
+		"xquery":  "text/xml",
+		"xsd":     "text/xml",
+		"xsl":     "text/xml",
+		"xslt":    "text/xml",
+		"xwd":     "application/x-xwd",
+		"yaml":    "text/yaml",
+		"yml":     "text/yaml",
+		"zip":     "application/zip",
+	}
+)
+
+type HttpMethodType string
+
+const (
+	HttpMethodGet     HttpMethodType = HTTP_GET
+	HttpMethodPut     HttpMethodType = HTTP_PUT
+	HttpMethodPost    HttpMethodType = HTTP_POST
+	HttpMethodDelete  HttpMethodType = HTTP_DELETE
+	HttpMethodHead    HttpMethodType = HTTP_HEAD
+	HttpMethodOptions HttpMethodType = HTTP_OPTIONS
+)
+
+type SubResourceType string
+
+const (
+	SubResourceStoragePolicy SubResourceType = "storagePolicy"
+	SubResourceStorageClass  SubResourceType = "storageClass"
+	SubResourceQuota         SubResourceType = "quota"
+	SubResourceStorageInfo   SubResourceType = "storageinfo"
+	SubResourceLocation      SubResourceType = "location"
+	SubResourceAcl           SubResourceType = "acl"
+	SubResourcePolicy        SubResourceType = "policy"
+	SubResourceCors          SubResourceType = "cors"
+	SubResourceVersioning    SubResourceType = "versioning"
+	SubResourceWebsite       SubResourceType = "website"
+	SubResourceLogging       SubResourceType = "logging"
+	SubResourceLifecycle     SubResourceType = "lifecycle"
+	SubResourceNotification  SubResourceType = "notification"
+	SubResourceTagging       SubResourceType = "tagging"
+	SubResourceDelete        SubResourceType = "delete"
+	SubResourceVersions      SubResourceType = "versions"
+	SubResourceUploads       SubResourceType = "uploads"
+	SubResourceRestore       SubResourceType = "restore"
+	SubResourceMetadata      SubResourceType = "metadata"
+)
+
+type AclType string
+
+const (
+	AclPrivate                 AclType = "private"
+	AclPublicRead              AclType = "public-read"
+	AclPublicReadWrite         AclType = "public-read-write"
+	AclAuthenticatedRead       AclType = "authenticated-read"
+	AclBucketOwnerRead         AclType = "bucket-owner-read"
+	AclBucketOwnerFullControl  AclType = "bucket-owner-full-control"
+	AclLogDeliveryWrite        AclType = "log-delivery-write"
+	AclPublicReadDelivery      AclType = "public-read-delivered"
+	AclPublicReadWriteDelivery AclType = "public-read-write-delivered"
+)
+
+type StorageClassType string
+
+const (
+	StorageClassStandard StorageClassType = "STANDARD"
+	StorageClassWarm     StorageClassType = "WARM"
+	StorageClassCold     StorageClassType = "COLD"
+)
+
+type PermissionType string
+
+const (
+	PermissionRead        PermissionType = "READ"
+	PermissionWrite       PermissionType = "WRITE"
+	PermissionReadAcp     PermissionType = "READ_ACP"
+	PermissionWriteAcp    PermissionType = "WRITE_ACP"
+	PermissionFullControl PermissionType = "FULL_CONTROL"
+)
+
+type GranteeType string
+
+const (
+	GranteeGroup GranteeType = "Group"
+	GranteeUser  GranteeType = "CanonicalUser"
+)
+
+type GroupUriType string
+
+const (
+	GroupAllUsers           GroupUriType = "AllUsers"
+	GroupAuthenticatedUsers GroupUriType = "AuthenticatedUsers"
+	GroupLogDelivery        GroupUriType = "LogDelivery"
+)
+
+type VersioningStatusType string
+
+const (
+	VersioningStatusEnabled   VersioningStatusType = "Enabled"
+	VersioningStatusSuspended VersioningStatusType = "Suspended"
+)
+
+type ProtocolType string
+
+const (
+	ProtocolHttp  ProtocolType = "http"
+	ProtocolHttps ProtocolType = "https"
+)
+
+type RuleStatusType string
+
+const (
+	RuleStatusEnabled  RuleStatusType = "Enabled"
+	RuleStatusDisabled RuleStatusType = "Disabled"
+)
+
+type RestoreTierType string
+
+const (
+	RestoreTierExpedited RestoreTierType = "Expedited"
+	RestoreTierStandard  RestoreTierType = "Standard"
+	RestoreTierBulk      RestoreTierType = "Bulk"
+)
+
+type MetadataDirectiveType string
+
+const (
+	CopyMetadata    MetadataDirectiveType = "COPY"
+	ReplaceNew      MetadataDirectiveType = "REPLACE_NEW"
+	ReplaceMetadata MetadataDirectiveType = "REPLACE"
+)
+
+type EventType string
+
+const (
+	ObjectCreatedAll  EventType = "ObjectCreated:*"
+	ObjectCreatedPut  EventType = "ObjectCreated:Put"
+	ObjectCreatedPost EventType = "ObjectCreated:Post"
+
+	ObjectCreatedCopy                    EventType = "ObjectCreated:Copy"
+	ObjectCreatedCompleteMultipartUpload EventType = "ObjectCreated:CompleteMultipartUpload"
+	ObjectRemovedAll                     EventType = "ObjectRemoved:*"
+	ObjectRemovedDelete                  EventType = "ObjectRemoved:Delete"
+	ObjectRemovedDeleteMarkerCreated     EventType = "ObjectRemoved:DeleteMarkerCreated"
+)

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/convert.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/convert.go
@@ -1,0 +1,792 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strings"
+	"time"
+)
+
+func cleanHeaderPrefix(header http.Header) map[string][]string {
+	responseHeaders := make(map[string][]string)
+	for key, value := range header {
+		if len(value) > 0 {
+			key = strings.ToLower(key)
+			if strings.HasPrefix(key, HEADER_PREFIX) || strings.HasPrefix(key, HEADER_PREFIX_OBS) {
+				key = key[len(HEADER_PREFIX):]
+			}
+			responseHeaders[key] = value
+		}
+	}
+	return responseHeaders
+}
+
+func ParseStringToEventType(value string) (ret EventType) {
+	switch value {
+	case "ObjectCreated:*", "s3:ObjectCreated:*":
+		ret = ObjectCreatedAll
+	case "ObjectCreated:Put", "s3:ObjectCreated:Put":
+		ret = ObjectCreatedPut
+	case "ObjectCreated:Post", "s3:ObjectCreated:Post":
+		ret = ObjectCreatedPost
+	case "ObjectCreated:Copy", "s3:ObjectCreated:Copy":
+		ret = ObjectCreatedCopy
+	case "ObjectCreated:CompleteMultipartUpload", "s3:ObjectCreated:CompleteMultipartUpload":
+		ret = ObjectCreatedCompleteMultipartUpload
+	case "ObjectRemoved:*", "s3:ObjectRemoved:*":
+		ret = ObjectRemovedAll
+	case "ObjectRemoved:Delete", "s3:ObjectRemoved:Delete":
+		ret = ObjectRemovedDelete
+	case "ObjectRemoved:DeleteMarkerCreated", "s3:ObjectRemoved:DeleteMarkerCreated":
+		ret = ObjectRemovedDeleteMarkerCreated
+	default:
+		ret = ""
+	}
+	return
+}
+
+func ParseStringToStorageClassType(value string) (ret StorageClassType) {
+	switch value {
+	case "STANDARD":
+		ret = StorageClassStandard
+	case "STANDARD_IA", "WARM":
+		ret = StorageClassWarm
+	case "GLACIER", "COLD":
+		ret = StorageClassCold
+	default:
+		ret = ""
+	}
+	return
+}
+
+func convertGrantToXml(grant Grant, isObs bool, isBucket bool) string {
+	xml := make([]string, 0, 4)
+	if !isObs {
+		xml = append(xml, fmt.Sprintf("<Grant><Grantee xsi:type=\"%s\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">", grant.Grantee.Type))
+	}
+
+	if grant.Grantee.Type == GranteeUser {
+		if isObs {
+			xml = append(xml, "<Grant><Grantee>")
+		}
+		if grant.Grantee.ID != "" {
+			granteeID := XmlTranscoding(grant.Grantee.ID)
+			xml = append(xml, fmt.Sprintf("<ID>%s</ID>", granteeID))
+		}
+		if !isObs && grant.Grantee.DisplayName != "" {
+			granteeDisplayName := XmlTranscoding(grant.Grantee.DisplayName)
+			xml = append(xml, fmt.Sprintf("<DisplayName>%s</DisplayName>", granteeDisplayName))
+		}
+		xml = append(xml, "</Grantee>")
+	} else {
+		if !isObs {
+			if grant.Grantee.URI == GroupAllUsers || grant.Grantee.URI == GroupAuthenticatedUsers {
+				xml = append(xml, fmt.Sprintf("<URI>%s%s</URI>", "http://acs.amazonaws.com/groups/global/", grant.Grantee.URI))
+			} else if grant.Grantee.URI == GroupLogDelivery {
+				xml = append(xml, fmt.Sprintf("<URI>%s%s</URI>", "http://acs.amazonaws.com/groups/s3/", grant.Grantee.URI))
+			} else {
+				xml = append(xml, fmt.Sprintf("<URI>%s</URI>", grant.Grantee.URI))
+			}
+			xml = append(xml, "</Grantee>")
+		} else if grant.Grantee.URI == GroupAllUsers {
+			xml = append(xml, "<Grant><Grantee>")
+			xml = append(xml, fmt.Sprintf("<Canned>Everyone</Canned>"))
+			xml = append(xml, "</Grantee>")
+		} else {
+			return strings.Join(xml, "")
+		}
+	}
+
+	xml = append(xml, fmt.Sprintf("<Permission>%s</Permission>", grant.Permission))
+	if isObs && isBucket {
+		xml = append(xml, fmt.Sprintf("<Delivered>%t</Delivered>", grant.Delivered))
+	}
+	xml = append(xml, fmt.Sprintf("</Grant>"))
+	return strings.Join(xml, "")
+}
+
+func ConvertLoggingStatusToXml(input BucketLoggingStatus, returnMd5 bool, isObs bool) (data string, md5 string) {
+	grantsLength := len(input.TargetGrants)
+	xml := make([]string, 0, 8+grantsLength)
+
+	xml = append(xml, "<BucketLoggingStatus>")
+	if isObs && input.Agency != "" {
+		agency := XmlTranscoding(input.Agency)
+		xml = append(xml, fmt.Sprintf("<Agency>%s</Agency>", agency))
+	}
+	if input.TargetBucket != "" || input.TargetPrefix != "" || grantsLength > 0 {
+		xml = append(xml, "<LoggingEnabled>")
+		if input.TargetBucket != "" {
+			xml = append(xml, fmt.Sprintf("<TargetBucket>%s</TargetBucket>", input.TargetBucket))
+		}
+		if input.TargetPrefix != "" {
+			targetPrefix := XmlTranscoding(input.TargetPrefix)
+			xml = append(xml, fmt.Sprintf("<TargetPrefix>%s</TargetPrefix>", targetPrefix))
+		}
+		if grantsLength > 0 {
+			xml = append(xml, "<TargetGrants>")
+			for _, grant := range input.TargetGrants {
+				xml = append(xml, convertGrantToXml(grant, isObs, false))
+			}
+			xml = append(xml, "</TargetGrants>")
+		}
+
+		xml = append(xml, "</LoggingEnabled>")
+	}
+	xml = append(xml, "</BucketLoggingStatus>")
+	data = strings.Join(xml, "")
+	if returnMd5 {
+		md5 = Base64Md5([]byte(data))
+	}
+	return
+}
+
+func ConvertAclToXml(input AccessControlPolicy, returnMd5 bool, isObs bool) (data string, md5 string) {
+	xml := make([]string, 0, 4+len(input.Grants))
+	ownerID := XmlTranscoding(input.Owner.ID)
+	xml = append(xml, fmt.Sprintf("<AccessControlPolicy><Owner><ID>%s</ID>", ownerID))
+	if !isObs && input.Owner.DisplayName != "" {
+		ownerDisplayName := XmlTranscoding(input.Owner.DisplayName)
+		xml = append(xml, fmt.Sprintf("<DisplayName>%s</DisplayName>", ownerDisplayName))
+	}
+	if isObs && input.Delivered != "" {
+		objectDelivered := XmlTranscoding(input.Delivered)
+		xml = append(xml, fmt.Sprintf("</Owner><Delivered>%s</Delivered><AccessControlList>", objectDelivered))
+	} else {
+		xml = append(xml, "</Owner><AccessControlList>")
+	}
+	for _, grant := range input.Grants {
+		xml = append(xml, convertGrantToXml(grant, isObs, false))
+	}
+	xml = append(xml, "</AccessControlList></AccessControlPolicy>")
+	data = strings.Join(xml, "")
+	if returnMd5 {
+		md5 = Base64Md5([]byte(data))
+	}
+	return
+}
+
+func convertBucketAclToXml(input AccessControlPolicy, returnMd5 bool, isObs bool) (data string, md5 string) {
+	xml := make([]string, 0, 4+len(input.Grants))
+	ownerID := XmlTranscoding(input.Owner.ID)
+	xml = append(xml, fmt.Sprintf("<AccessControlPolicy><Owner><ID>%s</ID>", ownerID))
+	if !isObs && input.Owner.DisplayName != "" {
+		ownerDisplayName := XmlTranscoding(input.Owner.DisplayName)
+		xml = append(xml, fmt.Sprintf("<DisplayName>%s</DisplayName>", ownerDisplayName))
+	}
+
+	xml = append(xml, "</Owner><AccessControlList>")
+
+	for _, grant := range input.Grants {
+		xml = append(xml, convertGrantToXml(grant, isObs, true))
+	}
+	xml = append(xml, "</AccessControlList></AccessControlPolicy>")
+	data = strings.Join(xml, "")
+	if returnMd5 {
+		md5 = Base64Md5([]byte(data))
+	}
+	return
+}
+
+func convertConditionToXml(condition Condition) string {
+	xml := make([]string, 0, 2)
+	if condition.KeyPrefixEquals != "" {
+		keyPrefixEquals := XmlTranscoding(condition.KeyPrefixEquals)
+		xml = append(xml, fmt.Sprintf("<KeyPrefixEquals>%s</KeyPrefixEquals>", keyPrefixEquals))
+	}
+	if condition.HttpErrorCodeReturnedEquals != "" {
+		xml = append(xml, fmt.Sprintf("<HttpErrorCodeReturnedEquals>%s</HttpErrorCodeReturnedEquals>", condition.HttpErrorCodeReturnedEquals))
+	}
+	if len(xml) > 0 {
+		return fmt.Sprintf("<Condition>%s</Condition>", strings.Join(xml, ""))
+	}
+	return ""
+}
+
+func ConvertWebsiteConfigurationToXml(input BucketWebsiteConfiguration, returnMd5 bool) (data string, md5 string) {
+	routingRuleLength := len(input.RoutingRules)
+	xml := make([]string, 0, 6+routingRuleLength*10)
+	xml = append(xml, "<WebsiteConfiguration>")
+
+	if input.RedirectAllRequestsTo.HostName != "" {
+		xml = append(xml, fmt.Sprintf("<RedirectAllRequestsTo><HostName>%s</HostName>", input.RedirectAllRequestsTo.HostName))
+		if input.RedirectAllRequestsTo.Protocol != "" {
+			xml = append(xml, fmt.Sprintf("<Protocol>%s</Protocol>", input.RedirectAllRequestsTo.Protocol))
+		}
+		xml = append(xml, "</RedirectAllRequestsTo>")
+	} else {
+		if input.IndexDocument.Suffix != "" {
+			indexDocumentSuffix := XmlTranscoding(input.IndexDocument.Suffix)
+			xml = append(xml, fmt.Sprintf("<IndexDocument><Suffix>%s</Suffix></IndexDocument>", indexDocumentSuffix))
+		}
+		if input.ErrorDocument.Key != "" {
+			errorDocumentKey := XmlTranscoding(input.ErrorDocument.Key)
+			xml = append(xml, fmt.Sprintf("<ErrorDocument><Key>%s</Key></ErrorDocument>", errorDocumentKey))
+		}
+		if routingRuleLength > 0 {
+			xml = append(xml, "<RoutingRules>")
+			for _, routingRule := range input.RoutingRules {
+				xml = append(xml, "<RoutingRule>")
+				xml = append(xml, "<Redirect>")
+				if routingRule.Redirect.Protocol != "" {
+					xml = append(xml, fmt.Sprintf("<Protocol>%s</Protocol>", routingRule.Redirect.Protocol))
+				}
+				if routingRule.Redirect.HostName != "" {
+					xml = append(xml, fmt.Sprintf("<HostName>%s</HostName>", routingRule.Redirect.HostName))
+				}
+				if routingRule.Redirect.ReplaceKeyPrefixWith != "" {
+					replaceKeyPrefixWith := XmlTranscoding(routingRule.Redirect.ReplaceKeyPrefixWith)
+					xml = append(xml, fmt.Sprintf("<ReplaceKeyPrefixWith>%s</ReplaceKeyPrefixWith>", replaceKeyPrefixWith))
+				}
+
+				if routingRule.Redirect.ReplaceKeyWith != "" {
+					replaceKeyWith := XmlTranscoding(routingRule.Redirect.ReplaceKeyWith)
+					xml = append(xml, fmt.Sprintf("<ReplaceKeyWith>%s</ReplaceKeyWith>", replaceKeyWith))
+				}
+				if routingRule.Redirect.HttpRedirectCode != "" {
+					xml = append(xml, fmt.Sprintf("<HttpRedirectCode>%s</HttpRedirectCode>", routingRule.Redirect.HttpRedirectCode))
+				}
+				xml = append(xml, "</Redirect>")
+
+				if ret := convertConditionToXml(routingRule.Condition); ret != "" {
+					xml = append(xml, ret)
+				}
+				xml = append(xml, "</RoutingRule>")
+			}
+			xml = append(xml, "</RoutingRules>")
+		}
+	}
+
+	xml = append(xml, "</WebsiteConfiguration>")
+	data = strings.Join(xml, "")
+	if returnMd5 {
+		md5 = Base64Md5([]byte(data))
+	}
+	return
+}
+
+func convertTransitionsToXml(transitions []Transition, isObs bool) string {
+	if length := len(transitions); length > 0 {
+		xml := make([]string, 0, length)
+		for _, transition := range transitions {
+			var temp string
+			if transition.Days > 0 {
+				temp = fmt.Sprintf("<Days>%d</Days>", transition.Days)
+			} else if !transition.Date.IsZero() {
+				temp = fmt.Sprintf("<Date>%s</Date>", transition.Date.UTC().Format(ISO8601_MIDNIGHT_DATE_FORMAT))
+			}
+			if temp != "" {
+				if !isObs {
+					storageClass := string(transition.StorageClass)
+					if transition.StorageClass == "WARM" {
+						storageClass = "STANDARD_IA"
+					} else if transition.StorageClass == "COLD" {
+						storageClass = "GLACIER"
+					}
+					xml = append(xml, fmt.Sprintf("<Transition>%s<StorageClass>%s</StorageClass></Transition>", temp, storageClass))
+				} else {
+					xml = append(xml, fmt.Sprintf("<Transition>%s<StorageClass>%s</StorageClass></Transition>", temp, transition.StorageClass))
+				}
+			}
+		}
+		return strings.Join(xml, "")
+	}
+	return ""
+}
+
+func convertExpirationToXml(expiration Expiration) string {
+	if expiration.Days > 0 {
+		return fmt.Sprintf("<Expiration><Days>%d</Days></Expiration>", expiration.Days)
+	} else if !expiration.Date.IsZero() {
+		return fmt.Sprintf("<Expiration><Date>%s</Date></Expiration>", expiration.Date.UTC().Format(ISO8601_MIDNIGHT_DATE_FORMAT))
+	}
+	return ""
+}
+func convertNoncurrentVersionTransitionsToXml(noncurrentVersionTransitions []NoncurrentVersionTransition, isObs bool) string {
+	if length := len(noncurrentVersionTransitions); length > 0 {
+		xml := make([]string, 0, length)
+		for _, noncurrentVersionTransition := range noncurrentVersionTransitions {
+			if noncurrentVersionTransition.NoncurrentDays > 0 {
+				storageClass := string(noncurrentVersionTransition.StorageClass)
+				if !isObs {
+					if storageClass == "WARM" {
+						storageClass = "STANDARD_IA"
+					} else if storageClass == "COLD" {
+						storageClass = "GLACIER"
+					}
+				}
+				xml = append(xml, fmt.Sprintf("<NoncurrentVersionTransition><NoncurrentDays>%d</NoncurrentDays>"+
+					"<StorageClass>%s</StorageClass></NoncurrentVersionTransition>",
+					noncurrentVersionTransition.NoncurrentDays, storageClass))
+			}
+		}
+		return strings.Join(xml, "")
+	}
+	return ""
+}
+func convertNoncurrentVersionExpirationToXml(noncurrentVersionExpiration NoncurrentVersionExpiration) string {
+	if noncurrentVersionExpiration.NoncurrentDays > 0 {
+		return fmt.Sprintf("<NoncurrentVersionExpiration><NoncurrentDays>%d</NoncurrentDays></NoncurrentVersionExpiration>", noncurrentVersionExpiration.NoncurrentDays)
+	}
+	return ""
+}
+
+func ConvertLifecyleConfigurationToXml(input BucketLifecyleConfiguration, returnMd5 bool, isObs bool) (data string, md5 string) {
+	xml := make([]string, 0, 2+len(input.LifecycleRules)*9)
+	xml = append(xml, "<LifecycleConfiguration>")
+	for _, lifecyleRule := range input.LifecycleRules {
+		xml = append(xml, "<Rule>")
+		if lifecyleRule.ID != "" {
+			lifecyleRuleID := XmlTranscoding(lifecyleRule.ID)
+			xml = append(xml, fmt.Sprintf("<ID>%s</ID>", lifecyleRuleID))
+		}
+		lifecyleRulePrefix := XmlTranscoding(lifecyleRule.Prefix)
+		xml = append(xml, fmt.Sprintf("<Prefix>%s</Prefix>", lifecyleRulePrefix))
+		xml = append(xml, fmt.Sprintf("<Status>%s</Status>", lifecyleRule.Status))
+		if ret := convertTransitionsToXml(lifecyleRule.Transitions, isObs); ret != "" {
+			xml = append(xml, ret)
+		}
+		if ret := convertExpirationToXml(lifecyleRule.Expiration); ret != "" {
+			xml = append(xml, ret)
+		}
+		if ret := convertNoncurrentVersionTransitionsToXml(lifecyleRule.NoncurrentVersionTransitions, isObs); ret != "" {
+			xml = append(xml, ret)
+		}
+		if ret := convertNoncurrentVersionExpirationToXml(lifecyleRule.NoncurrentVersionExpiration); ret != "" {
+			xml = append(xml, ret)
+		}
+		xml = append(xml, "</Rule>")
+	}
+	xml = append(xml, "</LifecycleConfiguration>")
+	data = strings.Join(xml, "")
+	if returnMd5 {
+		md5 = Base64Md5([]byte(data))
+	}
+	return
+}
+
+func converntFilterRulesToXml(filterRules []FilterRule, isObs bool) string {
+	if length := len(filterRules); length > 0 {
+		xml := make([]string, 0, length*4)
+		for _, filterRule := range filterRules {
+			xml = append(xml, "<FilterRule>")
+			if filterRule.Name != "" {
+				filterRuleName := XmlTranscoding(filterRule.Name)
+				xml = append(xml, fmt.Sprintf("<Name>%s</Name>", filterRuleName))
+			}
+			if filterRule.Value != "" {
+				filterRuleValue := XmlTranscoding(filterRule.Value)
+				xml = append(xml, fmt.Sprintf("<Value>%s</Value>", filterRuleValue))
+			}
+			xml = append(xml, "</FilterRule>")
+		}
+		if !isObs {
+			return fmt.Sprintf("<Filter><S3Key>%s</S3Key></Filter>", strings.Join(xml, ""))
+		} else {
+			return fmt.Sprintf("<Filter><Object>%s</Object></Filter>", strings.Join(xml, ""))
+		}
+	}
+	return ""
+}
+
+func converntEventsToXml(events []EventType, isObs bool) string {
+	if length := len(events); length > 0 {
+		xml := make([]string, 0, length)
+		if !isObs {
+			for _, event := range events {
+				xml = append(xml, fmt.Sprintf("<Event>%s%s</Event>", "s3:", event))
+			}
+		} else {
+			for _, event := range events {
+				xml = append(xml, fmt.Sprintf("<Event>%s</Event>", event))
+			}
+		}
+		return strings.Join(xml, "")
+	}
+	return ""
+}
+
+func converntConfigureToXml(topicConfiguration TopicConfiguration, xmlElem string, isObs bool) string {
+	xml := make([]string, 0, 6)
+	xml = append(xml, xmlElem)
+	if topicConfiguration.ID != "" {
+		topicConfigurationID := XmlTranscoding(topicConfiguration.ID)
+		xml = append(xml, fmt.Sprintf("<Id>%s</Id>", topicConfigurationID))
+	}
+	topicConfigurationTopic := XmlTranscoding(topicConfiguration.Topic)
+	xml = append(xml, fmt.Sprintf("<Topic>%s</Topic>", topicConfigurationTopic))
+
+	if ret := converntEventsToXml(topicConfiguration.Events, isObs); ret != "" {
+		xml = append(xml, ret)
+	}
+	if ret := converntFilterRulesToXml(topicConfiguration.FilterRules, isObs); ret != "" {
+		xml = append(xml, ret)
+	}
+	tempElem := xmlElem[0:1] + "/" + xmlElem[1:]
+	xml = append(xml, tempElem)
+	return strings.Join(xml, "")
+}
+
+func ConverntObsRestoreToXml(restoreObjectInput RestoreObjectInput) string {
+	xml := make([]string, 0, 2)
+	xml = append(xml, fmt.Sprintf("<RestoreRequest><Days>%d</Days>", restoreObjectInput.Days))
+	if restoreObjectInput.Tier != "Bulk" {
+		xml = append(xml, fmt.Sprintf("<RestoreJob><Tier>%s</Tier></RestoreJob>", restoreObjectInput.Tier))
+	}
+	xml = append(xml, fmt.Sprintf("</RestoreRequest>"))
+	data := strings.Join(xml, "")
+	return data
+}
+
+func ConvertNotificationToXml(input BucketNotification, returnMd5 bool, isObs bool) (data string, md5 string) {
+	xml := make([]string, 0, 2+len(input.TopicConfigurations)*6)
+	xml = append(xml, "<NotificationConfiguration>")
+	for _, topicConfiguration := range input.TopicConfigurations {
+		ret := converntConfigureToXml(topicConfiguration, "<TopicConfiguration>", isObs)
+		xml = append(xml, ret)
+	}
+	xml = append(xml, "</NotificationConfiguration>")
+	data = strings.Join(xml, "")
+	if returnMd5 {
+		md5 = Base64Md5([]byte(data))
+	}
+	return
+}
+
+func ConvertCompleteMultipartUploadInputToXml(input CompleteMultipartUploadInput, returnMd5 bool) (data string, md5 string) {
+	xml := make([]string, 0, 2+len(input.Parts)*4)
+	xml = append(xml, "<CompleteMultipartUpload>")
+	for _, part := range input.Parts {
+		xml = append(xml, "<Part>")
+		xml = append(xml, fmt.Sprintf("<PartNumber>%d</PartNumber>", part.PartNumber))
+		xml = append(xml, fmt.Sprintf("<ETag>%s</ETag>", part.ETag))
+		xml = append(xml, "</Part>")
+	}
+	xml = append(xml, "</CompleteMultipartUpload>")
+	data = strings.Join(xml, "")
+	if returnMd5 {
+		md5 = Base64Md5([]byte(data))
+	}
+	return
+}
+
+func parseSseHeader(responseHeaders map[string][]string) (sseHeader ISseHeader) {
+	if ret, ok := responseHeaders[HEADER_SSEC_ENCRYPTION]; ok {
+		sseCHeader := SseCHeader{Encryption: ret[0]}
+		if ret, ok = responseHeaders[HEADER_SSEC_KEY_MD5]; ok {
+			sseCHeader.KeyMD5 = ret[0]
+		}
+		sseHeader = sseCHeader
+	} else if ret, ok := responseHeaders[HEADER_SSEKMS_ENCRYPTION]; ok {
+		sseKmsHeader := SseKmsHeader{Encryption: ret[0]}
+		if ret, ok = responseHeaders[HEADER_SSEKMS_KEY]; ok {
+			sseKmsHeader.Key = ret[0]
+		} else if ret, ok = responseHeaders[HEADER_SSEKMS_ENCRYPT_KEY_OBS]; ok {
+			sseKmsHeader.Key = ret[0]
+		}
+		sseHeader = sseKmsHeader
+	}
+	return
+}
+
+func ParseGetObjectMetadataOutput(output *GetObjectMetadataOutput) {
+	if ret, ok := output.ResponseHeaders[HEADER_VERSION_ID]; ok {
+		output.VersionId = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_WEBSITE_REDIRECT_LOCATION]; ok {
+		output.WebsiteRedirectLocation = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_EXPIRATION]; ok {
+		output.Expiration = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_RESTORE]; ok {
+		output.Restore = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_OBJECT_TYPE]; ok {
+		output.Restore = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_NEXT_APPEND_POSITION]; ok {
+		output.Restore = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_STORAGE_CLASS2]; ok {
+		output.StorageClass = ParseStringToStorageClassType(ret[0])
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ETAG]; ok {
+		output.ETag = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_TYPE]; ok {
+		output.ContentType = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ACCESS_CONRTOL_ALLOW_ORIGIN]; ok {
+		output.AllowOrigin = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ACCESS_CONRTOL_ALLOW_HEADERS]; ok {
+		output.AllowHeader = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ACCESS_CONRTOL_MAX_AGE]; ok {
+		output.MaxAgeSeconds = StringToInt(ret[0], 0)
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ACCESS_CONRTOL_ALLOW_METHODS]; ok {
+		output.AllowMethod = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ACCESS_CONRTOL_EXPOSE_HEADERS]; ok {
+		output.ExposeHeader = ret[0]
+	}
+
+	output.SseHeader = parseSseHeader(output.ResponseHeaders)
+	if ret, ok := output.ResponseHeaders[HEADER_LASTMODIFIED]; ok {
+		ret, err := time.Parse(time.RFC1123, ret[0])
+		if err == nil {
+			output.LastModified = ret
+		}
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_LENGTH]; ok {
+		output.ContentLength = StringToInt64(ret[0], 0)
+	}
+
+	output.Metadata = make(map[string]string)
+
+	for key, value := range output.ResponseHeaders {
+		if strings.HasPrefix(key, PREFIX_META) {
+			_key := key[len(PREFIX_META):]
+			output.ResponseHeaders[_key] = value
+			output.Metadata[_key] = value[0]
+			delete(output.ResponseHeaders, key)
+		}
+	}
+
+}
+
+func ParseCopyObjectOutput(output *CopyObjectOutput) {
+	if ret, ok := output.ResponseHeaders[HEADER_VERSION_ID]; ok {
+		output.VersionId = ret[0]
+	}
+	output.SseHeader = parseSseHeader(output.ResponseHeaders)
+	if ret, ok := output.ResponseHeaders[HEADER_COPY_SOURCE_VERSION_ID]; ok {
+		output.CopySourceVersionId = ret[0]
+	}
+}
+
+func ParsePutObjectOutput(output *PutObjectOutput) {
+	if ret, ok := output.ResponseHeaders[HEADER_VERSION_ID]; ok {
+		output.VersionId = ret[0]
+	}
+	output.SseHeader = parseSseHeader(output.ResponseHeaders)
+	if ret, ok := output.ResponseHeaders[HEADER_STORAGE_CLASS2]; ok {
+		output.StorageClass = ParseStringToStorageClassType(ret[0])
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ETAG]; ok {
+		output.ETag = ret[0]
+	}
+}
+
+func ParseInitiateMultipartUploadOutput(output *InitiateMultipartUploadOutput) {
+	output.SseHeader = parseSseHeader(output.ResponseHeaders)
+}
+
+func ParseUploadPartOutput(output *UploadPartOutput) {
+	output.SseHeader = parseSseHeader(output.ResponseHeaders)
+	if ret, ok := output.ResponseHeaders[HEADER_ETAG]; ok {
+		output.ETag = ret[0]
+	}
+}
+
+func ParseCompleteMultipartUploadOutput(output *CompleteMultipartUploadOutput) {
+	output.SseHeader = parseSseHeader(output.ResponseHeaders)
+	if ret, ok := output.ResponseHeaders[HEADER_VERSION_ID]; ok {
+		output.VersionId = ret[0]
+	}
+}
+
+func ParseCopyPartOutput(output *CopyPartOutput) {
+	output.SseHeader = parseSseHeader(output.ResponseHeaders)
+}
+
+func ParseGetBucketMetadataOutput(output *GetBucketMetadataOutput) {
+	if ret, ok := output.ResponseHeaders[HEADER_STORAGE_CLASS]; ok {
+		output.StorageClass = ParseStringToStorageClassType(ret[0])
+	} else if ret, ok := output.ResponseHeaders[HEADER_STORAGE_CLASS2]; ok {
+		output.StorageClass = ParseStringToStorageClassType(ret[0])
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_VERSION_OBS]; ok {
+		output.Version = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_BUCKET_REGION]; ok {
+		output.Location = ret[0]
+	} else if ret, ok := output.ResponseHeaders[HEADER_BUCKET_LOCATION_OBS]; ok {
+		output.Location = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ACCESS_CONRTOL_ALLOW_ORIGIN]; ok {
+		output.AllowOrigin = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ACCESS_CONRTOL_ALLOW_HEADERS]; ok {
+		output.AllowHeader = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ACCESS_CONRTOL_MAX_AGE]; ok {
+		output.MaxAgeSeconds = StringToInt(ret[0], 0)
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ACCESS_CONRTOL_ALLOW_METHODS]; ok {
+		output.AllowMethod = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_ACCESS_CONRTOL_EXPOSE_HEADERS]; ok {
+		output.ExposeHeader = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_EPID_HEADERS]; ok {
+		output.Epid = ret[0]
+	}
+}
+
+func ParseSetObjectMetadataOutput(output *SetObjectMetadataOutput) {
+	if ret, ok := output.ResponseHeaders[HEADER_STORAGE_CLASS]; ok {
+		output.StorageClass = ParseStringToStorageClassType(ret[0])
+	} else if ret, ok := output.ResponseHeaders[HEADER_STORAGE_CLASS2]; ok {
+		output.StorageClass = ParseStringToStorageClassType(ret[0])
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_METADATA_DIRECTIVE]; ok {
+		output.MetadataDirective = MetadataDirectiveType(ret[0])
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_CACHE_CONTROL]; ok {
+		output.CacheControl = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_DISPOSITION]; ok {
+		output.ContentDisposition = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_ENCODING]; ok {
+		output.ContentEncoding = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_LANGUAGE]; ok {
+		output.ContentLanguage = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_TYPE]; ok {
+		output.ContentType = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_EXPIRES]; ok {
+		output.Expires = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_WEBSITE_REDIRECT_LOCATION]; ok {
+		output.WebsiteRedirectLocation = ret[0]
+	}
+	output.Metadata = make(map[string]string)
+
+	for key, value := range output.ResponseHeaders {
+		if strings.HasPrefix(key, PREFIX_META) {
+			_key := key[len(PREFIX_META):]
+			output.ResponseHeaders[_key] = value
+			output.Metadata[_key] = value[0]
+			delete(output.ResponseHeaders, key)
+		}
+	}
+}
+func ParseDeleteObjectOutput(output *DeleteObjectOutput) {
+	if versionId, ok := output.ResponseHeaders[HEADER_VERSION_ID]; ok {
+		output.VersionId = versionId[0]
+	}
+
+	if deleteMarker, ok := output.ResponseHeaders[HEADER_DELETE_MARKER]; ok {
+		output.DeleteMarker = deleteMarker[0] == "true"
+	}
+}
+
+func ParseGetObjectOutput(output *GetObjectOutput) {
+	ParseGetObjectMetadataOutput(&output.GetObjectMetadataOutput)
+	if ret, ok := output.ResponseHeaders[HEADER_DELETE_MARKER]; ok {
+		output.DeleteMarker = ret[0] == "true"
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_CACHE_CONTROL]; ok {
+		output.CacheControl = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_DISPOSITION]; ok {
+		output.ContentDisposition = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_ENCODING]; ok {
+		output.ContentEncoding = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_LANGUAGE]; ok {
+		output.ContentLanguage = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_EXPIRES]; ok {
+		output.Expires = ret[0]
+	}
+}
+
+func ConvertRequestToIoReaderV2(req interface{}) (io.Reader, string, error) {
+	data, err := TransToXml(req)
+	if err == nil {
+		if isDebugLogEnabled() {
+			doLog(LEVEL_DEBUG, "Do http request with data: %s", string(data))
+		}
+		return bytes.NewReader(data), Base64Md5(data), nil
+	}
+	return nil, "", err
+}
+
+func ConvertRequestToIoReader(req interface{}) (io.Reader, error) {
+	body, err := TransToXml(req)
+	if err == nil {
+		if isDebugLogEnabled() {
+			doLog(LEVEL_DEBUG, "Do http request with data: %s", string(body))
+		}
+		return bytes.NewReader(body), nil
+	}
+	return nil, err
+}
+
+func ParseResponseToBaseModel(resp *http.Response, baseModel IBaseModel, xmlResult bool, isObs bool) (err error) {
+	readCloser, ok := baseModel.(IReadCloser)
+	if !ok {
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err == nil && len(body) > 0 {
+			if xmlResult {
+				err = ParseXml(body, baseModel)
+				if err != nil {
+					doLog(LEVEL_ERROR, "Unmarshal error: %v", err)
+				}
+			} else {
+				s := reflect.TypeOf(baseModel).Elem()
+				for i := 0; i < s.NumField(); i++ {
+					if s.Field(i).Tag == "json:\"body\"" {
+						reflect.ValueOf(baseModel).Elem().FieldByName(s.Field(i).Name).SetString(string(body))
+						break
+					}
+				}
+			}
+		}
+	} else {
+		readCloser.setReadCloser(resp.Body)
+	}
+
+	baseModel.setStatusCode(resp.StatusCode)
+	responseHeaders := cleanHeaderPrefix(resp.Header)
+	baseModel.setResponseHeaders(responseHeaders)
+	if values, ok := responseHeaders[HEADER_REQUEST_ID]; ok {
+		baseModel.setRequestId(values[0])
+	}
+	return
+}
+
+func ParseResponseToObsError(resp *http.Response, isObs bool) error {
+	obsError := ObsError{}
+	respError := ParseResponseToBaseModel(resp, &obsError, true, isObs)
+	if respError != nil {
+		doLog(LEVEL_WARN, "Parse response to BaseModel with error: %v", respError)
+	}
+	obsError.Status = resp.Status
+	return obsError
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/error.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/error.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type ObsError struct {
+	BaseModel
+	Status   string
+	XMLName  xml.Name `xml:"Error"`
+	Code     string   `xml:"Code"`
+	Message  string   `xml:"Message"`
+	Resource string   `xml:"Resource"`
+	HostId   string   `xml:"HostId"`
+}
+
+func (err ObsError) Error() string {
+	return fmt.Sprintf("obs: service returned error: Status=%s, Code=%s, Message=%s, RequestId=%s",
+		err.Status, err.Code, err.Message, err.RequestId)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/http.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/http.go
@@ -1,0 +1,501 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+func prepareHeaders(headers map[string][]string, meta bool, isObs bool) map[string][]string {
+	_headers := make(map[string][]string, len(headers))
+	if headers != nil {
+		for key, value := range headers {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			_key := strings.ToLower(key)
+			if _, ok := allowed_request_http_header_metadata_names[_key]; !ok && !strings.HasPrefix(key, HEADER_PREFIX) && !strings.HasPrefix(key, HEADER_PREFIX_OBS) {
+				if !meta {
+					continue
+				}
+				if !isObs {
+					_key = HEADER_PREFIX_META + _key
+				} else {
+					_key = HEADER_PREFIX_META_OBS + _key
+				}
+			} else {
+				_key = key
+			}
+			_headers[_key] = value
+		}
+	}
+	return _headers
+}
+
+func (obsClient ObsClient) doActionWithoutBucket(action, method string, input ISerializable, output IBaseModel) error {
+	return obsClient.doAction(action, method, "", "", input, output, true, true)
+}
+
+func (obsClient ObsClient) doActionWithBucketV2(action, method, bucketName string, input ISerializable, output IBaseModel) error {
+	if strings.TrimSpace(bucketName) == "" && !obsClient.conf.cname {
+		return errors.New("Bucket is empty")
+	}
+	return obsClient.doAction(action, method, bucketName, "", input, output, false, true)
+}
+
+func (obsClient ObsClient) doActionWithBucket(action, method, bucketName string, input ISerializable, output IBaseModel) error {
+	if strings.TrimSpace(bucketName) == "" && !obsClient.conf.cname {
+		return errors.New("Bucket is empty")
+	}
+	return obsClient.doAction(action, method, bucketName, "", input, output, true, true)
+}
+
+func (obsClient ObsClient) doActionWithBucketAndKey(action, method, bucketName, objectKey string, input ISerializable, output IBaseModel) error {
+	return obsClient._doActionWithBucketAndKey(action, method, bucketName, objectKey, input, output, true)
+}
+
+func (obsClient ObsClient) doActionWithBucketAndKeyUnRepeatable(action, method, bucketName, objectKey string, input ISerializable, output IBaseModel) error {
+	return obsClient._doActionWithBucketAndKey(action, method, bucketName, objectKey, input, output, false)
+}
+
+func (obsClient ObsClient) _doActionWithBucketAndKey(action, method, bucketName, objectKey string, input ISerializable, output IBaseModel, repeatable bool) error {
+	if strings.TrimSpace(bucketName) == "" && !obsClient.conf.cname {
+		return errors.New("Bucket is empty")
+	}
+	if strings.TrimSpace(objectKey) == "" {
+		return errors.New("Key is empty")
+	}
+	return obsClient.doAction(action, method, bucketName, objectKey, input, output, true, repeatable)
+}
+
+func (obsClient ObsClient) doAction(action, method, bucketName, objectKey string, input ISerializable, output IBaseModel, xmlResult bool, repeatable bool) error {
+
+	var resp *http.Response
+	var respError error
+	doLog(LEVEL_INFO, "Enter method %s...", action)
+	start := GetCurrentTimestamp()
+
+	params, headers, data, err := input.trans(obsClient.conf.signature == SignatureObs)
+	if err != nil {
+		return err
+	}
+	if params == nil {
+		params = make(map[string]string)
+	}
+
+	if headers == nil {
+		headers = make(map[string][]string)
+	}
+
+	switch method {
+	case HTTP_GET:
+		resp, respError = obsClient.doHttpGet(bucketName, objectKey, params, headers, data, repeatable)
+	case HTTP_POST:
+		resp, respError = obsClient.doHttpPost(bucketName, objectKey, params, headers, data, repeatable)
+	case HTTP_PUT:
+		resp, respError = obsClient.doHttpPut(bucketName, objectKey, params, headers, data, repeatable)
+	case HTTP_DELETE:
+		resp, respError = obsClient.doHttpDelete(bucketName, objectKey, params, headers, data, repeatable)
+	case HTTP_HEAD:
+		resp, respError = obsClient.doHttpHead(bucketName, objectKey, params, headers, data, repeatable)
+	case HTTP_OPTIONS:
+		resp, respError = obsClient.doHttpOptions(bucketName, objectKey, params, headers, data, repeatable)
+	default:
+		respError = errors.New("Unexpect http method error")
+	}
+	if respError == nil && output != nil {
+		respError = ParseResponseToBaseModel(resp, output, xmlResult, obsClient.conf.signature == SignatureObs)
+		if respError != nil {
+			doLog(LEVEL_WARN, "Parse response to BaseModel with error: %v", respError)
+		}
+	} else {
+		doLog(LEVEL_WARN, "Do http request with error: %v", respError)
+	}
+
+	if isDebugLogEnabled() {
+		doLog(LEVEL_DEBUG, "End method %s, obsclient cost %d ms", action, (GetCurrentTimestamp() - start))
+	}
+
+	return respError
+}
+
+func (obsClient ObsClient) doHttpGet(bucketName, objectKey string, params map[string]string,
+	headers map[string][]string, data interface{}, repeatable bool) (*http.Response, error) {
+	return obsClient.doHttp(HTTP_GET, bucketName, objectKey, params, prepareHeaders(headers, false, obsClient.conf.signature == SignatureObs), data, repeatable)
+}
+
+func (obsClient ObsClient) doHttpHead(bucketName, objectKey string, params map[string]string,
+	headers map[string][]string, data interface{}, repeatable bool) (*http.Response, error) {
+	return obsClient.doHttp(HTTP_HEAD, bucketName, objectKey, params, prepareHeaders(headers, false, obsClient.conf.signature == SignatureObs), data, repeatable)
+}
+
+func (obsClient ObsClient) doHttpOptions(bucketName, objectKey string, params map[string]string,
+	headers map[string][]string, data interface{}, repeatable bool) (*http.Response, error) {
+	return obsClient.doHttp(HTTP_OPTIONS, bucketName, objectKey, params, prepareHeaders(headers, false, obsClient.conf.signature == SignatureObs), data, repeatable)
+}
+
+func (obsClient ObsClient) doHttpDelete(bucketName, objectKey string, params map[string]string,
+	headers map[string][]string, data interface{}, repeatable bool) (*http.Response, error) {
+	return obsClient.doHttp(HTTP_DELETE, bucketName, objectKey, params, prepareHeaders(headers, false, obsClient.conf.signature == SignatureObs), data, repeatable)
+}
+
+func (obsClient ObsClient) doHttpPut(bucketName, objectKey string, params map[string]string,
+	headers map[string][]string, data interface{}, repeatable bool) (*http.Response, error) {
+	return obsClient.doHttp(HTTP_PUT, bucketName, objectKey, params, prepareHeaders(headers, true, obsClient.conf.signature == SignatureObs), data, repeatable)
+}
+
+func (obsClient ObsClient) doHttpPost(bucketName, objectKey string, params map[string]string,
+	headers map[string][]string, data interface{}, repeatable bool) (*http.Response, error) {
+	return obsClient.doHttp(HTTP_POST, bucketName, objectKey, params, prepareHeaders(headers, true, obsClient.conf.signature == SignatureObs), data, repeatable)
+}
+
+func (obsClient ObsClient) doHttpWithSignedUrl(action, method string, signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader, output IBaseModel, xmlResult bool) (respError error) {
+	req, err := http.NewRequest(method, signedUrl, data)
+	if err != nil {
+		return err
+	}
+	if obsClient.conf.ctx != nil {
+		req = req.WithContext(obsClient.conf.ctx)
+	}
+	var resp *http.Response
+
+	doLog(LEVEL_INFO, "Do %s with signedUrl %s...", action, signedUrl)
+
+	req.Header = actualSignedRequestHeaders
+	if value, ok := req.Header[HEADER_HOST_CAMEL]; ok {
+		req.Host = value[0]
+		delete(req.Header, HEADER_HOST_CAMEL)
+	} else if value, ok := req.Header[HEADER_HOST]; ok {
+		req.Host = value[0]
+		delete(req.Header, HEADER_HOST)
+	}
+
+	if value, ok := req.Header[HEADER_CONTENT_LENGTH_CAMEL]; ok {
+		req.ContentLength = StringToInt64(value[0], -1)
+		delete(req.Header, HEADER_CONTENT_LENGTH_CAMEL)
+	} else if value, ok := req.Header[HEADER_CONTENT_LENGTH]; ok {
+		req.ContentLength = StringToInt64(value[0], -1)
+		delete(req.Header, HEADER_CONTENT_LENGTH)
+	}
+
+	req.Header[HEADER_USER_AGENT_CAMEL] = []string{USER_AGENT}
+	start := GetCurrentTimestamp()
+	resp, err = obsClient.httpClient.Do(req)
+	if isInfoLogEnabled() {
+		doLog(LEVEL_INFO, "Do http request cost %d ms", (GetCurrentTimestamp() - start))
+	}
+
+	var msg interface{}
+	if err != nil {
+		respError = err
+		resp = nil
+	} else {
+		doLog(LEVEL_DEBUG, "Response headers: %v", resp.Header)
+		if resp.StatusCode >= 300 {
+			respError = ParseResponseToObsError(resp, obsClient.conf.signature == SignatureObs)
+			msg = resp.Status
+			resp = nil
+		} else {
+			if output != nil {
+				respError = ParseResponseToBaseModel(resp, output, xmlResult, obsClient.conf.signature == SignatureObs)
+			}
+			if respError != nil {
+				doLog(LEVEL_WARN, "Parse response to BaseModel with error: %v", respError)
+			}
+		}
+	}
+
+	if msg != nil {
+		doLog(LEVEL_ERROR, "Failed to send request with reason:%v", msg)
+	}
+
+	if isDebugLogEnabled() {
+		doLog(LEVEL_DEBUG, "End method %s, obsclient cost %d ms", action, (GetCurrentTimestamp() - start))
+	}
+
+	return
+}
+
+func (obsClient ObsClient) doHttp(method, bucketName, objectKey string, params map[string]string,
+	headers map[string][]string, data interface{}, repeatable bool) (resp *http.Response, respError error) {
+
+	bucketName = strings.TrimSpace(bucketName)
+
+	method = strings.ToUpper(method)
+
+	var redirectUrl string
+	var requestUrl string
+	maxRetryCount := obsClient.conf.maxRetryCount
+	maxRedirectCount := obsClient.conf.maxRedirectCount
+
+	var _data io.Reader
+	if data != nil {
+		if dataStr, ok := data.(string); ok {
+			doLog(LEVEL_DEBUG, "Do http request with string: %s", dataStr)
+			headers["Content-Length"] = []string{IntToString(len(dataStr))}
+			_data = strings.NewReader(dataStr)
+		} else if dataByte, ok := data.([]byte); ok {
+			doLog(LEVEL_DEBUG, "Do http request with byte array")
+			headers["Content-Length"] = []string{IntToString(len(dataByte))}
+			_data = bytes.NewReader(dataByte)
+		} else if dataReader, ok := data.(io.Reader); ok {
+			_data = dataReader
+		} else {
+			doLog(LEVEL_WARN, "Data is not a valid io.Reader")
+			return nil, errors.New("Data is not a valid io.Reader")
+		}
+	}
+
+	var lastRequest *http.Request
+	redirectFlag := false
+	for i, redirectCount := 0, 0; i <= maxRetryCount; i++ {
+		if redirectUrl != "" {
+			if !redirectFlag {
+				parsedRedirectUrl, err := url.Parse(redirectUrl)
+				if err != nil {
+					return nil, err
+				}
+				requestUrl, _ = obsClient.doAuth(method, bucketName, objectKey, params, headers, parsedRedirectUrl.Host)
+				if parsedRequestUrl, err := url.Parse(requestUrl); err != nil {
+					return nil, err
+				} else if parsedRequestUrl.RawQuery != "" && parsedRedirectUrl.RawQuery == "" {
+					redirectUrl += "?" + parsedRequestUrl.RawQuery
+				}
+			}
+			requestUrl = redirectUrl
+		} else {
+			var err error
+			requestUrl, err = obsClient.doAuth(method, bucketName, objectKey, params, headers, "")
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		req, err := http.NewRequest(method, requestUrl, _data)
+		if obsClient.conf.ctx != nil {
+			req = req.WithContext(obsClient.conf.ctx)
+		}
+		if err != nil {
+			return nil, err
+		}
+		doLog(LEVEL_DEBUG, "Do request with url [%s] and method [%s]", requestUrl, method)
+
+		if isDebugLogEnabled() {
+			auth := headers[HEADER_AUTH_CAMEL]
+			delete(headers, HEADER_AUTH_CAMEL)
+			doLog(LEVEL_DEBUG, "Request headers: %v", headers)
+			headers[HEADER_AUTH_CAMEL] = auth
+		}
+
+		for key, value := range headers {
+			if key == HEADER_HOST_CAMEL {
+				req.Host = value[0]
+				delete(headers, key)
+			} else if key == HEADER_CONTENT_LENGTH_CAMEL {
+				req.ContentLength = StringToInt64(value[0], -1)
+				delete(headers, key)
+			} else {
+				req.Header[key] = value
+			}
+		}
+
+		lastRequest = req
+
+		req.Header[HEADER_USER_AGENT_CAMEL] = []string{USER_AGENT}
+
+		if lastRequest != nil {
+			req.Host = lastRequest.Host
+			req.ContentLength = lastRequest.ContentLength
+		}
+
+		start := GetCurrentTimestamp()
+		resp, err = obsClient.httpClient.Do(req)
+		if isInfoLogEnabled() {
+			doLog(LEVEL_INFO, "Do http request cost %d ms", (GetCurrentTimestamp() - start))
+		}
+
+		var msg interface{}
+		if err != nil {
+			msg = err
+			respError = err
+			resp = nil
+			if !repeatable {
+				break
+			}
+		} else {
+			doLog(LEVEL_DEBUG, "Response headers: %v", resp.Header)
+			if resp.StatusCode < 300 {
+				break
+			} else if !repeatable || (resp.StatusCode >= 400 && resp.StatusCode < 500) || resp.StatusCode == 304 {
+				respError = ParseResponseToObsError(resp, obsClient.conf.signature == SignatureObs)
+				resp = nil
+				break
+			} else if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+				if location := resp.Header.Get(HEADER_LOCATION_CAMEL); location != "" && redirectCount < maxRedirectCount {
+					redirectUrl = location
+					doLog(LEVEL_WARN, "Redirect request to %s", redirectUrl)
+					msg = resp.Status
+					maxRetryCount++
+					redirectCount++
+					if resp.StatusCode == 302 && method == HTTP_GET {
+						redirectFlag = true
+					} else {
+						redirectFlag = false
+					}
+				} else {
+					respError = ParseResponseToObsError(resp, obsClient.conf.signature == SignatureObs)
+					resp = nil
+					break
+				}
+			} else {
+				msg = resp.Status
+			}
+		}
+		if i != maxRetryCount {
+			if resp != nil {
+				_err := resp.Body.Close()
+				if _err != nil {
+					doLog(LEVEL_WARN, "Failed to close resp body with reason: %v", _err)
+				}
+				resp = nil
+			}
+			if _, ok := headers[HEADER_AUTH_CAMEL]; ok {
+				delete(headers, HEADER_AUTH_CAMEL)
+			}
+			doLog(LEVEL_WARN, "Failed to send request with reason:%v, will try again", msg)
+			if r, ok := _data.(*strings.Reader); ok {
+				_, err := r.Seek(0, 0)
+				if err != nil {
+					return nil, err
+				}
+			} else if r, ok := _data.(*bytes.Reader); ok {
+				_, err := r.Seek(0, 0)
+				if err != nil {
+					return nil, err
+				}
+			} else if r, ok := _data.(*fileReaderWrapper); ok {
+				fd, err := os.Open(r.filePath)
+				if err != nil {
+					return nil, err
+				}
+				defer fd.Close()
+				fileReaderWrapper := &fileReaderWrapper{filePath: r.filePath}
+				fileReaderWrapper.mark = r.mark
+				fileReaderWrapper.reader = fd
+				fileReaderWrapper.totalCount = r.totalCount
+				_data = fileReaderWrapper
+				_, err = fd.Seek(r.mark, 0)
+				if err != nil {
+					return nil, err
+				}
+			} else if r, ok := _data.(*readerWrapper); ok {
+				_, err := r.seek(0, 0)
+				if err != nil {
+					return nil, err
+				}
+			}
+			time.Sleep(time.Duration(float64(i+2) * rand.Float64() * float64(time.Second)))
+		} else {
+			doLog(LEVEL_ERROR, "Failed to send request with reason:%v", msg)
+			if resp != nil {
+				respError = ParseResponseToObsError(resp, obsClient.conf.signature == SignatureObs)
+				resp = nil
+			}
+		}
+	}
+	return
+}
+
+type connDelegate struct {
+	conn          net.Conn
+	socketTimeout time.Duration
+	finalTimeout  time.Duration
+}
+
+func getConnDelegate(conn net.Conn, socketTimeout int, finalTimeout int) *connDelegate {
+	return &connDelegate{
+		conn:          conn,
+		socketTimeout: time.Second * time.Duration(socketTimeout),
+		finalTimeout:  time.Second * time.Duration(finalTimeout),
+	}
+}
+
+func (delegate *connDelegate) Read(b []byte) (n int, err error) {
+	setReadDeadlineErr := delegate.SetReadDeadline(time.Now().Add(delegate.socketTimeout))
+	flag := isDebugLogEnabled()
+
+	if setReadDeadlineErr != nil && flag {
+		doLog(LEVEL_DEBUG, "Failed to set read deadline with reason: %v, but it's ok", setReadDeadlineErr)
+	}
+
+	n, err = delegate.conn.Read(b)
+	setReadDeadlineErr = delegate.SetReadDeadline(time.Now().Add(delegate.finalTimeout))
+	if setReadDeadlineErr != nil && flag {
+		doLog(LEVEL_DEBUG, "Failed to set read deadline with reason: %v, but it's ok", setReadDeadlineErr)
+	}
+	return n, err
+}
+
+func (delegate *connDelegate) Write(b []byte) (n int, err error) {
+	setWriteDeadlineErr := delegate.SetWriteDeadline(time.Now().Add(delegate.socketTimeout))
+	flag := isDebugLogEnabled()
+	if setWriteDeadlineErr != nil && flag {
+		doLog(LEVEL_DEBUG, "Failed to set write deadline with reason: %v, but it's ok", setWriteDeadlineErr)
+	}
+
+	n, err = delegate.conn.Write(b)
+	finalTimeout := time.Now().Add(delegate.finalTimeout)
+	setWriteDeadlineErr = delegate.SetWriteDeadline(finalTimeout)
+	if setWriteDeadlineErr != nil && flag {
+		doLog(LEVEL_DEBUG, "Failed to set write deadline with reason: %v, but it's ok", setWriteDeadlineErr)
+	}
+	setReadDeadlineErr := delegate.SetReadDeadline(finalTimeout)
+	if setReadDeadlineErr != nil && flag {
+		doLog(LEVEL_DEBUG, "Failed to set read deadline with reason: %v, but it's ok", setReadDeadlineErr)
+	}
+	return n, err
+}
+
+func (delegate *connDelegate) Close() error {
+	return delegate.conn.Close()
+}
+
+func (delegate *connDelegate) LocalAddr() net.Addr {
+	return delegate.conn.LocalAddr()
+}
+
+func (delegate *connDelegate) RemoteAddr() net.Addr {
+	return delegate.conn.RemoteAddr()
+}
+
+func (delegate *connDelegate) SetDeadline(t time.Time) error {
+	return delegate.conn.SetDeadline(t)
+}
+
+func (delegate *connDelegate) SetReadDeadline(t time.Time) error {
+	return delegate.conn.SetReadDeadline(t)
+}
+
+func (delegate *connDelegate) SetWriteDeadline(t time.Time) error {
+	return delegate.conn.SetWriteDeadline(t)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/log.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/log.go
@@ -1,0 +1,298 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+type Level int
+
+const (
+	LEVEL_OFF   Level = 500
+	LEVEL_ERROR Level = 400
+	LEVEL_WARN  Level = 300
+	LEVEL_INFO  Level = 200
+	LEVEL_DEBUG Level = 100
+)
+
+var logLevelMap = map[Level]string{
+	LEVEL_OFF:   "[OFF]: ",
+	LEVEL_ERROR: "[ERROR]: ",
+	LEVEL_WARN:  "[WARN]: ",
+	LEVEL_INFO:  "[INFO]: ",
+	LEVEL_DEBUG: "[DEBUG]: ",
+}
+
+type logConfType struct {
+	level        Level
+	logToConsole bool
+	logFullPath  string
+	maxLogSize   int64
+	backups      int
+}
+
+func getDefaultLogConf() logConfType {
+	return logConfType{
+		level:        LEVEL_WARN,
+		logToConsole: false,
+		logFullPath:  "",
+		maxLogSize:   1024 * 1024 * 30, //30MB
+		backups:      10,
+	}
+}
+
+var logConf logConfType
+
+type loggerWrapper struct {
+	fullPath   string
+	fd         *os.File
+	ch         chan string
+	wg         sync.WaitGroup
+	queue      []string
+	logger     *log.Logger
+	index      int
+	cacheCount int
+	closed     bool
+}
+
+func (lw *loggerWrapper) doInit() {
+	lw.queue = make([]string, 0, lw.cacheCount)
+	lw.logger = log.New(lw.fd, "", 0)
+	lw.ch = make(chan string, lw.cacheCount)
+	lw.wg.Add(1)
+	go lw.doWrite()
+}
+
+func (lw *loggerWrapper) rotate() {
+	stat, err := lw.fd.Stat()
+	if err != nil {
+		lw.fd.Close()
+		panic(err)
+	}
+	if stat.Size() >= logConf.maxLogSize {
+		_err := lw.fd.Sync()
+		if _err != nil {
+			panic(err)
+		}
+		lw.fd.Close()
+		if lw.index > logConf.backups {
+			lw.index = 1
+		}
+		_err = os.Rename(lw.fullPath, lw.fullPath+"."+IntToString(lw.index))
+		if _err != nil {
+			panic(err)
+		}
+		lw.index += 1
+
+		fd, err := os.OpenFile(lw.fullPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err != nil {
+			panic(err)
+		}
+		lw.fd = fd
+		lw.logger.SetOutput(lw.fd)
+	}
+}
+
+func (lw *loggerWrapper) doFlush() {
+	lw.rotate()
+	for _, m := range lw.queue {
+		lw.logger.Println(m)
+	}
+	err := lw.fd.Sync()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (lw *loggerWrapper) doClose() {
+	lw.closed = true
+	close(lw.ch)
+	lw.wg.Wait()
+}
+
+func (lw *loggerWrapper) doWrite() {
+	defer lw.wg.Done()
+	for {
+		msg, ok := <-lw.ch
+		if !ok {
+			lw.doFlush()
+			lw.fd.Close()
+			break
+		}
+		if len(lw.queue) >= lw.cacheCount {
+			lw.doFlush()
+			lw.queue = make([]string, 0, lw.cacheCount)
+		}
+		lw.queue = append(lw.queue, msg)
+	}
+
+}
+
+func (lw *loggerWrapper) Printf(format string, v ...interface{}) {
+	if !lw.closed {
+		msg := fmt.Sprintf(format, v...)
+		lw.ch <- msg
+	}
+}
+
+var consoleLogger *log.Logger
+var fileLogger *loggerWrapper
+var lock *sync.RWMutex = new(sync.RWMutex)
+
+func isDebugLogEnabled() bool {
+	return logConf.level <= LEVEL_DEBUG
+}
+
+func isErrorLogEnabled() bool {
+	return logConf.level <= LEVEL_ERROR
+}
+
+func isWarnLogEnabled() bool {
+	return logConf.level <= LEVEL_WARN
+}
+
+func isInfoLogEnabled() bool {
+	return logConf.level <= LEVEL_INFO
+}
+
+func reset() {
+	if fileLogger != nil {
+		fileLogger.doClose()
+		fileLogger = nil
+	}
+	consoleLogger = nil
+	logConf = getDefaultLogConf()
+}
+
+func InitLog(logFullPath string, maxLogSize int64, backups int, level Level, logToConsole bool) error {
+	return InitLogWithCacheCnt(logFullPath, maxLogSize, backups, level, logToConsole, 50)
+}
+
+func InitLogWithCacheCnt(logFullPath string, maxLogSize int64, backups int, level Level, logToConsole bool, cacheCnt int) error {
+	lock.Lock()
+	defer lock.Unlock()
+	if cacheCnt <= 0 {
+		cacheCnt = 50
+	}
+	reset()
+	if fullPath := strings.TrimSpace(logFullPath); fullPath != "" {
+		_fullPath, err := filepath.Abs(fullPath)
+		if err != nil {
+			return err
+		}
+
+		if !strings.HasSuffix(_fullPath, ".log") {
+			_fullPath += ".log"
+		}
+
+		stat, err := os.Stat(_fullPath)
+		if err == nil && stat.IsDir() {
+			return errors.New(fmt.Sprintf("logFullPath:[%s] is a directory", _fullPath))
+		} else if err := os.MkdirAll(filepath.Dir(_fullPath), os.ModePerm); err != nil {
+			return err
+		}
+
+		fd, err := os.OpenFile(_fullPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err != nil {
+			return err
+		}
+
+		if stat == nil {
+			stat, err = os.Stat(_fullPath)
+			if err != nil {
+				fd.Close()
+				return err
+			}
+		}
+
+		prefix := stat.Name() + "."
+		index := 1
+		walkFunc := func(path string, info os.FileInfo, err error) error {
+			if err == nil {
+				if name := info.Name(); strings.HasPrefix(name, prefix) {
+					if i := StringToInt(name[len(prefix):], 0); i >= index {
+						index = i + 1
+					}
+				}
+			}
+			return err
+		}
+
+		if err = filepath.Walk(filepath.Dir(_fullPath), walkFunc); err != nil {
+			fd.Close()
+			return err
+		}
+
+		fileLogger = &loggerWrapper{fullPath: _fullPath, fd: fd, index: index, cacheCount: cacheCnt, closed: false}
+		fileLogger.doInit()
+	}
+	if maxLogSize > 0 {
+		logConf.maxLogSize = maxLogSize
+	}
+	if backups > 0 {
+		logConf.backups = backups
+	}
+	logConf.level = level
+	if logToConsole {
+		consoleLogger = log.New(os.Stdout, "", log.LstdFlags)
+	}
+	return nil
+}
+
+func CloseLog() {
+	if logEnabled() {
+		lock.Lock()
+		defer lock.Unlock()
+		reset()
+	}
+}
+
+func SyncLog() {
+}
+
+func logEnabled() bool {
+	return consoleLogger != nil || fileLogger != nil
+}
+
+func DoLog(level Level, format string, v ...interface{}) {
+	doLog(level, format, v...)
+}
+
+func doLog(level Level, format string, v ...interface{}) {
+	if logEnabled() && logConf.level <= level {
+		msg := fmt.Sprintf(format, v...)
+		if _, file, line, ok := runtime.Caller(1); ok {
+			index := strings.LastIndex(file, "/")
+			if index >= 0 {
+				file = file[index+1:]
+			}
+			msg = fmt.Sprintf("%s:%d|%s", file, line, msg)
+		}
+		prefix := logLevelMap[level]
+		if consoleLogger != nil {
+			consoleLogger.Printf("%s%s", prefix, msg)
+		}
+		if fileLogger != nil {
+			nowDate := FormatUtcNow("2006-01-02T15:04:05Z")
+			fileLogger.Printf("%s %s%s", nowDate, prefix, msg)
+		}
+	}
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/model.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/model.go
@@ -1,0 +1,974 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"time"
+)
+
+type BaseModel struct {
+	StatusCode      int                 `xml:"-"`
+	RequestId       string              `xml:"RequestId"`
+	ResponseHeaders map[string][]string `xml:"-"`
+}
+
+type Bucket struct {
+	XMLName      xml.Name  `xml:"Bucket"`
+	Name         string    `xml:"Name"`
+	CreationDate time.Time `xml:"CreationDate"`
+	Location     string    `xml:"Location"`
+}
+
+type Owner struct {
+	XMLName     xml.Name `xml:"Owner"`
+	ID          string   `xml:"ID"`
+	DisplayName string   `xml:"DisplayName,omitempty"`
+}
+
+type Initiator struct {
+	XMLName     xml.Name `xml:"Initiator"`
+	ID          string   `xml:"ID"`
+	DisplayName string   `xml:"DisplayName,omitempty"`
+}
+
+type ListBucketsInput struct {
+	QueryLocation bool
+}
+
+type ListBucketsOutput struct {
+	BaseModel
+	XMLName xml.Name `xml:"ListAllMyBucketsResult"`
+	Owner   Owner    `xml:"Owner"`
+	Buckets []Bucket `xml:"Buckets>Bucket"`
+}
+
+type bucketLocationObs struct {
+	XMLName  xml.Name `xml:"Location"`
+	Location string   `xml:",chardata"`
+}
+
+type BucketLocation struct {
+	XMLName  xml.Name `xml:"CreateBucketConfiguration"`
+	Location string   `xml:"LocationConstraint,omitempty"`
+}
+
+type CreateBucketInput struct {
+	BucketLocation
+	Bucket                      string           `xml:"-"`
+	ACL                         AclType          `xml:"-"`
+	StorageClass                StorageClassType `xml:"-"`
+	GrantReadId                 string           `xml:"-"`
+	GrantWriteId                string           `xml:"-"`
+	GrantReadAcpId              string           `xml:"-"`
+	GrantWriteAcpId             string           `xml:"-"`
+	GrantFullControlId          string           `xml:"-"`
+	GrantReadDeliveredId        string           `xml:"-"`
+	GrantFullControlDeliveredId string           `xml:"-"`
+	Epid                        string           `xml:"-"`
+}
+
+type BucketStoragePolicy struct {
+	XMLName      xml.Name         `xml:"StoragePolicy"`
+	StorageClass StorageClassType `xml:"DefaultStorageClass"`
+}
+
+type SetBucketStoragePolicyInput struct {
+	Bucket string `xml:"-"`
+	BucketStoragePolicy
+}
+
+type getBucketStoragePolicyOutputS3 struct {
+	BaseModel
+	BucketStoragePolicy
+}
+
+type GetBucketStoragePolicyOutput struct {
+	BaseModel
+	StorageClass string
+}
+
+type bucketStoragePolicyObs struct {
+	XMLName      xml.Name `xml:"StorageClass"`
+	StorageClass string   `xml:",chardata"`
+}
+type getBucketStoragePolicyOutputObs struct {
+	BaseModel
+	bucketStoragePolicyObs
+}
+
+type ListObjsInput struct {
+	Prefix        string
+	MaxKeys       int
+	Delimiter     string
+	Origin        string
+	RequestHeader string
+}
+
+type ListObjectsInput struct {
+	ListObjsInput
+	Bucket string
+	Marker string
+}
+
+type Content struct {
+	XMLName      xml.Name         `xml:"Contents"`
+	Owner        Owner            `xml:"Owner"`
+	ETag         string           `xml:"ETag"`
+	Key          string           `xml:"Key"`
+	LastModified time.Time        `xml:"LastModified"`
+	Size         int64            `xml:"Size"`
+	StorageClass StorageClassType `xml:"StorageClass"`
+}
+
+type ListObjectsOutput struct {
+	BaseModel
+	XMLName        xml.Name  `xml:"ListBucketResult"`
+	Delimiter      string    `xml:"Delimiter"`
+	IsTruncated    bool      `xml:"IsTruncated"`
+	Marker         string    `xml:"Marker"`
+	NextMarker     string    `xml:"NextMarker"`
+	MaxKeys        int       `xml:"MaxKeys"`
+	Name           string    `xml:"Name"`
+	Prefix         string    `xml:"Prefix"`
+	Contents       []Content `xml:"Contents"`
+	CommonPrefixes []string  `xml:"CommonPrefixes>Prefix"`
+	Location       string    `xml:"-"`
+}
+
+type ListVersionsInput struct {
+	ListObjsInput
+	Bucket          string
+	KeyMarker       string
+	VersionIdMarker string
+}
+
+type Version struct {
+	DeleteMarker
+	XMLName xml.Name `xml:"Version"`
+	ETag    string   `xml:"ETag"`
+	Size    int64    `xml:"Size"`
+}
+
+type DeleteMarker struct {
+	XMLName      xml.Name         `xml:"DeleteMarker"`
+	Key          string           `xml:"Key"`
+	VersionId    string           `xml:"VersionId"`
+	IsLatest     bool             `xml:"IsLatest"`
+	LastModified time.Time        `xml:"LastModified"`
+	Owner        Owner            `xml:"Owner"`
+	StorageClass StorageClassType `xml:"StorageClass"`
+}
+
+type ListVersionsOutput struct {
+	BaseModel
+	XMLName             xml.Name       `xml:"ListVersionsResult"`
+	Delimiter           string         `xml:"Delimiter"`
+	IsTruncated         bool           `xml:"IsTruncated"`
+	KeyMarker           string         `xml:"KeyMarker"`
+	NextKeyMarker       string         `xml:"NextKeyMarker"`
+	VersionIdMarker     string         `xml:"VersionIdMarker"`
+	NextVersionIdMarker string         `xml:"NextVersionIdMarker"`
+	MaxKeys             int            `xml:"MaxKeys"`
+	Name                string         `xml:"Name"`
+	Prefix              string         `xml:"Prefix"`
+	Versions            []Version      `xml:"Version"`
+	DeleteMarkers       []DeleteMarker `xml:"DeleteMarker"`
+	CommonPrefixes      []string       `xml:"CommonPrefixes>Prefix"`
+	Location            string         `xml:"-"`
+}
+
+type ListMultipartUploadsInput struct {
+	Bucket         string
+	Prefix         string
+	MaxUploads     int
+	Delimiter      string
+	KeyMarker      string
+	UploadIdMarker string
+}
+
+type Upload struct {
+	XMLName      xml.Name         `xml:"Upload"`
+	Key          string           `xml:"Key"`
+	UploadId     string           `xml:"UploadId"`
+	Initiated    time.Time        `xml:"Initiated"`
+	StorageClass StorageClassType `xml:"StorageClass"`
+	Owner        Owner            `xml:"Owner"`
+	Initiator    Initiator        `xml:"Initiator"`
+}
+
+type ListMultipartUploadsOutput struct {
+	BaseModel
+	XMLName            xml.Name `xml:"ListMultipartUploadsResult"`
+	Bucket             string   `xml:"Bucket"`
+	KeyMarker          string   `xml:"KeyMarker"`
+	NextKeyMarker      string   `xml:"NextKeyMarker"`
+	UploadIdMarker     string   `xml:"UploadIdMarker"`
+	NextUploadIdMarker string   `xml:"NextUploadIdMarker"`
+	Delimiter          string   `xml:"Delimiter"`
+	IsTruncated        bool     `xml:"IsTruncated"`
+	MaxUploads         int      `xml:"MaxUploads"`
+	Prefix             string   `xml:"Prefix"`
+	Uploads            []Upload `xml:"Upload"`
+	CommonPrefixes     []string `xml:"CommonPrefixes>Prefix"`
+}
+
+type BucketQuota struct {
+	XMLName xml.Name `xml:"Quota"`
+	Quota   int64    `xml:"StorageQuota"`
+}
+
+type SetBucketQuotaInput struct {
+	Bucket string `xml:"-"`
+	BucketQuota
+}
+
+type GetBucketQuotaOutput struct {
+	BaseModel
+	BucketQuota
+}
+
+type GetBucketStorageInfoOutput struct {
+	BaseModel
+	XMLName      xml.Name `xml:"GetBucketStorageInfoResult"`
+	Size         int64    `xml:"Size"`
+	ObjectNumber int      `xml:"ObjectNumber"`
+}
+
+type getBucketLocationOutputS3 struct {
+	BaseModel
+	BucketLocation
+}
+type getBucketLocationOutputObs struct {
+	BaseModel
+	bucketLocationObs
+}
+type GetBucketLocationOutput struct {
+	BaseModel
+	Location string `xml:"-"`
+}
+
+type Grantee struct {
+	XMLName     xml.Name     `xml:"Grantee"`
+	Type        GranteeType  `xml:"type,attr"`
+	ID          string       `xml:"ID,omitempty"`
+	DisplayName string       `xml:"DisplayName,omitempty"`
+	URI         GroupUriType `xml:"URI,omitempty"`
+}
+
+type granteeObs struct {
+	XMLName     xml.Name    `xml:"Grantee"`
+	Type        GranteeType `xml:"type,attr"`
+	ID          string      `xml:"ID,omitempty"`
+	DisplayName string      `xml:"DisplayName,omitempty"`
+	Canned      string      `xml:"Canned,omitempty"`
+}
+
+type Grant struct {
+	XMLName    xml.Name       `xml:"Grant"`
+	Grantee    Grantee        `xml:"Grantee"`
+	Permission PermissionType `xml:"Permission"`
+	Delivered  bool           `xml:"Delivered"`
+}
+type grantObs struct {
+	XMLName    xml.Name       `xml:"Grant"`
+	Grantee    granteeObs     `xml:"Grantee"`
+	Permission PermissionType `xml:"Permission"`
+	Delivered  bool           `xml:"Delivered"`
+}
+
+type AccessControlPolicy struct {
+	XMLName   xml.Name `xml:"AccessControlPolicy"`
+	Owner     Owner    `xml:"Owner"`
+	Grants    []Grant  `xml:"AccessControlList>Grant"`
+	Delivered string   `xml:"Delivered,omitempty"`
+}
+
+type accessControlPolicyObs struct {
+	XMLName xml.Name   `xml:"AccessControlPolicy"`
+	Owner   Owner      `xml:"Owner"`
+	Grants  []grantObs `xml:"AccessControlList>Grant"`
+}
+
+type GetBucketAclOutput struct {
+	BaseModel
+	AccessControlPolicy
+}
+
+type getBucketAclOutputObs struct {
+	BaseModel
+	accessControlPolicyObs
+}
+
+type SetBucketAclInput struct {
+	Bucket string  `xml:"-"`
+	ACL    AclType `xml:"-"`
+	AccessControlPolicy
+}
+
+type SetBucketPolicyInput struct {
+	Bucket string
+	Policy string
+}
+
+type GetBucketPolicyOutput struct {
+	BaseModel
+	Policy string `json:"body"`
+}
+
+type CorsRule struct {
+	XMLName       xml.Name `xml:"CORSRule"`
+	ID            string   `xml:"ID,omitempty"`
+	AllowedOrigin []string `xml:"AllowedOrigin"`
+	AllowedMethod []string `xml:"AllowedMethod"`
+	AllowedHeader []string `xml:"AllowedHeader,omitempty"`
+	MaxAgeSeconds int      `xml:"MaxAgeSeconds"`
+	ExposeHeader  []string `xml:"ExposeHeader,omitempty"`
+}
+
+type BucketCors struct {
+	XMLName   xml.Name   `xml:"CORSConfiguration"`
+	CorsRules []CorsRule `xml:"CORSRule"`
+}
+
+type SetBucketCorsInput struct {
+	Bucket string `xml:"-"`
+	BucketCors
+}
+
+type GetBucketCorsOutput struct {
+	BaseModel
+	BucketCors
+}
+
+type BucketVersioningConfiguration struct {
+	XMLName xml.Name             `xml:"VersioningConfiguration"`
+	Status  VersioningStatusType `xml:"Status"`
+}
+
+type SetBucketVersioningInput struct {
+	Bucket string `xml:"-"`
+	BucketVersioningConfiguration
+}
+
+type GetBucketVersioningOutput struct {
+	BaseModel
+	BucketVersioningConfiguration
+}
+
+type IndexDocument struct {
+	Suffix string `xml:"Suffix"`
+}
+
+type ErrorDocument struct {
+	Key string `xml:"Key,omitempty"`
+}
+
+type Condition struct {
+	XMLName                     xml.Name `xml:"Condition"`
+	KeyPrefixEquals             string   `xml:"KeyPrefixEquals,omitempty"`
+	HttpErrorCodeReturnedEquals string   `xml:"HttpErrorCodeReturnedEquals,omitempty"`
+}
+
+type Redirect struct {
+	XMLName              xml.Name     `xml:"Redirect"`
+	Protocol             ProtocolType `xml:"Protocol,omitempty"`
+	HostName             string       `xml:"HostName,omitempty"`
+	ReplaceKeyPrefixWith string       `xml:"ReplaceKeyPrefixWith,omitempty"`
+	ReplaceKeyWith       string       `xml:"ReplaceKeyWith,omitempty"`
+	HttpRedirectCode     string       `xml:"HttpRedirectCode,omitempty"`
+}
+
+type RoutingRule struct {
+	XMLName   xml.Name  `xml:"RoutingRule"`
+	Condition Condition `xml:"Condition,omitempty"`
+	Redirect  Redirect  `xml:"Redirect"`
+}
+
+type RedirectAllRequestsTo struct {
+	XMLName  xml.Name     `xml:"RedirectAllRequestsTo"`
+	Protocol ProtocolType `xml:"Protocol,omitempty"`
+	HostName string       `xml:"HostName"`
+}
+
+type BucketWebsiteConfiguration struct {
+	XMLName               xml.Name              `xml:"WebsiteConfiguration"`
+	RedirectAllRequestsTo RedirectAllRequestsTo `xml:"RedirectAllRequestsTo,omitempty"`
+	IndexDocument         IndexDocument         `xml:"IndexDocument,omitempty"`
+	ErrorDocument         ErrorDocument         `xml:"ErrorDocument,omitempty"`
+	RoutingRules          []RoutingRule         `xml:"RoutingRules>RoutingRule,omitempty"`
+}
+
+type SetBucketWebsiteConfigurationInput struct {
+	Bucket string `xml:"-"`
+	BucketWebsiteConfiguration
+}
+
+type GetBucketWebsiteConfigurationOutput struct {
+	BaseModel
+	BucketWebsiteConfiguration
+}
+
+type GetBucketMetadataInput struct {
+	Bucket        string
+	Origin        string
+	RequestHeader string
+}
+
+type SetObjectMetadataInput struct {
+	Bucket                  string
+	Key                     string
+	VersionId               string
+	MetadataDirective       MetadataDirectiveType
+	CacheControl            string
+	ContentDisposition      string
+	ContentEncoding         string
+	ContentLanguage         string
+	ContentType             string
+	Expires                 string
+	WebsiteRedirectLocation string
+	StorageClass            StorageClassType
+	Metadata                map[string]string
+}
+
+type SetObjectMetadataOutput struct {
+	BaseModel
+	MetadataDirective       MetadataDirectiveType
+	CacheControl            string
+	ContentDisposition      string
+	ContentEncoding         string
+	ContentLanguage         string
+	ContentType             string
+	Expires                 string
+	WebsiteRedirectLocation string
+	StorageClass            StorageClassType
+	Metadata                map[string]string
+}
+
+type GetBucketMetadataOutput struct {
+	BaseModel
+	StorageClass  StorageClassType
+	Location      string
+	Version       string
+	AllowOrigin   string
+	AllowMethod   string
+	AllowHeader   string
+	MaxAgeSeconds int
+	ExposeHeader  string
+	Epid          string
+}
+
+type BucketLoggingStatus struct {
+	XMLName      xml.Name `xml:"BucketLoggingStatus"`
+	Agency       string   `xml:"Agency,omitempty"`
+	TargetBucket string   `xml:"LoggingEnabled>TargetBucket,omitempty"`
+	TargetPrefix string   `xml:"LoggingEnabled>TargetPrefix,omitempty"`
+	TargetGrants []Grant  `xml:"LoggingEnabled>TargetGrants>Grant,omitempty"`
+}
+
+type SetBucketLoggingConfigurationInput struct {
+	Bucket string `xml:"-"`
+	BucketLoggingStatus
+}
+
+type GetBucketLoggingConfigurationOutput struct {
+	BaseModel
+	BucketLoggingStatus
+}
+
+type Transition struct {
+	XMLName      xml.Name         `xml:"Transition"`
+	Date         time.Time        `xml:"Date,omitempty"`
+	Days         int              `xml:"Days,omitempty"`
+	StorageClass StorageClassType `xml:"StorageClass"`
+}
+
+type Expiration struct {
+	XMLName xml.Name  `xml:"Expiration"`
+	Date    time.Time `xml:"Date,omitempty"`
+	Days    int       `xml:"Days,omitempty"`
+}
+
+type NoncurrentVersionTransition struct {
+	XMLName        xml.Name         `xml:"NoncurrentVersionTransition"`
+	NoncurrentDays int              `xml:"NoncurrentDays"`
+	StorageClass   StorageClassType `xml:"StorageClass"`
+}
+
+type NoncurrentVersionExpiration struct {
+	XMLName        xml.Name `xml:"NoncurrentVersionExpiration"`
+	NoncurrentDays int      `xml:"NoncurrentDays"`
+}
+
+type LifecycleRule struct {
+	ID                           string                        `xml:"ID,omitempty"`
+	Prefix                       string                        `xml:"Prefix"`
+	Status                       RuleStatusType                `xml:"Status"`
+	Transitions                  []Transition                  `xml:"Transition,omitempty"`
+	Expiration                   Expiration                    `xml:"Expiration,omitempty"`
+	NoncurrentVersionTransitions []NoncurrentVersionTransition `xml:"NoncurrentVersionTransition,omitempty"`
+	NoncurrentVersionExpiration  NoncurrentVersionExpiration   `xml:"NoncurrentVersionExpiration,omitempty"`
+}
+
+type BucketLifecyleConfiguration struct {
+	XMLName        xml.Name        `xml:"LifecycleConfiguration"`
+	LifecycleRules []LifecycleRule `xml:"Rule"`
+}
+
+type SetBucketLifecycleConfigurationInput struct {
+	Bucket string `xml:"-"`
+	BucketLifecyleConfiguration
+}
+
+type GetBucketLifecycleConfigurationOutput struct {
+	BaseModel
+	BucketLifecyleConfiguration
+}
+
+type Tag struct {
+	XMLName xml.Name `xml:"Tag"`
+	Key     string   `xml:"Key"`
+	Value   string   `xml:"Value"`
+}
+
+type BucketTagging struct {
+	XMLName xml.Name `xml:"Tagging"`
+	Tags    []Tag    `xml:"TagSet>Tag"`
+}
+
+type SetBucketTaggingInput struct {
+	Bucket string `xml:"-"`
+	BucketTagging
+}
+
+type GetBucketTaggingOutput struct {
+	BaseModel
+	BucketTagging
+}
+
+type FilterRule struct {
+	XMLName xml.Name `xml:"FilterRule"`
+	Name    string   `xml:"Name,omitempty"`
+	Value   string   `xml:"Value,omitempty"`
+}
+
+type TopicConfiguration struct {
+	XMLName     xml.Name     `xml:"TopicConfiguration"`
+	ID          string       `xml:"Id,omitempty"`
+	Topic       string       `xml:"Topic"`
+	Events      []EventType  `xml:"Event"`
+	FilterRules []FilterRule `xml:"Filter>Object>FilterRule"`
+}
+
+type BucketNotification struct {
+	XMLName             xml.Name             `xml:"NotificationConfiguration"`
+	TopicConfigurations []TopicConfiguration `xml:"TopicConfiguration"`
+}
+
+type SetBucketNotificationInput struct {
+	Bucket string `xml:"-"`
+	BucketNotification
+}
+
+type topicConfigurationS3 struct {
+	XMLName     xml.Name     `xml:"TopicConfiguration"`
+	ID          string       `xml:"Id,omitempty"`
+	Topic       string       `xml:"Topic"`
+	Events      []string     `xml:"Event"`
+	FilterRules []FilterRule `xml:"Filter>S3Key>FilterRule"`
+}
+
+type bucketNotificationS3 struct {
+	XMLName             xml.Name               `xml:"NotificationConfiguration"`
+	TopicConfigurations []topicConfigurationS3 `xml:"TopicConfiguration"`
+}
+
+type getBucketNotificationOutputS3 struct {
+	BaseModel
+	bucketNotificationS3
+}
+
+type GetBucketNotificationOutput struct {
+	BaseModel
+	BucketNotification
+}
+
+type DeleteObjectInput struct {
+	Bucket    string
+	Key       string
+	VersionId string
+}
+
+type DeleteObjectOutput struct {
+	BaseModel
+	VersionId    string
+	DeleteMarker bool
+}
+
+type ObjectToDelete struct {
+	XMLName   xml.Name `xml:"Object"`
+	Key       string   `xml:"Key"`
+	VersionId string   `xml:"VersionId,omitempty"`
+}
+
+type DeleteObjectsInput struct {
+	Bucket  string           `xml:"-"`
+	XMLName xml.Name         `xml:"Delete"`
+	Quiet   bool             `xml:"Quiet,omitempty"`
+	Objects []ObjectToDelete `xml:"Object"`
+}
+
+type Deleted struct {
+	XMLName               xml.Name `xml:"Deleted"`
+	Key                   string   `xml:"Key"`
+	VersionId             string   `xml:"VersionId"`
+	DeleteMarker          bool     `xml:"DeleteMarker"`
+	DeleteMarkerVersionId string   `xml:"DeleteMarkerVersionId"`
+}
+
+type Error struct {
+	XMLName   xml.Name `xml:"Error"`
+	Key       string   `xml:"Key"`
+	VersionId string   `xml:"VersionId"`
+	Code      string   `xml:"Code"`
+	Message   string   `xml:"Message"`
+}
+
+type DeleteObjectsOutput struct {
+	BaseModel
+	XMLName  xml.Name  `xml:"DeleteResult"`
+	Deleteds []Deleted `xml:"Deleted"`
+	Errors   []Error   `xml:"Error"`
+}
+
+type SetObjectAclInput struct {
+	Bucket    string  `xml:"-"`
+	Key       string  `xml:"-"`
+	VersionId string  `xml:"-"`
+	ACL       AclType `xml:"-"`
+	AccessControlPolicy
+}
+
+type GetObjectAclInput struct {
+	Bucket    string
+	Key       string
+	VersionId string
+}
+
+type GetObjectAclOutput struct {
+	BaseModel
+	VersionId string
+	AccessControlPolicy
+}
+
+type RestoreObjectInput struct {
+	Bucket    string          `xml:"-"`
+	Key       string          `xml:"-"`
+	VersionId string          `xml:"-"`
+	XMLName   xml.Name        `xml:"RestoreRequest"`
+	Days      int             `xml:"Days"`
+	Tier      RestoreTierType `xml:"GlacierJobParameters>Tier,omitempty"`
+}
+
+type ISseHeader interface {
+	GetEncryption() string
+	GetKey() string
+}
+
+type SseKmsHeader struct {
+	Encryption string
+	Key        string
+	isObs      bool
+}
+
+type SseCHeader struct {
+	Encryption string
+	Key        string
+	KeyMD5     string
+}
+
+type GetObjectMetadataInput struct {
+	Bucket        string
+	Key           string
+	VersionId     string
+	Origin        string
+	RequestHeader string
+	SseHeader     ISseHeader
+}
+
+type GetObjectMetadataOutput struct {
+	BaseModel
+	VersionId               string
+	WebsiteRedirectLocation string
+	Expiration              string
+	Restore                 string
+	ObjectType              string
+	NextAppendPosition      string
+	StorageClass            StorageClassType
+	ContentLength           int64
+	ContentType             string
+	ETag                    string
+	AllowOrigin             string
+	AllowHeader             string
+	AllowMethod             string
+	ExposeHeader            string
+	MaxAgeSeconds           int
+	LastModified            time.Time
+	SseHeader               ISseHeader
+	Metadata                map[string]string
+}
+
+type GetObjectInput struct {
+	GetObjectMetadataInput
+	IfMatch                    string
+	IfNoneMatch                string
+	IfUnmodifiedSince          time.Time
+	IfModifiedSince            time.Time
+	RangeStart                 int64
+	RangeEnd                   int64
+	ImageProcess               string
+	ResponseCacheControl       string
+	ResponseContentDisposition string
+	ResponseContentEncoding    string
+	ResponseContentLanguage    string
+	ResponseContentType        string
+	ResponseExpires            string
+}
+
+type GetObjectOutput struct {
+	GetObjectMetadataOutput
+	DeleteMarker       bool
+	CacheControl       string
+	ContentDisposition string
+	ContentEncoding    string
+	ContentLanguage    string
+	Expires            string
+	Body               io.ReadCloser
+}
+
+type ObjectOperationInput struct {
+	Bucket                  string
+	Key                     string
+	ACL                     AclType
+	GrantReadId             string
+	GrantReadAcpId          string
+	GrantWriteAcpId         string
+	GrantFullControlId      string
+	StorageClass            StorageClassType
+	WebsiteRedirectLocation string
+	Expires                 int64
+	SseHeader               ISseHeader
+	Metadata                map[string]string
+}
+
+type PutObjectBasicInput struct {
+	ObjectOperationInput
+	ContentType   string
+	ContentMD5    string
+	ContentLength int64
+}
+
+type PutObjectInput struct {
+	PutObjectBasicInput
+	Body io.Reader
+}
+
+type PutFileInput struct {
+	PutObjectBasicInput
+	SourceFile string
+}
+
+type PutObjectOutput struct {
+	BaseModel
+	VersionId    string
+	SseHeader    ISseHeader
+	StorageClass StorageClassType
+	ETag         string
+}
+
+type CopyObjectInput struct {
+	ObjectOperationInput
+	CopySourceBucket            string
+	CopySourceKey               string
+	CopySourceVersionId         string
+	CopySourceIfMatch           string
+	CopySourceIfNoneMatch       string
+	CopySourceIfUnmodifiedSince time.Time
+	CopySourceIfModifiedSince   time.Time
+	SourceSseHeader             ISseHeader
+	CacheControl                string
+	ContentDisposition          string
+	ContentEncoding             string
+	ContentLanguage             string
+	ContentType                 string
+	Expires                     string
+	MetadataDirective           MetadataDirectiveType
+	SuccessActionRedirect       string
+}
+
+type CopyObjectOutput struct {
+	BaseModel
+	CopySourceVersionId string     `xml:"-"`
+	VersionId           string     `xml:"-"`
+	SseHeader           ISseHeader `xml:"-"`
+	XMLName             xml.Name   `xml:"CopyObjectResult"`
+	LastModified        time.Time  `xml:"LastModified"`
+	ETag                string     `xml:"ETag"`
+}
+
+type AbortMultipartUploadInput struct {
+	Bucket   string
+	Key      string
+	UploadId string
+}
+
+type InitiateMultipartUploadInput struct {
+	ObjectOperationInput
+	ContentType string
+}
+
+type InitiateMultipartUploadOutput struct {
+	BaseModel
+	XMLName   xml.Name `xml:"InitiateMultipartUploadResult"`
+	Bucket    string   `xml:"Bucket"`
+	Key       string   `xml:"Key"`
+	UploadId  string   `xml:"UploadId"`
+	SseHeader ISseHeader
+}
+
+type UploadPartInput struct {
+	Bucket     string
+	Key        string
+	PartNumber int
+	UploadId   string
+	ContentMD5 string
+	SseHeader  ISseHeader
+	Body       io.Reader
+	SourceFile string
+	Offset     int64
+	PartSize   int64
+}
+
+type UploadPartOutput struct {
+	BaseModel
+	PartNumber int
+	ETag       string
+	SseHeader  ISseHeader
+}
+
+type Part struct {
+	XMLName      xml.Name  `xml:"Part"`
+	PartNumber   int       `xml:"PartNumber"`
+	ETag         string    `xml:"ETag"`
+	LastModified time.Time `xml:"LastModified,omitempty"`
+	Size         int64     `xml:"Size,omitempty"`
+}
+
+type CompleteMultipartUploadInput struct {
+	Bucket   string   `xml:"-"`
+	Key      string   `xml:"-"`
+	UploadId string   `xml:"-"`
+	XMLName  xml.Name `xml:"CompleteMultipartUpload"`
+	Parts    []Part   `xml:"Part"`
+}
+
+type CompleteMultipartUploadOutput struct {
+	BaseModel
+	VersionId string     `xml:"-"`
+	SseHeader ISseHeader `xml:"-"`
+	XMLName   xml.Name   `xml:"CompleteMultipartUploadResult"`
+	Location  string     `xml:"Location"`
+	Bucket    string     `xml:"Bucket"`
+	Key       string     `xml:"Key"`
+	ETag      string     `xml:"ETag"`
+}
+
+type ListPartsInput struct {
+	Bucket           string
+	Key              string
+	UploadId         string
+	MaxParts         int
+	PartNumberMarker int
+}
+
+type ListPartsOutput struct {
+	BaseModel
+	XMLName              xml.Name         `xml:"ListPartsResult"`
+	Bucket               string           `xml:"Bucket"`
+	Key                  string           `xml:"Key"`
+	UploadId             string           `xml:"UploadId"`
+	PartNumberMarker     int              `xml:"PartNumberMarker"`
+	NextPartNumberMarker int              `xml:"NextPartNumberMarker"`
+	MaxParts             int              `xml:"MaxParts"`
+	IsTruncated          bool             `xml:"IsTruncated"`
+	StorageClass         StorageClassType `xml:"StorageClass"`
+	Initiator            Initiator        `xml:"Initiator"`
+	Owner                Owner            `xml:"Owner"`
+	Parts                []Part           `xml:"Part"`
+}
+
+type CopyPartInput struct {
+	Bucket               string
+	Key                  string
+	UploadId             string
+	PartNumber           int
+	CopySourceBucket     string
+	CopySourceKey        string
+	CopySourceVersionId  string
+	CopySourceRangeStart int64
+	CopySourceRangeEnd   int64
+	SseHeader            ISseHeader
+	SourceSseHeader      ISseHeader
+}
+
+type CopyPartOutput struct {
+	BaseModel
+	XMLName      xml.Name   `xml:"CopyPartResult"`
+	PartNumber   int        `xml:"-"`
+	ETag         string     `xml:"ETag"`
+	LastModified time.Time  `xml:"LastModified"`
+	SseHeader    ISseHeader `xml:"-"`
+}
+
+type CreateSignedUrlInput struct {
+	Method      HttpMethodType
+	Bucket      string
+	Key         string
+	SubResource SubResourceType
+	Expires     int
+	Headers     map[string]string
+	QueryParams map[string]string
+}
+
+type CreateSignedUrlOutput struct {
+	SignedUrl                  string
+	ActualSignedRequestHeaders http.Header
+}
+
+type CreateBrowserBasedSignatureInput struct {
+	Bucket     string
+	Key        string
+	Expires    int
+	FormParams map[string]string
+}
+
+type CreateBrowserBasedSignatureOutput struct {
+	OriginPolicy string
+	Policy       string
+	Algorithm    string
+	Credential   string
+	Date         string
+	Signature    string
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/temporary.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/temporary.go
@@ -1,0 +1,682 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func (obsClient ObsClient) CreateSignedUrl(input *CreateSignedUrlInput) (output *CreateSignedUrlOutput, err error) {
+	if input == nil {
+		return nil, errors.New("CreateSignedUrlInput is nil")
+	}
+
+	params := make(map[string]string, len(input.QueryParams))
+	for key, value := range input.QueryParams {
+		params[key] = value
+	}
+
+	if input.SubResource != "" {
+		params[string(input.SubResource)] = ""
+	}
+
+	headers := make(map[string][]string, len(input.Headers))
+	for key, value := range input.Headers {
+		headers[key] = []string{value}
+	}
+
+	if input.Expires <= 0 {
+		input.Expires = 300
+	}
+
+	requestUrl, err := obsClient.doAuthTemporary(string(input.Method), input.Bucket, input.Key, params, headers, int64(input.Expires))
+	if err != nil {
+		return nil, err
+	}
+
+	output = &CreateSignedUrlOutput{
+		SignedUrl:                  requestUrl,
+		ActualSignedRequestHeaders: headers,
+	}
+	return
+}
+
+func (obsClient ObsClient) CreateBrowserBasedSignature(input *CreateBrowserBasedSignatureInput) (output *CreateBrowserBasedSignatureOutput, err error) {
+	if input == nil {
+		return nil, errors.New("CreateBrowserBasedSignatureInput is nil")
+	}
+
+	params := make(map[string]string, len(input.FormParams))
+	for key, value := range input.FormParams {
+		params[key] = value
+	}
+
+	date := time.Now().UTC()
+	shortDate := date.Format(SHORT_DATE_FORMAT)
+	longDate := date.Format(LONG_DATE_FORMAT)
+
+	credential, _ := getCredential(obsClient.conf.securityProvider.ak, obsClient.conf.region, shortDate)
+
+	if input.Expires <= 0 {
+		input.Expires = 300
+	}
+
+	expiration := date.Add(time.Second * time.Duration(input.Expires)).Format(ISO8601_DATE_FORMAT)
+	params[PARAM_ALGORITHM_AMZ_CAMEL] = V4_HASH_PREFIX
+	params[PARAM_CREDENTIAL_AMZ_CAMEL] = credential
+	params[PARAM_DATE_AMZ_CAMEL] = longDate
+
+	if obsClient.conf.securityProvider.securityToken != "" {
+		if obsClient.conf.signature == SignatureObs {
+			params[HEADER_STS_TOKEN_OBS] = obsClient.conf.securityProvider.securityToken
+		} else {
+			params[HEADER_STS_TOKEN_AMZ] = obsClient.conf.securityProvider.securityToken
+		}
+	}
+
+	matchAnyBucket := true
+	matchAnyKey := true
+	count := 5
+	if bucket := strings.TrimSpace(input.Bucket); bucket != "" {
+		params["bucket"] = bucket
+		matchAnyBucket = false
+		count--
+	}
+
+	if key := strings.TrimSpace(input.Key); key != "" {
+		params["key"] = key
+		matchAnyKey = false
+		count--
+	}
+
+	originPolicySlice := make([]string, 0, len(params)+count)
+	originPolicySlice = append(originPolicySlice, fmt.Sprintf("{\"expiration\":\"%s\",", expiration))
+	originPolicySlice = append(originPolicySlice, "\"conditions\":[")
+	for key, value := range params {
+		if _key := strings.TrimSpace(strings.ToLower(key)); _key != "" {
+			originPolicySlice = append(originPolicySlice, fmt.Sprintf("{\"%s\":\"%s\"},", _key, value))
+		}
+	}
+
+	if matchAnyBucket {
+		originPolicySlice = append(originPolicySlice, "[\"starts-with\", \"$bucket\", \"\"],")
+	}
+
+	if matchAnyKey {
+		originPolicySlice = append(originPolicySlice, "[\"starts-with\", \"$key\", \"\"],")
+	}
+
+	originPolicySlice = append(originPolicySlice, "]}")
+
+	originPolicy := strings.Join(originPolicySlice, "")
+	policy := Base64Encode([]byte(originPolicy))
+	signature := getSignature(policy, obsClient.conf.securityProvider.sk, obsClient.conf.region, shortDate)
+
+	output = &CreateBrowserBasedSignatureOutput{
+		OriginPolicy: originPolicy,
+		Policy:       policy,
+		Algorithm:    params[PARAM_ALGORITHM_AMZ_CAMEL],
+		Credential:   params[PARAM_CREDENTIAL_AMZ_CAMEL],
+		Date:         params[PARAM_DATE_AMZ_CAMEL],
+		Signature:    signature,
+	}
+	return
+}
+
+func (obsClient ObsClient) ListBucketsWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *ListBucketsOutput, err error) {
+	output = &ListBucketsOutput{}
+	err = obsClient.doHttpWithSignedUrl("ListBuckets", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) CreateBucketWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("CreateBucket", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucketWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("DeleteBucket", HTTP_DELETE, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketStoragePolicyWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetBucketStoragePolicy", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketStoragePolicyWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketStoragePolicyOutput, err error) {
+	output = &GetBucketStoragePolicyOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketStoragePolicy", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) ListObjectsWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *ListObjectsOutput, err error) {
+	output = &ListObjectsOutput{}
+	err = obsClient.doHttpWithSignedUrl("ListObjects", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		if location, ok := output.ResponseHeaders[HEADER_BUCKET_REGION]; ok {
+			output.Location = location[0]
+		}
+	}
+	return
+}
+
+func (obsClient ObsClient) ListVersionsWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *ListVersionsOutput, err error) {
+	output = &ListVersionsOutput{}
+	err = obsClient.doHttpWithSignedUrl("ListVersions", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		if location, ok := output.ResponseHeaders[HEADER_BUCKET_REGION]; ok {
+			output.Location = location[0]
+		}
+	}
+	return
+}
+
+func (obsClient ObsClient) ListMultipartUploadsWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *ListMultipartUploadsOutput, err error) {
+	output = &ListMultipartUploadsOutput{}
+	err = obsClient.doHttpWithSignedUrl("ListMultipartUploads", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketQuotaWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetBucketQuota", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketQuotaWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketQuotaOutput, err error) {
+	output = &GetBucketQuotaOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketQuota", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) HeadBucketWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("HeadBucket", HTTP_HEAD, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketMetadataWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketMetadataOutput, err error) {
+	output = &GetBucketMetadataOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketMetadata", HTTP_HEAD, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParseGetBucketMetadataOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketStorageInfoWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketStorageInfoOutput, err error) {
+	output = &GetBucketStorageInfoOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketStorageInfo", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketLocationWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketLocationOutput, err error) {
+	output = &GetBucketLocationOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketLocation", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketAclWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetBucketAcl", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketAclWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketAclOutput, err error) {
+	output = &GetBucketAclOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketAcl", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketPolicyWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetBucketPolicy", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketPolicyWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketPolicyOutput, err error) {
+	output = &GetBucketPolicyOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketPolicy", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, false)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucketPolicyWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("DeleteBucketPolicy", HTTP_DELETE, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketCorsWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetBucketCors", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketCorsWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketCorsOutput, err error) {
+	output = &GetBucketCorsOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketCors", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucketCorsWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("DeleteBucketCors", HTTP_DELETE, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketVersioningWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetBucketVersioning", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketVersioningWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketVersioningOutput, err error) {
+	output = &GetBucketVersioningOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketVersioning", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketWebsiteConfigurationWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetBucketWebsiteConfiguration", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketWebsiteConfigurationWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketWebsiteConfigurationOutput, err error) {
+	output = &GetBucketWebsiteConfigurationOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketWebsiteConfiguration", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucketWebsiteConfigurationWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("DeleteBucketWebsiteConfiguration", HTTP_DELETE, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketLoggingConfigurationWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetBucketLoggingConfiguration", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketLoggingConfigurationWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketLoggingConfigurationOutput, err error) {
+	output = &GetBucketLoggingConfigurationOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketLoggingConfiguration", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketLifecycleConfigurationWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetBucketLifecycleConfiguration", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketLifecycleConfigurationWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketLifecycleConfigurationOutput, err error) {
+	output = &GetBucketLifecycleConfigurationOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketLifecycleConfiguration", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucketLifecycleConfigurationWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("DeleteBucketLifecycleConfiguration", HTTP_DELETE, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketTaggingWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetBucketTagging", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketTaggingWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketTaggingOutput, err error) {
+	output = &GetBucketTaggingOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketTagging", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteBucketTaggingWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("DeleteBucketTagging", HTTP_DELETE, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketNotificationWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetBucketNotification", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketNotificationWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetBucketNotificationOutput, err error) {
+	output = &GetBucketNotificationOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetBucketNotification", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteObjectWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *DeleteObjectOutput, err error) {
+	output = &DeleteObjectOutput{}
+	err = obsClient.doHttpWithSignedUrl("DeleteObject", HTTP_DELETE, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParseDeleteObjectOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteObjectsWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *DeleteObjectsOutput, err error) {
+	output = &DeleteObjectsOutput{}
+	err = obsClient.doHttpWithSignedUrl("DeleteObjects", HTTP_POST, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetObjectAclWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("SetObjectAcl", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetObjectAclWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetObjectAclOutput, err error) {
+	output = &GetObjectAclOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetObjectAcl", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		if versionId, ok := output.ResponseHeaders[HEADER_VERSION_ID]; ok {
+			output.VersionId = versionId[0]
+		}
+	}
+	return
+}
+
+func (obsClient ObsClient) RestoreObjectWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("RestoreObject", HTTP_POST, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetObjectMetadataWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetObjectMetadataOutput, err error) {
+	output = &GetObjectMetadataOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetObjectMetadata", HTTP_HEAD, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParseGetObjectMetadataOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) GetObjectWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *GetObjectOutput, err error) {
+	output = &GetObjectOutput{}
+	err = obsClient.doHttpWithSignedUrl("GetObject", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParseGetObjectOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) PutObjectWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *PutObjectOutput, err error) {
+	output = &PutObjectOutput{}
+	err = obsClient.doHttpWithSignedUrl("PutObject", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParsePutObjectOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) PutFileWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, sourceFile string) (output *PutObjectOutput, err error) {
+	var data io.Reader
+	sourceFile = strings.TrimSpace(sourceFile)
+	if sourceFile != "" {
+		fd, err := os.Open(sourceFile)
+		if err != nil {
+			return nil, err
+		}
+		defer fd.Close()
+
+		stat, err := fd.Stat()
+		if err != nil {
+			return nil, err
+		}
+		fileReaderWrapper := &fileReaderWrapper{filePath: sourceFile}
+		fileReaderWrapper.reader = fd
+
+		var contentLength int64
+		if value, ok := actualSignedRequestHeaders[HEADER_CONTENT_LENGTH_CAMEL]; ok {
+			contentLength = StringToInt64(value[0], -1)
+		} else if value, ok := actualSignedRequestHeaders[HEADER_CONTENT_LENGTH]; ok {
+			contentLength = StringToInt64(value[0], -1)
+		} else {
+			contentLength = stat.Size()
+		}
+		if contentLength > stat.Size() {
+			return nil, errors.New("ContentLength is larger than fileSize")
+		}
+		fileReaderWrapper.totalCount = contentLength
+		data = fileReaderWrapper
+	}
+
+	output = &PutObjectOutput{}
+	err = obsClient.doHttpWithSignedUrl("PutObject", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParsePutObjectOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) CopyObjectWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *CopyObjectOutput, err error) {
+	output = &CopyObjectOutput{}
+	err = obsClient.doHttpWithSignedUrl("CopyObject", HTTP_PUT, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParseCopyObjectOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) AbortMultipartUploadWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHttpWithSignedUrl("AbortMultipartUpload", HTTP_DELETE, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) InitiateMultipartUploadWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *InitiateMultipartUploadOutput, err error) {
+	output = &InitiateMultipartUploadOutput{}
+	err = obsClient.doHttpWithSignedUrl("InitiateMultipartUpload", HTTP_POST, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParseInitiateMultipartUploadOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) UploadPartWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *UploadPartOutput, err error) {
+	output = &UploadPartOutput{}
+	err = obsClient.doHttpWithSignedUrl("UploadPart", HTTP_PUT, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParseUploadPartOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) CompleteMultipartUploadWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header, data io.Reader) (output *CompleteMultipartUploadOutput, err error) {
+	output = &CompleteMultipartUploadOutput{}
+	err = obsClient.doHttpWithSignedUrl("CompleteMultipartUpload", HTTP_POST, signedUrl, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParseCompleteMultipartUploadOutput(output)
+	}
+	return
+}
+
+func (obsClient ObsClient) ListPartsWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *ListPartsOutput, err error) {
+	output = &ListPartsOutput{}
+	err = obsClient.doHttpWithSignedUrl("ListParts", HTTP_GET, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) CopyPartWithSignedUrl(signedUrl string, actualSignedRequestHeaders http.Header) (output *CopyPartOutput, err error) {
+	output = &CopyPartOutput{}
+	err = obsClient.doHttpWithSignedUrl("CopyPart", HTTP_PUT, signedUrl, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParseCopyPartOutput(output)
+	}
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/trait.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/trait.go
@@ -1,0 +1,817 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+type IReadCloser interface {
+	setReadCloser(body io.ReadCloser)
+}
+
+func (output *GetObjectOutput) setReadCloser(body io.ReadCloser) {
+	output.Body = body
+}
+
+func setHeaders(headers map[string][]string, header string, headerValue []string, isObs bool) {
+	if isObs {
+		header = HEADER_PREFIX_OBS + header
+		headers[header] = headerValue
+	} else {
+		header = HEADER_PREFIX + header
+		headers[header] = headerValue
+	}
+}
+
+func setHeadersNext(headers map[string][]string, header string, headerNext string, headerValue []string, isObs bool) {
+	if isObs {
+		headers[header] = headerValue
+	} else {
+		headers[headerNext] = headerValue
+	}
+}
+
+type IBaseModel interface {
+	setStatusCode(statusCode int)
+
+	setRequestId(requestId string)
+
+	setResponseHeaders(responseHeaders map[string][]string)
+}
+
+type ISerializable interface {
+	trans(isObs bool) (map[string]string, map[string][]string, interface{}, error)
+}
+
+type DefaultSerializable struct {
+	params  map[string]string
+	headers map[string][]string
+	data    interface{}
+}
+
+func (input DefaultSerializable) trans(isObs bool) (map[string]string, map[string][]string, interface{}, error) {
+	return input.params, input.headers, input.data, nil
+}
+
+var defaultSerializable = &DefaultSerializable{}
+
+func newSubResourceSerial(subResource SubResourceType) *DefaultSerializable {
+	return &DefaultSerializable{map[string]string{string(subResource): ""}, nil, nil}
+}
+
+func trans(subResource SubResourceType, input interface{}) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(subResource): ""}
+	data, err = ConvertRequestToIoReader(input)
+	return
+}
+
+func (baseModel *BaseModel) setStatusCode(statusCode int) {
+	baseModel.StatusCode = statusCode
+}
+
+func (baseModel *BaseModel) setRequestId(requestId string) {
+	baseModel.RequestId = requestId
+}
+
+func (baseModel *BaseModel) setResponseHeaders(responseHeaders map[string][]string) {
+	baseModel.ResponseHeaders = responseHeaders
+}
+
+func (input ListBucketsInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	headers = make(map[string][]string)
+	if input.QueryLocation && !isObs {
+		setHeaders(headers, HEADER_LOCATION_AMZ, []string{"true"}, isObs)
+	}
+	return
+}
+
+func (input CreateBucketInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	headers = make(map[string][]string)
+	if acl := string(input.ACL); acl != "" {
+		setHeaders(headers, HEADER_ACL, []string{acl}, isObs)
+	}
+	if storageClass := string(input.StorageClass); storageClass != "" {
+		if !isObs {
+			if storageClass == "WARM" {
+				storageClass = "STANDARD_IA"
+			} else if storageClass == "COLD" {
+				storageClass = "GLACIER"
+			}
+		}
+		setHeadersNext(headers, HEADER_STORAGE_CLASS_OBS, HEADER_STORAGE_CLASS, []string{storageClass}, isObs)
+		if epid := string(input.Epid); epid != "" {
+			setHeaders(headers, HEADER_EPID_HEADERS, []string{epid}, isObs)
+		}
+	}
+	if grantReadId := string(input.GrantReadId); grantReadId != "" {
+		setHeaders(headers, HEADER_GRANT_READ_OBS, []string{grantReadId}, isObs)
+	}
+	if grantWriteId := string(input.GrantWriteId); grantWriteId != "" {
+		setHeaders(headers, HEADER_GRANT_WRITE_OBS, []string{grantWriteId}, isObs)
+	}
+	if grantReadAcpId := string(input.GrantReadAcpId); grantReadAcpId != "" {
+		setHeaders(headers, HEADER_GRANT_READ_ACP_OBS, []string{grantReadAcpId}, isObs)
+	}
+	if grantWriteAcpId := string(input.GrantWriteAcpId); grantWriteAcpId != "" {
+		setHeaders(headers, HEADER_GRANT_WRITE_ACP_OBS, []string{grantWriteAcpId}, isObs)
+	}
+	if grantFullControlId := string(input.GrantFullControlId); grantFullControlId != "" {
+		setHeaders(headers, HEADER_GRANT_FULL_CONTROL_OBS, []string{grantFullControlId}, isObs)
+	}
+	if grantReadDeliveredId := string(input.GrantReadDeliveredId); grantReadDeliveredId != "" {
+		setHeaders(headers, HEADER_GRANT_READ_DELIVERED_OBS, []string{grantReadDeliveredId}, true)
+	}
+	if grantFullControlDeliveredId := string(input.GrantFullControlDeliveredId); grantFullControlDeliveredId != "" {
+		setHeaders(headers, HEADER_GRANT_FULL_CONTROL_DELIVERED_OBS, []string{grantFullControlDeliveredId}, true)
+	}
+	if location := strings.TrimSpace(input.Location); location != "" {
+		input.Location = location
+
+		xml := make([]string, 0, 3)
+		xml = append(xml, "<CreateBucketConfiguration>")
+		if isObs {
+			xml = append(xml, fmt.Sprintf("<Location>%s</Location>", input.Location))
+		} else {
+			xml = append(xml, fmt.Sprintf("<LocationConstraint>%s</LocationConstraint>", input.Location))
+		}
+		xml = append(xml, "</CreateBucketConfiguration>")
+
+		data = strings.Join(xml, "")
+	}
+	return
+}
+
+func (input SetBucketStoragePolicyInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	xml := make([]string, 0, 1)
+	if !isObs {
+		storageClass := "STANDARD"
+		if input.StorageClass == "WARM" {
+			storageClass = "STANDARD_IA"
+		} else if input.StorageClass == "COLD" {
+			storageClass = "GLACIER"
+		}
+		params = map[string]string{string(SubResourceStoragePolicy): ""}
+		xml = append(xml, fmt.Sprintf("<StoragePolicy><DefaultStorageClass>%s</DefaultStorageClass></StoragePolicy>", storageClass))
+	} else {
+		if input.StorageClass != "WARM" && input.StorageClass != "COLD" {
+			input.StorageClass = StorageClassStandard
+		}
+		params = map[string]string{string(SubResourceStorageClass): ""}
+		xml = append(xml, fmt.Sprintf("<StorageClass>%s</StorageClass>", input.StorageClass))
+	}
+	data = strings.Join(xml, "")
+	return
+}
+
+func (input ListObjsInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = make(map[string]string)
+	if input.Prefix != "" {
+		params["prefix"] = input.Prefix
+	}
+	if input.Delimiter != "" {
+		params["delimiter"] = input.Delimiter
+	}
+	if input.MaxKeys > 0 {
+		params["max-keys"] = IntToString(input.MaxKeys)
+	}
+	headers = make(map[string][]string)
+	if origin := strings.TrimSpace(input.Origin); origin != "" {
+		headers[HEADER_ORIGIN_CAMEL] = []string{origin}
+	}
+	if requestHeader := strings.TrimSpace(input.RequestHeader); requestHeader != "" {
+		headers[HEADER_ACCESS_CONTROL_REQUEST_HEADER_CAMEL] = []string{requestHeader}
+	}
+	return
+}
+
+func (input ListObjectsInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params, headers, data, err = input.ListObjsInput.trans(isObs)
+	if err != nil {
+		return
+	}
+	if input.Marker != "" {
+		params["marker"] = input.Marker
+	}
+	return
+}
+
+func (input ListVersionsInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params, headers, data, err = input.ListObjsInput.trans(isObs)
+	if err != nil {
+		return
+	}
+	params[string(SubResourceVersions)] = ""
+	if input.KeyMarker != "" {
+		params["key-marker"] = input.KeyMarker
+	}
+	if input.VersionIdMarker != "" {
+		params["version-id-marker"] = input.VersionIdMarker
+	}
+	return
+}
+
+func (input ListMultipartUploadsInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceUploads): ""}
+	if input.Prefix != "" {
+		params["prefix"] = input.Prefix
+	}
+	if input.Delimiter != "" {
+		params["delimiter"] = input.Delimiter
+	}
+	if input.MaxUploads > 0 {
+		params["max-uploads"] = IntToString(input.MaxUploads)
+	}
+	if input.KeyMarker != "" {
+		params["key-marker"] = input.KeyMarker
+	}
+	if input.UploadIdMarker != "" {
+		params["upload-id-marker"] = input.UploadIdMarker
+	}
+	return
+}
+
+func (input SetBucketQuotaInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	return trans(SubResourceQuota, input)
+}
+
+func (input SetBucketAclInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceAcl): ""}
+	headers = make(map[string][]string)
+
+	if acl := string(input.ACL); acl != "" {
+		setHeaders(headers, HEADER_ACL, []string{acl}, isObs)
+	} else {
+		data, _ = convertBucketAclToXml(input.AccessControlPolicy, false, isObs)
+	}
+	return
+}
+
+func (input SetBucketPolicyInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourcePolicy): ""}
+	data = strings.NewReader(input.Policy)
+	return
+}
+
+func (input SetBucketCorsInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceCors): ""}
+	data, md5, err := ConvertRequestToIoReaderV2(input)
+	if err != nil {
+		return
+	}
+	headers = map[string][]string{HEADER_MD5_CAMEL: []string{md5}}
+	return
+}
+
+func (input SetBucketVersioningInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	return trans(SubResourceVersioning, input)
+}
+
+func (input SetBucketWebsiteConfigurationInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceWebsite): ""}
+	data, _ = ConvertWebsiteConfigurationToXml(input.BucketWebsiteConfiguration, false)
+	return
+}
+
+func (input GetBucketMetadataInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	headers = make(map[string][]string)
+	if origin := strings.TrimSpace(input.Origin); origin != "" {
+		headers[HEADER_ORIGIN_CAMEL] = []string{origin}
+	}
+	if requestHeader := strings.TrimSpace(input.RequestHeader); requestHeader != "" {
+		headers[HEADER_ACCESS_CONTROL_REQUEST_HEADER_CAMEL] = []string{requestHeader}
+	}
+	return
+}
+
+func (input SetBucketLoggingConfigurationInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceLogging): ""}
+	data, _ = ConvertLoggingStatusToXml(input.BucketLoggingStatus, false, isObs)
+	return
+}
+
+func (input SetBucketLifecycleConfigurationInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceLifecycle): ""}
+	data, md5 := ConvertLifecyleConfigurationToXml(input.BucketLifecyleConfiguration, true, isObs)
+	headers = map[string][]string{HEADER_MD5_CAMEL: []string{md5}}
+	return
+}
+
+func (input SetBucketTaggingInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceTagging): ""}
+	data, md5, err := ConvertRequestToIoReaderV2(input)
+	if err != nil {
+		return
+	}
+	headers = map[string][]string{HEADER_MD5_CAMEL: []string{md5}}
+	return
+}
+
+func (input SetBucketNotificationInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceNotification): ""}
+	data, _ = ConvertNotificationToXml(input.BucketNotification, false, isObs)
+	return
+}
+
+func (input DeleteObjectInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = make(map[string]string)
+	if input.VersionId != "" {
+		params[PARAM_VERSION_ID] = input.VersionId
+	}
+	return
+}
+
+func (input DeleteObjectsInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceDelete): ""}
+	data, md5, err := ConvertRequestToIoReaderV2(input)
+	if err != nil {
+		return
+	}
+	headers = map[string][]string{HEADER_MD5_CAMEL: []string{md5}}
+	return
+}
+
+func (input SetObjectAclInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceAcl): ""}
+	if input.VersionId != "" {
+		params[PARAM_VERSION_ID] = input.VersionId
+	}
+	headers = make(map[string][]string)
+	if acl := string(input.ACL); acl != "" {
+		setHeaders(headers, HEADER_ACL, []string{acl}, isObs)
+	} else {
+		data, _ = ConvertAclToXml(input.AccessControlPolicy, false, isObs)
+	}
+	return
+}
+
+func (input GetObjectAclInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceAcl): ""}
+	if input.VersionId != "" {
+		params[PARAM_VERSION_ID] = input.VersionId
+	}
+	return
+}
+
+func (input RestoreObjectInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceRestore): ""}
+	if input.VersionId != "" {
+		params[PARAM_VERSION_ID] = input.VersionId
+	}
+	if !isObs {
+		data, err = ConvertRequestToIoReader(input)
+	} else {
+		data = ConverntObsRestoreToXml(input)
+	}
+	return
+}
+
+func (header SseKmsHeader) GetEncryption() string {
+	if header.Encryption != "" {
+		return header.Encryption
+	}
+	if !header.isObs {
+		return DEFAULT_SSE_KMS_ENCRYPTION
+	} else {
+		return DEFAULT_SSE_KMS_ENCRYPTION_OBS
+	}
+}
+
+func (header SseKmsHeader) GetKey() string {
+	return header.Key
+}
+
+func (header SseCHeader) GetEncryption() string {
+	if header.Encryption != "" {
+		return header.Encryption
+	}
+	return DEFAULT_SSE_C_ENCRYPTION
+}
+
+func (header SseCHeader) GetKey() string {
+	return header.Key
+}
+
+func (header SseCHeader) GetKeyMD5() string {
+	if header.KeyMD5 != "" {
+		return header.KeyMD5
+	}
+
+	if ret, err := Base64Decode(header.GetKey()); err == nil {
+		return Base64Md5(ret)
+	}
+	return ""
+}
+
+func setSseHeader(headers map[string][]string, sseHeader ISseHeader, sseCOnly bool, isObs bool) {
+	if sseHeader != nil {
+		if sseCHeader, ok := sseHeader.(SseCHeader); ok {
+			setHeaders(headers, HEADER_SSEC_ENCRYPTION, []string{sseCHeader.GetEncryption()}, isObs)
+			setHeaders(headers, HEADER_SSEC_KEY, []string{sseCHeader.GetKey()}, isObs)
+			setHeaders(headers, HEADER_SSEC_KEY_MD5, []string{sseCHeader.GetEncryption()}, isObs)
+		} else if sseKmsHeader, ok := sseHeader.(SseKmsHeader); !sseCOnly && ok {
+			sseKmsHeader.isObs = isObs
+			setHeaders(headers, HEADER_SSEKMS_ENCRYPTION, []string{sseKmsHeader.GetEncryption()}, isObs)
+			setHeadersNext(headers, HEADER_SSEKMS_KEY_OBS, HEADER_SSEKMS_KEY_AMZ, []string{sseKmsHeader.GetKey()}, isObs)
+		}
+	}
+}
+
+func (input GetObjectMetadataInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = make(map[string]string)
+	if input.VersionId != "" {
+		params[PARAM_VERSION_ID] = input.VersionId
+	}
+	headers = make(map[string][]string)
+
+	if input.Origin != "" {
+		headers[HEADER_ORIGIN_CAMEL] = []string{input.Origin}
+	}
+
+	if input.RequestHeader != "" {
+		headers[HEADER_ACCESS_CONTROL_REQUEST_HEADER_CAMEL] = []string{input.RequestHeader}
+	}
+	setSseHeader(headers, input.SseHeader, true, isObs)
+	return
+}
+
+func (input SetObjectMetadataInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = make(map[string]string)
+	params = map[string]string{string(SubResourceMetadata): ""}
+	if input.VersionId != "" {
+		params[PARAM_VERSION_ID] = input.VersionId
+	}
+	headers = make(map[string][]string)
+
+	if directive := string(input.MetadataDirective); directive != "" {
+		setHeaders(headers, HEADER_METADATA_DIRECTIVE, []string{string(input.MetadataDirective)}, isObs)
+	} else {
+		setHeaders(headers, HEADER_METADATA_DIRECTIVE, []string{string(ReplaceNew)}, isObs)
+	}
+	if input.CacheControl != "" {
+		headers[HEADER_CACHE_CONTROL_CAMEL] = []string{input.CacheControl}
+	}
+	if input.ContentDisposition != "" {
+		headers[HEADER_CONTENT_DISPOSITION_CAMEL] = []string{input.ContentDisposition}
+	}
+	if input.ContentEncoding != "" {
+		headers[HEADER_CONTENT_ENCODING_CAMEL] = []string{input.ContentEncoding}
+	}
+	if input.ContentLanguage != "" {
+		headers[HEADER_CONTENT_LANGUAGE_CAMEL] = []string{input.ContentLanguage}
+	}
+
+	if input.ContentType != "" {
+		headers[HEADER_CONTENT_TYPE_CAML] = []string{input.ContentType}
+	}
+	if input.Expires != "" {
+		headers[HEADER_EXPIRES_CAMEL] = []string{input.Expires}
+	}
+	if input.WebsiteRedirectLocation != "" {
+		setHeaders(headers, HEADER_WEBSITE_REDIRECT_LOCATION, []string{input.WebsiteRedirectLocation}, isObs)
+	}
+	if storageClass := string(input.StorageClass); storageClass != "" {
+		if !isObs {
+			if storageClass == "WARM" {
+				storageClass = "STANDARD_IA"
+			} else if storageClass == "COLD" {
+				storageClass = "GLACIER"
+			}
+		}
+		setHeaders(headers, HEADER_STORAGE_CLASS2, []string{storageClass}, isObs)
+	}
+	if input.Metadata != nil {
+		for key, value := range input.Metadata {
+			key = strings.TrimSpace(key)
+			setHeadersNext(headers, HEADER_PREFIX_META_OBS+key, HEADER_PREFIX_META+key, []string{value}, isObs)
+		}
+	}
+	return
+}
+
+func (input GetObjectInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params, headers, data, err = input.GetObjectMetadataInput.trans(isObs)
+	if err != nil {
+		return
+	}
+	if input.ResponseCacheControl != "" {
+		params[PARAM_RESPONSE_CACHE_CONTROL] = input.ResponseCacheControl
+	}
+	if input.ResponseContentDisposition != "" {
+		params[PARAM_RESPONSE_CONTENT_DISPOSITION] = input.ResponseContentDisposition
+	}
+	if input.ResponseContentEncoding != "" {
+		params[PARAM_RESPONSE_CONTENT_ENCODING] = input.ResponseContentEncoding
+	}
+	if input.ResponseContentLanguage != "" {
+		params[PARAM_RESPONSE_CONTENT_LANGUAGE] = input.ResponseContentLanguage
+	}
+	if input.ResponseContentType != "" {
+		params[PARAM_RESPONSE_CONTENT_TYPE] = input.ResponseContentType
+	}
+	if input.ResponseExpires != "" {
+		params[PARAM_RESPONSE_EXPIRES] = input.ResponseExpires
+	}
+	if input.ImageProcess != "" {
+		params[PARAM_IMAGE_PROCESS] = input.ImageProcess
+	}
+	if input.RangeStart >= 0 && input.RangeEnd > input.RangeStart {
+		headers[HEADER_RANGE] = []string{fmt.Sprintf("bytes=%d-%d", input.RangeStart, input.RangeEnd)}
+	}
+
+	if input.IfMatch != "" {
+		headers[HEADER_IF_MATCH] = []string{input.IfMatch}
+	}
+	if input.IfNoneMatch != "" {
+		headers[HEADER_IF_NONE_MATCH] = []string{input.IfNoneMatch}
+	}
+	if !input.IfModifiedSince.IsZero() {
+		headers[HEADER_IF_MODIFIED_SINCE] = []string{FormatUtcToRfc1123(input.IfModifiedSince)}
+	}
+	if !input.IfUnmodifiedSince.IsZero() {
+		headers[HEADER_IF_UNMODIFIED_SINCE] = []string{FormatUtcToRfc1123(input.IfUnmodifiedSince)}
+	}
+	return
+}
+
+func (input ObjectOperationInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	headers = make(map[string][]string)
+	params = make(map[string]string)
+	if acl := string(input.ACL); acl != "" {
+		setHeaders(headers, HEADER_ACL, []string{acl}, isObs)
+	}
+	if GrantReadId := string(input.GrantReadId); GrantReadId != "" {
+		setHeaders(headers, HEADER_GRANT_READ_OBS, []string{GrantReadId}, true)
+	}
+	if GrantReadAcpId := string(input.GrantReadAcpId); GrantReadAcpId != "" {
+		setHeaders(headers, HEADER_GRANT_READ_ACP_OBS, []string{GrantReadAcpId}, true)
+	}
+	if GrantWriteAcpId := string(input.GrantWriteAcpId); GrantWriteAcpId != "" {
+		setHeaders(headers, HEADER_GRANT_WRITE_ACP_OBS, []string{GrantWriteAcpId}, true)
+	}
+	if GrantFullControlId := string(input.GrantFullControlId); GrantFullControlId != "" {
+		setHeaders(headers, HEADER_GRANT_FULL_CONTROL_OBS, []string{GrantFullControlId}, true)
+	}
+	if storageClass := string(input.StorageClass); storageClass != "" {
+		if !isObs {
+			if storageClass == "WARM" {
+				storageClass = "STANDARD_IA"
+			} else if storageClass == "COLD" {
+				storageClass = "GLACIER"
+			}
+		}
+		setHeaders(headers, HEADER_STORAGE_CLASS2, []string{storageClass}, isObs)
+	}
+	if input.WebsiteRedirectLocation != "" {
+		setHeaders(headers, HEADER_WEBSITE_REDIRECT_LOCATION, []string{input.WebsiteRedirectLocation}, isObs)
+
+	}
+	setSseHeader(headers, input.SseHeader, false, isObs)
+	if input.Expires != 0 {
+		setHeaders(headers, HEADER_EXPIRES, []string{Int64ToString(input.Expires)}, true)
+	}
+	if input.Metadata != nil {
+		for key, value := range input.Metadata {
+			key = strings.TrimSpace(key)
+			setHeadersNext(headers, HEADER_PREFIX_META_OBS+key, HEADER_PREFIX_META+key, []string{value}, isObs)
+		}
+	}
+	return
+}
+
+func (input PutObjectBasicInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params, headers, data, err = input.ObjectOperationInput.trans(isObs)
+	if err != nil {
+		return
+	}
+
+	if input.ContentMD5 != "" {
+		headers[HEADER_MD5_CAMEL] = []string{input.ContentMD5}
+	}
+
+	if input.ContentLength > 0 {
+		headers[HEADER_CONTENT_LENGTH_CAMEL] = []string{Int64ToString(input.ContentLength)}
+	}
+	if input.ContentType != "" {
+		headers[HEADER_CONTENT_TYPE_CAML] = []string{input.ContentType}
+	}
+
+	return
+}
+
+func (input PutObjectInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params, headers, data, err = input.PutObjectBasicInput.trans(isObs)
+	if err != nil {
+		return
+	}
+	if input.Body != nil {
+		data = input.Body
+	}
+	return
+}
+
+func (input CopyObjectInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params, headers, data, err = input.ObjectOperationInput.trans(isObs)
+	if err != nil {
+		return
+	}
+
+	var copySource string
+	if input.CopySourceVersionId != "" {
+		copySource = fmt.Sprintf("%s/%s?versionId=%s", input.CopySourceBucket, UrlEncode(input.CopySourceKey, false), input.CopySourceVersionId)
+	} else {
+		copySource = fmt.Sprintf("%s/%s", input.CopySourceBucket, UrlEncode(input.CopySourceKey, false))
+	}
+	setHeaders(headers, HEADER_COPY_SOURCE, []string{copySource}, isObs)
+
+	if directive := string(input.MetadataDirective); directive != "" {
+		setHeaders(headers, HEADER_METADATA_DIRECTIVE, []string{directive}, isObs)
+	}
+
+	if input.MetadataDirective == ReplaceMetadata {
+		if input.CacheControl != "" {
+			headers[HEADER_CACHE_CONTROL] = []string{input.CacheControl}
+		}
+		if input.ContentDisposition != "" {
+			headers[HEADER_CONTENT_DISPOSITION] = []string{input.ContentDisposition}
+		}
+		if input.ContentEncoding != "" {
+			headers[HEADER_CONTENT_ENCODING] = []string{input.ContentEncoding}
+		}
+		if input.ContentLanguage != "" {
+			headers[HEADER_CONTENT_LANGUAGE] = []string{input.ContentLanguage}
+		}
+		if input.ContentType != "" {
+			headers[HEADER_CONTENT_TYPE] = []string{input.ContentType}
+		}
+		if input.Expires != "" {
+			headers[HEADER_EXPIRES] = []string{input.Expires}
+		}
+	}
+
+	if input.CopySourceIfMatch != "" {
+		setHeaders(headers, HEADER_COPY_SOURCE_IF_MATCH, []string{input.CopySourceIfMatch}, isObs)
+	}
+	if input.CopySourceIfNoneMatch != "" {
+		setHeaders(headers, HEADER_COPY_SOURCE_IF_NONE_MATCH, []string{input.CopySourceIfNoneMatch}, isObs)
+	}
+	if !input.CopySourceIfModifiedSince.IsZero() {
+		setHeaders(headers, HEADER_COPY_SOURCE_IF_MODIFIED_SINCE, []string{FormatUtcToRfc1123(input.CopySourceIfModifiedSince)}, isObs)
+	}
+	if !input.CopySourceIfUnmodifiedSince.IsZero() {
+		setHeaders(headers, HEADER_COPY_SOURCE_IF_UNMODIFIED_SINCE, []string{FormatUtcToRfc1123(input.CopySourceIfUnmodifiedSince)}, isObs)
+	}
+	if input.SourceSseHeader != nil {
+		if sseCHeader, ok := input.SourceSseHeader.(SseCHeader); ok {
+			setHeaders(headers, HEADER_SSEC_COPY_SOURCE_ENCRYPTION, []string{sseCHeader.GetEncryption()}, isObs)
+			setHeaders(headers, HEADER_SSEC_COPY_SOURCE_KEY, []string{sseCHeader.GetKey()}, isObs)
+			setHeaders(headers, HEADER_SSEC_COPY_SOURCE_KEY_MD5, []string{sseCHeader.GetKeyMD5()}, isObs)
+		}
+	}
+	if input.SuccessActionRedirect != "" {
+		headers[HEADER_SUCCESS_ACTION_REDIRECT] = []string{input.SuccessActionRedirect}
+	}
+	return
+}
+
+func (input AbortMultipartUploadInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{"uploadId": input.UploadId}
+	return
+}
+
+func (input InitiateMultipartUploadInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params, headers, data, err = input.ObjectOperationInput.trans(isObs)
+	if err != nil {
+		return
+	}
+	if input.ContentType != "" {
+		headers[HEADER_CONTENT_TYPE_CAML] = []string{input.ContentType}
+	}
+	params[string(SubResourceUploads)] = ""
+	return
+}
+
+func (input UploadPartInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{"uploadId": input.UploadId, "partNumber": IntToString(input.PartNumber)}
+	headers = make(map[string][]string)
+	setSseHeader(headers, input.SseHeader, true, isObs)
+	if input.ContentMD5 != "" {
+		headers[HEADER_MD5_CAMEL] = []string{input.ContentMD5}
+	}
+	if input.Body != nil {
+		data = input.Body
+	}
+	return
+}
+
+func (input CompleteMultipartUploadInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{"uploadId": input.UploadId}
+	data, _ = ConvertCompleteMultipartUploadInputToXml(input, false)
+	return
+}
+
+func (input ListPartsInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{"uploadId": input.UploadId}
+	if input.MaxParts > 0 {
+		params["max-parts"] = IntToString(input.MaxParts)
+	}
+	if input.PartNumberMarker > 0 {
+		params["part-number-marker"] = IntToString(input.PartNumberMarker)
+	}
+	return
+}
+
+func (input CopyPartInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{"uploadId": input.UploadId, "partNumber": IntToString(input.PartNumber)}
+	headers = make(map[string][]string, 1)
+	var copySource string
+	if input.CopySourceVersionId != "" {
+		copySource = fmt.Sprintf("%s/%s?versionId=%s", input.CopySourceBucket, UrlEncode(input.CopySourceKey, false), input.CopySourceVersionId)
+	} else {
+		copySource = fmt.Sprintf("%s/%s", input.CopySourceBucket, UrlEncode(input.CopySourceKey, false))
+	}
+	setHeaders(headers, HEADER_COPY_SOURCE, []string{copySource}, isObs)
+	if input.CopySourceRangeStart >= 0 && input.CopySourceRangeEnd > input.CopySourceRangeStart {
+		setHeaders(headers, HEADER_COPY_SOURCE_RANGE, []string{fmt.Sprintf("bytes=%d-%d", input.CopySourceRangeStart, input.CopySourceRangeEnd)}, isObs)
+	}
+
+	setSseHeader(headers, input.SseHeader, true, isObs)
+	if input.SourceSseHeader != nil {
+		if sseCHeader, ok := input.SourceSseHeader.(SseCHeader); ok {
+			setHeaders(headers, HEADER_SSEC_COPY_SOURCE_ENCRYPTION, []string{sseCHeader.GetEncryption()}, isObs)
+			setHeaders(headers, HEADER_SSEC_COPY_SOURCE_KEY, []string{sseCHeader.GetKey()}, isObs)
+			setHeaders(headers, HEADER_SSEC_COPY_SOURCE_KEY_MD5, []string{sseCHeader.GetKeyMD5()}, isObs)
+		}
+
+	}
+	return
+}
+
+type partSlice []Part
+
+func (parts partSlice) Len() int {
+	return len(parts)
+}
+
+func (parts partSlice) Less(i, j int) bool {
+	return parts[i].PartNumber < parts[j].PartNumber
+}
+
+func (parts partSlice) Swap(i, j int) {
+	parts[i], parts[j] = parts[j], parts[i]
+}
+
+type readerWrapper struct {
+	reader      io.Reader
+	mark        int64
+	totalCount  int64
+	readedCount int64
+}
+
+func (rw *readerWrapper) seek(offset int64, whence int) (int64, error) {
+	if r, ok := rw.reader.(*strings.Reader); ok {
+		return r.Seek(offset, whence)
+	} else if r, ok := rw.reader.(*bytes.Reader); ok {
+		return r.Seek(offset, whence)
+	} else if r, ok := rw.reader.(*os.File); ok {
+		return r.Seek(offset, whence)
+	}
+	return offset, nil
+}
+
+func (rw *readerWrapper) Read(p []byte) (n int, err error) {
+	if rw.totalCount == 0 {
+		return 0, io.EOF
+	}
+	if rw.totalCount > 0 {
+		n, err = rw.reader.Read(p)
+		readedOnce := int64(n)
+		if remainCount := rw.totalCount - rw.readedCount; remainCount > readedOnce {
+			rw.readedCount += readedOnce
+			return n, err
+		} else {
+			rw.readedCount += remainCount
+			return int(remainCount), io.EOF
+		}
+	}
+	return rw.reader.Read(p)
+}
+
+type fileReaderWrapper struct {
+	readerWrapper
+	filePath string
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/util.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/util.go
@@ -1,0 +1,494 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+package obs
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var regex = regexp.MustCompile("^[\u4e00-\u9fa5]$")
+var ipRegex = regexp.MustCompile("^((2[0-4]\\d|25[0-5]|[01]?\\d\\d?)\\.){3}(2[0-4]\\d|25[0-5]|[01]?\\d\\d?)$")
+var v4AuthRegex = regexp.MustCompile("Credential=(.+?),SignedHeaders=(.+?),Signature=.+")
+var regionRegex = regexp.MustCompile(".+/\\d+/(.+?)/.+")
+
+func StringContains(src string, subStr string, subTranscoding string) string {
+	return strings.Replace(src, subStr, subTranscoding, -1)
+}
+func XmlTranscoding(src string) string {
+	srcTmp := StringContains(src, "&", "&amp;")
+	srcTmp = StringContains(srcTmp, "<", "&lt;")
+	srcTmp = StringContains(srcTmp, ">", "&gt;")
+	srcTmp = StringContains(srcTmp, "'", "&apos;")
+	srcTmp = StringContains(srcTmp, "\"", "&quot;")
+	return srcTmp
+}
+func StringToInt(value string, def int) int {
+	ret, err := strconv.Atoi(value)
+	if err != nil {
+		ret = def
+	}
+	return ret
+}
+
+func StringToInt64(value string, def int64) int64 {
+	ret, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		ret = def
+	}
+	return ret
+}
+
+func IntToString(value int) string {
+	return strconv.Itoa(value)
+}
+
+func Int64ToString(value int64) string {
+	return strconv.FormatInt(value, 10)
+}
+
+func GetCurrentTimestamp() int64 {
+	return time.Now().UnixNano() / 1000000
+}
+
+func FormatUtcNow(format string) string {
+	return time.Now().UTC().Format(format)
+}
+
+func FormatUtcToRfc1123(t time.Time) string {
+	ret := t.UTC().Format(time.RFC1123)
+	return ret[:strings.LastIndex(ret, "UTC")] + "GMT"
+}
+
+func Md5(value []byte) []byte {
+	m := md5.New()
+	_, err := m.Write(value)
+	if err != nil {
+		doLog(LEVEL_WARN, "MD5 failed to write with reason: %v", err)
+	}
+	return m.Sum(nil)
+}
+
+func HmacSha1(key, value []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	_, err := mac.Write(value)
+	if err != nil {
+		doLog(LEVEL_WARN, "HmacSha1 failed to write with reason: %v", err)
+	}
+	return mac.Sum(nil)
+}
+
+func HmacSha256(key, value []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, err := mac.Write(value)
+	if err != nil {
+		doLog(LEVEL_WARN, "HmacSha256 failed to write with reason: %v", err)
+	}
+	return mac.Sum(nil)
+}
+
+func Base64Encode(value []byte) string {
+	return base64.StdEncoding.EncodeToString(value)
+}
+
+func Base64Decode(value string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(value)
+}
+
+func HexMd5(value []byte) string {
+	return Hex(Md5(value))
+}
+
+func Base64Md5(value []byte) string {
+	return Base64Encode(Md5(value))
+}
+
+func Sha256Hash(value []byte) []byte {
+	hash := sha256.New()
+	_, err := hash.Write(value)
+	if err != nil {
+		doLog(LEVEL_WARN, "Sha256Hash failed to write with reason: %v", err)
+	}
+	return hash.Sum(nil)
+}
+
+func ParseXml(value []byte, result interface{}) error {
+	if len(value) == 0 {
+		return nil
+	}
+	return xml.Unmarshal(value, result)
+}
+
+func TransToXml(value interface{}) ([]byte, error) {
+	if value == nil {
+		return []byte{}, nil
+	}
+	return xml.Marshal(value)
+}
+
+func Hex(value []byte) string {
+	return hex.EncodeToString(value)
+}
+
+func HexSha256(value []byte) string {
+	return Hex(Sha256Hash(value))
+}
+
+func UrlDecode(value string) (string, error) {
+	ret, err := url.QueryUnescape(value)
+	if err == nil {
+		return ret, nil
+	}
+	return "", err
+}
+
+func UrlDecodeWithoutError(value string) string {
+	ret, err := UrlDecode(value)
+	if err == nil {
+		return ret
+	}
+	if isErrorLogEnabled() {
+		doLog(LEVEL_ERROR, "Url decode error: %v", err)
+	}
+	return ""
+}
+
+func IsIP(value string) bool {
+	return ipRegex.MatchString(value)
+}
+
+func UrlEncode(value string, chineseOnly bool) string {
+	if chineseOnly {
+		values := make([]string, 0, len(value))
+		for _, val := range value {
+			_value := string(val)
+			if regex.MatchString(_value) {
+				_value = url.QueryEscape(_value)
+			}
+			values = append(values, _value)
+		}
+		return strings.Join(values, "")
+	}
+	return url.QueryEscape(value)
+}
+
+func copyHeaders(m map[string][]string) (ret map[string][]string) {
+	if m != nil {
+		ret = make(map[string][]string, len(m))
+		for key, values := range m {
+			_values := make([]string, 0, len(values))
+			for _, value := range values {
+				_values = append(_values, value)
+			}
+			ret[strings.ToLower(key)] = _values
+		}
+	} else {
+		ret = make(map[string][]string)
+	}
+
+	return
+}
+
+func parseHeaders(headers map[string][]string) (signature string, region string, signedHeaders string) {
+	signature = "v2"
+	if receviedAuthorization, ok := headers[strings.ToLower(HEADER_AUTH_CAMEL)]; ok && len(receviedAuthorization) > 0 {
+		if strings.HasPrefix(receviedAuthorization[0], V4_HASH_PREFIX) {
+			signature = "v4"
+			matches := v4AuthRegex.FindStringSubmatch(receviedAuthorization[0])
+			if len(matches) >= 3 {
+				region = matches[1]
+				regions := regionRegex.FindStringSubmatch(region)
+				if len(regions) >= 2 {
+					region = regions[1]
+				}
+				signedHeaders = matches[2]
+			}
+
+		} else if strings.HasPrefix(receviedAuthorization[0], V2_HASH_PREFIX) {
+			signature = "v2"
+		}
+	}
+	return
+}
+
+func getTemporaryKeys() []string {
+	return []string{
+		"Signature",
+		"signature",
+		"X-Amz-Signature",
+		"x-amz-signature",
+	}
+}
+
+func getIsObs(isTemporary bool, querys []string, headers map[string][]string) bool {
+	isObs := true
+	if isTemporary {
+		for _, value := range querys {
+			keyPrefix := strings.ToLower(value)
+			if strings.HasPrefix(keyPrefix, HEADER_PREFIX) {
+				isObs = false
+			} else if strings.HasPrefix(value, HEADER_ACCESSS_KEY_AMZ) {
+				isObs = false
+			}
+		}
+	} else {
+		for key, _ := range headers {
+			keyPrefix := strings.ToLower(key)
+			if strings.HasPrefix(keyPrefix, HEADER_PREFIX) {
+				isObs = false
+				break
+			}
+		}
+	}
+	return isObs
+}
+
+func GetV2Authorization(ak, sk, method, bucketName, objectKey, queryUrl string, headers map[string][]string) (ret map[string]string) {
+
+	if strings.HasPrefix(queryUrl, "?") {
+		queryUrl = queryUrl[1:]
+	}
+
+	method = strings.ToUpper(method)
+
+	querys := strings.Split(queryUrl, "&")
+	querysResult := make([]string, 0)
+	for _, value := range querys {
+		if value != "=" && len(value) != 0 {
+			querysResult = append(querysResult, value)
+		}
+	}
+	params := make(map[string]string)
+
+	for _, value := range querysResult {
+		kv := strings.Split(value, "=")
+		length := len(kv)
+		if length == 1 {
+			key := UrlDecodeWithoutError(kv[0])
+			params[key] = ""
+		} else if length >= 2 {
+			key := UrlDecodeWithoutError(kv[0])
+			vals := make([]string, 0, length-1)
+			for i := 1; i < length; i++ {
+				val := UrlDecodeWithoutError(kv[i])
+				vals = append(vals, val)
+			}
+			params[key] = strings.Join(vals, "=")
+		}
+	}
+	headers = copyHeaders(headers)
+	pathStyle := false
+	if receviedHost, ok := headers[HEADER_HOST]; ok && len(receviedHost) > 0 && !strings.HasPrefix(receviedHost[0], bucketName+".") {
+		pathStyle = true
+	}
+	conf := &config{securityProvider: &securityProvider{ak: ak, sk: sk},
+		urlHolder: &urlHolder{scheme: "https", host: "dummy", port: 443},
+		pathStyle: pathStyle}
+	conf.signature = SignatureObs
+	_, canonicalizedURL := conf.formatUrls(bucketName, objectKey, params, false)
+	ret = v2Auth(ak, sk, method, canonicalizedURL, headers, true)
+	v2HashPrefix := OBS_HASH_PREFIX
+	ret[HEADER_AUTH_CAMEL] = fmt.Sprintf("%s %s:%s", v2HashPrefix, ak, ret["Signature"])
+	return
+}
+
+func GetAuthorization(ak, sk, method, bucketName, objectKey, queryUrl string, headers map[string][]string) (ret map[string]string) {
+
+	if strings.HasPrefix(queryUrl, "?") {
+		queryUrl = queryUrl[1:]
+	}
+
+	method = strings.ToUpper(method)
+
+	querys := strings.Split(queryUrl, "&")
+	querysResult := make([]string, 0)
+	for _, value := range querys {
+		if value != "=" && len(value) != 0 {
+			querysResult = append(querysResult, value)
+		}
+	}
+	params := make(map[string]string)
+
+	for _, value := range querysResult {
+		kv := strings.Split(value, "=")
+		length := len(kv)
+		if length == 1 {
+			key := UrlDecodeWithoutError(kv[0])
+			params[key] = ""
+		} else if length >= 2 {
+			key := UrlDecodeWithoutError(kv[0])
+			vals := make([]string, 0, length-1)
+			for i := 1; i < length; i++ {
+				val := UrlDecodeWithoutError(kv[i])
+				vals = append(vals, val)
+			}
+			params[key] = strings.Join(vals, "=")
+		}
+	}
+	isTemporary := false
+	signature := "v2"
+	temporaryKeys := getTemporaryKeys()
+	for _, key := range temporaryKeys {
+		if _, ok := params[key]; ok {
+			isTemporary = true
+			if strings.ToLower(key) == "signature" {
+				signature = "v2"
+			} else if strings.ToLower(key) == "x-amz-signature" {
+				signature = "v4"
+			}
+			break
+		}
+	}
+	isObs := getIsObs(isTemporary, querysResult, headers)
+	headers = copyHeaders(headers)
+	pathStyle := false
+	if receviedHost, ok := headers[HEADER_HOST]; ok && len(receviedHost) > 0 && !strings.HasPrefix(receviedHost[0], bucketName+".") {
+		pathStyle = true
+	}
+	conf := &config{securityProvider: &securityProvider{ak: ak, sk: sk},
+		urlHolder: &urlHolder{scheme: "https", host: "dummy", port: 443},
+		pathStyle: pathStyle}
+
+	if isTemporary {
+		return getTemporaryAuthorization(ak, sk, method, bucketName, objectKey, signature, conf, params, headers, isObs)
+	} else {
+		signature, region, signedHeaders := parseHeaders(headers)
+		if signature == "v4" {
+			conf.signature = SignatureV4
+			requestUrl, canonicalizedUrl := conf.formatUrls(bucketName, objectKey, params, false)
+			parsedRequestUrl, _err := url.Parse(requestUrl)
+			if _err != nil {
+				doLog(LEVEL_WARN, "Failed to parse requestUrl with reason: %v", _err)
+				return nil
+			}
+			headerKeys := strings.Split(signedHeaders, ";")
+			_headers := make(map[string][]string, len(headerKeys))
+			for _, headerKey := range headerKeys {
+				_headers[headerKey] = headers[headerKey]
+			}
+			ret = v4Auth(ak, sk, region, method, canonicalizedUrl, parsedRequestUrl.RawQuery, _headers)
+			ret[HEADER_AUTH_CAMEL] = fmt.Sprintf("%s Credential=%s,SignedHeaders=%s,Signature=%s", V4_HASH_PREFIX, ret["Credential"], ret["SignedHeaders"], ret["Signature"])
+		} else if signature == "v2" {
+			if isObs {
+				conf.signature = SignatureObs
+			} else {
+				conf.signature = SignatureV2
+			}
+			_, canonicalizedUrl := conf.formatUrls(bucketName, objectKey, params, false)
+			ret = v2Auth(ak, sk, method, canonicalizedUrl, headers, isObs)
+			v2HashPrefix := V2_HASH_PREFIX
+			if isObs {
+				v2HashPrefix = OBS_HASH_PREFIX
+			}
+			ret[HEADER_AUTH_CAMEL] = fmt.Sprintf("%s %s:%s", v2HashPrefix, ak, ret["Signature"])
+		}
+		return
+	}
+
+}
+
+func getTemporaryAuthorization(ak, sk, method, bucketName, objectKey, signature string, conf *config, params map[string]string,
+	headers map[string][]string, isObs bool) (ret map[string]string) {
+
+	if signature == "v4" {
+		conf.signature = SignatureV4
+
+		longDate, ok := params[PARAM_DATE_AMZ_CAMEL]
+		if !ok {
+			longDate = params[HEADER_DATE_AMZ]
+		}
+		shortDate := longDate[:8]
+
+		credential, ok := params[PARAM_CREDENTIAL_AMZ_CAMEL]
+		if !ok {
+			credential = params[strings.ToLower(PARAM_CREDENTIAL_AMZ_CAMEL)]
+		}
+
+		_credential := UrlDecodeWithoutError(credential)
+
+		regions := regionRegex.FindStringSubmatch(_credential)
+		var region string
+		if len(regions) >= 2 {
+			region = regions[1]
+		}
+
+		_, scope := getCredential(ak, region, shortDate)
+
+		expires, ok := params[PARAM_EXPIRES_AMZ_CAMEL]
+		if !ok {
+			expires = params[strings.ToLower(PARAM_EXPIRES_AMZ_CAMEL)]
+		}
+
+		signedHeaders, ok := params[PARAM_SIGNEDHEADERS_AMZ_CAMEL]
+		if !ok {
+			signedHeaders = params[strings.ToLower(PARAM_SIGNEDHEADERS_AMZ_CAMEL)]
+		}
+
+		algorithm, ok := params[PARAM_ALGORITHM_AMZ_CAMEL]
+		if !ok {
+			algorithm = params[strings.ToLower(PARAM_ALGORITHM_AMZ_CAMEL)]
+		}
+
+		if _, ok := params[PARAM_SIGNATURE_AMZ_CAMEL]; ok {
+			delete(params, PARAM_SIGNATURE_AMZ_CAMEL)
+		} else if _, ok := params[strings.ToLower(PARAM_SIGNATURE_AMZ_CAMEL)]; ok {
+			delete(params, strings.ToLower(PARAM_SIGNATURE_AMZ_CAMEL))
+		}
+
+		ret = make(map[string]string, 6)
+		ret[PARAM_ALGORITHM_AMZ_CAMEL] = algorithm
+		ret[PARAM_CREDENTIAL_AMZ_CAMEL] = credential
+		ret[PARAM_DATE_AMZ_CAMEL] = longDate
+		ret[PARAM_EXPIRES_AMZ_CAMEL] = expires
+		ret[PARAM_SIGNEDHEADERS_AMZ_CAMEL] = signedHeaders
+
+		requestUrl, canonicalizedUrl := conf.formatUrls(bucketName, objectKey, params, false)
+		parsedRequestUrl, _err := url.Parse(requestUrl)
+		if _err != nil {
+			doLog(LEVEL_WARN, "Failed to parse requestUrl with reason: %v", _err)
+			return nil
+		}
+		stringToSign := getV4StringToSign(method, canonicalizedUrl, parsedRequestUrl.RawQuery, scope, longDate, UNSIGNED_PAYLOAD, strings.Split(signedHeaders, ";"), headers)
+		ret[PARAM_SIGNATURE_AMZ_CAMEL] = UrlEncode(getSignature(stringToSign, sk, region, shortDate), false)
+	} else if signature == "v2" {
+		if isObs {
+			conf.signature = SignatureObs
+		} else {
+			conf.signature = SignatureV2
+		}
+		_, canonicalizedUrl := conf.formatUrls(bucketName, objectKey, params, false)
+		expires, ok := params["Expires"]
+		if !ok {
+			expires = params["expires"]
+		}
+		headers[HEADER_DATE_CAMEL] = []string{expires}
+		stringToSign := getV2StringToSign(method, canonicalizedUrl, headers, isObs)
+		ret = make(map[string]string, 3)
+		ret["Signature"] = UrlEncode(Base64Encode(HmacSha1([]byte(sk), []byte(stringToSign))), false)
+		ret["AWSAccessKeyId"] = UrlEncode(ak, false)
+		ret["Expires"] = UrlEncode(expires, false)
+	}
+
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -476,6 +476,9 @@ github.com/hashicorp/vault/helper/jsonutil
 github.com/hashicorp/vault/helper/pgpkeys
 # github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb
 github.com/hashicorp/yamux
+# github.com/huaweicloud/golangsdk v0.0.0-20200323070305-98b64a3f37ba
+## explicit
+github.com/huaweicloud/golangsdk/openstack/obs
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 ## explicit
 github.com/jmespath/go-jmespath

--- a/website/docs/backends/types/obs.html.md
+++ b/website/docs/backends/types/obs.html.md
@@ -1,0 +1,78 @@
+---
+layout: "backend-types"
+page_title: "Backend Type: obs"
+sidebar_current: "docs-backends-types-standard-obs"
+description: |-
+  Terraform can store the state remotely, making it easier to version and work with in a team.
+---
+
+# OBS
+
+**Kind: Standard (with locking)**
+
+Stores the state as a given key in a given bucket on
+[HuaweiCloud OBS](https://www.huaweicloud.com/intl/en-us/product/obs.html).
+This backend also supports [state locking](/docs/state/locking.html).
+
+~> **Warning!** It is highly recommended that you enable
+[Bucket Versioning](https://support.huaweicloud.com/intl/en-us/usermanual-obs/en-us_topic_0045853504.html)
+on the OBS bucket to allow for state recovery in the case of accidental deletions and human error.
+
+## Example Configuration
+
+```hcl
+terraform {
+  backend "obs" {
+    bucket = "testbucket"
+    prefix = "terraform/state"
+    key    = "terraform.tfstate"
+    region = "cn-north-1"
+  }
+}
+```
+
+This assumes we have a bucket created called `testbucket`. The
+Terraform state will be written to the key `terraform/state/terraform.tfstate`.
+
+Note that for the access credentials we recommend using
+`OS_ACCESS_KEY` and `OS_SECRET_KEY`.
+
+## Using the OBS remote state
+
+To make use of the OBS remote state we can use the
+[`terraform_remote_state` data
+source](/docs/providers/terraform/d/remote_state.html).
+
+```hcl
+data "terraform_remote_state" "foo" {
+  backend = "obs"
+
+  config = {
+    bucket = "tf-backend"
+    prefix = "terraform/state"
+    key    = "terraform.tfstate"
+    region = "cn-north-1"
+  }
+}
+```
+
+The `terraform_remote_state` data source will return all of the root module
+outputs defined in the referenced remote state (but not any outputs from
+nested modules unless they are explicitly output again in the root). 
+
+## Configuration variables
+
+The following configuration options or environment variables are supported:
+
+ * `access_key_id` - (Optional) HuaweiCloud access key. It supports environment variable `OS_ACCESS_KEY`.
+ * `secret_key_id` - (Optional) HuaweiCloud secret access key. It supports environment variable `OS_SECRET_KEY`.
+ * `region` - (Required) The region of the OBS bucket. It supports environment variable `OS_REGION_NAME`.
+ * `bucket` - (Required) The name of the OBS bucket. You shall manually create it first.
+ * `prefix` - (Optional) The directory for saving the state file in bucket.
+ * `key` - (Optional) The path to the state file inside the bucket. Defaults to `terraform.tfstate`. 
+ * `encrypt` - (Optional) Whether to enable [server side
+   encryption](https://support.huaweicloud.com/intl/en-us/usermanual-obs/en-us_topic_0066036553.html)
+   of the state file.
+ * `kms_key_id` - (Optional) The KMS Key to use for encrypting the state.
+ * `acl` - Object ACL to be applied to the state file. Defaults to `private`.
+ * `endpoint` - (Optional) A custom endpoint for the OBS API.

--- a/website/docs/state/workspaces.html.md
+++ b/website/docs/state/workspaces.html.md
@@ -31,6 +31,7 @@ Multiple workspaces are currently supported by the following backends:
  * [GCS](/docs/backends/types/gcs.html)
  * [Local](/docs/backends/types/local.html)
  * [Manta](/docs/backends/types/manta.html)
+ * [OBS](/docs/backends/types/obs.html)
  * [Postgres](/docs/backends/types/pg.html)
  * [Remote](/docs/backends/types/remote.html)
  * [S3](/docs/backends/types/s3.html)

--- a/website/layouts/backend-types.erb
+++ b/website/layouts/backend-types.erb
@@ -54,6 +54,9 @@
                   <li<%= sidebar_current("docs-backends-types-standard-manta") %>>
                     <a href="/docs/backends/types/manta.html">manta</a>
                   </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-obs") %>>
+                    <a href="/docs/backends/types/obs.html">obs</a>
+                  </li>
                   <li<%= sidebar_current("docs-backends-types-standard-oss") %>>
                     <a href="/docs/backends/types/oss.html">oss</a>
                   </li>


### PR DESCRIPTION
Hello,
This PR provides a new backend that terraform can store state remotely in HuaweiCloud OBS with locking.

the result of testing as follows:
```
=== RUN   TestStateFile
=== PAUSE TestStateFile
=== RUN   TestRemoteClient
=== PAUSE TestRemoteClient
=== RUN   TestRemoteClientWithPrefix
=== PAUSE TestRemoteClientWithPrefix
=== RUN   TestRemoteClientWithEncryption
=== PAUSE TestRemoteClientWithEncryption
=== RUN   TestRemoteLocks
=== PAUSE TestRemoteLocks
=== RUN   TestBackend
=== PAUSE TestBackend
=== RUN   TestBackendWithPrefix
=== PAUSE TestBackendWithPrefix
=== RUN   TestBackendWithEncryption
=== PAUSE TestBackendWithEncryption
=== CONT  TestStateFile
--- PASS: TestStateFile (0.00s)
=== CONT  TestRemoteLocks
=== CONT  TestBackend
=== CONT  TestRemoteClientWithPrefix
=== CONT  TestRemoteClientWithEncryption
...
PASS
ok      github.com/hashicorp/terraform/backend/remote-state/obs 10.683s
```

for more details, please download the attachment:
[test_result.log](https://github.com/hashicorp/terraform/files/4379957/test_result.log)

Fixes #23888 