### PR TITLE
Support reading module outputs in terraform console

### DIFF
--- a/command/testdata/modules/.terraform/modules/modules.json
+++ b/command/testdata/modules/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"child","Source":"./child","Dir":"child"}]}

--- a/command/testdata/modules/.terraform/modules/modules.json
+++ b/command/testdata/modules/.terraform/modules/modules.json
@@ -1,1 +1,1 @@
-{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"child","Source":"./child","Dir":"child"}]}
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"child","Source":"./child","Dir":"child"},{"Key":"count_child","Source":"./child","Dir":"child"}]}

--- a/command/testdata/modules/child/main.tf
+++ b/command/testdata/modules/child/main.tf
@@ -1,5 +1,5 @@
 resource "test_instance" "test" {
 }
 output "myoutput" {
-  value = "literal string"
+  value = "bar"
 }

--- a/command/testdata/modules/child/main.tf
+++ b/command/testdata/modules/child/main.tf
@@ -1,0 +1,5 @@
+resource "test_instance" "test" {
+}
+output "myoutput" {
+  value = "literal string"
+}

--- a/command/testdata/modules/main.tf
+++ b/command/testdata/modules/main.tf
@@ -1,0 +1,3 @@
+module "child" {
+  source = "./child"
+}

--- a/command/testdata/modules/main.tf
+++ b/command/testdata/modules/main.tf
@@ -1,3 +1,11 @@
+locals {
+  foo = 3
+}
+
 module "child" {
+  source = "./child"
+}
+module "count_child" {
+  count = 1
   source = "./child"
 }

--- a/command/testdata/modules/terraform.tfstate
+++ b/command/testdata/modules/terraform.tfstate
@@ -1,0 +1,23 @@
+{
+    "version": 4,
+    "terraform_version": "0.13.0",
+    "serial": 7,
+    "lineage": "9cb740e3-d64d-e53e-a8e4-99b9bcacf24b",
+    "outputs": {},
+    "resources": [
+      {
+        "module": "module.child",
+        "mode": "managed",
+        "type": "test_instance",
+        "name": "test",
+        "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+        "instances": [
+          {
+            "schema_version": 0,
+            "attributes": {}
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -222,7 +222,7 @@ func (n *NodeApplyableOutput) EvalTree() EvalNode {
 	return &EvalSequence{
 		Nodes: []EvalNode{
 			&EvalOpFilter{
-				Ops: []walkOperation{walkRefresh, walkPlan, walkApply, walkValidate, walkDestroy, walkPlanDestroy},
+				Ops: []walkOperation{walkEval, walkRefresh, walkPlan, walkApply, walkValidate, walkDestroy, walkPlanDestroy},
 				Node: &EvalWriteOutput{
 					Addr:      n.Addr.OutputValue,
 					Sensitive: n.Config.Sensitive,


### PR DESCRIPTION
This allows outputs to be evaluated in `walkEval`, impacting `terraform console`.

Outputs are still not evaluated for `terraform console` in the root module, so this has no impact on writing to state (as child module outputs are not written to state). 

An open question I have is if this could have external effects I'm not seeing w.r.t. writing outputs to state, but all tests pass currently. I am concerned about this because the EvalNode is `EvalWriteOutput`. If someone has advice on how I might test this to ensure it's _not_ causing externalities, please share!

Also adds test coverage to the `console` command for evaluating module outputs generally, as well as locals.

