### PR TITLE
internal/getproviders: Add configurable HTTP retry & timeout support

### DIFF
--- a/internal/getproviders/registry_source_test.go
+++ b/internal/getproviders/registry_source_test.go
@@ -52,7 +52,7 @@ func TestSourceAvailableVersions(t *testing.T) {
 		{
 			"fails.example.com/foo/bar",
 			nil,
-			`could not query provider registry for fails.example.com/foo/bar: Get "` + baseURL + `/fails-immediately/foo/bar/versions": EOF`,
+			`could not query provider registry for fails.example.com/foo/bar: the request failed after 2 attempts, please try again later: Get "` + baseURL + `/fails-immediately/foo/bar/versions": EOF`,
 		},
 	}
 
@@ -169,7 +169,7 @@ func TestSourcePackageMeta(t *testing.T) {
 			"1.2.0",
 			"linux", "amd64",
 			PackageMeta{},
-			`could not query provider registry for fails.example.com/awesomesauce/happycloud: Get "http://placeholder-origin/fails-immediately/awesomesauce/happycloud/1.2.0/download/linux/amd64": EOF`,
+			`could not query provider registry for fails.example.com/awesomesauce/happycloud: the request failed after 2 attempts, please try again later: Get "http://placeholder-origin/fails-immediately/awesomesauce/happycloud/1.2.0/download/linux/amd64": EOF`,
 		},
 	}
 

--- a/internal/providercache/installer_events.go
+++ b/internal/providercache/installer_events.go
@@ -63,11 +63,9 @@ type InstallerEvents struct {
 	// identifier to correlate between successive events.
 	//
 	// The Begin, Success, and Failure events will each occur only once per
-	// distinct provider. The Retry event can occur zero or more times, and
-	// signals a failure that the installer is considering transient.
+	// distinct provider.
 	QueryPackagesBegin   func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints)
 	QueryPackagesSuccess func(provider addrs.Provider, selectedVersion getproviders.Version)
-	QueryPackagesRetry   func(provider addrs.Provider, err error)
 	QueryPackagesFailure func(provider addrs.Provider, err error)
 
 	// The LinkFromCache... family of events delimit the operation of linking
@@ -99,12 +97,10 @@ type InstallerEvents struct {
 	// or the FetchPackage... events, never both in the same install operation.
 	//
 	// The Query, Begin, Success, and Failure events will each occur only once
-	// per distinct provider. The Retry event can occur zero or more times, and
-	// signals a failure that the installer is considering transient.
+	// per distinct provider.
 	FetchPackageMeta    func(provider addrs.Provider, version getproviders.Version) // fetching metadata prior to real download
 	FetchPackageBegin   func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation)
 	FetchPackageSuccess func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult)
-	FetchPackageRetry   func(provider addrs.Provider, version getproviders.Version, err error)
 	FetchPackageFailure func(provider addrs.Provider, version getproviders.Version, err error)
 
 	// HashPackageFailure is called if the installer is unable to determine


### PR DESCRIPTION
This is a port of the retry/timeout logic added in #24260 and #24259, using the same environment variables to configure the retry and timeout settings. It uses [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp) to wrap the `http.Client` instance.

In a separate commit, remove the unused retry events from the provider installer. I previously tried to use transient error values and retry event handlers to handle retries. This had much better UI than the basic logging in this PR, but at least [my implementation was much more fragile](https://github.com/hashicorp/terraform/compare/alisdair/getproviders-retries-bad-branch-do-not-use). I was unable to find an abstraction that made sense and felt robust.

I don't think this PR is the best possible approach, but it does work, and feels like a reasonable effort/value compromise to me for now.