### PR TITLE
command: Add redirect support to 0.13upgrade

### DIFF
--- a/command/013_config_upgrade_test.go
+++ b/command/013_config_upgrade_test.go
@@ -57,7 +57,7 @@ func verifyExpectedFiles(t *testing.T, expectedPath string) {
 			t.Fatalf("failed to read expected %s: %s", filePath, err)
 		}
 
-		if diff := cmp.Diff(expected, output); diff != "" {
+		if diff := cmp.Diff(string(expected), string(output)); diff != "" {
 			t.Fatalf("expected and output file for %s do not match\n%s", filePath, diff)
 		}
 	}
@@ -81,6 +81,8 @@ func TestZeroThirteenUpgrade_success(t *testing.T) {
 		"multiple files":        "013upgrade-multiple-files",
 		"existing versions.tf":  "013upgrade-existing-versions-tf",
 		"skipped files":         "013upgrade-skipped-files",
+		"provider redirect":     "013upgrade-provider-redirect",
+		"version unavailable":   "013upgrade-provider-redirect-version-unavailable",
 	}
 	for name, testPath := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/command/init.go
+++ b/command/init.go
@@ -695,9 +695,13 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 		source := c.providerInstallSource()
 		for provider, fetchErr := range missingProviderErrors {
 			addr := addrs.NewLegacyProvider(provider.Type)
-			p, err := getproviders.LookupLegacyProvider(addr, source)
+			p, redirect, err := getproviders.LookupLegacyProvider(addr, source)
 			if err == nil {
-				foundProviders[provider] = p
+				if redirect.IsZero() {
+					foundProviders[provider] = p
+				} else {
+					foundProviders[provider] = redirect
+				}
 			} else {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,

--- a/command/testdata/013upgrade-provider-redirect-version-unavailable/expected/main.tf
+++ b/command/testdata/013upgrade-provider-redirect-version-unavailable/expected/main.tf
@@ -1,0 +1,3 @@
+provider "qux" {
+  version = "~> 0.9.0"
+}

--- a/command/testdata/013upgrade-provider-redirect-version-unavailable/expected/versions.tf
+++ b/command/testdata/013upgrade-provider-redirect-version-unavailable/expected/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    qux = {
+      source = "hashicorp/qux"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/command/testdata/013upgrade-provider-redirect-version-unavailable/input/main.tf
+++ b/command/testdata/013upgrade-provider-redirect-version-unavailable/input/main.tf
@@ -1,0 +1,3 @@
+provider "qux" {
+  version = "~> 0.9.0"
+}

--- a/command/testdata/013upgrade-provider-redirect/expected/main.tf
+++ b/command/testdata/013upgrade-provider-redirect/expected/main.tf
@@ -1,0 +1,3 @@
+provider "qux" {
+  version = ">= 1.0.0"
+}

--- a/command/testdata/013upgrade-provider-redirect/expected/versions.tf
+++ b/command/testdata/013upgrade-provider-redirect/expected/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    qux = {
+      source = "acme/qux"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/command/testdata/013upgrade-provider-redirect/input/main.tf
+++ b/command/testdata/013upgrade-provider-redirect/input/main.tf
@@ -1,0 +1,3 @@
+provider "qux" {
+  version = ">= 1.0.0"
+}

--- a/internal/getproviders/legacy_lookup.go
+++ b/internal/getproviders/legacy_lookup.go
@@ -25,13 +25,13 @@ import (
 // configurations that don't include explicit provider source addresses. New
 // configurations should not rely on it, and this fallback mechanism is
 // likely to be removed altogether in a future Terraform version.
-func LookupLegacyProvider(addr addrs.Provider, source Source) (addrs.Provider, error) {
+func LookupLegacyProvider(addr addrs.Provider, source Source) (addrs.Provider, addrs.Provider, error) {
 	if addr.Namespace != "-" {
-		return addr, nil
+		return addr, addrs.Provider{}, nil
 	}
 	if addr.Hostname != defaultRegistryHost { // condition above assures namespace is also "-"
 		// Legacy providers must always belong to the default registry host.
-		return addrs.Provider{}, fmt.Errorf("invalid provider type %q: legacy provider addresses must always belong to %s", addr, defaultRegistryHost)
+		return addrs.Provider{}, addrs.Provider{}, fmt.Errorf("invalid provider type %q: legacy provider addresses must always belong to %s", addr, defaultRegistryHost)
 	}
 
 	// Now we need to derive a suitable *RegistrySource from the given source,
@@ -45,19 +45,28 @@ func LookupLegacyProvider(addr addrs.Provider, source Source) (addrs.Provider, e
 		// based on the CLI configuration, which isn't necessarily true but
 		// is true in all cases where this error message will ultimately be
 		// presented to an end-user, so good enough for now.
-		return addrs.Provider{}, fmt.Errorf("unqualified provider type %q cannot be resolved because direct installation from %s is disabled in the CLI configuration; declare an explicit provider namespace for this provider", addr.Type, addr.Hostname)
+		return addrs.Provider{}, addrs.Provider{}, fmt.Errorf("unqualified provider type %q cannot be resolved because direct installation from %s is disabled in the CLI configuration; declare an explicit provider namespace for this provider", addr.Type, addr.Hostname)
 	}
 
-	defaultNamespace, err := regSource.LookupLegacyProviderNamespace(addr.Hostname, addr.Type)
+	defaultNamespace, redirectNamespace, err := regSource.LookupLegacyProviderNamespace(addr.Hostname, addr.Type)
 	if err != nil {
-		return addrs.Provider{}, err
+		return addrs.Provider{}, addrs.Provider{}, err
 	}
-
-	return addrs.Provider{
+	provider := addrs.Provider{
 		Hostname:  addr.Hostname,
 		Namespace: defaultNamespace,
 		Type:      addr.Type,
-	}, nil
+	}
+	var redirect addrs.Provider
+	if redirectNamespace != "" {
+		redirect = addrs.Provider{
+			Hostname:  addr.Hostname,
+			Namespace: redirectNamespace,
+			Type:      addr.Type,
+		}
+	}
+
+	return provider, redirect, nil
 }
 
 // findLegacyProviderLookupSource tries to find a *RegistrySource that can talk

--- a/internal/getproviders/legacy_lookup_test.go
+++ b/internal/getproviders/legacy_lookup_test.go
@@ -11,7 +11,7 @@ func TestLookupLegacyProvider(t *testing.T) {
 	source, _, close := testRegistrySource(t)
 	defer close()
 
-	got, err := LookupLegacyProvider(
+	got, gotMoved, err := LookupLegacyProvider(
 		addrs.NewLegacyProvider("legacy"),
 		source,
 	)
@@ -27,13 +27,46 @@ func TestLookupLegacyProvider(t *testing.T) {
 	if got != want {
 		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
 	}
+	if !gotMoved.IsZero() {
+		t.Errorf("wrong moved result\ngot:  %#v\nwant: %#v", gotMoved, addrs.Provider{})
+	}
+}
+
+func TestLookupLegacyProvider_moved(t *testing.T) {
+	source, _, close := testRegistrySource(t)
+	defer close()
+
+	got, gotMoved, err := LookupLegacyProvider(
+		addrs.NewLegacyProvider("moved"),
+		source,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	want := addrs.Provider{
+		Hostname:  defaultRegistryHost,
+		Namespace: "hashicorp",
+		Type:      "moved",
+	}
+	wantMoved := addrs.Provider{
+		Hostname:  defaultRegistryHost,
+		Namespace: "acme",
+		Type:      "moved",
+	}
+	if got != want {
+		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+	}
+	if gotMoved != wantMoved {
+		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", gotMoved, wantMoved)
+	}
 }
 
 func TestLookupLegacyProvider_invalidResponse(t *testing.T) {
 	source, _, close := testRegistrySource(t)
 	defer close()
 
-	got, err := LookupLegacyProvider(
+	got, _, err := LookupLegacyProvider(
 		addrs.NewLegacyProvider("invalid"),
 		source,
 	)
@@ -50,7 +83,7 @@ func TestLookupLegacyProvider_unexpectedTypeChange(t *testing.T) {
 	source, _, close := testRegistrySource(t)
 	defer close()
 
-	got, err := LookupLegacyProvider(
+	got, _, err := LookupLegacyProvider(
 		addrs.NewLegacyProvider("changetype"),
 		source,
 	)

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -408,18 +408,18 @@ FindMatch:
 // This method exists only to allow compatibility with unqualified names
 // in older configurations. New configurations should be written so as not to
 // depend on it.
-func (c *registryClient) LegacyProviderDefaultNamespace(typeName string) (string, error) {
+func (c *registryClient) LegacyProviderDefaultNamespace(typeName string) (string, string, error) {
 	endpointPath, err := url.Parse(path.Join("-", typeName, "versions"))
 	if err != nil {
 		// Should never happen because we're constructing this from
 		// already-validated components.
-		return "", err
+		return "", "", err
 	}
 	endpointURL := c.baseURL.ResolveReference(endpointPath)
 
 	req, err := retryablehttp.NewRequest("GET", endpointURL.String(), nil)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	c.addHeadersToRequest(req.Request)
 
@@ -429,7 +429,7 @@ func (c *registryClient) LegacyProviderDefaultNamespace(typeName string) (string
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", c.errQueryFailed(placeholderProviderAddr, err)
+		return "", "", c.errQueryFailed(placeholderProviderAddr, err)
 	}
 	defer resp.Body.Close()
 
@@ -437,35 +437,48 @@ func (c *registryClient) LegacyProviderDefaultNamespace(typeName string) (string
 	case http.StatusOK:
 		// Great!
 	case http.StatusNotFound:
-		return "", ErrProviderNotFound{
+		return "", "", ErrProviderNotFound{
 			Provider: placeholderProviderAddr,
 		}
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return "", c.errUnauthorized(placeholderProviderAddr.Hostname)
+		return "", "", c.errUnauthorized(placeholderProviderAddr.Hostname)
 	default:
-		return "", c.errQueryFailed(placeholderProviderAddr, errors.New(resp.Status))
+		return "", "", c.errQueryFailed(placeholderProviderAddr, errors.New(resp.Status))
 	}
 
 	type ResponseBody struct {
-		Id string
+		Id      string `json:"id"`
+		MovedTo string `json:"moved_to"`
 	}
 	var body ResponseBody
 
 	dec := json.NewDecoder(resp.Body)
 	if err := dec.Decode(&body); err != nil {
-		return "", c.errQueryFailed(placeholderProviderAddr, err)
+		return "", "", c.errQueryFailed(placeholderProviderAddr, err)
 	}
 
 	provider, diags := addrs.ParseProviderSourceString(body.Id)
 	if diags.HasErrors() {
-		return "", fmt.Errorf("Error parsing provider ID from Registry: %s", diags.Err())
+		return "", "", fmt.Errorf("Error parsing provider ID from Registry: %s", diags.Err())
 	}
 
 	if provider.Type != typeName {
-		return "", fmt.Errorf("Registry returned provider with type %q, expected %q", provider.Type, typeName)
+		return "", "", fmt.Errorf("Registry returned provider with type %q, expected %q", provider.Type, typeName)
 	}
 
-	return provider.Namespace, nil
+	var movedTo addrs.Provider
+	if body.MovedTo != "" {
+		movedTo, diags = addrs.ParseProviderSourceString(body.MovedTo)
+		if diags.HasErrors() {
+			return "", "", fmt.Errorf("Error parsing provider ID from Registry: %s", diags.Err())
+		}
+
+		if movedTo.Type != typeName {
+			return "", "", fmt.Errorf("Registry returned provider with type %q, expected %q", movedTo.Type, typeName)
+		}
+	}
+
+	return provider.Namespace, movedTo.Namespace, nil
 }
 
 func (c *registryClient) addHeadersToRequest(req *http.Request) {

--- a/internal/getproviders/registry_client_test.go
+++ b/internal/getproviders/registry_client_test.go
@@ -226,6 +226,11 @@ func fakeRegistryHandler(resp http.ResponseWriter, req *http.Request) {
 			resp.WriteHeader(200)
 			// This response is used for testing LookupLegacyProvider
 			resp.Write([]byte(`{"id":"legacycorp/legacy"}`))
+		case "-/moved":
+			resp.Header().Set("Content-Type", "application/json")
+			resp.WriteHeader(200)
+			// This response is used for testing LookupLegacyProvider
+			resp.Write([]byte(`{"id":"hashicorp/moved","moved_to":"acme/moved"}`))
 		case "-/changetype":
 			resp.Header().Set("Content-Type", "application/json")
 			resp.WriteHeader(200)

--- a/internal/getproviders/registry_source.go
+++ b/internal/getproviders/registry_source.go
@@ -118,10 +118,10 @@ func (s *RegistrySource) PackageMeta(provider addrs.Provider, version Version, t
 // in older configurations. New configurations should be written so as not to
 // depend on it, and this fallback mechanism will likely be removed altogether
 // in a future Terraform version.
-func (s *RegistrySource) LookupLegacyProviderNamespace(hostname svchost.Hostname, typeName string) (string, error) {
+func (s *RegistrySource) LookupLegacyProviderNamespace(hostname svchost.Hostname, typeName string) (string, string, error) {
 	client, err := s.registryClient(hostname)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	return client.LegacyProviderDefaultNamespace(typeName)
 }


### PR DESCRIPTION
If a provider changes namespace in the registry, we can detect this when running the `0.13upgrade` command. As long as there is a version matching the user's constraints, we now use the provider's new source address. Otherwise, warn the user that the provider has moved and a version upgrade is necessary to move to it.

### Screenshots

Successful provider redirect, due to version constraint being met by the redirect target:

<img width="842" alt="moved" src="https://user-images.githubusercontent.com/68917/91739821-73d68000-eb80-11ea-8368-ed301716c63b.png">

Cannot follow the redirect, as the version constraint cannot be met:

<img width="926" alt="warning" src="https://user-images.githubusercontent.com/68917/91755980-fcade580-eb99-11ea-8c6a-0901bfd7f53c.png">
