### PR TITLE
adding terraform ls as an alias to list

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -350,6 +350,12 @@ func initCommands(config *cliconfig.Config, services *disco.Disco, providerSrc g
 			}, nil
 		},
 
+		"state ls": func() (cli.Command, error) {
+			return &command.StateListCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"state rm": func() (cli.Command, error) {
 			return &command.StateRmCommand{
 				StateMeta: command.StateMeta{


### PR DESCRIPTION
The commands in "terraform state are inconsistent, there's "mv" and not move, but "list"  instead of "ls".
I'm adding an alias "ls" to "list" for convenience.