### PR TITLE
Fix terraform bundle broken with custom plugins

### DIFF
--- a/tools/terraform-bundle/e2etest/package_test.go
+++ b/tools/terraform-bundle/e2etest/package_test.go
@@ -125,6 +125,9 @@ func TestPackage_manyProviders(t *testing.T) {
 
 			for _, file := range read.File {
 				if _, exists := expectedFiles[file.Name]; exists {
+					if !file.FileInfo().Mode().IsRegular() {
+						t.Errorf("Expected file is not a regular file: %s", file.Name)
+					}
 					delete(expectedFiles, file.Name)
 				} else {
 					extraFiles[file.Name] = struct{}{}
@@ -195,6 +198,9 @@ func TestPackage_localProviders(t *testing.T) {
 
 			for _, file := range read.File {
 				if _, exists := expectedFiles[file.Name]; exists {
+					if !file.FileInfo().Mode().IsRegular() {
+						t.Errorf("Expected file is not a regular file: %s", file.Name)
+					}
 					delete(expectedFiles, file.Name)
 				} else {
 					extraFiles[file.Name] = struct{}{}

--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -226,7 +226,7 @@ func (c *PackageCommand) Run(args []string) int {
 						return addZipFile(
 							filepath.Join(linkPath, file.Name()), // the link to this provider binary
 							filepath.Join(relPath, file.Name()),  // the expected directory for the binary
-							info, outZ,
+							file, outZ,
 						)
 					}
 				}


### PR DESCRIPTION
Hi,

We are using the Terraform bundle tool, and it seems broken with custom plugins (v0.13.3)

Command:
`terraform-bundle package -plugin-dir ./custom-plugins ./terraform-bundle.hcl`

Inspect:
```
# unzip -l terraform_0.13.3-bundle2020092409_linux_amd64.zip 
Archive:  terraform_0.13.3-bundle2020092409_linux_amd64.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
 36373356  09-24-2020 09:19   plugins/github.com/carlpett/sops/0.5.1/linux_amd64/terraform-provider-sops
 26763888  09-24-2020 09:19   plugins/github.com/dihedron/jenkins/0.0.0-1abf850/linux_amd64/terraform-provider-jenkins
 31781827  09-24-2020 09:19   plugins/github.com/mrparkers/keycloak/1.20.0/linux_amd64/terraform-provider-keycloak
158158848  09-24-2020 09:19   plugins/registry.terraform.io/hashicorp/aws/2.70.0/linux_amd64/terraform-provider-aws_v2.70.0_x4
 20427104  09-24-2020 09:19   plugins/registry.terraform.io/hashicorp/external/1.2.0/linux_amd64/terraform-provider-external_v1.2.0_x4
 51478528  09-24-2020 09:19   plugins/registry.terraform.io/hashicorp/helm/1.2.4/linux_amd64/terraform-provider-helm_v1.2.4_x4
 43843584  09-24-2020 09:19   plugins/registry.terraform.io/hashicorp/kubernetes/1.12.0/linux_amd64/terraform-provider-kubernetes_v1.12.0_x4
 20373856  09-24-2020 09:19   plugins/registry.terraform.io/hashicorp/null/2.1.2/linux_amd64/terraform-provider-null_v2.1.2_x4
 21704704  09-24-2020 09:19   plugins/registry.terraform.io/hashicorp/random/2.3.0/linux_amd64/terraform-provider-random_v2.3.0_x4
 20812960  09-24-2020 09:19   plugins/registry.terraform.io/hashicorp/template/2.1.2/linux_amd64/terraform-provider-template_v2.1.2_x4
 22036480  09-24-2020 09:19   plugins/registry.terraform.io/hashicorp/time/0.5.0/linux_amd64/terraform-provider-time_v0.5.0_x4
 85549444  09-24-2020 09:19   terraform
---------                     -------
570228996                     12 files

# cd terraform-bundle
# find . -type l -exec ls -l {} \; 
lrwxrwxrwx    1 root     root             7 Sep 24 09:20 ./plugins/github.com/carlpett/sops/0.5.1/linux_amd64/terraform-provider-sops -> ?ELF???
lrwxrwxrwx    1 root     root             7 Sep 24 09:20 ./plugins/github.com/mrparkers/keycloak/1.20.0/linux_amd64/terraform-provider-keycloak -> ?ELF???
lrwxrwxrwx    1 root     root             7 Sep 24 09:20 ./plugins/github.com/dihedron/jenkins/0.0.0-1abf850/linux_amd64/terraform-provider-jenkins -> ?ELF???
```
As we can see, all the custom plugins binary is a symlink and pointing to broken targets. After inspecting the code, look like the code is passing the wrong file header. We create this PR with the fix and add the test coverage (the test will fail without the PR changes).

Please help to have a look, thanks for your time!

P/S: We were using 0.12.x and have carefully followed the migration document for 0.13.x before creating this PR.