### PR TITLE
internal/getproviders: A new shared model for provider requirements

### DIFF
--- a/configs/testdata/provider-reqs/child/provider-reqs-child.tf
+++ b/configs/testdata/provider-reqs/child/provider-reqs-child.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    cloud = {
+      source = "tf.example.com/awesomecorp/happycloud"
+    }
+    null = {
+      # This should merge with the null provider constraint in the root module
+      version = "2.0.1"
+    }
+  }
+}

--- a/configs/testdata/provider-reqs/provider-reqs-root.tf
+++ b/configs/testdata/provider-reqs/provider-reqs-root.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    null = "~> 2.0.0"
+    random = {
+      version = "~> 1.2.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# There is no provider in required_providers called "implied", so this
+# implicitly declares a dependency on "hashicorp/implied".
+resource "implied_foo" "bar" {
+}
+
+module "child" {
+  source = "./child"
+}

--- a/internal/earlyconfig/config.go
+++ b/internal/earlyconfig/config.go
@@ -7,6 +7,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/moduledeps"
 	"github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/hashicorp/terraform/tfdiags"
@@ -68,8 +69,79 @@ type Config struct {
 	Version *version.Version
 }
 
-// ProviderDependencies returns the provider dependencies for the recieving
-// config, including all of its descendent modules.
+// ProviderRequirements searches the full tree of modules under the receiver
+// for both explicit and implicit dependencies on providers.
+//
+// The result is a full manifest of all of the providers that must be available
+// in order to work with the receiving configuration.
+//
+// If the returned diagnostics includes errors then the resulting Requirements
+// may be incomplete.
+func (c *Config) ProviderRequirements() (getproviders.Requirements, tfdiags.Diagnostics) {
+	reqs := make(getproviders.Requirements)
+	diags := c.addProviderRequirements(reqs)
+	return reqs, diags
+}
+
+// addProviderRequirements is the main part of the ProviderRequirements
+// implementation, gradually mutating a shared requirements object to
+// eventually return.
+func (c *Config) addProviderRequirements(reqs getproviders.Requirements) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// First we'll deal with the requirements directly in _our_ module...
+	for localName, providerReqs := range c.Module.RequiredProviders {
+		var fqn addrs.Provider
+		if source := providerReqs.Source; source != "" {
+			addr, moreDiags := addrs.ParseProviderSourceString(source)
+			if moreDiags.HasErrors() {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid provider source address",
+					fmt.Sprintf("Invalid source %q for provider %q in %s", source, localName, c.Path),
+				))
+				continue
+			}
+			fqn = addr
+		}
+		if fqn.IsZero() {
+			fqn = addrs.NewDefaultProvider(localName)
+		}
+		if _, ok := reqs[fqn]; !ok {
+			// We'll at least have an unconstrained dependency then, but might
+			// add to this in the loop below.
+			reqs[fqn] = nil
+		}
+		for _, constraintsStr := range providerReqs.VersionConstraints {
+			if constraintsStr != "" {
+				constraints, err := getproviders.ParseVersionConstraints(constraintsStr)
+				if err != nil {
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						"Invalid provider version constraint",
+						fmt.Sprintf("Provider %q in %s has invalid version constraint %q: %s.", localName, c.Path, constraintsStr, err),
+					))
+					continue
+				}
+				reqs[fqn] = append(reqs[fqn], constraints...)
+			}
+		}
+	}
+
+	// ...and now we'll recursively visit all of the child modules to merge
+	// in their requirements too.
+	for _, childConfig := range c.Children {
+		moreDiags := childConfig.addProviderRequirements(reqs)
+		diags = diags.Append(moreDiags)
+	}
+
+	return diags
+}
+
+// ProviderDependencies is a deprecated variant of ProviderRequirements which
+// uses the moduledeps models for representation. This is preserved to allow
+// a gradual transition over to ProviderRequirements, but note that its
+// support for fully-qualified provider addresses has some idiosyncracies.
 func (c *Config) ProviderDependencies() (*moduledeps.Module, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 

--- a/internal/earlyconfig/config_test.go
+++ b/internal/earlyconfig/config_test.go
@@ -1,0 +1,84 @@
+package earlyconfig
+
+import (
+	"log"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+	svchost "github.com/hashicorp/terraform-svchost"
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/internal/getproviders"
+	"github.com/hashicorp/terraform/tfdiags"
+)
+
+func TestConfigProviderRequirements(t *testing.T) {
+	cfg := testConfig(t, "testdata/provider-reqs")
+
+	impliedProvider := addrs.NewProvider(
+		addrs.DefaultRegistryHost,
+		"hashicorp", "implied",
+	)
+	nullProvider := addrs.NewProvider(
+		addrs.DefaultRegistryHost,
+		"hashicorp", "null",
+	)
+	randomProvider := addrs.NewProvider(
+		addrs.DefaultRegistryHost,
+		"hashicorp", "random",
+	)
+	tlsProvider := addrs.NewProvider(
+		addrs.DefaultRegistryHost,
+		"hashicorp", "tls",
+	)
+	happycloudProvider := addrs.NewProvider(
+		svchost.Hostname("tf.example.com"),
+		"awesomecorp", "happycloud",
+	)
+
+	got, diags := cfg.ProviderRequirements()
+	if diags.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Err().Error())
+	}
+	want := getproviders.Requirements{
+		// the nullProvider constraints from the two modules are merged
+		nullProvider:       getproviders.MustParseVersionConstraints("~> 2.0.0, 2.0.1"),
+		randomProvider:     getproviders.MustParseVersionConstraints("~> 1.2.0"),
+		tlsProvider:        getproviders.MustParseVersionConstraints("~> 3.0"),
+		impliedProvider:    nil,
+		happycloudProvider: nil,
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("wrong result\n%s", diff)
+	}
+}
+
+func testConfig(t *testing.T, baseDir string) *Config {
+	rootMod, diags := LoadModule(baseDir)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Err().Error())
+	}
+
+	cfg, diags := BuildConfig(rootMod, ModuleWalkerFunc(testModuleWalkerFunc))
+	if diags.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Err().Error())
+	}
+
+	return cfg
+}
+
+// testModuleWalkerFunc is a simple implementation of ModuleWalkerFunc that
+// only understands how to resolve relative filesystem paths, using source
+// location information from the call.
+func testModuleWalkerFunc(req *ModuleRequest) (*tfconfig.Module, *version.Version, tfdiags.Diagnostics) {
+	callFilename := req.CallPos.Filename
+	sourcePath := req.SourceAddr
+	finalPath := filepath.Join(filepath.Dir(callFilename), sourcePath)
+	log.Printf("[TRACE] %s in %s -> %s", sourcePath, callFilename, finalPath)
+
+	newMod, diags := LoadModule(finalPath)
+	return newMod, version.Must(version.NewVersion("0.0.0")), diags
+}

--- a/internal/earlyconfig/testdata/provider-reqs/child/provider-reqs-child.tf
+++ b/internal/earlyconfig/testdata/provider-reqs/child/provider-reqs-child.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    cloud = {
+      source = "tf.example.com/awesomecorp/happycloud"
+    }
+    null = {
+      # This should merge with the null provider constraint in the root module
+      version = "2.0.1"
+    }
+  }
+}

--- a/internal/earlyconfig/testdata/provider-reqs/provider-reqs-root.tf
+++ b/internal/earlyconfig/testdata/provider-reqs/provider-reqs-root.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    null = "~> 2.0.0"
+    random = {
+      version = "~> 1.2.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# There is no provider in required_providers called "implied", so this
+# implicitly declares a dependency on "hashicorp/implied".
+resource "implied_foo" "bar" {
+}
+
+module "child" {
+  source = "./child"
+}

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -88,7 +88,7 @@ func (i *Installer) SetGlobalCacheDir(cacheDir *Dir) {
 // failures then those notifications will be redundant with the ones included
 // in the final returned error value so callers should show either one or the
 // other, and not both.
-func (i *Installer) EnsureProviderVersions(ctx context.Context, reqs map[addrs.Provider]getproviders.VersionConstraints, mode InstallMode) (map[addrs.Provider]getproviders.Version, error) {
+func (i *Installer) EnsureProviderVersions(ctx context.Context, reqs getproviders.Requirements, mode InstallMode) (getproviders.Selections, error) {
 	// FIXME: Currently the context isn't actually propagated into all of the
 	// other functions we call here, because they are not context-aware.
 	// Anything that could be making network requests here should take a

--- a/states/state.go
+++ b/states/state.go
@@ -6,6 +6,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/internal/getproviders"
 )
 
 // State is the top-level type of a Terraform state.
@@ -220,6 +221,22 @@ func (s *State) ProviderAddrs() []addrs.AbsProviderConfig {
 		ret[i] = m[key]
 	}
 
+	return ret
+}
+
+// ProviderRequirements returns a description of all of the providers that
+// are required to work with the receiving state.
+//
+// Because the state does not track specific version information for providers,
+// the requirements returned by this method will always be unconstrained.
+// The result should usually be merged with a Requirements derived from the
+// current configuration in order to apply some constraints.
+func (s *State) ProviderRequirements() getproviders.Requirements {
+	configAddrs := s.ProviderAddrs()
+	ret := make(getproviders.Requirements, len(configAddrs))
+	for _, configAddr := range configAddrs {
+		ret[configAddr.Provider] = nil // unconstrained dependency
+	}
 	return ret
 }
 


### PR DESCRIPTION
We've been using the models from the `moduledeps` package to represent our provider dependencies everywhere since the idea of provider dependencies was introduced in Terraform 0.10, but that model is not very convenient to use for any use-case other than the `terraform providers` command that needs individual-module-level detail.

To make things easier for new codepaths working with the new-style provider installer, here we introduce a new model type `getproviders.Requirements` which is based on the type the new installer was already taking as its input. We have new methods in the `states`, `configs`, and `earlyconfig` packages to produce values of this type, and a helper to merge `Requirements` together so we can combine config-derived and state-derived requirements together during installation.

The advantage of this new model over the `moduledeps` one is that all of recursive module walking is done up front and we produce a simple, flat structure that is more convenient for the main use-cases of selecting providers for installation and then finding providers in the local cache to use them for other operations.

This new model is _not_ suitable for implementing `terraform providers` because it does not retain module-specific requirement details. Therefore we will likely keep using `moduledeps` for `terraform providers` for now, and then possibly at a later time consider specializing the `moduledeps` logic for only what "terraform providers" needs, because it seems to be the only use-case that needs to retain that level of detail.

This is still all just dead code not called from anywhere, but I'll be updating my branch in progress to wire the new installer into `terraform init` to use these new functions if we go ahead with them, which should reduce the amount of code directly inside the `terraform init` command's implementation.
