### PR TITLE
backend/http workspace support

### DIFF
--- a/backend/remote-state/http/backend.go
+++ b/backend/remote-state/http/backend.go
@@ -3,9 +3,11 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
@@ -14,6 +16,10 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statemgr"
+)
+
+var (
+	ErrWorkspaceDisabled = errors.New("workspace_enabled is not true, workspaces disabled")
 )
 
 func New() backend.Backend {
@@ -91,6 +97,48 @@ func New() backend.Backend {
 				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_RETRY_WAIT_MAX", 30),
 				Description: "The maximum time in seconds to wait between HTTP request attempts.",
 			},
+			"workspace_enabled": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enable workspace support.",
+			},
+			"workspace_path_element": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "<workspace>",
+				Description: "The URL path string to replace with the active workspace name.",
+			},
+			"workspace_list_address": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The address of the workspace list REST endpoint.",
+			},
+			"workspace_list_method": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "GET",
+				Description: "The HTTP method to use when fetching workspace list",
+			},
+			"workspace_delete_address": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The address of the workspace delete REST endpoint.",
+			},
+			"workspace_delete_method": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "DELETE",
+				Description: "The HTTP method to use when deleting a workspace.",
+			},
+			"headers": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:        schema.TypeString,
+					Description: "Header Value",
+				},
+			},
 		},
 	}
 
@@ -101,6 +149,13 @@ func New() backend.Backend {
 
 type Backend struct {
 	*schema.Backend
+
+	workspaceEnabled     bool
+	workspacePathElement string
+
+	updateURL *url.URL
+	lockURL   *url.URL
+	unlockURL *url.URL
 
 	client *httpClient
 }
@@ -118,6 +173,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	}
 
 	updateMethod := data.Get("update_method").(string)
+	b.updateURL = updateURL
 
 	var lockURL *url.URL
 	if v, ok := data.GetOk("lock_address"); ok && v.(string) != "" {
@@ -132,6 +188,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	}
 
 	lockMethod := data.Get("lock_method").(string)
+	b.lockURL = lockURL
 
 	var unlockURL *url.URL
 	if v, ok := data.GetOk("unlock_address"); ok && v.(string) != "" {
@@ -146,6 +203,15 @@ func (b *Backend) configure(ctx context.Context) error {
 	}
 
 	unlockMethod := data.Get("unlock_method").(string)
+	b.unlockURL = unlockURL
+
+	headers := map[string]string{}
+	rawHeaders := data.Get("headers").(map[string]interface{})
+	if rawHeaders != nil {
+		for k, v := range rawHeaders {
+			headers[k] = v.(string)
+		}
+	}
 
 	client := cleanhttp.DefaultPooledClient()
 
@@ -163,6 +229,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	rClient.RetryWaitMax = time.Duration(data.Get("retry_wait_max").(int)) * time.Second
 
 	b.client = &httpClient{
+		Headers:      headers,
 		URL:          updateURL,
 		UpdateMethod: updateMethod,
 
@@ -177,21 +244,106 @@ func (b *Backend) configure(ctx context.Context) error {
 		// accessible only for testing use
 		Client: rClient,
 	}
+
+	b.workspaceEnabled = data.Get("workspace_enabled").(bool)
+
+	if b.workspaceEnabled {
+		b.workspacePathElement = data.Get("workspace_path_element").(string)
+		if b.workspacePathElement == "" {
+			return fmt.Errorf("workspace_path_element required when workspace_enabled is true")
+		}
+
+		workspaceListURL, err := url.Parse(data.Get("workspace_list_address").(string))
+		if err != nil {
+			return fmt.Errorf("failed to parse workspace_list_address URL: %s", err)
+		}
+		if workspaceListURL.Scheme != "http" && workspaceListURL.Scheme != "https" {
+			return fmt.Errorf("workspace_list_address must be HTTP or HTTPS")
+		}
+		workspaceListMethod := data.Get("workspace_list_method").(string)
+
+		// optional
+		var workspaceDeleteURL *url.URL
+		if v, ok := data.GetOk("workspace_delete_address"); ok && v.(string) != "" {
+			var err error
+			workspaceDeleteURL, err = url.Parse(data.Get("workspace_delete_address").(string))
+			if err != nil {
+				return fmt.Errorf("failed to parse workspace_delete_address URL: %s", err)
+			}
+			if workspaceDeleteURL.Scheme != "http" && workspaceDeleteURL.Scheme != "https" {
+				return fmt.Errorf("workspace_delete_address must be HTTP or HTTPS")
+			}
+		} else { // default to stateUrl
+			u := *updateURL
+			workspaceDeleteURL = &u
+		}
+		workspaceDeleteMethod := data.Get("workspace_delete_method").(string)
+
+		b.client.WorkspaceListURL = workspaceListURL
+		b.client.WorkspaceListMethod = workspaceListMethod
+		b.client.WorkspaceDeleteURL = workspaceDeleteURL
+		b.client.WorkspaceDeleteMethod = workspaceDeleteMethod
+	}
+
 	return nil
 }
 
 func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
-	if name != backend.DefaultStateName {
-		return nil, backend.ErrWorkspacesNotSupported
+	if b.workspaceEnabled {
+		updateUrl, err := b.workspaceUrlSubstitute(b.updateURL, b.workspacePathElement, name)
+		if err != nil {
+			return nil, err
+		}
+		b.client.URL = updateUrl
+
+		lockUrl, err := b.workspaceUrlSubstitute(b.lockURL, b.workspacePathElement, name)
+		if err != nil {
+			return nil, err
+		}
+		b.client.LockURL = lockUrl
+
+		unlockUrl, err := b.workspaceUrlSubstitute(b.unlockURL, b.workspacePathElement, name)
+		if err != nil {
+			return nil, err
+		}
+		b.client.UnlockURL = unlockUrl
+
+	} else {
+		if name != backend.DefaultStateName {
+			return nil, ErrWorkspaceDisabled
+		}
 	}
 
 	return &remote.State{Client: b.client}, nil
 }
 
 func (b *Backend) Workspaces() ([]string, error) {
-	return nil, backend.ErrWorkspacesNotSupported
+	if !b.workspaceEnabled {
+		return nil, ErrWorkspaceDisabled
+	}
+	return b.client.WorkspaceList()
 }
 
-func (b *Backend) DeleteWorkspace(string) error {
-	return backend.ErrWorkspacesNotSupported
+func (b *Backend) workspaceUrlSubstitute(u *url.URL, old string, new string) (*url.URL, error) {
+	origPath := u.RawPath
+	if origPath == "" {
+		origPath = u.Path
+	}
+	newPath := strings.ReplaceAll(origPath, old, new)
+	newUrl, err := u.Parse(newPath)
+	if err != nil {
+		return nil, err
+	}
+	return newUrl, nil
+}
+
+func (b *Backend) DeleteWorkspace(del string) error {
+	if !b.workspaceEnabled {
+		return ErrWorkspaceDisabled
+	}
+	u, err := b.workspaceUrlSubstitute(b.client.WorkspaceDeleteURL, b.workspacePathElement, del)
+	if err != nil {
+		return err
+	}
+	return b.client.WorkspaceDelete(u)
 }

--- a/backend/remote-state/http/backend.go
+++ b/backend/remote-state/http/backend.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -76,7 +77,7 @@ func New() backend.Backend {
 			"skip_cert_verification": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_SKIP_CERT", false),
 				Description: "Whether to skip TLS verification.",
 			},
 			"retry_max": &schema.Schema{
@@ -100,40 +101,54 @@ func New() backend.Backend {
 			"workspace_enabled": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_WORKSPACE_ENABLED", false),
 				Description: "Enable workspace support.",
 			},
 			"workspace_path_element": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "<workspace>",
+				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_WORKSPACE_PATH_ELEMENT", "<workspace>"),
 				Description: "The URL path string to replace with the active workspace name.",
 			},
 			"workspace_list_address": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_WORKSPACE_LIST_ADDRESS", nil),
 				Description: "The address of the workspace list REST endpoint.",
 			},
 			"workspace_list_method": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "GET",
+				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_WORKSPACE_LIST_METHOD", "GET"),
 				Description: "The HTTP method to use when fetching workspace list",
 			},
 			"workspace_delete_address": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_WORKSPACE_DELETE_ADDRESS", nil),
 				Description: "The address of the workspace delete REST endpoint.",
 			},
 			"workspace_delete_method": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "DELETE",
+				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_WORKSPACE_DELETE_METHOD", "DELETE"),
 				Description: "The HTTP method to use when deleting a workspace.",
 			},
 			"headers": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
+				DefaultFunc: func() (interface{}, error) {
+					v, err := schema.EnvDefaultFunc("TF_HTTP_HEADERS", nil)()
+					if err != nil || v == nil {
+						return nil, err
+					}
+					decode := map[string]interface{}{}
+					err = json.Unmarshal([]byte(v.(string)), &decode)
+					if err != nil {
+						return nil, err
+					}
+					return decode, nil
+				},
 				Elem: &schema.Schema{
 					Type:        schema.TypeString,
 					Description: "Header Value",

--- a/backend/remote-state/http/client.go
+++ b/backend/remote-state/http/client.go
@@ -21,12 +21,19 @@ type httpClient struct {
 	// Update & Retrieve
 	URL          *url.URL
 	UpdateMethod string
+	Headers      map[string]string
 
 	// Locking
 	LockURL      *url.URL
 	LockMethod   string
 	UnlockURL    *url.URL
 	UnlockMethod string
+
+	// Workspace
+	WorkspaceListURL      *url.URL
+	WorkspaceListMethod   string
+	WorkspaceDeleteURL    *url.URL
+	WorkspaceDeleteMethod string
 
 	// HTTP
 	Client   *retryablehttp.Client
@@ -63,6 +70,11 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 		hash := md5.Sum(*data)
 		b64 := base64.StdEncoding.EncodeToString(hash[:])
 		req.Header.Set("Content-MD5", b64)
+	}
+
+	// Set user provided override headers
+	for k, v := range c.Headers {
+		req.Header.Set(k, v)
 	}
 
 	// Make the request
@@ -232,6 +244,51 @@ func (c *httpClient) Put(data []byte) error {
 func (c *httpClient) Delete() error {
 	// Make the request
 	resp, err := c.httpRequest("DELETE", c.URL, nil, "delete state")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Handle the error codes
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	default:
+		return fmt.Errorf("HTTP error: %d", resp.StatusCode)
+	}
+}
+
+func (c *httpClient) WorkspaceList() ([]string, error) {
+	resp, err := c.httpRequest(c.WorkspaceListMethod, c.WorkspaceListURL, nil, "workspace list")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response body")
+		}
+		arr := []string{}
+		err = json.Unmarshal(body, &arr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal response body")
+		}
+
+		return arr, nil
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("HTTP remote state endpoint requires auth")
+	case http.StatusForbidden:
+		return nil, fmt.Errorf("HTTP remote state endpoint invalid auth")
+	default:
+		return nil, fmt.Errorf("Unexpected HTTP response code %d", resp.StatusCode)
+	}
+}
+
+func (c *httpClient) WorkspaceDelete(u *url.URL) error {
+	resp, err := c.httpRequest(c.WorkspaceDeleteMethod, u, nil, "workspace delete")
 	if err != nil {
 		return err
 	}

--- a/backend/remote-state/http/client_test.go
+++ b/backend/remote-state/http/client_test.go
@@ -2,12 +2,12 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -19,15 +19,25 @@ func TestHTTPClient_impl(t *testing.T) {
 	var _ remote.ClientLocker = new(httpClient)
 }
 
-func TestHTTPClient(t *testing.T) {
+func createTestServer() (*testHTTPHandler, *httptest.Server, *url.URL, error) {
 	handler := new(testHTTPHandler)
+	handler.Reset()
 	ts := httptest.NewServer(http.HandlerFunc(handler.Handle))
-	defer ts.Close()
 
 	url, err := url.Parse(ts.URL)
 	if err != nil {
+		ts.Close()
+		return nil, nil, nil, err
+	}
+	return handler, ts, url, nil
+}
+
+func TestHTTPClient(t *testing.T) {
+	handler, ts, url, err := createTestServer()
+	if err != nil {
 		t.Fatalf("Parse: %s", err)
 	}
+	defer ts.Close()
 
 	// Test basic get/update
 	client := &httpClient{URL: url, Client: retryablehttp.NewClient()}
@@ -63,113 +73,165 @@ func TestHTTPClient(t *testing.T) {
 	remote.TestRemoteLocks(t, a, b)
 
 	// test a WebDAV-ish backend
-	davhandler := new(testHTTPHandler)
-	ts = httptest.NewServer(http.HandlerFunc(davhandler.HandleWebDAV))
-	defer ts.Close()
-
-	url, err = url.Parse(ts.URL)
+	handler.Reset()
+	handler.webDav = true
 	client = &httpClient{
 		URL:          url,
 		UpdateMethod: "PUT",
 		Client:       retryablehttp.NewClient(),
 	}
-	if err != nil {
-		t.Fatalf("Parse: %s", err)
-	}
-
 	remote.TestClient(t, client) // first time through: 201
 	remote.TestClient(t, client) // second time, with identical data: 204
 
-	// test a broken backend
-	brokenHandler := new(testBrokenHTTPHandler)
-	brokenHandler.handler = new(testHTTPHandler)
-	ts = httptest.NewServer(http.HandlerFunc(brokenHandler.Handle))
-	defer ts.Close()
-
-	url, err = url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Parse: %s", err)
-	}
-	client = &httpClient{URL: url, Client: retryablehttp.NewClient()}
+	// test an intermittent broken backend
+	handler.Reset()
+	handler.failNext = true
 	remote.TestClient(t, client)
+
+	// test a workspace backend
+	handler.Reset()
+
+	url2, _ := url.Parse("/state/workspace1")
+	url3, _ := url.Parse("/workspace/list")
+
+	// workspace list
+	client = &httpClient{
+		URL:                   url2,
+		UpdateMethod:          "PUT",
+		Client:                retryablehttp.NewClient(),
+		WorkspaceListURL:      url3,
+		WorkspaceDeleteMethod: "DELETE",
+	}
+	// disable retrys as to not hold up test
+	client.Client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		return false, nil
+	}
+
+	// empty
+	handler.Data["/workspace/list"] = "[]"
+
+	res, err := client.WorkspaceList()
+	if err != nil {
+		t.Fatal("unexpected error from workspaceList")
+	}
+	if len(res) != 0 {
+		t.Fatal("unexpected number of workspaces returned for empty array")
+	}
+
+	// multi
+	handler.Data["/workspace/list"] = "[\"entry1\",\"entry2\"]"
+	res, err = client.WorkspaceList()
+	if err != nil {
+		t.Fatal("unexpected error from workspaceList with multi")
+	}
+	if len(res) != 2 {
+		t.Fatal("unexpected number of workspaces returned for populated array")
+	}
+	if res[0] != "entry1" || res[1] != "entry2" {
+		t.Fatalf("workspace entries do not match expected values %+v", res)
+	}
+
+	// error code
+	handler.fail = true
+	res, err = client.WorkspaceList()
+	if err == nil {
+		t.Fatal("expected an error when http service returns an error code")
+	}
+
+	// bad json
+	handler.Data["/workspace/list"] = "[\"entry1\",\"entry2]"
+	res, err = client.WorkspaceList()
+	if err == nil {
+		t.Fatalf("expected an error when attempting to decode invalid json, got payload %#v", res)
+	}
+
+	// workspace delete
+	handler.Reset()
+	handler.Data["/state/workspace1"] = "{}"
+	err = client.WorkspaceDelete(url2)
+	if err != nil {
+		t.Fatalf("unexpected error from workspace delete, %s", err)
+	}
+	if _, ok := handler.Data["/state/workspace1"]; ok {
+		t.Fatal("workspace delete did not remove state")
+	}
+
+	// non exist
+	handler.fail = true
+	err = client.WorkspaceDelete(url2)
+	if err == nil {
+		t.Fatal("expected error with bad response code from workspace delete")
+	}
 }
 
 type testHTTPHandler struct {
-	Data   []byte
-	Locked bool
+	failNext bool
+	fail     bool
+	webDav   bool
+	Data     map[string]string
+	Locked   map[string]bool
+}
+
+func (h *testHTTPHandler) Reset() {
+	h.failNext = false
+	h.fail = false
+	h.webDav = false
+	h.Data = nil
+	h.Locked = nil
+	h.Data = map[string]string{}
+	h.Locked = map[string]bool{}
 }
 
 func (h *testHTTPHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	if h.failNext || h.fail {
+		w.WriteHeader(500)
+		h.failNext = false
+		return
+	}
+	path := r.URL.Path
+
 	switch r.Method {
 	case "GET":
-		w.Write(h.Data)
+		if d, ok := h.Data[path]; ok {
+			w.Write([]byte(d))
+		} else {
+			w.WriteHeader(404)
+		}
 	case "PUT":
 		buf := new(bytes.Buffer)
 		if _, err := io.Copy(buf, r.Body); err != nil {
 			w.WriteHeader(500)
 		}
-		w.WriteHeader(201)
-		h.Data = buf.Bytes()
+		bufAsString := string(buf.Bytes())
+
+		// only difference from webdav function is 204 on match
+		if d, ok := h.Data[path]; ok && h.webDav && bufAsString == d {
+			w.WriteHeader(204)
+		} else {
+			w.WriteHeader(201)
+		}
+
+		h.Data[path] = bufAsString
 	case "POST":
 		buf := new(bytes.Buffer)
 		if _, err := io.Copy(buf, r.Body); err != nil {
 			w.WriteHeader(500)
 		}
-		h.Data = buf.Bytes()
+		h.Data[path] = string(buf.Bytes())
+		w.WriteHeader(201)
 	case "LOCK":
-		if h.Locked {
+		if v, ok := h.Locked[path]; ok && v {
 			w.WriteHeader(423)
 		} else {
-			h.Locked = true
+			h.Locked[path] = true
 		}
 	case "UNLOCK":
-		h.Locked = false
+		delete(h.Locked, path)
 	case "DELETE":
-		h.Data = nil
+		delete(h.Data, path)
 		w.WriteHeader(200)
 	default:
 		w.WriteHeader(500)
 		w.Write([]byte(fmt.Sprintf("Unknown method: %s", r.Method)))
-	}
-}
-
-// mod_dav-ish behavior
-func (h *testHTTPHandler) HandleWebDAV(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case "GET":
-		w.Write(h.Data)
-	case "PUT":
-		buf := new(bytes.Buffer)
-		if _, err := io.Copy(buf, r.Body); err != nil {
-			w.WriteHeader(500)
-		}
-		if reflect.DeepEqual(h.Data, buf.Bytes()) {
-			h.Data = buf.Bytes()
-			w.WriteHeader(204)
-		} else {
-			h.Data = buf.Bytes()
-			w.WriteHeader(201)
-		}
-	case "DELETE":
-		h.Data = nil
-		w.WriteHeader(200)
-	default:
-		w.WriteHeader(500)
-		w.Write([]byte(fmt.Sprintf("Unknown method: %s", r.Method)))
-	}
-}
-
-type testBrokenHTTPHandler struct {
-	lastRequestWasBroken bool
-	handler              *testHTTPHandler
-}
-
-func (h *testBrokenHTTPHandler) Handle(w http.ResponseWriter, r *http.Request) {
-	if h.lastRequestWasBroken {
-		h.lastRequestWasBroken = false
-		h.handler.Handle(w, r)
-	} else {
-		h.lastRequestWasBroken = true
-		w.WriteHeader(500)
 	}
 }

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -672,18 +672,25 @@ func TestApply_plan_remoteState(t *testing.T) {
 
 	_, snap := testModuleWithSnapshot(t, "apply")
 	backendConfig := cty.ObjectVal(map[string]cty.Value{
-		"address":                cty.StringVal(srv.URL),
-		"update_method":          cty.NullVal(cty.String),
-		"lock_address":           cty.NullVal(cty.String),
-		"unlock_address":         cty.NullVal(cty.String),
-		"lock_method":            cty.NullVal(cty.String),
-		"unlock_method":          cty.NullVal(cty.String),
-		"username":               cty.NullVal(cty.String),
-		"password":               cty.NullVal(cty.String),
-		"skip_cert_verification": cty.NullVal(cty.Bool),
-		"retry_max":              cty.NullVal(cty.String),
-		"retry_wait_min":         cty.NullVal(cty.String),
-		"retry_wait_max":         cty.NullVal(cty.String),
+		"address":                  cty.StringVal(srv.URL),
+		"update_method":            cty.NullVal(cty.String),
+		"lock_address":             cty.NullVal(cty.String),
+		"unlock_address":           cty.NullVal(cty.String),
+		"lock_method":              cty.NullVal(cty.String),
+		"unlock_method":            cty.NullVal(cty.String),
+		"username":                 cty.NullVal(cty.String),
+		"password":                 cty.NullVal(cty.String),
+		"skip_cert_verification":   cty.NullVal(cty.Bool),
+		"retry_max":                cty.NullVal(cty.String),
+		"retry_wait_min":           cty.NullVal(cty.String),
+		"retry_wait_max":           cty.NullVal(cty.String),
+		"workspace_enabled":        cty.NullVal(cty.Bool),
+		"workspace_path_element":   cty.NullVal(cty.String),
+		"workspace_list_address":   cty.NullVal(cty.String),
+		"workspace_list_method":    cty.NullVal(cty.String),
+		"workspace_delete_address": cty.NullVal(cty.String),
+		"workspace_delete_method":  cty.NullVal(cty.String),
+		"headers":                  cty.ObjectVal(map[string]cty.Value{}),
 	})
 	backendConfigRaw, err := plans.NewDynamicValue(backendConfig, backendConfig.Type())
 	if err != nil {

--- a/website/docs/backends/types/http.html.md
+++ b/website/docs/backends/types/http.html.md
@@ -60,7 +60,7 @@ The following configuration options / environment variables are supported:
    authentication
  * `password` / `TF_HTTP_PASSWORD` - (Optional) The password for HTTP basic
    authentication
- * `skip_cert_verification` - (Optional) Whether to skip TLS verification.
+ * `skip_cert_verification` / `TF_HTTP_SKIP_CERT` - (Optional) Whether to skip TLS verification.
    Defaults to `false`.
  * `retry_max` / `TF_HTTP_RETRY_MAX` – (Optional) The number of HTTP request
    retries. Defaults to `2`.
@@ -68,15 +68,15 @@ The following configuration options / environment variables are supported:
    seconds to wait between HTTP request attempts. Defaults to `1`.
  * `retry_wait_max` / `TF_HTTP_RETRY_WAIT_MAX` – (Optional) The maximum time in
    seconds to wait between HTTP request attempts. Defaults to `30`.
- * `workspace_enabled` - (Optional) Boolean, enable workspace support.
-   Defaults to false.
- * `workspace_path_element` - (Required when workspace_enabled is true) String to replace with workspace name in address URLs.
+ * `workspace_enabled` / `TF_HTTP_WORKSPACE_ENABLED` (Optional) Enable workspace support
+   Defaults to `false`.
+ * `workspace_path_element` / `TF_HTTP_WORKSPACE_PATH_ELEMENT` (Required when workspace_enabled is true) String to replace with workspace name in address URLs.
    Defaults to `<workspace>`.
- * `workspace_list_address` - (Required when workspace_enabled is true) The address of the REST endpoint returning a JSON array of workspace names.
- * `workspace_list_method` - (Optional) The HTTP method for the REST endpoint for workspace list.
+ * `workspace_list_address` / `TF_HTTP_WORKSPACE_LIST_ADDRESS` - (Required when workspace_enabled is true) The address of the REST endpoint returning a JSON array of workspace names.
+ * `workspace_list_method` / `TF_HTTP_WORKSPACE_LIST_METHOD`- (Optional) The HTTP method for the REST endpoint for workspace list.
    Defaults to `GET`.
- * `workspace_delete_address` - (Optional) The address of the REST endpoint to delete a workspace.
+ * `workspace_delete_address` / `TF_HTTP_WORKSPACE_DELETE_ADDRESS` - (Optional) The address of the REST endpoint to delete a workspace.
    Defaults to the value of `address`.
- * `workspace_delete_method` - (Optional) The HTTP method for the REST endpoint for workspace delete.
+ * `workspace_delete_method` / `TF_HTTP_WORKSPACE_DELETE_METHOD` - (Optional) The HTTP method for the REST endpoint for workspace delete.
    Defaults to `DELETE`.
- * `headers` - (Optional) Map of HTTP headers to include with every request.
+ * `headers` / `TF_HTTP_HEADERS` - (Optional) Map of HTTP headers to include with every request.

--- a/website/docs/backends/types/http.html.md
+++ b/website/docs/backends/types/http.html.md
@@ -68,3 +68,15 @@ The following configuration options / environment variables are supported:
    seconds to wait between HTTP request attempts. Defaults to `1`.
  * `retry_wait_max` / `TF_HTTP_RETRY_WAIT_MAX` – (Optional) The maximum time in
    seconds to wait between HTTP request attempts. Defaults to `30`.
+ * `workspace_enabled` - (Optional) Boolean, enable workspace support.
+   Defaults to false.
+ * `workspace_path_element` - (Required when workspace_enabled is true) String to replace with workspace name in address URLs.
+   Defaults to `<workspace>`.
+ * `workspace_list_address` - (Required when workspace_enabled is true) The address of the REST endpoint returning a JSON array of workspace names.
+ * `workspace_list_method` - (Optional) The HTTP method for the REST endpoint for workspace list.
+   Defaults to `GET`.
+ * `workspace_delete_address` - (Optional) The address of the REST endpoint to delete a workspace.
+   Defaults to the value of `address`.
+ * `workspace_delete_method` - (Optional) The HTTP method for the REST endpoint for workspace delete.
+   Defaults to `DELETE`.
+ * `headers` - (Optional) Map of HTTP headers to include with every request.


### PR DESCRIPTION
Addition of path based workspace support.

Extra configuration attributes to support.
All are optional, behaviour without setting workspace_enabled true should remain unchanged from pre PR.
(except for a slight different error code (workspace unsupported -> workspace disabled))

Added http header injection support (let me know if this needs to be split to another PR, but its pretty minor)