### PR TITLE
configs: Error on invalid required_providers attrs

### DIFF
--- a/configs/provider_requirements.go
+++ b/configs/provider_requirements.go
@@ -113,6 +113,19 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (*RequiredProviders, hcl.Dia
 					}
 				}
 			}
+			attrTypes := expr.Type().AttributeTypes()
+			for name := range attrTypes {
+				if name == "version" || name == "source" {
+					continue
+				}
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid required_providers object",
+					Detail:   `required_providers objects can only contain "version" and "source" attributes. To configure a provider, use a "provider" block.`,
+					Subject:  attr.Expr.Range().Ptr(),
+				})
+				break
+			}
 
 		default:
 			// should not happen

--- a/configs/provider_requirements_test.go
+++ b/configs/provider_requirements_test.go
@@ -332,6 +332,37 @@ func TestDecodeRequiredProvidersBlock(t *testing.T) {
 			},
 			Error: "Invalid source",
 		},
+		"additional attributes": {
+			Block: &hcl.Block{
+				Type: "required_providers",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"my-test": {
+							Name: "my-test",
+							Expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
+								"source":  cty.StringVal("mycloud/test"),
+								"version": cty.StringVal("2.0.0"),
+								"invalid": cty.BoolVal(true),
+							})),
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			Want: &RequiredProviders{
+				RequiredProviders: map[string]*RequiredProvider{
+					"my-test": {
+						Name:        "my-test",
+						Source:      "mycloud/test",
+						Type:        addrs.NewProvider(addrs.DefaultRegistryHost, "mycloud", "test"),
+						Requirement: testVC("2.0.0"),
+						DeclRange:   mockRange,
+					},
+				},
+				DeclRange: blockRange,
+			},
+			Error: "Invalid required_providers object",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
A few users have recently been confused about the purpose of the `required_providers` objects, adding provider configuration parameters in addition to `version` and `source`. This previously did not cause an error so would result in a confusingly distant failure.

This commit adds a single diagnostic for any `required_providers` object which includes attributes other than `version` or `source`. Very open to suggestions on the diagnostic text!

Fixes #26160

### Screenshot

<img width="856" alt="required-providers-attrs" src="https://user-images.githubusercontent.com/68917/92622459-07036a00-f293-11ea-89fc-b8463ae9c0ce.png">
