### PR TITLE
website/docs: document difference in formatting strings with width and precision

### DIFF
--- a/website/docs/configuration/functions/format.html.md
+++ b/website/docs/configuration/functions/format.html.md
@@ -117,6 +117,10 @@ The function produces an error if the format string requests an impossible
 conversion or access more arguments than are given. An error is produced also
 for an unsupported format verb.
 
+-> **Note:** Width and precision modifiers with non-numeric types such as
+strings (`%s`) are interpreted differently. Setting either width or precision to
+zero is the same as not including them at all.
+
 ## Related Functions
 
 * [`formatdate`](./formatdate.html) is a specialized formatting function for


### PR DESCRIPTION
This addresses the documentation portion of #23189 but does not close it (we may go back and fix this behavior in a future major release, since it will be a breaking change)

EDIT: Closes #23189  