### PR TITLE
command: Taint should respect required_version

### DIFF
--- a/command/testdata/taint-check-required-version/main.tf
+++ b/command/testdata/taint-check-required-version/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.9.0"
+}
+
+terraform {
+  required_version = ">= 0.13.0"
+}


### PR DESCRIPTION
Despite not requiring the configuration for any other reason, the taint subcommand should not execute if the required_version constraints cannot be met. Doing so can result in an undesirable state file upgrade.

Fixes #26325. Fixes #23049.

Question for reviewers: it feels to me like there ought to be a neater way of loading the config to check the constraints are met. Can you think of one? 🙏 