### PR TITLE
website: Terraform import and remote backends

### DIFF
--- a/website/docs/import/index.html.md
+++ b/website/docs/import/index.html.md
@@ -44,7 +44,7 @@ importing existing resources.
 ## Remote Backends
 
 When using Terraform import on the command line with a [remote
-backend](/docs/backends/types/remote.html), such a Terraform Cloud, the import
+backend](/docs/backends/types/remote.html), such as Terraform Cloud, the import
 command runs locally, unlike commands such as apply, which run inside your
 Terraform Cloud environment. Because of this, the import command will not have
 access to information from the remote backend, such as workspace variables.

--- a/website/docs/import/index.html.md
+++ b/website/docs/import/index.html.md
@@ -41,5 +41,9 @@ imported object will be mapped.
 While this may seem tedious, it still gives Terraform users an avenue for
 importing existing resources.
 
-You can follow the [Terraform Import guide](https://learn.hashicorp.com/terraform/state/import?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on HashiCorp learn for a hands-on
-introduction to using the `terraform import` command.
+## Hands-On Tutorial
+
+You can follow the [Terraform Import
+tutorial](https://learn.hashicorp.com/tutorials/terraform/state-import?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
+on HashiCorp learn for a hands-on introduction to using the `terraform import`
+command.

--- a/website/docs/import/index.html.md
+++ b/website/docs/import/index.html.md
@@ -41,6 +41,17 @@ imported object will be mapped.
 While this may seem tedious, it still gives Terraform users an avenue for
 importing existing resources.
 
+## Remote Backends
+
+When using Terraform import on the command line with a [remote
+backend](/docs/backends/types/remote.html), such a Terraform Cloud, the import
+command runs locally, unlike commands such as apply, which run inside your
+Terraform Cloud environment. Because of this, the import command will not have
+access to information from the remote backend, such as workspace variables.
+
+In order to use Terraform import with a remote state backend, you may need to
+set local variables equivalent to the remote workspace variables.
+
 ## Hands-On Tutorial
 
 You can follow the [Terraform Import

--- a/website/docs/import/usage.html.md
+++ b/website/docs/import/usage.html.md
@@ -85,5 +85,7 @@ not done, Terraform will plan to destroy the imported objects on the next run.
 If you want to rename or otherwise move the imported resources, the
 [state management commands](/docs/commands/state/index.html) can be used.
 
-You can also follow the [Terraform Import guide](https://learn.hashicorp.com/terraform/state/import?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on HashiCorp learn for a hands-on
+## Hands-On Tutorial
+
+You can also follow the [Terraform Import tutorial](https://learn.hashicorp.com/tutorials/terraform/state-import?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on HashiCorp learn for a hands-on
 introduction to using the `terraform import` command.


### PR DESCRIPTION
In feedback for the [Terraform import tutorial](https://learn.hashicorp.com/tutorials/terraform/state-import) on HashiCorp Learn, @sudomateo [mentioned](https://github.com/hashicorp/learn/pull/1615#issuecomment-642151768) that the tutorial doesn't talk about the limitations of using Terraform import with a remote backend. The docs don't mention this limitation either.

This PR adds a note mentioning this limitation, and also updates the references to the import tutorial. A separate PR will update the tutorial on Learn.