### PR TITLE
build: Enable Consul remote backend tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ jobs:
   go-test:
     executor:
       name: go
+    environment:
+      TF_CONSUL_TEST: 1
     parallelism: 4
     steps:
       - checkout


### PR DESCRIPTION
Despite installing Consul as part of the build, we haven't actually been running the Consul remote state backend tests in CI. This commit sets the environment variable needed to do this.

[I verified that tests are running on this branch](https://github.com/hashicorp/terraform/compare/alisdair/are-consul-tests-running), where I pushed an intentionally failing test (which passed CI), then enabled the tests (which failed CI), and finally removed the failing test (and CI is green).