### PR TITLE
terraform: improve error message when for_each encounters `cty.DynamicPseudoTypes`

### DIFF
--- a/terraform/eval_for_each.go
+++ b/terraform/eval_for_each.go
@@ -83,6 +83,12 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext) (cty.V
 	}
 
 	if ty.IsSetType() {
+		// since we can't use a set values that are unknown, we treat the
+		// entire set as unknown
+		if !forEachVal.IsWhollyKnown() {
+			return cty.UnknownVal(ty), diags
+		}
+
 		if ty.ElementType() != cty.String {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -91,12 +97,6 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext) (cty.V
 				Subject:  expr.Range().Ptr(),
 			})
 			return cty.NullVal(ty), diags
-		}
-
-		// since we can't use a set values that are unknown, we treat the
-		// entire set as unknown
-		if !forEachVal.IsWhollyKnown() {
-			return cty.UnknownVal(ty), diags
 		}
 
 		// A set of strings may contain null, which makes it impossible to

--- a/terraform/eval_for_each_test.go
+++ b/terraform/eval_for_each_test.go
@@ -125,6 +125,11 @@ func TestEvaluateForEachExpression_errors(t *testing.T) {
 			"Invalid for_each argument",
 			"depends on resource attributes that cannot be determined until apply",
 		},
+		"set containing dynamic unknown value": {
+			hcltest.MockExprLiteral(cty.SetVal([]cty.Value{cty.UnknownVal(cty.DynamicPseudoType)})),
+			"Invalid for_each argument",
+			"depends on resource attributes that cannot be determined until apply",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
The error message when `evaluateForEachExpression` encountered an unknown
value of `cty.DynamicPseudoType` was not clear to users:

```
The given "for_each" argument value is unsuitable: "for_each" supports maps
and sets of strings, but you have provided a set containing type dynamic.
```

By moving the check for unknowns before the validation of set element types,
the following error is returned instead:

```
The "for_each" value depends on resource attributes that cannot be
determined until apply (...)
```

Fixes #24012