### PR TITLE
website/docs: clarify behavior of -state flag  

### DIFF
--- a/website/docs/commands/apply.html.markdown
+++ b/website/docs/commands/apply.html.markdown
@@ -57,7 +57,11 @@ The command-line flags are all optional. The list of available flags are:
   apply.
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
-  Ignored when [remote state](/docs/state/remote.html) is used.
+  Ignored when [remote state](/docs/state/remote.html) is used. This setting
+  does not persist and other commands, such as init, may not be aware of the
+  alternate statefile. To configure an alternate statefile path which is
+  available to all terraform commands, use the [local
+  backend](/docs/state/local.html).
 
 * `-state-out=path` - Path to write updated state file. By default, the
   `-state` path will be used. Ignored when

--- a/website/docs/commands/apply.html.markdown
+++ b/website/docs/commands/apply.html.markdown
@@ -60,8 +60,7 @@ The command-line flags are all optional. The list of available flags are:
   Ignored when [remote state](/docs/state/remote.html) is used. This setting
   does not persist and other commands, such as init, may not be aware of the
   alternate statefile. To configure an alternate statefile path which is
-  available to all terraform commands, use the [local
-  backend](/docs/state/local.html).
+  available to all terraform commands, use the [local backend](/docs/state/local.html).
 
 * `-state-out=path` - Path to write updated state file. By default, the
   `-state` path will be used. Ignored when


### PR DESCRIPTION
There has been some confusion regarding use of the `-state` option on apply, and the upgrade from terraform v0.12 to v0.13 introduced an additional rough edge: `terraform init` has no knowledge of the alternative statefile path specified on the command line, and therefore ends up missing some important information about the providers required by the state. This could have been an issue for anyone with, for example, providers required by the state that aren't in the configuraiton, but it's especially noticeable in the v013 upgrade path because terraform init needs to know that the state still has "legacy" style providers. 


If a user wants to configure an alternate statefile path that can persist through all terraform commands (init being the interesting one today), they should configure a local backend any specify the path there.

This adds some (awkward) words about the limitation of the `state` flag in apply. 