### PR TITLE
command: Providers schema shows required_providers

### DIFF
--- a/command/testdata/providers-schema/required/output.json
+++ b/command/testdata/providers-schema/required/output.json
@@ -1,0 +1,41 @@
+{
+    "format_version": "0.1",
+    "provider_schemas": {
+        "registry.terraform.io/hashicorp/test": {
+            "provider": {
+                "version": 0,
+                "block": {
+                    "attributes": {
+                        "region": {
+                            "description_kind": "plain",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    },
+                    "description_kind": "plain"
+                }
+            },
+            "resource_schemas": {
+                "test_instance": {
+                    "version": 0,
+                    "block": {
+                        "attributes": {
+                            "ami": {
+                                "type": "string",
+                                "optional": true,
+                                "description_kind": "plain"
+                            },
+                            "id": {
+                                "type": "string",
+                                "optional": true,
+                                "computed": true,
+                                "description_kind": "plain"
+                            }
+                        },
+                        "description_kind": "plain"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/command/testdata/providers-schema/required/provider.tf
+++ b/command/testdata/providers-schema/required/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+}

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -32,6 +32,7 @@ func TestConfigProviderTypes(t *testing.T) {
 		addrs.NewDefaultProvider("aws"),
 		addrs.NewDefaultProvider("null"),
 		addrs.NewDefaultProvider("template"),
+		addrs.NewDefaultProvider("test"),
 	}
 	for _, problem := range deep.Equal(got, want) {
 		t.Error(problem)

--- a/configs/testdata/valid-files/providers-explicit-implied.tf
+++ b/configs/testdata/valid-files/providers-explicit-implied.tf
@@ -13,3 +13,11 @@ resource "aws_instance" "foo" {
 resource "null_resource" "foo" {
 
 }
+
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+}


### PR DESCRIPTION
The providers schema command is using the `Config.ProviderTypes` method, which had not been kept up to date with the changes to provider requirements detection made in `Config.ProviderRequirements`. This resulted in any currently-unused providers being omitted from the output.

This commit changes the `ProviderTypes` method to use the same underlying logic as `ProviderRequirements`, which ensures that `required_providers` blocks are taken into account.

Includes an integration test case to verify that this fixes the provider schemas command bug.

Fixes #26306. Diff [best viewed ignoring whitespace](https://github.com/hashicorp/terraform/pull/26318/files?diff=unified&w=1), due to the new nil check if statement.