### PR TITLE
Finish up support for built-in providers

### DIFF
--- a/addrs/provider.go
+++ b/addrs/provider.go
@@ -78,6 +78,30 @@ func NewProvider(hostname svchost.Hostname, namespace, typeName string) Provider
 	}
 }
 
+// ImpliedProviderForUnqualifiedType represents the rules for inferring what
+// provider FQN a user intended when only a naked type name is available.
+//
+// For all except the type name "terraform" this returns a so-called "default"
+// provider, which is under the registry.terraform.io/hashicorp/ namespace.
+//
+// As a special case, the string "terraform" maps to
+// "terraform.io/builtin/terraform" because that is the more likely user
+// intent than the now-unmaintained "registry.terraform.io/hashicorp/terraform"
+// which remains only for compatibility with older Terraform versions.
+func ImpliedProviderForUnqualifiedType(typeName string) Provider {
+	switch typeName {
+	case "terraform":
+		// Note for future maintainers: any additional strings we add here
+		// as implied to be builtin must never also be use as provider names
+		// in the registry.terraform.io/hashicorp/... namespace, because
+		// otherwise older versions of Terraform could implicitly select
+		// the registry name instead of the internal one.
+		return NewBuiltInProvider(typeName)
+	default:
+		return NewDefaultProvider(typeName)
+	}
+}
+
 // NewDefaultProvider returns the default address of a HashiCorp-maintained,
 // Registry-hosted provider.
 func NewDefaultProvider(name string) Provider {

--- a/command/init.go
+++ b/command/init.go
@@ -467,6 +467,16 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 		ProviderAlreadyInstalled: func(provider addrs.Provider, selectedVersion getproviders.Version) {
 			c.Ui.Info(fmt.Sprintf("- Using previously-installed %s v%s", provider, selectedVersion))
 		},
+		BuiltInProviderAvailable: func(provider addrs.Provider) {
+			c.Ui.Info(fmt.Sprintf("- %s is built in to Terraform", provider))
+		},
+		BuiltInProviderFailure: func(provider addrs.Provider, err error) {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid dependency on built-in provider",
+				fmt.Sprintf("Cannot use %s: %s.", provider, err),
+			))
+		},
 		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints) {
 			if len(versionConstraints) > 0 {
 				c.Ui.Info(fmt.Sprintf("- Finding %s versions matching %q...", provider, getproviders.VersionConstraintsString(versionConstraints)))

--- a/command/meta_providers.go
+++ b/command/meta_providers.go
@@ -58,6 +58,11 @@ func (m *Meta) providerInstallerCustomSource(source getproviders.Source) *provid
 	if globalCacheDir != nil {
 		inst.SetGlobalCacheDir(globalCacheDir)
 	}
+	var builtinProviderTypes []string
+	for ty := range m.internalProviders() {
+		builtinProviderTypes = append(builtinProviderTypes, ty)
+	}
+	inst.SetBuiltInProviderTypes(builtinProviderTypes)
 	return inst
 }
 

--- a/command/testdata/init-internal-invalid/main.tf
+++ b/command/testdata/init-internal-invalid/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    nonexist = {
+      source = "terraform.io/builtin/nonexist"
+    }
+    terraform = {
+      version = "1.2.0"
+    }
+  }
+}

--- a/configs/config.go
+++ b/configs/config.go
@@ -310,7 +310,7 @@ func (c *Config) ResolveAbsProviderAddr(addr addrs.ProviderConfig, inModule addr
 		if providerReq, exists := c.Module.ProviderRequirements[addr.LocalName]; exists {
 			provider = providerReq.Type
 		} else {
-			provider = addrs.NewDefaultProvider(addr.LocalName)
+			provider = addrs.ImpliedProviderForUnqualifiedType(addr.LocalName)
 		}
 
 		return addrs.AbsProviderConfig{

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -124,6 +124,7 @@ func TestConfigProviderRequirements(t *testing.T) {
 	nullProvider := addrs.NewDefaultProvider("null")
 	randomProvider := addrs.NewDefaultProvider("random")
 	impliedProvider := addrs.NewDefaultProvider("implied")
+	terraformProvider := addrs.NewBuiltInProvider("terraform")
 
 	got, diags := cfg.ProviderRequirements()
 	assertNoDiagnostics(t, diags)
@@ -134,6 +135,7 @@ func TestConfigProviderRequirements(t *testing.T) {
 		tlsProvider:        getproviders.MustParseVersionConstraints("~> 3.0"),
 		impliedProvider:    nil,
 		happycloudProvider: nil,
+		terraformProvider:  nil,
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/configs/module.go
+++ b/configs/module.go
@@ -195,7 +195,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			}
 			diags = append(diags, hclDiags...)
 		} else {
-			fqn = addrs.NewDefaultProvider(reqd.Name)
+			fqn = addrs.ImpliedProviderForUnqualifiedType(reqd.Name)
 		}
 		if existing, exists := m.ProviderRequirements[reqd.Name]; exists {
 			if existing.Type != fqn {
@@ -286,11 +286,11 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			if existing, exists := m.ProviderRequirements[r.ProviderConfigAddr().LocalName]; exists {
 				r.Provider = existing.Type
 			} else {
-				r.Provider = addrs.NewDefaultProvider(r.ProviderConfigAddr().LocalName)
+				r.Provider = addrs.ImpliedProviderForUnqualifiedType(r.ProviderConfigAddr().LocalName)
 			}
 			continue
 		}
-		r.Provider = addrs.NewDefaultProvider(r.Addr().ImpliedProvider())
+		r.Provider = addrs.ImpliedProviderForUnqualifiedType(r.Addr().ImpliedProvider())
 	}
 
 	for _, r := range file.DataResources {
@@ -310,13 +310,12 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 		if r.ProviderConfigRef != nil {
 			if existing, exists := m.ProviderRequirements[r.ProviderConfigAddr().LocalName]; exists {
 				r.Provider = existing.Type
-
 			} else {
-				r.Provider = addrs.NewDefaultProvider(r.ProviderConfigAddr().LocalName)
+				r.Provider = addrs.ImpliedProviderForUnqualifiedType(r.ProviderConfigAddr().LocalName)
 			}
 			continue
 		}
-		r.Provider = addrs.NewDefaultProvider(r.Addr().ImpliedProvider())
+		r.Provider = addrs.ImpliedProviderForUnqualifiedType(r.Addr().ImpliedProvider())
 	}
 
 	return diags
@@ -511,5 +510,5 @@ func (m *Module) ProviderForLocalConfig(pc addrs.LocalProviderConfig) addrs.Prov
 	if provider, exists := m.ProviderRequirements[pc.LocalName]; exists {
 		return provider.Type
 	}
-	return addrs.NewDefaultProvider(pc.LocalName)
+	return addrs.ImpliedProviderForUnqualifiedType(pc.LocalName)
 }

--- a/configs/module_merge.go
+++ b/configs/module_merge.go
@@ -48,7 +48,7 @@ func mergeProviderVersionConstraints(recv map[string]ProviderRequirements, ovrd 
 			// any errors parsing the source string will have already been captured.
 			fqn, _ = addrs.ParseProviderSourceString(reqd.Source.SourceStr)
 		} else {
-			fqn = addrs.NewDefaultProvider(reqd.Name)
+			fqn = addrs.ImpliedProviderForUnqualifiedType(reqd.Name)
 		}
 		recv[reqd.Name] = ProviderRequirements{Type: fqn, VersionConstraints: []VersionConstraint{reqd.Requirement}}
 	}
@@ -218,7 +218,7 @@ func (r *Resource) merge(or *Resource, prs map[string]ProviderRequirements) hcl.
 		if existing, exists := prs[or.ProviderConfigRef.Name]; exists {
 			r.Provider = existing.Type
 		} else {
-			r.Provider = addrs.NewDefaultProvider(r.ProviderConfigRef.Name)
+			r.Provider = addrs.ImpliedProviderForUnqualifiedType(r.ProviderConfigRef.Name)
 		}
 	}
 

--- a/configs/module_test.go
+++ b/configs/module_test.go
@@ -33,6 +33,18 @@ func TestNewModule_provider_local_name(t *testing.T) {
 	if localName != "nonexist" {
 		t.Error("wrong local name returned for a non-local provider")
 	}
+
+	// can also look up the "terraform" provider and see that it sources is
+	// allowed to be overridden, even though there is a builtin provider
+	// called "terraform".
+	p = addrs.NewProvider(addrs.DefaultRegistryHost, "not-builtin", "not-terraform")
+	if name, exists := mod.ProviderLocalNames[p]; !exists {
+		t.Fatal("provider FQN not-builtin/not-terraform not found")
+	} else {
+		if name != "terraform" {
+			t.Fatalf("provider localname mismatch: got %s, want terraform", name)
+		}
+	}
 }
 
 // This test validates the provider FQNs set in each Resource

--- a/configs/testdata/provider-reqs/provider-reqs-root.tf
+++ b/configs/testdata/provider-reqs/provider-reqs-root.tf
@@ -19,3 +19,10 @@ resource "implied_foo" "bar" {
 module "child" {
   source = "./child"
 }
+
+# There is no provider in required_providers called "terraform", but for
+# this name in particular we imply terraform.io/builtin/terraform instead,
+# to avoid selecting the now-unmaintained
+# registry.terraform.io/hashicorp/terraform.
+data "terraform_remote_state" "bar" {
+}

--- a/configs/testdata/providers-explicit-fqn/root.tf
+++ b/configs/testdata/providers-explicit-fqn/root.tf
@@ -4,5 +4,8 @@ terraform {
     foo-test = {
       source = "foo/test"
     }
+    terraform = {
+      source = "not-builtin/not-terraform"
+    }
   }
 }

--- a/internal/earlyconfig/config.go
+++ b/internal/earlyconfig/config.go
@@ -105,7 +105,7 @@ func (c *Config) addProviderRequirements(reqs getproviders.Requirements) tfdiags
 			fqn = addr
 		}
 		if fqn.IsZero() {
-			fqn = addrs.NewDefaultProvider(localName)
+			fqn = addrs.ImpliedProviderForUnqualifiedType(localName)
 		}
 		if _, ok := reqs[fqn]; !ok {
 			// We'll at least have an unconstrained dependency then, but might

--- a/internal/providercache/installer_events.go
+++ b/internal/providercache/installer_events.go
@@ -40,6 +40,19 @@ type InstallerEvents struct {
 	// available version.
 	ProviderAlreadyInstalled func(provider addrs.Provider, selectedVersion getproviders.Version)
 
+	// The BuiltInProvider... family of events describe the outcome for any
+	// requested providers that are built in to Terraform. Only one of these
+	// methods will be called for each such provider, and no other method
+	// will be called for them except that they are included in the
+	// aggregate PendingProviders map.
+	//
+	// The "Available" event reports that the requested builtin provider is
+	// available in this release of Terraform. The "Failure" event reports
+	// either that the provider is unavailable or that the request for it
+	// is invalid somehow.
+	BuiltInProviderAvailable func(provider addrs.Provider)
+	BuiltInProviderFailure   func(provider addrs.Provider, err error)
+
 	// The QueryPackages... family of events delimit the operation of querying
 	// a provider source for information about available packages matching
 	// a particular version constraint, prior to selecting a single version

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -305,7 +305,7 @@ func (n *NodeAbstractResource) Provider() addrs.Provider {
 	if n.Config != nil {
 		return n.Config.Provider
 	}
-	return addrs.NewDefaultProvider(n.Addr.Resource.ImpliedProvider())
+	return addrs.ImpliedProviderForUnqualifiedType(n.Addr.Resource.ImpliedProvider())
 }
 
 // GraphNodeProviderConsumer


### PR DESCRIPTION
An earlier changeset established the addressing scheme for "built-in" providers in the `addrs` package, which was intended to represent the special providers that are built in to Terraform itself, rather than separately installable, which we defined to live in the namespace `terraform.io/builtin/`. The `terraform` provider is currently the only built-in provider, and it was made available in the set of provider factories passed to `terraform.NewContext` already in an earlier change.

This PR introduces that concept into the provider installer too, both so that it knows not to try to install them the "normal" way and so it can verify that the requested built-in providers are valid and thus we retain the characteristic that `Installer.EnsureProviderVersions` will return without error only once it's ensured that all of the requested providers are available.

---

This PR also introduces a special case: an unqualified reference to the name "terraform" is implied to mean `terraform.io/builtin/terraform` rather than `registry.terraform.io/hashicorp/terraform`. This is important because the one on `registry.terraform.io` is an old release we've retained to preserve compatibility with older versions of Terraform that didn't have this provider built-in, but existing configurations that lack a specific source declaration ought to be selecting the built-in one rather than this stale separate one.

This special case is handled entirely inside the `configs` and `internal/earlyconfig` packages (using `addrs.ImpliedProviderForUnqualifiedType` to encapsulate the actual logic), so the rest of Terraform doesn't need to worry about it and can just deal generically in `addrs.Provider` as before.

---

This is ongoing work targeting our integration branch represented as #24477, so the full test suite doesn't pass here but the ones related to internal providers in `terraform init` _do_ now pass, having been updated here. More test fixes will follow in later commits, and improved test coverage for `internal/providercache` itself will follow once we get the already-existing tests back in good shape again.
