### PR TITLE
TestStateClient_UnresolvableConflict: fix goroutine leak

### DIFF
--- a/backend/atlas/state_client_test.go
+++ b/backend/atlas/state_client_test.go
@@ -217,7 +217,7 @@ func TestStateClient_UnresolvableConflict(t *testing.T) {
 	if err := terraform.WriteState(state, &stateJson); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		defer close(errCh)
 		if err := client.Put(stateJson.Bytes()); err == nil {


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

If the goroutine times out then it will block on writing to the channel errCh without a corresponding reader thus causing a leak. To fix this, make it a buffered channel.