### PR TITLE
Don't panic if the new version constraint parser is stricter than the old one

### DIFF
--- a/command/testdata/init-get-providers/main.tf
+++ b/command/testdata/init-get-providers/main.tf
@@ -7,5 +7,8 @@ provider "greater-than" {
 }
 
 provider "between" {
-  version = "> 1.0.0 , < 3.0.0"
+  # The second constraint here intentionally has
+  # no space after the < operator to make sure
+  # that we can parse that form too.
+  version = "> 1.0.0 , <3.0.0"
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.0.1
 	github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0
 	github.com/apparentlymart/go-userdirs v0.0.0-20190512014041-4a23807e62b9
-	github.com/apparentlymart/go-versions v0.0.2-0.20180815153302-64b99f7cb171
+	github.com/apparentlymart/go-versions v1.0.0
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
 	github.com/armon/go-radix v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/apparentlymart/go-userdirs v0.0.0-20190512014041-4a23807e62b9 h1:GRMI
 github.com/apparentlymart/go-userdirs v0.0.0-20190512014041-4a23807e62b9/go.mod h1:7kfpUbyCdGJ9fDRCp3fopPQi5+cKNHgTE4ZuNrO71Cw=
 github.com/apparentlymart/go-versions v0.0.2-0.20180815153302-64b99f7cb171 h1:19Seu/H5gq3Ugtx+CGenwF89SDG3S1REX5i6PJj3RK4=
 github.com/apparentlymart/go-versions v0.0.2-0.20180815153302-64b99f7cb171/go.mod h1:JXY95WvQrPJQtudvNARshgWajS7jNNlM90altXIPNyI=
+github.com/apparentlymart/go-versions v1.0.0 h1:4A4CekGuwDUQqc+uTXCrdb9Y98JZsML2sdfNTeVjsK4=
+github.com/apparentlymart/go-versions v1.0.0/go.mod h1:YF5j7IQtrOAOnsGkniupEA5bfCjzd7i14yu0shZavyM=
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 h1:7Ip0wMmLHLRJdrloDxZfhMm0xrLXZS8+COSu2bXmEQs=
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da h1:8GUt8eRujhVEGZFFEjBj46YV4rDjvGrNxb0KMWYkL2I=

--- a/vendor/github.com/apparentlymart/go-versions/versions/constraints/ruby_style.go
+++ b/vendor/github.com/apparentlymart/go-versions/versions/constraints/ruby_style.go
@@ -136,9 +136,9 @@ func parseRubyStyle(str string) (SelectionSpec, string, error) {
 
 	switch raw.sep {
 	case "":
-		if raw.op != "" {
-			return spec, remain, fmt.Errorf("a space separator is required after the operator %q", raw.op)
-		}
+		// No separator is always okay. Although all of the examples in the
+		// rubygems docs show a space separator, the parser doesn't actually
+		// require it.
 	case " ":
 		if raw.op == "" {
 			return spec, remain, fmt.Errorf("extraneous spaces at start of specification")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -100,7 +100,7 @@ github.com/apparentlymart/go-userdirs/macosbase
 github.com/apparentlymart/go-userdirs/userdirs
 github.com/apparentlymart/go-userdirs/windowsbase
 github.com/apparentlymart/go-userdirs/xdgbase
-# github.com/apparentlymart/go-versions v0.0.2-0.20180815153302-64b99f7cb171
+# github.com/apparentlymart/go-versions v1.0.0
 ## explicit
 github.com/apparentlymart/go-versions/versions
 github.com/apparentlymart/go-versions/versions/constraints


### PR DESCRIPTION
The new provider install logic for 0.13 uses a different version constraint parser that makes an effort to produce user-actionable error messages when the user enters something invalid or non-sensical, but as of right now the `configs` package is still in an in-between state between old and new because we didn't change the other places where version constraints appear to use the new parser yet.

The new parser is intentionally a little stricter than the old one, because it's no longer just a regex match and aims to give feedback when it finds something weird, but it was inadvertently a little _too_ strict in that it was enforcing the space between the operator and the boundary like in `~> 1.0.0`, due to a mistaken impression on my part that this was required by rubygems (which our constraint syntax is based on). Turns out that rubygems does accept the space being absent and that's just not mentioned in any of the documentation.

So with all of that said, there are two different things in this PR:

1. Accept a constraint like `~>1.0.0` as equivalent to `~> 1.0.0`, which is non-idiomatic but also a pretty harmless thing to be making a fuss about. (That's achieved by upgrading the upstream dependency containing the parser.)
2. If the input contains any other case where the new parser is stricter than the old (which should, after the change mentioned in the previous item, be much more marginal things that would be unlikely to appear in real configuration), return it as a proper error message rather than a panic.

    I did consider going all the way to switching over to the new parser for other cases here, but that ended up being too invasive a change to make this close to final release, and so instead this is a short-term robustness improvement, focused only on avoiding panics, with the intent of using the new parser exclusively in a future release.

This closes #25177.
