### PR TITLE
vendor: Upgrade mitchellh/cli

### DIFF
--- a/command/state_replace_provider_test.go
+++ b/command/state_replace_provider_test.go
@@ -75,7 +75,7 @@ func TestStateReplaceProvider(t *testing.T) {
 
 		inputBuf := &bytes.Buffer{}
 		ui.InputReader = inputBuf
-		inputBuf.WriteString("yes")
+		inputBuf.WriteString("yes\n")
 
 		args := []string{
 			"-state", statePath,
@@ -143,7 +143,7 @@ func TestStateReplaceProvider(t *testing.T) {
 
 		inputBuf := &bytes.Buffer{}
 		ui.InputReader = inputBuf
-		inputBuf.WriteString("no")
+		inputBuf.WriteString("no\n")
 
 		args := []string{
 			"-state", statePath,

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/mattn/go-isatty v0.0.5
 	github.com/mattn/go-shellwords v1.0.4
 	github.com/miekg/dns v1.0.8 // indirect
-	github.com/mitchellh/cli v1.0.0
+	github.com/mitchellh/cli v1.1.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.8 h1:Zi8HNpze3NeRWH1PQV6O71YcvJRQ6j0lORO6DAEmAAI=
 github.com/miekg/dns v1.0.8/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/mitchellh/cli v1.0.0 h1:iGBIsUe3+HZ/AD/Vd7DErOt5sU9fa8Uj7A2s1aggv1Y=
-github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
+github.com/mitchellh/cli v1.1.0 h1:tEElEatulEHDeedTxwckzyYMA5c86fbmNIUL1hBIiTg=
+github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/vendor/github.com/mitchellh/cli/.travis.yml
+++ b/vendor/github.com/mitchellh/cli/.travis.yml
@@ -2,10 +2,14 @@ sudo: false
 
 language: go
 
+env:
+  - GO111MODULE=on
+
 go:
-  - "1.8"
-  - "1.9"
-  - "1.10"
+  - "1.11"
+  - "1.12"
+  - "1.13"
+  - "1.14"
 
 branches:
   only:

--- a/vendor/github.com/mitchellh/cli/Makefile
+++ b/vendor/github.com/mitchellh/cli/Makefile
@@ -12,9 +12,6 @@ testrace:
 
 # updatedeps installs all the dependencies to run and build
 updatedeps:
-	go list ./... \
-		| xargs go list -f '{{ join .Deps "\n" }}{{ printf "\n" }}{{ join .TestImports "\n" }}' \
-		| grep -v github.com/mitchellh/cli \
-		| xargs go get -f -u -v
+	go mod download
 
 .PHONY: test testrace updatedeps

--- a/vendor/github.com/mitchellh/cli/cli.go
+++ b/vendor/github.com/mitchellh/cli/cli.go
@@ -109,17 +109,22 @@ type CLI struct {
 	AutocompleteGlobalFlags    complete.Flags
 	autocompleteInstaller      autocompleteInstaller // For tests
 
-	// HelpFunc and HelpWriter are used to output help information, if
-	// requested.
-	//
 	// HelpFunc is the function called to generate the generic help
 	// text that is shown if help must be shown for the CLI that doesn't
 	// pertain to a specific command.
-	//
-	// HelpWriter is the Writer where the help text is outputted to. If
-	// not specified, it will default to Stderr.
-	HelpFunc   HelpFunc
+	HelpFunc HelpFunc
+
+	// HelpWriter is used to print help text and version when requested.
+	// Defaults to os.Stderr for backwards compatibility.
+	// It is recommended that you set HelpWriter to os.Stdout, and
+	// ErrorWriter to os.Stderr.
 	HelpWriter io.Writer
+
+	// ErrorWriter used to output errors when a command can not be run.
+	// Defaults to the value of HelpWriter for backwards compatibility.
+	// It is recommended that you set HelpWriter to os.Stdout, and
+	// ErrorWriter to os.Stderr.
+	ErrorWriter io.Writer
 
 	//---------------------------------------------------------------
 	// Internal fields set automatically
@@ -228,7 +233,7 @@ func (c *CLI) Run() (int, error) {
 	// implementation. If the command is invalid or blank, it is an error.
 	raw, ok := c.commandTree.Get(c.Subcommand())
 	if !ok {
-		c.HelpWriter.Write([]byte(c.HelpFunc(c.helpCommands(c.subcommandParent())) + "\n"))
+		c.ErrorWriter.Write([]byte(c.HelpFunc(c.helpCommands(c.subcommandParent())) + "\n"))
 		return 127, nil
 	}
 
@@ -239,23 +244,23 @@ func (c *CLI) Run() (int, error) {
 
 	// If we've been instructed to just print the help, then print it
 	if c.IsHelp() {
-		c.commandHelp(command)
+		c.commandHelp(c.HelpWriter, command)
 		return 0, nil
 	}
 
 	// If there is an invalid flag, then error
 	if len(c.topFlags) > 0 {
-		c.HelpWriter.Write([]byte(
+		c.ErrorWriter.Write([]byte(
 			"Invalid flags before the subcommand. If these flags are for\n" +
 				"the subcommand, please put them after the subcommand.\n\n"))
-		c.commandHelp(command)
+		c.commandHelp(c.ErrorWriter, command)
 		return 1, nil
 	}
 
 	code := command.Run(c.SubcommandArgs())
 	if code == RunResultHelp {
 		// Requesting help
-		c.commandHelp(command)
+		c.commandHelp(c.ErrorWriter, command)
 		return 1, nil
 	}
 
@@ -309,6 +314,9 @@ func (c *CLI) init() {
 
 	if c.HelpWriter == nil {
 		c.HelpWriter = os.Stderr
+	}
+	if c.ErrorWriter == nil {
+		c.ErrorWriter = c.HelpWriter
 	}
 
 	// Build our hidden commands
@@ -404,8 +412,8 @@ func (c *CLI) initAutocomplete() {
 		cmd.Flags = map[string]complete.Predictor{
 			"-" + c.AutocompleteInstall:   complete.PredictNothing,
 			"-" + c.AutocompleteUninstall: complete.PredictNothing,
-			"-help":    complete.PredictNothing,
-			"-version": complete.PredictNothing,
+			"-help":                       complete.PredictNothing,
+			"-version":                    complete.PredictNothing,
 		}
 	}
 	cmd.GlobalFlags = c.AutocompleteGlobalFlags
@@ -483,7 +491,7 @@ func (c *CLI) initAutocompleteSub(prefix string) complete.Command {
 	return cmd
 }
 
-func (c *CLI) commandHelp(command Command) {
+func (c *CLI) commandHelp(out io.Writer, command Command) {
 	// Get the template to use
 	tpl := strings.TrimSpace(defaultHelpTemplate)
 	if t, ok := command.(CommandHelpTemplate); ok {
@@ -533,12 +541,12 @@ func (c *CLI) commandHelp(command Command) {
 			// Get the command
 			raw, ok := subcommands[k]
 			if !ok {
-				c.HelpWriter.Write([]byte(fmt.Sprintf(
+				c.ErrorWriter.Write([]byte(fmt.Sprintf(
 					"Error getting subcommand %q", k)))
 			}
 			sub, err := raw()
 			if err != nil {
-				c.HelpWriter.Write([]byte(fmt.Sprintf(
+				c.ErrorWriter.Write([]byte(fmt.Sprintf(
 					"Error instantiating %q: %s", k, err)))
 			}
 
@@ -559,13 +567,13 @@ func (c *CLI) commandHelp(command Command) {
 	data["Subcommands"] = subcommandsTpl
 
 	// Write
-	err = t.Execute(c.HelpWriter, data)
+	err = t.Execute(out, data)
 	if err == nil {
 		return
 	}
 
 	// An error, just output...
-	c.HelpWriter.Write([]byte(fmt.Sprintf(
+	c.ErrorWriter.Write([]byte(fmt.Sprintf(
 		"Internal error rendering help: %s", err)))
 }
 

--- a/vendor/github.com/mitchellh/cli/go.mod
+++ b/vendor/github.com/mitchellh/cli/go.mod
@@ -1,5 +1,7 @@
 module github.com/mitchellh/cli
 
+go 1.11
+
 require (
 	github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310
 	github.com/bgentry/speakeasy v0.1.0

--- a/vendor/github.com/mitchellh/cli/ui_mock.go
+++ b/vendor/github.com/mitchellh/cli/ui_mock.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 )
 
@@ -35,9 +37,12 @@ func (u *MockUi) Ask(query string) (string, error) {
 
 	var result string
 	fmt.Fprint(u.OutputWriter, query)
-	if _, err := fmt.Fscanln(u.InputReader, &result); err != nil {
+	r := bufio.NewReader(u.InputReader)
+	line, err := r.ReadString('\n')
+	if err != nil {
 		return "", err
 	}
+	result = strings.TrimRight(line, "\r\n")
 
 	return result, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -478,7 +478,7 @@ github.com/mattn/go-isatty
 github.com/mattn/go-shellwords
 # github.com/miekg/dns v1.0.8
 ## explicit
-# github.com/mitchellh/cli v1.0.0
+# github.com/mitchellh/cli v1.1.0
 ## explicit
 github.com/mitchellh/cli
 # github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db


### PR DESCRIPTION
Update tests to match the fix in mitchellh/cli#71, which aligns `MockUi` with `BasicUi` and allows newlines in user input.

We are not using the new `ErrorWriter`, added in mitchellh/cli#81, as it does not appear to interact correctly with `panicwrap`. All error output from CLI parsing will continue to appear on stdout, not stderr.

I'm upgrading this dependency to split out these changes from the Consul upgrade in #23601, hopefully for easier review.