### PR TITLE
Always return all module instances during evaluation

### DIFF
--- a/addrs/parse_ref.go
+++ b/addrs/parse_ref.go
@@ -120,10 +120,9 @@ func parseRef(traversal hcl.Traversal) (*Reference, tfdiags.Diagnostics) {
 			return nil, diags
 		}
 
-		// A traversal starting with "module" can either be a reference to
-		// an entire module instance or to a single output from a module
-		// instance, depending on what we find after this introducer.
-
+		// A traversal starting with "module" can either be a reference to an
+		// entire module, or to a single output from a module instance,
+		// depending on what we find after this introducer.
 		callInstance := ModuleCallInstance{
 			Call: ModuleCall{
 				Name: callName,
@@ -132,12 +131,12 @@ func parseRef(traversal hcl.Traversal) (*Reference, tfdiags.Diagnostics) {
 		}
 
 		if len(remain) == 0 {
-			// Reference to an entire module instance. Might alternatively
-			// be a reference to a collection of instances of a particular
-			// module, but the caller will need to deal with that ambiguity
-			// since we don't have enough context here.
+			// Reference to an entire module. Might alternatively be a
+			// reference to a single instance of a particular module, but the
+			// caller will need to deal with that ambiguity since we don't have
+			// enough context here.
 			return &Reference{
-				Subject:     callInstance,
+				Subject:     callInstance.Call,
 				SourceRange: tfdiags.SourceRangeFromHCL(callRange),
 				Remaining:   remain,
 			}, diags

--- a/addrs/parse_ref_test.go
+++ b/addrs/parse_ref_test.go
@@ -281,10 +281,8 @@ func TestParseRef(t *testing.T) {
 		{
 			`module.foo`,
 			&Reference{
-				Subject: ModuleCallInstance{
-					Call: ModuleCall{
-						Name: "foo",
-					},
+				Subject: ModuleCall{
+					Name: "foo",
 				},
 				SourceRange: tfdiags.SourceRange{
 					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},

--- a/lang/data.go
+++ b/lang/data.go
@@ -27,7 +27,6 @@ type Data interface {
 	GetResource(addrs.Resource, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetLocalValue(addrs.LocalValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetModule(addrs.ModuleCall, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetModuleInstanceOutput(addrs.AbsModuleCallOutput, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetPathAttr(addrs.PathAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetTerraformAttr(addrs.TerraformAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetInputVariable(addrs.InputVariable, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)

--- a/lang/data.go
+++ b/lang/data.go
@@ -26,7 +26,7 @@ type Data interface {
 	GetForEachAttr(addrs.ForEachAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetResource(addrs.Resource, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetLocalValue(addrs.LocalValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetModuleInstance(addrs.ModuleCallInstance, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetModule(addrs.ModuleCall, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetModuleInstanceOutput(addrs.AbsModuleCallOutput, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetPathAttr(addrs.PathAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetTerraformAttr(addrs.TerraformAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)

--- a/lang/data_test.go
+++ b/lang/data_test.go
@@ -43,7 +43,7 @@ func (d *dataForTests) GetLocalValue(addr addrs.LocalValue, rng tfdiags.SourceRa
 	return d.LocalValues[addr.Name], nil
 }
 
-func (d *dataForTests) GetModuleInstance(addr addrs.ModuleCallInstance, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetModule(addr addrs.ModuleCall, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.Modules[addr.String()], nil
 }
 

--- a/lang/eval.go
+++ b/lang/eval.go
@@ -195,7 +195,6 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 	dataResources := map[string]map[string]cty.Value{}
 	managedResources := map[string]map[string]cty.Value{}
 	wholeModules := map[string]cty.Value{}
-	moduleOutputs := map[string]map[addrs.InstanceKey]map[string]cty.Value{}
 	inputVariables := map[string]cty.Value{}
 	localValues := map[string]cty.Value{}
 	pathAttrs := map[string]cty.Value{}
@@ -291,20 +290,6 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 			val, valDiags := normalizeRefValue(s.Data.GetModule(subj, rng))
 			diags = diags.Append(valDiags)
 			wholeModules[subj.Name] = val
-
-		case addrs.AbsModuleCallOutput:
-			val, valDiags := normalizeRefValue(s.Data.GetModuleInstanceOutput(subj, rng))
-			diags = diags.Append(valDiags)
-
-			callName := subj.Call.Call.Name
-			callKey := subj.Call.Key
-			if moduleOutputs[callName] == nil {
-				moduleOutputs[callName] = make(map[addrs.InstanceKey]map[string]cty.Value)
-			}
-			if moduleOutputs[callName][callKey] == nil {
-				moduleOutputs[callName][callKey] = make(map[string]cty.Value)
-			}
-			moduleOutputs[callName][callKey][subj.Name] = val
 
 		case addrs.InputVariable:
 			val, valDiags := normalizeRefValue(s.Data.GetInputVariable(subj, rng))

--- a/lang/eval.go
+++ b/lang/eval.go
@@ -2,8 +2,6 @@ package lang
 
 import (
 	"fmt"
-	"log"
-	"strconv"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/dynblock"
@@ -196,7 +194,7 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 	// that's redundant in the process of populating our values map.
 	dataResources := map[string]map[string]cty.Value{}
 	managedResources := map[string]map[string]cty.Value{}
-	wholeModules := map[string]map[addrs.InstanceKey]cty.Value{}
+	wholeModules := map[string]cty.Value{}
 	moduleOutputs := map[string]map[addrs.InstanceKey]map[string]cty.Value{}
 	inputVariables := map[string]cty.Value{}
 	localValues := map[string]cty.Value{}
@@ -258,9 +256,14 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 
 		// This type switch must cover all of the "Referenceable" implementations
 		// in package addrs, however we are removing the possibility of
-		// ResourceInstance beforehand.
-		if addr, ok := rawSubj.(addrs.ResourceInstance); ok {
+		// Instances beforehand.
+		switch addr := rawSubj.(type) {
+		case addrs.ResourceInstance:
 			rawSubj = addr.ContainingResource()
+		case addrs.ModuleCallInstance:
+			rawSubj = addr.Call
+		case addrs.AbsModuleCallOutput:
+			rawSubj = addr.Call.Call
 		}
 
 		switch subj := rawSubj.(type) {
@@ -284,14 +287,10 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 			}
 			into[r.Type][r.Name] = val
 
-		case addrs.ModuleCallInstance:
-			val, valDiags := normalizeRefValue(s.Data.GetModuleInstance(subj, rng))
+		case addrs.ModuleCall:
+			val, valDiags := normalizeRefValue(s.Data.GetModule(subj, rng))
 			diags = diags.Append(valDiags)
-
-			if wholeModules[subj.Call.Name] == nil {
-				wholeModules[subj.Call.Name] = make(map[addrs.InstanceKey]cty.Value)
-			}
-			wholeModules[subj.Call.Name][subj.Key] = val
+			wholeModules[subj.Name] = val
 
 		case addrs.AbsModuleCallOutput:
 			val, valDiags := normalizeRefValue(s.Data.GetModuleInstanceOutput(subj, rng))
@@ -347,7 +346,7 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 		vals[k] = v
 	}
 	vals["data"] = cty.ObjectVal(buildResourceObjects(dataResources))
-	vals["module"] = cty.ObjectVal(buildModuleObjects(wholeModules, moduleOutputs))
+	vals["module"] = cty.ObjectVal(wholeModules)
 	vals["var"] = cty.ObjectVal(inputVariables)
 	vals["local"] = cty.ObjectVal(localValues)
 	vals["path"] = cty.ObjectVal(pathAttrs)
@@ -367,102 +366,6 @@ func buildResourceObjects(resources map[string]map[string]cty.Value) map[string]
 		vals[typeName] = cty.ObjectVal(nameVals)
 	}
 	return vals
-}
-
-func buildModuleObjects(wholeModules map[string]map[addrs.InstanceKey]cty.Value, moduleOutputs map[string]map[addrs.InstanceKey]map[string]cty.Value) map[string]cty.Value {
-	vals := make(map[string]cty.Value)
-
-	for name, keys := range wholeModules {
-		vals[name] = buildInstanceObjects(keys)
-	}
-
-	for name, keys := range moduleOutputs {
-		if _, exists := wholeModules[name]; exists {
-			// If we also have a whole module value for this name then we'll
-			// skip this since the individual outputs are embedded in that result.
-			continue
-		}
-
-		// The shape of this collection isn't compatible with buildInstanceObjects,
-		// but rather than replicating most of the buildInstanceObjects logic
-		// here we'll instead first transform the structure to be what that
-		// function expects and then use it. This is a little wasteful, but
-		// we do not expect this these maps to be large and so the extra work
-		// here should not hurt too much.
-		flattened := make(map[addrs.InstanceKey]cty.Value, len(keys))
-		for k, vals := range keys {
-			flattened[k] = cty.ObjectVal(vals)
-		}
-		vals[name] = buildInstanceObjects(flattened)
-	}
-
-	return vals
-}
-
-func buildInstanceObjects(keys map[addrs.InstanceKey]cty.Value) cty.Value {
-	if val, exists := keys[addrs.NoKey]; exists {
-		// If present, a "no key" value supersedes all other values,
-		// since they should be embedded inside it.
-		return val
-	}
-
-	// If we only have individual values then we need to construct
-	// either a list or a map, depending on what sort of keys we
-	// have.
-	haveInt := false
-	haveString := false
-	maxInt := 0
-
-	for k := range keys {
-		switch tk := k.(type) {
-		case addrs.IntKey:
-			haveInt = true
-			if int(tk) > maxInt {
-				maxInt = int(tk)
-			}
-		case addrs.StringKey:
-			haveString = true
-		}
-	}
-
-	// We should either have ints or strings and not both, but
-	// if we have both then we'll prefer strings and let the
-	// language interpreter try to convert the int keys into
-	// strings in a map.
-	switch {
-	case haveString:
-		vals := make(map[string]cty.Value)
-		for k, v := range keys {
-			switch tk := k.(type) {
-			case addrs.StringKey:
-				vals[string(tk)] = v
-			case addrs.IntKey:
-				sk := strconv.Itoa(int(tk))
-				vals[sk] = v
-			}
-		}
-		return cty.ObjectVal(vals)
-	case haveInt:
-		// We'll make a tuple that is long enough for our maximum
-		// index value. It doesn't matter if we end up shorter than
-		// the number of instances because if length(...) were
-		// being evaluated we would've got a NoKey reference and
-		// thus not ended up in this codepath at all.
-		vals := make([]cty.Value, maxInt+1)
-		for i := range vals {
-			if v, exists := keys[addrs.IntKey(i)]; exists {
-				vals[i] = v
-			} else {
-				// Just a placeholder, since nothing will access this anyway
-				vals[i] = cty.DynamicVal
-			}
-		}
-		return cty.TupleVal(vals)
-	default:
-		// Should never happen because there are no other key types.
-		log.Printf("[ERROR] strange makeInstanceObjects call with no supported key types")
-		return cty.EmptyObjectVal
-	}
 }
 
 func normalizeRefValue(val cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {

--- a/lang/eval_test.go
+++ b/lang/eval_test.go
@@ -179,6 +179,22 @@ func TestScopeEvalContext(t *testing.T) {
 			},
 		},
 		{
+			// at this level, all instance references return the entire resource
+			`null_resource.each["each1"].attr`,
+			map[string]cty.Value{
+				"null_resource": cty.ObjectVal(map[string]cty.Value{
+					"each": cty.ObjectVal(map[string]cty.Value{
+						"each0": cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("each0"),
+						}),
+						"each1": cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("each1"),
+						}),
+					}),
+				}),
+			},
+		},
+		{
 			`foo(null_resource.multi, null_resource.multi[1])`,
 			map[string]cty.Value{
 				"null_resource": cty.ObjectVal(map[string]cty.Value{
@@ -216,11 +232,13 @@ func TestScopeEvalContext(t *testing.T) {
 				}),
 			},
 		},
+		// any module reference returns the entire module
 		{
 			`module.foo.output1`,
 			map[string]cty.Value{
 				"module": cty.ObjectVal(map[string]cty.Value{
 					"foo": cty.ObjectVal(map[string]cty.Value{
+						"output0": cty.StringVal("bar0"),
 						"output1": cty.StringVal("bar1"),
 					}),
 				}),

--- a/plans/changes.go
+++ b/plans/changes.go
@@ -81,6 +81,31 @@ func (c *Changes) OutputValue(addr addrs.AbsOutputValue) *OutputChangeSrc {
 	return nil
 }
 
+// OutputValues returns planned changes for all outputs for all module
+// instances that reside in the parent path.  Returns nil if no changes are
+// planned.
+func (c *Changes) OutputValues(parent addrs.ModuleInstance, module addrs.ModuleCall) []*OutputChangeSrc {
+	var res []*OutputChangeSrc
+
+	for _, oc := range c.Outputs {
+		changeMod, changeCall := oc.Addr.Module.Call()
+		// this does not reside on our parent instance path
+		if !changeMod.Equal(parent) {
+			continue
+		}
+
+		// this is not the module you're looking for
+		if changeCall.Name != module.Name {
+			continue
+		}
+
+		res = append(res, oc)
+
+	}
+
+	return res
+}
+
 // SyncWrapper returns a wrapper object around the receiver that can be used
 // to make certain changes to the receiver in a concurrency-safe way, as long
 // as all callers share the same wrapper object.

--- a/plans/changes.go
+++ b/plans/changes.go
@@ -88,6 +88,11 @@ func (c *Changes) OutputValues(parent addrs.ModuleInstance, module addrs.ModuleC
 	var res []*OutputChangeSrc
 
 	for _, oc := range c.Outputs {
+		// we can't evaluate root module outputs
+		if oc.Addr.Module.Equal(addrs.RootModuleInstance) {
+			continue
+		}
+
 		changeMod, changeCall := oc.Addr.Module.Call()
 		// this does not reside on our parent instance path
 		if !changeMod.Equal(parent) {

--- a/plans/changes_sync.go
+++ b/plans/changes_sync.go
@@ -123,6 +123,23 @@ func (cs *ChangesSync) GetOutputChange(addr addrs.AbsOutputValue) *OutputChangeS
 	return cs.changes.OutputValue(addr)
 }
 
+// GetOutputChanges searches the set of output changes for any that reside in
+// module instances beneath the given module. If no changes exist, nil
+// is returned.
+//
+// The returned objects are a deep copy of the change recorded in the plan, so
+// callers may mutate them although it's generally better (less confusing) to
+// treat planned changes as immutable after they've been initially constructed.
+func (cs *ChangesSync) GetOutputChanges(parent addrs.ModuleInstance, module addrs.ModuleCall) []*OutputChangeSrc {
+	if cs == nil {
+		panic("GetOutputChange on nil ChangesSync")
+	}
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
+
+	return cs.changes.OutputValues(parent, module)
+}
+
 // RemoveOutputChange searches the set of output value changes for one matching
 // the given address, and removes it from the set if it exists.
 func (cs *ChangesSync) RemoveOutputChange(addr addrs.AbsOutputValue) {

--- a/repl/session_test.go
+++ b/repl/session_test.go
@@ -125,7 +125,7 @@ func TestSession_basicState(t *testing.T) {
 				{
 					Input:         "module.module.foo",
 					Error:         true,
-					ErrorContains: `An output value with the name "foo" has not been declared in module.module`,
+					ErrorContains: `Unsupported attribute: This object does not have an attribute named "foo"`,
 				},
 			},
 		})

--- a/states/module.go
+++ b/states/module.go
@@ -259,6 +259,12 @@ func (ms *Module) maybeRestoreResourceInstanceDeposed(addr addrs.ResourceInstanc
 // existing value of the same name.
 func (ms *Module) SetOutputValue(name string, value cty.Value, sensitive bool) *OutputValue {
 	os := &OutputValue{
+		Addr: addrs.AbsOutputValue{
+			Module: ms.Addr,
+			OutputValue: addrs.OutputValue{
+				Name: name,
+			},
+		},
 		Value:     value,
 		Sensitive: sensitive,
 	}

--- a/states/output_value.go
+++ b/states/output_value.go
@@ -1,6 +1,7 @@
 package states
 
 import (
+	"github.com/hashicorp/terraform/addrs"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -9,6 +10,7 @@ import (
 // It is not valid to mutate an OutputValue object once it has been created.
 // Instead, create an entirely new OutputValue to replace the previous one.
 type OutputValue struct {
+	Addr      addrs.AbsOutputValue
 	Value     cty.Value
 	Sensitive bool
 }

--- a/states/state.go
+++ b/states/state.go
@@ -82,6 +82,35 @@ func (s *State) ModuleInstances(addr addrs.Module) []*Module {
 	return ms
 }
 
+// ModuleOutputs returns all outputs for the given module call under the
+// parentAddr instance.
+func (s *State) ModuleOutputs(parentAddr addrs.ModuleInstance, module addrs.ModuleCall) []*OutputValue {
+	var os []*OutputValue
+	for _, m := range s.Modules {
+		// can't get outputs from the root module
+		if m.Addr.IsRoot() {
+			continue
+		}
+
+		parent, call := m.Addr.Call()
+		// make sure this is a descendent in the correct path
+		if !parentAddr.Equal(parent) {
+			continue
+		}
+
+		// and check if this is the correct child
+		if call.Name != module.Name {
+			continue
+		}
+
+		for _, o := range m.OutputValues {
+			os = append(os, o)
+		}
+	}
+
+	return os
+}
+
 // RemoveModule removes the module with the given address from the state,
 // unless it is the root module. The root module cannot be deleted, and so
 // this method will panic if that is attempted.

--- a/states/state_deepcopy.go
+++ b/states/state_deepcopy.go
@@ -226,6 +226,7 @@ func (os *OutputValue) DeepCopy() *OutputValue {
 	}
 
 	return &OutputValue{
+		Addr:      os.Addr,
 		Value:     os.Value,
 		Sensitive: os.Sensitive,
 	}

--- a/states/state_test.go
+++ b/states/state_test.go
@@ -53,10 +53,20 @@ func TestState(t *testing.T) {
 				},
 				OutputValues: map[string]*OutputValue{
 					"bar": {
+						Addr: addrs.AbsOutputValue{
+							OutputValue: addrs.OutputValue{
+								Name: "bar",
+							},
+						},
 						Value:     cty.StringVal("bar value"),
 						Sensitive: false,
 					},
 					"secret": {
+						Addr: addrs.AbsOutputValue{
+							OutputValue: addrs.OutputValue{
+								Name: "secret",
+							},
+						},
 						Value:     cty.StringVal("secret value"),
 						Sensitive: true,
 					},
@@ -92,6 +102,12 @@ func TestState(t *testing.T) {
 				LocalValues: map[string]cty.Value{},
 				OutputValues: map[string]*OutputValue{
 					"pizza": {
+						Addr: addrs.AbsOutputValue{
+							Module: addrs.RootModuleInstance.Child("child", addrs.NoKey),
+							OutputValue: addrs.OutputValue{
+								Name: "pizza",
+							},
+						},
 						Value:     cty.StringVal("hawaiian"),
 						Sensitive: false,
 					},

--- a/states/statefile/version4.go
+++ b/states/statefile/version4.go
@@ -281,7 +281,13 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 	{
 		rootModule := state.RootModule()
 		for name, fos := range sV4.RootOutputs {
-			os := &states.OutputValue{}
+			os := &states.OutputValue{
+				Addr: addrs.AbsOutputValue{
+					OutputValue: addrs.OutputValue{
+						Name: name,
+					},
+				},
+			}
 			os.Sensitive = fos.Sensitive
 
 			ty, err := ctyjson.UnmarshalType([]byte(fos.ValueTypeRaw))

--- a/states/sync.go
+++ b/states/sync.go
@@ -48,6 +48,18 @@ func (s *SyncState) Module(addr addrs.ModuleInstance) *Module {
 	return ret
 }
 
+// ModuleOutputs returns the set of OutputValues that matches the given path.
+func (s *SyncState) ModuleOutputs(parentAddr addrs.ModuleInstance, module addrs.ModuleCall) []*OutputValue {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	var os []*OutputValue
+
+	for _, o := range s.state.ModuleOutputs(parentAddr, module) {
+		os = append(os, o.DeepCopy())
+	}
+	return os
+}
+
 // RemoveModule removes the entire state for the given module, taking with
 // it any resources associated with the module. This should generally be
 // called only for modules whose resources have all been destroyed, but

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -1421,6 +1421,7 @@ module "mod1" {
 module "mod2" {
   for_each = module.mod1
   source = "./mod"
+  input = module.mod1["a"].out
 }
 
 module "mod3" {
@@ -1430,6 +1431,15 @@ module "mod3" {
 `,
 		"mod/main.tf": `
 resource "aws_instance" "foo" {
+}
+
+output "out" {
+  value = 1
+}
+
+variable "input" {
+  type = number
+  default = 0
 }
 
 module "nested" {


### PR DESCRIPTION
In order to be able to use module values, and handle operations like possibly invalid module indexes in conditional statements; whole, expanded modules must always be returned during evaluation. This is the same methodology applied to resources in #22846.

This also requires some new methods on the Changes and State, since the evaluation is happening from within a known `addrs.ModuleInstance` path, but we need to retrieve all instances of the child module being referenced. We need to collect all outputs from all possible module instances, as module outputs are handled individually (as opposed to resources which are stored as objects containing all their attributes), so this allows us to compile a data structure with all the outputs for each module in order to build the `cty.Object` values that evaluation expects without copying all module resources as well. 

