### PR TITLE
terraform: Fix createEmptyBlocks NestingSingle bug

### DIFF
--- a/terraform/eval_read_data_plan.go
+++ b/terraform/eval_read_data_plan.go
@@ -239,8 +239,6 @@ func createEmptyBlocks(schema *configschema.Block, val cty.Value) cty.Value {
 			continue
 		}
 
-		ety := block.Type().ElementType()
-
 		// helper to build the recursive block values
 		nextBlocks := func() []cty.Value {
 			// this is only called once we know this is a non-null List or Set
@@ -259,6 +257,7 @@ func createEmptyBlocks(schema *configschema.Block, val cty.Value) cty.Value {
 		// We are only concerned with block types that can come from the legacy
 		// sdk, which means TypeList or TypeSet.
 		case configschema.NestingList:
+			ety := block.Type().ElementType()
 			switch {
 			case block.IsNull():
 				objMap[name] = cty.ListValEmpty(ety)
@@ -269,6 +268,7 @@ func createEmptyBlocks(schema *configschema.Block, val cty.Value) cty.Value {
 			}
 
 		case configschema.NestingSet:
+			ety := block.Type().ElementType()
 			switch {
 			case block.IsNull():
 				objMap[name] = cty.SetValEmpty(ety)

--- a/terraform/eval_read_data_plan_test.go
+++ b/terraform/eval_read_data_plan_test.go
@@ -86,6 +86,22 @@ func TestReadDataCreateEmptyBlocks(t *testing.T) {
 		},
 	}
 
+	singleSchema := &configschema.Block{
+		BlockTypes: map[string]*configschema.NestedBlock{
+			"single": {
+				Nesting: configschema.NestingSingle,
+				Block: configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"attr": {
+							Type:     cty.String,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
 	for _, tc := range []struct {
 		name   string
 		schema *configschema.Block
@@ -328,6 +344,20 @@ func TestReadDataCreateEmptyBlocks(t *testing.T) {
 						),
 					}),
 				}),
+			}),
+		},
+		{
+			"single-block-null",
+			singleSchema,
+			cty.ObjectVal(map[string]cty.Value{
+				"single": cty.NullVal(cty.Object(map[string]cty.Type{
+					"attr": cty.String,
+				})),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"single": cty.NullVal(cty.Object(map[string]cty.Type{
+					"attr": cty.String,
+				})),
 			}),
 		},
 	} {


### PR DESCRIPTION
When calling `createEmptyBlocks`, we only intend to process legacy SDK blocks (`NestingList` or `NestingSet`), but the function also needs to pass through `NestingSingle` block types untouched. To do so we must only look up the container's element type after we've established that the block is backed by a container.

Fixes #26011