### PR TITLE
configs: Fix nested provider requirements bug

### DIFF
--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -130,6 +130,7 @@ func TestConfigProviderRequirements(t *testing.T) {
 	impliedProvider := addrs.NewDefaultProvider("implied")
 	terraformProvider := addrs.NewBuiltInProvider("terraform")
 	configuredProvider := addrs.NewDefaultProvider("configured")
+	grandchildProvider := addrs.NewDefaultProvider("grandchild")
 
 	got, diags := cfg.ProviderRequirements()
 	assertNoDiagnostics(t, diags)
@@ -142,6 +143,7 @@ func TestConfigProviderRequirements(t *testing.T) {
 		impliedProvider:    nil,
 		happycloudProvider: nil,
 		terraformProvider:  nil,
+		grandchildProvider: nil,
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -166,6 +168,7 @@ func TestConfigProviderRequirementsByModule(t *testing.T) {
 	impliedProvider := addrs.NewDefaultProvider("implied")
 	terraformProvider := addrs.NewBuiltInProvider("terraform")
 	configuredProvider := addrs.NewDefaultProvider("configured")
+	grandchildProvider := addrs.NewDefaultProvider("grandchild")
 
 	got, diags := cfg.ProviderRequirementsByModule()
 	assertNoDiagnostics(t, diags)
@@ -191,7 +194,17 @@ func TestConfigProviderRequirementsByModule(t *testing.T) {
 					nullProvider:       getproviders.MustParseVersionConstraints("= 2.0.1"),
 					happycloudProvider: nil,
 				},
-				Children: map[string]*ModuleRequirements{},
+				Children: map[string]*ModuleRequirements{
+					"nested": {
+						Name:       "nested",
+						SourceAddr: "./grandchild",
+						SourceDir:  "testdata/provider-reqs/child/grandchild",
+						Requirements: getproviders.Requirements{
+							grandchildProvider: nil,
+						},
+						Children: map[string]*ModuleRequirements{},
+					},
+				},
 			},
 		},
 	}
@@ -227,6 +240,6 @@ func TestConfigAddProviderRequirements(t *testing.T) {
 	reqs := getproviders.Requirements{
 		addrs.NewDefaultProvider("null"): nil,
 	}
-	diags = cfg.addProviderRequirements(reqs)
+	diags = cfg.addProviderRequirements(reqs, true)
 	assertNoDiagnostics(t, diags)
 }

--- a/configs/testdata/provider-reqs/child/grandchild/provider-reqs-grandchild.tf
+++ b/configs/testdata/provider-reqs/child/grandchild/provider-reqs-grandchild.tf
@@ -1,0 +1,4 @@
+# There is no provider in required_providers called "grandchild", so this
+# implicitly declares a dependency on "hashicorp/grandchild".
+resource "grandchild_foo" "bar" {
+}

--- a/configs/testdata/provider-reqs/child/provider-reqs-child.tf
+++ b/configs/testdata/provider-reqs/child/provider-reqs-child.tf
@@ -9,3 +9,7 @@ terraform {
     }
   }
 }
+
+module "nested" {
+  source = "./grandchild"
+}


### PR DESCRIPTION
[In a recent PR](https://github.com/hashicorp/terraform/pull/25190), we changed the provider requirements code to permit per-module requirements gathering, to enhance the provider command output. This had an incorrect implementation of recursive requirements gathering for the normal case, which resulted in only depth-1 modules being inspected.

This commit fixes the broken recursion and adds a grandchild module to the unit tests as test coverage. This also demanded fixing the `testNestedModuleConfigFromDir` helper function to cope with nested modules in test configs.

Fixes #25312, #25310.