### PR TITLE
configs: include "providers" when overriding modules

### DIFF
--- a/configs/module_merge.go
+++ b/configs/module_merge.go
@@ -164,6 +164,10 @@ func (mc *ModuleCall) merge(omc *ModuleCall) hcl.Diagnostics {
 
 	mc.Config = MergeBodies(mc.Config, omc.Config)
 
+	if len(omc.Providers) != 0 {
+		mc.Providers = omc.Providers
+	}
+
 	// We don't allow depends_on to be overridden because that is likely to
 	// cause confusing misbehavior.
 	if len(mc.DependsOn) != 0 {

--- a/configs/module_merge_test.go
+++ b/configs/module_merge_test.go
@@ -109,6 +109,32 @@ func TestModuleOverrideModule(t *testing.T) {
 				Byte:   17,
 			},
 		},
+		Providers: []PassedProviderConfig{
+			{
+				InChild: &ProviderConfigRef{
+					Name: "test",
+					NameRange: hcl.Range{
+						Filename: "testdata/valid-modules/override-module/b_override.tf",
+						Start:    hcl.Pos{Line: 7, Column: 5, Byte: 97},
+						End:      hcl.Pos{Line: 7, Column: 9, Byte: 101},
+					},
+				},
+				InParent: &ProviderConfigRef{
+					Name: "test",
+					NameRange: hcl.Range{
+						Filename: "testdata/valid-modules/override-module/b_override.tf",
+						Start:    hcl.Pos{Line: 7, Column: 12, Byte: 104},
+						End:      hcl.Pos{Line: 7, Column: 16, Byte: 108},
+					},
+					Alias: "b_override",
+					AliasRange: &hcl.Range{
+						Filename: "testdata/valid-modules/override-module/b_override.tf",
+						Start:    hcl.Pos{Line: 7, Column: 16, Byte: 108},
+						End:      hcl.Pos{Line: 7, Column: 27, Byte: 119},
+					},
+				},
+			},
+		},
 	}
 
 	// We're going to extract and nil out our hcl.Body here because DeepEqual

--- a/configs/testdata/valid-modules/override-module/a_override.tf
+++ b/configs/testdata/valid-modules/override-module/a_override.tf
@@ -4,4 +4,8 @@ module "example" {
 
   foo = "a_override foo"
   new = "a_override new"
+
+  providers = {
+    test = test.a_override
+  }
 }

--- a/configs/testdata/valid-modules/override-module/b_override.tf
+++ b/configs/testdata/valid-modules/override-module/b_override.tf
@@ -2,4 +2,8 @@
 module "example" {
   new   = "b_override new"
   newer = "b_override newer"
+
+  providers = {
+    test = test.b_override
+  }
 }

--- a/configs/testdata/valid-modules/override-module/primary.tf
+++ b/configs/testdata/valid-modules/override-module/primary.tf
@@ -4,4 +4,8 @@ module "example" {
 
   kept = "primary kept"
   foo  = "primary foo"
+
+  providers = {
+    test = test.foo
+  }
 }


### PR DESCRIPTION
The module `merge` function was not overriding `providers` blocks inside module calls. This fixes that and adds a test.

Fixes #24291