### PR TITLE
Updating import usage doc with accurate example of complex import with secondary resources

### DIFF
--- a/website/docs/import/usage.html.md
+++ b/website/docs/import/usage.html.md
@@ -64,8 +64,8 @@ align with the current (or desired) state of the imported object.
 
 The above import is considered a "simple import": one resource is imported
 into the state file. An import may also result in a "complex import" where
-multiple resources are imported. For example, an AWS security group imports
-an `aws_security_group` but also one `aws_security_group_rule` for each rule.
+multiple resources are imported. For example, an AWS network ACL imports
+an `aws_network_acl` but also one `aws_network_acl_rule` for each rule.
 
 In this scenario, the secondary resources will not already exist in
 configuration, so it is necessary to consult the import output and create


### PR DESCRIPTION
This pull request has no code change but only contains documentation update resulting from changes proposed to the terraform-provider-aws.

<h3>Reason for Change</h3>

[terraform-provider-aws pull request](https://github.com/terraform-providers/terraform-provider-aws/pull/12616) contains changes that alter behavior of AWS security group such that import of aws_security_group will no longer implicitly import aws_security_group_rule for associated rules.
<p>This change, therefore, removes mention of aws_security_group and replaces with example of aws_network_acl that exhibits such complex import behavior discussed in the doc.</p>