### PR TITLE
website: add providers mirror command to providers sidebar

### DIFF
--- a/website/layouts/commands-providers.erb
+++ b/website/layouts/commands-providers.erb
@@ -10,6 +10,9 @@
             <li<%= sidebar_current("docs-commands-providers") %>>
               <a href="/docs/commands/providers.html">providers</a>
               <ul class="nav">
+                <li<%= sidebar_current("docs-commands-providers-mirror") %>>
+                  <a href="/docs/commands/providers/mirror.html">schema</a>
+                </li>
                 <li<%= sidebar_current("docs-commands-providers-schema") %>>
                   <a href="/docs/commands/providers/schema.html">schema</a>
                 </li>


### PR DESCRIPTION
The `providers mirror` subcommand documentation is up, but missing from the sidebar:
<img width="181" alt="Screen Shot 2020-08-14 at 10 05 03 AM" src="https://user-images.githubusercontent.com/6210214/90257804-a14bcb80-de15-11ea-87fe-14aeaf28d6f9.png">
