### PR TITLE
terraform: add GraphNodeExecutable interface

### DIFF
--- a/terraform/execute.go
+++ b/terraform/execute.go
@@ -1,0 +1,9 @@
+package terraform
+
+// GraphNodeExecutable is the interface that graph nodes must implement to
+// enable execution. This is an alternative to GraphNodeEvalable, which is in
+// the process of being removed. A given graph node should _not_ implement both
+// GraphNodeExecutable and GraphNodeEvalable.
+type GraphNodeExecutable interface {
+	Execute(EvalContext, walkOperation) error
+}

--- a/terraform/graph_walk.go
+++ b/terraform/graph_walk.go
@@ -12,10 +12,9 @@ type GraphWalker interface {
 	EvalContext() EvalContext
 	EnterPath(addrs.ModuleInstance) EvalContext
 	ExitPath(addrs.ModuleInstance)
-	EnterVertex(dag.Vertex)
-	ExitVertex(dag.Vertex, tfdiags.Diagnostics)
 	EnterEvalTree(dag.Vertex, EvalNode) EvalNode
 	ExitEvalTree(dag.Vertex, interface{}, error) tfdiags.Diagnostics
+	Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics
 }
 
 // NullGraphWalker is a GraphWalker implementation that does nothing.
@@ -26,9 +25,8 @@ type NullGraphWalker struct{}
 func (NullGraphWalker) EvalContext() EvalContext                        { return new(MockEvalContext) }
 func (NullGraphWalker) EnterPath(addrs.ModuleInstance) EvalContext      { return new(MockEvalContext) }
 func (NullGraphWalker) ExitPath(addrs.ModuleInstance)                   {}
-func (NullGraphWalker) EnterVertex(dag.Vertex)                          {}
-func (NullGraphWalker) ExitVertex(dag.Vertex, tfdiags.Diagnostics)      {}
 func (NullGraphWalker) EnterEvalTree(v dag.Vertex, n EvalNode) EvalNode { return n }
 func (NullGraphWalker) ExitEvalTree(dag.Vertex, interface{}, error) tfdiags.Diagnostics {
 	return nil
 }
+func (NullGraphWalker) Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics { return nil }

--- a/terraform/graph_walk_context.go
+++ b/terraform/graph_walk_context.go
@@ -162,3 +162,38 @@ func (w *ContextGraphWalker) init() {
 		w.variableValues[""][k] = iv.Value
 	}
 }
+
+func (w *ContextGraphWalker) Execute(ctx EvalContext, n GraphNodeExecutable) tfdiags.Diagnostics {
+	// Acquire a lock on the semaphore
+	w.Context.parallelSem.Acquire()
+
+	err := n.Execute(ctx, w.Operation)
+
+	// Release the semaphore
+	w.Context.parallelSem.Release()
+
+	if err == nil {
+		return nil
+	}
+
+	// Acquire the lock because anything is going to require a lock.
+	w.errorLock.Lock()
+	defer w.errorLock.Unlock()
+
+	// If the error is non-fatal then we'll accumulate its diagnostics in our
+	// non-fatal list, rather than returning it directly, so that the graph
+	// walk can continue.
+	if nferr, ok := err.(tfdiags.NonFatalError); ok {
+		w.NonFatalDiagnostics = w.NonFatalDiagnostics.Append(nferr.Diagnostics)
+		return nil
+	}
+
+	// Otherwise, we'll let our usual diagnostics machinery figure out how to
+	// unpack this as one or more diagnostic messages and return that. If we
+	// get down here then the returned diagnostics will contain at least one
+	// error, causing the graph walk to halt.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(err)
+	return diags
+
+}


### PR DESCRIPTION
This introduces a new `GraphNode`, `GraphNodeExecutable`, which will
gradually replace` GraphNodeEvalable` as part of the overall removal of
terraform's `EvalNode`s. Terraform's `Graph.walk` function will now check if a node implements
`GraphNodeExecutable` and run `walker.Execute()`.

For the time being, terraform will panic if a node implements both
`GraphNodeExecutable` and `GraphNodeEvalable`. This will be removed when
we've finished removing all `GraphNodeEvalable` implementations.

The new` GraphWalker` function, `Execute()`, is meant to replace both
`EnterEvalTree` and `ExitEvalTree`, and wraps the call to the
`GraphNodeExecutable`'s `Execute` function.

This PR departs from my original (internal) proposal, which did not include the`walker.Execute()` wrapper around `GraphNodeExecutable.Execute()`. When I originally wrote my POC for this project I had completely glossed over `walker.EnterEvalTree` and `walker.ExitEvalTree`, which handled some _very important_ locking and error message processing. 

A second departure from my original proposal is the signature of `GraphNodeExecutable.Execute()`, to which I've added the `walkOperation`: this is primarily to simplify testing, since my original method for determining the `walkOperation` required a type assertion that would block us from using the `MockEvalContext` in tests. 
