### PR TITLE
Adds pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: fmt
+  name: Terraform Format
+  description: Formats Terraform files
+  entry: terraform fmt
+  pass_filenames: false
+  language: golang
+  types: ["file", "non-executable", "terraform", "text"]


### PR DESCRIPTION
Pre-commit (https://pre-commit.com) is a tool for automating the
management and installation of pre-commit Git hooks. This change
introduces a configuration file which allows pre-commit to read the
terraform repository, build it, and use `terraform fmt` as a pre-commit
hook.

A repository seeking to use `terraform fmt` as a pre-commit hook would
need to create a file .pre-commit-config.yaml in their own repository,
with contents similar to:

```
repos:
- repo: https://github.com/hashicorp/terraform
  rev: stable
  hooks:
  - id: fmt
```

This commit introduces no code or functionality changes.