### PR TITLE
[vendor] upgrade go-cty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/xanzy/ssh-agent v0.2.1
 	github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 // indirect
 	github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
-	github.com/zclconf/go-cty v1.4.1
+	github.com/zclconf/go-cty v1.4.2
 	github.com/zclconf/go-cty-yaml v1.0.1
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,8 @@ github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6Ut
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
-github.com/zclconf/go-cty v1.4.1 h1:Xzr4m4utRDhHDifag1onwwUSq32HLoLBsp+w6tD0880=
-github.com/zclconf/go-cty v1.4.1/go.mod h1:nHzOclRkoj++EU9ZjSrZvRG0BXIWt8c7loYc0qXAFGQ=
+github.com/zclconf/go-cty v1.4.2 h1:GKcsRGjxZnRRlyVk2Y6PyG3fdcn3Pv0D7KT4xyYTLlE=
+github.com/zclconf/go-cty v1.4.2/go.mod h1:nHzOclRkoj++EU9ZjSrZvRG0BXIWt8c7loYc0qXAFGQ=
 github.com/zclconf/go-cty-yaml v1.0.1 h1:up11wlgAaDvlAGENcFDnZgkn0qUJurso7k6EpURKNF8=
 github.com/zclconf/go-cty-yaml v1.0.1/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/vendor/github.com/zclconf/go-cty/cty/function/stdlib/json.go
+++ b/vendor/github.com/zclconf/go-cty/cty/function/stdlib/json.go
@@ -12,6 +12,7 @@ var JSONEncodeFunc = function.New(&function.Spec{
 			Name:             "val",
 			Type:             cty.DynamicPseudoType,
 			AllowDynamicType: true,
+			AllowNull:        true,
 		},
 	},
 	Type: function.StaticReturnType(cty.String),
@@ -22,6 +23,10 @@ var JSONEncodeFunc = function.New(&function.Spec{
 			// contains any _nested_ unknowns then our result must be
 			// unknown.
 			return cty.UnknownVal(retType), nil
+		}
+
+		if val.IsNull() {
+			return cty.StringVal("null"), nil
 		}
 
 		buf, err := json.Marshal(val, val.Type())

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -50,8 +50,6 @@ github.com/ChrisTrenkamp/goxpath/tree/xmltree/xmlbuilder
 github.com/ChrisTrenkamp/goxpath/tree/xmltree/xmlele
 github.com/ChrisTrenkamp/goxpath/tree/xmltree/xmlnode
 github.com/ChrisTrenkamp/goxpath/xconst
-# github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292
-## explicit
 # github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af
 ## explicit
 # github.com/agext/levenshtein v1.2.2
@@ -214,8 +212,6 @@ github.com/davecgh/go-spew/spew
 github.com/dgrijalva/jwt-go
 # github.com/dimchansky/utfbom v1.1.0
 github.com/dimchansky/utfbom
-# github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31
-## explicit
 # github.com/dylanmei/iso8601 v0.1.0
 ## explicit
 github.com/dylanmei/iso8601
@@ -591,7 +587,7 @@ github.com/xanzy/ssh-agent
 # github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
 ## explicit
 github.com/xlab/treeprint
-# github.com/zclconf/go-cty v1.4.1
+# github.com/zclconf/go-cty v1.4.2
 ## explicit
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/convert


### PR DESCRIPTION
Upgrade go-cty to get `jsonencode` fix, closes #23062

```
$ go get -u github.com/zclconf/go-cty
$ go mod vendor
$ go mod tidy
```