### PR TITLE
docs: Vendor provisioner deprecation version

### DIFF
--- a/website/docs/provisioners/chef.html.markdown
+++ b/website/docs/provisioners/chef.html.markdown
@@ -12,7 +12,7 @@ The `chef` provisioner installs, configures and runs the Chef Client on a remote
 resource. The `chef` provisioner supports both `ssh` and `winrm` type
 [connections](/docs/provisioners/connection.html).
 
--> **Note:** This provisioner has been deprecated as of Terraform 0.13.3 and will be
+-> **Note:** This provisioner has been deprecated as of Terraform 0.13.4 and will be
 removed in a future version of Terraform. For most common situations there are better
 alternatives to using provisioners. For more information, see
 [the main Provisioners page](./).

--- a/website/docs/provisioners/habitat.html.markdown
+++ b/website/docs/provisioners/habitat.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 The `habitat` provisioner installs the [Habitat](https://habitat.sh) supervisor and loads configured services. This provisioner only supports Linux targets using the `ssh` connection type at this time.
 
--> **Note:** This provisioner has been deprecated as of Terraform 0.13.3 and will be
+-> **Note:** This provisioner has been deprecated as of Terraform 0.13.4 and will be
 removed in a future version of Terraform. For most common situations there are better
 alternatives to using provisioners. For more information, see
 [the main Provisioners page](./).

--- a/website/docs/provisioners/puppet.html.markdown
+++ b/website/docs/provisioners/puppet.html.markdown
@@ -12,7 +12,7 @@ The `puppet` provisioner installs, configures and runs the Puppet agent on a
 remote resource. The `puppet` provisioner supports both `ssh` and `winrm` type
 [connections](/docs/provisioners/connection.html).
 
--> **Note:** This provisioner has been deprecated as of Terraform 0.13.3 and will be
+-> **Note:** This provisioner has been deprecated as of Terraform 0.13.4 and will be
 removed in a future version of Terraform. For most common situations there are better
 alternatives to using provisioners. For more information, see
 [the main Provisioners page](./).

--- a/website/docs/provisioners/salt-masterless.html.md
+++ b/website/docs/provisioners/salt-masterless.html.md
@@ -13,7 +13,7 @@ Type: `salt-masterless`
 The `salt-masterless` Terraform provisioner provisions machines built by Terraform
 using [Salt](http://saltstack.com/) states, without connecting to a Salt master. The `salt-masterless` provisioner supports `ssh` [connections](/docs/provisioners/connection.html).
 
--> **Note:** This provisioner has been deprecated as of Terraform 0.13.3 and will be
+-> **Note:** This provisioner has been deprecated as of Terraform 0.13.4 and will be
 removed in a future version of Terraform. For most common situations there are better
 alternatives to using provisioners. For more information, see
 [the main Provisioners page](./).


### PR DESCRIPTION
This updates the provisioner docs to the (what will be) correct version the deprecation notice appears.