### PR TITLE
Update create_before_destroy in state during refresh

### DIFF
--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -534,6 +534,8 @@ func (n *EvalWriteResourceState) Eval(ctx EvalContext) (interface{}, error) {
 // the status of the lifecycle options stored in the state.
 // This currently only applies to create_before_destroy.
 type EvalRefreshLifecycle struct {
+	Addr addrs.AbsResourceInstance
+
 	Config *configs.Resource
 	// Prior State
 	State **states.ResourceInstanceObject
@@ -552,7 +554,8 @@ func (n *EvalRefreshLifecycle) Eval(ctx EvalContext) (interface{}, error) {
 	// In 0.13 we could be refreshing a resource with no config.
 	// We should be operating on managed resource, but check here to be certain
 	if n.Config == nil || n.Config.Managed == nil {
-		log.Print("[WARN] no Managed config value found in instance state")
+		log.Printf("[WARN] EvalRefreshLifecycle: no Managed config value found in instance state for %q", n.Addr)
+		return nil, nil
 	}
 
 	state.CreateBeforeDestroy = n.Config.Managed.CreateBeforeDestroy || n.ForceCreateBeforeDestroy

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -149,6 +149,7 @@ func (n *NodePlannableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 							Output:         &instanceRefreshState,
 						},
 						&EvalRefreshLifecycle{
+							Addr:                     addr,
 							Config:                   n.Config,
 							State:                    &instanceRefreshState,
 							ForceCreateBeforeDestroy: n.ForceCreateBeforeDestroy,

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -148,6 +148,11 @@ func (n *NodePlannableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 							ProviderSchema: &providerSchema,
 							Output:         &instanceRefreshState,
 						},
+						&EvalRefreshLifecycle{
+							Config:                   n.Config,
+							State:                    &instanceRefreshState,
+							ForceCreateBeforeDestroy: n.ForceCreateBeforeDestroy,
+						},
 						&EvalRefresh{
 							Addr:           addr.Resource,
 							ProviderAddr:   n.ResolvedProvider,


### PR DESCRIPTION
While `create_before_destroy` is stored in the instance state, the status would only be updated when a change to the resource was applied. This meant that if a resource was incorrectly created with the wrong option, it would require a change to the resource itself to fix, which may not be possible with all resources.

This change updates the stored `create_before_destroy` value while the resource is being refreshed.

Fixes #25473