### PR TITLE
website: Add docs for state replace-provider

### DIFF
--- a/command/state_replace_provider.go
+++ b/command/state_replace_provider.go
@@ -170,9 +170,6 @@ Usage: terraform state replace-provider [options] FROM_PROVIDER_FQN TO_PROVIDER_
 
   Replace provider for resources in the Terraform state.
 
-  An error will be returned if any of the resources or modules given as
-  filter addresses do not exist in the state.
-
 Options:
 
   -auto-approve       Skip interactive approval.

--- a/website/docs/commands/state/replace-provider.html.md
+++ b/website/docs/commands/state/replace-provider.html.md
@@ -1,0 +1,47 @@
+---
+layout: "commands-state"
+page_title: "Command: state replace-provider"
+sidebar_current: "docs-commands-state-sub-replace-provider"
+description: |-
+  The `terraform state replace-provider` command replaces the provider for resources in the Terraform state.
+---
+
+# Command: state replace-provider
+
+The `terraform state replace-provider` command is used to replace the provider
+for resources in a [Terraform state](/docs/state/index.html).
+
+## Usage
+
+Usage: `terraform state replace-provider [options] FROM_PROVIDER_FQN TO_PROVIDER_FQN`
+
+This command will update all resources using the "from" provider, setting the
+provider to the specified "to" provider. This allows changing the source of a
+provider which currently has resources in state.
+
+This command will output a backup copy of the state prior to saving any
+changes. The backup cannot be disabled. Due to the destructive nature
+of this command, backups are required.
+
+The command-line flags are all optional. The list of available flags are:
+
+* `-auto-approve` - Skip interactive approval.
+
+* `-backup=path` - Path where Terraform should write the backup for the
+  original state. This can't be disabled. If not set, Terraform will write it
+  to the same path as the statefile with a ".backup" extension.
+
+* `-lock=true`- Lock the state files when locking is supported.
+
+* `-lock-timeout=0s` - Duration to retry a state lock.
+
+* `-state=path` - Path to the source state file to read from. Defaults to the
+  configured backend, or "terraform.tfstate".
+
+## Example
+
+The example below replaces the `hashicorp/aws` provider with a fork by `acme`, hosted at a private registry at `registry.acme.corp`:
+
+```shell
+$ terraform state replace-provider hashicorp/aws registry.acme.corp/acme/aws
+```

--- a/website/layouts/commands-state.erb
+++ b/website/layouts/commands-state.erb
@@ -30,6 +30,10 @@
                 <a href="/docs/commands/state/push.html">push</a>
               </li>
 
+              <li<%= sidebar_current("docs-commands-state-sub-replace-provider") %>>
+                <a href="/docs/commands/state/replace-provider.html">replace-provider</a>
+              </li>
+
               <li<%= sidebar_current("docs-commands-state-sub-rm") %>>
                 <a href="/docs/commands/state/rm.html">rm</a>
               </li>


### PR DESCRIPTION
[Rendered](https://github.com/hashicorp/terraform/blob/alisdair/terraform-state-replace-provider-docs/website/docs/commands/state/replace-provider.html.md). Documentation for `terraform state replace-provider`, added in #24523.

We should update this page to link to the docs on provider FQN when that's available.