### PR TITLE
statemgr: add a NewUnlockErrorFull state manager for tests

### DIFF
--- a/states/statemgr/statemgr_fake.go
+++ b/states/statemgr/statemgr_fake.go
@@ -100,32 +100,15 @@ func (m *fakeFull) Unlock(id string) error {
 // does not return an error because clistate.Locker Lock()s the state at the
 // start of Unlock(), so Lock() must succeeded for Unlock() to get called.
 func NewUnlockErrorFull(t Transient, initial *states.State) Full {
-	if t == nil {
-		t = NewTransientInMemory(nil)
-	}
-
-	// The "persistent" part of our manager is actually just another in-memory
-	// transient used to fake a secondary storage layer.
-	fakeP := NewTransientInMemory(initial.DeepCopy())
-
-	return &fakeErrorFull{
-		t:     t,
-		fakeP: fakeP,
-	}
+	return &fakeErrorFull{}
 }
 
-type fakeErrorFull struct {
-	t     Transient
-	fakeP Transient
-
-	lockLock sync.Mutex
-	locked   bool
-}
+type fakeErrorFull struct{}
 
 var _ Full = (*fakeErrorFull)(nil)
 
 func (m *fakeErrorFull) State() *states.State {
-	return m.t.State()
+	return nil
 }
 
 func (m *fakeErrorFull) WriteState(s *states.State) error {


### PR DESCRIPTION
I've frequently needed to coerce `Unlock()` errors for tests and it's been
awkward and fraught every time, so I decided to add a full state manger
that returns *mostly* errors. I intend to use this in conjunction with
the `clistate.Locker` interface, which first calls `statemgr.Lock()` (to block if the
mutex is in use) at the start of `clistate.Unlock()`, so `statemgr.Lock()` rather awkwardly needed to succeed.

