### PR TITLE
command: Add state replace-provider subcommand

### DIFF
--- a/addrs/provider.go
+++ b/addrs/provider.go
@@ -192,7 +192,7 @@ func ParseProviderSourceString(str string) (Provider, tfdiags.Diagnostics) {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid provider type",
-			Detail:   fmt.Sprintf(`Invalid provider type %q in source %q: %s"`, name, str, err),
+			Detail:   fmt.Sprintf(`Invalid provider type %q in source %q: %s"`, givenName, str, err),
 		})
 		return ret, diags
 	}

--- a/command/state_meta.go
+++ b/command/state_meta.go
@@ -196,3 +196,14 @@ func (c *StateMeta) collectResourceInstances(moduleAddr addrs.ModuleInstance, rs
 	}
 	return ret
 }
+
+func (c *StateMeta) lookupAllResources(state *states.State) ([]*states.Resource, tfdiags.Diagnostics) {
+	var ret []*states.Resource
+	var diags tfdiags.Diagnostics
+	for _, ms := range state.Modules {
+		for _, resource := range ms.Resources {
+			ret = append(ret, resource)
+		}
+	}
+	return ret, diags
+}

--- a/command/state_replace_provider.go
+++ b/command/state_replace_provider.go
@@ -1,0 +1,197 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/command/clistate"
+	"github.com/hashicorp/terraform/states"
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/mitchellh/cli"
+)
+
+// StateReplaceProviderCommand is a Command implementation that allows users
+// to change the provider associated with existing resources. This is only
+// likely to be useful if a provider is forked or changes its fully-qualified
+// name.
+
+type StateReplaceProviderCommand struct {
+	StateMeta
+}
+
+func (c *StateReplaceProviderCommand) Run(args []string) int {
+	args = c.Meta.process(args)
+
+	var autoApprove bool
+	cmdFlags := c.Meta.defaultFlagSet("state replace-provider")
+	cmdFlags.BoolVar(&autoApprove, "auto-approve", false, "skip interactive approval of replacements")
+	cmdFlags.StringVar(&c.backupPath, "backup", "-", "backup")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock states")
+	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
+	cmdFlags.StringVar(&c.statePath, "state", "", "path")
+	if err := cmdFlags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
+		return cli.RunResultHelp
+	}
+	args = cmdFlags.Args()
+	if len(args) != 2 {
+		c.Ui.Error("Exactly two arguments expected.\n")
+		return cli.RunResultHelp
+	}
+
+	var diags tfdiags.Diagnostics
+
+	// Parse from/to arguments into providers
+	from, fromDiags := addrs.ParseProviderSourceString(args[0])
+	if fromDiags.HasErrors() {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			fmt.Sprintf(`Invalid "from" provider %q`, args[0]),
+			fromDiags.Err().Error(),
+		))
+	}
+	to, toDiags := addrs.ParseProviderSourceString(args[1])
+	if toDiags.HasErrors() {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			fmt.Sprintf(`Invalid "to" provider %q`, args[1]),
+			toDiags.Err().Error(),
+		))
+	}
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	// Initialize the state manager as configured
+	stateMgr, err := c.State()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
+		return 1
+	}
+
+	// Acquire lock if requested
+	if c.stateLock {
+		stateLocker := clistate.NewLocker(context.Background(), c.stateLockTimeout, c.Ui, c.Colorize())
+		if err := stateLocker.Lock(stateMgr, "state-replace-provider"); err != nil {
+			c.Ui.Error(fmt.Sprintf("Error locking source state: %s", err))
+			return 1
+		}
+		defer stateLocker.Unlock(nil)
+	}
+
+	// Refresh and load state
+	if err := stateMgr.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to refresh source state: %s", err))
+		return 1
+	}
+
+	state := stateMgr.State()
+	if state == nil {
+		c.Ui.Error(fmt.Sprintf(errStateNotFound))
+		return 1
+	}
+
+	// Fetch all resources from the state
+	resources, diags := c.lookupAllResources(state)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	var willReplace []*states.Resource
+
+	// Update all matching resources with new provider
+	for _, resource := range resources {
+		if resource.ProviderConfig.Provider.Equals(from) {
+			willReplace = append(willReplace, resource)
+		}
+	}
+	c.showDiagnostics(diags)
+
+	if len(willReplace) == 0 {
+		c.Ui.Output("No matching resources found.")
+		return 0
+	}
+
+	// Explain the changes
+	colorize := c.Colorize()
+	c.Ui.Output("Terraform will perform the following actions:\n")
+	c.Ui.Output(colorize.Color(fmt.Sprintf("  [yellow]~[reset] Updating provider:")))
+	c.Ui.Output(colorize.Color(fmt.Sprintf("    [red]-[reset] %s", from)))
+	c.Ui.Output(colorize.Color(fmt.Sprintf("    [green]+[reset] %s\n", to)))
+
+	c.Ui.Output(colorize.Color(fmt.Sprintf("[bold]Changing[reset] %d resources:\n", len(willReplace))))
+	for _, resource := range willReplace {
+		c.Ui.Output(colorize.Color(fmt.Sprintf("  %s", resource.Addr)))
+	}
+
+	// Confirm
+	if !autoApprove {
+		c.Ui.Output(colorize.Color(
+			"\n[bold]Do you want to make these changes?[reset]\n" +
+				"Only 'yes' will be accepted to continue.\n",
+		))
+		v, err := c.Ui.Ask(fmt.Sprintf("Enter a value:"))
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error asking for approval: %s", err))
+			return 1
+		}
+		if v != "yes" {
+			c.Ui.Output("Cancelled replacing providers.")
+			return 0
+		}
+	}
+
+	// Update the provider for each resource
+	for _, resource := range willReplace {
+		resource.ProviderConfig.Provider = to
+	}
+
+	// Write the updated state
+	if err := stateMgr.WriteState(state); err != nil {
+		c.Ui.Error(fmt.Sprintf(errStateRmPersist, err))
+		return 1
+	}
+	if err := stateMgr.PersistState(); err != nil {
+		c.Ui.Error(fmt.Sprintf(errStateRmPersist, err))
+		return 1
+	}
+
+	c.Ui.Output(fmt.Sprintf("\nSuccessfully replaced provider for %d resources.", len(willReplace)))
+	return 0
+}
+
+func (c *StateReplaceProviderCommand) Help() string {
+	helpText := `
+Usage: terraform state replace-provider [options] FROM_PROVIDER_FQN TO_PROVIDER_FQN
+
+  Replace provider for resources in the Terraform state.
+
+  An error will be returned if any of the resources or modules given as
+  filter addresses do not exist in the state.
+
+Options:
+
+  -auto-approve       Skip interactive approval.
+
+  -backup=PATH        Path where Terraform should write the backup for the
+                      state file. This can't be disabled. If not set, Terraform
+                      will write it to the same path as the state file with
+                      a ".backup" extension.
+
+  -lock=true          Lock the state files when locking is supported.
+
+  -lock-timeout=0s    Duration to retry a state lock.
+
+  -state=PATH         Path to the state file to update. Defaults to the configured
+                      backend, or "terraform.tfstate"
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *StateReplaceProviderCommand) Synopsis() string {
+	return "Replace provider in the state"
+}

--- a/command/state_replace_provider_test.go
+++ b/command/state_replace_provider_test.go
@@ -1,0 +1,315 @@
+package command
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/states"
+)
+
+func TestStateReplaceProvider(t *testing.T) {
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "aws_instance",
+				Name: "alpha",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"id":"alpha","foo":"value","bar":"value"}`),
+				Status:    states.ObjectReady,
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("aws"),
+				Module:   addrs.RootModule,
+			},
+		)
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "aws_instance",
+				Name: "beta",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"id":"beta","foo":"value","bar":"value"}`),
+				Status:    states.ObjectReady,
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("aws"),
+				Module:   addrs.RootModule,
+			},
+		)
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "azurerm_virtual_machine",
+				Name: "gamma",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"id":"gamma","baz":"value"}`),
+				Status:    states.ObjectReady,
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewLegacyProvider("azurerm"),
+				Module:   addrs.RootModule,
+			},
+		)
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		statePath := testStateFile(t, state)
+
+		ui := new(cli.MockUi)
+		c := &StateReplaceProviderCommand{
+			StateMeta{
+				Meta: Meta{
+					Ui: ui,
+				},
+			},
+		}
+
+		inputBuf := &bytes.Buffer{}
+		ui.InputReader = inputBuf
+		inputBuf.WriteString("yes")
+
+		args := []string{
+			"-state", statePath,
+			"hashicorp/aws",
+			"acmecorp/aws",
+		}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("return code: %d\n\n%s", code, ui.ErrorWriter.String())
+		}
+
+		testStateOutput(t, statePath, testStateReplaceProviderOutput)
+
+		backups := testStateBackups(t, filepath.Dir(statePath))
+		if len(backups) != 1 {
+			t.Fatalf("unexpected backups: %#v", backups)
+		}
+		testStateOutput(t, backups[0], testStateReplaceProviderOutputOriginal)
+	})
+
+	t.Run("auto approve", func(t *testing.T) {
+		statePath := testStateFile(t, state)
+
+		ui := new(cli.MockUi)
+		c := &StateReplaceProviderCommand{
+			StateMeta{
+				Meta: Meta{
+					Ui: ui,
+				},
+			},
+		}
+
+		inputBuf := &bytes.Buffer{}
+		ui.InputReader = inputBuf
+
+		args := []string{
+			"-state", statePath,
+			"-auto-approve",
+			"hashicorp/aws",
+			"acmecorp/aws",
+		}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("return code: %d\n\n%s", code, ui.ErrorWriter.String())
+		}
+
+		testStateOutput(t, statePath, testStateReplaceProviderOutput)
+
+		backups := testStateBackups(t, filepath.Dir(statePath))
+		if len(backups) != 1 {
+			t.Fatalf("unexpected backups: %#v", backups)
+		}
+		testStateOutput(t, backups[0], testStateReplaceProviderOutputOriginal)
+	})
+
+	t.Run("cancel at approval step", func(t *testing.T) {
+		statePath := testStateFile(t, state)
+
+		ui := new(cli.MockUi)
+		c := &StateReplaceProviderCommand{
+			StateMeta{
+				Meta: Meta{
+					Ui: ui,
+				},
+			},
+		}
+
+		inputBuf := &bytes.Buffer{}
+		ui.InputReader = inputBuf
+		inputBuf.WriteString("no")
+
+		args := []string{
+			"-state", statePath,
+			"hashicorp/aws",
+			"acmecorp/aws",
+		}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("return code: %d\n\n%s", code, ui.ErrorWriter.String())
+		}
+
+		testStateOutput(t, statePath, testStateReplaceProviderOutputOriginal)
+
+		backups := testStateBackups(t, filepath.Dir(statePath))
+		if len(backups) != 0 {
+			t.Fatalf("unexpected backups: %#v", backups)
+		}
+	})
+
+	t.Run("no matching provider found", func(t *testing.T) {
+		statePath := testStateFile(t, state)
+
+		ui := new(cli.MockUi)
+		c := &StateReplaceProviderCommand{
+			StateMeta{
+				Meta: Meta{
+					Ui: ui,
+				},
+			},
+		}
+
+		args := []string{
+			"-state", statePath,
+			"hashicorp/google",
+			"acmecorp/google",
+		}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("return code: %d\n\n%s", code, ui.ErrorWriter.String())
+		}
+
+		testStateOutput(t, statePath, testStateReplaceProviderOutputOriginal)
+
+		backups := testStateBackups(t, filepath.Dir(statePath))
+		if len(backups) != 0 {
+			t.Fatalf("unexpected backups: %#v", backups)
+		}
+	})
+
+	t.Run("invalid flags", func(t *testing.T) {
+		ui := new(cli.MockUi)
+		c := &StateReplaceProviderCommand{
+			StateMeta{
+				Meta: Meta{
+					Ui: ui,
+				},
+			},
+		}
+
+		args := []string{
+			"-invalid",
+			"hashicorp/google",
+			"acmecorp/google",
+		}
+		if code := c.Run(args); code == 0 {
+			t.Fatalf("successful exit; want error")
+		}
+
+		if got, want := ui.ErrorWriter.String(), "Error parsing command-line flags"; !strings.Contains(got, want) {
+			t.Fatalf("missing expected error message\nwant: %s\nfull output:\n%s", want, got)
+		}
+	})
+
+	t.Run("wrong number of arguments", func(t *testing.T) {
+		ui := new(cli.MockUi)
+		c := &StateReplaceProviderCommand{
+			StateMeta{
+				Meta: Meta{
+					Ui: ui,
+				},
+			},
+		}
+
+		args := []string{"a", "b", "c", "d"}
+		if code := c.Run(args); code == 0 {
+			t.Fatalf("successful exit; want error")
+		}
+
+		if got, want := ui.ErrorWriter.String(), "Exactly two arguments expected"; !strings.Contains(got, want) {
+			t.Fatalf("missing expected error message\nwant: %s\nfull output:\n%s", want, got)
+		}
+	})
+
+	t.Run("invalid provider strings", func(t *testing.T) {
+		ui := new(cli.MockUi)
+		c := &StateReplaceProviderCommand{
+			StateMeta{
+				Meta: Meta{
+					Ui: ui,
+				},
+			},
+		}
+
+		args := []string{
+			"hashicorp/google_cloud",
+			"-/-/google",
+		}
+		if code := c.Run(args); code == 0 {
+			t.Fatalf("successful exit; want error")
+		}
+
+		got := ui.ErrorWriter.String()
+		msgs := []string{
+			`Invalid "from" provider "hashicorp/google_cloud"`,
+			"Invalid provider type",
+			`Invalid "to" provider "-/-/google"`,
+			"Invalid provider source hostname",
+		}
+		for _, msg := range msgs {
+			if !strings.Contains(got, msg) {
+				t.Errorf("missing expected error message\nwant: %s\nfull output:\n%s", msg, got)
+			}
+		}
+	})
+}
+
+func TestStateReplaceProvider_docs(t *testing.T) {
+	c := &StateReplaceProviderCommand{}
+
+	if got, want := c.Help(), "Usage: terraform state replace-provider"; !strings.Contains(got, want) {
+		t.Fatalf("unexpected help text\nwant: %s\nfull output:\n%s", want, got)
+	}
+
+	if got, want := c.Synopsis(), "Replace provider in the state"; got != want {
+		t.Fatalf("unexpected synopsis\nwant: %s\nfull output:\n%s", want, got)
+	}
+}
+
+const testStateReplaceProviderOutputOriginal = `
+aws_instance.alpha:
+  ID = alpha
+  provider = provider["registry.terraform.io/hashicorp/aws"]
+  bar = value
+  foo = value
+aws_instance.beta:
+  ID = beta
+  provider = provider["registry.terraform.io/hashicorp/aws"]
+  bar = value
+  foo = value
+azurerm_virtual_machine.gamma:
+  ID = gamma
+  provider = provider["registry.terraform.io/-/azurerm"]
+  baz = value
+`
+
+const testStateReplaceProviderOutput = `
+aws_instance.alpha:
+  ID = alpha
+  provider = provider["registry.terraform.io/acmecorp/aws"]
+  bar = value
+  foo = value
+aws_instance.beta:
+  ID = beta
+  provider = provider["registry.terraform.io/acmecorp/aws"]
+  bar = value
+  foo = value
+azurerm_virtual_machine.gamma:
+  ID = gamma
+  provider = provider["registry.terraform.io/-/azurerm"]
+  baz = value
+`

--- a/commands.go
+++ b/commands.go
@@ -374,6 +374,14 @@ func initCommands(config *cliconfig.Config, services *disco.Disco, providerSrc g
 				Meta: meta,
 			}, nil
 		},
+
+		"state replace-provider": func() (cli.Command, error) {
+			return &command.StateReplaceProviderCommand{
+				StateMeta: command.StateMeta{
+					Meta: meta,
+				},
+			}, nil
+		},
 	}
 }
 


### PR DESCRIPTION
Terraform 0.13 will allow the installation of providers from various sources. If a user updates their configuration to change the source of an in-use provider (for example, if the provider namespace changes), they will also need to update the state file accordingly.

This commit introduces a new `state replace-provider` subcommand which supports this. All resources using the `from` provider will be updated to use the `to` provider.

## Screenshots

<img width="900" alt="success" src="https://user-images.githubusercontent.com/68917/78248327-71310b00-74ba-11ea-822b-faba53ac3367.png">
<img width="900" alt="cancelled" src="https://user-images.githubusercontent.com/68917/78248328-71c9a180-74ba-11ea-814f-baac97c53a74.png">
<img width="864" alt="no-matches" src="https://user-images.githubusercontent.com/68917/78173124-3761f500-7425-11ea-8f0f-06553b2eb384.png">
<img width="864" alt="invalid" src="https://user-images.githubusercontent.com/68917/78173122-36c95e80-7425-11ea-9992-7414ef4ef9b4.png">
