### PR TITLE
updates `description` to reflect endpoint usage

### DIFF
--- a/website/docs/registry/api.html.md
+++ b/website/docs/registry/api.html.md
@@ -3,7 +3,7 @@ layout: "registry"
 page_title: "Terraform Registry - HTTP API"
 sidebar_current: "docs-registry-api"
 description: |-
-  The /acl endpoints create, update, destroy, and query ACL tokens in Consul.
+  The /api endpoints list modules according to some criteria.
 ---
 
 # HTTP API


### PR DESCRIPTION
Hello maintainers 👋🏼 

This PR updates the `description` for https://www.terraform.io/docs/registry/api.html as it incorrectly referenced Consul and ACL tokens.

The sentence I chose is based on what is used in the [List Modules](https://www.terraform.io/docs/registry/api.html#list-modules) section.