### PR TITLE
command: Fix panic for nil credentials source

### DIFF
--- a/command/cliconfig/credentials.go
+++ b/command/cliconfig/credentials.go
@@ -12,7 +12,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
-	"github.com/hashicorp/terraform-svchost"
+	svchost "github.com/hashicorp/terraform-svchost"
 	svcauth "github.com/hashicorp/terraform-svchost/auth"
 	"github.com/hashicorp/terraform/configs/hcl2shim"
 	pluginDiscovery "github.com/hashicorp/terraform/plugin/discovery"
@@ -152,6 +152,9 @@ type CredentialsSource struct {
 var _ svcauth.CredentialsSource = (*CredentialsSource)(nil)
 
 func (s *CredentialsSource) ForHost(host svchost.Hostname) (svcauth.HostCredentials, error) {
+	if s == nil {
+		return nil, nil
+	}
 	v, ok := s.configured[host]
 	if ok {
 		return svcauth.HostCredentialsFromObject(v), nil
@@ -178,6 +181,9 @@ func (s *CredentialsSource) ForgetForHost(host svchost.Hostname) error {
 // The current location of credentials determines whether updates are possible
 // at all and, if they are, where any updates will be written.
 func (s *CredentialsSource) HostCredentialsLocation(host svchost.Hostname) CredentialsLocation {
+	if s == nil {
+		return CredentialsNotAvailable
+	}
 	if _, unwritable := s.unwritable[host]; unwritable {
 		return CredentialsInOtherFile
 	}
@@ -201,12 +207,18 @@ func (s *CredentialsSource) HostCredentialsLocation(host svchost.Hostname) Crede
 // directory, so this function will return an error in the unlikely event that
 // we cannot determine a suitable home directory to resolve relative to.
 func (s *CredentialsSource) CredentialsFilePath() (string, error) {
+	if s == nil {
+		return "", nil
+	}
 	return s.credentialsFilePath, nil
 }
 
 // CredentialsHelperType returns the name of the configured credentials helper
 // type, or an empty string if no credentials helper is configured.
 func (s *CredentialsSource) CredentialsHelperType() string {
+	if s == nil {
+		return ""
+	}
 	return s.helperType
 }
 
@@ -237,6 +249,9 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 	// This function updates the local credentials file in particular,
 	// regardless of whether a credentials helper is active. It should be
 	// called only indirectly via updateHostCredentials.
+	if s == nil {
+		return nil
+	}
 
 	filename, err := s.CredentialsFilePath()
 	if err != nil {

--- a/command/cliconfig/credentials_test.go
+++ b/command/cliconfig/credentials_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/hashicorp/terraform-svchost"
+	svchost "github.com/hashicorp/terraform-svchost"
 	svcauth "github.com/hashicorp/terraform-svchost/auth"
 )
 
@@ -85,6 +85,40 @@ func TestCredentialsForHost(t *testing.T) {
 			t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
 		}
 	})
+}
+
+func TestCredentialsNilReceiver(t *testing.T) {
+	var credSrc *CredentialsSource
+
+	creds, err := credSrc.ForHost(svchost.Hostname("configured.example.com"))
+	if creds != nil {
+		t.Errorf("unexpected creds: %#v", creds)
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	err = credSrc.StoreForHost(
+		svchost.Hostname("manually-configured.example.com"),
+		svcauth.HostCredentialsToken("not-manually-configured"),
+	)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	loc := credSrc.HostCredentialsLocation(
+		svchost.Hostname("manually-configured.example.com"),
+	)
+	if loc != CredentialsNotAvailable {
+		t.Errorf("unexpected location: %#v", loc)
+	}
+
+	err = credSrc.ForgetForHost(
+		svchost.Hostname("manually-configured.example.com"),
+	)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
 }
 
 func TestCredentialsStoreForget(t *testing.T) {


### PR DESCRIPTION
If loading credentials fails, the credentials source can be nil. Calling any of its methods would then result in a panic. This commit adds nil receiver checks to each of the public methods to cope with this case.

The user-facing bug that triggered this work is that running init when the HOME environment variable is unset would result in a panic on macOS.

The `terraform-svchost` package [does attempt to nil-check the credentials source before calling its methods](https://github.com/hashicorp/terraform-svchost/blob/d2e4933b91362709122c21cd14b6b51cf6e5bfca/disco/disco.go#L86). But since the credentials source is an interface, this nil check is always false.

I think the correct fix here is for all implementations of the interface to cope with a nil value, rather than trying to use reflection or similar in svchost. Assuming that's agreed-upon, I'll create a PR to svchost to remove these checks.

Fixes #24520.