### PR TITLE
Store sensitive attribute paths in state

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -767,12 +767,6 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 	ty := old.Type()
 	typesEqual := ctyTypesEqual(ty, new.Type())
 
-	// If either the old or new value is marked, don't display the value
-	if old.ContainsMarked() || new.ContainsMarked() {
-		p.buf.WriteString("(sensitive)")
-		return
-	}
-
 	// We have some specialized diff implementations for certain complex
 	// values where it's useful to see a visualization of the diff of
 	// the nested elements rather than just showing the entire old and
@@ -787,8 +781,18 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 			// to apply, both old and new must be valid JSON.
 			// For single-line strings that don't parse as JSON we just fall
 			// out of this switch block and do the default old -> new rendering.
-			oldS := old.AsString()
-			newS := new.AsString()
+
+			var oldS, newS string
+			if old.ContainsMarked() {
+				oldS = "(sensitive)"
+			} else {
+				oldS = old.AsString()
+			}
+			if new.ContainsMarked() {
+				newS = "(sensitive)"
+			} else {
+				newS = new.AsString()
+			}
 
 			{
 				// Special behavior for JSON strings containing object or

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3678,7 +3678,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			},
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
-      ~ ami = (sensitive) -> "ami-AFTER"
+      ~ ami = (sensitive)
         id  = "i-02ae66f368e8518a9"
     }
 `,
@@ -3714,9 +3714,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
         id   = "i-02ae66f368e8518a9"
-      ~ tags = {
-          ~ "name" = "anna" -> "(sensitive)"
-        }
+      ~ tags = (sensitive)
     }
 `,
 		},
@@ -3751,7 +3749,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			},
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
-      ~ ami = (sensitive) -> (sensitive)
+      ~ ami = (sensitive)
         id  = "i-02ae66f368e8518a9"
     }
 `,
@@ -3779,7 +3777,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			},
 			ExpectedOutput: `  # test_instance.example will be destroyed
   - resource "test_instance" "example" {
-      - ami = (sensitive) -> null
+      - ami = (sensitive)
       - id  = "i-02ae66f368e8518a9" -> null
     }
 `,

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3683,6 +3683,34 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
     }
 `,
 		},
+		"deletion": {
+			Action: plans.Delete,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+			}),
+			After: cty.NullVal(cty.EmptyObject),
+			BeforeValMarks: []cty.PathValueMarks{
+				{
+					Path:  cty.Path{cty.GetAttrStep{Name: "ami"}},
+					Marks: cty.NewValueMarks("sensitive"),
+				}},
+			RequiredReplace: cty.NewPathSet(),
+			Tainted:         false,
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":  {Type: cty.String, Optional: true, Computed: true},
+					"ami": {Type: cty.String, Optional: true},
+				},
+			},
+			ExpectedOutput: `  # test_instance.example will be destroyed
+  - resource "test_instance" "example" {
+      - ami = (sensitive)
+      - id  = "i-02ae66f368e8518a9" -> null
+    }
+`,
+		},
 	}
 	runTestCases(t, testCases)
 }

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3678,7 +3678,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			},
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
-      ~ ami = (sensitive)
+      ~ ami = "ami-BEFORE" -> (sensitive)
         id  = "i-02ae66f368e8518a9"
     }
 `,
@@ -3706,7 +3706,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			},
 			ExpectedOutput: `  # test_instance.example will be destroyed
   - resource "test_instance" "example" {
-      - ami = (sensitive)
+      - ami = (sensitive) -> null
       - id  = "i-02ae66f368e8518a9" -> null
     }
 `,

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3683,34 +3683,40 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
     }
 `,
 		},
-		"in-place update - after sensitive": {
+		"in-place update - after sensitive, map type": {
 			Action: plans.Update,
 			Mode:   addrs.ManagedResourceMode,
 			Before: cty.ObjectVal(map[string]cty.Value{
-				"id":  cty.StringVal("i-02ae66f368e8518a9"),
-				"ami": cty.StringVal("ami-BEFORE"),
+				"id": cty.StringVal("i-02ae66f368e8518a9"),
+				"tags": cty.MapVal(map[string]cty.Value{
+					"name": cty.StringVal("anna"),
+				}),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{
-				"id":  cty.StringVal("i-02ae66f368e8518a9"),
-				"ami": cty.StringVal("ami-AFTER"),
+				"id": cty.StringVal("i-02ae66f368e8518a9"),
+				"tags": cty.MapVal(map[string]cty.Value{
+					"name": cty.StringVal("bob"),
+				}),
 			}),
 			AfterValMarks: []cty.PathValueMarks{
 				{
-					Path:  cty.Path{cty.GetAttrStep{Name: "ami"}},
+					Path:  cty.Path{cty.GetAttrStep{Name: "tags"}, cty.IndexStep{Key: cty.StringVal("name")}},
 					Marks: cty.NewValueMarks("sensitive"),
 				}},
 			RequiredReplace: cty.NewPathSet(),
 			Tainted:         false,
 			Schema: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
+					"id":   {Type: cty.String, Optional: true, Computed: true},
+					"tags": {Type: cty.Map(cty.String), Optional: true},
 				},
 			},
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
-      ~ ami = "ami-BEFORE" -> (sensitive)
-        id  = "i-02ae66f368e8518a9"
+        id   = "i-02ae66f368e8518a9"
+      ~ tags = {
+          ~ "name" = "anna" -> "(sensitive)"
+        }
     }
 `,
 		},

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -238,7 +238,7 @@ type PlanResourceChangeResponse struct {
 	// configuration is applied.
 	PlannedState cty.Value
 
-	// RequiresReplace is the list of thee attributes that are requiring
+	// RequiresReplace is the list of the attributes that are requiring
 	// resource replacement.
 	RequiresReplace []cty.Path
 

--- a/states/instance_object.go
+++ b/states/instance_object.go
@@ -1,8 +1,6 @@
 package states
 
 import (
-	"fmt"
-
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
@@ -89,7 +87,6 @@ const (
 // so the caller must not mutate the receiver any further once once this
 // method is called.
 func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64) (*ResourceInstanceObjectSrc, error) {
-	fmt.Println("encode called")
 	// Our state serialization can't represent unknown values, so we convert
 	// them to nulls here. This is lossy, but nobody should be writing unknown
 	// values here and expecting to get them out again later.
@@ -106,9 +103,7 @@ func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64) (*Res
 	var pvm []cty.PathValueMarks
 	if val.ContainsMarked() {
 		unmarked, pvm = val.UnmarkDeepWithPaths()
-		fmt.Printf("Encode(): %#v\n", pvm)
 	}
-	fmt.Printf("pvm length is >0 %v\n", len(pvm) > 0)
 	src, err := ctyjson.Marshal(unmarked, ty)
 	if err != nil {
 		return nil, err

--- a/states/instance_object.go
+++ b/states/instance_object.go
@@ -112,7 +112,7 @@ func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64) (*Res
 	return &ResourceInstanceObjectSrc{
 		SchemaVersion:       schemaVersion,
 		AttrsJSON:           src,
-		AttrPaths:           pvm,
+		AttrSensitivePaths:  pvm,
 		Private:             o.Private,
 		Status:              o.Status,
 		Dependencies:        o.Dependencies,

--- a/states/instance_object_src.go
+++ b/states/instance_object_src.go
@@ -1,6 +1,8 @@
 package states
 
 import (
+	"fmt"
+
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
@@ -49,6 +51,10 @@ type ResourceInstanceObjectSrc struct {
 	// the recommendations in the AttrsJSON documentation above.
 	AttrsFlat map[string]string
 
+	// AttrPaths is an array of paths to mark as sensitive coming out of
+	// state, or to save as sensitive paths when saving state
+	AttrPaths []cty.PathValueMarks
+
 	// These fields all correspond to the fields of the same name on
 	// ResourceInstanceObject.
 	Private             []byte
@@ -78,6 +84,12 @@ func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObjec
 		}
 	} else {
 		val, err = ctyjson.Unmarshal(os.AttrsJSON, ty)
+		// Mark the value with paths if applicable
+		if os.AttrPaths != nil {
+			fmt.Println("Marking in Decode")
+			val = val.MarkWithPaths(os.AttrPaths)
+			fmt.Println("val after mark in decode: ", val)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/states/instance_object_src.go
+++ b/states/instance_object_src.go
@@ -1,8 +1,6 @@
 package states
 
 import (
-	"fmt"
-
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
@@ -86,9 +84,7 @@ func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObjec
 		val, err = ctyjson.Unmarshal(os.AttrsJSON, ty)
 		// Mark the value with paths if applicable
 		if os.AttrPaths != nil {
-			fmt.Println("Marking in Decode")
 			val = val.MarkWithPaths(os.AttrPaths)
-			fmt.Println("val after mark in decode: ", val)
 		}
 		if err != nil {
 			return nil, err

--- a/states/instance_object_src.go
+++ b/states/instance_object_src.go
@@ -49,9 +49,9 @@ type ResourceInstanceObjectSrc struct {
 	// the recommendations in the AttrsJSON documentation above.
 	AttrsFlat map[string]string
 
-	// AttrPaths is an array of paths to mark as sensitive coming out of
+	// AttrSensitivePaths is an array of paths to mark as sensitive coming out of
 	// state, or to save as sensitive paths when saving state
-	AttrPaths []cty.PathValueMarks
+	AttrSensitivePaths []cty.PathValueMarks
 
 	// These fields all correspond to the fields of the same name on
 	// ResourceInstanceObject.
@@ -83,8 +83,8 @@ func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObjec
 	} else {
 		val, err = ctyjson.Unmarshal(os.AttrsJSON, ty)
 		// Mark the value with paths if applicable
-		if os.AttrPaths != nil {
-			val = val.MarkWithPaths(os.AttrPaths)
+		if os.AttrSensitivePaths != nil {
+			val = val.MarkWithPaths(os.AttrSensitivePaths)
 		}
 		if err != nil {
 			return nil, err

--- a/states/state_deepcopy.go
+++ b/states/state_deepcopy.go
@@ -145,9 +145,9 @@ func (obj *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 	}
 
 	var attrPaths []cty.PathValueMarks
-	if obj.AttrPaths != nil {
-		attrPaths = make([]cty.PathValueMarks, len(obj.AttrPaths))
-		copy(attrPaths, obj.AttrPaths)
+	if obj.AttrSensitivePaths != nil {
+		attrPaths = make([]cty.PathValueMarks, len(obj.AttrSensitivePaths))
+		copy(attrPaths, obj.AttrSensitivePaths)
 	}
 
 	var private []byte
@@ -170,7 +170,7 @@ func (obj *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		Private:             private,
 		AttrsFlat:           attrsFlat,
 		AttrsJSON:           attrsJSON,
-		AttrPaths:           attrPaths,
+		AttrSensitivePaths:  attrPaths,
 		Dependencies:        dependencies,
 		CreateBeforeDestroy: obj.CreateBeforeDestroy,
 	}

--- a/states/state_deepcopy.go
+++ b/states/state_deepcopy.go
@@ -144,6 +144,12 @@ func (obj *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		copy(attrsJSON, obj.AttrsJSON)
 	}
 
+	var attrPaths []cty.PathValueMarks
+	if obj.AttrPaths != nil {
+		attrPaths = make([]cty.PathValueMarks, len(obj.AttrPaths))
+		copy(attrPaths, obj.AttrPaths)
+	}
+
 	var private []byte
 	if obj.Private != nil {
 		private = make([]byte, len(obj.Private))
@@ -164,6 +170,7 @@ func (obj *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		Private:             private,
 		AttrsFlat:           attrsFlat,
 		AttrsJSON:           attrsJSON,
+		AttrPaths:           attrPaths,
 		Dependencies:        dependencies,
 		CreateBeforeDestroy: obj.CreateBeforeDestroy,
 	}

--- a/states/state_test.go
+++ b/states/state_test.go
@@ -230,7 +230,14 @@ func TestStateDeepCopy(t *testing.T) {
 			Status:        ObjectReady,
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
-			Private:       []byte("private data"),
+			// Sensitive path at "woozles"
+			AttrPaths: []cty.PathValueMarks{
+				{
+					Path:  cty.Path{cty.GetAttrStep{Name: "woozles"}},
+					Marks: cty.NewValueMarks("sensitive"),
+				},
+			},
+			Private: []byte("private data"),
 			Dependencies: []addrs.ConfigResource{
 				{
 					Module: addrs.RootModule,

--- a/states/state_test.go
+++ b/states/state_test.go
@@ -231,7 +231,7 @@ func TestStateDeepCopy(t *testing.T) {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 			// Sensitive path at "woozles"
-			AttrPaths: []cty.PathValueMarks{
+			AttrSensitivePaths: []cty.PathValueMarks{
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "woozles"}},
 					Marks: cty.NewValueMarks("sensitive"),

--- a/states/statefile/version4.go
+++ b/states/statefile/version4.go
@@ -167,7 +167,7 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 						Marks: cty.NewValueMarks("sensitive"),
 					})
 				}
-				obj.AttrPaths = pvm
+				obj.AttrSensitivePaths = pvm
 			}
 
 			{
@@ -473,7 +473,7 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 
 	// Extract paths from path value marks
 	var paths []cty.Path
-	for _, vm := range obj.AttrPaths {
+	for _, vm := range obj.AttrSensitivePaths {
 		paths = append(paths, vm.Path)
 	}
 

--- a/states/statefile/version4.go
+++ b/states/statefile/version4.go
@@ -153,8 +153,8 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 			}
 
 			// Sensitive paths
-			if isV4.AttributePaths != nil {
-				paths, pathsDiags := unmarshalPaths([]byte(isV4.AttributePaths))
+			if isV4.AttributeSensitivePaths != nil {
+				paths, pathsDiags := unmarshalPaths([]byte(isV4.AttributeSensitivePaths))
 				diags = diags.Append(pathsDiags)
 				if pathsDiags.HasErrors() {
 					continue
@@ -478,20 +478,20 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 	}
 
 	// Marshal paths to JSON
-	attributePaths, pathsDiags := marshalPaths(paths)
+	attributeSensitivePaths, pathsDiags := marshalPaths(paths)
 	diags = diags.Append(pathsDiags)
 
 	return append(isV4s, instanceObjectStateV4{
-		IndexKey:            rawKey,
-		Deposed:             string(deposed),
-		Status:              status,
-		SchemaVersion:       obj.SchemaVersion,
-		AttributesFlat:      obj.AttrsFlat,
-		AttributesRaw:       obj.AttrsJSON,
-		AttributePaths:      attributePaths,
-		PrivateRaw:          privateRaw,
-		Dependencies:        deps,
-		CreateBeforeDestroy: obj.CreateBeforeDestroy,
+		IndexKey:                rawKey,
+		Deposed:                 string(deposed),
+		Status:                  status,
+		SchemaVersion:           obj.SchemaVersion,
+		AttributesFlat:          obj.AttrsFlat,
+		AttributesRaw:           obj.AttrsJSON,
+		AttributeSensitivePaths: attributeSensitivePaths,
+		PrivateRaw:              privateRaw,
+		Dependencies:            deps,
+		CreateBeforeDestroy:     obj.CreateBeforeDestroy,
 	}), diags
 }
 
@@ -535,10 +535,10 @@ type instanceObjectStateV4 struct {
 	Status   string      `json:"status,omitempty"`
 	Deposed  string      `json:"deposed,omitempty"`
 
-	SchemaVersion  uint64            `json:"schema_version"`
-	AttributesRaw  json.RawMessage   `json:"attributes,omitempty"`
-	AttributesFlat map[string]string `json:"attributes_flat,omitempty"`
-	AttributePaths json.RawMessage   `json:"sensitive_attributes,omitempty,"`
+	SchemaVersion           uint64            `json:"schema_version"`
+	AttributesRaw           json.RawMessage   `json:"attributes,omitempty"`
+	AttributesFlat          map[string]string `json:"attributes_flat,omitempty"`
+	AttributeSensitivePaths json.RawMessage   `json:"sensitive_attributes,omitempty,"`
 
 	PrivateRaw []byte `json:"private,omitempty"`
 

--- a/states/statefile/version4.go
+++ b/states/statefile/version4.go
@@ -472,13 +472,10 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 	}
 
 	// Extract paths from path value marks
-	fmt.Println("writing state attr paths")
-	fmt.Printf("obj.AttrPaths: %#v\n", obj.AttrPaths)
 	var paths []cty.Path
 	for _, vm := range obj.AttrPaths {
 		paths = append(paths, vm.Path)
 	}
-	fmt.Printf("paths: %#v\n", paths)
 
 	// Marshal paths to JSON
 	attributePaths, pathsDiags := marshalPaths(paths)

--- a/states/statefile/version4_test.go
+++ b/states/statefile/version4_test.go
@@ -2,7 +2,11 @@ package statefile
 
 import (
 	"sort"
+	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // This test verifies that modules are sorted before resources:
@@ -37,5 +41,218 @@ func TestVersion4_sort(t *testing.T) {
 		if resource.Module != moduleOrder[i] {
 			t.Errorf("wrong sort order: expected %q, got %q\n", moduleOrder[i], resource.Module)
 		}
+	}
+}
+
+func TestVersion4_unmarshalPaths(t *testing.T) {
+	testCases := map[string]struct {
+		json  string
+		paths []cty.Path
+		diags []string
+	}{
+		"no paths": {
+			json:  `[]`,
+			paths: []cty.Path{},
+		},
+		"attribute path": {
+			json: `[
+  [
+    {
+      "type": "get_attr",
+	  "value": "password"
+    }
+  ]
+]`,
+			paths: []cty.Path{cty.GetAttrPath("password")},
+		},
+		"attribute and string index": {
+			json: `[
+  [
+    {
+      "type": "get_attr",
+	  "value": "triggers"
+    },
+    {
+      "type": "index",
+      "value": {
+        "value": "secret",
+		"type": "string"
+      }
+    }
+  ]
+]`,
+			paths: []cty.Path{cty.GetAttrPath("triggers").IndexString("secret")},
+		},
+		"attribute, number index, attribute": {
+			json: `[
+  [
+    {
+      "type": "get_attr",
+	  "value": "identities"
+    },
+    {
+      "type": "index",
+      "value": {
+        "value": 2,
+		"type": "number"
+      }
+    },
+    {
+      "type": "get_attr",
+      "value": "private_key"
+    }
+  ]
+]`,
+			paths: []cty.Path{cty.GetAttrPath("identities").IndexInt(2).GetAttr("private_key")},
+		},
+		"multiple paths": {
+			json: `[
+  [
+    {
+      "type": "get_attr",
+	  "value": "alpha"
+    }
+  ],
+  [
+    {
+      "type": "get_attr",
+	  "value": "beta"
+    }
+  ],
+  [
+    {
+      "type": "get_attr",
+	  "value": "gamma"
+    }
+  ]
+]`,
+			paths: []cty.Path{cty.GetAttrPath("alpha"), cty.GetAttrPath("beta"), cty.GetAttrPath("gamma")},
+		},
+		"errors": {
+			json: `[
+  [
+    {
+      "type": "get_attr",
+	  "value": 5
+    }
+  ],
+  [
+    {
+      "type": "index",
+	  "value": "test"
+    }
+  ],
+  [
+    {
+      "type": "invalid_type",
+	  "value": ["this is invalid too"]
+    }
+  ]
+]`,
+			paths: []cty.Path{},
+			diags: []string{
+				"Failed to unmarshal get attr step name",
+				"Failed to unmarshal index step key",
+				"Unsupported path step",
+			},
+		},
+		"one invalid path, others valid": {
+			json: `[
+  [
+    {
+      "type": "get_attr",
+	  "value": "alpha"
+    }
+  ],
+  [
+    {
+      "type": "invalid_type",
+	  "value": ["this is invalid too"]
+    }
+  ],
+  [
+    {
+      "type": "get_attr",
+	  "value": "gamma"
+    }
+  ]
+]`,
+			paths: []cty.Path{cty.GetAttrPath("alpha"), cty.GetAttrPath("gamma")},
+			diags: []string{"Unsupported path step"},
+		},
+		"invalid structure": {
+			json:  `{}`,
+			paths: []cty.Path{},
+			diags: []string{"Error unmarshaling path steps"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			paths, diags := unmarshalPaths([]byte(tc.json))
+
+			if len(tc.diags) == 0 {
+				if len(diags) != 0 {
+					t.Errorf("expected no diags, got: %#v", diags)
+				}
+			} else {
+				if got, want := len(diags), len(tc.diags); got != want {
+					t.Fatalf("got %d diags, want %d\n%s", got, want, diags.Err())
+				}
+				for i := range tc.diags {
+					got := tfdiags.Diagnostics{diags[i]}.Err().Error()
+					if !strings.Contains(got, tc.diags[i]) {
+						t.Errorf("expected diag %d to contain %q, but was:\n%s", i, tc.diags[i], got)
+					}
+				}
+			}
+
+			if len(paths) != len(tc.paths) {
+				t.Fatalf("got %d paths, want %d", len(paths), len(tc.paths))
+			}
+			for i, path := range paths {
+				if !path.Equals(tc.paths[i]) {
+					t.Errorf("wrong paths\n got: %#v\nwant: %#v", path, tc.paths[i])
+				}
+			}
+		})
+	}
+}
+
+func TestVersion4_marshalPaths(t *testing.T) {
+	testCases := map[string]struct {
+		paths []cty.Path
+		json  string
+	}{
+		"no paths": {
+			paths: []cty.Path{},
+			json:  `[]`,
+		},
+		"attribute path": {
+			paths: []cty.Path{cty.GetAttrPath("password")},
+			json:  `[[{"type":"get_attr","value":"password"}]]`,
+		},
+		"attribute, number index, attribute": {
+			paths: []cty.Path{cty.GetAttrPath("identities").IndexInt(2).GetAttr("private_key")},
+			json:  `[[{"type":"get_attr","value":"identities"},{"type":"index","value":{"value":2,"type":"number"}},{"type":"get_attr","value":"private_key"}]]`,
+		},
+		"multiple paths": {
+			paths: []cty.Path{cty.GetAttrPath("a"), cty.GetAttrPath("b"), cty.GetAttrPath("c")},
+			json:  `[[{"type":"get_attr","value":"a"}],[{"type":"get_attr","value":"b"}],[{"type":"get_attr","value":"c"}]]`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			json, diags := marshalPaths(tc.paths)
+
+			if len(diags) != 0 {
+				t.Fatalf("expected no diags, got: %#v", diags)
+			}
+
+			if got, want := string(json), tc.json; got != want {
+				t.Fatalf("wrong JSON output\n got: %s\nwant: %s\n", got, want)
+			}
+		})
 	}
 }

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -11954,6 +11954,7 @@ resource "test_resource" "foo" {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
+	// Run a second apply with no changes
 	ctx = testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -11966,7 +11967,7 @@ resource "test_resource" "foo" {
 		t.Fatalf("plan errors: %s", diags.Err())
 	}
 
-	_, diags = ctx.Apply()
+	state, diags = ctx.Apply()
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -115,7 +115,7 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 
 	unmarkedBefore := change.Before
 	var beforePaths []cty.PathValueMarks
-	if change.After.ContainsMarked() {
+	if change.Before.ContainsMarked() {
 		unmarkedBefore, beforePaths = change.Before.UnmarkDeepWithPaths()
 	}
 

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -105,7 +105,7 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 
 	log.Printf("[DEBUG] %s: applying the planned %s change", n.Addr.Absolute(ctx.Path()), change.Action)
 
-	// If our config or After value contain any marked values,
+	// If our config, Before or After value contain any marked values,
 	// ensure those are stripped out before sending
 	// this to the provider
 	unmarkedConfigVal := configVal
@@ -114,9 +114,8 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	unmarkedBefore := change.Before
-	var beforePaths []cty.PathValueMarks
 	if change.Before.ContainsMarked() {
-		unmarkedBefore, beforePaths = change.Before.UnmarkDeepWithPaths()
+		unmarkedBefore, _ = change.Before.UnmarkDeep()
 	}
 
 	unmarkedAfter := change.After
@@ -147,9 +146,6 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 	newVal := resp.NewState
 
 	// If we have paths to mark, mark those on this new value
-	if len(beforePaths) > 0 {
-		newVal = newVal.MarkWithPaths(beforePaths)
-	}
 	if len(afterPaths) > 0 {
 		newVal = newVal.MarkWithPaths(afterPaths)
 	}

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -552,8 +552,6 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 
 	// Update the state if we care
 	if n.OutputState != nil {
-		fmt.Println("writing output state in eval diff")
-		fmt.Printf("planned new val contains marks %v\n", plannedNewVal.ContainsMarked())
 		*n.OutputState = &states.ResourceInstanceObject{
 			// We use the special "planned" status here to note that this
 			// object's value is not yet complete. Objects with this status

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -214,11 +214,10 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	unmarkedPriorVal := priorVal
-	var priorPaths []cty.PathValueMarks
 	if priorVal.ContainsMarked() {
 		// store the marked values so we can re-mark them later after
 		// we've sent things over the wire.
-		unmarkedPriorVal, priorPaths = priorVal.UnmarkDeepWithPaths()
+		unmarkedPriorVal, _ = priorVal.UnmarkDeep()
 	}
 
 	proposedNewVal := objchange.ProposedNewObject(schema, unmarkedPriorVal, unmarkedConfigVal)
@@ -284,9 +283,6 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 	// Add the marks back to the planned new value
 	if configVal.ContainsMarked() {
 		plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
-	}
-	if priorVal.ContainsMarked() {
-		plannedNewVal = plannedNewVal.MarkWithPaths(priorPaths)
 	}
 
 	// We allow the planned new value to disagree with configuration _values_

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -395,8 +395,8 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 				plannedChangedVal = cty.NullVal(priorChangedVal.Type())
 			}
 
-			// Unmark for this test for equality
-			// TODO: If one is marked and one is not, they are not equal!
+			// Unmark for this value for the equality test. If only sensitivity has changed,
+			// this does not require an Update or Replace
 			unmarkedPlannedChangedVal, _ := plannedChangedVal.UnmarkDeep()
 			eqV := unmarkedPlannedChangedVal.Equals(priorChangedVal)
 			if !eqV.IsKnown() || eqV.False() {
@@ -408,10 +408,9 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 		}
 	}
 
-	// Unmark for this test for equality
+	// Unmark for this test for equality. If only sensitivity has changed,
+	// this does not require an Update or Replace
 	unmarkedPlannedNewVal, _ := plannedNewVal.UnmarkDeep()
-
-	// TODO if one is marked and one is not, they are not equal!
 	eqV := unmarkedPlannedNewVal.Equals(unmarkedPriorVal)
 	eq := eqV.IsKnown() && eqV.True()
 

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -281,7 +281,7 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	// Add the marks back to the planned new value
-	if configVal.ContainsMarked() {
+	if len(unmarkedPaths) > 0 {
 		plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
 	}
 


### PR DESCRIPTION
When marking a variable value as sensitive, we want to be able to track that value's sensitivity when it changes, or when it is destroyed. Without having a sense of sensitivity of the "prior" value, this would mean that a `terraform plan` with a changed value to a non-sensitive value would expose the prior sensitive value, or any `terraform destroy` would expose the sensitive value.

The commits attached to this PR have a few commits dedicated to tests, but hopefully I've squashed down the commits into chunks that are more understandable.

The commit implementing the serialization strategy is https://github.com/hashicorp/terraform/pull/26338/commits/3049c29fcdcd3dd354c2cc42bf681506951a92e7, and the areas of interest are likely to be the states/instance_object.go, states/statefile/version4.go, and changes in terraform/eval_diff.go and terraform/eval_apply.go

