### PR TITLE
`terraform show` supports for `-input` option

### DIFF
--- a/command/show.go
+++ b/command/show.go
@@ -27,7 +27,9 @@ func (c *ShowCommand) Run(args []string) int {
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("show")
 	var jsonOutput bool
+	var inputOnly bool
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "produce JSON output")
+	cmdFlags.BoolVar(&inputOnly, "input", false, "don't show the output attributes")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
@@ -181,9 +183,10 @@ func (c *ShowCommand) Run(args []string) int {
 			return 0
 		}
 		c.Ui.Output(format.State(&format.StateOpts{
-			State:   stateFile.State,
-			Color:   c.Colorize(),
-			Schemas: schemas,
+			State:     stateFile.State,
+			Color:     c.Colorize(),
+			Schemas:   schemas,
+			InputOnly: inputOnly,
 		}))
 	}
 

--- a/configs/configschema/none_computed.go
+++ b/configs/configschema/none_computed.go
@@ -1,0 +1,35 @@
+package configschema
+
+// NoneComputed returns a deep copy of the receiver with any computed
+// attributes removed.
+func (b *Block) NoneComputed() *Block {
+	ret := &Block{}
+
+	if b.Attributes != nil {
+		ret.Attributes = make(map[string]*Attribute, len(b.Attributes))
+	}
+	for name, attrS := range b.Attributes {
+		if attrS.Computed {
+			continue
+		}
+		attr := *attrS
+		ret.Attributes[name] = &attr
+	}
+
+	if b.BlockTypes != nil {
+		ret.BlockTypes = make(map[string]*NestedBlock, len(b.BlockTypes))
+	}
+	for name, blockS := range b.BlockTypes {
+		ret.BlockTypes[name] = blockS.noneComputed()
+	}
+
+	return ret
+}
+
+func (b *NestedBlock) noneComputed() *NestedBlock {
+	ret := *b
+	ret.Block = *(ret.Block.NoneComputed())
+	ret.MinItems = 0
+	ret.MaxItems = 0
+	return &ret
+}


### PR DESCRIPTION
Adding `-input` option to `terraform show` so that users can output the formated state with input attributes only.

This helps user to easily convert the state to a workable terraform config, e.g., by redirecting the output of `terraform show -input` to a file.

If this is merged, we can use this command in the [import guide](https://learn.hashicorp.com/tutorials/terraform/state-import),
rather than asking user to do some rounds of manual tuning based on the error message.

This is just a first step to allow user to get a workable config file based on the state file. This doesn't include the dependency resolvation however. As the resource dependency is heavily coupled with different provider (even with different version), we shall come up with another solution for that. Indeed, I have post a [proposal](https://discuss.hashicorp.com/t/terraform-bulk-import-proposal/13103) about bulk import topic in Terraform Community.