### PR TITLE
CI: migrate travis to circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,175 @@
 version: 2.1
-jobs:
-  build:
+
+executors:
+  go:
     docker:
       - image: circleci/golang:1.14
+    environment:
+      CONSUL_VERSION: 1.7.2
+      GOMAXPROCS: 4
+      GO111MODULE: "on"
+      GOPROXY: https://proxy.golang.org/
+      TEST_RESULTS_DIR: &TEST_RESULTS_DIR /tmp/test-results
+      ARTIFACTS_DIR: &ARTIFACTS_DIR /tmp/artifacts
+      GOFLAGS: "-mod=vendor"
+
+jobs:
+  go-checks:
+    executor:
+      name: go
     steps:
-      - run: echo "hello world"
+      - checkout
+      - run: go mod verify
+      - run: make fmtcheck generate
+      - run:
+          name: verify no code was generated
+          command: |
+            if [[ -z $(git status --porcelain) ]]; then
+              echo "clean"
+            else
+              echo "dirty"
+              git status --porcelain
+              exit 1
+            fi
+
+  go-test:
+    executor:
+      name: go
+    parallelism: 4
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: install consul
+          command: |
+            curl -sLo consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
+            unzip consul.zip
+            mkdir -p ~/bin
+            mv consul ~/bin
+            echo 'export PATH="~/bin:$PATH"'
+      - run: mkdir -p $TEST_RESULTS_DIR
+      - run: |
+          PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+          echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
+          echo $PACKAGE_NAMES
+          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -p 2 -cover -coverprofile=cov_$CIRCLE_NODE_INDEX.part $PACKAGE_NAMES
+
+      # save coverage report parts
+      - persist_to_workspace:
+          root: .
+          paths:
+            - cov_*.part
+
+      - store_test_results:
+          path: *TEST_RESULTS_DIR
+      - store_artifacts:
+          path: *TEST_RESULTS_DIR
+
+  go-test-e2e:
+    executor:
+      name: go
+    environment:
+      TF_ACC: 1
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: mkdir -p $TEST_RESULTS_DIR
+      - run: |
+          PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+          echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
+          echo $PACKAGE_NAMES
+          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -p 2 -cover -coverprofile=cov_e2e.part ./command/e2etest
+
+      # save coverage report parts
+      - persist_to_workspace:
+          root: .
+          paths:
+            - cov_*.part
+
+      - store_test_results:
+          path: *TEST_RESULTS_DIR
+      - store_artifacts:
+          path: *TEST_RESULTS_DIR
+
+  # combine code coverage results from the parallel circleci executors
+  coverage-merge:
+    executor:
+      name: go
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: mkdir -p $TEST_RESULTS_DIR
+      - run:
+          name: merge coverage reports
+          command: |
+            echo "mode: set" > coverage.out
+            grep -h -v "mode: set" cov_*.part >> coverage.out
+            go tool cover -html=coverage.out -o $TEST_RESULTS_DIR/coverage.html
+      - run:
+          name: codecov upload
+          command: bash <(curl -s https://codecov.io/bash) -v -C $CIRCLE_SHA1
+      - store_artifacts:
+          path: *TEST_RESULTS_DIR
+
+  # build all distros
+  build-distros: &build-distros
+    executor: go
+    environment: &build-env
+      TF_RELEASE: 1
+    steps:
+      - run: go get -u github.com/mitchellh/gox # go get gox before detecting go mod
+      - checkout
+      - run: ./scripts/build.sh
+      - run: mkdir -p $ARTIFACTS_DIR
+      - run: cp pkg/*.zip /tmp/artifacts
+      # save dev build to CircleCI
+      - store_artifacts:
+          path: *ARTIFACTS_DIR
+
+  # build all 386 architecture supported OS binaries
+  build-386:
+    <<: *build-distros
+    environment:
+      <<: *build-env
+      XC_OS: "freebsd linux openbsd windows"
+      XC_ARCH: "386"
+
+  # build all amd64 architecture supported OS binaries
+  build-amd64:
+    <<: *build-distros
+    environment:
+      <<: *build-env
+      XC_OS: "darwin freebsd linux solaris windows"
+      XC_ARCH: "amd64"
+
+  # build all arm architecture supported OS binaries
+  build-arm:
+    <<: *build-distros
+    environment:
+      <<: *build-env
+      XC_OS: "freebsd linux"
+      XC_ARCH: "arm"
 
 workflows:
   version: 2
-  sample:
+  test:
     jobs:
-      - build:
-          filters:
-            branches:
-              ignore:
-                - /.*/
+      - go-checks
+      - go-test:
+          requires:
+            - go-checks
+      - go-test-e2e:
+          requires:
+            - go-checks
+      - coverage-merge:
+          requires:
+            - go-test
+            - go-test-e2e
+  build-distros:
+    jobs:
+      - build-386
+      - build-amd64
+      - build-arm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,11 +49,13 @@ jobs:
             mv consul ~/bin
             echo 'export PATH="~/bin:$PATH"'
       - run: mkdir -p $TEST_RESULTS_DIR
-      - run: |
-          PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-          echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
-          echo $PACKAGE_NAMES
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -p 2 -cover -coverprofile=cov_$CIRCLE_NODE_INDEX.part $PACKAGE_NAMES
+      - run:
+          name: Run Go Tests
+          command: |
+            PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+            echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
+            echo $PACKAGE_NAMES
+            gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -p 2 -cover -coverprofile=cov_$CIRCLE_NODE_INDEX.part $PACKAGE_NAMES
 
       # save coverage report parts
       - persist_to_workspace:
@@ -76,11 +78,13 @@ jobs:
       - attach_workspace:
           at: .
       - run: mkdir -p $TEST_RESULTS_DIR
-      - run: |
-          PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-          echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
-          echo $PACKAGE_NAMES
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -p 2 -cover -coverprofile=cov_e2e.part ./command/e2etest
+      - run:
+          name: Run Go E2E Tests
+          command: |
+            PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+            echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
+            echo $PACKAGE_NAMES
+            gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -p 2 -cover -coverprofile=cov_e2e.part ./command/e2etest
 
       # save coverage report parts
       - persist_to_workspace:


### PR DESCRIPTION
This PR migrates Terraform from Travis over to CircleCI. I tried to copy most of the configuration and added in bits that I thought would be useful from some of the other projects I have worked on. 

A summary of the more notable changes:
1. I am bumping consul to 1.7.2 (latest) to run tests against.
2. There is a check to make sure `make generate` does not generate a dirty git directory. This should be a command that is run locally and committed back to the repo.
3. Go tests are [parallelized](https://app.circleci.com/pipelines/github/hashicorp/terraform/20/workflows/0a188038-4f96-4125-948d-15ac865072c4) across 4 executors based on package runtimes calculated by `go list ./... | circleci tests split --split-by=timings --timings-type=classname`. They run with the `-cover` flag and these coverage results are aggregated together and uploaded to Codecov. Example: https://codecov.io/gh/hashicorp/terraform/commit/4e52a7a878c5550fcf218d756f9c49b4b17f869e. More info on test splitting can be found in the [CircleCI docs](https://circleci.com/docs/2.0/parallelism-faster-jobs/). 
4. There are[ parallel builds](https://app.circleci.com/pipelines/github/hashicorp/terraform/20/workflows/8616ec7d-10de-4606-8097-f06fb6c4ae82) of all the various architectures Terraform builds that runs on every PR. These artifacts and test builds can be directly downloaded from the CircleCI interface. For example: https://app.circleci.com/pipelines/github/hashicorp/terraform/20/workflows/8616ec7d-10de-4606-8097-f06fb6c4ae82/jobs/85/artifacts. This was something we ran into on Consul where there was an upstream dependency that had a build tag to exclude Solaris that we couldn't build since Consul builds on Solaris. Rather than finding this out at release time, these parallel builds will give you a quick smoke test that everything still compiles for all the OS_ARCH that Terraform builds. 
5. The tests are no longer using the `make test` and `make e2etest` make targets because they use gotestsum to generate XML that CircleCI can then understand and parse for failed test results. 