### PR TITLE
website: Add Google and Microsoft products to the summary for supported remote backends

### DIFF
--- a/website/docs/state/remote.html.md
+++ b/website/docs/state/remote.html.md
@@ -17,7 +17,7 @@ Terraform at the same time.
 With _remote_ state, Terraform writes the state data to a remote data store,
 which can then be shared between all members of a team. Terraform supports
 storing state in [Terraform Cloud](https://www.hashicorp.com/products/terraform/),
-[HashiCorp Consul](https://www.consul.io/), Amazon S3, Alibaba Cloud OSS, and more.
+[HashiCorp Consul](https://www.consul.io/), Google Cloud Storage, Azure Blob Storage, Amazon S3, Alibaba Cloud OSS, and more.
 
 Remote state is a feature of [backends](/docs/backends). Configuring and
 using remote backends is easy and you can get started with remote state

--- a/website/docs/state/remote.html.md
+++ b/website/docs/state/remote.html.md
@@ -17,7 +17,7 @@ Terraform at the same time.
 With _remote_ state, Terraform writes the state data to a remote data store,
 which can then be shared between all members of a team. Terraform supports
 storing state in [Terraform Cloud](https://www.hashicorp.com/products/terraform/),
-[HashiCorp Consul](https://www.consul.io/), Google Cloud Storage, Azure Blob Storage, Amazon S3, Alibaba Cloud OSS, and more.
+[HashiCorp Consul](https://www.consul.io/), Amazon S3, Azure Blob Storage, Google Cloud Storage, Alibaba Cloud OSS, and more.
 
 Remote state is a feature of [backends](/docs/backends). Configuring and
 using remote backends is easy and you can get started with remote state


### PR DESCRIPTION
Some of our key partners were conspicuously missing from our remote state summary page. 