### PR TITLE
don't update deps of gox in docker build and use -mod=readonly

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,11 +36,14 @@ fi
 
 if ! which gox > /dev/null; then
     echo "==> Installing gox..."
-    go get -u github.com/mitchellh/gox
+    go get github.com/mitchellh/gox
 fi
 
 # Instruct gox to build statically linked binaries
 export CGO_ENABLED=0
+
+# Set module download mode to readonly to not implicitly update go.mod
+export GOFLAGS="-mod=readonly"
 
 # In release mode we don't want debug information in the binary
 if [[ -n "${TF_RELEASE}" ]]; then


### PR DESCRIPTION
This removes updating dependencies of gox in the `full` image docker build and also uses `-mod=readonly` to prevent automatic updates of `go.mod`