### PR TITLE
CreateBeforeDestroy inheritence and state serializaton

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -265,7 +265,6 @@ func testState() *states.State {
 				AttrsJSON:    []byte("{\n            \"id\": \"bar\"\n          }"),
 				Status:       states.ObjectReady,
 				Dependencies: []addrs.ConfigResource{},
-				DependsOn:    []addrs.Referenceable{},
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewDefaultProvider("test"),

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -278,7 +278,6 @@ func TestRefresh_defaultState(t *testing.T) {
 		Status:       states.ObjectReady,
 		AttrsJSON:    []byte("{\n            \"ami\": null,\n            \"id\": \"yes\"\n          }"),
 		Dependencies: []addrs.ConfigResource{},
-		DependsOn:    []addrs.Referenceable{},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("wrong new object\ngot:  %swant: %s", spew.Sdump(actual), spew.Sdump(expected))
@@ -343,7 +342,6 @@ func TestRefresh_outPath(t *testing.T) {
 		Status:       states.ObjectReady,
 		AttrsJSON:    []byte("{\n            \"ami\": null,\n            \"id\": \"yes\"\n          }"),
 		Dependencies: []addrs.ConfigResource{},
-		DependsOn:    []addrs.Referenceable{},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("wrong new object\ngot:  %swant: %s", spew.Sdump(actual), spew.Sdump(expected))
@@ -573,7 +571,6 @@ func TestRefresh_backup(t *testing.T) {
 		Status:       states.ObjectReady,
 		AttrsJSON:    []byte("{\n            \"ami\": null,\n            \"id\": \"changed\"\n          }"),
 		Dependencies: []addrs.ConfigResource{},
-		DependsOn:    []addrs.Referenceable{},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("wrong new object\ngot:  %swant: %s", spew.Sdump(actual), spew.Sdump(expected))
@@ -640,7 +637,6 @@ func TestRefresh_disableBackup(t *testing.T) {
 		Status:       states.ObjectReady,
 		AttrsJSON:    []byte("{\n            \"ami\": null,\n            \"id\": \"yes\"\n          }"),
 		Dependencies: []addrs.ConfigResource{},
-		DependsOn:    []addrs.Referenceable{},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("wrong new object\ngot:  %swant: %s", spew.Sdump(actual), spew.Sdump(expected))

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -83,7 +83,6 @@ func TestShow_aliasedProvider(t *testing.T) {
 				AttrsJSON:    []byte("{\n            \"id\": \"bar\"\n          }"),
 				Status:       states.ObjectReady,
 				Dependencies: []addrs.ConfigResource{},
-				DependsOn:    []addrs.Referenceable{},
 			},
 			addrs.RootModuleInstance.ProviderConfigAliased(addrs.NewDefaultProvider("test"), "alias"),
 		)

--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -87,10 +87,6 @@ func shimNewState(newState *states.State, providers map[string]terraform.Resourc
 						resState.Primary.Meta["schema_version"] = i.Current.SchemaVersion
 					}
 
-					for _, dep := range i.Current.DependsOn {
-						resState.Dependencies = append(resState.Dependencies, dep.String())
-					}
-
 					// convert the indexes to the old style flapmap indexes
 					idx := ""
 					switch key.(type) {

--- a/helper/resource/state_shim_test.go
+++ b/helper/resource/state_shim_test.go
@@ -31,15 +31,6 @@ func TestStateShim(t *testing.T) {
 			Status:        states.ObjectReady,
 			AttrsFlat:     map[string]string{"id": "foo", "bazzle": "dazzle"},
 			SchemaVersion: 7,
-			DependsOn: []addrs.Referenceable{
-				addrs.ResourceInstance{
-					Resource: addrs.Resource{
-						Mode: 'M',
-						Type: "test_thing",
-						Name: "baz",
-					},
-				},
-			},
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
@@ -55,7 +46,6 @@ func TestStateShim(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsFlat: map[string]string{"id": "baz", "bazzle": "dazzle"},
-			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
@@ -74,7 +64,6 @@ func TestStateShim(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id": "bar", "fuzzle":"wuzzle"}`),
-			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
@@ -90,15 +79,6 @@ func TestStateShim(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id": "bar", "fizzle":"wizzle"}`),
-			DependsOn: []addrs.Referenceable{
-				addrs.ResourceInstance{
-					Resource: addrs.Resource{
-						Mode: 'D',
-						Type: "test_data_thing",
-						Name: "foo",
-					},
-				},
-			},
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
@@ -116,15 +96,6 @@ func TestStateShim(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsFlat: map[string]string{"id": "old", "fizzle": "wizzle"},
-			DependsOn: []addrs.Referenceable{
-				addrs.ResourceInstance{
-					Resource: addrs.Resource{
-						Mode: 'D',
-						Type: "test_data_thing",
-						Name: "foo",
-					},
-				},
-			},
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
@@ -141,7 +112,6 @@ func TestStateShim(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsFlat: map[string]string{"id": "0", "bazzle": "dazzle"},
-			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
@@ -157,7 +127,6 @@ func TestStateShim(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectTainted,
 			AttrsFlat: map[string]string{"id": "1", "bazzle": "dazzle"},
-			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
@@ -174,7 +143,6 @@ func TestStateShim(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id": "single", "bazzle":"dazzle"}`),
-			DependsOn: []addrs.Referenceable{},
 		},
 		addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
@@ -223,7 +191,6 @@ func TestStateShim(t *testing.T) {
 								"schema_version": 7,
 							},
 						},
-						Dependencies: []string{"test_thing.baz"},
 					},
 				},
 			},
@@ -249,7 +216,6 @@ func TestStateShim(t *testing.T) {
 								},
 							},
 						},
-						Dependencies: []string{"data.test_data_thing.foo"},
 					},
 					"data.test_data_thing.foo": &terraform.ResourceState{
 						Type:     "test_data_thing",
@@ -386,7 +352,6 @@ func TestShimLegacyState(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsFlat:    map[string]string{"id": "baz", "bazzle": "dazzle"},
-			DependsOn:    []addrs.Referenceable{},
 			Dependencies: []addrs.ConfigResource{},
 		},
 		addrs.AbsProviderConfig{
@@ -404,7 +369,6 @@ func TestShimLegacyState(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsFlat:    map[string]string{"id": "bar", "fizzle": "wizzle"},
-			DependsOn:    []addrs.Referenceable{},
 			Dependencies: []addrs.ConfigResource{},
 		},
 		addrs.AbsProviderConfig{

--- a/states/instance_object.go
+++ b/states/instance_object.go
@@ -109,11 +109,12 @@ func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64) (*Res
 	}
 
 	return &ResourceInstanceObjectSrc{
-		SchemaVersion: schemaVersion,
-		AttrsJSON:     src,
-		Private:       o.Private,
-		Status:        o.Status,
-		Dependencies:  o.Dependencies,
+		SchemaVersion:       schemaVersion,
+		AttrsJSON:           src,
+		Private:             o.Private,
+		Status:              o.Status,
+		Dependencies:        o.Dependencies,
+		CreateBeforeDestroy: o.CreateBeforeDestroy,
 	}, nil
 }
 

--- a/states/instance_object.go
+++ b/states/instance_object.go
@@ -42,11 +42,6 @@ type ResourceInstanceObject struct {
 	// destroy operations, we need to record the status to ensure a resource
 	// removed from the config will still be destroyed in the same manner.
 	CreateBeforeDestroy bool
-
-	// DependsOn corresponds to the deprecated `depends_on` field in the state.
-	// This field contained the configuration `depends_on` values, and some of
-	// the references from within a single module.
-	DependsOn []addrs.Referenceable
 }
 
 // ObjectStatus represents the status of a RemoteObject.

--- a/states/instance_object_src.go
+++ b/states/instance_object_src.go
@@ -55,8 +55,6 @@ type ResourceInstanceObjectSrc struct {
 	Status              ObjectStatus
 	Dependencies        []addrs.ConfigResource
 	CreateBeforeDestroy bool
-	// deprecated
-	DependsOn []addrs.Referenceable
 }
 
 // Decode unmarshals the raw representation of the object attributes. Pass the
@@ -89,7 +87,6 @@ func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObjec
 		Value:               val,
 		Status:              os.Status,
 		Dependencies:        os.Dependencies,
-		DependsOn:           os.DependsOn,
 		Private:             os.Private,
 		CreateBeforeDestroy: os.CreateBeforeDestroy,
 	}, nil

--- a/states/state_deepcopy.go
+++ b/states/state_deepcopy.go
@@ -158,12 +158,6 @@ func (obj *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		copy(dependencies, obj.Dependencies)
 	}
 
-	var dependsOn []addrs.Referenceable
-	if obj.DependsOn != nil {
-		dependsOn = make([]addrs.Referenceable, len(obj.DependsOn))
-		copy(dependsOn, obj.DependsOn)
-	}
-
 	return &ResourceInstanceObjectSrc{
 		Status:              obj.Status,
 		SchemaVersion:       obj.SchemaVersion,
@@ -171,7 +165,6 @@ func (obj *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		AttrsFlat:           attrsFlat,
 		AttrsJSON:           attrsJSON,
 		Dependencies:        dependencies,
-		DependsOn:           dependsOn,
 		CreateBeforeDestroy: obj.CreateBeforeDestroy,
 	}
 }

--- a/states/statefile/testdata/roundtrip/v4-cbd.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-cbd.in.tfstate
@@ -1,0 +1,34 @@
+{
+  "version": 4,
+  "serial": 0,
+  "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+  "terraform_version": "0.12.0",
+  "outputs": {
+    "numbers": {
+      "type": "string",
+      "value": "0,1"
+    }
+  },
+  "resources": [
+    {
+      "module": "module.modA",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "resource",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4639265839606265182",
+            "triggers": {
+              "input": "test"
+            }
+          },
+          "create_before_destroy": true,
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ]
+}

--- a/states/statefile/testdata/roundtrip/v4-cbd.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-cbd.out.tfstate
@@ -1,0 +1,1 @@
+v4-cbd.in.tfstate

--- a/states/statefile/version3_upgrade.go
+++ b/states/statefile/version3_upgrade.go
@@ -370,7 +370,6 @@ func upgradeInstanceObjectV3ToV4(rsOld *resourceStateV2, isOld *instanceStateV2,
 		Status:         status,
 		Deposed:        string(deposedKey),
 		AttributesFlat: attributes,
-		DependsOn:      dependencies,
 		SchemaVersion:  schemaVersion,
 		PrivateRaw:     privateJSON,
 	}, nil

--- a/states/statefile/version4.go
+++ b/states/statefile/version4.go
@@ -130,7 +130,8 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 			instAddr := rAddr.Instance(key)
 
 			obj := &states.ResourceInstanceObjectSrc{
-				SchemaVersion: isV4.SchemaVersion,
+				SchemaVersion:       isV4.SchemaVersion,
+				CreateBeforeDestroy: isV4.CreateBeforeDestroy,
 			}
 
 			{
@@ -484,15 +485,16 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 	}
 
 	return append(isV4s, instanceObjectStateV4{
-		IndexKey:       rawKey,
-		Deposed:        string(deposed),
-		Status:         status,
-		SchemaVersion:  obj.SchemaVersion,
-		AttributesFlat: obj.AttrsFlat,
-		AttributesRaw:  obj.AttrsJSON,
-		PrivateRaw:     privateRaw,
-		Dependencies:   deps,
-		DependsOn:      depOn,
+		IndexKey:            rawKey,
+		Deposed:             string(deposed),
+		Status:              status,
+		SchemaVersion:       obj.SchemaVersion,
+		AttributesFlat:      obj.AttrsFlat,
+		AttributesRaw:       obj.AttrsJSON,
+		PrivateRaw:          privateRaw,
+		Dependencies:        deps,
+		DependsOn:           depOn,
+		CreateBeforeDestroy: obj.CreateBeforeDestroy,
 	}), diags
 }
 
@@ -544,6 +546,8 @@ type instanceObjectStateV4 struct {
 
 	Dependencies []string `json:"dependencies,omitempty"`
 	DependsOn    []string `json:"depends_on,omitempty"`
+
+	CreateBeforeDestroy bool `json:"create_before_destroy"`
 }
 
 // stateVersionV4 is a weird special type we use to produce our hard-coded

--- a/states/statefile/version4.go
+++ b/states/statefile/version4.go
@@ -512,7 +512,7 @@ type instanceObjectStateV4 struct {
 
 	Dependencies []string `json:"dependencies,omitempty"`
 
-	CreateBeforeDestroy bool `json:"create_before_destroy"`
+	CreateBeforeDestroy bool `json:"create_before_destroy,omitempty"`
 }
 
 // stateVersionV4 is a weird special type we use to produce our hard-coded

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -305,9 +305,10 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 	var newState *states.ResourceInstanceObject
 	if !newVal.IsNull() { // null value indicates that the object is deleted, so we won't set a new state in that case
 		newState = &states.ResourceInstanceObject{
-			Status:  newStatus,
-			Value:   newVal,
-			Private: resp.Private,
+			Status:              newStatus,
+			Value:               newVal,
+			Private:             resp.Private,
+			CreateBeforeDestroy: n.Config.Managed.CreateBeforeDestroy,
 		}
 	}
 

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -22,17 +22,18 @@ import (
 // EvalApply is an EvalNode implementation that writes the diff to
 // the full diff.
 type EvalApply struct {
-	Addr           addrs.ResourceInstance
-	Config         *configs.Resource
-	State          **states.ResourceInstanceObject
-	Change         **plans.ResourceInstanceChange
-	ProviderAddr   addrs.AbsProviderConfig
-	Provider       *providers.Interface
-	ProviderMetas  map[addrs.Provider]*configs.ProviderMeta
-	ProviderSchema **ProviderSchema
-	Output         **states.ResourceInstanceObject
-	CreateNew      *bool
-	Error          *error
+	Addr                addrs.ResourceInstance
+	Config              *configs.Resource
+	State               **states.ResourceInstanceObject
+	Change              **plans.ResourceInstanceChange
+	ProviderAddr        addrs.AbsProviderConfig
+	Provider            *providers.Interface
+	ProviderMetas       map[addrs.Provider]*configs.ProviderMeta
+	ProviderSchema      **ProviderSchema
+	Output              **states.ResourceInstanceObject
+	CreateNew           *bool
+	Error               *error
+	CreateBeforeDestroy bool
 }
 
 // TODO: test
@@ -308,7 +309,7 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 			Status:              newStatus,
 			Value:               newVal,
 			Private:             resp.Private,
-			CreateBeforeDestroy: n.Config.Managed.CreateBeforeDestroy,
+			CreateBeforeDestroy: n.CreateBeforeDestroy,
 		}
 	}
 

--- a/terraform/eval_refresh.go
+++ b/terraform/eval_refresh.go
@@ -119,6 +119,7 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 	newState.Value = resp.NewState
 	newState.Private = resp.Private
 	newState.Dependencies = state.Dependencies
+	newState.CreateBeforeDestroy = state.CreateBeforeDestroy
 
 	// Call post-refresh hook
 	err = ctx.Hook(func(h Hook) (HookAction, error) {

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -228,7 +228,6 @@ func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
 		log.Printf("[TRACE] EvalWriteState: removing state object for %s", absAddr)
 		return nil, nil
 	}
-	fmt.Printf("OBJ: %#v\n", obj)
 
 	// store the new deps in the state
 	if n.Dependencies != nil {

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -228,6 +228,7 @@ func (n *EvalWriteState) Eval(ctx EvalContext) (interface{}, error) {
 		log.Printf("[TRACE] EvalWriteState: removing state object for %s", absAddr)
 		return nil, nil
 	}
+	fmt.Printf("OBJ: %#v\n", obj)
 
 	// store the new deps in the state
 	if n.Dependencies != nil {

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -143,6 +143,10 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&ReferenceTransformer{},
 		&AttachDependenciesTransformer{},
 
+		// Detect when create_before_destroy must be forced on for a particular
+		// node due to dependency edges, to avoid graph cycles during apply.
+		&ForcedCBDTransformer{},
+
 		// Destruction ordering
 		&DestroyEdgeTransformer{
 			Config:  b.Config,


### PR DESCRIPTION
The serialization of create_before_destroy into state was never completed. Here we serialize the new state field, and in the process remove the deprecated DependsOn field from the serialized output. 

The resource apply nodes need to be GraphNodeDestroyerCBD in order to correctly inherit create_before_destroy. While the plan will have recorded this to create the correct deposed nodes, the edges still need to be transformed correctly. We also need create_before_destroy to be saved to state for nodes that inherited it, so that if they are removed from state the destroy will happen in the correct order.