### PR TITLE
helper: Add helper function JsonEnvDefaultFunc and its test

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -13,6 +13,7 @@ package schema
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
@@ -295,6 +296,23 @@ func MultiEnvDefaultFunc(ks []string, dv interface{}) SchemaDefaultFunc {
 				return v, nil
 			}
 		}
+		return dv, nil
+	}
+}
+
+// JsonEnvDefaultFunc is a helper function that parses the given environment
+// variable as a JSON object, or returns the default value otherwise.
+func JsonEnvDefaultFunc(k string, dv interface{}) SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		if valStr := os.Getenv(k); valStr != "" {
+			var valObj map[string]interface{}
+			err := json.Unmarshal([]byte(valStr), &valObj)
+			if err != nil {
+				return nil, err
+			}
+			return valObj, nil
+		}
+
 		return dv, nil
 	}
 }

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -103,6 +103,45 @@ func TestMultiEnvDefaultFunc(t *testing.T) {
 	}
 }
 
+func TestJsonEnvDefaultFunc(t *testing.T) {
+	key := "TF_TEST_JSON_ENV_DEFAULT_FUNC"
+	defer os.Unsetenv(key)
+
+	def := map[string]interface{} {"foo": "default"}
+	f := JsonEnvDefaultFunc(key, def)
+	if err := os.Setenv(key, "{\"foo\":\"bar\"}"); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actualAbs, err := f()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	actual, ok := actualAbs.(map[string]interface{})
+	if !ok {
+		t.Fatalf("bad: %#v", actualAbs)
+	}
+	if actual["foo"] != "bar" {
+		t.Fatalf("bad: %#v", actual)
+	}
+
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actualAbs, err = f()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	actual, ok = actualAbs.(map[string]interface{})
+	if !ok {
+		t.Fatalf("bad: %#v", actualAbs)
+	}
+	if actual["foo"] != "default" {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
 func TestValueType_Zero(t *testing.T) {
 	cases := []struct {
 		Type  ValueType


### PR DESCRIPTION
Currently, there are only two simple helper functions available for providing default values in schema definitions. These read env variables and can only return a single string.

This PR adds a helper function `JsonEnvDefaultFunc` that can be used in more complex scenarios that require a map with arbitrary keys (to be used with `TypeMap`). It expects the map to be encoded as an JSON object in a string.

For example if you have a provider that needs support for arbitrary HTTP headers:

```
provider "foo" {
  url  = "http://..."
  headers = {
    "Cookies" = "foo=bar"
  }
}
```

With this helper function it could be possible to pass the HTTP headers using an env variable:

```
$ FOO_HTTP_HEADERS='{"Cookies":"foo=bar"}' terraform plan
```