### PR TITLE
cmd workspace list output as json

### DIFF
--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -106,6 +106,56 @@ func TestWorkspace_createAndList(t *testing.T) {
 	if actual != expected {
 		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)
 	}
+
+	// Json without env override
+
+	// Make sure an override does not exist
+	if _, ok := os.LookupEnv("TF_WORKSPACE"); ok {
+		t.Fatalf("TF_WORKSPACE must not be set.")
+	}
+
+	args := []string{
+		"-json",
+	}
+	listCmd = &WorkspaceListCommand{}
+	ui = new(cli.MockUi)
+	listCmd.Meta = Meta{Ui: ui}
+
+	if code := listCmd.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+	}
+
+	actual = strings.TrimSpace(ui.OutputWriter.String())
+	expected = "{\"terraform_version\":\"0.13.0-dev\",\"workspaces\":[{\"name\":\"default\",\"selected\":false},{\"name\":\"test_a\",\"selected\":false},{\"name\":\"test_b\",\"selected\":false},{\"name\":\"test_c\",\"selected\":true}],\"is_overridden\":false,\"overridden_note\":\"\"}"
+
+	if actual != expected {
+		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)
+	}
+
+	// With workspace override
+
+	// Set the workspace override
+	defer os.Unsetenv("TF_WORKSPACE")
+	os.Setenv("TF_WORKSPACE", "test_a")
+
+	args = []string{
+		"-json",
+	}
+	listCmd = &WorkspaceListCommand{}
+	ui = new(cli.MockUi)
+	listCmd.Meta = Meta{Ui: ui}
+
+	if code := listCmd.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+	}
+
+	actual = strings.TrimSpace(ui.OutputWriter.String())
+	expected = "{\"terraform_version\":\"0.13.0-dev\",\"workspaces\":[{\"name\":\"default\",\"selected\":false},{\"name\":\"test_a\",\"selected\":true},{\"name\":\"test_b\",\"selected\":false},{\"name\":\"test_c\",\"selected\":false}],\"is_overridden\":true,\"overridden_note\":\"\\n\\nThe active workspace is being overridden using the TF_WORKSPACE environment\\nvariable.\\n\"}"
+
+	if actual != expected {
+		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)
+	}
+
 }
 
 // Create some workspaces and test the show output.

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -2,7 +2,9 @@ package command
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	tfversion "github.com/hashicorp/terraform/version"
 	"strings"
 
 	"github.com/hashicorp/terraform/tfdiags"
@@ -14,6 +16,18 @@ type WorkspaceListCommand struct {
 	LegacyName bool
 }
 
+type WorkspaceList struct {
+	Name string  `json:"name"`
+	Selected bool `json:"selected"`
+}
+
+type WorkspaceListOutput struct {
+	TerraformVersion string  `json:"terraform_version"`
+	WorkspaceList              []WorkspaceList  `json:"workspaces"`
+	IsOverridden bool  `json:"is_overridden"`
+	OverriddenNote string  `json:"overridden_note"`
+}
+
 func (c *WorkspaceListCommand) Run(args []string) int {
 	args, err := c.Meta.process(args, true)
 	if err != nil {
@@ -23,6 +37,8 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
 	cmdFlags := c.Meta.defaultFlagSet("workspace list")
+	var jsonOutput bool
+	cmdFlags.BoolVar(&jsonOutput, "json", false, "produce JSON output")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
@@ -63,6 +79,31 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 
 	env, isOverridden := c.WorkspaceOverridden()
 
+	// If json
+	if jsonOutput == true {
+		var wsOutput WorkspaceListOutput
+		wsOutput.TerraformVersion = tfversion.String()
+		wsOutput.IsOverridden = isOverridden
+		if isOverridden {
+			wsOutput.OverriddenNote =  envIsOverriddenNote
+		}
+
+		for _, s := range states {
+			ws := WorkspaceList{Name: s, Selected: s == env}
+			wsOutput.WorkspaceList = append(wsOutput.WorkspaceList, ws)
+		}
+
+		jsonOutput, err := json.Marshal(wsOutput)
+
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to marshal workspace list to json: %s", err))
+			return 1
+		}
+		c.Ui.Output(string(jsonOutput))
+		return 0
+	}
+
+	// If not json
 	var out bytes.Buffer
 	for _, s := range states {
 		if s == env {
@@ -92,9 +133,13 @@ func (c *WorkspaceListCommand) AutocompleteFlags() complete.Flags {
 
 func (c *WorkspaceListCommand) Help() string {
 	helpText := `
-Usage: terraform workspace list [DIR]
+Usage: terraform workspace list [DIR] [options] 
 
   List Terraform workspaces.
+
+Options:
+
+  -json               If specified, output to a machine-readable form.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -17,15 +17,15 @@ type WorkspaceListCommand struct {
 }
 
 type WorkspaceList struct {
-	Name string  `json:"name"`
-	Selected bool `json:"selected"`
+	Name     string `json:"name"`
+	Selected bool   `json:"selected"`
 }
 
 type WorkspaceListOutput struct {
-	TerraformVersion string  `json:"terraform_version"`
-	WorkspaceList              []WorkspaceList  `json:"workspaces"`
-	IsOverridden bool  `json:"is_overridden"`
-	OverriddenNote string  `json:"overridden_note"`
+	TerraformVersion string          `json:"terraform_version"`
+	WorkspaceList    []WorkspaceList `json:"workspaces"`
+	IsOverridden     bool            `json:"is_overridden"`
+	OverriddenNote   string          `json:"overridden_note"`
 }
 
 func (c *WorkspaceListCommand) Run(args []string) int {
@@ -85,7 +85,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 		wsOutput.TerraformVersion = tfversion.String()
 		wsOutput.IsOverridden = isOverridden
 		if isOverridden {
-			wsOutput.OverriddenNote =  envIsOverriddenNote
+			wsOutput.OverriddenNote = envIsOverriddenNote
 		}
 
 		for _, s := range states {


### PR DESCRIPTION
Add command line option `workspace list -json` to output workspaces in json format

- strut contains `terraform_version` to be consistent with `terraform show -json` output

Signed-off-by: S.Cavallo <smcavallo@hotmail.com>