### PR TITLE
Added info re additional step re private key to the Example Config intro docs

### DIFF
--- a/website/intro/examples/index.html.markdown
+++ b/website/intro/examples/index.html.markdown
@@ -45,6 +45,11 @@ cd terraform-provider-aws/examples/two-tier
 ```
 
 You can then use your preferred code editor to browse and read the configurations.
+
+Note that in this example, the connection block defaults to using a local SSH agent for authentication with the instance. 
+Therefore ensure that the appropriate private key has been added to the agent before running the below steps. 
+Alternatively, as can be seen in some of the other examples, the `private_key` argument can also be used. 
+
 To try out an example, run Terraform's init and apply commands while in the example's directory:
 
 ```


### PR DESCRIPTION
Reasoning for docs update:
Had an issue when completing the 2 tier aws example, and it looks like I wasn't the only one. 
The page mentions that the configuration is "intuitive", and it seems to list all the commands needed, and implies that Terraform will prompt you for any other required info. 
However, unless you have added the required private key to your ssh-agent using ssh-add, the example fails! Not a good start for newcomers! 
I know there's a comment in the main.tf file about it using a local SSH agent to connect, but i don't think that's explicit enough. 
It's an easy step to miss, and you'd be inclined to think it's an issue with your Terraform install, or your AWS settings etc... 

Relevant Terraform version:
Current version