### PR TITLE
internal: Fix init provider lockfile test

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -1153,7 +1153,7 @@ func TestInit_providerLockFile(t *testing.T) {
 	wantLockFile := strings.TrimSpace(`
 {
   "registry.terraform.io/hashicorp/test": {
-    "hash": "h1:4RzJudhcE4CkEwtVNRqdMKumSXu6bj8fkFTbPaX5G14=",
+    "hash": "h1:wlbEC2mChQZ2hhgUhl6SeVLPP7fMqOFUZAQhQ9GIIno=",
     "version": "1.2.3"
   }
 }

--- a/internal/getproviders/mock_source.go
+++ b/internal/getproviders/mock_source.go
@@ -162,7 +162,7 @@ func FakeInstallablePackageMeta(provider addrs.Provider, version Version, target
 	if err != nil {
 		return PackageMeta{}, close, fmt.Errorf("failed to add %s to mock zip file: %s", execFilename, err)
 	}
-	fmt.Fprintf(fw, "This is a fake provider package for %s %s %s, not a real provider.\n", provider, version, target)
+	fmt.Fprintf(fw, "This is a fake provider package for %s %s, not a real provider.\n", provider, version)
 	err = zw.Close()
 	if err != nil {
 		return PackageMeta{}, close, fmt.Errorf("failed to close the mock zip file: %s", err)


### PR DESCRIPTION
The fake installable package meta used a ZIP archive which gave different checksums between macOS and Linux targets. This commit removes the target from the contents of this archive, and updates the golden hash value in the test to match. This test should now pass on both platforms.