### PR TITLE
Generate correct address for terraform builtin for orphaned resource

### DIFF
--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -360,7 +360,7 @@ func (n *NodeAbstractResourceInstance) Provider() addrs.Provider {
 	if n.Config != nil {
 		return n.Config.Provider
 	}
-	return addrs.NewDefaultProvider(n.Addr.Resource.ContainingResource().ImpliedProvider())
+	return addrs.ImpliedProviderForUnqualifiedType(n.Addr.Resource.ContainingResource().ImpliedProvider())
 }
 
 // GraphNodeProvisionerConsumer


### PR DESCRIPTION
Fixes #25719

It seems that with 0.13-rc1 when a terraform_remote_state resource is orphaned the implied provider
address becomes `registry.terraform.io/hashicorp/terraform` rather than the expected
`terraform.io/builtin/terraform` that is expected by the existing state. This causes
a "Provider configuration not present" error.

This is resolved by using the helper from `addrs/provider.go` to generate the correct implied
address for an unqualified provider. Based on my read of `Resource.ImpliedProvider` it will always
be unqualified so this will be valid. Additionally, this brings the behaviour of
`NodeAbstractResourceInstance.Provider()` in line with `NodeAbstractResource.Provider()`