### PR TITLE
configs: More interpolation-only expr deprecations

### DIFF
--- a/configs/named_values.go
+++ b/configs/named_values.go
@@ -433,6 +433,8 @@ type Output struct {
 }
 
 func decodeOutputBlock(block *hcl.Block, override bool) (*Output, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
 	o := &Output{
 		Name:      block.Labels[0],
 		DeclRange: block.DefRange,
@@ -443,7 +445,13 @@ func decodeOutputBlock(block *hcl.Block, override bool) (*Output, hcl.Diagnostic
 		schema = schemaForOverrides(schema)
 	}
 
-	content, diags := block.Body.Content(schema)
+	// Produce deprecation messages for any pre-0.12-style
+	// single-interpolation-only expressions.
+	moreDiags := warnForDeprecatedInterpolationsInBody(block.Body)
+	diags = append(diags, moreDiags...)
+
+	content, moreDiags := block.Body.Content(schema)
+	diags = append(diags, moreDiags...)
 
 	if !hclsyntax.ValidIdentifier(o.Name) {
 		diags = append(diags, &hcl.Diagnostic{
@@ -505,6 +513,11 @@ func decodeLocalsBlock(block *hcl.Block) ([]*Local, hcl.Diagnostics) {
 				Subject:  &attr.NameRange,
 			})
 		}
+
+		// Produce deprecation messages for any pre-0.12-style
+		// single-interpolation-only expressions.
+		moreDiags := warnForDeprecatedInterpolationsInExpr(attr.Expr)
+		diags = append(diags, moreDiags...)
 
 		locals = append(locals, &Local{
 			Name:      name,

--- a/configs/resource.go
+++ b/configs/resource.go
@@ -290,6 +290,7 @@ func decodeResourceBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 }
 
 func decodeDataBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
 	r := &Resource{
 		Mode:      addrs.DataResourceMode,
 		Type:      block.Labels[0],
@@ -298,7 +299,13 @@ func decodeDataBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 		TypeRange: block.LabelRanges[0],
 	}
 
-	content, remain, diags := block.Body.PartialContent(dataBlockSchema)
+	// Produce deprecation messages for any pre-0.12-style
+	// single-interpolation-only expressions.
+	moreDiags := warnForDeprecatedInterpolationsInBody(block.Body)
+	diags = append(diags, moreDiags...)
+
+	content, remain, moreDiags := block.Body.PartialContent(dataBlockSchema)
+	diags = append(diags, moreDiags...)
 	r.Config = remain
 
 	if !hclsyntax.ValidIdentifier(r.Type) {

--- a/configs/testdata/warning-files/redundant_interp.tf
+++ b/configs/testdata/warning-files/redundant_interp.tf
@@ -34,3 +34,20 @@ resource "null_resource" "a" {
     wrapped = ["${var.triggers["greeting"]}"]
   }
 }
+
+module "foo" {
+  source = "./foo"
+  foo = "${var.foo}" # WARNING: Interpolation-only expressions are deprecated
+}
+
+data "null_data_source" "b" {
+  has_computed_default = "${var.foo}" # WARNING: Interpolation-only expressions are deprecated
+}
+
+output "output" {
+  value = "${var.foo}" # WARNING: Interpolation-only expressions are deprecated
+}
+
+locals {
+  foo = "${var.foo}" # WARNING: Interpolation-only expressions are deprecated
+}


### PR DESCRIPTION
Extend the deprecation for interpolation-only expressions to include module calls, data sources, outputs, and locals.

Backport of #26105 to 0.13.

### Changelog entry

UPGRADE NOTES:

- Deprecated interpolation-only expressions are detected in more contexts in addition to resources and provider configurations. Module calls, data sources, outputs, and locals are now also covered. An expression like `"${foo}"` should be rewritten as just `foo`.