### PR TITLE
configs: Interpolation deprecation for module call

### DIFF
--- a/configs/testdata/warning-files/redundant_interp.tf
+++ b/configs/testdata/warning-files/redundant_interp.tf
@@ -34,3 +34,8 @@ resource "null_resource" "a" {
     wrapped = ["${var.triggers["greeting"]}"]
   }
 }
+
+module "foo" {
+  source = "./foo"
+  foo = "${var.foo}" # WARNING: Interpolation-only expressions are deprecated
+}


### PR DESCRIPTION
Add the deprecation for interpolation-only expressions for module calls, matching resource and provider blocks.

Fixes #25430, although I am not certain that this is the right direction for these deprecation warnings.