### PR TITLE
specify that `timestamp` returns UTC

### DIFF
--- a/website/docs/configuration/functions/timestamp.html.md
+++ b/website/docs/configuration/functions/timestamp.html.md
@@ -13,7 +13,7 @@ description: |-
 earlier, see
 [0.11 Configuration Language: Interpolation Syntax](../../configuration-0-11/interpolation.html).
 
-`timestamp` returns the current date and time.
+`timestamp` returns the current date and time in UTC.
 
 In the Terraform language, timestamps are conventionally represented as
 strings using [RFC 3339](https://tools.ietf.org/html/rfc3339)

--- a/website/docs/configuration/functions/timestamp.html.md
+++ b/website/docs/configuration/functions/timestamp.html.md
@@ -13,7 +13,7 @@ description: |-
 earlier, see
 [0.11 Configuration Language: Interpolation Syntax](../../configuration-0-11/interpolation.html).
 
-`timestamp` returns the current date and time in UTC.
+`timestamp` returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format.
 
 In the Terraform language, timestamps are conventionally represented as
 strings using [RFC 3339](https://tools.ietf.org/html/rfc3339)


### PR DESCRIPTION
Adding clarification that `timestamp` returns date and time in UTC.