### PR TITLE
remove LegacyProvider

### DIFF
--- a/addrs/provider_config_test.go
+++ b/addrs/provider_config_test.go
@@ -168,25 +168,25 @@ func TestAbsProviderConfigString(t *testing.T) {
 		{
 			AbsProviderConfig{
 				Module:   RootModule.Child("child_module"),
-				Provider: NewLegacyProvider("foo"),
+				Provider: NewDefaultProvider("foo"),
 			},
-			`module.child_module.provider["registry.terraform.io/-/foo"]`,
+			`module.child_module.provider["registry.terraform.io/hashicorp/foo"]`,
 		},
 		{
 			AbsProviderConfig{
 				Module:   RootModule,
 				Alias:    "bar",
-				Provider: NewLegacyProvider("foo"),
+				Provider: NewDefaultProvider("foo"),
 			},
-			`provider["registry.terraform.io/-/foo"].bar`,
+			`provider["registry.terraform.io/hashicorp/foo"].bar`,
 		},
 		{
 			AbsProviderConfig{
 				Module:   RootModule.Child("child_module"),
 				Alias:    "bar",
-				Provider: NewLegacyProvider("foo"),
+				Provider: NewDefaultProvider("foo"),
 			},
-			`module.child_module.provider["registry.terraform.io/-/foo"].bar`,
+			`module.child_module.provider["registry.terraform.io/hashicorp/foo"].bar`,
 		},
 	}
 

--- a/backend/testing.go
+++ b/backend/testing.go
@@ -150,7 +150,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 				SchemaVersion: 0,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -373,7 +373,7 @@ func testStateFile(t *testing.T, s *states.State) string {
 
 // testStateFileDefault writes the state out to the default statefile
 // in the cwd. Use `testCwd` to change into a temp cwd.
-func testStateFileDefault(t *testing.T, s *terraform.State) string {
+func testStateFileDefault(t *testing.T, s *states.State) {
 	t.Helper()
 
 	f, err := os.Create(DefaultStateFilename)
@@ -382,11 +382,9 @@ func testStateFileDefault(t *testing.T, s *terraform.State) string {
 	}
 	defer f.Close()
 
-	if err := terraform.WriteState(s, f); err != nil {
+	if err := writeStateForTesting(s, f); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-
-	return DefaultStateFilename
 }
 
 // testStateFileWorkspaceDefault writes the state out to the default statefile

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3965,7 +3965,7 @@ func runTestCases(t *testing.T, testCases map[string]testCase) {
 					Name: "example",
 				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 				ProviderAddr: addrs.AbsProviderConfig{
-					Provider: addrs.NewLegacyProvider("test"),
+					Provider: addrs.NewDefaultProvider("test"),
 					Module:   addrs.RootModule,
 				},
 				ChangeSrc: plans.ChangeSrc{

--- a/command/format/state_test.go
+++ b/command/format/state_test.go
@@ -139,7 +139,7 @@ func testSchemas() *terraform.Schemas {
 	provider := testProvider()
 	return &terraform.Schemas{
 		Providers: map[addrs.Provider]*terraform.ProviderSchema{
-			addrs.NewLegacyProvider("test"): provider.GetSchemaReturn,
+			addrs.NewDefaultProvider("test"): provider.GetSchemaReturn,
 		},
 	}
 }
@@ -244,7 +244,7 @@ func basicState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)
@@ -260,7 +260,7 @@ func basicState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"compute":"sure"}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)
@@ -296,7 +296,7 @@ func stateWithMoreOutputs(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)
@@ -323,7 +323,7 @@ func nestedState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)
@@ -346,7 +346,7 @@ func deposedState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)
@@ -375,7 +375,7 @@ func onlyDeposedState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)
@@ -392,7 +392,7 @@ func onlyDeposedState(t *testing.T) *states.State {
 			AttrsJSON:     []byte(`{"woozles":"confuzles","nested": [{"value": "42"}]}`),
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -126,7 +126,7 @@ func TestGraph_plan(t *testing.T) {
 			After:  plans.DynamicValue(`null`),
 		},
 		ProviderAddr: addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	})

--- a/command/jsonprovider/provider_test.go
+++ b/command/jsonprovider/provider_test.go
@@ -133,7 +133,7 @@ func TestMarshalProvider(t *testing.T) {
 func testProviders() *terraform.Schemas {
 	return &terraform.Schemas{
 		Providers: map[addrs.Provider]*terraform.ProviderSchema{
-			addrs.NewLegacyProvider("test"): testProvider(),
+			addrs.NewDefaultProvider("test"): testProvider(),
 		},
 	}
 }

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/helper/copy"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statefile"
 	"github.com/hashicorp/terraform/states/statemgr"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
 
@@ -1783,21 +1783,9 @@ func TestMetaBackend_localDoesNotDeleteLocal(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
-	// create our local state
-	orig := &terraform.State{
-		Modules: []*terraform.ModuleState{
-			{
-				Path: []string{"root"},
-				Outputs: map[string]*terraform.OutputState{
-					"foo": {
-						Value: "bar",
-						Type:  "string",
-					},
-				},
-			},
-		},
-	}
-
+	// // create our local state
+	orig := states.NewState()
+	orig.Module(addrs.RootModuleInstance).SetOutputValue("foo", cty.StringVal("bar"), false)
 	testStateFileDefault(t, orig)
 
 	m := testMetaBackend(t, nil)

--- a/command/state_mv_test.go
+++ b/command/state_mv_test.go
@@ -27,7 +27,7 @@ func TestStateMv(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -43,7 +43,7 @@ func TestStateMv(t *testing.T) {
 				Dependencies: []addrs.ConfigResource{mustResourceAddr("test_instance.foo")},
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -161,7 +161,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -177,7 +177,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 				Dependencies: []addrs.ConfigResource{mustResourceAddr("test_instance.foo")},
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -188,7 +188,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 				Name: "bar",
 			}.Absolute(addrs.RootModuleInstance),
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -219,12 +219,12 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 	testStateOutput(t, statePath, `
 test_instance.bar.0:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.baz:
   ID = foo
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `)
@@ -250,7 +250,7 @@ func TestStateMv_instanceToResource(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -265,7 +265,7 @@ func TestStateMv_instanceToResource(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -296,12 +296,12 @@ func TestStateMv_instanceToResource(t *testing.T) {
 	testStateOutput(t, statePath, `
 test_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.baz:
   ID = foo
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `)
@@ -314,12 +314,12 @@ test_instance.baz:
 	testStateOutput(t, backups[0], `
 test_instance.baz:
   ID = foo
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.0:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `)
@@ -338,7 +338,7 @@ func TestStateMv_instanceToNewResource(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -369,7 +369,7 @@ func TestStateMv_instanceToNewResource(t *testing.T) {
 	testStateOutput(t, statePath, `
 test_instance.bar["new"]:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `)
@@ -390,7 +390,7 @@ test_instance.bar["new"]:
 module.test:
   test_instance.baz["new"]:
     ID = bar
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
     bar = value
     foo = value
 `)
@@ -409,7 +409,7 @@ func TestStateMv_differentResourceTypes(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -462,7 +462,7 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -477,7 +477,7 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -537,7 +537,7 @@ func TestStateMv_backupExplicit(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -553,7 +553,7 @@ func TestStateMv_backupExplicit(t *testing.T) {
 				Dependencies: []addrs.ConfigResource{mustResourceAddr("test_instance.foo")},
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -602,7 +602,7 @@ func TestStateMv_stateOutNew(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -656,7 +656,7 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -675,7 +675,7 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -755,7 +755,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -770,7 +770,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -785,7 +785,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -843,7 +843,7 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 					Status:    states.ObjectReady,
 				},
 				addrs.AbsProviderConfig{
-					Provider: addrs.NewLegacyProvider("test"),
+					Provider: addrs.NewDefaultProvider("test"),
 					Module:   addrs.RootModule,
 				},
 			)
@@ -859,7 +859,7 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -913,7 +913,7 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -928,7 +928,7 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -983,7 +983,7 @@ func TestStateMv_toNewModule(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -1056,7 +1056,7 @@ func TestStateMv_withinBackend(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -1072,7 +1072,7 @@ func TestStateMv_withinBackend(t *testing.T) {
 				Dependencies: []addrs.ConfigResource{mustResourceAddr("test_instance.foo")},
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -1130,7 +1130,7 @@ func TestStateMv_fromBackendToLocal(t *testing.T) {
 			Status:    states.ObjectReady,
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)
@@ -1141,7 +1141,7 @@ func TestStateMv_fromBackendToLocal(t *testing.T) {
 			Status:    states.ObjectReady,
 		},
 		addrs.AbsProviderConfig{
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	)
@@ -1204,7 +1204,7 @@ func TestStateMv_onlyResourceInModule(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -1247,7 +1247,7 @@ func TestStateMv_onlyResourceInModule(t *testing.T) {
 const testStateMvOutputOriginal = `
 test_instance.baz:
   ID = foo
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 
@@ -1255,7 +1255,7 @@ test_instance.baz:
     test_instance.foo
 test_instance.foo:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1263,12 +1263,12 @@ test_instance.foo:
 const testStateMvOutput = `
 test_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.baz:
   ID = foo
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1276,12 +1276,12 @@ test_instance.baz:
 const testStateMvCount_stateOut = `
 test_instance.bar.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.bar.1:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1289,7 +1289,7 @@ test_instance.bar.1:
 const testStateMvCount_stateOutSrc = `
 test_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1297,17 +1297,17 @@ test_instance.bar:
 const testStateMvCount_stateOutOriginal = `
 test_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.0:
   ID = foo
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.1:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1315,57 +1315,57 @@ test_instance.foo.1:
 const testStateMvLargeCount_stateOut = `
 test_instance.bar.0:
   ID = foo0
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.bar.1:
   ID = foo1
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.bar.2:
   ID = foo2
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.bar.3:
   ID = foo3
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.bar.4:
   ID = foo4
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.bar.5:
   ID = foo5
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.bar.6:
   ID = foo6
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.bar.7:
   ID = foo7
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.bar.8:
   ID = foo8
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.bar.9:
   ID = foo9
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.bar.10:
   ID = foo10
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1373,7 +1373,7 @@ test_instance.bar.10:
 const testStateMvLargeCount_stateOutSrc = `
 test_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1381,62 +1381,62 @@ test_instance.bar:
 const testStateMvLargeCount_stateOutOriginal = `
 test_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.0:
   ID = foo0
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.1:
   ID = foo1
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.2:
   ID = foo2
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.3:
   ID = foo3
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.4:
   ID = foo4
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.5:
   ID = foo5
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.6:
   ID = foo6
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.7:
   ID = foo7
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.8:
   ID = foo8
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.9:
   ID = foo9
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo.10:
   ID = foo10
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1446,13 +1446,13 @@ const testStateMvNestedModule_stateOut = `
 module.bar.child1:
   test_instance.foo:
     ID = bar
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
     bar = value
     foo = value
 module.bar.child2:
   test_instance.foo:
     ID = bar
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
     bar = value
     foo = value
 `
@@ -1462,7 +1462,7 @@ const testStateMvNewModule_stateOut = `
 module.bar:
   test_instance.bar:
     ID = bar
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
     bar = value
     foo = value
 `
@@ -1472,7 +1472,7 @@ const testStateMvModuleNewModule_stateOut = `
 module.foo:
   test_instance.bar:
     ID = bar
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
     bar = value
     foo = value
 `
@@ -1480,7 +1480,7 @@ module.foo:
 const testStateMvNewModule_stateOutOriginal = `
 test_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1494,13 +1494,13 @@ const testStateMvNestedModule_stateOutOriginal = `
 module.foo.child1:
   test_instance.foo:
     ID = bar
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
     bar = value
     foo = value
 module.foo.child2:
   test_instance.foo:
     ID = bar
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
     bar = value
     foo = value
 `
@@ -1508,7 +1508,7 @@ module.foo.child2:
 const testStateMvOutput_stateOut = `
 test_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1520,7 +1520,7 @@ const testStateMvOutput_stateOutSrc = `
 const testStateMvOutput_stateOutOriginal = `
 test_instance.foo:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1532,18 +1532,18 @@ const testStateMvExisting_stateSrc = `
 const testStateMvExisting_stateDst = `
 test_instance.bar:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.qux:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
 `
 
 const testStateMvExisting_stateSrcOriginal = `
 test_instance.foo:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1551,13 +1551,13 @@ test_instance.foo:
 const testStateMvExisting_stateDstOriginal = `
 test_instance.qux:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
 `
 
 const testStateMvOriginal_backend = `
 test_instance.baz:
   ID = foo
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -1567,7 +1567,7 @@ const testStateMvOnlyResourceInModule_original = `
 module.foo:
   test_instance.foo.0:
     ID = bar
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
     bar = value
     foo = value
 `
@@ -1577,7 +1577,7 @@ const testStateMvOnlyResourceInModule_output = `
 module.foo:
   test_instance.bar.0:
     ID = bar
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
     bar = value
     foo = value
 `

--- a/command/state_rm_test.go
+++ b/command/state_rm_test.go
@@ -26,7 +26,7 @@ func TestStateRm(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -41,7 +41,7 @@ func TestStateRm(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -91,7 +91,7 @@ func TestStateRmNotChildModule(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -109,7 +109,7 @@ func TestStateRmNotChildModule(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -141,7 +141,7 @@ func TestStateRmNotChildModule(t *testing.T) {
 module.child:
   test_instance.foo:
     ID = foo
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
     bar = value
     foo = value
 `)
@@ -154,14 +154,14 @@ module.child:
 	testStateOutput(t, backups[0], `
 test_instance.foo:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 
 module.child:
   test_instance.foo:
     ID = foo
-    provider = provider["registry.terraform.io/-/test"]
+    provider = provider["registry.terraform.io/hashicorp/test"]
     bar = value
     foo = value
 `)
@@ -180,7 +180,7 @@ func TestStateRmNoArgs(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -195,7 +195,7 @@ func TestStateRmNoArgs(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -239,7 +239,7 @@ func TestStateRmNonExist(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -254,7 +254,7 @@ func TestStateRmNonExist(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -294,7 +294,7 @@ func TestStateRm_backupExplicit(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -309,7 +309,7 @@ func TestStateRm_backupExplicit(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -410,7 +410,7 @@ func TestStateRm_backendState(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -425,7 +425,7 @@ func TestStateRm_backendState(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)
@@ -474,12 +474,12 @@ func TestStateRm_backendState(t *testing.T) {
 const testStateRmOutputOriginal = `
 test_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 test_instance.foo:
   ID = bar
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `
@@ -487,7 +487,7 @@ test_instance.foo:
 const testStateRmOutput = `
 test_instance.bar:
   ID = foo
-  provider = provider["registry.terraform.io/-/test"]
+  provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value
 `

--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -241,7 +241,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 				Status:    states.ObjectReady,
 			},
 			addrs.AbsProviderConfig{
-				Provider: addrs.NewLegacyProvider("test"),
+				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
 		)

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -74,7 +74,7 @@ func TestConfigResolveAbsProviderAddr(t *testing.T) {
 	t.Run("already absolute", func(t *testing.T) {
 		addr := addrs.AbsProviderConfig{
 			Module:   addrs.RootModule,
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 			Alias:    "boop",
 		}
 		got := cfg.ResolveAbsProviderAddr(addr, addrs.RootModule)

--- a/configs/module_test.go
+++ b/configs/module_test.go
@@ -30,7 +30,7 @@ func TestNewModule_provider_local_name(t *testing.T) {
 	}
 
 	// if there is not a local name for a provider, it should return the type name
-	localName = mod.LocalNameForProvider(addrs.NewLegacyProvider("nonexist"))
+	localName = mod.LocalNameForProvider(addrs.NewDefaultProvider("nonexist"))
 	if localName != "nonexist" {
 		t.Error("wrong local name returned for a non-local provider")
 	}

--- a/internal/earlyconfig/config.go
+++ b/internal/earlyconfig/config.go
@@ -170,7 +170,7 @@ func (c *Config) ProviderDependencies() (*moduledeps.Module, tfdiags.Diagnostics
 			fqn = addr
 		}
 		if fqn.IsZero() {
-			fqn = addrs.NewLegacyProvider(name)
+			fqn = addrs.NewDefaultProvider(name)
 		}
 		var constraints version.Constraints
 		for _, reqStr := range reqs.VersionConstraints {
@@ -180,7 +180,7 @@ func (c *Config) ProviderDependencies() (*moduledeps.Module, tfdiags.Diagnostics
 					diags = diags.Append(wrapDiagnostic(tfconfig.Diagnostic{
 						Severity: tfconfig.DiagError,
 						Summary:  "Invalid provider version constraint",
-						Detail:   fmt.Sprintf("Invalid version constraint %q for provider %s.", reqStr, fqn.LegacyString()),
+						Detail:   fmt.Sprintf("Invalid version constraint %q for provider %s.", reqStr, fqn.String()),
 					}))
 					continue
 				}

--- a/moduledeps/module.go
+++ b/moduledeps/module.go
@@ -110,11 +110,11 @@ func (s sortModules) Swap(i, j int) {
 func (m *Module) ProviderRequirements() discovery.PluginRequirements {
 	ret := make(discovery.PluginRequirements)
 	for pFqn, dep := range m.Providers {
-		providerStr := pFqn.LegacyString()
-		if existing, exists := ret[providerStr]; exists {
-			ret[providerStr].Versions = existing.Versions.Append(dep.Constraints)
+		providerType := pFqn.Type
+		if existing, exists := ret[providerType]; exists {
+			ret[providerType].Versions = existing.Versions.Append(dep.Constraints)
 		} else {
-			ret[providerStr] = &discovery.PluginConstraints{
+			ret[providerType] = &discovery.PluginConstraints{
 				Versions: dep.Constraints,
 			}
 		}

--- a/moduledeps/module_test.go
+++ b/moduledeps/module_test.go
@@ -192,10 +192,10 @@ func TestModuleProviderRequirements(t *testing.T) {
 	m := &Module{
 		Name: "root",
 		Providers: Providers{
-			addrs.NewLegacyProvider("foo"): ProviderDependency{
+			addrs.NewDefaultProvider("foo"): ProviderDependency{
 				Constraints: discovery.ConstraintStr(">=1.0.0").MustParse(),
 			},
-			addrs.NewLegacyProvider("baz"): ProviderDependency{
+			addrs.NewDefaultProvider("baz"): ProviderDependency{
 				Constraints: discovery.ConstraintStr(">=3.0.0").MustParse(),
 			},
 		},

--- a/plans/plan_test.go
+++ b/plans/plan_test.go
@@ -22,7 +22,7 @@ func TestProviderAddrs(t *testing.T) {
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
-						Provider: addrs.NewLegacyProvider("test"),
+						Provider: addrs.NewDefaultProvider("test"),
 					},
 				},
 				{
@@ -34,7 +34,7 @@ func TestProviderAddrs(t *testing.T) {
 					DeposedKey: "foodface",
 					ProviderAddr: addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
-						Provider: addrs.NewLegacyProvider("test"),
+						Provider: addrs.NewDefaultProvider("test"),
 					},
 				},
 				{
@@ -45,7 +45,7 @@ func TestProviderAddrs(t *testing.T) {
 					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: addrs.AbsProviderConfig{
 						Module:   addrs.RootModule.Child("foo"),
-						Provider: addrs.NewLegacyProvider("test"),
+						Provider: addrs.NewDefaultProvider("test"),
 					},
 				},
 			},
@@ -56,11 +56,11 @@ func TestProviderAddrs(t *testing.T) {
 	want := []addrs.AbsProviderConfig{
 		addrs.AbsProviderConfig{
 			Module:   addrs.RootModule.Child("foo"),
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 		},
 		addrs.AbsProviderConfig{
 			Module:   addrs.RootModule,
-			Provider: addrs.NewLegacyProvider("test"),
+			Provider: addrs.NewDefaultProvider("test"),
 		},
 	}
 

--- a/providers/addressed_types_test.go
+++ b/providers/addressed_types_test.go
@@ -12,32 +12,32 @@ func TestAddressedTypesAbs(t *testing.T) {
 	providerAddrs := []addrs.AbsProviderConfig{
 		addrs.AbsProviderConfig{
 			Module:   addrs.RootModule,
-			Provider: addrs.NewLegacyProvider("aws"),
+			Provider: addrs.NewDefaultProvider("aws"),
 		},
 		addrs.AbsProviderConfig{
 			Module:   addrs.RootModule,
-			Provider: addrs.NewLegacyProvider("aws"),
+			Provider: addrs.NewDefaultProvider("aws"),
 			Alias:    "foo",
 		},
 		addrs.AbsProviderConfig{
 			Module:   addrs.RootModule,
-			Provider: addrs.NewLegacyProvider("azure"),
+			Provider: addrs.NewDefaultProvider("azure"),
 		},
 		addrs.AbsProviderConfig{
 			Module:   addrs.RootModule,
-			Provider: addrs.NewLegacyProvider("null"),
+			Provider: addrs.NewDefaultProvider("null"),
 		},
 		addrs.AbsProviderConfig{
 			Module:   addrs.RootModule,
-			Provider: addrs.NewLegacyProvider("null"),
+			Provider: addrs.NewDefaultProvider("null"),
 		},
 	}
 
 	got := AddressedTypesAbs(providerAddrs)
 	want := []addrs.Provider{
-		addrs.NewLegacyProvider("aws"),
-		addrs.NewLegacyProvider("azure"),
-		addrs.NewLegacyProvider("null"),
+		addrs.NewDefaultProvider("aws"),
+		addrs.NewDefaultProvider("azure"),
+		addrs.NewDefaultProvider("null"),
 	}
 	for _, problem := range deep.Equal(got, want) {
 		t.Error(problem)

--- a/states/statefile/write.go
+++ b/states/statefile/write.go
@@ -15,3 +15,12 @@ func Write(s *File, w io.Writer) error {
 	diags := writeStateV4(s, w)
 	return diags.Err()
 }
+
+// WriteForTest writes the given state to the given writer in the current state
+// serialization format without recording the current terraform version. This is
+// intended for use in tests that need to override the current terraform
+// version.
+func WriteForTest(s *File, w io.Writer) error {
+	diags := writeStateV4(s, w)
+	return diags.Err()
+}

--- a/states/statemgr/testing.go
+++ b/states/statemgr/testing.go
@@ -151,7 +151,7 @@ func TestFullInitialState() *states.State {
 		Name: "foo",
 	}
 	providerAddr := addrs.AbsProviderConfig{
-		Provider: addrs.NewLegacyProvider(rAddr.ImpliedProvider()),
+		Provider: addrs.NewDefaultProvider(rAddr.ImpliedProvider()),
 		Module:   addrs.RootModule,
 	}
 	childMod.SetResourceProvider(rAddr, providerAddr)


### PR DESCRIPTION
This PR _mostly_  includes test updates but I will summarize (and then comment on) "real" changes below. I've removed as many calls to `addrs.NewLegacyProvider` as possibly, leaving (I hope) only the load-bearing ones.

I needed to update tests that were using the older `terraform.State`s in the command package (to avoid winding through some shims which default to legacy providers - that's a future project). This led me on a small sidequest to refactor the testStateFileDefault helper function in command_test.go to take a states.State instead of terraform.State (which let me simplify a couple of tests). None of the test functionally (should have) changed and using the modern states is More Correct anyhow.

The final bit of fallout from the above came in the init tests: one test set a future terraform version, but that was *only* an option when starting with a `terraform.State`, so I added a fairly-silly `statefile.WriteForTest` function to enable writing a `statefile.File` with the `TerraformVersion` that I wanted. The existing `statefile.Write` function always sets the current terraform version (overriding what is in the given `File`), and I needed something that could write exactly `statefile.File` provided. I originally named the function `statefile.WriteExact` but decided it wasn't at all clear that this should only be used for testing - I'm open to suggestions, as always!

I will leave comments on the bigger (non-test) changes so they are easier for reviewers to find. 