### PR TITLE
Recursive DeepMerge function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.dll
 *.exe
 .DS_Store
+.vscode
 example.tf
 terraform.tfplan
 terraform.tfstate

--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -128,6 +128,12 @@ var DeepMergeFunc = function.New(&function.Spec{
 		// check for invalid arguments
 		for _, arg := range args {
 			ty := arg.Type()
+
+			// we can't work with dynamic types, so move along
+			if ty.Equals(cty.DynamicPseudoType) {
+				return cty.DynamicPseudoType, nil
+			}
+
 			if !ty.IsMapType() && !ty.IsObjectType() {
 				return cty.NilType, fmt.Errorf("arguments must be maps or objects, got %#v", ty.FriendlyName())
 			}
@@ -158,6 +164,12 @@ var DeepMergeFunc = function.New(&function.Spec{
 })
 
 func recursiveMerge(newValue cty.Value, existingValue cty.Value) cty.Value {
+
+	// unknown types trump known ones, don't merge
+	if !existingValue.IsKnown() {
+		return existingValue
+	}
+
 	// New value isn't mergeable, so just replace.
 	newValueMergeable := newValue.Type().IsMapType() || newValue.Type().IsObjectType()
 	existingValueMergeable := existingValue.Type().IsMapType() || existingValue.Type().IsObjectType()

--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -158,7 +158,6 @@ var DeepMergeFunc = function.New(&function.Spec{
 })
 
 func recursiveMerge(newValue cty.Value, existingValue cty.Value) cty.Value {
-	// TODO test around overriding with null. should it leave existing stuff alone or wipe it out?
 	// New value isn't mergeable, so just replace.
 	newValueMergeable := newValue.Type().IsMapType() || newValue.Type().IsObjectType()
 	existingValueMergeable := existingValue.Type().IsMapType() || existingValue.Type().IsObjectType()

--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -192,6 +192,12 @@ func recursiveMerge(newValue cty.Value, existingValue cty.Value) cty.Value {
 
 		mergedMap[key] = recursiveMerge(newValue, mergedMap[key])
 	}
+	// strip out any null properties
+	for key, value := range mergedMap {
+		if value.IsNull() {
+			delete(mergedMap, key)
+		}
+	}
 
 	return wrapAsObjectOrMap(mergedMap)
 }

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -112,26 +112,26 @@ func TestDeepMerge(t *testing.T) {
 			}),
 			false,
 		},
-		// { // handle unknowns
-		// 	[]cty.Value{
-		// 		cty.UnknownVal(cty.Map(cty.String)),
-		// 		cty.MapVal(map[string]cty.Value{
-		// 			"c": cty.StringVal("d"),
-		// 		}),
-		// 	},
-		// 	cty.UnknownVal(cty.Map(cty.String)),
-		// 	false,
-		// },
-		// { // handle dynamic unknown
-		// 	[]cty.Value{
-		// 		cty.UnknownVal(cty.DynamicPseudoType),
-		// 		cty.MapVal(map[string]cty.Value{
-		// 			"c": cty.StringVal("d"),
-		// 		}),
-		// 	},
-		// 	cty.DynamicVal,
-		// 	false,
-		// },
+		{ // handle unknowns
+			[]cty.Value{
+				cty.UnknownVal(cty.Map(cty.String)),
+				cty.MapVal(map[string]cty.Value{
+					"c": cty.StringVal("d"),
+				}),
+			},
+			cty.UnknownVal(cty.Map(cty.String)),
+			false,
+		},
+		{ // handle dynamic unknown
+			[]cty.Value{
+				cty.UnknownVal(cty.DynamicPseudoType),
+				cty.MapVal(map[string]cty.Value{
+					"c": cty.StringVal("d"),
+				}),
+			},
+			cty.DynamicVal,
+			false,
+		},
 		{ // merge with conflicts is ok, last in wins
 			[]cty.Value{
 				cty.MapVal(map[string]cty.Value{

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -14,6 +14,27 @@ func TestDeepMerge(t *testing.T) {
 		Want   cty.Value
 		Err    bool
 	}{
+		{ // remove props if set to null
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("a"),
+					"b": cty.StringVal("b"),
+					"c": cty.NullVal(cty.String),
+					"d": cty.StringVal("d"),
+				}),
+				cty.MapVal(map[string]cty.Value{
+					"b": cty.NullVal(cty.String),
+					"c": cty.StringVal("c"),
+					"e": cty.NullVal(cty.String),
+				}),
+			},
+			cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("a"),
+				"c": cty.StringVal("c"),
+				"d": cty.StringVal("d"),
+			}),
+			false,
+		},
 		{
 			[]cty.Value{
 				cty.ObjectVal(map[string]cty.Value{

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -93,7 +93,9 @@ func TestDeepMerge(t *testing.T) {
 					"a": cty.List(cty.String),
 				})),
 			},
-			cty.NullVal(cty.EmptyObject),
+			cty.NullVal(cty.Object(map[string]cty.Type{
+				"a": cty.List(cty.String),
+			})),
 			false,
 		},
 		{ // handle null object
@@ -298,11 +300,57 @@ func TestDeepMerge(t *testing.T) {
 				}),
 			},
 			cty.ObjectVal(map[string]cty.Value{
-				"a": cty.MapVal(map[string]cty.Value{
+				"a": cty.ObjectVal(map[string]cty.Value{
 					"e": cty.StringVal("f"),
 				}),
 				"b": cty.StringVal("b"),
 			}),
+			false,
+		},
+		{ // replacing a non-map/object with a map/object
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("b"),
+				}),
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.MapVal(map[string]cty.Value{
+						"c": cty.StringVal("d"),
+					}),
+				}),
+			},
+			cty.MapVal(map[string]cty.Value{
+				"a": cty.MapVal(map[string]cty.Value{
+					"c": cty.StringVal("d"),
+				}),
+			}),
+			false,
+		},
+		{ // replacing a map/object with a non-map/object
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.MapVal(map[string]cty.Value{
+						"c": cty.StringVal("d"),
+					}),
+				}),
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("b"),
+				}),
+			},
+			cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("b"),
+			}),
+			false,
+		},
+		{ // value of null deletes a field
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("b"),
+				}),
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.NullVal(cty.String),
+				}),
+			},
+			cty.EmptyObjectVal,
 			false,
 		},
 		{ // argument error: non map type

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -112,26 +112,26 @@ func TestDeepMerge(t *testing.T) {
 			}),
 			false,
 		},
-		{ // handle unknowns
-			[]cty.Value{
-				cty.UnknownVal(cty.Map(cty.String)),
-				cty.MapVal(map[string]cty.Value{
-					"c": cty.StringVal("d"),
-				}),
-			},
-			cty.UnknownVal(cty.Map(cty.String)),
-			false,
-		},
-		{ // handle dynamic unknown
-			[]cty.Value{
-				cty.UnknownVal(cty.DynamicPseudoType),
-				cty.MapVal(map[string]cty.Value{
-					"c": cty.StringVal("d"),
-				}),
-			},
-			cty.DynamicVal,
-			false,
-		},
+		// { // handle unknowns
+		// 	[]cty.Value{
+		// 		cty.UnknownVal(cty.Map(cty.String)),
+		// 		cty.MapVal(map[string]cty.Value{
+		// 			"c": cty.StringVal("d"),
+		// 		}),
+		// 	},
+		// 	cty.UnknownVal(cty.Map(cty.String)),
+		// 	false,
+		// },
+		// { // handle dynamic unknown
+		// 	[]cty.Value{
+		// 		cty.UnknownVal(cty.DynamicPseudoType),
+		// 		cty.MapVal(map[string]cty.Value{
+		// 			"c": cty.StringVal("d"),
+		// 		}),
+		// 	},
+		// 	cty.DynamicVal,
+		// 	false,
+		// },
 		{ // merge with conflicts is ok, last in wins
 			[]cty.Value{
 				cty.MapVal(map[string]cty.Value{

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/zclconf/go-cty/cty/function"
 )
 
-func TestMerge(t *testing.T) {
+func TestDeepMerge(t *testing.T) {
 	tests := []struct {
 		Values []cty.Value
 		Want   cty.Value
@@ -33,7 +33,7 @@ func TestMerge(t *testing.T) {
 					}),
 				}),
 			},
-			cty.ObjectVal(map[string]cty.Value{
+			cty.MapVal(map[string]cty.Value{
 				"a": cty.MapVal(map[string]cty.Value{
 					"a2": cty.MapVal(map[string]cty.Value{
 						"a3": cty.StringVal("a3-changed"),
@@ -86,7 +86,7 @@ func TestMerge(t *testing.T) {
 			}),
 			false,
 		},
-		{ // handle null map
+		{ // handle null map **BROKEN**
 			[]cty.Value{
 				cty.NullVal(cty.Map(cty.String)),
 				cty.NullVal(cty.Object(map[string]cty.Type{
@@ -105,7 +105,7 @@ func TestMerge(t *testing.T) {
 					"a": cty.List(cty.String),
 				})),
 			},
-			cty.ObjectVal(map[string]cty.Value{
+			cty.MapVal(map[string]cty.Value{
 				"c": cty.StringVal("d"),
 			}),
 			false,
@@ -170,7 +170,7 @@ func TestMerge(t *testing.T) {
 			cty.NilVal,
 			true,
 		},
-		{ // merge maps of maps //TODO: BROKEN
+		{ // merge maps of maps
 			[]cty.Value{
 				cty.MapVal(map[string]cty.Value{
 					"a": cty.MapVal(map[string]cty.Value{
@@ -220,7 +220,7 @@ func TestMerge(t *testing.T) {
 			}),
 			false,
 		},
-		{ // merge map of various kinds //TODO: BROKEN
+		{ // merge map of various kinds
 			[]cty.Value{
 				cty.MapVal(map[string]cty.Value{
 					"a": cty.ListVal([]cty.Value{
@@ -283,44 +283,44 @@ func TestMerge(t *testing.T) {
 			}),
 			false,
 		},
-		// { // attr a type and value is overridden
-		// 	[]cty.Value{
-		// 		cty.ObjectVal(map[string]cty.Value{
-		// 			"a": cty.ListVal([]cty.Value{
-		// 				cty.StringVal("b"),
-		// 			}),
-		// 			"b": cty.StringVal("b"),
-		// 		}),
-		// 		cty.ObjectVal(map[string]cty.Value{
-		// 			"a": cty.ObjectVal(map[string]cty.Value{
-		// 				"e": cty.StringVal("f"),
-		// 			}),
-		// 		}),
-		// 	},
-		// 	cty.ObjectVal(map[string]cty.Value{
-		// 		"a": cty.MapVal(map[string]cty.Value{
-		// 			"e": cty.StringVal("f"),
-		// 		}),
-		// 		"b": cty.StringVal("b"),
-		// 	}),
-		// 	false,
-		// },
-		// { // argument error: non map type
-		// 	[]cty.Value{
-		// 		cty.MapVal(map[string]cty.Value{
-		// 			"a": cty.ListVal([]cty.Value{
-		// 				cty.StringVal("b"),
-		// 				cty.StringVal("c"),
-		// 			}),
-		// 		}),
-		// 		cty.ListVal([]cty.Value{
-		// 			cty.StringVal("d"),
-		// 			cty.StringVal("e"),
-		// 		}),
-		// 	},
-		// 	cty.NilVal,
-		// 	true,
-		// },
+		{ // attr a type and value is overridden
+			[]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.ListVal([]cty.Value{
+						cty.StringVal("b"),
+					}),
+					"b": cty.StringVal("b"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"e": cty.StringVal("f"),
+					}),
+				}),
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.MapVal(map[string]cty.Value{
+					"e": cty.StringVal("f"),
+				}),
+				"b": cty.StringVal("b"),
+			}),
+			false,
+		},
+		{ // argument error: non map type
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.ListVal([]cty.Value{
+						cty.StringVal("b"),
+						cty.StringVal("c"),
+					}),
+				}),
+				cty.ListVal([]cty.Value{
+					cty.StringVal("d"),
+					cty.StringVal("e"),
+				}),
+			},
+			cty.NilVal,
+			true,
+		},
 	}
 
 	for _, test := range tests {

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -86,7 +86,7 @@ func TestDeepMerge(t *testing.T) {
 			}),
 			false,
 		},
-		{ // handle null map **BROKEN**
+		{ // handle null map
 			[]cty.Value{
 				cty.NullVal(cty.Map(cty.String)),
 				cty.NullVal(cty.Object(map[string]cty.Type{

--- a/lang/functions.go
+++ b/lang/functions.go
@@ -53,6 +53,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"concat":           stdlib.ConcatFunc,
 			"contains":         stdlib.ContainsFunc,
 			"csvdecode":        stdlib.CSVDecodeFunc,
+			"deepmerge":        funcs.DeepMergeFunc,
 			"dirname":          funcs.DirnameFunc,
 			"distinct":         stdlib.DistinctFunc,
 			"element":          stdlib.ElementFunc,

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -278,7 +278,7 @@ func TestFunctions(t *testing.T) {
 		"deepmerge": {
 			{
 				`deepmerge({"a"="b"}, {"c"="d"})`,
-				cty.ObjectVal(map[string]cty.Value{
+				cty.MapVal(map[string]cty.Value{
 					"a": cty.StringVal("b"),
 					"c": cty.StringVal("d"),
 				}),

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -275,6 +275,16 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"deepmerge": {
+			{
+				`deepmerge({"a"="b"}, {"c"="d"})`,
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.StringVal("b"),
+					"c": cty.StringVal("d"),
+				}),
+			},
+		},
+
 		"dirname": {
 			{
 				`dirname("testdata/hello.txt")`,

--- a/website/docs/configuration/functions/deepmerge.html.md
+++ b/website/docs/configuration/functions/deepmerge.html.md
@@ -23,6 +23,10 @@ or object that contains a merged set of elements from all arguments.
 The behavior is exactly the same as `merge`, but it will recurse in to objects, and supports
 partial updates of nested objects.
 
+## Null Values
+Any properties that are set to a `null` value will be removed from the final object/map. If you wish
+to keep these properties, make sure to fill them with a default value (ex: `{}`)
+
 ## Examples
 
 ```

--- a/website/docs/configuration/functions/deepmerge.html.md
+++ b/website/docs/configuration/functions/deepmerge.html.md
@@ -1,0 +1,56 @@
+---
+layout: "functions"
+page_title: "deepmerge - Functions - Configuration Language"
+sidebar_current: "docs-funcs-collection-merge"
+description: |-
+  The deepmerge function takes an arbitrary number maps or objects, and returns a
+  single map or object that contains a merged set of elements from all
+  arguments.
+
+  The behavior is exactly the same as `merge`, but it will recurse in to objects, and supports
+  partial updates of nested objects.
+---
+
+# `deepmerge` Function
+
+-> **Note:** This page is about Terraform 0.12 and later. For Terraform 0.11 and
+earlier, see
+[0.11 Configuration Language: Interpolation Syntax](../../configuration-0-11/interpolation.html).
+
+`deepmerge` takes an arbitrary number of maps or objects, and returns a single map
+or object that contains a merged set of elements from all arguments.
+
+The behavior is exactly the same as `merge`, but it will recurse in to objects, and supports
+partial updates of nested objects.
+
+## Examples
+
+```
+> deepmerge({a={a="a",a2="a2"},b="b",c={c={c="c"}}}, {a={a="a-updated",a3="new-prop"}, b="b",c={c={c1="new-prop"}}})
+{
+  "a" = {
+    "a" = "a-updated"
+    "a2" = "a2"
+    "a3" = "new-prop"
+  }
+  "b" = "b"
+}
+```
+
+```
+> deepmerge({a={a="a",a2="a2"},b="b",c={c={c="c"}}}, {a={a="a-updated",a3="new-prop"}, b="b",c={c={c1="new-prop"}}})
+{
+  "a" = {
+    "a" = "a-updated"
+    "a2" = "a2"
+    "a3" = "new-prop"
+  }
+  "b" = "b"
+  "c" = {
+    "c" = {
+      "c" = "c"
+      "c1" = "new-prop"
+    }
+  }
+}
+```

--- a/website/layouts/functions.erb
+++ b/website/layouts/functions.erb
@@ -207,6 +207,10 @@
               </li>
 
               <li>
+                <a href="/docs/configuration/functions/deepmerge.html">deepmerge</a>
+              </li>
+
+              <li>
                 <a href="/docs/configuration/functions/range.html">range</a>
               </li>
 

--- a/website/layouts/functions.erb
+++ b/website/layouts/functions.erb
@@ -161,6 +161,10 @@
               <li>
                 <a href="/docs/configuration/functions/contains.html">contains</a>
               </li>
+              
+              <li>
+                <a href="/docs/configuration/functions/deepmerge.html">deepmerge</a>
+              </li>
 
               <li>
                 <a href="/docs/configuration/functions/distinct.html">distinct</a>
@@ -204,10 +208,6 @@
 
               <li>
                 <a href="/docs/configuration/functions/merge.html">merge</a>
-              </li>
-
-              <li>
-                <a href="/docs/configuration/functions/deepmerge.html">deepmerge</a>
               </li>
 
               <li>


### PR DESCRIPTION
## Description
This function duplicates the existing behavior of the `merge` function, and supplements it with recursive scanning to child objects. This *fixes* scenarios where you may want to do a partial update of a nested object, but the current `merge` function can't perform it due to it only operating at the root level. Any type can be overridden with a different type by a later map/object. 

A new function was created to avoid breaking code that relies on the current `merge` behavior.

## Tests
All the original `merge` unit tests were copied, and pass against `deepmerge`. Additional tests were added for overriding child properties.

## Example
```terraform
variable map1 {
    default = {
        a = "test"
        b = {
            b1 = "b1"
            b2 = "b2"
            b4 = {
                b5 = "b5"
            }
        }
        c = [1,2,3]
    }
}

variable map2 {
    default = {
        b = {
            b1 = "b1-updated"
            b3 = "b3"
            b4 = {
                b5 = "b5-updated"
            }
        }
        c = [1,2,3,4]
    }
}

locals{
    output = deepmerge(var.map1, var.map2)
}

output o {
    value = local.output
}
```
```sh
Outputs:

o = {
  "a" = "test"
  "b" = {
    "b1" = "b1-updated"
    "b2" = "b2"
    "b3" = "b3"
    "b4" = {
      "b5" = "b5-updated"
    }
  }
  "c" = [
    1,
    2,
    3,
    4,
  ]
}
```