### PR TITLE
Make 0.13upgrade confirmation more user-friendly

### DIFF
--- a/command/013_config_upgrade.go
+++ b/command/013_config_upgrade.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/internal/getproviders"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
 	tfversion "github.com/hashicorp/terraform/version"
 	"github.com/zclconf/go-cty/cty"
@@ -148,7 +150,11 @@ command and dealing with them before running this command again.
 		if dir != "." {
 			query = fmt.Sprintf("Would you like to upgrade the module in %s?", dir)
 		}
-		v, err := c.Ui.Ask(query)
+		v, err := c.UIInput().Input(context.Background(), &terraform.InputOpts{
+			Id:          "approve",
+			Query:       query,
+			Description: `Only 'yes' will be accepted to confirm.`,
+		})
 		if err != nil {
 			diags = diags.Append(err)
 			c.showDiagnostics(diags)

--- a/command/013_config_upgrade_test.go
+++ b/command/013_config_upgrade_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"path"
@@ -215,10 +214,10 @@ func TestZeroThirteenUpgrade_confirm(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
+	// Ask input
+	defer testInteractiveInput(t, []string{"yes"})()
+
 	ui := new(cli.MockUi)
-	inputBuf := &bytes.Buffer{}
-	ui.InputReader = inputBuf
-	inputBuf.WriteString("yes")
 	c := &ZeroThirteenUpgradeCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -244,10 +243,10 @@ func TestZeroThirteenUpgrade_cancel(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
+	// Ask input
+	defer testInteractiveInput(t, []string{"no"})()
+
 	ui := new(cli.MockUi)
-	inputBuf := &bytes.Buffer{}
-	ui.InputReader = inputBuf
-	inputBuf.WriteString("no")
 	c := &ZeroThirteenUpgradeCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),


### PR DESCRIPTION
I feel the current confirmation prompt for 0.13upgrade command is ambiguous what is expected. Actually, when I used it for the first time, I cancelled it by typing `y` instead of `yes`.

I believe it would be great if the 0.13upgrade command tell us the expected value for confirmation like 0.12upgrade.

https://github.com/hashicorp/terraform/blob/v0.12.26/command/012_config_upgrade.go#L137-L141

## Before

```
$ terraform 0.13upgrade

This command will update the configuration files in the given directory to use
the new provider source features from Terraform v0.13. It will also highlight
any providers for which the source cannot be detected, and advise how to
proceed.

We recommend using this command in a clean version control work tree, so that
you can easily see the proposed changes as a diff against the latest commit.
If you have uncommited changes already present, we recommend aborting this
command and dealing with them before running this command again.

Would you like to upgrade the module in the current directory? y
Upgrade cancelled.
```

## After

```
$ $GOPATH/bin/terraform 0.13upgrade

This command will update the configuration files in the given directory to use
the new provider source features from Terraform v0.13. It will also highlight
any providers for which the source cannot be detected, and advise how to
proceed.

We recommend using this command in a clean version control work tree, so that
you can easily see the proposed changes as a diff against the latest commit.
If you have uncommited changes already present, we recommend aborting this
command and dealing with them before running this command again.

Would you like to upgrade the module in the current directory?
  Only 'yes' will be accepted to confirm.

  Enter a value: yes

-----------------------------------------------------------------------------

Upgrade complete!

Use your version control system to review the proposed changes, make any
necessary adjustments, and then commit.
```