### PR TITLE
configs: deprecate version argument inside provider configuration blocks

### DIFF
--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -115,7 +115,12 @@ func TestConfigResolveAbsProviderAddr(t *testing.T) {
 
 func TestConfigProviderRequirements(t *testing.T) {
 	cfg, diags := testNestedModuleConfigFromDir(t, "testdata/provider-reqs")
-	assertNoDiagnostics(t, diags)
+	// TODO: Version Constraint Deprecation.
+	// Once we've removed the version argument from provider configuration
+	// blocks, this can go back to expected 0 diagnostics.
+	// assertNoDiagnostics(t, diags)
+	assertDiagnosticCount(t, diags, 1)
+	assertDiagnosticSummary(t, diags, "Version constraints inside provider configuration blocks are deprecated")
 
 	tlsProvider := addrs.NewProvider(
 		addrs.DefaultRegistryHost,
@@ -153,7 +158,12 @@ func TestConfigProviderRequirements(t *testing.T) {
 
 func TestConfigProviderRequirementsByModule(t *testing.T) {
 	cfg, diags := testNestedModuleConfigFromDir(t, "testdata/provider-reqs")
-	assertNoDiagnostics(t, diags)
+	// TODO: Version Constraint Deprecation.
+	// Once we've removed the version argument from provider configuration
+	// blocks, this can go back to expected 0 diagnostics.
+	// assertNoDiagnostics(t, diags)
+	assertDiagnosticCount(t, diags, 1)
+	assertDiagnosticSummary(t, diags, "Version constraints inside provider configuration blocks are deprecated")
 
 	tlsProvider := addrs.NewProvider(
 		addrs.DefaultRegistryHost,

--- a/configs/configload/testdata/expand-modules/provider-configured/child/main.tf
+++ b/configs/configload/testdata/expand-modules/provider-configured/child/main.tf
@@ -1,8 +1,7 @@
 provider "aws" {
-  version = "1.0"
+  region = "us-west-2"
 }
 
 output "my_output" {
   value = "my output"
 }
-

--- a/configs/parser_test.go
+++ b/configs/parser_test.go
@@ -83,13 +83,12 @@ func testNestedModuleConfigFromDir(t *testing.T, path string) (*Config, hcl.Diag
 
 	parser := NewParser(nil)
 	mod, diags := parser.LoadConfigDir(path)
-	assertNoDiagnostics(t, diags)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
 	}
 
 	versionI := 0
-	cfg, diags := BuildConfig(mod, ModuleWalkerFunc(
+	cfg, nestedDiags := BuildConfig(mod, ModuleWalkerFunc(
 		func(req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {
 			// For the sake of this test we're going to just treat our
 			// SourceAddr as a path relative to the calling module.
@@ -111,6 +110,8 @@ func testNestedModuleConfigFromDir(t *testing.T, path string) (*Config, hcl.Diag
 			return mod, version, diags
 		},
 	))
+
+	diags = append(diags, nestedDiags...)
 	return cfg, diags
 }
 

--- a/configs/provider.go
+++ b/configs/provider.go
@@ -72,7 +72,7 @@ func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagWarning,
 			Summary:  "Version constraints inside provider configuration blocks are deprecated",
-			Detail:   "Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of Terraform. To silence this warning, move the provider version constraint into required_providers.",
+			Detail:   "Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of Terraform. To silence this warning, move the provider version constraint into the required_providers block.",
 			Subject:  attr.Expr.Range().Ptr(),
 		})
 		var versionDiags hcl.Diagnostics

--- a/configs/provider.go
+++ b/configs/provider.go
@@ -69,6 +69,12 @@ func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
 	}
 
 	if attr, exists := content.Attributes["version"]; exists {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Version constraints inside provider configuration blocks are deprecated",
+			Detail:   "Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of Terraform. To silence this warning, move the provider version constraint into required_providers.",
+			Subject:  attr.Expr.Range().Ptr(),
+		})
 		var versionDiags hcl.Diagnostics
 		provider.Version, versionDiags = decodeVersionConstraint(attr)
 		diags = append(diags, versionDiags...)

--- a/configs/provider_test.go
+++ b/configs/provider_test.go
@@ -21,6 +21,8 @@ func TestProviderReservedNames(t *testing.T) {
 	_, diags := parser.LoadConfigFile("config.tf")
 
 	assertExactDiagnostics(t, diags, []string{
+		//TODO: This deprecation warning will be removed in terraform v0.15.
+		`config.tf:4,13-20: Version constraints inside provider configuration blocks are deprecated; Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of Terraform. To silence this warning, move the provider version constraint into required_providers.`,
 		`config.tf:10,3-8: Reserved argument name in provider block; The provider argument name "count" is reserved for use by Terraform in a future version.`,
 		`config.tf:11,3-13: Reserved argument name in provider block; The provider argument name "depends_on" is reserved for use by Terraform in a future version.`,
 		`config.tf:12,3-11: Reserved argument name in provider block; The provider argument name "for_each" is reserved for use by Terraform in a future version.`,

--- a/configs/provider_test.go
+++ b/configs/provider_test.go
@@ -22,7 +22,7 @@ func TestProviderReservedNames(t *testing.T) {
 
 	assertExactDiagnostics(t, diags, []string{
 		//TODO: This deprecation warning will be removed in terraform v0.15.
-		`config.tf:4,13-20: Version constraints inside provider configuration blocks are deprecated; Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of Terraform. To silence this warning, move the provider version constraint into required_providers.`,
+		`config.tf:4,13-20: Version constraints inside provider configuration blocks are deprecated; Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of Terraform. To silence this warning, move the provider version constraint into the required_providers block.`,
 		`config.tf:10,3-8: Reserved argument name in provider block; The provider argument name "count" is reserved for use by Terraform in a future version.`,
 		`config.tf:11,3-13: Reserved argument name in provider block; The provider argument name "depends_on" is reserved for use by Terraform in a future version.`,
 		`config.tf:12,3-11: Reserved argument name in provider block; The provider argument name "for_each" is reserved for use by Terraform in a future version.`,

--- a/configs/testdata/valid-files/provider-configs.tf
+++ b/configs/testdata/valid-files/provider-configs.tf
@@ -3,8 +3,6 @@ provider "foo" {
 }
 
 provider "bar" {
-  version = ">= 1.0.2"
-
   other = 12
 }
 

--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -177,12 +177,12 @@ works the same way as the `version` argument in a
 constraint in a provider configuration is only used if `required_providers`
 does not include one for that provider.
 
-**We do not recommend using the `version` argument in provider configurations.**
+**The `version` argument in provider configurations is deprecated.** 
 In Terraform 0.13 and later, version constraints should always be declared in
-[the `required_providers` block](./provider-requirements.html).
+[the `required_providers` block](./provider-requirements.html). The `version`
+argument will be removed in a future version of Terraform.
 
 -> **Note:** The `version` meta-argument made sense before Terraform 0.13, since
 Terraform could only install providers that were distributed by HashiCorp. Now
 that Terraform can install providers from multiple sources, it makes more sense
 to keep version constraints and provider source addresses together.
-


### PR DESCRIPTION
The version argument is deprecated in Terraform v0.14 in favor of
required_providers and will be removed in a future version of terraform
(expected to be v0.15). The provider configuration documentation already
discourages use of 'version' inside provider configuration blocks, so it
only needed an extra note that it is actively deprecated.

I took advantage of an existing test, TestProviderReservedNames in provider_test.go, to verify the diagnostic, instead of writing a test just for this. That felt ok to do since we'll be removing it all in v0.15 (probably).