### PR TITLE
Fix link to "v0.12-Compatible Provider Requirements" section

### DIFF
--- a/website/docs/configuration/provider-requirements.html.md
+++ b/website/docs/configuration/provider-requirements.html.md
@@ -102,7 +102,7 @@ was added in Terraform v0.13. Previous versions of Terraform used a version
 constraint string instead of an object (like `mycloud = "~> 1.0"`), and had no
 way to specify provider source addresses. If you want to write a module that
 works with both Terraform v0.12 and v0.13, see [v0.12-Compatible Provider
-Requirements](#v012-compatible-provider-requirements) below.
+Requirements](#v0-12-compatible-provider-requirements) below.
 
 ## Names and Addresses
 


### PR DESCRIPTION
On the https://www.terraform.io/docs/configuration/provider-requirements.html#requiring-providers page, the link to the `v0.12-Compatible Provider Requirements` section is broken:
* current link: https://www.terraform.io/docs/configuration/provider-requirements.html#v012-compatible-provider-requirements
* correct link: https://www.terraform.io/docs/configuration/provider-requirements.html#v0-12-compatible-provider-requirements