### PR TITLE
Issue 26320 - lookup(): only treat map as unknown if it is wholly unknown

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -315,7 +315,7 @@ var LookupFunc = function.New(&function.Spec{
 		mapVar := args[0]
 		lookupKey := args[1].AsString()
 
-		if !mapVar.IsWhollyKnown() {
+		if !mapVar.IsKnown() {
 			return cty.UnknownVal(retType), nil
 		}
 

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -722,6 +722,14 @@ func TestLookup(t *testing.T) {
 		},
 		{
 			[]cty.Value{
+				mapWithUnknowns,
+				cty.StringVal("foo"),
+			},
+			cty.StringVal("bar"),
+			false,
+		},
+		{
+			[]cty.Value{
 				simpleMap,
 				cty.UnknownVal(cty.String),
 			},


### PR DESCRIPTION
Fix for issue #26320 - this allows us to derive known values from partially known maps where we can, and may prevent unnecessary destroy/rebuild cycles during apply in some cases.

Based on @apparentlymart 's suggestions in the issue thread.

Most of this PR is changes to `primary_test.go` and `automation_test.go` as I have added a very basic regression test to the primary workflow. Happy to change or adjust this if you feel it would be cleaner/preferable to have a separate HCL file and test set for this.