### PR TITLE
Refactor expansion to always use cty.Value

### DIFF
--- a/instances/expander.go
+++ b/instances/expander.go
@@ -68,32 +68,6 @@ func (e *Expander) SetResourceExpansion(moduleAddr addrs.ModuleInstance, resourc
 	e.setResourceExpansion(moduleAddr, resourceAddr, expansionValue(exp))
 }
 
-// SetResourceSingle records that the given resource inside the given module
-// does not use any repetition arguments and is therefore a singleton.
-func (e *Expander) SetResourceSingle(moduleAddr addrs.ModuleInstance, resourceAddr addrs.Resource) {
-	e.setResourceExpansion(moduleAddr, resourceAddr, expansionValue(cty.NilVal))
-}
-
-// SetResourceCount records that the given resource inside the given module
-// uses the "count" repetition argument, with the given value.
-func (e *Expander) SetResourceCount(moduleAddr addrs.ModuleInstance, resourceAddr addrs.Resource, count int) {
-	e.setResourceExpansion(moduleAddr, resourceAddr, expansionValue(cty.NumberIntVal(int64(count))))
-}
-
-// SetResourceForEach records that the given resource inside the given module
-// uses the "for_each" repetition argument, with the given map value.
-//
-// In the configuration language the for_each argument can also accept a set.
-// It's the caller's responsibility to convert that into an identity map before
-// calling this method.
-func (e *Expander) SetResourceForEach(moduleAddr addrs.ModuleInstance, resourceAddr addrs.Resource, mapping map[string]cty.Value) {
-	m := cty.MapValEmpty(cty.DynamicPseudoType)
-	if len(mapping) > 0 {
-		m = cty.MapVal(mapping)
-	}
-	e.setResourceExpansion(moduleAddr, resourceAddr, expansionValue(m))
-}
-
 // ExpandModule finds the exhaustive set of module instances resulting from
 // the expansion of the given module and all of its ancestor modules.
 //

--- a/instances/expander.go
+++ b/instances/expander.go
@@ -64,16 +64,20 @@ func (e *Expander) SetModuleExpansion(parentAddr addrs.ModuleInstance, callAddr 
 	e.setModuleExpansion(parentAddr, callAddr, expansionValue(exp))
 }
 
+func (e *Expander) SetResourceExpansion(moduleAddr addrs.ModuleInstance, resourceAddr addrs.Resource, exp cty.Value) {
+	e.setResourceExpansion(moduleAddr, resourceAddr, expansionValue(exp))
+}
+
 // SetResourceSingle records that the given resource inside the given module
 // does not use any repetition arguments and is therefore a singleton.
 func (e *Expander) SetResourceSingle(moduleAddr addrs.ModuleInstance, resourceAddr addrs.Resource) {
-	e.setResourceExpansion(moduleAddr, resourceAddr, expansionSingleVal)
+	e.setResourceExpansion(moduleAddr, resourceAddr, expansionValue(cty.NilVal))
 }
 
 // SetResourceCount records that the given resource inside the given module
 // uses the "count" repetition argument, with the given value.
 func (e *Expander) SetResourceCount(moduleAddr addrs.ModuleInstance, resourceAddr addrs.Resource, count int) {
-	e.setResourceExpansion(moduleAddr, resourceAddr, expansionCount(count))
+	e.setResourceExpansion(moduleAddr, resourceAddr, expansionValue(cty.NumberIntVal(int64(count))))
 }
 
 // SetResourceForEach records that the given resource inside the given module
@@ -83,7 +87,11 @@ func (e *Expander) SetResourceCount(moduleAddr addrs.ModuleInstance, resourceAdd
 // It's the caller's responsibility to convert that into an identity map before
 // calling this method.
 func (e *Expander) SetResourceForEach(moduleAddr addrs.ModuleInstance, resourceAddr addrs.Resource, mapping map[string]cty.Value) {
-	e.setResourceExpansion(moduleAddr, resourceAddr, expansionForEach(mapping))
+	m := cty.MapValEmpty(cty.DynamicPseudoType)
+	if len(mapping) > 0 {
+		m = cty.MapVal(mapping)
+	}
+	e.setResourceExpansion(moduleAddr, resourceAddr, expansionValue(m))
 }
 
 // ExpandModule finds the exhaustive set of module instances resulting from

--- a/instances/expander.go
+++ b/instances/expander.go
@@ -47,27 +47,21 @@ func NewExpander() *Expander {
 	}
 }
 
-// SetModuleSingle records that the given module call inside the given parent
-// module does not use any repetition arguments and is therefore a singleton.
-func (e *Expander) SetModuleSingle(parentAddr addrs.ModuleInstance, callAddr addrs.ModuleCall) {
-	e.setModuleExpansion(parentAddr, callAddr, expansionSingleVal)
-}
-
-// SetModuleCount records that the given module call inside the given parent
-// module instance uses the "count" repetition argument, with the given value.
-func (e *Expander) SetModuleCount(parentAddr addrs.ModuleInstance, callAddr addrs.ModuleCall, count int) {
-	e.setModuleExpansion(parentAddr, callAddr, expansionCount(count))
-}
-
-// SetModuleForEach records that the given module call inside the given parent
-// module instance uses the "for_each" repetition argument, with the given
-// map value.
+// SetModuleExpansion records the expansion information for the given module call inside
+// the given parent.
 //
-// In the configuration language the for_each argument can also accept a set.
-// It's the caller's responsibility to convert that into an identity map before
-// calling this method.
-func (e *Expander) SetModuleForEach(parentAddr addrs.ModuleInstance, callAddr addrs.ModuleCall, mapping map[string]cty.Value) {
-	e.setModuleExpansion(parentAddr, callAddr, expansionForEach(mapping))
+// If there is no repetition argument, the exp must be a cty.NilVal.
+//
+// If the module call uses the "count" repetition argument, record the number
+// of instances is equal to the exp value. The exp value must be a cty.Number,
+// and may be unknown.
+//
+// If the module call uses the "for_each" repetition argument, record the key
+// and value for each instance. The exp value must be a cty.Map or cty.Set(cty.String)
+// type. A map type may contain unknown values since the keys will be known. A
+// set may be unknown, but it may not contain an unknown string value.
+func (e *Expander) SetModuleExpansion(parentAddr addrs.ModuleInstance, callAddr addrs.ModuleCall, exp cty.Value) {
+	e.setModuleExpansion(parentAddr, callAddr, expansionValue(exp))
 }
 
 // SetResourceSingle records that the given resource inside the given module

--- a/instances/expander_test.go
+++ b/instances/expander_test.go
@@ -84,7 +84,7 @@ func TestExpander(t *testing.T) {
 		ex.SetResourceCount(addrs.RootModuleInstance, count0ResourceAddr, 0)
 		ex.SetResourceForEach(addrs.RootModuleInstance, forEachResourceAddr, eachMap)
 
-		ex.SetModuleSingle(addrs.RootModuleInstance, singleModuleAddr)
+		ex.SetModuleExpansion(addrs.RootModuleInstance, singleModuleAddr, cty.NilVal)
 		{
 			// The single instance of the module
 			moduleInstanceAddr := addrs.RootModuleInstance.Child("single", addrs.NoKey)
@@ -92,19 +92,19 @@ func TestExpander(t *testing.T) {
 			ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
 		}
 
-		ex.SetModuleCount(addrs.RootModuleInstance, count2ModuleAddr, 2)
+		ex.SetModuleExpansion(addrs.RootModuleInstance, count2ModuleAddr, cty.NumberIntVal(2))
 		for i1 := 0; i1 < 2; i1++ {
 			moduleInstanceAddr := addrs.RootModuleInstance.Child("count2", addrs.IntKey(i1))
 			ex.SetResourceSingle(moduleInstanceAddr, singleResourceAddr)
 			ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
-			ex.SetModuleCount(moduleInstanceAddr, count2ModuleAddr, 2)
+			ex.SetModuleExpansion(moduleInstanceAddr, count2ModuleAddr, cty.NumberIntVal(2))
 			for i2 := 0; i2 < 2; i2++ {
 				moduleInstanceAddr := moduleInstanceAddr.Child("count2", addrs.IntKey(i2))
 				ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
 			}
 		}
 
-		ex.SetModuleCount(addrs.RootModuleInstance, count0ModuleAddr, 0)
+		ex.SetModuleExpansion(addrs.RootModuleInstance, count0ModuleAddr, cty.NumberIntVal(0))
 		{
 			// There are no instances of module "count0", so our nested module
 			// would never actually get registered here: the expansion node
@@ -112,7 +112,7 @@ func TestExpander(t *testing.T) {
 			// instances and so do nothing.
 		}
 
-		ex.SetModuleForEach(addrs.RootModuleInstance, forEachModuleAddr, eachMap)
+		ex.SetModuleExpansion(addrs.RootModuleInstance, forEachModuleAddr, cty.MapVal(eachMap))
 		for k := range eachMap {
 			moduleInstanceAddr := addrs.RootModuleInstance.Child("for_each", addrs.StringKey(k))
 			ex.SetResourceSingle(moduleInstanceAddr, singleResourceAddr)

--- a/instances/expander_test.go
+++ b/instances/expander_test.go
@@ -79,28 +79,28 @@ func TestExpander(t *testing.T) {
 	// registering anything inside them, so we'll work through the above
 	// in a depth-first order in the registration steps that follow.
 	{
-		ex.SetResourceSingle(addrs.RootModuleInstance, singleResourceAddr)
-		ex.SetResourceCount(addrs.RootModuleInstance, count2ResourceAddr, 2)
-		ex.SetResourceCount(addrs.RootModuleInstance, count0ResourceAddr, 0)
-		ex.SetResourceForEach(addrs.RootModuleInstance, forEachResourceAddr, eachMap)
+		ex.SetResourceExpansion(addrs.RootModuleInstance, singleResourceAddr, cty.NilVal)
+		ex.SetResourceExpansion(addrs.RootModuleInstance, count2ResourceAddr, cty.NumberIntVal(2))
+		ex.SetResourceExpansion(addrs.RootModuleInstance, count0ResourceAddr, cty.NumberIntVal(0))
+		ex.SetResourceExpansion(addrs.RootModuleInstance, forEachResourceAddr, cty.MapVal(eachMap))
 
 		ex.SetModuleExpansion(addrs.RootModuleInstance, singleModuleAddr, cty.NilVal)
 		{
 			// The single instance of the module
 			moduleInstanceAddr := addrs.RootModuleInstance.Child("single", addrs.NoKey)
-			ex.SetResourceSingle(moduleInstanceAddr, singleResourceAddr)
-			ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
+			ex.SetResourceExpansion(moduleInstanceAddr, singleResourceAddr, cty.NilVal)
+			ex.SetResourceExpansion(moduleInstanceAddr, count2ResourceAddr, cty.NumberIntVal(2))
 		}
 
 		ex.SetModuleExpansion(addrs.RootModuleInstance, count2ModuleAddr, cty.NumberIntVal(2))
 		for i1 := 0; i1 < 2; i1++ {
 			moduleInstanceAddr := addrs.RootModuleInstance.Child("count2", addrs.IntKey(i1))
-			ex.SetResourceSingle(moduleInstanceAddr, singleResourceAddr)
-			ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
+			ex.SetResourceExpansion(moduleInstanceAddr, singleResourceAddr, cty.NilVal)
+			ex.SetResourceExpansion(moduleInstanceAddr, count2ResourceAddr, cty.NumberIntVal(2))
 			ex.SetModuleExpansion(moduleInstanceAddr, count2ModuleAddr, cty.NumberIntVal(2))
 			for i2 := 0; i2 < 2; i2++ {
 				moduleInstanceAddr := moduleInstanceAddr.Child("count2", addrs.IntKey(i2))
-				ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
+				ex.SetResourceExpansion(moduleInstanceAddr, count2ResourceAddr, cty.NumberIntVal(2))
 			}
 		}
 
@@ -115,8 +115,8 @@ func TestExpander(t *testing.T) {
 		ex.SetModuleExpansion(addrs.RootModuleInstance, forEachModuleAddr, cty.MapVal(eachMap))
 		for k := range eachMap {
 			moduleInstanceAddr := addrs.RootModuleInstance.Child("for_each", addrs.StringKey(k))
-			ex.SetResourceSingle(moduleInstanceAddr, singleResourceAddr)
-			ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
+			ex.SetResourceExpansion(moduleInstanceAddr, singleResourceAddr, cty.NilVal)
+			ex.SetResourceExpansion(moduleInstanceAddr, count2ResourceAddr, cty.NumberIntVal(2))
 		}
 	}
 

--- a/instances/expansion_mode.go
+++ b/instances/expansion_mode.go
@@ -17,6 +17,88 @@ type expansion interface {
 	repetitionData(addrs.InstanceKey) RepetitionData
 }
 
+type expansionValue cty.Value
+
+func (s expansionValue) instanceKeys() []addrs.InstanceKey {
+	v := cty.Value(s)
+	switch {
+	case v.Type() == cty.Number:
+		n, _ := v.AsBigFloat().Int64()
+		ret := make([]addrs.InstanceKey, int(n))
+		for i := range ret {
+			ret[i] = addrs.IntKey(i)
+		}
+		return ret
+
+	case v.Type().IsMapType() || v.Type().IsSetType() || v.Type().IsObjectType():
+		ret := make([]addrs.InstanceKey, 0, v.LengthInt())
+
+		for it := v.ElementIterator(); it.Next(); {
+			k, _ := it.Element()
+			ret = append(ret, addrs.StringKey(k.AsString()))
+		}
+
+		sort.Slice(ret, func(i, j int) bool {
+			return ret[i].(addrs.StringKey) < ret[j].(addrs.StringKey)
+		})
+		return ret
+
+	case v == cty.NilVal:
+		return singleKeys
+	default:
+		panic(fmt.Sprintf("unexpected expansion value: %#v", v))
+	}
+}
+
+func (s expansionValue) repetitionData(key addrs.InstanceKey) RepetitionData {
+	v := cty.Value(s)
+
+	switch {
+	case v.Type() == cty.Number:
+		if !v.IsKnown() {
+			return RepetitionData{
+				CountIndex: cty.UnknownVal(cty.Number),
+			}
+		}
+
+		n, _ := v.AsBigFloat().Int64()
+		i := int(key.(addrs.IntKey))
+		if i < 0 || i >= int(n) {
+			panic(fmt.Sprintf("instance key %d out of range for count %d", i, n))
+		}
+		return RepetitionData{
+			CountIndex: cty.NumberIntVal(int64(i)),
+		}
+
+	case v.Type().IsMapType() || v.Type().IsSetType() || v.Type().IsObjectType():
+		k := string(key.(addrs.StringKey))
+
+		if !v.IsKnown() {
+			return RepetitionData{
+				EachKey:   cty.UnknownVal(cty.String),
+				EachValue: cty.DynamicVal,
+			}
+		}
+
+		m := v.AsValueMap()
+		v, ok := m[k]
+		if !ok {
+			panic(fmt.Sprintf("instance key %q does not match any instance", k))
+		}
+
+		return RepetitionData{
+			EachKey:   cty.StringVal(k),
+			EachValue: v,
+		}
+
+	case v == cty.NilVal:
+		return RepetitionData{}
+
+	default:
+		panic(fmt.Sprintf("unexpected expansion value: %#v", v))
+	}
+}
+
 // expansionSingle is the expansion corresponding to no repetition arguments
 // at all, producing a single object with no key.
 //

--- a/instances/expansion_mode.go
+++ b/instances/expansion_mode.go
@@ -17,6 +17,8 @@ type expansion interface {
 	repetitionData(addrs.InstanceKey) RepetitionData
 }
 
+var singleKeys = []addrs.InstanceKey{addrs.NoKey}
+
 type expansionValue cty.Value
 
 func (s expansionValue) instanceKeys() []addrs.InstanceKey {
@@ -96,72 +98,5 @@ func (s expansionValue) repetitionData(key addrs.InstanceKey) RepetitionData {
 
 	default:
 		panic(fmt.Sprintf("unexpected expansion value: %#v", v))
-	}
-}
-
-// expansionSingle is the expansion corresponding to no repetition arguments
-// at all, producing a single object with no key.
-//
-// expansionSingleVal is the only valid value of this type.
-type expansionSingle uintptr
-
-var singleKeys = []addrs.InstanceKey{addrs.NoKey}
-var expansionSingleVal expansionSingle
-
-func (e expansionSingle) instanceKeys() []addrs.InstanceKey {
-	return singleKeys
-}
-
-func (e expansionSingle) repetitionData(key addrs.InstanceKey) RepetitionData {
-	if key != addrs.NoKey {
-		panic("cannot use instance key with non-repeating object")
-	}
-	return RepetitionData{}
-}
-
-// expansionCount is the expansion corresponding to the "count" argument.
-type expansionCount int
-
-func (e expansionCount) instanceKeys() []addrs.InstanceKey {
-	ret := make([]addrs.InstanceKey, int(e))
-	for i := range ret {
-		ret[i] = addrs.IntKey(i)
-	}
-	return ret
-}
-
-func (e expansionCount) repetitionData(key addrs.InstanceKey) RepetitionData {
-	i := int(key.(addrs.IntKey))
-	if i < 0 || i >= int(e) {
-		panic(fmt.Sprintf("instance key %d out of range for count %d", i, e))
-	}
-	return RepetitionData{
-		CountIndex: cty.NumberIntVal(int64(i)),
-	}
-}
-
-// expansionForEach is the expansion corresponding to the "for_each" argument.
-type expansionForEach map[string]cty.Value
-
-func (e expansionForEach) instanceKeys() []addrs.InstanceKey {
-	ret := make([]addrs.InstanceKey, 0, len(e))
-	for k := range e {
-		ret = append(ret, addrs.StringKey(k))
-	}
-	sort.Slice(ret, func(i, j int) bool {
-		return ret[i].(addrs.StringKey) < ret[j].(addrs.StringKey)
-	})
-	return ret
-}
-
-func (e expansionForEach) repetitionData(key addrs.InstanceKey) RepetitionData {
-	k := string(key.(addrs.StringKey))
-	v, ok := e[k]
-	if !ok {
-		panic(fmt.Sprintf("instance key %q does not match any instance", k))
-	}
-	return RepetitionData{
-		EachKey:   cty.StringVal(k),
-		EachValue: v,
 	}
 }

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -1424,7 +1424,7 @@ module "mod2" {
 }
 
 module "mod3" {
-  count = len(module.mod2)
+  count = length(module.mod2)
   source = "./mod"
 }
 `,

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -61,8 +61,9 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 	configVal := cty.NullVal(cty.DynamicPseudoType)
 	if n.Config != nil {
 		var configDiags tfdiags.Diagnostics
-		forEach, _ := evaluateResourceForEachExpression(n.Config.ForEach, ctx)
-		keyData := EvalDataForInstanceKey(n.Addr.Key, forEach)
+		forEach, _ := evaluateForEachExpression(n.Config.ForEach, ctx)
+		// FIXME: update this!
+		keyData := EvalDataForInstanceKey(n.Addr.Key, forEach.AsValueMap())
 		configVal, _, configDiags = ctx.EvaluateBlock(n.Config.Config, schema, nil, keyData)
 		diags = diags.Append(configDiags)
 		if configDiags.HasErrors() {
@@ -595,9 +596,9 @@ func (n *EvalApplyProvisioners) apply(ctx EvalContext, provs []*configs.Provisio
 		// in its result. That's okay because each.value is prohibited for
 		// destroy-time provisioners.
 		if n.When != configs.ProvisionerWhenDestroy {
-			m, forEachDiags := evaluateResourceForEachExpression(n.ResourceConfig.ForEach, ctx)
+			m, forEachDiags := evaluateForEachExpression(n.ResourceConfig.ForEach, ctx)
 			diags = diags.Append(forEachDiags)
-			forEach = m
+			forEach = m.AsValueMap()
 		}
 
 		keyData := EvalDataForInstanceKey(instanceAddr.Key, forEach)

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -133,8 +133,10 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 		// Should be caught during validation, so we don't bother with a pretty error here
 		return nil, fmt.Errorf("provider does not support resource type %q", n.Addr.Resource.Type)
 	}
-	forEach, _ := evaluateResourceForEachExpression(n.Config.ForEach, ctx)
-	keyData := EvalDataForInstanceKey(n.Addr.Key, forEach)
+
+	forEach, _ := evaluateForEachExpression(n.Config.ForEach, ctx)
+	//FIXME: update this!
+	keyData := EvalDataForInstanceKey(n.Addr.Key, forEach.AsValueMap())
 	configVal, _, configDiags := ctx.EvaluateBlock(config.Config, schema, nil, keyData)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {

--- a/terraform/eval_read_data.go
+++ b/terraform/eval_read_data.go
@@ -96,8 +96,8 @@ func (n *EvalReadData) Eval(ctx EvalContext) (interface{}, error) {
 	objTy := schema.ImpliedType()
 	priorVal := cty.NullVal(objTy) // for data resources, prior is always null because we start fresh every time
 
-	forEach, _ := evaluateResourceForEachExpression(n.Config.ForEach, ctx)
-	keyData := EvalDataForInstanceKey(n.Addr.Key, forEach)
+	forEach, _ := evaluateForEachExpression(n.Config.ForEach, ctx)
+	keyData := EvalDataForInstanceKey(n.Addr.Key, forEach.AsValueMap())
 
 	var configDiags tfdiags.Diagnostics
 	configVal, _, configDiags = ctx.EvaluateBlock(config.Config, schema, nil, keyData)

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // EvalReadState is an EvalNode implementation that reads the
@@ -466,37 +467,30 @@ func (n *EvalWriteResourceState) Eval(ctx EvalContext) (interface{}, error) {
 	// can refer to it. Since this node represents the abstract module, we need
 	// to expand the module here to create all resources.
 	expander := ctx.InstanceExpander()
-	count, countDiags := evaluateResourceCountExpression(n.Config.Count, ctx)
-	diags = diags.Append(countDiags)
-	if countDiags.HasErrors() {
-		return nil, diags.Err()
-	}
+	switch {
+	case n.Config.Count != nil:
+		count, countDiags := evaluateCountExpression(n.Config.Count, ctx)
+		diags = diags.Append(countDiags)
+		if countDiags.HasErrors() {
+			return nil, diags.Err()
+		}
 
-	eachMode := states.NoEach
-	if count >= 0 { // -1 signals "count not set"
-		eachMode = states.EachList
-	}
+		state.SetResourceMeta(n.Addr, states.EachList, n.ProviderAddr)
+		expander.SetResourceExpansion(n.Addr.Module, n.Addr.Resource, count)
 
-	forEach, forEachDiags := evaluateResourceForEachExpression(n.Config.ForEach, ctx)
-	diags = diags.Append(forEachDiags)
-	if forEachDiags.HasErrors() {
-		return nil, diags.Err()
-	}
+	case n.Config.ForEach != nil:
+		forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx)
+		diags = diags.Append(forEachDiags)
+		if forEachDiags.HasErrors() {
+			return nil, diags.Err()
+		}
 
-	if forEach != nil {
-		eachMode = states.EachMap
-	}
-	// This method takes care of all of the business logic of updating this
-	// while ensuring that any existing instances are preserved, etc.
-	state.SetResourceMeta(n.Addr, eachMode, n.ProviderAddr)
+		state.SetResourceMeta(n.Addr, states.EachMap, n.ProviderAddr)
+		expander.SetResourceExpansion(n.Addr.Module, n.Addr.Resource, forEach)
 
-	switch eachMode {
-	case states.EachList:
-		expander.SetResourceCount(n.Addr.Module, n.Addr.Resource, count)
-	case states.EachMap:
-		expander.SetResourceForEach(n.Addr.Module, n.Addr.Resource, forEach)
 	default:
-		expander.SetResourceSingle(n.Addr.Module, n.Addr.Resource)
+		state.SetResourceMeta(n.Addr, states.NoEach, n.ProviderAddr)
+		expander.SetResourceExpansion(n.Addr.Module, n.Addr.Resource, cty.NilVal)
 	}
 
 	return nil, nil

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -539,6 +539,7 @@ func (n *EvalValidateResource) Eval(ctx EvalContext) (interface{}, error) {
 	}
 }
 
+// FIXME: these should be broken out and shared with modules
 func (n *EvalValidateResource) validateCount(ctx EvalContext, expr hcl.Expression) tfdiags.Diagnostics {
 	if expr == nil {
 		return nil
@@ -608,10 +609,10 @@ func (n *EvalValidateResource) validateCount(ctx EvalContext, expr hcl.Expressio
 }
 
 func (n *EvalValidateResource) validateForEach(ctx EvalContext, expr hcl.Expression) (diags tfdiags.Diagnostics) {
-	_, known, forEachDiags := evaluateResourceForEachExpressionKnown(expr, ctx)
+	forEach, forEachDiags := evaluateForEachExpressionKnown(expr, ctx)
 	// If the value isn't known then that's the best we can do for now, but
 	// we'll check more thoroughly during the plan walk
-	if !known {
+	if !forEach.IsKnown() {
 		return diags
 	}
 

--- a/terraform/node_module_expand.go
+++ b/terraform/node_module_expand.go
@@ -198,18 +198,18 @@ func (n *evalPrepareModuleExpansion) Eval(ctx EvalContext) (interface{}, error) 
 
 		switch {
 		case n.ModuleCall.Count != nil:
-			count, diags := evaluateResourceCountExpression(n.ModuleCall.Count, ctx)
+			count, diags := evaluateCountExpression(n.ModuleCall.Count, ctx)
 			if diags.HasErrors() {
 				return nil, diags.Err()
 			}
-			expander.SetModuleExpansion(module, call, cty.NumberIntVal(int64(count)))
+			expander.SetModuleExpansion(module, call, count)
 
 		case n.ModuleCall.ForEach != nil:
-			forEach, diags := evaluateResourceForEachExpression(n.ModuleCall.ForEach, ctx)
+			forEach, diags := evaluateForEachExpression(n.ModuleCall.ForEach, ctx)
 			if diags.HasErrors() {
 				return nil, diags.Err()
 			}
-			expander.SetModuleExpansion(module, call, cty.MapVal(forEach))
+			expander.SetModuleExpansion(module, call, forEach)
 
 		default:
 			expander.SetModuleExpansion(module, call, cty.NilVal)
@@ -249,35 +249,18 @@ func (n *evalValidateModule) Eval(ctx EvalContext) (interface{}, error) {
 		ctx = ctx.WithPath(module)
 		switch {
 		case n.ModuleCall.Count != nil:
-			count, known, diags := evaluateResourceCountExpressionKnown(n.ModuleCall.Count, ctx)
+			count, diags := evaluateCountExpressionKnown(n.ModuleCall.Count, ctx)
 			if diags.HasErrors() {
 				return nil, diags.Err()
 			}
-			ct := cty.NumberIntVal(int64(count))
-			if !known {
-				ct = cty.UnknownVal(cty.Number)
-			}
-
-			expander.SetModuleExpansion(module, call, ct)
+			expander.SetModuleExpansion(module, call, count)
 
 		case n.ModuleCall.ForEach != nil:
-			forEach, known, diags := evaluateResourceForEachExpressionKnown(n.ModuleCall.ForEach, ctx)
+			forEach, diags := evaluateForEachExpressionKnown(n.ModuleCall.ForEach, ctx)
 			if diags.HasErrors() {
 				return nil, diags.Err()
 			}
-
-			m := cty.MapValEmpty(cty.DynamicPseudoType)
-
-			switch {
-			case len(forEach) > 0:
-				// we need to check the forEach length first, because we can't
-				// create an empty map with no value type
-				m = cty.MapVal(forEach)
-			case !known:
-				m = cty.UnknownVal(cty.Map(cty.DynamicPseudoType))
-			}
-
-			expander.SetModuleExpansion(module, call, m)
+			expander.SetModuleExpansion(module, call, forEach)
 
 		default:
 			expander.SetModuleExpansion(module, call, cty.NilVal)


### PR DESCRIPTION
Because expansion is now recursive, in order to correctly validate
nested modules, we need to be able to evaluate their expressions
which may include variables. Since expansion data may not be known
during validation, there needs to be a method to handle unknown
repetition data.

Set*ForEach was already partly there, by using cty.Value map values
which could be unknown, but there was no way to set the entire value as
unknown and still retrieve the expansion mode. This takes the usage of
values one step further and uses a cty.Value for count and for_each,
allowing us to store the mode and known-ness of the value.
