### PR TITLE
add sample circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.14
+    steps:
+      - run: echo "hello world"
+
+workflows:
+  version: 2
+  sample:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore:
+                - /.*/


### PR DESCRIPTION
This is a sample CircleCI configuration to allow testing of CircleCI configuration on a branch without Circle's webhook complaining there is no configuration on every PR. This branch filter prevents Circle from running on every branch so it shouldn't even show up in the PR checks.