### PR TITLE
Use saved plan to determine CreateBeforeDestroy status

### DIFF
--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -263,10 +263,15 @@ func (n *NodeApplyableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 					destroy := false
 					if diffApply != nil {
 						destroy = (diffApply.Action == plans.Delete || diffApply.Action.IsReplace())
+
+						// Get the stored action for CBD if we have a plan already
+						createBeforeDestroyEnabled = diffApply.Change.Action == plans.CreateThenDelete
 					}
+
 					if destroy && n.CreateBeforeDestroy() {
 						createBeforeDestroyEnabled = true
 					}
+
 					return createBeforeDestroyEnabled, nil
 				},
 				Then: &EvalDeposeState{


### PR DESCRIPTION
If the planed action changes from CreateThenDelete to DeleteThenCreate,
terraform will present an error like:

```
Error: Provider produced inconsistent final plan

When expanding the plan for null_resource.a to include new values learned so
far during apply, provider "registry.terraform.io/hashicorp/null" changed the
planned action from CreateThenDelete to DeleteThenCreate.

This is a bug in the provider, which should be reported in the provider's own
issue tracker.
```

This was being reported to providers as the message indicated, so wasn't
immediately visible to core developers, e.g.

https://github.com/terraform-providers/terraform-provider-aws/issues/15044
https://github.com/terraform-providers/terraform-provider-aws/issues/15048
https://discuss.hashicorp.com/t/this-is-a-bug-in-the-provider-which-should-be-reported-in-the-providers-own-issue-tracker/13190
https://github.com/terraform-providers/terraform-provider-aws/issues/13823#issuecomment-678813110
https://github.com/terraform-providers/terraform-provider-aws/issues/10297#issuecomment-685765702

Since the provider does not influence the status of `CreateBeforeDestroy`, 
we first fix the output to indicate that this is a bug in terraform.


In order to prevent the error, we need to check for a saved plan with a
`CreateThenDelete` action and rely on that to determine the status of
`CreateBeforeDestroy`. Due to the eval-node pattern currently in use,
this needs to be maintained in both the apply node and the eval nodes.
Future refactoring can work on unifying these codepaths, and making
these internal flags less fragile.

Fixes #26180

