### PR TITLE
configs: Custom variable validation is no longer experimental

### DIFF
--- a/configs/experiments.go
+++ b/configs/experiments.go
@@ -139,18 +139,5 @@ func checkModuleExperiments(m *Module) hcl.Diagnostics {
 		}
 	*/
 
-	if !m.ActiveExperiments.Has(experiments.VariableValidation) {
-		for _, vc := range m.Variables {
-			if len(vc.Validations) != 0 {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Custom variable validation is experimental",
-					Detail:   "This feature is currently an opt-in experiment, subject to change in future releases based on feedback.\n\nActivate the feature for this module by adding variable_validation to the list of active experiments.",
-					Subject:  vc.Validations[0].DeclRange.Ptr(),
-				})
-			}
-		}
-	}
-
 	return diags
 }

--- a/configs/testdata/invalid-files/variable-validation-bad-msg.tf
+++ b/configs/testdata/invalid-files/variable-validation-bad-msg.tf
@@ -1,8 +1,3 @@
-
-terraform {
-  experiments = [variable_validation]
-}
-
 variable "validation" {
   validation {
     condition     = var.validation != 4

--- a/configs/testdata/invalid-files/variable-validation-condition-badref.tf
+++ b/configs/testdata/invalid-files/variable-validation-condition-badref.tf
@@ -1,8 +1,4 @@
 
-terraform {
-  experiments = [variable_validation]
-}
-
 locals {
   foo = 1
 }

--- a/configs/testdata/invalid-files/variable-validation-condition-noref.tf
+++ b/configs/testdata/invalid-files/variable-validation-condition-noref.tf
@@ -1,8 +1,4 @@
 
-terraform {
-  experiments = [variable_validation]
-}
-
 variable "validation" {
   validation {
     condition     = true # ERROR: Invalid variable validation condition

--- a/configs/testdata/invalid-modules/variable-validation-without-optin/variable-validation-without-optin.tf
+++ b/configs/testdata/invalid-modules/variable-validation-without-optin/variable-validation-without-optin.tf
@@ -1,7 +1,0 @@
-
-variable "validation_without_optin" {
-  validation { # ERROR: Custom variable validation is experimental
-    condition     = var.validation_without_optin != 4
-    error_message = "Must not be four."
-  }
-}

--- a/configs/testdata/valid-files/variable_validation.tf
+++ b/configs/testdata/valid-files/variable_validation.tf
@@ -1,7 +1,3 @@
-terraform {
-  experiments = [variable_validation] # WARNING: Experimental feature "variable_validation" is active
-}
-
 variable "validation" {
   validation {
     condition     = var.validation == 5

--- a/experiments/experiment.go
+++ b/experiments/experiment.go
@@ -19,7 +19,7 @@ const (
 func init() {
 	// Each experiment constant defined above must be registered here as either
 	// a current or a concluded experiment.
-	registerCurrentExperiment(VariableValidation)
+	registerConcludedExperiment(VariableValidation, "Custom variable validation can now be used by default, without enabling an experiment.")
 }
 
 // GetCurrent takes an experiment name and returns the experiment value

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -1371,14 +1371,6 @@ func TestContext2Validate_variableCustomValidationsRoot(t *testing.T) {
 	// altogether. (Root module variables are never known during validation.)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
-# This feature is currently experimental.
-# (If you're currently cleaning up after concluding the experiment,
-# remember to also clean up similar references in the configs package
-# under "invalid-files" and "invalid-modules".)
-terraform {
-  experiments = [variable_validation]
-}
-
 variable "test" {
   type = string
 

--- a/terraform/testdata/validate-variable-custom-validations-child/child/child.tf
+++ b/terraform/testdata/validate-variable-custom-validations-child/child/child.tf
@@ -1,11 +1,3 @@
-# This feature is currently experimental.
-# (If you're currently cleaning up after concluding the experiment,
-# remember to also clean up similar references in the configs package
-# under "invalid-files" and "invalid-modules".)
-terraform {
-  experiments = [variable_validation]
-}
-
 variable "test" {
   type = string
 

--- a/website/docs/configuration/functions/can.html.md
+++ b/website/docs/configuration/functions/can.html.md
@@ -30,7 +30,7 @@ For example:
 variable "timestamp" {
   type        = string
 
-  validation { # NOTE: custom validation is currently an opt-in experiment (see link above)
+  validation {
     # formatdate fails if the second argument is not a valid timestamp
     condition     = can(formatdate("", var.timestamp))
     error_message = "The timestamp argument requires a valid RFC 3339 timestamp."

--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -166,9 +166,7 @@ commentary for module maintainers, use comments.
 
 ## Custom Validation Rules
 
-~> *Warning:* This feature is currently experimental and is subject to breaking
-changes even in minor releases. We welcome your feedback, but cannot
-recommend using this feature in production modules yet.
+-> This feature was introduced in Terraform CLI v0.13.0.
 
 In addition to Type Constraints as described above, a module author can specify
 arbitrary custom validation rules for a particular variable using a `validation`
@@ -211,16 +209,6 @@ If `condition` evaluates to `false`, Terraform will produce an error message
 that includes the sentences given in `error_message`. The error message string
 should be at least one full sentence explaining the constraint that failed,
 using a sentence structure similar to the above examples.
-
-This is [an experimental language feature](./terraform.html#experimental-language-features)
-that currently requires an explicit opt-in using the experiment keyword
-`variable_validation`:
-
-```hcl
-terraform {
-  experiments = [variable_validation]
-}
-```
 
 ## Assigning Values to Root Module Variables
 


### PR DESCRIPTION
All of the feedback from the experiment described enhancements that can potentially be added later without breaking changes, so this change simply removes the experiment gate from the feature as originally implemented with no changes to its functionality.

Further enhancements may follow in later releases, but the goal of this change is just to ship the feature exactly as it was under the experiment.

Most of the changes here are cleaning up the experiment opt-ins from our test cases. The most important parts are in `configs/experiments.go` and in `experiments/experiment.go`.
