### PR TITLE
website: Provider requirements are not inherited

### DIFF
--- a/website/docs/configuration/modules.html.md
+++ b/website/docs/configuration/modules.html.md
@@ -372,6 +372,8 @@ resource "aws_s3_bucket" "example" {
 We recommend using this approach when a single configuration for each provider
 is sufficient for an entire configuration.
 
+~> **Note:** Only provider configurations are inherited by child modules, not provider source or version requirements. Each module must [declare its own provider requirements](provider-requirements.html). This is especially important for non-HashiCorp providers.
+
 In more complex situations there may be
 [multiple provider configurations](/docs/configuration/providers.html#alias-multiple-provider-configurations),
 or a child module may need to use different provider settings than


### PR DESCRIPTION
Add a note to the provider configuration section explaining that only config can be inherited by child modules, not source or version requirements.

Copy editing suggestions very welcome here!

Raised in #25984