### PR TITLE
internal/providercache: Fix bug when symlink fails

### DIFF
--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -157,7 +157,7 @@ func installFromLocalDir(ctx context.Context, meta getproviders.PackageMeta, tar
 
 	parentDir := filepath.Dir(absNew)
 	err = os.MkdirAll(parentDir, 0755)
-	if err != nil && os.IsExist(err) {
+	if err != nil {
 		return nil, fmt.Errorf("failed to create parent directories leading to %s: %s", targetDir, err)
 	}
 
@@ -168,7 +168,12 @@ func installFromLocalDir(ctx context.Context, meta getproviders.PackageMeta, tar
 	}
 
 	// If we get down here then symlinking failed and we need a deep copy
-	// instead.
+	// instead. To make a copy, we first need to create the target directory,
+	// which would otherwise be a symlink.
+	err = os.Mkdir(absNew, 0755)
+	if err != nil && os.IsExist(err) {
+		return nil, fmt.Errorf("failed to create directory %s: %s", absNew, err)
+	}
 	err = copydir.CopyDir(absNew, absCurrent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to either symlink or copy %s to %s: %s", absCurrent, absNew, err)


### PR DESCRIPTION
When installing a provider which is already cached, we attempt to create a symlink from the install directory targeting the cache. If symlinking fails due to missing OS/filesystem support, we instead want to copy the cached provider.

The fallback code to do this would always fail, due to a missing target directory. This commit fixes that. I was unable to find a way to add automated tests around this, but I have manually verified the fix on Windows 8.1.

Fixes #25652

### Reproduction/verification

Steps to reproduce:

1. On a Windows 7 or 8 host, create a simple configuration:

```hcl
provider "random" {}
```

1. Run `terraform init` to download the random provider
1. Copy the `.terraform\plugins` folder to `%APPDATA%\terraform.d`
1. Remove the `.terraform` folder
1. Rerun `terraform init`

With 0.13.0-rc1:

<img src="https://user-images.githubusercontent.com/68917/88307082-833cf080-ccd9-11ea-8abe-3d757999268d.png" width=579>

With this commit:

<img src="https://user-images.githubusercontent.com/68917/88307105-8932d180-ccd9-11ea-9cfc-1d34c350c71d.png" width=579>


