### PR TITLE
provisioner comment fix.

### DIFF
--- a/terraform/resource_provisioner.go
+++ b/terraform/resource_provisioner.go
@@ -28,8 +28,8 @@ type ResourceProvisioner interface {
 	// are set and that the general structure is correct.
 	Validate(*ResourceConfig) ([]string, []error)
 
-	// Apply runs the provisioner on a specific resource and returns an error. 
-	// Instead of a diff, the ResourceConfig is provided since provisioners 
+	// Apply runs the provisioner on a specific resource and returns an error.
+	// Instead of a diff, the ResourceConfig is provided since provisioners
 	// only run after a resource has been newly created.
 	Apply(UIOutput, *InstanceState, *ResourceConfig) error
 

--- a/terraform/resource_provisioner.go
+++ b/terraform/resource_provisioner.go
@@ -28,10 +28,9 @@ type ResourceProvisioner interface {
 	// are set and that the general structure is correct.
 	Validate(*ResourceConfig) ([]string, []error)
 
-	// Apply runs the provisioner on a specific resource and returns the new
-	// resource state along with an error. Instead of a diff, the ResourceConfig
-	// is provided since provisioners only run after a resource has been
-	// newly created.
+	// Apply runs the provisioner on a specific resource and returns an error. 
+	// Instead of a diff, the ResourceConfig is provided since provisioners 
+	// only run after a resource has been newly created.
 	Apply(UIOutput, *InstanceState, *ResourceConfig) error
 
 	// Stop is called when the provisioner should halt any in-flight actions.


### PR DESCRIPTION
Fix comment for `type ResourceProvisioner interface` as the `Apply` method is only returning an `error` and not the new resource state.