### PR TITLE
TestRetry_error: fix goroutine leak

### DIFF
--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -79,7 +79,7 @@ func TestRetry_error(t *testing.T) {
 		return NonRetryableError(expected)
 	}
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		errCh <- Retry(1*time.Second, f)
 	}()


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

If the goroutine times out then it will block on writing to the channel errCh without a corresponding reader thus causing a leak. To fix this, make it a buffered channel.