### PR TITLE
prevent panic in remote backend retry

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -495,7 +495,7 @@ func (b *Remote) retryLogHook(attemptNum int, resp *http.Response) {
 		// The retry logic in the TFE client will retry both rate limited
 		// requests and server errors, but in the remote backend we only
 		// care about server errors so we ignore rate limit (429) errors.
-		if attemptNum == 0 || resp.StatusCode == 429 {
+		if attemptNum == 0 || (resp != nil && resp.StatusCode == 429) {
 			// Reset the last retry time.
 			b.lastRetry = time.Now()
 			return


### PR DESCRIPTION
Ensure that the *http.Response is not nil before checking the status.
This can happen when retrying transport errors multiple times.