### PR TITLE
command: 0.13upgrade provider config version merge

### DIFF
--- a/command/013_config_upgrade_test.go
+++ b/command/013_config_upgrade_test.go
@@ -57,7 +57,7 @@ func verifyExpectedFiles(t *testing.T, expectedPath string) {
 			t.Fatalf("failed to read expected %s: %s", filePath, err)
 		}
 
-		if diff := cmp.Diff(expected, output); diff != "" {
+		if diff := cmp.Diff(string(expected), string(output)); diff != "" {
 			t.Fatalf("expected and output file for %s do not match\n%s", filePath, diff)
 		}
 	}
@@ -79,6 +79,7 @@ func TestZeroThirteenUpgrade_success(t *testing.T) {
 		"preserves comments":    "013upgrade-preserves-comments",
 		"multiple blocks":       "013upgrade-multiple-blocks",
 		"multiple files":        "013upgrade-multiple-files",
+		"multiple versions":     "013upgrade-multiple-versions",
 		"existing versions.tf":  "013upgrade-existing-versions-tf",
 		"skipped files":         "013upgrade-skipped-files",
 	}

--- a/command/testdata/013upgrade-multiple-versions/expected/foo.tf
+++ b/command/testdata/013upgrade-multiple-versions/expected/foo.tf
@@ -1,0 +1,5 @@
+provider "foo" {
+}
+
+resource "foo_bar" "baz" {
+}

--- a/command/testdata/013upgrade-multiple-versions/expected/main.tf
+++ b/command/testdata/013upgrade-multiple-versions/expected/main.tf
@@ -1,21 +1,12 @@
-provider "foo" {
-}
-
 terraform {
   required_providers {
-    bar = {
-      source  = "hashicorp/bar"
-      version = "1.0.0"
-    }
     baz = {
       source  = "terraform-providers/baz"
       version = "~> 2.0.0"
     }
     foo = {
       source  = "hashicorp/foo"
-      version = "1.2.3"
+      version = "< 2.0.0,~> 1.2.3"
     }
   }
 }
-
-provider "terraform" {}

--- a/command/testdata/013upgrade-multiple-versions/expected/versions.tf
+++ b/command/testdata/013upgrade-multiple-versions/expected/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}

--- a/command/testdata/013upgrade-multiple-versions/input/foo.tf
+++ b/command/testdata/013upgrade-multiple-versions/input/foo.tf
@@ -1,0 +1,6 @@
+provider "foo" {
+  version = "~> 1.2.3"
+}
+
+resource "foo_bar" "baz" {
+}

--- a/command/testdata/013upgrade-multiple-versions/input/main.tf
+++ b/command/testdata/013upgrade-multiple-versions/input/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    baz = {
+      version = "~> 2.0.0"
+    }
+    foo = "< 2.0.0"
+  }
+}

--- a/command/testdata/013upgrade-skipped-files/expected/main.tf
+++ b/command/testdata/013upgrade-skipped-files/expected/main.tf
@@ -1,5 +1,4 @@
 provider foo {
-  version = "1.2.3"
 }
 
 terraform {
@@ -13,7 +12,8 @@ terraform {
       version = "~> 2.0.0"
     }
     foo = {
-      source = "hashicorp/foo"
+      source  = "hashicorp/foo"
+      version = "1.2.3"
     }
   }
 }


### PR DESCRIPTION
When rewriting configuration with `0.13upgrade` we now merge any version constraints from `provider` blocks into the `required_providers` block. We also rewrite those `provider` blocks to remove the `version` attribute, so that the versions aren't redundantly specified.

The result is that it is easier to comprehend the provider version constraints for a module: after running `0.13upgrade`, all such constraints are in the same file, in a `required_providers` block.