### PR TITLE
command: Fix init flags silent exit bug

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -137,6 +137,7 @@ func (c *InitCommand) Run(args []string) int {
 	empty, err := configs.IsEmptyDir(path)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Error checking configuration: %s", err))
+		c.showDiagnostics(diags)
 		return 1
 	}
 	if empty {


### PR DESCRIPTION
When using `-flag=value` with Powershell, unquoted values are broken into separate arguments. This means that the following command:

    terraform init -backend-config=./backend.conf

is interpreted by Terraform as:

    terraform init -backend-config= ./backend.conf

This results in an empty backend-config setting (which is semantically valid!) followed by a custom configuration path (pointing at a file).

Due to a bug where we could exit without printing diagnostics, this would result in a silent failure that was very difficult to diagnose. See #25266.