### PR TITLE
Warnings and specialized diffs when switching between sensitive values

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -790,6 +790,11 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 			unmarkedNew, _ = new.UnmarkDeep()
 		}
 		switch {
+		case ty == cty.Bool || ty == cty.Number:
+			if old.ContainsMarked() || new.ContainsMarked() {
+				p.buf.WriteString("(sensitive)")
+				return
+			}
 		case ty == cty.String:
 			// We have special behavior for both multi-line strings in general
 			// and for strings that can parse as JSON. For the JSON handling

--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -338,10 +338,7 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 
 	p.buf.WriteString("\n")
 
-	// Write sensitivity warning for non-delete plans
-	if action != plans.Delete && action != plans.Create {
-		p.writeSensitivityWarning(old, new, indent)
-	}
+	p.writeSensitivityWarning(old, new, indent, action)
 
 	p.buf.WriteString(strings.Repeat(" ", indent))
 	p.writeActionSymbol(action)
@@ -1138,7 +1135,7 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 
 				oldV := old.Index(kV)
 				newV := new.Index(kV)
-				p.writeSensitivityWarning(oldV, newV, indent+2)
+				p.writeSensitivityWarning(oldV, newV, indent+2, action)
 
 				p.buf.WriteString(strings.Repeat(" ", indent+2))
 				p.writeActionSymbol(action)
@@ -1316,7 +1313,12 @@ func (p *blockBodyDiffPrinter) writeActionSymbol(action plans.Action) {
 	}
 }
 
-func (p *blockBodyDiffPrinter) writeSensitivityWarning(old, new cty.Value, indent int) {
+func (p *blockBodyDiffPrinter) writeSensitivityWarning(old, new cty.Value, indent int, action plans.Action) {
+	// Dont' show this warning for create or delete
+	if action == plans.Create || action == plans.Delete {
+		return
+	}
+
 	if new.IsMarked() && !old.IsMarked() {
 		p.buf.WriteString(strings.Repeat(" ", indent))
 		p.buf.WriteString(p.color.Color("[yellow]# Warning: this attribute value will be marked as sensitive and will\n"))

--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -777,18 +777,12 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 	// However, these specialized implementations can apply only if both
 	// values are known and non-null.
 	if old.IsKnown() && new.IsKnown() && !old.IsNull() && !new.IsNull() && typesEqual {
-		// If marked, create unmarked values for comparisons
-		unmarkedOld := old
-		unmarkedNew := new
-		if old.ContainsMarked() {
-			unmarkedOld, _ = old.UnmarkDeep()
-		}
-		if new.ContainsMarked() {
-			unmarkedNew, _ = new.UnmarkDeep()
-		}
+		// Create unmarked values for comparisons
+		unmarkedOld, oldMarks := old.UnmarkDeep()
+		unmarkedNew, newMarks := new.UnmarkDeep()
 		switch {
 		case ty == cty.Bool || ty == cty.Number:
-			if old.ContainsMarked() || new.ContainsMarked() {
+			if len(oldMarks) > 0 || len(newMarks) > 0 {
 				p.buf.WriteString("(sensitive)")
 				return
 			}
@@ -799,7 +793,7 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 			// For single-line strings that don't parse as JSON we just fall
 			// out of this switch block and do the default old -> new rendering.
 
-			if old.ContainsMarked() || new.ContainsMarked() {
+			if len(oldMarks) > 0 || len(newMarks) > 0 {
 				p.buf.WriteString("(sensitive)")
 				return
 			}

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3652,36 +3652,57 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
     }
 `,
 		},
-		"in-place update - before sensitive": {
+		"in-place update - before sensitive, primitive types": {
 			Action: plans.Update,
 			Mode:   addrs.ManagedResourceMode,
 			Before: cty.ObjectVal(map[string]cty.Value{
-				"id":  cty.StringVal("i-02ae66f368e8518a9"),
-				"ami": cty.StringVal("ami-BEFORE"),
+				"id":          cty.StringVal("i-02ae66f368e8518a9"),
+				"ami":         cty.StringVal("ami-BEFORE"),
+				"special":     cty.BoolVal(true),
+				"some_number": cty.NumberIntVal(1),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{
-				"id":  cty.StringVal("i-02ae66f368e8518a9"),
-				"ami": cty.StringVal("ami-AFTER"),
+				"id":          cty.StringVal("i-02ae66f368e8518a9"),
+				"ami":         cty.StringVal("ami-AFTER"),
+				"special":     cty.BoolVal(false),
+				"some_number": cty.NumberIntVal(2),
 			}),
 			BeforeValMarks: []cty.PathValueMarks{
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "ami"}},
 					Marks: cty.NewValueMarks("sensitive"),
-				}},
+				},
+				{
+					Path:  cty.Path{cty.GetAttrStep{Name: "special"}},
+					Marks: cty.NewValueMarks("sensitive"),
+				},
+				{
+					Path:  cty.Path{cty.GetAttrStep{Name: "some_number"}},
+					Marks: cty.NewValueMarks("sensitive"),
+				},
+			},
 			RequiredReplace: cty.NewPathSet(),
 			Tainted:         false,
 			Schema: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
+					"id":          {Type: cty.String, Optional: true, Computed: true},
+					"ami":         {Type: cty.String, Optional: true},
+					"special":     {Type: cty.Bool, Optional: true},
+					"some_number": {Type: cty.Number, Optional: true},
 				},
 			},
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change
-      ~ ami = (sensitive)
-        id  = "i-02ae66f368e8518a9"
+      ~ ami         = (sensitive)
+        id          = "i-02ae66f368e8518a9"
+      # Warning: this attribute value will no longer be marked as sensitive
+      # after applying this change
+      ~ some_number = (sensitive)
+      # Warning: this attribute value will no longer be marked as sensitive
+      # after applying this change
+      ~ special     = (sensitive)
     }
 `,
 		},

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3678,6 +3678,8 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			},
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
+      # Warning: this attribute value will no longer be marked as sensitive
+      # after applying this change
       ~ ami = (sensitive)
         id  = "i-02ae66f368e8518a9"
     }
@@ -3714,7 +3716,11 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
         id   = "i-02ae66f368e8518a9"
-      ~ tags = (sensitive)
+      ~ tags = {
+          # Warning: this attribute value will be marked as sensitive and will
+          # not display in UI output after applying this change
+          ~ "name" = (sensitive)
+        }
     }
 `,
 		},
@@ -3777,7 +3783,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			},
 			ExpectedOutput: `  # test_instance.example will be destroyed
   - resource "test_instance" "example" {
-      - ami = (sensitive)
+      - ami = (sensitive) -> null
       - id  = "i-02ae66f368e8518a9" -> null
     }
 `,


### PR DESCRIPTION
This PR adds a warning that will display in the diff output if a value is changing its sensitivity. It is conservative, in that if the sensitivity is changing (either to _or_ from sensitive) it will not display the value, but will show a `(sensitive)`.

Some examples of this in action:

Changing from one sensitive value to another sensitive value, the `(sensitive)` remains in place and no warning is displayed:
<img width="729" alt="Screen Shot 2020-09-23 at 4 14 52 PM" src="https://user-images.githubusercontent.com/204372/94179112-0b6e7c00-fe6a-11ea-8871-3c928ad00017.png">

Changing from a sensitive value to a non sensitive value, a warning is displayed in the UI:
<img width="753" alt="Screen Shot 2020-09-23 at 4 15 30 PM" src="https://user-images.githubusercontent.com/204372/94179117-0c9fa900-fe6a-11ea-85b6-c5dffdf29630.png">
Same thing, but showing this appearing more than once in a plan:
<img width="804" alt="Screen Shot 2020-09-23 at 4 16 01 PM" src="https://user-images.githubusercontent.com/204372/94179120-0dd0d600-fe6a-11ea-941f-6d638f08b1c1.png">
When a value will no longer be sensitive, this warning displays:
<img width="736" alt="Screen Shot 2020-09-23 at 4 17 06 PM" src="https://user-images.githubusercontent.com/204372/94179121-0e696c80-fe6a-11ea-9e02-3162b9731e7f.png">

This PR adds coverage for this specialized diff between all primitive types, as more work is needed (both in `diff.go` but also more widely in Terraform) on complex values and sensitivity, so I indend to do that in a separate PR so we can discuss the design of "how we show sensitivity" here. 

Edit to add: There is some dealing with map types already in here, but it is not exhaustive.
