### PR TITLE
Updating CODEOWNERS with our deprecated status for tool-specific provisioners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,11 +18,11 @@
 /backend/remote-state/kubernetes        @jrhouston @alexsomesan 
 
 # Provisioners
-builtin/provisioners/chef               Unmaintained
+builtin/provisioners/chef               Deprecated
 builtin/provisioners/file               @hashicorp/terraform-core
-builtin/provisioners/habitat            Unmaintained
+builtin/provisioners/habitat            Deprecated
 builtin/provisioners/local-exec         @hashicorp/terraform-core
-builtin/provisioners/puppet             Unmaintained
+builtin/provisioners/puppet             Deprecated
 builtin/provisioners/remote-exec        @hashicorp/terraform-core
-builtin/provisioners/salt-masterless    Unmaintained
+builtin/provisioners/salt-masterless    Deprecated
 


### PR DESCRIPTION
With `0.13.4` targeted for release this week, I thought it wise to be consistent with the status of built-in tool-specific code. This small change makes clear we are no longer looking for maintainers for the tool specific provisioners.