### PR TITLE
Cloud-init provider link

### DIFF
--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -47,6 +47,7 @@ down to see all providers.
 - [Cisco ASA](/docs/providers/ciscoasa/index.html)
 - [Cisco ACI](/docs/providers/aci/index.html)
 - [Cloudflare](/docs/providers/cloudflare/index.html)
+- [Cloud-init](/docs/providers/cloudinit/index.html)
 - [CloudScale.ch](/docs/providers/cloudscale/index.html)
 - [CloudStack](/docs/providers/cloudstack/index.html)
 - [Cobbler](/docs/providers/cobbler/index.html)


### PR DESCRIPTION
Link to [terraform-provider-cloudinit](https://github.com/hashicorp/terraform-provider-cloudinit) documentation.