### PR TITLE
Fix JSON output format documentation

### DIFF
--- a/website/docs/internals/json-format.html.md
+++ b/website/docs/internals/json-format.html.md
@@ -66,9 +66,9 @@ For ease of consumption by callers, the plan representation includes a partial r
   // being applied to, using the state representation described above.
   "prior_state": <state-representation>,
 
-  // "config" is a representation of the configuration being applied to the
+  // "configuration" is a representation of the configuration being applied to the
   // prior state, using the configuration representation described above.
-  "config": <config-representation>,
+  "configuration": <configuration-representation>,
 
   // "planned_values" is a description of what is known so far of the outcome in
   // the standard value representation, with any as-yet-unknown values omitted.
@@ -206,7 +206,7 @@ The following example illustrates the structure of a `<values-representation>`:
         // resource, whose structure depends on the resource type schema. Any
         // unknown values are omitted or set to null, making them
         // indistinguishable from absent values; callers which need to distinguish
-        // unknown from unset must use the plan-specific or config-specific
+        // unknown from unset must use the plan-specific or configuration-specific
         // structures described in later sections.
         "values": {
           "id": "i-abc123",
@@ -379,7 +379,7 @@ Because the configuration models are produced at a stage prior to expression eva
         // "module" is a representation of the configuration of the child module
         // itself, using the same structure as the "root_module" object,
         // recursively describing the full module tree.
-        "module": <module-config-representation>,
+        "module": <module-configuration-representation>,
       }
     }
   }


### PR DESCRIPTION
This PR updates the [JSON output format](https://www.terraform.io/docs/internals/json-format.html) documentation page. In this page, the Plan representation is described as having a top level `"config"` key mapping to a config-representation object. But with the latest version of Terraform, the config-representation object is mapped under a top level `"configuration"` key.
Related code: [command/jsonplan/plan.go](https://github.com/hashicorp/terraform/blob/bc386234d528747ad244574f72f1fc30a486d5c2/command/jsonplan/plan.go#L39)

---

Examples to reproduce with terraform `v0.12.26`:
* `main.tf` file:
```tf
resource "null_resource" "test" {
  provisioner "local-exec" {
    command = "echo 'hello world'"
  }
}
```
Run
```shell
terraform init
terraform plan -out=plan
terraform show -json plan
```
the last command outputs the following JSON (pretty printed here for readability): 
```json
{
  "format_version": "0.1",
  "terraform_version": "0.12.26",
  "planned_values": {
    "root_module": {
      "resources": [
        {
          "address": "null_resource.test",
          "mode": "managed",
          "type": "null_resource",
          "name": "test",
          "provider_name": "null",
          "schema_version": 0,
          "values": {
            "triggers": null
          }
        }
      ]
    }
  },
  "resource_changes": [
    {
      "address": "null_resource.test",
      "mode": "managed",
      "type": "null_resource",
      "name": "test",
      "provider_name": "null",
      "change": {
        "actions": [
          "create"
        ],
        "before": null,
        "after": {
          "triggers": null
        },
        "after_unknown": {
          "id": true
        }
      }
    }
  ],
  "configuration": {
    "root_module": {
      "resources": [
        {
          "address": "null_resource.test",
          "mode": "managed",
          "type": "null_resource",
          "name": "test",
          "provider_config_key": "null",
          "provisioners": [
            {
              "type": "local-exec",
              "expressions": {
                "command": {
                  "constant_value": "echo 'hello world'"
                }
              }
            }
          ],
          "schema_version": 0
        }
      ]
    }
  }
}
```
We can see that the config-representation object is under the `"configuration"` key.