### PR TITLE
Re-implement -refresh=false

### DIFF
--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -78,6 +78,11 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, *configload.
 	opts.Targets = op.Targets
 	opts.UIInput = op.UIIn
 
+	opts.SkipRefresh = op.Type == backend.OperationTypePlan && !op.PlanRefresh
+	if opts.SkipRefresh {
+		log.Printf("[DEBUG] backend/local: skipping refresh of managed resources")
+	}
+
 	// Load the latest state. If we enter contextFromPlanFile below then the
 	// state snapshot in the plan file must match this, or else it'll return
 	// error diagnostics.

--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -678,6 +678,7 @@ func TestLocal_planOutPathNoChange(t *testing.T) {
 		Type:   "local",
 		Config: cfgRaw,
 	}
+	op.PlanRefresh = true
 
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {

--- a/backend/local/backend_refresh.go
+++ b/backend/local/backend_refresh.go
@@ -42,6 +42,9 @@ func (b *Local) opRefresh(
 		}
 	}
 
+	// Refresh now happens via a plan, so we need to ensure this is enabled
+	op.PlanRefresh = true
+
 	// Get our context
 	tfCtx, _, opState, contextDiags := b.context(op)
 	diags = diags.Append(contextDiags)

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -47,13 +47,14 @@ var (
 // ContextOpts are the user-configurable options to create a context with
 // NewContext.
 type ContextOpts struct {
-	Config    *configs.Config
-	Changes   *plans.Changes
-	State     *states.State
-	Targets   []addrs.Targetable
-	Variables InputValues
-	Meta      *ContextMeta
-	Destroy   bool
+	Config      *configs.Config
+	Changes     *plans.Changes
+	State       *states.State
+	Targets     []addrs.Targetable
+	Variables   InputValues
+	Meta        *ContextMeta
+	Destroy     bool
+	SkipRefresh bool
 
 	Hooks        []Hook
 	Parallelism  int
@@ -97,6 +98,7 @@ type Context struct {
 	changes      *plans.Changes
 	state        *states.State
 	refreshState *states.State
+	skipRefresh  bool
 	targets      []addrs.Targetable
 	variables    InputValues
 	meta         *ContextMeta
@@ -233,6 +235,7 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 		config:       config,
 		state:        state,
 		refreshState: state.DeepCopy(),
+		skipRefresh:  opts.SkipRefresh,
 		targets:      opts.Targets,
 		uiInput:      opts.UIInput,
 		variables:    variables,
@@ -293,12 +296,13 @@ func (c *Context) Graph(typ GraphType, opts *ContextGraphOpts) (*Graph, tfdiags.
 	case GraphTypePlan:
 		// Create the plan graph builder
 		return (&PlanGraphBuilder{
-			Config:     c.config,
-			State:      c.state,
-			Components: c.components,
-			Schemas:    c.schemas,
-			Targets:    c.targets,
-			Validate:   opts.Validate,
+			Config:      c.config,
+			State:       c.state,
+			Components:  c.components,
+			Schemas:     c.schemas,
+			Targets:     c.targets,
+			Validate:    opts.Validate,
+			skipRefresh: c.skipRefresh,
 		}).Build(addrs.RootModuleInstance)
 
 	case GraphTypePlanDestroy:

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -42,6 +42,9 @@ type PlanGraphBuilder struct {
 	// Validate will do structural validation of the graph.
 	Validate bool
 
+	// skipRefresh indicates that we should skip refreshing managed resources
+	skipRefresh bool
+
 	// CustomConcrete can be set to customize the node types created
 	// for various parts of the plan. This is useful in order to customize
 	// the plan behavior.
@@ -196,6 +199,7 @@ func (b *PlanGraphBuilder) init() {
 	b.ConcreteResource = func(a *NodeAbstractResource) dag.Vertex {
 		return &nodeExpandPlannableResource{
 			NodeAbstractResource: a,
+			skipRefresh:          b.skipRefresh,
 		}
 	}
 

--- a/terraform/node_resource_plan.go
+++ b/terraform/node_resource_plan.go
@@ -21,6 +21,9 @@ type nodeExpandPlannableResource struct {
 	// on regardless of what the configuration says.
 	ForceCreateBeforeDestroy *bool
 
+	// skipRefresh indicates that we should skip refreshing individual instances
+	skipRefresh bool
+
 	// We attach dependencies to the Resource during refresh, since the
 	// instances are instantiated during DynamicExpand.
 	dependencies []addrs.ConfigResource
@@ -82,6 +85,7 @@ func (n *nodeExpandPlannableResource) DynamicExpand(ctx EvalContext) (*Graph, er
 			Addr:                     resAddr,
 			ForceCreateBeforeDestroy: n.ForceCreateBeforeDestroy,
 			dependencies:             n.dependencies,
+			skipRefresh:              n.skipRefresh,
 		})
 	}
 
@@ -143,6 +147,9 @@ type NodePlannableResource struct {
 	// during graph construction, if dependencies require us to force this
 	// on regardless of what the configuration says.
 	ForceCreateBeforeDestroy *bool
+
+	// skipRefresh indicates that we should skip refreshing individual instances
+	skipRefresh bool
 
 	dependencies []addrs.ConfigResource
 }
@@ -243,6 +250,7 @@ func (n *NodePlannableResource) DynamicExpand(ctx EvalContext) (*Graph, error) {
 			// to force on CreateBeforeDestroy due to dependencies on other
 			// nodes that have it.
 			ForceCreateBeforeDestroy: n.CreateBeforeDestroy(),
+			skipRefresh:              n.skipRefresh,
 		}
 	}
 

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -16,6 +16,7 @@ import (
 type NodePlannableResourceInstance struct {
 	*NodeAbstractResourceInstance
 	ForceCreateBeforeDestroy bool
+	skipRefresh              bool
 }
 
 var (
@@ -134,29 +135,38 @@ func (n *NodePlannableResourceInstance) evalTreeManagedResource(addr addrs.AbsRe
 				ProviderSchema: &providerSchema,
 			},
 
-			// Refresh the instance
-			&EvalReadState{
-				Addr:           addr.Resource,
-				Provider:       &provider,
-				ProviderSchema: &providerSchema,
-				Output:         &instanceRefreshState,
-			},
-			&EvalRefresh{
-				Addr:           addr.Resource,
-				ProviderAddr:   n.ResolvedProvider,
-				Provider:       &provider,
-				ProviderMetas:  n.ProviderMetas,
-				ProviderSchema: &providerSchema,
-				State:          &instanceRefreshState,
-				Output:         &instanceRefreshState,
-			},
-			&EvalWriteState{
-				Addr:           addr.Resource,
-				ProviderAddr:   n.ResolvedProvider,
-				State:          &instanceRefreshState,
-				ProviderSchema: &providerSchema,
-				targetState:    refreshState,
-				Dependencies:   &n.Dependencies,
+			&EvalIf{
+				If: func(ctx EvalContext) (bool, error) {
+					return !n.skipRefresh, nil
+				},
+				Then: &EvalSequence{
+					Nodes: []EvalNode{
+						// Refresh the instance
+						&EvalReadState{
+							Addr:           addr.Resource,
+							Provider:       &provider,
+							ProviderSchema: &providerSchema,
+							Output:         &instanceRefreshState,
+						},
+						&EvalRefresh{
+							Addr:           addr.Resource,
+							ProviderAddr:   n.ResolvedProvider,
+							Provider:       &provider,
+							ProviderMetas:  n.ProviderMetas,
+							ProviderSchema: &providerSchema,
+							State:          &instanceRefreshState,
+							Output:         &instanceRefreshState,
+						},
+						&EvalWriteState{
+							Addr:           addr.Resource,
+							ProviderAddr:   n.ResolvedProvider,
+							State:          &instanceRefreshState,
+							ProviderSchema: &providerSchema,
+							targetState:    refreshState,
+							Dependencies:   &n.Dependencies,
+						},
+					},
+				},
 			},
 
 			// Plan the instance


### PR DESCRIPTION
Recreate the behavior of `-refresh=false` in plan. While this would previously skip some refreshing of data sources, this is now limited specifically to managed resources.

Since there is no longer a separate refresh walk, we need to thread the `-refresh=false` option all the way to the instance node for planning. We reverse the bool and use `skipRefresh` in core to prevent any unintended changes from the default behavior.
