### PR TITLE
command: Fix backend config override validation

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -856,16 +856,31 @@ func (c *InitCommand) backendConfigOverrideBody(flags rawFlags, schema *configsc
 			// The value is interpreted as a filename.
 			newBody, fileDiags := c.loadHCLFile(item.Value)
 			diags = diags.Append(fileDiags)
-			// Verify that the file contains only key-values pairs, and not a
-			// full backend config block. JustAttributes() will return an error
-			// if blocks are found
-			_, attrDiags := newBody.JustAttributes()
-			if attrDiags.HasErrors() {
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Error,
-					"Invalid backend configuration file",
-					fmt.Sprintf("The backend configuration file %q given on the command line must contain key-value pairs only, and not configuration blocks.", item.Value),
-				))
+			if fileDiags.HasErrors() {
+				continue
+			}
+			// Generate an HCL body schema for the backend block.
+			var bodySchema hcl.BodySchema
+			for name, attr := range schema.Attributes {
+				bodySchema.Attributes = append(bodySchema.Attributes, hcl.AttributeSchema{
+					Name:     name,
+					Required: attr.Required,
+				})
+			}
+			for name, block := range schema.BlockTypes {
+				var labelNames []string
+				if block.Nesting == configschema.NestingMap {
+					labelNames = append(labelNames, "key")
+				}
+				bodySchema.Blocks = append(bodySchema.Blocks, hcl.BlockHeaderSchema{
+					Type:       name,
+					LabelNames: labelNames,
+				})
+			}
+			// Verify that the file body matches the expected backend schema.
+			_, schemaDiags := newBody.Content(&bodySchema)
+			diags = diags.Append(schemaDiags)
+			if schemaDiags.HasErrors() {
 				continue
 			}
 			flushVals() // deal with any accumulated individual values first

--- a/command/testdata/init-backend-config-file/backend.config
+++ b/command/testdata/init-backend-config-file/backend.config
@@ -1,5 +1,5 @@
 // the -backend-config flag on init cannot be used to point to a "full" backend
-// block, only key-value pairs (like terraform.tfvars) 
+// block
 terraform {
     backend "local" {
         path = "hello"

--- a/command/testdata/init-backend-config-file/invalid.config
+++ b/command/testdata/init-backend-config-file/invalid.config
@@ -1,0 +1,2 @@
+path = "hello"
+foo  = "bar"


### PR DESCRIPTION
When loading a backend config override file, init was doing two things wrong:

- First, if the file failed to parse, we accidentally didn't return, which caused a panic due to the parsed body being nil;
- Secondly, we were overzealous with the validation of the file, allowing only attributes. While most backend configs are attributes only, the enhanced remote backend body also contains a `workspaces` block, which we need to support here.

This commit fixes the first bug with an early return and adds test cases for missing file and intentionally-blank filename (to clear the config).

We also add a schema validation for the backend block, based on the backend schema itself. This requires constructing an HCL body schema so that we can call `Content` and check for diagnostic errors.

The result is more useful errors when an invalid backend config override file is used, while also supporting the enhanced remote backend config fully.

Does not include tests specific to the remote backend, because the mocking involved to allow the backend to fully initialize is too involved to be worth it. Here's what that looks like: 159cdd30

Fixes #25793