### PR TITLE
[WIP] Add more validation to expanding modules

### DIFF
--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -1425,7 +1425,7 @@ module "mod2" {
 }
 
 module "mod3" {
-  count = len(module.mod2)
+  count = length(module.mod2)
   source = "./mod"
 }
 `,

--- a/terraform/node_module_expand.go
+++ b/terraform/node_module_expand.go
@@ -291,7 +291,7 @@ func (n *evalValidateModule) Eval(ctx EvalContext) (interface{}, error) {
 		// in the error to the user.
 		switch {
 		case n.ModuleCall.Count != nil:
-			_, diags := evaluateCountExpression(n.ModuleCall.Count, ctx)
+			_, diags := evaluateCountExpressionValue(n.ModuleCall.Count, ctx)
 			if diags.HasErrors() {
 				return nil, diags.Err()
 			}
@@ -307,7 +307,7 @@ func (n *evalValidateModule) Eval(ctx EvalContext) (interface{}, error) {
 			}
 
 		case n.ModuleCall.ForEach != nil:
-			_, diags := evaluateForEachExpression(n.ModuleCall.ForEach, ctx)
+			_, diags := evaluateForEachExpressionValue(n.ModuleCall.ForEach, ctx)
 			if diags.HasErrors() {
 				return nil, diags.Err()
 			}


### PR DESCRIPTION
_EDIT: This is a WIP, this needs to allow provider blocks where a valid provider has been passed in through the ModuleCall's provider block_

We cannot allow provider blocks in expanding modules. While it would be preferable to catch this in the config loader, there is not a relationship at that time between a given `Module` and its `ModuleCall`, so we cannot inspect whether a module that is being created is related to a `ModuleCall` with `count` or `for_each`. It is likely some work will need to be done in terraform-config-inspect for that to happen.

For now, this will catch this on the validate step, throwing an error if an expanding module has any `provider` blocks.

Additionally, this adds some minimal validation for the `count` and `for_each` values in a `ModuleCall`; previously invalid values could be passed (for example, an array to a `for_each` argument).

