### PR TITLE
Document jsonencode HTML escape behaviour

### DIFF
--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -472,6 +472,12 @@ func TestFunctions(t *testing.T) {
 				`jsonencode({"hello"="world"})`,
 				cty.StringVal("{\"hello\":\"world\"}"),
 			},
+			// We are intentionally choosing to escape <, >, and & characters
+			// to preserve backwards compatibility with Terraform 0.11
+			{
+				`jsonencode({"hello"="<cats & kittens>"})`,
+				cty.StringVal("{\"hello\":\"\\u003ccats \\u0026 kittens\\u003e\"}"),
+			},
 		},
 
 		"keys": {

--- a/website/docs/configuration/functions/jsonencode.html.md
+++ b/website/docs/configuration/functions/jsonencode.html.md
@@ -37,6 +37,11 @@ types, passing the `jsonencode` result to `jsondecode` will not produce an
 identical value, but the automatic type conversion rules mean that this is
 rarely a problem in practice.
 
+When encoding strings, this function escapes some characters using
+Unicode escape sequences: replacing `<`, `>`, `&`, `U+2028`, and `U+2029` with
+`\u003c`, `\u003e`, `\u0026`, `\u2028`, and `\u2029`. This is to preserve
+compatibility with Terraform 0.11 behavior.
+
 ## Examples
 
 ```


### PR DESCRIPTION
The `jsonencode` function has some slightly unintuitive character escaping edge cases:

```shellsession
$ echo 'jsonencode("(>_<)")' | terraform console
"(\u003e_\u003c)"
```

This behaviour always been there, but was undocumented and not covered by tests. This PR adds a small note to the function documentation, and a test case. While it's unusual looking, this is valid JSON, and we don't intend to change how it works, as it would be disruptive to users.

I think this closes #26110, since we're not going to change the behaviour.