### PR TITLE
Deprecate vendor provisioners in 0.13

### DIFF
--- a/configs/provisioner.go
+++ b/configs/provisioner.go
@@ -31,6 +31,16 @@ func decodeProvisionerBlock(block *hcl.Block) (*Provisioner, hcl.Diagnostics) {
 	content, config, diags := block.Body.PartialContent(provisionerBlockSchema)
 	pv.Config = config
 
+	switch pv.Type {
+	case "chef", "habitat", "puppet", "salt-masterless":
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  fmt.Sprintf("The \"%s\" provisioner is deprecated", pv.Type),
+			Detail:   fmt.Sprintf("The \"%s\" provisioner is deprecated and will be removed from future versions of Terraform. Visit https://learn.hashicorp.com/collections/terraform/provision for alternatives to using provisioners that are a better fit for the Terraform workflow.", pv.Type),
+			Subject:  &pv.TypeRange,
+		})
+	}
+
 	if attr, exists := content.Attributes["when"]; exists {
 		expr, shimDiags := shimTraversalInString(attr.Expr, true)
 		diags = append(diags, shimDiags...)

--- a/configs/testdata/warning-files/vendor_provisioners.tf
+++ b/configs/testdata/warning-files/vendor_provisioners.tf
@@ -1,0 +1,3 @@
+resource "null_resource" "test" {
+  provisioner "habitat" {} # WARNING: The "habitat" provisioner is deprecated
+}

--- a/website/docs/provisioners/chef.html.markdown
+++ b/website/docs/provisioners/chef.html.markdown
@@ -12,8 +12,9 @@ The `chef` provisioner installs, configures and runs the Chef Client on a remote
 resource. The `chef` provisioner supports both `ssh` and `winrm` type
 [connections](/docs/provisioners/connection.html).
 
--> **Note:** Provisioners should only be used as a last resort. For most
-common situations there are better alternatives. For more information, see
+-> **Note:** This provisioner has been deprecated as of Terraform 0.13.4 and will be
+removed in a future version of Terraform. For most common situations there are better
+alternatives to using provisioners. For more information, see
 [the main Provisioners page](./).
 
 ## Requirements

--- a/website/docs/provisioners/habitat.html.markdown
+++ b/website/docs/provisioners/habitat.html.markdown
@@ -10,8 +10,9 @@ description: |-
 
 The `habitat` provisioner installs the [Habitat](https://habitat.sh) supervisor and loads configured services. This provisioner only supports Linux targets using the `ssh` connection type at this time.
 
--> **Note:** Provisioners should only be used as a last resort. For most
-common situations there are better alternatives. For more information, see
+-> **Note:** This provisioner has been deprecated as of Terraform 0.13.4 and will be
+removed in a future version of Terraform. For most common situations there are better
+alternatives to using provisioners. For more information, see
 [the main Provisioners page](./).
 
 ## Requirements

--- a/website/docs/provisioners/puppet.html.markdown
+++ b/website/docs/provisioners/puppet.html.markdown
@@ -12,8 +12,9 @@ The `puppet` provisioner installs, configures and runs the Puppet agent on a
 remote resource. The `puppet` provisioner supports both `ssh` and `winrm` type
 [connections](/docs/provisioners/connection.html).
 
--> **Note:** Provisioners should only be used as a last resort. For most
-common situations there are better alternatives. For more information, see
+-> **Note:** This provisioner has been deprecated as of Terraform 0.13.4 and will be
+removed in a future version of Terraform. For most common situations there are better
+alternatives to using provisioners. For more information, see
 [the main Provisioners page](./).
 
 ## Requirements

--- a/website/docs/provisioners/salt-masterless.html.md
+++ b/website/docs/provisioners/salt-masterless.html.md
@@ -13,8 +13,9 @@ Type: `salt-masterless`
 The `salt-masterless` Terraform provisioner provisions machines built by Terraform
 using [Salt](http://saltstack.com/) states, without connecting to a Salt master. The `salt-masterless` provisioner supports `ssh` [connections](/docs/provisioners/connection.html).
 
--> **Note:** Provisioners should only be used as a last resort. For most
-common situations there are better alternatives. For more information, see
+-> **Note:** This provisioner has been deprecated as of Terraform 0.13.4 and will be
+removed in a future version of Terraform. For most common situations there are better
+alternatives to using provisioners. For more information, see
 [the main Provisioners page](./).
 
 ## Requirements


### PR DESCRIPTION
This cherry-picks https://github.com/hashicorp/terraform/pull/26203 to v0.13 -- which means that deprecation notice didn't actually get released in 0.13.3, so the docs here have been amended to 0.13.4. I'll also update master so that this deprecation notice doesn't get mangled in 0.14.