### PR TITLE
Support sensitivity within nested blocks

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -1373,10 +1373,15 @@ func ctyCollectionValues(val cty.Value) []cty.Value {
 		return nil
 	}
 
+	// Sets with marks mark the whole set as marked,
+	// so when we unmark it, apply those marks to all members
+	// of the set
+	val, marks := val.Unmark()
+
 	ret := make([]cty.Value, 0, val.LengthInt())
 	for it := val.ElementIterator(); it.Next(); {
 		_, value := it.Element()
-		ret = append(ret, value)
+		ret = append(ret, value.WithMarks(marks))
 	}
 	return ret
 }

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3739,6 +3739,12 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 					"breakfast": cty.StringVal("pizza"),
 					"dinner":    cty.StringVal("pizza"),
 				}),
+				"nested_block": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"an_attr": cty.StringVal("secretval"),
+						"another": cty.StringVal("not secret"),
+					}),
+				}),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":          cty.StringVal("i-02ae66f368e8518a9"),
@@ -3757,6 +3763,12 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 				"map_whole": cty.MapVal(map[string]cty.Value{
 					"breakfast": cty.StringVal("cereal"),
 					"dinner":    cty.StringVal("pizza"),
+				}),
+				"nested_block": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"an_attr": cty.StringVal("changed"),
+						"another": cty.StringVal("not secret"),
+					}),
 				}),
 			}),
 			BeforeValMarks: []cty.PathValueMarks{
@@ -3784,6 +3796,10 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_whole"}},
 					Marks: cty.NewValueMarks("sensitive"),
 				},
+				{
+					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block"}},
+					Marks: cty.NewValueMarks("sensitive"),
+				},
 			},
 			RequiredReplace: cty.NewPathSet(),
 			Tainted:         false,
@@ -3796,6 +3812,17 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 					"some_number": {Type: cty.Number, Optional: true},
 					"map_key":     {Type: cty.Map(cty.Number), Optional: true},
 					"map_whole":   {Type: cty.Map(cty.String), Optional: true},
+				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"nested_block": {
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"an_attr": {Type: cty.String, Optional: true},
+								"another": {Type: cty.String, Optional: true},
+							},
+						},
+						Nesting: configschema.NestingList,
+					},
 				},
 			},
 			ExpectedOutput: `  # test_instance.example will be updated in-place
@@ -3825,6 +3852,13 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change
       ~ special     = (sensitive)
+
+      ~ nested_block {
+          # Warning: this attribute value will no longer be marked as sensitive
+          # after applying this change
+          ~ an_attr = (sensitive)
+            # (1 unchanged attribute hidden)
+        }
     }
 `,
 		},
@@ -4026,6 +4060,12 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 					"breakfast": cty.StringVal("pizza"),
 					"dinner":    cty.StringVal("pizza"),
 				}),
+				"nested_block": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"an_attr": cty.StringVal("secret"),
+						"another": cty.StringVal("not secret"),
+					}),
+				}),
 			}),
 			After: cty.NullVal(cty.EmptyObject),
 			BeforeValMarks: []cty.PathValueMarks{
@@ -4045,6 +4085,10 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_whole"}},
 					Marks: cty.NewValueMarks("sensitive"),
 				},
+				{
+					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block"}},
+					Marks: cty.NewValueMarks("sensitive"),
+				},
 			},
 			RequiredReplace: cty.NewPathSet(),
 			Tainted:         false,
@@ -4055,6 +4099,17 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 					"list_field": {Type: cty.List(cty.String), Optional: true},
 					"map_key":    {Type: cty.Map(cty.Number), Optional: true},
 					"map_whole":  {Type: cty.Map(cty.String), Optional: true},
+				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"nested_block": {
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"an_attr": {Type: cty.String, Optional: true},
+								"another": {Type: cty.String, Optional: true},
+							},
+						},
+						Nesting: configschema.NestingList,
+					},
 				},
 			},
 			ExpectedOutput: `  # test_instance.example will be destroyed
@@ -4070,6 +4125,11 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
           - "dinner"    = (sensitive)
         } -> null
       - map_whole  = (sensitive) -> null
+
+      - nested_block {
+          - an_attr = (sensitive) -> null
+          - another = (sensitive) -> null
+        }
     }
 `,
 		},

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -4025,7 +4025,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 				}),
 				"nested_block_map": cty.MapVal(map[string]cty.Value{
 					"foo": cty.ObjectVal(map[string]cty.Value{
-						"an_attr": cty.StringVal("changed"),
+						"an_attr": cty.UnknownVal(cty.String),
 					}),
 				}),
 			}),

--- a/plans/objchange/compatible.go
+++ b/plans/objchange/compatible.go
@@ -73,8 +73,9 @@ func assertObjectCompatible(schema *configschema.Block, planned, actual cty.Valu
 		}
 	}
 	for name, blockS := range schema.BlockTypes {
-		plannedV := planned.GetAttr(name)
-		actualV := actual.GetAttr(name)
+		// Unmark values before testing compatibility
+		plannedV, _ := planned.GetAttr(name).UnmarkDeep()
+		actualV, _ := actual.GetAttr(name).UnmarkDeep()
 
 		// As a special case, if there were any blocks whose leaf attributes
 		// are all unknown then we assume (possibly incorrectly) that the

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -11939,8 +11939,17 @@ variable "sensitive_var" {
 	sensitive = true
 }
 
+variable "sensitive_id" {
+	default = "secret id"
+	sensitive = true
+}
+
 resource "test_resource" "foo" {
 	value   = var.sensitive_var
+
+	network_interface {
+		network_interface_id = var.sensitive_id
+	}
 }`,
 	})
 
@@ -11982,7 +11991,7 @@ resource "test_resource" "foo" {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
-	// Now change the variable value
+	// Now change the variable value for sensitive_var
 	ctx = testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -636,6 +636,17 @@ func testProviderSchema(name string) *ProviderSchema {
 						Optional: true,
 					},
 				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"network_interface": {
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"network_interface_id": {Type: cty.String, Optional: true},
+								"device_index":         {Type: cty.Number, Optional: true},
+							},
+						},
+						Nesting: configschema.NestingSet,
+					},
+				},
 			},
 			name + "_ami_list": {
 				Attributes: map[string]*configschema.Attribute{


### PR DESCRIPTION
Before this PR, using a sensitive value in a nested block would result in a panic. This adjusts `Encode` to unmark a value before processing `UnknownAsNull` and calls `AssertPlanValid` with all unmarked values for value-validation. There is also additional testing added to test blocks through apply, and adjusts compatibility testing to drop marks for such testing (as it is testing whether values are compatible). As far as printing the diff, we have a special behavior to obfuscate the whole nested block when either the old or new value is sensitive (see note).

**Note** : When a member of a set is marked, the set itself is marked, so we must consider all members of the set as sensitive. This results in _highly_ conservative behavior when a sensitive value is used in a nested block, but at least allows the behavior.

A screenshot of this behavior in action. Preferences/comments on wording welcome

<img width="650" alt="Screen Shot 2020-09-29 at 1 29 08 PM" src="https://user-images.githubusercontent.com/204372/94594741-d8582e00-0257-11eb-886a-dabf78a12d31.png">


