### PR TITLE
internal/modsdir: Fix Dropped Error

### DIFF
--- a/internal/modsdir/manifest.go
+++ b/internal/modsdir/manifest.go
@@ -77,7 +77,9 @@ func ReadManifestSnapshot(r io.Reader) (Manifest, error) {
 
 	var read manifestSnapshotFile
 	err = json.Unmarshal(src, &read)
-
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling snapshot: %v", err)
+	}
 	new := make(Manifest)
 	for _, record := range read.Records {
 		if record.VersionStr != "" {

--- a/internal/modsdir/manifest.go
+++ b/internal/modsdir/manifest.go
@@ -78,7 +78,7 @@ func ReadManifestSnapshot(r io.Reader) (Manifest, error) {
 	var read manifestSnapshotFile
 	err = json.Unmarshal(src, &read)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling snapshot: %v", err)
+		return nil, fmt.Errorf("error unmarshalling snapshot: %v", err)
 	}
 	new := make(Manifest)
 	for _, record := range read.Records {


### PR DESCRIPTION
This fixes a dropped error in the `internal/modsdir` package.