### PR TITLE
command/meta: document correctly ShutdownCh

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -89,7 +89,8 @@ type Meta struct {
 	// web browser.
 	BrowserLauncher webbrowser.Launcher
 
-	// When this channel is closed, the command will be cancelled.
+	// When a message is received on this channel, the command will be
+	// cancelled.
 	ShutdownCh <-chan struct{}
 
 	//----------------------------------------------------------


### PR DESCRIPTION
The ShutdownCh is never closed; on the other hand, messages are sent to it.

More in details:

The `ShutdownCh` field is initialized here:

https://github.com/hashicorp/terraform/blob/c28044d2329fae82cc2cb8625a4a87d3c850edb8/commands.go#L79

Function `makeShutdownCh()` is here:

https://github.com/hashicorp/terraform/blob/c28044d2329fae82cc2cb8625a4a87d3c850edb8/commands.go#L390

Each time it receives a signal (SIGTERM or SIGINT), it sends an empty message on the `ShutdownCh` channel.

The `ShutdownCh` channel is read in function `RunOperation()` here. If a message is received, the operation is cancelled (gracefully if 1 message, forcibly if 2 messages):

https://github.com/hashicorp/terraform/blob/c28044d2329fae82cc2cb8625a4a87d3c850edb8/command/meta.go#L286