### PR TITLE
internal: Fix providercache test failures on macOS

### DIFF
--- a/internal/providercache/dir_modify_test.go
+++ b/internal/providercache/dir_modify_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/apparentlymart/go-versions/versions"
@@ -19,6 +20,10 @@ func TestInstallPackage(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDirPath)
+	tmpDirPath, err = filepath.EvalSymlinks(tmpDirPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	linuxPlatform := getproviders.Platform{
 		OS:   "linux",
@@ -74,6 +79,10 @@ func TestLinkFromOtherCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDirPath)
+	tmpDirPath, err = filepath.EvalSymlinks(tmpDirPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	windowsPlatform := getproviders.Platform{
 		OS:   "windows",


### PR DESCRIPTION
For reasons that are unclear, these two tests just started failing on macOS very recently. The failure looked like:

```
    PackageDir: strings.Join({
      "/",
+     "private/",
      "var/folders/3h/foobar/T/terraform-test-p",
      "rovidercache655312854/registry.terraform.io/hashicorp/null/2.0.0",
      "/windows_amd64",
    },
```

Speculating that the macOS temporary directory moved into the /private directory, I added a couple of EvalSymlinks calls and the tests pass again.

No other unit tests appear to be affected by this at the moment.

🤷‍♂️