### PR TITLE
fix broken hcl json spec link

### DIFF
--- a/website/docs/configuration/syntax-json.html.md
+++ b/website/docs/configuration/syntax-json.html.md
@@ -36,7 +36,7 @@ of a specification called _HCL_. It is not necessary to know all of the details
 of HCL syntax or its JSON mapping in order to use Terraform, and so this page
 summarizes the most important differences between native and JSON syntax.
 If you are interested, you can find a full definition of HCL's JSON syntax
-in [its specification](https://github.com/hashicorp/hcl/blob/hcl2/hcl/json/spec.md).
+in [its specification](https://github.com/hashicorp/hcl/blob/hcl2/json/spec.md).
 
 ## JSON File Structure
 


### PR DESCRIPTION
is this the right place to fix the docs on the [website](https://www.terraform.io/docs/configuration/syntax-json.html)? Found a broken link and wanted to fix it