### PR TITLE
terraform: fix dropped test error

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -118,6 +118,9 @@ func TestContext2Apply_unstable(t *testing.T) {
 	}
 
 	rs, err := rss.Current.Decode(schema.ImpliedType())
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
 	got := rs.Value.GetAttr("random")
 	if !got.IsKnown() {
 		t.Fatalf("random is still unknown after apply")


### PR DESCRIPTION
This fixes a dropped test `err` variable in the `terraform` package.