### PR TITLE
command/init: return an error with invalid -backend-config files

### DIFF
--- a/command/testdata/init-backend-config-file/backend.config
+++ b/command/testdata/init-backend-config-file/backend.config
@@ -1,0 +1,7 @@
+// the -backend-config flag on init cannot be used to point to a "full" backend
+// block, only key-value pairs (like terraform.tfvars) 
+terraform {
+    backend "local" {
+        path = "hello"
+    }
+}

--- a/website/docs/backends/config.html.md
+++ b/website/docs/backends/config.html.md
@@ -63,12 +63,12 @@ There are several ways to supply the remaining arguments:
     values, unless interactive input is disabled. Terraform will not prompt for
     optional values.
 
-  * **File**: A configuration file may be specified via the `init` command line.
-    To specify a file, use the `-backend-config=PATH` option when running
-    `terraform init`. If the file contains secrets it may be kept in
-    a secure data store, such as
-    [Vault](https://www.vaultproject.io/), in which case it must be downloaded
-    to the local disk before running Terraform.
+  * **File**: A [backend configuration file](#backend-configuration-file) may be specified via the
+    `init` command line. To specify a file, use the `-backend-config=PATH`
+    option when running `terraform init`. If the file contains secrets it may be
+    kept in a secure data store, such as [Vault](https://www.vaultproject.io/),
+    in which case it must be downloaded to the local disk before running
+    Terraform.
 
   * **Command-line key/value pairs**: Key/value pairs can be specified via the
     `init` command line. Note that many shells retain command-line flags in a
@@ -96,6 +96,7 @@ terraform {
 }
 ```
 
+## Backend Configuration File
 A backend configuration file has the contents of the `backend` block as
 top-level attributes, without the need to wrap it in another `terraform`
 or `backend` block:


### PR DESCRIPTION
The -backend-config flag expects a set of key-value pairs or a file
containing key-value pairs. If the file instead contains a full backend
configuration block, it was silently ignored. This commit adds a check
for blocks in the file and returns an error if they are encountered.

Fixes #24845

Please feel encouraged to nitpick the error message!

```
        Error: Invalid backend configuration file

        The backend configuration file "backend.config" given on the command line must
        only contain key-value pairs, and not full configuration blocks
```