### PR TITLE
command/init: include config loader diagnostics in output

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -213,9 +213,9 @@ func (c *InitCommand) Run(args []string) int {
 	}
 
 	_, confDiags = c.loadConfig(path)
+	diags = diags.Append(confDiags)
 	if confDiags.HasErrors() {
 		c.Ui.Error(strings.TrimSpace(errInitConfigError))
-		diags = diags.Append(confDiags)
 		c.showDiagnostics(diags)
 		return 1
 	}


### PR DESCRIPTION
Previously the diagnostics from the config loaders (earlyconfig and
regular) were only appended to the overall diags if an error was found.
This adds all diagnostics from the regular config loader so that any
generated warnings will be displayed, even if there are no errors.

I did not add the `earlyconfig` warnings since they will be displayed if
there is an error and are likely to be duplicated by the config loader (it will be easy to add in if I'm mistaken).