### PR TITLE
0.13 backport 26343

### DIFF
--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -1698,3 +1698,56 @@ aws_instance.foo:
 
 	checkStateString(t, result, expect)
 }
+
+// verify that create_before_destroy is updated in the state during refresh
+func TestRefresh_updateLifecycle(t *testing.T) {
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "bar",
+		}.Instance(addrs.NoKey),
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"bar"}`),
+		},
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("aws"),
+			Module:   addrs.RootModule,
+		},
+	)
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "aws_instance" "bar" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`,
+	})
+
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+		State: state,
+	})
+
+	state, diags := ctx.Refresh()
+	if diags.HasErrors() {
+		t.Fatalf("plan errors: %s", diags.Err())
+	}
+
+	r := state.ResourceInstance(mustResourceInstanceAddr("aws_instance.bar"))
+	if !r.Current.CreateBeforeDestroy {
+		t.Fatal("create_before_destroy not updated in instance state")
+	}
+}

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -583,3 +583,36 @@ func (n *EvalRefreshDependencies) Eval(ctx EvalContext) (interface{}, error) {
 
 	return nil, nil
 }
+
+// EvalRefreshLifecycle is an EvalNode implementation that updates
+// the status of the lifecycle options stored in the state.
+// This currently only applies to create_before_destroy.
+type EvalRefreshLifecycle struct {
+	Addr addrs.AbsResourceInstance
+
+	Config *configs.Resource
+	// Prior State
+	State **states.ResourceInstanceObject
+	// ForceCreateBeforeDestroy indicates a create_before_destroy resource
+	// depends on this resource.
+	ForceCreateBeforeDestroy bool
+}
+
+func (n *EvalRefreshLifecycle) Eval(ctx EvalContext) (interface{}, error) {
+	state := *n.State
+	if state == nil {
+		// no existing state
+		return nil, nil
+	}
+
+	// In 0.13 we could be refreshing a resource with no config.
+	// We should be operating on managed resource, but check here to be certain
+	if n.Config == nil || n.Config.Managed == nil {
+		log.Printf("[WARN] EvalRefreshLifecycle: no Managed config value found in instance state for %q", n.Addr)
+		return nil, nil
+	}
+
+	state.CreateBeforeDestroy = n.Config.Managed.CreateBeforeDestroy || n.ForceCreateBeforeDestroy
+
+	return nil, nil
+}

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -283,6 +283,12 @@ func (n *NodeRefreshableManagedResourceInstance) evalTreeManagedResource() EvalN
 				Dependencies: &n.Dependencies,
 			},
 
+			&EvalRefreshLifecycle{
+				Addr:   n.Addr,
+				Config: n.Config,
+				State:  &state,
+			},
+
 			&EvalRefresh{
 				Addr:           addr.Resource,
 				ProviderAddr:   n.ResolvedProvider,


### PR DESCRIPTION
This is a 0.13 backport of #26343

Update the `create_before_destroy` status in state during refresh, in order to reflect the current configuration.

It's not quite as complete as the 0.14 version, as we can't update the forced `create_before_destroy` behavior due to the refresh walk not having that information, but it still allows a misconfigured resource to be manually updated in state with a refresh.
