### PR TITLE
configs: fix panic with provider aliases

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -222,8 +222,8 @@ func (c *Config) addProviderRequirements(reqs getproviders.Requirements) hcl.Dia
 	}
 
 	// "provider" block can also contain version constraints
-	for name, provider := range c.Module.ProviderConfigs {
-		fqn := c.Module.ProviderForLocalConfig(addrs.LocalProviderConfig{LocalName: name})
+	for _, provider := range c.Module.ProviderConfigs {
+		fqn := c.Module.ProviderForLocalConfig(addrs.LocalProviderConfig{LocalName: provider.Name})
 		if _, ok := reqs[fqn]; !ok {
 			// We'll at least have an unconstrained dependency then, but might
 			// add to this in the loop below.

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -162,3 +162,14 @@ func TestConfigProviderForConfigAddr(t *testing.T) {
 		t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
 	}
 }
+
+func TestConfigAddProviderRequirements(t *testing.T) {
+	cfg, diags := testModuleConfigFromFile("testdata/valid-files/providers-explicit-implied.tf")
+	assertNoDiagnostics(t, diags)
+
+	reqs := getproviders.Requirements{
+		addrs.NewDefaultProvider("null"): nil,
+	}
+	diags = cfg.addProviderRequirements(reqs)
+	assertNoDiagnostics(t, diags)
+}


### PR DESCRIPTION
`addProviderRequirements()` was incorrectly using the map keys from the module
provider configs when looking up the provider FQN. The map keys include
alias, so this resulted in a panic. 

This commit updates `addProviderRequirements()` to use the provider's name (only) when looking up the FQN and includes a test which reproduced the panic.


Fixes https://github.com/hashicorp/terraform/issues/25089