### PR TITLE
command/format: Fix empty overlap diagnostics

### DIFF
--- a/command/format/diagnostic.go
+++ b/command/format/diagnostic.go
@@ -100,7 +100,7 @@ func Diagnostic(diag tfdiags.Diagnostic, sources map[string][]byte, color *color
 				if !lineRange.Overlaps(snippetRange) {
 					continue
 				}
-				if lineRange.Overlaps(highlightRange) {
+				if !lineRange.Overlap(highlightRange).Empty() {
 					beforeRange, highlightedRange, afterRange := lineRange.PartitionAround(highlightRange)
 					before := beforeRange.SliceBytes(src)
 					highlighted := highlightedRange.SliceBytes(src)


### PR DESCRIPTION
Diagnostics where the highlight range has an empty overlap with a line would skip lines of the output. This is because if two ranges abut each other, they can be considered to overlap, but that overlap is empty. This results in an edge case in the diagnostic printer which causes the line not to be printed.

### Screenshots

Config:

```hcl
variable "x" {
  default = {
    "foo"
  }
}
```

Before:

<img width="849" alt="before" src="https://user-images.githubusercontent.com/68917/83919450-9c4d0a80-a748-11ea-9318-6daacf5d8b03.png">

After:

<img width="849" alt="after" src="https://user-images.githubusercontent.com/68917/83919411-863f4a00-a748-11ea-94f6-b286e6a2065a.png">
