### PR TITLE
Mildwonkey/refactor primary evaltrees

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -290,7 +290,7 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"parent"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("module.child.aws_instance.child")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("module.child.aws_instance.child")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -1187,7 +1187,7 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"foo"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("aws_instance.bar")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.bar")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -2517,7 +2517,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"b"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("module.child.aws_instance.a")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("module.child.aws_instance.a")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -7133,7 +7133,7 @@ func TestContext2Apply_taintDep(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"bar","num": "2", "type": "aws_instance", "foo": "baz"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("aws_instance.foo")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.foo")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -7185,7 +7185,7 @@ func TestContext2Apply_taintDepRequiresNew(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"bar","num": "2", "type": "aws_instance", "foo": "baz"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("aws_instance.foo")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.foo")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -7431,7 +7431,7 @@ func TestContext2Apply_targetedDestroyCountDeps(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"i-abc123"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("aws_instance.foo")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.foo")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -11355,7 +11355,7 @@ locals {
 		&states.ResourceInstanceObjectSrc{
 			Status:              states.ObjectReady,
 			AttrsJSON:           []byte(`{"id":"b", "require_new":"old.old"}`),
-			Dependencies:        []addrs.ConfigResource{mustResourceAddr("test_instance.a")},
+			Dependencies:        []addrs.ConfigResource{mustConfigResourceAddr("test_instance.a")},
 			CreateBeforeDestroy: true,
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
@@ -11366,8 +11366,8 @@ locals {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"c", "require_new":"b"}`),
 			Dependencies: []addrs.ConfigResource{
-				mustResourceAddr("test_instance.a"),
-				mustResourceAddr("test_instance.b"),
+				mustConfigResourceAddr("test_instance.a"),
+				mustConfigResourceAddr("test_instance.b"),
 			},
 			CreateBeforeDestroy: true,
 		},

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -5221,7 +5221,7 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"bar0"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("aws_instance.foo")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.foo")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -5230,7 +5230,7 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"bar1"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("aws_instance.foo")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.foo")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -5239,7 +5239,7 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"baz0"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("aws_instance.bar")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.bar")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -5248,7 +5248,7 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"baz1"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("aws_instance.bar")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.bar")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
@@ -6236,7 +6236,7 @@ resource "test_instance" "b" {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"b"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("test_instance.a")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_instance.a")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)

--- a/terraform/eval_state.go
+++ b/terraform/eval_state.go
@@ -475,61 +475,6 @@ func (n *EvalMaybeRestoreDeposedObject) Eval(ctx EvalContext) (interface{}, erro
 	return nil, nil
 }
 
-// EvalWriteResourceState is an EvalNode implementation that ensures that
-// a suitable resource-level state record is present in the state, if that's
-// required for the "each mode" of that resource.
-//
-// This is important primarily for the situation where count = 0, since this
-// eval is the only change we get to set the resource "each mode" to list
-// in that case, allowing expression evaluation to see it as a zero-element
-// list rather than as not set at all.
-type EvalWriteResourceState struct {
-	Addr         addrs.AbsResource
-	Config       *configs.Resource
-	ProviderAddr addrs.AbsProviderConfig
-}
-
-func (n *EvalWriteResourceState) Eval(ctx EvalContext) (interface{}, error) {
-	var diags tfdiags.Diagnostics
-	state := ctx.State()
-
-	// We'll record our expansion decision in the shared "expander" object
-	// so that later operations (i.e. DynamicExpand and expression evaluation)
-	// can refer to it. Since this node represents the abstract module, we need
-	// to expand the module here to create all resources.
-	expander := ctx.InstanceExpander()
-
-	switch {
-	case n.Config.Count != nil:
-		count, countDiags := evaluateCountExpression(n.Config.Count, ctx)
-		diags = diags.Append(countDiags)
-		if countDiags.HasErrors() {
-			return nil, diags.Err()
-		}
-
-		state.SetResourceProvider(n.Addr, n.ProviderAddr)
-		expander.SetResourceCount(n.Addr.Module, n.Addr.Resource, count)
-
-	case n.Config.ForEach != nil:
-		forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx)
-		diags = diags.Append(forEachDiags)
-		if forEachDiags.HasErrors() {
-			return nil, diags.Err()
-		}
-
-		// This method takes care of all of the business logic of updating this
-		// while ensuring that any existing instances are preserved, etc.
-		state.SetResourceProvider(n.Addr, n.ProviderAddr)
-		expander.SetResourceForEach(n.Addr.Module, n.Addr.Resource, forEach)
-
-	default:
-		state.SetResourceProvider(n.Addr, n.ProviderAddr)
-		expander.SetResourceSingle(n.Addr.Module, n.Addr.Resource)
-	}
-
-	return nil, nil
-}
-
 // EvalRefreshLifecycle is an EvalNode implementation that updates
 // the status of the lifecycle options stored in the state.
 // This currently only applies to create_before_destroy.

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -104,7 +104,7 @@ func TestApplyGraphBuilder_depCbd(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("test_object.A")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
@@ -272,7 +272,7 @@ func TestApplyGraphBuilder_destroyStateOnly(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"bar"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("module.child.test_object.A")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("module.child.test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
@@ -398,7 +398,7 @@ func TestApplyGraphBuilder_moduleDestroy(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"foo","value":"foo"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("module.A.test_object.foo")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("module.A.test_object.foo")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)

--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/dag"
 	"github.com/hashicorp/terraform/lang"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // nodeExpandApplyableResource handles the first layer of resource
@@ -71,7 +72,7 @@ type NodeApplyableResource struct {
 var (
 	_ GraphNodeModuleInstance       = (*NodeApplyableResource)(nil)
 	_ GraphNodeConfigResource       = (*NodeApplyableResource)(nil)
-	_ GraphNodeEvalable             = (*NodeApplyableResource)(nil)
+	_ GraphNodeExecutable           = (*NodeApplyableResource)(nil)
 	_ GraphNodeProviderConsumer     = (*NodeApplyableResource)(nil)
 	_ GraphNodeAttachResourceConfig = (*NodeApplyableResource)(nil)
 	_ GraphNodeReferencer           = (*NodeApplyableResource)(nil)
@@ -100,17 +101,49 @@ func (n *NodeApplyableResource) References() []*addrs.Reference {
 	return result
 }
 
-// GraphNodeEvalable
-func (n *NodeApplyableResource) EvalTree() EvalNode {
+// GraphNodeExecutable
+func (n *NodeApplyableResource) Execute(ctx EvalContext, op walkOperation) error {
 	if n.Config == nil {
 		// Nothing to do, then.
 		log.Printf("[TRACE] NodeApplyableResource: no configuration present for %s", n.Name())
-		return &EvalNoop{}
+		return nil
 	}
 
-	return &EvalWriteResourceState{
-		Addr:         n.Addr,
-		Config:       n.Config,
-		ProviderAddr: n.ResolvedProvider,
+	var diags tfdiags.Diagnostics
+	state := ctx.State()
+
+	// We'll record our expansion decision in the shared "expander" object
+	// so that later operations (i.e. DynamicExpand and expression evaluation)
+	// can refer to it. Since this node represents the abstract module, we need
+	// to expand the module here to create all resources.
+	expander := ctx.InstanceExpander()
+
+	switch {
+	case n.Config.Count != nil:
+		count, countDiags := evaluateCountExpression(n.Config.Count, ctx)
+		diags = diags.Append(countDiags)
+		if countDiags.HasErrors() {
+			return diags.Err()
+		}
+
+		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
+		expander.SetResourceCount(n.Addr.Module, n.Addr.Resource, count)
+
+	case n.Config.ForEach != nil:
+		forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx)
+		diags = diags.Append(forEachDiags)
+		if forEachDiags.HasErrors() {
+			return diags.Err()
+		}
+
+		// This method takes care of all of the business logic of updating this
+		// while ensuring that any existing instances are preserved, etc.
+		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
+		expander.SetResourceForEach(n.Addr.Module, n.Addr.Resource, forEach)
+
+	default:
+		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
+		expander.SetResourceSingle(n.Addr.Module, n.Addr.Resource)
 	}
+	return nil
 }

--- a/terraform/node_resource_apply_test.go
+++ b/terraform/node_resource_apply_test.go
@@ -1,0 +1,63 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/instances"
+	"github.com/hashicorp/terraform/states"
+)
+
+func TestNodeApplyableResourceExecute(t *testing.T) {
+	state := states.NewState()
+	ctx := &MockEvalContext{
+		StateState:               state.SyncWrapper(),
+		InstanceExpanderExpander: instances.NewExpander(),
+	}
+
+	t.Run("no config", func(t *testing.T) {
+		node := NodeApplyableResource{
+			NodeAbstractResource: &NodeAbstractResource{
+				Config: nil,
+			},
+			Addr: mustAbsResourceAddr("test_instance.foo"),
+		}
+		err := node.Execute(ctx, walkApply)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err.Error())
+		}
+		if !state.Empty() {
+			t.Fatalf("expected no state, got:\n %s", state.String())
+		}
+	})
+
+	t.Run("simple", func(t *testing.T) {
+
+		node := NodeApplyableResource{
+			NodeAbstractResource: &NodeAbstractResource{
+				Config: &configs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "test_instance",
+					Name: "foo",
+				},
+				ResolvedProvider: addrs.AbsProviderConfig{
+					Provider: addrs.NewDefaultProvider("test"),
+					Module:   addrs.RootModule,
+				},
+			},
+			Addr: mustAbsResourceAddr("test_instance.foo"),
+		}
+		err := node.Execute(ctx, walkApply)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err.Error())
+		}
+		if state.Empty() {
+			t.Fatal("expected resources in state, got empty state")
+		}
+		r := state.Resource(mustAbsResourceAddr("test_instance.foo"))
+		if r == nil {
+			t.Fatal("test_instance.foo not found in state")
+		}
+	})
+}

--- a/terraform/node_resource_plan.go
+++ b/terraform/node_resource_plan.go
@@ -177,20 +177,51 @@ func (n *NodePlannableResource) ModuleInstance() addrs.ModuleInstance {
 	return n.Addr.Module
 }
 
-// GraphNodeEvalable
-func (n *NodePlannableResource) EvalTree() EvalNode {
+// GraphNodeExecutable
+func (n *NodePlannableResource) Execute(ctx EvalContext, op walkOperation) error {
 	if n.Config == nil {
 		// Nothing to do, then.
 		log.Printf("[TRACE] NodeApplyableResource: no configuration present for %s", n.Name())
-		return &EvalNoop{}
+		return nil
 	}
 
-	// this ensures we can reference the resource even if the count is 0
-	return &EvalWriteResourceState{
-		Addr:         n.Addr,
-		Config:       n.Config,
-		ProviderAddr: n.ResolvedProvider,
+	var diags tfdiags.Diagnostics
+	state := ctx.State()
+
+	// We'll record our expansion decision in the shared "expander" object
+	// so that later operations (i.e. DynamicExpand and expression evaluation)
+	// can refer to it. Since this node represents the abstract module, we need
+	// to expand the module here to create all resources.
+	expander := ctx.InstanceExpander()
+
+	switch {
+	case n.Config.Count != nil:
+		count, countDiags := evaluateCountExpression(n.Config.Count, ctx)
+		diags = diags.Append(countDiags)
+		if countDiags.HasErrors() {
+			return diags.Err()
+		}
+
+		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
+		expander.SetResourceCount(n.Addr.Module, n.Addr.Resource, count)
+
+	case n.Config.ForEach != nil:
+		forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx)
+		diags = diags.Append(forEachDiags)
+		if forEachDiags.HasErrors() {
+			return diags.Err()
+		}
+
+		// This method takes care of all of the business logic of updating this
+		// while ensuring that any existing instances are preserved, etc.
+		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
+		expander.SetResourceForEach(n.Addr.Module, n.Addr.Resource, forEach)
+
+	default:
+		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
+		expander.SetResourceSingle(n.Addr.Module, n.Addr.Resource)
 	}
+	return nil
 }
 
 // GraphNodeDestroyerCBD

--- a/terraform/node_resource_plan_test.go
+++ b/terraform/node_resource_plan_test.go
@@ -1,0 +1,63 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/instances"
+	"github.com/hashicorp/terraform/states"
+)
+
+func TestNodePlannableResourceExecute(t *testing.T) {
+	state := states.NewState()
+	ctx := &MockEvalContext{
+		StateState:               state.SyncWrapper(),
+		InstanceExpanderExpander: instances.NewExpander(),
+	}
+
+	t.Run("no config", func(t *testing.T) {
+		node := NodePlannableResource{
+			NodeAbstractResource: &NodeAbstractResource{
+				Config: nil,
+			},
+			Addr: mustAbsResourceAddr("test_instance.foo"),
+		}
+		err := node.Execute(ctx, walkApply)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err.Error())
+		}
+		if !state.Empty() {
+			t.Fatalf("expected no state, got:\n %s", state.String())
+		}
+	})
+
+	t.Run("simple", func(t *testing.T) {
+
+		node := NodePlannableResource{
+			NodeAbstractResource: &NodeAbstractResource{
+				Config: &configs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "test_instance",
+					Name: "foo",
+				},
+				ResolvedProvider: addrs.AbsProviderConfig{
+					Provider: addrs.NewDefaultProvider("test"),
+					Module:   addrs.RootModule,
+				},
+			},
+			Addr: mustAbsResourceAddr("test_instance.foo"),
+		}
+		err := node.Execute(ctx, walkApply)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err.Error())
+		}
+		if state.Empty() {
+			t.Fatal("expected resources in state, got empty state")
+		}
+		r := state.Resource(mustAbsResourceAddr("test_instance.foo"))
+		if r == nil {
+			t.Fatal("test_instance.foo not found in state")
+		}
+	})
+}

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -250,12 +250,20 @@ func mustResourceInstanceAddr(s string) addrs.AbsResourceInstance {
 	return addr
 }
 
-func mustResourceAddr(s string) addrs.ConfigResource {
+func mustConfigResourceAddr(s string) addrs.ConfigResource {
 	addr, diags := addrs.ParseAbsResourceStr(s)
 	if diags.HasErrors() {
 		panic(diags.Err())
 	}
 	return addr.Config()
+}
+
+func mustAbsResourceAddr(s string) addrs.AbsResource {
+	addr, diags := addrs.ParseAbsResourceStr(s)
+	if diags.HasErrors() {
+		panic(diags.Err())
+	}
+	return addr
 }
 
 func mustProviderConfig(s string) addrs.AbsProviderConfig {

--- a/terraform/transform_destroy_cbd_test.go
+++ b/terraform/transform_destroy_cbd_test.go
@@ -94,7 +94,7 @@ func TestCBDEdgeTransformer(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("test_object.A")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
@@ -165,8 +165,8 @@ func TestCBDEdgeTransformerMulti(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"C","test_list":["x"]}`),
 			Dependencies: []addrs.ConfigResource{
-				mustResourceAddr("test_object.A"),
-				mustResourceAddr("test_object.B"),
+				mustConfigResourceAddr("test_object.A"),
+				mustConfigResourceAddr("test_object.B"),
 			},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
@@ -234,7 +234,7 @@ func TestCBDEdgeTransformer_depNonCBDCount(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("test_object.A")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
@@ -243,7 +243,7 @@ func TestCBDEdgeTransformer_depNonCBDCount(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("test_object.A")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
@@ -320,7 +320,7 @@ func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("test_object.A")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
@@ -329,7 +329,7 @@ func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"B","test_list":["x"]}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("test_object.A")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)

--- a/terraform/transform_destroy_edge_test.go
+++ b/terraform/transform_destroy_edge_test.go
@@ -29,7 +29,7 @@ func TestDestroyEdgeTransformer_basic(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"B","test_string":"x"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("test_object.A")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
@@ -73,7 +73,7 @@ func TestDestroyEdgeTransformer_multi(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"B","test_string":"x"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("test_object.A")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
@@ -83,8 +83,8 @@ func TestDestroyEdgeTransformer_multi(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"C","test_string":"x"}`),
 			Dependencies: []addrs.ConfigResource{
-				mustResourceAddr("test_object.A"),
-				mustResourceAddr("test_object.B"),
+				mustConfigResourceAddr("test_object.A"),
+				mustConfigResourceAddr("test_object.B"),
 			},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
@@ -139,7 +139,7 @@ func TestDestroyEdgeTransformer_module(t *testing.T) {
 		&states.ResourceInstanceObjectSrc{
 			Status:       states.ObjectReady,
 			AttrsJSON:    []byte(`{"id":"a"}`),
-			Dependencies: []addrs.ConfigResource{mustResourceAddr("module.child.test_object.b")},
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("module.child.test_object.b")},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
@@ -195,7 +195,7 @@ func TestDestroyEdgeTransformer_moduleOnly(t *testing.T) {
 				Status:    states.ObjectReady,
 				AttrsJSON: []byte(`{"id":"b","test_string":"x"}`),
 				Dependencies: []addrs.ConfigResource{
-					mustResourceAddr("module.child.test_object.a"),
+					mustConfigResourceAddr("module.child.test_object.a"),
 				},
 			},
 			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
@@ -206,8 +206,8 @@ func TestDestroyEdgeTransformer_moduleOnly(t *testing.T) {
 				Status:    states.ObjectReady,
 				AttrsJSON: []byte(`{"id":"c","test_string":"x"}`),
 				Dependencies: []addrs.ConfigResource{
-					mustResourceAddr("module.child.test_object.a"),
-					mustResourceAddr("module.child.test_object.b"),
+					mustConfigResourceAddr("module.child.test_object.a"),
+					mustConfigResourceAddr("module.child.test_object.b"),
 				},
 			},
 			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),


### PR DESCRIPTION
I recommend reviewing this commit-by-commit, as the first commit is a small-but-noisy test fixture name change. 

The `EvalWriteResourceState` code, which I've copied entirely inline in both `NodePlannableResource` and `NodeApplyableResource`, might be too much and should be refactored into its own (non-eval) function. I'm ambivalent - is this nicely streamlined, or pointlessly copied? - and will go along with what the core team reviewers prefers.