### PR TITLE
Disallow provider configuration in expanding modules

### DIFF
--- a/configs/configload/loader_load.go
+++ b/configs/configload/loader_load.go
@@ -112,8 +112,8 @@ func (l *Loader) moduleWalkerLoad(req *configs.ModuleRequest) (*configs.Module, 
 				if pcConfigDiags.HasErrors() || pc.Version.Required != nil {
 					diags = append(diags, &hcl.Diagnostic{
 						Severity: hcl.DiagError,
-						Summary:  "Cannot configure a provider in an expanding module",
-						Detail:   fmt.Sprintf("A provider configuration %s was declared in %s. Providers must be passed to expanding child modules.", key, mc.Name),
+						Summary:  "Cannot configure a provider in a module using count or for_each",
+						Detail:   fmt.Sprintf(`A provider configuration "%s" was declared in module "%s". Providers must be passed to modules with count or for_each arguments, and cannot be configured in the module (this includes defining a version).`, key, mc.Name),
 						Subject:  &pc.DeclRange,
 					})
 				}
@@ -131,8 +131,8 @@ func (l *Loader) moduleWalkerLoad(req *configs.ModuleRequest) (*configs.Module, 
 				if !found {
 					diags = append(diags, &hcl.Diagnostic{
 						Severity: hcl.DiagError,
-						Summary:  "Must pass provider to expanding module",
-						Detail:   fmt.Sprintf("A provider configuration %s was declared in %s. Providers must be passed to expanding child modules.", key, mc.Name),
+						Summary:  "Must pass provider to module with count or for_each",
+						Detail:   fmt.Sprintf(`A provider configuration "%s" was declared in module "%s". Pass a corresponding "%[1]s" provider in the "providers" argument in the "%[2]s" module block.`, key, mc.Name),
 						Subject:  &mc.DeclRange,
 					})
 				}

--- a/configs/configload/loader_load.go
+++ b/configs/configload/loader_load.go
@@ -122,9 +122,8 @@ func (l *Loader) moduleWalkerLoad(req *configs.ModuleRequest) (*configs.Module, 
 				// does this provider exist in our proxy configs?
 				var found bool
 				for _, r := range mc.Providers {
-					// Do we have provider in the child referenced by this name,
-					// or by its declared alias?
-					if r.InChild.Name == key || r.InChild.Name == pc.Alias {
+					// Must match on name and Alias
+					if pc.Name == r.InChild.Name && pc.Alias == r.InChild.Alias {
 						found = true
 						break
 					}

--- a/configs/configload/loader_load_test.go
+++ b/configs/configload/loader_load_test.go
@@ -83,12 +83,11 @@ func TestLoaderLoadConfig_addVersion(t *testing.T) {
 }
 
 func TestLoaderLoadConfig_moduleExpand(t *testing.T) {
-	// This test goes out to all those who thought they could put a provider in an expanding module
 	// We do not allow providers to be configured in expanding modules
 	// In addition, if a provider is present but an empty block, it is allowed,
 	// but IFF a provider is passed through the module call
 	paths := []string{"provider-configured", "no-provider-passed"}
-	wanted := []string{"Cannot configure a provider in an expanding module", "Must pass provider to expanding module"}
+	wanted := []string{"Cannot configure a provider", "Must pass provider"}
 	for idx, p := range paths {
 		fixtureDir := filepath.Clean(fmt.Sprintf("testdata/expand-modules/%s", p))
 		loader, err := NewLoader(&Config{

--- a/configs/configload/loader_load_test.go
+++ b/configs/configload/loader_load_test.go
@@ -109,3 +109,18 @@ func TestLoaderLoadConfig_moduleExpand(t *testing.T) {
 		}
 	}
 }
+
+func TestLoaderLoadConfig_moduleExpandValid(t *testing.T) {
+	// This tests for when valid configs are passing a provider through as a proxy,
+	// either with or without an alias present.
+	fixtureDir := filepath.Clean("testdata/expand-modules/valid")
+	loader, err := NewLoader(&Config{
+		ModulesDir: filepath.Join(fixtureDir, ".terraform/modules"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from NewLoader: %s", err)
+	}
+
+	_, diags := loader.LoadConfig(fixtureDir)
+	assertNoDiagnostics(t, diags)
+}

--- a/configs/configload/loader_load_test.go
+++ b/configs/configload/loader_load_test.go
@@ -87,8 +87,7 @@ func TestLoaderLoadConfig_moduleExpand(t *testing.T) {
 	// In addition, if a provider is present but an empty block, it is allowed,
 	// but IFF a provider is passed through the module call
 	paths := []string{"provider-configured", "no-provider-passed"}
-	wanted := []string{"Cannot configure a provider", "Must pass provider"}
-	for idx, p := range paths {
+	for _, p := range paths {
 		fixtureDir := filepath.Clean(fmt.Sprintf("testdata/expand-modules/%s", p))
 		loader, err := NewLoader(&Config{
 			ModulesDir: filepath.Join(fixtureDir, ".terraform/modules"),
@@ -102,7 +101,7 @@ func TestLoaderLoadConfig_moduleExpand(t *testing.T) {
 			t.Fatalf("success; want error")
 		}
 		got := diags.Error()
-		want := wanted[idx]
+		want := "Module does not support count"
 		if !strings.Contains(got, want) {
 			t.Fatalf("wrong error\ngot:\n%s\n\nwant: containing %q", got, want)
 		}

--- a/configs/configload/testdata/expand-modules/no-provider-passed/.terraform/modules/modules.json
+++ b/configs/configload/testdata/expand-modules/no-provider-passed/.terraform/modules/modules.json
@@ -1,0 +1,14 @@
+{
+    "Modules": [
+        {
+            "Key": "",
+            "Source": "",
+            "Dir": "testdata/expand-modules/no-provider-passed"
+        },
+        {
+            "Key": "child",
+            "Source": "./child",
+            "Dir": "testdata/expand-modules/no-provider-passed/child"
+        }
+    ]
+}

--- a/configs/configload/testdata/expand-modules/no-provider-passed/child/main.tf
+++ b/configs/configload/testdata/expand-modules/no-provider-passed/child/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+}
+
+output "my_output" {
+  value = "my output"
+}
+

--- a/configs/configload/testdata/expand-modules/no-provider-passed/root.tf
+++ b/configs/configload/testdata/expand-modules/no-provider-passed/root.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  alias  = "usw2"
+  region = "us-west-2"
+}
+module "child" {
+  count = 1
+  source = "./child"
+  # To make this test fail, add a valid providers {} block passing "aws" to the child
+}

--- a/configs/configload/testdata/expand-modules/provider-configured/.terraform/modules/modules.json
+++ b/configs/configload/testdata/expand-modules/provider-configured/.terraform/modules/modules.json
@@ -1,0 +1,14 @@
+{
+    "Modules": [
+        {
+            "Key": "",
+            "Source": "",
+            "Dir": "testdata/expand-modules/provider-configured"
+        },
+        {
+            "Key": "child",
+            "Source": "./child",
+            "Dir": "testdata/expand-modules/provider-configured/child"
+        }
+    ]
+}

--- a/configs/configload/testdata/expand-modules/provider-configured/child/main.tf
+++ b/configs/configload/testdata/expand-modules/provider-configured/child/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  version = "1.0"
+}
+
+output "my_output" {
+  value = "my output"
+}
+

--- a/configs/configload/testdata/expand-modules/provider-configured/root.tf
+++ b/configs/configload/testdata/expand-modules/provider-configured/root.tf
@@ -1,0 +1,4 @@
+module "child" {
+  count = 1
+  source = "./child"
+}

--- a/configs/configload/testdata/expand-modules/provider-configured/root.tf
+++ b/configs/configload/testdata/expand-modules/provider-configured/root.tf
@@ -1,4 +1,11 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
 module "child" {
   count = 1
   source = "./child"
+  providers = {
+    aws = aws.w2
+  }
 }

--- a/configs/configload/testdata/expand-modules/valid/.terraform/modules/modules.json
+++ b/configs/configload/testdata/expand-modules/valid/.terraform/modules/modules.json
@@ -1,0 +1,19 @@
+{
+    "Modules": [
+        {
+            "Key": "",
+            "Source": "",
+            "Dir": "testdata/expand-modules/valid"
+        },
+        {
+            "Key": "child",
+            "Source": "./child",
+            "Dir": "testdata/expand-modules/valid/child"
+        },
+        {
+            "Key": "child_with_alias",
+            "Source": "./child-with-alias",
+            "Dir": "testdata/expand-modules/valid/child-with-alias"
+        }
+    ]
+}

--- a/configs/configload/testdata/expand-modules/valid/child-with-alias/main.tf
+++ b/configs/configload/testdata/expand-modules/valid/child-with-alias/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  alias = "east"
+}
+
+output "my_output" {
+  value = "my output"
+}
+

--- a/configs/configload/testdata/expand-modules/valid/child/main.tf
+++ b/configs/configload/testdata/expand-modules/valid/child/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+}
+
+output "my_output" {
+  value = "my output"
+}
+

--- a/configs/configload/testdata/expand-modules/valid/root.tf
+++ b/configs/configload/testdata/expand-modules/valid/root.tf
@@ -1,0 +1,20 @@
+provider "aws" {
+  region = "us-east-1"
+  alias = "east"
+}
+
+module "child" {
+  count = 1
+  source = "./child"
+  providers = {
+    aws = aws.east
+  }
+}
+
+module "child_with_alias" {
+  count = 1
+  source = "./child-with-alias"
+  providers = {
+    aws.east = aws.east
+  }
+}

--- a/configs/configload/testdata/expand-modules/valid/root.tf
+++ b/configs/configload/testdata/expand-modules/valid/root.tf
@@ -12,7 +12,7 @@ module "child" {
 }
 
 module "child_with_alias" {
-  count = 1
+  for_each = toset(["a", "b"])
   source = "./child-with-alias"
   providers = {
     aws.east = aws.east


### PR DESCRIPTION
Expanding modules cannot have providers configured in them as this can cause issues with removal of the module. This PR updates the `moduleWalkerLoad` method in the `configload` package, where we have information about the caller (where the `count` or `for_each` is declared) and the module being loaded (which may have 0 or more provider configurations in it).

*Edited* Updated error message (changes to `for_each` when referring to `for_each`):

```
Error: Module does not support count

  on main.tf line 15, in module "child":
  15:   count = 1

Module "child" cannot be used with count because it contains a nested provider
configuration for "aws", at child/main.tf:2,10-15.

This module can be made compatible with count by changing it to receive all of
its provider configurations from the calling module, by using the "providers"
argument in the calling module block.
```

Closes #24851