### PR TITLE
Avoid configuring backend when validating terraform_remote_state

### DIFF
--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -48,7 +48,7 @@ func dataSourceRemoteStateValidate(cfg cty.Value) tfdiags.Diagnostics {
 	// Getting the backend implicitly validates the configuration for it,
 	// but we can only do that if it's all known already.
 	if cfg.GetAttr("config").IsWhollyKnown() && cfg.GetAttr("backend").IsKnown() {
-		_, moreDiags := getBackend(cfg)
+		_, _, moreDiags := getBackend(cfg)
 		diags = diags.Append(moreDiags)
 	} else {
 		// Otherwise we'll just type-check the config object itself.
@@ -81,9 +81,15 @@ func dataSourceRemoteStateValidate(cfg cty.Value) tfdiags.Diagnostics {
 func dataSourceRemoteStateRead(d cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	b, moreDiags := getBackend(d)
+	b, cfg, moreDiags := getBackend(d)
 	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
+	if moreDiags.HasErrors() {
+		return cty.NilVal, diags
+	}
+
+	configureDiags := b.Configure(cfg)
+	if configureDiags.HasErrors() {
+		diags = diags.Append(configureDiags.Err())
 		return cty.NilVal, diags
 	}
 
@@ -152,7 +158,7 @@ func dataSourceRemoteStateRead(d cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	return cty.ObjectVal(newState), diags
 }
 
-func getBackend(cfg cty.Value) (backend.Backend, tfdiags.Diagnostics) {
+func getBackend(cfg cty.Value) (backend.Backend, cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	backendType := cfg.GetAttr("backend").AsString()
@@ -173,7 +179,7 @@ func getBackend(cfg cty.Value) (backend.Backend, tfdiags.Diagnostics) {
 			fmt.Sprintf("There is no backend type named %q.", backendType),
 			cty.Path(nil).GetAttr("backend"),
 		))
-		return nil, diags
+		return nil, cty.NilVal, diags
 	}
 	b := f()
 
@@ -199,21 +205,14 @@ func getBackend(cfg cty.Value) (backend.Backend, tfdiags.Diagnostics) {
 				tfdiags.FormatError(err)),
 			cty.Path(nil).GetAttr("config"),
 		))
-		return nil, diags
+		return nil, cty.NilVal, diags
 	}
 
 	newVal, validateDiags := b.PrepareConfig(configVal)
 	diags = diags.Append(validateDiags)
 	if validateDiags.HasErrors() {
-		return nil, diags
-	}
-	configVal = newVal
-
-	configureDiags := b.Configure(configVal)
-	if configureDiags.HasErrors() {
-		diags = diags.Append(configureDiags.Err())
-		return nil, diags
+		return nil, cty.NilVal, diags
 	}
 
-	return b, diags
+	return b, newVal, diags
 }

--- a/builtin/providers/terraform/data_source_state_test.go
+++ b/builtin/providers/terraform/data_source_state_test.go
@@ -1,11 +1,11 @@
 package terraform
 
 import (
-	"github.com/hashicorp/terraform/tfdiags"
 	"testing"
 
 	"github.com/apparentlymart/go-dump/dump"
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -30,6 +30,26 @@ func TestState_basic(t *testing.T) {
 			}),
 			cty.ObjectVal(map[string]cty.Value{
 				"backend": cty.StringVal("local"),
+				"config": cty.ObjectVal(map[string]cty.Value{
+					"path": cty.StringVal("./testdata/basic.tfstate"),
+				}),
+				"outputs": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("bar"),
+				}),
+				"workspace": cty.StringVal(backend.DefaultStateName),
+				"defaults":  cty.NullVal(cty.DynamicPseudoType),
+			}),
+			false,
+		},
+		"_local": {
+			cty.ObjectVal(map[string]cty.Value{
+				"backend": cty.StringVal("_local"),
+				"config": cty.ObjectVal(map[string]cty.Value{
+					"path": cty.StringVal("./testdata/basic.tfstate"),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"backend": cty.StringVal("_local"),
 				"config": cty.ObjectVal(map[string]cty.Value{
 					"path": cty.StringVal("./testdata/basic.tfstate"),
 				}),
@@ -212,6 +232,24 @@ func TestState_basic(t *testing.T) {
 				"workspace": cty.StringVal(backend.DefaultStateName),
 			}),
 			false,
+		},
+		"nonexistent backend": {
+			cty.ObjectVal(map[string]cty.Value{
+				"backend": cty.StringVal("nonexistent"),
+				"config": cty.ObjectVal(map[string]cty.Value{
+					"path": cty.StringVal("./testdata/basic.tfstate"),
+				}),
+			}),
+			cty.NilVal,
+			true,
+		},
+		"null config": {
+			cty.ObjectVal(map[string]cty.Value{
+				"backend": cty.StringVal("local"),
+				"config":  cty.NullVal(cty.DynamicPseudoType),
+			}),
+			cty.NilVal,
+			true,
 		},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
This PR ensures that the `Configure` method for a backend object powering a `terraform_remote_state` data source is not called during `terraform validate`. This ensures that only the supplied configuration will be validated but the state itself will not be loaded.

I followed @apparentlymart's ever-helpful advice and slightly refactored `getBackend` to accomplish this. Rather than return a configured backend object, `getBackend` now returns an un-configured object and the validated configuration (plus diags). 

`dataSourceRemoteStateValidate` continues to ignore the backend, and now the config too, and just cares about diags. `dataSourceRemoteStateRead` can combine those two values into a `b.Configure(cfg)` call to actually configure the backend and invoke any remote API calls that may entail.

To test this, I built a binary and tested against a module that could not be validated without credentials that has an S3 remote state dependency:

```
$ terraform validate

Error: The role "arn:aws:iam::123456789:role/terraform" cannot be assumed.

  There are a number of possible causes of this - the most common are:
    * The credentials used in order to assume the role are invalid
    * The credentials do not have appropriate permission to assume the role
    * The role ARN is not valid
```

And after:

```
$ $GOBIN/terraform validate
Success! The configuration is valid.
```

Closes #21761, Closes #15811