### PR TITLE
command: Fix 0.13upgrade to preserve more comments

### DIFF
--- a/command/testdata/013upgrade-preserves-comments/expected/main.tf
+++ b/command/testdata/013upgrade-preserves-comments/expected/main.tf
@@ -9,8 +9,15 @@ terraform {
       source  = "hashicorp/bar"
       version = "0.5.0"
     }
+    # An explicit requirement
+    baz = {
+      # Comment inside the block should stay
+      source = "foo/baz"
+    }
+    # Foo is required
     foo = {
-      source = "hashicorp/foo"
+      source  = "hashicorp/foo"
+      version = "1.0.0"
     }
   }
 }

--- a/command/testdata/013upgrade-preserves-comments/input/main.tf
+++ b/command/testdata/013upgrade-preserves-comments/input/main.tf
@@ -6,5 +6,15 @@ terraform {
   required_providers {
     # Pin bar to this version
     bar = "0.5.0"
+    # An explicit requirement
+    baz = {
+      # Comment inside the block should stay
+      source = "foo/baz"
+    }
+    # Foo is required
+    foo = {
+      # This comment sadly won't make it
+      version = "1.0.0"
+    }
   }
 }


### PR DESCRIPTION
Previously, any comments inside the required provider configuration for a given provider would be wiped out upon rerunning the `0.13upgrade` command. This commit attempts to preserve those comments if the existing entry is semantically equivalent to the entry we are about to write.

Fixes #24958.