### PR TITLE
don't allow providers in modules using depends_on

### DIFF
--- a/configs/configload/loader_load.go
+++ b/configs/configload/loader_load.go
@@ -111,7 +111,7 @@ func (l *Loader) moduleWalkerLoad(req *configs.ModuleRequest) (*configs.Module, 
 }
 
 func validateProviderConfigs(mc *configs.ModuleCall, mod *configs.Module, parent *configs.Config, diags hcl.Diagnostics) hcl.Diagnostics {
-	if mc.Count != nil || mc.ForEach != nil {
+	if mc.Count != nil || mc.ForEach != nil || mc.DependsOn != nil {
 		for key, pc := range mod.ProviderConfigs {
 			// Use these to track if a provider is configured (not allowed),
 			// or if we've found its matching proxy
@@ -148,6 +148,14 @@ func validateProviderConfigs(mc *configs.ModuleCall, mod *configs.Module, parent
 						Summary:  "Module does not support for_each",
 						Detail:   fmt.Sprintf(moduleProviderError, mc.Name, "for_each", key, pc.NameRange),
 						Subject:  mc.ForEach.Range().Ptr(),
+					})
+				}
+				if mc.DependsOn != nil {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Module does not support depends_on",
+						Detail:   fmt.Sprintf(moduleProviderError, mc.Name, "depends_on", key, pc.NameRange),
+						Subject:  mc.SourceAddrRange.Ptr(),
 					})
 				}
 			}

--- a/configs/configload/loader_load_test.go
+++ b/configs/configload/loader_load_test.go
@@ -122,3 +122,24 @@ func TestLoaderLoadConfig_moduleExpandValid(t *testing.T) {
 	_, diags := loader.LoadConfig(fixtureDir)
 	assertNoDiagnostics(t, diags)
 }
+
+func TestLoaderLoadConfig_moduleDependsOnProviders(t *testing.T) {
+	// We do not allow providers to be configured in module using depends_on.
+	fixtureDir := filepath.Clean("testdata/module-depends-on")
+	loader, err := NewLoader(&Config{
+		ModulesDir: filepath.Join(fixtureDir, ".terraform/modules"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from NewLoader: %s", err)
+	}
+
+	_, diags := loader.LoadConfig(fixtureDir)
+	if !diags.HasErrors() {
+		t.Fatal("success; want error")
+	}
+	got := diags.Error()
+	want := "Module does not support depends_on"
+	if !strings.Contains(got, want) {
+		t.Fatalf("wrong error\ngot:\n%s\n\nwant: containing %q", got, want)
+	}
+}

--- a/configs/configload/testdata/module-depends-on/.terraform/modules/modules.json
+++ b/configs/configload/testdata/module-depends-on/.terraform/modules/modules.json
@@ -1,0 +1,24 @@
+{
+    "Modules": [
+        {
+            "Key": "",
+            "Source": "",
+            "Dir": "testdata/expand-modules/nested-provider"
+        },
+        {
+            "Key": "child",
+            "Source": "./child",
+            "Dir": "testdata/expand-modules/nested-provider/child"
+        },
+        {
+            "Key": "child2",
+            "Source": "./child2",
+            "Dir": "testdata/expand-modules/nested-provider/child2"
+        },
+        {
+            "Key": "child.child2",
+            "Source": "../child2",
+            "Dir": "testdata/expand-modules/nested-provider/child2"
+        }
+    ]
+}

--- a/configs/configload/testdata/module-depends-on/child/main.tf
+++ b/configs/configload/testdata/module-depends-on/child/main.tf
@@ -1,0 +1,3 @@
+module "child2" {
+  source = "../child2"
+}

--- a/configs/configload/testdata/module-depends-on/child2/main.tf
+++ b/configs/configload/testdata/module-depends-on/child2/main.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+}
+
+output "my_output" {
+  value = "my output"
+}

--- a/configs/configload/testdata/module-depends-on/root.tf
+++ b/configs/configload/testdata/module-depends-on/root.tf
@@ -1,0 +1,7 @@
+module "child" {
+  source = "./child"
+  depends_on = [test_resource.a]
+}
+
+resource "test_resource" "a" {
+}


### PR DESCRIPTION
Providers themselves don't support `depends_on`, and therefore a module
with providers also cannot use `depends_on`.

Fixes #25330