### PR TITLE
Replace internal Refresh command with Plan

### DIFF
--- a/backend/local/testdata/refresh-var-unset/main.tf
+++ b/backend/local/testdata/refresh-var-unset/main.tf
@@ -1,7 +1,7 @@
 variable "should_ask" {}
 
 provider "test" {
-  value = "${var.should_ask}"
+  value = var.should_ask
 }
 
 resource "test_instance" "foo" {

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -466,9 +466,11 @@ func testStateOutput(t *testing.T, path string, expected string) {
 
 func testProvider() *terraform.MockProvider {
 	p := new(terraform.MockProvider)
-	p.PlanResourceChangeResponse = providers.PlanResourceChangeResponse{
-		PlannedState: cty.EmptyObjectVal,
+	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+		resp.PlannedState = req.ProposedNewState
+		return resp
 	}
+
 	p.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
 		return providers.ReadResourceResponse{
 			NewState: req.PriorState,

--- a/command/testdata/show-json/basic-create/output.json
+++ b/command/testdata/show-json/basic-create/output.json
@@ -53,7 +53,18 @@
             ]
         }
     },
-    "prior_state": {},
+    "prior_state": {
+        "format_version": "0.1",
+        "values": {
+            "outputs": {
+                "test": {
+                    "sensitive": false,
+                    "value": "bar"
+                }
+            },
+            "root_module": {}
+        }
+    },
     "resource_changes": [
         {
             "address": "test_instance.test[0]",

--- a/command/testdata/show-json/basic-delete/terraform.tfstate
+++ b/command/testdata/show-json/basic-delete/terraform.tfstate
@@ -3,12 +3,7 @@
   "terraform_version": "0.12.0",
   "serial": 7,
   "lineage": "configuredUnchanged",
-  "outputs": {
-    "test": {
-      "value": "bar",
-      "type": "string"
-    }
-  },
+  "outputs": {},
   "resources": [
     {
       "mode": "managed",

--- a/command/testdata/show-json/basic-update/terraform.tfstate
+++ b/command/testdata/show-json/basic-update/terraform.tfstate
@@ -3,12 +3,7 @@
     "terraform_version": "0.12.0",
     "serial": 7,
     "lineage": "configuredUnchanged",
-    "outputs": {
-        "test": {
-            "value": "bar",
-            "type": "string"
-        }
-    },
+    "outputs": {},
     "resources": [
         {
             "mode": "managed",

--- a/command/testdata/show-json/modules/output.json
+++ b/command/testdata/show-json/modules/output.json
@@ -69,7 +69,18 @@
             ]
         }
     },
-    "prior_state": {},
+    "prior_state": {
+        "format_version": "0.1",
+        "values": {
+            "outputs": {
+                "test": {
+                    "sensitive": false,
+                    "value": "baz"
+                }
+            },
+            "root_module": {}
+        }
+    },
     "resource_changes": [
         {
             "address": "module.module_test_bar.test_instance.test",

--- a/command/testdata/show-json/multi-resource-update/output.json
+++ b/command/testdata/show-json/multi-resource-update/output.json
@@ -101,14 +101,20 @@
         "format_version": "0.1",
         "terraform_version": "0.13.0",
         "values": {
+            "outputs": {
+                "test": {
+                    "sensitive": false,
+                    "value": "bar"
+                }
+            },
             "root_module": {
                 "resources": [
                     {
                         "address": "test_instance.test[0]",
-                        "index": 0,
                         "mode": "managed",
                         "type": "test_instance",
                         "name": "test",
+                        "index": 0,
                         "provider_name": "registry.terraform.io/hashicorp/test",
                         "schema_version": 0,
                         "values": {

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -567,7 +567,8 @@ The -target option is not for routine use, and is provided only for exceptional 
 	}
 	p.Changes = c.changes
 
-	p.State = c.refreshState
+	c.refreshState.SyncWrapper().RemovePlannedResourceInstanceObjects()
+	p.State = c.refreshState.DeepCopy()
 
 	// replace the working state with the updated state, so that immediate calls
 	// to Apply work as expected.

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -3987,77 +3987,6 @@ func TestContext2Apply_nilDiff(t *testing.T) {
 	}
 }
 
-func TestContext2Apply_outputDependsOn(t *testing.T) {
-	m := testModule(t, "apply-output-depends-on")
-	p := testProvider("aws")
-	p.DiffFn = testDiffFn
-
-	{
-		// Create a custom apply function that sleeps a bit (to allow parallel
-		// graph execution) and then returns an error to force a partial state
-		// return. We then verify the output is NOT there.
-		p.ApplyFn = func(
-			info *InstanceInfo,
-			is *InstanceState,
-			id *InstanceDiff) (*InstanceState, error) {
-			// Sleep to allow parallel execution
-			time.Sleep(50 * time.Millisecond)
-
-			// Return error to force partial state
-			return nil, fmt.Errorf("abcd")
-		}
-
-		ctx := testContext2(t, &ContextOpts{
-			Config: m,
-			Providers: map[addrs.Provider]providers.Factory{
-				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
-			},
-		})
-
-		if _, diags := ctx.Plan(); diags.HasErrors() {
-			t.Fatalf("diags: %s", diags.Err())
-		}
-
-		state, diags := ctx.Apply()
-		if !diags.HasErrors() || !strings.Contains(diags.Err().Error(), "abcd") {
-			t.Fatalf("err: %s", diags.Err())
-		}
-
-		checkStateString(t, state, `<no state>`)
-	}
-
-	{
-		// Create the standard apply function and verify we get the output
-		p.ApplyFn = testApplyFn
-
-		ctx := testContext2(t, &ContextOpts{
-			Config: m,
-			Providers: map[addrs.Provider]providers.Factory{
-				addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
-			},
-		})
-
-		if _, diags := ctx.Plan(); diags.HasErrors() {
-			t.Fatalf("diags: %s", diags.Err())
-		}
-
-		state, diags := ctx.Apply()
-		if diags.HasErrors() {
-			t.Fatalf("diags: %s", diags.Err())
-		}
-
-		checkStateString(t, state, `
-aws_instance.foo:
-  ID = foo
-  provider = provider["registry.terraform.io/hashicorp/aws"]
-
-Outputs:
-
-value = result
-		`)
-	}
-}
-
 func TestContext2Apply_outputOrphan(t *testing.T) {
 	m := testModule(t, "apply-output-orphan")
 	p := testProvider("aws")
@@ -8604,6 +8533,16 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"eip-abc123","instance":"i-abc123"}`),
+			Dependencies: []addrs.ConfigResource{
+				addrs.ConfigResource{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "aws_instance",
+						Name: "foo",
+					},
+					Module: addrs.RootModule,
+				},
+			},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -8612,6 +8551,16 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"eip-bcd234","instance":"i-bcd234"}`),
+			Dependencies: []addrs.ConfigResource{
+				addrs.ConfigResource{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "aws_instance",
+						Name: "foo",
+					},
+					Module: addrs.RootModule,
+				},
+			},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -8621,7 +8570,7 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 		Providers: map[addrs.Provider]providers.Factory{
 			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 		},
-		State: state,
+		State: state.DeepCopy(),
 	})
 
 	_, diags := ctx.Plan()
@@ -8801,10 +8750,7 @@ resource "null_instance" "depends" {
 		}
 	}
 
-	_, diags := ctx.Refresh()
-	assertNoErrors(t, diags)
-
-	_, diags = ctx.Plan()
+	_, diags := ctx.Plan()
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply()
@@ -10594,45 +10540,6 @@ func TestContext2Apply_ProviderMeta_refresh_set(t *testing.T) {
 	}
 }
 
-func TestContext2Apply_ProviderMeta_refresh_unset(t *testing.T) {
-	m := testModule(t, "provider-meta-unset")
-	p := testProvider("test")
-	p.ApplyFn = testApplyFn
-	p.DiffFn = testDiffFn
-	schema := p.GetSchemaReturn
-	schema.ProviderMeta = &configschema.Block{
-		Attributes: map[string]*configschema.Attribute{
-			"baz": {
-				Type:     cty.String,
-				Required: true,
-			},
-		},
-	}
-	p.GetSchemaReturn = schema
-	ctx := testContext2(t, &ContextOpts{
-		Config: m,
-		Providers: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
-		},
-	})
-
-	_, diags := ctx.Plan()
-	assertNoErrors(t, diags)
-
-	_, diags = ctx.Apply()
-	assertNoErrors(t, diags)
-
-	_, diags = ctx.Refresh()
-	assertNoErrors(t, diags)
-
-	if !p.ReadResourceCalled {
-		t.Fatalf("ReadResource not called")
-	}
-	if !p.ReadResourceRequest.ProviderMeta.IsNull() {
-		t.Fatalf("Expected null ProviderMeta in ReadResource, got %v", p.ReadResourceRequest.ProviderMeta)
-	}
-}
-
 func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 	m := testModule(t, "provider-meta-set")
 	p := testProvider("test")
@@ -10924,10 +10831,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_unset(t *testing.T) {
 		}
 	}
 
-	_, diags := ctx.Refresh()
-	assertNoErrors(t, diags)
-
-	_, diags = ctx.Plan()
+	_, diags := ctx.Plan()
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply()
@@ -11228,12 +11132,7 @@ func TestContext2Apply_moduleDependsOn(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Refresh()
-	if diags.HasErrors() {
-		t.Fatal(diags.ErrWithWarnings())
-	}
-
-	_, diags = ctx.Plan()
+	_, diags := ctx.Plan()
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11243,11 +11142,6 @@ func TestContext2Apply_moduleDependsOn(t *testing.T) {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	// run the plan again to ensure that data sources are not going to be re-read
-	_, diags = ctx.Refresh()
-	if diags.HasErrors() {
-		t.Fatal(diags.ErrWithWarnings())
-	}
 	plan, diags := ctx.Plan()
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
@@ -11798,10 +11692,6 @@ output "outputs" {
 			State:   state,
 			Destroy: true,
 		})
-
-		if _, diags := ctx.Refresh(); diags.HasErrors() {
-			t.Fatalf("destroy plan errors: %s", diags.Err())
-		}
 
 		if _, diags := ctx.Plan(); diags.HasErrors() {
 			t.Fatalf("destroy plan errors: %s", diags.Err())

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -549,18 +549,18 @@ func (n *EvalRefreshDependencies) Eval(ctx EvalContext) (interface{}, error) {
 		return nil, nil
 	}
 
-	depMap := make(map[string]addrs.ConfigResource)
-	for _, d := range *n.Dependencies {
-		depMap[d.String()] = d
-	}
-
-	// We have already dependencies in state, so we need to trust those for
+	// We already have dependencies in state, so we need to trust those for
 	// refresh. We can't write out new dependencies until apply time in case
 	// the configuration has been changed in a manner the conflicts with the
 	// stored dependencies.
 	if len(state.Dependencies) > 0 {
 		*n.Dependencies = state.Dependencies
 		return nil, nil
+	}
+
+	depMap := make(map[string]addrs.ConfigResource)
+	for _, d := range *n.Dependencies {
+		depMap[d.String()] = d
 	}
 
 	deps := make([]addrs.ConfigResource, 0, len(depMap))

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -146,6 +146,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.
 		&ReferenceTransformer{},
+		&AttachDependenciesTransformer{},
 
 		// Make sure data sources are aware of any depends_on from the
 		// configuration

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -230,6 +230,13 @@ func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) error {
 			return diags.Err()
 		}
 		n.setValue(state, changes, val)
+
+		// If we were able to evaluate a new value, we can update that in the
+		// refreshed state as well.
+		if state = ctx.RefreshState(); state != nil && val.IsWhollyKnown() {
+			n.setValue(state, changes, val)
+		}
+
 		return nil
 	default:
 		return nil

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -160,6 +160,7 @@ func (n *NodePlannableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 				State:          &instanceRefreshState,
 				ProviderSchema: &providerSchema,
 				targetState:    refreshState,
+				Dependencies:   &n.Dependencies,
 			},
 
 			// Plan the instance

--- a/terraform/testdata/apply-output-depends-on/main.tf
+++ b/terraform/testdata/apply-output-depends-on/main.tf
@@ -1,7 +1,0 @@
-resource "aws_instance" "foo" {}
-
-output "value" {
-    value = "result"
-
-    depends_on = ["aws_instance.foo"]
-}

--- a/terraform/testdata/refresh-data-count/refresh-data-count.tf
+++ b/terraform/testdata/refresh-data-count/refresh-data-count.tf
@@ -1,5 +1,4 @@
 resource "test" "foo" {
-  things = ["foo"]
 }
 
 data "test" "foo" {

--- a/terraform/testdata/refresh-module-input-computed-output/child/main.tf
+++ b/terraform/testdata/refresh-module-input-computed-output/child/main.tf
@@ -1,11 +1,11 @@
 variable "input" {
-    type = list(string)
+    type = string
 }
 
 resource "aws_instance" "foo" {
-    foo = "${var.input}"
+    foo = var.input
 }
 
 output "foo" {
-    value = "${aws_instance.foo.foo}"
+    value = aws_instance.foo.foo
 }

--- a/terraform/testdata/refresh-module-input-computed-output/main.tf
+++ b/terraform/testdata/refresh-module-input-computed-output/main.tf
@@ -1,5 +1,5 @@
 module "child" {
-    input = "${aws_instance.bar.foo}"
+    input = aws_instance.bar.foo
     source = "./child"
 }
 

--- a/terraform/testdata/refresh-schema-upgrade/main.tf
+++ b/terraform/testdata/refresh-schema-upgrade/main.tf
@@ -1,0 +1,2 @@
+resource "test_thing" "bar" {
+}


### PR DESCRIPTION
Since all resources are refreshed during plan now, we can use the state generated by plan for the purpose of refreshing. The refresh step has been removed from the `plan` command, and this changes the refresh command to use the plan output rather than it's own unique graph.

The majority of this change set is fixing refresh tests that were incorrect, had incomplete fixtures, or no longer make sense. The removal of the old Refresh code will come in another PR to reduce the size of the diffs for review. 

