### PR TITLE
added masterport variable to puppet provisioner

### DIFF
--- a/builtin/provisioners/puppet/linux_provisioner.go
+++ b/builtin/provisioners/puppet/linux_provisioner.go
@@ -48,8 +48,9 @@ func (p *provisioner) linuxInstallPuppetAgent() error {
 
 func (p *provisioner) linuxRunPuppetAgent() error {
 	_, err := p.runCommand(fmt.Sprintf(
-		"/opt/puppetlabs/puppet/bin/puppet agent --test --server %s --environment %s",
+		"/opt/puppetlabs/puppet/bin/puppet agent --test --server %s --masterport %d --environment %s",
 		p.Server,
+		p.MasterPort,
 		p.Environment,
 	))
 

--- a/builtin/provisioners/puppet/linux_provisioner_test.go
+++ b/builtin/provisioners/puppet/linux_provisioner_test.go
@@ -314,7 +314,7 @@ func TestResourceProvisioner_linuxRunPuppetAgent(t *testing.T) {
 				"use_sudo": false,
 			},
 			Commands: map[string]bool{
-				"/opt/puppetlabs/puppet/bin/puppet agent --test --server puppet.test.com --environment production": true,
+				"/opt/puppetlabs/puppet/bin/puppet agent --test --server puppet.test.com --masterport 8140 --environment production": true,
 			},
 		},
 		"When puppet returns 2 (changes applied without error)": {

--- a/builtin/provisioners/puppet/resource_provisioner.go
+++ b/builtin/provisioners/puppet/resource_provisioner.go
@@ -20,6 +20,7 @@ import (
 
 type provisioner struct {
 	Server            string
+	MasterPort        int
 	ServerUser        string
 	OSType            string
 	Certname          string
@@ -53,6 +54,11 @@ func Provisioner() terraform.ResourceProvisioner {
 			"server": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+			},
+			"masterport": &schema.Schema{
+				Type:     schema.TypeInt,
+				Default:  8140,
+				Optional: true,
 			},
 			"server_user": &schema.Schema{
 				Type:     schema.TypeString,
@@ -331,6 +337,7 @@ func decodeConfig(d *schema.ResourceData) (*provisioner, error) {
 	p := &provisioner{
 		UseSudo:           d.Get("use_sudo").(bool),
 		Server:            d.Get("server").(string),
+		MasterPort:        d.Get("masterport").(int),
 		ServerUser:        d.Get("server_user").(string),
 		OSType:            strings.ToLower(d.Get("os_type").(string)),
 		Autosign:          d.Get("autosign").(bool),

--- a/builtin/provisioners/puppet/windows_provisioner.go
+++ b/builtin/provisioners/puppet/windows_provisioner.go
@@ -59,7 +59,7 @@ func (p *provisioner) windowsInstallPuppetAgent() error {
 }
 
 func (p *provisioner) windowsRunPuppetAgent() error {
-	_, err := p.runCommand(fmt.Sprintf("puppet agent --test --server %s --environment %s", p.Server, p.Environment))
+	_, err := p.runCommand(fmt.Sprintf("puppet agent --test --server %s --masterport %d --environment %s", p.Server, p.MasterPort, p.Environment))
 	if err != nil {
 		errStruct, _ := err.(*remote.ExitError)
 		if errStruct.ExitStatus == 2 {

--- a/builtin/provisioners/puppet/windows_provisioner_test.go
+++ b/builtin/provisioners/puppet/windows_provisioner_test.go
@@ -18,7 +18,7 @@ const (
 	domainQueryCmd       = `powershell -Command "& {(Get-WmiObject -Query 'select DNSDomain from Win32_NetworkAdapterConfiguration where IPEnabled = True').DNSDomain}"`
 	downloadInstallerCmd = `powershell -Command "& {[Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; (New-Object System.Net.WebClient).DownloadFile('https://puppet.test.com:8140/packages/current/install.ps1', 'install.ps1')}"`
 	runInstallerCmd      = `powershell -Command "& .\install.ps1 -PuppetServiceEnsure stopped"`
-	runPuppetCmd         = "puppet agent --test --server puppet.test.com --environment production"
+	runPuppetCmd         = "puppet agent --test --server puppet.test.com --masterport 8140 --environment production"
 )
 
 func TestResourceProvisioner_windowsUploadFile(t *testing.T) {

--- a/website/docs/provisioners/puppet.html.markdown
+++ b/website/docs/provisioners/puppet.html.markdown
@@ -56,6 +56,8 @@ The following arguments are supported:
 * `server (string)` - (Required) The FQDN of the Puppet master that the agent
   is to connect to.
 
+* `masterport (string)` - (Optional) Port that the puppetmaster is listening to (defaults to `8140`).
+
 * `server_user (string)` - (Optional) The user that Bolt should connect to the
   server as (defaults to `root`).
 


### PR DESCRIPTION
Hi,
This PR is for being able to specify the port on which the puppetmaster is listening to. The default value is the actual default port and I have also updated the documentation for this provisioner

Could you please review it and let me know if you feel something should be improved?

thanks,