### PR TITLE
Further work towards provider dependency pinning MVP

### DIFF
--- a/command/providers_mirror.go
+++ b/command/providers_mirror.go
@@ -269,8 +269,8 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 				indexArchives[version] = map[string]interface{}{}
 			}
 			indexArchives[version][platform.String()] = map[string]interface{}{
-				"url":    archiveFilename, // a relative URL from the index file's URL
-				"hashes": []string{hash},  // an array to allow for additional hash formats in future
+				"url":    archiveFilename,         // a relative URL from the index file's URL
+				"hashes": []string{hash.String()}, // an array to allow for additional hash formats in future
 			}
 		}
 		mainIndex := map[string]interface{}{

--- a/internal/depsfile/locks.go
+++ b/internal/depsfile/locks.go
@@ -2,7 +2,6 @@ package depsfile
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/internal/getproviders"
@@ -58,13 +57,10 @@ func (l *Locks) Provider(addr addrs.Provider) *ProviderLock {
 // non-lockable provider address then this function will panic. Use
 // function ProviderIsLockable to determine whether a particular provider
 // should participate in the version locking mechanism.
-func (l *Locks) SetProvider(addr addrs.Provider, version getproviders.Version, constraints getproviders.VersionConstraints, hashes []string) *ProviderLock {
+func (l *Locks) SetProvider(addr addrs.Provider, version getproviders.Version, constraints getproviders.VersionConstraints, hashes []getproviders.Hash) *ProviderLock {
 	if !ProviderIsLockable(addr) {
 		panic(fmt.Sprintf("Locks.SetProvider with non-lockable provider %s", addr))
 	}
-
-	// Normalize the hash lists into a consistent order.
-	sort.Strings(hashes)
 
 	new := &ProviderLock{
 		addr:               addr,
@@ -137,7 +133,7 @@ type ProviderLock struct {
 	// means we can only populate the hash for the current platform, and so
 	// it won't be possible to verify a subsequent installation of the same
 	// provider on a different platform.
-	hashes []string
+	hashes []getproviders.Hash
 }
 
 // Provider returns the address of the provider this lock applies to.
@@ -172,7 +168,7 @@ func (l *ProviderLock) VersionConstraints() getproviders.VersionConstraints {
 // of which must match in order for verification to be considered successful.
 //
 // Do not modify the backing array of the returned slice.
-func (l *ProviderLock) AllHashes() []string {
+func (l *ProviderLock) AllHashes() []getproviders.Hash {
 	return l.hashes
 }
 
@@ -183,6 +179,6 @@ func (l *ProviderLock) AllHashes() []string {
 //
 // At least one of the given hashes must match for a package to be considered
 // valud.
-func (l *ProviderLock) PreferredHashes() []string {
+func (l *ProviderLock) PreferredHashes() []getproviders.Hash {
 	return getproviders.PreferredHashes(l.hashes)
 }

--- a/internal/depsfile/locks.go
+++ b/internal/depsfile/locks.go
@@ -58,15 +58,13 @@ func (l *Locks) Provider(addr addrs.Provider) *ProviderLock {
 // non-lockable provider address then this function will panic. Use
 // function ProviderIsLockable to determine whether a particular provider
 // should participate in the version locking mechanism.
-func (l *Locks) SetProvider(addr addrs.Provider, version getproviders.Version, constraints getproviders.VersionConstraints, hashes map[getproviders.Platform][]string) *ProviderLock {
+func (l *Locks) SetProvider(addr addrs.Provider, version getproviders.Version, constraints getproviders.VersionConstraints, hashes []string) *ProviderLock {
 	if !ProviderIsLockable(addr) {
 		panic(fmt.Sprintf("Locks.SetProvider with non-lockable provider %s", addr))
 	}
 
 	// Normalize the hash lists into a consistent order.
-	for _, slice := range hashes {
-		sort.Strings(slice)
-	}
+	sort.Strings(hashes)
 
 	new := &ProviderLock{
 		addr:               addr,
@@ -112,9 +110,9 @@ type ProviderLock struct {
 	version            getproviders.Version
 	versionConstraints getproviders.VersionConstraints
 
-	// hashes contains one or more hashes of packages or package contents
-	// for the package associated with the selected version on each supported
-	// architecture.
+	// hashes contains zero or more hashes of packages or package contents
+	// for the package associated with the selected version across all of
+	// the supported platforms.
 	//
 	// hashes can contain a mixture of hashes in different formats to support
 	// changes over time. The new-style hash format is to have a string
@@ -131,7 +129,7 @@ type ProviderLock struct {
 	// when we have the original .zip file exactly; we can't verify a local
 	// directory containing the unpacked contents of that .zip file.
 	//
-	// We ideally want to populate hashes for all available architectures at
+	// We ideally want to populate hashes for all available platforms at
 	// once, by referring to the signed checksums file in the upstream
 	// registry. In that ideal case it's possible to later work with the same
 	// configuration on a different platform while still verifying the hashes.
@@ -139,7 +137,7 @@ type ProviderLock struct {
 	// means we can only populate the hash for the current platform, and so
 	// it won't be possible to verify a subsequent installation of the same
 	// provider on a different platform.
-	hashes map[getproviders.Platform][]string
+	hashes []string
 }
 
 // Provider returns the address of the provider this lock applies to.
@@ -164,23 +162,27 @@ func (l *ProviderLock) VersionConstraints() getproviders.VersionConstraints {
 	return l.versionConstraints
 }
 
-// HashesForPlatform returns all of the package hashes that were recorded for
-// the given platform when this lock was created. If no hashes were recorded
-// for that platform, the result is a zero-length slice.
+// AllHashes returns all of the package hashes that were recorded when this
+// lock was created. If no hashes were recorded for that platform, the result
+// is a zero-length slice.
 //
 // If your intent is to verify a package against the recorded hashes, use
-// PreferredHashForPlatform to get a single hash which the current version
-// of Terraform considers the strongest of the available hashes, which is
-// the one that must pass for verification to be considered successful.
+// PreferredHashes to get only the hashes which the current version
+// of Terraform considers the strongest of the available hashing schemes, one
+// of which must match in order for verification to be considered successful.
 //
 // Do not modify the backing array of the returned slice.
-func (l *ProviderLock) HashesForPlatform(platform getproviders.Platform) []string {
-	return l.hashes[platform]
+func (l *ProviderLock) AllHashes() []string {
+	return l.hashes
 }
 
-// PreferredHashForPlatform returns a single hash which must match for a package
-// for the given platform to be considered valid, or an empty string if there
-// are no acceptable hashes recorded for the given platform.
-func (l *ProviderLock) PreferredHashForPlatform(platform getproviders.Platform) string {
-	return getproviders.PreferredHash(l.hashes[platform])
+// PreferredHashes returns a filtered version of the AllHashes return value
+// which includes only the strongest of the availabile hash schemes, in
+// case legacy hash schemes are deprecated over time but still supported for
+// upgrade purposes.
+//
+// At least one of the given hashes must match for a package to be considered
+// valud.
+func (l *ProviderLock) PreferredHashes() []string {
+	return getproviders.PreferredHashes(l.hashes)
 }

--- a/internal/depsfile/locks_file.go
+++ b/internal/depsfile/locks_file.go
@@ -101,29 +101,15 @@ func SaveLocksToFile(locks *Locks, filename string) tfdiags.Diagnostics {
 			body.SetAttributeValue("constraints", cty.StringVal(constraintsStr))
 		}
 		if len(lock.hashes) != 0 {
-			platforms := make([]getproviders.Platform, 0, len(lock.hashes))
-			for platform := range lock.hashes {
-				platforms = append(platforms, platform)
+			hashVals := make([]cty.Value, 0, len(lock.hashes))
+			for _, str := range lock.hashes {
+				hashVals = append(hashVals, cty.StringVal(str))
 			}
-			sort.Slice(platforms, func(i, j int) bool {
-				return platforms[i].LessThan(platforms[j])
-			})
-			body.AppendNewline()
-			hashesBlock := body.AppendNewBlock("hashes", nil)
-			hashesBody := hashesBlock.Body()
-			for platform, hashes := range lock.hashes {
-				vals := make([]cty.Value, len(hashes))
-				for i := range hashes {
-					vals[i] = cty.StringVal(hashes[i])
-				}
-				var hashList cty.Value
-				if len(vals) > 0 {
-					hashList = cty.ListVal(vals)
-				} else {
-					hashList = cty.ListValEmpty(cty.String)
-				}
-				hashesBody.SetAttributeValue(platform.String(), hashList)
-			}
+			// We're using a set rather than a list here because the order
+			// isn't significant and SetAttributeValue will automatically
+			// write the set elements in a consistent lexical order.
+			hashSet := cty.SetVal(hashVals)
+			body.SetAttributeValue("hashes", hashSet)
 		}
 	}
 
@@ -276,44 +262,38 @@ func decodeProviderLockFromHCL(block *hcl.Block) (*ProviderLock, tfdiags.Diagnos
 
 	ret.addr = addr
 
-	// We'll decode the block body using gohcl, because we don't have any
-	// special structural validation to do other than what gohcl will naturally
-	// do for us here.
-	type RawHashes struct {
-		// We'll consume all of the attributes and process them dynamically.
-		Hashes hcl.Attributes `hcl:",remain"`
-	}
-	type Provider struct {
-		Version            hcl.Expression `hcl:"version,attr"`
-		VersionConstraints hcl.Expression `hcl:"constraints,attr"`
-		HashesBlock        *RawHashes     `hcl:"hashes,block"`
-	}
-	var raw Provider
-	hclDiags := gohcl.DecodeBody(block.Body, nil, &raw)
+	content, hclDiags := block.Body.Content(&hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{Name: "version", Required: true},
+			{Name: "constraints"},
+			{Name: "hashes"},
+		},
+	})
 	diags = diags.Append(hclDiags)
-	if hclDiags.HasErrors() {
-		return ret, diags
-	}
 
-	version, moreDiags := decodeProviderVersionArgument(addr, raw.Version)
+	version, moreDiags := decodeProviderVersionArgument(addr, content.Attributes["version"])
 	ret.version = version
 	diags = diags.Append(moreDiags)
 
-	constraints, moreDiags := decodeProviderVersionConstraintsArgument(addr, raw.VersionConstraints)
+	constraints, moreDiags := decodeProviderVersionConstraintsArgument(addr, content.Attributes["constraints"])
 	ret.versionConstraints = constraints
 	diags = diags.Append(moreDiags)
 
-	if raw.HashesBlock != nil {
-		hashes, moreDiags := decodeProviderHashesArgument(addr, raw.HashesBlock.Hashes)
-		ret.hashes = hashes
-		diags = diags.Append(moreDiags)
-	}
+	hashes, moreDiags := decodeProviderHashesArgument(addr, content.Attributes["hashes"])
+	ret.hashes = hashes
+	diags = diags.Append(moreDiags)
 
 	return ret, diags
 }
 
-func decodeProviderVersionArgument(provider addrs.Provider, expr hcl.Expression) (getproviders.Version, tfdiags.Diagnostics) {
+func decodeProviderVersionArgument(provider addrs.Provider, attr *hcl.Attribute) (getproviders.Version, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
+	if attr == nil {
+		// It's not okay to omit this argument, but the caller should already
+		// have generated diagnostics about that.
+		return getproviders.UnspecifiedVersion, diags
+	}
+	expr := attr.Expr
 
 	var raw *string
 	hclDiags := gohcl.DecodeExpression(expr, nil, &raw)
@@ -334,7 +314,7 @@ func decodeProviderVersionArgument(provider addrs.Provider, expr hcl.Expression)
 	if err != nil {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  "Invalid version number",
+			Summary:  "Invalid provider version number",
 			Detail:   fmt.Sprintf("The selected version number for provider %s is invalid: %s.", provider, err),
 			Subject:  expr.Range().Ptr(),
 		})
@@ -344,7 +324,7 @@ func decodeProviderVersionArgument(provider addrs.Provider, expr hcl.Expression)
 		// that a file diff will show changes that are entirely cosmetic.
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  "Invalid version number",
+			Summary:  "Invalid provider version number",
 			Detail:   fmt.Sprintf("The selected version number for provider %s must be written in normalized form: %q.", provider, canon),
 			Subject:  expr.Range().Ptr(),
 		})
@@ -352,34 +332,35 @@ func decodeProviderVersionArgument(provider addrs.Provider, expr hcl.Expression)
 	return version, diags
 }
 
-func decodeProviderVersionConstraintsArgument(provider addrs.Provider, expr hcl.Expression) (getproviders.VersionConstraints, tfdiags.Diagnostics) {
+func decodeProviderVersionConstraintsArgument(provider addrs.Provider, attr *hcl.Attribute) (getproviders.VersionConstraints, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
+	if attr == nil {
+		// It's okay to omit this argument.
+		return nil, diags
+	}
+	expr := attr.Expr
 
-	var raw *string
+	var raw string
 	hclDiags := gohcl.DecodeExpression(expr, nil, &raw)
 	diags = diags.Append(hclDiags)
 	if hclDiags.HasErrors() {
 		return nil, diags
 	}
-	if raw == nil {
-		// It's okay to omit this argument.
-		return nil, diags
-	}
-	constraints, err := getproviders.ParseVersionConstraints(*raw)
+	constraints, err := getproviders.ParseVersionConstraints(raw)
 	if err != nil {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  "Invalid version constraints",
+			Summary:  "Invalid provider version constraints",
 			Detail:   fmt.Sprintf("The recorded version constraints for provider %s are invalid: %s.", provider, err),
 			Subject:  expr.Range().Ptr(),
 		})
 	}
-	if canon := getproviders.VersionConstraintsString(constraints); canon != *raw {
+	if canon := getproviders.VersionConstraintsString(constraints); canon != raw {
 		// Canonical forms are required in the lock file, to reduce the risk
 		// that a file diff will show changes that are entirely cosmetic.
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  "Invalid version constraints",
+			Summary:  "Invalid provider version constraints",
 			Detail:   fmt.Sprintf("The recorded version constraints for provider %s must be written in normalized form: %q.", provider, canon),
 			Subject:  expr.Range().Ptr(),
 		})
@@ -388,49 +369,45 @@ func decodeProviderVersionConstraintsArgument(provider addrs.Provider, expr hcl.
 	return constraints, diags
 }
 
-func decodeProviderHashesArgument(provider addrs.Provider, attrs hcl.Attributes) (map[getproviders.Platform][]string, tfdiags.Diagnostics) {
-	if len(attrs) == 0 {
-		return nil, nil
-	}
-	ret := make(map[getproviders.Platform][]string, len(attrs))
+func decodeProviderHashesArgument(provider addrs.Provider, attr *hcl.Attribute) ([]string, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
+	if attr == nil {
+		// It's okay to omit this argument.
+		return nil, diags
+	}
+	expr := attr.Expr
 
-	for platformStr, attr := range attrs {
-		platform, err := getproviders.ParsePlatform(platformStr)
-		if err != nil {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid provider hash platform",
-				Detail:   fmt.Sprintf("The string %q is not a valid platform specification: %s.", platformStr, err),
-				Subject:  attr.NameRange.Ptr(),
-			})
-			continue
-		}
-		if canon := platform.String(); canon != platformStr {
-			// Canonical forms are required in the lock file, to reduce the risk
-			// that a file diff will show changes that are entirely cosmetic.
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid provider hash platform",
-				Detail:   fmt.Sprintf("The platform specification %q must be written in the normalized form %q.", platformStr, canon),
-				Subject:  attr.NameRange.Ptr(),
-			})
-			continue
-		}
+	// We'll decode this argument using the HCL static analysis mode, because
+	// there's no reason for the hashes list to be dynamic and this way we can
+	// give more precise feedback on individual elements that are invalid,
+	// with direct source locations.
+	hashExprs, hclDiags := hcl.ExprList(expr)
+	diags = diags.Append(hclDiags)
+	if hclDiags.HasErrors() {
+		return nil, diags
+	}
+	if len(hashExprs) == 0 {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid provider hash set",
+			Detail:   "The \"hashes\" argument must either be omitted or contain at least one hash value.",
+			Subject:  expr.Range().Ptr(),
+		})
+		return nil, diags
+	}
 
-		var hashes []string
-		hclDiags := gohcl.DecodeExpression(attr.Expr, nil, &hashes)
+	ret := make([]string, 0, len(hashExprs))
+	for _, hashExpr := range hashExprs {
+		var raw string
+		hclDiags := gohcl.DecodeExpression(hashExpr, nil, &raw)
 		diags = diags.Append(hclDiags)
 		if hclDiags.HasErrors() {
 			continue
 		}
-
-		// We don't validate the hashes, because we expect to support different
-		// hash formats over time and so we'll assume any that are in formats
-		// we don't understand are from later Terraform versions, or perhaps
-		// from an origin registry that is offering hashes aimed at a later
-		// Terraform version.
-		ret[platform] = hashes
+		// TODO: Validate the hash syntax, but not the actual hash schemes
+		// because we expect to support different hash formats over time and
+		// will silently ignore ones that we no longer prefer.
+		ret = append(ret, raw)
 	}
 
 	return ret, diags

--- a/internal/depsfile/locks_file_test.go
+++ b/internal/depsfile/locks_file_test.go
@@ -144,14 +144,10 @@ func TestLoadLocksFromFile(t *testing.T) {
 						if got, want := getproviders.VersionConstraintsString(lock.VersionConstraints()), ">= 3.0.2"; got != want {
 							t.Errorf("wrong version constraints\ngot:  %s\nwant: %s", got, want)
 						}
-						wantHashes := map[getproviders.Platform][]string{
-							{OS: "amigaos", Arch: "m68k"}: {
-								"placeholder-hash-1",
-							},
-							{OS: "tos", Arch: "m68k"}: {
-								"placeholder-hash-2",
-								"placeholder-hash-3",
-							},
+						wantHashes := []string{
+							"test:placeholder-hash-1",
+							"test:placeholder-hash-2",
+							"test:placeholder-hash-3",
 						}
 						if diff := cmp.Diff(wantHashes, lock.hashes); diff != "" {
 							t.Errorf("wrong hashes\n%s", diff)
@@ -173,12 +169,10 @@ func TestSaveLocksToFile(t *testing.T) {
 	oneDotTwo := getproviders.MustParseVersion("1.2.0")
 	atLeastOneDotOh := getproviders.MustParseVersionConstraints(">= 1.0.0")
 	pessimisticOneDotOh := getproviders.MustParseVersionConstraints("~> 1")
-	hashes := map[getproviders.Platform][]string{
-		{OS: "riscos", Arch: "arm"}: {
-			"cccccccccccccccccccccccccccccccccccccccccccccccc",
-			"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		},
+	hashes := []string{
+		"test:cccccccccccccccccccccccccccccccccccccccccccccccc",
+		"test:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"test:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}
 	locks.SetProvider(fooProvider, oneDotOh, atLeastOneDotOh, hashes)
 	locks.SetProvider(barProvider, oneDotTwo, pessimisticOneDotOh, nil)
@@ -216,10 +210,7 @@ provider "registry.terraform.io/test/baz" {
 provider "registry.terraform.io/test/foo" {
   version     = "1.0.0"
   constraints = ">= 1.0.0"
-
-  hashes {
-    riscos_arm = ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "cccccccccccccccccccccccccccccccccccccccccccccccc"]
-  }
+  hashes      = ["test:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "test:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "test:cccccccccccccccccccccccccccccccccccccccccccccccc"]
 }
 `
 	if diff := cmp.Diff(wantContent, gotContent); diff != "" {

--- a/internal/depsfile/locks_file_test.go
+++ b/internal/depsfile/locks_file_test.go
@@ -144,10 +144,10 @@ func TestLoadLocksFromFile(t *testing.T) {
 						if got, want := getproviders.VersionConstraintsString(lock.VersionConstraints()), ">= 3.0.2"; got != want {
 							t.Errorf("wrong version constraints\ngot:  %s\nwant: %s", got, want)
 						}
-						wantHashes := []string{
-							"test:placeholder-hash-1",
-							"test:placeholder-hash-2",
-							"test:placeholder-hash-3",
+						wantHashes := []getproviders.Hash{
+							getproviders.MustParseHash("test:placeholder-hash-1"),
+							getproviders.MustParseHash("test:placeholder-hash-2"),
+							getproviders.MustParseHash("test:placeholder-hash-3"),
 						}
 						if diff := cmp.Diff(wantHashes, lock.hashes); diff != "" {
 							t.Errorf("wrong hashes\n%s", diff)
@@ -169,10 +169,10 @@ func TestSaveLocksToFile(t *testing.T) {
 	oneDotTwo := getproviders.MustParseVersion("1.2.0")
 	atLeastOneDotOh := getproviders.MustParseVersionConstraints(">= 1.0.0")
 	pessimisticOneDotOh := getproviders.MustParseVersionConstraints("~> 1")
-	hashes := []string{
-		"test:cccccccccccccccccccccccccccccccccccccccccccccccc",
-		"test:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-		"test:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	hashes := []getproviders.Hash{
+		getproviders.MustParseHash("test:cccccccccccccccccccccccccccccccccccccccccccccccc"),
+		getproviders.MustParseHash("test:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+		getproviders.MustParseHash("test:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
 	}
 	locks.SetProvider(fooProvider, oneDotOh, atLeastOneDotOh, hashes)
 	locks.SetProvider(barProvider, oneDotTwo, pessimisticOneDotOh, nil)

--- a/internal/depsfile/testdata/locks-files/invalid-versions.hcl
+++ b/internal/depsfile/testdata/locks-files/invalid-versions.hcl
@@ -1,25 +1,25 @@
 provider "terraform.io/test/foo" {
-  version = "" # ERROR: Invalid version number
+  version = "" # ERROR: Invalid provider version number
 }
 
 provider "terraform.io/test/bar" {
   # The "v" prefix is not expected here
-  version = "v1.0.0" # ERROR: Invalid version number
+  version = "v1.0.0" # ERROR: Invalid provider version number
 }
 
 provider "terraform.io/test/baz" {
   # Must be written in the canonical form, with three parts
-  version = "1.0" # ERROR: Invalid version number
+  version = "1.0" # ERROR: Invalid provider version number
 }
 
 provider "terraform.io/test/boop" {
   # Must be written in the canonical form, with three parts
-  version = "1" # ERROR: Invalid version number
+  version = "1" # ERROR: Invalid provider version number
 }
 
 provider "terraform.io/test/blep" {
   # Mustn't use redundant extra zero padding
-  version = "1.02" # ERROR: Invalid version number
+  version = "1.02" # ERROR: Invalid provider version number
 }
 
 provider "terraform.io/test/huzzah" { # ERROR: Missing required argument

--- a/internal/depsfile/testdata/locks-files/valid-provider-locks.hcl
+++ b/internal/depsfile/testdata/locks-files/valid-provider-locks.hcl
@@ -12,13 +12,9 @@ provider "terraform.io/test/all-the-things" {
   version = "3.0.10"
   constraints = ">= 3.0.2"
 
-  hashes {
-    amigaos_m68k = [
-      "placeholder-hash-1",
-    ]
-    tos_m68k = [
-      "placeholder-hash-2",
-      "placeholder-hash-3",
-    ]
-  }
+  hashes = [
+    "test:placeholder-hash-1",
+    "test:placeholder-hash-2",
+    "test:placeholder-hash-3",
+  ]
 }

--- a/internal/getproviders/filesystem_mirror_source_test.go
+++ b/internal/getproviders/filesystem_mirror_source_test.go
@@ -140,6 +140,10 @@ func TestFilesystemMirrorSourcePackageMeta(t *testing.T) {
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("incorrect result\n%s", diff)
 		}
+
+		if gotHashes := got.AcceptableHashes(); len(gotHashes) != 0 {
+			t.Errorf("wrong acceptable hashes\ngot:  %#v\nwant: none", gotHashes)
+		}
 	})
 	t.Run("unavailable platform", func(t *testing.T) {
 		source := NewFilesystemMirrorSource("testdata/filesystem-mirror")

--- a/internal/getproviders/hash.go
+++ b/internal/getproviders/hash.go
@@ -57,7 +57,7 @@ func PackageMatchesHash(loc PackageLocation, want string) (bool, error) {
 	}
 }
 
-// PreferredHash examines all of the given hash strings and returns the one
+// PreferredHashes examines all of the given hash strings and returns the one
 // that the current version of Terraform considers to provide the strongest
 // verification.
 //
@@ -65,13 +65,14 @@ func PackageMatchesHash(loc PackageLocation, want string) (bool, error) {
 // format. If PreferredHash returns a non-empty string then it will be one
 // of the hash strings in "given", and that hash is the one that must pass
 // verification in order for a package to be considered valid.
-func PreferredHash(given []string) string {
+func PreferredHashes(given []string) []string {
+	var ret []string
 	for _, s := range given {
 		if strings.HasPrefix(s, h1Prefix) {
-			return s
+			return append(ret, s)
 		}
 	}
-	return ""
+	return ret
 }
 
 // PackageHashLegacyZipSHA implements the old provider package hashing scheme

--- a/internal/getproviders/hash_test.go
+++ b/internal/getproviders/hash_test.go
@@ -1,0 +1,70 @@
+package getproviders
+
+import (
+	"testing"
+)
+
+func TestParseHash(t *testing.T) {
+	tests := []struct {
+		Input   string
+		Want    Hash
+		WantErr string
+	}{
+		{
+			Input: "h1:foo",
+			Want:  HashScheme1.New("foo"),
+		},
+		{
+			Input: "zh:bar",
+			Want:  HashSchemeZip.New("bar"),
+		},
+		{
+			// A scheme we don't know is considered valid syntax, it just won't match anything.
+			Input: "unknown:baz",
+			Want:  HashScheme("unknown:").New("baz"),
+		},
+		{
+			// A scheme with an empty value is weird, but allowed.
+			Input: "unknown:",
+			Want:  HashScheme("unknown:").New(""),
+		},
+		{
+			Input:   "",
+			WantErr: "hash string must start with a scheme keyword followed by a colon",
+		},
+		{
+			// A naked SHA256 hash in hex format is not sufficient
+			Input:   "1e5f7a5f3ade7b8b1d1d59c5cea2e1a2f8d2f8c3f41962dbbe8647e222be8239",
+			WantErr: "hash string must start with a scheme keyword followed by a colon",
+		},
+		{
+			// An empty scheme is not allowed
+			Input:   ":blah",
+			WantErr: "hash string must start with a scheme keyword followed by a colon",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			got, err := ParseHash(test.Input)
+
+			if test.WantErr != "" {
+				if err == nil {
+					t.Fatalf("want error: %s", test.WantErr)
+				}
+				if got, want := err.Error(), test.WantErr; got != want {
+					t.Fatalf("wrong error\ngot:  %s\nwant: %s", got, want)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			if got != test.Want {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}

--- a/internal/getproviders/http_mirror_source.go
+++ b/internal/getproviders/http_mirror_source.go
@@ -225,7 +225,18 @@ func (s *HTTPMirrorSource) PackageMeta(provider addrs.Provider, version Version,
 	// A network mirror might not provide any hashes at all, in which case
 	// the package has no source-defined authentication whatsoever.
 	if len(archiveMeta.Hashes) > 0 {
-		ret.Authentication = NewPackageHashAuthentication(target, archiveMeta.Hashes)
+		hashes := make([]Hash, 0, len(archiveMeta.Hashes))
+		for _, hashStr := range archiveMeta.Hashes {
+			hash, err := ParseHash(hashStr)
+			if err != nil {
+				return PackageMeta{}, s.errQueryFailed(
+					provider,
+					fmt.Errorf("provider mirror returned invalid provider hash %q: %s", hashStr, err),
+				)
+			}
+			hashes = append(hashes, hash)
+		}
+		ret.Authentication = NewPackageHashAuthentication(target, hashes)
 	}
 
 	return ret, nil

--- a/internal/getproviders/http_mirror_source.go
+++ b/internal/getproviders/http_mirror_source.go
@@ -225,7 +225,7 @@ func (s *HTTPMirrorSource) PackageMeta(provider addrs.Provider, version Version,
 	// A network mirror might not provide any hashes at all, in which case
 	// the package has no source-defined authentication whatsoever.
 	if len(archiveMeta.Hashes) > 0 {
-		ret.Authentication = NewPackageHashAuthentication(archiveMeta.Hashes)
+		ret.Authentication = NewPackageHashAuthentication(target, archiveMeta.Hashes)
 	}
 
 	return ret, nil

--- a/internal/getproviders/http_mirror_source_test.go
+++ b/internal/getproviders/http_mirror_source_test.go
@@ -124,10 +124,20 @@ func TestHTTPMirrorSource(t *testing.T) {
 			Location:       PackageHTTPURL(httpServer.URL + "/terraform.io/test/exists/terraform-provider-test_v1.0.0_tos_m68k.zip"),
 			Authentication: packageHashAuthentication{
 				RequiredHash: "h1:placeholder-hash",
+				ValidHashes:  []string{"h1:placeholder-hash", "h0:unacceptable-hash"},
+				Platform:     Platform{"tos", "m68k"},
 			},
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("wrong result\n%s", diff)
+		}
+
+		gotHashes := got.AcceptableHashes()
+		wantHashes := map[Platform][]string{
+			tosPlatform: {"h1:placeholder-hash", "h0:unacceptable-hash"},
+		}
+		if diff := cmp.Diff(wantHashes, gotHashes); diff != "" {
+			t.Errorf("wrong acceptable hashes\n%s", diff)
 		}
 	})
 	t.Run("PackageMeta for a version that exists and has no hash", func(t *testing.T) {
@@ -238,7 +248,8 @@ func testHTTPMirrorSourceHandler(resp http.ResponseWriter, req *http.Request) {
 					"tos_m68k": {
 						"url": "terraform-provider-test_v1.0.0_tos_m68k.zip",
 						"hashes": [
-							"h1:placeholder-hash"
+							"h1:placeholder-hash",
+							"h0:unacceptable-hash"
 						]
 					}
 				}

--- a/internal/getproviders/http_mirror_source_test.go
+++ b/internal/getproviders/http_mirror_source_test.go
@@ -123,9 +123,9 @@ func TestHTTPMirrorSource(t *testing.T) {
 			Filename:       "terraform-provider-test_v1.0.0_tos_m68k.zip",
 			Location:       PackageHTTPURL(httpServer.URL + "/terraform.io/test/exists/terraform-provider-test_v1.0.0_tos_m68k.zip"),
 			Authentication: packageHashAuthentication{
-				RequiredHash: "h1:placeholder-hash",
-				ValidHashes:  []Hash{"h1:placeholder-hash", "h0:unacceptable-hash"},
-				Platform:     Platform{"tos", "m68k"},
+				RequiredHashes: []Hash{"h1:placeholder-hash"},
+				AllHashes:      []Hash{"h1:placeholder-hash", "h0:unacceptable-hash"},
+				Platform:       Platform{"tos", "m68k"},
 			},
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
@@ -133,9 +133,7 @@ func TestHTTPMirrorSource(t *testing.T) {
 		}
 
 		gotHashes := got.AcceptableHashes()
-		wantHashes := map[Platform][]Hash{
-			tosPlatform: {"h1:placeholder-hash", "h0:unacceptable-hash"},
-		}
+		wantHashes := []Hash{"h1:placeholder-hash", "h0:unacceptable-hash"}
 		if diff := cmp.Diff(wantHashes, gotHashes); diff != "" {
 			t.Errorf("wrong acceptable hashes\n%s", diff)
 		}

--- a/internal/getproviders/http_mirror_source_test.go
+++ b/internal/getproviders/http_mirror_source_test.go
@@ -124,7 +124,7 @@ func TestHTTPMirrorSource(t *testing.T) {
 			Location:       PackageHTTPURL(httpServer.URL + "/terraform.io/test/exists/terraform-provider-test_v1.0.0_tos_m68k.zip"),
 			Authentication: packageHashAuthentication{
 				RequiredHash: "h1:placeholder-hash",
-				ValidHashes:  []string{"h1:placeholder-hash", "h0:unacceptable-hash"},
+				ValidHashes:  []Hash{"h1:placeholder-hash", "h0:unacceptable-hash"},
 				Platform:     Platform{"tos", "m68k"},
 			},
 		}
@@ -133,7 +133,7 @@ func TestHTTPMirrorSource(t *testing.T) {
 		}
 
 		gotHashes := got.AcceptableHashes()
-		wantHashes := map[Platform][]string{
+		wantHashes := map[Platform][]Hash{
 			tosPlatform: {"h1:placeholder-hash", "h0:unacceptable-hash"},
 		}
 		if diff := cmp.Diff(wantHashes, gotHashes); diff != "" {

--- a/internal/getproviders/mock_source.go
+++ b/internal/getproviders/mock_source.go
@@ -206,7 +206,7 @@ func FakeInstallablePackageMeta(provider addrs.Provider, version Version, protoc
 		// knows what the future holds?)
 		Filename: fmt.Sprintf("terraform-provider-%s_%s_%s.zip", provider.Type, version.String(), target.String()),
 
-		Authentication: NewArchiveChecksumAuthentication(checksum),
+		Authentication: NewArchiveChecksumAuthentication(target, checksum),
 	}
 	return meta, close, nil
 }

--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -147,7 +147,7 @@ type PackageAuthenticationHashes interface {
 	// Authenticators that don't use hashes as their authentication procedure
 	// will either not implement this interface or will have an implementation
 	// that returns an empty result.
-	AcceptableHashes() map[Platform][]string
+	AcceptableHashes() map[Platform][]Hash
 }
 
 type packageAuthenticationAll []PackageAuthentication
@@ -183,7 +183,7 @@ func (checks packageAuthenticationAll) AuthenticatePackage(localLocation Package
 	return authResult, nil
 }
 
-func (checks packageAuthenticationAll) AcceptableHashes() map[Platform][]string {
+func (checks packageAuthenticationAll) AcceptableHashes() map[Platform][]Hash {
 	// The elements of checks are expected to be ordered so that the strongest
 	// one is later in the list, so we'll visit them in reverse order and
 	// take the first one that implements the interface and returns a non-empty
@@ -202,8 +202,8 @@ func (checks packageAuthenticationAll) AcceptableHashes() map[Platform][]string 
 }
 
 type packageHashAuthentication struct {
-	RequiredHash string
-	ValidHashes  []string
+	RequiredHash Hash
+	ValidHashes  []Hash
 	Platform     Platform
 }
 
@@ -215,10 +215,10 @@ type packageHashAuthentication struct {
 // The PreferredHash function will select which of the given hashes is
 // considered by Terraform to be the strongest verification, and authentication
 // succeeds as long as that chosen hash matches.
-func NewPackageHashAuthentication(platform Platform, validHashes []string) PackageAuthentication {
+func NewPackageHashAuthentication(platform Platform, validHashes []Hash) PackageAuthentication {
 	requiredHashes := PreferredHashes(validHashes)
 	// TODO: Update to support multiple hashes
-	var requiredHash string
+	var requiredHash Hash
 	if len(requiredHashes) > 0 {
 		requiredHash = requiredHashes[0]
 	}
@@ -248,8 +248,8 @@ func (a packageHashAuthentication) AuthenticatePackage(localLocation PackageLoca
 	return nil, fmt.Errorf("provider package doesn't match the expected checksum %q", a.RequiredHash)
 }
 
-func (a packageHashAuthentication) AcceptableHashes() map[Platform][]string {
-	return map[Platform][]string{
+func (a packageHashAuthentication) AcceptableHashes() map[Platform][]Hash {
+	return map[Platform][]Hash{
 		a.Platform: a.ValidHashes,
 	}
 }
@@ -295,8 +295,8 @@ func (a archiveHashAuthentication) AuthenticatePackage(localLocation PackageLoca
 	return &PackageAuthenticationResult{result: verifiedChecksum}, nil
 }
 
-func (a archiveHashAuthentication) AcceptableHashes() map[Platform][]string {
-	return map[Platform][]string{
+func (a archiveHashAuthentication) AcceptableHashes() map[Platform][]Hash {
+	return map[Platform][]Hash{
 		a.Platform: {HashLegacyZipSHAFromSHA(a.WantSHA256Sum)},
 	}
 }

--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -216,7 +216,12 @@ type packageHashAuthentication struct {
 // considered by Terraform to be the strongest verification, and authentication
 // succeeds as long as that chosen hash matches.
 func NewPackageHashAuthentication(platform Platform, validHashes []string) PackageAuthentication {
-	requiredHash := PreferredHash(validHashes)
+	requiredHashes := PreferredHashes(validHashes)
+	// TODO: Update to support multiple hashes
+	var requiredHash string
+	if len(requiredHashes) > 0 {
+		requiredHash = requiredHashes[0]
+	}
 	return packageHashAuthentication{
 		RequiredHash: requiredHash,
 		ValidHashes:  validHashes,

--- a/internal/getproviders/package_authentication_test.go
+++ b/internal/getproviders/package_authentication_test.go
@@ -104,9 +104,9 @@ func TestPackageHashAuthentication_success(t *testing.T) {
 	// Location must be a PackageLocalArchive path
 	location := PackageLocalDir("testdata/filesystem-mirror/registry.terraform.io/hashicorp/null/2.0.0/linux_amd64")
 
-	wantHashes := []string{
+	wantHashes := []Hash{
 		// Known-good HashV1 result for this directory
-		"h1:qjsREM4DqEWECD43FcPqddZ9oxCG+IaMTxvWPciS05g=",
+		Hash("h1:qjsREM4DqEWECD43FcPqddZ9oxCG+IaMTxvWPciS05g="),
 	}
 
 	auth := NewPackageHashAuthentication(Platform{"linux", "amd64"}, wantHashes)
@@ -145,7 +145,7 @@ func TestPackageHashAuthentication_failure(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// Invalid expected hash, either because we'll error before we
 			// reach it, or we want to force a checksum mismatch.
-			auth := NewPackageHashAuthentication(Platform{"linux", "amd64"}, []string{"h1:invalid"})
+			auth := NewPackageHashAuthentication(Platform{"linux", "amd64"}, []Hash{"h1:invalid"})
 			result, err := auth.AuthenticatePackage(test.location)
 
 			if result != nil {

--- a/internal/getproviders/package_authentication_test.go
+++ b/internal/getproviders/package_authentication_test.go
@@ -109,7 +109,7 @@ func TestPackageHashAuthentication_success(t *testing.T) {
 		"h1:qjsREM4DqEWECD43FcPqddZ9oxCG+IaMTxvWPciS05g=",
 	}
 
-	auth := NewPackageHashAuthentication(wantHashes)
+	auth := NewPackageHashAuthentication(Platform{"linux", "amd64"}, wantHashes)
 	result, err := auth.AuthenticatePackage(location)
 
 	wantResult := PackageAuthenticationResult{result: verifiedChecksum}
@@ -143,9 +143,9 @@ func TestPackageHashAuthentication_failure(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			// Empty expected hash, either because we'll error before we
+			// Invalid expected hash, either because we'll error before we
 			// reach it, or we want to force a checksum mismatch.
-			auth := NewPackageHashAuthentication([]string{"h1:invalid"})
+			auth := NewPackageHashAuthentication(Platform{"linux", "amd64"}, []string{"h1:invalid"})
 			result, err := auth.AuthenticatePackage(test.location)
 
 			if result != nil {
@@ -172,7 +172,7 @@ func TestArchiveChecksumAuthentication_success(t *testing.T) {
 		0x5a, 0x79, 0x2a, 0xde, 0x97, 0x11, 0xf5, 0x01,
 	}
 
-	auth := NewArchiveChecksumAuthentication(wantSHA256Sum)
+	auth := NewArchiveChecksumAuthentication(Platform{"linux", "amd64"}, wantSHA256Sum)
 	result, err := auth.AuthenticatePackage(location)
 
 	wantResult := PackageAuthenticationResult{result: verifiedChecksum}
@@ -194,11 +194,11 @@ func TestArchiveChecksumAuthentication_failure(t *testing.T) {
 	}{
 		"missing file": {
 			PackageLocalArchive("testdata/no-package-here.zip"),
-			"open testdata/no-package-here.zip: no such file or directory",
+			"failed to compute checksum for testdata/no-package-here.zip: lstat testdata/no-package-here.zip: no such file or directory",
 		},
 		"checksum mismatch": {
 			PackageLocalArchive("testdata/filesystem-mirror/registry.terraform.io/hashicorp/null/terraform-provider-null_2.1.0_linux_amd64.zip"),
-			"archive has incorrect SHA-256 checksum 4fb39849f2e138eb16a18ba0c682635d781cb8c3b25901dd5a792ade9711f501 (expected 0000000000000000000000000000000000000000000000000000000000000000)",
+			"archive has incorrect checksum zh:4fb39849f2e138eb16a18ba0c682635d781cb8c3b25901dd5a792ade9711f501 (expected zh:0000000000000000000000000000000000000000000000000000000000000000)",
 		},
 		"invalid location": {
 			PackageLocalDir("testdata/filesystem-mirror/tfe.example.com/AwesomeCorp/happycloud/0.1.0-alpha.2/darwin_amd64"),
@@ -210,7 +210,7 @@ func TestArchiveChecksumAuthentication_failure(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// Zero expected checksum, either because we'll error before we
 			// reach it, or we want to force a checksum mismatch
-			auth := NewArchiveChecksumAuthentication([sha256.Size]byte{0})
+			auth := NewArchiveChecksumAuthentication(Platform{"linux", "amd64"}, [sha256.Size]byte{0})
 			result, err := auth.AuthenticatePackage(test.location)
 
 			if result != nil {

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -275,6 +275,10 @@ func (c *registryClient) PackageMeta(provider addrs.Provider, version Version, t
 		}
 	}
 
+	if body.OS != target.OS || body.Arch != target.Arch {
+		return PackageMeta{}, fmt.Errorf("registry response to request for %s archive has incorrect target %s", target, Platform{body.OS, body.Arch})
+	}
+
 	downloadURL, err := url.Parse(body.DownloadURL)
 	if err != nil {
 		return PackageMeta{}, fmt.Errorf("registry response includes invalid download URL: %s", err)
@@ -351,7 +355,7 @@ func (c *registryClient) PackageMeta(provider addrs.Provider, version Version, t
 
 	ret.Authentication = PackageAuthenticationAll(
 		NewMatchingChecksumAuthentication(document, body.Filename, checksum),
-		NewArchiveChecksumAuthentication(checksum),
+		NewArchiveChecksumAuthentication(ret.TargetPlatform, checksum),
 		NewSignatureAuthentication(document, signature, keys),
 	)
 

--- a/internal/getproviders/registry_client_test.go
+++ b/internal/getproviders/registry_client_test.go
@@ -174,7 +174,7 @@ func fakeRegistryHandler(resp http.ResponseWriter, req *http.Request) {
 		case "/pkg/awesomesauce/happycloud_1.2.0.zip":
 			resp.Write([]byte("some zip file"))
 		case "/pkg/awesomesauce/happycloud_1.2.0_SHA256SUMS":
-			resp.Write([]byte("000000000000000000000000000000000000000000000000000000000000f00d happycloud_1.2.0.zip\n"))
+			resp.Write([]byte("000000000000000000000000000000000000000000000000000000000000f00d happycloud_1.2.0.zip\n000000000000000000000000000000000000000000000000000000000000face happycloud_1.2.0_face.zip\n"))
 		case "/pkg/awesomesauce/happycloud_1.2.0_SHA256SUMS.sig":
 			resp.Write([]byte("GPG signature"))
 		default:

--- a/internal/getproviders/registry_source_test.go
+++ b/internal/getproviders/registry_source_test.go
@@ -115,11 +115,11 @@ func TestSourcePackageMeta(t *testing.T) {
 		version    string
 		os, arch   string
 		want       PackageMeta
-		wantHashes map[Platform][]Hash
+		wantHashes []Hash
 		wantErr    string
 	}{
 		// These test cases are relying on behaviors of the fake provider
-		// registry server implemented in client_test.go.
+		// registry server implemented in registry_client_test.go.
 		{
 			"example.com/awesomesauce/happycloud",
 			"1.2.0",
@@ -135,13 +135,13 @@ func TestSourcePackageMeta(t *testing.T) {
 				Location:         PackageHTTPURL(baseURL + "/pkg/awesomesauce/happycloud_1.2.0.zip"),
 				Authentication: PackageAuthenticationAll(
 					NewMatchingChecksumAuthentication(
-						[]byte("000000000000000000000000000000000000000000000000000000000000f00d happycloud_1.2.0.zip\n"),
+						[]byte("000000000000000000000000000000000000000000000000000000000000f00d happycloud_1.2.0.zip\n000000000000000000000000000000000000000000000000000000000000face happycloud_1.2.0_face.zip\n"),
 						"happycloud_1.2.0.zip",
 						[32]byte{30: 0xf0, 31: 0x0d},
 					),
 					NewArchiveChecksumAuthentication(Platform{"linux", "amd64"}, [32]byte{30: 0xf0, 31: 0x0d}),
 					NewSignatureAuthentication(
-						[]byte("000000000000000000000000000000000000000000000000000000000000f00d happycloud_1.2.0.zip\n"),
+						[]byte("000000000000000000000000000000000000000000000000000000000000f00d happycloud_1.2.0.zip\n000000000000000000000000000000000000000000000000000000000000face happycloud_1.2.0_face.zip\n"),
 						[]byte("GPG signature"),
 						[]SigningKey{
 							{ASCIIArmor: HashicorpPublicKey},
@@ -149,10 +149,9 @@ func TestSourcePackageMeta(t *testing.T) {
 					),
 				),
 			},
-			map[Platform][]Hash{
-				{"linux", "amd64"}: {
-					"zh:000000000000000000000000000000000000000000000000000000000000f00d",
-				},
+			[]Hash{
+				"zh:000000000000000000000000000000000000000000000000000000000000f00d",
+				"zh:000000000000000000000000000000000000000000000000000000000000face",
 			},
 			``,
 		},

--- a/internal/getproviders/registry_source_test.go
+++ b/internal/getproviders/registry_source_test.go
@@ -115,7 +115,7 @@ func TestSourcePackageMeta(t *testing.T) {
 		version    string
 		os, arch   string
 		want       PackageMeta
-		wantHashes map[Platform][]string
+		wantHashes map[Platform][]Hash
 		wantErr    string
 	}{
 		// These test cases are relying on behaviors of the fake provider
@@ -149,7 +149,7 @@ func TestSourcePackageMeta(t *testing.T) {
 					),
 				),
 			},
-			map[Platform][]string{
+			map[Platform][]Hash{
 				{"linux", "amd64"}: {
 					"zh:000000000000000000000000000000000000000000000000000000000000f00d",
 				},

--- a/internal/getproviders/types.go
+++ b/internal/getproviders/types.go
@@ -244,9 +244,19 @@ func (m PackageMeta) PackedFilePath(baseDir string) string {
 	return PackedFilePathForPackage(baseDir, m.Provider, m.Version, m.TargetPlatform)
 }
 
-// AcceptableHashes returns a set of hashes (grouped by target platform) that
-// could be recorded for comparison to future results for the same provider
-// version, to implement a "trust on first use" scheme.
+// AcceptableHashes returns a set of hashes that could be recorded for
+// comparison to future results for the same provider version, to implement a
+// "trust on first use" scheme.
+//
+// The AcceptableHashes result is a platform-agnostic set of hashes, with the
+// intent that in most cases it will be used as an additional cross-check in
+// addition to a platform-specific hash check made during installation. However,
+// there are some situations (such as verifying an already-installed package
+// that's on local disk) where Terraform would check only against the results
+// of this function, meaning that it would in principle accept another
+// platform's package as a substitute for the correct platform. That's a
+// pragmatic compromise to allow lock files derived from the result of this
+// method to be portable across platforms.
 //
 // Callers of this method should typically also verify the package using the
 // object in the Authentication field, and consider how much trust to give
@@ -259,7 +269,7 @@ func (m PackageMeta) PackedFilePath(baseDir string) string {
 // Authentication field. AcceptableHashes therefore returns an empty result
 // for a PackageMeta that has no authentication object, or has one that does
 // not make use of hashes.
-func (m PackageMeta) AcceptableHashes() map[Platform][]Hash {
+func (m PackageMeta) AcceptableHashes() []Hash {
 	auth, ok := m.Authentication.(PackageAuthenticationHashes)
 	if !ok {
 		return nil

--- a/internal/getproviders/types.go
+++ b/internal/getproviders/types.go
@@ -259,7 +259,7 @@ func (m PackageMeta) PackedFilePath(baseDir string) string {
 // Authentication field. AcceptableHashes therefore returns an empty result
 // for a PackageMeta that has no authentication object, or has one that does
 // not make use of hashes.
-func (m PackageMeta) AcceptableHashes() map[Platform][]string {
+func (m PackageMeta) AcceptableHashes() map[Platform][]Hash {
 	auth, ok := m.Authentication.(PackageAuthenticationHashes)
 	if !ok {
 		return nil

--- a/internal/getproviders/types.go
+++ b/internal/getproviders/types.go
@@ -244,6 +244,29 @@ func (m PackageMeta) PackedFilePath(baseDir string) string {
 	return PackedFilePathForPackage(baseDir, m.Provider, m.Version, m.TargetPlatform)
 }
 
+// AcceptableHashes returns a set of hashes (grouped by target platform) that
+// could be recorded for comparison to future results for the same provider
+// version, to implement a "trust on first use" scheme.
+//
+// Callers of this method should typically also verify the package using the
+// object in the Authentication field, and consider how much trust to give
+// the result of this method depending on the authentication result: an
+// unauthenticated result or one that only verified a checksum could be
+// considered less trustworthy than one that checked the package against
+// a signature provided by the origin registry.
+//
+// The AcceptableHashes result is actually provided by the object in the
+// Authentication field. AcceptableHashes therefore returns an empty result
+// for a PackageMeta that has no authentication object, or has one that does
+// not make use of hashes.
+func (m PackageMeta) AcceptableHashes() map[Platform][]string {
+	auth, ok := m.Authentication.(PackageAuthenticationHashes)
+	if !ok {
+		return nil
+	}
+	return auth.AcceptableHashes()
+}
+
 // PackageLocation represents a location where a provider distribution package
 // can be obtained. A value of this type contains one of the following
 // concrete types: PackageLocalArchive, PackageLocalDir, or PackageHTTPURL.

--- a/internal/providercache/cached_provider.go
+++ b/internal/providercache/cached_provider.go
@@ -43,7 +43,7 @@ func (cp *CachedProvider) PackageLocation() getproviders.PackageLocalDir {
 // If you need a specific version of hash rather than just whichever one is
 // current default, call that version's corresponding method (e.g. HashV1)
 // directly instead.
-func (cp *CachedProvider) Hash() (string, error) {
+func (cp *CachedProvider) Hash() (getproviders.Hash, error) {
 	return getproviders.PackageHash(cp.PackageLocation())
 }
 
@@ -54,7 +54,7 @@ func (cp *CachedProvider) Hash() (string, error) {
 //
 // MatchesHash may accept hashes in a number of different formats. Over time
 // the set of supported formats may grow and shrink.
-func (cp *CachedProvider) MatchesHash(want string) (bool, error) {
+func (cp *CachedProvider) MatchesHash(want getproviders.Hash) (bool, error) {
 	return getproviders.PackageMatchesHash(cp.PackageLocation(), want)
 }
 
@@ -69,7 +69,7 @@ func (cp *CachedProvider) MatchesHash(want string) (bool, error) {
 // being added (in a backward-compatible way) in future. The result from
 // HashV1 always begins with the prefix "h1:" so that callers can distinguish
 // the results of potentially multiple different hash algorithms in future.
-func (cp *CachedProvider) HashV1() (string, error) {
+func (cp *CachedProvider) HashV1() (getproviders.Hash, error) {
 	return getproviders.PackageHashV1(cp.PackageLocation())
 }
 

--- a/internal/providercache/cached_provider_test.go
+++ b/internal/providercache/cached_provider_test.go
@@ -18,7 +18,7 @@ func TestCachedProviderHash(t *testing.T) {
 		PackageDir: "testdata/cachedir/registry.terraform.io/hashicorp/null/2.0.0/darwin_amd64",
 	}
 
-	want := "h1:qjsREM4DqEWECD43FcPqddZ9oxCG+IaMTxvWPciS05g="
+	want := getproviders.MustParseHash("h1:qjsREM4DqEWECD43FcPqddZ9oxCG+IaMTxvWPciS05g=")
 	got, err := cp.Hash()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -418,7 +418,7 @@ NeedProvider:
 		}
 		lockEntries[provider] = lockFileEntry{
 			SelectedVersion: version,
-			PackageHash:     hash,
+			PackageHash:     hash.String(),
 		}
 	}
 	err := i.lockFile().Write(lockEntries)
@@ -471,7 +471,13 @@ func (i *Installer) SelectedPackages() (map[addrs.Provider]*CachedProvider, erro
 			continue
 		}
 
-		ok, err := cached.MatchesHash(entry.PackageHash)
+		hash, err := getproviders.ParseHash(entry.PackageHash)
+		if err != nil {
+			errs[provider] = fmt.Errorf("local cache for %s has invalid hash %q: %s", provider, entry.PackageHash, err)
+			continue
+		}
+
+		ok, err := cached.MatchesHash(hash)
 		if err != nil {
 			errs[provider] = fmt.Errorf("failed to verify checksum for v%s package: %s", entry.SelectedVersion, err)
 			continue


### PR DESCRIPTION
There's a few different things going on here because I'm trying to quickly drive a thread all the way through to an MVP before going back to refine. Unfortunately that means this diff will be quite hard to read as a whole, and so I'd recommend going commit-by-commit for this one.

In earlier work I introduced the `internal/depsfile` package to represent the new lock file format. While investigating the next step I found that maintaining a separate set of locked hashes per platform isn't really practical because our different installation methods each have their own constraints that prevent us from reliably distinguishing which hash belongs to which platform.

As a compromise then, the lock file will now just record an undifferentiated set of hashes across all platforms, and will consider any of them to be valid. In the common cases when we're either installing from an origin registry or from a network mirror, the registry install step will still verify that the package matches one of the platform-specific hashes, but we'll then do the additional cross-check against the lock file in a platform-agnostic way. The main consequence of this compromise is that when we verify packages _entirely_ locally (e.g. from a filesystem mirror) Terraform would accept the contents of the `windows_amd64` package as valid contents for the `linux_amd64` package; that's not ideal, but such a situation seems unlikely to arise in practice.

---

There are some other things going on here that are somewhat unrelated to the main theme of this PR described above:

* I've formalized our registry protocol's existing hashing scheme (a SHA256 hash of the official `.zip` file) as a lockable hashing scheme (with the `zh:` scheme prefix, meaning "ziphash") so that we can blend both the legacy and new hash formats together in the lock files, at least until we find a path forward to using the content-based hashing scheme `h1:` in the provider registry protocol. The `zh:` scheme can match only for an original `.zip` file, so the later code (not yet written) which writes these into the lock file will need to pair the `zh:` hashes with `h1:` hashes so we can also verify the unpacked providers cached on local disk.
* I defined a new named type `getproviders.Hash` to represent the idea of a package hash, because I found that the implicit conventions for the hash strings were getting strewn across a number of different files/packages. It's still just a string underneath, but this centralizes the definition of what is a valid hash string and the logic for common operations like "what scheme does this hash use?".
* I added a new optional interface extending the `PackageAuthentication` interface, which allows an authenticator to indicate which hashes it considers to represent a package. My intent is that a future commit will use this result, combined with the selection metadata produced by the provider installer itself, to generate an aggregate `hashes` value to write into the lock file. As the comment docs suggest, the installer would trust the result only if the corresponding authentication succeeds. I'll flesh this out some more in a future commit, and may adjust the interface further if that later work indicates a missing requirement.

---

As with the previous commit, this is a checkpoint along the way rather than a finished feature, so there are some loose ends here I intend to address in a future commit. Some of these changes do affect live codepaths, but I believe the results are functionally equivalent to before because the frontend code doesn't yet make use of the new API surface.

With that said then, my intent here is to land this accepting that it has some awkward parts, continue driving toward the MVP, and then return to tidy some details up once the basics are working.

