### PR TITLE
Ensure depends_on is in module calls for config

### DIFF
--- a/command/jsonconfig/config.go
+++ b/command/jsonconfig/config.go
@@ -48,6 +48,7 @@ type moduleCall struct {
 	ForEachExpression *expression            `json:"for_each_expression,omitempty"`
 	Module            module                 `json:"module,omitempty"`
 	VersionConstraint string                 `json:"version_constraint,omitempty"`
+	DependsOn         []string               `json:"depends_on,omitempty"`
 }
 
 // variables is the JSON representation of the variables provided to the current
@@ -269,6 +270,20 @@ func marshalModuleCall(c *configs.Config, mc *configs.ModuleCall, schemas *terra
 	ret.Expressions = marshalExpressions(mc.Config, schema)
 	module, _ := marshalModule(c, schemas, mc.Name)
 	ret.Module = module
+
+	if len(mc.DependsOn) > 0 {
+		dependencies := make([]string, len(mc.DependsOn))
+		for i, d := range mc.DependsOn {
+			ref, diags := addrs.ParseRef(d)
+			// we should not get an error here, because `terraform validate`
+			// would have complained well before this point, but if we do we'll
+			// silenty skip it.
+			if !diags.HasErrors() {
+				dependencies[i] = ref.Subject.String()
+			}
+		}
+		ret.DependsOn = dependencies
+	}
 
 	return ret
 }

--- a/command/testdata/show-json/module-depends-on/foo/main.tf
+++ b/command/testdata/show-json/module-depends-on/foo/main.tf
@@ -1,0 +1,3 @@
+variable "test_var" {
+  default = "foo-var"
+}

--- a/command/testdata/show-json/module-depends-on/main.tf
+++ b/command/testdata/show-json/module-depends-on/main.tf
@@ -1,0 +1,11 @@
+module "foo" {
+    source = "./foo"
+
+    depends_on = [
+        test_instance.test
+    ]
+}
+
+resource "test_instance" "test" {
+    ami   = "foo-bar"
+}

--- a/command/testdata/show-json/module-depends-on/output.json
+++ b/command/testdata/show-json/module-depends-on/output.json
@@ -1,0 +1,76 @@
+{
+    "format_version": "0.1",
+    "terraform_version": "0.13.1-dev",
+    "planned_values": {
+        "root_module": {
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
+                    "schema_version": 0,
+                    "values": {
+                        "ami": "foo-bar"
+                    }
+                }
+            ]
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "test_instance.test",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/test",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after": {
+                    "ami": "foo-bar"
+                },
+                "after_unknown": {
+                    "id": true
+                }
+            }
+        }
+    ],
+    "configuration": {
+        "root_module": {
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_config_key": "test",
+                    "expressions": {
+                        "ami": {
+                            "constant_value": "foo-bar"
+                        }
+                    },
+                    "schema_version": 0
+                }
+            ],
+            "module_calls": {
+                "foo": {
+                    "depends_on": [
+                        "test_instance.test"
+                    ],
+                    "source": "./foo",
+                    "module": {
+                        "variables": {
+                            "test_var": {
+                                "default": "foo-var"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
With the recent addition of the `depends_on` meta-argument, we also need to ensure that `depends_on` is being added to the module calls within the config. This PR adds the `depends_on` field as well as a test for validating it is output via `terraform show`.

Codecov is reporting the drop in test coverage due to the tests being in a different package to `jsonconfig`.