### PR TITLE
Update workDir of e2e binary to eval symlinks

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -37,6 +37,11 @@ func NewBinary(binaryPath, workingDir string) *binary {
 		panic(err)
 	}
 
+	tmpDir, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		panic(err)
+	}
+
 	// For our purposes here we do a very simplistic file copy that doesn't
 	// attempt to preserve file permissions, attributes, alternate data
 	// streams, etc. Since we only have to deal with our own fixtures in


### PR DESCRIPTION
Due to a recent update to OS X, this is necessary so that the correct working directory is saved, so that methods like Path() on the e2e binary will return the correct value. This is the same fix as in https://github.com/hashicorp/terraform/pull/26136, but used to apply to the failing test `TestPrimaryChdirOption`