### PR TITLE
Correctly connect module output references during plan

### DIFF
--- a/addrs/module_call.go
+++ b/addrs/module_call.go
@@ -80,7 +80,7 @@ type AbsModuleCallOutput struct {
 	Name string
 }
 
-// ModuelCallOutput returns the referenceable ModuleCallOutput for this
+// ModuleCallOutput returns the referenceable ModuleCallOutput for this
 // particular instance.
 func (co AbsModuleCallOutput) ModuleCallOutput() ModuleCallOutput {
 	return ModuleCallOutput{

--- a/addrs/module_call.go
+++ b/addrs/module_call.go
@@ -80,6 +80,15 @@ type AbsModuleCallOutput struct {
 	Name string
 }
 
+// ModuelCallOutput returns the referenceable ModuleCallOutput for this
+// particular instance.
+func (co AbsModuleCallOutput) ModuleCallOutput() ModuleCallOutput {
+	return ModuleCallOutput{
+		Call: co.Call.Call,
+		Name: co.Name,
+	}
+}
+
 func (co AbsModuleCallOutput) String() string {
 	return fmt.Sprintf("%s.%s", co.Call.String(), co.Name)
 }

--- a/states/state_string.go
+++ b/states/state_string.go
@@ -55,9 +55,7 @@ func (s *State) String() string {
 			buf.WriteByte('.')
 			buf.WriteString(step.Name)
 			if step.InstanceKey != addrs.NoKey {
-				buf.WriteByte('[')
 				buf.WriteString(step.InstanceKey.String())
-				buf.WriteByte(']')
 			}
 		}
 		buf.WriteString(":\n")

--- a/terraform/transform_reference.go
+++ b/terraform/transform_reference.go
@@ -262,6 +262,11 @@ func (m *ReferenceMap) References(v dag.Vertex) []dag.Vertex {
 				subject = ri.ContainingResource()
 			case addrs.ResourceInstancePhase:
 				subject = ri.ContainingResource()
+			case addrs.AbsModuleCallOutput:
+				subject = ri.ModuleCallOutput()
+			default:
+				log.Printf("[WARN] ReferenceTransformer: reference not found: %q", subject)
+				continue
 			}
 			key = m.referenceMapKey(v, subject)
 		}


### PR DESCRIPTION
Like resource references, we need to make instance references less
specific when they aren't expanded yet during plan. 

Add a method to get the `ModuleCallOutput` which will allow the
reference transformer to connect to the unexpanded node during plan.