### PR TITLE
tests: Added tests to exercise hyphenated providers

### DIFF
--- a/addrs/provider_test.go
+++ b/addrs/provider_test.go
@@ -18,7 +18,15 @@ func TestProviderString(t *testing.T) {
 				Hostname:  DefaultRegistryHost,
 				Namespace: "hashicorp",
 			},
-			DefaultRegistryHost.ForDisplay() + "/hashicorp/test",
+			NewDefaultProvider("test").String(),
+		},
+		{
+			Provider{
+				Type:      "test-beta",
+				Hostname:  DefaultRegistryHost,
+				Namespace: "hashicorp",
+			},
+			NewDefaultProvider("test-beta").String(),
 		},
 		{
 			Provider{

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -858,8 +858,9 @@ func TestInit_providerSource(t *testing.T) {
 	defer testChdir(t, td)()
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
-		"test":   []string{"1.2.3", "1.2.4"},
-		"source": []string{"1.2.2", "1.2.3", "1.2.1"},
+		"test":      []string{"1.2.3", "1.2.4"},
+		"test-beta": []string{"1.2.4"},
+		"source":    []string{"1.2.2", "1.2.3", "1.2.1"},
 	})
 	defer close()
 
@@ -894,6 +895,14 @@ func TestInit_providerSource(t *testing.T) {
 				ExecutableFile: expectedPackageInstallPath("test", "1.2.3", true),
 			},
 		},
+		addrs.NewDefaultProvider("test-beta"): {
+			{
+				Provider:       addrs.NewDefaultProvider("test-beta"),
+				Version:        getproviders.MustParseVersion("1.2.4"),
+				PackageDir:     expectedPackageInstallPath("test-beta", "1.2.4", false),
+				ExecutableFile: expectedPackageInstallPath("test-beta", "1.2.4", true),
+			},
+		},
 		addrs.NewDefaultProvider("source"): {
 			{
 				Provider:       addrs.NewDefaultProvider("source"),
@@ -913,6 +922,12 @@ func TestInit_providerSource(t *testing.T) {
 		t.Fatalf("failed to get selected packages from installer: %s", err)
 	}
 	wantSelected := map[addrs.Provider]*providercache.CachedProvider{
+		addrs.NewDefaultProvider("test-beta"): {
+			Provider:       addrs.NewDefaultProvider("test-beta"),
+			Version:        getproviders.MustParseVersion("1.2.4"),
+			PackageDir:     expectedPackageInstallPath("test-beta", "1.2.4", false),
+			ExecutableFile: expectedPackageInstallPath("test-beta", "1.2.4", true),
+		},
 		addrs.NewDefaultProvider("test"): {
 			Provider:       addrs.NewDefaultProvider("test"),
 			Version:        getproviders.MustParseVersion("1.2.3"),

--- a/command/testdata/init-required-providers/main.tf
+++ b/command/testdata/init-required-providers/main.tf
@@ -4,5 +4,8 @@ terraform {
     source = {
       version = "1.2.3"
     }
+    test-beta = {
+      version = "1.2.4"
+    }
   }
 }

--- a/internal/getproviders/filesystem_mirror_source_test.go
+++ b/internal/getproviders/filesystem_mirror_source_test.go
@@ -48,6 +48,15 @@ func TestFilesystemMirrorSourceAllAvailablePackages(t *testing.T) {
 				Location:       PackageLocalDir("testdata/filesystem-mirror/registry.terraform.io/hashicorp/null/2.0.0/windows_amd64"),
 			},
 		},
+		randomBetaProvider: {
+			{
+				Provider:       randomBetaProvider,
+				Version:        versions.MustParseVersion("1.2.0"),
+				TargetPlatform: Platform{"linux", "amd64"},
+				Filename:       "terraform-provider-random-beta_1.2.0_linux_amd64.zip",
+				Location:       PackageLocalDir("testdata/filesystem-mirror/registry.terraform.io/hashicorp/random-beta/1.2.0/linux_amd64"),
+			},
+		},
 		randomProvider: {
 			{
 				Provider:       randomProvider,
@@ -57,6 +66,7 @@ func TestFilesystemMirrorSourceAllAvailablePackages(t *testing.T) {
 				Location:       PackageLocalDir("testdata/filesystem-mirror/registry.terraform.io/hashicorp/random/1.2.0/linux_amd64"),
 			},
 		},
+
 		happycloudProvider: {
 			{
 				Provider:       happycloudProvider,
@@ -157,6 +167,11 @@ var randomProvider = addrs.Provider{
 	Hostname:  svchost.Hostname("registry.terraform.io"),
 	Namespace: "hashicorp",
 	Type:      "random",
+}
+var randomBetaProvider = addrs.Provider{
+	Hostname:  svchost.Hostname("registry.terraform.io"),
+	Namespace: "hashicorp",
+	Type:      "random-beta",
 }
 var happycloudProvider = addrs.Provider{
 	Hostname:  svchost.Hostname("tfe.example.com"),

--- a/internal/getproviders/testdata/filesystem-mirror/registry.terraform.io/hashicorp/random-beta/1.2.0/linux_amd64/terraform-provider-random-beta
+++ b/internal/getproviders/testdata/filesystem-mirror/registry.terraform.io/hashicorp/random-beta/1.2.0/linux_amd64/terraform-provider-random-beta
@@ -1,0 +1,1 @@
+# This is just a placeholder file for discovery testing, not a real provider plugin.

--- a/internal/providercache/dir_test.go
+++ b/internal/providercache/dir_test.go
@@ -30,6 +30,9 @@ func TestDirReading(t *testing.T) {
 	randomProvider := addrs.NewProvider(
 		addrs.DefaultRegistryHost, "hashicorp", "random",
 	)
+	randomBetaProvider := addrs.NewProvider(
+		addrs.DefaultRegistryHost, "hashicorp", "random-beta",
+	)
 	nonExistProvider := addrs.NewProvider(
 		addrs.DefaultRegistryHost, "bloop", "nonexist",
 	)
@@ -158,6 +161,14 @@ func TestDirReading(t *testing.T) {
 					Version:        versions.MustParseVersion("1.2.0"),
 					PackageDir:     "testdata/cachedir/registry.terraform.io/hashicorp/random/1.2.0/linux_amd64",
 					ExecutableFile: "testdata/cachedir/registry.terraform.io/hashicorp/random/1.2.0/linux_amd64/terraform-provider-random",
+				},
+			},
+			randomBetaProvider: {
+				{
+					Provider:       randomBetaProvider,
+					Version:        versions.MustParseVersion("1.2.0"),
+					PackageDir:     "testdata/cachedir/registry.terraform.io/hashicorp/random-beta/1.2.0/linux_amd64",
+					ExecutableFile: "testdata/cachedir/registry.terraform.io/hashicorp/random-beta/1.2.0/linux_amd64/terraform-provider-random-beta",
 				},
 			},
 		}

--- a/internal/providercache/testdata/cachedir/registry.terraform.io/hashicorp/random-beta/1.2.0/linux_amd64/terraform-provider-random-beta
+++ b/internal/providercache/testdata/cachedir/registry.terraform.io/hashicorp/random-beta/1.2.0/linux_amd64/terraform-provider-random-beta
@@ -1,0 +1,1 @@
+# This is just a placeholder file for discovery testing, not a real provider plugin.


### PR DESCRIPTION
This PR adds a number of tests in various packages to exercise use with hyphenated providers, for example `google-beta`. I started this work while tracking down an issue with terraform-bundle. It turns out that the issue was not unique to the hyphenated provider, that was a red herring, but these tests may prove useful during future refactoring.