### PR TITLE
Enable count.index and each.key/value in module expansion

### DIFF
--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -34,7 +34,7 @@ type BuiltinEvalContext struct {
 
 	// pathSet indicates that this context was explicitly created for a
 	// specific path, and can be safely used for evaluation. This lets us
-	// differentiate between Pathvalue being unset, and the zero value which is
+	// differentiate between PathValue being unset, and the zero value which is
 	// equivalent to RootModuleInstance.  Path and Evaluation methods will
 	// panic if this is not set.
 	pathSet bool

--- a/terraform/eval_variable.go
+++ b/terraform/eval_variable.go
@@ -75,7 +75,7 @@ func (n *EvalModuleCallArgument) Eval(ctx EvalContext) (interface{}, error) {
 	scope := ctx.EvaluationScope(nil, moduleInstanceRepetitionData)
 	val, diags := scope.EvalExpr(expr, cty.DynamicPseudoType)
 
-	// We intentionally passed DynamicPseudoType to EvaluateExpr above because
+	// We intentionally passed DynamicPseudoType to EvalExpr above because
 	// now we can do our own local type conversion and produce an error message
 	// with better context if it fails.
 	var convErr error

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -144,7 +144,7 @@ func (d *evaluationStateData) GetCountAttr(addr addrs.CountAttr, rng tfdiags.Sou
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  `Reference to "count" in non-counted context`,
-				Detail:   fmt.Sprintf(`The "count" object can be used only in "resource" and "data" blocks, and only when the "count" argument is set.`),
+				Detail:   fmt.Sprintf(`The "count" object can only be used in "module", "resource", and "data" blocks, and only when the "count" argument is set.`),
 				Subject:  rng.ToHCL().Ptr(),
 			})
 			return cty.UnknownVal(cty.Number), diags
@@ -195,7 +195,7 @@ func (d *evaluationStateData) GetForEachAttr(addr addrs.ForEachAttr, rng tfdiags
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  `Reference to "each" in context without for_each`,
-			Detail:   fmt.Sprintf(`The "each" object can be used only in "resource" blocks, and only when the "for_each" argument is set.`),
+			Detail:   fmt.Sprintf(`The "each" object can be used only in "module" or "resource" blocks, and only when the "for_each" argument is set.`),
 			Subject:  rng.ToHCL().Ptr(),
 		})
 		return cty.UnknownVal(cty.DynamicPseudoType), diags

--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -224,7 +224,7 @@ func (n *NodeApplyableModuleVariable) EvalTree() EvalNode {
 		Nodes: []EvalNode{
 			&EvalOpFilter{
 				Ops: []walkOperation{walkRefresh, walkPlan, walkApply,
-					walkDestroy},
+					walkDestroy, walkValidate},
 				Node: &EvalModuleCallArgument{
 					Addr:           n.Addr.Variable,
 					Config:         n.Config,

--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -38,9 +38,10 @@ func (n *NodePlannableModuleVariable) DynamicExpand(ctx EvalContext) (*Graph, er
 	expander := ctx.InstanceExpander()
 	for _, module := range expander.ExpandModule(n.Module) {
 		o := &NodeApplyableModuleVariable{
-			Addr:   n.Addr.Absolute(module),
-			Config: n.Config,
-			Expr:   n.Expr,
+			Addr:           n.Addr.Absolute(module),
+			Config:         n.Config,
+			Expr:           n.Expr,
+			ModuleInstance: module,
 		}
 		g.Add(o)
 	}
@@ -114,6 +115,9 @@ type NodeApplyableModuleVariable struct {
 	Addr   addrs.AbsInputVariableInstance
 	Config *configs.Variable // Config is the var in the config
 	Expr   hcl.Expression    // Expr is the value expression given in the call
+	// ModuleInstance in order to create the appropriate context for evaluating
+	// ModuleCallArguments, ex. so count.index and each.key can resolve
+	ModuleInstance addrs.ModuleInstance
 }
 
 // Ensure that we are implementing all of the interfaces we think we are
@@ -220,12 +224,13 @@ func (n *NodeApplyableModuleVariable) EvalTree() EvalNode {
 		Nodes: []EvalNode{
 			&EvalOpFilter{
 				Ops: []walkOperation{walkRefresh, walkPlan, walkApply,
-					walkDestroy, walkValidate},
+					walkDestroy},
 				Node: &EvalModuleCallArgument{
-					Addr:   n.Addr.Variable,
-					Config: n.Config,
-					Expr:   n.Expr,
-					Values: vals,
+					Addr:           n.Addr.Variable,
+					Config:         n.Config,
+					Expr:           n.Expr,
+					ModuleInstance: n.ModuleInstance,
+					Values:         vals,
 
 					IgnoreDiagnostics: false,
 				},

--- a/terraform/testdata/plan-modules-expand/main.tf
+++ b/terraform/testdata/plan-modules-expand/main.tf
@@ -20,7 +20,7 @@ module "count_child" {
 module "for_each_child" {
   for_each = aws_instance.foo
   foo = 2
-  bar = var.myvar
+  bar = each.key
   source = "./child"
 }
 

--- a/terraform/testdata/plan-modules-expand/main.tf
+++ b/terraform/testdata/plan-modules-expand/main.tf
@@ -10,10 +10,9 @@ variable "myvar" {
   default = "baz"
 }
 
-
 module "count_child" {
   count = local.val
-  foo = 2
+  foo = count.index
   bar = var.myvar
   source = "./child"
 }


### PR DESCRIPTION
When evaluating ModuleCallArguments, we need to use the appropriate ModuleInstance as the scope of the evaluation, as that instance key data is what is used to evaluate `count.index` and `each.key`/`each.value` references appropriately.

Note: As of this PR, `count.index` etc usage will still fail when used in a config to plan, as it does not yet pass the validate step, but that will be fixed in a separate PR.