### PR TITLE
Fix a bug about checking empty string value for map<string>

### DIFF
--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -730,6 +730,11 @@ func (d *InstanceDiff) applySingleAttrDiff(path []string, attrs map[string]strin
 		if attrSchema.Type == cty.String {
 			result[attr] = ""
 		}
+
+		// this can only be a valid empty string value in map
+		if attrSchema.Type.IsMapType() && attrSchema.Type.ElementType() == cty.String {
+			result[attr] = ""
+		}
 		return result, nil
 	}
 


### PR DESCRIPTION
Empty string value in map is dropped in `diff` stage so that the behavior I expect doesn't work.

I found this issue from [here](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_autoscaling_group.go#L395) in `terraform-provider-aws` repository.

For example, suppose that I write a code like below.
```hcl
resource "aws_autoscaling_group" "this" {
  name      = "foo"
  max_size  = 0
  min_size  = 0

  tags = [
      { key = "foo", value = "", propagate_at_launch = true }
  ]
}
```
In this example, an element in `tags` map must have three keys; `key`, `value` and `propagate_at_launch`.
But the output by `terraform plan` shows the below without `value` which has empty string.
```hcl
      + tags = [
          + {
              + "key"                 = "foo"
              + "propagate_at_launch" = "true"
            }
        ]
```

In the current code, only `string` type is checked during `diff`. I added a condition that element type of map is `string`.
This change will show the output like below.
```hcl
      + tags = [
          + {
              + "key"                 = "foo"
              + "value"               = ""
              + "propagate_at_launch" = "true"
            }
        ]
```

If my suggestion looks fine, I am not sure how or where to add test code to validate. Please let me know.

Related issues:
* https://github.com/hashicorp/terraform-plugin-sdk/issues/486
* https://github.com/terraform-providers/terraform-provider-aws/issues/9049