### PR TITLE
Data source within modules using depends_on

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -11121,16 +11121,35 @@ func TestContext2Apply_moduleDependsOn(t *testing.T) {
 	m := testModule(t, "apply-module-depends-on")
 
 	p := testProvider("test")
-	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
-		State: cty.ObjectVal(map[string]cty.Value{
-			"id":  cty.StringVal("data"),
-			"foo": cty.NullVal(cty.String),
-		}),
-	}
-	p.DiffFn = testDiffFn
 
 	// each instance being applied should happen in sequential order
 	applied := int64(0)
+
+	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+		cfg := req.Config.AsValueMap()
+		foo := cfg["foo"].AsString()
+		ord := atomic.LoadInt64(&applied)
+
+		resp := providers.ReadDataSourceResponse{
+			State: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("data"),
+				"foo": cfg["foo"],
+			}),
+		}
+
+		if foo == "a" && ord < 4 {
+			// due to data source "a"'s module depending on instance 4, this
+			// should not be less than 4
+			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("data source a read too early"))
+		}
+		if foo == "b" && ord < 1 {
+			// due to data source "b"'s module depending on instance 1, this
+			// should not be less than 1
+			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("data source b read too early"))
+		}
+		return resp
+	}
+	p.DiffFn = testDiffFn
 
 	p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
 		state := req.PlannedState.AsValueMap()
@@ -11154,7 +11173,12 @@ func TestContext2Apply_moduleDependsOn(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan()
+	_, diags := ctx.Refresh()
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+
+	_, diags = ctx.Plan()
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11165,6 +11189,10 @@ func TestContext2Apply_moduleDependsOn(t *testing.T) {
 	}
 
 	// run the plan again to ensure that data sources are not going to be re-read
+	_, diags = ctx.Refresh()
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
 	plan, diags := ctx.Plan()
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())

--- a/terraform/eval_read_data.go
+++ b/terraform/eval_read_data.go
@@ -58,6 +58,9 @@ type evalReadData struct {
 	// determine if there are any changes that will force this data sources to
 	// be deferred to apply.
 	dependsOn []addrs.ConfigResource
+	// forceDependsOn indicates that resources may be missing from dependsOn,
+	// but the parent module may have depends_on configured.
+	forceDependsOn bool
 }
 
 // readDataSource handles everything needed to call ReadDataSource on the provider.
@@ -302,5 +305,5 @@ func (n *evalReadDataRefresh) Eval(ctx EvalContext) (interface{}, error) {
 // immediately reading from the data source where possible, instead forcing us
 // to generate a plan.
 func (n *evalReadDataRefresh) forcePlanRead() bool {
-	return len(n.Config.DependsOn) > 0 || len(n.dependsOn) > 0
+	return len(n.Config.DependsOn) > 0 || len(n.dependsOn) > 0 || n.forceDependsOn
 }

--- a/terraform/eval_read_data.go
+++ b/terraform/eval_read_data.go
@@ -52,6 +52,12 @@ type evalReadData struct {
 	// - If planned action is plans.Update, it indicates that the data source
 	// was read, and the result needs to be stored in state during apply.
 	OutputChange **plans.ResourceInstanceChange
+
+	// dependsOn stores the list of transitive resource addresses that any
+	// configuration depends_on references may resolve to. This is used to
+	// determine if there are any changes that will force this data sources to
+	// be deferred to apply.
+	dependsOn []addrs.ConfigResource
 }
 
 // readDataSource handles everything needed to call ReadDataSource on the provider.
@@ -235,7 +241,7 @@ func (n *evalReadDataRefresh) Eval(ctx EvalContext) (interface{}, error) {
 	// refresh, that we can read this resource. If there are dependency updates
 	// in the config, they we be discovered in plan and the data source will be
 	// read again.
-	if !configKnown || (priorVal.IsNull() && len(n.Config.DependsOn) > 0) {
+	if !configKnown || (priorVal.IsNull() && n.forcePlanRead()) {
 		if configKnown {
 			log.Printf("[TRACE] evalReadDataRefresh: %s configuration is fully known, but we're forcing a read plan to be created", absAddr)
 		} else {
@@ -290,4 +296,11 @@ func (n *evalReadDataRefresh) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	return nil, diags.ErrWithWarnings()
+}
+
+// forcePlanRead determines if we need to override the usual behavior of
+// immediately reading from the data source where possible, instead forcing us
+// to generate a plan.
+func (n *evalReadDataRefresh) forcePlanRead() bool {
+	return len(n.Config.DependsOn) > 0 || len(n.dependsOn) > 0
 }

--- a/terraform/eval_read_data_plan.go
+++ b/terraform/eval_read_data_plan.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/plans/objchange"
 	"github.com/hashicorp/terraform/states"
@@ -18,12 +17,6 @@ import (
 // or generating a plan to do so.
 type evalReadDataPlan struct {
 	evalReadData
-
-	// dependsOn stores the list of transitive resource addresses that any
-	// configuration depends_on references may resolve to. This is used to
-	// determine if there are any changes that will force this data sources to
-	// be deferred to apply.
-	dependsOn []addrs.ConfigResource
 }
 
 func (n *evalReadDataPlan) Eval(ctx EvalContext) (interface{}, error) {

--- a/terraform/graph_builder_refresh.go
+++ b/terraform/graph_builder_refresh.go
@@ -171,6 +171,7 @@ func (b *RefreshGraphBuilder) Steps() []GraphTransformer {
 		// have to connect again later for providers and so on.
 		&ReferenceTransformer{},
 		&AttachDependenciesTransformer{},
+		&attachDataResourceDependenciesTransformer{},
 
 		// Target
 		&TargetsTransformer{

--- a/terraform/node_data_refresh.go
+++ b/terraform/node_data_refresh.go
@@ -122,6 +122,7 @@ func (n *NodeRefreshableDataResource) DynamicExpand(ctx EvalContext) (*Graph, er
 		a.ResolvedProvider = n.ResolvedProvider
 		a.ProviderMetas = n.ProviderMetas
 		a.dependsOn = n.dependsOn
+		a.forceDependsOn = n.forceDependsOn
 
 		return &NodeRefreshableDataResourceInstance{
 			NodeAbstractResourceInstance: a,
@@ -229,6 +230,7 @@ func (n *NodeRefreshableDataResourceInstance) EvalTree() EvalNode {
 					OutputChange:   &change,
 					State:          &state,
 					dependsOn:      n.dependsOn,
+					forceDependsOn: n.forceDependsOn,
 				},
 			},
 

--- a/terraform/node_data_refresh.go
+++ b/terraform/node_data_refresh.go
@@ -121,6 +121,7 @@ func (n *NodeRefreshableDataResource) DynamicExpand(ctx EvalContext) (*Graph, er
 		a.Config = n.Config
 		a.ResolvedProvider = n.ResolvedProvider
 		a.ProviderMetas = n.ProviderMetas
+		a.dependsOn = n.dependsOn
 
 		return &NodeRefreshableDataResourceInstance{
 			NodeAbstractResourceInstance: a,
@@ -227,6 +228,7 @@ func (n *NodeRefreshableDataResourceInstance) EvalTree() EvalNode {
 					ProviderSchema: &providerSchema,
 					OutputChange:   &change,
 					State:          &state,
+					dependsOn:      n.dependsOn,
 				},
 			},
 

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -61,8 +61,9 @@ type NodeAbstractResource struct {
 	// Set from GraphNodeTargetable
 	Targets []addrs.Targetable
 
-	// Set from GraphNodeDependsOn
-	dependsOn []addrs.ConfigResource
+	// Set from AttachResourceDependencies
+	dependsOn      []addrs.ConfigResource
+	forceDependsOn bool
 
 	// The address of the provider this resource will use
 	ResolvedProvider addrs.AbsProviderConfig
@@ -402,8 +403,9 @@ func (n *NodeAbstractResource) SetTargets(targets []addrs.Targetable) {
 }
 
 // graphNodeAttachResourceDependencies
-func (n *NodeAbstractResource) AttachResourceDependencies(deps []addrs.ConfigResource) {
+func (n *NodeAbstractResource) AttachResourceDependencies(deps []addrs.ConfigResource, force bool) {
 	n.dependsOn = deps
+	n.forceDependsOn = force
 }
 
 // GraphNodeAttachResourceState

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -83,8 +83,8 @@ func (n *NodePlannableResourceInstance) evalTreeDataResource(addr addrs.AbsResou
 					ProviderSchema: &providerSchema,
 					OutputChange:   &change,
 					State:          &state,
+					dependsOn:      n.dependsOn,
 				},
-				dependsOn: n.dependsOn,
 			},
 
 			&EvalWriteState{

--- a/terraform/testdata/apply-module-depends-on/moda/main.tf
+++ b/terraform/testdata/apply-module-depends-on/moda/main.tf
@@ -3,6 +3,7 @@ resource "test_instance" "a" {
 }
 
 data "test_data_source" "a" {
+  foo = "a"
 }
 
 output "out" {

--- a/terraform/testdata/apply-module-depends-on/modb/main.tf
+++ b/terraform/testdata/apply-module-depends-on/modb/main.tf
@@ -3,6 +3,7 @@ resource "test_instance" "b" {
 }
 
 data "test_data_source" "b" {
+  foo = "b"
 }
 
 output "out" {

--- a/terraform/transform_reference.go
+++ b/terraform/transform_reference.go
@@ -43,6 +43,12 @@ type GraphNodeAttachDependencies interface {
 	AttachDependencies([]addrs.ConfigResource)
 }
 
+// graphNodeDependsOn is implemented by resources that need to expose any
+// references set via DependsOn in their configuration.
+type graphNodeDependsOn interface {
+	DependsOn() []*addrs.Reference
+}
+
 // graphNodeAttachResourceDependencies records all resources that are transitively
 // referenced through depends_on in the configuration. This is used by data
 // resources to determine if they can be read during the plan, or if they need
@@ -55,8 +61,8 @@ type GraphNodeAttachDependencies interface {
 // "perpetual diff"
 type graphNodeAttachResourceDependencies interface {
 	GraphNodeConfigResource
+	graphNodeDependsOn
 	AttachResourceDependencies([]addrs.ConfigResource)
-	DependsOn() []*addrs.Reference
 }
 
 // GraphNodeReferenceOutside is an interface that can optionally be implemented.
@@ -122,7 +128,7 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 
 type depMap map[string]addrs.ConfigResource
 
-// addDep adds the vertex if it represents a resource in the
+// add stores the vertex if it represents a resource in the
 // graph.
 func (m depMap) add(v dag.Vertex) {
 	// we're only concerned with resources which may have changes that
@@ -155,34 +161,32 @@ func (t attachDataResourceDependenciesTransformer) Transform(g *Graph) error {
 		if !ok {
 			continue
 		}
-		selfAddr := depender.ResourceAddr()
 
 		// Only data need to attach depends_on, so they can determine if they
 		// are eligible to be read during plan.
-		if selfAddr.Resource.Mode != addrs.DataResourceMode {
+		if depender.ResourceAddr().Resource.Mode != addrs.DataResourceMode {
 			continue
 		}
 
-		// depMap will only add resource references and dedupe
-		m := make(depMap)
-
-		for _, dep := range refMap.DependsOn(v) {
+		// depMap will only add resource references then dedupe
+		deps := make(depMap)
+		for _, dep := range refMap.dependsOn(g, depender) {
 			// any the dependency
-			m.add(dep)
-			// and check any ancestors
+			deps.add(dep)
+			// and check any ancestors for transitive dependencies
 			ans, _ := g.Ancestors(dep)
 			for _, v := range ans {
-				m.add(v)
+				deps.add(v)
 			}
 		}
 
-		deps := make([]addrs.ConfigResource, 0, len(m))
-		for _, d := range m {
-			deps = append(deps, d)
+		res := make([]addrs.ConfigResource, 0, len(deps))
+		for _, d := range deps {
+			res = append(res, d)
 		}
 
-		log.Printf("[TRACE] AttachDependsOnTransformer: %s depends on %s", depender.ResourceAddr(), deps)
-		depender.AttachResourceDependencies(deps)
+		log.Printf("[TRACE] attachDataDependenciesTransformer: %s depends on %s", depender.ResourceAddr(), res)
+		depender.AttachResourceDependencies(res)
 	}
 
 	return nil
@@ -304,35 +308,62 @@ func (m ReferenceMap) References(v dag.Vertex) []dag.Vertex {
 	return matches
 }
 
-// DependsOn returns the set of vertices that the given vertex refers to from
+// dependsOn returns the set of vertices that the given vertex refers to from
 // the configured depends_on.
-func (m ReferenceMap) DependsOn(v dag.Vertex) []dag.Vertex {
-	depender, ok := v.(graphNodeAttachResourceDependencies)
-	if !ok {
-		return nil
-	}
-
+func (m ReferenceMap) dependsOn(g *Graph, depender graphNodeDependsOn) []dag.Vertex {
 	var matches []dag.Vertex
+	refs := depender.DependsOn()
 
-	for _, ref := range depender.DependsOn() {
+	for _, ref := range refs {
 		subject := ref.Subject
 
-		key := m.referenceMapKey(v, subject)
+		key := m.referenceMapKey(depender, subject)
 		vertices, ok := m[key]
 		if !ok {
-			log.Printf("[WARN] DependOn: reference not found: %q", subject)
+			log.Printf("[WARN] DependsOn: reference not found: %q", subject)
 			continue
 		}
 		for _, rv := range vertices {
 			// don't include self-references
-			if rv == v {
+			if rv == depender {
 				continue
 			}
 			matches = append(matches, rv)
 		}
 	}
 
+	matches = append(matches, m.parentModuleDependsOn(g, depender)...)
+
 	return matches
+}
+
+// parentModuleDependsOn returns the set of vertices that a data sources parent
+// module references through the module call's depends_on.
+func (n ReferenceMap) parentModuleDependsOn(g *Graph, depender graphNodeDependsOn) []dag.Vertex {
+	var res []dag.Vertex
+
+	// look for containing modules with DependsOn
+	for _, v := range g.DownEdges(depender) {
+		mod, ok := v.(*nodeExpandModule)
+		if !ok {
+			continue
+		}
+
+		for _, dep := range n.dependsOn(g, mod) {
+			// add the dependency
+			res = append(res, dep)
+			// and check any ancestors
+			ans, _ := g.Ancestors(dep)
+			for _, v := range ans {
+				res = append(res, v)
+			}
+		}
+
+		// recurse up through parent modules
+		res = append(res, n.parentModuleDependsOn(g, mod)...)
+	}
+
+	return res
 }
 
 func (m *ReferenceMap) mapKey(path addrs.Module, addr addrs.Referenceable) string {

--- a/terraform/transform_reference.go
+++ b/terraform/transform_reference.go
@@ -62,7 +62,15 @@ type graphNodeDependsOn interface {
 type graphNodeAttachResourceDependencies interface {
 	GraphNodeConfigResource
 	graphNodeDependsOn
-	AttachResourceDependencies([]addrs.ConfigResource)
+
+	// AttachResourceDependencies stored the discovered dependencies in the
+	// resource node for evaluation later.
+	//
+	// The force parameter indicates that even if there are no dependencies,
+	// force the data source to act as though there are for refresh purposes.
+	// This is needed because yet-to-be-created resources won't be in the
+	// initial refresh graph, but may still be referenced through depends_on.
+	AttachResourceDependencies(deps []addrs.ConfigResource, force bool)
 }
 
 // GraphNodeReferenceOutside is an interface that can optionally be implemented.
@@ -186,7 +194,7 @@ func (t attachDataResourceDependenciesTransformer) Transform(g *Graph) error {
 		}
 
 		log.Printf("[TRACE] attachDataDependenciesTransformer: %s depends on %s", depender.ResourceAddr(), res)
-		depender.AttachResourceDependencies(res)
+		depender.AttachResourceDependencies(res, false)
 	}
 
 	return nil


### PR DESCRIPTION
This adds the ability for data source evaluation to be deferred within modules using `depends_on`.

We start by extending the lookup of `depends_on` resources from the data source to walk back through any modules found that return references from `DependsOn()`. This is adequate for plan, since the data source is going to check for changes to these dependencies, but during refresh not-yet-created nodes don't exist in the graph.

To handle refresh, we do the same lookup, but only record if there are _any_ parent modules that returned `depends_on` references. This allows us to prevent the first read of the data source during an initial refresh in the same way we do when the data source has `depends_on` in its own configuration. 

Fixes #25121