### PR TITLE
build: disable github pr annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,6 @@ coverage:
       default:
         target: auto
         threshold: "0.5%"
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
The annotations are  distracting and make some PRs difficult (for me) to read. 

![idontlikechange](https://user-images.githubusercontent.com/6210214/90801612-233f6700-e2e4-11ea-8028-94d5285e0ecf.gif)
