### PR TITLE
Change variable errors on remote backend

### DIFF
--- a/backend/unparsed_value.go
+++ b/backend/unparsed_value.go
@@ -42,6 +42,47 @@ type UnparsedVariableValue interface {
 // that were successfully processed, allowing for careful analysis of the
 // partial result.
 func ParseVariableValues(vv map[string]UnparsedVariableValue, decls map[string]*configs.Variable) (terraform.InputValues, tfdiags.Diagnostics) {
+	ret, diags := ParseVariableValuesWithoutDefaults(vv, decls)
+
+	// Populate any variables we haven't gathered as their defaults and fail if any of
+	// the missing ones are required.
+	for name, vc := range decls {
+		if _, defined := ret[name]; defined {
+			continue
+		}
+
+		if vc.Required() {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "No value for required variable",
+				Detail:   fmt.Sprintf("The root module input variable %q is not set, and has no default value. Use a -var or -var-file command line argument to provide a value for this variable.", name),
+				Subject:  vc.DeclRange.Ptr(),
+			})
+
+			// We'll include a placeholder value anyway, just so that our
+			// result is complete for any calling code that wants to cautiously
+			// analyze it for diagnostic purposes. Since our diagnostics now
+			// includes an error, normal processing will ignore this result.
+			ret[name] = &terraform.InputValue{
+				Value:       cty.DynamicVal,
+				SourceType:  terraform.ValueFromConfig,
+				SourceRange: tfdiags.SourceRangeFromHCL(vc.DeclRange),
+			}
+		} else {
+			ret[name] = &terraform.InputValue{
+				Value:       vc.Default,
+				SourceType:  terraform.ValueFromConfig,
+				SourceRange: tfdiags.SourceRangeFromHCL(vc.DeclRange),
+			}
+		}
+	}
+	return ret, diags
+}
+
+// ParseVariableValuesWithoutDefaults performs the same operation as
+// ParseVariableValues, but does not set any default values or return any
+// errors for variables which are unset.
+func ParseVariableValuesWithoutDefaults(vv map[string]UnparsedVariableValue, decls map[string]*configs.Variable) (terraform.InputValues, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	ret := make(terraform.InputValues, len(vv))
 
@@ -121,41 +162,6 @@ func ParseVariableValues(vv map[string]UnparsedVariableValue, decls map[string]*
 			Summary:  "Values for undeclared variables",
 			Detail:   fmt.Sprintf("In addition to the other similar warnings shown, %d other variable(s) defined without being declared.", extras),
 		})
-	}
-
-	// By this point we should've gathered all of the required root module
-	// variables from one of the many possible sources. We'll now populate
-	// any we haven't gathered as their defaults and fail if any of the
-	// missing ones are required.
-	for name, vc := range decls {
-		if _, defined := ret[name]; defined {
-			continue
-		}
-
-		if vc.Required() {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "No value for required variable",
-				Detail:   fmt.Sprintf("The root module input variable %q is not set, and has no default value. Use a -var or -var-file command line argument to provide a value for this variable.", name),
-				Subject:  vc.DeclRange.Ptr(),
-			})
-
-			// We'll include a placeholder value anyway, just so that our
-			// result is complete for any calling code that wants to cautiously
-			// analyze it for diagnostic purposes. Since our diagnostics now
-			// includes an error, normal processing will ignore this result.
-			ret[name] = &terraform.InputValue{
-				Value:       cty.DynamicVal,
-				SourceType:  terraform.ValueFromConfig,
-				SourceRange: tfdiags.SourceRangeFromHCL(vc.DeclRange),
-			}
-		} else {
-			ret[name] = &terraform.InputValue{
-				Value:       vc.Default,
-				SourceType:  terraform.ValueFromConfig,
-				SourceRange: tfdiags.SourceRangeFromHCL(vc.DeclRange),
-			}
-		}
 	}
 
 	return ret, diags


### PR DESCRIPTION
When a user fails to set a variable in Terraform Cloud/Enterprise but that var is in their config, the error message tells the user to use -var or -var-file to set the variable, but these are not supported if you are running the command remotely.

This allows the remote backend context to provide the error messages for these variable errors, and instead of wrongly saying "user -var or -var-file" it points the user to the variables page where they can set the vars.