### PR TITLE
Fix race conditions

### DIFF
--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -12,10 +12,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/copystructure"
 )
 
 type mockClient struct {
@@ -693,6 +695,8 @@ func (m *mockPolicyChecks) Logs(ctx context.Context, policyCheckID string) (io.R
 }
 
 type mockRuns struct {
+	sync.Mutex
+
 	client     *mockClient
 	runs       map[string]*tfe.Run
 	workspaces map[string][]*tfe.Run
@@ -712,13 +716,21 @@ func newMockRuns(client *mockClient) *mockRuns {
 }
 
 func (m *mockRuns) List(ctx context.Context, workspaceID string, options tfe.RunListOptions) (*tfe.RunList, error) {
+	m.Lock()
+	defer m.Unlock()
+
 	w, ok := m.client.Workspaces.workspaceIDs[workspaceID]
 	if !ok {
 		return nil, tfe.ErrResourceNotFound
 	}
 
-	rl := &tfe.RunList{
-		Items: m.workspaces[w.ID],
+	rl := &tfe.RunList{}
+	for _, run := range m.workspaces[w.ID] {
+		rc, err := copystructure.Copy(run)
+		if err != nil {
+			panic(err)
+		}
+		rl.Items = append(rl.Items, rc.(*tfe.Run))
 	}
 
 	rl.Pagination = &tfe.Pagination{
@@ -733,6 +745,9 @@ func (m *mockRuns) List(ctx context.Context, workspaceID string, options tfe.Run
 }
 
 func (m *mockRuns) Create(ctx context.Context, options tfe.RunCreateOptions) (*tfe.Run, error) {
+	m.Lock()
+	defer m.Unlock()
+
 	a, err := m.client.Applies.create(options.ConfigurationVersion.ID, options.Workspace.ID)
 	if err != nil {
 		return nil, err
@@ -798,6 +813,9 @@ func (m *mockRuns) Create(ctx context.Context, options tfe.RunCreateOptions) (*t
 }
 
 func (m *mockRuns) Read(ctx context.Context, runID string) (*tfe.Run, error) {
+	m.Lock()
+	defer m.Unlock()
+
 	r, ok := m.runs[runID]
 	if !ok {
 		return nil, tfe.ErrResourceNotFound
@@ -833,10 +851,19 @@ func (m *mockRuns) Read(ctx context.Context, runID string) (*tfe.Run, error) {
 		}
 	}
 
-	return r, nil
+	// we must return a copy for the client
+	rc, err := copystructure.Copy(r)
+	if err != nil {
+		panic(err)
+	}
+
+	return rc.(*tfe.Run), nil
 }
 
 func (m *mockRuns) Apply(ctx context.Context, runID string, options tfe.RunApplyOptions) error {
+	m.Lock()
+	defer m.Unlock()
+
 	r, ok := m.runs[runID]
 	if !ok {
 		return tfe.ErrResourceNotFound
@@ -859,6 +886,9 @@ func (m *mockRuns) ForceCancel(ctx context.Context, runID string, options tfe.Ru
 }
 
 func (m *mockRuns) Discard(ctx context.Context, runID string, options tfe.RunDiscardOptions) error {
+	m.Lock()
+	defer m.Unlock()
+
 	r, ok := m.runs[runID]
 	if !ok {
 		return tfe.ErrResourceNotFound

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -562,11 +562,13 @@ The -target option is not for routine use, and is provided only for exceptional 
 	p.Changes = c.changes
 
 	c.refreshState.SyncWrapper().RemovePlannedResourceInstanceObjects()
-	p.State = c.refreshState.DeepCopy()
+
+	refreshedState := c.refreshState.DeepCopy()
+	p.State = refreshedState
 
 	// replace the working state with the updated state, so that immediate calls
 	// to Apply work as expected.
-	c.state = c.refreshState
+	c.state = refreshedState
 
 	return p, diags
 }

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -743,12 +743,11 @@ func (c *Context) graphWalker(operation walkOperation) *ContextGraphWalker {
 	switch operation {
 	case walkValidate:
 		// validate should not use any state
-		s := states.NewState()
-		state = s.SyncWrapper()
+		state = states.NewState().SyncWrapper()
 
 		// validate currently uses the plan graph, so we have to populate the
 		// refreshState.
-		refreshState = s.SyncWrapper()
+		refreshState = states.NewState().SyncWrapper()
 
 	case walkPlan:
 		state = c.state.SyncWrapper()

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -10135,9 +10135,15 @@ func TestContext2Apply_ProviderMeta_apply_set(t *testing.T) {
 			},
 		},
 	}
+
+	var pmMu sync.Mutex
 	arcPMs := map[string]cty.Value{}
+
 	p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+		pmMu.Lock()
+		defer pmMu.Unlock()
 		arcPMs[req.TypeName] = req.ProviderMeta
+
 		s := req.PlannedState.AsValueMap()
 		s["id"] = cty.StringVal("ID")
 		return providers.ApplyResourceChangeResponse{
@@ -10209,9 +10215,13 @@ func TestContext2Apply_ProviderMeta_apply_unset(t *testing.T) {
 			},
 		},
 	}
+	var pmMu sync.Mutex
 	arcPMs := map[string]cty.Value{}
 	p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+		pmMu.Lock()
+		defer pmMu.Unlock()
 		arcPMs[req.TypeName] = req.ProviderMeta
+
 		s := req.PlannedState.AsValueMap()
 		s["id"] = cty.StringVal("ID")
 		return providers.ApplyResourceChangeResponse{

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -79,8 +79,8 @@ type BuiltinEvalContext struct {
 var _ EvalContext = (*BuiltinEvalContext)(nil)
 
 func (ctx *BuiltinEvalContext) WithPath(path addrs.ModuleInstance) EvalContext {
-	ctx.pathSet = true
 	newCtx := *ctx
+	newCtx.pathSet = true
 	newCtx.PathValue = path
 	return &newCtx
 }


### PR DESCRIPTION
`go test -race ./...` now passes