### PR TITLE
Fix for #20669

### DIFF
--- a/scripts/docker-release/push.sh
+++ b/scripts/docker-release/push.sh
@@ -10,11 +10,17 @@ set -eu
 
 VERSION="$1"
 VERSION_SLUG="${VERSION#v}"
+VERSION_MAJOR_MINOR=$(echo ${VERSION_SLUG} |  awk -F . '{print $1"."$2}')
 
-echo "-- Pushing tags $VERSION_SLUG, light, full and latest up to dockerhub --"
+
+echo "-- Pushing tags ${VERSION_SLUG}, light, full and latest up to dockerhub --"
 echo ""
 
-docker push "hashicorp/terraform:$VERSION_SLUG"
+docker push "hashicorp/terraform:${VERSION_SLUG}"
 docker push "hashicorp/terraform:light"
 docker push "hashicorp/terraform:full"
 docker push "hashicorp/terraform:latest"
+
+docker push "hashicorp/terraform:${VERSION_MAJOR_MINOR}-light"
+docker push "hashicorp/terraform:${VERSION_MAJOR_MINOR}-full"
+docker push "hashicorp/terraform:${VERSION_MAJOR_MINOR}"

--- a/scripts/docker-release/tag.sh
+++ b/scripts/docker-release/tag.sh
@@ -31,4 +31,4 @@ docker tag "hashicorp/terraform:${VERSION_SLUG}" "hashicorp/terraform:${VERSION_
 docker tag "hashicorp/terraform:${VERSION_SLUG}" "hashicorp/terraform:${VERSION_MAJOR_MINOR}"
 docker tag "hashicorp/terraform:${VERSION_SLUG}-full" "hashicorp/terraform:${VERSION_MAJOR_MINOR}-full"
 
-docker images --format "table {{.Repository}}:{{.Tag}}\t{{.CreatedAt}}\t{{.Size}}" | grep hashicorp/terraform:${VERSION_MAJOR_MINOR}
+docker images --format "table {{.Repository}}:{{.Tag}}\t{{.CreatedAt}}\t{{.Size}}" | grep hashicorp/terraform

--- a/scripts/docker-release/tag.sh
+++ b/scripts/docker-release/tag.sh
@@ -17,10 +17,18 @@ set -eu
 
 VERSION="$1"
 VERSION_SLUG="${VERSION#v}"
+VERSION_MAJOR_MINOR=$(echo ${VERSION_SLUG} |  awk -F . '{print $1"."$2}')
 
-echo "-- Updating tags to point to version $VERSION --"
+
+echo "-- Updating tags to point to version ${VERSION} --"
 echo ""
 
 docker tag "hashicorp/terraform:${VERSION_SLUG}" "hashicorp/terraform:light"
 docker tag "hashicorp/terraform:${VERSION_SLUG}" "hashicorp/terraform:latest"
 docker tag "hashicorp/terraform:${VERSION_SLUG}-full" "hashicorp/terraform:full"
+
+docker tag "hashicorp/terraform:${VERSION_SLUG}" "hashicorp/terraform:${VERSION_MAJOR_MINOR}-light"
+docker tag "hashicorp/terraform:${VERSION_SLUG}" "hashicorp/terraform:${VERSION_MAJOR_MINOR}"
+docker tag "hashicorp/terraform:${VERSION_SLUG}-full" "hashicorp/terraform:${VERSION_MAJOR_MINOR}-full"
+
+docker images --format "table {{.Repository}}:{{.Tag}}\t{{.CreatedAt}}\t{{.Size}}" | grep hashicorp/terraform:${VERSION_MAJOR_MINOR}


### PR DESCRIPTION
Example run :

```
$ ./tag.sh v0.12.25
-- Updating tags to point to version v0.12.25 --

hashicorp/terraform:0.12                                           2020-05-13 10:09:39 -0700 PDT   80.2MB
hashicorp/terraform:0.12-full                                      2020-05-13 10:09:39 -0700 PDT   80.2MB
hashicorp/terraform:0.12-light                                     2020-05-13 10:09:39 -0700 PDT   80.2MB
hashicorp/terraform:0.12.25                                        2020-05-13 10:09:39 -0700 PDT   80.2MB
hashicorp/terraform:0.12.25-full                                   2020-05-13 10:09:39 -0700 PDT   80.2MB
hashicorp/terraform:full                                           2020-05-13 10:09:39 -0700 PDT   80.2MB
hashicorp/terraform:latest                                         2020-05-13 10:09:39 -0700 PDT   80.2MB
hashicorp/terraform:light                                          2020-05-13 10:09:39 -0700 PDT   80.2MB
```


Left the build process alone, but tag and push scripts were adjusted to be able to use a major.minor tagged image rolling forward.

See #20669
