### PR TITLE
states/version3 upgrade: revert provider FQN changes

### DIFF
--- a/states/statefile/testdata/roundtrip/v3-bigint.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-bigint.out.tfstate
@@ -28,7 +28,7 @@
             "type": "null_resource",
             "name": "bar",
             "each": "list",
-            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "provider": "provider.null",
             "instances": [
                 {
                     "attributes_flat": {
@@ -60,7 +60,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "baz",
-            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "provider": "provider.null",
             "instances": [
                 {
                     "attributes_flat": {
@@ -86,7 +86,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "foo",
-            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "provider": "provider.null",
             "instances": [
                 {
                     "attributes_flat": {

--- a/states/statefile/testdata/roundtrip/v3-grabbag.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-grabbag.out.tfstate
@@ -28,7 +28,7 @@
             "type": "null_resource",
             "name": "bar",
             "each": "list",
-            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "provider": "provider.null",
             "instances": [
                 {
                     "attributes_flat": {
@@ -60,7 +60,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "baz",
-            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "provider": "provider.null",
             "instances": [
                 {
                     "attributes_flat": {
@@ -86,7 +86,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "foo",
-            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "provider": "provider.null",
             "instances": [
                 {
                     "attributes_flat": {

--- a/states/statefile/testdata/roundtrip/v3-invalid-depends.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-invalid-depends.out.tfstate
@@ -14,7 +14,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "bar",
-            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "provider": "provider.null",
             "instances": [
                 {
                     "schema_version": 0,

--- a/states/statefile/testdata/roundtrip/v3-simple.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-simple.out.tfstate
@@ -14,7 +14,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "bar",
-            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "provider": "provider.null",
             "instances": [
                 {
                     "schema_version": 0,
@@ -35,7 +35,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "foo",
-            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "provider": "provider.null",
             "each": "list",
             "instances": [
                 {
@@ -62,7 +62,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "foobar",
-            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "provider": "provider.null",
             "instances": [
                 {
                     "schema_version": 0,

--- a/states/statefile/testdata/roundtrip/v4-simple.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-simple.in.tfstate
@@ -33,7 +33,7 @@
             "mode": "managed",
             "type": "null_resource",
             "name": "foo",
-            "provider": "provider.null",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
             "each": "list",
             "instances": [
                 {

--- a/states/statefile/version3_upgrade.go
+++ b/states/statefile/version3_upgrade.go
@@ -154,7 +154,7 @@ func upgradeStateV3ToV4(old *stateV3) (*stateV4, error) {
 					Type:           resAddr.Type,
 					Name:           resAddr.Name,
 					Instances:      []instanceObjectStateV4{},
-					ProviderConfig: providerAddr.String(),
+					ProviderConfig: providerAddr.LegacyString(),
 				}
 				resourceStates[resAddr.String()] = rs
 			}


### PR DESCRIPTION
This commit reverts an earlier change which automatically converted
provider strings to legacy provider FQNs. It is now reverted back to legacy-style strings. 

It has become apparent that a state upgrade step will be required before upgrading to v0.13 and we should do that explicitly, instead of hidden assumptions like this one. 

This PR is targeting the f-init-new-installer branch and will cause many broken tests; I can hold off on merging and fix them here OR merge (pending review) and deal with the tests in the f-init-new-installer branch.  The reason I haven't started fixing tests is that we are debating a fairly substantial change to terraform.NewContext which (greatly) impacts all the same tests and I'd rather do it all at once if possible/reasonable. 