### PR TITLE
Grammar nit: "setup" as a verb should be spelled "set up"

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,7 @@ The Terraform team is not merging PRs for new state storage backends at the curr
 
 Please see the [CODEOWNERS](https://github.com/hashicorp/terraform/blob/master/CODEOWNERS) file for the status of a given backend. Community members with an interest in a particular standard backend are welcome to help maintain it.
 
-Currently, merging state storage backends places a significant burden on the Terraform team. The team must setup an environment and cloud service provider account, or a new database/storage/key-value service, in order to build and test remote state storage backends. The time and complexity of doing so prevents us from moving Terraform forward in other ways.
+Currently, merging state storage backends places a significant burden on the Terraform team. The team must set up an environment and cloud service provider account, or a new database/storage/key-value service, in order to build and test remote state storage backends. The time and complexity of doing so prevents us from moving Terraform forward in other ways.
 
 We are working to remove ourselves from the critical path of state storage backends by moving them towards a plugin model. In the meantime, we won't be accepting new remote state backends into Terraform.
 

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -39,7 +39,7 @@ func (b *Local) opApply(
 		return
 	}
 
-	// Setup our count hook that keeps track of resource changes
+	// Set up our count hook that keeps track of resource changes
 	countHook := new(CountHook)
 	stateHook := new(StateHook)
 	if b.ContextOpts == nil {
@@ -137,7 +137,7 @@ func (b *Local) opApply(
 		}
 	}
 
-	// Setup our hook for continuous state updates
+	// Set up our hook for continuous state updates
 	stateHook.StateMgr = opState
 
 	// Start the apply in a goroutine so that we can be interrupted.

--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -59,7 +59,7 @@ func (b *Local) opPlan(
 		return
 	}
 
-	// Setup our count hook that keeps track of resource changes
+	// Set up our count hook that keeps track of resource changes
 	countHook := new(CountHook)
 	if b.ContextOpts == nil {
 		b.ContextOpts = new(terraform.ContextOpts)

--- a/backend/local/testing.go
+++ b/backend/local/testing.go
@@ -125,7 +125,7 @@ func TestLocalProvider(t *testing.T, b *Local, name string, schema *terraform.Pr
 		b.ContextOpts = &terraform.ContextOpts{}
 	}
 
-	// Setup our provider
+	// Set up our provider
 	b.ContextOpts.Providers = map[addrs.Provider]providers.Factory{
 		addrs.NewDefaultProvider(name): providers.FactoryFixed(p),
 	}

--- a/backend/remote-state/http/client.go
+++ b/backend/remote-state/http/client.go
@@ -49,7 +49,7 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	if err != nil {
 		return nil, fmt.Errorf("Failed to make %s HTTP request: %s", what, err)
 	}
-	// Setup basic auth
+	// Set up basic auth
 	if c.Username != "" {
 		req.SetBasicAuth(c.Username, c.Password)
 	}

--- a/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/builtin/provisioners/local-exec/resource_provisioner.go
@@ -110,7 +110,7 @@ func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceReques
 		workingdir = wdVal.AsString()
 	}
 
-	// Setup the reader that will read the output from the command.
+	// Set up the reader that will read the output from the command.
 	// We use an os.Pipe so that the *os.File can be passed directly to the
 	// process, and not rely on goroutines copying the data which may block.
 	// See golang.org/issue/18874
@@ -124,7 +124,7 @@ func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceReques
 	cmdEnv = os.Environ()
 	cmdEnv = append(cmdEnv, env...)
 
-	// Setup the command
+	// Set up the command
 	cmd := exec.CommandContext(p.ctx, cmdargs[0], cmdargs[1:]...)
 	cmd.Stderr = pw
 	cmd.Stdout = pw

--- a/command/cliconfig/config_unix.go
+++ b/command/cliconfig/config_unix.go
@@ -31,7 +31,7 @@ func homeDir() (string, error) {
 	// First prefer the HOME environmental variable
 	if home := os.Getenv("HOME"); home != "" {
 		// FIXME: homeDir gets called from globalPluginDirs during init, before
-		// the logging is setup.  We should move meta initializtion outside of
+		// the logging is set up.  We should move meta initializtion outside of
 		// init, but in the meantime we just need to silence this output.
 		//log.Printf("[DEBUG] Detected home directory from env var: %s", home)
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -630,7 +630,7 @@ func testInteractiveInput(t *testing.T, answers []string) func() {
 	// Disable test mode so input is called
 	test = false
 
-	// Setup reader/writers
+	// Set up reader/writers
 	testInputResponse = answers
 	defaultInputReader = bytes.NewBufferString("")
 	defaultInputWriter = new(bytes.Buffer)
@@ -651,7 +651,7 @@ func testInputMap(t *testing.T, answers map[string]string) func() {
 	// Disable test mode so input is called
 	test = false
 
-	// Setup reader/writers
+	// Set up reader/writers
 	defaultInputReader = bytes.NewBufferString("")
 	defaultInputWriter = new(bytes.Buffer)
 

--- a/command/console.go
+++ b/command/console.go
@@ -110,7 +110,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 		}
 	}()
 
-	// Setup the UI so we can output directly to stdout
+	// Set up the UI so we can output directly to stdout
 	ui := &cli.BasicUi{
 		Writer:      wrappedstreams.Stdout(),
 		ErrorWriter: wrappedstreams.Stderr(),

--- a/command/init.go
+++ b/command/init.go
@@ -123,7 +123,7 @@ func (c *InitCommand) Run(args []string) int {
 		c.Ui.Output("")
 	}
 
-	// If our directory is empty, then we're done. We can't get or setup
+	// If our directory is empty, then we're done. We can't get or set up
 	// the backend with an empty directory.
 	empty, err := configs.IsEmptyDir(path)
 	if err != nil {

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -102,7 +102,7 @@ func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, tfdiags.Diagnostics
 		log.Printf("[TRACE] Meta.Backend: instantiated backend of type %T", b)
 	}
 
-	// Setup the CLI opts we pass into backends that support it.
+	// Set up the CLI opts we pass into backends that support it.
 	cliOpts, err := m.backendCLIOpts()
 	if err != nil {
 		diags = diags.Append(err)
@@ -1206,7 +1206,7 @@ Terraform configuration you're using is using a custom configuration for
 the Terraform backend.
 
 Changes to backend configurations require reinitialization. This allows
-Terraform to setup the new configuration, copy existing state, etc. This is
+Terraform to set up the new configuration, copy existing state, etc. This is
 only done during "terraform init". Please run that command now then try again.
 
 If the change reason above is incorrect, please verify your configuration

--- a/command/meta_backend_migrate.go
+++ b/command/meta_backend_migrate.go
@@ -65,7 +65,7 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 			errMigrateLoadStates), opts.TwoType, err)
 	}
 
-	// Setup defaults
+	// Set up defaults
 	opts.oneEnv = backend.DefaultStateName
 	opts.twoEnv = backend.DefaultStateName
 	opts.force = m.forceInitCopy

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -285,7 +285,7 @@ func TestPlan_outBackend(t *testing.T) {
 		)
 	})
 
-	// Setup our backend state
+	// Set up our backend state
 	dataState, srv := testBackendState(t, originalState, 200)
 	defer srv.Close()
 	testStateFileRemote(t, dataState)

--- a/command/state_push_test.go
+++ b/command/state_push_test.go
@@ -110,7 +110,7 @@ func TestStatePush_replaceMatchStdin(t *testing.T) {
 
 	expected := testStateRead(t, "replace.tfstate")
 
-	// Setup the replacement to come from stdin
+	// Set up the replacement to come from stdin
 	var buf bytes.Buffer
 	if err := writeStateForTesting(expected, &buf); err != nil {
 		t.Fatalf("err: %s", err)

--- a/communicator/communicator.go
+++ b/communicator/communicator.go
@@ -19,7 +19,7 @@ import (
 // Communicator is an interface that must be implemented by all communicators
 // used for any of the provisioners
 type Communicator interface {
-	// Connect is used to setup the connection
+	// Connect is used to set up the connection
 	Connect(provisioners.UIOutput) error
 
 	// Disconnect is used to terminate the connection

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -97,7 +97,7 @@ func New(v cty.Value) (*Communicator, error) {
 		return nil, err
 	}
 
-	// Setup the random number generator once. The seed value is the
+	// Set up the random number generator once. The seed value is the
 	// time multiplied by the PID. This can overflow the int64 but that
 	// is okay. We multiply by the PID in case we have multiple processes
 	// grabbing this at the same time. This is possible with Terraform and
@@ -342,7 +342,7 @@ func (c *Communicator) Start(cmd *remote.Cmd) error {
 		return err
 	}
 
-	// Setup our session
+	// Set up our session
 	session.Stdin = cmd.Stdin
 	session.Stdout = cmd.Stdout
 	session.Stderr = cmd.Stderr

--- a/communicator/ssh/ssh_test.go
+++ b/communicator/ssh/ssh_test.go
@@ -16,7 +16,7 @@ import (
 
 // verify that we can locate public key data
 func TestFindKeyData(t *testing.T) {
-	// setup a test directory
+	// set up a test directory
 	td, err := ioutil.TempDir("", "ssh")
 	if err != nil {
 		t.Fatal(err)

--- a/dag/walk.go
+++ b/dag/walk.go
@@ -298,7 +298,7 @@ func (w *Walker) Update(g *AcyclicGraph) {
 	}
 
 	// Start all the new vertices. We do this at the end so that all
-	// the edge waiters and changes are setup above.
+	// the edge waiters and changes are set up above.
 	for _, raw := range newVerts {
 		v := raw.(Vertex)
 		go w.walkVertex(v, w.vertexMap[v])

--- a/internal/helper/wrappedstreams/streams.go
+++ b/internal/helper/wrappedstreams/streams.go
@@ -35,7 +35,7 @@ func fds() (stdin, stdout, stderr *os.File) {
 	return
 }
 
-// These are the wrapped standard streams. These are setup by the
+// These are the wrapped standard streams. These are set up by the
 // platform specific code in initPlatform.
 var (
 	wrappedStdin  *os.File

--- a/internal/legacy/helper/schema/schema.go
+++ b/internal/legacy/helper/schema/schema.go
@@ -1286,7 +1286,7 @@ func (m schemaMap) diffString(
 
 	if os == ns && !all && !computed {
 		// They're the same value. If there old value is not blank or we
-		// have an ID, then return right away since we're already setup.
+		// have an ID, then return right away since we're already set up.
 		if os != "" || d.Id() != "" {
 			return nil
 		}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -45,7 +45,7 @@ func init() {
 	logger = newHCLogger("")
 	logWriter = logger.StandardWriter(&hclog.StandardLoggerOptions{InferLevels: true})
 
-	// setup the default std library logger to use our output
+	// set up the default std library logger to use our output
 	log.SetFlags(0)
 	log.SetPrefix("")
 	log.SetOutput(logWriter)

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func realMain() int {
 		// there is a panic. Otherwise, we delete it.
 		logTempFile, err := ioutil.TempFile("", "terraform-log")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Couldn't setup logging tempfile: %s", err)
+			fmt.Fprintf(os.Stderr, "Couldn't set up logging tempfile: %s", err)
 			return 1
 		}
 		// Now that we have the file, close it and leave it for the wrapped

--- a/main_test.go
+++ b/main_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestMain_cliArgsFromEnv(t *testing.T) {
-	// Setup the state. This test really messes with the environment and
+	// Set up the state. This test really messes with the environment and
 	// global state so we set things up to be restored.
 
 	// Restore original CLI args
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 
-	// Setup test command and restore that
+	// Set up test command and restore that
 	Commands = make(map[string]cli.CommandFactory)
 	defer func() {
 		Commands = nil
@@ -122,7 +122,7 @@ func TestMain_cliArgsFromEnv(t *testing.T) {
 				}
 			}
 
-			// Setup the args
+			// Set up the args
 			args := make([]string, len(tc.Args)+1)
 			args[0] = oldArgs[0] // process name
 			copy(args[1:], tc.Args)
@@ -153,7 +153,7 @@ func TestMain_cliArgsFromEnvAdvanced(t *testing.T) {
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 
-	// Setup test command and restore that
+	// Set up test command and restore that
 	Commands = make(map[string]cli.CommandFactory)
 	defer func() {
 		Commands = nil
@@ -211,7 +211,7 @@ func TestMain_cliArgsFromEnvAdvanced(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
-			// Setup test command and restore that
+			// Set up test command and restore that
 			testCommandName := tc.Command
 			testCommand := &testCommandCLI{}
 			defer func() { delete(Commands, testCommandName) }()
@@ -229,7 +229,7 @@ func TestMain_cliArgsFromEnvAdvanced(t *testing.T) {
 				}
 			}
 
-			// Setup the args
+			// Set up the args
 			args := make([]string, len(tc.Args)+1)
 			args[0] = oldArgs[0] // process name
 			copy(args[1:], tc.Args)


### PR DESCRIPTION
While setting up terraform on a new computer, I ran into this verbiage:

> Changes to backend configurations require reinitialization. This allows
Terraform to setup the new configuration, copy existing state, etc. This is
only done during "terraform init". Please run that command now then try again.

Which should be (emphasis added to show the change).

> Changes to backend configurations require reinitialization. This allows
Terraform to **set up** the new configuration, copy existing state, etc. This is
only done during "terraform init". Please run that command now then try again.

So while changing that, I also changed the other instances of "setup" when used as a verb, to be properly spelled as "set up".  Note this is purely a documentation change, except in the case of two error messages in `main.go`, which are also changed. If that's considered a breaking change, I can revert those two.