### PR TITLE
command/init: add a warning that "source" is ignored in terraform v0.12

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -180,6 +180,8 @@ func (c *InitCommand) Run(args []string) int {
 	// dependencies aren't right, and only then use the real loader to deal
 	// with the backend configuration.
 	rootMod, confDiags := c.loadSingleModule(path)
+	diags = diags.Append(confDiags)
+
 	rootModEarly, earlyConfDiags := c.loadSingleModuleEarly(path)
 	configUpgradeProbablyNeeded := false
 	if confDiags.HasErrors() {
@@ -189,7 +191,6 @@ func (c *InitCommand) Run(args []string) int {
 			// Since this may be the user's first ever interaction with Terraform,
 			// we'll provide some additional context in this case.
 			c.Ui.Error(strings.TrimSpace(errInitConfigError))
-			diags = diags.Append(confDiags)
 			c.showDiagnostics(diags)
 			return 1
 		}
@@ -205,7 +206,6 @@ func (c *InitCommand) Run(args []string) int {
 			if already, _ := sources.MaybeAlreadyUpgraded(); already {
 				// Just report the errors as normal, then.
 				c.Ui.Error(strings.TrimSpace(errInitConfigError))
-				diags = diags.Append(confDiags)
 				c.showDiagnostics(diags)
 				return 1
 			}

--- a/command/testdata/init-provider-source/main.tf
+++ b/command/testdata/init-provider-source/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    test = {
+      # Terraform >= v0.12.25 prints a warning that "source" is ignored
+      source = "hashicorp/test"
+    }
+  }
+}


### PR DESCRIPTION
Up until now, terraform v0.12 would silently ignore any "source" attributes
found in a required_provider block. This adds a warning when "source" is
found informing users that the attribute is ignored in terraform v0.12.

We were previously throwing away any warnings from the config loader if
there were no errors, so as a side effect any other warnings out of the
config loader that had not been displayed previously are now shown.

Here's a slightly off-center example of the output from `init` (also displayed on `validate`):
<img width="925" alt="Screen Shot 2020-05-11 at 3 48 05 PM" src="https://user-images.githubusercontent.com/6210214/81605037-d8d25400-939e-11ea-9344-a73ed639a6dd.png">

NOTE FOR REVIEWERS: I am concerned that displaying previously-swallowed warnings may be a surprise for some users, though it also feels correct.  Thoughts? 
