### PR TITLE
addrs: Fix LegacyString for builtin providers

### DIFF
--- a/addrs/provider.go
+++ b/addrs/provider.go
@@ -156,8 +156,8 @@ func (pt Provider) LegacyString() string {
 	if pt.IsZero() {
 		panic("called LegacyString on zero-value addrs.Provider")
 	}
-	if pt.Namespace != LegacyProviderNamespace {
-		panic(pt.String() + " is not a legacy addrs.Provider")
+	if pt.Namespace != LegacyProviderNamespace && pt.Namespace != BuiltInProviderNamespace {
+		panic(pt.String() + " cannot be represented as a legacy string")
 	}
 	return pt.Type
 }

--- a/addrs/provider_test.go
+++ b/addrs/provider_test.go
@@ -54,6 +54,37 @@ func TestProviderString(t *testing.T) {
 	}
 }
 
+func TestProviderLegacyString(t *testing.T) {
+	tests := []struct {
+		Input Provider
+		Want  string
+	}{
+		{
+			Provider{
+				Type:      "test",
+				Hostname:  DefaultRegistryHost,
+				Namespace: LegacyProviderNamespace,
+			},
+			"test",
+		},
+		{
+			Provider{
+				Type:      "terraform",
+				Hostname:  BuiltInProviderHost,
+				Namespace: BuiltInProviderNamespace,
+			},
+			"terraform",
+		},
+	}
+
+	for _, test := range tests {
+		got := test.Input.LegacyString()
+		if got != test.Want {
+			t.Errorf("wrong result for %s\ngot:  %s\nwant: %s", test.Input.String(), got, test.Want)
+		}
+	}
+}
+
 func TestProviderDisplay(t *testing.T) {
 	tests := []struct {
 		Input Provider

--- a/states/statefile/testdata/roundtrip/v3-builtin.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-builtin.in.tfstate
@@ -1,0 +1,39 @@
+{
+    "version": 3,
+    "terraform_version": "0.11.14",
+    "serial": 1,
+    "lineage": "b707851e-4209-9792-e752-bc0dd6c81fcf",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {
+                "data.terraform_remote_state.test": {
+                    "type": "terraform_remote_state",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "2020-08-14 19:13:36.875081 +0000 UTC",
+                        "attributes": {
+                            "backend": "remote",
+                            "config.#": "1",
+                            "config.345861710.organization": "hashicorp",
+                            "config.345861710.workspaces.#": "1",
+                            "config.345861710.workspaces.0.%": "1",
+                            "config.345861710.workspaces.0.name": "test",
+                            "environment": "default",
+                            "id": "2020-08-14 19:13:36.875081 +0000 UTC",
+                            "workspace": "default"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.terraform"
+                }
+            },
+            "depends_on": []
+        }
+    ]
+}

--- a/states/statefile/testdata/roundtrip/v3-builtin.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v3-builtin.out.tfstate
@@ -1,0 +1,31 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.28",
+  "serial": 1,
+  "lineage": "b707851e-4209-9792-e752-bc0dd6c81fcf",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "data",
+      "type": "terraform_remote_state",
+      "name": "test",
+      "provider": "provider.terraform",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes_flat": {
+            "backend": "remote",
+            "config.#": "1",
+            "config.345861710.organization": "hashicorp",
+            "config.345861710.workspaces.#": "1",
+            "config.345861710.workspaces.0.%": "1",
+            "config.345861710.workspaces.0.name": "test",
+            "environment": "default",
+            "id": "2020-08-14 19:13:36.875081 +0000 UTC",
+            "workspace": "default"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Builtin provider addrs (i.e. `"terraform.io/builtin/terraform"`) should be able to convert to legacy string form (i.e. `"terraform"`). This ensures that we can safely round-trip through `ParseLegacyAbsProviderConfig`,
which can return either a legacy or a builtin provider addr.

Fixes #25803. The test in the second commit reproduces the panic without the first commit.