### PR TITLE
ensure root module locals and vars are pruned

### DIFF
--- a/terraform/testdata/apply-destroy-outputs/main.tf
+++ b/terraform/testdata/apply-destroy-outputs/main.tf
@@ -1,11 +1,19 @@
+data "test_data_source" "bar" {
+  for_each = {
+    a = "b"
+  }
+  foo = "zing"
+}
+
 data "test_data_source" "foo" {
+  for_each = data.test_data_source.bar
   foo = "ok"
 }
 
 locals {
   l = [
     {
-      name = data.test_data_source.foo.id
+      name = data.test_data_source.foo["a"].id
       val = "null"
     },
   ]

--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -252,17 +252,16 @@ func (m *pruneUnusedNodesMod) removeUnused(g *Graph) {
 			// dealing with complex looping and labels
 			func() {
 				n := nodes[i]
-				switch n.(type) {
+				switch n := n.(type) {
 				case graphNodeTemporaryValue:
-					// temporary value, which consist of variables, locals, and
-					// outputs, must be kept if anything refers to them.
-					if n, ok := n.(GraphNodeModulePath); ok {
-						// root outputs always have an implicit dependency on
-						// remote state.
-						if n.ModulePath().IsRoot() {
-							return
-						}
+					// root module outputs indicate they are not temporary by
+					// returning false here.
+					if !n.temporaryValue() {
+						return
 					}
+
+					// temporary values, which consist of variables, locals,
+					// and outputs, must be kept if anything refers to them.
 					for _, v := range g.UpEdges(n) {
 						// keep any value which is connected through a
 						// reference


### PR DESCRIPTION
The pruneUnusedNodes transformer was skipping root level locals and
variables, causing them to be left in the graph during a full destroy.
Use the return value from `temporaryValue` to indicate if the node is
truly temporary or not, rather than keeping the entire root module.

Fixes #25532