### PR TITLE
vendor: update go-cty-yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 // indirect
 	github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
 	github.com/zclconf/go-cty v1.5.0
-	github.com/zclconf/go-cty-yaml v1.0.1
+	github.com/zclconf/go-cty-yaml v1.0.2
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -513,8 +513,8 @@ github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLE
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.5.0 h1:U0USwJxGTnUd+dT565f92paYOlRtd201pI7+ZGW36XY=
 github.com/zclconf/go-cty v1.5.0/go.mod h1:nHzOclRkoj++EU9ZjSrZvRG0BXIWt8c7loYc0qXAFGQ=
-github.com/zclconf/go-cty-yaml v1.0.1 h1:up11wlgAaDvlAGENcFDnZgkn0qUJurso7k6EpURKNF8=
-github.com/zclconf/go-cty-yaml v1.0.1/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
+github.com/zclconf/go-cty-yaml v1.0.2 h1:dNyg4QLTrv2IfJpm7Wtxi55ed5gLGOlPrZ6kMd51hY0=
+github.com/zclconf/go-cty-yaml v1.0.2/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -978,6 +978,12 @@ func TestFunctions(t *testing.T) {
 				`yamldecode("true")`,
 				cty.True,
 			},
+			{
+				`yamldecode("key: 0ba")`,
+				cty.ObjectVal(map[string]cty.Value{
+					"key": cty.StringVal("0ba"),
+				}),
+			},
 		},
 
 		"yamlencode": {

--- a/vendor/github.com/zclconf/go-cty-yaml/CHANGELOG.md
+++ b/vendor/github.com/zclconf/go-cty-yaml/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.2 (June 17, 2020)
+
+* The YAML decoder now follows the YAML specification more closely when parsing
+  numeric values.
+  ([#6](https://github.com/zclconf/go-cty-yaml/pull/6))
+
 # 1.0.1 (July 30, 2019)
 
 * The YAML decoder is now correctly treating quoted scalars as verbatim literal

--- a/vendor/github.com/zclconf/go-cty-yaml/resolve.go
+++ b/vendor/github.com/zclconf/go-cty-yaml/resolve.go
@@ -20,6 +20,25 @@ type resolveMapItem struct {
 var resolveTable = make([]byte, 256)
 var resolveMap = make(map[string]resolveMapItem)
 
+// Numeric literal regular expressions from the YAML 1.2 spec:
+//
+// https://yaml.org/spec/1.2/spec.html#id2805071
+var integerLiteralRegexp = regexp.MustCompile(`` +
+	// start of string, optional sign, and one of:
+	`\A[-+]?(` +
+	// octal literal with 0o prefix and optional _ spaces
+	`|0o[0-7_]+` +
+	// decimal literal and optional _ spaces
+	`|[0-9_]+` +
+	// hexadecimal literal with 0x prefix and optional _ spaces
+	`|0x[0-9a-fA-F_]+` +
+	// end of group, and end of string
+	`)\z`,
+)
+var floatLiteralRegexp = regexp.MustCompile(
+	`\A[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?\z`,
+)
+
 func init() {
 	t := resolveTable
 	t[int('+')] = 'S' // Sign
@@ -140,12 +159,13 @@ func (c *Converter) resolveScalar(tag string, src string, style yaml_scalar_styl
 				}
 			}
 
-			plain := strings.Replace(src, "_", "", -1)
-			if numberVal, err := cty.ParseNumberVal(plain); err == nil {
-				return numberVal, nil
-			}
-			if strings.HasPrefix(plain, "0b") || strings.HasPrefix(plain, "-0b") {
+			if integerLiteralRegexp.MatchString(src) {
 				tag = yaml_INT_TAG // will handle parsing below in our tag switch
+				break
+			}
+			if floatLiteralRegexp.MatchString(src) {
+				tag = yaml_FLOAT_TAG // will handle parsing below in our tag switch
+				break
 			}
 		default:
 			panic(fmt.Sprintf("cannot resolve tag %q with source %q", tag, src))
@@ -186,21 +206,6 @@ func (c *Converter) resolveScalar(tag string, src string, style yaml_scalar_styl
 		}
 		if uintv, err := strconv.ParseUint(plain, 0, 64); err == nil { // handles 0x and 00 prefixes
 			return cty.NumberUIntVal(uintv), nil
-		}
-		if strings.HasPrefix(plain, "0b") {
-			intv, err := strconv.ParseInt(plain[2:], 2, 64)
-			if err == nil {
-				return cty.NumberIntVal(intv), nil
-			}
-			uintv, err := strconv.ParseUint(plain[2:], 2, 64)
-			if err == nil {
-				return cty.NumberUIntVal(uintv), nil
-			}
-		} else if strings.HasPrefix(plain, "-0b") {
-			intv, err := strconv.ParseInt("-"+plain[3:], 2, 64)
-			if err == nil {
-				return cty.NumberIntVal(intv), nil
-			}
 		}
 		return cty.NilVal, fmt.Errorf("cannot parse %q as %s", src, tag)
 	case yaml_TIMESTAMP_TAG:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -612,7 +612,7 @@ github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/json
 github.com/zclconf/go-cty/cty/msgpack
 github.com/zclconf/go-cty/cty/set
-# github.com/zclconf/go-cty-yaml v1.0.1
+# github.com/zclconf/go-cty-yaml v1.0.2
 ## explicit
 github.com/zclconf/go-cty-yaml
 # go.opencensus.io v0.22.0


### PR DESCRIPTION
Update go-cty-yaml for the YAML numeric literal parsing fix in zclconf/go-cty-yaml#6.

Fixes #23770, with a small test to verify that.