### PR TITLE
Add format/diff coverage for maps with sensitivity

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -1070,23 +1070,16 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 			return
 
 		case ty.IsMapType():
+			if old.IsMarked() || new.IsMarked() {
+				p.buf.WriteString("(sensitive)")
+				return
+			}
+
 			p.buf.WriteString("{")
 			if p.pathForcesNewResource(path) {
 				p.buf.WriteString(p.color.Color(forcesNewResourceCaption))
 			}
 			p.buf.WriteString("\n")
-
-			// If the whole map is marked, we need to show our
-			// sensitive block warning rather than attempt to iterate
-			// through a marked map
-			if old.IsMarked() || new.IsMarked() {
-				p.buf.WriteString(strings.Repeat(" ", indent+2))
-				p.buf.WriteString("# This map is (or was) sensitive and will not be displayed")
-				p.buf.WriteString("\n")
-				p.buf.WriteString(strings.Repeat(" ", indent))
-				p.buf.WriteString("}")
-				return
-			}
 
 			var allKeys []string
 			keyLen := 0

--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -777,23 +777,18 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 	// However, these specialized implementations can apply only if both
 	// values are known and non-null.
 	if old.IsKnown() && new.IsKnown() && !old.IsNull() && !new.IsNull() && typesEqual {
+		if old.IsMarked() || new.IsMarked() {
+			p.buf.WriteString("(sensitive)")
+			return
+		}
+
 		switch {
-		case ty == cty.Bool || ty == cty.Number:
-			if old.IsMarked() || new.IsMarked() {
-				p.buf.WriteString("(sensitive)")
-				return
-			}
 		case ty == cty.String:
 			// We have special behavior for both multi-line strings in general
 			// and for strings that can parse as JSON. For the JSON handling
 			// to apply, both old and new must be valid JSON.
 			// For single-line strings that don't parse as JSON we just fall
 			// out of this switch block and do the default old -> new rendering.
-
-			if old.IsMarked() || new.IsMarked() {
-				p.buf.WriteString("(sensitive)")
-				return
-			}
 			oldS := old.AsString()
 			newS := new.AsString()
 
@@ -1070,11 +1065,6 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 			return
 
 		case ty.IsMapType():
-			if old.IsMarked() || new.IsMarked() {
-				p.buf.WriteString("(sensitive)")
-				return
-			}
-
 			p.buf.WriteString("{")
 			if p.pathForcesNewResource(path) {
 				p.buf.WriteString(p.color.Color(forcesNewResourceCaption))

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -3791,9 +3791,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
         }
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change
-      ~ map_whole   = {
-          # This map is (or was) sensitive and will not be displayed
-        }
+      ~ map_whole   = (sensitive)
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change
       ~ some_number = (sensitive)
@@ -3880,9 +3878,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
         }
       # Warning: this attribute value will be marked as sensitive and will
       # not display in UI output after applying this change
-      ~ map_whole  = {
-          # This map is (or was) sensitive and will not be displayed
-        }
+      ~ map_whole  = (sensitive)
     }
 `,
 		},
@@ -3981,9 +3977,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
           ~ "dinner"    = (sensitive)
             # (1 unchanged element hidden)
         }
-      ~ map_whole  = {
-          # This map is (or was) sensitive and will not be displayed
-        }
+      ~ map_whole  = (sensitive)
     }
 `,
 		},


### PR DESCRIPTION
Considers wholly marked maps as well as map keys when considering sensitivity.