### PR TITLE
command/import: Fix allow-missing-config option

### DIFF
--- a/command/import_test.go
+++ b/command/import_test.go
@@ -601,7 +601,7 @@ func TestImport_providerConfigWithVarFile(t *testing.T) {
 	testStateOutput(t, statePath, testImportStr)
 }
 
-func TestImport_disallowMissingResourceConfig(t *testing.T) {
+func TestImport_allowMissingResourceConfig(t *testing.T) {
 	defer testChdir(t, testFixturePath("import-missing-resource-config"))()
 
 	statePath := testTempFile(t)
@@ -643,15 +643,15 @@ func TestImport_disallowMissingResourceConfig(t *testing.T) {
 		"bar",
 	}
 
-	if code := c.Run(args); code != 1 {
-		t.Fatalf("import succeeded; expected failure")
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 
-	msg := ui.ErrorWriter.String()
-
-	if want := `Error: Resource test_instance.foo not found in the configuration.`; !strings.Contains(msg, want) {
-		t.Errorf("incorrect message\nwant substring: %s\ngot:\n%s", want, msg)
+	if !p.ImportResourceStateCalled {
+		t.Fatal("ImportResourceState should be called")
 	}
+
+	testStateOutput(t, statePath, testImportStr)
 }
 
 func TestImport_emptyConfig(t *testing.T) {

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -49,40 +49,6 @@ func TestContextImport_basic(t *testing.T) {
 	}
 }
 
-// Importing a resource which does not exist in the configuration results in an error
-func TestContextImport_basic_errpr(t *testing.T) {
-	p := testProvider("aws")
-	m := testModule(t, "import-provider")
-	ctx := testContext2(t, &ContextOpts{
-		Config: m,
-		Providers: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
-		},
-	})
-
-	p.ImportStateReturn = []*InstanceState{
-		&InstanceState{
-			ID:        "foo",
-			Ephemeral: EphemeralState{Type: "aws_instance"},
-		},
-	}
-
-	_, diags := ctx.Import(&ImportOpts{
-		Targets: []*ImportTarget{
-			&ImportTarget{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "test", addrs.NoKey,
-				),
-				ID: "bar",
-			},
-		},
-	})
-
-	if !diags.HasErrors() {
-		t.Fatal("should error")
-	}
-}
-
 func TestContextImport_countIndex(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "import-provider")


### PR DESCRIPTION
We previously intentionally removed support for the `allow-missing-config` option to terraform import, requiring that all imported resources have matching config. See #24412.

However, the option was not removed from the import command, and it is widely used. This commit reintroduces support for importing with a missing configuration by falling back to implying the provider FQN based on the resource type.

Fixes #25294