### PR TITLE
core: Skip edges between resource instances in different module instances

### DIFF
--- a/terraform/testdata/transform-destroy-edge-module-only/main.tf
+++ b/terraform/testdata/transform-destroy-edge-module-only/main.tf
@@ -1,3 +1,4 @@
 module "child" {
     source = "./child"
+    count  = 2
 }

--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -105,9 +105,12 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 
 			for _, resAddr := range ri.StateDependencies() {
 				for _, desDep := range destroyersByResource[resAddr.String()] {
-					log.Printf("[TRACE] DestroyEdgeTransformer: %s has stored dependency of %s\n", dag.VertexName(desDep), dag.VertexName(des))
-					g.Connect(dag.BasicEdge(desDep, des))
-
+					if !graphNodesAreResourceInstancesInDifferentInstancesOfSameModule(desDep, des) {
+						log.Printf("[TRACE] DestroyEdgeTransformer: %s has stored dependency of %s\n", dag.VertexName(desDep), dag.VertexName(des))
+						g.Connect(dag.BasicEdge(desDep, des))
+					} else {
+						log.Printf("[TRACE] DestroyEdgeTransformer: skipping %s => %s inter-module-instance dependency\n", dag.VertexName(desDep), dag.VertexName(des))
+					}
 				}
 			}
 		}
@@ -122,9 +125,12 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 
 		for _, resAddr := range ri.StateDependencies() {
 			for _, desDep := range destroyersByResource[resAddr.String()] {
-				log.Printf("[TRACE] DestroyEdgeTransformer: %s has stored dependency of %s\n", dag.VertexName(c), dag.VertexName(desDep))
-				g.Connect(dag.BasicEdge(c, desDep))
-
+				if !graphNodesAreResourceInstancesInDifferentInstancesOfSameModule(c, desDep) {
+					log.Printf("[TRACE] DestroyEdgeTransformer: %s has stored dependency of %s\n", dag.VertexName(c), dag.VertexName(desDep))
+					g.Connect(dag.BasicEdge(c, desDep))
+				} else {
+					log.Printf("[TRACE] DestroyEdgeTransformer: skipping %s => %s inter-module-instance dependency\n", dag.VertexName(c), dag.VertexName(desDep))
+				}
 			}
 		}
 	}

--- a/terraform/transform_destroy_edge_test.go
+++ b/terraform/transform_destroy_edge_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -172,41 +173,46 @@ func TestDestroyEdgeTransformer_module(t *testing.T) {
 
 func TestDestroyEdgeTransformer_moduleOnly(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
-	g.Add(testDestroyNode("module.child[0].test_object.a"))
-	g.Add(testDestroyNode("module.child[0].test_object.b"))
-	g.Add(testDestroyNode("module.child[0].test_object.c"))
 
 	state := states.NewState()
-	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.IntKey(0)))
-	child.SetResourceInstanceCurrent(
-		mustResourceInstanceAddr("test_object.a").Resource,
-		&states.ResourceInstanceObjectSrc{
-			Status:    states.ObjectReady,
-			AttrsJSON: []byte(`{"id":"a"}`),
-		},
-		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
-	)
-	child.SetResourceInstanceCurrent(
-		mustResourceInstanceAddr("test_object.b").Resource,
-		&states.ResourceInstanceObjectSrc{
-			Status:       states.ObjectReady,
-			AttrsJSON:    []byte(`{"id":"b","test_string":"x"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("module.child.test_object.a")},
-		},
-		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
-	)
-	child.SetResourceInstanceCurrent(
-		mustResourceInstanceAddr("test_object.c").Resource,
-		&states.ResourceInstanceObjectSrc{
-			Status:    states.ObjectReady,
-			AttrsJSON: []byte(`{"id":"c","test_string":"x"}`),
-			Dependencies: []addrs.ConfigResource{
-				mustResourceAddr("module.child.test_object.a"),
-				mustResourceAddr("module.child.test_object.b"),
+	for moduleIdx := 0; moduleIdx < 2; moduleIdx++ {
+		g.Add(testDestroyNode(fmt.Sprintf("module.child[%d].test_object.a", moduleIdx)))
+		g.Add(testDestroyNode(fmt.Sprintf("module.child[%d].test_object.b", moduleIdx)))
+		g.Add(testDestroyNode(fmt.Sprintf("module.child[%d].test_object.c", moduleIdx)))
+
+		child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.IntKey(moduleIdx)))
+		child.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_object.a").Resource,
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"a"}`),
 			},
-		},
-		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
-	)
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+		child.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_object.b").Resource,
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"b","test_string":"x"}`),
+				Dependencies: []addrs.ConfigResource{
+					mustResourceAddr("module.child.test_object.a"),
+				},
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+		child.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_object.c").Resource,
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"c","test_string":"x"}`),
+				Dependencies: []addrs.ConfigResource{
+					mustResourceAddr("module.child.test_object.a"),
+					mustResourceAddr("module.child.test_object.b"),
+				},
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	}
 
 	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
 		t.Fatal(err)
@@ -220,6 +226,20 @@ func TestDestroyEdgeTransformer_moduleOnly(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
+	// The analyses done in the destroy edge transformer are between
+	// not-yet-expanded objects, which is conservative and so it will generate
+	// edges that aren't strictly necessary. As a special case we filter out
+	// any edges that are between resources instances that are in different
+	// instances of the same module, because those edges are never needed
+	// (one instance of a module cannot depend on another instance of the
+	// same module) and including them can, in complex cases, cause cycles due
+	// to unnecessary interactions between destroyed and created module
+	// instances in the same plan.
+	//
+	// Therefore below we expect to see the dependencies within each instance
+	// of module.child reflected, but we should not see any dependencies
+	// _between_ instances of module.child.
+
 	actual := strings.TrimSpace(g.String())
 	expected := strings.TrimSpace(`
 module.child[0].test_object.a (destroy)
@@ -228,6 +248,12 @@ module.child[0].test_object.a (destroy)
 module.child[0].test_object.b (destroy)
   module.child[0].test_object.c (destroy)
 module.child[0].test_object.c (destroy)
+module.child[1].test_object.a (destroy)
+  module.child[1].test_object.b (destroy)
+  module.child[1].test_object.c (destroy)
+module.child[1].test_object.b (destroy)
+  module.child[1].test_object.c (destroy)
+module.child[1].test_object.c (destroy)
 `)
 	if actual != expected {
 		t.Fatalf("wrong result\n\ngot:\n%s\n\nwant:\n%s", actual, expected)

--- a/terraform/transform_reference.go
+++ b/terraform/transform_reference.go
@@ -123,7 +123,11 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 			dag.VertexName(v), parentsDbg)
 
 		for _, parent := range parents {
-			g.Connect(dag.BasicEdge(v, parent))
+			if !graphNodesAreResourceInstancesInDifferentInstancesOfSameModule(v, parent) {
+				g.Connect(dag.BasicEdge(v, parent))
+			} else {
+				log.Printf("[TRACE] ReferenceTransformer: skipping %s => %s inter-module-instance dependency", v, parent)
+			}
 		}
 
 		if len(parents) > 0 {


### PR DESCRIPTION
Our reference transformer analyses and our destroy transformer analyses are built around static (not-yet-expanded) addresses so that they can correctly handle mixtures of expanded and not-yet-expanded objects in the same graph.

However, this characteristic also makes them unnecessarily conservative in their handling of references between resources within different instances of the same module: we know they can never interact with each other in practice because the dependencies for all instances of a module are the same and so one instance cannot possibly depend on another, but ignoring the instance keys in the analyses causes resources in different instances of the same module to become interconnected.

As a compromise then, here we introduce a new helper function that can recognize when a proposed edge is between two resource instances that belong to different instances of the same module, and thus allow us to skip actually creating those edges even though our imprecise analyses believe them to be needed.

As well as significantly reducing the number of edges in situations where multi-instance resources appear inside multi-instance modules, this also fixes some potential cycles in situations where a single plan includes both destroying an instance of a module and creating a new instance of the same module: the dependencies between the objects in the instance being destroyed and the objects in the instance being created can, if allowed to connect, cause Terraform to believe that the create and the destroy both depend on one another even though there is no need for that to be true in practice.

This involves a very specialized helper function to encode the situation where this exception applies. The function is intentionally constrained to activate this filtering only for pairs of resource instance nodes that belong to different instances of the _same_ module, because that condition can only arise when module `count` or `for_each` are in use and thus we can be confident that this exception should not affect any behaviors for unexpanded modules in existing configurations targeting Terraform 0.12. This function has an ugly name to reflect how specialized it is: it's not intended to be of any use outside of these three situations in particular.

This change only removes some edges that were unnecessary anyway, so it didn't affect the result of any existing tests and here I focused on testing these behaviors at the graph builder level. We know of one situation where these extra edges caused a cycle, but it was in a specific complex module with lots of objects and so we don't have a smaller reproduction to include here as a context test.
