### PR TITLE
Update taint.html.markdown

### DIFF
--- a/website/docs/commands/taint.html.markdown
+++ b/website/docs/commands/taint.html.markdown
@@ -80,7 +80,7 @@ It is necessary to wrap the resource in single quotes and escape the quotes.
 This example will taint a single resource created with for_each:
 
 ```
-$ terraform taint 'module.route_tables.azurerm_route_table.rt[\"DefaultSubnet\"]'
+$ terraform taint "module.route_tables.azurerm_route_table.rt[\"DefaultSubnet\"]"
 The resource module.route_tables.azurerm_route_table.rt["DefaultSubnet"] in the module root has been marked as tainted.
 ```
 


### PR DESCRIPTION
In terraform 0.12.24, using single qoutes in this context causes:

```
Error: Invalid character

  on  line 1:
  (source code not available)

This character is not used within the language.
```

Removing the single qoutes has the desired effect.