### PR TITLE
update bolt for puppet provisioner to 2.x

### DIFF
--- a/builtin/provisioners/puppet/bolt/bolt.go
+++ b/builtin/provisioners/puppet/bolt/bolt.go
@@ -39,7 +39,7 @@ func runCommand(command string, timeout time.Duration) ([]byte, error) {
 
 func Task(connInfo map[string]string, timeout time.Duration, sudo bool, task string, args map[string]string) (*Result, error) {
 	cmdargs := []string{
-		"bolt", "task", "run", "--nodes", connInfo["type"] + "://" + connInfo["host"], "-u", connInfo["user"],
+		"bolt", "task", "run", "--targets", connInfo["type"] + "://" + connInfo["host"], "-u", connInfo["user"],
 	}
 
 	if connInfo["type"] == "winrm" {


### PR DESCRIPTION
In 2.x, bolt uses --targets to specify the target, this PR changes the task in puppet provisioner to bolt 2.x compatable.