### PR TITLE
Backport .terraformignore support to 0.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90
 	github.com/hashicorp/go-safetemp v0.0.0-20180326211150-b1a1dbde6fdc // indirect
 	github.com/hashicorp/go-sockaddr v1.0.0 // indirect
-	github.com/hashicorp/go-tfe v0.3.14
+	github.com/hashicorp/go-tfe v0.3.25
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/hashicorp/go-version v1.0.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f

--- a/go.sum
+++ b/go.sum
@@ -125,12 +125,12 @@ github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90 h1:VBj0QYQ0
 github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90/go.mod h1:o4zcYY1e0GEZI6eSEr+43QDYmuGglw1qSO6qdHUHCgg=
 github.com/hashicorp/go-safetemp v0.0.0-20180326211150-b1a1dbde6fdc h1:wAa9fGALVHfjYxZuXRnmuJG2CnwRpJYOTvY6YdErAh0=
 github.com/hashicorp/go-safetemp v0.0.0-20180326211150-b1a1dbde6fdc/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
-github.com/hashicorp/go-slug v0.3.0 h1:L0c+AvH/J64iMNF4VqRaRku2DMTEuHioPVS7kMjWIU8=
-github.com/hashicorp/go-slug v0.3.0/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
+github.com/hashicorp/go-slug v0.4.0 h1:YSz3afoEZZJVVB46NITf0+opd2cHpaYJ1XSojOyP0x8=
+github.com/hashicorp/go-slug v0.4.0/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
-github.com/hashicorp/go-tfe v0.3.14 h1:1eWmq4RAICGufydNUWu7ahb0gtq24pN9jatD2FkdxdE=
-github.com/hashicorp/go-tfe v0.3.14/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
+github.com/hashicorp/go-tfe v0.3.25 h1:4rPk/9rSYuRoujKk5FsxSvtC/AjJCQphLS/57yr6wUM=
+github.com/hashicorp/go-tfe v0.3.25/go.mod h1:IJQ30WzRajD/W0Z8SY4lhuoOX8h5saTe95t80z8hRsk=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=

--- a/vendor/github.com/hashicorp/go-slug/README.md
+++ b/vendor/github.com/hashicorp/go-slug/README.md
@@ -31,7 +31,7 @@ package main
 
 import (
 	"bytes"
-	"ioutil"
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -40,11 +40,11 @@ import (
 
 func main() {
 	// First create a buffer for storing the slug.
-	slug := bytes.NewBuffer(nil)
+	buf := bytes.NewBuffer(nil)
 
 	// Then call the Pack function with a directory path containing the
 	// configuration files and an io.Writer to write the slug to.
-	if _, err := Pack("test-fixtures/archive-dir", slug); err != nil {
+	if _, err := slug.Pack("testdata/archive-dir", buf, false); err != nil {
 		log.Fatal(err)
 	}
 
@@ -58,7 +58,7 @@ func main() {
 	// Unpacking a slug is done by calling the Unpack function with an
 	// io.Reader to read the slug from and a directory path of an existing
 	// directory to store the unpacked configuration files.
-	if err := Unpack(slug, dst); err != nil {
+	if err := slug.Unpack(buf, dst); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/vendor/github.com/hashicorp/go-slug/terraformignore.go
+++ b/vendor/github.com/hashicorp/go-slug/terraformignore.go
@@ -1,0 +1,225 @@
+package slug
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/scanner"
+)
+
+func parseIgnoreFile(rootPath string) []rule {
+	// Look for .terraformignore at our root path/src
+	file, err := os.Open(filepath.Join(rootPath, ".terraformignore"))
+	defer file.Close()
+
+	// If there's any kind of file error, punt and use the default ignore patterns
+	if err != nil {
+		// Only show the error debug if an error *other* than IsNotExist
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Error reading .terraformignore, default exclusions will apply: %v \n", err)
+		}
+		return defaultExclusions
+	}
+	return readRules(file)
+}
+
+func readRules(input io.Reader) []rule {
+	rules := defaultExclusions
+	scanner := bufio.NewScanner(input)
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		pattern := scanner.Text()
+		// Ignore blank lines
+		if len(pattern) == 0 {
+			continue
+		}
+		// Trim spaces
+		pattern = strings.TrimSpace(pattern)
+		// Ignore comments
+		if pattern[0] == '#' {
+			continue
+		}
+		// New rule structure
+		rule := rule{}
+		// Exclusions
+		if pattern[0] == '!' {
+			rule.excluded = true
+			pattern = pattern[1:]
+		}
+		// If it is a directory, add ** so we catch descendants
+		if pattern[len(pattern)-1] == os.PathSeparator {
+			pattern = pattern + "**"
+		}
+		// If it starts with /, it is absolute
+		if pattern[0] == os.PathSeparator {
+			pattern = pattern[1:]
+		} else {
+			// Otherwise prepend **/
+			pattern = "**" + string(os.PathSeparator) + pattern
+		}
+		rule.val = pattern
+		rule.dirs = strings.Split(pattern, string(os.PathSeparator))
+		rules = append(rules, rule)
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading .terraformignore, default exclusions will apply: %v \n", err)
+		return defaultExclusions
+	}
+	return rules
+}
+
+func matchIgnoreRule(path string, rules []rule) bool {
+	matched := false
+	path = filepath.FromSlash(path)
+	for _, rule := range rules {
+		match, _ := rule.match(path)
+
+		if match {
+			matched = !rule.excluded
+		}
+	}
+
+	if matched {
+		debug(true, path, "Skipping excluded path:", path)
+	}
+
+	return matched
+}
+
+type rule struct {
+	val      string         // the value of the rule itself
+	excluded bool           // ! is present, an exclusion rule
+	dirs     []string       // directories of the rule
+	regex    *regexp.Regexp // regular expression to match for the rule
+}
+
+func (r *rule) match(path string) (bool, error) {
+	if r.regex == nil {
+		if err := r.compile(); err != nil {
+			return false, filepath.ErrBadPattern
+		}
+	}
+
+	b := r.regex.MatchString(path)
+	debug(false, path, path, r.regex, b)
+	return b, nil
+}
+
+func (r *rule) compile() error {
+	regStr := "^"
+	pattern := r.val
+	// Go through the pattern and convert it to a regexp.
+	// Use a scanner to support utf-8 chars.
+	var scan scanner.Scanner
+	scan.Init(strings.NewReader(pattern))
+
+	sl := string(os.PathSeparator)
+	escSL := sl
+	if sl == `\` {
+		escSL += `\`
+	}
+
+	for scan.Peek() != scanner.EOF {
+		ch := scan.Next()
+		if ch == '*' {
+			if scan.Peek() == '*' {
+				// is some flavor of "**"
+				scan.Next()
+
+				// Treat **/ as ** so eat the "/"
+				if string(scan.Peek()) == sl {
+					scan.Next()
+				}
+
+				if scan.Peek() == scanner.EOF {
+					// is "**EOF" - to align with .gitignore just accept all
+					regStr += ".*"
+				} else {
+					// is "**"
+					// Note that this allows for any # of /'s (even 0) because
+					// the .* will eat everything, even /'s
+					regStr += "(.*" + escSL + ")?"
+				}
+			} else {
+				// is "*" so map it to anything but "/"
+				regStr += "[^" + escSL + "]*"
+			}
+		} else if ch == '?' {
+			// "?" is any char except "/"
+			regStr += "[^" + escSL + "]"
+		} else if ch == '.' || ch == '$' {
+			// Escape some regexp special chars that have no meaning
+			// in golang's filepath.Match
+			regStr += `\` + string(ch)
+		} else if ch == '\\' {
+			// escape next char. Note that a trailing \ in the pattern
+			// will be left alone (but need to escape it)
+			if sl == `\` {
+				// On windows map "\" to "\\", meaning an escaped backslash,
+				// and then just continue because filepath.Match on
+				// Windows doesn't allow escaping at all
+				regStr += escSL
+				continue
+			}
+			if scan.Peek() != scanner.EOF {
+				regStr += `\` + string(scan.Next())
+			} else {
+				regStr += `\`
+			}
+		} else {
+			regStr += string(ch)
+		}
+	}
+
+	regStr += "$"
+	re, err := regexp.Compile(regStr)
+	if err != nil {
+		return err
+	}
+
+	r.regex = re
+	return nil
+}
+
+/*
+	Default rules as they would appear in .terraformignore:
+	.git/
+	.terraform/
+	!.terraform/modules/
+*/
+
+var defaultExclusions = []rule{
+	{
+		val:      "**/.git/**",
+		excluded: false,
+	},
+	{
+		val:      "**/.terraform/**",
+		excluded: false,
+	},
+	{
+		val:      "**/.terraform/modules/**",
+		excluded: true,
+	},
+}
+
+func debug(printAll bool, path string, message ...interface{}) {
+	logLevel := os.Getenv("TF_IGNORE") == "trace"
+	debugPath := os.Getenv("TF_IGNORE_DEBUG")
+	isPath := debugPath != ""
+	if isPath {
+		isPath = strings.Contains(path, debugPath)
+	}
+
+	if logLevel {
+		if printAll || isPath {
+			fmt.Println(message...)
+		}
+	}
+}

--- a/vendor/github.com/hashicorp/go-tfe/README.md
+++ b/vendor/github.com/hashicorp/go-tfe/README.md
@@ -136,6 +136,7 @@ tests:
 $ export TFE_ADDRESS=https://tfe.local
 $ export TFE_TOKEN=xxxxxxxxxxxxxxxxxxx
 $ export GITHUB_TOKEN=xxxxxxxxxxxxxxxx
+$ export GITHUB_IDENTIFIER=xxxxxxxxxxx
 ```
 
 In order for the tests relating to queuing and capacity to pass, FRQ should be

--- a/vendor/github.com/hashicorp/go-tfe/cost_estimate.go
+++ b/vendor/github.com/hashicorp/go-tfe/cost_estimate.go
@@ -1,0 +1,129 @@
+package tfe
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"time"
+)
+
+// Compile-time proof of interface implementation.
+var _ CostEstimates = (*costEstimates)(nil)
+
+// CostEstimates describes all the costEstimate related methods that
+// the Terraform Enterprise API supports.
+//
+// TFE API docs: https://www.terraform.io/docs/enterprise/api/ (TBD)
+type CostEstimates interface {
+	// Read a costEstimate by its ID.
+	Read(ctx context.Context, costEstimateID string) (*CostEstimate, error)
+
+	// Logs retrieves the logs of a costEstimate.
+	Logs(ctx context.Context, costEstimateID string) (io.Reader, error)
+}
+
+// costEstimates implements CostEstimates.
+type costEstimates struct {
+	client *Client
+}
+
+// CostEstimateStatus represents a costEstimate state.
+type CostEstimateStatus string
+
+//List all available costEstimate statuses.
+const (
+	CostEstimateCanceled CostEstimateStatus = "canceled"
+	CostEstimateErrored  CostEstimateStatus = "errored"
+	CostEstimateFinished CostEstimateStatus = "finished"
+	CostEstimatePending  CostEstimateStatus = "pending"
+	CostEstimateQueued   CostEstimateStatus = "queued"
+)
+
+// CostEstimate represents a Terraform Enterprise costEstimate.
+type CostEstimate struct {
+	ID                      string                        `jsonapi:"primary,cost-estimates"`
+	DeltaMonthlyCost        string                        `jsonapi:"attr,delta-monthly-cost"`
+	ErrorMessage            string                        `jsonapi:"attr,error-message"`
+	MatchedResourcesCount   int                           `jsonapi:"attr,matched-resources-count"`
+	PriorMonthlyCost        string                        `jsonapi:"attr,prior-monthly-cost"`
+	ProposedMonthlyCost     string                        `jsonapi:"attr,proposed-monthly-cost"`
+	ResourcesCount          int                           `jsonapi:"attr,resources-count"`
+	Status                  CostEstimateStatus            `jsonapi:"attr,status"`
+	StatusTimestamps        *CostEstimateStatusTimestamps `jsonapi:"attr,status-timestamps"`
+	UnmatchedResourcesCount int                           `jsonapi:"attr,unmatched-resources-count"`
+}
+
+// CostEstimateStatusTimestamps holds the timestamps for individual costEstimate statuses.
+type CostEstimateStatusTimestamps struct {
+	CanceledAt time.Time `json:"canceled-at"`
+	ErroredAt  time.Time `json:"errored-at"`
+	FinishedAt time.Time `json:"finished-at"`
+	PendingAt  time.Time `json:"pending-at"`
+	QueuedAt   time.Time `json:"queued-at"`
+}
+
+// Read a costEstimate by its ID.
+func (s *costEstimates) Read(ctx context.Context, costEstimateID string) (*CostEstimate, error) {
+	if !validStringID(&costEstimateID) {
+		return nil, errors.New("invalid value for cost estimate ID")
+	}
+
+	u := fmt.Sprintf("cost-estimates/%s", url.QueryEscape(costEstimateID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ce := &CostEstimate{}
+	err = s.client.do(ctx, req, ce)
+	if err != nil {
+		return nil, err
+	}
+
+	return ce, nil
+}
+
+// Logs retrieves the logs of a costEstimate.
+func (s *costEstimates) Logs(ctx context.Context, costEstimateID string) (io.Reader, error) {
+	if !validStringID(&costEstimateID) {
+		return nil, errors.New("invalid value for cost estimate ID")
+	}
+
+	// Loop until the context is canceled or the cost estimate is finished
+	// running. The cost estimate logs are not streamed and so only available
+	// once the estimate is finished.
+	for {
+		// Get the costEstimate to make sure it exists.
+		ce, err := s.Read(ctx, costEstimateID)
+		if err != nil {
+			return nil, err
+		}
+
+		switch ce.Status {
+		case CostEstimateQueued:
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(1000 * time.Millisecond):
+				continue
+			}
+		}
+
+		u := fmt.Sprintf("cost-estimates/%s/output", url.QueryEscape(costEstimateID))
+		req, err := s.client.newRequest("GET", u, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		logs := bytes.NewBuffer(nil)
+		err = s.client.do(ctx, req, logs)
+		if err != nil {
+			return nil, err
+		}
+
+		return logs, nil
+	}
+}

--- a/vendor/github.com/hashicorp/go-tfe/go.mod
+++ b/vendor/github.com/hashicorp/go-tfe/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/google/go-querystring v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/go-retryablehttp v0.5.2
-	github.com/hashicorp/go-slug v0.3.0
+	github.com/hashicorp/go-slug v0.4.0
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/stretchr/testify v1.3.0
 	github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d

--- a/vendor/github.com/hashicorp/go-tfe/go.sum
+++ b/vendor/github.com/hashicorp/go-tfe/go.sum
@@ -8,8 +8,8 @@ github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6K
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-retryablehttp v0.5.2 h1:AoISa4P4IsW0/m4T6St8Yw38gTl5GtBAgfkhYh1xAz4=
 github.com/hashicorp/go-retryablehttp v0.5.2/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
-github.com/hashicorp/go-slug v0.3.0 h1:L0c+AvH/J64iMNF4VqRaRku2DMTEuHioPVS7kMjWIU8=
-github.com/hashicorp/go-slug v0.3.0/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
+github.com/hashicorp/go-slug v0.4.0 h1:YSz3afoEZZJVVB46NITf0+opd2cHpaYJ1XSojOyP0x8=
+github.com/hashicorp/go-slug v0.4.0/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/vendor/github.com/hashicorp/go-tfe/organization.go
+++ b/vendor/github.com/hashicorp/go-tfe/organization.go
@@ -77,6 +77,7 @@ type OrganizationList struct {
 type Organization struct {
 	Name                   string                   `jsonapi:"primary,organizations"`
 	CollaboratorAuthPolicy AuthPolicyType           `jsonapi:"attr,collaborator-auth-policy"`
+	CostEstimationEnabled  bool                     `jsonapi:"attr,cost-estimation-enabled"`
 	CreatedAt              time.Time                `jsonapi:"attr,created-at,iso8601"`
 	Email                  string                   `jsonapi:"attr,email"`
 	EnterprisePlan         EnterprisePlanType       `jsonapi:"attr,enterprise-plan"`
@@ -167,6 +168,9 @@ type OrganizationCreateOptions struct {
 	// Authentication policy.
 	CollaboratorAuthPolicy *AuthPolicyType `jsonapi:"attr,collaborator-auth-policy,omitempty"`
 
+	// Enable Cost Estimation
+	CostEstimationEnabled *bool `jsonapi:"attr,cost-estimation-enabled,omitempty"`
+
 	// The name of the "owners" team
 	OwnersTeamSAMLRoleID *string `jsonapi:"attr,owners-team-saml-role-id,omitempty"`
 }
@@ -247,6 +251,9 @@ type OrganizationUpdateOptions struct {
 
 	// Authentication policy.
 	CollaboratorAuthPolicy *AuthPolicyType `jsonapi:"attr,collaborator-auth-policy,omitempty"`
+
+	// Enable Cost Estimation
+	CostEstimationEnabled *bool `jsonapi:"attr,cost-estimation-enabled,omitempty"`
 
 	// The name of the "owners" team
 	OwnersTeamSAMLRoleID *string `jsonapi:"attr,owners-team-saml-role-id,omitempty"`

--- a/vendor/github.com/hashicorp/go-tfe/plan.go
+++ b/vendor/github.com/hashicorp/go-tfe/plan.go
@@ -55,6 +55,9 @@ type Plan struct {
 	ResourceDestructions int                   `jsonapi:"attr,resource-destructions"`
 	Status               PlanStatus            `jsonapi:"attr,status"`
 	StatusTimestamps     *PlanStatusTimestamps `jsonapi:"attr,status-timestamps"`
+
+	// Relations
+	Exports []*PlanExport `jsonapi:"relation,exports"`
 }
 
 // PlanStatusTimestamps holds the timestamps for individual plan statuses.

--- a/vendor/github.com/hashicorp/go-tfe/plan_export.go
+++ b/vendor/github.com/hashicorp/go-tfe/plan_export.go
@@ -1,0 +1,175 @@
+package tfe
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Compile-time proof of interface implementation.
+var _ PlanExports = (*planExports)(nil)
+
+// PlanExports describes all the plan export related methods that the Terraform
+// Enterprise API supports.
+//
+// TFE API docs: https://www.terraform.io/docs/enterprise/api/plan-exports.html
+type PlanExports interface {
+	// Export a plan by its ID with the given options.
+	Create(ctx context.Context, options PlanExportCreateOptions) (*PlanExport, error)
+
+	// Read a plan export by its ID.
+	Read(ctx context.Context, planExportID string) (*PlanExport, error)
+
+	// Delete a plan export by its ID.
+	Delete(ctx context.Context, planExportID string) error
+
+	// Download the data of an plan export.
+	Download(ctx context.Context, planExportID string) ([]byte, error)
+}
+
+// planExports implements PlanExports.
+type planExports struct {
+	client *Client
+}
+
+// PlanExportDataType represents the type of data exported from a plan.
+type PlanExportDataType string
+
+// List all available plan export data types.
+const (
+	PlanExportSentinelMockBundleV0 PlanExportDataType = "sentinel-mock-bundle-v0"
+)
+
+// PlanExportStatus represents a plan export state.
+type PlanExportStatus string
+
+// List all available plan export statuses.
+const (
+	PlanExportCanceled PlanExportStatus = "canceled"
+	PlanExportErrored  PlanExportStatus = "errored"
+	PlanExportExpired  PlanExportStatus = "expired"
+	PlanExportFinished PlanExportStatus = "finished"
+	PlanExportPending  PlanExportStatus = "pending"
+	PlanExportQueued   PlanExportStatus = "queued"
+)
+
+// PlanExportStatusTimestamps holds the timestamps for plan export statuses.
+type PlanExportStatusTimestamps struct {
+	CanceledAt time.Time `json:"canceled-at"`
+	ErroredAt  time.Time `json:"errored-at"`
+	ExpiredAt  time.Time `json:"expired-at"`
+	FinishedAt time.Time `json:"finished-at"`
+	QueuedAt   time.Time `json:"queued-at"`
+}
+
+// PlanExport represents an export of Terraform Enterprise plan data.
+type PlanExport struct {
+	ID               string                      `jsonapi:"primary,plan-exports"`
+	DataType         PlanExportDataType          `jsonapi:"attr,data-type"`
+	Status           PlanExportStatus            `jsonapi:"attr,status"`
+	StatusTimestamps *PlanExportStatusTimestamps `jsonapi:"attr,status-timestamps"`
+}
+
+// PlanExportCreateOptions represents the options for exporting data from a plan.
+type PlanExportCreateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,plan-exports"`
+
+	// The plan to export.
+	Plan *Plan `jsonapi:"relation,plan"`
+
+	// The name of the policy set.
+	DataType *PlanExportDataType `jsonapi:"attr,data-type"`
+}
+
+func (o PlanExportCreateOptions) valid() error {
+	if o.Plan == nil {
+		return errors.New("plan is required")
+	}
+	if o.DataType == nil {
+		return errors.New("data type is required")
+	}
+	return nil
+}
+
+func (s *planExports) Create(ctx context.Context, options PlanExportCreateOptions) (*PlanExport, error) {
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	req, err := s.client.newRequest("POST", "plan-exports", &options)
+	if err != nil {
+		return nil, err
+	}
+
+	pe := &PlanExport{}
+	err = s.client.do(ctx, req, pe)
+	if err != nil {
+		return nil, err
+	}
+
+	return pe, err
+}
+
+// Read a plan export by its ID.
+func (s *planExports) Read(ctx context.Context, planExportID string) (*PlanExport, error) {
+	if !validStringID(&planExportID) {
+		return nil, errors.New("invalid value for plan export ID")
+	}
+
+	u := fmt.Sprintf("plan-exports/%s", url.QueryEscape(planExportID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	pe := &PlanExport{}
+	err = s.client.do(ctx, req, pe)
+	if err != nil {
+		return nil, err
+	}
+
+	return pe, nil
+}
+
+// Delete a plan export by ID.
+func (s *planExports) Delete(ctx context.Context, planExportID string) error {
+	if !validStringID(&planExportID) {
+		return errors.New("invalid value for plan export ID")
+	}
+
+	u := fmt.Sprintf("plan-exports/%s", url.QueryEscape(planExportID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// Download a plan export's data. Data is exported in a .tar.gz format.
+func (s *planExports) Download(ctx context.Context, planExportID string) ([]byte, error) {
+	if !validStringID(&planExportID) {
+		return nil, errors.New("invalid value for plan export ID")
+	}
+
+	u := fmt.Sprintf("plan-exports/%s/download", url.QueryEscape(planExportID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	err = s.client.do(ctx, req, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/vendor/github.com/hashicorp/go-tfe/policy_set.go
+++ b/vendor/github.com/hashicorp/go-tfe/policy_set.go
@@ -28,10 +28,12 @@ type PolicySets interface {
 	// Update an existing policy set.
 	Update(ctx context.Context, policySetID string, options PolicySetUpdateOptions) (*PolicySet, error)
 
-	// Add policies to a policy set.
+	// Add policies to a policy set. This function can only be used when
+	// there is no VCS repository associated with the policy set.
 	AddPolicies(ctx context.Context, policySetID string, options PolicySetAddPoliciesOptions) error
 
-	// Remove policies from a policy set.
+	// Remove policies from a policy set. This function can only be used
+	// when there is no VCS repository associated with the policy set.
 	RemovePolicies(ctx context.Context, policySetID string, options PolicySetRemovePoliciesOptions) error
 
 	// Add workspaces to a policy set.
@@ -61,7 +63,9 @@ type PolicySet struct {
 	Name           string    `jsonapi:"attr,name"`
 	Description    string    `jsonapi:"attr,description"`
 	Global         bool      `jsonapi:"attr,global"`
+	PoliciesPath   string    `jsonapi:"attr,policies-path"`
 	PolicyCount    int       `jsonapi:"attr,policy-count"`
+	VCSRepo        *VCSRepo  `jsonapi:"attr,vcs-repo"`
 	WorkspaceCount int       `jsonapi:"attr,workspace-count"`
 	CreatedAt      time.Time `jsonapi:"attr,created-at,iso8601"`
 	UpdatedAt      time.Time `jsonapi:"attr,updated-at,iso8601"`
@@ -115,8 +119,20 @@ type PolicySetCreateOptions struct {
 	// Whether or not the policy set is global.
 	Global *bool `jsonapi:"attr,global,omitempty"`
 
+	// The sub-path within the attached VCS repository to ingress. All
+	// files and directories outside of this sub-path will be ignored.
+	// This option may only be specified when a VCS repo is present.
+	PoliciesPath *string `jsonapi:"attr,policies-path,omitempty"`
+
 	// The initial members of the policy set.
 	Policies []*Policy `jsonapi:"relation,policies,omitempty"`
+
+	// VCS repository information. When present, the policies and
+	// configuration will be sourced from the specified VCS repository
+	// instead of being defined within the policy set itself. Note that
+	// this option is mutually exclusive with the Policies option and
+	// both cannot be used at the same time.
+	VCSRepo *VCSRepoOptions `jsonapi:"attr,vcs-repo,omitempty"`
 
 	// The initial list of workspaces for which the policy set should be enforced.
 	Workspaces []*Workspace `jsonapi:"relation,workspaces,omitempty"`

--- a/vendor/github.com/hashicorp/go-tfe/run.go
+++ b/vendor/github.com/hashicorp/go-tfe/run.go
@@ -49,12 +49,16 @@ type RunStatus string
 //List all available run statuses.
 const (
 	RunApplied            RunStatus = "applied"
+	RunApplyQueued        RunStatus = "apply_queued"
 	RunApplying           RunStatus = "applying"
 	RunCanceled           RunStatus = "canceled"
 	RunConfirmed          RunStatus = "confirmed"
+	RunCostEstimated      RunStatus = "cost_estimated"
+	RunCostEstimating     RunStatus = "cost_estimating"
 	RunDiscarded          RunStatus = "discarded"
 	RunErrored            RunStatus = "errored"
 	RunPending            RunStatus = "pending"
+	RunPlanQueued         RunStatus = "plan_queued"
 	RunPlanned            RunStatus = "planned"
 	RunPlannedAndFinished RunStatus = "planned_and_finished"
 	RunPlanning           RunStatus = "planning"
@@ -98,6 +102,7 @@ type Run struct {
 	// Relations
 	Apply                *Apply                `jsonapi:"relation,apply"`
 	ConfigurationVersion *ConfigurationVersion `jsonapi:"relation,configuration-version"`
+	CostEstimate         *CostEstimate         `jsonapi:"relation,cost-estimate"`
 	Plan                 *Plan                 `jsonapi:"relation,plan"`
 	PolicyChecks         []*PolicyCheck        `jsonapi:"relation,policy-checks"`
 	Workspace            *Workspace            `jsonapi:"relation,workspace"`
@@ -274,7 +279,7 @@ func (s *runs) Cancel(ctx context.Context, runID string, options RunCancelOption
 	return s.client.do(ctx, req, nil)
 }
 
-// RunCancelOptions represents the options for force-canceling a run.
+// RunForceCancelOptions represents the options for force-canceling a run.
 type RunForceCancelOptions struct {
 	// An optional comment explaining the reason for the force-cancel.
 	Comment *string `json:"comment,omitempty"`

--- a/vendor/github.com/hashicorp/go-tfe/tfe.go
+++ b/vendor/github.com/hashicorp/go-tfe/tfe.go
@@ -32,6 +32,8 @@ const (
 	DefaultAddress = "https://app.terraform.io"
 	// DefaultBasePath on which the API is served.
 	DefaultBasePath = "/api/v2/"
+	// No-op API endpoint used to configure the rate limiter
+	PingEndpoint = "ping"
 )
 
 var (
@@ -106,12 +108,14 @@ type Client struct {
 
 	Applies                    Applies
 	ConfigurationVersions      ConfigurationVersions
+	CostEstimates              CostEstimates
 	NotificationConfigurations NotificationConfigurations
 	OAuthClients               OAuthClients
 	OAuthTokens                OAuthTokens
 	Organizations              Organizations
 	OrganizationTokens         OrganizationTokens
 	Plans                      Plans
+	PlanExports                PlanExports
 	Policies                   Policies
 	PolicyChecks               PolicyChecks
 	PolicySets                 PolicySets
@@ -195,12 +199,14 @@ func NewClient(cfg *Config) (*Client, error) {
 	// Create the services.
 	client.Applies = &applies{client: client}
 	client.ConfigurationVersions = &configurationVersions{client: client}
+	client.CostEstimates = &costEstimates{client: client}
 	client.NotificationConfigurations = &notificationConfigurations{client: client}
 	client.OAuthClients = &oAuthClients{client: client}
 	client.OAuthTokens = &oAuthTokens{client: client}
 	client.Organizations = &organizations{client: client}
 	client.OrganizationTokens = &organizationTokens{client: client}
 	client.Plans = &plans{client: client}
+	client.PlanExports = &planExports{client: client}
 	client.Policies = &policies{client: client}
 	client.PolicyChecks = &policyChecks{client: client}
 	client.PolicySets = &policySets{client: client}
@@ -247,7 +253,7 @@ func (c *Client) retryHTTPBackoff(min, max time.Duration, attemptNum int, resp *
 	}
 
 	// Use the rate limit backoff function when we are rate limited.
-	if resp.StatusCode == 429 {
+	if resp != nil && resp.StatusCode == 429 {
 		return rateLimitBackoff(min, max, attemptNum, resp)
 	}
 
@@ -289,7 +295,11 @@ func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Respons
 // configureLimiter configures the rate limiter.
 func (c *Client) configureLimiter() error {
 	// Create a new request.
-	req, err := http.NewRequest("GET", c.baseURL.String(), nil)
+	u, err := c.baseURL.Parse(PingEndpoint)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/hashicorp/go-tfe/type_helpers.go
+++ b/vendor/github.com/hashicorp/go-tfe/type_helpers.go
@@ -40,6 +40,11 @@ func NotificationDestination(v NotificationDestinationType) *NotificationDestina
 	return &v
 }
 
+// PlanExportType returns a pointer to the given plan export data type.
+func PlanExportType(v PlanExportDataType) *PlanExportDataType {
+	return &v
+}
+
 // ServiceProvider returns a pointer to the given service provider type.
 func ServiceProvider(v ServiceProviderType) *ServiceProviderType {
 	return &v

--- a/vendor/github.com/hashicorp/go-tfe/workspace.go
+++ b/vendor/github.com/hashicorp/go-tfe/workspace.go
@@ -25,14 +25,26 @@ type Workspaces interface {
 	// Read a workspace by its name.
 	Read(ctx context.Context, organization string, workspace string) (*Workspace, error)
 
+	// ReadByID reads a workspace by its ID.
+	ReadByID(ctx context.Context, workspaceID string) (*Workspace, error)
+
 	// Update settings of an existing workspace.
 	Update(ctx context.Context, organization string, workspace string, options WorkspaceUpdateOptions) (*Workspace, error)
+
+	// UpdateByID updates the settings of an existing workspace.
+	UpdateByID(ctx context.Context, workspaceID string, options WorkspaceUpdateOptions) (*Workspace, error)
 
 	// Delete a workspace by its name.
 	Delete(ctx context.Context, organization string, workspace string) error
 
+	// DeleteByID deletes a workspace by its ID.
+	DeleteByID(ctx context.Context, workspaceID string) error
+
 	// RemoveVCSConnection from a workspace.
 	RemoveVCSConnection(ctx context.Context, organization, workspace string) (*Workspace, error)
+
+	// RemoveVCSConnectionByID removes a VCS connection from a workspace.
+	RemoveVCSConnectionByID(ctx context.Context, workspaceID string) (*Workspace, error)
 
 	// Lock a workspace by its ID.
 	Lock(ctx context.Context, workspaceID string, options WorkspaceLockOptions) (*Workspace, error)
@@ -69,6 +81,7 @@ type Workspace struct {
 	CanQueueDestroyPlan  bool                  `jsonapi:"attr,can-queue-destroy-plan"`
 	CreatedAt            time.Time             `jsonapi:"attr,created-at,iso8601"`
 	Environment          string                `jsonapi:"attr,environment"`
+	FileTriggersEnabled  bool                  `jsonapi:"attr,file-triggers-enabled"`
 	Locked               bool                  `jsonapi:"attr,locked"`
 	MigrationEnvironment string                `jsonapi:"attr,migration-environment"`
 	Name                 string                `jsonapi:"attr,name"`
@@ -76,6 +89,7 @@ type Workspace struct {
 	Permissions          *WorkspacePermissions `jsonapi:"attr,permissions"`
 	QueueAllRuns         bool                  `jsonapi:"attr,queue-all-runs"`
 	TerraformVersion     string                `jsonapi:"attr,terraform-version"`
+	TriggerPrefixes      []string              `jsonapi:"attr,trigger-prefixes"`
 	VCSRepo              *VCSRepo              `jsonapi:"attr,vcs-repo"`
 	WorkingDirectory     string                `jsonapi:"attr,working-directory"`
 
@@ -149,6 +163,12 @@ type WorkspaceCreateOptions struct {
 	// Whether to automatically apply changes when a Terraform plan is successful.
 	AutoApply *bool `jsonapi:"attr,auto-apply,omitempty"`
 
+	// Whether to filter runs based on the changed files in a VCS push. If
+	// enabled, the working directory and trigger prefixes describe a set of
+	// paths which must contain changes for a VCS push to trigger a run. If
+	// disabled, any push will trigger a run.
+	FileTriggersEnabled *bool `jsonapi:"attr,file-triggers-enabled,omitempty"`
+
 	// The legacy TFE environment to use as the source of the migration, in the
 	// form organization/environment. Omit this unless you are migrating a legacy
 	// environment.
@@ -159,6 +179,9 @@ type WorkspaceCreateOptions struct {
 	// organization.
 	Name *string `jsonapi:"attr,name"`
 
+	// Whether the workspace will use remote or local execution mode.
+	Operations *bool `jsonapi:"attr,operations,omitempty"`
+
 	// Whether to queue all runs. Unless this is set to true, runs triggered by
 	// a webhook will not be queued until at least one run is manually queued.
 	QueueAllRuns *bool `jsonapi:"attr,queue-all-runs,omitempty"`
@@ -166,6 +189,10 @@ type WorkspaceCreateOptions struct {
 	// The version of Terraform to use for this workspace. Upon creating a
 	// workspace, the latest version is selected unless otherwise specified.
 	TerraformVersion *string `jsonapi:"attr,terraform-version,omitempty"`
+
+	// List of repository-root-relative paths which list all locations to be
+	// tracked for changes. See FileTriggersEnabled above for more details.
+	TriggerPrefixes []string `jsonapi:"attr,trigger-prefixes,omitempty"`
 
 	// Settings for the workspace's VCS repository. If omitted, the workspace is
 	// created without a VCS repo. If included, you must specify at least the
@@ -251,6 +278,27 @@ func (s *workspaces) Read(ctx context.Context, organization, workspace string) (
 	return w, nil
 }
 
+// ReadByID reads a workspace by its ID.
+func (s *workspaces) ReadByID(ctx context.Context, workspaceID string) (*Workspace, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
+
+	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Workspace{}
+	err = s.client.do(ctx, req, w)
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
 // WorkspaceUpdateOptions represents the options for updating a workspace.
 type WorkspaceUpdateOptions struct {
 	// For internal use only!
@@ -265,12 +313,25 @@ type WorkspaceUpdateOptions struct {
 	// API and UI.
 	Name *string `jsonapi:"attr,name,omitempty"`
 
+	// Whether to filter runs based on the changed files in a VCS push. If
+	// enabled, the working directory and trigger prefixes describe a set of
+	// paths which must contain changes for a VCS push to trigger a run. If
+	// disabled, any push will trigger a run.
+	FileTriggersEnabled *bool `jsonapi:"attr,file-triggers-enabled,omitempty"`
+
+	// Whether the workspace will use remote or local execution mode.
+	Operations *bool `jsonapi:"attr,operations,omitempty"`
+
 	// Whether to queue all runs. Unless this is set to true, runs triggered by
 	// a webhook will not be queued until at least one run is manually queued.
 	QueueAllRuns *bool `jsonapi:"attr,queue-all-runs,omitempty"`
 
 	// The version of Terraform to use for this workspace.
 	TerraformVersion *string `jsonapi:"attr,terraform-version,omitempty"`
+
+	// List of repository-root-relative paths which list all locations to be
+	// tracked for changes. See FileTriggersEnabled above for more details.
+	TriggerPrefixes []string `jsonapi:"attr,trigger-prefixes,omitempty"`
 
 	// To delete a workspace's existing VCS repo, specify null instead of an
 	// object. To modify a workspace's existing VCS repo, include whichever of
@@ -317,6 +378,30 @@ func (s *workspaces) Update(ctx context.Context, organization, workspace string,
 	return w, nil
 }
 
+// UpdateByID updates the settings of an existing workspace.
+func (s *workspaces) UpdateByID(ctx context.Context, workspaceID string, options WorkspaceUpdateOptions) (*Workspace, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Workspace{}
+	err = s.client.do(ctx, req, w)
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
 // Delete a workspace by its name.
 func (s *workspaces) Delete(ctx context.Context, organization, workspace string) error {
 	if !validStringID(&organization) {
@@ -331,6 +416,21 @@ func (s *workspaces) Delete(ctx context.Context, organization, workspace string)
 		url.QueryEscape(organization),
 		url.QueryEscape(workspace),
 	)
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// DeleteByID deletes a workspace by its ID.
+func (s *workspaces) DeleteByID(ctx context.Context, workspaceID string) error {
+	if !validStringID(&workspaceID) {
+		return errors.New("invalid value for workspace ID")
+	}
+
+	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
 	req, err := s.client.newRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -359,6 +459,28 @@ func (s *workspaces) RemoveVCSConnection(ctx context.Context, organization, work
 		url.QueryEscape(organization),
 		url.QueryEscape(workspace),
 	)
+
+	req, err := s.client.newRequest("PATCH", u, &workspaceRemoveVCSConnectionOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Workspace{}
+	err = s.client.do(ctx, req, w)
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+// RemoveVCSConnectionByID removes a VCS connection from a workspace.
+func (s *workspaces) RemoveVCSConnectionByID(ctx context.Context, workspaceID string) (*Workspace, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
+
+	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
 
 	req, err := s.client.newRequest("PATCH", u, &workspaceRemoveVCSConnectionOptions{})
 	if err != nil {


### PR DESCRIPTION
Thanks to https://github.com/hashicorp/terraform/pull/23105, Terraform 0.12.11 gained support for a [`.terraformignore` file](https://www.terraform.io/docs/backends/types/remote.html#excluding-files-from-upload-with-terraformignore).

This unfortunately, was never backported to 0.11. Anybody using Terraform 0.11 in a repository that houses multiple terraform workspaces can quickly run into issues where terraform tries to upload gigabytes of data, making it almost unusable. In many cases, simply upgrading to 0.12 isn't an option.

The only change required is an upgrade to go-tfe. I've tested this against a Terraform Enterprise environment and it works well.