### PR TITLE
command: Fix backend config schema validation

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -866,10 +866,13 @@ func (c *InitCommand) backendConfigOverrideBody(flags rawFlags, schema *configsc
 			}
 			// Generate an HCL body schema for the backend block.
 			var bodySchema hcl.BodySchema
-			for name, attr := range schema.Attributes {
+			for name := range schema.Attributes {
+				// We intentionally ignore the `Required` attribute here
+				// because backend config override files can be partial. The
+				// goal is to make sure we're not loading a file with
+				// extraneous attributes or blocks.
 				bodySchema.Attributes = append(bodySchema.Attributes, hcl.AttributeSchema{
-					Name:     name,
-					Required: attr.Required,
+					Name: name,
 				})
 			}
 			for name, block := range schema.BlockTypes {


### PR DESCRIPTION
When applying a backend config override file, we must not check for the presence of all required fields, as the override can be a partial configuration. It is only valid to check for required fields after all overrides have been merged, which init already does.

I can't find any way to add test coverage for this change. I've validated that this fixes the issue reported in #26002 manually, but the only backends which have required attributes in their schema also need to access remote services for `init` to succeed.

Fixes #26002