### PR TITLE
[build] Fix missing VERSION for running make website

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 WEBSITE_REPO=github.com/hashicorp/terraform-website
+VERSION?="0.3.44"
 
 # generate runs `go generate` to build the dynamically generated
 # source files, except the protobuf stubs which are built instead with


### PR DESCRIPTION
Running `make website` would result in a missing image error from Docker, as a result of the `VERSION` variable missing from the Makefile. This value matches that in the Makefile of the terraform-website repository.