### PR TITLE
command: Better in-house provider install errors

### DIFF
--- a/command/format/diagnostic.go
+++ b/command/format/diagnostic.go
@@ -175,11 +175,17 @@ func Diagnostic(diag tfdiags.Diagnostic, sources map[string][]byte, color *color
 	}
 
 	if desc.Detail != "" {
-		detail := desc.Detail
 		if width != 0 {
-			detail = wordwrap.WrapString(detail, uint(width))
+			lines := strings.Split(desc.Detail, "\n")
+			for _, line := range lines {
+				if !strings.HasPrefix(line, " ") {
+					line = wordwrap.WrapString(line, uint(width))
+				}
+				fmt.Fprintf(&buf, "%s\n", line)
+			}
+		} else {
+			fmt.Fprintf(&buf, "%s\n", desc.Detail)
 		}
-		fmt.Fprintf(&buf, "%s\n", detail)
 	}
 
 	return buf.String()

--- a/command/format/diagnostic_test.go
+++ b/command/format/diagnostic_test.go
@@ -167,3 +167,35 @@ Error: Some error
 		t.Fatalf("unexpected output: got:\n%s\nwant\n%s\n", output, expected)
 	}
 }
+
+func TestDiagnostic_wrapDetailIncludingCommand(t *testing.T) {
+	var diags tfdiags.Diagnostics
+
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Everything went wrong",
+		Detail:   "This is a very long sentence about whatever went wrong which is supposed to wrap onto multiple lines. Thank-you very much for listening.\n\nTo fix this, run this very long command:\n  terraform read-my-mind -please -thanks -but-do-not-wrap-this-line-because-it-is-prefixed-with-spaces\n\nHere is a coda which is also long enough to wrap and so it should eventually make it onto multiple lines. THE END",
+	})
+	color := &colorstring.Colorize{
+		Colors:  colorstring.DefaultColors,
+		Reset:   true,
+		Disable: true,
+	}
+	expected := `
+Error: Everything went wrong
+
+This is a very long sentence about whatever went wrong which is supposed to
+wrap onto multiple lines. Thank-you very much for listening.
+
+To fix this, run this very long command:
+  terraform read-my-mind -please -thanks -but-do-not-wrap-this-line-because-it-is-prefixed-with-spaces
+
+Here is a coda which is also long enough to wrap and so it should eventually
+make it onto multiple lines. THE END
+`
+	output := Diagnostic(diags[0], nil, color, 76)
+
+	if output != expected {
+		t.Fatalf("unexpected output: got:\n%s\nwant\n%s\n", output, expected)
+	}
+}

--- a/command/testdata/init-get-provider-legacy-from-state/main.tf
+++ b/command/testdata/init-get-provider-legacy-from-state/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    alpha = {
+      source  = "acme/alpha"
+      version = "1.2.3"
+    }
+  }
+}
+
+resource "alpha_resource" "a" {
+  index = 1
+}

--- a/command/testdata/init-get-provider-legacy-from-state/terraform.tfstate
+++ b/command/testdata/init-get-provider-legacy-from-state/terraform.tfstate
@@ -1,0 +1,25 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.28",
+  "serial": 1,
+  "lineage": "481bf512-f245-4c60-42dc-7005f4fa9181",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "alpha_resource",
+      "name": "a",
+      "provider": "provider.alpha",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "a",
+            "index": 1
+          },
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ]
+}

--- a/website/upgrade-guides/0-13.html.markdown
+++ b/website/upgrade-guides/0-13.html.markdown
@@ -302,11 +302,13 @@ situation, `terraform init` will produce the following error message after
 you complete the configuration changes described above:
 
 ```
-Error: Failed to query available provider packages
+Error: Failed to install legacy providers required by state
 
-Could not retrieve the list of available versions for provider -/happycloud:
-provider registry registry.terraform.io does not have a provider named
-registry.terraform.io/-/happycloud
+Found unresolvable legacy provider references in state. It looks like these
+refer to in-house providers. You can update the resources in state with the
+following command:
+
+    terraform state replace-provider registry.terraform.io/-/happycloud terraform.example.com/awesomecorp/happycloud
 ```
 
 Provider source addresses starting with `registry.terraform.io/-/` are a special


### PR DESCRIPTION
When `init` attempts to install a legacy provider required by state and fails, but another provider with the same type is successfully installed, this almost definitely means that the user is migrating an in-house provider. The solution here is to use the `terraform state replace-provider` subcommand.

This commit makes that next step clearer, by detecting this specific case.

### Screenshots

Before:

<img width="888" alt="before" src="https://user-images.githubusercontent.com/68917/91768843-3f78b900-ebac-11ea-9544-7d530dd62e21.png">

After:

<img width="882" alt="after" src="https://user-images.githubusercontent.com/68917/91864673-7e574f00-ec3e-11ea-953f-3642a8402c45.png">
