### PR TITLE
use alpine:latest as the base image for terraform docker containers

### DIFF
--- a/scripts/docker-release/Dockerfile-release
+++ b/scripts/docker-release/Dockerfile-release
@@ -7,7 +7,7 @@
 # tree, without any dependency on there being an existing release on
 # releases.hashicorp.com.
 
-FROM alpine:3.12 as build
+FROM alpine:latest as build
 LABEL maintainer="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
 # This is intended to be run from the hooks/build script, which sets this
@@ -33,7 +33,7 @@ RUN apk add --no-cache git curl openssh gnupg && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin && \
     rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip terraform_${TERRAFORM_VERSION}_SHA256SUMS*
 
-FROM alpine:3.12 as final
+FROM alpine:latest as final
 ARG TERRAFORM_VERSION=UNSPECIFIED
 
 LABEL "com.hashicorp.terraform.version"="${TERRAFORM_VERSION}"


### PR DESCRIPTION
This PR modifies the Dockerfile used for releases to use `alpine:latest`. Previously, our release process relied on a Dockerfile separate from this repo which used `alpine:latest` but when we switched CI providers, we relied on the one in this repo instead. This brings them in sync and future releases should use the Dockerfile in `scripts/docker-release/Dockerfile-release`

Closes #25397 