### PR TITLE
configs: Deprecate nested redundant interpolations

### DIFF
--- a/configs/testdata/warning-files/redundant_interp.tf
+++ b/configs/testdata/warning-files/redundant_interp.tf
@@ -29,9 +29,7 @@ resource "null_resource" "a" {
     # in the template.
     template = " ${var.triggers["greeting"]} "
 
-    # No warning for this one, because it's embedded inside a more complex
-    # expression and our check is only for direct assignment to attributes.
-    wrapped = ["${var.triggers["greeting"]}"]
+    wrapped = ["${var.triggers["greeting"]}"] # WARNING: Interpolation-only expressions are deprecated
   }
 }
 
@@ -41,6 +39,10 @@ module "foo" {
 }
 
 data "null_data_source" "b" {
+  inputs = {
+    host = "${var.triggers["host"]}" # WARNING: Interpolation-only expressions are deprecated
+  }
+
   has_computed_default = "${var.foo}" # WARNING: Interpolation-only expressions are deprecated
 }
 


### PR DESCRIPTION
Backport of #26334 to v0.13. Will update the "upgrade notes" section about these deprecations in the changelog.