### PR TITLE
command: Fix state mv for only resource in module

### DIFF
--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -190,10 +190,7 @@ func (c *StateMvCommand) Run(args []string) int {
 				return 1
 			}
 			diags = diags.Append(c.validateResourceMove(addrFrom, addrTo))
-			if stateTo.Module(addrTo.Module) == nil {
-				// moving something to a mew module, so we need to ensure it exists
-				stateTo.EnsureModule(addrTo.Module)
-			}
+
 			if stateTo.Resource(addrTo) != nil {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
@@ -223,7 +220,7 @@ func (c *StateMvCommand) Run(args []string) int {
 
 				// Update the address before adding it to the state.
 				rs.Addr = addrTo
-				stateTo.Module(addrTo.Module).Resources[addrTo.Resource.String()] = rs
+				stateTo.EnsureModule(addrTo.Module).Resources[addrTo.Resource.String()] = rs
 			}
 
 		case addrs.AbsResourceInstance:


### PR DESCRIPTION
When moving a resource block with multiple instances to a new address within the same module, we need to ensure that the target module is present as late as possible. Otherwise, deleting the resource from the original address triggers pruning, and the module is removed just before we try to add the resource to it, which causes a crash.

Includes regression test which panics without this code change.

Fixes #25520