### PR TITLE
internal: Fix LookupLegacyProvider

### DIFF
--- a/command/013_config_upgrade_test.go
+++ b/command/013_config_upgrade_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -361,21 +362,22 @@ func fakeRegistryHandler(resp http.ResponseWriter, req *http.Request) {
 
 	pathParts := strings.Split(path, "/")[3:]
 
-	if len(pathParts) != 2 {
+	if len(pathParts) != 3 {
 		resp.WriteHeader(404)
 		resp.Write([]byte(`unrecognized path scheme`))
 		return
 	}
 
-	if pathParts[0] != "-" {
+	if pathParts[0] != "-" || pathParts[2] != "versions" {
 		resp.WriteHeader(404)
 		resp.Write([]byte(`this registry only supports legacy namespace lookup requests`))
 	}
 
-	if namespace, ok := legacyProviderNamespaces[pathParts[1]]; ok {
+	name := pathParts[1]
+	if namespace, ok := legacyProviderNamespaces[name]; ok {
 		resp.Header().Set("Content-Type", "application/json")
 		resp.WriteHeader(200)
-		resp.Write([]byte(`{"namespace":"` + namespace + `"}`))
+		resp.Write([]byte(fmt.Sprintf(`{"id":"%s/%s"}`, namespace, name)))
 	} else {
 		resp.WriteHeader(404)
 		resp.Write([]byte(`provider not found`))

--- a/internal/getproviders/registry_client_test.go
+++ b/internal/getproviders/registry_client_test.go
@@ -114,34 +114,12 @@ func fakeRegistryHandler(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	pathParts := strings.Split(path, "/")[3:]
-	if len(pathParts) < 2 {
-		resp.WriteHeader(404)
-		resp.Write([]byte(`unexpected number of path parts`))
-		return
-	}
-	log.Printf("[TRACE] fake provider registry request for %#v", pathParts)
-	if len(pathParts) == 2 {
-		switch pathParts[0] + "/" + pathParts[1] {
-
-		case "-/legacy":
-			// NOTE: This legacy lookup endpoint is specific to
-			// registry.terraform.io and not expected to work on any other
-			// registry host.
-			resp.Header().Set("Content-Type", "application/json")
-			resp.WriteHeader(200)
-			resp.Write([]byte(`{"namespace":"legacycorp"}`))
-
-		default:
-			resp.WriteHeader(404)
-			resp.Write([]byte(`unknown namespace or provider type for direct lookup`))
-		}
-	}
-
 	if len(pathParts) < 3 {
 		resp.WriteHeader(404)
 		resp.Write([]byte(`unexpected number of path parts`))
 		return
 	}
+	log.Printf("[TRACE] fake provider registry request for %#v", pathParts)
 
 	if pathParts[2] == "versions" {
 		if len(pathParts) != 3 {
@@ -162,6 +140,21 @@ func fakeRegistryHandler(resp http.ResponseWriter, req *http.Request) {
 			resp.Header().Set("Content-Type", "application/json")
 			resp.WriteHeader(200)
 			resp.Write([]byte(`{"versions":[]}`))
+		case "-/legacy":
+			resp.Header().Set("Content-Type", "application/json")
+			resp.WriteHeader(200)
+			// This response is used for testing LookupLegacyProvider
+			resp.Write([]byte(`{"id":"legacycorp/legacy"}`))
+		case "-/changetype":
+			resp.Header().Set("Content-Type", "application/json")
+			resp.WriteHeader(200)
+			// This (unrealistic) response is used for error handling code coverage
+			resp.Write([]byte(`{"id":"legacycorp/newtype"}`))
+		case "-/invalid":
+			resp.Header().Set("Content-Type", "application/json")
+			resp.WriteHeader(200)
+			// This (unrealistic) response is used for error handling code coverage
+			resp.Write([]byte(`{"id":"some/invalid/id/string"}`))
 		default:
 			resp.WriteHeader(404)
 			resp.Write([]byte(`unknown namespace or provider type`))


### PR DESCRIPTION
When looking up the namespace for a legacy provider source, we need to use the `/v1/providers/-/{name}/versions` endpoint. For non-HashiCorp providers, the `/v1/providers/-/{name}` endpoint returns a 404.

This commit updates the `LegacyProviderDefaultNamespace` method and the mock registry servers accordingly, and increases test coverage for `LookupLegacyProvider`.

### Testing

I ran a manual test of the `0.13upgrade` command using the following config in `main.tf`:

```hcl
# Configure the Datadog provider
provider "datadog" {
  api_key = var.datadog_api_key
  app_key = var.datadog_app_key
}

# Create a new monitor
resource "datadog_monitor" "default" {
  # ...
}
```

The command executed successfully and output this `versions.tf`:

```hcl
terraform {
  required_providers {
    datadog = {
      source = "terraform-providers/datadog"
    }
  }
  required_version = ">= 0.13"
}
```

(Prior to this commit, the `datadog` provider source could not be detected.)