### PR TITLE
Return known empty containers from resource evaluation during plan

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -8754,11 +8754,12 @@ resource "null_instance" "write" {
 }
 
 data "null_data_source" "read" {
+  count = 1
   depends_on = ["null_instance.write"]
 }
 
 resource "null_instance" "depends" {
-  foo = data.null_data_source.read.foo
+  foo = data.null_data_source.read[0].foo
 }
 `})
 
@@ -8804,7 +8805,7 @@ resource "null_instance" "depends" {
 		Mode: addrs.DataResourceMode,
 		Type: "null_data_source",
 		Name: "read",
-	}.Instance(addrs.NoKey))
+	}.Instance(addrs.IntKey(0)))
 	if is == nil {
 		t.Fatal("data resource instance is not present in state; should be")
 	}

--- a/terraform/eval_read_data_plan.go
+++ b/terraform/eval_read_data_plan.go
@@ -88,7 +88,7 @@ func (n *evalReadDataPlan) Eval(ctx EvalContext) (interface{}, error) {
 		}
 
 		*n.State = &states.ResourceInstanceObject{
-			Value:  cty.NullVal(objTy),
+			Value:  proposedNewVal,
 			Status: states.ObjectPlanned,
 		}
 


### PR DESCRIPTION
When looking up a resource during plan, we need to return an empty
container type when we're certain there are going to be no instances.
It's now more common to reference resources in a context that needs to
be known during plan (e.g. for_each), and always returning a DynamicVal
here blocks plan from succeeding when there are 0 instances.