### PR TITLE
Move resource refreshing into plan

### DIFF
--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -80,18 +80,6 @@ func (b *Local) opApply(
 
 	// If we weren't given a plan, then we refresh/plan
 	if op.PlanFile == nil {
-		// If we're refreshing before apply, perform that
-		if op.PlanRefresh {
-			log.Printf("[INFO] backend/local: apply calling Refresh")
-			_, refreshDiags := tfCtx.Refresh()
-			diags = diags.Append(refreshDiags)
-			if diags.HasErrors() {
-				runningOp.Result = backend.OperationFailure
-				b.ShowDiagnostics(diags)
-				return
-			}
-		}
-
 		// Perform the plan
 		log.Printf("[INFO] backend/local: apply calling Plan")
 		plan, planDiags := tfCtx.Plan()

--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -830,7 +830,7 @@ func testPlanState_tainted() *states.State {
 			Mode: addrs.ManagedResourceMode,
 			Type: "test_instance",
 			Name: "foo",
-		}.Instance(addrs.IntKey(0)),
+		}.Instance(addrs.NoKey),
 		&states.ResourceInstanceObjectSrc{
 			Status: states.ObjectTainted,
 			AttrsJSON: []byte(`{

--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -357,8 +357,8 @@ func TestLocal_planDeposedOnly(t *testing.T) {
 	if run.Result != backend.OperationSuccess {
 		t.Fatalf("plan operation failed")
 	}
-	if !p.ReadResourceCalled {
-		t.Fatal("ReadResource should be called")
+	if p.ReadResourceCalled {
+		t.Fatal("ReadResource should not be called")
 	}
 	if run.PlanEmpty {
 		t.Fatal("plan should not be empty")
@@ -543,8 +543,8 @@ func TestLocal_planDestroy(t *testing.T) {
 		t.Fatalf("plan operation failed")
 	}
 
-	if !p.ReadResourceCalled {
-		t.Fatal("ReadResource should be called")
+	if p.ReadResourceCalled {
+		t.Fatal("ReadResource should not be called")
 	}
 
 	if run.PlanEmpty {
@@ -599,12 +599,12 @@ func TestLocal_planDestroy_withDataSources(t *testing.T) {
 		t.Fatalf("plan operation failed")
 	}
 
-	if !p.ReadResourceCalled {
-		t.Fatal("ReadResource should be called")
+	if p.ReadResourceCalled {
+		t.Fatal("ReadResource should not be called")
 	}
 
-	if !p.ReadDataSourceCalled {
-		t.Fatal("ReadDataSourceCalled should be called")
+	if p.ReadDataSourceCalled {
+		t.Fatal("ReadDataSourceCalled should not be called")
 	}
 
 	if run.PlanEmpty {
@@ -621,7 +621,7 @@ func TestLocal_planDestroy_withDataSources(t *testing.T) {
 	// Data source should not be rendered in the output
 	expectedOutput := `Terraform will perform the following actions:
 
-  # test_instance.foo will be destroyed
+  # test_instance.foo[0] will be destroyed
   - resource "test_instance" "foo" {
       - ami = "bar" -> null
 
@@ -635,7 +635,7 @@ Plan: 0 to add, 0 to change, 1 to destroy.`
 
 	output := b.CLI.(*cli.MockUi).OutputWriter.String()
 	if !strings.Contains(output, expectedOutput) {
-		t.Fatalf("Unexpected output (expected no data source):\n%s", output)
+		t.Fatalf("Unexpected output:\n%s", output)
 	}
 }
 

--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -478,6 +478,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.`
 }
 
 func TestLocal_planRefreshFalse(t *testing.T) {
+	// since there is no longer a separate Refresh walk, `-refresh=false
+	// doesn't do anything.
+	// FIXME: determine if we need a refresh option for the new plan, or remove
+	// this test
+	t.Skip()
+
 	b, cleanup := TestLocal(t)
 	defer cleanup()
 

--- a/command/e2etest/automation_test.go
+++ b/command/e2etest/automation_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/e2e"
+	"github.com/hashicorp/terraform/plans"
 )
 
 // The tests in this file run through different scenarios recommended in our
@@ -72,9 +73,23 @@ func TestPlanApplyInAutomation(t *testing.T) {
 
 	// stateResources := plan.Changes.Resources
 	diffResources := plan.Changes.Resources
-
-	if len(diffResources) != 1 || diffResources[0].Addr.String() != "null_resource.test" {
+	if len(diffResources) != 2 {
 		t.Errorf("incorrect number of resources in plan")
+	}
+
+	expected := map[string]plans.Action{
+		"data.template_file.test": plans.Read,
+		"null_resource.test":      plans.Create,
+	}
+
+	for _, r := range diffResources {
+		expectedAction, ok := expected[r.Addr.String()]
+		if !ok {
+			t.Fatalf("unexpected change for %q", r.Addr)
+		}
+		if r.Action != expectedAction {
+			t.Fatalf("unexpected action %q for %q", r.Action, r.Addr)
+		}
 	}
 
 	//// APPLY

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -96,10 +96,6 @@ func TestPlan_plan(t *testing.T) {
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("wrong exit status %d; want 1\nstderr: %s", code, ui.ErrorWriter.String())
 	}
-
-	if p.ReadResourceCalled {
-		t.Fatal("ReadResource should not have been called")
-	}
 }
 
 func TestPlan_destroy(t *testing.T) {
@@ -140,10 +136,6 @@ func TestPlan_destroy(t *testing.T) {
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
-	}
-
-	if !p.ReadResourceCalled {
-		t.Fatal("ReadResource should have been called")
 	}
 
 	plan := testReadPlan(t, outPath)

--- a/command/testdata/show-json/basic-create/output.json
+++ b/command/testdata/show-json/basic-create/output.json
@@ -53,18 +53,7 @@
             ]
         }
     },
-    "prior_state": {
-        "format_version": "0.1",
-        "values": {
-            "outputs": {
-                "test": {
-                    "sensitive": false,
-                    "value": "bar"
-                }
-            },
-            "root_module": {}
-        }
-    },
+    "prior_state": {},
     "resource_changes": [
         {
             "address": "test_instance.test[0]",

--- a/command/testdata/show-json/basic-delete/terraform.tfstate
+++ b/command/testdata/show-json/basic-delete/terraform.tfstate
@@ -3,7 +3,12 @@
   "terraform_version": "0.12.0",
   "serial": 7,
   "lineage": "configuredUnchanged",
-  "outputs": {},
+  "outputs": {
+    "test": {
+      "value": "bar",
+      "type": "string"
+    }
+  },
   "resources": [
     {
       "mode": "managed",

--- a/command/testdata/show-json/basic-update/terraform.tfstate
+++ b/command/testdata/show-json/basic-update/terraform.tfstate
@@ -3,7 +3,12 @@
     "terraform_version": "0.12.0",
     "serial": 7,
     "lineage": "configuredUnchanged",
-    "outputs": {},
+    "outputs": {
+        "test": {
+            "value": "bar",
+            "type": "string"
+        }
+    },
     "resources": [
         {
             "mode": "managed",

--- a/command/testdata/show-json/modules/output.json
+++ b/command/testdata/show-json/modules/output.json
@@ -69,18 +69,7 @@
             ]
         }
     },
-    "prior_state": {
-        "format_version": "0.1",
-        "values": {
-            "outputs": {
-                "test": {
-                    "sensitive": false,
-                    "value": "baz"
-                }
-            },
-            "root_module": {}
-        }
-    },
+    "prior_state": {},
     "resource_changes": [
         {
             "address": "module.module_test_bar.test_instance.test",

--- a/command/testdata/show-json/multi-resource-update/output.json
+++ b/command/testdata/show-json/multi-resource-update/output.json
@@ -101,20 +101,14 @@
         "format_version": "0.1",
         "terraform_version": "0.13.0",
         "values": {
-            "outputs": {
-                "test": {
-                    "sensitive": false,
-                    "value": "bar"
-                }
-            },
             "root_module": {
                 "resources": [
                     {
                         "address": "test_instance.test[0]",
+                        "index": 0,
                         "mode": "managed",
                         "type": "test_instance",
                         "name": "test",
-                        "index": 0,
                         "provider_name": "registry.terraform.io/hashicorp/test",
                         "schema_version": 0,
                         "values": {

--- a/helper/resource/testing_config.go
+++ b/helper/resource/testing_config.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/hcl2shim"
 	"github.com/hashicorp/terraform/states"
 
@@ -61,27 +60,17 @@ func testStep(opts terraform.ContextOpts, state *terraform.State, step TestStep)
 		log.Printf("[WARN] Config warnings:\n%s", stepDiags)
 	}
 
-	// Refresh!
-	newState, stepDiags := ctx.Refresh()
-	// shim the state first so the test can check the state on errors
-
-	state, err = shimNewState(newState, step.providers)
-	if err != nil {
-		return nil, err
-	}
-	if stepDiags.HasErrors() {
-		return state, newOperationError("refresh", stepDiags)
-	}
-
 	// If this step is a PlanOnly step, skip over this first Plan and subsequent
 	// Apply, and use the follow up Plan that checks for perpetual diffs
 	if !step.PlanOnly {
 		// Plan!
-		if p, stepDiags := ctx.Plan(); stepDiags.HasErrors() {
+		p, stepDiags := ctx.Plan()
+		if stepDiags.HasErrors() {
 			return state, newOperationError("plan", stepDiags)
-		} else {
-			log.Printf("[WARN] Test: Step plan: %s", legacyPlanComparisonString(newState, p.Changes))
 		}
+
+		newState := p.State
+		log.Printf("[WARN] Test: Step plan: %s", legacyPlanComparisonString(newState, p.Changes))
 
 		// We need to keep a copy of the state prior to destroying
 		// such that destroy steps can verify their behavior in the check
@@ -115,49 +104,26 @@ func testStep(opts terraform.ContextOpts, state *terraform.State, step TestStep)
 
 	// Now, verify that Plan is now empty and we don't have a perpetual diff issue
 	// We do this with TWO plans. One without a refresh.
-	var p *plans.Plan
-	if p, stepDiags = ctx.Plan(); stepDiags.HasErrors() {
+	p, stepDiags := ctx.Plan()
+	if stepDiags.HasErrors() {
 		return state, newOperationError("follow-up plan", stepDiags)
 	}
-	if !p.Changes.Empty() {
+
+	// we don't technically need this any longer with plan handling refreshing,
+	// but run it anyway to ensure the context is working as expected.
+	p, stepDiags = ctx.Plan()
+	if stepDiags.HasErrors() {
+		return state, newOperationError("second follow-up plan", stepDiags)
+	}
+	empty := p.Changes.Empty()
+	newState := p.State
+
+	if !empty {
 		if step.ExpectNonEmptyPlan {
 			log.Printf("[INFO] Got non-empty plan, as expected:\n\n%s", legacyPlanComparisonString(newState, p.Changes))
 		} else {
 			return state, fmt.Errorf(
 				"After applying this step, the plan was not empty:\n\n%s", legacyPlanComparisonString(newState, p.Changes))
-		}
-	}
-
-	// And another after a Refresh.
-	if !step.Destroy || (step.Destroy && !step.PreventPostDestroyRefresh) {
-		newState, stepDiags = ctx.Refresh()
-		if stepDiags.HasErrors() {
-			return state, newOperationError("follow-up refresh", stepDiags)
-		}
-
-		state, err = shimNewState(newState, step.providers)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if p, stepDiags = ctx.Plan(); stepDiags.HasErrors() {
-		return state, newOperationError("second follow-up refresh", stepDiags)
-	}
-	empty := p.Changes.Empty()
-
-	// Data resources are tricky because they legitimately get instantiated
-	// during refresh so that they will be already populated during the
-	// plan walk. Because of this, if we have any data resources in the
-	// config we'll end up wanting to destroy them again here. This is
-	// acceptable and expected, and we'll treat it as "empty" for the
-	// sake of this testing.
-	if step.Destroy && !empty {
-		empty = true
-		for _, change := range p.Changes.Resources {
-			if change.Addr.Resource.Resource.Mode != addrs.DataResourceMode {
-				empty = false
-				break
-			}
 		}
 	}
 

--- a/plans/plan.go
+++ b/plans/plan.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/states"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -16,15 +17,16 @@ import (
 // result that will be completed during apply by resolving any values that
 // cannot be predicted.
 //
-// A plan must always be accompanied by the state and configuration it was
-// built from, since the plan does not itself include all of the information
-// required to make the changes indicated.
+// A plan must always be accompanied by the configuration it was built from,
+// since the plan does not itself include all of the information required to
+// make the changes indicated.
 type Plan struct {
 	VariableValues  map[string]DynamicValue
 	Changes         *Changes
 	TargetAddrs     []addrs.Targetable
 	ProviderSHA256s map[string][]byte
 	Backend         Backend
+	State           *states.State
 }
 
 // Backend represents the backend-related configuration and other data as it

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -492,6 +492,10 @@ Note that the -target option is not suitable for routine use, and is provided on
 		))
 	}
 
+	// This isn't technically needed, but don't leave an old refreshed state
+	// around in case we re-use the context in internal tests.
+	c.refreshState = c.state.DeepCopy()
+
 	return c.state, diags
 }
 

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -2376,12 +2376,10 @@ func TestContext2Apply_provisionerInterpCount(t *testing.T) {
 		t.Fatalf("plan failed unexpectedly: %s", diags.Err())
 	}
 
-	state := ctx.State()
-
 	// We'll marshal and unmarshal the plan here, to ensure that we have
 	// a clean new context as would be created if we separately ran
 	// terraform plan -out=tfplan && terraform apply tfplan
-	ctxOpts, err := contextOptsForPlanViaFile(snap, state, plan)
+	ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6014,7 +6012,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 
 		t.Logf("Step 2 plan: %s", legacyDiffComparisonString(plan.Changes))
 
-		ctxOpts, err := contextOptsForPlanViaFile(snap, state, plan)
+		ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 		if err != nil {
 			t.Fatalf("failed to round-trip through planfile: %s", err)
 		}
@@ -6089,7 +6087,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 			t.Fatalf("destroy plan err: %s", diags.Err())
 		}
 
-		ctxOpts, err := contextOptsForPlanViaFile(snap, state, plan)
+		ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 		if err != nil {
 			t.Fatalf("failed to round-trip through planfile: %s", err)
 		}
@@ -6245,7 +6243,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 			t.Fatalf("destroy plan err: %s", diags.Err())
 		}
 
-		ctxOpts, err := contextOptsForPlanViaFile(snap, state, plan)
+		ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 		if err != nil {
 			t.Fatalf("failed to round-trip through planfile: %s", err)
 		}
@@ -8319,7 +8317,7 @@ func TestContext2Apply_issue7824(t *testing.T) {
 	}
 
 	// Write / Read plan to simulate running it through a Plan file
-	ctxOpts, err := contextOptsForPlanViaFile(snap, ctx.State(), plan)
+	ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 	if err != nil {
 		t.Fatalf("failed to round-trip through planfile: %s", err)
 	}
@@ -8396,7 +8394,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 	}
 
 	// Write / Read plan to simulate running it through a Plan file
-	ctxOpts, err := contextOptsForPlanViaFile(snap, state, plan)
+	ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 	if err != nil {
 		t.Fatalf("failed to round-trip through planfile: %s", err)
 	}
@@ -8473,7 +8471,7 @@ func TestContext2Apply_targetedWithTaintedInState(t *testing.T) {
 	}
 
 	// Write / Read plan to simulate running it through a Plan file
-	ctxOpts, err := contextOptsForPlanViaFile(snap, ctx.State(), plan)
+	ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 	if err != nil {
 		t.Fatalf("failed to round-trip through planfile: %s", err)
 	}
@@ -8730,7 +8728,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 			t.Fatalf("destroy plan err: %s", diags.Err())
 		}
 
-		ctxOpts, err := contextOptsForPlanViaFile(snap, state, plan)
+		ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 		if err != nil {
 			t.Fatalf("failed to round-trip through planfile: %s", err)
 		}
@@ -9313,7 +9311,7 @@ func TestContext2Apply_plannedInterpolatedCount(t *testing.T) {
 	// We'll marshal and unmarshal the plan here, to ensure that we have
 	// a clean new context as would be created if we separately ran
 	// terraform plan -out=tfplan && terraform apply tfplan
-	ctxOpts, err := contextOptsForPlanViaFile(snap, ctx.State(), plan)
+	ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 	if err != nil {
 		t.Fatalf("failed to round-trip through planfile: %s", err)
 	}
@@ -9376,7 +9374,7 @@ func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
 	// We'll marshal and unmarshal the plan here, to ensure that we have
 	// a clean new context as would be created if we separately ran
 	// terraform plan -out=tfplan && terraform apply tfplan
-	ctxOpts, err := contextOptsForPlanViaFile(snap, ctx.State(), plan)
+	ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 	if err != nil {
 		t.Fatalf("failed to round-trip through planfile: %s", err)
 	}
@@ -9826,7 +9824,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 	// We'll marshal and unmarshal the plan here, to ensure that we have
 	// a clean new context as would be created if we separately ran
 	// terraform plan -out=tfplan && terraform apply tfplan
-	ctxOpts, err := contextOptsForPlanViaFile(snap, state, plan)
+	ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -10141,7 +10139,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 	// We'll marshal and unmarshal the plan here, to ensure that we have
 	// a clean new context as would be created if we separately ran
 	// terraform plan -out=tfplan && terraform apply tfplan
-	ctxOpts, err := contextOptsForPlanViaFile(snap, state, plan)
+	ctxOpts, err := contextOptsForPlanViaFile(snap, plan)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -9155,11 +9155,16 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 	}
 
 	// correct the state
-	state.Modules["module.mod.module.removed"].Resources["aws_instance.child"].ProviderConfig = addrs.AbsProviderConfig{
-		Provider: addrs.NewDefaultProvider("aws"),
-		Alias:    "bar",
-		Module:   addrs.RootModule,
-	}
+	state.Modules["module.mod.module.removed"].Resources["aws_instance.child"].ProviderConfig = mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"].bar`)
+
+	ctx = testContext2(t, &ContextOpts{
+		Config: m,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+		State:   state,
+		Destroy: true,
+	})
 
 	if _, diags := ctx.Plan(); diags.HasErrors() {
 		t.Fatal(diags.Err())

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -9861,6 +9861,22 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 
 		return testApplyFn(info, s, d)
 	}
+	p.GetSchemaReturn = &ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_instance": {
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Computed: true,
+					},
+					"foo": {
+						Type:     cty.String,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -9981,7 +9997,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 		t.Fatal("test_instance.c should have no deposed instances")
 	}
 
-	if string(c.Current.AttrsJSON) != `{"id":"c","foo":"old"}` {
+	if string(c.Current.AttrsJSON) != `{"foo":"old","id":"c"}` {
 		t.Fatalf("unexpected attrs for c: %q\n", c.Current.AttrsJSON)
 	}
 }

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -2829,7 +2829,7 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 		}
 	}
 
-	expectedState := `aws_instance.foo.0:
+	expectedState := `aws_instance.foo:
   ID = bar
   provider = provider["registry.terraform.io/hashicorp/aws"]
   foo = foo
@@ -4068,7 +4068,7 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			Providers: map[addrs.Provider]providers.Factory{
 				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 			},
-			State: state,
+			State: state.DeepCopy(),
 		})
 
 		plan, diags := ctx.Plan()
@@ -4092,7 +4092,7 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			switch i := ric.Addr.String(); i {
 			case "aws_instance.foo[0]":
 				if res.Action != plans.DeleteThenCreate {
-					t.Fatalf("resource %s should be replaced", i)
+					t.Fatalf("resource %s should be replaced, not %s", i, res.Action)
 				}
 				checkVals(t, objectVal(t, schema, map[string]cty.Value{
 					"id": cty.StringVal("bar"),

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -749,7 +749,7 @@ func testProviderSchema(name string) *ProviderSchema {
 // our context tests try to exercise lots of stuff at once and so having them
 // round-trip things through on-disk files is often an important part of
 // fully representing an old bug in a regression test.
-func contextOptsForPlanViaFile(configSnap *configload.Snapshot, state *states.State, plan *plans.Plan) (*ContextOpts, error) {
+func contextOptsForPlanViaFile(configSnap *configload.Snapshot, plan *plans.Plan) (*ContextOpts, error) {
 	dir, err := ioutil.TempDir("", "terraform-contextForPlanViaFile")
 	if err != nil {
 		return nil, err
@@ -760,7 +760,7 @@ func contextOptsForPlanViaFile(configSnap *configload.Snapshot, state *states.St
 	// to run through any of the codepaths that care about Lineage/Serial/etc
 	// here anyway.
 	stateFile := &statefile.File{
-		State: state,
+		State: plan.State,
 	}
 
 	// To make life a little easier for test authors, we'll populate a simple

--- a/terraform/eval_context.go
+++ b/terraform/eval_context.go
@@ -152,6 +152,11 @@ type EvalContext interface {
 	// the global state.
 	State() *states.SyncState
 
+	// RefreshState returns a wrapper object that provides safe concurrent
+	// access to the state used to store the most recently refreshed resource
+	// values.
+	RefreshState() *states.SyncState
+
 	// InstanceExpander returns a helper object for tracking the expansion of
 	// graph nodes during the plan phase in response to "count" and "for_each"
 	// arguments.

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -71,6 +71,7 @@ type BuiltinEvalContext struct {
 	ProvisionerLock       *sync.Mutex
 	ChangesValue          *plans.ChangesSync
 	StateValue            *states.SyncState
+	RefreshStateValue     *states.SyncState
 	InstanceExpanderValue *instances.Expander
 }
 
@@ -348,6 +349,10 @@ func (ctx *BuiltinEvalContext) Changes() *plans.ChangesSync {
 
 func (ctx *BuiltinEvalContext) State() *states.SyncState {
 	return ctx.StateValue
+}
+
+func (ctx *BuiltinEvalContext) RefreshState() *states.SyncState {
+	return ctx.RefreshStateValue
 }
 
 func (ctx *BuiltinEvalContext) InstanceExpander() *instances.Expander {

--- a/terraform/eval_context_mock.go
+++ b/terraform/eval_context_mock.go
@@ -126,6 +126,9 @@ type MockEvalContext struct {
 	StateCalled bool
 	StateState  *states.SyncState
 
+	RefreshStateCalled bool
+	RefreshStateState  *states.SyncState
+
 	InstanceExpanderCalled   bool
 	InstanceExpanderExpander *instances.Expander
 }
@@ -336,6 +339,11 @@ func (c *MockEvalContext) Changes() *plans.ChangesSync {
 func (c *MockEvalContext) State() *states.SyncState {
 	c.StateCalled = true
 	return c.StateState
+}
+
+func (c *MockEvalContext) RefreshState() *states.SyncState {
+	c.RefreshStateCalled = true
+	return c.RefreshStateState
 }
 
 func (c *MockEvalContext) InstanceExpander() *instances.Expander {

--- a/terraform/eval_count.go
+++ b/terraform/eval_count.go
@@ -117,8 +117,12 @@ func evaluateCountExpressionValue(expr hcl.Expression, ctx EvalContext) (cty.Val
 // or this function will block forever awaiting the lock.
 func fixResourceCountSetTransition(ctx EvalContext, addr addrs.ConfigResource, countEnabled bool) {
 	state := ctx.State()
-	changed := state.MaybeFixUpResourceInstanceAddressForCount(addr, countEnabled)
-	if changed {
+	if state.MaybeFixUpResourceInstanceAddressForCount(addr, countEnabled) {
+		log.Printf("[TRACE] renamed first %s instance in transient state due to count argument change", addr)
+	}
+
+	refreshState := ctx.RefreshState()
+	if refreshState != nil && refreshState.MaybeFixUpResourceInstanceAddressForCount(addr, countEnabled) {
 		log.Printf("[TRACE] renamed first %s instance in transient state due to count argument change", addr)
 	}
 }

--- a/terraform/graph_walk_context.go
+++ b/terraform/graph_walk_context.go
@@ -26,6 +26,7 @@ type ContextGraphWalker struct {
 	// Configurable values
 	Context            *Context
 	State              *states.SyncState   // Used for safe concurrent access to state
+	RefreshState       *states.SyncState   // Used for safe concurrent access to state
 	Changes            *plans.ChangesSync  // Used for safe concurrent writes to changes
 	InstanceExpander   *instances.Expander // Tracks our gradual expansion of module and resource instances
 	Operation          walkOperation
@@ -96,6 +97,7 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 		ProvisionerLock:       &w.provisionerLock,
 		ChangesValue:          w.Changes,
 		StateValue:            w.State,
+		RefreshStateValue:     w.RefreshState,
 		Evaluator:             evaluator,
 		VariableValues:        w.variableValues,
 		VariableValuesLock:    &w.variableValuesLock,

--- a/terraform/testdata/apply-destroy-module-with-attrs/child/main.tf
+++ b/terraform/testdata/apply-destroy-module-with-attrs/child/main.tf
@@ -1,9 +1,9 @@
 variable "vpc_id" {}
 
 resource "aws_instance" "child" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 }
 
 output "modout" {
-  value = "${aws_instance.child.id}"
+  value = aws_instance.child.id
 }

--- a/terraform/testdata/apply-destroy-module-with-attrs/main.tf
+++ b/terraform/testdata/apply-destroy-module-with-attrs/main.tf
@@ -2,9 +2,9 @@ resource "aws_instance" "vpc" { }
 
 module "child" {
   source = "./child"
-  vpc_id = "${aws_instance.vpc.id}"
+  vpc_id = aws_instance.vpc.id
 }
 
 output "out" {
-  value = "${module.child.modout}"
+  value = module.child.modout
 }


### PR DESCRIPTION
This removes the separate `Refresh` operation that happens during planning, having each resource instance refresh "just in time" during the plan walk. The refresh walk has numerous problems, mostly stemming from the graph being generated by a mix of the state for managed resources, the configuration for temporary values, and a combination of configuration and state for data sources. This can lead to incongruities during refresh that cannot be resolved, often requiring the use of `plan -refresh=false` in order to apply some configurations. We also skip the problem of data sources reading "stale" state that will be updated during apply, by having data sources evaluated during plan where we have all the change information available.

Merging of refresh into planning is primarily accomplished by moving the bulk of the refresh node eval tree from `NodeRefreshableManagedResourceInstance` into the managed eval tree for `NodePlannableResourceInstance`.  This alone works for the majority of test cases, and proves out the concept for merging the refresh and plan walk. 

The more difficult part of merging the two operations is that in order to have all the prior state information available to render a plan, the plan walk must simultaneously operate on 2 separate states. To do that we add a second "refresh state" to the global terraform `Context`, along with a `RefreshState()` getter method. In order to save instances to this state, there is now a `phaseState` flag for `EvalWriteState` to switch which state to target during different phases of each instance's planning. This is admittedly clunky, but we are concurrently refactoring the EvalNode pattern and can smooth that out in tandem with upcoming changes.

Another change around handling the refreshed state, is that because planning is responsible for generating the most current state, the `plans.Plan` structure now includes a `states.State`. Rather than needing to combine the refreshed state with the plan out of band to create the plan, the refreshed state is now managed directly by `Context.Plan()`.

The ability to plan data sources introduced in 0.13 allows them to generally work correctly without the added refresh step. We can leave cleaning up data source planning for another PR to keep this one smaller. 

The current `Refresh` operation will be left as-is for now, and will no longer be used in the normal operation workflow. Future plans are currently to remove the internals, and refactor the CLI command in terms of a plan and apply with no configuration changes. 