### PR TITLE
terraform-bundle: initial changelog

### DIFF
--- a/tools/terraform-bundle/CHANGELOG.md
+++ b/tools/terraform-bundle/CHANGELOG.md
@@ -1,0 +1,8 @@
+## (Unreleased)
+
+## 0.13.0 (August 10, 2020)
+
+> This is a list of changes relative to terraform-bundle tagged v0.12.
+
+Breaking Changes: 
+* Terraform v0.13.0 has introduced a new heirarchical namespace for providers. Terraform v0.13 requires a new directory layout in order to discover locally-installed provider plugins, and terraform-bundle has been updated to match. Please see the [README](README.md) to learn more about the new directory layout.


### PR DESCRIPTION
This is something I'd meant to do during the 0.13 development cycle. It's purposefully small and simple: terraform-bundle isn't likely to change much (if at all) in the next release(s), but I said I'd do it, so here it is!