### PR TITLE
website: Move provisioners into language section of nav sidebar

### DIFF
--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -58,6 +58,58 @@
                     <a href="/docs/configuration/terraform.html">Terraform Settings</a>
                   </li>
 
+                  <li<%= sidebar_current("docs-provisioners") %>>
+                    <a href="/docs/provisioners/index.html">Provisioners</a>
+                    <ul class="nav">
+                      <li<%= sidebar_current("docs-provisioners-connection") %>>
+                        <a href="/docs/provisioners/connection.html">Provisioner Connections</a>
+                      </li>
+
+                      <li<%= sidebar_current("docs-provisioners-null-resource") %>>
+                        <a href="/docs/provisioners/null_resource.html">Provisioners Without a Resource</a>
+                      </li>
+
+                      <li>
+                        <a href="#">Generic Provisioners</a>
+                        <ul class="nav nav-auto-expand">
+                          <li<%= sidebar_current("docs-provisioners-file") %>>
+                            <a href="/docs/provisioners/file.html">file Provisioner</a>
+                          </li>
+
+                          <li<%= sidebar_current("docs-provisioners-local") %>>
+                            <a href="/docs/provisioners/local-exec.html">local-exec Provisioner</a>
+                          </li>
+
+                          <li<%= sidebar_current("docs-provisioners-remote") %>>
+                            <a href="/docs/provisioners/remote-exec.html">remote-exec Provisioner</a>
+                          </li>
+                        </ul>
+                      </li>
+
+                      <li>
+                        <a href="#">Vendor Provisioners</a>
+                        <ul class="nav nav-auto-expand">
+                          <li<%= sidebar_current("docs-provisioners-chef") %>>
+                            <a href="/docs/provisioners/chef.html">chef Provisioner</a>
+                          </li>
+
+                          <li<%= sidebar_current("docs-provisioners-habitat") %>>
+                            <a href="/docs/provisioners/habitat.html">habitat Provisioner</a>
+                          </li>
+
+                          <li<%= sidebar_current("docs-provisioners-puppet") %>>
+                            <a href="/docs/provisioners/puppet.html">puppet Provisioner</a>
+                          </li>
+
+                          <li<%= sidebar_current("docs-provisioners-salt-masterless") %>>
+                            <a href="/docs/provisioners/salt-masterless.html">salt-masterless Provisioner</a>
+                          </li>
+                        </ul>
+                      </li>
+
+                    </ul>
+                  </li>
+
                 </ul>
               </li>
 
@@ -153,6 +205,10 @@
 
               <li<%= sidebar_current("docs-conf-old-terraform") %>>
                 <a href="/docs/configuration-0-11/terraform.html">Terraform</a>
+              </li>
+
+              <li<%= sidebar_current("docs-provisioners") %>>
+                <a href="/docs/provisioners/index.html?v=011">Provisioners</a>
               </li>
 
               <li<%= sidebar_current("docs-conf-old-push") %>>
@@ -360,53 +416,6 @@
 
           <li<%= sidebar_current("docs-providers-community") %>>
              <a href="/docs/providers/type/community-index.html">Community</a>
-          </li>
-
-        </ul>
-      </li>
-
-      <li<%= sidebar_current("docs-provisioners") %>>
-        <a href="/docs/provisioners/index.html">Provisioners</a>
-        <ul class="nav">
-          <li<%= sidebar_current("docs-provisioners-connection") %>>
-            <a href="/docs/provisioners/connection.html">Provisioner Connections</a>
-          </li>
-
-          <li<%= sidebar_current("docs-provisioners-null-resource") %>>
-            <a href="/docs/provisioners/null_resource.html">Provisioners Without a Resource</a>
-          </li>
-
-          <li>
-            <a href="#">Built-in Provisioners</a>
-            <ul class="nav nav-auto-expand">
-              <li<%= sidebar_current("docs-provisioners-chef") %>>
-                <a href="/docs/provisioners/chef.html">chef Provisioner</a>
-              </li>
-
-              <li<%= sidebar_current("docs-provisioners-file") %>>
-                <a href="/docs/provisioners/file.html">file Provisioner</a>
-              </li>
-
-              <li<%= sidebar_current("docs-provisioners-habitat") %>>
-                <a href="/docs/provisioners/habitat.html">habitat Provisioner</a>
-              </li>
-
-              <li<%= sidebar_current("docs-provisioners-local") %>>
-                <a href="/docs/provisioners/local-exec.html">local-exec Provisioner</a>
-              </li>
-
-              <li<%= sidebar_current("docs-provisioners-puppet") %>>
-                <a href="/docs/provisioners/puppet.html">puppet Provisioner</a>
-              </li>
-
-              <li<%= sidebar_current("docs-provisioners-remote") %>>
-                <a href="/docs/provisioners/remote-exec.html">remote-exec Provisioner</a>
-              </li>
-
-              <li<%= sidebar_current("docs-provisioners-salt-masterless") %>>
-                <a href="/docs/provisioners/salt-masterless.html">salt-masterless Provisioner</a>
-              </li>
-            </ul>
           </li>
 
         </ul>


### PR DESCRIPTION
This is an adjustment to the sidebar nav to demote provisioners from a top-level item to a subsection of the language docs. A few things worth noting: 

- This doesn't mess with the actual URL paths yet, so we don't need to do any redirecting or link updates yet. It just changes the sidebar. 
- Both the 0.12+ language docs and the 0.11 language docs get a "provisioners" nav item in the sidebar, but only the 0.12 one is complete. When viewing a page in the provisioners section, it looks like you're within the 0.12+ language docs, even if you clicked the link from the 0.11 section. This is a pretty degraded experience for 0.11 users, BUT, hopefully we're far enough along in getting the community onto the modern language that it isn't a huge problem. 
- I'm using some trickery to keep the 0.11 language docs from popping open when you're viewing the front page of the provisioners section -- the URL in 0.11 adds a bogus query parameter, which fools the "which link is active" part of the sidebar template code without interfering with navigation at all. 
- I sorted the provisioners into "generic" and "vendor" categories, so the separation is more obvious

![image](https://user-images.githubusercontent.com/484309/89833230-8fb4ac00-db15-11ea-9bd4-1353f5dcb1ec.png)
