### PR TITLE
Add link to new modules track on learn

### DIFF
--- a/website/docs/modules/index.html.markdown
+++ b/website/docs/modules/index.html.markdown
@@ -23,6 +23,10 @@ To learn how to _use_ modules, see [the Modules configuration section](/docs/con
 This section is about _creating_ re-usable modules that other configurations
 can include using `module` blocks.
 
+For hands-on guides that will walk you through the process of using and creating
+modules, see our [track on
+learn.hashicorp.com](https://learn.hashicorp.com/terraform/modules/modules-overview).
+
 ## Module structure
 
 Re-usable modules are defined using all of the same
@@ -97,7 +101,7 @@ don't need to do any extra work to follow the standard structure.
   directory like this](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples).
   Consider including a visual diagram depicting the infrastructure resources
   the module may create and their relationship.
-  
+
   The README doesn't need to document inputs or outputs of the module because
   tooling will automatically generate this. If you are linking to a file or
   embedding an image contained in the repository itself, use a commit-specific


### PR DESCRIPTION
We have a new "modules" track on learn: https://learn.hashicorp.com/terraform/modules/modules-overview

This PR adds a link to it in what seemed like a good place in the modules docs.