### PR TITLE
Allow updating configuration files with specific terraform and provider versions

### DIFF
--- a/command/013_config_upgrade_test.go
+++ b/command/013_config_upgrade_test.go
@@ -67,33 +67,35 @@ func TestZeroThirteenUpgrade_success(t *testing.T) {
 	registrySource, close := testRegistrySource(t)
 	defer close()
 
-	testCases := map[string]string{
-		"implicit":              "013upgrade-implicit-providers",
-		"explicit":              "013upgrade-explicit-providers",
-		"provider not found":    "013upgrade-provider-not-found",
-		"implicit not found":    "013upgrade-implicit-not-found",
-		"file exists":           "013upgrade-file-exists",
-		"no providers":          "013upgrade-no-providers",
-		"submodule":             "013upgrade-submodule",
-		"providers with source": "013upgrade-providers-with-source",
-		"preserves comments":    "013upgrade-preserves-comments",
-		"multiple blocks":       "013upgrade-multiple-blocks",
-		"multiple files":        "013upgrade-multiple-files",
-		"existing versions.tf":  "013upgrade-existing-versions-tf",
-		"skipped files":         "013upgrade-skipped-files",
-		"provider redirect":     "013upgrade-provider-redirect",
-		"version unavailable":   "013upgrade-provider-redirect-version-unavailable",
+	testCases := map[string][]string{
+		"implicit":              {"013upgrade-implicit-providers", "-yes"},
+		"explicit":              {"013upgrade-explicit-providers", "-yes"},
+		"provider not found":    {"013upgrade-provider-not-found", "-yes"},
+		"implicit not found":    {"013upgrade-implicit-not-found", "-yes"},
+		"file exists":           {"013upgrade-file-exists", "-yes"},
+		"no providers":          {"013upgrade-no-providers", "-yes"},
+		"submodule":             {"013upgrade-submodule", "-yes"},
+		"providers with source": {"013upgrade-providers-with-source", "-yes"},
+		"preserves comments":    {"013upgrade-preserves-comments", "-yes"},
+		"multiple blocks":       {"013upgrade-multiple-blocks", "-yes"},
+		"multiple files":        {"013upgrade-multiple-files", "-yes"},
+		"existing versions.tf":  {"013upgrade-existing-versions-tf", "-yes"},
+		"skipped files":         {"013upgrade-skipped-files", "-yes"},
+		"provider redirect":     {"013upgrade-provider-redirect", "-yes"},
+		"version unavailable":   {"013upgrade-provider-redirect-version-unavailable", "-yes"},
+		"specific versions":     {"013upgrade-specific-versions", "-yes", "-terraform-version=0.13.2", "-provider-version", "hashicorp/bar=2.0.0", "-provider-version", "terraform-providers/baz=3.0.0", "-provider-version", "foo=1.2.4"},
 	}
-	for name, testPath := range testCases {
+
+	for name, testArgs := range testCases {
 		t.Run(name, func(t *testing.T) {
-			inputPath, err := filepath.Abs(testFixturePath(path.Join(testPath, "input")))
+			inputPath, err := filepath.Abs(testFixturePath(path.Join(testArgs[0], "input")))
 			if err != nil {
-				t.Fatalf("failed to find input path %s: %s", testPath, err)
+				t.Fatalf("failed to find input path %s: %s", testArgs[0], err)
 			}
 
-			expectedPath, err := filepath.Abs(testFixturePath(path.Join(testPath, "expected")))
+			expectedPath, err := filepath.Abs(testFixturePath(path.Join(testArgs[0], "expected")))
 			if err != nil {
-				t.Fatalf("failed to find expected path %s: %s", testPath, err)
+				t.Fatalf("failed to find expected path %s: %s", testArgs[0], err)
 			}
 
 			td := tempDir(t)
@@ -110,7 +112,7 @@ func TestZeroThirteenUpgrade_success(t *testing.T) {
 				},
 			}
 
-			if code := c.Run([]string{"-yes"}); code != 0 {
+			if code := c.Run(testArgs[1:]); code != 0 {
 				t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 			}
 

--- a/command/testdata/013upgrade-specific-versions/expected/main.tf
+++ b/command/testdata/013upgrade-specific-versions/expected/main.tf
@@ -1,0 +1,21 @@
+provider "foo" {
+  version = "1.2.3"
+}
+
+terraform {
+  required_providers {
+    bar = {
+      source  = "hashicorp/bar"
+      version = "2.0.0"
+    }
+    baz = {
+      source  = "terraform-providers/baz"
+      version = "3.0.0"
+    }
+    foo = {
+      source = "hashicorp/foo"
+    }
+  }
+}
+
+provider "terraform" {}

--- a/command/testdata/013upgrade-specific-versions/expected/versions.tf
+++ b/command/testdata/013upgrade-specific-versions/expected/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "0.13.2"
+}

--- a/command/testdata/013upgrade-specific-versions/input/main.tf
+++ b/command/testdata/013upgrade-specific-versions/input/main.tf
@@ -1,0 +1,14 @@
+provider "foo" {
+  version = "1.2.3"
+}
+
+terraform {
+  required_providers {
+    bar = "1.0.0"
+    baz = {
+      version = "~> 2.0.0"
+    }
+  }
+}
+
+provider "terraform" { }


### PR DESCRIPTION
This is a PR to discuss extending the `0.13upgrade` command to allow setting the target terraform and providers versions that are used in written configuration files.

Until now, I used to run somewhat complex `sed` commands to achieve this but figured it would be cleaner to just let terraform do that.

Example usage:

```
# cat versions.tf
terraform {
  required_version = "0.13.1"

  required_providers {
    google = {
      version = "3.35.0"
      source  = "hashicorp/google"
    }

    google-beta = {
      version = "3.35.0"
      source  = "hashicorp/google-beta"
    }
  }
}

# ~/go/bin/terraform 0.13upgrade -yes -terraform-version="0.13.2" -provider-version "hashicorp/google=3.37.0" -provider-version "hashicorp/google-beta=3.37.0"

# cat versions.tf
terraform {
  required_version = "0.13.2"

  required_providers {
    google = {
      source  = "hashicorp/google"
      version = "3.37.0"
    }

    google-beta = {
      source  = "hashicorp/google-beta"
      version = "3.37.0"
    }
  }
}
```

This can then be used to mass update `versions.tf` files, e.g.:
```
for dir in $(find . \( -path .git -o -path "*/.terraform" \) -prune -o -name 'versions.tf' -exec dirname {} \;) ; do
  ~/go/bin/terraform 0.13upgrade -yes -terraform-version="0.13.2" -provider-version "hashicorp/google=3.37.0" -provider-version "hashicorp/google-beta=3.37.0" $dir
done
```

As `0.13upgrade` is described to only work on pre-0.13 configurations, an alternative may be to add a new dedicated subcommand.

The current implementation only supports selecting providers by their namespaced `source` attribute. An alternative may be to select them by their name which may allow more flexible use cases if several aliased versions of a single provider were allowed (which does not seem the case right now).

One known issue is that specifying a version for a provider whose version is specified in its `provider` instead of the `required_providers` block will create conflicting configurations.

I'd be glad to hear from terraform maintainers if such a feature would be accepted. If so, I'll implement any requested changes and add several other test cases to cover corner use cases.