### PR TITLE
configs: Simplify required_providers blocks

### DIFF
--- a/configs/module_test.go
+++ b/configs/module_test.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/addrs"
@@ -109,5 +110,96 @@ func TestProviderForLocalConfig(t *testing.T) {
 	want := addrs.NewProvider(addrs.DefaultRegistryHost, "foo", "test")
 	if !got.Equals(want) {
 		t.Fatalf("wrong result! got %#v, want %#v\n", got, want)
+	}
+}
+
+// At most one required_providers block per module is permitted.
+func TestModule_required_providers_multiple(t *testing.T) {
+	_, diags := testModuleFromDir("testdata/invalid-modules/multiple-required-providers")
+	if !diags.HasErrors() {
+		t.Fatal("module should have error diags, but does not")
+	}
+
+	want := `Duplicate required providers configuration`
+	if got := diags.Error(); !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q\nerror was:\n%s", want, got)
+	}
+}
+
+// A module may have required_providers configured in files loaded later than
+// resources. These provider settings should still be reflected in the
+// resources' configuration.
+func TestModule_required_providers_after_resource(t *testing.T) {
+	mod, diags := testModuleFromDir("testdata/valid-modules/required-providers-after-resource")
+	if diags.HasErrors() {
+		t.Fatal(diags.Error())
+	}
+
+	want := addrs.NewProvider(addrs.DefaultRegistryHost, "foo", "test")
+
+	req, exists := mod.ProviderRequirements.RequiredProviders["test"]
+	if !exists {
+		t.Fatal("no provider requirements found for \"test\"")
+	}
+	if req.Type != want {
+		t.Errorf("wrong provider addr for \"test\"\ngot:  %s\nwant: %s",
+			req.Type, want,
+		)
+	}
+
+	if got := mod.ManagedResources["test_instance.my-instance"].Provider; !got.Equals(want) {
+		t.Errorf("wrong provider addr for \"test_instance.my-instance\"\ngot:  %s\nwant: %s",
+			got, want,
+		)
+	}
+}
+
+// We support overrides for required_providers blocks, which should replace the
+// entire block for each provider localname, leaving other blocks unaffected.
+// This should also be reflected in any resources in the module using this
+// provider.
+func TestModule_required_provider_overrides(t *testing.T) {
+	mod, diags := testModuleFromDir("testdata/valid-modules/required-providers-overrides")
+	if diags.HasErrors() {
+		t.Fatal(diags.Error())
+	}
+
+	// The foo provider and resource should be unaffected
+	want := addrs.NewProvider(addrs.DefaultRegistryHost, "acme", "foo")
+	req, exists := mod.ProviderRequirements.RequiredProviders["foo"]
+	if !exists {
+		t.Fatal("no provider requirements found for \"foo\"")
+	}
+	if req.Type != want {
+		t.Errorf("wrong provider addr for \"foo\"\ngot:  %s\nwant: %s",
+			req.Type, want,
+		)
+	}
+	if got := mod.ManagedResources["foo_thing.ft"].Provider; !got.Equals(want) {
+		t.Errorf("wrong provider addr for \"foo_thing.ft\"\ngot:  %s\nwant: %s",
+			got, want,
+		)
+	}
+
+	// The bar provider and resource should be using the override config
+	want = addrs.NewProvider(addrs.DefaultRegistryHost, "blorp", "bar")
+	req, exists = mod.ProviderRequirements.RequiredProviders["bar"]
+	if !exists {
+		t.Fatal("no provider requirements found for \"bar\"")
+	}
+	if req.Type != want {
+		t.Errorf("wrong provider addr for \"bar\"\ngot:  %s\nwant: %s",
+			req.Type, want,
+		)
+	}
+	if gotVer, wantVer := req.Requirement.Required.String(), "~>2.0.0"; gotVer != wantVer {
+		t.Errorf("wrong provider version constraint for \"bar\"\ngot:  %s\nwant: %s",
+			gotVer, wantVer,
+		)
+	}
+	if got := mod.ManagedResources["bar_thing.bt"].Provider; !got.Equals(want) {
+		t.Errorf("wrong provider addr for \"bar_thing.bt\"\ngot:  %s\nwant: %s",
+			got, want,
+		)
 	}
 }

--- a/configs/parser_config.go
+++ b/configs/parser_config.go
@@ -75,7 +75,7 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 				case "required_providers":
 					reqs, reqsDiags := decodeRequiredProvidersBlock(innerBlock)
 					diags = append(diags, reqsDiags...)
-					file.RequiredProviders = append(file.RequiredProviders, reqs...)
+					file.RequiredProviders = append(file.RequiredProviders, reqs)
 
 				case "provider_meta":
 					providerCfg, cfgDiags := decodeProviderMetaBlock(innerBlock)

--- a/configs/provider_requirements.go
+++ b/configs/provider_requirements.go
@@ -12,41 +12,40 @@ import (
 // parent.
 type RequiredProvider struct {
 	Name        string
-	Source      Source
+	Type        addrs.Provider
 	Requirement VersionConstraint
+	DeclRange   hcl.Range
 }
 
-type Source struct {
-	SourceStr string
-	DeclRange hcl.Range
+type RequiredProviders struct {
+	RequiredProviders map[string]*RequiredProvider
+	DeclRange         hcl.Range
 }
 
-// ProviderRequirements represents provider version constraints from
-// required_providers blocks.
-type ProviderRequirements struct {
-	Type               addrs.Provider
-	VersionConstraints []VersionConstraint
-}
-
-func decodeRequiredProvidersBlock(block *hcl.Block) ([]*RequiredProvider, hcl.Diagnostics) {
+func decodeRequiredProvidersBlock(block *hcl.Block) (*RequiredProviders, hcl.Diagnostics) {
 	attrs, diags := block.Body.JustAttributes()
-	var reqs []*RequiredProvider
+	ret := &RequiredProviders{
+		RequiredProviders: make(map[string]*RequiredProvider),
+		DeclRange:         block.DefRange,
+	}
 	for name, attr := range attrs {
 		expr, err := attr.Expr.Value(nil)
 		if err != nil {
 			diags = append(diags, err...)
 		}
 
+		rp := &RequiredProvider{
+			Name:      name,
+			DeclRange: attr.Expr.Range(),
+		}
+
 		switch {
 		case expr.Type().IsPrimitiveType():
 			vc, reqDiags := decodeVersionConstraint(attr)
 			diags = append(diags, reqDiags...)
-			reqs = append(reqs, &RequiredProvider{
-				Name:        name,
-				Requirement: vc,
-			})
+			rp.Requirement = vc
+
 		case expr.Type().IsObjectType():
-			ret := &RequiredProvider{Name: name}
 			if expr.Type().HasAttribute("version") {
 				vc := VersionConstraint{
 					DeclRange: attr.Range,
@@ -64,25 +63,55 @@ func decodeRequiredProvidersBlock(block *hcl.Block) ([]*RequiredProvider, hcl.Di
 					})
 				} else {
 					vc.Required = constraints
-					ret.Requirement = vc
+					rp.Requirement = vc
 				}
 			}
 			if expr.Type().HasAttribute("source") {
-				ret.Source.SourceStr = expr.GetAttr("source").AsString()
-				ret.Source.DeclRange = attr.Range
+				fqn, sourceDiags := addrs.ParseProviderSourceString(expr.GetAttr("source").AsString())
+
+				if sourceDiags.HasErrors() {
+					hclDiags := sourceDiags.ToHCL()
+					// The diagnostics from ParseProviderSourceString don't contain
+					// source location information because it has no context to compute
+					// them from, and so we'll add those in quickly here before we
+					// return.
+					for _, diag := range hclDiags {
+						if diag.Subject == nil {
+							diag.Subject = attr.Expr.Range().Ptr()
+						}
+					}
+					diags = append(diags, hclDiags...)
+				} else {
+					rp.Type = fqn
+				}
 			}
-			reqs = append(reqs, ret)
+
 		default:
 			// should not happen
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "Invalid provider_requirements syntax",
-				Detail:   "provider_requirements entries must be strings or objects.",
+				Summary:  "Invalid required_providers syntax",
+				Detail:   "required_providers entries must be strings or objects.",
 				Subject:  attr.Expr.Range().Ptr(),
 			})
-			reqs = append(reqs, &RequiredProvider{Name: name})
-			return reqs, diags
 		}
+
+		if rp.Type.IsZero() {
+			pType, err := addrs.ParseProviderPart(rp.Name)
+			if err != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid provider name",
+					Detail:   err.Error(),
+					Subject:  attr.Expr.Range().Ptr(),
+				})
+			} else {
+				rp.Type = addrs.ImpliedProviderForUnqualifiedType(pType)
+			}
+		}
+
+		ret.RequiredProviders[rp.Name] = rp
 	}
-	return reqs, diags
+
+	return ret, diags
 }

--- a/configs/provider_requirements_test.go
+++ b/configs/provider_requirements_test.go
@@ -1,8 +1,6 @@
 package configs
 
 import (
-	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,6 +8,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/hashicorp/terraform/addrs"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -19,173 +18,281 @@ var (
 		if x.Name != y.Name {
 			return false
 		}
-		if x.Source != y.Source {
+		if x.Type != y.Type {
 			return false
 		}
 		if x.Requirement.Required.String() != y.Requirement.Required.String() {
 			return false
 		}
+		if x.DeclRange != y.DeclRange {
+			return false
+		}
 		return true
 	})
-)
-
-func TestDecodeRequiredProvidersBlock_legacy(t *testing.T) {
-	block := &hcl.Block{
-		Type: "required_providers",
-		Body: hcltest.MockBody(&hcl.BodyContent{
-			Attributes: hcl.Attributes{
-				"default": {
-					Name: "default",
-					Expr: hcltest.MockExprLiteral(cty.StringVal("1.0.0")),
-				},
-			},
-		}),
-	}
-
-	want := &RequiredProvider{
-		Name:        "default",
-		Requirement: testVC("1.0.0"),
-	}
-
-	got, diags := decodeRequiredProvidersBlock(block)
-	if diags.HasErrors() {
-		t.Fatalf("unexpected error")
-	}
-	if len(got) != 1 {
-		t.Fatalf("wrong number of results, got %d, wanted 1", len(got))
-	}
-	if !cmp.Equal(got[0], want, ignoreUnexported, comparer) {
-		t.Fatalf("wrong result:\n %s", cmp.Diff(got[0], want, ignoreUnexported, comparer))
-	}
-}
-
-func TestDecodeRequiredProvidersBlock_provider_source(t *testing.T) {
-	mockRange := hcl.Range{
+	blockRange = hcl.Range{
 		Filename: "mock.tf",
 		Start:    hcl.Pos{Line: 3, Column: 12, Byte: 27},
 		End:      hcl.Pos{Line: 3, Column: 19, Byte: 34},
 	}
+	mockRange = hcl.Range{
+		Filename: "MockExprLiteral",
+	}
+)
 
-	block := &hcl.Block{
-		Type: "required_providers",
-		Body: hcltest.MockBody(&hcl.BodyContent{
-			Attributes: hcl.Attributes{
-				"my_test": {
-					Name: "my_test",
-					Expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
-						"source":  cty.StringVal("mycloud/test"),
-						"version": cty.StringVal("2.0.0"),
-					})),
-					Range: mockRange,
-				},
+func TestDecodeRequiredProvidersBlock(t *testing.T) {
+	tests := map[string]struct {
+		Block *hcl.Block
+		Want  *RequiredProviders
+		Error string
+	}{
+		"legacy": {
+			Block: &hcl.Block{
+				Type: "required_providers",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"default": {
+							Name: "default",
+							Expr: hcltest.MockExprLiteral(cty.StringVal("1.0.0")),
+						},
+					},
+				}),
+				DefRange: blockRange,
 			},
-		}),
-	}
-
-	want := &RequiredProvider{
-		Name:        "my_test",
-		Source:      Source{SourceStr: "mycloud/test", DeclRange: mockRange},
-		Requirement: testVC("2.0.0"),
-	}
-	got, diags := decodeRequiredProvidersBlock(block)
-	if diags.HasErrors() {
-		t.Fatalf("unexpected error")
-	}
-	if len(got) != 1 {
-		t.Fatalf("wrong number of results, got %d, wanted 1", len(got))
-	}
-	if !cmp.Equal(got[0], want, ignoreUnexported, comparer) {
-		t.Fatalf("wrong result:\n %s", cmp.Diff(got[0], want, ignoreUnexported, comparer))
-	}
-}
-
-func TestDecodeRequiredProvidersBlock_mixed(t *testing.T) {
-	block := &hcl.Block{
-		Type: "required_providers",
-		Body: hcltest.MockBody(&hcl.BodyContent{
-			Attributes: hcl.Attributes{
-				"legacy": {
-					Name: "legacy",
-					Expr: hcltest.MockExprLiteral(cty.StringVal("1.0.0")),
+			Want: &RequiredProviders{
+				RequiredProviders: map[string]*RequiredProvider{
+					"default": {
+						Name:        "default",
+						Type:        addrs.NewDefaultProvider("default"),
+						Requirement: testVC("1.0.0"),
+						DeclRange:   mockRange,
+					},
 				},
-				"my_test": {
-					Name: "my_test",
-					Expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
-						"source":  cty.StringVal("mycloud/test"),
-						"version": cty.StringVal("2.0.0"),
-					})),
-				},
+				DeclRange: blockRange,
 			},
-		}),
-	}
-
-	want := []*RequiredProvider{
-		{
-			Name:        "legacy",
-			Requirement: testVC("1.0.0"),
 		},
-		{
-			Name:        "my_test",
-			Source:      Source{SourceStr: "mycloud/test", DeclRange: hcl.Range{}},
-			Requirement: testVC("2.0.0"),
-		},
-	}
-
-	got, diags := decodeRequiredProvidersBlock(block)
-
-	sort.SliceStable(got, func(i, j int) bool {
-		return got[i].Name < got[j].Name
-	})
-
-	if diags.HasErrors() {
-		t.Fatalf("unexpected error")
-	}
-	if len(got) != 2 {
-		t.Fatalf("wrong number of results, got %d, wanted 2", len(got))
-	}
-	for i, rp := range want {
-		if !cmp.Equal(got[i], rp, ignoreUnexported, comparer) {
-			t.Fatalf("wrong result:\n %s", cmp.Diff(got[0], rp, ignoreUnexported, comparer))
-		}
-	}
-}
-
-func TestDecodeRequiredProvidersBlock_version_error(t *testing.T) {
-	block := &hcl.Block{
-		Type: "required_providers",
-		Body: hcltest.MockBody(&hcl.BodyContent{
-			Attributes: hcl.Attributes{
-				"my_test": {
-					Name: "my_test",
-					Expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
-						"source":  cty.StringVal("mycloud/test"),
-						"version": cty.StringVal("invalid"),
-					})),
-				},
+		"provider source": {
+			Block: &hcl.Block{
+				Type: "required_providers",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"my_test": {
+							Name: "my_test",
+							Expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
+								"source":  cty.StringVal("mycloud/test"),
+								"version": cty.StringVal("2.0.0"),
+							})),
+						},
+					},
+				}),
+				DefRange: blockRange,
 			},
-		}),
-	}
-
-	want := []*RequiredProvider{
-		{
-			Name:   "my_test",
-			Source: Source{SourceStr: "mycloud/test", DeclRange: hcl.Range{}},
+			Want: &RequiredProviders{
+				RequiredProviders: map[string]*RequiredProvider{
+					"my_test": {
+						Name:        "my_test",
+						Type:        addrs.NewProvider(addrs.DefaultRegistryHost, "mycloud", "test"),
+						Requirement: testVC("2.0.0"),
+						DeclRange:   mockRange,
+					},
+				},
+				DeclRange: blockRange,
+			},
+		},
+		"mixed": {
+			Block: &hcl.Block{
+				Type: "required_providers",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"legacy": {
+							Name: "legacy",
+							Expr: hcltest.MockExprLiteral(cty.StringVal("1.0.0")),
+						},
+						"my_test": {
+							Name: "my_test",
+							Expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
+								"source":  cty.StringVal("mycloud/test"),
+								"version": cty.StringVal("2.0.0"),
+							})),
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			Want: &RequiredProviders{
+				RequiredProviders: map[string]*RequiredProvider{
+					"legacy": {
+						Name:        "legacy",
+						Type:        addrs.NewDefaultProvider("legacy"),
+						Requirement: testVC("1.0.0"),
+						DeclRange:   mockRange,
+					},
+					"my_test": {
+						Name:        "my_test",
+						Type:        addrs.NewProvider(addrs.DefaultRegistryHost, "mycloud", "test"),
+						Requirement: testVC("2.0.0"),
+						DeclRange:   mockRange,
+					},
+				},
+				DeclRange: blockRange,
+			},
+		},
+		"version-only block": {
+			Block: &hcl.Block{
+				Type: "required_providers",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"test": {
+							Name: "test",
+							Expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
+								"version": cty.StringVal("~>2.0.0"),
+							})),
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			Want: &RequiredProviders{
+				RequiredProviders: map[string]*RequiredProvider{
+					"test": {
+						Name:        "test",
+						Type:        addrs.NewDefaultProvider("test"),
+						Requirement: testVC("~>2.0.0"),
+						DeclRange:   mockRange,
+					},
+				},
+				DeclRange: blockRange,
+			},
+		},
+		"invalid source": {
+			Block: &hcl.Block{
+				Type: "required_providers",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"my_test": {
+							Name: "my_test",
+							Expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
+								"source":  cty.StringVal("some/invalid/provider/source/test"),
+								"version": cty.StringVal("~>2.0.0"),
+							})),
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			Want: &RequiredProviders{
+				RequiredProviders: map[string]*RequiredProvider{
+					"my_test": {
+						Name:        "my_test",
+						Type:        addrs.Provider{},
+						Requirement: testVC("~>2.0.0"),
+						DeclRange:   mockRange,
+					},
+				},
+				DeclRange: blockRange,
+			},
+			Error: "Invalid provider source string",
+		},
+		"localname is invalid provider name": {
+			Block: &hcl.Block{
+				Type: "required_providers",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"my_test": {
+							Name: "my_test",
+							Expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
+								"version": cty.StringVal("~>2.0.0"),
+							})),
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			Want: &RequiredProviders{
+				RequiredProviders: map[string]*RequiredProvider{
+					"my_test": {
+						Name:        "my_test",
+						Type:        addrs.Provider{},
+						Requirement: testVC("~>2.0.0"),
+						DeclRange:   mockRange,
+					},
+				},
+				DeclRange: blockRange,
+			},
+			Error: "Invalid provider name",
+		},
+		"version constraint error": {
+			Block: &hcl.Block{
+				Type: "required_providers",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"my_test": {
+							Name: "my_test",
+							Expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
+								"source":  cty.StringVal("mycloud/test"),
+								"version": cty.StringVal("invalid"),
+							})),
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			Want: &RequiredProviders{
+				RequiredProviders: map[string]*RequiredProvider{
+					"my_test": {
+						Name:      "my_test",
+						Type:      addrs.NewProvider(addrs.DefaultRegistryHost, "mycloud", "test"),
+						DeclRange: mockRange,
+					},
+				},
+				DeclRange: blockRange,
+			},
+			Error: "Invalid version constraint",
+		},
+		"invalid required_providers attribute value": {
+			Block: &hcl.Block{
+				Type: "required_providers",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"test": {
+							Name: "test",
+							Expr: hcltest.MockExprLiteral(cty.ListVal([]cty.Value{cty.StringVal("2.0.0")})),
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			Want: &RequiredProviders{
+				RequiredProviders: map[string]*RequiredProvider{
+					"test": {
+						Name:      "test",
+						Type:      addrs.NewDefaultProvider("test"),
+						DeclRange: mockRange,
+					},
+				},
+				DeclRange: blockRange,
+			},
+			Error: "Invalid required_providers syntax",
 		},
 	}
 
-	got, diags := decodeRequiredProvidersBlock(block)
-	if !diags.HasErrors() {
-		t.Fatalf("expected error, got success")
-	} else {
-		fmt.Printf(diags[0].Summary)
-	}
-	if len(got) != 1 {
-		t.Fatalf("wrong number of results, got %d, wanted 1", len(got))
-	}
-	for i, rp := range want {
-		if !cmp.Equal(got[i], rp, ignoreUnexported, comparer) {
-			t.Fatalf("wrong result:\n %s", cmp.Diff(got[0], rp, ignoreUnexported, comparer))
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, diags := decodeRequiredProvidersBlock(test.Block)
+			if diags.HasErrors() {
+				if test.Error == "" {
+					t.Fatalf("unexpected error")
+				}
+				if gotErr := diags[0].Summary; gotErr != test.Error {
+					t.Errorf("wrong error, got %q, want %q", gotErr, test.Error)
+				}
+			} else if test.Error != "" {
+				t.Fatalf("expected error")
+			}
+
+			if !cmp.Equal(got, test.Want, ignoreUnexported, comparer) {
+				t.Fatalf("wrong result:\n %s", cmp.Diff(got, test.Want, ignoreUnexported, comparer))
+			}
+		})
 	}
 }
 

--- a/configs/testdata/invalid-modules/multiple-required-providers/a.tf
+++ b/configs/testdata/invalid-modules/multiple-required-providers/a.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    bar = {
+      version = "~>1.0.0"
+    }
+  }
+}

--- a/configs/testdata/invalid-modules/multiple-required-providers/b.tf
+++ b/configs/testdata/invalid-modules/multiple-required-providers/b.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    foo = {
+      version = "~>2.0.0"
+    }
+  }
+}

--- a/configs/testdata/valid-modules/required-providers-after-resource/main.tf
+++ b/configs/testdata/valid-modules/required-providers-after-resource/main.tf
@@ -1,0 +1,3 @@
+resource test_instance "my-instance" {
+  provider = test
+}

--- a/configs/testdata/valid-modules/required-providers-after-resource/providers.tf
+++ b/configs/testdata/valid-modules/required-providers-after-resource/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    test = {
+      source = "foo/test"
+      version = "~>1.0.0"
+    }
+  }
+}

--- a/configs/testdata/valid-modules/required-providers-overrides/bar_provider_override.tf
+++ b/configs/testdata/valid-modules/required-providers-overrides/bar_provider_override.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    bar = {
+      source = "blorp/bar"
+      version = "~>2.0.0"
+    }
+  }
+}
+

--- a/configs/testdata/valid-modules/required-providers-overrides/main.tf
+++ b/configs/testdata/valid-modules/required-providers-overrides/main.tf
@@ -1,0 +1,7 @@
+resource bar_thing "bt" {
+  provider = bar
+}
+
+resource foo_thing "ft" {
+  provider = foo
+}

--- a/configs/testdata/valid-modules/required-providers-overrides/providers.tf
+++ b/configs/testdata/valid-modules/required-providers-overrides/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    bar = {
+      source = "acme/bar"
+    }
+
+    foo = {
+      source = "acme/foo"
+    }
+  }
+}


### PR DESCRIPTION
We now permit at most one `required_providers` block per module (except for overrides). This prevents users (and Terraform) from struggling to understand how to merge multiple `required_providers` configurations, with `version` and `source` attributes split across multiple blocks.

Because only one `required_providers` block is permitted, there is no need to concatenate version constraints and resolve them. This allows us to simplify the structs used to represent provider requirements, aligning more closely with other structs in this package.

This commit also fixes a semantic use-before-initialize bug, where resources defined before a `required_providers` block would be unable to use its source attribute. We achieve this by processing the module's `required_providers` configuration (and overrides) before resources.

Overrides for `required_providers` work as before, replacing the entire block per provider.