### PR TITLE
build: put codecov in informational mode

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,7 @@ coverage:
   status:
     project:
       default:
+        informational: true
         target: auto
         threshold: "0.5%"
 


### PR DESCRIPTION
While we like codecov, and the coverage goals, we've frequently ignored
the failures for various reasons. These have confused community members
submitting PRs and it can be confusing to look at a list of merged PRs
with the big X indicating failed checks ("confusing" isn't really a
problem, but if there were actually a bad merge, it could be hard to
find which in a list of commits actually had an important failure).

Fixes a mild inconvenience.