### PR TITLE
:pencil: LocalStack backend example

### DIFF
--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -413,3 +413,32 @@ to lock any workspace state, even if they do not have access to read or write
 that state. If a malicious user has such access they could block attempts to
 use Terraform against some or all of your workspaces as long as locking is
 enabled in the backend configuration.
+
+## Connecting to Local AWS Compatible Solutions
+
+~> **NOTE:** This information is not intended to be exhaustive for all local AWS compatible solutions or necessarily authoritative configurations for those documented. Check the documentation for each of these solutions for the most up to date information.
+
+### LocalStack
+
+[LocalStack](https://localstack.cloud/) provides an easy-to-use test/mocking framework for developing Cloud applications.
+
+An example backend configuration:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket = "state_bucket"
+    key = "state.key"
+
+    access_key = "mock_access_key"
+    region = "us-east-1"
+    force_path_style = true
+    secret_key = "mock_secret_key"
+    skip_credentials_validation = true
+    
+    endpoint = "http://localhost:4566"
+  }
+}
+```
+
+This comes in handy when combined with [Terraform AWS Provider configured towards LocalStack](https://www.terraform.io/docs/providers/aws/guides/custom-service-endpoints.html#localstack)


### PR DESCRIPTION
This documentation is to accompany [the corresponding part](https://www.terraform.io/docs/providers/aws/guides/custom-service-endpoints.html#localstack) of AWS Provider documentation.