### PR TITLE
website: Credentials helper response for no creds

### DIFF
--- a/website/docs/internals/credentials-helpers.html.md
+++ b/website/docs/internals/credentials-helpers.html.md
@@ -83,9 +83,12 @@ If the credentials helper is able to provide credentials for the given host
 then it must print a JSON credentials object to its stdout stream and then
 exit with status code zero to indicate success.
 
-If it is unable to provide the requested credentials for any reason, it must
-print an end-user-oriented plain text error message to its stderr stream and
-then exit with a _non-zero_ status code.
+If the credentials helper definitively has no credentials for the given host,
+then it must print an empty JSON object to stdout and exit with status zero.
+
+If the credentials helper is unable to provide the requested credentials for
+any other reason, it must print an end-user-oriented plain text error message
+to its stderr stream and then exit with a _non-zero_ status code.
 
 ## `store`: store new credentials for the given hostname
 


### PR DESCRIPTION
For a credentials helper plugin to be useful with Terraform 0.13+, we need to cope with the case of having no credentials for a host without this being an error. This is to allow the public Terraform Registry to be accessed without supplying a token.

The way to implement this is to respond to queries for credentials for a host which has no credentials stored with an empty object and a success exit code. This contradicts the previous documentation, which calls for an error response in this case.

See #25938.