### PR TITLE
Add dotenvdecode() function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/davecgh/go-spew v1.1.1
+	github.com/direnv/go-dotenv v0.0.0-20210516213449-d90326084211
 	github.com/dylanmei/iso8601 v0.1.0 // indirect
 	github.com/dylanmei/winrmtest v0.0.0-20190225150635-99b7fe2fddf1
 	github.com/go-test/deep v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/direnv/go-dotenv v0.0.0-20210516213449-d90326084211 h1:WdqUL3fCUJSYuFMgA18Sqv3R6Qp1yYbo0L6i1umswqk=
+github.com/direnv/go-dotenv v0.0.0-20210516213449-d90326084211/go.mod h1:K5R9ofHu1mQRwNWMZgDnr0s1Ca1nkvz9r09NN/U2UyM=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4 h1:qk/FSDDxo05wdJH28W+p5yivv7LuLYLRXPPD8KQCtZs=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/internal/lang/funcs/encoding_test.go
+++ b/internal/lang/funcs/encoding_test.go
@@ -317,3 +317,52 @@ func TestBase64TextDecode(t *testing.T) {
 		})
 	}
 }
+
+func TestDotEnvDecode(t *testing.T) {
+	tests := []struct {
+		String cty.Value
+		Want   cty.Value
+		Err    bool
+	}{
+		{
+			cty.StringVal("TEST_VAR=testvalue"),
+			cty.MapVal(map[string]cty.Value{
+				"TEST_VAR": cty.StringVal("testvalue"),
+			}),
+			false,
+		},
+		{
+			cty.StringVal("TEST_VAR=test=value"),
+			cty.MapVal(map[string]cty.Value{
+				"TEST_VAR": cty.StringVal("test=value"),
+			}),
+			false,
+		},
+		{
+			cty.StringVal("TEST_VAR=\"test value\""),
+			cty.MapVal(map[string]cty.Value{
+				"TEST_VAR": cty.StringVal("test value"),
+			}),
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("dotenvdecode(%#v)", test.String), func(t *testing.T) {
+			got, err := DotEnvDecode(test.String)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -59,6 +59,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"defaults":         s.experimentalFunction(experiments.ModuleVariableOptionalAttrs, funcs.DefaultsFunc),
 			"dirname":          funcs.DirnameFunc,
 			"distinct":         stdlib.DistinctFunc,
+			"dotenvdecode":     funcs.DotEnvDecodeFunc,
 			"element":          stdlib.ElementFunc,
 			"chunklist":        stdlib.ChunklistFunc,
 			"file":             funcs.MakeFileFunc(s.BaseDir, false),


### PR DESCRIPTION
This PR adds a native way to handle "dotenv" files using Terraform by introducing a `dotenvdecode` function. Similar to yamldecode and jsondecode this function will accept a string in the "dotenv" format and produce a value of type map. Here's an example using the terraform console:

```
> dotenvdecode("PGHOST=localhost\nPGUSER=postgres")
{
  "PGHOST" = "localhost"
  "PGUSER" = "postgres"
}
```

The "dotenv" is not a standard per se like YAML and JSON, but has become an established practice across a lot of different projects and languages, born from the 12-factor-app manifesto. See references section below.

Resolves https://github.com/hashicorp/terraform/issues/23906
Resolves https://github.com/hashicorp/terraform-provider-kubernetes/issues/889

### References

https://github.com/motdotla/dotenv
https://github.com/vlucas/phpdotenv
https://pypi.org/project/python-dotenv
https://github.com/joho/godotenv
https://github.com/direnv/go-dotenv
https://github.com/cdimascio/java-dotenv
https://12factor.net/config
