### PR TITLE
lang/funcs: update cidrsubnet and cidrhost for 64-bit systems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190103054945-8205d1f41e70
 	github.com/aliyun/aliyun-tablestore-go-sdk v4.1.2+incompatible
-	github.com/apparentlymart/go-cidr v1.0.1
+	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0
 	github.com/apparentlymart/go-userdirs v0.0.0-20190512014041-4a23807e62b9
 	github.com/apparentlymart/go-versions v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0 h1:JaCC8jz0zdMLk2m+
 github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0/go.mod h1:LzD22aAzDP8/dyiCKFp31He4m2GPjl0AFyzDtZzUu9M=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
+github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=

--- a/lang/funcs/cidr.go
+++ b/lang/funcs/cidr.go
@@ -2,6 +2,7 @@ package funcs
 
 import (
 	"fmt"
+	"math/big"
 	"net"
 
 	"github.com/apparentlymart/go-cidr/cidr"
@@ -25,7 +26,7 @@ var CidrHostFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.String),
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
-		var hostNum int
+		var hostNum *big.Int
 		if err := gocty.FromCtyValue(args[1], &hostNum); err != nil {
 			return cty.UnknownVal(cty.String), err
 		}
@@ -34,7 +35,7 @@ var CidrHostFunc = function.New(&function.Spec{
 			return cty.UnknownVal(cty.String), fmt.Errorf("invalid CIDR expression: %s", err)
 		}
 
-		ip, err := cidr.Host(network, hostNum)
+		ip, err := cidr.HostBig(network, hostNum)
 		if err != nil {
 			return cty.UnknownVal(cty.String), err
 		}
@@ -86,7 +87,7 @@ var CidrSubnetFunc = function.New(&function.Spec{
 		if err := gocty.FromCtyValue(args[1], &newbits); err != nil {
 			return cty.UnknownVal(cty.String), err
 		}
-		var netnum int
+		var netnum *big.Int
 		if err := gocty.FromCtyValue(args[2], &netnum); err != nil {
 			return cty.UnknownVal(cty.String), err
 		}
@@ -96,15 +97,11 @@ var CidrSubnetFunc = function.New(&function.Spec{
 			return cty.UnknownVal(cty.String), fmt.Errorf("invalid CIDR expression: %s", err)
 		}
 
-		// For portability with 32-bit systems where the subnet number
-		// will be a 32-bit int, we only allow extension of 32 bits in
-		// one call even if we're running on a 64-bit machine.
-		// (Of course, this is significant only for IPv6.)
-		if newbits > 32 {
-			return cty.UnknownVal(cty.String), fmt.Errorf("may not extend prefix by more than 32 bits")
+		if newbits > 64 {
+			return cty.UnknownVal(cty.String), fmt.Errorf("may not extend prefix by more than 64 bits")
 		}
 
-		newNetwork, err := cidr.Subnet(network, newbits, netnum)
+		newNetwork, err := cidr.SubnetBig(network, newbits, netnum)
 		if err != nil {
 			return cty.UnknownVal(cty.String), err
 		}

--- a/lang/funcs/cidr.go
+++ b/lang/funcs/cidr.go
@@ -97,10 +97,6 @@ var CidrSubnetFunc = function.New(&function.Spec{
 			return cty.UnknownVal(cty.String), fmt.Errorf("invalid CIDR expression: %s", err)
 		}
 
-		if newbits > 64 {
-			return cty.UnknownVal(cty.String), fmt.Errorf("may not extend prefix by more than 64 bits")
-		}
-
 		newNetwork, err := cidr.SubnetBig(network, newbits, netnum)
 		if err != nil {
 			return cty.UnknownVal(cty.String), err

--- a/lang/funcs/cidr_test.go
+++ b/lang/funcs/cidr_test.go
@@ -165,6 +165,13 @@ func TestCidrSubnet(t *testing.T) {
 			cty.StringVal("192.168.6.0/24"),
 			false,
 		},
+		{
+			cty.StringVal("fe80::/48"),
+			cty.NumberIntVal(33),
+			cty.NumberIntVal(6),
+			cty.StringVal("fe80::3:0:0:0/81"),
+			false,
+		},
 		{ // not enough bits left
 			cty.StringVal("192.168.0.0/30"),
 			cty.NumberIntVal(4),

--- a/lang/funcs/cidr_test.go
+++ b/lang/funcs/cidr_test.go
@@ -56,6 +56,12 @@ func TestCidrHost(t *testing.T) {
 			cty.UnknownVal(cty.String),
 			true, // can't have an octet >255
 		},
+		{ // fractions are Not Ok
+			cty.StringVal("10.256.0.0/8"),
+			cty.NumberFloatVal(.75),
+			cty.UnknownVal(cty.String),
+			true,
+		},
 	}
 
 	for _, test := range tests {
@@ -183,21 +189,28 @@ func TestCidrSubnet(t *testing.T) {
 			cty.StringVal("192.168.0.0/168"),
 			cty.NumberIntVal(2),
 			cty.NumberIntVal(16),
-			cty.StringVal("fe80:0:0:6::/64"),
+			cty.UnknownVal(cty.String),
 			true,
 		},
 		{ // not a valid CIDR mask
 			cty.StringVal("not-a-cidr"),
 			cty.NumberIntVal(4),
 			cty.NumberIntVal(6),
-			cty.StringVal("fe80:0:0:6::/64"),
+			cty.UnknownVal(cty.String),
 			true,
 		},
 		{ // can't have an octet >255
 			cty.StringVal("10.256.0.0/8"),
 			cty.NumberIntVal(4),
 			cty.NumberIntVal(6),
-			cty.StringVal("fe80:0:0:6::/64"),
+			cty.UnknownVal(cty.String),
+			true,
+		},
+		{ // fractions are Not Ok
+			cty.StringVal("10.256.0.0/8"),
+			cty.NumberFloatVal(2 / 3),
+			cty.NumberFloatVal(.75),
+			cty.UnknownVal(cty.String),
 			true,
 		},
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -87,7 +87,7 @@ github.com/aliyun/aliyun-tablestore-go-sdk/tablestore/search
 github.com/antchfx/xpath
 # github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0
 github.com/antchfx/xquery/xml
-# github.com/apparentlymart/go-cidr v1.0.1
+# github.com/apparentlymart/go-cidr v1.1.0
 ## explicit
 github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0


### PR DESCRIPTION
The `cidrsubnet` and `cidrhost` functions were limited to supporting 32-bit systems. This PR:
* updates the `"github.com/apparentlymart/go-cidr"` library, which was recently extended with SubnetBig and HostBig functions
* switches to the new go-cidr functions, including passing appropriate values as `big.Int`s
* modifies terraform's validation check in `cidrsubnet` to check for bits > 64 instead of 32

Fixes  #25360

There's a new test, but for good measure, have some `terraform console` output:
```
> cidrsubnet("fe08::/64", 63, 0)
fe08::/127
```