### PR TITLE
internal/getproviders: fix panic with invalid path parts

### DIFF
--- a/internal/getproviders/filesystem_mirror_source_test.go
+++ b/internal/getproviders/filesystem_mirror_source_test.go
@@ -92,6 +92,16 @@ func TestFilesystemMirrorSourceAllAvailablePackages(t *testing.T) {
 	}
 }
 
+// In this test the directory layout is invalid (missing the hostname
+// subdirectory). The provider installer should ignore the invalid directory.
+func TestFilesystemMirrorSourceAllAvailablePackages_invalid(t *testing.T) {
+	source := NewFilesystemMirrorSource("testdata/filesystem-mirror-invalid")
+	_, err := source.AllAvailablePackages()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestFilesystemMirrorSourceAvailableVersions(t *testing.T) {
 	source := NewFilesystemMirrorSource("testdata/filesystem-mirror")
 	got, err := source.AvailableVersions(nullProvider)

--- a/internal/getproviders/filesystem_search.go
+++ b/internal/getproviders/filesystem_search.go
@@ -52,6 +52,18 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 		namespace := parts[1]
 		typeName := parts[2]
 
+		// validate each part
+		_, err = addrs.ParseProviderPart(namespace)
+		if err != nil {
+			log.Printf("[WARN] local provider path %q contains invalid namespace %q; ignoring", fullPath, namespace)
+			return nil
+		}
+		_, err = addrs.ParseProviderPart(typeName)
+		if err != nil {
+			log.Printf("[WARN] local provider path %q contains invalid type %q; ignoring", fullPath, typeName)
+			return nil
+		}
+
 		hostname, err := svchost.ForComparison(hostnameGiven)
 		if err != nil {
 			log.Printf("[WARN] local provider path %q contains invalid hostname %q; ignoring", fullPath, hostnameGiven)

--- a/internal/getproviders/filesystem_search.go
+++ b/internal/getproviders/filesystem_search.go
@@ -53,16 +53,15 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 		typeName := parts[2]
 
 		// validate each part
-		switch {
-		case namespace == addrs.LegacyProviderNamespace:
-			break
-		default:
+		// The legacy provider namespace is a special case.
+		if namespace != addrs.LegacyProviderNamespace {
 			_, err = addrs.ParseProviderPart(namespace)
 			if err != nil {
 				log.Printf("[WARN] local provider path %q contains invalid namespace %q; ignoring", fullPath, namespace)
 				return nil
 			}
 		}
+
 		_, err = addrs.ParseProviderPart(typeName)
 		if err != nil {
 			log.Printf("[WARN] local provider path %q contains invalid type %q; ignoring", fullPath, typeName)

--- a/internal/getproviders/filesystem_search.go
+++ b/internal/getproviders/filesystem_search.go
@@ -53,10 +53,15 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 		typeName := parts[2]
 
 		// validate each part
-		_, err = addrs.ParseProviderPart(namespace)
-		if err != nil {
-			log.Printf("[WARN] local provider path %q contains invalid namespace %q; ignoring", fullPath, namespace)
-			return nil
+		switch {
+		case namespace == addrs.LegacyProviderNamespace:
+			break
+		default:
+			_, err = addrs.ParseProviderPart(namespace)
+			if err != nil {
+				log.Printf("[WARN] local provider path %q contains invalid namespace %q; ignoring", fullPath, namespace)
+				return nil
+			}
 		}
 		_, err = addrs.ParseProviderPart(typeName)
 		if err != nil {

--- a/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/2.0.0/darwin_amd64/terraform-provider-null
+++ b/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/2.0.0/darwin_amd64/terraform-provider-null
@@ -1,0 +1,1 @@
+# This is just a placeholder file for discovery testing, not a real provider plugin.

--- a/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/2.0.0/linux_amd64/terraform-provider-null
+++ b/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/2.0.0/linux_amd64/terraform-provider-null
@@ -1,0 +1,1 @@
+# This is just a placeholder file for discovery testing, not a real provider plugin.

--- a/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/invalid
+++ b/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/invalid
@@ -1,0 +1,1 @@
+This should be ignored because it doesn't follow the provider package naming scheme.

--- a/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/terraform-provider-null_2.1.0_linux_amd64.zip
+++ b/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/terraform-provider-null_2.1.0_linux_amd64.zip
@@ -1,0 +1,5 @@
+This is just a placeholder file for discovery testing, not a real provider package.
+
+This file is what we'd find for mirrors using the "packed" mirror layout,
+where the mirror maintainer can just download the packages from upstream and
+have Terraform unpack them automatically when installing.

--- a/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/terraform-provider-null_invalid.zip
+++ b/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/terraform-provider-null_invalid.zip
@@ -1,0 +1,1 @@
+This should be ignored because it doesn't follow the provider package naming scheme.

--- a/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/terraform-provider-null_invalid_invalid_invalid.zip
+++ b/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/null/terraform-provider-null_invalid_invalid_invalid.zip
@@ -1,0 +1,1 @@
+This should be ignored because it doesn't follow the provider package naming scheme.

--- a/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/random-beta/1.2.0/linux_amd64/terraform-provider-random-beta
+++ b/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/random-beta/1.2.0/linux_amd64/terraform-provider-random-beta
@@ -1,0 +1,1 @@
+# This is just a placeholder file for discovery testing, not a real provider plugin.

--- a/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/random/1.2.0/linux_amd64/terraform-provider-random
+++ b/internal/getproviders/testdata/filesystem-mirror-invalid/hashicorp/random/1.2.0/linux_amd64/terraform-provider-random
@@ -1,0 +1,1 @@
+# This is just a placeholder file for discovery testing, not a real provider plugin.


### PR DESCRIPTION
If the search path is missing a directory, the provider installer would
try to create an `addrs.Provider` with the wrong parts. For example if the
hostname was missing (as in the test case), it would call
`addrs.NewProvider(namespace, typename, version)` and panic (because the version contains `.`, which makes it an invalid type). 

This commit adds a validation step for each part before calling `addrs.NewProvider` to avoid
the panic. For consistency with the rest of the function, it does not return an error in this case and instead ignores the directory.