### PR TITLE
Fixed nested list conversion in setElementCompare

### DIFF
--- a/plans/objchange/objchange.go
+++ b/plans/objchange/objchange.go
@@ -357,13 +357,13 @@ func setElementCompareValue(schema *configschema.Block, v cty.Value, isConfig bo
 					// set and we've not changed the types of any elements here.
 					attrs[name] = cty.SetVal(elems)
 				} else {
-					attrs[name] = cty.TupleVal(elems)
+					attrs[name] = cty.ListVal(elems)
 				}
 			} else {
 				if blockType.Nesting == configschema.NestingSet {
 					attrs[name] = cty.SetValEmpty(blockType.Block.ImpliedType())
 				} else {
-					attrs[name] = cty.EmptyTupleVal
+					attrs[name] = cty.ListValEmpty(blockType.Block.ImpliedType())
 				}
 			}
 

--- a/plans/objchange/objchange_test.go
+++ b/plans/objchange/objchange_test.go
@@ -572,6 +572,70 @@ func TestProposedNewObject(t *testing.T) {
 				}),
 			}),
 		},
+		"nested list in sed": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							BlockTypes: map[string]*configschema.NestedBlock{
+								"bar": {
+									Nesting: configschema.NestingList,
+									Block: configschema.Block{
+										Attributes: map[string]*configschema.Attribute{
+											"baz": {
+												Type: cty.String,
+											},
+											"qux": {
+												Type:     cty.String,
+												Computed: true,
+												Optional: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("beep"),
+								"qux": cty.StringVal("boop"),
+							}),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("beep"),
+								"qux": cty.NullVal(cty.String),
+							}),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("beep"),
+								"qux": cty.StringVal("boop"),
+							}),
+						}),
+					}),
+				}),
+			}),
+		},
 	}
 
 	for name, test := range tests {

--- a/plans/objchange/objchange_test.go
+++ b/plans/objchange/objchange_test.go
@@ -572,7 +572,7 @@ func TestProposedNewObject(t *testing.T) {
 				}),
 			}),
 		},
-		"nested list in sed": {
+		"nested list in set": {
 			&configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"foo": {
@@ -632,6 +632,44 @@ func TestProposedNewObject(t *testing.T) {
 								"qux": cty.StringVal("boop"),
 							}),
 						}),
+					}),
+				}),
+			}),
+		},
+		"empty nested list in set": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							BlockTypes: map[string]*configschema.NestedBlock{
+								"bar": {
+									Nesting: configschema.NestingList,
+									Block:   configschema.Block{},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListValEmpty((&configschema.Block{}).ImpliedType()),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListValEmpty((&configschema.Block{}).ImpliedType()),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListValEmpty((&configschema.Block{}).ImpliedType()),
 					}),
 				}),
 			}),


### PR DESCRIPTION
When preparing set elements for comparison `setElementCompareValue` converts all nested lists to tuples.
This leads to every comparison between set element from prior state and set element from user config evalutes to false.