### PR TITLE
always load instance state when -refresh=false

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -6403,11 +6403,17 @@ resource "test_instance" "a" {
 		SkipRefresh: true,
 	})
 
-	_, diags := ctx.Plan()
+	plan, diags := ctx.Plan()
 	assertNoErrors(t, diags)
 
 	if p.ReadResourceCalled {
 		t.Fatal("Resource should not have been refreshed")
+	}
+
+	for _, c := range plan.Changes.Resources {
+		if c.Action != plans.NoOp {
+			t.Fatalf("expected no changes, got %s for %q", c.Action, c.Addr)
+		}
 	}
 }
 

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -146,24 +146,23 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext, 
 		return err
 	}
 
+	instanceRefreshState, err = n.ReadResourceInstanceState(ctx, addr)
+	if err != nil {
+		return err
+	}
+	refreshLifecycle := &EvalRefreshLifecycle{
+		Addr:                     addr,
+		Config:                   n.Config,
+		State:                    &instanceRefreshState,
+		ForceCreateBeforeDestroy: n.ForceCreateBeforeDestroy,
+	}
+	_, err = refreshLifecycle.Eval(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Refresh, maybe
 	if !skipRefresh {
-		instanceRefreshState, err = n.ReadResourceInstanceState(ctx, addr)
-		if err != nil {
-			return err
-		}
-
-		refreshLifecycle := &EvalRefreshLifecycle{
-			Addr:                     addr,
-			Config:                   n.Config,
-			State:                    &instanceRefreshState,
-			ForceCreateBeforeDestroy: n.ForceCreateBeforeDestroy,
-		}
-		_, err = refreshLifecycle.Eval(ctx)
-		if err != nil {
-			return err
-		}
-
 		refresh := &EvalRefresh{
 			Addr:           addr.Resource,
 			ProviderAddr:   n.ResolvedProvider,


### PR DESCRIPTION
The loading of the initial instance state was inadvertently skipped when
-refresh=false, causing all resources to appear to be missing from the
state during plan.