### PR TITLE
Pass ARG to second stage in light Dockerfile

### DIFF
--- a/scripts/docker-release/Dockerfile-release
+++ b/scripts/docker-release/Dockerfile-release
@@ -7,7 +7,7 @@
 # tree, without any dependency on there being an existing release on
 # releases.hashicorp.com.
 
-FROM alpine:3.9.2 as build
+FROM alpine:3.12 as build
 LABEL maintainer="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
 # This is intended to be run from the hooks/build script, which sets this
@@ -33,7 +33,7 @@ RUN apk add --no-cache git curl openssh gnupg && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin && \
     rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip terraform_${TERRAFORM_VERSION}_SHA256SUMS*
 
-FROM alpine:3.9.2 as final
+FROM alpine:3.12 as final
 ARG TERRAFORM_VERSION=UNSPECIFIED
 
 LABEL "com.hashicorp.terraform.version"="${TERRAFORM_VERSION}"

--- a/scripts/docker-release/Dockerfile-release
+++ b/scripts/docker-release/Dockerfile-release
@@ -34,6 +34,7 @@ RUN apk add --no-cache git curl openssh gnupg && \
     rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip terraform_${TERRAFORM_VERSION}_SHA256SUMS*
 
 FROM alpine:3.9.2 as final
+ARG TERRAFORM_VERSION=UNSPECIFIED
 
 LABEL "com.hashicorp.terraform.version"="${TERRAFORM_VERSION}"
 


### PR DESCRIPTION
`TERRAFORM_VERSION` is used to set a label in the final docker stage for the light docker image but because it was only declared in the first stage, it never made it to the 2nd stage in the multistage build. This fixes that issue.

I have also bumped the base image from `alpine:3.9.2` to `alpine:3.12`