### PR TITLE
Create module validation nodes

### DIFF
--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -1518,3 +1518,58 @@ variable "test" {
 		t.Fatalf("unexpected error\ngot: %s", diags.Err().Error())
 	}
 }
+
+func TestContext2Validate_expandModules(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "mod1" {
+  for_each = toset(["a", "b"])
+  source = "./mod"
+}
+
+module "mod2" {
+  for_each = module.mod1
+  source = "./mod"
+}
+
+module "mod3" {
+  count = len(module.mod2)
+  source = "./mod"
+}
+`,
+		"mod/main.tf": `
+resource "aws_instance" "foo" {
+}
+
+module "nested" {
+  count = 2
+  source = "./nested"
+  input = 2
+}
+`,
+		"mod/nested/main.tf": `
+variable "input" {
+}
+
+resource "aws_instance" "foo" {
+  count = var.input
+}
+`,
+	})
+
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		ProviderResolver: providers.ResolverFixed(
+			map[addrs.Provider]providers.Factory{
+				addrs.NewLegacyProvider("aws"): testProviderFuncFixed(p),
+			},
+		),
+	})
+
+	diags := ctx.Validate()
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+}

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -52,6 +52,7 @@ type PlanGraphBuilder struct {
 	ConcreteProvider       ConcreteProviderNodeFunc
 	ConcreteResource       ConcreteResourceNodeFunc
 	ConcreteResourceOrphan ConcreteResourceInstanceNodeFunc
+	ConcreteModule         ConcreteModuleNodeFunc
 
 	once sync.Once
 }
@@ -140,7 +141,10 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// Create expansion nodes for all of the module calls. This must
 		// come after all other transformers that create nodes representing
 		// objects that can belong to modules.
-		&ModuleExpansionTransformer{Config: b.Config},
+		&ModuleExpansionTransformer{
+			Concrete: b.ConcreteModule,
+			Config:   b.Config,
+		},
 
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.

--- a/terraform/graph_builder_validate.go
+++ b/terraform/graph_builder_validate.go
@@ -27,6 +27,12 @@ func ValidateGraphBuilder(p *PlanGraphBuilder) GraphBuilder {
 		}
 	}
 
+	p.ConcreteModule = func(n *nodeExpandModule) dag.Vertex {
+		return &nodeValidateModule{
+			nodeExpandModule: *n,
+		}
+	}
+
 	// We purposely don't set any other concrete types since they don't
 	// require validation.
 

--- a/terraform/transform_module_expansion.go
+++ b/terraform/transform_module_expansion.go
@@ -16,7 +16,10 @@ import (
 // This transform must be applied only after all nodes representing objects
 // that can be contained within modules have already been added.
 type ModuleExpansionTransformer struct {
-	Config   *configs.Config
+	Config *configs.Config
+
+	// Concrete allows injection of a wrapped module node by the graph builder
+	// to alter the evaluation behavior.
 	Concrete ConcreteModuleNodeFunc
 }
 


### PR DESCRIPTION
We cannot evaluate expansion during validation, since the values may not
be known at that time.

Inject a `nodeValidateModule`, using the "Concrete" pattern used for other
node types during graph building. This node will always evaluates to a
single module instance, so that we have a valid context within which to
evaluate all sub resources.