### PR TITLE
quote dot node names

### DIFF
--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -33,7 +33,7 @@ func TestGraph(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `provider["registry.terraform.io/hashicorp/test"]`) {
+	if !strings.Contains(output, `provider[\"registry.terraform.io/hashicorp/test\"]`) {
 		t.Fatalf("doesn't look like digraph: %s", output)
 	}
 }
@@ -80,7 +80,7 @@ func TestGraph_noArgs(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `provider["registry.terraform.io/hashicorp/test"]`) {
+	if !strings.Contains(output, `provider[\"registry.terraform.io/hashicorp/test\"]`) {
 		t.Fatalf("doesn't look like digraph: %s", output)
 	}
 }
@@ -161,7 +161,7 @@ func TestGraph_plan(t *testing.T) {
 	}
 
 	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `provider["registry.terraform.io/hashicorp/test"]`) {
+	if !strings.Contains(output, `provider[\"registry.terraform.io/hashicorp/test\"]`) {
 		t.Fatalf("doesn't look like digraph: %s", output)
 	}
 }

--- a/dag/marshal.go
+++ b/dag/marshal.go
@@ -108,9 +108,14 @@ func newMarshalVertex(v Vertex) *marshalVertex {
 		dn = nil
 	}
 
+	// the name will be quoted again later, so we need to ensure it's properly
+	// escaped without quotes.
+	name := strconv.Quote(VertexName(v))
+	name = name[1 : len(name)-1]
+
 	return &marshalVertex{
 		ID:              marshalVertexID(v),
-		Name:            VertexName(v),
+		Name:            name,
 		Attrs:           make(map[string]string),
 		graphNodeDotter: dn,
 	}

--- a/dag/marshal_test.go
+++ b/dag/marshal_test.go
@@ -32,6 +32,21 @@ func TestGraphDot_basic(t *testing.T) {
 	}
 }
 
+func TestGraphDot_quoted(t *testing.T) {
+	var g Graph
+	quoted := `name["with-quotes"]`
+	other := `other`
+	g.Add(quoted)
+	g.Add(other)
+	g.Connect(BasicEdge(quoted, other))
+
+	actual := strings.TrimSpace(string(g.Dot(nil)))
+	expected := strings.TrimSpace(testGraphDotQuotedStr)
+	if actual != expected {
+		t.Fatalf("\ngot:   %q\nwanted %q\n", actual, expected)
+	}
+}
+
 func TestGraphDot_attrs(t *testing.T) {
 	var g Graph
 	g.Add(&testGraphNodeDotter{
@@ -52,6 +67,14 @@ type testGraphNodeDotter struct{ Result *DotNode }
 
 func (n *testGraphNodeDotter) Name() string                      { return n.Result.Name }
 func (n *testGraphNodeDotter) DotNode(string, *DotOpts) *DotNode { return n.Result }
+
+const testGraphDotQuotedStr = `digraph {
+	compound = "true"
+	newrank = "true"
+	subgraph "root" {
+		"[root] name[\"with-quotes\"]" -> "[root] other"
+	}
+}`
 
 const testGraphDotBasicStr = `digraph {
 	compound = "true"


### PR DESCRIPTION
Providers can contain quotes, so we need to ensure proper quoting in the
dot format.

While it would be nice to make some other changes to the dot format, like better layout and clustering of modules, the abstractions are not what we need to do. The existing code was left halfway between transitioning from the line-by-line dot writer, to a structured json output, but the json graph project was abandoned. We can get much better output leveraging dot, but we need to start with better base abstractions.

Fixes #25237