### PR TITLE
Fix doc typo replacing "and" with "as"

### DIFF
--- a/website/docs/providers/type/network-index.html.markdown
+++ b/website/docs/providers/type/network-index.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Network Providers
 
 This is a group of network providers that offer specific network capabilities
-such and DNS, routing, and firewall configuration.  The providers generally
+such as DNS, routing, and firewall configuration.  The providers generally
 offer a cloud-based service and Terraform integrates with these services using
 the specific providers.  These providers are primarily supported by the vendor
 in close collaboration with HashiCorp, and are tested by HashiCorp.


### PR DESCRIPTION
Fixes a typo in the documentation for Network Providers.