### PR TITLE
Feature/salt masterless formulas

### DIFF
--- a/builtin/provisioners/salt-masterless/resource_provisioner.go
+++ b/builtin/provisioners/salt-masterless/resource_provisioner.go
@@ -267,16 +267,6 @@ func applyFn(ctx context.Context) error {
 		return fmt.Errorf("Unable to move %s/states to %s: %s", p.TempConfigDir, dst, err)
 	}
 
-	// Remove the local Salt formulas if present
-	if p.Formulas != nil {
-		for _, f := range formulas {
-			if _, err := os.Stat(f); !os.IsNotExist(err) && f != p.LocalStateTree {
-				o.Output(fmt.Sprintf("Removing Salt formula: %s", f))
-				defer os.RemoveAll(f)
-			}
-		}
-	}
-
 	if p.LocalPillarRoots != "" {
 		o.Output(fmt.Sprintf("Uploading local pillar roots: %s", p.LocalPillarRoots))
 		src = p.LocalPillarRoots
@@ -317,6 +307,16 @@ func applyFn(ctx context.Context) error {
 	if err := cmd.Wait(); err != nil {
 		return err
 	}
+
+	// Notify re: the local Salt formulas if present
+	if p.Formulas != nil {
+		for _, f := range formulas {
+			if _, err := os.Stat(f); !os.IsNotExist(err) && f != p.LocalStateTree {
+				o.Output(fmt.Sprintf("Salt formula remaining: %s", f))
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/builtin/provisioners/salt-masterless/resource_provisioner_test.go
+++ b/builtin/provisioners/salt-masterless/resource_provisioner_test.go
@@ -450,3 +450,57 @@ func TestProvisionerPrepare_LogLevel(t *testing.T) {
 		t.Fatal("-l debug should be set in CmdArgs")
 	}
 }
+
+func TestProvisionerPrepare_BadFormulaURL(t *testing.T) {
+
+	dir, err := ioutil.TempDir("", "_terraform_saltmasterless_test")
+	if err != nil {
+		t.Fatalf("Error when creating temp dir: %v", err)
+	}
+
+	defer os.RemoveAll(dir) // clean up
+
+	c := testConfig(t, map[string]interface{}{
+		"local_state_tree": dir,
+		"formulas": []interface{}{
+			"git::https://github.com/org/some-formula.git//",
+		},
+	})
+
+	warn, errs := Provisioner().Validate(c)
+
+	if len(warn) > 0 {
+		t.Fatalf("Warnings: %v", warn)
+	}
+	if len(errs) == 0 {
+		t.Fatalf("Expected invalid formula URL")
+	}
+}
+
+func TestProvisionerPrepare_ValidFormulaURLs(t *testing.T) {
+
+	dir, err := ioutil.TempDir("", "_terraform_saltmasterless_test")
+	if err != nil {
+		t.Fatalf("Error when creating temp dir: %v", err)
+	}
+
+	defer os.RemoveAll(dir) // clean up
+
+	c := testConfig(t, map[string]interface{}{
+		"local_state_tree": dir,
+		"formulas": []interface{}{
+			"git::https://github.com/org/some-formula.git//example",
+			"git@github.com:org/some-formula.git//example",
+			"git::https://github.com/org/some-formula.git//example?ref=example",
+		},
+	})
+
+	warn, errs := Provisioner().Validate(c)
+
+	if len(warn) > 0 {
+		t.Fatalf("Warnings: %v", warn)
+	}
+	if len(errs) > 0 {
+		t.Fatalf("Unexpected error in formula URLs")
+	}
+}

--- a/website/docs/provisioners/salt-masterless.html.md
+++ b/website/docs/provisioners/salt-masterless.html.md
@@ -92,3 +92,8 @@ Optional:
 
 -   `salt_bin_dir` (string) - Path to the `salt-call` executable. Useful if it is not
     on the PATH.
+
+-   `formulas` (array) - An array of git source formulas to be downloaded to the local
+    state tree prior to moving to the remote state tree. Note: `//directory` must be included in
+    the URL to download the appropriate formula directory. Example:
+    `git::https://github.com/saltstack-formulas/vault-formula.git//vault?ref=v1.2.3`


### PR DESCRIPTION
This is a new feature for Terraform's salt-masterless provisioner. It is equivalent to a recently merged PR in Packer: https://github.com/hashicorp/packer/pull/9726

Use case: The salt-masterless provisioner uploads a local state tree, which is required. This feature gives the option to download community SaltStack formulas as an array of URLs (consumed by go-getter) inside the states directory before the state tree is uploaded to the destination. This allows operators using the provisioner to consume any formula on https://github.com/saltstack-formulas using git-style URLs.

```
resource "null_resource" "cluster" {
  ...
  provisioner "salt-masterless" {
    local_state_tree    = "salt/states"
    formulas = [
      "git::https://github.com/saltstack-formulas/consul-formula.git//consul",
      "git::https://github.com/saltstack-formulas/consul-formula.git//consul-template",
    ]
  }
}
```

Prior to this, we were pulling in community formulas with the shell provisioner, which resulted in an identical script for each Terraform repo. The goal is to provide a more native experience in Terraform to download salt formulas from external sources while still using salt-masterless.

One question I have is: Is there a decent way to clear out the downloaded formulas after all resources (in a count) are finished? The only difference with this implementation compared to the Packer feature is that this version doesn't clean up afterward due to resource parallelism.

Thanks for your time.