### PR TITLE
Add sensitive attribute to variables

### DIFF
--- a/command/format/diagnostic.go
+++ b/command/format/diagnostic.go
@@ -302,6 +302,10 @@ func compactValueStr(val cty.Value) string {
 	// helpful but concise messages in diagnostics. It is not comprehensive
 	// nor intended to be used for other purposes.
 
+	if val.ContainsMarked() {
+		return "(sensitive value)"
+	}
+
 	ty := val.Type()
 	switch {
 	case val.IsNull():

--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -127,14 +127,16 @@ func ResourceChange(
 
 	// Now that the change is decoded, add back the marks at the defined paths
 	// change.Markinfo
-	changeV.Change.After, _ = cty.Transform(changeV.Change.After, func(p cty.Path, v cty.Value) (cty.Value, error) {
-		if p.Equals(change.ValMarks.Path) {
-			// TODO The mark is at change.Markinfo.Marks and it would be proper
-			// to iterate through that set here
-			return v.Mark("sensitive"), nil
-		}
-		return v, nil
-	})
+	if len(change.ValMarks.Path) != 0 {
+		changeV.Change.After, _ = cty.Transform(changeV.Change.After, func(p cty.Path, v cty.Value) (cty.Value, error) {
+			if p.Equals(change.ValMarks.Path) {
+				// TODO The mark is at change.Markinfo.Marks and it would be proper
+				// to iterate through that set here
+				return v.Mark("sensitive"), nil
+			}
+			return v, nil
+		})
+	}
 
 	bodyWritten := p.writeBlockBodyDiff(schema, changeV.Before, changeV.After, 6, path)
 	if bodyWritten {

--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -126,16 +126,11 @@ func ResourceChange(
 	changeV.Change.After = objchange.NormalizeObjectFromLegacySDK(changeV.Change.After, schema)
 
 	// Now that the change is decoded, add back the marks at the defined paths
-	// change.Markinfo
-	if len(change.ValMarks.Path) != 0 {
-		changeV.Change.After, _ = cty.Transform(changeV.Change.After, func(p cty.Path, v cty.Value) (cty.Value, error) {
-			if p.Equals(change.ValMarks.Path) {
-				// TODO The mark is at change.Markinfo.Marks and it would be proper
-				// to iterate through that set here
-				return v.Mark("sensitive"), nil
-			}
-			return v, nil
-		})
+	if len(change.BeforeValMarks) > 0 {
+		changeV.Change.Before = changeV.Change.Before.MarkWithPaths(change.BeforeValMarks)
+	}
+	if len(change.AfterValMarks) > 0 {
+		changeV.Change.After = changeV.Change.After.MarkWithPaths(change.AfterValMarks)
 	}
 
 	bodyWritten := p.writeBlockBodyDiff(schema, changeV.Before, changeV.After, 6, path)

--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -133,8 +133,8 @@ func ResourceChange(
 		changeV.Change.After = changeV.Change.After.MarkWithPaths(change.AfterValMarks)
 	}
 
-	bodyWritten := p.writeBlockBodyDiff(schema, changeV.Before, changeV.After, 6, path)
-	if bodyWritten {
+	result := p.writeBlockBodyDiff(schema, changeV.Before, changeV.After, 6, path)
+	if result.bodyWritten {
 		buf.WriteString("\n")
 		buf.WriteString(strings.Repeat(" ", 4))
 	}

--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -125,10 +125,21 @@ func ResourceChange(
 	changeV.Change.Before = objchange.NormalizeObjectFromLegacySDK(changeV.Change.Before, schema)
 	changeV.Change.After = objchange.NormalizeObjectFromLegacySDK(changeV.Change.After, schema)
 
-	result := p.writeBlockBodyDiff(schema, changeV.Before, changeV.After, 6, path)
-	if result.bodyWritten {
-		p.buf.WriteString("\n")
-		p.buf.WriteString(strings.Repeat(" ", 4))
+	// Now that the change is decoded, add back the marks at the defined paths
+	// change.Markinfo
+	changeV.Change.After, _ = cty.Transform(changeV.Change.After, func(p cty.Path, v cty.Value) (cty.Value, error) {
+		if p.Equals(change.ValMarks.Path) {
+			// TODO The mark is at change.Markinfo.Marks and it would be proper
+			// to iterate through that set here
+			return v.Mark("sensitive"), nil
+		}
+		return v, nil
+	})
+
+	bodyWritten := p.writeBlockBodyDiff(schema, changeV.Before, changeV.After, 6, path)
+	if bodyWritten {
+		buf.WriteString("\n")
+		buf.WriteString(strings.Repeat(" ", 4))
 	}
 	buf.WriteString("}\n")
 
@@ -586,6 +597,12 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiff(name string, label *string, 
 }
 
 func (p *blockBodyDiffPrinter) writeValue(val cty.Value, action plans.Action, indent int) {
+	// Could check specifically for the sensitivity marker
+	if val.IsMarked() {
+		p.buf.WriteString("(sensitive)")
+		return
+	}
+
 	if !val.IsKnown() {
 		p.buf.WriteString("(known after apply)")
 		return
@@ -1284,7 +1301,8 @@ func ctyGetAttrMaybeNull(val cty.Value, name string) cty.Value {
 	// This allows us to avoid spurious diffs
 	// until we introduce null to the SDK.
 	attrValue := val.GetAttr(name)
-	if ctyEmptyString(attrValue) {
+	// If the value is marked, the ctyEmptyString function will fail
+	if !val.ContainsMarked() && ctyEmptyString(attrValue) {
 		return cty.NullVal(attrType)
 	}
 

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3622,10 +3622,75 @@ func TestResourceChange_nestedMap(t *testing.T) {
 	runTestCases(t, testCases)
 }
 
+func TestResourceChange_sensitiveVariable(t *testing.T) {
+	testCases := map[string]testCase{
+		"in-place update - creation": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+				"root_block_device": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+				})),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"root_block_device": cty.MapVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp2"),
+					}),
+				}),
+			}),
+			AfterValMarks: []cty.PathValueMarks{
+				{
+					Path:  cty.Path{cty.GetAttrStep{Name: "ami"}},
+					Marks: cty.NewValueMarks("sensitive"),
+				}},
+			RequiredReplace: cty.NewPathSet(),
+			Tainted:         false,
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":  {Type: cty.String, Optional: true, Computed: true},
+					"ami": {Type: cty.String, Optional: true},
+				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"root_block_device": {
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"volume_type": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+						Nesting: configschema.NestingMap,
+					},
+				},
+			},
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami = (sensitive)
+        id  = "i-02ae66f368e8518a9"
+
+      + root_block_device "a" {
+          + volume_type = "gp2"
+        }
+    }
+`,
+		},
+	}
+	runTestCases(t, testCases)
+}
+
 type testCase struct {
 	Action          plans.Action
 	Mode            addrs.ResourceMode
 	Before          cty.Value
+	BeforeValMarks  []cty.PathValueMarks
+	AfterValMarks   []cty.PathValueMarks
 	After           cty.Value
 	Schema          *configschema.Block
 	RequiredReplace cty.PathSet
@@ -3679,9 +3744,11 @@ func runTestCases(t *testing.T, testCases map[string]testCase) {
 					Module:   addrs.RootModule,
 				},
 				ChangeSrc: plans.ChangeSrc{
-					Action: tc.Action,
-					Before: before,
-					After:  after,
+					Action:         tc.Action,
+					Before:         before,
+					After:          after,
+					BeforeValMarks: tc.BeforeValMarks,
+					AfterValMarks:  tc.AfterValMarks,
 				},
 				RequiredReplace: tc.RequiredReplace,
 			}

--- a/configs/experiments.go
+++ b/configs/experiments.go
@@ -138,6 +138,17 @@ func checkModuleExperiments(m *Module) hcl.Diagnostics {
 			}
 		}
 	*/
-
+	if !m.ActiveExperiments.Has(experiments.SensitiveVariables) {
+		for _, v := range m.Variables {
+			if v.Sensitive {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Variable sensitivity is experimental",
+					Detail:   "This feature is currently an opt-in experiment, subject to change in future releases based on feedback.\n\nActivate the feature for this module by adding sensitive_variables to the list of active experiments.",
+					Subject:  v.DeclRange.Ptr(),
+				})
+			}
+		}
+	}
 	return diags
 }

--- a/configs/named_values.go
+++ b/configs/named_values.go
@@ -25,6 +25,7 @@ type Variable struct {
 	Type        cty.Type
 	ParsingMode VariableParsingMode
 	Validations []*VariableValidation
+	Sensitive   bool
 
 	DescriptionSet bool
 
@@ -92,6 +93,11 @@ func decodeVariableBlock(block *hcl.Block, override bool) (*Variable, hcl.Diagno
 		diags = append(diags, tyDiags...)
 		v.Type = ty
 		v.ParsingMode = parseMode
+	}
+
+	if attr, exists := content.Attributes["sensitive"]; exists {
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &v.Sensitive)
+		diags = append(diags, valDiags...)
 	}
 
 	if attr, exists := content.Attributes["default"]; exists {
@@ -533,6 +539,9 @@ var variableBlockSchema = &hcl.BodySchema{
 		},
 		{
 			Name: "type",
+		},
+		{
+			Name: "sensitive",
 		},
 	},
 	Blocks: []hcl.BlockHeaderSchema{

--- a/configs/testdata/valid-files/variables.tf
+++ b/configs/testdata/valid-files/variables.tf
@@ -22,7 +22,3 @@ variable "cheeze_pizza" {
 variable "π" {
   default = 3.14159265359
 }
-
-variable "sensitive-value" {
-  sensitive = true
-}

--- a/configs/testdata/valid-files/variables.tf
+++ b/configs/testdata/valid-files/variables.tf
@@ -22,3 +22,7 @@ variable "cheeze_pizza" {
 variable "π" {
   default = 3.14159265359
 }
+
+variable "sensitive-value" {
+  sensitive = true
+}

--- a/configs/testdata/warning-files/variables-sensitive.tf
+++ b/configs/testdata/warning-files/variables-sensitive.tf
@@ -1,0 +1,7 @@
+terraform {
+  experiments = [sensitive_variables] # WARNING: Experimental feature "sensitive_variables" is active
+}
+
+variable "sensitive-value" {
+  sensitive = true
+}

--- a/experiments/experiment.go
+++ b/experiments/experiment.go
@@ -14,12 +14,14 @@ type Experiment string
 // identifier so that it can be specified in configuration.
 const (
 	VariableValidation = Experiment("variable_validation")
+	SensitiveVariables = Experiment("sensitive_variables")
 )
 
 func init() {
 	// Each experiment constant defined above must be registered here as either
 	// a current or a concluded experiment.
 	registerConcludedExperiment(VariableValidation, "Custom variable validation can now be used by default, without enabling an experiment.")
+	registerCurrentExperiment(SensitiveVariables)
 }
 
 // GetCurrent takes an experiment name and returns the experiment value

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 	github.com/xanzy/ssh-agent v0.2.1
 	github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 // indirect
 	github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
-	github.com/zclconf/go-cty v1.6.1
+	github.com/zclconf/go-cty v1.6.2-0.20200908203537-4ad5e68430d3
 	github.com/zclconf/go-cty-yaml v1.0.2
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -503,6 +503,8 @@ github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLE
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.6.1 h1:wHtZ+LSSQVwUSb+XIJ5E9hgAQxyWATZsAWT+ESJ9dQ0=
 github.com/zclconf/go-cty v1.6.1/go.mod h1:VDR4+I79ubFBGm1uJac1226K5yANQFHeauxPBoP54+o=
+github.com/zclconf/go-cty v1.6.2-0.20200908203537-4ad5e68430d3 h1:iGouBJrrvGf/H4L6a2n7YBCO0FDhq81FEHI4ILDphkw=
+github.com/zclconf/go-cty v1.6.2-0.20200908203537-4ad5e68430d3/go.mod h1:VDR4+I79ubFBGm1uJac1226K5yANQFHeauxPBoP54+o=
 github.com/zclconf/go-cty-yaml v1.0.2 h1:dNyg4QLTrv2IfJpm7Wtxi55ed5gLGOlPrZ6kMd51hY0=
 github.com/zclconf/go-cty-yaml v1.0.2/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/plans/changes.go
+++ b/plans/changes.go
@@ -341,14 +341,15 @@ func (c *Change) Encode(ty cty.Type) (*ChangeSrc, error) {
 	if err != nil {
 		return nil, err
 	}
-	afterDV, err := NewDynamicValue(c.After, ty)
+	afterDV, err, marks := NewDynamicValueMarks(c.After, ty)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ChangeSrc{
-		Action: c.Action,
-		Before: beforeDV,
-		After:  afterDV,
+		Action:   c.Action,
+		Before:   beforeDV,
+		After:    afterDV,
+		ValMarks: marks,
 	}, nil
 }

--- a/plans/changes_src.go
+++ b/plans/changes_src.go
@@ -157,7 +157,11 @@ type ChangeSrc struct {
 	// storage.
 	Before, After DynamicValue
 
-	// Marked Paths
+	// BeforeValMarks and AfterValMarks are stored path+mark combinations
+	// that might be discovered when encoding a change. Marks are removed
+	// to enable encoding (marked values cannot be marshalled), and so storing
+	// the path+mark combinations allow us to re-mark the value later
+	// when, for example, displaying the diff to the UI.
 	BeforeValMarks, AfterValMarks []cty.PathValueMarks
 }
 

--- a/plans/changes_src.go
+++ b/plans/changes_src.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/states"
 	"github.com/zclconf/go-cty/cty"
+	ctymsgpack "github.com/zclconf/go-cty/cty/msgpack"
 )
 
 // ResourceInstanceChangeSrc is a not-yet-decoded ResourceInstanceChange.
@@ -156,6 +157,9 @@ type ChangeSrc struct {
 	// but have not yet been decoded from the serialized value used for
 	// storage.
 	Before, After DynamicValue
+
+	// Marked Paths
+	ValMarks *ctymsgpack.MarkInfo
 }
 
 // Decode unmarshals the raw representations of the before and after values

--- a/plans/changes_src.go
+++ b/plans/changes_src.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/states"
 	"github.com/zclconf/go-cty/cty"
-	ctymsgpack "github.com/zclconf/go-cty/cty/msgpack"
 )
 
 // ResourceInstanceChangeSrc is a not-yet-decoded ResourceInstanceChange.
@@ -159,7 +158,7 @@ type ChangeSrc struct {
 	Before, After DynamicValue
 
 	// Marked Paths
-	ValMarks *ctymsgpack.MarkInfo
+	BeforeValMarks, AfterValMarks []cty.PathValueMarks
 }
 
 // Decode unmarshals the raw representations of the before and after values

--- a/plans/dynamic_value.go
+++ b/plans/dynamic_value.go
@@ -55,6 +55,26 @@ func NewDynamicValue(val cty.Value, ty cty.Type) (DynamicValue, error) {
 	return DynamicValue(buf), nil
 }
 
+// NewDynamicValueMarks returns a new dynamic value along with a
+// associated marking info for the value
+func NewDynamicValueMarks(val cty.Value, ty cty.Type) (DynamicValue, error, *ctymsgpack.MarkInfo) {
+	// If we're given cty.NilVal (the zero value of cty.Value, which is
+	// distinct from a typed null value created by cty.NullVal) then we'll
+	// assume the caller is trying to represent the _absense_ of a value,
+	// and so we'll return a nil DynamicValue.
+	if val == cty.NilVal {
+		return DynamicValue(nil), nil, nil
+	}
+
+	// Currently our internal encoding is msgpack, via ctymsgpack.
+	buf, err, marks := ctymsgpack.MarshalWithMarks(val, ty)
+	if err != nil {
+		return nil, err, marks
+	}
+
+	return DynamicValue(buf), nil, marks
+}
+
 // Decode retrieves the effective value from the receiever by interpreting the
 // serialized form against the given type constraint. For correct results,
 // the type constraint must match (or be consistent with) the one that was

--- a/plans/dynamic_value.go
+++ b/plans/dynamic_value.go
@@ -55,26 +55,6 @@ func NewDynamicValue(val cty.Value, ty cty.Type) (DynamicValue, error) {
 	return DynamicValue(buf), nil
 }
 
-// NewDynamicValueMarks returns a new dynamic value along with a
-// associated marking info for the value
-func NewDynamicValueMarks(val cty.Value, ty cty.Type) (DynamicValue, error, *ctymsgpack.MarkInfo) {
-	// If we're given cty.NilVal (the zero value of cty.Value, which is
-	// distinct from a typed null value created by cty.NullVal) then we'll
-	// assume the caller is trying to represent the _absense_ of a value,
-	// and so we'll return a nil DynamicValue.
-	if val == cty.NilVal {
-		return DynamicValue(nil), nil, nil
-	}
-
-	// Currently our internal encoding is msgpack, via ctymsgpack.
-	buf, err, marks := ctymsgpack.MarshalWithMarks(val, ty)
-	if err != nil {
-		return nil, err, marks
-	}
-
-	return DynamicValue(buf), nil, marks
-}
-
 // Decode retrieves the effective value from the receiever by interpreting the
 // serialized form against the given type constraint. For correct results,
 // the type constraint must match (or be consistent with) the one that was

--- a/plans/objchange/compatible.go
+++ b/plans/objchange/compatible.go
@@ -51,7 +51,11 @@ func assertObjectCompatible(schema *configschema.Block, planned, actual cty.Valu
 		actualV := actual.GetAttr(name)
 
 		path := append(path, cty.GetAttrStep{Name: name})
-		moreErrs := assertValueCompatible(plannedV, actualV, path)
+
+		// HACK Unmark the values here so we can get past this testing in Apply
+		unmarked, _ := plannedV.UnmarkDeep()
+		unmarkedActual, _ := actualV.UnmarkDeep()
+		moreErrs := assertValueCompatible(unmarked, unmarkedActual, path)
 		if attrS.Sensitive {
 			if len(moreErrs) > 0 {
 				// Use a vague placeholder message instead, to avoid disclosing

--- a/states/instance_object.go
+++ b/states/instance_object.go
@@ -19,9 +19,6 @@ type ResourceInstanceObject struct {
 	// Terraform.
 	Value cty.Value
 
-	// PathValueMarks is a slice of paths and value marks of the value
-	PathValueMarks []cty.PathValueMarks
-
 	// Private is an opaque value set by the provider when this object was
 	// last created or updated. Terraform Core does not use this value in
 	// any way and it is not exposed anywhere in the user interface, so
@@ -104,9 +101,7 @@ func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64) (*Res
 	// If it contains marks, dump those now
 	unmarked := val
 	if val.ContainsMarked() {
-		var pvm []cty.PathValueMarks
-		unmarked, pvm = val.UnmarkDeepWithPaths()
-		o.PathValueMarks = pvm
+		unmarked, _ = val.UnmarkDeep()
 	}
 	src, err := ctyjson.Marshal(unmarked, ty)
 	if err != nil {

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -503,7 +503,6 @@ Note that the -target option is not suitable for routine use, and is provided on
 func (c *Context) Plan() (*plans.Plan, tfdiags.Diagnostics) {
 	defer c.acquireRun("plan")()
 	c.changes = plans.NewChanges()
-
 	var diags tfdiags.Diagnostics
 
 	if len(c.targets) > 0 {
@@ -575,6 +574,7 @@ The -target option is not for routine use, and is provided only for exceptional 
 	diags = diags.Append(walker.NonFatalDiagnostics)
 	diags = diags.Append(walkDiags)
 	if walkDiags.HasErrors() {
+		fmt.Println("walkerr")
 		return nil, diags
 	}
 	p.Changes = c.changes

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -78,26 +78,6 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 		)
 	}
 
-	// Copy paste from eval_diff
-	var markedPath cty.Path
-	// var marks cty.ValueMarks
-	if configVal.ContainsMarked() {
-		// store the marked values so we can re-mark them later after
-		// we've sent things over the wire. Right now this stores
-		// one path for proof of concept, but we should store multiple
-		cty.Walk(configVal, func(p cty.Path, v cty.Value) (bool, error) {
-			if v.IsMarked() {
-				markedPath = p
-				return false, nil
-				// marks = v.Marks()
-			}
-			return true, nil
-		})
-		// Unmark the value for sending over the wire
-		// to providers as marks cannot be serialized
-		configVal, _ = configVal.UnmarkDeep()
-	}
-
 	metaConfigVal := cty.NullVal(cty.DynamicPseudoType)
 	if n.ProviderMetas != nil {
 		log.Printf("[DEBUG] EvalApply: ProviderMeta config value set")
@@ -125,14 +105,23 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 
 	log.Printf("[DEBUG] %s: applying the planned %s change", n.Addr.Absolute(ctx.Path()), change.Action)
 
-	// HACK The after val is also marked so let's fix that
-	unmarked, _ := change.After.UnmarkDeep()
+	// If our config or After value contain any marked values,
+	// ensure those are stripped out before sending
+	// this to the provider
+	unmarkedConfigVal := configVal
+	if configVal.ContainsMarked() {
+		unmarkedConfigVal, _ = configVal.UnmarkDeep()
+	}
+	unmarkedAfter := change.After
+	if change.After.ContainsMarked() {
+		unmarkedAfter, _ = change.After.UnmarkDeep()
+	}
 
 	resp := provider.ApplyResourceChange(providers.ApplyResourceChangeRequest{
 		TypeName:       n.Addr.Resource.Type,
 		PriorState:     change.Before,
-		Config:         configVal,
-		PlannedState:   unmarked,
+		Config:         unmarkedConfigVal,
+		PlannedState:   unmarkedAfter,
 		PlannedPrivate: change.Private,
 		ProviderMeta:   metaConfigVal,
 	})
@@ -148,16 +137,6 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 	// to completion but must be defensive against the new value being
 	// incomplete.
 	newVal := resp.NewState
-
-	// Add the mark back to the planned new value
-	if len(markedPath) != 0 {
-		newVal, _ = cty.Transform(newVal, func(p cty.Path, v cty.Value) (cty.Value, error) {
-			if p.Equals(markedPath) {
-				return v.Mark("sensitive"), nil
-			}
-			return v, nil
-		})
-	}
 
 	if newVal == cty.NilVal {
 		// Providers are supposed to return a partial new value even when errors

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -148,8 +148,7 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 	var unmarkedPaths []cty.PathValueMarks
 	if configVal.ContainsMarked() {
 		// store the marked values so we can re-mark them later after
-		// we've sent things over the wire. Right now this stores
-		// one path for proof of concept, but we should store multiple
+		// we've sent things over the wire.
 		unmarkedConfigVal, unmarkedPaths = configVal.UnmarkDeepWithPaths()
 	}
 

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -256,12 +256,14 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 	plannedNewVal := resp.PlannedState
 
 	// Add the mark back to the planned new value
-	plannedNewVal, _ = cty.Transform(plannedNewVal, func(p cty.Path, v cty.Value) (cty.Value, error) {
-		if p.Equals(markedPath) {
-			return v.Mark("sensitive"), nil
-		}
-		return v, nil
-	})
+	if len(markedPath) != 0 {
+		plannedNewVal, _ = cty.Transform(plannedNewVal, func(p cty.Path, v cty.Value) (cty.Value, error) {
+			if p.Equals(markedPath) {
+				return v.Mark("sensitive"), nil
+			}
+			return v, nil
+		})
+	}
 
 	plannedPrivate := resp.PlannedPrivate
 

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -247,13 +247,6 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	plannedNewVal := resp.PlannedState
-
-	// Add the marks back to the planned new value
-	markedPlannedNewVal := plannedNewVal
-	if configVal.ContainsMarked() {
-		markedPlannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
-	}
-
 	plannedPrivate := resp.PlannedPrivate
 
 	if plannedNewVal == cty.NilVal {
@@ -480,6 +473,11 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 		}
 	}
 
+	// Add the marks back to the planned new value
+	if configVal.ContainsMarked() {
+		plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
+	}
+
 	// Call post-refresh hook
 	if !n.Stub {
 		err := ctx.Hook(func(h Hook) (HookAction, error) {
@@ -499,10 +497,10 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 			Change: plans.Change{
 				Action: action,
 				Before: priorVal,
-				// Pass the marked value through in our change
+				// Pass the marked planned value through in our change
 				// to propogate through evaluation.
 				// Marks will be removed when encoding.
-				After: markedPlannedNewVal,
+				After: plannedNewVal,
 			},
 			RequiredReplace: reqRep,
 		}

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -146,7 +146,6 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 	// necessary
 	unmarkedConfigVal := configVal
 	var unmarkedPaths []cty.PathValueMarks
-	// var marks cty.ValueMarks
 	if configVal.ContainsMarked() {
 		// store the marked values so we can re-mark them later after
 		// we've sent things over the wire. Right now this stores
@@ -250,8 +249,9 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 	plannedNewVal := resp.PlannedState
 
 	// Add the marks back to the planned new value
+	markedPlannedNewVal := plannedNewVal
 	if configVal.ContainsMarked() {
-		plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
+		markedPlannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
 	}
 
 	plannedPrivate := resp.PlannedPrivate
@@ -499,7 +499,10 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 			Change: plans.Change{
 				Action: action,
 				Before: priorVal,
-				After:  plannedNewVal,
+				// Pass the marked value through in our change
+				// to propogate through evaluation.
+				// Marks will be removed when encoding.
+				After: markedPlannedNewVal,
 			},
 			RequiredReplace: reqRep,
 		}

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -256,6 +256,11 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 		panic(fmt.Sprintf("PlanResourceChange of %s produced nil value", absAddr.String()))
 	}
 
+	// Add the marks back to the planned new value
+	if configVal.ContainsMarked() {
+		plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
+	}
+
 	// We allow the planned new value to disagree with configuration _values_
 	// here, since that allows the provider to do special logic like a
 	// DiffSuppressFunc, but we still require that the provider produces
@@ -471,11 +476,6 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 			action = prevChange.Action
 			priorVal = prevChange.Before
 		}
-	}
-
-	// Add the marks back to the planned new value
-	if configVal.ContainsMarked() {
-		plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
 	}
 
 	// Call post-refresh hook

--- a/terraform/eval_for_each.go
+++ b/terraform/eval_for_each.go
@@ -48,6 +48,14 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext) (cty.V
 
 	forEachVal, forEachDiags := ctx.EvaluateExpr(expr, cty.DynamicPseudoType, nil)
 	diags = diags.Append(forEachDiags)
+	if forEachVal.ContainsMarked() {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid for_each argument",
+			Detail:   "Sensitive variable, or values derived from sensitive variables, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource instance key.",
+			Subject:  expr.Range().Ptr(),
+		})
+	}
 	if diags.HasErrors() {
 		return nullMap, diags
 	}

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -292,6 +292,10 @@ func (d *evaluationStateData) GetInputVariable(addr addrs.InputVariable, rng tfd
 		val = cty.UnknownVal(wantType)
 	}
 
+	if config.Sensitive {
+		val = val.Mark("sensitive")
+	}
+
 	return val, diags
 }
 

--- a/terraform/testdata/plan-ignore-changes/main.tf
+++ b/terraform/testdata/plan-ignore-changes/main.tf
@@ -1,9 +1,9 @@
 variable "foo" {}
 
 resource "aws_instance" "foo" {
-  ami = "${var.foo}"
+  ami = var.foo
 
   lifecycle {
-    ignore_changes = ["ami"]
+    ignore_changes = [ami]
   }
 }

--- a/terraform/testdata/plan-variable-sensitivity/main.tf
+++ b/terraform/testdata/plan-variable-sensitivity/main.tf
@@ -1,0 +1,12 @@
+terraform {
+    experiments = [sensitive_variables]
+}
+
+variable "sensitive_var" {
+    default = "foo"
+    sensitive = true
+}
+
+resource "aws_instance" "foo" {
+  foo   = var.sensitive_var
+}

--- a/vendor/github.com/zclconf/go-cty/cty/json/marshal.go
+++ b/vendor/github.com/zclconf/go-cty/cty/json/marshal.go
@@ -10,8 +10,7 @@ import (
 
 func marshal(val cty.Value, t cty.Type, path cty.Path, b *bytes.Buffer) error {
 	if val.IsMarked() {
-		// For now, dump the marks when serializing JSON for POC purposes
-		val, _ = val.UnmarkDeep()
+		return path.NewErrorf("value has marks, so it cannot be serialized as JSON")
 	}
 
 	// If we're going to decode as DynamicPseudoType then we need to save

--- a/vendor/github.com/zclconf/go-cty/cty/json/marshal.go
+++ b/vendor/github.com/zclconf/go-cty/cty/json/marshal.go
@@ -10,7 +10,8 @@ import (
 
 func marshal(val cty.Value, t cty.Type, path cty.Path, b *bytes.Buffer) error {
 	if val.IsMarked() {
-		return path.NewErrorf("value has marks, so it cannot be seralized")
+		// For now, dump the marks when serializing JSON for POC purposes
+		val, _ = val.UnmarkDeep()
 	}
 
 	// If we're going to decode as DynamicPseudoType then we need to save

--- a/vendor/github.com/zclconf/go-cty/cty/marks.go
+++ b/vendor/github.com/zclconf/go-cty/cty/marks.go
@@ -192,13 +192,13 @@ func (val Value) Mark(mark interface{}) Value {
 }
 
 // MarkWithPaths accepts a slice of PathValueMarks to apply
-// marker particular paths
+// markers to particular paths and returns the marked
+// Value.
 func (val Value) MarkWithPaths(pvm []PathValueMarks) Value {
 	ret, _ := Transform(val, func(p Path, v Value) (Value, error) {
 		for _, path := range pvm {
 			if p.Equals(path.Path) {
 				return v.WithMarks(path.Marks), nil
-
 			}
 		}
 		return v, nil
@@ -241,6 +241,10 @@ func (val Value) UnmarkDeep() (Value, ValueMarks) {
 	return ret, marks
 }
 
+// UnmarkDeepWithPaths is like UnmarkDeep, except it returns a slice
+// of PathValueMarks rather than a superset of all marks. This allows
+// a caller to know which marks are associated with which paths
+// in the Value.
 func (val Value) UnmarkDeepWithPaths() (Value, []PathValueMarks) {
 	var marks []PathValueMarks
 	ret, _ := Transform(val, func(p Path, v Value) (Value, error) {

--- a/vendor/github.com/zclconf/go-cty/cty/marks.go
+++ b/vendor/github.com/zclconf/go-cty/cty/marks.go
@@ -67,6 +67,23 @@ func (m ValueMarks) GoString() string {
 	return s.String()
 }
 
+// PathValueMarks is a structure that enables tracking marks
+// and the paths where they are located in one type
+type PathValueMarks struct {
+	Path  Path
+	Marks ValueMarks
+}
+
+func (p PathValueMarks) Equal(o PathValueMarks) bool {
+	if !p.Path.Equals(o.Path) {
+		return false
+	}
+	if !p.Marks.Equal(o.Marks) {
+		return false
+	}
+	return true
+}
+
 // IsMarked returns true if and only if the receiving value carries at least
 // one mark. A marked value cannot be used directly with integration methods
 // without explicitly unmarking it (and retrieving the markings) first.
@@ -174,6 +191,21 @@ func (val Value) Mark(mark interface{}) Value {
 	}
 }
 
+// MarkWithPaths accepts a slice of PathValueMarks to apply
+// marker particular paths
+func (val Value) MarkWithPaths(pvm []PathValueMarks) Value {
+	ret, _ := Transform(val, func(p Path, v Value) (Value, error) {
+		for _, path := range pvm {
+			if p.Equals(path.Path) {
+				return v.WithMarks(path.Marks), nil
+
+			}
+		}
+		return v, nil
+	})
+	return ret
+}
+
 // Unmark separates the marks of the receiving value from the value itself,
 // removing a new unmarked value and a map (representing a set) of the marks.
 //
@@ -203,6 +235,18 @@ func (val Value) UnmarkDeep() (Value, ValueMarks) {
 		unmarkedV, valueMarks := v.Unmark()
 		for m, s := range valueMarks {
 			marks[m] = s
+		}
+		return unmarkedV, nil
+	})
+	return ret, marks
+}
+
+func (val Value) UnmarkDeepWithPaths() (Value, []PathValueMarks) {
+	var marks []PathValueMarks
+	ret, _ := Transform(val, func(p Path, v Value) (Value, error) {
+		unmarkedV, valueMarks := v.Unmark()
+		if v.IsMarked() {
+			marks = append(marks, PathValueMarks{p, valueMarks})
 		}
 		return unmarkedV, nil
 	})

--- a/vendor/github.com/zclconf/go-cty/cty/msgpack/marshal.go
+++ b/vendor/github.com/zclconf/go-cty/cty/msgpack/marshal.go
@@ -41,39 +41,9 @@ func Marshal(val cty.Value, ty cty.Type) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// This type should (likely) be a map of paths
-// and marks, so that multiple marks can be found
-// in case of a value containing multiple marked values
-type MarkInfo struct {
-	Marks cty.ValueMarks
-	Path  cty.Path
-}
-
-func MarshalWithMarks(val cty.Value, ty cty.Type) ([]byte, error, *MarkInfo) {
-	markInfo := MarkInfo{}
-	if val.ContainsMarked() {
-		// store the marked values so we can re-mark them later after
-		// we've sent things over the wire
-		cty.Walk(val, func(p cty.Path, v cty.Value) (bool, error) {
-			if v.IsMarked() {
-				markInfo.Path = p
-				markInfo.Marks = v.Marks()
-			}
-			return true, nil
-		})
-		val, _ = val.UnmarkDeep()
-	}
-	by, err := Marshal(val, ty)
-	if err != nil {
-		return nil, err, &markInfo
-	}
-
-	return by, nil, &markInfo
-}
-
 func marshal(val cty.Value, ty cty.Type, path cty.Path, enc *msgpack.Encoder) error {
 	if val.IsMarked() {
-		return path.NewErrorf("value has marks, so it cannot be seralized")
+		return path.NewErrorf("value has marks, so it cannot be serialized")
 	}
 
 	// If we're going to decode as DynamicPseudoType then we need to save

--- a/vendor/github.com/zclconf/go-cty/cty/msgpack/marshal.go
+++ b/vendor/github.com/zclconf/go-cty/cty/msgpack/marshal.go
@@ -41,6 +41,36 @@ func Marshal(val cty.Value, ty cty.Type) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// This type should (likely) be a map of paths
+// and marks, so that multiple marks can be found
+// in case of a value containing multiple marked values
+type MarkInfo struct {
+	Marks cty.ValueMarks
+	Path  cty.Path
+}
+
+func MarshalWithMarks(val cty.Value, ty cty.Type) ([]byte, error, *MarkInfo) {
+	markInfo := MarkInfo{}
+	if val.ContainsMarked() {
+		// store the marked values so we can re-mark them later after
+		// we've sent things over the wire
+		cty.Walk(val, func(p cty.Path, v cty.Value) (bool, error) {
+			if v.IsMarked() {
+				markInfo.Path = p
+				markInfo.Marks = v.Marks()
+			}
+			return true, nil
+		})
+		val, _ = val.UnmarkDeep()
+	}
+	by, err := Marshal(val, ty)
+	if err != nil {
+		return nil, err, &markInfo
+	}
+
+	return by, nil, &markInfo
+}
+
 func marshal(val cty.Value, ty cty.Type, path cty.Path, enc *msgpack.Encoder) error {
 	if val.IsMarked() {
 		return path.NewErrorf("value has marks, so it cannot be seralized")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -605,7 +605,7 @@ github.com/xanzy/ssh-agent
 # github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
 ## explicit
 github.com/xlab/treeprint
-# github.com/zclconf/go-cty v1.6.1
+# github.com/zclconf/go-cty v1.6.2-0.20200908203537-4ad5e68430d3
 ## explicit
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/convert


### PR DESCRIPTION
This PR allows `sensitive` to be added to a variable declaration, after enabling the `sensitive_variables` experiment:

```terraform
terraform {
  experiments = [sensitive_variables]
}

variable "foo" {
  sensitive = true
}

resource "some_resource" "bar" {
  some_val = var.foo
}
```

At this current stage of the project, this works on some very basic configurations. When sensitivity is defined, when Terraform outputs the plan to the CLI, attributes using this variable will not be displayed:

```
  # some_resource.bar will be created
  + resource "some_resource" "bar" {
      + id          = (known after apply)
      + some_val    = (sensitive)
    }

```

This PR depends on changes in https://github.com/zclconf/go-cty -- at the moment, go.mod points to `master`, while this feature is in progress. Once the methods have stabilized and there is a new release to point at, go.mod will point to that release.

I see that there's not strong covered diff coverage in this PR, which is semi-intentional, the idea to add more tests in a following PR. Saying "that's better to do here, now" would be completely valid -- my intention is that this PR be some reviewable amount of work where Terraform as-is functions, and hard edges are only discovered when using the `sensitive` attribute.