### PR TITLE
Whole module references

### DIFF
--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -95,11 +95,7 @@ func (n *nodeExpandModuleVariable) ReferenceOutside() (selfPath, referencePath a
 
 // GraphNodeReferenceable
 func (n *nodeExpandModuleVariable) ReferenceableAddrs() []addrs.Referenceable {
-	// FIXME: References for module variables probably need to be thought out a bit more
-	// Otherwise, we can reference the output via the address itself, or the
-	// module call
-	_, call := n.Module.Call()
-	return []addrs.Referenceable{n.Addr, call}
+	return []addrs.Referenceable{n.Addr}
 }
 
 // RemovableIfNotTargeted

--- a/terraform/transform_reference.go
+++ b/terraform/transform_reference.go
@@ -303,6 +303,8 @@ func (m ReferenceMap) References(v dag.Vertex) []dag.Vertex {
 				subject = ri.ContainingResource()
 			case addrs.AbsModuleCallOutput:
 				subject = ri.ModuleCallOutput()
+			case addrs.ModuleCallInstance:
+				subject = ri.Call
 			default:
 				log.Printf("[WARN] ReferenceTransformer: reference not found: %q", subject)
 				continue


### PR DESCRIPTION
Normally module outputs are referenced directly, but with the new addressing scheme we can reference modules as objects, or groups of objects containing their outputs. When building the initial graph however module are not yet expanded, so like resource instances, we need to de-specify the module instance to the entire module when connecting references.

Fixes #25246