### PR TITLE
Configure proper organization case in plan URL

### DIFF
--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -380,6 +380,13 @@ func (m *mockOrganizations) Create(ctx context.Context, options tfe.Organization
 }
 
 func (m *mockOrganizations) Read(ctx context.Context, name string) (*tfe.Organization, error) {
+	// Perform a case-insensitive search for the organization name.
+	for key, _ := range m.organizations {
+		if strings.EqualFold(key, name) {
+			name = key
+			break
+		}
+	}
 	org, ok := m.organizations[name]
 	if !ok {
 		return nil, tfe.ErrResourceNotFound


### PR DESCRIPTION
Organization names in Terraform Cloud/Enterprise are not case-sensitive. That is, an organization named `TeSTinG` is the same as an organization named `testing`. However, when accessing a URL to view the run of a given workspace, the case _does_ matter. If your Terraform Cloud/Enterprise organization is named `TeSTinG`, then accessing a URL of `https://app.terraform.io/app/testing/workspace/runs/run-123456789` will return 404 but accessing a URL of `https://app.terraform.io/app/TeSTinG/workspace/runs/run-123456789` will return the actual page content.

When a user has an organization named `TeSTinG` and uses a remote backend block like so.

```
terraform {
  backend "remote" {
    ...
    organization = "testing"
    ...
  }
}
```

Terraform CLI will output a URL like so.

```
To view this run in a browser, visit:
https://app.terraform.io/app/testing/workspace/runs/run-123456789
```

That is because the remote backend uses the value of the `organization` argument within the remote backend to build the URL. When the user clicks on this URL, they will be greeted with a 404. They should have instead seen an URL like so.

```
To view this run in a browser, visit:
https://app.terraform.io/app/TeSTinG/workspace/runs/run-123456789
```

This pull request handles this behavior by pulling the correct case of the organization name from the API and using it to display the correct plan URL for a speculative plan to the user instead of using the value of the `organization` argument defined in the remote backend block.

If this should instead be handled by the Terraform Cloud/Enterprise API, please feel free to say so and we can close this pull request and focus on fixing this behavior in the upstream API instead.