### PR TITLE
Fix 0.13 upgrade guide

### DIFF
--- a/draft-upgrade-guide.md
+++ b/draft-upgrade-guide.md
@@ -205,7 +205,7 @@ control to establish a _virtual_ source registry to serve as a separate
 namespace for your local use. For example:
 
 ```
-terraform.example.com/awesomecorp/happycloud/v1.0.0/linux_amd64/terraform-provider-happycloud_v1.0.0
+terraform.example.com/awesomecorp/happycloud/1.0.0/linux_amd64/terraform-provider-happycloud_v1.0.0
 ```
 
 You can then specify explicitly the requirement for that in-house provider


### PR DESCRIPTION
With in-house providers, the correct plugin path does not contain the `v` in the version directory.

Should fix https://github.com/mildred/terraform/pull/new/fix-guide-v0.13-beta