### PR TITLE
Mildwonkey/command tests

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -701,7 +701,7 @@ func testInputMap(t *testing.T, answers map[string]string) func() {
 // be returned about the backend configuration having changed and that
 // "terraform init" must be run, since the test backend config cache created
 // by this function contains the hash for an empty configuration.
-func testBackendState(t *testing.T, s *terraform.State, c int) (*terraform.State, *httptest.Server) {
+func testBackendState(t *testing.T, s *states.State, c int) (*terraform.State, *httptest.Server) {
 	t.Helper()
 
 	var b64md5 string
@@ -723,8 +723,8 @@ func testBackendState(t *testing.T, s *terraform.State, c int) (*terraform.State
 
 	// If a state was given, make sure we calculate the proper b64md5
 	if s != nil {
-		enc := json.NewEncoder(buf)
-		if err := enc.Encode(s); err != nil {
+		err := statefile.Write(&statefile.File{State: s}, buf)
+		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		md5 := md5.Sum(buf.Bytes())

--- a/command/format/state.go
+++ b/command/format/state.go
@@ -147,7 +147,7 @@ func formatStateModule(p blockBodyDiffPrinter, m *states.Module, schemas *terraf
 					// loaded all of the schemas and checked things prior to this
 					// point. We can't return errors here, but since this is UI code
 					// we will try to do _something_ reasonable.
-					p.buf.WriteString(fmt.Sprintf("# missing schema for provider %q\n\n", provider.LegacyString()))
+					p.buf.WriteString(fmt.Sprintf("# missing schema for provider %q\n\n", provider.String()))
 					continue
 				}
 

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -33,7 +33,7 @@ func TestGraph(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `provider["registry.terraform.io/-/test"]`) {
+	if !strings.Contains(output, `provider["registry.terraform.io/hashicorp/test"]`) {
 		t.Fatalf("doesn't look like digraph: %s", output)
 	}
 }
@@ -80,7 +80,7 @@ func TestGraph_noArgs(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `provider["registry.terraform.io/-/test"]`) {
+	if !strings.Contains(output, `provider["registry.terraform.io/hashicorp/test"]`) {
 		t.Fatalf("doesn't look like digraph: %s", output)
 	}
 }
@@ -161,7 +161,7 @@ func TestGraph_plan(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `provider["registry.terraform.io/-/test"]`) {
+	if !strings.Contains(output, `provider["registry.terraform.io/hashicorp/test"]`) {
 		t.Fatalf("doesn't look like digraph: %s", output)
 	}
 }

--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -252,7 +252,7 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 		r.ModuleAddress = addr.Module.String()
 		r.Name = addr.Resource.Resource.Name
 		r.Type = addr.Resource.Resource.Type
-		r.ProviderName = rc.ProviderAddr.Provider.LegacyString()
+		r.ProviderName = rc.ProviderAddr.Provider.String()
 
 		p.ResourceChanges = append(p.ResourceChanges, r)
 

--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -164,7 +164,7 @@ func marshalPlanResources(changes *plans.Changes, ris []addrs.AbsResourceInstanc
 			Address:      r.Addr.String(),
 			Type:         r.Addr.Resource.Resource.Type,
 			Name:         r.Addr.Resource.Resource.Name,
-			ProviderName: r.ProviderAddr.Provider.LegacyString(),
+			ProviderName: r.ProviderAddr.Provider.String(),
 			Index:        r.Addr.Resource.Key,
 		}
 

--- a/command/jsonplan/values_test.go
+++ b/command/jsonplan/values_test.go
@@ -198,7 +198,7 @@ func TestMarshalPlanResources(t *testing.T) {
 				Type:            "test_thing",
 				Name:            "example",
 				Index:           addrs.InstanceKey(nil),
-				ProviderName:    "test",
+				ProviderName:    "registry.terraform.io/hashicorp/test",
 				SchemaVersion:   1,
 				AttributeValues: attributeValues{},
 			}},
@@ -227,7 +227,7 @@ func TestMarshalPlanResources(t *testing.T) {
 				Type:          "test_thing",
 				Name:          "example",
 				Index:         addrs.InstanceKey(nil),
-				ProviderName:  "test",
+				ProviderName:  "registry.terraform.io/hashicorp/test",
 				SchemaVersion: 1,
 				AttributeValues: attributeValues{
 
@@ -259,7 +259,7 @@ func TestMarshalPlanResources(t *testing.T) {
 							Name: "example",
 						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 						ProviderAddr: addrs.AbsProviderConfig{
-							Provider: addrs.NewLegacyProvider("test"),
+							Provider: addrs.NewDefaultProvider("test"),
 							Module:   addrs.RootModule,
 						},
 						ChangeSrc: plans.ChangeSrc{
@@ -294,7 +294,7 @@ func TestMarshalPlanResources(t *testing.T) {
 func testSchemas() *terraform.Schemas {
 	return &terraform.Schemas{
 		Providers: map[addrs.Provider]*terraform.ProviderSchema{
-			addrs.NewLegacyProvider("test"): &terraform.ProviderSchema{
+			addrs.NewDefaultProvider("test"): &terraform.ProviderSchema{
 				ResourceTypes: map[string]*configschema.Block{
 					"test_thing": {
 						Attributes: map[string]*configschema.Attribute{

--- a/command/jsonprovider/provider.go
+++ b/command/jsonprovider/provider.go
@@ -35,7 +35,7 @@ func Marshal(s *terraform.Schemas) ([]byte, error) {
 	providers := newProviders()
 
 	for k, v := range s.Providers {
-		providers.Schemas[k.LegacyString()] = marshalProvider(v)
+		providers.Schemas[k.String()] = marshalProvider(v)
 	}
 
 	ret, err := json.Marshal(providers)

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -261,7 +261,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 				Address:      r.Addr.Instance(k).String(),
 				Type:         resAddr.Type,
 				Name:         resAddr.Name,
-				ProviderName: r.ProviderConfig.Provider.LegacyString(),
+				ProviderName: r.ProviderConfig.Provider.String(),
 			}
 
 			switch resAddr.Mode {

--- a/command/jsonstate/state_test.go
+++ b/command/jsonstate/state_test.go
@@ -204,7 +204,7 @@ func TestMarshalResources(t *testing.T) {
 						},
 					},
 					ProviderConfig: addrs.AbsProviderConfig{
-						Provider: addrs.NewLegacyProvider("test"),
+						Provider: addrs.NewDefaultProvider("test"),
 						Module:   addrs.RootModule,
 					},
 				},
@@ -217,7 +217,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:          "test_thing",
 					Name:          "bar",
 					Index:         addrs.InstanceKey(nil),
-					ProviderName:  "test",
+					ProviderName:  "registry.terraform.io/hashicorp/test",
 					SchemaVersion: 1,
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),
@@ -248,7 +248,7 @@ func TestMarshalResources(t *testing.T) {
 						},
 					},
 					ProviderConfig: addrs.AbsProviderConfig{
-						Provider: addrs.NewLegacyProvider("test"),
+						Provider: addrs.NewDefaultProvider("test"),
 						Module:   addrs.RootModule,
 					},
 				},
@@ -261,7 +261,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:          "test_thing",
 					Name:          "bar",
 					Index:         addrs.IntKey(0),
-					ProviderName:  "test",
+					ProviderName:  "registry.terraform.io/hashicorp/test",
 					SchemaVersion: 1,
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),
@@ -292,7 +292,7 @@ func TestMarshalResources(t *testing.T) {
 						},
 					},
 					ProviderConfig: addrs.AbsProviderConfig{
-						Provider: addrs.NewLegacyProvider("test"),
+						Provider: addrs.NewDefaultProvider("test"),
 						Module:   addrs.RootModule,
 					},
 				},
@@ -305,7 +305,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:          "test_thing",
 					Name:          "bar",
 					Index:         addrs.StringKey("rockhopper"),
-					ProviderName:  "test",
+					ProviderName:  "registry.terraform.io/hashicorp/test",
 					SchemaVersion: 1,
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),
@@ -338,7 +338,7 @@ func TestMarshalResources(t *testing.T) {
 						},
 					},
 					ProviderConfig: addrs.AbsProviderConfig{
-						Provider: addrs.NewLegacyProvider("test"),
+						Provider: addrs.NewDefaultProvider("test"),
 						Module:   addrs.RootModule,
 					},
 				},
@@ -351,7 +351,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:         "test_thing",
 					Name:         "bar",
 					Index:        addrs.InstanceKey(nil),
-					ProviderName: "test",
+					ProviderName: "registry.terraform.io/hashicorp/test",
 					DeposedKey:   deposedKey.String(),
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),
@@ -389,7 +389,7 @@ func TestMarshalResources(t *testing.T) {
 						},
 					},
 					ProviderConfig: addrs.AbsProviderConfig{
-						Provider: addrs.NewLegacyProvider("test"),
+						Provider: addrs.NewDefaultProvider("test"),
 						Module:   addrs.RootModule,
 					},
 				},
@@ -402,7 +402,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:          "test_thing",
 					Name:          "bar",
 					Index:         addrs.InstanceKey(nil),
-					ProviderName:  "test",
+					ProviderName:  "registry.terraform.io/hashicorp/test",
 					SchemaVersion: 1,
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),
@@ -415,7 +415,7 @@ func TestMarshalResources(t *testing.T) {
 					Type:         "test_thing",
 					Name:         "bar",
 					Index:        addrs.InstanceKey(nil),
-					ProviderName: "test",
+					ProviderName: "registry.terraform.io/hashicorp/test",
 					DeposedKey:   deposedKey.String(),
 					AttributeValues: attributeValues{
 						"foozles": json.RawMessage(`null`),
@@ -461,7 +461,7 @@ func TestMarshalModules_basic(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -476,7 +476,7 @@ func TestMarshalModules_basic(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   childModule.Module(),
 			},
 		)
@@ -491,7 +491,7 @@ func TestMarshalModules_basic(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   subModule.Module(),
 			},
 		)
@@ -530,7 +530,7 @@ func TestMarshalModules_nested(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -545,7 +545,7 @@ func TestMarshalModules_nested(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   childModule.Module(),
 			},
 		)
@@ -560,7 +560,7 @@ func TestMarshalModules_nested(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   subModule.Module(),
 			},
 		)
@@ -591,7 +591,7 @@ func TestMarshalModules_nested(t *testing.T) {
 func testSchemas() *terraform.Schemas {
 	return &terraform.Schemas{
 		Providers: map[addrs.Provider]*terraform.ProviderSchema{
-			addrs.NewLegacyProvider("test"): &terraform.ProviderSchema{
+			addrs.NewDefaultProvider("test"): &terraform.ProviderSchema{
 				ResourceTypes: map[string]*configschema.Block{
 					"test_thing": {
 						Attributes: map[string]*configschema.Attribute{

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -757,10 +757,10 @@ foo = "bar"
 const testRefreshStr = `
 test_instance.foo:
   ID = yes
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
 `
 const testRefreshCwdStr = `
 test_instance.foo:
   ID = yes
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
 `

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -85,7 +85,7 @@ func TestShow_aliasedProvider(t *testing.T) {
 				Dependencies: []addrs.ConfigResource{},
 				DependsOn:    []addrs.Referenceable{},
 			},
-			addrs.RootModuleInstance.ProviderConfigAliased(addrs.NewLegacyProvider("test"), "alias"),
+			addrs.RootModuleInstance.ProviderConfigAliased(addrs.NewDefaultProvider("test"), "alias"),
 		)
 	})
 
@@ -486,7 +486,7 @@ func showFixturePlanFile(t *testing.T, action plans.Action) string {
 			Name: "foo",
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 		ProviderAddr: addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 		ChangeSrc: plans.ChangeSrc{

--- a/command/state_show_test.go
+++ b/command/state_show_test.go
@@ -26,7 +26,7 @@ func TestStateShow(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -84,7 +84,7 @@ func TestStateShow_multi(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -99,7 +99,7 @@ func TestStateShow_multi(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   submod.Module(),
 			},
 		)
@@ -205,7 +205,7 @@ func TestStateShow_configured_provider(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test-beta"),
+				Provider: addrs.NewDefaultProvider("test-beta"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -230,7 +230,7 @@ func TestStateShow_configured_provider(t *testing.T) {
 		Meta: Meta{
 			testingOverrides: &testingOverrides{
 				Providers: map[addrs.Provider]providers.Factory{
-					addrs.NewLegacyProvider("test-beta"): providers.FactoryFixed(p),
+					addrs.NewDefaultProvider("test-beta"): providers.FactoryFixed(p),
 				},
 			},
 			Ui: ui,

--- a/command/testdata/providers-schema/basic/output.json
+++ b/command/testdata/providers-schema/basic/output.json
@@ -1,7 +1,7 @@
 {
     "format_version": "0.1",
     "provider_schemas": {
-        "test": {
+        "registry.terraform.io/hashicorp/test": {
             "resource_schemas": {
                 "test_instance": {
                     "version": 0,

--- a/command/testdata/show-json-state/basic/terraform.tfstate
+++ b/command/testdata/show-json-state/basic/terraform.tfstate
@@ -10,7 +10,7 @@
             "type": "test_instance",
             "name": "example",
             "each": "list",
-            "provider": "provider.test",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
             "instances": [
                 {
                     "index_key": 0,

--- a/command/testdata/show-json-state/modules/output.json
+++ b/command/testdata/show-json-state/modules/output.json
@@ -17,7 +17,7 @@
                             "mode": "managed",
                             "type": "test_instance",
                             "name": "example",
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/hashicorp/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "bar-var",
@@ -35,7 +35,7 @@
                             "type": "test_instance",
                             "name": "example",
                             "index": 0,
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/hashicorp/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "foo-var",

--- a/command/testdata/show-json-state/modules/terraform.tfstate
+++ b/command/testdata/show-json-state/modules/terraform.tfstate
@@ -16,7 +16,7 @@
             "type": "test_instance",
             "name": "example",
             "each": "list",
-            "provider": "provider.test",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
             "instances": [
                 {
                     "index_key": 0,
@@ -33,7 +33,7 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "example",
-            "provider": "provider.test",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
             "instances": [
                 {
                     "schema_version": 0,

--- a/command/testdata/show-json/basic-create/output.json
+++ b/command/testdata/show-json/basic-create/output.json
@@ -20,7 +20,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar"
@@ -32,7 +32,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar"
@@ -44,7 +44,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar"
@@ -71,7 +71,7 @@
             "index": 0,
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "name": "test",
             "change": {
                 "actions": [
@@ -91,7 +91,7 @@
             "index": 1,
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "name": "test",
             "change": {
                 "actions": [
@@ -111,7 +111,7 @@
             "index": 2,
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "name": "test",
             "change": {
                 "actions": [

--- a/command/testdata/show-json/basic-delete/output.json
+++ b/command/testdata/show-json/basic-delete/output.json
@@ -19,7 +19,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar",
@@ -34,7 +34,7 @@
             "address": "test_instance.test",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "name": "test",
             "change": {
                 "actions": [
@@ -55,7 +55,7 @@
             "address": "test_instance.test-delete",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "name": "test-delete",
             "change": {
                 "actions": [
@@ -97,7 +97,7 @@
                         "mode": "managed",
                         "type": "test_instance",
                         "name": "test",
-                        "provider_name": "test",
+                        "provider_name": "registry.terraform.io/hashicorp/test",
                         "values": {
                             "ami": "foo",
                             "id": "placeholder"
@@ -109,7 +109,7 @@
                         "mode": "managed",
                         "type": "test_instance",
                         "name": "test-delete",
-                        "provider_name": "test",
+                        "provider_name": "registry.terraform.io/hashicorp/test",
                         "values": {
                             "ami": "foo",
                             "id": "placeholder"

--- a/command/testdata/show-json/basic-delete/terraform.tfstate
+++ b/command/testdata/show-json/basic-delete/terraform.tfstate
@@ -9,7 +9,7 @@
       "mode": "managed",
       "type": "test_instance",
       "name": "test",
-      "provider": "provider[\"registry.terraform.io/-/test\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -24,7 +24,7 @@
       "mode": "managed",
       "type": "test_instance",
       "name": "test-delete",
-      "provider": "provider[\"registry.terraform.io/-/test\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
       "instances": [
         {
           "schema_version": 0,

--- a/command/testdata/show-json/basic-update/output.json
+++ b/command/testdata/show-json/basic-update/output.json
@@ -19,7 +19,7 @@
                     "mode": "managed",
                     "type": "test_instance",
                     "name": "test",
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar",
@@ -34,7 +34,7 @@
             "address": "test_instance.test",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "name": "test",
             "change": {
                 "actions": [
@@ -79,7 +79,7 @@
                         "type": "test_instance",
                         "name": "test",
                         "schema_version": 0,
-                        "provider_name": "test",
+                        "provider_name": "registry.terraform.io/hashicorp/test",
                         "values": {
                             "ami": "bar",
                             "id": "placeholder"

--- a/command/testdata/show-json/basic-update/terraform.tfstate
+++ b/command/testdata/show-json/basic-update/terraform.tfstate
@@ -9,7 +9,7 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
-            "provider": "provider[\"registry.terraform.io/-/test\"]",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
             "instances": [
                 {
                     "schema_version": 0,

--- a/command/testdata/show-json/modules/output.json
+++ b/command/testdata/show-json/modules/output.json
@@ -16,7 +16,7 @@
                             "mode": "managed",
                             "type": "test_instance",
                             "name": "test",
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/hashicorp/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "bar-var"
@@ -33,7 +33,7 @@
                             "type": "test_instance",
                             "name": "test",
                             "index": 0,
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/hashicorp/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "baz"
@@ -45,7 +45,7 @@
                             "type": "test_instance",
                             "name": "test",
                             "index": 1,
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/hashicorp/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "baz"
@@ -57,7 +57,7 @@
                             "type": "test_instance",
                             "name": "test",
                             "index": 2,
-                            "provider_name": "test",
+                            "provider_name": "registry.terraform.io/hashicorp/test",
                             "schema_version": 0,
                             "values": {
                                 "ami": "baz"
@@ -88,7 +88,7 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "change": {
                 "actions": [
                     "create"
@@ -107,7 +107,7 @@
             "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "name": "test",
             "index": 0,
             "change": {
@@ -128,7 +128,7 @@
             "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "name": "test",
             "index": 1,
             "change": {
@@ -149,7 +149,7 @@
             "module_address": "module.module_test_foo",
             "mode": "managed",
             "type": "test_instance",
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "name": "test",
             "index": 2,
             "change": {

--- a/command/testdata/show-json/multi-resource-update/output.json
+++ b/command/testdata/show-json/multi-resource-update/output.json
@@ -21,7 +21,7 @@
                     "type": "test_instance",
                     "name": "test",
                     "index": 0,
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar",
@@ -34,7 +34,7 @@
                     "type": "test_instance",
                     "name": "test",
                     "index": 1,
-                    "provider_name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
                     "schema_version": 0,
                     "values": {
                         "ami": "bar"
@@ -50,7 +50,7 @@
             "type": "test_instance",
             "name": "test",
             "index": 0,
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "change": {
                 "actions": [
                     "no-op"
@@ -72,7 +72,7 @@
             "type": "test_instance",
             "name": "test",
             "index": 1,
-            "provider_name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
             "change": {
                 "actions": [
                     "create"
@@ -115,7 +115,7 @@
                         "type": "test_instance",
                         "name": "test",
                         "index": 0,
-                        "provider_name": "test",
+                        "provider_name": "registry.terraform.io/hashicorp/test",
                         "schema_version": 0,
                         "values": {
                             "ami": "bar",

--- a/command/testdata/show-json/multi-resource-update/terraform.tfstate
+++ b/command/testdata/show-json/multi-resource-update/terraform.tfstate
@@ -9,7 +9,7 @@
             "mode": "managed",
             "type": "test_instance",
             "name": "test",
-            "provider": "provider[\"registry.terraform.io/-/test\"]",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
             "instances": [
                 {
                     "schema_version": 0,

--- a/command/testdata/show-json/nested-modules/output.json
+++ b/command/testdata/show-json/nested-modules/output.json
@@ -13,7 +13,7 @@
                   "mode": "managed",
                   "type": "test_instance",
                   "name": "test",
-                  "provider_name": "test",
+                  "provider_name": "registry.terraform.io/hashicorp/test",
                   "schema_version": 0,
                   "values": {
                     "ami": "bar-var"
@@ -34,7 +34,7 @@
       "mode": "managed",
       "type": "test_instance",
       "name": "test",
-      "provider_name": "test",
+      "provider_name": "registry.terraform.io/hashicorp/test",
       "change": {
         "actions": [
           "create"


### PR DESCRIPTION
Notable changes that impact other tests: 
- `command/command_test.go`: refactored `testBackendState` to take (and write) `states.State` instead of `terraform.State`
- `command/format/state.go`: Replace provider `LegacyString()` w/ plain old `String()`.

Tests passing:
- json* packages
- graph
- plan
- state show

Worked on but not passing:
- show (updated fixtures and expected output; still need to figure out how to tell show which provider schemas [by fqn] to load)