### PR TITLE
Mildwonkey/node resource destroy

### DIFF
--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -187,6 +187,27 @@ func (n *EvalUpdateStateHook) Eval(ctx EvalContext) (interface{}, error) {
 	return nil, nil
 }
 
+// UpdateStateHook calls the PostStateUpdate hook with the current state.
+//
+// TODO: UpdateStateHook will eventually replace EvalUpdateStateHook, at which
+// point EvalUpdateStateHook can be removed and this comment updated.
+func UpdateStateHook(ctx EvalContext) error {
+	// In principle we could grab the lock here just long enough to take a
+	// deep copy and then pass that to our hooks below, but we'll instead
+	// hold the hook for the duration to avoid the potential confusing
+	// situation of us racing to call PostStateUpdate concurrently with
+	// different state snapshots.
+	stateSync := ctx.State()
+	state := stateSync.Lock().DeepCopy()
+	defer stateSync.Unlock()
+
+	// Call the hook
+	err := ctx.Hook(func(h Hook) (HookAction, error) {
+		return h.PostStateUpdate(state)
+	})
+	return err
+}
+
 // evalWriteEmptyState wraps EvalWriteState to specifically record an empty
 // state for a particular object.
 type evalWriteEmptyState struct {

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -143,25 +143,6 @@ func (n *EvalReadStateDeposed) Eval(ctx EvalContext) (interface{}, error) {
 	return obj, nil
 }
 
-// EvalRequireState is an EvalNode implementation that exits early if the given
-// object is null.
-type EvalRequireState struct {
-	State **states.ResourceInstanceObject
-}
-
-func (n *EvalRequireState) Eval(ctx EvalContext) (interface{}, error) {
-	if n.State == nil {
-		return nil, EvalEarlyExitError{}
-	}
-
-	state := *n.State
-	if state == nil || state.Value.IsNull() {
-		return nil, EvalEarlyExitError{}
-	}
-
-	return nil, nil
-}
-
 // EvalUpdateStateHook is an EvalNode implementation that calls the
 // PostStateUpdate hook with the current state.
 type EvalUpdateStateHook struct{}

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -510,34 +510,6 @@ func (n *EvalWriteResourceState) Eval(ctx EvalContext) (interface{}, error) {
 	return nil, nil
 }
 
-// EvalForgetResourceState is an EvalNode implementation that prunes out an
-// empty resource-level state for a given resource address, or produces an
-// error if it isn't empty after all.
-//
-// This should be the last action taken for a resource that has been removed
-// from the configuration altogether, to clean up the leftover husk of the
-// resource in the state after other EvalNodes have destroyed and removed
-// all of the instances and instance objects beneath it.
-type EvalForgetResourceState struct {
-	Addr addrs.Resource
-}
-
-func (n *EvalForgetResourceState) Eval(ctx EvalContext) (interface{}, error) {
-	absAddr := n.Addr.Absolute(ctx.Path())
-	state := ctx.State()
-
-	pruned := state.RemoveResourceIfEmpty(absAddr)
-	if !pruned {
-		// If this produces an error, it indicates a bug elsewhere in Terraform
-		// -- probably missing graph nodes, graph edges, or
-		// incorrectly-implemented evaluation steps.
-		return nil, fmt.Errorf("orphan resource %s still has a non-empty state after apply; this is a bug in Terraform", absAddr)
-	}
-	log.Printf("[TRACE] EvalForgetResourceState: Pruned husk of %s from state", absAddr)
-
-	return nil, nil
-}
-
 // EvalRefreshDependencies is an EvalNode implementation that appends any newly
 // found dependencies to those saved in the state. The existing dependencies
 // are retained, as they may be missing from the config, and will be required

--- a/terraform/eval_state_test.go
+++ b/terraform/eval_state_test.go
@@ -12,57 +12,6 @@ import (
 	"github.com/hashicorp/terraform/states"
 )
 
-func TestEvalRequireState(t *testing.T) {
-	ctx := new(MockEvalContext)
-
-	cases := []struct {
-		State *states.ResourceInstanceObject
-		Exit  bool
-	}{
-		{
-			nil,
-			true,
-		},
-		{
-			&states.ResourceInstanceObject{
-				Value: cty.NullVal(cty.Object(map[string]cty.Type{
-					"id": cty.String,
-				})),
-				Status: states.ObjectReady,
-			},
-			true,
-		},
-		{
-			&states.ResourceInstanceObject{
-				Value: cty.ObjectVal(map[string]cty.Value{
-					"id": cty.StringVal("foo"),
-				}),
-				Status: states.ObjectReady,
-			},
-			false,
-		},
-	}
-
-	var exitVal EvalEarlyExitError
-	for _, tc := range cases {
-		node := &EvalRequireState{State: &tc.State}
-		_, err := node.Eval(ctx)
-		if tc.Exit {
-			if err != exitVal {
-				t.Fatalf("should've exited: %#v", tc.State)
-			}
-
-			continue
-		}
-		if !tc.Exit && err != nil {
-			t.Fatalf("shouldn't exit: %#v", tc.State)
-		}
-		if err != nil {
-			t.Fatalf("err: %s", err)
-		}
-	}
-}
-
 func TestEvalUpdateStateHook(t *testing.T) {
 	mockHook := new(MockHook)
 
@@ -274,4 +223,29 @@ aws_instance.foo: (1 deposed)
   provider = provider["registry.terraform.io/hashicorp/aws"]
   Deposed ID 1 = i-abc123
 	`)
+}
+
+// Same test as TestEvalUpdateStateHook, similar function, slightly different
+// signature. The EvalUpdateStateHook test and function will be removed when the
+// EvalNode Removal is complete.
+func TestUpdateStateHook(t *testing.T) {
+	mockHook := new(MockHook)
+
+	state := states.NewState()
+	state.Module(addrs.RootModuleInstance).SetLocalValue("foo", cty.StringVal("hello"))
+
+	ctx := new(MockEvalContext)
+	ctx.HookHook = mockHook
+	ctx.StateState = state.SyncWrapper()
+
+	if err := UpdateStateHook(ctx); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !mockHook.PostStateUpdateCalled {
+		t.Fatal("should call PostStateUpdate")
+	}
+	if mockHook.PostStateUpdateState.LocalValue(addrs.LocalValue{Name: "foo"}.Absolute(addrs.RootModuleInstance)) != cty.StringVal("hello") {
+		t.Fatalf("wrong state passed to hook: %s", spew.Sdump(mockHook.PostStateUpdateState))
+	}
 }

--- a/terraform/graph_walk_context.go
+++ b/terraform/graph_walk_context.go
@@ -188,6 +188,11 @@ func (w *ContextGraphWalker) Execute(ctx EvalContext, n GraphNodeExecutable) tfd
 		return nil
 	}
 
+	//  If we early exit, it isn't an error.
+	if _, isEarlyExit := err.(EvalEarlyExitError); isEarlyExit {
+		return nil
+	}
+
 	// Otherwise, we'll let our usual diagnostics machinery figure out how to
 	// unpack this as one or more diagnostic messages and return that. If we
 	// get down here then the returned diagnostics will contain at least one

--- a/terraform/node_data_refresh.go
+++ b/terraform/node_data_refresh.go
@@ -251,12 +251,11 @@ func (n *NodeRefreshableDataResourceInstance) Execute(ctx EvalContext, op walkOp
 			return err
 		}
 
-		// EvalUpdateStateHook
-		updateStateHookReq := EvalUpdateStateHook{}
-		_, err = updateStateHookReq.Eval(ctx)
+		err = UpdateStateHook(ctx)
 		if err != nil {
 			return err
 		}
+
 	} else {
 		// EvalWriteDiff
 		writeDiffReq := &EvalWriteDiff{


### PR DESCRIPTION
The focus of this PR is the `NodeDestroyResourceInstance.EvalTree()` refactor. I also removed some unused code, folded two Eval*State functions directly into `NodeDestroyResourceInstance.Execute`, and added `UpdateStateHook`, which is a copy of `EvalUpdateStateHook` (now just a function, not a method on a struct). 

`NodeDestroyResourceInstance.Execute()` is full of `.Eval()`s: I'm getting to the Eval nodes that are used by multiple nodes (all the key plan/apply functionality) and I've decided to finish refactoring `EvalTree()`s first (which helps me identify and remove/refactor all of those single-use Evals) before tackling those `Eval()`s.

One other thing you might note is the addition to `(w *ContextGraphWalker) Execute`: that check for `EvalEarlyExitError{}` should have been in there all along, but wasn't relevant until this refactor and I apparently forgot 😁 