### PR TITLE
terraform: fix panic with non extant resource and dynamics

### DIFF
--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -40,6 +40,30 @@ func TestContext2Validate_badCount(t *testing.T) {
 	}
 }
 
+func TestContext2Validate_badResource_reference(t *testing.T) {
+	p := testProvider("aws")
+	p.GetSchemaReturn = &ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"aws_instance": {
+				Attributes: map[string]*configschema.Attribute{},
+			},
+		},
+	}
+
+	m := testModule(t, "validate-bad-resource-count")
+	c := testContext2(t, &ContextOpts{
+		Config: m,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := c.Validate()
+	if !diags.HasErrors() {
+		t.Fatalf("succeeded; want error")
+	}
+}
+
 func TestContext2Validate_badVar(t *testing.T) {
 	p := testProvider("aws")
 	p.GetSchemaReturn = &ProviderSchema{

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -183,9 +183,10 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 		result = append(result, n.DependsOn()...)
 
 		if n.Schema == nil {
-			// Should never happens, but we'll log if it does so that we can
+			// Should never happen, but we'll log if it does so that we can
 			// see this easily when debugging.
 			log.Printf("[WARN] no schema is attached to %s, so config references cannot be detected", n.Name())
+			return nil
 		}
 
 		refs, _ := lang.ReferencesInExpr(c.Count)

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -186,14 +186,18 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 			// Should never happen, but we'll log if it does so that we can
 			// see this easily when debugging.
 			log.Printf("[WARN] no schema is attached to %s, so config references cannot be detected", n.Name())
-			return nil
 		}
 
 		refs, _ := lang.ReferencesInExpr(c.Count)
 		result = append(result, refs...)
 		refs, _ = lang.ReferencesInExpr(c.ForEach)
 		result = append(result, refs...)
-		refs, _ = lang.ReferencesInBlock(c.Config, n.Schema)
+
+		// ReferencesInBlock() requires a schema
+		if n.Schema != nil {
+			refs, _ = lang.ReferencesInBlock(c.Config, n.Schema)
+		}
+
 		result = append(result, refs...)
 		if c.Managed != nil {
 			if c.Managed.Connection != nil {

--- a/terraform/testdata/validate-bad-resource-count/main.tf
+++ b/terraform/testdata/validate-bad-resource-count/main.tf
@@ -1,0 +1,22 @@
+// a resource named "aws_security_groups" does not exist in the schema
+variable "sg_ports" {
+  type        = list(number)
+  description = "List of ingress ports"
+  default     = [8200, 8201, 8300, 9200, 9500]
+}
+
+
+resource "aws_security_groups" "dynamicsg" {
+  name        = "dynamicsg"
+  description = "Ingress for Vault"
+
+  dynamic "ingress" {
+    for_each = var.sg_ports
+    content {
+      from_port   = ingress.value
+      to_port     = ingress.value
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+}


### PR DESCRIPTION
Fixes a panic when a configuration had a non-existing resource *with* a dynamic block. The `References()` function was missing a necessary return if the resource schema was empty (because the resource did not exist), and would panic when it tried to use the nil schema to parse dynamic blocks.

Added a test that panicked before this change was made.

--- 
EDIT: Adding a `return` after `References()` found that there was no schema caused another test to fail. I changed it so it *just* skips evaluating references which require a schema. I'm leaving both commits in place for now: if the former commit seems more correct, I can change the test output to match the new output. Otherwise we can stick with my second commit (I will squash).



Fixes #24838 