### PR TITLE
Generalize target addresses before expansion

### DIFF
--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -157,12 +157,6 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// Target
 		&TargetsTransformer{
 			Targets: b.Targets,
-
-			// Resource nodes from config have not yet been expanded for
-			// "count", so we must apply targeting without indices. Exact
-			// targeting will be dealt with later when these resources
-			// DynamicExpand.
-			IgnoreIndices: true,
 		},
 
 		// Detect when create_before_destroy must be forced on for a particular

--- a/terraform/graph_builder_refresh.go
+++ b/terraform/graph_builder_refresh.go
@@ -176,12 +176,6 @@ func (b *RefreshGraphBuilder) Steps() []GraphTransformer {
 		// Target
 		&TargetsTransformer{
 			Targets: b.Targets,
-
-			// Resource nodes from config have not yet been expanded for
-			// "count", so we must apply targeting without indices. Exact
-			// targeting will be dealt with later when these resources
-			// DynamicExpand.
-			IgnoreIndices: true,
 		},
 
 		// Close opened plugin connections

--- a/terraform/testdata/plan-targeted/main.tf
+++ b/terraform/testdata/plan-targeted/main.tf
@@ -3,5 +3,10 @@ resource "aws_instance" "foo" {
 }
 
 resource "aws_instance" "bar" {
-    foo = "${aws_instance.foo.num}"
+    foo = aws_instance.foo.num
+}
+
+module "mod" {
+  source = "./mod"
+  count = 1
 }

--- a/terraform/testdata/plan-targeted/mod/main.tf
+++ b/terraform/testdata/plan-targeted/mod/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+    num = "2"
+}

--- a/terraform/transform_targets.go
+++ b/terraform/transform_targets.go
@@ -145,6 +145,8 @@ func (t *TargetsTransformer) nodeIsTarget(v dag.Vertex, targets []addrs.Targetab
 				targetAddr = target.ContainingResource().Config()
 			case addrs.AbsResource:
 				targetAddr = target.Config()
+			case addrs.ModuleInstance:
+				targetAddr = target.Module()
 			}
 		}
 

--- a/terraform/transform_targets.go
+++ b/terraform/transform_targets.go
@@ -22,12 +22,6 @@ type GraphNodeTargetable interface {
 type TargetsTransformer struct {
 	// List of targeted resource names specified by the user
 	Targets []addrs.Targetable
-
-	// If set, the index portions of resource addresses will be ignored
-	// for comparison. This is used when transforming a graph where
-	// counted resources have not yet been expanded, since otherwise
-	// the unexpanded nodes (which never have indices) would not match.
-	IgnoreIndices bool
 }
 
 func (t *TargetsTransformer) Transform(g *Graph) error {
@@ -133,25 +127,27 @@ func (t *TargetsTransformer) nodeIsTarget(v dag.Vertex, targets []addrs.Targetab
 		vertexAddr = r.ResourceInstanceAddr()
 	case GraphNodeConfigResource:
 		vertexAddr = r.ResourceAddr()
+
 	default:
 		// Only resource and resource instance nodes can be targeted.
 		return false
 	}
 
 	for _, targetAddr := range targets {
-		if t.IgnoreIndices {
-			// If we're ignoring indices then we'll convert any resource instance
-			// addresses into resource addresses. We don't need to convert
-			// vertexAddr because instance addresses are contained within
-			// their associated resources, and so .TargetContains will take
-			// care of this for us.
-			switch instance := targetAddr.(type) {
+		switch vertexAddr.(type) {
+		case addrs.ConfigResource:
+			// Before expansion happens, we only have nodes that know their
+			// ConfigResource address.  We need to take the more specific
+			// target addresses and generalize them in order to compare with a
+			// ConfigResource.
+			switch target := targetAddr.(type) {
 			case addrs.AbsResourceInstance:
-				targetAddr = instance.ContainingResource().Config()
-			case addrs.ModuleInstance:
-				targetAddr = instance.Module()
+				targetAddr = target.ContainingResource().Config()
+			case addrs.AbsResource:
+				targetAddr = target.Config()
 			}
 		}
+
 		if targetAddr.TargetContains(vertexAddr) {
 			return true
 		}


### PR DESCRIPTION
Before expansion happens, we only have expansion resource nodes that
know their ConfigResource address. In order to properly compare these to
targets within a module instance, we need to generalize the target to
also be a ConfigResource.

We can also remove the IgnoreIndices field from the transformer, since
we have addresses that are properly scoped and can compare them in the
correct context.

Fixes #25748