### PR TITLE
Add test file for bad sensitive value

### DIFF
--- a/configs/testdata/invalid-files/variable-bad-sensitive.tf
+++ b/configs/testdata/invalid-files/variable-bad-sensitive.tf
@@ -1,0 +1,7 @@
+terraform {
+  experiments = [sensitive_variables]
+}
+
+variable "sensitive-value" {
+  sensitive = "123" # must be boolean
+}


### PR DESCRIPTION
Adds a test file for an incorrectly typed (non-boolean) sensitive value to ensure it errors. This behavior is caught/diags are added when the config is loaded, so all this PR does is adds a test file.