### PR TITLE
Add format alias to fmt command

### DIFF
--- a/command/fmt.go
+++ b/command/fmt.go
@@ -56,7 +56,7 @@ func (c *FmtCommand) Run(args []string) int {
 
 	args = cmdFlags.Args()
 	if len(args) > 1 {
-		c.Ui.Error("The fmt command expects at most one argument.")
+		c.Ui.Error("The format command expects at most one argument.")
 		cmdFlags.Usage()
 		return 1
 	}
@@ -143,7 +143,7 @@ func (c *FmtCommand) fmt(paths []string, stdin io.Reader, stdout io.Writer) tfdi
 				diags = diags.Append(fileDiags)
 				f.Close()
 			default:
-				diags = diags.Append(fmt.Errorf("Only .tf and .tfvars files can be processed with terraform fmt"))
+				diags = diags.Append(fmt.Errorf("Only .tf and .tfvars files can be processed with terraform format"))
 				continue
 			}
 		}
@@ -155,7 +155,7 @@ func (c *FmtCommand) fmt(paths []string, stdin io.Reader, stdout io.Writer) tfdi
 func (c *FmtCommand) processFile(path string, r io.Reader, w io.Writer, isStdout bool) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	log.Printf("[TRACE] terraform fmt: Formatting %s", path)
+	log.Printf("[TRACE] terraform format: Formatting %s", path)
 
 	src, err := ioutil.ReadAll(r)
 	if err != nil {
@@ -213,7 +213,7 @@ func (c *FmtCommand) processFile(path string, r io.Reader, w io.Writer, isStdout
 func (c *FmtCommand) processDir(path string, stdout io.Writer) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	log.Printf("[TRACE] terraform fmt: looking for files in %s", path)
+	log.Printf("[TRACE] terraform format: looking for files in %s", path)
 
 	entries, err := ioutil.ReadDir(path)
 	if err != nil {
@@ -268,7 +268,7 @@ func (c *FmtCommand) processDir(path string, stdout io.Writer) tfdiags.Diagnosti
 
 func (c *FmtCommand) Help() string {
 	helpText := `
-Usage: terraform fmt [options] [DIR]
+Usage: terraform format [options] [DIR]
 
 	Rewrites all Terraform configuration files to a canonical format. Both
 	configuration files (.tf) and variables files (.tfvars) are updated.

--- a/command/fmt_test.go
+++ b/command/fmt_test.go
@@ -118,7 +118,7 @@ func TestFmt_tooManyArgs(t *testing.T) {
 		t.Fatalf("wrong exit code. errors: \n%s", ui.ErrorWriter.String())
 	}
 
-	expected := "The fmt command expects at most one argument."
+	expected := "The format command expects at most one argument."
 	if actual := ui.ErrorWriter.String(); !strings.Contains(actual, expected) {
 		t.Fatalf("expected:\n%s\n\nto include: %q", actual, expected)
 	}

--- a/commands.go
+++ b/commands.go
@@ -155,6 +155,12 @@ func initCommands(config *cliconfig.Config, services *disco.Disco, providerSrc g
 			}, nil
 		},
 
+		"format": func() (cli.Command, error) {
+			return &command.FmtCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"get": func() (cli.Command, error) {
 			return &command.GetCommand{
 				Meta: meta,

--- a/website/docs/commands/fmt.html.markdown
+++ b/website/docs/commands/fmt.html.markdown
@@ -1,34 +1,34 @@
 ---
 layout: "docs"
-page_title: "Command: fmt"
-sidebar_current: "docs-commands-fmt"
+page_title: "Command: format"
+sidebar_current: "docs-commands-format"
 description: |-
-  The `terraform fmt` command is used to rewrite Terraform configuration files to a canonical format and style.
+  The `terraform format` command is used to rewrite Terraform configuration files to a canonical format and style.
 ---
 
-# Command: fmt
+# Command: format
 
-The `terraform fmt` command is used to rewrite Terraform configuration files
+The `terraform format` command is used to rewrite Terraform configuration files
 to a canonical format and style. This command applies a subset of
 the [Terraform language style conventions](/docs/configuration/style.html),
 along with other minor adjustments for readability.
 
 Other Terraform commands that generate Terraform configuration will produce
-configuration files that conform to the style imposed by `terraform fmt`, so
+configuration files that conform to the style imposed by `terraform format`, so
 using this style in your own files will ensure consistency.
 
 The canonical format may change in minor ways between Terraform versions, so
-after upgrading Terraform we recommend to proactively run `terraform fmt`
+after upgrading Terraform we recommend to proactively run `terraform format`
 on your modules along with any other changes you are making to adopt the new
 version.
 
 ## Usage
 
-Usage: `terraform fmt [options] [DIR]`
+Usage: `terraform format [options] [DIR]`
 
-By default, `fmt` scans the current directory for configuration files. If
+By default, `format` scans the current directory for configuration files. If
 the `dir` argument is provided then it will scan that given directory
-instead. If `dir` is a single dash (`-`) then `fmt` will read from standard
+instead. If `dir` is a single dash (`-`) then `format` will read from standard
 input (STDIN).
 
 The command-line flags are all optional. The list of available flags are:


### PR DESCRIPTION
For some reason, "fmt" is one of the few commands that is not an entire word, yet an abbreviation.
It doesn't seem consistent, considering there  are even longer words like "providers", "console" and "workspace" that are being used for commands.

That causes confusion, and it should be fixed.

In order to avoid backward-incompatibility, adding an alias to format and still supporting "fmt" seems like the best choice.