### PR TITLE
configs: Process required_providers blocks first

### DIFF
--- a/configs/testdata/invalid-modules/conflicting-required-providers/main.tf
+++ b/configs/testdata/invalid-modules/conflicting-required-providers/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    test = {
+      source = "acme/test"
+      version = "~>1.0.0"
+    }
+  }
+}

--- a/configs/testdata/invalid-modules/conflicting-required-providers/providers.tf
+++ b/configs/testdata/invalid-modules/conflicting-required-providers/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    test = {
+      source = "foo/test"
+    }
+  }
+}

--- a/configs/testdata/valid-modules/multiple-required-providers/a.tf
+++ b/configs/testdata/valid-modules/multiple-required-providers/a.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    test = {
+      version = "~>1.0.0"
+    }
+  }
+}

--- a/configs/testdata/valid-modules/multiple-required-providers/b.tf
+++ b/configs/testdata/valid-modules/multiple-required-providers/b.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    test = {
+      source = "foo/test"
+    }
+  }
+}

--- a/configs/testdata/valid-modules/required-providers-after-resource/main.tf
+++ b/configs/testdata/valid-modules/required-providers-after-resource/main.tf
@@ -1,0 +1,3 @@
+resource test_instance "my-instance" {
+  provider = test
+}

--- a/configs/testdata/valid-modules/required-providers-after-resource/providers.tf
+++ b/configs/testdata/valid-modules/required-providers-after-resource/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    test = {
+      source = "foo/test"
+      version = "~>1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
Modules can have `terraform.required_provider` blocks, which are used to specify both version constraints and sources for providers. These can appear anywhere in the configuration, before or after resources, and it is valid to have multiple blocks.

This commit fixes two problems with the use of `required_providers`:

- If a provider appeared in multiple `required_provider` blocks, and a later block specified the source, Terraform would panic. This should not be an error unless multiple blocks specify conflicting sources.
- If resources had a specific `provider` attribute, but evaluated before the corresponding `required_provider` block which defined a non-default source for the provider, the resource would incorrectly use an implied default source for that provider.

When loading a module, we now process `required_providers` in a separate step, merging all of the files and resolving missing or conflicting provider source declarations. Once this is complete, we continue to process the rest of the blocks in the module.