### PR TITLE
always check the CreateBeforeDestroy value from state

### DIFF
--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -21,7 +21,6 @@ import (
 type NodeApplyableResourceInstance struct {
 	*NodeAbstractResourceInstance
 
-	destroyNode      GraphNodeDestroyerCBD
 	graphNodeDeposer // implementation of GraphNodeDeposerConfig
 
 	// If this node is forced to be CreateBeforeDestroy, we need to record that
@@ -39,13 +38,7 @@ var (
 	_ GraphNodeAttachDependencies = (*NodeApplyableResourceInstance)(nil)
 )
 
-// GraphNodeAttachDestroyer
-func (n *NodeApplyableResourceInstance) AttachDestroyNode(d GraphNodeDestroyerCBD) {
-	n.destroyNode = d
-}
-
-// CreateBeforeDestroy checks this nodes config status and the status af any
-// companion destroy node for CreateBeforeDestroy.
+// CreateBeforeDestroy returns this node's CreateBeforeDestroy status.
 func (n *NodeApplyableResourceInstance) CreateBeforeDestroy() bool {
 	if n.ForceCreateBeforeDestroy {
 		return n.ForceCreateBeforeDestroy
@@ -53,10 +46,6 @@ func (n *NodeApplyableResourceInstance) CreateBeforeDestroy() bool {
 
 	if n.Config != nil && n.Config.Managed != nil {
 		return n.Config.Managed.CreateBeforeDestroy
-	}
-
-	if n.destroyNode != nil {
-		return n.destroyNode.CreateBeforeDestroy()
 	}
 
 	return false

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -21,8 +21,6 @@ type NodeDestroyResourceInstance struct {
 	// this node destroys a deposed object of the associated instance
 	// rather than its current object.
 	DeposedKey states.DeposedKey
-
-	CreateBeforeDestroyOverride *bool
 }
 
 var (
@@ -63,10 +61,6 @@ func (n *NodeDestroyResourceInstance) CreateBeforeDestroy() bool {
 		}
 	}
 
-	if n.CreateBeforeDestroyOverride != nil {
-		return *n.CreateBeforeDestroyOverride
-	}
-
 	if n.Config != nil && n.Config.Managed != nil {
 		return n.Config.Managed.CreateBeforeDestroy
 	}
@@ -76,7 +70,6 @@ func (n *NodeDestroyResourceInstance) CreateBeforeDestroy() bool {
 
 // GraphNodeDestroyerCBD
 func (n *NodeDestroyResourceInstance) ModifyCreateBeforeDestroy(v bool) error {
-	n.CreateBeforeDestroyOverride = &v
 	return nil
 }
 

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -53,20 +53,22 @@ func (n *NodeDestroyResourceInstance) DestroyAddr() *addrs.AbsResourceInstance {
 
 // GraphNodeDestroyerCBD
 func (n *NodeDestroyResourceInstance) CreateBeforeDestroy() bool {
-	if n.CreateBeforeDestroyOverride != nil {
-		return *n.CreateBeforeDestroyOverride
-	}
-
-	// Config takes precedence
-	if n.Config != nil && n.Config.Managed != nil {
-		return n.Config.Managed.CreateBeforeDestroy
-	}
-
-	// Otherwise check the state for a stored destroy order
+	// State takes precedence during destroy.
+	// If the resource was removed, there is no config to check.
+	// If CBD was forced from descendent, it should be saved in the state
+	// already.
 	if s := n.instanceState; s != nil {
 		if s.Current != nil {
 			return s.Current.CreateBeforeDestroy
 		}
+	}
+
+	if n.CreateBeforeDestroyOverride != nil {
+		return *n.CreateBeforeDestroyOverride
+	}
+
+	if n.Config != nil && n.Config.Managed != nil {
+		return n.Config.Managed.CreateBeforeDestroy
 	}
 
 	return false

--- a/terraform/transform_destroy_cbd.go
+++ b/terraform/transform_destroy_cbd.go
@@ -23,20 +23,6 @@ type GraphNodeDestroyerCBD interface {
 	ModifyCreateBeforeDestroy(bool) error
 }
 
-// GraphNodeAttachDestroyer is implemented by applyable nodes that have a
-// companion destroy node. This allows the creation node to look up the status
-// of the destroy node and determine if it needs to depose the existing state,
-// or replace it.
-// If a node is not marked as create-before-destroy in the configuration, but a
-// dependency forces that status, only the destroy node will be aware of that
-// status.
-type GraphNodeAttachDestroyer interface {
-	// AttachDestroyNode takes a destroy node and saves a reference to that
-	// node in the receiver, so it can later check the status of
-	// CreateBeforeDestroy().
-	AttachDestroyNode(n GraphNodeDestroyerCBD)
-}
-
 // ForcedCBDTransformer detects when a particular CBD-able graph node has
 // dependencies with another that has create_before_destroy set that require
 // it to be forced on, and forces it on.

--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -157,16 +157,6 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 				dag.VertexName(a), dag.VertexName(a_d))
 
 			g.Connect(dag.BasicEdge(a, a_d))
-
-			// Attach the destroy node to the creator
-			// There really shouldn't be more than one destroyer, but even if
-			// there are, any of them will represent the correct
-			// CreateBeforeDestroy status.
-			if n, ok := cn.(GraphNodeAttachDestroyer); ok {
-				if d, ok := d.(GraphNodeDestroyerCBD); ok {
-					n.AttachDestroyNode(d)
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
When destroying an instance which was forced to be `CreateBeforeDestroy` from downstream consumers, we were inadvertently preferring the config value over the state value for `CreateBeforeDestroy`. The `CreateBeforeDestroyOverride` was not useful in this case, because a destroy node does not have the same descendants as the plan node, and we cannot check for a forced `CreateBeforeDestroy` in the same manner, so we need to trust the value from state.

The last commit is extra cleanup of some unnecessary interfaces, and is not going to be part of the backport candidate.

This fixes the cycle in #26226, and converts it into a duplicate of #25631. 