### PR TITLE
eval node removal: data nodes refresh & destroy

### DIFF
--- a/terraform/eval_provider.go
+++ b/terraform/eval_provider.go
@@ -46,6 +46,22 @@ func buildProviderConfig(ctx EvalContext, addr addrs.AbsProviderConfig, config *
 	}
 }
 
+// GetProvider returns the providers interface and schema for a given provider.
+func GetProvider(ctx EvalContext, addr addrs.AbsProviderConfig) (providers.Interface, *ProviderSchema, error) {
+	if addr.Provider.Type == "" {
+		// Should never happen
+		panic("EvalGetProvider used with uninitialized provider configuration address")
+	}
+	provider := ctx.Provider(addr)
+	if provider == nil {
+		return nil, &ProviderSchema{}, fmt.Errorf("provider %s not initialized", addr)
+	}
+	// Not all callers require a schema, so we will leave checking for a nil
+	// schema to the callers.
+	schema := ctx.ProviderSchema(addr)
+	return provider, schema, nil
+}
+
 // EvalConfigProvider is an EvalNode implementation that configures
 // a provider that is already initialized and retrieved.
 type EvalConfigProvider struct {

--- a/terraform/execute.go
+++ b/terraform/execute.go
@@ -5,5 +5,5 @@ package terraform
 // the process of being removed. A given graph node should _not_ implement both
 // GraphNodeExecutable and GraphNodeEvalable.
 type GraphNodeExecutable interface {
-	Execute(EvalContext, walkOperation) error
+	Execute(EvalContext, *walkOperation) error
 }

--- a/terraform/graph_walk_context.go
+++ b/terraform/graph_walk_context.go
@@ -167,7 +167,7 @@ func (w *ContextGraphWalker) Execute(ctx EvalContext, n GraphNodeExecutable) tfd
 	// Acquire a lock on the semaphore
 	w.Context.parallelSem.Acquire()
 
-	err := n.Execute(ctx, w.Operation)
+	err := n.Execute(ctx, &w.Operation)
 
 	// Release the semaphore
 	w.Context.parallelSem.Release()

--- a/terraform/node_data_destroy.go
+++ b/terraform/node_data_destroy.go
@@ -1,9 +1,6 @@
 package terraform
 
-import (
-	"github.com/hashicorp/terraform/providers"
-	"github.com/hashicorp/terraform/states"
-)
+import "log"
 
 // NodeDestroyableDataResourceInstance represents a resource that is "destroyable":
 // it is ready to be destroyed.
@@ -11,30 +8,13 @@ type NodeDestroyableDataResourceInstance struct {
 	*NodeAbstractResourceInstance
 }
 
-// GraphNodeEvalable
-func (n *NodeDestroyableDataResourceInstance) EvalTree() EvalNode {
-	addr := n.ResourceInstanceAddr()
+var (
+	_ GraphNodeExecutable = (*NodeDestroyableDataResourceInstance)(nil)
+)
 
-	var providerSchema *ProviderSchema
-	// We don't need the provider, but we're calling EvalGetProvider to load the
-	// schema.
-	var provider providers.Interface
-
-	// Just destroy it.
-	var state *states.ResourceInstanceObject
-	return &EvalSequence{
-		Nodes: []EvalNode{
-			&EvalGetProvider{
-				Addr:   n.ResolvedProvider,
-				Output: &provider,
-				Schema: &providerSchema,
-			},
-			&EvalWriteState{
-				Addr:           addr.Resource,
-				State:          &state,
-				ProviderAddr:   n.ResolvedProvider,
-				ProviderSchema: &providerSchema,
-			},
-		},
-	}
+// GraphNodeExecutable
+func (n *NodeDestroyableDataResourceInstance) Execute(ctx EvalContext, op *walkOperation) error {
+	log.Printf("[TRACE] NodeDestroyableDataResourceInstance: removing state object for %s", n.Addr)
+	ctx.State().SetResourceInstanceCurrent(n.Addr, nil, n.ResolvedProvider)
+	return nil
 }

--- a/terraform/node_data_destroy_test.go
+++ b/terraform/node_data_destroy_test.go
@@ -1,0 +1,48 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/states"
+)
+
+func TestNodeDataDestroyExecute(t *testing.T) {
+	state := states.NewState()
+	state.Module(addrs.RootModuleInstance).SetResourceInstanceCurrent(
+		addrs.Resource{
+			Mode: addrs.DataResourceMode,
+			Type: "test_instance",
+			Name: "foo",
+		}.Instance(addrs.NoKey),
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"dynamic":{"type":"string","value":"hello"}}`),
+		},
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   addrs.RootModule,
+		},
+	)
+	ctx := &MockEvalContext{
+		StateState: state.SyncWrapper(),
+	}
+
+	node := NodeDestroyableDataResourceInstance{&NodeAbstractResourceInstance{
+		Addr: addrs.Resource{
+			Mode: addrs.DataResourceMode,
+			Type: "test_instance",
+			Name: "foo",
+		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+	}}
+
+	err := node.Execute(ctx, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+
+	// verify resource removed from state
+	if state.HasResources() {
+		t.Fatal("resources still in state after NodeDataDestroy.Execute")
+	}
+}

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -199,7 +199,7 @@ var (
 	_ GraphNodeResourceInstance     = (*NodeRefreshableManagedResourceInstance)(nil)
 	_ GraphNodeAttachResourceConfig = (*NodeRefreshableManagedResourceInstance)(nil)
 	_ GraphNodeAttachResourceState  = (*NodeRefreshableManagedResourceInstance)(nil)
-	_ GraphNodeEvalable             = (*NodeRefreshableManagedResourceInstance)(nil)
+	_ GraphNodeExecutable           = (*NodeRefreshableManagedResourceInstance)(nil)
 )
 
 // GraphNodeDestroyer
@@ -209,7 +209,7 @@ func (n *NodeRefreshableManagedResourceInstance) DestroyAddr() *addrs.AbsResourc
 }
 
 // GraphNodeEvalable
-func (n *NodeRefreshableManagedResourceInstance) EvalTree() EvalNode {
+func (n *NodeRefreshableManagedResourceInstance) Execute(ctx EvalContext, op *walkOperation) error {
 	addr := n.ResourceInstanceAddr()
 
 	// Eval info is different depending on what kind of resource this is
@@ -217,15 +217,17 @@ func (n *NodeRefreshableManagedResourceInstance) EvalTree() EvalNode {
 	case addrs.ManagedResourceMode:
 		if n.instanceState == nil {
 			log.Printf("[TRACE] NodeRefreshableManagedResourceInstance: %s has no existing state to refresh", addr)
-			return n.evalTreeManagedResourceNoState()
+			_, err := n.evalTreeManagedResourceNoState().Eval(ctx)
+			return err
 		}
 		log.Printf("[TRACE] NodeRefreshableManagedResourceInstance: %s will be refreshed", addr)
-		return n.evalTreeManagedResource()
+		_, err := n.evalTreeManagedResource().Eval(ctx)
+		return err
 
 	case addrs.DataResourceMode:
 		// Get the data source node. If we don't have a configuration
 		// then it is an orphan so we destroy it (remove it from the state).
-		var dn GraphNodeEvalable
+		var dn GraphNodeExecutable
 		if n.Config != nil {
 			dn = &NodeRefreshableDataResourceInstance{
 				NodeAbstractResourceInstance: n.NodeAbstractResourceInstance,
@@ -236,7 +238,7 @@ func (n *NodeRefreshableManagedResourceInstance) EvalTree() EvalNode {
 			}
 		}
 
-		return dn.EvalTree()
+		return dn.Execute(ctx, nil)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", addr.Resource.Resource.Mode))
 	}

--- a/terraform/node_resource_refresh_test.go
+++ b/terraform/node_resource_refresh_test.go
@@ -1,10 +1,8 @@
 package terraform
 
 import (
-	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/addrs"
@@ -157,22 +155,5 @@ root - terraform.graphNodeRoot
 `
 	if expected != actual {
 		t.Fatalf("Expected:\n%s\nGot:\n%s", expected, actual)
-	}
-}
-
-func TestNodeRefreshableManagedResourceEvalTree_scaleOut(t *testing.T) {
-	m := testModule(t, "refresh-resource-scale-inout")
-
-	n := &NodeRefreshableManagedResourceInstance{
-		NodeAbstractResourceInstance: NewNodeAbstractResourceInstance(addrs.RootModuleInstance.Resource(addrs.ManagedResourceMode, "aws_instance", "foo").Instance(addrs.IntKey(2))),
-	}
-
-	n.AttachResourceConfig(m.Module.ManagedResources["aws_instance.foo"])
-
-	actual := n.EvalTree()
-	expected := n.evalTreeManagedResourceNoState()
-
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("Expected:\n\n%s\nGot:\n\n%s\n", spew.Sdump(expected), spew.Sdump(actual))
 	}
 }


### PR DESCRIPTION
Two commits, three notable changes:
- refactor the `Execute()` signature to talk a _pointer_ to a `walkOperation` (easier test writing, most commonly not required)
- add a `GetProvider` function that will (eventually) replace all of the `EvalGetProvider` nodes
- refactor `NodeDestroyableDataResourceInstance` and `NodeRefreshableDataResourceInstance`


Note: The "refactor" of `NodeRefreshableDataResourceInstance` is intentionally using what I might call the "last resort" or perhaps "minimal effort" refactor, where each step in the eval tree is replaced with a bunch of direct `Eval()`s. This is in part necessary to keep individual changes minimal, but in this case, another current project's stretch goal may end up removing `NodeRefreshable`*s altogether so I don't want to spend too much time on it now. This function will inevitably be revisited as all the other `Eval()`s get refactored, so I'll have plenty of opportunities to look at it again anyway.

