### PR TITLE
save read data in the refresh state during plan

### DIFF
--- a/terraform/eval_read_data_plan.go
+++ b/terraform/eval_read_data_plan.go
@@ -138,6 +138,8 @@ func (n *evalReadDataPlan) Eval(ctx EvalContext) (interface{}, error) {
 		}
 	}
 
+	// We still default to read here, to indicate any changes in the plan, even
+	// though this will already be written in the refreshed state.
 	action := plans.Read
 	if priorVal.Equals(newVal).True() {
 		action = plans.NoOp
@@ -159,7 +161,7 @@ func (n *evalReadDataPlan) Eval(ctx EvalContext) (interface{}, error) {
 
 	*n.State = &states.ResourceInstanceObject{
 		Value:  newVal,
-		Status: states.ObjectPlanned,
+		Status: states.ObjectReady,
 	}
 
 	if err := ctx.Hook(func(h Hook) (HookAction, error) {

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -86,6 +86,16 @@ func (n *NodePlannableResourceInstance) evalTreeDataResource(addr addrs.AbsResou
 				},
 			},
 
+			// write the data source into both the refresh state and the
+			// working state
+			&EvalWriteState{
+				Addr:           addr.Resource,
+				ProviderAddr:   n.ResolvedProvider,
+				ProviderSchema: &providerSchema,
+				State:          &state,
+				targetState:    refreshState,
+			},
+
 			&EvalWriteState{
 				Addr:           addr.Resource,
 				ProviderAddr:   n.ResolvedProvider,


### PR DESCRIPTION
This only changes the refreshed state stored in the plan file. Since the
change is stored in the plan, the applied result would be the same, but
we should still store the refreshed data in the plan file for tools that
consume the plan file.

This will also be needed in order to implement a new refresh command
based on the plan itself.