### PR TITLE
Swap order of resource to be updated depended resource to be destroyed

### DIFF
--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -504,7 +504,7 @@ func TestApplyGraphBuilder_targetModule(t *testing.T) {
 	testGraphNotContains(t, g, "module.child1.output.instance_id")
 }
 
-// Ensure that an update resulting from the removal of a resource happens after
+// Ensure that an update resulting from the removal of a resource happens before
 // that resource is destroyed.
 func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 	schemas := simpleTestSchemas()
@@ -598,8 +598,8 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 
 	expected := strings.TrimSpace(`
 test_object.a (destroy)
+  test_object.b
 test_object.b
-  test_object.a (destroy)
 `)
 
 	instanceGraph := filterInstances(g)

--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -103,7 +103,7 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 
 			for _, resAddr := range ri.StateDependencies() {
 				for _, desDep := range destroyersByResource[resAddr.String()] {
-					log.Printf("[TRACE] DestroyEdgeTransformer: %s has stored dependency of %s\n", dag.VertexName(desDep), dag.VertexName(des))
+					log.Printf("[TRACE] DestroyEdgeTransformer: %s depends on %s\n", dag.VertexName(des), dag.VertexName(desDep))
 					g.Connect(dag.BasicEdge(desDep, des))
 
 				}
@@ -120,8 +120,8 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 
 		for _, resAddr := range ri.StateDependencies() {
 			for _, desDep := range destroyersByResource[resAddr.String()] {
-				log.Printf("[TRACE] DestroyEdgeTransformer: %s has stored dependency of %s\n", dag.VertexName(c), dag.VertexName(desDep))
-				g.Connect(dag.BasicEdge(c, desDep))
+				log.Printf("[TRACE] DestroyEdgeTransformer: %s depends on %s\n", dag.VertexName(c), dag.VertexName(desDep))
+				g.Connect(dag.BasicEdge(desDep, c))
 
 			}
 		}


### PR DESCRIPTION
For **resA** which depends on **resB** on creation. Then if **resB** is deleted and **resA** is updated accordingly, the actual order user expected (as mentioned in issues mentioned in #23252) is: `update resA -> delete resB`.

This PR just swap the dependency order for the creator and destroyer in destroy edge transformer, and also modify the test accordingly.