### PR TITLE
backend context: do not hold lock if there is an error

### DIFF
--- a/backend/local/backend_local_test.go
+++ b/backend/local/backend_local_test.go
@@ -1,0 +1,64 @@
+package local
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/internal/initwd"
+	"github.com/hashicorp/terraform/states/statemgr"
+)
+
+func TestLocalContext(t *testing.T) {
+	configDir := "./testdata/empty"
+	b, cleanup := TestLocal(t)
+	defer cleanup()
+
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir)
+	defer configCleanup()
+
+	op := &backend.Operation{
+		ConfigDir:    configDir,
+		ConfigLoader: configLoader,
+		Workspace:    backend.DefaultStateName,
+		LockState:    true,
+	}
+
+	_, _, diags := b.Context(op)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %s", diags.Err().Error())
+	}
+
+	// Conext() retains a lock on success, so this should fail.
+	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
+		t.Fatalf("unexpected success locking state")
+	}
+}
+
+func TestLocalContext_error(t *testing.T) {
+	configDir := "./testdata/apply-error"
+	b, cleanup := TestLocal(t)
+	defer cleanup()
+
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir)
+	defer configCleanup()
+
+	op := &backend.Operation{
+		ConfigDir:    configDir,
+		ConfigLoader: configLoader,
+		Workspace:    backend.DefaultStateName,
+		LockState:    true,
+	}
+
+	_, _, diags := b.Context(op)
+	if !diags.HasErrors() {
+		t.Fatal("unexpected success")
+	}
+
+	// When Context() returns an error, it also unlocks the state.
+	// This should therefore succeed.
+	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
+		t.Fatalf("unexpected error locking state: %s", err.Error())
+	}
+}

--- a/backend/remote/backend_context_test.go
+++ b/backend/remote/backend_context_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/internal/initwd"
+	"github.com/hashicorp/terraform/states/statemgr"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -186,6 +187,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 				ConfigDir:    configDir,
 				ConfigLoader: configLoader,
 				Workspace:    backend.DefaultStateName,
+				LockState:    true,
 			}
 
 			v := test.Opts
@@ -205,9 +207,20 @@ func TestRemoteContextWithVars(t *testing.T) {
 				if errStr != test.WantError {
 					t.Fatalf("wrong error\ngot:  %s\nwant: %s", errStr, test.WantError)
 				}
+				// When Context() returns an error, it should unlock the state,
+				// so re-locking it is expected to succeed.
+				stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
+					t.Fatalf("unexpected error locking state: %s", err.Error())
+				}
 			} else {
 				if diags.HasErrors() {
 					t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())
+				}
+				// If Context() succeeded, this should fail w/ "workspace already locked"
+				stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
+					t.Fatal("unexpected success locking state after Context")
 				}
 			}
 		})

--- a/command/console.go
+++ b/command/console.go
@@ -92,6 +92,11 @@ func (c *ConsoleCommand) Run(args []string) int {
 
 	// Get the context
 	ctx, _, ctxDiags := local.Context(opReq)
+	diags = diags.Append(ctxDiags)
+	if ctxDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
 
 	// Creating the context can result in a lock, so ensure we release it
 	defer func() {
@@ -100,12 +105,6 @@ func (c *ConsoleCommand) Run(args []string) int {
 			c.Ui.Error(err.Error())
 		}
 	}()
-
-	diags = diags.Append(ctxDiags)
-	if ctxDiags.HasErrors() {
-		c.showDiagnostics(diags)
-		return 1
-	}
 
 	// Setup the UI so we can output directly to stdout
 	ui := &cli.BasicUi{


### PR DESCRIPTION
The `remote` backend `Context` would exit without an active lock if there
was an error, while the `local` backend `Context` exited *with* a lock. This
caused a problem in `terraform console`, which would call unlock on the state manager
regardless of error status.

This commit makes the local and remote backend consistently unlock the
state in case of error, and updates terraform console to check for errors in `Context`
before trying to unlock the state.

The new output from `terraform console` with a (successfully) configured backend but some other issue (for ex, invalid config syntax) no longer contains the locking error and only includes whatever actual problems were encountered.

Fixes #24246

----
Update: I finally figured out tests in backend/local and backend/remote; I am not adding tests to the command package at this time because that task - I think! - requires some rethinking and refactoring so that we can override the backend(s) for command test fixtures.