### PR TITLE
use example.com address in consul backend config

### DIFF
--- a/website/docs/backends/types/consul.html.md
+++ b/website/docs/backends/types/consul.html.md
@@ -19,7 +19,7 @@ This backend supports [state locking](/docs/state/locking.html).
 ```hcl
 terraform {
   backend "consul" {
-    address = "demo.consul.io"
+    address = "consul.example.com"
     scheme  = "https"
     path    = "full/path"
   }


### PR DESCRIPTION
Currently the example config for the Consul backend uses a live Consul demo cluster at `demo.consul.io`. This results in TF state with sensitive information and all being stored on a public site when users just copy and paste the config. This PR changes it so that the config address isn't the public demo cluster.