### PR TITLE
Validation for provider blocks in expanding modules (nested)

### DIFF
--- a/configs/configload/loader_load.go
+++ b/configs/configload/loader_load.go
@@ -103,50 +103,70 @@ func (l *Loader) moduleWalkerLoad(req *configs.ModuleRequest) (*configs.Module, 
 	// The providers associated with expanding modules must be present in the proxy/passed providers
 	// block. Guarding here for accessing the module call just in case.
 	if mc, exists := req.Parent.Module.ModuleCalls[req.Name]; exists {
-		if mc.Count != nil || mc.ForEach != nil {
-			for key, pc := range mod.ProviderConfigs {
-				// Use these to track if a provider is configured (not allowed),
-				// or if we've found its matching proxy
-				var isConfigured bool
-				var foundMatchingProxy bool
+		validateDiags := validateProviderConfigs(mc, mod, req.Parent)
+		diags = append(diags, validateDiags...)
+	}
+	return mod, record.Version, diags
+}
 
-				// Validate the config against an empty schema to see if it's empty.
-				_, pcConfigDiags := pc.Config.Content(&hcl.BodySchema{})
-				if pcConfigDiags.HasErrors() || pc.Version.Required != nil {
-					isConfigured = true
-				}
+func validateProviderConfigs(mc *configs.ModuleCall, mod *configs.Module, parent *configs.Config) hcl.Diagnostics {
+	var diags hcl.Diagnostics
 
-				// If it is empty or only has an alias,
-				// does this provider exist in our proxy configs?
-				for _, r := range mc.Providers {
-					// Must match on name and Alias
-					if pc.Name == r.InChild.Name && pc.Alias == r.InChild.Alias {
-						foundMatchingProxy = true
-						break
-					}
+	if mc.Count != nil || mc.ForEach != nil {
+		for key, pc := range mod.ProviderConfigs {
+			// Use these to track if a provider is configured (not allowed),
+			// or if we've found its matching proxy
+			var isConfigured bool
+			var foundMatchingProxy bool
+
+			// Validate the config against an empty schema to see if it's empty.
+			_, pcConfigDiags := pc.Config.Content(&hcl.BodySchema{})
+			if pcConfigDiags.HasErrors() || pc.Version.Required != nil {
+				isConfigured = true
+			}
+
+			// If it is empty or only has an alias,
+			// does this provider exist in our proxy configs?
+			for _, r := range mc.Providers {
+				// Must match on name and Alias
+				if pc.Name == r.InChild.Name && pc.Alias == r.InChild.Alias {
+					foundMatchingProxy = true
+					break
 				}
-				if isConfigured || !foundMatchingProxy {
-					if mc.Count != nil {
-						diags = append(diags, &hcl.Diagnostic{
-							Severity: hcl.DiagError,
-							Summary:  "Module does not support count",
-							Detail:   fmt.Sprintf(moduleProviderError, mc.Name, "count", key, pc.NameRange),
-							Subject:  mc.Count.Range().Ptr(),
-						})
-					}
-					if mc.ForEach != nil {
-						diags = append(diags, &hcl.Diagnostic{
-							Severity: hcl.DiagError,
-							Summary:  "Module does not support for_each",
-							Detail:   fmt.Sprintf(moduleProviderError, mc.Name, "for_each", key, pc.NameRange),
-							Subject:  mc.ForEach.Range().Ptr(),
-						})
-					}
+			}
+			if isConfigured || !foundMatchingProxy {
+				if mc.Count != nil {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Module does not support count",
+						Detail:   fmt.Sprintf(moduleProviderError, mc.Name, "count", key, pc.NameRange),
+						Subject:  mc.Count.Range().Ptr(),
+					})
+				}
+				if mc.ForEach != nil {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Module does not support for_each",
+						Detail:   fmt.Sprintf(moduleProviderError, mc.Name, "for_each", key, pc.NameRange),
+						Subject:  mc.ForEach.Range().Ptr(),
+					})
 				}
 			}
 		}
 	}
-	return mod, record.Version, diags
+	// If this module has further parents, go through them recursively
+	if !parent.Path.IsRoot() {
+		// Use the path to get the name so we can look it up in the parent module calls
+		path := parent.Path
+		name := path[len(path)-1]
+		// This parent's module call, so we can check for count/for_each here,
+		// guarding with exists just in case
+		if mc, exists := parent.Parent.Module.ModuleCalls[name]; exists {
+			return validateProviderConfigs(mc, mod, parent.Parent)
+		}
+	}
+
+	return diags
 }
 
 var moduleProviderError = `Module "%s" cannot be used with %s because it contains a nested provider configuration for "%s", at %s.

--- a/configs/configload/loader_load_test.go
+++ b/configs/configload/loader_load_test.go
@@ -86,8 +86,7 @@ func TestLoaderLoadConfig_moduleExpand(t *testing.T) {
 	// We do not allow providers to be configured in expanding modules
 	// In addition, if a provider is present but an empty block, it is allowed,
 	// but IFF a provider is passed through the module call
-	paths := []string{"provider-configured", "no-provider-passed", "nested-provider"}
-	// paths := []string{"nested-provider"}
+	paths := []string{"provider-configured", "no-provider-passed", "nested-provider", "more-nested-provider"}
 	for _, p := range paths {
 		fixtureDir := filepath.Clean(fmt.Sprintf("testdata/expand-modules/%s", p))
 		loader, err := NewLoader(&Config{

--- a/configs/configload/loader_load_test.go
+++ b/configs/configload/loader_load_test.go
@@ -86,24 +86,25 @@ func TestLoaderLoadConfig_moduleExpand(t *testing.T) {
 	// We do not allow providers to be configured in expanding modules
 	// In addition, if a provider is present but an empty block, it is allowed,
 	// but IFF a provider is passed through the module call
-	paths := []string{"provider-configured", "no-provider-passed"}
+	paths := []string{"provider-configured", "no-provider-passed", "nested-provider"}
+	// paths := []string{"nested-provider"}
 	for _, p := range paths {
 		fixtureDir := filepath.Clean(fmt.Sprintf("testdata/expand-modules/%s", p))
 		loader, err := NewLoader(&Config{
 			ModulesDir: filepath.Join(fixtureDir, ".terraform/modules"),
 		})
 		if err != nil {
-			t.Fatalf("unexpected error from NewLoader: %s", err)
+			t.Fatalf("unexpected error from NewLoader at path %s: %s", p, err)
 		}
 
 		_, diags := loader.LoadConfig(fixtureDir)
 		if !diags.HasErrors() {
-			t.Fatalf("success; want error")
+			t.Fatalf("success; want error at path %s", p)
 		}
 		got := diags.Error()
 		want := "Module does not support count"
 		if !strings.Contains(got, want) {
-			t.Fatalf("wrong error\ngot:\n%s\n\nwant: containing %q", got, want)
+			t.Fatalf("wrong error at path %s \ngot:\n%s\n\nwant: containing %q", p, got, want)
 		}
 	}
 }

--- a/configs/configload/testdata/expand-modules/more-nested-provider/.terraform/modules/modules.json
+++ b/configs/configload/testdata/expand-modules/more-nested-provider/.terraform/modules/modules.json
@@ -1,0 +1,34 @@
+{
+    "Modules": [
+        {
+            "Key": "",
+            "Source": "",
+            "Dir": "testdata/expand-modules/nested-provider"
+        },
+        {
+            "Key": "child",
+            "Source": "./child",
+            "Dir": "testdata/expand-modules/nested-provider/child"
+        },
+        {
+            "Key": "child2",
+            "Source": "./child2",
+            "Dir": "testdata/expand-modules/nested-provider/child2"
+        },
+        {
+            "Key": "child3",
+            "Source": "./child3",
+            "Dir": "testdata/expand-modules/nested-provider/child3"
+        },
+        {
+            "Key": "child.child2",
+            "Source": "../child2",
+            "Dir": "testdata/expand-modules/nested-provider/child2"
+        },
+        {
+            "Key": "child.child2.child3",
+            "Source": "../child3",
+            "Dir": "testdata/expand-modules/nested-provider/child3"
+        }
+    ]
+}

--- a/configs/configload/testdata/expand-modules/more-nested-provider/child/main.tf
+++ b/configs/configload/testdata/expand-modules/more-nested-provider/child/main.tf
@@ -1,0 +1,4 @@
+module "child2" {
+  source = "../child2"
+  
+}

--- a/configs/configload/testdata/expand-modules/more-nested-provider/child2/main.tf
+++ b/configs/configload/testdata/expand-modules/more-nested-provider/child2/main.tf
@@ -1,0 +1,4 @@
+module "child3" {
+  source = "../child3"
+  
+}

--- a/configs/configload/testdata/expand-modules/more-nested-provider/child3/main.tf
+++ b/configs/configload/testdata/expand-modules/more-nested-provider/child3/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+
+}
+
+output "my_output" {
+  value = "my output"
+}

--- a/configs/configload/testdata/expand-modules/more-nested-provider/root.tf
+++ b/configs/configload/testdata/expand-modules/more-nested-provider/root.tf
@@ -1,0 +1,4 @@
+module "child" {
+  count = 1
+  source = "./child"
+}

--- a/configs/configload/testdata/expand-modules/nested-provider/.terraform/modules/modules.json
+++ b/configs/configload/testdata/expand-modules/nested-provider/.terraform/modules/modules.json
@@ -1,0 +1,24 @@
+{
+    "Modules": [
+        {
+            "Key": "",
+            "Source": "",
+            "Dir": "testdata/expand-modules/nested-provider"
+        },
+        {
+            "Key": "child",
+            "Source": "./child",
+            "Dir": "testdata/expand-modules/nested-provider/child"
+        },
+        {
+            "Key": "child2",
+            "Source": "./child2",
+            "Dir": "testdata/expand-modules/nested-provider/child2"
+        },
+        {
+            "Key": "child.child2",
+            "Source": "../child2",
+            "Dir": "testdata/expand-modules/nested-provider/child2"
+        }
+    ]
+}

--- a/configs/configload/testdata/expand-modules/nested-provider/child/main.tf
+++ b/configs/configload/testdata/expand-modules/nested-provider/child/main.tf
@@ -1,0 +1,4 @@
+module "child2" {
+  source = "../child2"
+  
+}

--- a/configs/configload/testdata/expand-modules/nested-provider/child2/main.tf
+++ b/configs/configload/testdata/expand-modules/nested-provider/child2/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+
+}
+
+output "my_output" {
+  value = "my output"
+}

--- a/configs/configload/testdata/expand-modules/nested-provider/root.tf
+++ b/configs/configload/testdata/expand-modules/nested-provider/root.tf
@@ -1,0 +1,4 @@
+module "child" {
+  count = 1
+  source = "./child"
+}


### PR DESCRIPTION
When a module is loaded, rather than only checking the first parent, provider validation has been refactored into a separate function such that we look for `count` or `for_each` on module calls. 

This covers the case when a module has a `provider {}` block and is the child (or child of a child) of a module that has `count` or `for_each` declared. Two tests are included, to ensure parent, and parent-of-parent.