### PR TITLE
command/init: Improve diags for legacy providers

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -951,14 +951,19 @@ func TestInit_getProviderDetectedLegacy(t *testing.T) {
 
 	// error output is the main focus of this test
 	errOutput := ui.ErrorWriter.String()
-	if !strings.Contains(errOutput, "Error while installing hashicorp/frob:") {
-		t.Fatalf("expected error for installing hashicorp/frob: %s", errOutput)
+	errors := []string{
+		"Error while installing hashicorp/frob:",
+		"Could not find required providers, but found possible alternatives",
+		"hashicorp/baz -> terraform-providers/baz",
+		"terraform 0.13upgrade .",
+		"terraform 0.13upgrade child",
+		"The following remote modules must also be upgraded",
+		"- module.dicerolls at acme/bar/random",
 	}
-	if !strings.Contains(errOutput, "Could not find required providers, but found possible alternatives") {
-		t.Fatalf("expected required provider suggestions: %s", errOutput)
-	}
-	if !strings.Contains(errOutput, "hashicorp/baz -> terraform-providers/baz") {
-		t.Fatalf("expected suggestion for hashicorp/baz: %s", errOutput)
+	for _, want := range errors {
+		if !strings.Contains(errOutput, want) {
+			t.Fatalf("expected error %q: %s", want, errOutput)
+		}
 	}
 }
 

--- a/command/testdata/init-get-provider-detected-legacy/.terraform/modules/dicerolls/terraform-random-bar-1.0.0/main.tf
+++ b/command/testdata/init-get-provider-detected-legacy/.terraform/modules/dicerolls/terraform-random-bar-1.0.0/main.tf
@@ -1,0 +1,7 @@
+// This will try to install hashicorp/baz, fail, and then suggest
+// terraform-providers/baz
+provider baz {}
+
+output "d6" {
+  value = 4 // chosen by fair dice roll, guaranteed to be random
+}

--- a/command/testdata/init-get-provider-detected-legacy/.terraform/modules/modules.json
+++ b/command/testdata/init-get-provider-detected-legacy/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"dicerolls","Source":"acme/bar/random","Version":"1.0.0","Dir":".terraform/modules/dicerolls/terraform-random-bar-1.0.0"},{"Key":"","Source":"","Dir":"."}]}

--- a/command/testdata/init-get-provider-detected-legacy/child/main.tf
+++ b/command/testdata/init-get-provider-detected-legacy/child/main.tf
@@ -1,0 +1,3 @@
+// This will try to install hashicorp/baz, fail, and then suggest
+// terraform-providers/baz
+provider baz {}

--- a/command/testdata/init-get-provider-detected-legacy/main.tf
+++ b/command/testdata/init-get-provider-detected-legacy/main.tf
@@ -8,3 +8,11 @@ provider baz {}
 // This will try to install hashicrop/frob, fail, find no suggestions, and
 // result in an error
 provider frob {}
+
+module "some-baz-stuff" {
+  source = "./child"
+}
+
+module "dicerolls" {
+  source = "acme/bar/random"
+}

--- a/configs/config.go
+++ b/configs/config.go
@@ -81,7 +81,9 @@ type Config struct {
 // module, along with references to any child modules. This is used to
 // determine which modules require which providers.
 type ModuleRequirements struct {
-	Module       *Module
+	Name         string
+	SourceAddr   string
+	SourceDir    string
 	Requirements getproviders.Requirements
 	Children     map[string]*ModuleRequirements
 }
@@ -206,12 +208,14 @@ func (c *Config) ProviderRequirementsByModule() (*ModuleRequirements, hcl.Diagno
 	children := make(map[string]*ModuleRequirements)
 	for name, child := range c.Children {
 		childReqs, childDiags := child.ProviderRequirementsByModule()
+		childReqs.Name = name
 		children[name] = childReqs
 		diags = append(diags, childDiags...)
 	}
 
 	ret := &ModuleRequirements{
-		Module:       c.Module,
+		SourceAddr:   c.SourceAddr,
+		SourceDir:    c.Module.SourceDir,
 		Requirements: reqs,
 		Children:     children,
 	}

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -169,12 +169,10 @@ func TestConfigProviderRequirementsByModule(t *testing.T) {
 
 	got, diags := cfg.ProviderRequirementsByModule()
 	assertNoDiagnostics(t, diags)
-	child, ok := cfg.Children["kinder"]
-	if !ok {
-		t.Fatalf(`could not find child config "kinder" in config children`)
-	}
 	want := &ModuleRequirements{
-		Module: cfg.Module,
+		Name:       "",
+		SourceAddr: "",
+		SourceDir:  "testdata/provider-reqs",
 		Requirements: getproviders.Requirements{
 			// Only the root module's version is present here
 			nullProvider:       getproviders.MustParseVersionConstraints("~> 2.0.0"),
@@ -186,7 +184,9 @@ func TestConfigProviderRequirementsByModule(t *testing.T) {
 		},
 		Children: map[string]*ModuleRequirements{
 			"kinder": {
-				Module: child.Module,
+				Name:       "kinder",
+				SourceAddr: "./child",
+				SourceDir:  "testdata/provider-reqs/child",
 				Requirements: getproviders.Requirements{
 					nullProvider:       getproviders.MustParseVersionConstraints("= 2.0.1"),
 					happycloudProvider: nil,


### PR DESCRIPTION
When initializing a configuration which refers to re-namespaced legacy providers, we attempt to detect this and display a diagnostic message. Previously this message would direct the user to run the `0.13upgrade` command, but without specifying in which directories.

This commit detects which modules are using the providers in question, and displays a list of upgrade commands which specify the source directories of these modules.

For remote modules, we display a separate list noting that they need to be upgraded elsewhere, providing both the local module call name and the module source address.

Addresses the root cause of #25153. 

### Screenshot

<img width="948" alt="init" src="https://user-images.githubusercontent.com/68917/84188548-c6ad0980-aa61-11ea-824b-24ee0dd1d647.png">

With a module from the registry:

![image](https://user-images.githubusercontent.com/68917/84315520-c8e19780-ab37-11ea-80b6-6e9f4424e57b.png)
