### PR TITLE
provider cache: log errors and validate dir exists

### DIFF
--- a/command/cliconfig/cliconfig.go
+++ b/command/cliconfig/cliconfig.go
@@ -273,6 +273,15 @@ func (c *Config) Validate() tfdiags.Diagnostics {
 		)
 	}
 
+	if c.PluginCacheDir != "" {
+		_, err := os.Stat(c.PluginCacheDir)
+		if err != nil {
+			diags = diags.Append(
+				fmt.Errorf("The specified plugin cache dir %s cannot be opened: %s", c.PluginCacheDir, err),
+			)
+		}
+	}
+
 	return diags
 }
 

--- a/command/cliconfig/cliconfig_test.go
+++ b/command/cliconfig/cliconfig_test.go
@@ -193,6 +193,12 @@ func TestConfigValidate(t *testing.T) {
 			},
 			1, // no more than one provider_installation block allowed
 		},
+		"plugin_cache_dir does not exist": {
+			&Config{
+				PluginCacheDir: "fake",
+			},
+			1, // The specified plugin cache dir %s cannot be opened
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/providercache/dir.go
+++ b/internal/providercache/dir.go
@@ -136,6 +136,7 @@ func (d *Dir) fillMetaCache() error {
 
 	allData, err := getproviders.SearchLocalDirectory(d.baseDir)
 	if err != nil {
+		log.Printf("[TRACE] providercache.fillMetaCache: error while scanning directory %s: %s", d.baseDir, err)
 		return err
 	}
 


### PR DESCRIPTION
This PR came about after I spent <a long time> tracking down an error that turned out to be caused by a weird broken symlink in my plugin cache dir. The `providercache` was swallowing the error. 

This PR adds logging for any error messages and adds a bonus validation check (in command/cliconfig) that the user-specified provider cache dir exists.