### PR TITLE
Remove terraform.ResourceProvider, use providercache.Installer instead

### DIFF
--- a/addrs/provider_test.go
+++ b/addrs/provider_test.go
@@ -46,6 +46,77 @@ func TestProviderIsDefault(t *testing.T) {
 	}
 }
 
+func TestProviderIsBuiltIn(t *testing.T) {
+	tests := []struct {
+		Input Provider
+		Want  bool
+	}{
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  BuiltInProviderHost,
+				Namespace: BuiltInProviderNamespace,
+			},
+			true,
+		},
+		{
+			Provider{
+				Type:      "terraform",
+				Hostname:  BuiltInProviderHost,
+				Namespace: BuiltInProviderNamespace,
+			},
+			true,
+		},
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  BuiltInProviderHost,
+				Namespace: "boop",
+			},
+			false,
+		},
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  DefaultRegistryHost,
+				Namespace: BuiltInProviderNamespace,
+			},
+			false,
+		},
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  DefaultRegistryHost,
+				Namespace: "hashicorp",
+			},
+			false,
+		},
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  "registry.terraform.com",
+				Namespace: "hashicorp",
+			},
+			false,
+		},
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  DefaultRegistryHost,
+				Namespace: "othercorp",
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		got := test.Input.IsBuiltIn()
+		if got != test.Want {
+			t.Errorf("wrong result for %s\ngot:  %#v\nwant: %#v", test.Input.String(), got, test.Want)
+		}
+	}
+}
+
 func TestProviderIsLegacy(t *testing.T) {
 	tests := []struct {
 		Input Provider

--- a/backend/local/testing.go
+++ b/backend/local/testing.go
@@ -112,11 +112,9 @@ func TestLocalProvider(t *testing.T, b *Local, name string, schema *terraform.Pr
 	}
 
 	// Setup our provider
-	b.ContextOpts.ProviderResolver = providers.ResolverFixed(
-		map[addrs.Provider]providers.Factory{
-			addrs.NewLegacyProvider(name): providers.FactoryFixed(p),
-		},
-	)
+	b.ContextOpts.Providers = map[addrs.Provider]providers.Factory{
+		addrs.NewLegacyProvider(name): providers.FactoryFixed(p),
+	}
 
 	return p
 

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -206,7 +206,7 @@ func TestApply_parallelism(t *testing.T) {
 		providerFactories[addrs.NewLegacyProvider(name)] = providers.FactoryFixed(provider)
 	}
 	testingOverrides := &testingOverrides{
-		ProviderResolver: providers.ResolverFixed(providerFactories),
+		Providers: providerFactories,
 	}
 
 	ui := new(cli.MockUi)

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -119,21 +119,17 @@ func testFixturePath(name string) string {
 
 func metaOverridesForProvider(p providers.Interface) *testingOverrides {
 	return &testingOverrides{
-		ProviderResolver: providers.ResolverFixed(
-			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): providers.FactoryFixed(p),
-			},
-		),
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewLegacyProvider("test"): providers.FactoryFixed(p),
+		},
 	}
 }
 
 func metaOverridesForProviderAndProvisioner(p providers.Interface, pr provisioners.Interface) *testingOverrides {
 	return &testingOverrides{
-		ProviderResolver: providers.ResolverFixed(
-			map[addrs.Provider]providers.Factory{
-				addrs.NewLegacyProvider("test"): providers.FactoryFixed(p),
-			},
-		),
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewLegacyProvider("test"): providers.FactoryFixed(p),
+		},
 		Provisioners: map[string]provisioners.Factory{
 			"shell": provisioners.FactoryFixed(pr),
 		},

--- a/command/init.go
+++ b/command/init.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/providercache"
-	"github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/tfdiags"
 )
@@ -32,12 +31,6 @@ type InitCommand struct {
 
 	// getPlugins is for the -get-plugins flag
 	getPlugins bool
-
-	// providerInstaller is used to download and install providers that
-	// aren't found locally. This uses a discovery.ProviderInstaller instance
-	// by default, but it can be overridden here as a way to mock fetching
-	// providers for tests.
-	providerInstaller discovery.Installer
 }
 
 func (c *InitCommand) Run(args []string) int {
@@ -75,18 +68,6 @@ func (c *InitCommand) Run(args []string) int {
 	if len(flagPluginPath) > 0 {
 		c.pluginPath = flagPluginPath
 		c.getPlugins = false
-	}
-
-	// set providerInstaller if we don't have a test version already
-	if c.providerInstaller == nil {
-		c.providerInstaller = &discovery.ProviderInstaller{
-			Dir:                   c.pluginDir(),
-			Cache:                 c.pluginCache(),
-			PluginProtocolVersion: discovery.PluginInstallProtocolVersion,
-			SkipVerify:            !flagVerifyPlugins,
-			Ui:                    c.Ui,
-			Services:              c.Services,
-		}
 	}
 
 	// Validate the arg count
@@ -460,15 +441,9 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 
 	// TODO: If the user gave at least one -plugin-dir option on the command
 	// line, we should construct a one-off getproviders.Source that consults
-	// only those directories and use that instead of c.providerInstallSource()
-	// here.
-	targetDir := c.providerLocalCacheDir()
-	globalCacheDir := c.providerGlobalCacheDir()
-	source := c.providerInstallSource()
-	inst := providercache.NewInstaller(targetDir, source)
-	if globalCacheDir != nil {
-		inst.SetGlobalCacheDir(globalCacheDir)
-	}
+	// only those directories and pass that to c.providerInstallerCustomSource
+	// instead.
+	inst := c.providerInstaller()
 
 	// Because we're currently just streaming a series of events sequentially
 	// into the terminal, we're showing only a subset of the events to keep

--- a/command/meta.go
+++ b/command/meta.go
@@ -187,8 +187,8 @@ type PluginOverrides struct {
 }
 
 type testingOverrides struct {
-	ProviderResolver providers.Resolver
-	Provisioners     map[string]provisioners.Factory
+	Providers    map[addrs.Provider]providers.Factory
+	Provisioners map[string]provisioners.Factory
 }
 
 // initStatePaths is used to initialize the default values for
@@ -350,10 +350,22 @@ func (m *Meta) contextOpts() *terraform.ContextOpts {
 	// and just work with what we've been given, thus allowing the tests
 	// to provide mock providers and provisioners.
 	if m.testingOverrides != nil {
-		opts.ProviderResolver = m.testingOverrides.ProviderResolver
+		opts.Providers = m.testingOverrides.Providers
 		opts.Provisioners = m.testingOverrides.Provisioners
 	} else {
-		opts.ProviderResolver = m.providerResolver()
+		providerFactories, err := m.providerFactories()
+		if err != nil {
+			// providerFactories can fail if the plugin selections file is
+			// invalid in some way, but we don't have any way to report that
+			// from here so we'll just behave as if no providers are available
+			// in that case. However, we will produce a warning in case this
+			// shows up unexpectedly and prompts a bug report.
+			// This situation shouldn't arise commonly in practice because
+			// the selections file is generated programmatically.
+			log.Printf("[WARN] Failed to determine selected providers: %s", err)
+			providerFactories = nil
+		}
+		opts.Providers = providerFactories
 		opts.Provisioners = m.provisionerFactories()
 	}
 

--- a/command/plugins.go
+++ b/command/plugins.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -15,104 +14,19 @@ import (
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/kardianos/osext"
 
-	"github.com/hashicorp/terraform/addrs"
-	terraformProvider "github.com/hashicorp/terraform/builtin/providers/terraform"
 	tfplugin "github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/plugin/discovery"
-	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/provisioners"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-// multiVersionProviderResolver is an implementation of
-// terraform.ResourceProviderResolver that matches the given version constraints
-// against a set of versioned provider plugins to find the newest version of
-// each that satisfies the given constraints.
-type multiVersionProviderResolver struct {
-	Available discovery.PluginMetaSet
-
-	// Internal is a map that overrides the usual plugin selection process
-	// for internal plugins. These plugins do not support version constraints
-	// (will produce an error if one is set). This should be used only in
-	// exceptional circumstances since it forces the provider's release
-	// schedule to be tied to that of Terraform Core.
-	Internal map[addrs.Provider]providers.Factory
-}
-
-func chooseProviders(avail discovery.PluginMetaSet, internal map[addrs.Provider]providers.Factory, reqd discovery.PluginRequirements) map[string]discovery.PluginMeta {
-	candidates := avail.ConstrainVersions(reqd)
-	ret := map[string]discovery.PluginMeta{}
-	for name, metas := range candidates {
-		// If the provider is in our internal map then we ignore any
-		// discovered plugins for it since these are dealt with separately.
-		if _, isInternal := internal[addrs.NewLegacyProvider(name)]; isInternal {
-			continue
-		}
-
-		if len(metas) == 0 {
-			continue
-		}
-		ret[name] = metas.Newest()
-	}
-	return ret
-}
-
-func (r *multiVersionProviderResolver) ResolveProviders(
-	reqd discovery.PluginRequirements,
-) (map[addrs.Provider]providers.Factory, []error) {
-	factories := make(map[addrs.Provider]providers.Factory, len(reqd))
-	var errs []error
-
-	chosen := chooseProviders(r.Available, r.Internal, reqd)
-	for name, req := range reqd {
-		if factory, isInternal := r.Internal[addrs.NewLegacyProvider(name)]; isInternal {
-			if !req.Versions.Unconstrained() {
-				errs = append(errs, fmt.Errorf("provider.%s: this provider is built in to Terraform and so it does not support version constraints", name))
-				continue
-			}
-			factories[addrs.NewLegacyProvider(name)] = factory
-			continue
-		}
-
-		if newest, available := chosen[name]; available {
-			digest, err := newest.SHA256()
-			if err != nil {
-				errs = append(errs, fmt.Errorf("provider.%s: failed to load plugin to verify its signature: %s", name, err))
-				continue
-			}
-			if !reqd[name].AcceptsSHA256(digest) {
-				errs = append(errs, fmt.Errorf("provider.%s: new or changed plugin executable", name))
-				continue
-			}
-
-			factories[addrs.NewLegacyProvider(name)] = providerFactory(newest)
-		} else {
-			msg := fmt.Sprintf("provider.%s: no suitable version installed", name)
-
-			required := req.Versions.String()
-			// no version is unconstrained
-			if required == "" {
-				required = "(any version)"
-			}
-
-			foundVersions := []string{}
-			for meta := range r.Available.WithName(name) {
-				foundVersions = append(foundVersions, fmt.Sprintf("%q", meta.Version))
-			}
-
-			found := "none"
-			if len(foundVersions) > 0 {
-				found = strings.Join(foundVersions, ", ")
-			}
-
-			msg += fmt.Sprintf("\n  version requirements: %q\n  versions installed: %s", required, found)
-
-			errs = append(errs, errors.New(msg))
-		}
-	}
-
-	return factories, errs
-}
+// NOTE WELL: The logic in this file is primarily about plugin types OTHER THAN
+// providers, which use an older set of approaches implemented here.
+//
+// The provider-related functions live primarily in meta_providers.go, and
+// lean on some different underlying mechanisms in order to support automatic
+// installation and a heirarchical addressing namespace, neither of which
+// are supported for other plugin types.
 
 // store the user-supplied path for plugin discovery
 func (m *Meta) storePluginPath(pluginPath []string) error {
@@ -216,101 +130,6 @@ func (m *Meta) pluginCache() discovery.PluginCache {
 	return discovery.NewLocalPluginCache(dir)
 }
 
-// providerPluginSet returns the set of valid providers that were discovered in
-// the defined search paths.
-func (m *Meta) providerPluginSet() discovery.PluginMetaSet {
-	plugins := discovery.FindPlugins("provider", m.pluginDirs(true))
-
-	// Add providers defined in the legacy .terraformrc,
-	if m.PluginOverrides != nil {
-		for k, v := range m.PluginOverrides.Providers {
-			log.Printf("[DEBUG] found plugin override in .terraformrc: %q, %q", k, v)
-		}
-		plugins = plugins.OverridePaths(m.PluginOverrides.Providers)
-	}
-
-	plugins, _ = plugins.ValidateVersions()
-
-	for p := range plugins {
-		log.Printf("[DEBUG] found valid plugin: %q, %q, %q", p.Name, p.Version, p.Path)
-	}
-
-	return plugins
-}
-
-// providerPluginAutoInstalledSet returns the set of providers that exist
-// within the auto-install directory.
-func (m *Meta) providerPluginAutoInstalledSet() discovery.PluginMetaSet {
-	plugins := discovery.FindPlugins("provider", []string{m.pluginDir()})
-	plugins, _ = plugins.ValidateVersions()
-
-	for p := range plugins {
-		log.Printf("[DEBUG] found valid plugin: %q", p.Name)
-	}
-
-	return plugins
-}
-
-// providerPluginManuallyInstalledSet returns the set of providers that exist
-// in all locations *except* the auto-install directory.
-func (m *Meta) providerPluginManuallyInstalledSet() discovery.PluginMetaSet {
-	plugins := discovery.FindPlugins("provider", m.pluginDirs(false))
-
-	// Add providers defined in the legacy .terraformrc,
-	if m.PluginOverrides != nil {
-		for k, v := range m.PluginOverrides.Providers {
-			log.Printf("[DEBUG] found plugin override in .terraformrc: %q, %q", k, v)
-		}
-
-		plugins = plugins.OverridePaths(m.PluginOverrides.Providers)
-	}
-
-	plugins, _ = plugins.ValidateVersions()
-
-	for p := range plugins {
-		log.Printf("[DEBUG] found valid plugin: %q, %q, %q", p.Name, p.Version, p.Path)
-	}
-
-	return plugins
-}
-
-func (m *Meta) providerResolver() providers.Resolver {
-	return &multiVersionProviderResolver{
-		Available: m.providerPluginSet(),
-		Internal:  m.internalProviders(),
-	}
-}
-
-func (m *Meta) internalProviders() map[addrs.Provider]providers.Factory {
-	return map[addrs.Provider]providers.Factory{
-		addrs.NewLegacyProvider("terraform"): func() (providers.Interface, error) {
-			return terraformProvider.NewProvider(), nil
-		},
-	}
-}
-
-// filter the requirements returning only the providers that we can't resolve
-func (m *Meta) missingProviders(avail discovery.PluginMetaSet, reqd discovery.PluginRequirements) discovery.PluginRequirements {
-	missing := make(discovery.PluginRequirements)
-
-	candidates := avail.ConstrainVersions(reqd)
-	internal := m.internalProviders()
-
-	for name, versionSet := range reqd {
-		// internal providers can't be missing
-		if _, ok := internal[addrs.NewLegacyProvider(name)]; ok {
-			continue
-		}
-
-		log.Printf("[DEBUG] plugin requirements: %q=%q", name, versionSet.Versions)
-		if metas := candidates[name]; metas.Count() == 0 {
-			missing[name] = versionSet
-		}
-	}
-
-	return missing
-}
-
 func (m *Meta) provisionerFactories() map[string]terraform.ProvisionerFactory {
 	dirs := m.pluginDirs(true)
 	plugins := discovery.FindPlugins("provisioner", dirs)
@@ -362,28 +181,6 @@ func internalPluginClient(kind, name string) (*plugin.Client, error) {
 	}
 
 	return plugin.NewClient(cfg), nil
-}
-
-func providerFactory(meta discovery.PluginMeta) providers.Factory {
-	return func() (providers.Interface, error) {
-		client := tfplugin.Client(meta)
-		// Request the RPC client so we can get the provider
-		// so we can build the actual RPC-implemented provider.
-		rpcClient, err := client.Client()
-		if err != nil {
-			return nil, err
-		}
-
-		raw, err := rpcClient.Dispense(tfplugin.ProviderPluginName)
-		if err != nil {
-			return nil, err
-		}
-
-		// store the client so that the plugin can kill the child process
-		p := raw.(*tfplugin.GRPCProvider)
-		p.PluginClient = client
-		return p, nil
-	}
 }
 
 func provisionerFactory(meta discovery.PluginMeta) terraform.ProvisionerFactory {

--- a/command/state_show_test.go
+++ b/command/state_show_test.go
@@ -229,11 +229,9 @@ func TestStateShow_configured_provider(t *testing.T) {
 	c := &StateShowCommand{
 		Meta: Meta{
 			testingOverrides: &testingOverrides{
-				ProviderResolver: providers.ResolverFixed(
-					map[addrs.Provider]providers.Factory{
-						addrs.NewLegacyProvider("test-beta"): providers.FactoryFixed(p),
-					},
-				),
+				Providers: map[addrs.Provider]providers.Factory{
+					addrs.NewLegacyProvider("test-beta"): providers.FactoryFixed(p),
+				},
 			},
 			Ui: ui,
 		},

--- a/command/version.go
+++ b/command/version.go
@@ -59,33 +59,19 @@ func (c *VersionCommand) Run(args []string) int {
 	// Generally-speaking this is a best-effort thing that will give us a good
 	// result in the usual case where the user successfully ran "terraform init"
 	// and then hit a problem running _another_ command.
-	providerPlugins := c.providerPluginSet()
-	pluginsLockFile := c.providerPluginsLock()
-	pluginsLock := pluginsLockFile.Read()
+	providerInstaller := c.providerInstaller()
+	providerSelections, err := providerInstaller.SelectedPackages()
 	var pluginVersions []string
-	for meta := range providerPlugins {
-		name := meta.Name
-		wantHash, wanted := pluginsLock[name]
-		if !wanted {
-			// Ignore providers that aren't used by the current config at all
-			continue
-		}
-		gotHash, err := meta.SHA256()
-		if err != nil {
-			// if we can't read the file to hash it, ignore it.
-			continue
-		}
-		if !bytes.Equal(gotHash, wantHash) {
-			// Not the plugin we've locked, so ignore it.
-			continue
-		}
-
-		// If we get here then we've found a selected plugin, so we'll print
-		// out its details.
-		if meta.Version == "0.0.0" {
-			pluginVersions = append(pluginVersions, fmt.Sprintf("+ provider.%s (unversioned)", name))
+	if err != nil {
+		// we'll just ignore it and show no plugins at all, then.
+		providerSelections = nil
+	}
+	for providerAddr, cached := range providerSelections {
+		version := cached.Version.String()
+		if version == "0.0.0" {
+			pluginVersions = append(pluginVersions, fmt.Sprintf("+ provider %s (unversioned)", providerAddr))
 		} else {
-			pluginVersions = append(pluginVersions, fmt.Sprintf("+ provider.%s v%s", name, meta.Version))
+			pluginVersions = append(pluginVersions, fmt.Sprintf("+ provider %s v%s", providerAddr, version))
 		}
 	}
 	if len(pluginVersions) != 0 {

--- a/providers/factory.go
+++ b/providers/factory.go
@@ -1,56 +1,5 @@
 package providers
 
-import (
-	"fmt"
-
-	"github.com/hashicorp/terraform/addrs"
-	"github.com/hashicorp/terraform/plugin/discovery"
-)
-
-// Resolver is an interface implemented by objects that are able to resolve
-// a given set of resource provider version constraints into Factory
-// callbacks.
-type Resolver interface {
-	// Given a constraint map, return a Factory for each requested provider.
-	// If some or all of the constraints cannot be satisfied, return a non-nil
-	// slice of errors describing the problems.
-	ResolveProviders(reqd discovery.PluginRequirements) (map[addrs.Provider]Factory, []error)
-}
-
-// ResolverFunc wraps a callback function and turns it into a Resolver
-// implementation, for convenience in situations where a function and its
-// associated closure are sufficient as a resolver implementation.
-type ResolverFunc func(reqd discovery.PluginRequirements) (map[addrs.Provider]Factory, []error)
-
-// ResolveProviders implements Resolver by calling the
-// wrapped function.
-func (f ResolverFunc) ResolveProviders(reqd discovery.PluginRequirements) (map[addrs.Provider]Factory, []error) {
-	return f(reqd)
-}
-
-// ResolverFixed returns a Resolver that has a fixed set of provider factories
-// provided by the caller. The returned resolver ignores version constraints
-// entirely and just returns the given factory for each requested provider
-// name.
-//
-// This function is primarily used in tests, to provide mock providers or
-// in-process providers under test.
-func ResolverFixed(factories map[addrs.Provider]Factory) Resolver {
-	return ResolverFunc(func(reqd discovery.PluginRequirements) (map[addrs.Provider]Factory, []error) {
-		ret := make(map[addrs.Provider]Factory, len(reqd))
-		var errs []error
-		for name := range reqd {
-			fqn := addrs.NewLegacyProvider(name)
-			if factory, exists := factories[fqn]; exists {
-				ret[fqn] = factory
-			} else {
-				errs = append(errs, fmt.Errorf("provider %q is not available", name))
-			}
-		}
-		return ret, errs
-	})
-}
-
 // Factory is a function type that creates a new instance of a resource
 // provider, or returns an error if that is impossible.
 type Factory func() (Interface, error)

--- a/terraform/context_components.go
+++ b/terraform/context_components.go
@@ -32,7 +32,7 @@ type basicComponentFactory struct {
 func (c *basicComponentFactory) ResourceProviders() []string {
 	var result []string
 	for k := range c.providers {
-		result = append(result, k.LegacyString())
+		result = append(result, k.String())
 	}
 	return result
 }
@@ -49,7 +49,7 @@ func (c *basicComponentFactory) ResourceProvisioners() []string {
 func (c *basicComponentFactory) ResourceProvider(typ addrs.Provider) (providers.Interface, error) {
 	f, ok := c.providers[typ]
 	if !ok {
-		return nil, fmt.Errorf("unknown provider %q", typ.LegacyString())
+		return nil, fmt.Errorf("unknown provider %q", typ.String())
 	}
 
 	return f()

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -1,24 +1,10 @@
 package terraform
 
-import (
-	"fmt"
-
-	"github.com/hashicorp/terraform/addrs"
-	"github.com/hashicorp/terraform/tfdiags"
-
-	"github.com/hashicorp/terraform/plugin/discovery"
-	"github.com/hashicorp/terraform/providers"
-)
-
-// ResourceProvider is an interface that must be implemented by any
-// resource provider: the thing that creates and manages the resources in
-// a Terraform configuration.
+// ResourceProvider is a legacy interface for providers.
 //
-// Important implementation note: All returned pointers, such as
-// *ResourceConfig, *InstanceState, *InstanceDiff, etc. must not point to
-// shared data. Terraform is highly parallel and assumes that this data is safe
-// to read/write in parallel so it must be unique references. Note that it is
-// safe to return arguments as results, however.
+// This is retained only for compatibility with legacy code. The current
+// interface for providers is providers.Interface, in the sibling directory
+// named "providers".
 type ResourceProvider interface {
 	/*********************************************************************
 	* Functions related to the provider
@@ -203,53 +189,6 @@ type DataSource struct {
 	SchemaAvailable bool
 }
 
-// ResourceProviderResolver is an interface implemented by objects that are
-// able to resolve a given set of resource provider version constraints
-// into ResourceProviderFactory callbacks.
-type ResourceProviderResolver interface {
-	// Given a constraint map, return a ResourceProviderFactory for each
-	// requested provider. If some or all of the constraints cannot be
-	// satisfied, return a non-nil slice of errors describing the problems.
-	ResolveProviders(reqd discovery.PluginRequirements) (map[addrs.Provider]ResourceProviderFactory, []error)
-}
-
-// ResourceProviderResolverFunc wraps a callback function and turns it into
-// a ResourceProviderResolver implementation, for convenience in situations
-// where a function and its associated closure are sufficient as a resolver
-// implementation.
-type ResourceProviderResolverFunc func(reqd discovery.PluginRequirements) (map[addrs.Provider]ResourceProviderFactory, []error)
-
-// ResolveProviders implements ResourceProviderResolver by calling the
-// wrapped function.
-func (f ResourceProviderResolverFunc) ResolveProviders(reqd discovery.PluginRequirements) (map[addrs.Provider]ResourceProviderFactory, []error) {
-	return f(reqd)
-}
-
-// ResourceProviderResolverFixed returns a ResourceProviderResolver that
-// has a fixed set of provider factories provided by the caller. The returned
-// resolver ignores version constraints entirely and just returns the given
-// factory for each requested provider name.
-//
-// This function is primarily used in tests, to provide mock providers or
-// in-process providers under test.
-func ResourceProviderResolverFixed(factories map[addrs.Provider]ResourceProviderFactory) ResourceProviderResolver {
-	return ResourceProviderResolverFunc(func(reqd discovery.PluginRequirements) (map[addrs.Provider]ResourceProviderFactory, []error) {
-		ret := make(map[addrs.Provider]ResourceProviderFactory, len(reqd))
-		var errs []error
-		for name := range reqd {
-			// FIXME: discovery.PluginRequirements should use addrs.Provider as
-			// the map keys instead of a string
-			fqn := addrs.NewLegacyProvider(name)
-			if factory, exists := factories[fqn]; exists {
-				ret[fqn] = factory
-			} else {
-				errs = append(errs, fmt.Errorf("provider %q is not available", name))
-			}
-		}
-		return ret, errs
-	})
-}
-
 // ResourceProviderFactory is a function type that creates a new instance
 // of a resource provider.
 type ResourceProviderFactory func() (ResourceProvider, error)
@@ -280,34 +219,6 @@ func ProviderHasDataSource(p ResourceProvider, n string) bool {
 	}
 
 	return false
-}
-
-// resourceProviderFactories matches available plugins to the given version
-// requirements to produce a map of compatible provider plugins if possible,
-// or an error if the currently-available plugins are insufficient.
-//
-// This should be called only with configurations that have passed calls
-// to config.Validate(), which ensures that all of the given version
-// constraints are valid. It will panic if any invalid constraints are present.
-func resourceProviderFactories(resolver providers.Resolver, reqd discovery.PluginRequirements) (map[addrs.Provider]providers.Factory, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-	ret, errs := resolver.ResolveProviders(reqd)
-	if errs != nil {
-		diags = diags.Append(
-			tfdiags.Sourceless(tfdiags.Error,
-				"Could not satisfy plugin requirements",
-				errPluginInit,
-			),
-		)
-
-		for _, err := range errs {
-			diags = diags.Append(err)
-		}
-
-		return nil, diags
-	}
-
-	return ret, nil
 }
 
 const errPluginInit = `

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -93,21 +93,20 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 	var diags tfdiags.Diagnostics
 
 	ensure := func(fqn addrs.Provider) {
-		// TODO: LegacyString() will be removed in an upcoming release
-		typeName := fqn.LegacyString()
+		name := fqn.String()
 
 		if _, exists := schemas[fqn]; exists {
 			return
 		}
 
-		log.Printf("[TRACE] LoadSchemas: retrieving schema for provider type %q", fqn.LegacyString())
+		log.Printf("[TRACE] LoadSchemas: retrieving schema for provider type %q", name)
 		provider, err := components.ResourceProvider(fqn)
 		if err != nil {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to instantiate provider %q to obtain schema: %s", typeName, err),
+				fmt.Errorf("Failed to instantiate provider %q to obtain schema: %s", name, err),
 			)
 			return
 		}
@@ -121,7 +120,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to retrieve schema from provider %q: %s", typeName, resp.Diagnostics.Err()),
+				fmt.Errorf("Failed to retrieve schema from provider %q: %s", name, resp.Diagnostics.Err()),
 			)
 			return
 		}
@@ -138,7 +137,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// We're not using the version numbers here yet, but we'll check
 			// for validity anyway in case we start using them in future.
 			diags = diags.Append(
-				fmt.Errorf("invalid negative schema version provider configuration for provider %q", typeName),
+				fmt.Errorf("invalid negative schema version provider configuration for provider %q", name),
 			)
 		}
 
@@ -147,7 +146,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			s.ResourceTypeSchemaVersions[t] = uint64(r.Version)
 			if r.Version < 0 {
 				diags = diags.Append(
-					fmt.Errorf("invalid negative schema version for resource type %s in provider %q", t, typeName),
+					fmt.Errorf("invalid negative schema version for resource type %s in provider %q", t, name),
 				)
 			}
 		}
@@ -158,7 +157,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 				// We're not using the version numbers here yet, but we'll check
 				// for validity anyway in case we start using them in future.
 				diags = diags.Append(
-					fmt.Errorf("invalid negative schema version for data source %s in provider %q", t, typeName),
+					fmt.Errorf("invalid negative schema version for data source %s in provider %q", t, name),
 				)
 			}
 		}


### PR DESCRIPTION
Back when we first introduced provider versioning in Terraform 0.10, we did the provider version resolution in `terraform.NewContext` because we weren't sure yet how exactly our versioning model was going to play out (whether different versions could be selected per provider configuration, for example) and because we were building around the limitations of our existing filesystem-based plugin discovery model.

However, the new installer codepath is new able to do all of the selections up front during installation, so we don't need such a heavy inversion of control abstraction to get this done: the command package can determine the exact provider versions previously selected during installation and pass their factories directly to `terraform.NewContext` as a simple static map.

The result of this set of chanegs is that CLI commands other than `init` are now able to consume the local cache directory and selections produced by the installation process in `terraform init`, passing all of the selected providers down to the `terraform.NewContext` function for use in implementing the main operations.

This is just enough to get the providers passing into the `terraform.Context`. There's still plenty more to do here, including to repair all of the tests this change has additionally broken.

(This PR is targeting our shared integration branch -- represented here as #24477 -- rather than the `master` branch. This is so we can address the test failures and other fixups we need to do before finally merging into `master`.)

---

There are a couple other small commits piggy-backing here that I needed to be able to verify this was working in manual testing. The other two commits are relatively small, but it might still help to look at this on a commit-by-commit basis to focus on the main event commit, which is the second one.

