### PR TITLE
Disallow provider source addresses starting with terraform-

### DIFF
--- a/addrs/provider.go
+++ b/addrs/provider.go
@@ -324,6 +324,51 @@ func ParseProviderSourceString(str string) (Provider, tfdiags.Diagnostics) {
 		return Provider{}, diags
 	}
 
+	// Due to how plugin executables are named and provider git repositories
+	// are conventionally named, it's a reasonable and
+	// apparently-somewhat-common user error to incorrectly use the
+	// "terraform-provider-" prefix in a provider source address. There is
+	// no good reason for a provider to have the prefix "terraform-" anyway,
+	// so we've made that invalid from the start both so we can give feedback
+	// to provider developers about the terraform- prefix being redundant
+	// and give specialized feedback to folks who incorrectly use the full
+	// terraform-provider- prefix to help them self-correct.
+	const redundantPrefix = "terraform-"
+	const userErrorPrefix = "terraform-provider-"
+	if strings.HasPrefix(ret.Type, redundantPrefix) {
+		if strings.HasPrefix(ret.Type, userErrorPrefix) {
+			// Likely user error. We only return this specialized error if
+			// whatever is after the prefix would otherwise be a
+			// syntactically-valid provider type, so we don't end up advising
+			// the user to try something that would be invalid for another
+			// reason anyway.
+			// (This is mainly just for robustness, because the validation
+			// we already did above should've rejected most/all ways for
+			// the suggestedType to end up invalid here.)
+			suggestedType := ret.Type[len(userErrorPrefix):]
+			if _, err := ParseProviderPart(suggestedType); err == nil {
+				suggestedAddr := ret
+				suggestedAddr.Type = suggestedType
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid provider type",
+					fmt.Sprintf("Provider source %q has a type with the prefix %q, which isn't valid. Although that prefix is often used in the names of version control repositories for Terraform providers, provider source strings should not include it.\n\nDid you mean %q?", ret.ForDisplay(), userErrorPrefix, suggestedAddr.ForDisplay()),
+				))
+				return Provider{}, diags
+			}
+		}
+		// Otherwise, probably instead an incorrectly-named provider, perhaps
+		// arising from a similar instinct to what causes there to be
+		// thousands of Python packages on PyPI with "python-"-prefixed
+		// names.
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid provider type",
+			fmt.Sprintf("Provider source %q has a type with the prefix %q, which isn't allowed because it would be redundant to name a Terraform provider with that prefix. If you are the author of this provider, rename it to not include the prefix.", ret, redundantPrefix),
+		))
+		return Provider{}, diags
+	}
+
 	return ret, diags
 }
 

--- a/addrs/provider_test.go
+++ b/addrs/provider_test.go
@@ -379,6 +379,20 @@ func TestParseProviderSourceStr(t *testing.T) {
 			Provider{},
 			true,
 		},
+
+		// We forbid the terraform- prefix both because it's redundant to
+		// include "terraform" in a Terraform provider name and because we use
+		// the longer prefix terraform-provider- to hint for users who might be
+		// accidentally using the git repository name or executable file name
+		// instead of the provider type.
+		"example.com/hashicorp/terraform-provider-bad": {
+			Provider{},
+			true,
+		},
+		"example.com/hashicorp/terraform-bad": {
+			Provider{},
+			true,
+		},
 	}
 
 	for name, test := range tests {

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -1657,38 +1657,6 @@ func TestInit_invalidBuiltInProviders(t *testing.T) {
 	}
 }
 
-// The module in this test uses terraform 0.11-style syntax. We expect that the
-// earlyconfig will succeed but the main loader fail, and return an error that
-// indicates that syntax upgrades may be required.
-func TestInit_syntaxErrorUpgradeHint(t *testing.T) {
-	// Create a temporary working directory that is empty
-	td := tempDir(t)
-
-	// This module
-	copy.CopyDir(testFixturePath("init-sniff-version-error"), td)
-	defer os.RemoveAll(td)
-	defer testChdir(t, td)()
-
-	ui := new(cli.MockUi)
-	c := &InitCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(testProvider()),
-			Ui:               ui,
-		},
-	}
-
-	args := []string{}
-	if code := c.Run(args); code != 1 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
-	}
-
-	// Check output.
-	output := ui.ErrorWriter.String()
-	if got, want := output, "If you've recently upgraded to Terraform v0.13 from Terraform\nv0.11, this may be because your configuration uses syntax constructs that are no\nlonger valid"; !strings.Contains(got, want) {
-		t.Fatalf("wrong output\ngot:\n%s\n\nwant: message containing %q", got, want)
-	}
-}
-
 // newMockProviderSource is a helper to succinctly construct a mock provider
 // source that contains a set of packages matching the given provider versions
 // that are available for installation (from temporary local files).

--- a/command/testdata/init-sniff-version-error/init-sniff-version-error.tf
+++ b/command/testdata/init-sniff-version-error/init-sniff-version-error.tf
@@ -1,9 +1,0 @@
-# The following is invalid because we don't permit multiple nested blocks
-# all one one line. Instead, we require the backend block to be on a line
-# of its own.
-# The purpose of this test case is to see that HCL still produces a valid-enough
-# AST that we can try to sniff in this block for a terraform_version argument
-# without crashing, since we do that during init to try to give a better
-# error message if we detect that the configuration is for a newer Terraform
-# version.
-terraform { backend "local" {} }

--- a/configs/testdata/error-files/provider-source-prefix.tf
+++ b/configs/testdata/error-files/provider-source-prefix.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    usererror = { # ERROR: Invalid provider type
+      source = "foo/terraform-provider-foo"
+    }
+    badname = { # ERROR: Invalid provider type
+      source = "foo/terraform-foo"
+    }
+  }
+}


### PR DESCRIPTION
The main motivation here is to produce a helpful error if a user incorrectly uses the terraform-provider- prefix (which we see on provider VCS repositories and plugin executables) as part of the source address.

![](https://user-images.githubusercontent.com/20180/86852659-06b7da00-c06a-11ea-9d06-bd8f61140b87.png)

However, this also more broadly blocks "terraform-" as a prefix in anticipation of whatever instinct causes the phenomenon where e.g. Python's PyPI has thousands of packages whose names start with "python-", even though everything on PyPI is for Python by definition. This is definitely not _necessary_, but it's better to be restrictive at first and weaken later as needed.

---

While I was testing this in various ways I encountered two other somewhat-confusing situations which led to me making some other changes at the same time:

* We were still returning the special `terraform init` message about potentially running the upgrade command when a validation error arises, which is not the first time we've had that be a false-positive giving misleading advice. For that reason, I removed the heuristic and reverted to the old pre-0.12 behavior of just treating all syntax errors the same way, though for now I've retained the `configs`/`earlyconfig` distinction because unpeeling that would be a far riskier change better saved for another time.

    This _does_ mean that anyone who tries to upgrade directly from Terraform 0.11 to 0.13 (contrary to the advice in the upgrade guide) will probably see a generic syntax error rather than specific advice on how to upgrade, but the advice we were previously printing here was incorrect for that situation anyway (it was suggesting to run `terraform 0.13upgrade`) and there isn't really anything specific we could tell a user to do here except to hint that either upgrading or downgrading Terraform might help, which seems too vague to be worth including.

* I noticed that if you put a GitHub repository URL (stripped of its scheme) in as provider source, perhaps mimicking how we treat GitHub repositories in the module block's `source` argument, the resulting error message was not super helpful in figuring out where you went wrong. So I added a specialized error message just for that hostname -- in recognition of the fact that currently far more providers have their repositories on GitHub than anywhere else -- to be clear that this is not something that is supposed to work and that the user should refer to the provider documentation to see what to do instead.

    ![](https://user-images.githubusercontent.com/20180/86853208-eccac700-c06a-11ea-83a9-6cd3d6f28f03.png)

    Due to the order of operations during `terraform init` this message can actually appear only for repositories whose names _don't_ start with `terraform-`, but a user could end up here if they initially try `github.com/apparentlymart/terraform-provider-baz` and follow Terraform's suggestion `Did you mean "github.com/apparentlymart/baz"?`. Ideally we'd not require the user to learn this in two steps, but implementing it this way means that `github.com` is not blocked from potentially _becoming_ a provider registry in future (as unlikely as that may seem right now), because we return this error only if registry discovery fails on that hostname.
