### PR TITLE
configs: Deprecate nested redundant interpolations

### DIFF
--- a/configs/testdata/warning-files/redundant_interp.tf
+++ b/configs/testdata/warning-files/redundant_interp.tf
@@ -29,9 +29,7 @@ resource "null_resource" "a" {
     # in the template.
     template = " ${var.triggers["greeting"]} "
 
-    # No warning for this one, because it's embedded inside a more complex
-    # expression and our check is only for direct assignment to attributes.
-    wrapped = ["${var.triggers["greeting"]}"]
+    wrapped = ["${var.triggers["greeting"]}"] # WARNING: Interpolation-only expressions are deprecated
   }
 }
 
@@ -41,6 +39,10 @@ module "foo" {
 }
 
 data "null_data_source" "b" {
+  inputs = {
+    host = "${var.triggers["host"]}" # WARNING: Interpolation-only expressions are deprecated
+  }
+
   has_computed_default = "${var.foo}" # WARNING: Interpolation-only expressions are deprecated
 }
 


### PR DESCRIPTION
Previous deprecations only included direct assignment of template-only expressions to arguments. That is, this was not deprecated:

```hcl
locals {
  foo = ["${var.foo}"]
}
```

This commit uses `hclsyntax.VisitAll` to detect and show deprecations for all template-only expressions, no matter how deep they are in a given expression.

Fixes #26331. Should be back-ported to 0.13 if merged, to go along with #26105.