### PR TITLE
Fix error when multiple -no-color arguments are used

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -435,14 +435,18 @@ func (m *Meta) process(args []string) []string {
 
 	// Set colorization
 	m.color = m.Color
-	for i, v := range args {
+	i := 0 // output index
+	for _, v := range args {
 		if v == "-no-color" {
 			m.color = false
 			m.Color = false
-			args = append(args[:i], args[i+1:]...)
-			break
+		} else {
+			// copy and increment index
+			args[i] = v
+			i++
 		}
 	}
+	args = args[:i]
 
 	// Set the UI
 	m.oldUi = m.Ui

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -55,6 +55,21 @@ func TestMetaColorize(t *testing.T) {
 	if !m.Colorize().Disable {
 		t.Fatal("should be disabled")
 	}
+
+	// Test disable #2
+	// Verify multiple -no-color options are removed from args slice.
+	// E.g. an additional -no-color arg could be added by TF_CLI_ARGS.
+	m = new(Meta)
+	m.Color = true
+	args = []string{"foo", "-no-color", "bar", "-no-color"}
+	args2 = []string{"foo", "bar"}
+	args = m.process(args)
+	if !reflect.DeepEqual(args, args2) {
+		t.Fatalf("bad: %#v", args)
+	}
+	if !m.Colorize().Disable {
+		t.Fatal("should be disabled")
+	}
 }
 
 func TestMetaInputMode(t *testing.T) {


### PR DESCRIPTION
Since `-no-color` is a global argument and not actually handled by terraform commands, it must be removed from the list of arguments sent to commands.  However the current code assumes only a single `-no-color` argument is ever added.  This can easily not be the case if someone has `TF_CLI_ARGS` set to include `-no-color`, e.g. in an automation system where color is not helpful, and a call to terraform also includes a `-no-color` argument.

This change removes all instances of `-no-color` from the argument list before sending it to the commands.

Fixes #25845