### PR TITLE
Mildwonkey/type func

### DIFF
--- a/command/console.go
+++ b/command/console.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/helper/wrappedstreams"
+	"github.com/hashicorp/terraform/lang/funcs"
 	"github.com/hashicorp/terraform/repl"
 	"github.com/hashicorp/terraform/tfdiags"
 
@@ -126,6 +127,8 @@ func (c *ConsoleCommand) Run(args []string) int {
 		c.showDiagnostics(diags)
 		return 1
 	}
+	scope.AddFunc("type", funcs.TypeFunc)
+
 	if diags.HasErrors() {
 		diags = diags.Append(tfdiags.SimpleWarning("Due to the problems above, some expressions may produce unexpected results."))
 	}

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,6 @@ github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb h1:ZbgmOQt8DOg796fi
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 h1:Pc5TCv9mbxFN6UVX0LH6CpQrdTM5YjbVI2w15237Pjk=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
-github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
-github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,8 @@ github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb h1:ZbgmOQt8DOg796fi
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 h1:Pc5TCv9mbxFN6UVX0LH6CpQrdTM5YjbVI2w15237Pjk=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
+github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
+github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=

--- a/lang/funcs/conversion.go
+++ b/lang/funcs/conversion.go
@@ -118,7 +118,6 @@ var TypeFunc = function.New(&function.Spec{
 func TypeString(ty cty.Type) string {
 	var b strings.Builder
 	writeType(ty, &b, 0)
-	b.WriteByte('\n') // always end with a newline for easier printing
 	return b.String()
 }
 
@@ -143,7 +142,7 @@ func writeType(ty cty.Type, b *strings.Builder, indent int) {
 		for _, name := range attrNames {
 			aty := atys[name]
 			b.WriteString(indentSpaces(indent))
-			fmt.Fprintf(b, "%q: ", name)
+			fmt.Fprintf(b, "%s: ", name)
 			writeType(aty, b, indent)
 			b.WriteString(",\n")
 		}
@@ -156,7 +155,7 @@ func writeType(ty cty.Type, b *strings.Builder, indent int) {
 			b.WriteString("tuple")
 			return
 		}
-		b.WriteString("tuple({\n")
+		b.WriteString("tuple([\n")
 		indent++
 		for _, ety := range etys {
 			b.WriteString(indentSpaces(indent))
@@ -165,7 +164,7 @@ func writeType(ty cty.Type, b *strings.Builder, indent int) {
 		}
 		indent--
 		b.WriteString(indentSpaces(indent))
-		b.WriteString("})")
+		b.WriteString("])")
 	case ty.IsCollectionType():
 		ety := ty.ElementType()
 		switch {
@@ -209,4 +208,8 @@ func writeType(ty cty.Type, b *strings.Builder, indent int) {
 
 func indentSpaces(level int) string {
 	return strings.Repeat("    ", level)
+}
+
+func Type(input []cty.Value) (cty.Value, error) {
+	return TypeFunc.Call(input)
 }

--- a/lang/funcs/conversion.go
+++ b/lang/funcs/conversion.go
@@ -101,7 +101,7 @@ var TypeFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.String),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		return cty.StringVal(TypeString(args[0].Type())), nil
+		return cty.StringVal(TypeString(args[0].Type())).Mark("raw"), nil
 	},
 })
 

--- a/lang/funcs/conversion.go
+++ b/lang/funcs/conversion.go
@@ -1,7 +1,10 @@
 package funcs
 
 import (
+	"fmt"
+	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
@@ -84,4 +87,126 @@ func MakeToFunc(wantTy cty.Type) function.Function {
 			return ret, nil
 		},
 	})
+}
+
+var TypeFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name:             "value",
+			Type:             cty.DynamicPseudoType,
+			AllowDynamicType: true,
+			AllowUnknown:     true,
+			AllowNull:        true,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		return cty.StringVal(TypeString(args[0].Type())), nil
+	},
+})
+
+// Modified copy of TypeString from go-cty:
+// https://github.com/zclconf/go-cty-debug/blob/master/ctydebug/type_string.go
+//
+// TypeString returns a string representation of a given type that is
+// reminiscent of Go syntax calling into the cty package but is mainly
+// intended for easy human inspection of values in tests, debug output, etc.
+//
+// The resulting string will include newlines and indentation in order to
+// increase the readability of complex structures. It always ends with a
+// newline, so you can print this result directly to your output.
+func TypeString(ty cty.Type) string {
+	var b strings.Builder
+	writeType(ty, &b, 0)
+	b.WriteByte('\n') // always end with a newline for easier printing
+	return b.String()
+}
+
+func writeType(ty cty.Type, b *strings.Builder, indent int) {
+	switch {
+	case ty == cty.NilType:
+		b.WriteString("nil")
+		return
+	case ty.IsObjectType():
+		atys := ty.AttributeTypes()
+		if len(atys) == 0 {
+			b.WriteString("object{}")
+			return
+		}
+		attrNames := make([]string, 0, len(atys))
+		for name := range atys {
+			attrNames = append(attrNames, name)
+		}
+		sort.Strings(attrNames)
+		b.WriteString("object({\n")
+		indent++
+		for _, name := range attrNames {
+			aty := atys[name]
+			b.WriteString(indentSpaces(indent))
+			fmt.Fprintf(b, "%q: ", name)
+			writeType(aty, b, indent)
+			b.WriteString(",\n")
+		}
+		indent--
+		b.WriteString(indentSpaces(indent))
+		b.WriteString("})")
+	case ty.IsTupleType():
+		etys := ty.TupleElementTypes()
+		if len(etys) == 0 {
+			b.WriteString("tuple")
+			return
+		}
+		b.WriteString("tuple({\n")
+		indent++
+		for _, ety := range etys {
+			b.WriteString(indentSpaces(indent))
+			writeType(ety, b, indent)
+			b.WriteString(",\n")
+		}
+		indent--
+		b.WriteString(indentSpaces(indent))
+		b.WriteString("})")
+	case ty.IsCollectionType():
+		ety := ty.ElementType()
+		switch {
+		case ty.IsListType():
+			b.WriteString("list(")
+		case ty.IsMapType():
+			b.WriteString("map(")
+		case ty.IsSetType():
+			b.WriteString("set(")
+		default:
+			// At the time of writing there are no other collection types,
+			// but we'll be robust here and just pass through the GoString
+			// of anything we don't recognize.
+			b.WriteString(ty.FriendlyName())
+			return
+		}
+		// Because object and tuple types render split over multiple
+		// lines, a collection type container around them can end up
+		// being hard to see when scanning, so we'll generate some extra
+		// indentation to make a collection of structural type more visually
+		// distinct from the structural type alone.
+		complexElem := ety.IsObjectType() || ety.IsTupleType()
+		if complexElem {
+			indent++
+			b.WriteString("\n")
+			b.WriteString(indentSpaces(indent))
+		}
+		writeType(ty.ElementType(), b, indent)
+		if complexElem {
+			indent--
+			b.WriteString(",\n")
+			b.WriteString(indentSpaces(indent))
+		}
+		b.WriteString(")")
+	default:
+		// For any other type we'll just use its GoString and assume it'll
+		// follow the usual GoString conventions.
+		b.WriteString(ty.FriendlyName())
+	}
+}
+
+func indentSpaces(level int) string {
+	return strings.Repeat("    ", level)
 }

--- a/lang/funcs/conversion_test.go
+++ b/lang/funcs/conversion_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -127,5 +128,66 @@ func TestTo(t *testing.T) {
 				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
 			}
 		})
+	}
+}
+
+func TestType(t *testing.T) {
+	tests := []struct {
+		Input cty.Value
+		Want  string
+	}{
+		// Primititves
+		{
+			cty.StringVal("a"),
+			"string",
+		},
+		{
+			cty.NumberIntVal(42),
+			"number",
+		},
+		{
+			cty.BoolVal(true),
+			"bool",
+		},
+		// Collections
+		{
+			cty.ListVal([]cty.Value{cty.StringVal("a")}),
+			`list(string)`,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.ListVal([]cty.Value{cty.NumberIntVal(42)})}),
+			`list(list(number))`,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.MapValEmpty(cty.String)}),
+			`list(map(string))`,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("bar"),
+			})}),
+			"list(\n    object({\n        foo: string,\n    }),\n)",
+		},
+		// Unknowns and Nulls
+		{
+			cty.UnknownVal(cty.String),
+			"string",
+		},
+		{
+			cty.NullVal(cty.Object(map[string]cty.Type{
+				"foo": cty.String,
+			})),
+			"object({\n    foo: string,\n})",
+		},
+	}
+	for _, test := range tests {
+		got, err := Type([]cty.Value{test.Input})
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if got.AsString() != test.Want {
+			t.Errorf("wrong result:\n%s", cmp.Diff(got.AsString(), test.Want))
+		}
 	}
 }

--- a/lang/funcs/conversion_test.go
+++ b/lang/funcs/conversion_test.go
@@ -185,6 +185,8 @@ func TestType(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
+		// The value is marked to help with formatting
+		got, _ = got.Unmark()
 
 		if got.AsString() != test.Want {
 			t.Errorf("wrong result:\n%s", cmp.Diff(got.AsString(), test.Want))

--- a/lang/functions.go
+++ b/lang/functions.go
@@ -199,3 +199,22 @@ func (s *Scope) experimentalFunction(experiment experiments.Experiment, fn funct
 		},
 	})
 }
+
+// AddFunc allows adding Functions directly to the scope. This is intended
+// for use by the console command, to allow for functions that aren't
+// otherwise supported in configuration.
+func (s *Scope) AddFunc(name string, newFunc function.Function) {
+	s.funcsLock.Lock()
+	if s.funcs == nil {
+		s.funcs = map[string]function.Function{
+			name: newFunc,
+		}
+	} else {
+		if _, ok := s.funcs[name]; ok {
+			panic("cannot re-register an existing function")
+		}
+		s.funcs[name] = newFunc
+	}
+	s.funcsLock.Unlock()
+	return
+}

--- a/repl/format.go
+++ b/repl/format.go
@@ -16,7 +16,11 @@ func FormatValue(v cty.Value, indent int) string {
 	if !v.IsKnown() {
 		return "(known after apply)"
 	}
-	if v.IsMarked() {
+	if v.Type().Equals(cty.String) && v.HasMark("raw") {
+		raw, _ := v.Unmark()
+		return raw.AsString()
+	}
+	if v.HasMark("sensitive") {
 		return "(sensitive)"
 	}
 	if v.IsNull() {

--- a/website/docs/configuration/functions/type.html.md
+++ b/website/docs/configuration/functions/type.html.md
@@ -1,0 +1,84 @@
+---
+layout: "language"
+page_title: "type - Functions - Configuration Language"
+sidebar_current: "docs-funcs-conversion-type"
+description: |-
+  The type function returns the type of a given value. 
+---
+
+# `type` Function
+
+-> **Note:** This page is about Terraform 0.12 and later. For Terraform 0.11 and
+earlier, see
+[0.11 Configuration Language: Interpolation Syntax](../../configuration-0-11/interpolation.html).
+
+`type` retuns the type of a given value.
+
+Sometimes a Terraform configuration can result in confusing errors regarding
+inconsistent types. This function displays terraform's evaluation of a given
+value's type, which is useful in understanding this error message.
+
+This is a special function which is only available in the Terraform console.
+
+## Examples
+
+Here we have a conditional `output` which prints either the value of `var.list` or a local named `default_list`.
+
+```hcl
+variable "list" {
+  default = []
+}
+
+locals {
+  default_list = [
+    {
+      foo = "bar"
+      map = { bleep = "bloop" }
+    },
+    {
+      beep = "boop"
+    },
+  ]
+}
+
+output "list" {
+  value = var.list != [] ? var.list : local.default_list
+}
+```
+
+Applying this configuration results in the following error:
+
+```
+Error: Inconsistent conditional result types
+
+  on main.tf line 18, in output "list":
+  18:   value = var.list != [] ? var.list : local.default_list
+    |----------------
+    | local.default_list is tuple with 2 elements
+    | var.list is empty tuple
+
+The true and false result expressions must have consistent types. The given
+expressions are tuple and tuple, respectively.
+```
+
+While this error message does include some type information, it can be helpful
+to inspect the exact type that Terraform has determined for each given input.
+Examining both `var.list` and `local.default_list` using the `type` function
+provides more context for the error message:
+
+```
+> type(var.list)
+tuple
+> type(local.default_list)
+tuple([
+    object({
+        foo: string,
+        map: object({
+            bleep: string,
+        }),
+    }),
+    object({
+        beep: string,
+    }),
+])
+```


### PR DESCRIPTION
Opening a draft PR to see what people think about this before I put any more time into it! 

The new `type()` function, which is only available for terraform console,
prints out the type of a given value. This is mainly intended for
debugging - it's nice to be able to print out terraform's understanding
of a complex variable.

This was a silly little side project, and I don't know if it's valuable (I like it!) and if the implementation is sound - especially note the change I made if the console is returning a multi-line string. I assume that will break things and needs to be improved. 

[UPDATE: I replaced the original image with the updated current output]
<img width="381" alt="Screen Shot 2020-12-02 at 10 56 04 AM" src="https://user-images.githubusercontent.com/6210214/100896820-0989f000-348d-11eb-8d8e-81d9a2a23385.png">

