### PR TITLE
allow evaluation of 0 instances during apply

### DIFF
--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -648,12 +648,10 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 
 	if rs == nil {
 		switch d.Operation {
-		case walkPlan:
-			// During plan as we evaluate each removed instance they are removed
-			// from the temporary working state. Since we know there there are
-			// no instances, and resources might be referenced in a context
-			// that needs to be known during plan, return an empty container of
-			// the expected type.
+		case walkPlan, walkApply:
+			// During plan and apply as we evaluate each removed instance they
+			// are removed from the working state. Since we know there are no
+			// instances, return an empty container of the expected type.
 			switch {
 			case config.Count != nil:
 				return cty.EmptyTupleVal, diags


### PR DESCRIPTION
While this was easier to spot during plan, it is also possible to
evaluate resources with 0 instances during apply as well.

This doesn't effect the failure when scaling CBD instances, it only
changes the fact that the inconsistent value is no longer unknown.

Fixes #26252