### PR TITLE
backend/remote: display cost estimate and policy check whenever available

### DIFF
--- a/backend/remote/backend_plan.go
+++ b/backend/remote/backend_plan.go
@@ -308,12 +308,11 @@ in order to capture the filesystem context the remote workspace expects:
 		return r, generalError("Failed to retrieve run", err)
 	}
 
-	// Return if the run is canceled or errored. We return without
-	// an error, even if the run errored, as the error is already
-	// displayed by the output of the remote run.
-	if r.Status == tfe.RunCanceled || r.Status == tfe.RunErrored {
-		return r, nil
-	}
+	// If the run is canceled or errored, we still continue to the
+	// cost-estimation and policy check phases to ensure we render any
+	// results available. In the case of a hard-failed policy check, the
+	// status of the run will be "errored", but there is still policy
+	// information which should be shown.
 
 	// Show any cost estimation output.
 	if r.CostEstimate != nil {


### PR DESCRIPTION
Fixes an issue in the `remote` backend, where a policy hard failure could cause the CLI to exit early without displaying the result of the policy check. This is because the run will end up in the `errored` state on policy hard failures. If the run enters the `errored` state before the cost-estimate and policy-check are rendered, the CLI would simply return early and never display the result.

This change ensures that we always query the cost-estimate and policy check when present, and render the results when available, resolving the race condition. This is largely just moving logic around.