### PR TITLE
Upgrade version of golang.org/x/crypto to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1 // indirect
-	golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e
+	golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79
 	golang.org/x/mod v0.2.0
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -464,6 +464,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e h1:egKlR8l7Nu9vHGWbcUV8lqR4987UfUbBd7GbhqGzNYU=
 golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79 h1:IaQbIIB2X/Mp/DKctl6ROxz1KyMlKp4uyvL6+kQ7C88=
+golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=


### PR DESCRIPTION
**Description**

`golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e` is found to be vulnerable due to possibility of DOS attack, while allowing to panic under verification of specifically crafted ssh-ed25519 or sk-ssh-ed25519@openssh.com public key (CVSS 3 Score: 7.5).

**References**

- https://github.com/golang/crypto/commit/bac4c82f69751a6dd76e702d54b3ceb88adab236
- https://groups.google.com/forum/#!topic/golang-announce/3L45YRc91SY
- https://packetstormsecurity.com/files/156480/Go-SSH-0.0.2-Denial-Of-Service.html

**Changes proposed in this pull request**

- Upgrade of `golang.org/x/crypto` to latest version.

*Comment*
I'm wondering if this change has an influence on the rest of system behaviour.
How do you feel about running tests on this PR?