### PR TITLE
website: Clear wording that GCS backend bucket must pre-exist

### DIFF
--- a/website/docs/backends/types/gcs.html.md
+++ b/website/docs/backends/types/gcs.html.md
@@ -10,8 +10,8 @@ description: |-
 
 **Kind: Standard (with locking)**
 
-Stores the state as an object in a configurable prefix in a given bucket on [Google Cloud Storage](https://cloud.google.com/storage/) (GCS).
-This backend also supports [state locking](/docs/state/locking.html).
+Stores the state as an object in a configurable prefix in a pre-existing bucket on [Google Cloud Storage](https://cloud.google.com/storage/) (GCS).
+This backend also supports [state locking](/docs/state/locking.html). The bucket must exist prior to configuring the backend.
 
 ~> **Warning!** It is highly recommended that you enable
 [Object Versioning](https://cloud.google.com/storage/docs/object-versioning)


### PR DESCRIPTION
Experienced similar issue as https://github.com/hashicorp/terraform/issues/18417 this updates the documentation so that it's more clear a storage bucket must exist prior to configuring the backend.