### PR TITLE
Allow building on non-terraform named directory

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -61,7 +61,7 @@ gox \
     -arch="${XC_ARCH}" \
     -osarch="${XC_EXCLUDE_OSARCH}" \
     -ldflags "${LD_FLAGS}" \
-    -output "pkg/{{.OS}}_{{.Arch}}/${PWD##*/}" \
+    -output "pkg/{{.OS}}_{{.Arch}}/terraform" \
     .
 
 # Move all the compiled things to the $GOPATH/bin

--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -80,11 +80,12 @@ func makeProviderMap(items []plugin) string {
 }
 
 func isProjectRoot() bool {
-  if _, err := os.Stat("go.mod"); os.IsNotExist(err) {
-    return false
-  }
+	_, err := os.Stat("go.mod")
+	if os.IsNotExist(err) {
+		return false
+	}
 
-  return true;
+	return true
 }
 
 // makeProvisionerMap creates a map of provisioners like this:

--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -19,8 +19,7 @@ import (
 const target = "command/internal_plugin_list.go"
 
 func main() {
-	wd, _ := os.Getwd()
-	if filepath.Base(wd) != "terraform" {
+	if isProjectRoot() == false {
 		log.Fatalf("This program must be invoked in the terraform project root; in %s", wd)
 	}
 
@@ -78,6 +77,14 @@ func makeProviderMap(items []plugin) string {
 		output += fmt.Sprintf("\t\"%s\":   %s.%s,\n", item.PluginName, item.ImportName, item.TypeName)
 	}
 	return output
+}
+
+func isProjectRoot() bool {
+  if _, err := os.Stat("go.mod"); os.IsNotExist(err) {
+    return false
+  }
+
+  return true;
 }
 
 // makeProvisionerMap creates a map of provisioners like this:

--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -20,7 +20,7 @@ const target = "command/internal_plugin_list.go"
 
 func main() {
 	if isProjectRoot() == false {
-		log.Fatalf("This program must be invoked in the terraform project root; in %s", wd)
+		log.Fatalf("This program must be invoked in the terraform project root")
 	}
 
 	//// Collect all of the data we need about plugins we have in the project


### PR DESCRIPTION
While trying to write a `SlackBuild` for [slackbuilds](https://slackbuilds.org) I found myself having to hack around with directory names to get `terraform` to build with the required template.
In `slackbuild` scripts, the build directories are usually named with the format `$PRGNAM-$VERSION` (so `terraform-0.13`, etc).
This PR makes `terraform` building process more agnostic about the build directory name, which can only be a good thing, right?