### PR TITLE
Fix sidebar link for Terraform standard backends to include link to Kubernetes backend docs

### DIFF
--- a/website/layouts/backend-types.erb
+++ b/website/layouts/backend-types.erb
@@ -52,7 +52,7 @@
                     <a href="/docs/backends/types/http.html">http</a>
                   </li>
                   <li<%= sidebar_current("docs-backends-types-standard-kubernetes") %>>
-                    <a href="/docs/backends/types/kubernetes.html">http</a>
+                    <a href="/docs/backends/types/kubernetes.html">kubernetes</a>
                   </li>
                   <li<%= sidebar_current("docs-backends-types-standard-manta") %>>
                     <a href="/docs/backends/types/manta.html">manta</a>

--- a/website/layouts/backend-types.erb
+++ b/website/layouts/backend-types.erb
@@ -51,6 +51,9 @@
                   <li<%= sidebar_current("docs-backends-types-standard-http") %>>
                     <a href="/docs/backends/types/http.html">http</a>
                   </li>
+                  <li<%= sidebar_current("docs-backends-types-standard-kubernetes") %>>
+                    <a href="/docs/backends/types/kubernetes.html">http</a>
+                  </li>
                   <li<%= sidebar_current("docs-backends-types-standard-manta") %>>
                     <a href="/docs/backends/types/manta.html">manta</a>
                   </li>


### PR DESCRIPTION
A small fix to include the sidebar link to the k8s state storage backend. 