### PR TITLE
command: remove unused method on pluginSHA256LockFile

### DIFF
--- a/command/fmt_test.go
+++ b/command/fmt_test.go
@@ -22,11 +22,15 @@ func TestFmt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tmpDir, err := ioutil.TempDir("", "terraform-fmt-test")
+	td, err := ioutil.TempDir("", "terraform-fmt-test")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir, err := filepath.EvalSymlinks(td)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(td)
 
 	for _, info := range entries {
 		if info.IsDir() {

--- a/command/plugins_lock.go
+++ b/command/plugins_lock.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"path/filepath"
 )
 
@@ -61,26 +60,4 @@ func (pf *pluginSHA256LockFile) Read() map[string][]byte {
 	}
 
 	return digests
-}
-
-// Write persists lock information to disk, where it will be retrieved by
-// future calls to Read. This entirely replaces any previous lock information,
-// so the given map must be comprehensive.
-func (pf *pluginSHA256LockFile) Write(digests map[string][]byte) error {
-	strDigests := map[string]string{}
-	for name, digest := range digests {
-		strDigests[name] = fmt.Sprintf("%x", digest)
-	}
-
-	buf, err := json.MarshalIndent(strDigests, "", "  ")
-	if err != nil {
-		// should never happen
-		return fmt.Errorf("failed to serialize plugin lock as JSON: %s", err)
-	}
-
-	os.MkdirAll(
-		filepath.Dir(pf.Filename), os.ModePerm,
-	) // ignore error since WriteFile below will generate a better one anyway
-
-	return ioutil.WriteFile(pf.Filename, buf, os.ModePerm)
 }

--- a/command/plugins_lock_test.go
+++ b/command/plugins_lock_test.go
@@ -2,18 +2,18 @@ package command
 
 import (
 	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 )
 
-func TestPluginSHA256LockFile(t *testing.T) {
+func TestPluginSHA256LockFile_Read(t *testing.T) {
 	f, err := ioutil.TempFile(testingDir, "tf-pluginsha1lockfile-test-")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}
 	f.Close()
-	//defer os.Remove(f.Name())
-	t.Logf("working in %s", f.Name())
+	defer os.Remove(f.Name())
 
 	plf := &pluginSHA256LockFile{
 		Filename: f.Name(),
@@ -23,18 +23,5 @@ func TestPluginSHA256LockFile(t *testing.T) {
 	digests := plf.Read()
 	if !reflect.DeepEqual(digests, map[string][]byte{}) {
 		t.Errorf("wrong initial content %#v; want empty map", digests)
-	}
-
-	digests = map[string][]byte{
-		"test": []byte("hello world"),
-	}
-	err = plf.Write(digests)
-	if err != nil {
-		t.Fatalf("failed to write lock file: %s", err)
-	}
-
-	got := plf.Read()
-	if !reflect.DeepEqual(got, digests) {
-		t.Errorf("wrong content %#v after write; want %#v", got, digests)
 	}
 }


### PR DESCRIPTION
This PR removes some unused code. The new provider installer is responsible for writing the lockfile, so I've removed the older Write() method.

This has an unfortunate side effect: now that I've removed the `Write` portion, the test as written is pretty pointless, and the provider installer's lock file test coverage is also lacking. I won't be offended if we decide not to merge this as-is, but I don't have the time or spoons to add (needed) test coverage at this moment. 

Bonus commit: `fmt` tests were failing on OSX because it is haunted (and `/tmp` is a symlink)