### PR TITLE
tests: Add test for GetInputVariable, with sensitive config

### DIFF
--- a/terraform/evaluate_test.go
+++ b/terraform/evaluate_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -77,4 +78,46 @@ func TestEvaluatorGetPathAttr(t *testing.T) {
 			t.Errorf("wrong result %#v; want %#v", got, want)
 		}
 	})
+}
+
+// This particularly tests that a sensitive attribute in config
+// results in a value that has a "sensitive" cty Mark
+func TestEvaluatorGetInputVariable(t *testing.T) {
+	evaluator := &Evaluator{
+		Meta: &ContextMeta{
+			Env: "foo",
+		},
+		Config: &configs.Config{
+			Module: &configs.Module{
+				Variables: map[string]*configs.Variable{
+					"some_var": {
+						Name:      "some_var",
+						Sensitive: true,
+						Default:   cty.StringVal("foo"),
+					},
+				},
+			},
+		},
+		VariableValues: map[string]map[string]cty.Value{
+			"": {"some_var": cty.StringVal("bar")},
+		},
+		VariableValuesLock: &sync.Mutex{},
+	}
+
+	data := &evaluationStateData{
+		Evaluator: evaluator,
+	}
+	scope := evaluator.Scope(data, nil)
+
+	want := cty.StringVal("bar").Mark("sensitive")
+	got, diags := scope.Data.GetInputVariable(addrs.InputVariable{
+		Name: "some_var",
+	}, tfdiags.SourceRange{})
+
+	if len(diags) != 0 {
+		t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
+	}
+	if !got.RawEquals(want) {
+		t.Errorf("wrong result %#v; want %#v", got, want)
+	}
 }


### PR DESCRIPTION
This adds a test for GetInputVariable, and includes a variable with a "sensitive" attribute in configuration, to test that that value is marked as sensitive.