### PR TITLE
configs: Fix for resources with implied providers

### DIFF
--- a/configs/testdata/valid-modules/implied-providers/providers.tf
+++ b/configs/testdata/valid-modules/implied-providers/providers.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    // This is an expected "real world" example of a community provider, which
+    // has resources named "foo_*" and will likely be used in configurations
+    // with the local name of "foo".
+    foo = {
+      source = "registry.acme.corp/acme/foo"
+    }
+
+    // However, implied provider lookups are based on local name, not provider
+    // type, and this example clarifies that. Only resources with addresses
+    // starting "whatever_" will be assigned this provider implicitly.
+    //
+    // This is _not_ a recommended usage pattern. The best practice is for
+    // local name and type to be the same, and only use a different local name
+    // if there are provider type collisions.
+    whatever = {
+      source = "acme/something"
+    }
+  }
+}

--- a/configs/testdata/valid-modules/implied-providers/resources.tf
+++ b/configs/testdata/valid-modules/implied-providers/resources.tf
@@ -1,0 +1,12 @@
+// These resources map to the configured "foo" provider"
+resource foo_resource "a" {}
+data foo_resource "b" {}
+
+// These resources map to a default "hashicorp/bar" provider
+resource bar_resource "c" {}
+data bar_resource "d" {}
+
+// These resources map to the configured "whatever" provider, which has FQN
+// "acme/something".
+resource whatever_resource "e" {}
+data whatever_resource "f" {}


### PR DESCRIPTION
Previously, resources without explicit provider configuration (i.e. a `provider =` attribute) would be assigned a default provider based upon the resource type. For example, a resource `foo_bar` would be assigned provider `hashicorp/foo`.

This behaviour did not work well with community or partner providers, with sources configured in `terraform.required_providers` blocks. With the following configuration:

```tf
terraform {
  required_providers {
    foo = {
      source = "acme/foo"
    }
  }
}

resource foo_bar "a" { }
```

the resource would be configured with the `hashicorp/foo` provider.

This commit fixes this implied provider behaviour. First we look for a provider with local name matching the resource type in the module's required providers map. If one is found, this provider is assigned to the resource. Otherwise, we still fall back to a default provider.