### PR TITLE
command/jsonconfig: Use correct provider address to access schema

### DIFF
--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -303,15 +303,13 @@ func marshalResources(resources map[string]*configs.Resource, schemas *terraform
 			}
 		}
 
-		// TODO: get actual providerFqn
-		providerFqn := addrs.NewLegacyProvider(v.ProviderConfigAddr().LocalName)
 		schema, schemaVer := schemas.ResourceTypeConfig(
-			providerFqn,
+			v.Provider,
 			v.Mode,
 			v.Type,
 		)
 		if schema == nil {
-			return nil, fmt.Errorf("no schema found for %s", v.Addr().String())
+			return nil, fmt.Errorf("no schema found for %s (in provider %s)", v.Addr().String(), v.Provider)
 		}
 		r.SchemaVersion = schemaVer
 

--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -183,7 +183,7 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 			addr.Resource.Resource.Type,
 		)
 		if schema == nil {
-			return fmt.Errorf("no schema found for %s", r.Address)
+			return fmt.Errorf("no schema found for %s (in provider %s)", r.Address, rc.ProviderAddr.Provider)
 		}
 
 		changeV, err := rc.Decode(schema.ImpliedType())

--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -291,7 +291,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 				current.SchemaVersion = ri.Current.SchemaVersion
 
 				if schema == nil {
-					return nil, fmt.Errorf("no schema found for %s", resAddr.String())
+					return nil, fmt.Errorf("no schema found for %s (in provider %s)", resAddr.String(), r.ProviderConfig.Provider)
 				}
 				riObj, err := ri.Current.Decode(schema.ImpliedType())
 				if err != nil {


### PR DESCRIPTION
There was a remaining TODO in this package to find the true provider FQN when looking up the schema for a resource type. We now have that data available in the Provider field of configs.Resource, so we can now complete that change.

The tests for this functionality actually live in the parent "command" package as part of the tests for the "terraform show" command, so this fix is verified by all of the `TestShow...` tests now passing except one, and that remaining one is failing for some other reason which we'll address in a later commit.

```
$ go test ./command -run ^TestShow
/tmp/tf958142578/tf669733492 <nil>
--- FAIL: TestShow_json_output_state (0.07s)
    --- FAIL: TestShow_json_output_state/basic (0.01s)
        show_test.go:404: wrong result:
               command.state{
              	FormatVersion:    "0.1",
              	TerraformVersion: "0.12.0",
              	Values: map[string]interface{}{
              		"root_module": map[string]interface{}{
              			"resources": []interface{}{
              				map[string]interface{}{
              					... // 2 identical entries
              					"mode":           string("managed"),
              					"name":           string("example"),
            - 					"provider_name":  string("registry.terraform.io/hashicorp/test"),
            + 					"provider_name":  string("test"),
              					"schema_version": float64(0),
              					"type":           string("test_instance"),
              					"values":         map[string]interface{}{"ami": nil, "id": string("621124146446964903")},
              				},
              				map[string]interface{}{
              					... // 2 identical entries
              					"mode":           string("managed"),
              					"name":           string("example"),
            - 					"provider_name":  string("registry.terraform.io/hashicorp/test"),
            + 					"provider_name":  string("test"),
              					"schema_version": float64(0),
              					"type":           string("test_instance"),
              					"values":         map[string]interface{}{"ami": nil, "id": string("4330206298367988603")},
              				},
              			},
              		},
              	},
              }
            
FAIL
FAIL	github.com/hashicorp/terraform/command	0.696s
FAIL
```

(This is part of an ongoing effort to get all the tests passing again in our integration branch, in #24477.)