### PR TITLE
don't allow count && for_each in module calls

### DIFF
--- a/configs/module_call.go
+++ b/configs/module_call.go
@@ -71,6 +71,15 @@ func decodeModuleBlock(block *hcl.Block, override bool) (*ModuleCall, hcl.Diagno
 	}
 
 	if attr, exists := content.Attributes["for_each"]; exists {
+		if mc.Count != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  `Invalid combination of "count" and "for_each"`,
+				Detail:   `The "count" and "for_each" meta-arguments are mutually-exclusive, only one should be used to be explicit about the number of resources to be created.`,
+				Subject:  &attr.NameRange,
+			})
+		}
+
 		mc.ForEach = attr.Expr
 	}
 

--- a/configs/module_call_test.go
+++ b/configs/module_call_test.go
@@ -21,6 +21,7 @@ func TestLoadModuleCall(t *testing.T) {
 	file, diags := parser.LoadConfigFile("module-calls.tf")
 	assertExactDiagnostics(t, diags, []string{
 		`module-calls.tf:22,3-13: Reserved argument name in module block; The name "depends_on" is reserved for use in a future version of Terraform.`,
+		`module-calls.tf:20,3-11: Invalid combination of "count" and "for_each"; The "count" and "for_each" meta-arguments are mutually-exclusive, only one should be used to be explicit about the number of resources to be created.`,
 	})
 
 	gotModules := file.ModuleCalls


### PR DESCRIPTION
`count` and `for_each` cannot used be used in the same resource or module. This is validated during config loading for resources; validate this during the loading of modules too.