### PR TITLE
terraform: Eval module call arguments for import

### DIFF
--- a/command/testdata/import-module-input-variable/child/main.tf
+++ b/command/testdata/import-module-input-variable/child/main.tf
@@ -1,0 +1,11 @@
+variable "foo" {
+  default = {}
+}
+
+locals {
+  baz = var.foo.bar.baz
+}
+
+resource "test_instance" "foo" {
+    foo = local.baz
+}

--- a/command/testdata/import-module-input-variable/main.tf
+++ b/command/testdata/import-module-input-variable/main.tf
@@ -1,0 +1,8 @@
+variable "foo" {
+  default = {}
+}
+
+module "child" {
+    source = "./child"
+    foo = var.foo
+}

--- a/command/testdata/import-module-input-variable/terraform.tfvars
+++ b/command/testdata/import-module-input-variable/terraform.tfvars
@@ -1,0 +1,1 @@
+foo = { bar = { baz = true } }

--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -154,7 +154,7 @@ func (n *nodeModuleVariable) EvalTree() EvalNode {
 		Nodes: []EvalNode{
 			&EvalOpFilter{
 				Ops: []walkOperation{walkRefresh, walkPlan, walkApply,
-					walkDestroy},
+					walkDestroy, walkImport},
 				Node: &EvalModuleCallArgument{
 					Addr:           n.Addr.Variable,
 					Config:         n.Config,


### PR DESCRIPTION
Include the import walk in the list of operations for which we create an `EvalModuleCallArgument` node. This causes module call arguments to be evaluated even if the module variables have defaults, ensuring that invalid default values (such as the common `{}` for variables thought of as maps) do not cause failures specific to import.

This fixes a bug where a child module evaluates an input variable in its locals block, assuming that it is a nested object structure. The bug report includes a default value of `{}`, which is overridden by a root variable value. Without the eval node added in this commit, the default value is used and the local evaluation errors.

**Note:** I'm surprised that we weren't evaluating module call arguments for imports, as that seems like it would break import for module expansion in many cases. Is this intentional, and will this change therefore break something else?

Fixes #25888; [see reproduction here](https://github.com/danieldreier/terraform-issue-reproductions/tree/master/25888).