### PR TITLE
index destroy dependencies by addrs.ConfigResource

### DIFF
--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -62,9 +62,10 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 	// are only being updated.
 	creators := make(map[string]GraphNodeCreator)
 
-	// destroyersByResource records each destroyer by the AbsResourceAddress.
-	// We use this because dependencies are only referenced as resources, but we
-	// will want to connect all the individual instances for correct ordering.
+	// destroyersByResource records each destroyer by the ConfigResource
+	// address.  We use this because dependencies are only referenced as
+	// resources and have no index or module instance information, but we will
+	// want to connect all the individual instances for correct ordering.
 	destroyersByResource := make(map[string][]GraphNodeDestroyer)
 	for _, v := range g.Vertices() {
 		switch n := v.(type) {
@@ -80,7 +81,7 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 			log.Printf("[TRACE] DestroyEdgeTransformer: %q (%T) destroys %s", dag.VertexName(n), v, key)
 			destroyers[key] = append(destroyers[key], n)
 
-			resAddr := addr.Resource.Resource.Absolute(addr.Module).String()
+			resAddr := addr.ContainingResource().Config().String()
 			destroyersByResource[resAddr] = append(destroyersByResource[resAddr], n)
 		case GraphNodeCreator:
 			addr := n.CreateAddr()

--- a/terraform/transform_destroy_edge_test.go
+++ b/terraform/transform_destroy_edge_test.go
@@ -172,12 +172,12 @@ func TestDestroyEdgeTransformer_module(t *testing.T) {
 
 func TestDestroyEdgeTransformer_moduleOnly(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
-	g.Add(testDestroyNode("module.child.test_object.a"))
-	g.Add(testDestroyNode("module.child.test_object.b"))
-	g.Add(testDestroyNode("module.child.test_object.c"))
+	g.Add(testDestroyNode("module.child[0].test_object.a"))
+	g.Add(testDestroyNode("module.child[0].test_object.b"))
+	g.Add(testDestroyNode("module.child[0].test_object.c"))
 
 	state := states.NewState()
-	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
+	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.IntKey(0)))
 	child.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.a").Resource,
 		&states.ResourceInstanceObjectSrc{
@@ -222,12 +222,12 @@ func TestDestroyEdgeTransformer_moduleOnly(t *testing.T) {
 
 	actual := strings.TrimSpace(g.String())
 	expected := strings.TrimSpace(`
-module.child.test_object.a (destroy)
-  module.child.test_object.b (destroy)
-  module.child.test_object.c (destroy)
-module.child.test_object.b (destroy)
-  module.child.test_object.c (destroy)
-module.child.test_object.c (destroy)
+module.child[0].test_object.a (destroy)
+  module.child[0].test_object.b (destroy)
+  module.child[0].test_object.c (destroy)
+module.child[0].test_object.b (destroy)
+  module.child[0].test_object.c (destroy)
+module.child[0].test_object.c (destroy)
 `)
 	if actual != expected {
 		t.Fatalf("wrong result\n\ngot:\n%s\n\nwant:\n%s", actual, expected)


### PR DESCRIPTION
When the DestroyEdgeTransformer was updated to handle stored
dependencies the addrs.ConfigResource type did not yet exist. The lookup
map keys in the transformer needed to be updated to remove module
indexes.

Fixes #25391