### PR TITLE
Some fixes for internal/providercache and internal/getproviders

### DIFF
--- a/internal/getproviders/filesystem_search.go
+++ b/internal/getproviders/filesystem_search.go
@@ -36,7 +36,7 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 		if err != nil {
 			// This should never happen because the filepath.Walk contract is
 			// for the paths to include the base path.
-			log.Printf("[TRACE] FilesystemMirrorSource: ignoring malformed path %q during walk: %s", fullPath, err)
+			log.Printf("[TRACE] getproviders.SearchLocalDirectory: ignoring malformed path %q during walk: %s", fullPath, err)
 			return nil
 		}
 		relPath := filepath.ToSlash(fsPath)
@@ -88,7 +88,7 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 				return nil
 			}
 
-			log.Printf("[TRACE] FilesystemMirrorSource: found %s v%s for %s at %s", providerAddr, version, platform, fullPath)
+			log.Printf("[TRACE] getproviders.SearchLocalDirectory: found %s v%s for %s at %s", providerAddr, version, platform, fullPath)
 
 			meta := PackageMeta{
 				Provider: providerAddr,
@@ -132,11 +132,11 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 			prefix := "terraform-provider-" + providerAddr.Type + "_"
 			const suffix = ".zip"
 			if !strings.HasPrefix(normFilename, prefix) {
-				log.Printf("[WARN] ignoring file %q as possible package for %s: lacks expected prefix %q", filename, providerAddr, prefix)
+				log.Printf("[WARN] ignoring file %q as possible package for %s: filename lacks expected prefix %q", fsPath, providerAddr, prefix)
 				return nil
 			}
 			if !strings.HasSuffix(normFilename, suffix) {
-				log.Printf("[WARN] ignoring file %q as possible package for %s: lacks expected suffix %q", filename, providerAddr, suffix)
+				log.Printf("[WARN] ignoring file %q as possible package for %s: filename lacks expected suffix %q", fsPath, providerAddr, suffix)
 				return nil
 			}
 
@@ -145,7 +145,7 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 			infoSlice := normFilename[len(prefix) : len(normFilename)-len(suffix)]
 			infoParts := strings.Split(infoSlice, "_")
 			if len(infoParts) < 3 {
-				log.Printf("[WARN] ignoring file %q as possible package for %s: filename does not include version number, target OS, and target architecture", filename, providerAddr)
+				log.Printf("[WARN] ignoring file %q as possible package for %s: filename does not include version number, target OS, and target architecture", fsPath, providerAddr)
 				return nil
 			}
 
@@ -165,7 +165,7 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 				return nil
 			}
 
-			log.Printf("[TRACE] FilesystemMirrorSource: found %s v%s for %s at %s", providerAddr, version, platform, fullPath)
+			log.Printf("[TRACE] getproviders.SearchLocalDirectory: found %s v%s for %s at %s", providerAddr, version, platform, fullPath)
 
 			meta := PackageMeta{
 				Provider: providerAddr,

--- a/internal/getproviders/filesystem_search.go
+++ b/internal/getproviders/filesystem_search.go
@@ -68,6 +68,15 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 			providerAddr = addrs.NewProvider(hostname, namespace, typeName)
 		}
 
+		// The "info" passed to our function is an Lstat result, so it might
+		// be referring to a symbolic link. We'll do a full "Stat" on it
+		// now to make sure we're making tests against the real underlying
+		// filesystem object below.
+		info, err = os.Stat(fullPath)
+		if err != nil {
+			return fmt.Errorf("failed to read metadata about %s: %s", fullPath, err)
+		}
+
 		switch len(parts) {
 		case 5: // Might be unpacked layout
 			if !info.IsDir() {

--- a/internal/providercache/dir_modify.go
+++ b/internal/providercache/dir_modify.go
@@ -78,7 +78,7 @@ func (d *Dir) LinkFromOtherCache(entry *CachedProvider) error {
 	d.metaCache = nil
 
 	// Delete anything that's already present at this path first.
-	err = os.RemoveAll(currentPath)
+	err = os.RemoveAll(newPath)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove existing %s before linking it to %s: %s", currentPath, newPath, err)
 	}

--- a/internal/providercache/dir_modify.go
+++ b/internal/providercache/dir_modify.go
@@ -3,6 +3,7 @@ package providercache
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -21,6 +22,7 @@ func (d *Dir) InstallPackage(ctx context.Context, meta getproviders.PackageMeta)
 		d.baseDir, meta.Provider, meta.Version, d.targetPlatform,
 	)
 
+	log.Printf("[TRACE] providercache.Dir.InstallPackage: installing %s v%s from %s", meta.Provider, meta.Version, meta.Location)
 	switch location := meta.Location.(type) {
 	case getproviders.PackageHTTPURL:
 		return installFromHTTPURL(ctx, string(location), newPath)
@@ -50,6 +52,7 @@ func (d *Dir) LinkFromOtherCache(entry *CachedProvider) error {
 		d.baseDir, entry.Provider, entry.Version, d.targetPlatform,
 	)
 	currentPath := entry.PackageDir
+	log.Printf("[TRACE] providercache.Dir.LinkFromOtherCache: linking %s v%s from existing cache %s to %s", entry.Provider, entry.Version, currentPath, newPath)
 
 	absNew, err := filepath.Abs(newPath)
 	if err != nil {

--- a/internal/providercache/dir_modify_test.go
+++ b/internal/providercache/dir_modify_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/getproviders"
 )
 
-func LinkFromOtherCache(t *testing.T) {
+func TestLinkFromOtherCache(t *testing.T) {
 	srcDirPath := "testdata/cachedir"
 	tmpDirPath, err := ioutil.TempDir("", "terraform-test-providercache")
 	if err != nil {
@@ -82,13 +82,8 @@ func LinkFromOtherCache(t *testing.T) {
 				// still packed and thus not considered to be a cache member.
 				Version: versions.MustParseVersion("2.0.0"),
 
-				// These are still pointed into the testdata directory because
-				// we created a symlink in our tmpDir. (This part of the test
-				// is expected to fail if the temporary directory is on a
-				// filesystem that cannot support symlinks, in which case
-				// we should see the temporary directory paths here instead.)
-				PackageDir:     "testdata/cachedir/registry.terraform.io/hashicorp/null/2.0.0/windows_amd64",
-				ExecutableFile: "testdata/cachedir/registry.terraform.io/hashicorp/null/2.0.0/windows_amd64/terraform-provider-null.exe",
+				PackageDir:     tmpDirPath + "/registry.terraform.io/hashicorp/null/2.0.0/windows_amd64",
+				ExecutableFile: tmpDirPath + "/registry.terraform.io/hashicorp/null/2.0.0/windows_amd64/terraform-provider-null.exe",
 			},
 		},
 	}

--- a/internal/providercache/testdata/cachedir/registry.terraform.io/hashicorp/null/2.0.0/windows_amd64/terraform-provider-null.exe
+++ b/internal/providercache/testdata/cachedir/registry.terraform.io/hashicorp/null/2.0.0/windows_amd64/terraform-provider-null.exe
@@ -1,0 +1,1 @@
+# This is just a placeholder file for discovery testing, not a real provider plugin.


### PR DESCRIPTION
The main thing here is fixing a bug I didn't spot before merging #24447, where the cache linking behavior was incorrectly deleting the _source_ of the link, rather than the target path.

However, in the process of fixing that I also noticed that the `LinkFromOtherCache` test hadn't been running at all due to it being named incorrectly, and so that's why this didn't show up as a problem in the previous PR.

Along the way I added a little more `TRACE`-level logging to the overall process because it was helpful in understanding what the problem was here and also because we know from experience with the old installer that trace logging tends to be very helpful when responding to user questions about why certain plugins were not detected as they expected.

As with #24447, this is all still just dead code not called from any real command. Real calls from the `terraform init` command will follow in a subsequent PR.
