### PR TITLE
configs: prevent panic with invalid type name

### DIFF
--- a/configs/module.go
+++ b/configs/module.go
@@ -289,7 +289,15 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 		if r.ProviderConfigRef != nil {
 			r.Provider = m.ProviderForLocalConfig(r.ProviderConfigAddr())
 		} else {
-			r.Provider = m.ImpliedProviderForUnqualifiedType(r.Addr().ImpliedProvider())
+			// an invalid resource name (for e.g. "null resource" instead of
+			// "null_resource") can cause a panic down the line in addrs:
+			// https://github.com/hashicorp/terraform/issues/25560
+			implied, err := addrs.ParseProviderPart(r.Addr().ImpliedProvider())
+			if err == nil {
+				r.Provider = m.ImpliedProviderForUnqualifiedType(implied)
+			}
+			// We don't return a diagnostic because the invalid resource name
+			// will already have been caught.
 		}
 	}
 
@@ -310,7 +318,15 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 		if r.ProviderConfigRef != nil {
 			r.Provider = m.ProviderForLocalConfig(r.ProviderConfigAddr())
 		} else {
-			r.Provider = m.ImpliedProviderForUnqualifiedType(r.Addr().ImpliedProvider())
+			// an invalid data source name (for e.g. "null resource" instead of
+			// "null_resource") can cause a panic down the line in addrs:
+			// https://github.com/hashicorp/terraform/issues/25560
+			implied, err := addrs.ParseProviderPart(r.Addr().ImpliedProvider())
+			if err == nil {
+				r.Provider = m.ImpliedProviderForUnqualifiedType(implied)
+			}
+			// We don't return a diagnostic because the invalid resource name
+			// will already have been caught.
 		}
 	}
 

--- a/configs/testdata/invalid-files/resource-name-invalid.tf
+++ b/configs/testdata/invalid-files/resource-name-invalid.tf
@@ -1,0 +1,7 @@
+resource "test resource" "test_resource" {
+
+}
+
+data "test resource" "test_resource" {
+
+}


### PR DESCRIPTION
An invalid type name in a resource (or data source) could cause a panic
when determining the implied provider for the resource. This commit adds
verification that the type name is valid. It does not add a diagnostic,
since the invalid type name would have already been caught by the
parser.

Fixes #25560