### PR TITLE
command/format: Fix multi-line diagnostic output

### DIFF
--- a/command/format/diagnostic.go
+++ b/command/format/diagnostic.go
@@ -100,15 +100,23 @@ func Diagnostic(diag tfdiags.Diagnostic, sources map[string][]byte, color *color
 				if !lineRange.Overlaps(snippetRange) {
 					continue
 				}
-				beforeRange, highlightedRange, afterRange := lineRange.PartitionAround(highlightRange)
-				before := beforeRange.SliceBytes(src)
-				highlighted := highlightedRange.SliceBytes(src)
-				after := afterRange.SliceBytes(src)
-				fmt.Fprintf(
-					&buf, color.Color("%4d: %s[underline]%s[reset]%s\n"),
-					lineRange.Start.Line,
-					before, highlighted, after,
-				)
+				if lineRange.Overlaps(highlightRange) {
+					beforeRange, highlightedRange, afterRange := lineRange.PartitionAround(highlightRange)
+					before := beforeRange.SliceBytes(src)
+					highlighted := highlightedRange.SliceBytes(src)
+					after := afterRange.SliceBytes(src)
+					fmt.Fprintf(
+						&buf, color.Color("%4d: %s[underline]%s[reset]%s\n"),
+						lineRange.Start.Line,
+						before, highlighted, after,
+					)
+				} else {
+					fmt.Fprintf(
+						&buf, "%4d: %s\n",
+						lineRange.Start.Line,
+						lineRange.SliceBytes(src),
+					)
+				}
 			}
 
 		}


### PR DESCRIPTION
Previously, if a diagnostic context spanned multiple lines, any lines which did not overlap with the highlight range would be displayed as blank. This commit fixes the bug.

The problem was caused by the unconditional use of `PartitionAround` to split the line into before/highlighted/after ranges. When two ranges don't overlap, this method returns empty ranges, which results in a blank line. Instead, we first check if the ranges do overlap, and if not we print the entire line from the context.

Fixes #21636

### Before

![image](https://user-images.githubusercontent.com/68917/77690869-57536d80-6f7a-11ea-9568-cfb8cace957a.png)

### After

![image](https://user-images.githubusercontent.com/68917/77690809-4571ca80-6f7a-11ea-99f0-b3e8644bd5b4.png)
