### PR TITLE
Mildwonkey/plan refactor

### DIFF
--- a/terraform/eval_check_prevent_destroy.go
+++ b/terraform/eval_check_prevent_destroy.go
@@ -45,5 +45,3 @@ func (n *EvalCheckPreventDestroy) Eval(ctx EvalContext) (interface{}, error) {
 
 	return nil, nil
 }
-
-const preventDestroyErrStr = `%s: the plan would destroy this resource, but it currently has lifecycle.prevent_destroy set to true. To avoid this error and continue with the plan, either disable lifecycle.prevent_destroy or adjust the scope of the plan using the -target flag.`

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -496,6 +496,48 @@ func (n *NodeAbstractResource) WriteResourceState(ctx EvalContext, addr addrs.Ab
 	return nil
 }
 
+func (n *NodeAbstractResource) ReadResourceInstanceState(ctx EvalContext, addr addrs.AbsResourceInstance) (*states.ResourceInstanceObject, error) {
+	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+
+	if provider == nil {
+		panic("ReadResourceInstanceState used with no Provider object")
+	}
+	if providerSchema == nil {
+		panic("ReadResourceInstanceState used with no ProviderSchema object")
+	}
+
+	log.Printf("[TRACE] ReadResourceInstanceState: reading state for %s", addr)
+
+	src := ctx.State().ResourceInstanceObject(addr, states.CurrentGen)
+	if src == nil {
+		// Presumably we only have deposed objects, then.
+		log.Printf("[TRACE] ReadResourceInstanceState: no state present for %s", addr)
+		return nil, nil
+	}
+
+	schema, currentVersion := (providerSchema).SchemaForResourceAddr(addr.Resource.ContainingResource())
+	if schema == nil {
+		// Shouldn't happen since we should've failed long ago if no schema is present
+		return nil, fmt.Errorf("no schema available for %s while reading state; this is a bug in Terraform and should be reported", addr)
+	}
+	var diags tfdiags.Diagnostics
+	src, diags = UpgradeResourceState(addr, provider, src, schema, currentVersion)
+	if diags.HasErrors() {
+		// Note that we don't have any channel to return warnings here. We'll
+		// accept that for now since warnings during a schema upgrade would
+		// be pretty weird anyway, since this operation is supposed to seem
+		// invisible to the user.
+		return nil, diags.Err()
+	}
+
+	obj, err := src.Decode(schema.ImpliedType())
+	if err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
 // graphNodesAreResourceInstancesInDifferentInstancesOfSameModule is an
 // annoyingly-task-specific helper function that returns true if and only if
 // the following conditions hold:

--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/dag"
 	"github.com/hashicorp/terraform/lang"
-	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // nodeExpandApplyableResource handles the first layer of resource
@@ -109,41 +108,6 @@ func (n *NodeApplyableResource) Execute(ctx EvalContext, op walkOperation) error
 		return nil
 	}
 
-	var diags tfdiags.Diagnostics
-	state := ctx.State()
-
-	// We'll record our expansion decision in the shared "expander" object
-	// so that later operations (i.e. DynamicExpand and expression evaluation)
-	// can refer to it. Since this node represents the abstract module, we need
-	// to expand the module here to create all resources.
-	expander := ctx.InstanceExpander()
-
-	switch {
-	case n.Config.Count != nil:
-		count, countDiags := evaluateCountExpression(n.Config.Count, ctx)
-		diags = diags.Append(countDiags)
-		if countDiags.HasErrors() {
-			return diags.Err()
-		}
-
-		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
-		expander.SetResourceCount(n.Addr.Module, n.Addr.Resource, count)
-
-	case n.Config.ForEach != nil:
-		forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx)
-		diags = diags.Append(forEachDiags)
-		if forEachDiags.HasErrors() {
-			return diags.Err()
-		}
-
-		// This method takes care of all of the business logic of updating this
-		// while ensuring that any existing instances are preserved, etc.
-		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
-		expander.SetResourceForEach(n.Addr.Module, n.Addr.Resource, forEach)
-
-	default:
-		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
-		expander.SetResourceSingle(n.Addr.Module, n.Addr.Resource)
-	}
-	return nil
+	err := n.WriteResourceState(ctx, n.Addr)
+	return err
 }

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -170,13 +170,7 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 			return EvalEarlyExitError{}
 		}
 
-		evalReadState := &EvalReadState{
-			Addr:           addr.Resource,
-			Output:         &state,
-			Provider:       &provider,
-			ProviderSchema: &providerSchema,
-		}
-		_, err = evalReadState.Eval(ctx)
+		state, err = n.ReadResourceInstanceState(ctx, addr)
 		if err != nil {
 			return err
 		}

--- a/terraform/node_resource_plan.go
+++ b/terraform/node_resource_plan.go
@@ -185,43 +185,8 @@ func (n *NodePlannableResource) Execute(ctx EvalContext, op walkOperation) error
 		return nil
 	}
 
-	var diags tfdiags.Diagnostics
-	state := ctx.State()
-
-	// We'll record our expansion decision in the shared "expander" object
-	// so that later operations (i.e. DynamicExpand and expression evaluation)
-	// can refer to it. Since this node represents the abstract module, we need
-	// to expand the module here to create all resources.
-	expander := ctx.InstanceExpander()
-
-	switch {
-	case n.Config.Count != nil:
-		count, countDiags := evaluateCountExpression(n.Config.Count, ctx)
-		diags = diags.Append(countDiags)
-		if countDiags.HasErrors() {
-			return diags.Err()
-		}
-
-		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
-		expander.SetResourceCount(n.Addr.Module, n.Addr.Resource, count)
-
-	case n.Config.ForEach != nil:
-		forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx)
-		diags = diags.Append(forEachDiags)
-		if forEachDiags.HasErrors() {
-			return diags.Err()
-		}
-
-		// This method takes care of all of the business logic of updating this
-		// while ensuring that any existing instances are preserved, etc.
-		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
-		expander.SetResourceForEach(n.Addr.Module, n.Addr.Resource, forEach)
-
-	default:
-		state.SetResourceProvider(n.Addr, n.ResolvedProvider)
-		expander.SetResourceSingle(n.Addr.Module, n.Addr.Resource)
-	}
-	return nil
+	err := n.WriteResourceState(ctx, n.Addr)
+	return err
 }
 
 // GraphNodeDestroyerCBD

--- a/terraform/node_resource_plan_orphan.go
+++ b/terraform/node_resource_plan_orphan.go
@@ -57,12 +57,7 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 		return err
 	}
 
-	checkPreventDestroy := &EvalCheckPreventDestroy{
-		Addr:   addr.Resource,
-		Config: n.Config,
-		Change: &change,
-	}
-	_, err = checkPreventDestroy.Eval(ctx)
+	err = n.CheckPreventDestroy(addr, change)
 	if err != nil {
 		return err
 	}
@@ -76,6 +71,7 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	if err != nil {
 		return err
 	}
+
 	writeState := &EvalWriteState{
 		Addr:           addr.Resource,
 		ProviderAddr:   n.ResolvedProvider,

--- a/terraform/node_resource_plan_orphan.go
+++ b/terraform/node_resource_plan_orphan.go
@@ -35,19 +35,12 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	var change *plans.ResourceInstanceChange
 	var state *states.ResourceInstanceObject
 
-	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return err
 	}
 
-	//EvalReadState
-	readState := &EvalReadState{
-		Addr:           addr.Resource,
-		Provider:       &provider,
-		ProviderSchema: &providerSchema,
-		Output:         &state,
-	}
-	_, err = readState.Eval(ctx)
+	state, err = n.ReadResourceInstanceState(ctx, addr)
 	if err != nil {
 		return err
 	}

--- a/terraform/node_resource_plan_orphan_test.go
+++ b/terraform/node_resource_plan_orphan_test.go
@@ -1,0 +1,64 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/instances"
+	"github.com/hashicorp/terraform/plans"
+	"github.com/hashicorp/terraform/states"
+)
+
+func TestNodeResourcePlanOrphanExecute(t *testing.T) {
+	state := states.NewState()
+	state.Module(addrs.RootModuleInstance).SetResourceInstanceCurrent(
+		addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "test_object",
+			Name: "foo",
+		}.Instance(addrs.NoKey),
+		&states.ResourceInstanceObjectSrc{
+			AttrsFlat: map[string]string{
+				"test_string": "foo",
+			},
+			Status: states.ObjectReady,
+		},
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   addrs.RootModule,
+		},
+	)
+
+	p := simpleMockProvider()
+	ctx := &MockEvalContext{
+		StateState:               state.SyncWrapper(),
+		InstanceExpanderExpander: instances.NewExpander(),
+		ProviderProvider:         p,
+		ProviderSchemaSchema: &ProviderSchema{
+			ResourceTypes: map[string]*configschema.Block{
+				"test_object": simpleTestSchema(),
+			},
+		},
+		ChangesChanges: plans.NewChanges().SyncWrapper(),
+	}
+
+	node := NodePlannableResourceInstanceOrphan{
+		NodeAbstractResourceInstance: &NodeAbstractResourceInstance{
+			NodeAbstractResource: NodeAbstractResource{
+				ResolvedProvider: addrs.AbsProviderConfig{
+					Provider: addrs.NewDefaultProvider("test"),
+					Module:   addrs.RootModule,
+				},
+			},
+			Addr: mustResourceInstanceAddr("test_object.foo"),
+		},
+	}
+	err := node.Execute(ctx, walkApply)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+	if !state.Empty() {
+		t.Fatalf("expected empty state, got %s", state.String())
+	}
+}


### PR DESCRIPTION
I'll leave it up to the reviewers to decide if this PR works better commit-by-commit, or reviewed as a whole. 

Summary of Changes:

The following `Eval()` nodes now *also* exist as methods on `NodeResourceAbstract`, and the corresponding `Eval()s` will be removed when they have no more callers:
- `EvalWriteResourceState.Eval()`    -> `NodeResourceAbstract.WriteResourceState()`
- `EvalCheckPreventDestroy.Eval()` -> `NodeResourceAbstract.CheckPreventDestroy()`
- `EvalReadState.Eval()` -> `NodeResourceAbstract.ReadResourceInstanceState()`

`NodePlannableResource` and `NodeApplyableResource`  updated to use the new `WriteResourceState`

`NodePlannableResourceInstanceOrphan` refactor (`GraphNodeEvalable` to `GraphNodeExecutable`)
