### PR TITLE
Makefile: remove unused targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,67 +1,4 @@
-VERSION?="0.3.32"
-TEST?=./...
-GOFMT_FILES?=$$(find . -not -path "./vendor/*" -type f -name '*.go')
 WEBSITE_REPO=github.com/hashicorp/terraform-website
-
-default: test
-
-# bin generates the releaseable binaries for Terraform
-bin: fmtcheck generate
-	@TF_RELEASE=1 sh -c "'$(CURDIR)/scripts/build.sh'"
-
-# dev creates binaries for testing Terraform locally. These are put
-# into ./bin/ as well as $GOPATH/bin
-dev: fmtcheck generate
-	go install -mod=vendor .
-
-quickdev: generate
-	go install -mod=vendor .
-
-# Shorthand for building and installing just one plugin for local testing.
-# Run as (for example): make plugin-dev PLUGIN=provider-aws
-plugin-dev: generate
-	go install github.com/hashicorp/terraform/builtin/bins/$(PLUGIN)
-	mv $(GOPATH)/bin/$(PLUGIN) $(GOPATH)/bin/terraform-$(PLUGIN)
-
-# test runs the unit tests
-# we run this one package at a time here because running the entire suite in
-# one command creates memory usage issues when running in Travis-CI.
-test: fmtcheck generate
-	go list -mod=vendor $(TEST) | xargs -t -n4 go test $(TESTARGS) -mod=vendor -timeout=2m -parallel=4
-
-# testacc runs acceptance tests
-testacc: fmtcheck generate
-	@if [ "$(TEST)" = "./..." ]; then \
-		echo "ERROR: Set TEST to a specific package. For example,"; \
-		echo "  make testacc TEST=./builtin/providers/test"; \
-		exit 1; \
-	fi
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -mod=vendor -timeout 120m
-
-# e2etest runs the end-to-end tests against a generated Terraform binary
-# and a generated terraform-bundle binary.
-# The TF_ACC here allows network access, but does not require any special
-# credentials.
-e2etest: generate
-	TF_ACC=1 go test -mod=vendor -v ./command/e2etest
-	TF_ACC=1 go test -mod=vendor -v ./tools/terraform-bundle/e2etest
-
-test-compile: fmtcheck generate
-	@if [ "$(TEST)" = "./..." ]; then \
-		echo "ERROR: Set TEST to a specific package. For example,"; \
-		echo "  make test-compile TEST=./builtin/providers/test"; \
-		exit 1; \
-	fi
-	go test -mod=vendor -c $(TEST) $(TESTARGS)
-
-# testrace runs the race checker
-testrace: fmtcheck generate
-	TF_ACC= go test -mod=vendor -race $(TEST) $(TESTARGS)
-
-cover:
-	go test $(TEST) -coverprofile=coverage.out
-	go tool cover -html=coverage.out
-	rm coverage.out
 
 # generate runs `go generate` to build the dynamically generated
 # source files, except the protobuf stubs which are built instead with
@@ -85,9 +22,6 @@ protobuf:
 	bash scripts/protobuf-check.sh
 	bash internal/tfplugin5/generate.sh
 	bash plans/internal/planproto/generate.sh
-
-fmt:
-	gofmt -w $(GOFMT_FILES)
 
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
@@ -141,4 +75,4 @@ endif
 # under parallel conditions.
 .NOTPARALLEL:
 
-.PHONY: bin cover default dev e2etest fmt fmtcheck generate protobuf plugin-dev quickdev test-compile test testacc testrace vendor-status website website-test
+.PHONY: fmtcheck generate protobuf website website-test


### PR DESCRIPTION
Most of the targets in the Makefile have not been used in either CI or the normal development workflow for some time. Removing them clarifies that the expected way to build Terraform locally is simple: `go install`.

Remaining targets:

- `fmtcheck`, `generate`: these are used in CI to verify that the code is correctly formatted and that generate has been run appropriately
- `protobuf`: [referenced in CONTRIBUTING.md](https://github.com/hashicorp/terraform/blob/master/.github/CONTRIBUTING.md#generated-code) as the simplest way to build the `proto` files
- `website`, `website-test`: used to compile and test the local website in isolation from [the terraform-website repo](https://github.com/hashicorp/terraform-website)