### PR TITLE
Fix bad string match that was causing TestInitProviderNotFound to fail

### DIFF
--- a/command/e2etest/init_test.go
+++ b/command/e2etest/init_test.go
@@ -357,7 +357,7 @@ func TestInitProviderNotFound(t *testing.T) {
 			t.Fatal("expected error, got success")
 		}
 
-		if !strings.Contains(stderr, "provider registry.terraform.io/hashicorp/nonexist was not\nfound in any of the search locations\n\n- "+pluginDir) {
+		if !strings.Contains(stderr, "provider registry.terraform.io/hashicorp/nonexist was not\nfound in any of the search locations\n\n  - "+pluginDir) {
 			t.Errorf("expected error message is missing from output:\n%s", stderr)
 		}
 	})

--- a/command/init.go
+++ b/command/init.go
@@ -505,7 +505,7 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 				sources := errorTy.Sources
 				displaySources := make([]string, len(sources))
 				for i, source := range sources {
-					displaySources[i] = fmt.Sprintf("- %s", source)
+					displaySources[i] = fmt.Sprintf("  - %s", source)
 				}
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,


### PR DESCRIPTION
Simple fix for https://github.com/hashicorp/terraform/issues/26411