### PR TITLE
New target transformer

### DIFF
--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -176,13 +176,13 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// These include variables, locals, and instance expanders.
 		&pruneUnusedNodesTransformer{},
 
+		// Target
+		&TargetsTransformer{Targets: b.Targets},
+
 		// Add the node to fix the state count boundaries
 		&CountBoundaryTransformer{
 			Config: b.Config,
 		},
-
-		// Target
-		&TargetsTransformer{Targets: b.Targets},
 
 		// Close opened plugin connections
 		&CloseProviderTransformer{},

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -154,11 +154,6 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// configuration
 		&attachDataResourceDependenciesTransformer{},
 
-		// Add the node to fix the state count boundaries
-		&CountBoundaryTransformer{
-			Config: b.Config,
-		},
-
 		// Target
 		&TargetsTransformer{
 			Targets: b.Targets,
@@ -173,6 +168,11 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// Detect when create_before_destroy must be forced on for a particular
 		// node due to dependency edges, to avoid graph cycles during apply.
 		&ForcedCBDTransformer{},
+
+		// Add the node to fix the state count boundaries
+		&CountBoundaryTransformer{
+			Config: b.Config,
+		},
 
 		// Close opened plugin connections
 		&CloseProviderTransformer{},

--- a/terraform/node_local.go
+++ b/terraform/node_local.go
@@ -18,7 +18,6 @@ type nodeExpandLocal struct {
 }
 
 var (
-	_ RemovableIfNotTargeted     = (*nodeExpandLocal)(nil)
 	_ GraphNodeReferenceable     = (*nodeExpandLocal)(nil)
 	_ GraphNodeReferencer        = (*nodeExpandLocal)(nil)
 	_ GraphNodeDynamicExpandable = (*nodeExpandLocal)(nil)
@@ -46,11 +45,6 @@ func (n *nodeExpandLocal) Name() string {
 // GraphNodeModulePath
 func (n *nodeExpandLocal) ModulePath() addrs.Module {
 	return n.Module
-}
-
-// RemovableIfNotTargeted
-func (n *nodeExpandLocal) RemoveIfNotTargeted() bool {
-	return true
 }
 
 // GraphNodeReferenceable
@@ -89,7 +83,6 @@ type NodeLocal struct {
 
 var (
 	_ GraphNodeModuleInstance = (*NodeLocal)(nil)
-	_ RemovableIfNotTargeted  = (*NodeLocal)(nil)
 	_ GraphNodeReferenceable  = (*NodeLocal)(nil)
 	_ GraphNodeReferencer     = (*NodeLocal)(nil)
 	_ GraphNodeEvalable       = (*NodeLocal)(nil)
@@ -114,11 +107,6 @@ func (n *NodeLocal) Path() addrs.ModuleInstance {
 // GraphNodeModulePath
 func (n *NodeLocal) ModulePath() addrs.Module {
 	return n.Addr.Module.Module()
-}
-
-// RemovableIfNotTargeted
-func (n *NodeLocal) RemoveIfNotTargeted() bool {
-	return true
 }
 
 // GraphNodeReferenceable

--- a/terraform/node_module_expand.go
+++ b/terraform/node_module_expand.go
@@ -22,7 +22,6 @@ type nodeExpandModule struct {
 }
 
 var (
-	_ RemovableIfNotTargeted    = (*nodeExpandModule)(nil)
 	_ GraphNodeEvalable         = (*nodeExpandModule)(nil)
 	_ GraphNodeReferencer       = (*nodeExpandModule)(nil)
 	_ GraphNodeReferenceOutside = (*nodeExpandModule)(nil)
@@ -99,13 +98,6 @@ func (n *nodeExpandModule) ReferenceOutside() (selfPath, referencePath addrs.Mod
 	return n.Addr, n.Addr.Parent()
 }
 
-// RemovableIfNotTargeted implementation
-func (n *nodeExpandModule) RemoveIfNotTargeted() bool {
-	// We need to add this so that this node will be removed if
-	// it isn't targeted or a dependency of a target.
-	return true
-}
-
 // GraphNodeEvalable
 func (n *nodeExpandModule) EvalTree() EvalNode {
 	return &evalPrepareModuleExpansion{
@@ -146,22 +138,11 @@ func (n *nodeCloseModule) ReferenceableAddrs() []addrs.Referenceable {
 	}
 }
 
-func (n *nodeCloseModule) TargetDownstream(targeted, untargeted dag.Set) bool {
-	return true
-}
-
 func (n *nodeCloseModule) Name() string {
 	if len(n.Addr) == 0 {
 		return "root"
 	}
 	return n.Addr.String() + " (close)"
-}
-
-// RemovableIfNotTargeted implementation
-func (n *nodeCloseModule) RemoveIfNotTargeted() bool {
-	// We need to add this so that this node will be removed if
-	// it isn't targeted or a dependency of a target.
-	return true
 }
 
 func (n *nodeCloseModule) EvalTree() EvalNode {

--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -26,7 +26,6 @@ var (
 	_ GraphNodeReferenceable     = (*nodeExpandModuleVariable)(nil)
 	_ GraphNodeReferencer        = (*nodeExpandModuleVariable)(nil)
 	_ graphNodeTemporaryValue    = (*nodeExpandModuleVariable)(nil)
-	_ RemovableIfNotTargeted     = (*nodeExpandModuleVariable)(nil)
 	_ graphNodeExpandsInstances  = (*nodeExpandModuleVariable)(nil)
 )
 
@@ -98,16 +97,6 @@ func (n *nodeExpandModuleVariable) ReferenceableAddrs() []addrs.Referenceable {
 	return []addrs.Referenceable{n.Addr}
 }
 
-// RemovableIfNotTargeted
-func (n *nodeExpandModuleVariable) RemoveIfNotTargeted() bool {
-	return true
-}
-
-// GraphNodeTargetDownstream
-func (n *nodeExpandModuleVariable) TargetDownstream(targetedDeps, untargetedDeps dag.Set) bool {
-	return true
-}
-
 // nodeModuleVariable represents a module variable input during
 // the apply step.
 type nodeModuleVariable struct {
@@ -123,7 +112,6 @@ type nodeModuleVariable struct {
 // implementing.
 var (
 	_ GraphNodeModuleInstance = (*nodeModuleVariable)(nil)
-	_ RemovableIfNotTargeted  = (*nodeModuleVariable)(nil)
 	_ GraphNodeEvalable       = (*nodeModuleVariable)(nil)
 	_ graphNodeTemporaryValue = (*nodeModuleVariable)(nil)
 	_ dag.GraphNodeDotter     = (*nodeModuleVariable)(nil)
@@ -147,13 +135,6 @@ func (n *nodeModuleVariable) Path() addrs.ModuleInstance {
 // GraphNodeModulePath
 func (n *nodeModuleVariable) ModulePath() addrs.Module {
 	return n.Addr.Module.Module()
-}
-
-// RemovableIfNotTargeted
-func (n *nodeModuleVariable) RemoveIfNotTargeted() bool {
-	// We need to add this so that this node will be removed if
-	// it isn't targeted or a dependency of a target.
-	return true
 }
 
 // GraphNodeEvalable

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -19,7 +19,6 @@ type nodeExpandOutput struct {
 }
 
 var (
-	_ RemovableIfNotTargeted     = (*nodeExpandOutput)(nil)
 	_ GraphNodeReferenceable     = (*nodeExpandOutput)(nil)
 	_ GraphNodeReferencer        = (*nodeExpandOutput)(nil)
 	_ GraphNodeReferenceOutside  = (*nodeExpandOutput)(nil)
@@ -100,16 +99,6 @@ func (n *nodeExpandOutput) References() []*addrs.Reference {
 	return appendResourceDestroyReferences(referencesForOutput(n.Config))
 }
 
-// RemovableIfNotTargeted
-func (n *nodeExpandOutput) RemoveIfNotTargeted() bool {
-	return true
-}
-
-// GraphNodeTargetDownstream
-func (n *nodeExpandOutput) TargetDownstream(targetedDeps, untargetedDeps dag.Set) bool {
-	return true
-}
-
 // NodeApplyableOutput represents an output that is "applyable":
 // it is ready to be applied.
 type NodeApplyableOutput struct {
@@ -119,8 +108,6 @@ type NodeApplyableOutput struct {
 
 var (
 	_ GraphNodeModuleInstance   = (*NodeApplyableOutput)(nil)
-	_ RemovableIfNotTargeted    = (*NodeApplyableOutput)(nil)
-	_ GraphNodeTargetDownstream = (*NodeApplyableOutput)(nil)
 	_ GraphNodeReferenceable    = (*NodeApplyableOutput)(nil)
 	_ GraphNodeReferencer       = (*NodeApplyableOutput)(nil)
 	_ GraphNodeReferenceOutside = (*NodeApplyableOutput)(nil)
@@ -146,21 +133,6 @@ func (n *NodeApplyableOutput) Path() addrs.ModuleInstance {
 // GraphNodeModulePath
 func (n *NodeApplyableOutput) ModulePath() addrs.Module {
 	return n.Addr.Module.Module()
-}
-
-// RemovableIfNotTargeted
-func (n *NodeApplyableOutput) RemoveIfNotTargeted() bool {
-	// We need to add this so that this node will be removed if
-	// it isn't targeted or a dependency of a target.
-	return true
-}
-
-// GraphNodeTargetDownstream
-func (n *NodeApplyableOutput) TargetDownstream(targetedDeps, untargetedDeps dag.Set) bool {
-	// If any of the direct dependencies of an output are targeted then
-	// the output must always be targeted as well, so its value will always
-	// be up-to-date at the completion of an apply walk.
-	return true
 }
 
 func referenceOutsideForOutput(addr addrs.AbsOutputValue) (selfPath, referencePath addrs.Module) {
@@ -255,10 +227,8 @@ type NodeDestroyableOutput struct {
 }
 
 var (
-	_ RemovableIfNotTargeted    = (*NodeDestroyableOutput)(nil)
-	_ GraphNodeTargetDownstream = (*NodeDestroyableOutput)(nil)
-	_ GraphNodeEvalable         = (*NodeDestroyableOutput)(nil)
-	_ dag.GraphNodeDotter       = (*NodeDestroyableOutput)(nil)
+	_ GraphNodeEvalable   = (*NodeDestroyableOutput)(nil)
+	_ dag.GraphNodeDotter = (*NodeDestroyableOutput)(nil)
 )
 
 func (n *NodeDestroyableOutput) Name() string {
@@ -273,19 +243,6 @@ func (n *NodeDestroyableOutput) ModulePath() addrs.Module {
 func (n *NodeDestroyableOutput) temporaryValue() bool {
 	// this must always be evaluated if it is a root module output
 	return !n.Addr.Module.IsRoot()
-}
-
-// RemovableIfNotTargeted
-func (n *NodeDestroyableOutput) RemoveIfNotTargeted() bool {
-	// We need to add this so that this node will be removed if
-	// it isn't targeted or a dependency of a target.
-	return true
-}
-
-// This will keep the destroy node in the graph if its corresponding output
-// node is also in the destroy graph.
-func (n *NodeDestroyableOutput) TargetDownstream(targetedDeps, untargetedDeps dag.Set) bool {
-	return true
 }
 
 // GraphNodeEvalable

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -270,6 +270,11 @@ func (n *NodeDestroyableOutput) ModulePath() addrs.Module {
 	return n.Addr.Module.Module()
 }
 
+func (n *NodeDestroyableOutput) temporaryValue() bool {
+	// this must always be evaluated if it is a root module output
+	return !n.Addr.Module.IsRoot()
+}
+
 // RemovableIfNotTargeted
 func (n *NodeDestroyableOutput) RemoveIfNotTargeted() bool {
 	// We need to add this so that this node will be removed if

--- a/terraform/node_provider_abstract.go
+++ b/terraform/node_provider_abstract.go
@@ -27,7 +27,6 @@ type NodeAbstractProvider struct {
 
 var (
 	_ GraphNodeModulePath                 = (*NodeAbstractProvider)(nil)
-	_ RemovableIfNotTargeted              = (*NodeAbstractProvider)(nil)
 	_ GraphNodeReferencer                 = (*NodeAbstractProvider)(nil)
 	_ GraphNodeProvider                   = (*NodeAbstractProvider)(nil)
 	_ GraphNodeAttachProvider             = (*NodeAbstractProvider)(nil)
@@ -49,13 +48,6 @@ func (n *NodeAbstractProvider) Path() addrs.ModuleInstance {
 // GraphNodeModulePath
 func (n *NodeAbstractProvider) ModulePath() addrs.Module {
 	return n.Addr.Module
-}
-
-// RemovableIfNotTargeted
-func (n *NodeAbstractProvider) RemoveIfNotTargeted() bool {
-	// We need to add this so that this node will be removed if
-	// it isn't targeted or a dependency of a target.
-	return true
 }
 
 // GraphNodeReferencer

--- a/terraform/node_provider_disabled.go
+++ b/terraform/node_provider_disabled.go
@@ -15,7 +15,6 @@ type NodeDisabledProvider struct {
 
 var (
 	_ GraphNodeModulePath     = (*NodeDisabledProvider)(nil)
-	_ RemovableIfNotTargeted  = (*NodeDisabledProvider)(nil)
 	_ GraphNodeReferencer     = (*NodeDisabledProvider)(nil)
 	_ GraphNodeProvider       = (*NodeDisabledProvider)(nil)
 	_ GraphNodeAttachProvider = (*NodeDisabledProvider)(nil)

--- a/terraform/testdata/destroy-targeted/child/main.tf
+++ b/terraform/testdata/destroy-targeted/child/main.tf
@@ -1,0 +1,10 @@
+variable "in" {
+}
+
+resource "aws_instance" "b" {
+  foo = var.in
+}
+
+output "out" {
+  value = var.in
+}

--- a/terraform/testdata/destroy-targeted/main.tf
+++ b/terraform/testdata/destroy-targeted/main.tf
@@ -1,0 +1,12 @@
+resource "aws_instance" "a" {
+    foo = "bar"
+}
+
+module "child" {
+  source = "./child"
+  in = aws_instance.a.id
+}
+
+output "out" {
+  value = aws_instance.a.id
+}

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -488,13 +488,6 @@ func (n *graphNodeCloseProvider) DotNode(name string, opts *dag.DotOpts) *dag.Do
 	}
 }
 
-// RemovableIfNotTargeted
-func (n *graphNodeCloseProvider) RemoveIfNotTargeted() bool {
-	// We need to add this so that this node will be removed if
-	// it isn't targeted or a dependency of a target.
-	return true
-}
-
 // graphNodeProxyProvider is a GraphNodeProvider implementation that is used to
 // store the name and value of a provider node for inheritance between modules.
 // These nodes are only used to store the data while loading the provider

--- a/terraform/transform_targets.go
+++ b/terraform/transform_targets.go
@@ -16,21 +16,6 @@ type GraphNodeTargetable interface {
 	SetTargets([]addrs.Targetable)
 }
 
-// GraphNodeTargetDownstream is an interface for graph nodes that need to
-// be remain present under targeting if any of their dependencies are targeted.
-// TargetDownstream is called with the set of vertices that are direct
-// dependencies for the node, and it should return true if the node must remain
-// in the graph in support of those dependencies.
-//
-// This is used in situations where the dependency edges are representing an
-// ordering relationship but the dependency must still be visited if its
-// dependencies are visited. This is true for outputs, for example, since
-// they must get updated if any of their dependent resources get updated,
-// which would not normally be true if one of their dependencies were targeted.
-type GraphNodeTargetDownstream interface {
-	TargetDownstream(targeted, untargeted dag.Set) bool
-}
-
 // TargetsTransformer is a GraphTransformer that, when the user specifies a
 // list of resources to target, limits the graph to only those resources and
 // their dependencies.
@@ -173,15 +158,4 @@ func (t *TargetsTransformer) nodeIsTarget(v dag.Vertex, targets []addrs.Targetab
 	}
 
 	return false
-}
-
-// RemovableIfNotTargeted is a special interface for graph nodes that
-// aren't directly addressable, but need to be removed from the graph when they
-// are not targeted. (Nodes that are not directly targeted end up in the set of
-// targeted nodes because something that _is_ targeted depends on them.) The
-// initial use case for this interface is GraphNodeConfigVariable, which was
-// having trouble interpolating for module variables in targeted scenarios that
-// filtered out the resource node being referenced.
-type RemovableIfNotTargeted interface {
-	RemoveIfNotTargeted() bool
 }


### PR DESCRIPTION
This simplifies the initial targeting logic, and removes the complex
algorithm for finding descendants that result in output changes, which
hid bugs that failed with modules.

The targeting is handled in 2 phases. First we find all individual
resource nodes that are targeted, then add all their dependencies to the
set of targets. This in essence is all we need for targeting, and is
straightforward to understand.

The next phase is to add any root module outputs that can be solely
derived from the set of targeted resources. There is currently no way to
target outputs themselves, so this is how we can allow these to be
updated as part of a target.

Rather than attempting to backtrack through the graph to find candidate
outputs, requiring each node on the chain to properly advertise if it
could be traversed, then backtracking again to determine if the
candidate is valid (which often got "off course"), we can start directly
from the outputs themselves. The algorithm here is simpler: if all the
root output's resource dependencies are targeted, add that output and
its dependencies to the targeted set.

Fixes #25319