### PR TITLE
configs: Fail early for invalid resource provider

### DIFF
--- a/configs/resource.go
+++ b/configs/resource.go
@@ -422,6 +422,9 @@ func decodeProviderConfigRef(expr hcl.Expression, argName string) (*ProviderConf
 	name := traversal.RootName()
 	nameDiags := checkProviderNameNormalized(name, traversal[0].SourceRange())
 	diags = append(diags, nameDiags...)
+	if diags.HasErrors() {
+		return nil, diags
+	}
 
 	ret := &ProviderConfigRef{
 		Name:      name,

--- a/configs/testdata/invalid-files/data-invalid-provider-reference.tf
+++ b/configs/testdata/invalid-files/data-invalid-provider-reference.tf
@@ -1,0 +1,3 @@
+data "test_resource" "t" {
+  provider = my_test
+}

--- a/configs/testdata/invalid-files/resource-invalid-provider-reference.tf
+++ b/configs/testdata/invalid-files/resource-invalid-provider-reference.tf
@@ -1,0 +1,3 @@
+resource "test_resource" "t" {
+  provider = my_test
+}


### PR DESCRIPTION
If a resource's "provider" reference is invalid and cannot be parsed, we should not store the reference as part of a `ProviderConfigRef`. Doing so creates an invalid data structure, which prevents us from using `MustParseProviderPart` with the name in later steps.

The invalid test files added in this commit will cause a panic without the code change.

Fixes #25311