### PR TITLE
Extend sensitive variable plan tests

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -5687,6 +5687,67 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_variableSensitivityModule(t *testing.T) {
+	m := testModule(t, "plan-variable-sensitivity-module")
+
+	p := testProvider("aws")
+	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+		resp.PlannedState = req.ProposedNewState
+		return
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan()
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	ty := schema.ImpliedType()
+
+	if len(plan.Changes.Resources) != 1 {
+		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
+	}
+
+	for _, res := range plan.Changes.Resources {
+		if res.Action != plans.Create {
+			t.Fatalf("expected resource creation, got %s", res.Action)
+		}
+		ric, err := res.Decode(ty)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		switch i := ric.Addr.String(); i {
+		case "module.child.aws_instance.foo":
+			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+				"foo": cty.StringVal("foo"),
+			}), ric.After)
+			if len(res.ChangeSrc.BeforeValMarks) != 0 {
+				t.Errorf("unexpected BeforeValMarks: %#v", res.ChangeSrc.BeforeValMarks)
+			}
+			if len(res.ChangeSrc.AfterValMarks) != 1 {
+				t.Errorf("unexpected AfterValMarks: %#v", res.ChangeSrc.AfterValMarks)
+				continue
+			}
+			pvm := res.ChangeSrc.AfterValMarks[0]
+			if got, want := pvm.Path, cty.GetAttrPath("foo"); !got.Equals(want) {
+				t.Errorf("unexpected path for mark\n got: %#v\nwant: %#v", got, want)
+			}
+			if got, want := pvm.Marks, cty.NewValueMarks("sensitive"); !got.Equal(want) {
+				t.Errorf("unexpected value for mark\n got: %#v\nwant: %#v", got, want)
+			}
+		default:
+			t.Fatal("unknown instance:", i)
+		}
+	}
+}
+
 func checkVals(t *testing.T, expected, got cty.Value) {
 	t.Helper()
 	if !cmp.Equal(expected, got, valueComparer, typeComparer, equateEmpty) {

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -5630,14 +5630,6 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 	m := testModule(t, "plan-variable-sensitivity")
 
 	p := testProvider("aws")
-	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) (resp providers.ValidateResourceTypeConfigResponse) {
-		foo := req.Config.GetAttr("foo").AsString()
-		if foo == "bar" {
-			resp.Diagnostics = resp.Diagnostics.Append(errors.New("foo cannot be bar"))
-		}
-		return
-	}
-
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
 		resp.PlannedState = req.ProposedNewState
 		return
@@ -5675,6 +5667,20 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 			checkVals(t, objectVal(t, schema, map[string]cty.Value{
 				"foo": cty.StringVal("foo"),
 			}), ric.After)
+			if len(res.ChangeSrc.BeforeValMarks) != 0 {
+				t.Errorf("unexpected BeforeValMarks: %#v", res.ChangeSrc.BeforeValMarks)
+			}
+			if len(res.ChangeSrc.AfterValMarks) != 1 {
+				t.Errorf("unexpected AfterValMarks: %#v", res.ChangeSrc.AfterValMarks)
+				continue
+			}
+			pvm := res.ChangeSrc.AfterValMarks[0]
+			if got, want := pvm.Path, cty.GetAttrPath("foo"); !got.Equals(want) {
+				t.Errorf("unexpected path for mark\n got: %#v\nwant: %#v", got, want)
+			}
+			if got, want := pvm.Marks, cty.NewValueMarks("sensitive"); !got.Equal(want) {
+				t.Errorf("unexpected value for mark\n got: %#v\nwant: %#v", got, want)
+			}
 		default:
 			t.Fatal("unknown instance:", i)
 		}

--- a/terraform/testdata/plan-variable-sensitivity-module/child/main.tf
+++ b/terraform/testdata/plan-variable-sensitivity-module/child/main.tf
@@ -1,0 +1,7 @@
+variable "foo" {
+  type = string
+}
+
+resource "aws_instance" "foo" {
+  foo = var.foo
+}

--- a/terraform/testdata/plan-variable-sensitivity-module/main.tf
+++ b/terraform/testdata/plan-variable-sensitivity-module/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  experiments = [sensitive_variables]
+}
+
+variable "sensitive_var" {
+  default   = "foo"
+  sensitive = true
+}
+
+module "child" {
+  source = "./child"
+  foo    = var.sensitive_var
+}


### PR DESCRIPTION
Two commits:

- 9e340ab: Extend the existing sensitive variable plan test, to verify that attributes using sensitive values have appropriate path value marks stored. This is the best way I can think of to test that sensitivity is being preserved for plan outputs, short of an end-to-end test.
- e1a41da: Add a test showing that sensitive variable values can be used as module input variables, while preserving sensitivity. Uses the same approach as above to verify this.

Note: the overall diff is really confusing. Thanks git! I'd recommend looking at each commit in turn for a clearer picture on what's changing.