### PR TITLE
command: Add UI hooks for read actions

### DIFF
--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -60,6 +60,7 @@ const (
 	uiResourceCreate
 	uiResourceModify
 	uiResourceDestroy
+	uiResourceRead
 )
 
 func (h *UiHook) PreApply(addr addrs.AbsResourceInstance, gen states.Generation, action plans.Action, priorState, plannedNewState cty.Value) (terraform.HookAction, error) {
@@ -83,6 +84,9 @@ func (h *UiHook) PreApply(addr addrs.AbsResourceInstance, gen states.Generation,
 	case plans.Update:
 		operation = "Modifying..."
 		op = uiResourceModify
+	case plans.Read:
+		operation = "Reading..."
+		op = uiResourceRead
 	default:
 		// We don't expect any other actions in here, so anything else is a
 		// bug in the caller but we'll ignore it in order to be robust.
@@ -196,6 +200,8 @@ func (h *UiHook) stillApplying(state uiResourceState) {
 			msg = "Still destroying..."
 		case uiResourceCreate:
 			msg = "Still creating..."
+		case uiResourceRead:
+			msg = "Still reading..."
 		case uiResourceUnknown:
 			return
 		}
@@ -241,6 +247,8 @@ func (h *UiHook) PostApply(addr addrs.AbsResourceInstance, gen states.Generation
 		msg = "Destruction complete"
 	case uiResourceCreate:
 		msg = "Creation complete"
+	case uiResourceRead:
+		msg = "Read complete"
 	case uiResourceUnknown:
 		return terraform.HookActionContinue, nil
 	}


### PR DESCRIPTION
Fixes an edge case where reading during apply would display "**(Unknown action Read for […])**" in the UI.

### Before

<img width="1110" alt="before" src="https://user-images.githubusercontent.com/68917/82601966-586dd900-9b7e-11ea-9cca-ba65039577cc.png">

### After

<img width="1110" alt="after" src="https://user-images.githubusercontent.com/68917/82601887-396f4700-9b7e-11ea-8919-8899dc23eb31.png">
