### PR TITLE
command/013upgrade: detect builtin terraform provider

### DIFF
--- a/command/013_config_upgrade.go
+++ b/command/013_config_upgrade.go
@@ -213,11 +213,6 @@ command and dealing with them before running this command again.
 		for _, rps := range file.RequiredProviders {
 			rewritePaths[path] = true
 			for _, rp := range rps.RequiredProviders {
-				// Skip internal providers
-				if rp.Type.IsBuiltIn() {
-					continue
-				}
-
 				if previous, exist := requiredProviders[rp.Name]; exist {
 					diags = diags.Append(&hcl.Diagnostic{
 						Summary:  "Duplicate required provider configuration",

--- a/command/013_config_upgrade.go
+++ b/command/013_config_upgrade.go
@@ -213,6 +213,11 @@ command and dealing with them before running this command again.
 		for _, rps := range file.RequiredProviders {
 			rewritePaths[path] = true
 			for _, rp := range rps.RequiredProviders {
+				// Skip internal providers
+				if rp.Type.IsBuiltIn() {
+					continue
+				}
+
 				if previous, exist := requiredProviders[rp.Name]; exist {
 					diags = diags.Append(&hcl.Diagnostic{
 						Summary:  "Duplicate required provider configuration",
@@ -240,6 +245,11 @@ command and dealing with them before running this command again.
 	for _, file := range files {
 		// Step 2: add missing provider requirements from provider blocks
 		for _, p := range file.ProviderConfigs {
+			// Skip internal providers
+			if p.Name == "terraform" {
+				continue
+			}
+
 			// If no explicit provider configuration exists for the
 			// provider configuration's local name, add one with a legacy
 			// provider address.
@@ -264,6 +274,11 @@ command and dealing with them before running this command again.
 					localName = r.ProviderConfigRef.Name
 				} else {
 					localName = r.Addr().ImpliedProvider()
+				}
+
+				// Skip internal providers
+				if localName == "terraform" {
+					continue
 				}
 
 				// If no explicit provider configuration exists for this local

--- a/command/testdata/013upgrade-explicit-providers/expected/main.tf
+++ b/command/testdata/013upgrade-explicit-providers/expected/main.tf
@@ -1,4 +1,4 @@
-provider foo {
+provider "foo" {
   version = "1.2.3"
 }
 
@@ -17,3 +17,5 @@ terraform {
     }
   }
 }
+
+provider "terraform" {}

--- a/command/testdata/013upgrade-explicit-providers/input/main.tf
+++ b/command/testdata/013upgrade-explicit-providers/input/main.tf
@@ -1,4 +1,4 @@
-provider foo {
+provider "foo" {
   version = "1.2.3"
 }
 
@@ -10,3 +10,5 @@ terraform {
     }
   }
 }
+
+provider "terraform" { }

--- a/command/testdata/013upgrade-implicit-providers/expected/main.tf
+++ b/command/testdata/013upgrade-implicit-providers/expected/main.tf
@@ -1,5 +1,6 @@
-resource foo_resource b {}
-resource bar_resource c {}
-resource bar_resource ab {
+resource "foo_resource" "b" {}
+resource "bar_resource" "c" {}
+resource "bar_resource" "ab" {
   provider = baz
 }
+resource "terraform_remote_state" "production" {}

--- a/command/testdata/013upgrade-implicit-providers/input/main.tf
+++ b/command/testdata/013upgrade-implicit-providers/input/main.tf
@@ -1,5 +1,6 @@
-resource foo_resource b {}
-resource bar_resource c {}
-resource bar_resource ab {
+resource "foo_resource" "b" {}
+resource "bar_resource" "c" {}
+resource "bar_resource" "ab" {
   provider = baz
 }
+resource "terraform_remote_state" "production" {}


### PR DESCRIPTION
I went with the admittedly-displeasing option of a string comparison each time we encountered a provider name since this is intended to run before any of the other provider-detecting logic (which already recognizes "terraform" as a builtin provider). 

Fixes https://github.com/hashicorp/terraform/issues/25210