### PR TITLE
website/docs: remove unclear provider version constraint description

### DIFF
--- a/website/docs/configuration/provider-requirements.html.md
+++ b/website/docs/configuration/provider-requirements.html.md
@@ -242,11 +242,11 @@ avoiding typing.
 
 ## Version Constraints
 
-A [source address](#source-addresses) uniquely identifies a particular
-provider, but each provider can have one or more distinct _versions_, allowing
-the functionality of the provider to evolve over time. Each provider dependency
-you declare should have a [version constraint](./version-constraints.html)
-given in the `version` argument.
+Each provider plugin has its own set of available versions, allowing the
+functionality of the provider to evolve over time. Each provider dependency you
+declare should have a [version constraint](./version-constraints.html) given in
+the `version` argument so Terraform can select a single version per provider
+that all modules are compatible with.
 
 The `version` argument is optional; if omitted, Terraform will accept any
 version of the provider as compatible. However, we strongly recommend specifying


### PR DESCRIPTION
The version constraint section could be read to suggest that terraform allows selection of multiple versions of a single provider. Suggestions _gleefully_ welcomed.

Fixes https://github.com/hashicorp/terraform/issues/25935

