### PR TITLE
Trimprefix: what happens when prefix is not in string?

### DIFF
--- a/website/docs/configuration/functions/trimprefix.html.md
+++ b/website/docs/configuration/functions/trimprefix.html.md
@@ -13,13 +13,18 @@ description: |-
 earlier, see
 [0.11 Configuration Language: Interpolation Syntax](../../configuration-0-11/interpolation.html).
 
-`trimprefix` removes the specified prefix from the start of the given string.
+`trimprefix` removes the specified prefix from the start of the given string. If the string does not start with the prefix, the string is returned unchanged.
 
 ## Examples
 
 ```
 > trimprefix("helloworld", "hello")
 world
+```
+
+```
+> trimprefix("helloworld", "cat")
+helloworld
 ```
 
 ## Related Functions


### PR DESCRIPTION
I was looking to find out what Terraform would return when the prefix isn't in the string(https://www.terraform.io/docs/configuration/functions/trimprefix.html). Needed to go look it up in the Terraform source, so I figured I'd help the next lost person figure it out faster.

https://github.com/hashicorp/terraform/blob/master/lang/functions.go#L126 shows that Terraform's Trimprefix comes directly from the standard go library. 
When prefix is absent in the go standard library, the original string is returned; https://golang.org/pkg/strings/#TrimPrefix.