### PR TITLE
Support list diffs with sensitivity

### DIFF
--- a/plans/objchange/lcs.go
+++ b/plans/objchange/lcs.go
@@ -26,8 +26,8 @@ func LongestCommonSubsequence(xs, ys []cty.Value) []cty.Value {
 
 	for y := 0; y < len(ys); y++ {
 		for x := 0; x < len(xs); x++ {
-			unmarkedX, xMarks := xs[x].Unmark()
-			unmarkedY, yMarks := ys[y].Unmark()
+			unmarkedX, xMarks := xs[x].UnmarkDeep()
+			unmarkedY, yMarks := ys[y].UnmarkDeep()
 			eqV := unmarkedX.Equals(unmarkedY)
 			if len(xMarks) != len(yMarks) {
 				eqV = cty.False

--- a/plans/objchange/lcs.go
+++ b/plans/objchange/lcs.go
@@ -26,7 +26,12 @@ func LongestCommonSubsequence(xs, ys []cty.Value) []cty.Value {
 
 	for y := 0; y < len(ys); y++ {
 		for x := 0; x < len(xs); x++ {
-			eqV := xs[x].Equals(ys[y])
+			unmarkedX, xMarks := xs[x].Unmark()
+			unmarkedY, yMarks := ys[y].Unmark()
+			eqV := unmarkedX.Equals(unmarkedY)
+			if len(xMarks) != len(yMarks) {
+				eqV = cty.False
+			}
 			eq := false
 			if eqV.IsKnown() && eqV.True() {
 				eq = true

--- a/plans/objchange/lcs_test.go
+++ b/plans/objchange/lcs_test.go
@@ -70,6 +70,23 @@ func TestLongestCommonSubsequence(t *testing.T) {
 			[]cty.Value{cty.UnknownVal(cty.Number)},
 			[]cty.Value{},
 		},
+
+		// marked values
+		{
+			[]cty.Value{cty.NumberIntVal(1).Mark("foo"), cty.NumberIntVal(2).Mark("foo"), cty.NumberIntVal(3)},
+			[]cty.Value{cty.NumberIntVal(1).Mark("foo"), cty.NumberIntVal(2).Mark("foo")},
+			[]cty.Value{cty.NumberIntVal(1).Mark("foo"), cty.NumberIntVal(2).Mark("foo")},
+		},
+		{
+			[]cty.Value{cty.NumberIntVal(1), cty.NumberIntVal(2).Mark("foo"), cty.NumberIntVal(3)},
+			[]cty.Value{cty.NumberIntVal(2), cty.NumberIntVal(3)},
+			[]cty.Value{cty.NumberIntVal(3)},
+		},
+		{
+			[]cty.Value{cty.NumberIntVal(1), cty.NumberIntVal(2).Mark("foo")},
+			[]cty.Value{cty.NumberIntVal(2)},
+			[]cty.Value{},
+		},
 	}
 
 	for _, test := range tests {

--- a/plans/objchange/lcs_test.go
+++ b/plans/objchange/lcs_test.go
@@ -87,6 +87,21 @@ func TestLongestCommonSubsequence(t *testing.T) {
 			[]cty.Value{cty.NumberIntVal(2)},
 			[]cty.Value{},
 		},
+		{
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x").Mark("sensitive")}),
+				cty.MapVal(map[string]cty.Value{"b": cty.StringVal("y")}),
+			},
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x").Mark("sensitive")}),
+				cty.MapVal(map[string]cty.Value{"b": cty.StringVal("y")}),
+				cty.MapVal(map[string]cty.Value{"c": cty.StringVal("z")}),
+			},
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x").Mark("sensitive")}),
+				cty.MapVal(map[string]cty.Value{"b": cty.StringVal("y")}),
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Adds support for specialized diffs with lists. Because indices aren't "special" in how they identify members of the list, no changes are made to suppress previously sensitive values/values becoming sensitive at a particular index (see the tests for output in various cases). A change was necessary to `LongestCommonSubsequence` to become mark-aware, and this chooses to say that values are not equal if they are equal on value, but not on whether they are marked.