### PR TITLE
init: fix issue loading local plugin directory

### DIFF
--- a/provider_source.go
+++ b/provider_source.go
@@ -142,7 +142,7 @@ func implicitProviderSource(services *disco.Disco) getproviders.Source {
 
 	addLocalDir("terraform.d/plugins") // our "vendor" directory
 	cliConfigDir, err := cliconfig.ConfigDir()
-	if err != nil {
+	if err == nil {
 		addLocalDir(filepath.Join(cliConfigDir, "plugins"))
 	}
 


### PR DESCRIPTION
A very very small bug caused terraform _not_ to include the default local plugin dir!

Fixes #25172 