### PR TITLE
command: Providers schema shows required_providers

### DIFF
--- a/command/testdata/providers-schema/required/output.json
+++ b/command/testdata/providers-schema/required/output.json
@@ -1,0 +1,41 @@
+{
+    "format_version": "0.1",
+    "provider_schemas": {
+        "registry.terraform.io/hashicorp/test": {
+            "provider": {
+                "version": 0,
+                "block": {
+                    "attributes": {
+                        "region": {
+                            "description_kind": "plain",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    },
+                    "description_kind": "plain"
+                }
+            },
+            "resource_schemas": {
+                "test_instance": {
+                    "version": 0,
+                    "block": {
+                        "attributes": {
+                            "ami": {
+                                "type": "string",
+                                "optional": true,
+                                "description_kind": "plain"
+                            },
+                            "id": {
+                                "type": "string",
+                                "optional": true,
+                                "computed": true,
+                                "description_kind": "plain"
+                            }
+                        },
+                        "description_kind": "plain"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/command/testdata/providers-schema/required/provider.tf
+++ b/command/testdata/providers-schema/required/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+}

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -32,6 +32,7 @@ func TestConfigProviderTypes(t *testing.T) {
 		addrs.NewDefaultProvider("aws"),
 		addrs.NewDefaultProvider("null"),
 		addrs.NewDefaultProvider("template"),
+		addrs.NewDefaultProvider("test"),
 	}
 	for _, problem := range deep.Equal(got, want) {
 		t.Error(problem)

--- a/configs/testdata/valid-files/providers-explicit-implied.tf
+++ b/configs/testdata/valid-files/providers-explicit-implied.tf
@@ -13,3 +13,11 @@ resource "aws_instance" "foo" {
 resource "null_resource" "foo" {
 
 }
+
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+}


### PR DESCRIPTION
Cherry-pick of #26318 to v0.13, to address #26306.

Proposed changelog entry:

```markdown
BUG FIXES:

* command: Include schemas from required but unused providers in the output of `terraform providers schema`.
  This allows development tools such as the Terraform language server to offer autocompletion for
  the first resource for a given provider. [GH-26318]
```