### PR TITLE
Remove resource state attributes that are no longer in the schema

### DIFF
--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -72,6 +72,13 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, *configload.
 	log.Printf("[TRACE] backend/local: retrieving local state snapshot for workspace %q", op.Workspace)
 	opts.State = s.State()
 
+	// Prepare a separate opts and context for validation, which doesn't use
+	// any state ensuring that we only validate the config, since evaluation
+	// will automatically reference the state when available.
+	validateOpts := opts
+	validateOpts.State = nil
+	var validateCtx *terraform.Context
+
 	var tfCtx *terraform.Context
 	var ctxDiags tfdiags.Diagnostics
 	var configSnap *configload.Snapshot
@@ -89,9 +96,18 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, *configload.
 		// Write sources into the cache of the main loader so that they are
 		// available if we need to generate diagnostic message snippets.
 		op.ConfigLoader.ImportSourcesFromSnapshot(configSnap)
+
+		// create a validation context with no state
+		validateCtx, _, _ = b.contextFromPlanFile(op.PlanFile, validateOpts, stateMeta)
+		// diags from here will be caught above
+
 	} else {
 		log.Printf("[TRACE] backend/local: building context for current working directory")
 		tfCtx, configSnap, ctxDiags = b.contextDirect(op, opts)
+
+		// create a validation context with no state
+		validateCtx, _, _ = b.contextDirect(op, validateOpts)
+		// diags from here will be caught above
 	}
 	diags = diags.Append(ctxDiags)
 	if diags.HasErrors() {
@@ -117,7 +133,7 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, *configload.
 		// If validation is enabled, validate
 		if b.OpValidation {
 			log.Printf("[TRACE] backend/local: running validation operation")
-			validateDiags := tfCtx.Validate()
+			validateDiags := validateCtx.Validate()
 			diags = diags.Append(validateDiags)
 		}
 	}

--- a/command/console_test.go
+++ b/command/console_test.go
@@ -8,8 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/helper/copy"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // ConsoleCommand is tested primarily with tests in the "repl" package.
@@ -60,6 +63,16 @@ func TestConsole_tfvars(t *testing.T) {
 	}
 
 	p := testProvider()
+	p.GetSchemaReturn = &terraform.ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_instance": {
+				Attributes: map[string]*configschema.Attribute{
+					"value": {Type: cty.String, Optional: true},
+				},
+			},
+		},
+	}
+
 	ui := new(cli.MockUi)
 	c := &ConsoleCommand{
 		Meta: Meta{
@@ -98,6 +111,15 @@ func TestConsole_unsetRequiredVars(t *testing.T) {
 	defer testFixCwd(t, tmp, cwd)
 
 	p := testProvider()
+	p.GetSchemaReturn = &terraform.ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_instance": {
+				Attributes: map[string]*configschema.Attribute{
+					"value": {Type: cty.String, Optional: true},
+				},
+			},
+		},
+	}
 	ui := new(cli.MockUi)
 	c := &ConsoleCommand{
 		Meta: Meta{
@@ -142,7 +164,7 @@ func TestConsole_modules(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
-	p := testProvider()
+	p := applyFixtureProvider()
 	ui := new(cli.MockUi)
 
 	c := &ConsoleCommand{

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -20,7 +20,7 @@ func TestGraph(t *testing.T) {
 	ui := new(cli.MockUi)
 	c := &GraphCommand{
 		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(testProvider()),
+			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 			Ui:               ui,
 		},
 	}
@@ -42,7 +42,7 @@ func TestGraph_multipleArgs(t *testing.T) {
 	ui := new(cli.MockUi)
 	c := &GraphCommand{
 		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(testProvider()),
+			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 			Ui:               ui,
 		},
 	}
@@ -69,7 +69,7 @@ func TestGraph_noArgs(t *testing.T) {
 	ui := new(cli.MockUi)
 	c := &GraphCommand{
 		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(testProvider()),
+			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 			Ui:               ui,
 		},
 	}
@@ -94,7 +94,7 @@ func TestGraph_noConfig(t *testing.T) {
 	ui := new(cli.MockUi)
 	c := &GraphCommand{
 		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(testProvider()),
+			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 			Ui:               ui,
 		},
 	}
@@ -148,7 +148,7 @@ func TestGraph_plan(t *testing.T) {
 	ui := new(cli.MockUi)
 	c := &GraphCommand{
 		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(testProvider()),
+			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 			Ui:               ui,
 		},
 	}

--- a/command/testdata/apply-vars/main.tf
+++ b/command/testdata/apply-vars/main.tf
@@ -1,5 +1,5 @@
 variable "foo" {}
 
 resource "test_instance" "foo" {
-    value = "${var.foo}"
+    value = var.foo
 }

--- a/terraform/eval_state_upgrade_test.go
+++ b/terraform/eval_state_upgrade_test.go
@@ -1,0 +1,148 @@
+package terraform
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestStripRemovedStateAttributes(t *testing.T) {
+	cases := []struct {
+		name     string
+		state    map[string]interface{}
+		expect   map[string]interface{}
+		ty       cty.Type
+		modified bool
+	}{
+		{
+			"removed string",
+			map[string]interface{}{
+				"a": "ok",
+				"b": "gone",
+			},
+			map[string]interface{}{
+				"a": "ok",
+			},
+			cty.Object(map[string]cty.Type{
+				"a": cty.String,
+			}),
+			true,
+		},
+		{
+			"removed null",
+			map[string]interface{}{
+				"a": "ok",
+				"b": nil,
+			},
+			map[string]interface{}{
+				"a": "ok",
+			},
+			cty.Object(map[string]cty.Type{
+				"a": cty.String,
+			}),
+			true,
+		},
+		{
+			"removed nested string",
+			map[string]interface{}{
+				"a": "ok",
+				"b": map[string]interface{}{
+					"a": "ok",
+					"b": "removed",
+				},
+			},
+			map[string]interface{}{
+				"a": "ok",
+				"b": map[string]interface{}{
+					"a": "ok",
+				},
+			},
+			cty.Object(map[string]cty.Type{
+				"a": cty.String,
+				"b": cty.Object(map[string]cty.Type{
+					"a": cty.String,
+				}),
+			}),
+			true,
+		},
+		{
+			"removed nested list",
+			map[string]interface{}{
+				"a": "ok",
+				"b": map[string]interface{}{
+					"a": "ok",
+					"b": []interface{}{"removed"},
+				},
+			},
+			map[string]interface{}{
+				"a": "ok",
+				"b": map[string]interface{}{
+					"a": "ok",
+				},
+			},
+			cty.Object(map[string]cty.Type{
+				"a": cty.String,
+				"b": cty.Object(map[string]cty.Type{
+					"a": cty.String,
+				}),
+			}),
+			true,
+		},
+		{
+			"removed keys in set of objs",
+			map[string]interface{}{
+				"a": "ok",
+				"b": map[string]interface{}{
+					"a": "ok",
+					"set": []interface{}{
+						map[string]interface{}{
+							"x": "ok",
+							"y": "removed",
+						},
+						map[string]interface{}{
+							"x": "ok",
+							"y": "removed",
+						},
+					},
+				},
+			},
+			map[string]interface{}{
+				"a": "ok",
+				"b": map[string]interface{}{
+					"a": "ok",
+					"set": []interface{}{
+						map[string]interface{}{
+							"x": "ok",
+						},
+						map[string]interface{}{
+							"x": "ok",
+						},
+					},
+				},
+			},
+			cty.Object(map[string]cty.Type{
+				"a": cty.String,
+				"b": cty.Object(map[string]cty.Type{
+					"a": cty.String,
+					"set": cty.Set(cty.Object(map[string]cty.Type{
+						"x": cty.String,
+					})),
+				}),
+			}),
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			modified := removeRemovedAttrs(tc.state, tc.ty)
+			if !reflect.DeepEqual(tc.state, tc.expect) {
+				t.Fatalf("expected: %#v\n      got: %#v\n", tc.expect, tc.state)
+			}
+			if modified != tc.modified {
+				t.Fatal("incorrect return value")
+			}
+		})
+	}
+}


### PR DESCRIPTION
While removal of attributes can be handled by providers through the
UpgradeResourceState call, data sources may need to be evaluated before
reading, and they have no upgrade path in the provider protocol.
Strip out extra attributes during state decoding when they are no longer
present in the schema, and there is no schema upgrade pending. If there 
is a pending schema upgrade, let the provider handle it since it may want to
check for the removed attribute values. 

Another option not explored here is declaring that providers must migrate
any attributes pending removal before they actually removed, which would
allow the possibility of making the decoder less strict and always strip out
unknown attributes (similar to `encoding/json`). Since we can
handle the case fully within core, it seems reasonable to let the decoder be
as strict as possible, though it might be useful to implement the functionality
upstream for other projects using zclconf.

The validate command should work only with the configuration, but when
validate was run at the start of a plan or apply command the state was
inserted in preparation for the next walk. This could lead to errors
when the resource schemas had changes and the state could not be
upgraded or decoded.

Fixes #25752