### PR TITLE
command: Fix bug with -v/-version/--version flags

### DIFF
--- a/command/version.go
+++ b/command/version.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // VersionCommand is a Command implementation prints the version.
@@ -38,7 +39,16 @@ type VersionCheckInfo struct {
 }
 
 func (c *VersionCommand) Help() string {
-	return ""
+	helpText := `
+Usage: terraform version [options]
+
+  Displays the version of Terraform and all installed plugins
+
+Options:
+
+  -json       Output the version information as a JSON object.
+`
+	return strings.TrimSpace(helpText)
 }
 
 func (c *VersionCommand) Run(args []string) int {
@@ -48,6 +58,13 @@ func (c *VersionCommand) Run(args []string) int {
 	var jsonOutput bool
 	cmdFlags := c.Meta.defaultFlagSet("version")
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "json")
+	// Enable but ignore the global version flags. In main.go, if any of the
+	// arguments are -v, -version, or --version, this command will be called
+	// with the rest of the arguments, so we need to be able to cope with
+	// those.
+	cmdFlags.Bool("v", true, "version")
+	cmdFlags.Bool("version", true, "version")
+	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
 		return 1

--- a/command/version_test.go
+++ b/command/version_test.go
@@ -33,7 +33,7 @@ func TestVersion(t *testing.T) {
 		ProviderSource:   providerSource,
 	}
 
-	// `terrafrom init`
+	// `terraform init`
 	ic := &InitCommand{
 		Meta: m,
 	}
@@ -61,6 +61,30 @@ func TestVersion(t *testing.T) {
 
 }
 
+func TestVersion_flags(t *testing.T) {
+	ui := new(cli.MockUi)
+	m := Meta{
+		Ui: ui,
+	}
+
+	// `terraform version`
+	c := &VersionCommand{
+		Meta:              m,
+		Version:           "4.5.6",
+		VersionPrerelease: "foo",
+	}
+
+	if code := c.Run([]string{"-v", "-version"}); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+
+	actual := strings.TrimSpace(ui.OutputWriter.String())
+	expected := "Terraform v4.5.6-foo"
+	if actual != expected {
+		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actual, expected)
+	}
+}
+
 func TestVersion_json(t *testing.T) {
 	fixtureDir := "testdata/providers-schema/basic"
 	td := tempDir(t)
@@ -81,7 +105,7 @@ func TestVersion_json(t *testing.T) {
 		ProviderSource:   providerSource,
 	}
 
-	// `terrafrom init`
+	// `terraform init`
 	ic := &InitCommand{
 		Meta: m,
 	}


### PR DESCRIPTION
We globally support a -`v`/`-version`/`--version` flag, which triggers the version subcommand: https://github.com/hashicorp/terraform/blob/d144c391fabbcdf9343c2524e9ce874301486b40/main.go#L246-L255

The recent introduction of JSON output support meant we started parsing the flags for the first time, but we didn't add flags for these global version arguments. The result is that for the Terraform 0.13.0-beta2 release, `terraform -v` no longer works.

This commit adds those flags (but doesn't check them, since they have no effect on the version command itself). Also adds usage information for terraform version.

```shellsession
$ terraform-0.13.0-beta2 version
Terraform v0.13.0-beta2
$ terraform-0.13.0-beta2 -v
Error parsing command-line flags: flag provided but not defined: -v

$ terraform-0.13.0-beta2 -version
Error parsing command-line flags: flag provided but not defined: -version

$ terraform-0.13.0-beta2 --version
Error parsing command-line flags: flag provided but not defined: -version

$ terraform version
Terraform v0.13.0-dev
$ terraform -v
Terraform v0.13.0-dev
$ terraform -version
Terraform v0.13.0-dev
$ terraform --version
Terraform v0.13.0-dev
```

Fixes #25276