### PR TITLE
provisioner-habitat: load services idempotently

### DIFF
--- a/builtin/provisioners/habitat/linux_provisioner.go
+++ b/builtin/provisioners/habitat/linux_provisioner.go
@@ -2,18 +2,21 @@ package habitat
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform/communicator"
-	"github.com/hashicorp/terraform/terraform"
 	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
+
+	"github.com/hashicorp/terraform/communicator/remote"
 )
 
 const installURL = "https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh"
-const systemdUnit = `[Unit]
+
+var systemdUnit = template.Must(template.New("hab-supervisor.service").Parse(`[Unit]
 Description=Habitat Supervisor
 
 [Service]
@@ -27,82 +30,67 @@ Environment="HAB_AUTH_TOKEN={{ .BuilderAuthToken }}"
 {{ end -}}
 
 [Install]
-WantedBy=default.target
-`
+WantedBy=default.target`))
 
-func (p *provisioner) linuxInstallHabitat(o terraform.UIOutput, comm communicator.Communicator) error {
+func (p *provisioner) linuxInstallHabitat() error {
+	var err error
+
 	// Download the hab installer
-	if err := p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("curl --silent -L0 %s > install.sh", installURL))); err != nil {
+	if err := p.linuxRunCommand(fmt.Sprintf("curl --silent -L0 %s > install.sh", installURL)); err != nil {
 		return err
 	}
 
 	// Run the install script
-	var command string
-	if p.Version == "" {
-		command = fmt.Sprintf("bash ./install.sh ")
-	} else {
+	command := "bash ./install.sh"
+	if p.Version != "" {
 		command = fmt.Sprintf("bash ./install.sh -v %s", p.Version)
 	}
 
-	if err := p.runCommand(o, comm, p.linuxGetCommand(command)); err != nil {
+	if err = p.linuxRunCommand(command); err != nil {
 		return err
 	}
 
 	// Accept the license
 	if p.AcceptLicense {
-		var cmd string
-
-		if p.UseSudo == true {
-			cmd = "env HAB_LICENSE=accept sudo -E /bin/bash -c 'hab -V'"
-		} else {
-			cmd = "env HAB_LICENSE=accept /bin/bash -c 'hab -V'"
-		}
-
-		if err := p.runCommand(o, comm, cmd); err != nil {
+		if err := p.linuxRunCommand("HAB_LICENSE=accept hab -V"); err != nil {
 			return err
 		}
 	}
 
 	// Create the hab user
-	if err := p.createHabUser(o, comm); err != nil {
+	if err = p.createHabUser(); err != nil {
 		return err
 	}
 
 	// Cleanup the installer
-	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("rm -f install.sh")))
+	return p.linuxRunCommand("rm -f install.sh")
 }
 
-func (p *provisioner) createHabUser(o terraform.UIOutput, comm communicator.Communicator) error {
-	var addUser bool
-
+func (p *provisioner) createHabUser() error {
 	// Install busybox to get us the user tools we need
-	if err := p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("hab install core/busybox"))); err != nil {
+	if err := p.linuxRunCommand("hab install core/busybox"); err != nil {
 		return err
 	}
 
 	// Check for existing hab user
-	if err := p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("hab pkg exec core/busybox id hab"))); err != nil {
-		o.Output("No existing hab user detected, creating...")
-		addUser = true
-	}
-
-	if addUser {
-		return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("hab pkg exec core/busybox adduser -D -g \"\" hab")))
+	if err := p.linuxRunCommand("hab pkg exec core/busybox id hab"); err != nil {
+		p.ui.Output("No existing hab user detected, creating...")
+		return p.linuxRunCommand(`hab pkg exec core/busybox adduser -D -g "" hab`)
 	}
 
 	return nil
 }
 
-func (p *provisioner) linuxStartHabitat(o terraform.UIOutput, comm communicator.Communicator) error {
+func (p *provisioner) linuxStartHabitat() error {
 	// Install the supervisor first
 	var command string
 	if p.Version == "" {
-		command += p.linuxGetCommand(fmt.Sprintf("hab install core/hab-sup"))
+		command = "hab install core/hab-sup"
 	} else {
-		command += p.linuxGetCommand(fmt.Sprintf("hab install core/hab-sup/%s", p.Version))
+		command = fmt.Sprintf("hab install core/hab-sup/%s", p.Version)
 	}
 
-	if err := p.runCommand(o, comm, command); err != nil {
+	if err := p.linuxRunCommand(command); err != nil {
 		return err
 	}
 
@@ -156,12 +144,12 @@ func (p *provisioner) linuxStartHabitat(o terraform.UIOutput, comm communicator.
 		options += fmt.Sprintf(" --org %s", p.Organization)
 	}
 
-	if p.HttpDisable == true {
-		options += fmt.Sprintf(" --http-disable")
+	if p.HttpDisable {
+		options += " --http-disable"
 	}
 
-	if p.AutoUpdate == true {
-		options += fmt.Sprintf(" --auto-update")
+	if p.AutoUpdate {
+		options += " --auto-update"
 	}
 
 	p.SupOptions = options
@@ -169,9 +157,9 @@ func (p *provisioner) linuxStartHabitat(o terraform.UIOutput, comm communicator.
 	// Start hab depending on service type
 	switch p.ServiceType {
 	case "unmanaged":
-		return p.linuxStartHabitatUnmanaged(o, comm, options)
+		return p.linuxStartHabitatUnmanaged(options)
 	case "systemd":
-		return p.linuxStartHabitatSystemd(o, comm, options)
+		return p.linuxStartHabitatSystemd(options)
 	default:
 		return errors.New("unsupported service type")
 	}
@@ -179,11 +167,11 @@ func (p *provisioner) linuxStartHabitat(o terraform.UIOutput, comm communicator.
 
 // This func is a little different than the others since we need to expose HAB_AUTH_TOKEN to a shell
 // sub-process that's actually running the supervisor.
-func (p *provisioner) linuxStartHabitatUnmanaged(o terraform.UIOutput, comm communicator.Communicator, options string) error {
+func (p *provisioner) linuxStartHabitatUnmanaged(options string) error {
 	var token string
 
 	// Create the sup directory for the log file
-	if err := p.runCommand(o, comm, p.linuxGetCommand("mkdir -p /hab/sup/default && chmod o+w /hab/sup/default")); err != nil {
+	if err := p.linuxRunCommand("mkdir -p /hab/sup/default && chmod o+w /hab/sup/default"); err != nil {
 		return err
 	}
 
@@ -192,82 +180,99 @@ func (p *provisioner) linuxStartHabitatUnmanaged(o terraform.UIOutput, comm comm
 		token = fmt.Sprintf("env HAB_AUTH_TOKEN=%s ", p.BuilderAuthToken)
 	}
 
-	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("(%ssetsid hab sup run%s > /hab/sup/default/sup.log 2>&1 <&1 &) ; sleep 1", token, options)))
+	return p.linuxRunCommand(fmt.Sprintf("(%ssetsid hab sup run%s > /hab/sup/default/sup.log 2>&1 <&1 &) ; sleep 1", token, options))
 }
 
-func (p *provisioner) linuxStartHabitatSystemd(o terraform.UIOutput, comm communicator.Communicator, options string) error {
-	// Create a new template and parse the client config into it
-	unitString := template.Must(template.New("hab-supervisor.service").Parse(systemdUnit))
-
+func (p *provisioner) linuxStartHabitatSystemd(options string) error {
 	var buf bytes.Buffer
-	err := unitString.Execute(&buf, p)
+	err := systemdUnit.Execute(&buf, p)
 	if err != nil {
 		return fmt.Errorf("error executing %s.service template: %s", p.ServiceName, err)
 	}
 
-	if err := p.linuxUploadSystemdUnit(o, comm, &buf); err != nil {
+	if err := p.linuxUploadSystemdUnit(&buf); err != nil {
 		return err
 	}
 
-	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("systemctl enable %s && systemctl start %s", p.ServiceName, p.ServiceName)))
+	return p.linuxRunCommand(fmt.Sprintf("systemctl enable %s && systemctl start %s", p.ServiceName, p.ServiceName))
 }
 
-func (p *provisioner) linuxUploadSystemdUnit(o terraform.UIOutput, comm communicator.Communicator, contents *bytes.Buffer) error {
+func (p *provisioner) linuxUploadSystemdUnit(contents *bytes.Buffer) error {
 	destination := fmt.Sprintf("/etc/systemd/system/%s.service", p.ServiceName)
 
 	if p.UseSudo {
 		tempPath := fmt.Sprintf("/tmp/%s.service", p.ServiceName)
-		if err := comm.Upload(tempPath, contents); err != nil {
+		if err := p.comm.Upload(tempPath, contents); err != nil {
 			return err
 		}
 
-		return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("mv %s %s", tempPath, destination)))
+		return p.linuxRunCommand(fmt.Sprintf("mv %s %s", tempPath, destination))
 	}
 
-	return comm.Upload(destination, contents)
+	return p.comm.Upload(destination, contents)
 }
 
-func (p *provisioner) linuxUploadRingKey(o terraform.UIOutput, comm communicator.Communicator) error {
-	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf(`echo -e "%s" | hab ring key import`, p.RingKeyContent)))
+func (p *provisioner) linuxUploadRingKey() error {
+	return p.linuxRunCommand(fmt.Sprintf(`echo -e "%s" | hab ring key import`, p.RingKeyContent))
 }
 
-func (p *provisioner) linuxUploadCtlSecret(o terraform.UIOutput, comm communicator.Communicator) error {
-	destination := fmt.Sprintf("/hab/sup/default/CTL_SECRET")
+func (p *provisioner) linuxUploadCtlSecret() error {
+	destination := "/hab/sup/default/CTL_SECRET"
+
 	// Create the destination directory
-	err := p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("mkdir -p %s", filepath.Dir(destination))))
+	err := p.linuxRunCommand(fmt.Sprintf("mkdir -p %s", filepath.Dir(destination)))
 	if err != nil {
 		return err
 	}
 
 	keyContent := strings.NewReader(p.CtlSecret)
 	if p.UseSudo {
-		tempPath := fmt.Sprintf("/tmp/CTL_SECRET")
-		if err := comm.Upload(tempPath, keyContent); err != nil {
+		tempPath := "/tmp/CTL_SECRET"
+		if err := p.comm.Upload(tempPath, keyContent); err != nil {
 			return err
 		}
 
-		return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("chown root:root %s && chmod 0600 %s && mv %s %s", tempPath, tempPath, tempPath, destination)))
+		return p.linuxRunCommand(fmt.Sprintf("chown root:root %s && chmod 0600 %s && mv %s %s", tempPath, tempPath, tempPath, destination))
 	}
 
-	return comm.Upload(destination, keyContent)
+	return p.comm.Upload(destination, keyContent)
 }
 
 //
 // Habitat Services
 //
-func (p *provisioner) linuxStartHabitatService(o terraform.UIOutput, comm communicator.Communicator, service Service) error {
+
+func (p *provisioner) linuxStartOrReconfigureHabitatService(service Service) error {
+	info, err := p.linuxGetHabitatServiceInfo(service)
+
+	if err != nil {
+		// If we're unable to get the service information we either haven't
+		// started the service, the HTTP API is disabled, the API payload
+		// is invalid, or there was an issue running curl, eg: it's not
+		// installed. In any of these cases we'll attempt to start the
+		// service.
+		p.ui.Output(fmt.Sprintf("Unable to determine state of %s: %v", service.Name, err))
+		return p.linuxStartHabitatService(service)
+	}
+
+	return p.linuxReconfigureHabitatService(info, service)
+}
+
+func (p *provisioner) linuxStartHabitatService(service Service) error {
+	p.ui.Output(fmt.Sprintf("Starting %s", service.Name))
+
 	var options string
 
-	if err := p.linuxInstallHabitatPackage(o, comm, service); err != nil {
+	if err := p.linuxInstallHabitatPackage(service); err != nil {
 		return err
 	}
-	if err := p.uploadUserTOML(o, comm, service); err != nil {
+	if err := p.uploadUserTOML(service); err != nil {
 		return err
 	}
 
 	// Upload service group key
 	if service.ServiceGroupKey != "" {
-		err := p.uploadServiceGroupKey(o, comm, service.ServiceGroupKey)
+		err := p.uploadServiceGroupKey(service.ServiceGroupKey)
 		if err != nil {
 			return err
 		}
@@ -297,13 +302,106 @@ func (p *provisioner) linuxStartHabitatService(o terraform.UIOutput, comm commun
 		options += fmt.Sprintf(" --bind %s", bind.toBindString())
 	}
 
-	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("hab svc load %s %s", service.Name, options)))
+	return p.linuxRunCommand(fmt.Sprintf("hab svc load %s %s", service.Name, options))
+}
+
+func (p *provisioner) linuxReconfigureHabitatService(info *ServiceInfo, service Service) error {
+	upToDate, err := info.Equal(service)
+	if err != nil {
+		return err
+	}
+
+	if upToDate {
+		p.ui.Output(fmt.Sprintf("%s is up-to-date", service.Name))
+		// Make sure we always have up-to-date TOML and service group encryption
+		if err := p.uploadUserTOML(service); err != nil {
+			return err
+		}
+
+		// Upload service group key
+		if service.ServiceGroupKey != "" {
+			err := p.uploadServiceGroupKey(service.ServiceGroupKey)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	p.ui.Output(fmt.Sprintf("Reloading %s because it has diverged", service.Name))
+	err = p.linuxRunCommand(fmt.Sprintf("hab svc unload %s", service.Name))
+	if err != nil {
+		return err
+	}
+
+	return p.linuxStartHabitatService(service)
+}
+
+func (p *provisioner) linuxGetHabitatServiceInfo(service Service) (*ServiceInfo, error) {
+	var err error
+
+	if p.HttpDisable {
+		p.ui.Output("Unable to determine Habitat service state because the Habitat supervisor HTTP API is disabled")
+		return nil, errors.New("Habitat supervisor metadata API is disabled")
+	}
+
+	supHTTPAddr := p.ListenHTTP
+	if supHTTPAddr == "" {
+		supHTTPAddr = "127.0.0.1:9631"
+	}
+
+	group := "default"
+	if service.Group != "" {
+		group = service.Group
+	}
+
+	name := service.Name
+	parts := strings.Split(service.Name, "/")
+	if len(parts) == 2 {
+		name = parts[1]
+	}
+
+	p.ui.Output(fmt.Sprintf("Getting %s state from the Habitat supervisor HTTP API", service.Name))
+	cmd := fmt.Sprintf("curl -s http://%s/services/%s/%s", supHTTPAddr, name, group)
+
+	// Sometimes it can take a few seconds for the habitat supervisor API to
+	// be available, in which case we'll retry a few times with a bit of backoff.
+	var stdout string
+	for i := 1; i < 4; i++ {
+		stdout, _, err = p.linuxOutputCommand(cmd)
+
+		if err == nil {
+			break
+		}
+
+		exitErr := &remote.ExitError{}
+		if errors.As(err, &exitErr) {
+			if exitErr.ExitStatus == 7 { // CURLE_COULDNT_CONNECT
+				time.Sleep(time.Duration(i) * time.Second)
+				continue
+			}
+		}
+
+		break
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to access the Habitat supervisor metadata API: %w", err)
+	}
+
+	info := &ServiceInfo{}
+	err = json.Unmarshal([]byte(stdout), info)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse Habitat supervisor metadata API response: %w", err)
+	}
+
+	return info, err
 }
 
 // In the future we'll remove the dedicated install once the synchronous load feature in hab-sup is
 // available. Until then we install here to provide output and a noisy failure mechanism because
 // if you install with the pkg load, it occurs asynchronously and fails quietly.
-func (p *provisioner) linuxInstallHabitatPackage(o terraform.UIOutput, comm communicator.Communicator, service Service) error {
+func (p *provisioner) linuxInstallHabitatPackage(service Service) error {
 	var options string
 
 	if service.Channel != "" {
@@ -314,33 +412,32 @@ func (p *provisioner) linuxInstallHabitatPackage(o terraform.UIOutput, comm comm
 		options += fmt.Sprintf(" --url %s", service.URL)
 	}
 
-	return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("hab pkg install %s %s", service.Name, options)))
+	return p.linuxRunCommand(fmt.Sprintf("hab pkg install %s %s", service.Name, options))
 }
 
-func (p *provisioner) uploadServiceGroupKey(o terraform.UIOutput, comm communicator.Communicator, key string) error {
+func (p *provisioner) uploadServiceGroupKey(key string) error {
 	keyName := strings.Split(key, "\n")[1]
-	o.Output("Uploading service group key: " + keyName)
+	p.ui.Output("Uploading service group key: " + keyName)
 	keyFileName := fmt.Sprintf("%s.box.key", keyName)
 	destPath := path.Join("/hab/cache/keys", keyFileName)
 	keyContent := strings.NewReader(key)
 	if p.UseSudo {
 		tempPath := path.Join("/tmp", keyFileName)
-		if err := comm.Upload(tempPath, keyContent); err != nil {
+		if err := p.comm.Upload(tempPath, keyContent); err != nil {
 			return err
 		}
 
-		return p.runCommand(o, comm, p.linuxGetCommand(fmt.Sprintf("mv %s %s", tempPath, destPath)))
+		return p.linuxRunCommand(fmt.Sprintf("mv %s %s", tempPath, destPath))
 	}
 
-	return comm.Upload(destPath, keyContent)
+	return p.comm.Upload(destPath, keyContent)
 }
 
-func (p *provisioner) uploadUserTOML(o terraform.UIOutput, comm communicator.Communicator, service Service) error {
+func (p *provisioner) uploadUserTOML(service Service) error {
 	// Create the hab svc directory to lay down the user.toml before loading the service
-	o.Output("Uploading user.toml for service: " + service.Name)
+	p.ui.Output(fmt.Sprintf("Uploading user.toml for %s", service.Name))
 	destDir := fmt.Sprintf("/hab/user/%s/config", service.getPackageName(service.Name))
-	command := p.linuxGetCommand(fmt.Sprintf("mkdir -p %s", destDir))
-	if err := p.runCommand(o, comm, command); err != nil {
+	if err := p.linuxRunCommand(fmt.Sprintf("mkdir -p %s", destDir)); err != nil {
 		return err
 	}
 
@@ -348,19 +445,27 @@ func (p *provisioner) uploadUserTOML(o terraform.UIOutput, comm communicator.Com
 
 	if p.UseSudo {
 		checksum := service.getServiceNameChecksum()
-		if err := comm.Upload(fmt.Sprintf("/tmp/user-%s.toml", checksum), userToml); err != nil {
+		if err := p.comm.Upload(fmt.Sprintf("/tmp/user-%s.toml", checksum), userToml); err != nil {
 			return err
 		}
-		command = p.linuxGetCommand(fmt.Sprintf("chmod o-r /tmp/user-%s.toml && mv /tmp/user-%s.toml %s/user.toml", checksum, checksum, destDir))
-		return p.runCommand(o, comm, command)
+		command := fmt.Sprintf("chmod o-r /tmp/user-%s.toml && mv /tmp/user-%s.toml %s/user.toml", checksum, checksum, destDir)
+		return p.linuxRunCommand(command)
 	}
 
-	return comm.Upload(path.Join(destDir, "user.toml"), userToml)
+	return p.comm.Upload(path.Join(destDir, "user.toml"), userToml)
 }
 
-func (p *provisioner) linuxGetCommand(command string) string {
+func (p *provisioner) linuxRunCommand(command string) error {
+	return p.runCommand(p.linuxExpandCommand(command))
+}
+
+func (p *provisioner) linuxOutputCommand(command string) (string, string, error) {
+	return p.outputCommand(p.linuxExpandCommand(command))
+}
+
+func (p *provisioner) linuxExpandCommand(command string) string {
 	// Always set HAB_NONINTERACTIVE & HAB_NOCOLORING
-	env := fmt.Sprintf("env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true")
+	env := "env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true"
 
 	// Set builder auth token
 	if p.BuilderAuthToken != "" {

--- a/communicator/communicator_mock.go
+++ b/communicator/communicator_mock.go
@@ -21,6 +21,8 @@ type MockCommunicator struct {
 	CommandFunc      func(*remote.Cmd) error
 	DisconnectFunc   func() error
 	ConnTimeout      time.Duration
+	Stdout           io.Reader
+	Stderr           io.Reader
 }
 
 // Connect implementation of communicator.Communicator interface
@@ -59,6 +61,20 @@ func (c *MockCommunicator) Start(r *remote.Cmd) error {
 
 	if !c.Commands[r.Command] {
 		return fmt.Errorf("Command not found!")
+	}
+
+	if c.Stderr != nil {
+		_, err := io.Copy(r.Stderr, c.Stderr)
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.Stdout != nil {
+		_, err := io.Copy(r.Stdout, c.Stdout)
+		if err != nil {
+			return err
+		}
 	}
 
 	r.SetExitStatus(0, nil)


### PR DESCRIPTION
Hello maintainers,

Let me start by thanking you all for building and maintaining a tool that has made my life better. I know that provisioners are out of fashion in Terraform and this is a PR to add more complexity to one that is already unmaintained, for that I apologize and appreciate the time and consideration. I'd also like to apologize for mixing code refactoring, bug fixes and a new feature into a single PR, for penance I'll fix a bug of your choosing. Here I'll provide a brief summary of the issues I encountered using the Habitat provisioner, why I think the previous implementation had some fundamentals issues, how I've chosen to resolve them, followed by a more detailed explanation.

### The problem
When using the Habitat provisioner with a base image that has already run habitat services, or when the `/hab` directory has been mounted to a volume because the applications are stateful, the provisioner will always fail, e.g.: 

```shell
null_resource.deploy_db (habitat): ✗✗✗
null_resource.deploy_db (habitat): ✗✗✗ [Err: 3] Service already loaded. Unload 'core/redis' and try again, or load with the --force flag to reload and restart the service.
null_resource.deploy_db (habitat): ✗✗✗

Error: error executing "env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab svc load core/redis  --topology standalone --strategy at-once --channel stable'": Process exited with status 1
```
This happens because provisioner assumes that it is always boostrapping a new instance of the Habitat supervisor and that it needs to load all services according to their given specifications and configuration, which is not true given the aforementioned conditions.

### The solution 
Rather than always attempting to load the Habitat services that are defined in the provisioner, we instead make service loading idempotent by gathering information from the Habitat supervisor and determining if the service specification has diverged, starting it as normal if the service is not loaded and only reloading it if it has diverged from the desired service specification.

A proper Habitat provider would be preferable to this provisioner, and indeed I would contribute one if I had the cycles, but at the current time these changes will allow us to use the Habitat provisioner. Without them we're forced use another configuration management system to provide what this provisioner could (is intended to?) provide , or we're forced to cargo cult a pile of shells provisioner scripts for every machine that uses Habitat.

### Details

Here's the slightly redacted Terraform definition that I used to reproduce what we've seen when attempting to use the Terraform Habitat provisioner with our stateful machines:

```hcl
locals {
  private_key = "-----BEGIN RSA PRIVATE KEY-----..."
}

provider "aws" {
  region = "us-east-1"
}

resource "aws_instance" "hab" {
  ami                         = "ami-0c34018d0aabaef93"
  instance_type               = "m5.large"
  availability_zone           = "us-east-1f"
  key_name                    = "ssh"
  associate_public_ip_address = true
  vpc_security_group_ids      = ["sg-0.."]
  subnet_id                   = "subnet-0..."
  tags                        = {"Name" = "hab_provisioner_bug"}
}

data "aws_ebs_volume" "hab" {
  filter {
    name   = "volume-id"
    values = ["vol-01.."]
  }
}

resource "aws_volume_attachment" "hab" {
  device_name = "/dev/sdh"
  volume_id   = data.aws_ebs_volume.hab.id
  instance_id = aws_instance.hab.id

  connection {
    type        = "ssh"
    user        = "ubuntu"
    host        = aws_instance.hab.public_ip
    private_key = local.private_key
  }

  provisioner "remote-exec" {
    inline = [
      "_dbvol=/dev/sdh",
      "sudo lsblk -pld -o name | grep $_dbvol || _dbvol=/dev/nvme1n1",
      "sudo sgdisk --info=1 $_dbvol | grep -q 'does not exist' && sudo sgdisk $_dbvol --new=1",
      "udevadm settle",
      "lsblk \"$_dbvol\"p1 --output FSTYPE --noheadings | grep -q -v ext4 && sudo mkfs -t ext4 \"$_dbvol\"p1",
      "udevadm settle",
      "uuid=$(lsblk \"$_dbvol\"p1 --output UUID --noheadings)",
      "grep -q \"$uuid\" /etc/fstab || echo \"UUID=$uuid    /hab     ext4    defaults,discard,nofail    0 0\" | sudo tee -a /etc/fstab",
      "sudo mkdir -p /hab",
      "findmnt /hab > /dev/null || sudo mount /hab",
    ]
  }
}

resource "null_resource" "deploy_db" {
  depends_on = [aws_volume_attachment.hab]

  triggers = {
    demo = "${uuid()}" // always trigger it for demo purposes
  }

  connection {
    type        = "ssh"
    user        = "ubuntu"
    host        = aws_instance.hab.public_ip
    private_key = local.private_key
  }

  provisioner "habitat" {
    use_sudo       = true
    service_type   = "systemd"
    accept_license = true

    service {
      name     = "core/redis"
      channel  = "current"
      strategy = "at-once"
      topology = "standalone"
    }
  }
}
```

In our real world scenarios, databases would be creating new volumes from the latest snapshot backups, we'd be using a custom built image that would already have general Habitat services installed, and we'd be using much smarter logic to trigger the provisioner, but the example exists to show that anybody that might be using the provisioner in these scenarios has likely run into this problem.

When we run the example we'll see it fail (assuming the volume isn't brand new), if it is you'll need to run it twice.

```
null_resource.deploy_db (habitat): » Installing core/redis
null_resource.deploy_db (habitat): ☁ Determining latest version of core/redis in the 'stable' channel
null_resource.deploy_db (habitat): → Using core/redis/4.0.14/20200403134602
null_resource.deploy_db (habitat): ★ Install of core/redis/4.0.14/20200403134602 complete with 0 new packages installed.
null_resource.deploy_db (habitat): Uploading user.toml for service: core/redis
null_resource.deploy_db (habitat): ✗✗✗
null_resource.deploy_db (habitat): ✗✗✗ [Err: 3] Service already loaded. Unload 'core/redis' and try again, or load with the --force flag to reload and restart the service.
null_resource.deploy_db (habitat): ✗✗✗


Error: error executing "env HAB_NONINTERACTIVE=true HAB_NOCOLORING=true sudo -E /bin/bash -c 'hab svc load core/redis  --topology standalone --strategy at-once --channel stable'": Process exited with status 1
```

With our changes, instead of always attempting to load the services that might already be loaded, we first attempt to gather information about the services. As `curl` is already a requirement of the provisioner we use it to access the Habitat supervisor metadata API and compare the any information that may exist for the service with the Terraform Habitat provisioner specification.
If it has diverged in any way we reload it, otherwise we move on. If the Habitat supervisor is disabled, curl doesn't exist, or there is no service information, we rollback to the previous behavior and assume that we need to load the service. That way it does not break compatibility in any way or require anything new.

Here's what we see when we re-run the example with our updated provisioner:

```
null_resource.deploy_db (habitat): Starting or reconfiguring Habitat service: core/redis
null_resource.deploy_db (habitat): Getting core/redis state from the Habitat supervisor HTTP API
null_resource.deploy_db (habitat): core/redis is up-to-date
null_resource.deploy_db (habitat): Uploading user.toml for core/redis
null_resource.deploy_db: Creation complete after 6s [id=6668573587360670082]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

And again if we modify the channel (or any other part of the service config) and re-run the updated provisioner:
```
null_resource.deploy_db (habitat): Starting or reconfiguring Habitat service: core/redis
null_resource.deploy_db (habitat): Getting core/redis state from the Habitat supervisor HTTP API
null_resource.deploy_db (habitat): Reloading core/redis because it has diverged
null_resource.deploy_db (habitat): Unloading core/redis
null_resource.deploy_db (habitat): Starting core/redis
null_resource.deploy_db (habitat): » Installing core/redis
null_resource.deploy_db (habitat): ☁ Determining latest version of core/redis in the 'current' channel
null_resource.deploy_db (habitat): ∵ Missing remote version of 'core/redis' in the 'current' channel, but an installed version was found locally (core/redis/4.0.14/20200403134602)
null_resource.deploy_db (habitat): → Using core/redis/4.0.14/20200403134602
null_resource.deploy_db (habitat): ★ Install of core/redis/4.0.14/20200403134602 complete with 0 new packages installed.
null_resource.deploy_db (habitat): Uploading user.toml for core/redis
null_resource.deploy_db (habitat): The core/redis service was successfully loaded
null_resource.deploy_db: Creation complete after 7s [id=6624599984441411301]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

As previously mentioned, I'm sorry for shoving a refactor of the code into this but I just couldn't help myself. The number of function signatures that changed causes a lot of noise in the diff but I think it adds a lot more clarity to the code itself.

Habitat is designed to ship the automation packaged with the application, thus removing a need for additional configuration management, however it still needs to be boostrapped and configured. While a Habitat provider would likely handle this better as we could resolve changes in the graph, that's an undertaking I don't currently have time for and I'm hopeful this provisioner gives us just enough of that to not require another additional configuration management system on top of Terraform and Habitat.