### PR TITLE
command: Add experimental concise diff renderer

### DIFF
--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -289,12 +289,9 @@ Terraform will perform the following actions:
 
   # test_instance.foo is tainted, so must be replaced
 -/+ resource "test_instance" "foo" {
-        ami = "bar"
+        # (1 unchanged attribute hidden)
 
-        network_interface {
-            description  = "Main network interface"
-            device_index = 0
-        }
+        # (1 unchanged block hidden)
     }
 
 Plan: 1 to add, 0 to change, 1 to destroy.`
@@ -468,12 +465,9 @@ Terraform will perform the following actions:
 
   # test_instance.foo is tainted, so must be replaced
 +/- resource "test_instance" "foo" {
-        ami = "bar"
+        # (1 unchanged attribute hidden)
 
-        network_interface {
-            description  = "Main network interface"
-            device_index = 0
-        }
+        # (1 unchanged block hidden)
     }
 
 Plan: 1 to add, 0 to change, 1 to destroy.`

--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/helper/experiment"
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/plans/objchange"
 	"github.com/hashicorp/terraform/states"
@@ -98,6 +99,7 @@ func ResourceChange(
 		color:           color,
 		action:          change.Action,
 		requiredReplace: change.RequiredReplace,
+		concise:         experiment.Enabled(experiment.X_concise_diff),
 	}
 
 	// Most commonly-used resources have nested blocks that result in us
@@ -123,10 +125,10 @@ func ResourceChange(
 	changeV.Change.Before = objchange.NormalizeObjectFromLegacySDK(changeV.Change.Before, schema)
 	changeV.Change.After = objchange.NormalizeObjectFromLegacySDK(changeV.Change.After, schema)
 
-	bodyWritten := p.writeBlockBodyDiff(schema, changeV.Before, changeV.After, 6, path)
-	if bodyWritten {
-		buf.WriteString("\n")
-		buf.WriteString(strings.Repeat(" ", 4))
+	result := p.writeBlockBodyDiff(schema, changeV.Before, changeV.After, 6, path)
+	if result.bodyWritten {
+		p.buf.WriteString("\n")
+		p.buf.WriteString(strings.Repeat(" ", 4))
 	}
 	buf.WriteString("}\n")
 
@@ -144,9 +146,10 @@ func OutputChanges(
 ) string {
 	var buf bytes.Buffer
 	p := blockBodyDiffPrinter{
-		buf:    &buf,
-		color:  color,
-		action: plans.Update, // not actually used in this case, because we're not printing a containing block
+		buf:     &buf,
+		color:   color,
+		action:  plans.Update, // not actually used in this case, because we're not printing a containing block
+		concise: experiment.Enabled(experiment.X_concise_diff),
 	}
 
 	// We're going to reuse the codepath we used for printing resource block
@@ -189,16 +192,24 @@ type blockBodyDiffPrinter struct {
 	color           *colorstring.Colorize
 	action          plans.Action
 	requiredReplace cty.PathSet
+	concise         bool
+}
+
+type blockBodyDiffResult struct {
+	bodyWritten       bool
+	skippedAttributes int
+	skippedBlocks     int
 }
 
 const forcesNewResourceCaption = " [red]# forces replacement[reset]"
 
 // writeBlockBodyDiff writes attribute or block differences
 // and returns true if any differences were found and written
-func (p *blockBodyDiffPrinter) writeBlockBodyDiff(schema *configschema.Block, old, new cty.Value, indent int, path cty.Path) bool {
+func (p *blockBodyDiffPrinter) writeBlockBodyDiff(schema *configschema.Block, old, new cty.Value, indent int, path cty.Path) blockBodyDiffResult {
 	path = ctyEnsurePathCapacity(path, 1)
 
-	bodyWritten := false
+	result := blockBodyDiffResult{}
+
 	blankBeforeBlocks := false
 	{
 		attrNames := make([]string, 0, len(schema.Attributes))
@@ -229,8 +240,21 @@ func (p *blockBodyDiffPrinter) writeBlockBodyDiff(schema *configschema.Block, ol
 			oldVal := ctyGetAttrMaybeNull(old, name)
 			newVal := ctyGetAttrMaybeNull(new, name)
 
-			bodyWritten = true
-			p.writeAttrDiff(name, attrS, oldVal, newVal, attrNameLen, indent, path)
+			result.bodyWritten = true
+			skipped := p.writeAttrDiff(name, attrS, oldVal, newVal, attrNameLen, indent, path)
+			if skipped {
+				result.skippedAttributes++
+			}
+		}
+
+		if result.skippedAttributes > 0 {
+			noun := "attributes"
+			if result.skippedAttributes == 1 {
+				noun = "attribute"
+			}
+			p.buf.WriteString("\n")
+			p.buf.WriteString(strings.Repeat(" ", indent+2))
+			p.buf.WriteString(p.color.Color(fmt.Sprintf("[dark_gray]# (%d unchanged %s hidden)[reset]", result.skippedAttributes, noun)))
 		}
 	}
 
@@ -246,21 +270,31 @@ func (p *blockBodyDiffPrinter) writeBlockBodyDiff(schema *configschema.Block, ol
 			oldVal := ctyGetAttrMaybeNull(old, name)
 			newVal := ctyGetAttrMaybeNull(new, name)
 
-			bodyWritten = true
-			p.writeNestedBlockDiffs(name, blockS, oldVal, newVal, blankBeforeBlocks, indent, path)
+			result.bodyWritten = true
+			skippedBlocks := p.writeNestedBlockDiffs(name, blockS, oldVal, newVal, blankBeforeBlocks, indent, path)
+			if skippedBlocks > 0 {
+				result.skippedBlocks += skippedBlocks
+			}
 
 			// Always include a blank for any subsequent block types.
 			blankBeforeBlocks = true
 		}
+		if result.skippedBlocks > 0 {
+			noun := "blocks"
+			if result.skippedBlocks == 1 {
+				noun = "block"
+			}
+			p.buf.WriteString("\n")
+			p.buf.WriteString(strings.Repeat(" ", indent+2))
+			p.buf.WriteString(p.color.Color(fmt.Sprintf("[dark_gray]# (%d unchanged %s hidden)[reset]", result.skippedBlocks, noun)))
+		}
 	}
 
-	return bodyWritten
+	return result
 }
 
-func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.Attribute, old, new cty.Value, nameLen, indent int, path cty.Path) {
+func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.Attribute, old, new cty.Value, nameLen, indent int, path cty.Path) bool {
 	path = append(path, cty.GetAttrStep{Name: name})
-	p.buf.WriteString("\n")
-	p.buf.WriteString(strings.Repeat(" ", indent))
 	showJustNew := false
 	var action plans.Action
 	switch {
@@ -276,6 +310,12 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 		action = plans.Update
 	}
 
+	if action == plans.NoOp && p.concise && !identifyingAttribute(name, attrS) {
+		return true
+	}
+
+	p.buf.WriteString("\n")
+	p.buf.WriteString(strings.Repeat(" ", indent))
 	p.writeActionSymbol(action)
 
 	p.buf.WriteString(p.color.Color("[bold]"))
@@ -300,13 +340,16 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 			p.writeValueDiff(old, new, indent+2, path)
 		}
 	}
+
+	return false
 }
 
-func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *configschema.NestedBlock, old, new cty.Value, blankBefore bool, indent int, path cty.Path) {
+func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *configschema.NestedBlock, old, new cty.Value, blankBefore bool, indent int, path cty.Path) int {
+	skippedBlocks := 0
 	path = append(path, cty.GetAttrStep{Name: name})
 	if old.IsNull() && new.IsNull() {
 		// Nothing to do if both old and new is null
-		return
+		return skippedBlocks
 	}
 
 	// Where old/new are collections representing a nesting mode other than
@@ -335,7 +378,10 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 		if blankBefore {
 			p.buf.WriteRune('\n')
 		}
-		p.writeNestedBlockDiff(name, nil, &blockS.Block, action, old, new, indent, path)
+		skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, action, old, new, indent, path)
+		if skipped {
+			return 1
+		}
 	case configschema.NestingList:
 		// For the sake of handling nested blocks, we'll treat a null list
 		// the same as an empty list since the config language doesn't
@@ -377,19 +423,28 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 			if oldItem.RawEquals(newItem) {
 				action = plans.NoOp
 			}
-			p.writeNestedBlockDiff(name, nil, &blockS.Block, action, oldItem, newItem, indent, path)
+			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, action, oldItem, newItem, indent, path)
+			if skipped {
+				skippedBlocks++
+			}
 		}
 		for i := commonLen; i < len(oldItems); i++ {
 			path := append(path, cty.IndexStep{Key: cty.NumberIntVal(int64(i))})
 			oldItem := oldItems[i]
 			newItem := cty.NullVal(oldItem.Type())
-			p.writeNestedBlockDiff(name, nil, &blockS.Block, plans.Delete, oldItem, newItem, indent, path)
+			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, plans.Delete, oldItem, newItem, indent, path)
+			if skipped {
+				skippedBlocks++
+			}
 		}
 		for i := commonLen; i < len(newItems); i++ {
 			path := append(path, cty.IndexStep{Key: cty.NumberIntVal(int64(i))})
 			newItem := newItems[i]
 			oldItem := cty.NullVal(newItem.Type())
-			p.writeNestedBlockDiff(name, nil, &blockS.Block, plans.Create, oldItem, newItem, indent, path)
+			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, plans.Create, oldItem, newItem, indent, path)
+			if skipped {
+				skippedBlocks++
+			}
 		}
 	case configschema.NestingSet:
 		// For the sake of handling nested blocks, we'll treat a null set
@@ -403,7 +458,7 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 
 		if (len(oldItems) + len(newItems)) == 0 {
 			// Nothing to do if both sets are empty
-			return
+			return 0
 		}
 
 		allItems := make([]cty.Value, 0, len(oldItems)+len(newItems))
@@ -437,7 +492,10 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 				newValue = val
 			}
 			path := append(path, cty.IndexStep{Key: val})
-			p.writeNestedBlockDiff(name, nil, &blockS.Block, action, oldValue, newValue, indent, path)
+			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, action, oldValue, newValue, indent, path)
+			if skipped {
+				skippedBlocks++
+			}
 		}
 
 	case configschema.NestingMap:
@@ -451,7 +509,7 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 		newItems := new.AsValueMap()
 		if (len(oldItems) + len(newItems)) == 0 {
 			// Nothing to do if both maps are empty
-			return
+			return 0
 		}
 
 		allKeys := make(map[string]bool)
@@ -489,12 +547,20 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 			}
 
 			path := append(path, cty.IndexStep{Key: cty.StringVal(k)})
-			p.writeNestedBlockDiff(name, &k, &blockS.Block, action, oldValue, newValue, indent, path)
+			skipped := p.writeNestedBlockDiff(name, &k, &blockS.Block, action, oldValue, newValue, indent, path)
+			if skipped {
+				skippedBlocks++
+			}
 		}
 	}
+	return skippedBlocks
 }
 
-func (p *blockBodyDiffPrinter) writeNestedBlockDiff(name string, label *string, blockS *configschema.Block, action plans.Action, old, new cty.Value, indent int, path cty.Path) {
+func (p *blockBodyDiffPrinter) writeNestedBlockDiff(name string, label *string, blockS *configschema.Block, action plans.Action, old, new cty.Value, indent int, path cty.Path) bool {
+	if action == plans.NoOp && p.concise {
+		return true
+	}
+
 	p.buf.WriteString("\n")
 	p.buf.WriteString(strings.Repeat(" ", indent))
 	p.writeActionSymbol(action)
@@ -509,12 +575,14 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiff(name string, label *string, 
 		p.buf.WriteString(p.color.Color(forcesNewResourceCaption))
 	}
 
-	bodyWritten := p.writeBlockBodyDiff(blockS, old, new, indent+4, path)
-	if bodyWritten {
+	result := p.writeBlockBodyDiff(blockS, old, new, indent+4, path)
+	if result.bodyWritten {
 		p.buf.WriteString("\n")
 		p.buf.WriteString(strings.Repeat(" ", indent+2))
 	}
 	p.buf.WriteString("}")
+
+	return false
 }
 
 func (p *blockBodyDiffPrinter) writeValue(val cty.Value, action plans.Action, indent int) {
@@ -819,10 +887,9 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 				removed = cty.SetValEmpty(ty.ElementType())
 			}
 
+			suppressedElements := 0
 			for it := all.ElementIterator(); it.Next(); {
 				_, val := it.Element()
-
-				p.buf.WriteString(strings.Repeat(" ", indent+2))
 
 				var action plans.Action
 				switch {
@@ -836,9 +903,26 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 					action = plans.NoOp
 				}
 
+				if action == plans.NoOp && p.concise {
+					suppressedElements++
+					continue
+				}
+
+				p.buf.WriteString(strings.Repeat(" ", indent+2))
 				p.writeActionSymbol(action)
 				p.writeValue(val, action, indent+4)
 				p.buf.WriteString(",\n")
+			}
+
+			if suppressedElements > 0 {
+				p.writeActionSymbol(plans.NoOp)
+				p.buf.WriteString(strings.Repeat(" ", indent+2))
+				noun := "elements"
+				if suppressedElements == 1 {
+					noun = "element"
+				}
+				p.buf.WriteString(p.color.Color(fmt.Sprintf("[dark_gray]# (%d unchanged %s hidden)[reset]", suppressedElements, noun)))
+				p.buf.WriteString("\n")
 			}
 
 			p.buf.WriteString(strings.Repeat(" ", indent))
@@ -852,7 +936,74 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 			p.buf.WriteString("\n")
 
 			elemDiffs := ctySequenceDiff(old.AsValueSlice(), new.AsValueSlice())
-			for _, elemDiff := range elemDiffs {
+
+			// Maintain a stack of suppressed lines in the diff for later
+			// display or elision
+			var suppressedElements []*plans.Change
+			var changeShown bool
+
+			for i := 0; i < len(elemDiffs); i++ {
+				// In concise mode, push any no-op diff elements onto the stack
+				if p.concise {
+					for i < len(elemDiffs) && elemDiffs[i].Action == plans.NoOp {
+						suppressedElements = append(suppressedElements, elemDiffs[i])
+						i++
+					}
+				}
+
+				// If we have some suppressed elements on the stack…
+				if len(suppressedElements) > 0 {
+					// If we've just rendered a change, display the first
+					// element in the stack as context
+					if changeShown {
+						elemDiff := suppressedElements[0]
+						p.buf.WriteString(strings.Repeat(" ", indent+4))
+						p.writeValue(elemDiff.After, elemDiff.Action, indent+4)
+						p.buf.WriteString(",\n")
+						suppressedElements = suppressedElements[1:]
+					}
+
+					hidden := len(suppressedElements)
+
+					// If we're not yet at the end of the list, capture the
+					// last element on the stack as context for the upcoming
+					// change to be rendered
+					var nextContextDiff *plans.Change
+					if hidden > 0 && i < len(elemDiffs) {
+						hidden--
+						nextContextDiff = suppressedElements[hidden]
+						suppressedElements = suppressedElements[:hidden]
+					}
+
+					// If there are still hidden elements, show an elision
+					// statement counting them
+					if hidden > 0 {
+						p.writeActionSymbol(plans.NoOp)
+						p.buf.WriteString(strings.Repeat(" ", indent+2))
+						noun := "elements"
+						if hidden == 1 {
+							noun = "element"
+						}
+						p.buf.WriteString(p.color.Color(fmt.Sprintf("[dark_gray]# (%d unchanged %s hidden)[reset]", hidden, noun)))
+						p.buf.WriteString("\n")
+					}
+
+					// Display the next context diff if it was captured above
+					if nextContextDiff != nil {
+						p.buf.WriteString(strings.Repeat(" ", indent+4))
+						p.writeValue(nextContextDiff.After, nextContextDiff.Action, indent+4)
+						p.buf.WriteString(",\n")
+					}
+
+					// Suppressed elements have now been handled so clear them again
+					suppressedElements = nil
+				}
+
+				if i >= len(elemDiffs) {
+					break
+				}
+
+				elemDiff := elemDiffs[i]
 				p.buf.WriteString(strings.Repeat(" ", indent+2))
 				p.writeActionSymbol(elemDiff.Action)
 				switch elemDiff.Action {
@@ -869,10 +1020,12 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 				}
 
 				p.buf.WriteString(",\n")
+				changeShown = true
 			}
 
 			p.buf.WriteString(strings.Repeat(" ", indent))
 			p.buf.WriteString("]")
+
 			return
 
 		case ty.IsMapType():
@@ -903,6 +1056,7 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 
 			sort.Strings(allKeys)
 
+			suppressedElements := 0
 			lastK := ""
 			for i, k := range allKeys {
 				if i > 0 && lastK == k {
@@ -910,7 +1064,6 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 				}
 				lastK = k
 
-				p.buf.WriteString(strings.Repeat(" ", indent+2))
 				kV := cty.StringVal(k)
 				var action plans.Action
 				if old.HasIndex(kV).False() {
@@ -923,8 +1076,14 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 					action = plans.Update
 				}
 
+				if action == plans.NoOp && p.concise {
+					suppressedElements++
+					continue
+				}
+
 				path := append(path, cty.IndexStep{Key: kV})
 
+				p.buf.WriteString(strings.Repeat(" ", indent+2))
 				p.writeActionSymbol(action)
 				p.writeValue(kV, action, indent+4)
 				p.buf.WriteString(strings.Repeat(" ", keyLen-len(k)))
@@ -946,8 +1105,20 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 				p.buf.WriteByte('\n')
 			}
 
+			if suppressedElements > 0 {
+				p.writeActionSymbol(plans.NoOp)
+				p.buf.WriteString(strings.Repeat(" ", indent+2))
+				noun := "elements"
+				if suppressedElements == 1 {
+					noun = "element"
+				}
+				p.buf.WriteString(p.color.Color(fmt.Sprintf("[dark_gray]# (%d unchanged %s hidden)[reset]", suppressedElements, noun)))
+				p.buf.WriteString("\n")
+			}
+
 			p.buf.WriteString(strings.Repeat(" ", indent))
 			p.buf.WriteString("}")
+
 			return
 		case ty.IsObjectType():
 			p.buf.WriteString("{")
@@ -976,6 +1147,7 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 
 			sort.Strings(allKeys)
 
+			suppressedElements := 0
 			lastK := ""
 			for i, k := range allKeys {
 				if i > 0 && lastK == k {
@@ -983,7 +1155,6 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 				}
 				lastK = k
 
-				p.buf.WriteString(strings.Repeat(" ", indent+2))
 				kV := k
 				var action plans.Action
 				if !old.Type().HasAttribute(kV) {
@@ -996,8 +1167,14 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 					action = plans.Update
 				}
 
+				if action == plans.NoOp && p.concise {
+					suppressedElements++
+					continue
+				}
+
 				path := append(path, cty.GetAttrStep{Name: kV})
 
+				p.buf.WriteString(strings.Repeat(" ", indent+2))
 				p.writeActionSymbol(action)
 				p.buf.WriteString(k)
 				p.buf.WriteString(strings.Repeat(" ", keyLen-len(k)))
@@ -1017,6 +1194,17 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 					p.writeValueDiff(oldV, newV, indent+4, path)
 				}
 
+				p.buf.WriteString("\n")
+			}
+
+			if suppressedElements > 0 {
+				p.writeActionSymbol(plans.NoOp)
+				p.buf.WriteString(strings.Repeat(" ", indent+2))
+				noun := "elements"
+				if suppressedElements == 1 {
+					noun = "element"
+				}
+				p.buf.WriteString(p.color.Color(fmt.Sprintf("[dark_gray]# (%d unchanged %s hidden)[reset]", suppressedElements, noun)))
 				p.buf.WriteString("\n")
 			}
 
@@ -1265,4 +1453,12 @@ func DiffActionSymbol(action plans.Action) string {
 	default:
 		return "  ?"
 	}
+}
+
+// Extremely coarse heuristic for determining whether or not a given attribute
+// name is important for identifying a resource. In the future, this may be
+// replaced by a flag in the schema, but for now this is likely to be good
+// enough.
+func identifyingAttribute(name string, attrSchema *configschema.Attribute) bool {
+	return name == "id" || name == "tags" || name == "name"
 }

--- a/command/format/state.go
+++ b/command/format/state.go
@@ -198,8 +198,8 @@ func formatStateModule(p blockBodyDiffPrinter, m *states.Module, schemas *terraf
 				}
 
 				path := make(cty.Path, 0, 3)
-				bodyWritten := p.writeBlockBodyDiff(schema, val.Value, val.Value, 2, path)
-				if bodyWritten {
+				result := p.writeBlockBodyDiff(schema, val.Value, val.Value, 2, path)
+				if result.bodyWritten {
 					p.buf.WriteString("\n")
 				}
 

--- a/helper/experiment/experiment.go
+++ b/helper/experiment/experiment.go
@@ -53,6 +53,9 @@ var (
 	// Shadow graph. This is already on by default. Disabling it will be
 	// allowed for awhile in order for it to not block operations.
 	X_shadow = newBasicID("shadow", "SHADOW", false)
+
+	// Concise plan diff output
+	X_concise_diff = newBasicID("concise_diff", "CONCISE_DIFF", true)
 )
 
 // Global variables this package uses because we are a package
@@ -73,6 +76,7 @@ func init() {
 	// The list of all experiments, update this when an experiment is added.
 	All = []ID{
 		X_shadow,
+		X_concise_diff,
 		x_force,
 	}
 


### PR DESCRIPTION
When rendering a diff between current state and projected state, we only show resources and outputs which have changes. However, we show a full structural diff for these values, which includes all attributes and blocks for a changed resource or output. The result can be a very long diff, which makes it difficult to verify what the changed fields are.

This commit adds an experimental concise diff renderer, which suppresses most unchanged fields, only displaying the most relevant changes and some identifying context. This means:

- Always show all identifying attributes, initially defined as `id`, `name`, and `tags`, even if unchanged;
- Only show changed, added, or removed primitive values: `string`, `number`, or `bool`;
- Only show added or removed elements in unordered collections and structural types: `map`, `set`, and `object`;
- Show added or removed elements with any surrounding unchanged elements for sequence types: `list` and `tuple`;
- Only show added or removed nested blocks, or blocks with changed attributes.

If any attributes, collection elements, or blocks are hidden, a count is kept and displayed at the end of the parent scope. This ensures that it is clear that the diff is only displaying a subset of the resource.

The experiment is currently enabled by default, but can be disabled by setting the `TF_X_CONCISE_DIFF` environment variable to 0. This will be documented in the CHANGELOG update.

### Screenshots

<img width="863" alt="list-changed" src="https://user-images.githubusercontent.com/68917/92629463-5601cd00-f29c-11ea-95ad-ecaca2eeac96.png">
<img width="815" alt="block-added" src="https://user-images.githubusercontent.com/68917/92629470-57cb9080-f29c-11ea-847f-10d728f0503f.png">
