### PR TITLE
[WIP] Porting Terraformfile to Terraform 0.12

### DIFF
--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -141,13 +141,16 @@ func (i *ModuleInstaller) installDescendentModules(rootMod *tfconfig.Module, roo
 
 			override := false
 			preTerraformfileSource := req.SourceAddr
-			preTerraformfileVersion := req.VersionConstraints
+			var terraformfileSetVersion string
 			// Check for overwrites in Terraformfile
 			if tfile, err := NewTerraformfile(); err == nil {
 				if tfileModule, ok := tfile.GetTerraformEntryOk(req.SourceAddr); ok {
 					log.Printf("[TRACE] ModuleInstaller: Terraformfile source found %s new source: %s", req.SourceAddr, tfileModule.Source)
 					req.SourceAddr = tfileModule.Source
 					req.VersionConstraints = nil
+					if tfileModule.SetVersion != nil {
+						terraformfileSetVersion = *tfileModule.SetVersion
+					}
 					override = true
 
 					if tfileModule.Version != "" {
@@ -225,7 +228,7 @@ func (i *ModuleInstaller) installDescendentModules(rootMod *tfconfig.Module, roo
 				mod, mDiags := i.installLocalModule(req, key, manifest, hooks)
 				diags = append(diags, mDiags...)
 				if override {
-					terraformFileOverrideManifestEntry(key, manifest, preTerraformfileSource, preTerraformfileVersion)
+					terraformFileOverrideManifestEntry(key, manifest, preTerraformfileSource, terraformfileSetVersion)
 				}
 				return mod, nil, diags
 
@@ -241,7 +244,7 @@ func (i *ModuleInstaller) installDescendentModules(rootMod *tfconfig.Module, roo
 				diags = append(diags, mDiags...)
 
 				if override {
-					terraformFileOverrideManifestEntry(key, manifest, preTerraformfileSource, preTerraformfileVersion)
+					terraformFileOverrideManifestEntry(key, manifest, preTerraformfileSource, terraformfileSetVersion)
 				}
 				return mod, v, diags
 
@@ -252,7 +255,7 @@ func (i *ModuleInstaller) installDescendentModules(rootMod *tfconfig.Module, roo
 				diags = append(diags, mDiags...)
 
 				if override {
-					terraformFileOverrideManifestEntry(key, manifest, preTerraformfileSource, preTerraformfileVersion)
+					terraformFileOverrideManifestEntry(key, manifest, preTerraformfileSource, terraformfileSetVersion)
 				}
 				return mod, nil, diags
 			}

--- a/internal/initwd/terraformfile.go
+++ b/internal/initwd/terraformfile.go
@@ -1,0 +1,67 @@
+package initwd
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+
+	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform/internal/modsdir"
+)
+
+type TerraformfileEntry struct {
+	MatchVersion string `json:"matchVersion,omitempty"`
+	Source       string `json:"source"`
+	Version      string `json:"version,omitempty"`
+}
+
+type Terraformfile map[string]TerraformfileEntry
+
+func NewTerraformfile() (*Terraformfile, error) {
+	var tfile Terraformfile
+	var tfilepath string
+	tfilepathenv := os.Getenv("TERRAFORMFILE_PATH")
+	if tfilepathenv != "" {
+		tfilepath = tfilepathenv
+	} else {
+		tfilepath = "./Terraformfile"
+	}
+
+	tfiledata, err := ioutil.ReadFile(tfilepath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Terrformfile is not a must.
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	err = json.Unmarshal(tfiledata, &tfile)
+	if err != nil {
+		return nil, err
+	}
+	return &tfile, nil
+}
+
+func (tfile *Terraformfile) GetTerraformEntryOk(source string) (TerraformfileEntry, bool) {
+	if tfile == nil {
+		return TerraformfileEntry{}, false
+	}
+	entry, ok := (*tfile)[source]
+	return entry, ok
+}
+
+func terraformFileOverrideManifestEntry(key string, manifest modsdir.Manifest, source string, version version.Constraints) {
+	record, _ := manifest[key]
+	record.SourceAddr = source
+
+	manifest[key] = record
+}
+
+//
+// func (tfile *Terraformfile) InTerraformfile() bool {
+// 	if len(tfile) < 1 {
+// 		return false
+// 	}
+// 	return
+// }

--- a/internal/initwd/terraformfile.go
+++ b/internal/initwd/terraformfile.go
@@ -3,6 +3,7 @@ package initwd
 import (
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"os"
 
 	version "github.com/hashicorp/go-version"
@@ -10,9 +11,10 @@ import (
 )
 
 type TerraformfileEntry struct {
-	MatchVersion string `json:"matchVersion,omitempty"`
-	Source       string `json:"source"`
-	Version      string `json:"version,omitempty"`
+	MatchVersion string  `json:"matchVersion,omitempty"`
+	Source       string  `json:"source"`
+	Version      string  `json:"version,omitempty"`
+	SetVersion   *string `json:"set_version,omitempty"`
 }
 
 type Terraformfile map[string]TerraformfileEntry
@@ -51,9 +53,18 @@ func (tfile *Terraformfile) GetTerraformEntryOk(source string) (TerraformfileEnt
 	return entry, ok
 }
 
-func terraformFileOverrideManifestEntry(key string, manifest modsdir.Manifest, source string, version version.Constraints) {
+func terraformFileOverrideManifestEntry(key string, manifest modsdir.Manifest, source string, setVersion string) {
 	record, _ := manifest[key]
 	record.SourceAddr = source
+	if setVersion != "" {
+		log.Printf("[TRACE] Terraformfile: found SetVersion %s", setVersion)
+		v, err := version.NewVersion(setVersion)
+		if err != nil {
+			log.Printf("[TRACE] Terraformfile: Version parsing error %s", err)
+		} else {
+			record.Version = v
+		}
+	}
 
 	manifest[key] = record
 }

--- a/internal/initwd/terraformfile_test.go
+++ b/internal/initwd/terraformfile_test.go
@@ -1,0 +1,18 @@
+package initwd
+
+import (
+	"testing"
+)
+
+func TestNewTerraformfile(t *testing.T) {
+	tfile, err := NewTerraformfile()
+	if err != nil {
+		t.Fatalf("unexpected error from NewLoader: %s", err)
+	}
+
+	//expected empty tfile
+	entry, ok := tfile.GetTerraformEntryOk("foo/bar/test")
+	if ok {
+		t.Fatalf("unexpected ok found entry %v", entry)
+	}
+}

--- a/internal/initwd/testdata/terraformfile/Terraformfile
+++ b/internal/initwd/testdata/terraformfile/Terraformfile
@@ -1,0 +1,5 @@
+{
+  "./child_a": {
+    "source": "./child_b"
+  }
+}

--- a/internal/initwd/testdata/terraformfile/Terraformfile
+++ b/internal/initwd/testdata/terraformfile/Terraformfile
@@ -1,5 +1,6 @@
 {
-  "./child_a": {
+  "fakemodule/childa/null": {
     "source": "./child_b"
+    "version_set": "1.2.3"
   }
 }

--- a/internal/initwd/testdata/terraformfile/child_a/main.tf
+++ b/internal/initwd/testdata/terraformfile/child_a/main.tf
@@ -1,0 +1,8 @@
+variable "v" {
+  description = "in child_a module"
+  default     = ""
+}
+
+output "hello" {
+  value = "Hello from child_a!"
+}

--- a/internal/initwd/testdata/terraformfile/child_b/main.tf
+++ b/internal/initwd/testdata/terraformfile/child_b/main.tf
@@ -1,0 +1,8 @@
+variable "v" {
+  description = "in child_b module"
+  default     = ""
+}
+
+output "hello" {
+  value = "Hello from child_b!"
+}

--- a/internal/initwd/testdata/terraformfile/main.tf
+++ b/internal/initwd/testdata/terraformfile/main.tf
@@ -1,0 +1,8 @@
+variable "v" {
+  description = "in root module"
+  default     = ""
+}
+
+module "child_a" {
+  source = "./child_a"
+}

--- a/internal/initwd/testdata/terraformfile/main.tf
+++ b/internal/initwd/testdata/terraformfile/main.tf
@@ -4,5 +4,5 @@ variable "v" {
 }
 
 module "child_a" {
-  source = "./child_a"
+  source = "fakemodule/childa/null"
 }


### PR DESCRIPTION
This PR is still work in progress and be considered as a POC

It uses the same file as described in #20229 in the form of:

```
{
  "dcos-terraform/instance/aws": {
    "source": "fatz/instance/aws"
    "version": "0.0.1",
    "set_version": "0.1.2"
  }
}
```

See #20229 for details.


@apparentlymart sorry to ping you directly but I'd like to follow up our discussion on #20229 having a way to manipulate module sources outside HCL code. 

We're starting to migrate our modules to terraform 0.12 so we need the same mechanism for our CI as being described before.

This PR is currently just a bad clone of the previous PR. It turned out that modules.json and downloads are treated a bit differently in TF0.12 so this is just a monkey patch for now.

We still think that this feature would be a great addition to Terraform. You mentioned in https://github.com/hashicorp/terraform/pull/20229#issuecomment-461963274 that there are some design sketches already existing. Is there already a finial design? Would it make sense if we can take a look at these designs and maybe donate the code for it?