### PR TITLE
init: return proper errors when config has an error and earlyconfig does not

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -165,7 +165,7 @@ func (c *InitCommand) Run(args []string) int {
 		// error suggesting the user upgrade their config manually or with
 		// Terraform v0.12
 		c.Ui.Error(strings.TrimSpace(errInitConfigErrorMaybeLegacySyntax))
-		c.showDiagnostics(earlyConfDiags)
+		c.showDiagnostics(confDiags)
 		return 1
 	}
 


### PR DESCRIPTION
Fixed a bug where we were returning the wrong `diags` to the user during `init`.

Here's an example when the user has multiple `required_providers` settings: 

<img width="922" alt="Screen Shot 2020-05-05 at 8 50 16 AM" src="https://user-images.githubusercontent.com/6210214/81067906-731d2e00-8ead-11ea-9e76-6f440e210ef4.png">
