### PR TITLE
terraform: return `initialization required` error when provider schemas not found

### DIFF
--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -877,8 +876,10 @@ func TestPlan_init_required(t *testing.T) {
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("expected error, got success")
 	}
-
-	fmt.Printf(ui.ErrorWriter.String())
+	output := ui.ErrorWriter.String()
+	if !strings.Contains(output, `Plugin reinitialization required. Please run "terraform init".`) {
+		t.Fatal("wrong error message in output:", output)
+	}
 }
 
 // planFixtureSchema returns a schema suitable for processing the

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -852,6 +853,32 @@ func TestPlan_shutdown(t *testing.T) {
 	default:
 		t.Error("command not cancelled")
 	}
+}
+
+func TestPlan_init_required(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := os.Chdir(testFixturePath("plan")); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Chdir(cwd)
+
+	ui := new(cli.MockUi)
+	c := &PlanCommand{
+		Meta: Meta{
+			// Running plan without setting testingOverrides is similar to plan without init
+			Ui: ui,
+		},
+	}
+
+	args := []string{}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("expected error, got success")
+	}
+
+	fmt.Printf(ui.ErrorWriter.String())
 }
 
 // planFixtureSchema returns a schema suitable for processing the

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -180,7 +180,7 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Could not satisfy plugin requirements",
-			errPluginInit,
+			fmt.Sprintf(errPluginInit, err),
 		))
 		return nil, diags
 	}

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -179,7 +179,7 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
-			"Could not satisfy plugin requirements",
+			"Could not load plugin",
 			fmt.Sprintf(errPluginInit, err),
 		))
 		return nil, diags

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -177,7 +177,11 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 	log.Printf("[TRACE] terraform.NewContext: loading provider schemas")
 	schemas, err := LoadSchemas(opts.Config, opts.State, components)
 	if err != nil {
-		diags = diags.Append(err)
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Could not satisfy plugin requirements",
+			errPluginInit,
+		))
 		return nil, diags
 	}
 

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -231,4 +231,6 @@ don't satisfy the version constraints, or are otherwise incompatible.
 Terraform automatically discovers provider requirements from your
 configuration, including providers used in child modules. To see the
 requirements and constraints from each module, run "terraform providers".
+
+%s
 `

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -230,7 +230,7 @@ don't satisfy the version constraints, or are otherwise incompatible.
 
 Terraform automatically discovers provider requirements from your
 configuration, including providers used in child modules. To see the
-requirements and constraints from each module, run "terraform providers".
+requirements and constraints, run "terraform providers".
 
 %s
 `


### PR DESCRIPTION
A side effect of the various changes to the provider installer included losing the `initialization required` error message which would occur if a user removed or modified the `.terraform` directory.

Previously, plugin factories were created after the configuration was loaded, in `terraform.NewContext`.  Terraform would compare the required providers (from config and state) to the available providers and return the aforementioned error if a provider was missing.

Provider factories are now loaded at the beginning of any terraform command, before terraform even loads the configuration, and therefore before terraform has a list of required providers. 

This PR replaces the current error when a providers' schema cannot be found in the provider factories with the `init` error, and adds a command test (to `plan` tests, for no real reason other than it's what I thought of first). 

