### PR TITLE
terraform: Fix required version constraint diags

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -1343,6 +1343,13 @@ func TestInit_checkRequiredVersion(t *testing.T) {
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("got exit status %d; want 1\nstderr:\n%s\n\nstdout:\n%s", code, ui.ErrorWriter.String(), ui.OutputWriter.String())
 	}
+	errStr := ui.ErrorWriter.String()
+	if !strings.Contains(errStr, `required_version = "~> 0.9.0"`) {
+		t.Fatalf("output should point to unmet version constraint, but is:\n\n%s", errStr)
+	}
+	if strings.Contains(errStr, `required_version = ">= 0.13.0"`) {
+		t.Fatalf("output should not point to met version constraint, but is:\n\n%s", errStr)
+	}
 }
 
 func TestInit_providerLockFile(t *testing.T) {

--- a/command/testdata/init-check-required-version/main.tf
+++ b/command/testdata/init-check-required-version/main.tf
@@ -1,3 +1,7 @@
 terraform {
     required_version = "~> 0.9.0"
 }
+
+terraform {
+    required_version = ">= 0.13.0"
+}

--- a/terraform/version_required.go
+++ b/terraform/version_required.go
@@ -37,7 +37,7 @@ func CheckCoreVersionRequirements(config *configs.Config) tfdiags.Diagnostics {
 						"This configuration does not support Terraform version %s. To proceed, either choose another supported Terraform version or update this version constraint. Version constraints are normally set for good reason, so updating the constraint may lead to other errors or unexpected behavior.",
 						tfversion.String(),
 					),
-					Subject: &constraint.DeclRange,
+					Subject: constraint.DeclRange.Ptr(),
 				})
 			default:
 				diags = diags.Append(&hcl.Diagnostic{
@@ -47,7 +47,7 @@ func CheckCoreVersionRequirements(config *configs.Config) tfdiags.Diagnostics {
 						"Module %s (from %s) does not support Terraform version %s. To proceed, either choose another supported Terraform version or update this version constraint. Version constraints are normally set for good reason, so updating the constraint may lead to other errors or unexpected behavior.",
 						config.Path, config.SourceAddr, tfversion.String(),
 					),
-					Subject: &constraint.DeclRange,
+					Subject: constraint.DeclRange.Ptr(),
 				})
 			}
 		}


### PR DESCRIPTION
If a module has multiple `terraform.required_version` constraints, any failures would point at the last constraint in the error diagnostics. If an earlier constraint was the actual problem, this leads to confusing errors like this:

```
    Error: Unsupported Terraform Core version

      on main.tf line 6, in terraform:
       6:   required_version = ">= 0.13.0"

    This configuration does not support Terraform version 0.13.0.
```

The error was due to storing the declaration range of the constraint as a pointer to the contents of a loop variable, which was later overwritten in later iterations of the loop.  Instead we now use HCL's handy `Range.Ptr` method to create a direct pointer to the range struct.

Fixes #25833