### PR TITLE
remove dangling debug code

### DIFF
--- a/dag/walk.go
+++ b/dag/walk.go
@@ -2,9 +2,7 @@ package dag
 
 import (
 	"errors"
-	"log"
 	"sync"
-	"time"
 
 	"github.com/hashicorp/terraform/tfdiags"
 )
@@ -383,10 +381,8 @@ func (w *Walker) walkVertex(v Vertex, info *walkerVertex) {
 	var diags tfdiags.Diagnostics
 	var upstreamFailed bool
 	if depsSuccess {
-		log.Printf("[TRACE] dag/walk: visiting %q", VertexName(v))
 		diags = w.Callback(v)
 	} else {
-		log.Printf("[TRACE] dag/walk: upstream of %q errored, so skipping", VertexName(v))
 		// This won't be displayed to the user because we'll set upstreamFailed,
 		// but we need to ensure there's at least one error in here so that
 		// the failures will cascade downstream.
@@ -417,7 +413,7 @@ func (w *Walker) waitDeps(
 	cancelCh <-chan struct{}) {
 
 	// For each dependency given to us, wait for it to complete
-	for dep, depCh := range deps {
+	for _, depCh := range deps {
 	DepSatisfied:
 		for {
 			select {
@@ -430,10 +426,6 @@ func (w *Walker) waitDeps(
 				// so that anything waiting on us also doesn't run.
 				doneCh <- false
 				return
-
-			case <-time.After(time.Second * 5):
-				log.Printf("[TRACE] dag/walk: vertex %q is waiting for %q",
-					VertexName(v), VertexName(dep))
 			}
 		}
 	}


### PR DESCRIPTION
Commit 43d93b2 removed a large chunk of debug code from dag/walk.go;
several log messages pertaining to the DAG walk remained. This commit
removes these messages, and an additional related dependancy (via
importing the 'time' lib).