### PR TITLE
command: Simplify Meta.process helper method

### DIFF
--- a/command/013_config_upgrade.go
+++ b/command/013_config_upgrade.go
@@ -20,11 +20,7 @@ type ZeroThirteenUpgradeCommand struct {
 }
 
 func (c *ZeroThirteenUpgradeCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	flags := c.Meta.defaultFlagSet("0.13upgrade")
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := flags.Parse(args); err != nil {
@@ -51,6 +47,7 @@ func (c *ZeroThirteenUpgradeCommand) Run(args []string) int {
 	}
 
 	// Check for user-supplied plugin path
+	var err error
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
 		return 1

--- a/command/apply.go
+++ b/command/apply.go
@@ -28,11 +28,7 @@ type ApplyCommand struct {
 
 func (c *ApplyCommand) Run(args []string) int {
 	var destroyForce, refresh, autoApprove bool
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdName := "apply"
 	if c.Destroy {
 		cmdName = "destroy"

--- a/command/console.go
+++ b/command/console.go
@@ -21,11 +21,7 @@ type ConsoleCommand struct {
 }
 
 func (c *ConsoleCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.extendedFlagSet("console")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }

--- a/command/fmt.go
+++ b/command/fmt.go
@@ -41,11 +41,7 @@ func (c *FmtCommand) Run(args []string) int {
 		c.input = os.Stdin
 	}
 
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("fmt")
 	cmdFlags.BoolVar(&c.list, "list", true, "list")
 	cmdFlags.BoolVar(&c.write, "write", true, "write")

--- a/command/get.go
+++ b/command/get.go
@@ -16,11 +16,7 @@ type GetCommand struct {
 func (c *GetCommand) Run(args []string) int {
 	var update bool
 
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("get")
 	cmdFlags.BoolVar(&update, "update", false, "update")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }

--- a/command/graph.go
+++ b/command/graph.go
@@ -24,11 +24,7 @@ func (c *GraphCommand) Run(args []string) int {
 	var moduleDepth int
 	var verbose bool
 
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("graph")
 	cmdFlags.BoolVar(&drawCycles, "draw-cycles", false, "draw-cycles")
 	cmdFlags.StringVar(&graphTypeStr, "type", "", "type")

--- a/command/import.go
+++ b/command/import.go
@@ -32,10 +32,7 @@ func (c *ImportCommand) Run(args []string) int {
 	}
 
 	var configPath string
-	args, err = c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
+	args = c.Meta.process(args)
 
 	cmdFlags := c.Meta.extendedFlagSet("import")
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")

--- a/command/init.go
+++ b/command/init.go
@@ -49,11 +49,7 @@ func (c *InitCommand) Run(args []string) int {
 	var flagVerifyPlugins bool
 	flagConfigExtra := newRawFlags("-backend-config")
 
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.extendedFlagSet("init")
 	cmdFlags.BoolVar(&flagBackend, "backend", true, "")
 	cmdFlags.Var(flagConfigExtra, "backend-config", "")

--- a/command/login.go
+++ b/command/login.go
@@ -35,11 +35,7 @@ type LoginCommand struct {
 
 // Run implements cli.Command.
 func (c *LoginCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.extendedFlagSet("login")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {

--- a/command/logout.go
+++ b/command/logout.go
@@ -18,11 +18,7 @@ type LogoutCommand struct {
 
 // Run implements cli.Command.
 func (c *LogoutCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("logout")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {

--- a/command/meta.go
+++ b/command/meta.go
@@ -410,11 +410,7 @@ func (m *Meta) extendedFlagSet(n string) *flag.FlagSet {
 // process will process the meta-parameters out of the arguments. This
 // will potentially modify the args in-place. It will return the resulting
 // slice.
-//
-// vars is now ignored. It used to control whether to process variables, but
-// that is no longer the responsibility of this function. (That happens
-// instead in Meta.collectVariableValues.)
-func (m *Meta) process(args []string, vars bool) ([]string, error) {
+func (m *Meta) process(args []string) []string {
 	// We do this so that we retain the ability to technically call
 	// process multiple times, even if we have no plans to do so
 	if m.oldUi != nil {
@@ -443,7 +439,7 @@ func (m *Meta) process(args []string, vars bool) ([]string, error) {
 		},
 	}
 
-	return args, nil
+	return args
 }
 
 // uiHook returns the UiHook to use with the context.

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -1888,7 +1888,7 @@ func TestBackendFromState(t *testing.T) {
 func testMetaBackend(t *testing.T, args []string) *Meta {
 	var m Meta
 	m.Ui = new(cli.MockUi)
-	m.process(args, true)
+	m.process(args)
 	f := m.extendedFlagSet("test")
 	if err := f.Parse(args); err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -23,10 +23,7 @@ func TestMetaColorize(t *testing.T) {
 	m.Color = true
 	args = []string{"foo", "bar"}
 	args2 = []string{"foo", "bar"}
-	args, err := m.process(args, false)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	args = m.process(args)
 	if !reflect.DeepEqual(args, args2) {
 		t.Fatalf("bad: %#v", args)
 	}
@@ -38,10 +35,7 @@ func TestMetaColorize(t *testing.T) {
 	m = new(Meta)
 	args = []string{"foo", "bar"}
 	args2 = []string{"foo", "bar"}
-	args, err = m.process(args, false)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	args = m.process(args)
 	if !reflect.DeepEqual(args, args2) {
 		t.Fatalf("bad: %#v", args)
 	}
@@ -54,10 +48,7 @@ func TestMetaColorize(t *testing.T) {
 	m.Color = true
 	args = []string{"foo", "-no-color", "bar"}
 	args2 = []string{"foo", "bar"}
-	args, err = m.process(args, false)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	args = m.process(args)
 	if !reflect.DeepEqual(args, args2) {
 		t.Fatalf("bad: %#v", args)
 	}
@@ -292,10 +283,7 @@ func TestMeta_process(t *testing.T) {
 			m := new(Meta)
 			m.Color = true // this is the default also for normal use, overridden by -no-color
 			args := test.GivenArgs
-			args, err = m.process(args, true)
-			if err != nil {
-				t.Fatalf("err: %s", err)
-			}
+			args = m.process(args)
 
 			if !cmp.Equal(test.FilteredArgs, args) {
 				t.Errorf("wrong filtered arguments\n%s", cmp.Diff(test.FilteredArgs, args))

--- a/command/output.go
+++ b/command/output.go
@@ -23,11 +23,7 @@ type OutputCommand struct {
 }
 
 func (c *OutputCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	var module, statePath string
 	var jsonOutput bool
 	cmdFlags := c.Meta.defaultFlagSet("output")

--- a/command/plan.go
+++ b/command/plan.go
@@ -20,11 +20,7 @@ func (c *PlanCommand) Run(args []string) int {
 	var destroy, refresh, detailed bool
 	var outPath string
 
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.extendedFlagSet("plan")
 	cmdFlags.BoolVar(&destroy, "destroy", false, "destroy")
 	cmdFlags.BoolVar(&refresh, "refresh", true, "refresh")

--- a/command/providers.go
+++ b/command/providers.go
@@ -27,11 +27,7 @@ func (c *ProvidersCommand) Synopsis() string {
 }
 
 func (c *ProvidersCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("providers")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {

--- a/command/providers_schema.go
+++ b/command/providers_schema.go
@@ -24,11 +24,7 @@ func (c *ProvidersSchemaCommand) Synopsis() string {
 }
 
 func (c *ProvidersSchemaCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("providers schema")
 	var jsonOutput bool
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "produce JSON output")
@@ -47,6 +43,7 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 	}
 
 	// Check for user-supplied plugin path
+	var err error
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
 		return 1

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -16,11 +16,7 @@ type RefreshCommand struct {
 }
 
 func (c *RefreshCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.extendedFlagSet("refresh")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")

--- a/command/show.go
+++ b/command/show.go
@@ -24,11 +24,7 @@ type ShowCommand struct {
 }
 
 func (c *ShowCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("show")
 	var jsonOutput bool
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "produce JSON output")
@@ -48,6 +44,7 @@ func (c *ShowCommand) Run(args []string) int {
 	}
 
 	// Check for user-supplied plugin path
+	var err error
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
 		return 1

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -18,11 +18,7 @@ type StateListCommand struct {
 }
 
 func (c *StateListCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	var statePath string
 	cmdFlags := c.Meta.defaultFlagSet("state list")
 	cmdFlags.StringVar(&statePath, "state", "", "path")

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -18,11 +18,7 @@ type StateMvCommand struct {
 }
 
 func (c *StateMvCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	// We create two metas to track the two states
 	var backupPathOut, statePathOut string
 

--- a/command/state_pull.go
+++ b/command/state_pull.go
@@ -16,11 +16,7 @@ type StatePullCommand struct {
 }
 
 func (c *StatePullCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("state pull")
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))

--- a/command/state_push.go
+++ b/command/state_push.go
@@ -20,11 +20,7 @@ type StatePushCommand struct {
 }
 
 func (c *StatePushCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	var flagForce bool
 	cmdFlags := c.Meta.defaultFlagSet("state push")
 	cmdFlags.BoolVar(&flagForce, "force", false, "")

--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -17,11 +17,7 @@ type StateRmCommand struct {
 }
 
 func (c *StateRmCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	var dryRun bool
 	cmdFlags := c.Meta.defaultFlagSet("state rm")
 	cmdFlags.BoolVar(&dryRun, "dry-run", false, "dry run")

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -19,11 +19,7 @@ type StateShowCommand struct {
 }
 
 func (c *StateShowCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("state show")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	if err := cmdFlags.Parse(args); err != nil {
@@ -37,6 +33,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	}
 
 	// Check for user-supplied plugin path
+	var err error
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
 		return 1

--- a/command/taint.go
+++ b/command/taint.go
@@ -18,11 +18,7 @@ type TaintCommand struct {
 }
 
 func (c *TaintCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	var module string
 	var allowMissing bool
 	cmdFlags := c.Meta.defaultFlagSet("taint")

--- a/command/unlock.go
+++ b/command/unlock.go
@@ -19,11 +19,7 @@ type UnlockCommand struct {
 }
 
 func (c *UnlockCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	var force bool
 	cmdFlags := c.Meta.defaultFlagSet("force-unlock")
 	cmdFlags.BoolVar(&force, "force", false, "force")

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -18,11 +18,7 @@ type UntaintCommand struct {
 }
 
 func (c *UntaintCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	var module string
 	var allowMissing bool
 	cmdFlags := c.Meta.defaultFlagSet("untaint")

--- a/command/validate.go
+++ b/command/validate.go
@@ -20,11 +20,7 @@ type ValidateCommand struct {
 const defaultPath = "."
 
 func (c *ValidateCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	// TODO: The `var` and `var-file` options are not actually used, and should
 	// be removed in the next major release.
 	if c.Meta.variableArgs.items == nil {

--- a/command/version.go
+++ b/command/version.go
@@ -35,11 +35,7 @@ func (c *VersionCommand) Help() string {
 
 func (c *VersionCommand) Run(args []string) int {
 	var versionString bytes.Buffer
-	args, err := c.Meta.process(args, false)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	fmt.Fprintf(&versionString, "Terraform v%s", c.Version)
 	if c.VersionPrerelease != "" {
 		fmt.Fprintf(&versionString, "-%s", c.VersionPrerelease)

--- a/command/workspace_command.go
+++ b/command/workspace_command.go
@@ -15,11 +15,7 @@ type WorkspaceCommand struct {
 }
 
 func (c *WorkspaceCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
 	cmdFlags := c.Meta.extendedFlagSet("workspace")

--- a/command/workspace_delete.go
+++ b/command/workspace_delete.go
@@ -18,11 +18,7 @@ type WorkspaceDeleteCommand struct {
 }
 
 func (c *WorkspaceDeleteCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
 	var force bool

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -15,11 +15,7 @@ type WorkspaceListCommand struct {
 }
 
 func (c *WorkspaceListCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
 	cmdFlags := c.Meta.defaultFlagSet("workspace list")

--- a/command/workspace_new.go
+++ b/command/workspace_new.go
@@ -20,11 +20,7 @@ type WorkspaceNewCommand struct {
 }
 
 func (c *WorkspaceNewCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
 	var stateLock bool

--- a/command/workspace_select.go
+++ b/command/workspace_select.go
@@ -15,11 +15,7 @@ type WorkspaceSelectCommand struct {
 }
 
 func (c *WorkspaceSelectCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
 	cmdFlags := c.Meta.defaultFlagSet("workspace select")

--- a/command/workspace_show.go
+++ b/command/workspace_show.go
@@ -12,11 +12,7 @@ type WorkspaceShowCommand struct {
 }
 
 func (c *WorkspaceShowCommand) Run(args []string) int {
-	args, err := c.Meta.process(args, true)
-	if err != nil {
-		return 1
-	}
-
+	args = c.Meta.process(args)
 	cmdFlags := c.Meta.extendedFlagSet("workspace show")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {


### PR DESCRIPTION
[After some refactoring](https://github.com/hashicorp/terraform/commit/c937c06a03386caee280c36ee10eebeb0dc7813b#diff-90b1eddd7a48b85e97074446d8cbb80aL459), this helper method had an unused argument (`vars`) and an always-`nil` `error` return value. This commit cleans this up.