### PR TITLE
Remove hashibot panic issue labeler

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,8 +1,3 @@
-behavior "regexp_issue_labeler" "panic_label" {
-  regexp = "panic:"
-  labels = ["crash", "bug"]
-}
-
 behavior "remove_labels_on_reply" "remove_stale" {
   labels               = ["waiting-response", "stale"]
   only_non_maintainers = true


### PR DESCRIPTION
HashiBot labels issues as "crash" and "bug" when they container "panic:". This causes issues to bypass human triage, which means that provider-specific panics are put in our issue list rather than being labeled correctly. This removes that rule to allow for human labeling.