### PR TITLE
command/apply: Remove implicit init call

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -3,11 +3,9 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/configs/hcl2shim"
@@ -53,11 +51,7 @@ func (c *ApplyCommand) Run(args []string) int {
 
 	var diags tfdiags.Diagnostics
 
-	// Get the args. The "maybeInit" flag tracks whether we may need to
-	// initialize the configuration from a remote path. This is true as long
-	// as we have an argument.
 	args = cmdFlags.Args()
-	maybeInit := len(args) == 1
 	configPath, err := ModulePath(args)
 	if err != nil {
 		c.Ui.Error(err.Error())
@@ -68,32 +62,6 @@ func (c *ApplyCommand) Run(args []string) int {
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
 		return 1
-	}
-
-	if !c.Destroy && maybeInit {
-		// We need the pwd for the getter operation below
-		pwd, err := os.Getwd()
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error getting pwd: %s", err))
-			return 1
-		}
-
-		// Do a detect to determine if we need to do an init + apply.
-		if detected, err := getter.Detect(configPath, pwd, getter.Detectors); err != nil {
-			c.Ui.Error(fmt.Sprintf("Invalid path: %s", err))
-			return 1
-		} else if !strings.HasPrefix(detected, "file") {
-			// If this isn't a file URL then we're doing an init +
-			// apply.
-			var init InitCommand
-			init.Meta = c.Meta
-			if code := init.Run([]string{detected}); code != 0 {
-				return code
-			}
-
-			// Change the config path to be the cwd
-			configPath = pwd
-		}
 	}
 
 	// Check if the path is a plan


### PR DESCRIPTION
The positional argument passed to apply was once used to specify a source for a Terraform module to fetch and initialize (#337). This functionality was removed from the `init` command later (#15032) but not completely removed from `apply`.

This code was non-functional but largely not harmful, except for a very specific case (#25068): when passing an absolute path to a plan file as the positional argument on Windows, the `getter.Detect` code would incorrectly interpret the path as a URL. This caused init to fail and the apply command would exit with code 1 but without diagnostics.

This commit removes this codepath, which fixes this bug, and should otherwise have no effect on the supported behaviour of apply.

Fixes #25068

### Screenshots

Manual verification of the fix on Windows 10:

![image](https://user-images.githubusercontent.com/68917/84528745-3a435680-acae-11ea-831d-60f4514e64c8.png)
