### PR TITLE
command/apply: Fix bug with absolute plan paths

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -82,7 +83,7 @@ func (c *ApplyCommand) Run(args []string) int {
 		if detected, err := getter.Detect(configPath, pwd, getter.Detectors); err != nil {
 			c.Ui.Error(fmt.Sprintf("Invalid path: %s", err))
 			return 1
-		} else if !strings.HasPrefix(detected, "file") {
+		} else if !strings.HasPrefix(detected, "file") && !filepath.IsAbs(detected) {
 			// If this isn't a file URL then we're doing an init +
 			// apply.
 			var init InitCommand


### PR DESCRIPTION
On Windows, passing the absolute path to a planfile as an argument to `terraform apply` would cause it to silently exit with error code 1. This was due to go-getter incorrectly interpreting an absolute Windows path as a URL, [returning it directly](https://github.com/hashicorp/terraform/blob/9d6cabadfcd638c617d739e351a0de82d472f393/vendor/github.com/hashicorp/go-getter/detect.go#L49-L53) rather than [converting it to a file URL](https://github.com/hashicorp/go-getter/blob/294934336035803eaf11297e5d98315ac1276107/detect_file.go#L55-L67), and Terraform assuming that any local path returned by go-getter would start with the string "file".

This commit adds an explicit test that the path is not an absolute path. For Windows hosts this will correct this specific bug, and it should have no effect on other systems.

Fixes #25068 (manually tested).