### PR TITLE
Add `-yes` flag to 0.13upgrade help message

### DIFF
--- a/command/013_config_upgrade.go
+++ b/command/013_config_upgrade.go
@@ -689,6 +689,16 @@ Usage: terraform 0.13upgrade [module-dir]
 
   Updates module configuration files to add provider source attributes and
   merge multiple required_providers blocks into one.
+
+  By default, 0.13upgrade rewrites the files in the current working directory.
+  However, a path to a different directory can be provided. The command will
+  prompt for confirmation interactively unless the -yes option is given.
+
+Options:
+
+  -yes        Skip the initial introduction messages and interactive
+              confirmation. This can be used to run this command in
+              batch from a script.
 `
 	return strings.TrimSpace(helpText)
 }


### PR DESCRIPTION
It seems to be implemented but not shown in help message.

FYI: A help message for 0.12upgrade command on the 0.12 branch.
https://github.com/hashicorp/terraform/blob/v0.12.26/command/012_config_upgrade.go#L235-L243