### PR TITLE
Changing the tmp directory to the current directory during the length check of terraform-upload

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -617,9 +617,18 @@ func checkSCPStatus(r *bufio.Reader) error {
 
 func scpUploadFile(dst string, src io.Reader, w io.Writer, r *bufio.Reader, size int64) error {
 	if size == 0 {
+		// While sending a multiple files to multiple server
+		// /tmp location occupies huge data due to that terraform fails
+		// due to less disk space.
+		// Below code change the /tmp location to the current directory
+		// where terraform runs
+		currentdir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
 		// Create a temporary file where we can copy the contents of the src
 		// so that we can determine the length, since SCP is length-prefixed.
-		tf, err := ioutil.TempFile("", "terraform-upload")
+		tf, err := ioutil.TempFile(currentdir, "terraform-upload")
 		if err != nil {
 			return fmt.Errorf("Error creating temporary file for upload: %s", err)
 		}


### PR DESCRIPTION
During the multiple uploads if the tmp location has less disk space(normally it will be mounted with root) it fails with an error.
Consider if the file size is 20GB and sending it to 10 servers parallelly almost 20*10GB is required to be in /tmp location and if the machine has less tmp size but has sufficient size in another mount the terraform user couldn't send the file to another machine.

As this was a problem was faced by me while uploading a data of 20gb to 100 servers which fails obviously, so changed the code to make sure wherever the user run the terraform, in the same location 'terraform-upload' files will be copied, it removed the factor of using the tmp location.

**Reduce the failure if the tmp location has less disk space.**