### PR TITLE
Rename expanders

### DIFF
--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -757,20 +757,20 @@ const testApplyGraphBuilderStr = `
 meta.count-boundary (EachMode fixup)
   module.child (close)
   test_object.other
-module.child
 module.child (close)
   module.child.test_object.other
+module.child (expand)
 module.child.test_object.create
-  module.child.test_object.create (prepare state)
-module.child.test_object.create (prepare state)
-  module.child
+  module.child.test_object.create (expand)
+module.child.test_object.create (expand)
+  module.child (expand)
   provider["registry.terraform.io/hashicorp/test"]
   provisioner.test
 module.child.test_object.other
   module.child.test_object.create
-  module.child.test_object.other (prepare state)
-module.child.test_object.other (prepare state)
-  module.child
+  module.child.test_object.other (expand)
+module.child.test_object.other (expand)
+  module.child (expand)
   provider["registry.terraform.io/hashicorp/test"]
 provider["registry.terraform.io/hashicorp/test"]
 provider["registry.terraform.io/hashicorp/test"] (close)
@@ -784,13 +784,13 @@ root
   provider["registry.terraform.io/hashicorp/test"] (close)
   provisioner.test (close)
 test_object.create
-  test_object.create (prepare state)
-test_object.create (prepare state)
+  test_object.create (expand)
+test_object.create (expand)
   provider["registry.terraform.io/hashicorp/test"]
 test_object.other
   test_object.create
-  test_object.other (prepare state)
-test_object.other (prepare state)
+  test_object.other (expand)
+test_object.other (expand)
   provider["registry.terraform.io/hashicorp/test"]
 `
 
@@ -803,14 +803,14 @@ provider["registry.terraform.io/hashicorp/test"] (close)
 root
   meta.count-boundary (EachMode fixup)
   provider["registry.terraform.io/hashicorp/test"] (close)
-test_object.A (prepare state)
+test_object.A (expand)
   provider["registry.terraform.io/hashicorp/test"]
 test_object.A[1] (destroy)
   provider["registry.terraform.io/hashicorp/test"]
 test_object.B
-  test_object.A (prepare state)
+  test_object.A (expand)
   test_object.A[1] (destroy)
-  test_object.B (prepare state)
-test_object.B (prepare state)
+  test_object.B (expand)
+test_object.B (expand)
   provider["registry.terraform.io/hashicorp/test"]
 `

--- a/terraform/graph_builder_plan_test.go
+++ b/terraform/graph_builder_plan_test.go
@@ -126,26 +126,26 @@ func TestPlanGraphBuilder_dynamicBlock(t *testing.T) {
 	expected := strings.TrimSpace(`
 meta.count-boundary (EachMode fixup)
   provider["registry.terraform.io/hashicorp/test"]
-  test_thing.a
-  test_thing.b
-  test_thing.c
+  test_thing.a (expand)
+  test_thing.b (expand)
+  test_thing.c (expand)
 provider["registry.terraform.io/hashicorp/test"]
 provider["registry.terraform.io/hashicorp/test"] (close)
   provider["registry.terraform.io/hashicorp/test"]
-  test_thing.a
-  test_thing.b
-  test_thing.c
+  test_thing.a (expand)
+  test_thing.b (expand)
+  test_thing.c (expand)
 root
   meta.count-boundary (EachMode fixup)
   provider["registry.terraform.io/hashicorp/test"] (close)
-test_thing.a
+test_thing.a (expand)
   provider["registry.terraform.io/hashicorp/test"]
-test_thing.b
+test_thing.b (expand)
   provider["registry.terraform.io/hashicorp/test"]
-test_thing.c
+test_thing.c (expand)
   provider["registry.terraform.io/hashicorp/test"]
-  test_thing.a
-  test_thing.b
+  test_thing.a (expand)
+  test_thing.b (expand)
 `)
 	if actual != expected {
 		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, actual)
@@ -205,21 +205,21 @@ func TestPlanGraphBuilder_attrAsBlocks(t *testing.T) {
 	expected := strings.TrimSpace(`
 meta.count-boundary (EachMode fixup)
   provider["registry.terraform.io/hashicorp/test"]
-  test_thing.a
-  test_thing.b
+  test_thing.a (expand)
+  test_thing.b (expand)
 provider["registry.terraform.io/hashicorp/test"]
 provider["registry.terraform.io/hashicorp/test"] (close)
   provider["registry.terraform.io/hashicorp/test"]
-  test_thing.a
-  test_thing.b
+  test_thing.a (expand)
+  test_thing.b (expand)
 root
   meta.count-boundary (EachMode fixup)
   provider["registry.terraform.io/hashicorp/test"] (close)
-test_thing.a
+test_thing.a (expand)
   provider["registry.terraform.io/hashicorp/test"]
-test_thing.b
+test_thing.b (expand)
   provider["registry.terraform.io/hashicorp/test"]
-  test_thing.a
+  test_thing.a (expand)
 `)
 	if actual != expected {
 		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, actual)
@@ -293,41 +293,41 @@ func TestPlanGraphBuilder_forEach(t *testing.T) {
 }
 
 const testPlanGraphBuilderStr = `
-aws_instance.web
-  aws_security_group.firewall
+aws_instance.web (expand)
+  aws_security_group.firewall (expand)
   provider["registry.terraform.io/hashicorp/aws"]
   var.foo
-aws_load_balancer.weblb
-  aws_instance.web
+aws_load_balancer.weblb (expand)
+  aws_instance.web (expand)
   provider["registry.terraform.io/hashicorp/aws"]
-aws_security_group.firewall
+aws_security_group.firewall (expand)
   provider["registry.terraform.io/hashicorp/aws"]
-local.instance_id
-  aws_instance.web
+local.instance_id (expand)
+  aws_instance.web (expand)
 meta.count-boundary (EachMode fixup)
-  aws_instance.web
-  aws_load_balancer.weblb
-  aws_security_group.firewall
-  local.instance_id
-  openstack_floating_ip.random
-  output.instance_id
+  aws_instance.web (expand)
+  aws_load_balancer.weblb (expand)
+  aws_security_group.firewall (expand)
+  local.instance_id (expand)
+  openstack_floating_ip.random (expand)
+  output.instance_id (expand)
   provider["registry.terraform.io/hashicorp/aws"]
   provider["registry.terraform.io/hashicorp/openstack"]
   var.foo
-openstack_floating_ip.random
+openstack_floating_ip.random (expand)
   provider["registry.terraform.io/hashicorp/openstack"]
-output.instance_id
-  local.instance_id
+output.instance_id (expand)
+  local.instance_id (expand)
 provider["registry.terraform.io/hashicorp/aws"]
-  openstack_floating_ip.random
+  openstack_floating_ip.random (expand)
 provider["registry.terraform.io/hashicorp/aws"] (close)
-  aws_instance.web
-  aws_load_balancer.weblb
-  aws_security_group.firewall
+  aws_instance.web (expand)
+  aws_load_balancer.weblb (expand)
+  aws_security_group.firewall (expand)
   provider["registry.terraform.io/hashicorp/aws"]
 provider["registry.terraform.io/hashicorp/openstack"]
 provider["registry.terraform.io/hashicorp/openstack"] (close)
-  openstack_floating_ip.random
+  openstack_floating_ip.random (expand)
   provider["registry.terraform.io/hashicorp/openstack"]
 root
   meta.count-boundary (EachMode fixup)
@@ -336,35 +336,35 @@ root
 var.foo
 `
 const testPlanGraphBuilderForEachStr = `
-aws_instance.bar
+aws_instance.bar (expand)
   provider["registry.terraform.io/hashicorp/aws"]
-aws_instance.bar2
+aws_instance.bar2 (expand)
   provider["registry.terraform.io/hashicorp/aws"]
-aws_instance.bat
-  aws_instance.boo
+aws_instance.bat (expand)
+  aws_instance.boo (expand)
   provider["registry.terraform.io/hashicorp/aws"]
-aws_instance.baz
+aws_instance.baz (expand)
   provider["registry.terraform.io/hashicorp/aws"]
-aws_instance.boo
+aws_instance.boo (expand)
   provider["registry.terraform.io/hashicorp/aws"]
-aws_instance.foo
+aws_instance.foo (expand)
   provider["registry.terraform.io/hashicorp/aws"]
 meta.count-boundary (EachMode fixup)
-  aws_instance.bar
-  aws_instance.bar2
-  aws_instance.bat
-  aws_instance.baz
-  aws_instance.boo
-  aws_instance.foo
+  aws_instance.bar (expand)
+  aws_instance.bar2 (expand)
+  aws_instance.bat (expand)
+  aws_instance.baz (expand)
+  aws_instance.boo (expand)
+  aws_instance.foo (expand)
   provider["registry.terraform.io/hashicorp/aws"]
 provider["registry.terraform.io/hashicorp/aws"]
 provider["registry.terraform.io/hashicorp/aws"] (close)
-  aws_instance.bar
-  aws_instance.bar2
-  aws_instance.bat
-  aws_instance.baz
-  aws_instance.boo
-  aws_instance.foo
+  aws_instance.bar (expand)
+  aws_instance.bar2 (expand)
+  aws_instance.bat (expand)
+  aws_instance.baz (expand)
+  aws_instance.boo (expand)
+  aws_instance.foo (expand)
   provider["registry.terraform.io/hashicorp/aws"]
 root
   meta.count-boundary (EachMode fixup)

--- a/terraform/graph_builder_refresh_test.go
+++ b/terraform/graph_builder_refresh_test.go
@@ -58,13 +58,13 @@ provider["registry.terraform.io/hashicorp/test"] (close) - *terraform.graphNodeC
   data.test_object.foo[1] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
   data.test_object.foo[2] - *terraform.NodeRefreshableManagedResourceInstance
   data.test_object.foo[2] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
-  test_object.foo - *terraform.nodeExpandRefreshableManagedResource
+  test_object.foo (expand) - *terraform.nodeExpandRefreshableManagedResource
   test_object.foo[0] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
   test_object.foo[1] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
   test_object.foo[2] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
 root - *terraform.nodeCloseModule
   provider["registry.terraform.io/hashicorp/test"] (close) - *terraform.graphNodeCloseProvider
-test_object.foo - *terraform.nodeExpandRefreshableManagedResource
+test_object.foo (expand) - *terraform.nodeExpandRefreshableManagedResource
   provider["registry.terraform.io/hashicorp/test"] - *terraform.NodeApplyableProvider
 test_object.foo[0] (deposed 00000001) - *terraform.NodePlanDeposedResourceInstanceObject
   provider["registry.terraform.io/hashicorp/test"] - *terraform.NodeApplyableProvider

--- a/terraform/node_data_refresh.go
+++ b/terraform/node_data_refresh.go
@@ -22,6 +22,10 @@ var (
 	_ GraphNodeAttachResourceConfig = (*nodeExpandRefreshableDataResource)(nil)
 )
 
+func (n *nodeExpandRefreshableDataResource) Name() string {
+	return n.NodeAbstractResource.Name() + " (expand)"
+}
+
 func (n *nodeExpandRefreshableDataResource) References() []*addrs.Reference {
 	return (&NodeRefreshableManagedResource{NodeAbstractResource: n.NodeAbstractResource}).References()
 }

--- a/terraform/node_local.go
+++ b/terraform/node_local.go
@@ -9,58 +9,59 @@ import (
 	"github.com/hashicorp/terraform/lang"
 )
 
-// NodePlannableLocal represents a named local value in a configuration module,
+// nodeExpandLocal represents a named local value in a configuration module,
 // which has not yet been expanded.
-type NodePlannableLocal struct {
+type nodeExpandLocal struct {
 	Addr   addrs.LocalValue
 	Module addrs.Module
 	Config *configs.Local
 }
 
 var (
-	_ RemovableIfNotTargeted     = (*NodePlannableLocal)(nil)
-	_ GraphNodeReferenceable     = (*NodePlannableLocal)(nil)
-	_ GraphNodeReferencer        = (*NodePlannableLocal)(nil)
-	_ GraphNodeDynamicExpandable = (*NodePlannableLocal)(nil)
-	_ graphNodeTemporaryValue    = (*NodePlannableLocal)(nil)
+	_ RemovableIfNotTargeted     = (*nodeExpandLocal)(nil)
+	_ GraphNodeReferenceable     = (*nodeExpandLocal)(nil)
+	_ GraphNodeReferencer        = (*nodeExpandLocal)(nil)
+	_ GraphNodeDynamicExpandable = (*nodeExpandLocal)(nil)
+	_ graphNodeTemporaryValue    = (*nodeExpandLocal)(nil)
 )
 
 // graphNodeTemporaryValue
-func (n *NodePlannableLocal) temporaryValue() bool {
+func (n *nodeExpandLocal) temporaryValue() bool {
 	return true
 }
 
-func (n *NodePlannableLocal) Name() string {
+func (n *nodeExpandLocal) Name() string {
 	path := n.Module.String()
-	addr := n.Addr.String()
+	addr := n.Addr.String() + " (expand)"
+
 	if path != "" {
 		return path + "." + addr
 	}
-	return addr + " (expand)"
+	return addr
 }
 
 // GraphNodeModulePath
-func (n *NodePlannableLocal) ModulePath() addrs.Module {
+func (n *nodeExpandLocal) ModulePath() addrs.Module {
 	return n.Module
 }
 
 // RemovableIfNotTargeted
-func (n *NodePlannableLocal) RemoveIfNotTargeted() bool {
+func (n *nodeExpandLocal) RemoveIfNotTargeted() bool {
 	return true
 }
 
 // GraphNodeReferenceable
-func (n *NodePlannableLocal) ReferenceableAddrs() []addrs.Referenceable {
+func (n *nodeExpandLocal) ReferenceableAddrs() []addrs.Referenceable {
 	return []addrs.Referenceable{n.Addr}
 }
 
 // GraphNodeReferencer
-func (n *NodePlannableLocal) References() []*addrs.Reference {
+func (n *nodeExpandLocal) References() []*addrs.Reference {
 	refs, _ := lang.ReferencesInExpr(n.Config.Expr)
 	return appendResourceDestroyReferences(refs)
 }
 
-func (n *NodePlannableLocal) DynamicExpand(ctx EvalContext) (*Graph, error) {
+func (n *nodeExpandLocal) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	var g Graph
 	expander := ctx.InstanceExpander()
 	for _, module := range expander.ExpandModule(n.Module) {

--- a/terraform/node_local.go
+++ b/terraform/node_local.go
@@ -36,7 +36,7 @@ func (n *NodePlannableLocal) Name() string {
 	if path != "" {
 		return path + "." + addr
 	}
-	return addr
+	return addr + " (expand)"
 }
 
 // GraphNodeModulePath

--- a/terraform/node_module_expand.go
+++ b/terraform/node_module_expand.go
@@ -33,7 +33,7 @@ var (
 )
 
 func (n *nodeExpandModule) Name() string {
-	return n.Addr.String()
+	return n.Addr.String() + " (expand)"
 }
 
 // GraphNodeModulePath implementation

--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -49,7 +49,7 @@ func (n *nodeExpandModuleVariable) DynamicExpand(ctx EvalContext) (*Graph, error
 }
 
 func (n *nodeExpandModuleVariable) Name() string {
-	return fmt.Sprintf("%s.%s", n.Module, n.Addr.String())
+	return fmt.Sprintf("%s.%s (expand)", n.Module, n.Addr.String())
 }
 
 // GraphNodeModulePath

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -10,28 +10,28 @@ import (
 	"github.com/hashicorp/terraform/lang"
 )
 
-// NodePlannableOutput is the placeholder for an output that has not yet had
+// nodeExpandOutput is the placeholder for an output that has not yet had
 // its module path expanded.
-type NodePlannableOutput struct {
+type nodeExpandOutput struct {
 	Addr   addrs.OutputValue
 	Module addrs.Module
 	Config *configs.Output
 }
 
 var (
-	_ RemovableIfNotTargeted     = (*NodePlannableOutput)(nil)
-	_ GraphNodeReferenceable     = (*NodePlannableOutput)(nil)
-	_ GraphNodeReferencer        = (*NodePlannableOutput)(nil)
-	_ GraphNodeDynamicExpandable = (*NodePlannableOutput)(nil)
+	_ RemovableIfNotTargeted     = (*nodeExpandOutput)(nil)
+	_ GraphNodeReferenceable     = (*nodeExpandOutput)(nil)
+	_ GraphNodeReferencer        = (*nodeExpandOutput)(nil)
+	_ GraphNodeDynamicExpandable = (*nodeExpandOutput)(nil)
 	_ graphNodeTemporaryValue    = (*NodeApplyableOutput)(nil)
 )
 
-func (n *NodePlannableOutput) temporaryValue() bool {
+func (n *nodeExpandOutput) temporaryValue() bool {
 	// this must always be evaluated if it is a root module output
 	return !n.Module.IsRoot()
 }
 
-func (n *NodePlannableOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
+func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	var g Graph
 	expander := ctx.InstanceExpander()
 	for _, module := range expander.ExpandModule(n.Module) {
@@ -45,9 +45,9 @@ func (n *NodePlannableOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	return &g, nil
 }
 
-func (n *NodePlannableOutput) Name() string {
+func (n *nodeExpandOutput) Name() string {
 	path := n.Module.String()
-	addr := n.Addr.String()
+	addr := n.Addr.String() + " (expand)"
 	if path != "" {
 		return path + "." + addr
 	}
@@ -55,12 +55,12 @@ func (n *NodePlannableOutput) Name() string {
 }
 
 // GraphNodeModulePath
-func (n *NodePlannableOutput) ModulePath() addrs.Module {
+func (n *nodeExpandOutput) ModulePath() addrs.Module {
 	return n.Module
 }
 
 // GraphNodeReferenceable
-func (n *NodePlannableOutput) ReferenceableAddrs() []addrs.Referenceable {
+func (n *nodeExpandOutput) ReferenceableAddrs() []addrs.Referenceable {
 	// An output in the root module can't be referenced at all.
 	if n.Module.IsRoot() {
 		return nil
@@ -80,7 +80,7 @@ func (n *NodePlannableOutput) ReferenceableAddrs() []addrs.Referenceable {
 }
 
 // GraphNodeReferenceOutside implementation
-func (n *NodePlannableOutput) ReferenceOutside() (selfPath, referencePath addrs.Module) {
+func (n *nodeExpandOutput) ReferenceOutside() (selfPath, referencePath addrs.Module) {
 	// Output values have their expressions resolved in the context of the
 	// module where they are defined.
 	referencePath = n.Module
@@ -92,17 +92,17 @@ func (n *NodePlannableOutput) ReferenceOutside() (selfPath, referencePath addrs.
 }
 
 // GraphNodeReferencer
-func (n *NodePlannableOutput) References() []*addrs.Reference {
+func (n *nodeExpandOutput) References() []*addrs.Reference {
 	return appendResourceDestroyReferences(referencesForOutput(n.Config))
 }
 
 // RemovableIfNotTargeted
-func (n *NodePlannableOutput) RemoveIfNotTargeted() bool {
+func (n *nodeExpandOutput) RemoveIfNotTargeted() bool {
 	return true
 }
 
 // GraphNodeTargetDownstream
-func (n *NodePlannableOutput) TargetDownstream(targetedDeps, untargetedDeps dag.Set) bool {
+func (n *nodeExpandOutput) TargetDownstream(targetedDeps, untargetedDeps dag.Set) bool {
 	return true
 }
 

--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -30,7 +30,7 @@ func (n *nodeExpandApplyableResource) References() []*addrs.Reference {
 }
 
 func (n *nodeExpandApplyableResource) Name() string {
-	return n.NodeAbstractResource.Name() + " (prepare state)"
+	return n.NodeAbstractResource.Name() + " (expand)"
 }
 
 func (n *nodeExpandApplyableResource) DynamicExpand(ctx EvalContext) (*Graph, error) {

--- a/terraform/node_resource_plan.go
+++ b/terraform/node_resource_plan.go
@@ -31,6 +31,10 @@ var (
 	_ GraphNodeAttachResourceConfig = (*nodeExpandPlannableResource)(nil)
 )
 
+func (n *nodeExpandPlannableResource) Name() string {
+	return n.NodeAbstractResource.Name() + " (expand)"
+}
+
 // GraphNodeDestroyerCBD
 func (n *nodeExpandPlannableResource) CreateBeforeDestroy() bool {
 	if n.ForceCreateBeforeDestroy != nil {

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -36,6 +36,10 @@ var (
 	_ GraphNodeAttachDependencies   = (*nodeExpandRefreshableManagedResource)(nil)
 )
 
+func (n *nodeExpandRefreshableManagedResource) Name() string {
+	return n.NodeAbstractResource.Name() + " (expand)"
+}
+
 // GraphNodeAttachDependencies
 func (n *nodeExpandRefreshableManagedResource) AttachDependencies(deps []addrs.ConfigResource) {
 	n.Dependencies = deps

--- a/terraform/transform_local.go
+++ b/terraform/transform_local.go
@@ -23,7 +23,7 @@ func (t *LocalTransformer) transformModule(g *Graph, c *configs.Config) error {
 
 	for _, local := range c.Module.Locals {
 		addr := addrs.LocalValue{Name: local.Name}
-		node := &NodePlannableLocal{
+		node := &nodeExpandLocal{
 			Addr:   addr,
 			Module: c.Path,
 			Config: local,

--- a/terraform/transform_module_variable_test.go
+++ b/terraform/transform_module_variable_test.go
@@ -58,10 +58,10 @@ func TestModuleVariableTransformer_nested(t *testing.T) {
 }
 
 const testTransformModuleVarBasicStr = `
-module.child.var.value
+module.child.var.value (expand)
 `
 
 const testTransformModuleVarNestedStr = `
-module.child.module.child.var.value
-module.child.var.value
+module.child.module.child.var.value (expand)
+module.child.var.value (expand)
 `

--- a/terraform/transform_output.go
+++ b/terraform/transform_output.go
@@ -41,7 +41,7 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 	// into NodeApplyableOutputs to reflect possible expansion
 	// through the presence of "count" or "for_each" on the modules.
 	for _, o := range c.Module.Outputs {
-		node := &NodePlannableOutput{
+		node := &nodeExpandOutput{
 			Addr:   addrs.OutputValue{Name: o.Name},
 			Module: c.Path,
 			Config: o,
@@ -67,7 +67,7 @@ func (t *DestroyOutputTransformer) Transform(g *Graph) error {
 	}
 
 	for _, v := range g.Vertices() {
-		output, ok := v.(*NodePlannableOutput)
+		output, ok := v.(*nodeExpandOutput)
 		if !ok {
 			continue
 		}

--- a/terraform/transform_targets_test.go
+++ b/terraform/transform_targets_test.go
@@ -118,12 +118,12 @@ func TestTargetsTransformer_downstream(t *testing.T) {
 	// outputs that descend from it are also targeted.
 	expected := strings.TrimSpace(`
 module.child.module.grandchild.aws_instance.foo
-module.child.module.grandchild.output.id
+module.child.module.grandchild.output.id (expand)
   module.child.module.grandchild.aws_instance.foo
-module.child.output.grandchild_id
-  module.child.module.grandchild.output.id
-output.grandchild_id
-  module.child.output.grandchild_id
+module.child.output.grandchild_id (expand)
+  module.child.module.grandchild.output.id (expand)
+output.grandchild_id (expand)
+  module.child.output.grandchild_id (expand)
 	`)
 	if actual != expected {
 		t.Fatalf("bad:\n\nexpected:\n%s\n\ngot:\n%s\n", expected, actual)
@@ -189,12 +189,12 @@ func TestTargetsTransformer_wholeModule(t *testing.T) {
 	// outputs that descend from it are also targeted.
 	expected := strings.TrimSpace(`
 module.child.module.grandchild.aws_instance.foo
-module.child.module.grandchild.output.id
+module.child.module.grandchild.output.id (expand)
   module.child.module.grandchild.aws_instance.foo
-module.child.output.grandchild_id
-  module.child.module.grandchild.output.id
-output.grandchild_id
-  module.child.output.grandchild_id
+module.child.output.grandchild_id (expand)
+  module.child.module.grandchild.output.id (expand)
+output.grandchild_id (expand)
+  module.child.output.grandchild_id (expand)
 	`)
 	if actual != expected {
 		t.Fatalf("bad:\n\nexpected:\n%s\n\ngot:\n%s\n", expected, actual)


### PR DESCRIPTION
The human-readable node names for many nodes were left to prevent this churn during implementation. Change all the expander nodes to show `(expand)`, replacing `(prepare state)` where applicable. 

Also change the name of the plannable local and output nodes, since they are now the expander nodes and used in contexts other than planning.