### PR TITLE
docs: fix the output format of state show command

### DIFF
--- a/website/docs/commands/state/show.html.md
+++ b/website/docs/commands/state/show.html.md
@@ -39,13 +39,15 @@ The example below shows a `packet_device` resource named `worker`:
 
 ```
 $ terraform state show 'packet_device.worker'
-id                = 6015bg2b-b8c4-4925-aad2-f0671d5d3b13
-billing_cycle     = hourly
-created           = 2015-12-17T00:06:56Z
-facility          = ewr1
-hostname          = prod-xyz01
-locked            = false
-...
+# packet_device.worker:
+resource "packet_device" "worker" {
+    billing_cycle = "hourly"
+    created       = "2015-12-17T00:06:56Z"
+    facility      = "ewr1"
+    hostname      = "prod-xyz01"
+    id            = "6015bg2b-b8c4-4925-aad2-f0671d5d3b13"
+    locked        = false
+}
 ```
 
 ## Example: Show a Module Resource


### PR DESCRIPTION
issue: https://github.com/hashicorp/terraform/issues/25616

From v0.12 the output format of state show command seems to be changed
but the old format is used in the document.

https://www.terraform.io/docs/commands/state/show.html

```
$ terraform version
Terraform v0.12.28
+ provider.packet v2.10.1

$ terraform state show 'packet_device.worker'
# packet_device.worker:
resource "packet_device" "worker" {
    billing_cycle = "hourly"
    created       = "2015-12-17T00:06:56Z"
    facility      = "ewr1"
    hostname      = "prod-xyz01"
    id            = "6015bg2b-b8c4-4925-aad2-f0671d5d3b13"
    locked        = false
}
```