### PR TITLE
command: Always validate workspace name

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -260,7 +260,12 @@ func (c *InitCommand) Run(args []string) int {
 	// on a previous run) we'll use the current state as a potential source
 	// of provider dependencies.
 	if back != nil {
-		sMgr, err := back.StateMgr(c.Workspace())
+		workspace, err := c.Workspace()
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+			return 1
+		}
+		sMgr, err := back.StateMgr(workspace)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error loading state: %s", err))
 			return 1

--- a/command/meta_backend_migrate.go
+++ b/command/meta_backend_migrate.go
@@ -181,7 +181,10 @@ func (m *Meta) backendMigrateState_S_S(opts *backendMigrateOpts) error {
 func (m *Meta) backendMigrateState_S_s(opts *backendMigrateOpts) error {
 	log.Printf("[TRACE] backendMigrateState: target backend type %q does not support named workspaces", opts.TwoType)
 
-	currentEnv := m.Workspace()
+	currentEnv, err := m.Workspace()
+	if err != nil {
+		return err
+	}
 
 	migrate := opts.force
 	if !migrate {
@@ -262,9 +265,12 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 				return nil, err
 			}
 
+			// Ignore invalid workspace name as it is irrelevant in this context.
+			workspace, _ := m.Workspace()
+
 			// If the currently selected workspace is the default workspace, then set
 			// the named workspace as the new selected workspace.
-			if m.Workspace() == backend.DefaultStateName {
+			if workspace == backend.DefaultStateName {
 				if err := m.SetWorkspace(opts.twoEnv); err != nil {
 					return nil, fmt.Errorf("Failed to set new workspace: %s", err)
 				}

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -1003,7 +1003,11 @@ func TestMetaBackend_configuredChangeCopy_multiToSingle(t *testing.T) {
 	}
 
 	// Verify we are now in the default env, or we may not be able to access the new backend
-	if env := m.Workspace(); env != backend.DefaultStateName {
+	env, err := m.Workspace()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env != backend.DefaultStateName {
 		t.Fatal("using non-default env with single-env backend")
 	}
 }

--- a/command/output.go
+++ b/command/output.go
@@ -64,7 +64,11 @@ func (c *OutputCommand) Run(args []string) int {
 		return 1
 	}
 
-	env := c.Workspace()
+	env, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
 
 	// Get the state
 	stateStore, err := b.StateMgr(env)

--- a/command/plan.go
+++ b/command/plan.go
@@ -135,7 +135,12 @@ func (c *PlanCommand) Run(args []string) int {
 		}
 		var backendForPlan plans.Backend
 		backendForPlan.Type = backendPseudoState.Type
-		backendForPlan.Workspace = c.Workspace()
+		workspace, err := c.Workspace()
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+			return 1
+		}
+		backendForPlan.Workspace = workspace
 
 		// Configuration is a little more awkward to handle here because it's
 		// stored in state as raw JSON but we need it as a plans.DynamicValue

--- a/command/providers.go
+++ b/command/providers.go
@@ -83,7 +83,11 @@ func (c *ProvidersCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	env := c.Workspace()
+	env, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
 	s, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))

--- a/command/show.go
+++ b/command/show.go
@@ -130,7 +130,11 @@ func (c *ShowCommand) Run(args []string) int {
 			}
 		}
 	} else {
-		env := c.Workspace()
+		env, err := c.Workspace()
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+			return 1
+		}
 		stateFile, stateErr = getStateFromEnv(b, env)
 		if stateErr != nil {
 			c.Ui.Error(stateErr.Error())

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -41,7 +41,11 @@ func (c *StateListCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	env := c.Workspace()
+	env, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
 	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))

--- a/command/state_meta.go
+++ b/command/state_meta.go
@@ -38,7 +38,10 @@ func (c *StateMeta) State() (state.State, error) {
 			return nil, backendDiags.Err()
 		}
 
-		workspace := c.Workspace()
+		workspace, err := c.Workspace()
+		if err != nil {
+			return nil, err
+		}
 		// Get the state
 		s, err := b.StateMgr(workspace)
 		if err != nil {

--- a/command/state_pull.go
+++ b/command/state_pull.go
@@ -32,7 +32,11 @@ func (c *StatePullCommand) Run(args []string) int {
 	}
 
 	// Get the state manager for the current workspace
-	env := c.Workspace()
+	env, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
 	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))

--- a/command/state_push.go
+++ b/command/state_push.go
@@ -72,7 +72,11 @@ func (c *StatePushCommand) Run(args []string) int {
 	}
 
 	// Get the state manager for the currently-selected workspace
-	env := c.Workspace()
+	env, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
 	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load destination state: %s", err))

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -89,7 +89,11 @@ func (c *StateShowCommand) Run(args []string) int {
 	schemas := ctx.Schemas()
 
 	// Get the state
-	env := c.Workspace()
+	env, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
 	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))

--- a/command/taint.go
+++ b/command/taint.go
@@ -71,7 +71,11 @@ func (c *TaintCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	env := c.Workspace()
+	env, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
 	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))

--- a/command/unlock.go
+++ b/command/unlock.go
@@ -65,7 +65,11 @@ func (c *UnlockCommand) Run(args []string) int {
 		return 1
 	}
 
-	env := c.Workspace()
+	env, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
 	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -66,7 +66,11 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	workspace := c.Workspace()
+	workspace, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
 	stateMgr, err := b.StateMgr(workspace)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))

--- a/command/validate.go
+++ b/command/validate.go
@@ -110,7 +110,11 @@ func (c *ValidateCommand) validate(dir string) tfdiags.Diagnostics {
 		}
 	}
 
-	opts := c.contextOpts()
+	opts, err := c.contextOpts()
+	if err != nil {
+		diags = diags.Append(err)
+		return diags
+	}
 	opts.Config = cfg
 	opts.Variables = varValues
 

--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -28,7 +28,7 @@ func TestWorkspace_createAndChange(t *testing.T) {
 
 	newCmd := &WorkspaceNewCommand{}
 
-	current := newCmd.Workspace()
+	current, _ := newCmd.Workspace()
 	if current != backend.DefaultStateName {
 		t.Fatal("current workspace should be 'default'")
 	}
@@ -40,7 +40,7 @@ func TestWorkspace_createAndChange(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
-	current = newCmd.Workspace()
+	current, _ = newCmd.Workspace()
 	if current != "test" {
 		t.Fatalf("current workspace should be 'test', got %q", current)
 	}
@@ -53,7 +53,7 @@ func TestWorkspace_createAndChange(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
-	current = newCmd.Workspace()
+	current, _ = newCmd.Workspace()
 	if current != backend.DefaultStateName {
 		t.Fatal("current workspace should be 'default'")
 	}
@@ -308,7 +308,7 @@ func TestWorkspace_delete(t *testing.T) {
 		Meta: Meta{Ui: ui},
 	}
 
-	current := delCmd.Workspace()
+	current, _ := delCmd.Workspace()
 	if current != "test" {
 		t.Fatal("wrong workspace:", current)
 	}
@@ -331,7 +331,7 @@ func TestWorkspace_delete(t *testing.T) {
 		t.Fatalf("error deleting workspace: %s", ui.ErrorWriter)
 	}
 
-	current = delCmd.Workspace()
+	current, _ = delCmd.Workspace()
 	if current != backend.DefaultStateName {
 		t.Fatalf("wrong workspace: %q", current)
 	}

--- a/command/workspace_delete.go
+++ b/command/workspace_delete.go
@@ -91,7 +91,12 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	if workspace == c.Workspace() {
+	currentWorkspace, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
+	if workspace == currentWorkspace {
 		c.Ui.Error(fmt.Sprintf(strings.TrimSpace(envDelCurrent), workspace))
 		return 1
 	}

--- a/command/workspace_show.go
+++ b/command/workspace_show.go
@@ -20,7 +20,11 @@ func (c *WorkspaceShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	workspace := c.Workspace()
+	workspace, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
 	c.Ui.Output(workspace)
 
 	return 0


### PR DESCRIPTION
The workspace name can be overridden by setting a `TF_WORKSPACE` environment variable. If this is done, we should still validate the resulting workspace name; otherwise, we could end up with an invalid and unselectable workspace.

This change updates the `Meta.Workspace` function to return an error, and handles that error wherever necessary.

Fixes #24564

### Screenshot

![image](https://user-images.githubusercontent.com/68917/84810094-d768fc80-afd8-11ea-8d04-870facc1b5c0.png)
