### PR TITLE
incorporate go-getter support for 'git::' filepaths

### DIFF
--- a/configs/configload/getter.go
+++ b/configs/configload/getter.go
@@ -17,13 +17,13 @@ import (
 // any meddling that might be done by other go-getter callers linked into our
 // executable.
 
-var goGetterDetectors = []getter.Detector{
-	new(getter.GitHubDetector),
-	new(getter.GitDetector),
-	new(getter.BitBucketDetector),
-	new(getter.GCSDetector),
-	new(getter.S3Detector),
-	new(getter.FileDetector),
+var goGetterCtxDetectors = []getter.CtxDetector{
+	new(getter.GitHubCtxDetector),
+	new(getter.GitCtxDetector),
+	new(getter.BitBucketCtxDetector),
+	new(getter.GCSCtxDetector),
+	new(getter.S3CtxDetector),
+	new(getter.FileCtxDetector),
 }
 
 var goGetterNoDetectors = []getter.Detector{}
@@ -80,12 +80,12 @@ type reusingGetter map[string]string
 // end-user-actionable error messages. At this time we do not have any
 // reasonable way to improve these error messages at this layer because
 // the underlying errors are not separatelyr recognizable.
-func (g reusingGetter) getWithGoGetter(instPath, addr string) (string, error) {
+func (g reusingGetter) getWithGoGetter(instPath, addr, srcAbs string) (string, error) {
 	packageAddr, subDir := splitAddrSubdir(addr)
 
 	log.Printf("[DEBUG] will download %q to %s", packageAddr, instPath)
 
-	realAddr, err := getter.Detect(packageAddr, instPath, goGetterDetectors)
+	realAddr, err := getter.CtxDetect(packageAddr, instPath, srcAbs, goGetterCtxDetectors)
 	if err != nil {
 		return "", err
 	}

--- a/internal/initwd/getter.go
+++ b/internal/initwd/getter.go
@@ -20,13 +20,13 @@ import (
 // any meddling that might be done by other go-getter callers linked into our
 // executable.
 
-var goGetterDetectors = []getter.Detector{
-	new(getter.GitHubDetector),
-	new(getter.GitDetector),
-	new(getter.BitBucketDetector),
-	new(getter.GCSDetector),
-	new(getter.S3Detector),
-	new(getter.FileDetector),
+var goGetterCtxDetectors = []getter.CtxDetector{
+	new(getter.GitHubCtxDetector),
+	new(getter.GitCtxDetector),
+	new(getter.BitBucketCtxDetector),
+	new(getter.GCSCtxDetector),
+	new(getter.S3CtxDetector),
+	new(getter.FileCtxDetector),
 }
 
 var goGetterNoDetectors = []getter.Detector{}
@@ -83,12 +83,12 @@ type reusingGetter map[string]string
 // end-user-actionable error messages. At this time we do not have any
 // reasonable way to improve these error messages at this layer because
 // the underlying errors are not separately recognizable.
-func (g reusingGetter) getWithGoGetter(instPath, addr string) (string, error) {
+func (g reusingGetter) getWithGoGetter(instPath, addr, srcAbs string) (string, error) {
 	packageAddr, subDir := splitAddrSubdir(addr)
 
 	log.Printf("[DEBUG] will download %q to %s", packageAddr, instPath)
 
-	realAddr, err := getter.Detect(packageAddr, instPath, goGetterDetectors)
+	realAddr, err := getter.CtxDetect(packageAddr, instPath, srcAbs, goGetterCtxDetectors)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**This _draft_ PR is a WIP, but please feel free to provide feedback.**

The changes noted below require a WIP version of the [go-getter][go-getter-hashicorp] project, currently available on the `ads/git-forced-rel-path-to-abs` branch of my GitHub fork of the project here:

   * https://github.com/salewski/go-getter/tree/ads/git-forced-rel-path-to-abs

The upstream project issue and draft PR for those changes is:

   * [hashicorp/go-getter issue #268][go-getter-issue-268]
   * [hashicorp/go-getter PR #269][go-getter-pr-269]

There has been some discussion of this feature on these terraform issues:

   * [hashicorp/terraform issue #25488][terraform-issue-25488]
   * [hashicorp/terraform issue #21107][terraform-issue-21107]

----
**DRAFT** **DRAFT** **DRAFT** **DRAFT** **DRAFT** **DRAFT** **DRAFT**
----

----
*(Tentative PR cover letter follows)*
----

The go-getters library now has support for local file system paths to Git repositories, specified with the `git::` forcing token. The feature works for both absolute and relative filepaths, and supports all the usual go-getter goodies including `//` delimited subdirs and URI-style query parameters.

The featurs was introduced into the [go-getter][go-getter-hashicorp] project with the following issue and PR for those changes is:

   * [hashicorp/go-getter issue #268][go-getter-issue-268]
   * [hashicorp/go-getter PR #269][go-getter-pr-269]


We incorporate that capability into Terraform, which allows users to specify paths to locally present Git repositories from which to clone other Terrform modules on which they are dependent. When coupled with Git submodules, this creates a powerful way to manage Terraform modules at specific versions without requiring those modules to be available on the network (e.g., on GitHub):

``` terraform
    module "my_module" {
        source = "git::../git-submodules/tf-modules/some-tf-module?ref=v0.1.0"
        // ...
    }
```


From the perspective of Terraform, such Git repositories are "remote" in the same way that repositories on GitHub are.

Note that within a Terraform module "call" block, the filepaths specified are relative to the directory in which the `*.tf` file lives, not relative to the current working directory of the Terraform process. (Thanks to @apparentlymart for pointing that out as one of the main challenges [in this comment](https://github.com/hashicorp/terraform/issues/21107#issuecomment-683156890)). In order to support this feature, Terraform needs to supply that contextual information to go-getter to allow relative filepath resolution to work. In order to do so, we needed to switch over to using go-getter's new "Contextual Detector" API. It works in the same basic way as the traditional Detector API, but allows us to provide this additional information.

In keeping with the "keep things simple" comment in the commit message of 2b2ac1f6deb9, we are here maintaining our custom go-getter detectors in two places. Only now each is called FooCtxDetector rather than FooDetector. Nevertheless, all except the `GitCtxDetector` do little more than "pass through" delegation to its analogous FooDetector counterpart.

Fixes #25488
Fixes #21107

[0] https://github.com/hashicorp/go-getter/issues/268
[1] https://github.com/hashicorp/go-getter/pull/269

[go-getter-hashicorp]:   https://github.com/hashicorp/go-getter              "GitHub repo: hashicorp/go-getter"
[go-getter-issue-268]:   https://github.com/hashicorp/go-getter/issues/268   "go-getter issue #268"
[go-getter-pr-269]:      https://github.com/hashicorp/go-getter/pull/269     "go-getter PR #269"

[terraform-issue-25488]: https://github.com/hashicorp/terraform/issues/25488 "terraform issue #25488"
[terraform-issue-21107]: https://github.com/hashicorp/terraform/issues/21107 "terraform issue #21107"
