### PR TITLE
command/init: fix panic on nonexisting config file

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -856,6 +856,9 @@ func (c *InitCommand) backendConfigOverrideBody(flags rawFlags, schema *configsc
 			// The value is interpreted as a filename.
 			newBody, fileDiags := c.loadHCLFile(item.Value)
 			diags = diags.Append(fileDiags)
+			if fileDiags.HasErrors() {
+				break
+			}
 			// Verify that the file contains only key-values pairs, and not a
 			// full backend config block. JustAttributes() will return an error
 			// if blocks are found

--- a/command/init.go
+++ b/command/init.go
@@ -857,7 +857,7 @@ func (c *InitCommand) backendConfigOverrideBody(flags rawFlags, schema *configsc
 			newBody, fileDiags := c.loadHCLFile(item.Value)
 			diags = diags.Append(fileDiags)
 			if fileDiags.HasErrors() {
-				break
+				continue
 			}
 			// Verify that the file contains only key-values pairs, and not a
 			// full backend config block. JustAttributes() will return an error

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -375,7 +375,7 @@ func TestInit_backendConfigFile(t *testing.T) {
 		}
 	})
 
-	// the backend config file must be a set of key-value pairs and not a full backend {} block
+	// the backend config file must exist
 	t.Run("nonexisting-config-file", func(t *testing.T) {
 		ui := new(cli.MockUi)
 		c := &InitCommand{

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -374,6 +374,24 @@ func TestInit_backendConfigFile(t *testing.T) {
 			t.Fatalf("wrong error: %s", ui.ErrorWriter)
 		}
 	})
+
+	// the backend config file must be a set of key-value pairs and not a full backend {} block
+	t.Run("nonexisting-config-file", func(t *testing.T) {
+		ui := new(cli.MockUi)
+		c := &InitCommand{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(testProvider()),
+				Ui:               ui,
+			},
+		}
+		args := []string{"-backend-config", "nonexisting"}
+		if code := c.Run(args); code != 1 {
+			t.Fatalf("expected error, got success\n")
+		}
+		if !strings.Contains(ui.ErrorWriter.String(), "Failed to read file") {
+			t.Fatalf("wrong error: %s", ui.ErrorWriter)
+		}
+	})
 }
 
 func TestInit_backendConfigFilePowershellConfusion(t *testing.T) {


### PR DESCRIPTION
When a backend file is provided using --backend-config with a nonexisting (or otherwise unaccessible) file, the nil body of this nonexisting file was still being read, causing a panic. This commit stops early if loadHCLFile returned error diagnostics.

The test is essentially a copy of an existing similar test. Without the fix, the test panics (same as running `terraform init`).