### PR TITLE
Docs: fix merge conflict in Import page

### DIFF
--- a/website/docs/import/index.html.md
+++ b/website/docs/import/index.html.md
@@ -29,12 +29,8 @@ manually a `resource` configuration block for the resource, to which the
 imported object will be mapped.
 
 While this may seem tedious, it still gives Terraform users an avenue for
-<<<<<<< HEAD
 importing existing resources. A future version of Terraform will fully generate
 configuration, significantly simplifying this process.
-=======
-importing existing resources.
 
 You can follow the [Terraform Import guide](https://learn.hashicorp.com/terraform/state/import?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on HashiCorp learn for a hands-on
 introduction to using the `terraform import` command.
->>>>>>> cd1cc9fc7... Add link to new Terraform Import guide on learn platform


### PR DESCRIPTION
Commit 92dc2d303085fc86396f4ea4b6a63cb4b0a5d8d8 introduced a merge conflict which is visible on the live docs website [here](https://www.terraform.io/docs/import/index.html), which this fixes.

This commit aligns the docs to the master branch, the current state of which can be viewed [here](https://github.com/hashicorp/terraform/blob/master/website/docs/import/index.html.md).