### PR TITLE
backend/local: refactor tests with modern state and default providers

### DIFF
--- a/backend/local/backend_apply_test.go
+++ b/backend/local/backend_apply_test.go
@@ -59,7 +59,7 @@ func TestLocal_applyBasic(t *testing.T) {
 	checkState(t, b.StateOutPath, `
 test_instance.foo:
   ID = yes
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   ami = bar
 `)
 }
@@ -176,7 +176,7 @@ func TestLocal_applyError(t *testing.T) {
 	checkState(t, b.StateOutPath, `
 test_instance.foo:
   ID = foo
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   ami = bar
 	`)
 }
@@ -226,7 +226,7 @@ func TestLocal_applyBackendFail(t *testing.T) {
 	checkState(t, "errored.tfstate", `
 test_instance.foo:
   ID = yes
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   ami = bar
 	`)
 }

--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -216,7 +216,7 @@ func TestLocal_planDeposedOnly(t *testing.T) {
 			}`),
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -660,7 +660,7 @@ func testPlanState() *states.State {
 			}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)
@@ -687,7 +687,7 @@ func testPlanState_withDataSource() *states.State {
 			}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)
@@ -704,7 +704,7 @@ func testPlanState_withDataSource() *states.State {
 			}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)
@@ -731,7 +731,7 @@ func testPlanState_tainted() *states.State {
 			}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)

--- a/backend/local/testing.go
+++ b/backend/local/testing.go
@@ -113,7 +113,7 @@ func TestLocalProvider(t *testing.T, b *Local, name string, schema *terraform.Pr
 
 	// Setup our provider
 	b.ContextOpts.Providers = map[addrs.Provider]providers.Factory{
-		addrs.NewLegacyProvider(name): providers.FactoryFixed(p),
+		addrs.NewDefaultProvider(name): providers.FactoryFixed(p),
 	}
 
 	return p
@@ -208,4 +208,20 @@ func testTempDir(t *testing.T) string {
 func testStateFile(t *testing.T, path string, s *states.State) {
 	stateFile := statemgr.NewFilesystem(path)
 	stateFile.WriteState(s)
+}
+
+func mustProviderConfig(s string) addrs.AbsProviderConfig {
+	p, diags := addrs.ParseAbsProviderConfigStr(s)
+	if diags.HasErrors() {
+		panic(diags.Err())
+	}
+	return p
+}
+
+func mustResourceInstanceAddr(s string) addrs.AbsResourceInstance {
+	addr, diags := addrs.ParseAbsResourceInstanceStr(s)
+	if diags.HasErrors() {
+		panic(diags.Err())
+	}
+	return addr
 }


### PR DESCRIPTION
I copied a couple of helper functions from `terraform`: there was little enough to copy and we don't expect to be writing tons of new backends so that seemed good enough for this purpose.