### PR TITLE
command/providers: Show provider requirements tree

### DIFF
--- a/command/providers.go
+++ b/command/providers.go
@@ -94,22 +94,31 @@ func (c *ProvidersCommand) Run(args []string) int {
 		return 1
 	}
 
-	reqs, reqDiags := config.ProviderRequirements()
-	if reqDiags.HasErrors() {
-		c.showDiagnostics(configDiags)
+	reqs, reqDiags := config.ProviderRequirementsByModule()
+	diags = diags.Append(reqDiags)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
 		return 1
 	}
 
 	state := s.State()
+	var stateReqs getproviders.Requirements
 	if state != nil {
-		stateReqs := state.ProviderRequirements()
-		reqs = reqs.Merge(stateReqs)
+		stateReqs = state.ProviderRequirements()
 	}
 
 	printRoot := treeprint.New()
-	providersCommandPopulateTreeNode(printRoot, reqs)
+	c.populateTreeNode(printRoot, reqs)
 
+	c.Ui.Output("\nProviders required by configuration:")
 	c.Ui.Output(printRoot.String())
+
+	if len(stateReqs) > 0 {
+		c.Ui.Output("Providers required by state:\n")
+		for fqn := range stateReqs {
+			c.Ui.Output(fmt.Sprintf("    provider[%s]\n", fqn.String()))
+		}
+	}
 
 	c.showDiagnostics(diags)
 	if diags.HasErrors() {
@@ -118,22 +127,27 @@ func (c *ProvidersCommand) Run(args []string) int {
 	return 0
 }
 
-func providersCommandPopulateTreeNode(node treeprint.Tree, deps getproviders.Requirements) {
-	for fqn, dep := range deps {
+func (c *ProvidersCommand) populateTreeNode(tree treeprint.Tree, node *configs.ModuleRequirements) {
+	for fqn, dep := range node.Requirements {
 		versionsStr := getproviders.VersionConstraintsString(dep)
 		if versionsStr != "" {
 			versionsStr = " " + versionsStr
 		}
-		node.AddNode(fmt.Sprintf("provider[%s]%s", fqn.String(), versionsStr))
+		tree.AddNode(fmt.Sprintf("provider[%s]%s", fqn.String(), versionsStr))
+	}
+	for name, childNode := range node.Children {
+		branch := tree.AddBranch(fmt.Sprintf("module.%s", name))
+		c.populateTreeNode(branch, childNode)
 	}
 }
 
 const providersCommandHelp = `
 Usage: terraform providers [dir]
 
-  Prints out a list of providers required by the configuration and state.
+  Prints out a tree of modules in the referenced configuration annotated with
+  their provider requirements.
 
-  This provides an overview of all of the provider requirements as an aid to
-  understanding why particular provider plugins are needed and why particular
-  versions are selected.
+  This provides an overview of all of the provider requirements across all
+  referenced modules, as an aid to understanding why particular provider
+  plugins are needed and why particular versions are selected.
 `

--- a/command/testdata/providers/modules/main.tf
+++ b/command/testdata/providers/modules/main.tf
@@ -10,6 +10,6 @@ provider "bar" {
   version = "2.0.0"
 }
 
-module "child" {
+module "kiddo" {
   source = "./child"
 }

--- a/configs/testdata/provider-reqs/provider-reqs-root.tf
+++ b/configs/testdata/provider-reqs/provider-reqs-root.tf
@@ -16,7 +16,7 @@ terraform {
 resource "implied_foo" "bar" {
 }
 
-module "child" {
+module "kinder" {
   source = "./child"
 }
 


### PR DESCRIPTION
Providers can be required from multiple sources. The previous implementation of the providers sub-command displayed only a flat list of provider requirements, which made it difficult to see which modules required each provider.

This commit reintroduces the tree display of provider requirements, and adds a separate output block for providers required by existing state.

### Screenshots

Configuration with nested modules:

<img width="920" alt="nested" src="https://user-images.githubusercontent.com/68917/84186028-df1b2500-aa5d-11ea-8c11-ecd28c3d5c43.png">

Un-upgraded configuration with providers required by configuration and state:

<img width="914" alt="state" src="https://user-images.githubusercontent.com/68917/84186056-ea6e5080-aa5d-11ea-86d6-dfc37905936a.png">
