### PR TITLE
internal: Clean up package install temp file

### DIFF
--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -53,6 +53,7 @@ func installFromHTTPURL(ctx context.Context, meta getproviders.PackageMeta, targ
 		return nil, fmt.Errorf("failed to open temporary file to download from %s", url)
 	}
 	defer f.Close()
+	defer os.Remove(f.Name())
 
 	// We'll borrow go-getter's "cancelable copy" implementation here so that
 	// the download can potentially be interrupted partway through.


### PR DESCRIPTION
The `installFromHTTPURL` function downloads a package to a temporary file, then delegates to `installFromLocalArchive` to install it. We were previously not deleting the temporary file afterwards. This commit fixes that.

I can't see any reasonable way to write a unit test for this, but I've manually tested it.

Fixes #25977