### PR TITLE
don't set remote workspace in state

### DIFF
--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -104,8 +104,6 @@ func dataSourceRemoteStateRead(d cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		workspaceName = workspaceVal.AsString()
 	}
 
-	newState["workspace"] = cty.StringVal(workspaceName)
-
 	state, err := b.StateMgr(workspaceName)
 	if err != nil {
 		diags = diags.Append(tfdiags.AttributeValue(

--- a/builtin/providers/terraform/data_source_state_test.go
+++ b/builtin/providers/terraform/data_source_state_test.go
@@ -40,8 +40,28 @@ func TestState_basic(t *testing.T) {
 				"outputs": cty.ObjectVal(map[string]cty.Value{
 					"foo": cty.StringVal("bar"),
 				}),
+				"defaults": cty.NullVal(cty.DynamicPseudoType),
+			}),
+			false,
+		},
+		"workspace": {
+			cty.ObjectVal(map[string]cty.Value{
+				"backend":   cty.StringVal("local"),
 				"workspace": cty.StringVal(backend.DefaultStateName),
-				"defaults":  cty.NullVal(cty.DynamicPseudoType),
+				"config": cty.ObjectVal(map[string]cty.Value{
+					"path": cty.StringVal("./testdata/basic.tfstate"),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"backend":   cty.StringVal("local"),
+				"workspace": cty.StringVal(backend.DefaultStateName),
+				"config": cty.ObjectVal(map[string]cty.Value{
+					"path": cty.StringVal("./testdata/basic.tfstate"),
+				}),
+				"outputs": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("bar"),
+				}),
+				"defaults": cty.NullVal(cty.DynamicPseudoType),
 			}),
 			false,
 		},
@@ -60,8 +80,7 @@ func TestState_basic(t *testing.T) {
 				"outputs": cty.ObjectVal(map[string]cty.Value{
 					"foo": cty.StringVal("bar"),
 				}),
-				"workspace": cty.StringVal(backend.DefaultStateName),
-				"defaults":  cty.NullVal(cty.DynamicPseudoType),
+				"defaults": cty.NullVal(cty.DynamicPseudoType),
 			}),
 			false,
 		},
@@ -94,8 +113,7 @@ func TestState_basic(t *testing.T) {
 						cty.StringVal("test2"),
 					}),
 				}),
-				"workspace": cty.StringVal(backend.DefaultStateName),
-				"defaults":  cty.NullVal(cty.DynamicPseudoType),
+				"defaults": cty.NullVal(cty.DynamicPseudoType),
 			}),
 			false,
 		},
@@ -115,8 +133,7 @@ func TestState_basic(t *testing.T) {
 					"map":  cty.NullVal(cty.DynamicPseudoType),
 					"list": cty.NullVal(cty.DynamicPseudoType),
 				}),
-				"workspace": cty.StringVal(backend.DefaultStateName),
-				"defaults":  cty.NullVal(cty.DynamicPseudoType),
+				"defaults": cty.NullVal(cty.DynamicPseudoType),
 			}),
 			false,
 		},
@@ -141,7 +158,6 @@ func TestState_basic(t *testing.T) {
 				"outputs": cty.ObjectVal(map[string]cty.Value{
 					"foo": cty.StringVal("bar"),
 				}),
-				"workspace": cty.StringVal(backend.DefaultStateName),
 			}),
 			false,
 		},
@@ -157,9 +173,8 @@ func TestState_basic(t *testing.T) {
 				"config": cty.ObjectVal(map[string]cty.Value{
 					"path": cty.StringVal("./testdata/missing.tfstate"),
 				}),
-				"defaults":  cty.NullVal(cty.DynamicPseudoType),
-				"outputs":   cty.EmptyObjectVal,
-				"workspace": cty.StringVal(backend.DefaultStateName),
+				"defaults": cty.NullVal(cty.DynamicPseudoType),
+				"outputs":  cty.EmptyObjectVal,
 			}),
 			true,
 		},
@@ -210,9 +225,8 @@ func TestState_basic(t *testing.T) {
 				"config": cty.MapVal(map[string]cty.Value{
 					"path": cty.StringVal("./testdata/empty.tfstate"),
 				}),
-				"defaults":  cty.NullVal(cty.DynamicPseudoType),
-				"outputs":   cty.EmptyObjectVal,
-				"workspace": cty.StringVal(backend.DefaultStateName),
+				"defaults": cty.NullVal(cty.DynamicPseudoType),
+				"outputs":  cty.EmptyObjectVal,
 			}),
 			false,
 		},
@@ -233,7 +247,6 @@ func TestState_basic(t *testing.T) {
 				"outputs": cty.ObjectVal(map[string]cty.Value{
 					"foo": cty.StringVal("bar"),
 				}),
-				"workspace": cty.StringVal(backend.DefaultStateName),
 			}),
 			false,
 		},


### PR DESCRIPTION
The workspace attribute is not computed, and therefor cannot be changed
from the configuration.

If the configuration has no `workspace` defined, the existing code will write `default` to the state. This will cause the next plan to see a change in the config from `default` to `null`, and force it to be read again. 

Fixes #25296 (2)