### PR TITLE
command/show: fix bug displaying provider config in json output of tf plan

### DIFF
--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -139,8 +139,7 @@ func marshalProviderConfigs(
 	}
 
 	for k, pc := range c.Module.ProviderConfigs {
-		// FIXME: lookup providerFqn from config
-		providerFqn := addrs.NewLegacyProvider(pc.Name)
+		providerFqn := c.ProviderForConfigAddr(addrs.LocalProviderConfig{LocalName: pc.Name})
 		schema := schemas.ProviderConfig(providerFqn)
 		p := providerConfig{
 			Name:              pc.Name,

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -411,6 +411,11 @@ func TestShow_json_output_state(t *testing.T) {
 // named "test".
 func showFixtureSchema() *terraform.ProviderSchema {
 	return &terraform.ProviderSchema{
+		Provider: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"region": {Type: cty.String, Optional: true},
+			},
+		},
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{

--- a/command/testdata/providers-schema/basic/output.json
+++ b/command/testdata/providers-schema/basic/output.json
@@ -2,6 +2,19 @@
     "format_version": "0.1",
     "provider_schemas": {
         "registry.terraform.io/hashicorp/test": {
+            "provider": {
+                "version": 0,
+                "block": {
+                    "attributes": {
+                        "region": {
+                            "description_kind": "plain",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    },
+                    "description_kind": "plain"
+                }
+            },
             "resource_schemas": {
                 "test_instance": {
                     "version": 0,

--- a/command/testdata/show-json/basic-create/main.tf
+++ b/command/testdata/show-json/basic-create/main.tf
@@ -1,6 +1,11 @@
+provider "test" {
+  region = "somewhere"
+}
+
 variable "test_var" {
   default = "bar"
 }
+
 resource "test_instance" "test" {
   ami   = var.test_var
   count = 3

--- a/command/testdata/show-json/basic-create/output.json
+++ b/command/testdata/show-json/basic-create/output.json
@@ -138,6 +138,16 @@
         }
     },
     "configuration": {
+        "provider_config": {
+            "test": {
+                "name": "test",
+                "expressions": {
+                    "region": {
+                        "constant_value": "somewhere"
+                    }
+                }
+            }
+        },
         "root_module": {
             "outputs": {
                 "test": {


### PR DESCRIPTION
A lingering FIXME caused missing configuration from provider config
blocks in the json output of terraform plan. This fixes the regression
and adds a regression test. For the sake of testing, I added an optional attribute
to the show test provider, which resulted in the providers schema test
getting an update - not a bad addition, but we can always add a
test-specific provider schema as needed.