### PR TITLE
Pin 'full' Dockerfile to go1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,16 @@ jobs:
       XC_OS: "freebsd linux"
       XC_ARCH: "arm"
 
+  test-docker-full:
+    executor:
+      name: go
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: test docker build for 'full' image
+          command: docker build -t test-docker-full .
+
 workflows:
   version: 2
   test:
@@ -180,6 +190,13 @@ workflows:
           requires:
             - go-test
             - go-test-e2e
+      - test-docker-full:
+          filters:
+            branches:
+              only:
+                - master
+                - /^v\d+\.\d+$/ # v0.11, v0.12, etc.
+
   build-distros:
     jobs:
       - build-386

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # binary from releases.hashicorp.com; these are built instead from
 # scripts/docker-release/Dockerfile-release.
 
-FROM golang:alpine
+FROM golang:1.13-alpine
 LABEL maintainer="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
 RUN apk add --no-cache git bash openssh


### PR DESCRIPTION
I was trying to build the 'full' docker image in CI and ran into issues:
```
Step 9/11 : RUN /bin/bash scripts/build.sh
 ---> Running in e470290e55cf
==> Removing old directory...
==> Installing gox...
go: downloading github.com/mitchellh/gox v1.0.1
go: github.com/mitchellh/gox upgrade => v1.0.1
go: downloading github.com/mitchellh/iochan v1.0.0
go: downloading github.com/hashicorp/go-version v1.2.0
go: github.com/hashicorp/go-version upgrade => v1.2.0
==> Building...
error reading Go version: exit status 1
Stderr: go: inconsistent vendoring in /go/src/github.com/hashicorp/terraform:
        github.com/mitchellh/gox@v1.0.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
```

This is because `golang:alpine` refers to the latest go release:
```
$ docker run golang:alpine go version
go version go1.14.4 linux/amd64
```
In Go1.14 the behavior changed for repos with a `vendor/` directory as described [here](https://golang.org/doc/go1.14#go-command) under `Vendoring`. In Go1.13 it used module mode but in Go1.14 it was flipped and is now using vendor unless you tell it not to. 

This PR pins the build to the Go1.13 container for now since that is the version we are using for the 0.13 Terraform release anyway. We will need to fix this vendor error for the next version of Terraform if we choose to move to Go1.14. 

This PR also adds a CircleCI test that will run on any `master`/`v#.##` branch. While it won't catch errors on PRs, I think this is a pragmatic compromise to not try and build a docker container all the time for every PR since it only affects the building of the docker image and not the actual development of the code. We can check for any build errors before releasing to make sure the current commit in the branch we are releasing does in fact build the docker image correctly. 

**Note:** This does not affect the 'light' Docker image in https://github.com/hashicorp/terraform/blob/master/scripts/docker-release/Dockerfile-release since that just copies in our binary rather than compile the code. 