### PR TITLE
Mildwonkey/ps installer logging errors

### DIFF
--- a/command/013_config_upgrade.go
+++ b/command/013_config_upgrade.go
@@ -576,13 +576,12 @@ func (c *ZeroThirteenUpgradeCommand) detectProviderSources(requiredProviders map
 		if err == nil {
 			rp.Type = p
 		} else {
-			if _, ok := err.(getproviders.ErrProviderNotKnown); ok {
-				// Setting the provider address to a zero value struct
-				// indicates that there is no known FQN for this provider,
-				// which will cause us to write an explanatory comment in the
-				// HCL output advising the user what to do about this.
-				rp.Type = addrs.Provider{}
-			}
+			// Setting the provider address to a zero value struct
+			// indicates that there is no known FQN for this provider,
+			// which will cause us to write an explanatory comment in the
+			// HCL output advising the user what to do about this.
+			rp.Type = addrs.Provider{}
+
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Warning,
 				"Could not detect provider source",

--- a/command/e2etest/testdata/provider-not-found/main.tf
+++ b/command/e2etest/testdata/provider-not-found/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    nonexist = {
+      source = "registry.terraform.io/hashicorp/nonexist"
+    }
+  }
+}

--- a/command/init.go
+++ b/command/init.go
@@ -505,7 +505,7 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Failed to query available provider packages",
-					fmt.Sprintf("Could not retrieve the list of available versions for provider %s: %s\n\n%s ",
+					fmt.Sprintf("Could not retrieve the list of available versions for provider %s: %s\n\n%s",
 						provider.ForDisplay(), err, strings.Join(displaySources, "\n"),
 					),
 				))
@@ -513,7 +513,7 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Failed to query available provider packages",
-					fmt.Sprintf("Could not retrieve the list of available versions for provider %s: %s ",
+					fmt.Sprintf("Could not retrieve the list of available versions for provider %s: %s",
 						provider.ForDisplay(), err,
 					),
 				))

--- a/command/init.go
+++ b/command/init.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -449,6 +450,11 @@ func (c *InitCommand) getProviders(earlyConfig *earlyconfig.Config, state *state
 		// is not available for installation.
 		source := c.providerCustomLocalDirectorySource(pluginDirs)
 		inst = c.providerInstallerCustomSource(source)
+
+		// The default (or configured) search paths are logged earlier, in provider_source.go
+		// Log that those are being overridden by the `-plugin-dir` command line options
+		log.Printf("[DEBUG] init: overriding provider plugin search paths")
+		log.Printf("[DEBUG] will search for provider plugins in %s", pluginDirs)
 	}
 
 	// Because we're currently just streaming a series of events sequentially

--- a/internal/getproviders/errors.go
+++ b/internal/getproviders/errors.go
@@ -196,7 +196,7 @@ func (err ErrQueryFailed) Unwrap() error {
 // grow in future.
 func ErrIsNotExist(err error) bool {
 	switch err.(type) {
-	case ErrProviderNotFound, ErrPlatformNotSupported:
+	case ErrProviderNotFound, ErrRegistryProviderNotKnown, ErrPlatformNotSupported:
 		return true
 	default:
 		return false

--- a/internal/getproviders/errors.go
+++ b/internal/getproviders/errors.go
@@ -73,7 +73,22 @@ func (err ErrUnauthorized) Error() string {
 	}
 }
 
-// ErrProviderNotKnown is an error type used to indicate that the hostname
+// ErrProviderNotFound is an error type used to indicate that requested provider
+// was not found in the source(s) included in the Description field. This can be
+// used to produce user-friendly error messages.
+type ErrProviderNotFound struct {
+	Provider addrs.Provider
+	Sources  []string
+}
+
+func (err ErrProviderNotFound) Error() string {
+	return fmt.Sprintf(
+		"provider %s was not found in any of the search locations",
+		err.Provider,
+	)
+}
+
+// ErrRegistryProviderNotKnown is an error type used to indicate that the hostname
 // given in a provider address does appear to be a provider registry but that
 // registry does not know about the given provider namespace or type.
 //
@@ -85,11 +100,11 @@ func (err ErrUnauthorized) Error() string {
 // because we expect that the caller will have better context to decide what
 // hints are appropriate, e.g. by looking at the configuration given by the
 // user.
-type ErrProviderNotKnown struct {
+type ErrRegistryProviderNotKnown struct {
 	Provider addrs.Provider
 }
 
-func (err ErrProviderNotKnown) Error() string {
+func (err ErrRegistryProviderNotKnown) Error() string {
 	return fmt.Sprintf(
 		"provider registry %s does not have a provider named %s",
 		err.Provider.Hostname.ForDisplay(),
@@ -181,7 +196,7 @@ func (err ErrQueryFailed) Unwrap() error {
 // grow in future.
 func ErrIsNotExist(err error) bool {
 	switch err.(type) {
-	case ErrProviderNotKnown, ErrPlatformNotSupported:
+	case ErrProviderNotFound, ErrPlatformNotSupported:
 		return true
 	default:
 		return false

--- a/internal/getproviders/filesystem_mirror_source.go
+++ b/internal/getproviders/filesystem_mirror_source.go
@@ -120,3 +120,8 @@ func (s *FilesystemMirrorSource) scanAllVersions() error {
 	s.allPackages = ret
 	return nil
 }
+
+func (s *FilesystemMirrorSource) ForDisplay(provider addrs.Provider) string {
+	// TODO: Since we have the provider, this could show the entire search path
+	return s.baseDir
+}

--- a/internal/getproviders/filesystem_mirror_source.go
+++ b/internal/getproviders/filesystem_mirror_source.go
@@ -122,6 +122,5 @@ func (s *FilesystemMirrorSource) scanAllVersions() error {
 }
 
 func (s *FilesystemMirrorSource) ForDisplay(provider addrs.Provider) string {
-	// TODO: Since we have the provider, this could show the entire search path
 	return s.baseDir
 }

--- a/internal/getproviders/http_mirror_source.go
+++ b/internal/getproviders/http_mirror_source.go
@@ -35,3 +35,8 @@ func (s *HTTPMirrorSource) AvailableVersions(provider addrs.Provider) (VersionLi
 func (s *HTTPMirrorSource) PackageMeta(provider addrs.Provider, version Version, target Platform) (PackageMeta, error) {
 	return PackageMeta{}, fmt.Errorf("Network-based provider mirrors are not supported in this version of Terraform")
 }
+
+// ForDisplay returns a string description of the source for user-facing output.
+func (s *HTTPMirrorSource) ForDisplay(provider addrs.Provider) string {
+	return "Network-based provider mirrors are not supported in this version of Terraform"
+}

--- a/internal/getproviders/memoize_source.go
+++ b/internal/getproviders/memoize_source.go
@@ -94,3 +94,7 @@ func (s *MemoizeSource) PackageMeta(provider addrs.Provider, version Version, ta
 	}
 	return ret, err
 }
+
+func (s *MemoizeSource) ForDisplay(provider addrs.Provider) string {
+	return s.underlying.ForDisplay(provider)
+}

--- a/internal/getproviders/memoize_source_test.go
+++ b/internal/getproviders/memoize_source_test.go
@@ -39,7 +39,7 @@ func TestMemoizeSource(t *testing.T) {
 		}
 
 		_, err = source.AvailableVersions(nonexistProvider)
-		if want, ok := err.(ErrProviderNotKnown); !ok {
+		if want, ok := err.(ErrProviderNotFound); !ok {
 			t.Fatalf("wrong error type from nonexist call:\ngot:  %T\nwant: %T", err, want)
 		}
 
@@ -122,11 +122,11 @@ func TestMemoizeSource(t *testing.T) {
 		source := NewMemoizeSource(mock)
 
 		_, err := source.AvailableVersions(nonexistProvider)
-		if want, ok := err.(ErrProviderNotKnown); !ok {
+		if want, ok := err.(ErrProviderNotFound); !ok {
 			t.Fatalf("wrong error type from first call:\ngot:  %T\nwant: %T", err, want)
 		}
 		_, err = source.AvailableVersions(nonexistProvider)
-		if want, ok := err.(ErrProviderNotKnown); !ok {
+		if want, ok := err.(ErrProviderNotFound); !ok {
 			t.Fatalf("wrong error type from second call:\ngot:  %T\nwant: %T", err, want)
 		}
 

--- a/internal/getproviders/memoize_source_test.go
+++ b/internal/getproviders/memoize_source_test.go
@@ -39,7 +39,7 @@ func TestMemoizeSource(t *testing.T) {
 		}
 
 		_, err = source.AvailableVersions(nonexistProvider)
-		if want, ok := err.(ErrProviderNotFound); !ok {
+		if want, ok := err.(ErrRegistryProviderNotKnown); !ok {
 			t.Fatalf("wrong error type from nonexist call:\ngot:  %T\nwant: %T", err, want)
 		}
 
@@ -122,11 +122,11 @@ func TestMemoizeSource(t *testing.T) {
 		source := NewMemoizeSource(mock)
 
 		_, err := source.AvailableVersions(nonexistProvider)
-		if want, ok := err.(ErrProviderNotFound); !ok {
+		if want, ok := err.(ErrRegistryProviderNotKnown); !ok {
 			t.Fatalf("wrong error type from first call:\ngot:  %T\nwant: %T", err, want)
 		}
 		_, err = source.AvailableVersions(nonexistProvider)
-		if want, ok := err.(ErrProviderNotFound); !ok {
+		if want, ok := err.(ErrRegistryProviderNotKnown); !ok {
 			t.Fatalf("wrong error type from second call:\ngot:  %T\nwant: %T", err, want)
 		}
 

--- a/internal/getproviders/mock_source.go
+++ b/internal/getproviders/mock_source.go
@@ -51,7 +51,7 @@ func (s *MockSource) AvailableVersions(provider addrs.Provider) (VersionList, er
 	if len(ret) == 0 {
 		// In this case, we'll behave like a registry that doesn't know about
 		// this provider at all, rather than just returning an empty result.
-		return nil, ErrProviderNotFound{provider, []string{"mock source"}}
+		return nil, ErrRegistryProviderNotKnown{provider}
 	}
 	ret.Sort()
 	return ret, nil

--- a/internal/getproviders/mock_source.go
+++ b/internal/getproviders/mock_source.go
@@ -51,7 +51,7 @@ func (s *MockSource) AvailableVersions(provider addrs.Provider) (VersionList, er
 	if len(ret) == 0 {
 		// In this case, we'll behave like a registry that doesn't know about
 		// this provider at all, rather than just returning an empty result.
-		return nil, ErrProviderNotKnown{provider}
+		return nil, ErrProviderNotFound{provider, []string{"mock source"}}
 	}
 	ret.Sort()
 	return ret, nil
@@ -197,4 +197,8 @@ func FakeInstallablePackageMeta(provider addrs.Provider, version Version, protoc
 		Authentication: NewArchiveChecksumAuthentication(checksum),
 	}
 	return meta, close, nil
+}
+
+func (s *MockSource) ForDisplay(provider addrs.Provider) string {
+	return "mock source"
 }

--- a/internal/getproviders/multi_source_test.go
+++ b/internal/getproviders/multi_source_test.go
@@ -73,7 +73,7 @@ func TestMultiSourceAvailableVersions(t *testing.T) {
 		}
 
 		_, err = multi.AvailableVersions(addrs.NewDefaultProvider("baz"))
-		if want, ok := err.(ErrProviderNotFound); !ok {
+		if want, ok := err.(ErrRegistryProviderNotKnown); !ok {
 			t.Fatalf("wrong error type:\ngot:  %T\nwant: %T", err, want)
 		}
 	})
@@ -147,7 +147,7 @@ func TestMultiSourceAvailableVersions(t *testing.T) {
 		}
 
 		_, err = multi.AvailableVersions(addrs.NewDefaultProvider("baz"))
-		if want, ok := err.(ErrProviderNotFound); !ok {
+		if want, ok := err.(ErrRegistryProviderNotKnown); !ok {
 			t.Fatalf("wrong error type:\ngot:  %T\nwant: %T", err, want)
 		}
 	})
@@ -165,8 +165,7 @@ func TestMultiSourceAvailableVersions(t *testing.T) {
 			t.Fatal("expected error, got success")
 		}
 
-		wantErr := `provider registry.terraform.io/hashicorp/foo was not found in any of the search locations`
-		_ = []string{"mock source", "mock source"}
+		wantErr := `provider registry registry.terraform.io does not have a provider named registry.terraform.io/hashicorp/foo`
 
 		if err.Error() != wantErr {
 			t.Fatalf("wrong error.\ngot:  %s\nwant: %s\n", err, wantErr)

--- a/internal/getproviders/multi_source_test.go
+++ b/internal/getproviders/multi_source_test.go
@@ -73,7 +73,7 @@ func TestMultiSourceAvailableVersions(t *testing.T) {
 		}
 
 		_, err = multi.AvailableVersions(addrs.NewDefaultProvider("baz"))
-		if want, ok := err.(ErrProviderNotKnown); !ok {
+		if want, ok := err.(ErrProviderNotFound); !ok {
 			t.Fatalf("wrong error type:\ngot:  %T\nwant: %T", err, want)
 		}
 	})
@@ -147,9 +147,31 @@ func TestMultiSourceAvailableVersions(t *testing.T) {
 		}
 
 		_, err = multi.AvailableVersions(addrs.NewDefaultProvider("baz"))
-		if want, ok := err.(ErrProviderNotKnown); !ok {
+		if want, ok := err.(ErrProviderNotFound); !ok {
 			t.Fatalf("wrong error type:\ngot:  %T\nwant: %T", err, want)
 		}
+	})
+
+	t.Run("provider not found", func(t *testing.T) {
+		s1 := NewMockSource(nil)
+		s2 := NewMockSource(nil)
+		multi := MultiSource{
+			{Source: s1},
+			{Source: s2},
+		}
+
+		_, err := multi.AvailableVersions(addrs.NewDefaultProvider("foo"))
+		if err == nil {
+			t.Fatal("expected error, got success")
+		}
+
+		wantErr := `provider registry.terraform.io/hashicorp/foo was not found in any of the search locations`
+		_ = []string{"mock source", "mock source"}
+
+		if err.Error() != wantErr {
+			t.Fatalf("wrong error.\ngot:  %s\nwant: %s\n", err, wantErr)
+		}
+
 	})
 }
 

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -93,7 +93,7 @@ func newRegistryClient(baseURL *url.URL, creds svcauth.HostCredentials) *registr
 // ProviderVersions returns the raw version and protocol strings produced by the
 // registry for the given provider.
 //
-// The returned error will be ErrProviderNotKnown if the registry responds with
+// The returned error will be ErrRegistryProviderNotKnown if the registry responds with
 // 404 Not Found to indicate that the namespace or provider type are not known,
 // ErrUnauthorized if the registry responds with 401 or 403 status codes, or
 // ErrQueryFailed for any other protocol or operational problem.
@@ -122,7 +122,7 @@ func (c *registryClient) ProviderVersions(addr addrs.Provider) (map[string][]str
 	case http.StatusOK:
 		// Great!
 	case http.StatusNotFound:
-		return nil, ErrProviderNotKnown{
+		return nil, ErrRegistryProviderNotKnown{
 			Provider: addr,
 		}
 	case http.StatusUnauthorized, http.StatusForbidden:
@@ -357,7 +357,6 @@ func (c *registryClient) PackageMeta(provider addrs.Provider, version Version, t
 	return ret, nil
 }
 
-// LegacyProviderDefaultNamespace returns the raw address strings produced by
 // findClosestProtocolCompatibleVersion searches for the provider version with the closest protocol match.
 func (c *registryClient) findClosestProtocolCompatibleVersion(provider addrs.Provider, version Version) (Version, error) {
 	var match Version
@@ -401,7 +400,7 @@ FindMatch:
 	return match, nil
 }
 
-// LegacyProviderCanonicalAddress returns the raw address strings produced by
+// LegacyProviderDefaultNamespace returns the raw address strings produced by
 // the registry when asked about the given unqualified provider type name.
 // The returned namespace string is taken verbatim from the registry's response.
 //
@@ -437,7 +436,7 @@ func (c *registryClient) LegacyProviderDefaultNamespace(typeName string) (string
 	case http.StatusOK:
 		// Great!
 	case http.StatusNotFound:
-		return "", ErrProviderNotKnown{
+		return "", ErrProviderNotFound{
 			Provider: placeholderProviderAddr,
 		}
 	case http.StatusUnauthorized, http.StatusForbidden:

--- a/internal/getproviders/registry_source.go
+++ b/internal/getproviders/registry_source.go
@@ -167,3 +167,7 @@ func (s *RegistrySource) registryClient(hostname svchost.Hostname) (*registryCli
 
 	return newRegistryClient(url, creds), nil
 }
+
+func (s *RegistrySource) ForDisplay(provider addrs.Provider) string {
+	return fmt.Sprintf("registry %s", provider.Hostname.ForDisplay())
+}

--- a/internal/getproviders/source.go
+++ b/internal/getproviders/source.go
@@ -9,4 +9,5 @@ import (
 type Source interface {
 	AvailableVersions(provider addrs.Provider) (VersionList, error)
 	PackageMeta(provider addrs.Provider, version Version, target Platform) (PackageMeta, error)
+	ForDisplay(provider addrs.Provider) string
 }


### PR DESCRIPTION
Two changes here:

* adds debug logging when the user overrides the default search paths with the `-plugin-dir` init flag (or env var).
* adds `ErrRegistryProviderNotKnown` so we can differentiate between providers not found on the registry and providers not found in searches _excluding_ a registry. 

The provider installer had been returning a single error when a provider was found, even if the registry hadn't been queried. This change adds an error type specifically for the registry, and refactors the original ErrProviderNotFound to take a `Description`. 

I added a `ForDisplay()` function to the `Source` interface which is used to generate a user-friendly Description for the `ErrProviderNotFound`. 

The `MultiSource` now checks for a registry error when searching for a provider. If there is a registry error, only the registry error message will be displayed. If the provider is not found and the registry was not searched, it iterates over all `Source`s to generate an error message that lists the search paths.

There is a `TODO` message in here that is more of a question: I could extend the output to show the search path + expected directory hierarchy, instead of just the search path. My concern is that could be confusing to users who might think they need to modify custom search path to match the output. Depending on what folks say here I will remove the TODO comment (either because I've done it, or we've decided not to).

----
Error, registry not queried:
 
<img width="900" alt="Screen Shot 2020-05-15 at 9 39 16 AM" src="https://user-images.githubusercontent.com/6210214/82056443-fac62200-968f-11ea-8a9b-9b63ea2a58fc.png">

Registry Error:
<img width="855" alt="Screen Shot 2020-05-15 at 9 40 15 AM" src="https://user-images.githubusercontent.com/6210214/82056545-1af5e100-9690-11ea-9057-e5df44b0485b.png">
