### PR TITLE
refactor tests to use modern states.State in favor of terraform.State where possible

### DIFF
--- a/backend/remote/backend_state_test.go
+++ b/backend/remote/backend_state_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/remote"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/states/statefile"
 )
 
 func TestRemoteClient_impl(t *testing.T) {
@@ -46,14 +47,13 @@ func TestRemoteClient_withRunID(t *testing.T) {
 	client := testRemoteClient(t)
 
 	// Create a new empty state.
-	state := bytes.NewBuffer(nil)
-	if err := terraform.WriteState(terraform.NewState(), state); err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
+	sf := statefile.New(states.NewState(), "", 0)
+	var buf bytes.Buffer
+	statefile.Write(sf, &buf)
 
 	// Store the new state to verify (this will be done
 	// by the mock that is used) that the run ID is set.
-	if err := client.Put(state.Bytes()); err != nil {
+	if err := client.Put(buf.Bytes()); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 }

--- a/builtin/providers/terraform/data_source_state_test.go
+++ b/builtin/providers/terraform/data_source_state_test.go
@@ -133,8 +133,8 @@ func TestState_basic(t *testing.T) {
 					"path": cty.StringVal("./testdata/null_outputs.tfstate"),
 				}),
 				"outputs": cty.ObjectVal(map[string]cty.Value{
-					"map":  cty.NullVal(cty.DynamicPseudoType),
-					"list": cty.NullVal(cty.DynamicPseudoType),
+					"map":  cty.NullVal(cty.Map(cty.String)),
+					"list": cty.NullVal(cty.List(cty.String)),
 				}),
 				"defaults":  cty.NullVal(cty.DynamicPseudoType),
 				"workspace": cty.NullVal(cty.String),

--- a/builtin/providers/terraform/testdata/basic.tfstate
+++ b/builtin/providers/terraform/testdata/basic.tfstate
@@ -1,7 +1,12 @@
 {
-    "version": 1,
-    "modules": [{
-        "path": ["root"],
-        "outputs": { "foo": "bar" }
-    }]
+    "version": 4,
+    "terraform_version": "0.13.0",
+    "serial": 0,
+    "lineage": "",
+    "outputs": {
+        "foo": {
+            "value": "bar",
+            "type": "string"
+        }
+    }
 }

--- a/builtin/providers/terraform/testdata/complex_outputs.tfstate
+++ b/builtin/providers/terraform/testdata/complex_outputs.tfstate
@@ -1,88 +1,70 @@
 {
-    "version": 3,
-    "terraform_version": "0.7.0",
-    "serial": 3,
-    "modules": [
-        {
-            "path": [
-                "root"
+    "version": 4,
+    "terraform_version": "0.13.0",
+    "serial": 0,
+    "lineage": "",
+    "outputs": {
+        "computed_map": {
+            "sensitive": false,
+            "type": [
+                "map",
+                "string"
             ],
-            "outputs": {
-                "computed_map": {
-                    "sensitive": false,
-                    "type": "map",
-                    "value": {
-                        "key1": "value1"
-                    }
-                },
-                "computed_set": {
-                    "sensitive": false,
-                    "type": "list",
-                    "value": [
-                        "setval1",
-                        "setval2"
-                    ]
-                },
-                "map": {
-                    "sensitive": false,
-                    "type": "map",
-                    "value": {
-                        "key": "test",
-                        "test": "test"
-                    }
-                },
-                "set": {
-                    "sensitive": false,
-                    "type": "list",
-                    "value": [
-                        "test1",
-                        "test2"
-                    ]
-                }
-            },
-            "resources": {
-                "test_resource.main": {
-                    "type": "test_resource",
-                    "primary": {
-                        "id": "testId",
-                        "attributes": {
-                            "computed_list.#": "2",
-                            "computed_list.0": "listval1",
-                            "computed_list.1": "listval2",
-                            "computed_map.%": "1",
-                            "computed_map.key1": "value1",
-                            "computed_read_only": "value_from_api",
-                            "computed_read_only_force_new": "value_from_api",
-                            "computed_set.#": "2",
-                            "computed_set.2337322984": "setval1",
-                            "computed_set.307881554": "setval2",
-                            "id": "testId",
-                            "list_of_map.#": "2",
-                            "list_of_map.0.%": "2",
-                            "list_of_map.0.key1": "value1",
-                            "list_of_map.0.key2": "value2",
-                            "list_of_map.1.%": "2",
-                            "list_of_map.1.key3": "value3",
-                            "list_of_map.1.key4": "value4",
-                            "map.%": "2",
-                            "map.key": "test",
-                            "map.test": "test",
-                            "map_that_look_like_set.%": "2",
-                            "map_that_look_like_set.12352223": "hello",
-                            "map_that_look_like_set.36234341": "world",
-                            "optional_computed_map.%": "0",
-                            "required": "Hello World",
-                            "required_map.%": "3",
-                            "required_map.key1": "value1",
-                            "required_map.key2": "value2",
-                            "required_map.key3": "value3",
-                            "set.#": "2",
-                            "set.2326977762": "test1",
-                            "set.331058520": "test2"
-                        }
-                    }
-                }
+            "value": {
+                "key1": "value1"
             }
+        },
+        "computed_set": {
+            "sensitive": false,
+            "type": [
+                "list",
+                "string"
+            ],
+            "value": [
+                "setval1",
+                "setval2"
+            ]
+        },
+        "map": {
+            "sensitive": false,
+            "type": [
+                "map",
+                "string"
+            ],
+            "value": {
+                "key": "test",
+                "test": "test"
+            }
+        },
+        "set": {
+            "sensitive": false,
+            "type": [
+                "list",
+                "string"
+            ],
+            "value": [
+                "test1",
+                "test2"
+            ]
+        }
+    },
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "test_resource",
+            "name": "main",
+            "each": "list",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "index_key": 0,
+                    "schema_version": 0,
+                    "attributes": {
+                        "id": "testId"
+                    },
+                    "private": "bnVsbA=="
+                }
+            ]
         }
     ]
 }

--- a/builtin/providers/terraform/testdata/empty.tfstate
+++ b/builtin/providers/terraform/testdata/empty.tfstate
@@ -1,13 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.7.0",
-    "serial": 3,
-    "modules": [
-        {
-            "path": [
-                "root"
-            ],
-            "outputs": {}
-        }
-    ]
+    "version": 4,
+    "terraform_version": "0.13.0",
+    "serial": 0,
+    "lineage": ""
 }

--- a/builtin/providers/terraform/testdata/null_outputs.tfstate
+++ b/builtin/providers/terraform/testdata/null_outputs.tfstate
@@ -1,24 +1,22 @@
 {
-    "version": 3,
-    "terraform_version": "0.7.0",
-    "serial": 3,
-    "modules": [
-        {
-            "path": [
-                "root"
-            ],
-            "outputs": {
-                "map": {
-                    "sensitive": false,
-                    "type": "map",
-                    "value": null
-                },
-                "list": {
-                    "sensitive": false,
-                    "type": "list",
-                    "value": null
-                }
-            }
+    "version": 4,
+    "terraform_version": "0.13.0",
+    "serial": 0,
+    "lineage": "",
+    "outputs": {
+        "map": {
+            "value": null,
+            "type": [
+                "map",
+                "string"
+            ]
+        },
+        "list": {
+            "value": null,
+            "type": [
+                "list",
+                "string"
+            ]
         }
-    ]
+    }
 }

--- a/command/testdata/backend-change-multi-default-to-single/local-state.tfstate
+++ b/command/testdata/backend-change-multi-default-to-single/local-state.tfstate
@@ -1,18 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-change",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-change-multi-to-multi/local-state.tfstate
+++ b/command/testdata/backend-change-multi-to-multi/local-state.tfstate
@@ -1,18 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-change",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-change-multi-to-multi/terraform.tfstate.d/env2/terraform.tfstate
+++ b/command/testdata/backend-change-multi-to-multi/terraform.tfstate.d/env2/terraform.tfstate
@@ -1,18 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-change-env2",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-change-multi-to-no-default-with-default/local-state.tfstate
+++ b/command/testdata/backend-change-multi-to-no-default-with-default/local-state.tfstate
@@ -1,18 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-change-env1",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-change-multi-to-no-default-with-default/terraform.tfstate.d/env2/terraform.tfstate
+++ b/command/testdata/backend-change-multi-to-no-default-with-default/terraform.tfstate.d/env2/terraform.tfstate
@@ -1,18 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-change-env2",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-change-multi-to-no-default-without-default/terraform.tfstate.d/env2/terraform.tfstate
+++ b/command/testdata/backend-change-multi-to-no-default-without-default/terraform.tfstate.d/env2/terraform.tfstate
@@ -1,18 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-change-env2",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-change-multi-to-single/terraform.tfstate.d/env1/terraform.tfstate
+++ b/command/testdata/backend-change-multi-to-single/terraform.tfstate.d/env1/terraform.tfstate
@@ -1,18 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-change",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-change-multi-to-single/terraform.tfstate.d/env2/terraform.tfstate
+++ b/command/testdata/backend-change-multi-to-single/terraform.tfstate.d/env2/terraform.tfstate
@@ -1,18 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-change-env2",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-change-single-to-single/local-state.tfstate
+++ b/command/testdata/backend-change-single-to-single/local-state.tfstate
@@ -1,18 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-change",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-change/local-state.tfstate
+++ b/command/testdata/backend-change/local-state.tfstate
@@ -1,18 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-change",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-changed-with-legacy/local-state-old.tfstate
+++ b/command/testdata/backend-changed-with-legacy/local-state-old.tfstate
@@ -1,6 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "legacy"
 }

--- a/command/testdata/backend-changed-with-legacy/local-state.tfstate
+++ b/command/testdata/backend-changed-with-legacy/local-state.tfstate
@@ -1,6 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "configured"
 }

--- a/command/testdata/backend-new-legacy/local-state-old.tfstate
+++ b/command/testdata/backend-new-legacy/local-state-old.tfstate
@@ -1,6 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-new-legacy",
     "remote": {

--- a/command/testdata/backend-new-migrate-existing/local-state.tfstate
+++ b/command/testdata/backend-new-migrate-existing/local-state.tfstate
@@ -1,16 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 8,
-    "lineage": "remote",
-    "modules": [
-        {
-            "path": [
-                "root"
-            ],
-            "outputs": {},
-            "resources": {},
-            "depends_on": []
-        }
-    ]
+    "lineage": "remote"
 }

--- a/command/testdata/backend-new-migrate-existing/terraform.tfstate
+++ b/command/testdata/backend-new-migrate-existing/terraform.tfstate
@@ -1,21 +1,12 @@
 {
-    "version": 3,
+    "version": 4,
     "terraform_version": "0.8.2",
     "serial": 8,
     "lineage": "local",
-    "modules": [
-        {
-            "path": [
-                "root"
-            ],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {},
-            "depends_on": []
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-new-migrate/terraform.tfstate
+++ b/command/testdata/backend-new-migrate/terraform.tfstate
@@ -1,21 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 8,
     "lineage": "backend-new-migrate",
-    "modules": [
-        {
-            "path": [
-                "root"
-            ],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {},
-            "depends_on": []
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/backend-plan-backend-empty-config/local-state.tfstate
+++ b/command/testdata/backend-plan-backend-empty-config/local-state.tfstate
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "serial": 0,
     "lineage": "hello"
 }

--- a/command/testdata/backend-plan-backend-match/local-state.tfstate
+++ b/command/testdata/backend-plan-backend-match/local-state.tfstate
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "serial": 0,
     "lineage": "hello"
 }

--- a/command/testdata/backend-plan-backend-mismatch/local-state.tfstate
+++ b/command/testdata/backend-plan-backend-mismatch/local-state.tfstate
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "serial": 0,
     "lineage": "different"
 }

--- a/command/testdata/backend-plan-legacy-data/local-state.tfstate
+++ b/command/testdata/backend-plan-legacy-data/local-state.tfstate
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "serial": 0,
     "lineage": "hello"
 }

--- a/command/testdata/backend-plan-legacy-data/state.tfstate
+++ b/command/testdata/backend-plan-legacy-data/state.tfstate
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "serial": 0,
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "remote": {
@@ -7,15 +7,5 @@
         "config": {
             "path": "local-state.tfstate"
         }
-    },
-    "modules": [
-        {
-            "path": [
-                "root"
-            ],
-            "outputs": {},
-            "resources": {},
-            "depends_on": []
-        }
-    ]
+    }
 }

--- a/command/testdata/backend-plan-local-match/terraform.tfstate
+++ b/command/testdata/backend-plan-local-match/terraform.tfstate
@@ -1,6 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "hello"
 }

--- a/command/testdata/backend-plan-local-mismatch-lineage/terraform.tfstate
+++ b/command/testdata/backend-plan-local-mismatch-lineage/terraform.tfstate
@@ -1,6 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "hello"
 }

--- a/command/testdata/backend-plan-local-newer/terraform.tfstate
+++ b/command/testdata/backend-plan-local-newer/terraform.tfstate
@@ -1,6 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 10,
     "lineage": "hello"
 }

--- a/command/testdata/backend-unchanged-with-legacy/local-state-old.tfstate
+++ b/command/testdata/backend-unchanged-with-legacy/local-state-old.tfstate
@@ -1,6 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend-unchanged-with-legacy"
 }

--- a/command/testdata/backend-unchanged-with-legacy/local-state.tfstate
+++ b/command/testdata/backend-unchanged-with-legacy/local-state.tfstate
@@ -1,6 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "configured"
 }

--- a/command/testdata/backend-unchanged/local-state.tfstate
+++ b/command/testdata/backend-unchanged/local-state.tfstate
@@ -1,6 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "configuredUnchanged"
 }

--- a/command/testdata/backend-unset-with-legacy/local-state-old.tfstate
+++ b/command/testdata/backend-unset-with-legacy/local-state-old.tfstate
@@ -1,6 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "legacy"
 }

--- a/command/testdata/backend-unset-with-legacy/local-state.tfstate
+++ b/command/testdata/backend-unset-with-legacy/local-state.tfstate
@@ -1,6 +1,6 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "backend"
 }

--- a/command/testdata/backend-unset/local-state.tfstate
+++ b/command/testdata/backend-unset/local-state.tfstate
@@ -1,18 +1,12 @@
 {
-    "version": 3,
-    "terraform_version": "0.8.2",
+    "version": 4,
+    "terraform_version": "0.14.0",
     "serial": 7,
     "lineage": "configuredUnset",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/state-push-bad-lineage/local-state.tfstate
+++ b/command/testdata/state-push-bad-lineage/local-state.tfstate
@@ -1,17 +1,11 @@
 {
-    "version": 3,
+    "version": 4,
     "serial": 1,
     "lineage": "mismatch",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "bar"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "bar"
         }
-    ]
+    }
 }

--- a/command/testdata/state-push-bad-lineage/replace.tfstate
+++ b/command/testdata/state-push-bad-lineage/replace.tfstate
@@ -1,17 +1,11 @@
 {
-    "version": 3,
+    "version": 4,
     "serial": 2,
     "lineage": "hello",
-    "modules": [
-        {
-            "path": ["root"],
-            "outputs": {
-                "foo": {
-                    "type": "string",
-                    "value": "baz"
-                }
-            },
-            "resources": {}
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "baz"
         }
-    ]
+    }
 }


### PR DESCRIPTION
This PR changes test fixtures _only_ and is a tiny step towards removing legacy state versions. 

You may notice I am working through packages alphabetically and got tired around `command`. I did not touch the `test` (builtin) provider; that will take actual work.