### PR TITLE
command: Warn instead of error for empty output

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -113,13 +113,17 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	if !jsonOutput && (state.Empty() || len(mod.OutputValues) == 0) {
-		c.Ui.Error(
-			"The state file either has no outputs defined, or all the defined\n" +
-				"outputs are empty. Please define an output in your configuration\n" +
-				"with the `output` keyword and run `terraform refresh` for it to\n" +
-				"become available. If you are using interpolation, please verify\n" +
-				"the interpolated value is not empty. You can use the \n" +
-				"`terraform console` command to assist.")
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"No outputs found",
+			"The state file either has no outputs defined, or all the defined "+
+				"outputs are empty. Please define an output in your configuration "+
+				"with the `output` keyword and run `terraform refresh` for it to "+
+				"become available. If you are using interpolation, please verify "+
+				"the interpolated value is not empty. You can use the "+
+				"`terraform console` command to assist.",
+		))
+		c.showDiagnostics(diags)
 		return 0
 	}
 

--- a/command/output_test.go
+++ b/command/output_test.go
@@ -120,7 +120,7 @@ func TestOutput_json(t *testing.T) {
 	}
 }
 
-func TestOutput_emptyOutputsErr(t *testing.T) {
+func TestOutput_emptyOutputs(t *testing.T) {
 	originalState := states.NewState()
 	statePath := testStateFile(t, originalState)
 
@@ -138,6 +138,9 @@ func TestOutput_emptyOutputsErr(t *testing.T) {
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+	if got, want := ui.ErrorWriter.String(), "Warning: No outputs found"; !strings.Contains(got, want) {
+		t.Fatalf("bad output: expected to contain %q, got:\n%s", want, got)
 	}
 }
 


### PR DESCRIPTION
When the output subcommand is called with no arguments, and there are no outputs to show, we previously rendered an error message but returned a non-error status code. This is confusing.

This commit changes the text UI to use a warning diagnostic, which makes it clearer that this is a non-error situation. We do not change the exit code or the text of the warning, so hopefully this is not considered a breaking change.

Fixes #25956