### PR TITLE
Validate depends_on in modules and outputs

### DIFF
--- a/terraform/eval_output_test.go
+++ b/terraform/eval_output_test.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/states"
 
 	"github.com/hashicorp/terraform/addrs"
@@ -44,7 +45,8 @@ func TestEvalWriteMapOutput(t *testing.T) {
 
 	for _, tc := range cases {
 		evalNode := &EvalWriteOutput{
-			Addr: addrs.OutputValue{Name: tc.name},
+			Config: &configs.Output{},
+			Addr:   addrs.OutputValue{Name: tc.name},
 		}
 		ctx.EvaluateExprResult = tc.val
 		t.Run(tc.name, func(t *testing.T) {

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -228,9 +228,8 @@ func (n *NodeApplyableOutput) EvalTree() EvalNode {
 			&EvalOpFilter{
 				Ops: []walkOperation{walkEval, walkRefresh, walkPlan, walkApply, walkValidate, walkDestroy, walkPlanDestroy},
 				Node: &EvalWriteOutput{
-					Addr:      n.Addr.OutputValue,
-					Sensitive: n.Config.Sensitive,
-					Expr:      n.Config.Expr,
+					Addr:   n.Addr.OutputValue,
+					Config: n.Config,
 				},
 			},
 		},


### PR DESCRIPTION
While output blocks allowed `depends_on`, the expressions were never validated. We can validate that during regular output evaluation, since outputs don't have a separate validation node.

Module block `depends_on` was also not be validated, which we can do using the same logic applied to resources.

Fixes #25260