### PR TITLE
Fix documentation example for the indent function

### DIFF
--- a/website/docs/configuration/functions/indent.html.md
+++ b/website/docs/configuration/functions/indent.html.md
@@ -26,7 +26,7 @@ This function is useful for inserting a multi-line string into an
 already-indented context in another string:
 
 ```
-> "  items: %{indent(2, "[\n  foo,\n  bar,\n]\n")}"
+> "  items: ${indent(2, "[\n  foo,\n  bar,\n]\n")}"
   items: [
     foo,
     bar,


### PR DESCRIPTION
We must use interpolation, using the %{} directive will trigger the following error  **"indent" is not a valid template control keyword**