### PR TITLE
Update maps docs to reflect v0.12 colon behavior

### DIFF
--- a/website/docs/configuration/types.html.md
+++ b/website/docs/configuration/types.html.md
@@ -95,6 +95,17 @@ The three kinds of collection type in the Terraform language are:
     element type as long as every element is the same type. This is for
     compatibility with older configurations; for new code, we recommend using
     the full form.
+
+    Maps can be made with braces ({}) and colons (:) or equals signs (=):
+    { "foo": "bar", "bar": "baz" } OR { foo = "bar", bar = "baz" }. Quotes
+    may be omitted on keys, unless the key starts with a number, in which
+    case quotes are required. Commas are required between key/value pairs
+    for single line maps. A newline between key/value pairs is sufficient
+    in multi-line maps.
+
+    Note: although colons are valid delimiters between keys and values,
+    they are currently ignored by `terraform fmt` (whereas `terraform fmt`
+    will attempt vertically align equals signs).
 * `set(...)`: a collection of unique values that do not have any secondary
   identifiers or ordering.
 


### PR DESCRIPTION
## Description
The [v0.11- docs](https://www.terraform.io/docs/configuration-0-11/syntax.html) give a pretty extensive description of how values of `map` type can be defined. There isn't quite as detailed an accounting of `map` considerations in the v0.12+ docs.

This PR brings forward some of that documentation detail for the `map` type, adding info about how while both equals signs and colons are valid delimiters in maps, they are currently handled differently by `terraform fmt`.

## Issue Link
This PR addresses (issue) https://github.com/hashicorp/terraform/issues/24198.