### PR TITLE
internal/providercache: fix error message for protocol mismatch

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -505,7 +505,7 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Failed to install provider",
-				fmt.Sprintf("Error while installing %s v%s: %s.", provider.ForDisplay(), version, err),
+				fmt.Sprintf("Error while installing %s v%s: %s", provider.ForDisplay(), version, err),
 			))
 		},
 		FetchPackageSuccess: func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -343,7 +343,8 @@ NeedProvider:
 					protoErr = providerProtocolTooOld
 				}
 
-				errs[provider] = fmt.Errorf(protoErr, provider, version, tfversion.String(), closestAvailable.String(), closestAvailable.String(), getproviders.VersionConstraintsString(reqs[provider]))
+				err := fmt.Errorf(protoErr, provider, version, tfversion.String(), closestAvailable.String(), closestAvailable.String(), getproviders.VersionConstraintsString(reqs[provider]))
+				errs[provider] = err
 				if cb := evts.FetchPackageFailure; cb != nil {
 					cb(provider, version, err)
 				}


### PR DESCRIPTION
There was a bug in the installer which was passing a nil error.
There is more work to be done here, but I wanted to get the simple bug fix in quickly. 

The registry source's `PackageMeta` function makes multiple GET requests to get the package metadata and shasums, which is more information than we need when searching for any provider versions with a protocol version supported by the current version of terraform (version). I am considering adding a `PartialPackageMetadata` function, but that seems like a lot of boilerplate for something unique to the registry installer, especially as there is some internal chatter about a new endpoint which could simplify this request (or reinforce the need for a second method; who knows just yet?).