### PR TITLE
Add expansion transformer to eval graph

### DIFF
--- a/terraform/graph_builder_eval.go
+++ b/terraform/graph_builder_eval.go
@@ -89,6 +89,13 @@ func (b *EvalGraphBuilder) Steps() []GraphTransformer {
 		// analyze the configuration to find references.
 		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
+		// Create expansion nodes for all of the module calls. This must
+		// come after all other transformers that create nodes representing
+		// objects that can belong to modules.
+		&ModuleExpansionTransformer{
+			Config: b.Config,
+		},
+
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.
 		&ReferenceTransformer{},


### PR DESCRIPTION
Add the expansion transformer to the eval graph, which is used in rare scenarios which includes running `terraform console`. Prevents panic when running `terraform console` in contexts with module expansion.

Currently, tests for `terraform console` don't have any existing states where `init` is required before running that command, which would be necessary in order to fully test-through this case, which is why there isn't a test included in this changeset -- I could work on it, but it feels a bit separate from this current task.