### PR TITLE
add note re. SSH host key validation to provisioner connection doc

### DIFF
--- a/website/docs/provisioners/connection.html.markdown
+++ b/website/docs/provisioners/connection.html.markdown
@@ -20,6 +20,12 @@ for some connection settings, so that `connection` blocks could sometimes be
 omitted. This feature was removed in 0.12 in order to make Terraform's behavior
 more predictable.
 
+-> **Note:** Since the SSH connection type is most often used with
+newly-created remote resources, validation of SSH host keys is disabled by
+default. In scenarios where this is not acceptable, a separate mechanism for
+key distribution could be established and the `host_key` directive documented
+below explicitly set to verify against a specific key or signing CA.
+
 Connection blocks don't take a block label, and can be nested within either a
 `resource` or a `provisioner`.
 


### PR DESCRIPTION
Terraform's provisioner SSH connection type does not validate SSH host keys by default (see use of ssh.InsecureIgnoreHosteKey at https://github.com/hashicorp/terraform/blob/master/communicator/ssh/provisioner.go#L217-L244), which is generally appropriate given Terraform's frequent use with newly-created remote resources that do not have a known-trusted or CA-signed host key deployed.

This adds a note to the documentation to explicitly highlight this behavior, and point to the `host_key` direct as a means by which SSH host key checking may be enabled.