### PR TITLE
command/init: Restore the unconstrained provider warnings

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -520,7 +521,7 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 	// TODO: Use a context that will be cancelled when the Terraform
 	// process receives SIGINT.
 	ctx := evts.OnContext(context.TODO())
-	_, err := inst.EnsureProviderVersions(ctx, reqs, mode)
+	selected, err := inst.EnsureProviderVersions(ctx, reqs, mode)
 	if err != nil {
 		// The errors captured in "err" should be redundant with what we
 		// received via the InstallerEvents callbacks above, so we'll
@@ -531,86 +532,31 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 		return true, diags
 	}
 
+	// If any providers have "floating" versions (completely unconstrained)
+	// we'll suggest the user constrain with a pessimistic constraint to
+	// avoid implicitly adopting a later major release.
+	constraintSuggestions := make(map[string]string)
+	for addr, version := range selected {
+		req := reqs[addr]
+
+		if len(req) == 0 {
+			constraintSuggestions[addr.ForDisplay()] = "~> " + version.String()
+		}
+	}
+	if len(constraintSuggestions) != 0 {
+		names := make([]string, 0, len(constraintSuggestions))
+		for name := range constraintSuggestions {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		c.Ui.Output(outputInitProvidersUnconstrained)
+		for _, name := range names {
+			c.Ui.Output(fmt.Sprintf("* %s: version = %q", name, constraintSuggestions[name]))
+		}
+	}
+
 	return true, diags
-
-	// TODO: Write the selections into the plugins lock file so we can be
-	// sure that future commands will use exactly those provider packages.
-	// TODO: Emit constraint suggestions for unconstrained providers.
-	/*
-		// With all the providers downloaded, we'll generate our lock file
-		// that ensures the provider binaries remain unchanged until we init
-		// again. If anything changes, other commands that use providers will
-		// fail with an error instructing the user to re-run this command.
-		available = c.providerPluginSet() // re-discover to see newly-installed plugins
-
-		// internal providers were already filtered out, since we don't need to get them.
-		chosen := chooseProviders(available, nil, requirements)
-
-		digests := map[string][]byte{}
-		for name, meta := range chosen {
-			digest, err := meta.SHA256()
-			if err != nil {
-				diags = diags.Append(fmt.Errorf("Failed to read provider plugin %s: %s", meta.Path, err))
-				return true, diags
-			}
-			digests[name] = digest
-			if c.ignorePluginChecksum {
-				digests[name] = nil
-			}
-		}
-		err := c.providerPluginsLock().Write(digests)
-		if err != nil {
-			diags = diags.Append(fmt.Errorf("failed to save provider manifest: %s", err))
-			return true, diags
-		}
-
-		{
-			// Purge any auto-installed plugins that aren't being used.
-			purged, err := c.providerInstaller.PurgeUnused(chosen)
-			if err != nil {
-				// Failure to purge old plugins is not a fatal error
-				c.Ui.Warn(fmt.Sprintf("failed to purge unused plugins: %s", err))
-			}
-			if purged != nil {
-				for meta := range purged {
-					log.Printf("[DEBUG] Purged unused %s plugin %s", meta.Name, meta.Path)
-				}
-			}
-		}
-
-		// If any providers have "floating" versions (completely unconstrained)
-		// we'll suggest the user constrain with a pessimistic constraint to
-		// avoid implicitly adopting a later major release.
-		constraintSuggestions := make(map[string]discovery.ConstraintStr)
-		for name, meta := range chosen {
-			req := requirements[name]
-			if req == nil {
-				// should never happen, but we don't want to crash here, so we'll
-				// be cautious.
-				continue
-			}
-
-			if req.Versions.Unconstrained() && meta.Version != discovery.VersionZero {
-				// meta.Version.MustParse is safe here because our "chosen" metas
-				// were already filtered for validity of versions.
-				constraintSuggestions[name] = meta.Version.MustParse().MinorUpgradeConstraintStr()
-			}
-		}
-		if len(constraintSuggestions) != 0 {
-			names := make([]string, 0, len(constraintSuggestions))
-			for name := range constraintSuggestions {
-				names = append(names, name)
-			}
-			sort.Strings(names)
-
-			c.Ui.Output(outputInitProvidersUnconstrained)
-			for _, name := range names {
-				c.Ui.Output(fmt.Sprintf("* provider.%s: version = %q", name, constraintSuggestions[name]))
-			}
-		}
-
-		return true, diags
-	*/
 }
 
 // backendConfigOverrideBody interprets the raw values of -backend-config
@@ -838,9 +784,8 @@ The following providers do not have any version constraints in configuration,
 so the latest version was installed.
 
 To prevent automatic upgrades to new major versions that may contain breaking
-changes, it is recommended to add version = "..." constraints to the
-corresponding provider blocks in configuration, with the constraint strings
-suggested below.
+changes, we recommend adding version constraints in a required_providers block
+in your configuration, with the constraint strings suggested below.
 `
 
 const errDiscoveryServiceUnreachable = `

--- a/configs/parser_config.go
+++ b/configs/parser_config.go
@@ -92,6 +92,15 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 				}
 			}
 
+		case "required_providers":
+			// required_providers should be nested inside a "terraform" block
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid required_providers block",
+				Detail:   "A \"required_providers\" block must be nested inside a \"terraform\" block.",
+				Subject:  block.TypeRange.Ptr(),
+			})
+
 		case "provider":
 			cfg, cfgDiags := decodeProviderBlock(block)
 			diags = append(diags, cfgDiags...)
@@ -192,6 +201,12 @@ var configFileSchema = &hcl.BodySchema{
 	Blocks: []hcl.BlockHeaderSchema{
 		{
 			Type: "terraform",
+		},
+		{
+			// This one is not really valid, but we include it here so we
+			// can create a specialized error message hinting the user to
+			// nest it inside a "terraform" block.
+			Type: "required_providers",
 		},
 		{
 			Type:       "provider",

--- a/configs/testdata/error-files/required-providers-toplevel.tf
+++ b/configs/testdata/error-files/required-providers-toplevel.tf
@@ -1,0 +1,9 @@
+# A top-level required_providers block is not valid, but we have a specialized
+# error for it to hint the user to move it into a terraform block.
+required_providers { # ERROR: Invalid required_providers block
+}
+
+# This one is valid, and what the user should rewrite the above to be like.
+terraform {
+  required_providers {}
+}


### PR DESCRIPTION
When a provider dependency is implicit rather than explicit, or otherwise when version constraints are lacking, we produce a warning recommending the addition of explicit version constraints in the configuration.

This restores the warning functionality from previous Terraform versions, adapting it slightly to account for the new provider FQN syntax and to recommend using a `required_providers` block rather than version constraints in `provider` blocks, because the latter is no longer recommended in the documentation.

Due to the constraints of how we're presenting this information the warning message might imply to a user new to Terraform that it's recommending putting a `required_providers` block at the toplevel of configuration, and so to help guide towards the right answer I also added here a specialized error message in the `configs` package for that case. I'm expecting that this won't be the only place (either in our own prose or in third-party prose) where a configuration snippet without sufficient context might give the false impression that `required_providers` is a top-level block type.

---

This commit also removes two other TODO comments while appearing not to do anything about them. That's because both of those are now addressed in a slightly different way by the underlying provider installer object:

* The selections are captured into a file automatically by the installer, though it's a different file with a different internal structure than was generated by the commented-out code that I removed here.
* We're no longer actively "pruning" unused packages from the cache here, because the main reason we did that before was to work around the fact that our discovery package considered the files in the directory as the source of record for which versions were selected and so having other versions there would cause misbehavior.

    The new selections file format includes exact version information, so we no longer _need_ to prune. We might choose to re-instate automatic cache management later for general disk space management reasons, but the focus on this commit was on the mandatory behavior required to get the tests passing again.

---

As with my last few PRs, this one is targeting our integration branch represented as #24477. However, this is hopefully the last changeset before that will land, because this should green the final remaining test failure: an existing e2etest specifically testing the unconstrained provider warnings.
