### PR TITLE
Update templatefile function error message to support multiple missing variables.

### DIFF
--- a/lang/funcs/filesystem_test.go
+++ b/lang/funcs/filesystem_test.go
@@ -110,6 +110,12 @@ func TestTemplateFile(t *testing.T) {
 			`vars map does not contain key "name", referenced at testdata/hello.tmpl:1,10-14`,
 		},
 		{
+			cty.StringVal("testdata/multivar.tmpl"),
+			cty.EmptyObjectVal,
+			cty.NilVal,
+			`vars map does not contain key "yourname", referenced at testdata/multivar.tmpl:1,10-18, key "myname", referenced at testdata/multivar.tmpl:1,34-40`,
+		},
+		{
 			cty.StringVal("testdata/func.tmpl"),
 			cty.ObjectVal(map[string]cty.Value{
 				"list": cty.ListVal([]cty.Value{

--- a/lang/funcs/testdata/multivar.tmpl
+++ b/lang/funcs/testdata/multivar.tmpl
@@ -1,0 +1,1 @@
+Hello, ${yourname}! my name is ${myname}.


### PR DESCRIPTION
In reference to issue #25382, this PR updates the error returned by `templatefile` when there is more than one undeclared template variable.  The new error  inform the user of each missing template variable. Previously, the error would only mention one. I added one test relevant to the change and a new test data file for it as well. 

Please let me know if any changes need to be made to get this PR approved! 