### PR TITLE
webside/docs: add note re: archive subdirectories to http download section

### DIFF
--- a/website/docs/modules/sources.html.markdown
+++ b/website/docs/modules/sources.html.markdown
@@ -348,6 +348,11 @@ module "vpc" {
 }
 ```
 
+-> **Note:** If the content of the archive file is a directory, you will need to
+include that directory in the module source. Read the section on 
+[Modules in Package Sub-directories](#modules-in-package-sub-directories) for more
+information.
+
 ## S3 Bucket
 
 You can use archives stored in S3 as module sources using the special `s3::`


### PR DESCRIPTION
The information on downloading archives (specifically the warning that an archive might be a directory) is all there, but it's not necessarily obvious that the information was relevant (and important) when looking at the http download section specifically. 

Closes #25873