### PR TITLE
explicit provider block non-default only

### DIFF
--- a/website/docs/configuration/modules.html.md
+++ b/website/docs/configuration/modules.html.md
@@ -290,7 +290,7 @@ from many different providers.
 
 Once the `providers` argument is used in a `module` block, it overrides all of
 the default inheritance behavior, so it is necessary to enumerate mappings
-for _all_ of the required providers. This is to avoid confusion and surprises
+for _all_ of the required providers other than default. This is to avoid confusion and surprises
 that may result when mixing both implicit and explicit provider passing.
 
 Additional provider configurations (those with the `alias` argument set) are


### PR DESCRIPTION
we only need to pass the non-default provider(s) to a child module, while the default too is passed, current statement states all providers need to be passed explicitly which is bit confusing as there is no clarity on the default provider also being passed.