### PR TITLE
Fix handling of ignore_changes

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -4626,18 +4626,14 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Action != plans.Update {
-		t.Fatalf("resource %s should be updated, got %s", ric.Addr, res.Action)
-	}
 
 	if ric.Addr.String() != "aws_instance.foo" {
 		t.Fatalf("unexpected resource: %s", ric.Addr)
 	}
 
 	checkVals(t, objectVal(t, schema, map[string]cty.Value{
-		"id":   cty.StringVal("bar"),
-		"ami":  cty.StringVal("ami-abcd1234"),
-		"type": cty.StringVal("aws_instance"),
+		"id":  cty.StringVal("bar"),
+		"ami": cty.StringVal("ami-abcd1234"),
 	}), ric.After)
 }
 

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -1712,3 +1712,47 @@ output "out" {
 		}
 	}
 }
+
+func TestContext2Validate_invalidIgnoreChanges(t *testing.T) {
+	// validate module and output depends_on
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "a" {
+  lifecycle {
+    ignore_changes = [foo]
+  }
+}
+
+`,
+	})
+
+	p := testProvider("test")
+	p.GetSchemaReturn = &ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_instance": {
+				Attributes: map[string]*configschema.Attribute{
+					"id":  {Type: cty.String, Computed: true},
+					"foo": {Type: cty.String, Computed: true, Optional: true},
+				},
+			},
+		},
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+	diags := ctx.Validate()
+	if !diags.HasErrors() {
+		t.Fatal("succeeded; want errors")
+	}
+
+	for _, d := range diags {
+		des := d.Description().Summary
+		if !strings.Contains(des, "Cannot ignore") {
+			t.Fatalf(`expected "Invalid depends_on reference", got %q`, des)
+		}
+	}
+}

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -334,16 +334,6 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 		}
 	}
 
-	// TODO: We should be able to remove this repeat of processing ignored changes
-	// after the plan, which helps providers relying on old behavior "just work"
-	// in the next major version, such that we can be stricter about ignore_changes
-	// values
-	plannedNewVal, ignoreChangeDiags = n.processIgnoreChanges(priorVal, plannedNewVal)
-	diags = diags.Append(ignoreChangeDiags)
-	if ignoreChangeDiags.HasErrors() {
-		return nil, diags.Err()
-	}
-
 	// The provider produces a list of paths to attributes whose changes mean
 	// that we must replace rather than update an existing remote object.
 	// However, we only need to do that if the identified attributes _have_

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -410,8 +410,39 @@ func (n *EvalValidateResource) Validate(ctx EvalContext) error {
 
 		if cfg.Managed != nil { // can be nil only in tests with poorly-configured mocks
 			for _, traversal := range cfg.Managed.IgnoreChanges {
+				// This will error out if the traversal contains an invalid
+				// index step. That is OK if we want users to be able to ignore
+				// a key that is no longer specified in the config.
 				moreDiags := schema.StaticValidateTraversal(traversal)
 				diags = diags.Append(moreDiags)
+				if diags.HasErrors() {
+					continue
+				}
+
+				// first check to see if this assigned in the config
+				v, _ := traversal.TraverseRel(configVal)
+				if !v.IsNull() {
+					// it's assigned, so we can also assume it's not computed-only
+					continue
+				}
+
+				// We can't ignore changes that don't exist in the configuration.
+				// We're not checking specifically if the traversal resolves to
+				// a computed-only value, but we can hint to the user that it
+				// might also be the case.
+				sourceRange := traversal.SourceRange()
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Cannot ignore argument not set in the configuration",
+					Detail: fmt.Sprintf("The ignore_changes argument is not set in the configuration.\n" +
+						"The ignore_changes mechanism only applies to changes " +
+						"within the configuration, and must be used with " +
+						"arguments set in the configuration and not computed by " +
+						"the provider.",
+					),
+					Subject: &sourceRange,
+				})
+				return diags.Err()
 			}
 		}
 

--- a/terraform/provider_mock.go
+++ b/terraform/provider_mock.go
@@ -308,7 +308,7 @@ func (p *MockProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 			Type: r.TypeName,
 		}
 		priorState := NewInstanceStateShimmedFromValue(r.PriorState, 0)
-		cfg := NewResourceConfigShimmed(r.Config, schema)
+		cfg := NewResourceConfigShimmed(r.ProposedNewState, schema)
 
 		legacyDiff, err := p.DiffFn(info, priorState, cfg)
 


### PR DESCRIPTION
Ignore changes was intended to only ignore changes happening within the configuration, and should not be applied to values set by the provider. We were previously re-applying this to the planned value for compatibility, but intended to remove the patch in a major release version.

It also turned out that we should have been applying `ignore_changes` directly to the configuration, rather than the proposed value created for the plan. Doing this ensures that the configuration used for comparison internally, the proposed value, and the configuration passed to the provider all show the same starting data minus the ignored changes. Without this change, because providers are required to create their plan based on the proposed value, `AssertPlanValid` would always show errors when comparing the planned value against the config, though they are currently only reported as warnings for legacy providers.

While there still are many documented cases in the providers' docs, `ignore_changes` is not something that providers can use to prevent changes to their configured values. In future versions of providers that are no longer in the legacy protocol exception, altering configuration values will be a hard error, so future providers cannot intentionally cause "drift" to configured values, and `ignore_changes` would not be useful in that configuration in the first place. 

This PR also adds some basic validation to the `ignore_changes` argument, preventing users from setting references to arguments not set in the configuration, which prevents the case of mistakingly trying to ignore changes to computed values.

The following configuration for example will result in the error below:
```
resource "null_resource" "a" {
  lifecycle {
    ignore_changes = [id]
  }
}
```

```
Error: Cannot ignore argument not set in the configuration

  on main.tf line 3, in resource "null_resource" "a":
   3:     ignore_changes = [id]

The ignore_changes argument is not set in the configuration.
The ignore_changes mechanism only applies to changes within the configuration,
and must be used with arguments set in the configuration and not computed by
the provider.
```