### PR TITLE
backend/kubernetes: Kubernetes supports multiple workspaces

### DIFF
--- a/website/docs/state/workspaces.html.md
+++ b/website/docs/state/workspaces.html.md
@@ -29,6 +29,7 @@ Multiple workspaces are currently supported by the following backends:
  * [Consul](/docs/backends/types/consul.html)
  * [COS](/docs/backends/types/cos.html)
  * [GCS](/docs/backends/types/gcs.html)
+ * [Kubernetes](/docs/backends/types/kubernetes.html)
  * [Local](/docs/backends/types/local.html)
  * [Manta](/docs/backends/types/manta.html)
  * [Postgres](/docs/backends/types/pg.html)


### PR DESCRIPTION
Documentation change.  Added Kubernetes backend to docs/state/workspaces, since the Kubernetes backend supports multiple workspaces.

https://github.com/hashicorp/terraform/blob/master/website/docs/backends/types/kubernetes.html.md

> The following configuration options are supported:
> secret_suffix - (Required) Suffix used when creating secrets. Secrets will be named in the format: tfstate-{workspace}-{secret_suffix}.