### PR TITLE
backend/remote: do not panic if PrepareConfig or Configure receive null

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -142,6 +142,9 @@ func (b *Remote) ConfigSchema() *configschema.Block {
 // PrepareConfig implements backend.Backend.
 func (b *Remote) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
+	if obj.IsNull() {
+		return obj, diags
+	}
 
 	if val := obj.GetAttr("organization"); val.IsNull() || val.AsString() == "" {
 		diags = diags.Append(tfdiags.AttributeValue(
@@ -188,6 +191,9 @@ func (b *Remote) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 // Configure implements backend.Enhanced.
 func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
+	if obj.IsNull() {
+		return diags
+	}
 
 	// Get the hostname.
 	if val := obj.GetAttr("hostname"); !val.IsNull() && val.AsString() != "" {

--- a/backend/remote/backend_test.go
+++ b/backend/remote/backend_test.go
@@ -123,6 +123,9 @@ func TestRemote_config(t *testing.T) {
 			}),
 			valErr: `Only one of workspace "name" or "prefix" is allowed`,
 		},
+		"null config": {
+			config: cty.NullVal(cty.EmptyObject),
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
objects

If a user cancels (ctrl-c) terraform init while it is requesting missing
configuration options for the remote backend, the PrepareConfig and
Configure functions would receive a null cty.Value which would result in
panics. This PR adds a check for null objects to the two functions in
question.

Fixes #23992

I have no idea how to test this, so please enjoy a screenshot showing the fix: 

<img width="1255" alt="Screen Shot 2020-06-04 at 11 50 48 AM" src="https://user-images.githubusercontent.com/6210214/83779600-2d918380-a65a-11ea-85c7-2f2c929dd14c.png">
