### PR TITLE
Incorrect early return in module expansion transformer

### DIFF
--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -1552,3 +1552,83 @@ resource "aws_instance" "foo" {
 		t.Fatalf("wrong error:\ngot:  %s\nwant: message containing %q", got, want)
 	}
 }
+
+func TestContext2Validate_expandMultipleNestedModules(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "modA" {
+  for_each = {
+    first = "m"
+	second = "n"
+  }
+  source = "./modA"
+}
+`,
+		"modA/main.tf": `
+locals {
+  m = {
+    first = "m"
+	second = "n"
+  }
+}
+
+module "modB" {
+  for_each = local.m
+  source = "./modB"
+  y = each.value
+}
+
+module "modC" {
+  for_each = local.m
+  source = "./modC"
+  x = module.modB[each.key].out
+  y = module.modB[each.key].out
+}
+
+`,
+		"modA/modB/main.tf": `
+variable "y" {
+  type = string
+}
+
+resource "aws_instance" "foo" {
+  foo = var.y
+}
+
+output "out" {
+  value = aws_instance.foo.id
+}
+`,
+		"modA/modC/main.tf": `
+variable "x" {
+  type = string
+}
+
+variable "y" {
+  type = string
+}
+
+resource "aws_instance" "foo" {
+  foo = var.x
+}
+
+output "out" {
+  value = var.y
+}
+`,
+	})
+
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate()
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+}

--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -150,7 +150,7 @@ func (n *nodeModuleVariable) Path() addrs.ModuleInstance {
 
 // GraphNodeModulePath
 func (n *nodeModuleVariable) ModulePath() addrs.Module {
-	return n.Addr.Module.Parent().Module()
+	return n.Addr.Module.Module()
 }
 
 // RemovableIfNotTargeted

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -22,6 +22,7 @@ var (
 	_ RemovableIfNotTargeted     = (*nodeExpandOutput)(nil)
 	_ GraphNodeReferenceable     = (*nodeExpandOutput)(nil)
 	_ GraphNodeReferencer        = (*nodeExpandOutput)(nil)
+	_ GraphNodeReferenceOutside  = (*nodeExpandOutput)(nil)
 	_ GraphNodeDynamicExpandable = (*nodeExpandOutput)(nil)
 	_ graphNodeTemporaryValue    = (*nodeExpandOutput)(nil)
 	_ graphNodeExpandsInstances  = (*nodeExpandOutput)(nil)

--- a/terraform/transform_module_expansion.go
+++ b/terraform/transform_module_expansion.go
@@ -120,8 +120,6 @@ func (t *ModuleExpansionTransformer) transform(g *Graph, c *configs.Config, pare
 
 		case GraphNodeModulePath:
 			path = t.ModulePath()
-		case GraphNodeReferenceOutside:
-			path, _ = t.ReferenceOutside()
 		default:
 			continue
 		}
@@ -134,7 +132,9 @@ func (t *ModuleExpansionTransformer) transform(g *Graph, c *configs.Config, pare
 
 	// Also visit child modules, recursively.
 	for _, cc := range c.Children {
-		return t.transform(g, cc, v)
+		if err := t.transform(g, cc, v); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The recursive transform call should only return immediately on error.
This was causing nested modules containing multiple modules to not
be properly expanded.

Fixes #25114