### PR TITLE
Add support for force pushing with the remote backend

### DIFF
--- a/backend/remote/backend_state.go
+++ b/backend/remote/backend_state.go
@@ -20,6 +20,7 @@ type remoteClient struct {
 	runID          string
 	stateUploadErr bool
 	workspace      *tfe.Workspace
+	forcePush      bool
 }
 
 // Get the remote state.
@@ -69,6 +70,7 @@ func (r *remoteClient) Put(state []byte) error {
 		Serial:  tfe.Int64(int64(stateFile.Serial)),
 		MD5:     tfe.String(fmt.Sprintf("%x", md5.Sum(state))),
 		State:   tfe.String(base64.StdEncoding.EncodeToString(state)),
+		Force:   tfe.Bool(r.forcePush),
 	}
 
 	// If we have a run ID, make sure to add it to the options
@@ -95,6 +97,12 @@ func (r *remoteClient) Delete() error {
 	}
 
 	return nil
+}
+
+// EnableForcePush to allow the remote client to overwrite state
+// by implementing remote.ClientForcePusher
+func (r *remoteClient) EnableForcePush() {
+	r.forcePush = true
 }
 
 // Lock the remote state.

--- a/state/remote/remote.go
+++ b/state/remote/remote.go
@@ -15,6 +15,14 @@ type Client interface {
 	Delete() error
 }
 
+// ClientForcePusher is an optional interface that allows a remote
+// state to force push by managing a flag on the client that is
+// toggled on by a call to EnableForcePush.
+type ClientForcePusher interface {
+	Client
+	EnableForcePush()
+}
+
 // ClientLocker is an optional interface that allows a remote state
 // backend to enable state lock/unlock.
 type ClientLocker interface {

--- a/state/remote/remote_test.go
+++ b/state/remote/remote_test.go
@@ -69,6 +69,7 @@ func (c nilClient) Delete() error { return nil }
 type mockClient struct {
 	current []byte
 	log     []mockClientRequest
+	force   bool
 }
 
 type mockClientRequest struct {
@@ -89,7 +90,11 @@ func (c *mockClient) Get() (*Payload, error) {
 }
 
 func (c *mockClient) Put(data []byte) error {
-	c.appendLog("Put", data)
+	if c.force {
+		c.appendLog("Force Put", data)
+	} else {
+		c.appendLog("Put", data)
+	}
 	c.current = data
 	return nil
 }
@@ -98,6 +103,11 @@ func (c *mockClient) Delete() error {
 	c.appendLog("Delete", c.current)
 	c.current = nil
 	return nil
+}
+
+// Implements remote.ClientForcePusher
+func (c *mockClient) EnableForcePush() {
+	c.force = true
 }
 
 func (c *mockClient) appendLog(method string, content []byte) {

--- a/state/remote/state_test.go
+++ b/state/remote/state_test.go
@@ -84,6 +84,27 @@ func TestStatePersist(t *testing.T) {
 		t.Fatalf("failed to PersistState: %s", err)
 	}
 
+	// We also don't persist state if the lineage or the serial change
+	originalSerial := mgr.serial
+	mgr.serial++
+	if err := mgr.WriteState(s); err != nil {
+		t.Fatalf("failed to WriteState: %s", err)
+	}
+	if err := mgr.PersistState(); err != nil {
+		t.Fatalf("failed to PersistState: %s", err)
+	}
+	mgr.serial = originalSerial
+
+	originalLineage := mgr.lineage
+	mgr.lineage = "behold-a-wild-lineage-appears"
+	if err := mgr.WriteState(s); err != nil {
+		t.Fatalf("failed to WriteState: %s", err)
+	}
+	if err := mgr.PersistState(); err != nil {
+		t.Fatalf("failed to PersistState: %s", err)
+	}
+	mgr.lineage = originalLineage
+
 	// ...but if we _do_ change something in the state then we should see
 	// it re-persist.
 	s.RootModule().SetOutputValue("foo", cty.StringVal("baz"), false)

--- a/state/remote/state_test.go
+++ b/state/remote/state_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"log"
 	"sync"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/states"
+	"github.com/hashicorp/terraform/states/statefile"
 	"github.com/hashicorp/terraform/states/statemgr"
 	"github.com/hashicorp/terraform/version"
 )
@@ -41,12 +43,176 @@ func TestStateRace(t *testing.T) {
 	wg.Wait()
 }
 
+// testCase encapsulates a test state test
+type testCase struct {
+	name string
+	// A function to mutate state and return a cleanup function
+	mutationFunc func(*State) (*states.State, func())
+	// The expected request to have taken place
+	expectedRequest mockClientRequest
+	// Mark this case as not having a request
+	noRequest bool
+}
+
+// isRequested ensures a test that is specified as not having
+// a request doesn't have one by checking if a method exists
+// on the expectedRequest.
+func (tc testCase) isRequested(t *testing.T) bool {
+	hasMethod := tc.expectedRequest.Method != ""
+	if tc.noRequest && hasMethod {
+		t.Fatalf("expected no content for %q but got: %v", tc.name, tc.expectedRequest)
+	}
+	return !tc.noRequest
+}
+
 func TestStatePersist(t *testing.T) {
+	testCases := []testCase{
+		// Refreshing state before we run the test loop causes a GET
+		{
+			name: "refresh state",
+			mutationFunc: func(mgr *State) (*states.State, func()) {
+				return mgr.State(), func() {}
+			},
+			expectedRequest: mockClientRequest{
+				Method: "Get",
+				Content: map[string]interface{}{
+					"version":           4.0, // encoding/json decodes this as float64 by default
+					"lineage":           "mock-lineage",
+					"serial":            1.0, // encoding/json decodes this as float64 by default
+					"terraform_version": "0.0.0",
+					"outputs":           map[string]interface{}{},
+					"resources":         []interface{}{},
+				},
+			},
+		},
+		{
+			name: "change lineage",
+			mutationFunc: func(mgr *State) (*states.State, func()) {
+				originalLineage := mgr.lineage
+				mgr.lineage = "some-new-lineage"
+				return mgr.State(), func() {
+					mgr.lineage = originalLineage
+				}
+			},
+			expectedRequest: mockClientRequest{
+				Method: "Put",
+				Content: map[string]interface{}{
+					"version":           4.0, // encoding/json decodes this as float64 by default
+					"lineage":           "some-new-lineage",
+					"serial":            2.0, // encoding/json decodes this as float64 by default
+					"terraform_version": version.Version,
+					"outputs":           map[string]interface{}{},
+					"resources":         []interface{}{},
+				},
+			},
+		},
+		{
+			name: "change serial",
+			mutationFunc: func(mgr *State) (*states.State, func()) {
+				originalSerial := mgr.serial
+				mgr.serial++
+				return mgr.State(), func() {
+					mgr.serial = originalSerial
+				}
+			},
+			expectedRequest: mockClientRequest{
+				Method: "Put",
+				Content: map[string]interface{}{
+					"version":           4.0, // encoding/json decodes this as float64 by default
+					"lineage":           "mock-lineage",
+					"serial":            4.0, // encoding/json decodes this as float64 by default
+					"terraform_version": version.Version,
+					"outputs":           map[string]interface{}{},
+					"resources":         []interface{}{},
+				},
+			},
+		},
+		{
+			name: "add output to state",
+			mutationFunc: func(mgr *State) (*states.State, func()) {
+				s := mgr.State()
+				s.RootModule().SetOutputValue("foo", cty.StringVal("bar"), false)
+				return s, func() {}
+			},
+			expectedRequest: mockClientRequest{
+				Method: "Put",
+				Content: map[string]interface{}{
+					"version":           4.0, // encoding/json decodes this as float64 by default
+					"lineage":           "mock-lineage",
+					"serial":            3.0, // encoding/json decodes this as float64 by default
+					"terraform_version": version.Version,
+					"outputs": map[string]interface{}{
+						"foo": map[string]interface{}{
+							"type":  "string",
+							"value": "bar",
+						},
+					},
+					"resources": []interface{}{},
+				},
+			},
+		},
+		{
+			name: "mutate state bar -> baz",
+			mutationFunc: func(mgr *State) (*states.State, func()) {
+				s := mgr.State()
+				s.RootModule().SetOutputValue("foo", cty.StringVal("baz"), false)
+				return s, func() {}
+			},
+			expectedRequest: mockClientRequest{
+				Method: "Put",
+				Content: map[string]interface{}{
+					"version":           4.0, // encoding/json decodes this as float64 by default
+					"lineage":           "mock-lineage",
+					"serial":            4.0, // encoding/json decodes this as float64 by default
+					"terraform_version": version.Version,
+					"outputs": map[string]interface{}{
+						"foo": map[string]interface{}{
+							"type":  "string",
+							"value": "baz",
+						},
+					},
+					"resources": []interface{}{},
+				},
+			},
+		},
+		{
+			name: "nothing changed",
+			mutationFunc: func(mgr *State) (*states.State, func()) {
+				s := mgr.State()
+				return s, func() {}
+			},
+			noRequest: true,
+		},
+		{
+			name: "reset serial (force push style)",
+			mutationFunc: func(mgr *State) (*states.State, func()) {
+				mgr.serial = 2
+				return mgr.State(), func() {}
+			},
+			expectedRequest: mockClientRequest{
+				Method: "Put",
+				Content: map[string]interface{}{
+					"version":           4.0, // encoding/json decodes this as float64 by default
+					"lineage":           "mock-lineage",
+					"serial":            3.0, // encoding/json decodes this as float64 by default
+					"terraform_version": version.Version,
+					"outputs": map[string]interface{}{
+						"foo": map[string]interface{}{
+							"type":  "string",
+							"value": "baz",
+						},
+					},
+					"resources": []interface{}{},
+				},
+			},
+		},
+	}
+
+	// Initial setup of state just to give us a fixed starting point for our
+	// test assertions below, or else we'd need to deal with
+	// random lineage.
 	mgr := &State{
 		Client: &mockClient{
-			// Initial state just to give us a fixed starting point for our
-			// test assertions below, or else we'd need to deal with
-			// random lineage.
 			current: []byte(`
 				{
 					"version": 4,
@@ -62,115 +228,218 @@ func TestStatePersist(t *testing.T) {
 
 	// In normal use (during a Terraform operation) we always refresh and read
 	// before any writes would happen, so we'll mimic that here for realism.
+	// NB This causes a GET to be logged so the first item in the test cases
+	// must account for this
 	if err := mgr.RefreshState(); err != nil {
 		t.Fatalf("failed to RefreshState: %s", err)
 	}
-	s := mgr.State()
 
-	s.RootModule().SetOutputValue("foo", cty.StringVal("bar"), false)
-	if err := mgr.WriteState(s); err != nil {
-		t.Fatalf("failed to WriteState: %s", err)
-	}
-	if err := mgr.PersistState(); err != nil {
-		t.Fatalf("failed to PersistState: %s", err)
-	}
+	// Our client is a mockClient which has a log we
+	// use to check that operations generate expected requests
+	mockClient := mgr.Client.(*mockClient)
 
-	// Persisting the same state again should be a no-op: it doesn't fail,
-	// but it ought not to appear in the client's log either.
-	if err := mgr.WriteState(s); err != nil {
-		t.Fatalf("failed to WriteState: %s", err)
-	}
-	if err := mgr.PersistState(); err != nil {
-		t.Fatalf("failed to PersistState: %s", err)
-	}
+	// logIdx tracks the current index of the log separate from
+	// the loop iteration so we can check operations that don't
+	// cause any requests to be generated
+	logIdx := 0
 
-	// We also don't persist state if the lineage or the serial change
-	originalSerial := mgr.serial
-	mgr.serial++
-	if err := mgr.WriteState(s); err != nil {
-		t.Fatalf("failed to WriteState: %s", err)
-	}
-	if err := mgr.PersistState(); err != nil {
-		t.Fatalf("failed to PersistState: %s", err)
-	}
-	mgr.serial = originalSerial
+	// Run tests in order.
+	for _, tc := range testCases {
+		s, cleanup := tc.mutationFunc(mgr)
 
-	originalLineage := mgr.lineage
-	mgr.lineage = "behold-a-wild-lineage-appears"
-	if err := mgr.WriteState(s); err != nil {
-		t.Fatalf("failed to WriteState: %s", err)
-	}
-	if err := mgr.PersistState(); err != nil {
-		t.Fatalf("failed to PersistState: %s", err)
-	}
-	mgr.lineage = originalLineage
+		if err := mgr.WriteState(s); err != nil {
+			t.Fatalf("failed to WriteState for %q: %s", tc.name, err)
+		}
+		if err := mgr.PersistState(); err != nil {
+			t.Fatalf("failed to PersistState for %q: %s", tc.name, err)
+		}
 
-	// ...but if we _do_ change something in the state then we should see
-	// it re-persist.
-	s.RootModule().SetOutputValue("foo", cty.StringVal("baz"), false)
-	if err := mgr.WriteState(s); err != nil {
-		t.Fatalf("failed to WriteState: %s", err)
+		if tc.isRequested(t) {
+			// Get captured request from the mock client log
+			// based on the index of the current test
+			if logIdx >= len(mockClient.log) {
+				t.Fatalf("request lock and index are out of sync on %q: idx=%d len=%d", tc.name, logIdx, len(mockClient.log))
+			}
+			loggedRequest := mockClient.log[logIdx]
+			logIdx++
+			if diff := cmp.Diff(tc.expectedRequest, loggedRequest); len(diff) > 0 {
+				t.Fatalf("incorrect client requests for %q:\n%s", tc.name, diff)
+			}
+		}
+		cleanup()
 	}
-	if err := mgr.PersistState(); err != nil {
-		t.Fatalf("failed to PersistState: %s", err)
+	logCnt := len(mockClient.log)
+	if logIdx != logCnt {
+		log.Fatalf("not all requests were read. Expected logIdx to be %d but got %d", logCnt, logIdx)
 	}
+}
 
-	got := mgr.Client.(*mockClient).log
-	want := []mockClientRequest{
-		// The initial fetch from mgr.RefreshState above.
-		{
-			Method: "Get",
-			Content: map[string]interface{}{
-				"version":           4.0, // encoding/json decodes this as float64 by default
-				"lineage":           "mock-lineage",
-				"serial":            1.0, // encoding/json decodes this as float64 by default
-				"terraform_version": "0.0.0",
-				"outputs":           map[string]interface{}{},
-				"resources":         []interface{}{},
-			},
+type migrationTestCase struct {
+	name string
+	// A function to generate a statefile
+	stateFile func(*State) *statefile.File
+	// The expected request to have taken place
+	expectedRequest mockClientRequest
+	// Mark this case as not having a request
+	expectedError string
+	// force flag passed to client
+	force bool
+}
+
+func TestWriteStateForMigration(t *testing.T) {
+	mgr := &State{
+		Client: &mockClient{
+			current: []byte(`
+				{
+					"version": 4,
+					"lineage": "mock-lineage",
+					"serial": 3,
+					"terraform_version":"0.0.0",
+					"outputs": {"foo": {"value":"bar", "type": "string"}},
+					"resources": []
+				}
+			`),
 		},
+	}
 
-		// First call to PersistState, with output "foo" set to "bar".
+	testCases := []migrationTestCase{
+		// Refreshing state before we run the test loop causes a GET
 		{
-			Method: "Put",
-			Content: map[string]interface{}{
-				"version":           4.0,
-				"lineage":           "mock-lineage",
-				"serial":            2.0, // serial increases because the outputs changed
-				"terraform_version": version.Version,
-				"outputs": map[string]interface{}{
-					"foo": map[string]interface{}{
-						"type":  "string",
-						"value": "bar",
-					},
+			name: "refresh state",
+			stateFile: func(mgr *State) *statefile.File {
+				return mgr.StateForMigration()
+			},
+			expectedRequest: mockClientRequest{
+				Method: "Get",
+				Content: map[string]interface{}{
+					"version":           4.0,
+					"lineage":           "mock-lineage",
+					"serial":            3.0,
+					"terraform_version": "0.0.0",
+					"outputs":           map[string]interface{}{"foo": map[string]interface{}{"type": string("string"), "value": string("bar")}},
+					"resources":         []interface{}{},
 				},
-				"resources": []interface{}{},
 			},
 		},
-
-		// Second call to PersistState generates no client requests, because
-		// nothing changed in the state itself.
-
-		// Third call to PersistState, with the "foo" output value updated
-		// to "baz".
 		{
-			Method: "Put",
-			Content: map[string]interface{}{
-				"version":           4.0,
-				"lineage":           "mock-lineage",
-				"serial":            3.0, // serial increases because the outputs changed
-				"terraform_version": version.Version,
-				"outputs": map[string]interface{}{
-					"foo": map[string]interface{}{
-						"type":  "string",
-						"value": "baz",
-					},
-				},
-				"resources": []interface{}{},
+			name: "cannot import lesser serial without force",
+			stateFile: func(mgr *State) *statefile.File {
+				return statefile.New(mgr.state, mgr.lineage, 1)
 			},
+			expectedError: "cannot import state with serial 1 over newer state with serial 3",
+		},
+		{
+			name: "cannot import differing lineage without force",
+			stateFile: func(mgr *State) *statefile.File {
+				return statefile.New(mgr.state, "different-lineage", mgr.serial)
+			},
+			expectedError: `cannot import state with lineage "different-lineage" over unrelated state with lineage "mock-lineage"`,
+		},
+		{
+			name: "can import lesser serial with force",
+			stateFile: func(mgr *State) *statefile.File {
+				return statefile.New(mgr.state, mgr.lineage, 1)
+			},
+			expectedRequest: mockClientRequest{
+				Method: "Force Put",
+				Content: map[string]interface{}{
+					"version":           4.0,
+					"lineage":           "mock-lineage",
+					"serial":            2.0,
+					"terraform_version": version.Version,
+					"outputs":           map[string]interface{}{"foo": map[string]interface{}{"type": string("string"), "value": string("bar")}},
+					"resources":         []interface{}{},
+				},
+			},
+			force: true,
+		},
+		{
+			name: "cannot import differing lineage without force",
+			stateFile: func(mgr *State) *statefile.File {
+				return statefile.New(mgr.state, "different-lineage", mgr.serial)
+			},
+			expectedRequest: mockClientRequest{
+				Method: "Force Put",
+				Content: map[string]interface{}{
+					"version":           4.0,
+					"lineage":           "different-lineage",
+					"serial":            3.0,
+					"terraform_version": version.Version,
+					"outputs":           map[string]interface{}{"foo": map[string]interface{}{"type": string("string"), "value": string("bar")}},
+					"resources":         []interface{}{},
+				},
+			},
+			force: true,
 		},
 	}
-	if diff := cmp.Diff(want, got); len(diff) > 0 {
-		t.Errorf("incorrect client requests\n%s", diff)
+
+	// In normal use (during a Terraform operation) we always refresh and read
+	// before any writes would happen, so we'll mimic that here for realism.
+	// NB This causes a GET to be logged so the first item in the test cases
+	// must account for this
+	if err := mgr.RefreshState(); err != nil {
+		t.Fatalf("failed to RefreshState: %s", err)
+	}
+
+	if err := mgr.WriteState(mgr.State()); err != nil {
+		t.Fatalf("failed to write initial state: %s", err)
+	}
+
+	// Our client is a mockClient which has a log we
+	// use to check that operations generate expected requests
+	mockClient := mgr.Client.(*mockClient)
+
+	if mockClient.force {
+		t.Fatalf("client should not default to force")
+	}
+
+	// logIdx tracks the current index of the log separate from
+	// the loop iteration so we can check operations that don't
+	// cause any requests to be generated
+	logIdx := 0
+
+	for _, tc := range testCases {
+		// Always reset client to not be force pushing
+		mockClient.force = false
+		sf := tc.stateFile(mgr)
+		err := mgr.WriteStateForMigration(sf, tc.force)
+		shouldError := tc.expectedError != ""
+
+		// If we are expecting and error check it and move on
+		if shouldError {
+			if err == nil {
+				t.Fatalf("test case %q should have failed with error %q", tc.name, tc.expectedError)
+			} else if err.Error() != tc.expectedError {
+				t.Fatalf("test case %q expected error %q but got %q", tc.name, tc.expectedError, err)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Fatalf("test case %q failed: %v", tc.name, err)
+		}
+
+		if tc.force && !mockClient.force {
+			t.Fatalf("test case %q should have enabled force push", tc.name)
+		}
+
+		// At this point we should just do a normal write and persist
+		// as would happen from the CLI
+		mgr.WriteState(mgr.State())
+		mgr.PersistState()
+
+		if logIdx >= len(mockClient.log) {
+			t.Fatalf("request lock and index are out of sync on %q: idx=%d len=%d", tc.name, logIdx, len(mockClient.log))
+		}
+		loggedRequest := mockClient.log[logIdx]
+		logIdx++
+		if diff := cmp.Diff(tc.expectedRequest, loggedRequest); len(diff) > 0 {
+			t.Fatalf("incorrect client requests for %q:\n%s", tc.name, diff)
+		}
+	}
+
+	logCnt := len(mockClient.log)
+	if logIdx != logCnt {
+		log.Fatalf("not all requests were read. Expected logIdx to be %d but got %d", logCnt, logIdx)
 	}
 }


### PR DESCRIPTION
This PR adds support for the `-force` flag for `state push` with the remote backend. Per the documentation around manual state push / pull https://www.terraform.io/docs/backends/state.html#manual-state-pull-push both differing serials and lineage protections can be bypassed with the -force flag.

- The first change you'll notice is the addition of a `forcePush` property on the remoteClient struct. This allows the client to know if it is operating in the context of a force push.

- The second change is an optional interface `ClientForcePusher` for clients (like the `remoteClient`) that would need to know they are operating in the context of a force push. There was a force flag added to the Go TFE client that needs to be specified at persistence time.

- The last change is tracking the serial and lineage in addition to the state. As noted above, lineage and serial can be overwritten with `-force` so we must look at them to determine if we can exit early from writing state.

To prevent changing every method signature of `PersistState` to accept `force bool` I added the optional interface. That provides a hook to flag the `Client` as operating in a force push context. Changing the method signature would be more explicit at the cost of not being used anywhere else currently or the optional interface pattern could be applied to the state itself so it could be upgraded to support `PersistState(force bool)` only when needed. Let me know if either of these seem preferable instead!

 ## Background

The Go TFE client received support for a `Force` attribute in March 2019 https://github.com/hashicorp/go-tfe/pull/63 however that was not brought over into Terraform via the remote backend. It is possible it worked until changes were made to prevent sending snapshots unless the resources had changed (otherwise the function exits early) https://github.com/hashicorp/terraform/commit/85eda8a059331d0b2027a929c5b165cd603f273b

## Existing remote state behaviors

I’ve compiled examples of the behavior of two backends, Postgres and S3 and how they currently work with and without the force flag. Lineages and serials are both flagged when trying to push but are correctly overridden when using the force flag as evidence by the diff when pulling after the force push.

https://gist.github.com/leetrout/51e605000fa1f59d1f6902023d685c8c

## Manual testing

### Configure Terraform Cloud

1. Setup an organization
1. Setup a workspace

### Add Terraform config

```
terraform {
  backend "remote" {
    hostname = "<Terraform Cloud/Enterprise>"
    organization = "terraform-testing"

    workspaces {
      name = "testing"
    }
  }
}

resource "random_integer" "rando" {
  min     = 1
  max     = 50000
}
```

### Create resource

1. init
1. apply

```
Terraform will perform the following actions:

  # random_integer.rando will be created
  + resource "random_integer" "rando" {
      + id     = (known after apply)
      + max    = 50000
      + min    = 1
      + result = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions in workspace "testing"?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

random_integer.rando: Creating...
random_integer.rando: Creation complete after 0s [id=23721]
```

### Mutate lineage

In this case, change all 1's to 2's in the lineage:

```
terraform state pull > remote.tfstate
jq ".lineage=\"$(jq -r '.lineage' remote.tfstate | sed 's/1/2/g')\"" remote.tfstate > edited.tfstate
```

Confirm what changed with `diff remote.tfstate edited.tfstate`

```
5c5
<   "lineage": "dd577646-0d5c-d9ba-93b2-d2e04881ebb7",
---
>   "lineage": "dd577646-0d5c-d9ba-93b2-d2e04882ebb7",
30d29
<
```

### Pushing

Try pushing (without `-force`) to ensure it doesn't work.

`terraform state push edited.tfstate` 

```
Failed to write state: cannot import state with lineage "dd577646-0d5c-d9ba-93b2-d2e04882ebb7" over unrelated state with lineage "dd577646-0d5c-d9ba-93b2-d2e04881ebb7"
```

Now add the force flag:

`terraform state push -force edited.tfstate`

There should be no output but exit status of 0 and you should see the new state in TFC.

<img width="901" alt="new-state" src="https://user-images.githubusercontent.com/524648/79587071-f8c46f80-809f-11ea-8b5c-0b65f40c274c.png">

<img width="899" alt="new-state-details" src="https://user-images.githubusercontent.com/524648/79587089-fc57f680-809f-11ea-8488-4603185d090b.png">

