### PR TITLE
build: allow tests to pass when $PWD contains symlinks

### DIFF
--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -122,6 +122,17 @@ func TestDirFromModule_submodules(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// DirFromModule will expand ("canonicalize") the pathnames, so we must do
+	// the same for our "wantCalls" comparison values. Otherwise this test
+	// will fail when building in a source tree with symlinks in $PWD.
+	//
+	// See also: https://github.com/hashicorp/terraform/issues/26014
+	//
+	fromModuleDirRealpath, err := filepath.EvalSymlinks(fromModuleDir)
+	if err != nil {
+		t.Error(err)
+	}
+
 	tmpDir, done := tempChdir(t, fixtureDir)
 	defer done()
 
@@ -138,12 +149,12 @@ func TestDirFromModule_submodules(t *testing.T) {
 		{
 			Name:       "Install",
 			ModuleAddr: "child_a",
-			LocalPath:  filepath.Join(fromModuleDir, "child_a"),
+			LocalPath:  filepath.Join(fromModuleDirRealpath, "child_a"),
 		},
 		{
 			Name:       "Install",
 			ModuleAddr: "child_a.child_b",
-			LocalPath:  filepath.Join(fromModuleDir, "child_a/child_b"),
+			LocalPath:  filepath.Join(fromModuleDirRealpath, "child_a/child_b"),
 		},
 	}
 


### PR DESCRIPTION
Fixes #26014

This PR contains a small change to the `from_module_test.go` unit test to canonicalize the directory path names in its "expected" values in the same way that the invoked code path does. Existing code is using the absolute path, but without the symlinks (if any) expanded.

Without this change, the unit test does not pass when run from a source tree whose `$PWD` contains symlinks because the "expected" values are constructed differently than the code being tested. Full details are described in issue #26014.
