### PR TITLE
Docs error

### DIFF
--- a/website/docs/commands/state/mv.html.md
+++ b/website/docs/commands/state/mv.html.md
@@ -125,3 +125,4 @@ Windows `cmd.exe`:
 ```shell
 $ terraform state mv packet_device.worker[\"example123\"] packet_device.helper[\"example456\"]
 ```
+


### PR DESCRIPTION
Ref https://github.com/hashicorp/terraform/pull/25225. The version of the docs that displays on the website does not match the current version (0.12). The change that was submitted to the master branch some time ago was a correction, not a preparation for 0.13