### PR TITLE
Module depends_on

### DIFF
--- a/configs/module_call.go
+++ b/configs/module_call.go
@@ -87,14 +87,6 @@ func decodeModuleBlock(block *hcl.Block, override bool) (*ModuleCall, hcl.Diagno
 		deps, depsDiags := decodeDependsOn(attr)
 		diags = append(diags, depsDiags...)
 		mc.DependsOn = append(mc.DependsOn, deps...)
-
-		// We currently parse this, but don't yet do anything with it.
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Reserved argument name in module block",
-			Detail:   fmt.Sprintf("The name %q is reserved for use in a future version of Terraform.", attr.Name),
-			Subject:  &attr.NameRange,
-		})
 	}
 
 	if attr, exists := content.Attributes["providers"]; exists {

--- a/configs/module_call_test.go
+++ b/configs/module_call_test.go
@@ -20,7 +20,6 @@ func TestLoadModuleCall(t *testing.T) {
 
 	file, diags := parser.LoadConfigFile("module-calls.tf")
 	assertExactDiagnostics(t, diags, []string{
-		`module-calls.tf:22,3-13: Reserved argument name in module block; The name "depends_on" is reserved for use in a future version of Terraform.`,
 		`module-calls.tf:20,3-11: Invalid combination of "count" and "for_each"; The "count" and "for_each" meta-arguments are mutually-exclusive, only one should be used to be explicit about the number of resources to be created.`,
 	})
 

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -11122,3 +11122,63 @@ resource "aws_instance" "cbd" {
 		t.Fatal("aws_instance.foo should also be create_before_destroy")
 	}
 }
+
+func TestContext2Apply_moduleDependsOn(t *testing.T) {
+	m := testModule(t, "apply-module-depends-on")
+
+	p := testProvider("test")
+	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+		State: cty.ObjectVal(map[string]cty.Value{
+			"id":  cty.StringVal("data"),
+			"foo": cty.NullVal(cty.String),
+		}),
+	}
+	p.DiffFn = testDiffFn
+
+	// each instance being applied should happen in sequential order
+	applied := int64(0)
+
+	p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+		state := req.PlannedState.AsValueMap()
+		num, _ := state["num"].AsBigFloat().Float64()
+		ord := int64(num)
+		if !atomic.CompareAndSwapInt64(&applied, ord-1, ord) {
+			actual := atomic.LoadInt64(&applied)
+			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("instance %d was applied after %d", ord, actual))
+		}
+
+		state["id"] = cty.StringVal(fmt.Sprintf("test_%d", ord))
+		resp.NewState = cty.ObjectVal(state)
+
+		return resp
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan()
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+
+	_, diags = ctx.Apply()
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+
+	// run the plan again to ensure that data sources are not going to be re-read
+	plan, diags := ctx.Plan()
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+
+	for _, res := range plan.Changes.Resources {
+		if res.Action != plans.NoOp {
+			t.Fatalf("expected NoOp, got %s for %s", res.Action, res.Addr)
+		}
+	}
+}

--- a/terraform/testdata/apply-module-depends-on/main.tf
+++ b/terraform/testdata/apply-module-depends-on/main.tf
@@ -1,0 +1,32 @@
+module "moda" {
+  source = "./moda"
+  depends_on = [test_instance.a, module.modb]
+}
+
+resource "test_instance" "a" {
+  depends_on = [module.modb]
+  num = 4
+  foo = test_instance.aa.id
+}
+
+resource "test_instance" "aa" {
+  num = 3
+  foo = module.modb.out
+}
+
+module "modb" {
+  source = "./modb"
+  depends_on = [test_instance.b]
+}
+
+resource "test_instance" "b" {
+  num = 1
+}
+
+output "moda_data" {
+  value = module.moda.out
+}
+
+output "modb_resource" {
+  value = module.modb.out
+}

--- a/terraform/testdata/apply-module-depends-on/moda/main.tf
+++ b/terraform/testdata/apply-module-depends-on/moda/main.tf
@@ -1,0 +1,10 @@
+resource "test_instance" "a" {
+  num = 5
+}
+
+data "test_data_source" "a" {
+}
+
+output "out" {
+  value = data.test_data_source.a.id
+}

--- a/terraform/testdata/apply-module-depends-on/modb/main.tf
+++ b/terraform/testdata/apply-module-depends-on/modb/main.tf
@@ -1,0 +1,10 @@
+resource "test_instance" "b" {
+  num = 2
+}
+
+data "test_data_source" "b" {
+}
+
+output "out" {
+  value = test_instance.b.id
+}


### PR DESCRIPTION
Allow the use of `depends_on` for modules.

This PR stands on the existing work already done for module expansion, evaluation, and data source planning. See #24461, #24697, and #24904 for the majority of the work involved in making that happen. 

Now that modules can be ordered and referenced as a whole, and data sources will cleanly allow forced ordering  by `depends_on`; all that is left is to enable the feature in the config and add the graph connections for the `depends_on` references. 

Closes #10462
Closes #17101