### PR TITLE
don't store an entire Resource's state in each ResourceInstance

### DIFF
--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -63,11 +63,9 @@ func (n *NodeDestroyResourceInstance) CreateBeforeDestroy() bool {
 	}
 
 	// Otherwise check the state for a stored destroy order
-	if rs := n.ResourceState; rs != nil {
-		if s := rs.Instance(n.Addr.Resource.Key); s != nil {
-			if s.Current != nil {
-				return s.Current.CreateBeforeDestroy
-			}
+	if s := n.instanceState; s != nil {
+		if s.Current != nil {
+			return s.Current.CreateBeforeDestroy
 		}
 	}
 
@@ -134,11 +132,7 @@ func (n *NodeDestroyResourceInstance) EvalTree() EvalNode {
 	addr := n.ResourceInstanceAddr()
 
 	// Get our state
-	rs := n.ResourceState
-	var is *states.ResourceInstance
-	if rs != nil {
-		is = rs.Instance(n.Addr.Resource.Key)
-	}
+	is := n.instanceState
 	if is == nil {
 		log.Printf("[WARN] NodeDestroyResourceInstance for %s with no state", addr)
 	}

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -215,7 +215,7 @@ func (n *NodeRefreshableManagedResourceInstance) EvalTree() EvalNode {
 	// Eval info is different depending on what kind of resource this is
 	switch addr.Resource.Resource.Mode {
 	case addrs.ManagedResourceMode:
-		if n.ResourceState == nil {
+		if n.instanceState == nil {
 			log.Printf("[TRACE] NodeRefreshableManagedResourceInstance: %s has no existing state to refresh", addr)
 			return n.evalTreeManagedResourceNoState()
 		}
@@ -253,7 +253,7 @@ func (n *NodeRefreshableManagedResourceInstance) evalTreeManagedResource() EvalN
 
 	// This happened during initial development. All known cases were
 	// fixed and tested but as a sanity check let's assert here.
-	if n.ResourceState == nil {
+	if n.instanceState == nil {
 		err := fmt.Errorf(
 			"No resource state attached for addr: %s\n\n"+
 				"This is a bug. Please report this to Terraform with your configuration\n"+


### PR DESCRIPTION
The AbstractResourceInstance type was storing the entire Resource from
the state, when it only needs the actual instance state. This would
cause resources to consume memory on the order of n^2, where n is the
number of instances of the resource.

Rather than attaching the entire resource state, which includes copying
each individual instance, only attach the ResourceInstance state, and
extract out the provider address from the Resource.