### PR TITLE
ensure modules are expanded during import

### DIFF
--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -527,7 +527,7 @@ func TestContextImport_module(t *testing.T) {
 	state, diags := ctx.Import(&ImportOpts{
 		Targets: []*ImportTarget{
 			&ImportTarget{
-				Addr: addrs.RootModuleInstance.Child("child", addrs.NoKey).ResourceInstance(
+				Addr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID: "bar",
@@ -565,7 +565,7 @@ func TestContextImport_moduleDepth2(t *testing.T) {
 	state, diags := ctx.Import(&ImportOpts{
 		Targets: []*ImportTarget{
 			&ImportTarget{
-				Addr: addrs.RootModuleInstance.Child("child", addrs.NoKey).Child("nested", addrs.NoKey).ResourceInstance(
+				Addr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).Child("nested", addrs.NoKey).ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID: "baz",
@@ -603,7 +603,7 @@ func TestContextImport_moduleDiff(t *testing.T) {
 	state, diags := ctx.Import(&ImportOpts{
 		Targets: []*ImportTarget{
 			&ImportTarget{
-				Addr: addrs.RootModuleInstance.Child("child", addrs.NoKey).ResourceInstance(
+				Addr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
 				ID: "baz",
@@ -765,7 +765,7 @@ aws_instance.foo.0:
 
 const testImportModuleStr = `
 <no state>
-module.child:
+module.child[0]:
   aws_instance.foo:
     ID = foo
     provider = provider["registry.terraform.io/hashicorp/aws"]
@@ -773,7 +773,7 @@ module.child:
 
 const testImportModuleDepth2Str = `
 <no state>
-module.child.nested:
+module.child[0].nested:
   aws_instance.foo:
     ID = foo
     provider = provider["registry.terraform.io/hashicorp/aws"]

--- a/terraform/graph_builder_import.go
+++ b/terraform/graph_builder_import.go
@@ -79,9 +79,20 @@ func (b *ImportGraphBuilder) Steps() []GraphTransformer {
 		// analyze the configuration to find references.
 		&AttachSchemaTransformer{Schemas: b.Schemas, Config: b.Config},
 
+		// Create expansion nodes for all of the module calls. This must
+		// come after all other transformers that create nodes representing
+		// objects that can belong to modules.
+		&ModuleExpansionTransformer{
+			Config: b.Config,
+		},
+
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.
 		&ReferenceTransformer{},
+
+		// Make sure data sources are aware of any depends_on from the
+		// configuration
+		&attachDataResourceDependenciesTransformer{},
 
 		// This validates that the providers only depend on variables
 		&ImportProviderValidateTransformer{},

--- a/terraform/testdata/import-module/main.tf
+++ b/terraform/testdata/import-module/main.tf
@@ -3,6 +3,7 @@ provider "aws" {
 }
 
 module "child" {
+  count = 1
   source = "./child"
   providers = {
     aws = aws


### PR DESCRIPTION
In order to import into a module, we have to make sure that module has
registered the expansion data.

Fixes #25192