### PR TITLE
Fix a typo in the Graylog provider name

### DIFF
--- a/website/docs/providers/type/community-index.html.markdown
+++ b/website/docs/providers/type/community-index.html.markdown
@@ -87,7 +87,7 @@ please fill out this [community providers form](https://docs.google.com/forms/d/
 - [Google Calendar](https://github.com/sethvargo/terraform-provider-googlecalendar)
 - [Google G Suite](https://github.com/DeviaVir/terraform-provider-gsuite)
 - [GorillaStack](https://github.com/GorillaStack/terraform-provider-gorillastack)
-- [Greylog](https://github.com/suzuki-shunsuke/go-graylog)
+- [Graylog](https://github.com/suzuki-shunsuke/go-graylog)
 - [Harbor](https://github.com/BESTSELLER/terraform-harbor-provider)
 - [Hiera](https://github.com/ribbybibby/terraform-provider-hiera)
 - [Hiera 5](https://gitlab.com/sbitio/terraform-provider-hiera5)


### PR DESCRIPTION
Fix a typo in the provider name. Makes it easier to find the link on the page.
![image](https://user-images.githubusercontent.com/282550/77923144-4f5d3b80-72a2-11ea-998f-a588f225b792.png)

