### PR TITLE
Use valid heredoc begin symbol in diff output.

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -733,7 +733,7 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 				break
 			}
 
-			p.buf.WriteString("<<~EOT")
+			p.buf.WriteString("<<-EOT")
 			if p.pathForcesNewResource(path) {
 				p.buf.WriteString(p.color.Color(forcesNewResourceCaption))
 			}

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -222,7 +222,7 @@ new line
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
       ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
-      ~ more_lines = <<~EOT
+      ~ more_lines = <<-EOT
             original
           + new line
         EOT
@@ -253,7 +253,7 @@ new line
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
       ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
-      + more_lines = <<~EOT
+      + more_lines = <<-EOT
             original
             new line
         EOT
@@ -287,7 +287,7 @@ new line
 			ExpectedOutput: `  # test_instance.example must be replaced
 -/+ resource "test_instance" "example" {
       ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
-      ~ more_lines = <<~EOT # forces replacement
+      ~ more_lines = <<-EOT # forces replacement
             original
           + new line
         EOT


### PR DESCRIPTION
Now, heredoc in `terraform plan` uses `<<~` as heredoc start symbol.

```hcl
              ~ filter          = <<~EOT
                    metric.type="agent.googleapis.com/memory/percent_used" resource.type="gce_instance" metadata.user_labels."name"="instancename""
                EOT

```

Because [HCL spec](https://github.com/hashicorp/hcl/blob/hcl2/hclsyntax/spec.md#template-expressions) says that `<<` and `<<-` are heredoc start symbol, I think it may be better to use `<<-` instead of `<<~`.

```hcl
              ~ filter          = <<-EOT
                    metric.type="agent.googleapis.com/memory/percent_used" resource.type="gce_instance" metadata.user_labels."name"="instancename""
                EOT

```