### PR TITLE
Return an error on unlock failure

### DIFF
--- a/command/clistate/state.go
+++ b/command/clistate/state.go
@@ -151,6 +151,8 @@ func (l *locker) Unlock(parentErr error) error {
 
 		if parentErr != nil {
 			parentErr = multierror.Append(parentErr, err)
+		} else {
+			return err
 		}
 	}
 

--- a/command/clistate/state.go
+++ b/command/clistate/state.go
@@ -149,11 +149,7 @@ func (l *locker) Unlock(parentErr error) error {
 		l.ui.Output(l.color.Color(fmt.Sprintf(
 			"\n"+strings.TrimSpace(UnlockErrorMessage)+"\n", err)))
 
-		if parentErr != nil {
-			parentErr = multierror.Append(parentErr, err)
-		} else {
-			return err
-		}
+		parentErr = multierror.Append(parentErr, err)
 	}
 
 	return parentErr

--- a/command/clistate/state_test.go
+++ b/command/clistate/state_test.go
@@ -1,0 +1,25 @@
+package clistate
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/states/statemgr"
+	"github.com/mitchellh/cli"
+	"github.com/mitchellh/colorstring"
+)
+
+func TestUnlock(t *testing.T) {
+	ui := new(cli.MockUi)
+
+	l := NewLocker(context.Background(), 0, ui, &colorstring.Colorize{Disable: true})
+	l.Lock(statemgr.NewUnlockErrorFull(nil, nil), "test-lock")
+
+	err := l.Unlock(nil)
+	if err != nil {
+		fmt.Printf(err.Error())
+	} else {
+		t.Error("expected error")
+	}
+}


### PR DESCRIPTION
This attempts to fix [Issue 23017](https://github.com/hashicorp/terraform/issues/23017)

When the lock can't be released return the err even if there is no previous error with the current action. This allows faster failure in CI/CD systems. Without this failure to remove the lock would result in the failure happening on a subsequent plan or apply which slows down the feedback loop in automated systems.
