### PR TITLE
command/init: Better diagnostics for provider 404s

### DIFF
--- a/command/013_config_upgrade_test.go
+++ b/command/013_config_upgrade_test.go
@@ -2,10 +2,7 @@ package command
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path"
 	"path/filepath"
@@ -13,21 +10,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	svchost "github.com/hashicorp/terraform-svchost"
-	"github.com/hashicorp/terraform-svchost/disco"
 	"github.com/hashicorp/terraform/helper/copy"
-	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/mitchellh/cli"
 )
-
-// This map from provider type name to namespace is used by the fake registry
-// when called via LookupLegacyProvider. Providers not in this map will return
-// a 404 Not Found error.
-var legacyProviderNamespaces = map[string]string{
-	"foo": "hashicorp",
-	"bar": "hashicorp",
-	"baz": "terraform-providers",
-}
 
 func verifyExpectedFiles(t *testing.T, expectedPath string) {
 	// Compare output and expected file trees
@@ -378,70 +363,5 @@ func TestZeroThirteenUpgrade_empty(t *testing.T) {
 	errMsg := ui.ErrorWriter.String()
 	if !strings.Contains(errMsg, "Not a module directory") {
 		t.Fatal("unexpected error:", errMsg)
-	}
-}
-
-// testServices starts up a local HTTP server running a fake provider registry
-// service which responds only to discovery requests and legacy provider lookup
-// API calls.
-//
-// The final return value is a function to call at the end of a test function
-// to shut down the test server. After you call that function, the discovery
-// object becomes useless.
-func testServices(t *testing.T) (services *disco.Disco, cleanup func()) {
-	server := httptest.NewServer(http.HandlerFunc(fakeRegistryHandler))
-
-	services = disco.New()
-	services.ForceHostServices(svchost.Hostname("registry.terraform.io"), map[string]interface{}{
-		"providers.v1": server.URL + "/providers/v1/",
-	})
-
-	return services, func() {
-		server.Close()
-	}
-}
-
-// testRegistrySource is a wrapper around testServices that uses the created
-// discovery object to produce a Source instance that is ready to use with the
-// fake registry services.
-//
-// As with testServices, the final return value is a function to call at the end
-// of your test in order to shut down the test server.
-func testRegistrySource(t *testing.T) (source *getproviders.RegistrySource, cleanup func()) {
-	services, close := testServices(t)
-	source = getproviders.NewRegistrySource(services)
-	return source, close
-}
-
-func fakeRegistryHandler(resp http.ResponseWriter, req *http.Request) {
-	path := req.URL.EscapedPath()
-
-	if !strings.HasPrefix(path, "/providers/v1/") {
-		resp.WriteHeader(404)
-		resp.Write([]byte(`not a provider registry endpoint`))
-		return
-	}
-
-	pathParts := strings.Split(path, "/")[3:]
-
-	if len(pathParts) != 3 {
-		resp.WriteHeader(404)
-		resp.Write([]byte(`unrecognized path scheme`))
-		return
-	}
-
-	if pathParts[0] != "-" || pathParts[2] != "versions" {
-		resp.WriteHeader(404)
-		resp.Write([]byte(`this registry only supports legacy namespace lookup requests`))
-	}
-
-	name := pathParts[1]
-	if namespace, ok := legacyProviderNamespaces[name]; ok {
-		resp.Header().Set("Content-Type", "application/json")
-		resp.WriteHeader(200)
-		resp.Write([]byte(fmt.Sprintf(`{"id":"%s/%s"}`, namespace, name)))
-	} else {
-		resp.WriteHeader(404)
-		resp.Write([]byte(`provider not found`))
 	}
 }

--- a/command/e2etest/init_test.go
+++ b/command/e2etest/init_test.go
@@ -329,7 +329,7 @@ func TestInitProviderNotFound(t *testing.T) {
 			t.Fatal("expected error, got success")
 		}
 
-		if !strings.Contains(stderr, "provider registry registry.terraform.io does not have a\nprovider named registry.terraform.io/hashicorp/nonexist") {
+		if !strings.Contains(stderr, "provider registry\nregistry.terraform.io does not have a provider named\nregistry.terraform.io/hashicorp/nonexist") {
 			t.Errorf("expected error message is missing from output:\n%s", stderr)
 		}
 	})

--- a/command/testdata/init-get-provider-detected-legacy/main.tf
+++ b/command/testdata/init-get-provider-detected-legacy/main.tf
@@ -1,0 +1,10 @@
+// This should result in installing hashicorp/foo
+provider foo {}
+
+// This will try to install hashicorp/baz, fail, and then suggest
+// terraform-providers/baz
+provider baz {}
+
+// This will try to install hashicrop/frob, fail, find no suggestions, and
+// result in an error
+provider frob {}


### PR DESCRIPTION
Fetching a default namespace provider from the public registry can result in 404 Not Found error. This might be caused by a previously-default provider moving to a new namespace, which means that the configuration needs to be upgraded to use an explicit provider source.

This commit adds a more detailed error for this situation. Terraform checks if a provider with the same type can be found in the registry alias table, and if so displays this information in the diagnostic output. The recommended course of action is to run the 0.13upgrade command to generate the correct required_providers configuration.

The diagnostic output looks like this:

```
Error: Failed to install providers

Could not find required providers, but found possible alternatives:

  hashicorp/foo -> acme/foo
  hashicorp/bar -> terraform-providers/bar

If these suggestions look correct, upgrade your configuration with the
following command:
    terraform 0.13upgrade
```

### Screenshot

<img width="850" alt="did-you-mean" src="https://user-images.githubusercontent.com/68917/83064094-3b7a4f80-a02f-11ea-81ac-2f937644b9af.png">
