### PR TITLE
Test case for changing backend hash during aborted state migration

### DIFF
--- a/command/testdata/init-backend-config-file-change-migrate-existing/.terraform/terraform.tfstate
+++ b/command/testdata/init-backend-config-file-change-migrate-existing/.terraform/terraform.tfstate
@@ -1,0 +1,22 @@
+{
+    "version": 3,
+    "serial": 0,
+    "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
+    "backend": {
+        "type": "local",
+        "config": {
+            "path": "local-state.tfstate"
+        },
+        "hash": 9073424445967744180
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/command/testdata/init-backend-config-file-change-migrate-existing/input.config
+++ b/command/testdata/init-backend-config-file-change-migrate-existing/input.config
@@ -1,0 +1,1 @@
+path = "hello"

--- a/command/testdata/init-backend-config-file-change-migrate-existing/local-state.tfstate
+++ b/command/testdata/init-backend-config-file-change-migrate-existing/local-state.tfstate
@@ -1,0 +1,21 @@
+{
+    "version": 3,
+    "terraform_version": "0.8.2",
+    "serial": 8,
+    "lineage": "local",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {
+                "foo": {
+                    "type": "string",
+                    "value": "bar"
+                }
+            },
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/command/testdata/init-backend-config-file-change-migrate-existing/main.tf
+++ b/command/testdata/init-backend-config-file-change-migrate-existing/main.tf
@@ -1,0 +1,5 @@
+terraform {
+    backend "local" {
+        path = "local-state.tfstate"
+    }
+}


### PR DESCRIPTION
Failing test case for issue #26259

Also, I tried to come up with a solution, but there are multiple cases when dealing with state migrations and that defeated me unfortunately. 

Simple fix by removing this early state update in 'backend_C_r_S_unchanged ' will not work as it brakes `init_test.go:TestInit_backendReinitConfigToExtra`. 
```go
func (m *Meta) backend_C_r_S_unchanged
[...]
	// it's possible for a backend to be unchanged, and the config itself to
	// have changed by moving a parameter from the config to `-backend-config`
	// In this case we only need to update the Hash.
	if c != nil && s.Backend.Hash != uint64(cHash) {
		s.Backend.Hash = uint64(cHash)
		if err := sMgr.WriteState(s); err != nil {
			diags = diags.Append(err)
			return nil, diags
		}
	}
[...]
```

What I have found so far is that `m.backend_C_r_S_changed` casually calls `m.backend_C_r_S_unchanged` which updates hash only: 
```go
func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr *clistate.LocalState, output bool) (backend.Backend, tfdiags.Diagnostics) {
// [...]
        // Grab the existing backend
	oldB, oldBDiags := m.backend_C_r_S_unchanged(c, cHash, sMgr)
// [...]
```

