### PR TITLE
AzureRM backend: correctly lookup environment from metadata host

### DIFF
--- a/backend/remote-state/azure/arm_client.go
+++ b/backend/remote-state/azure/arm_client.go
@@ -33,8 +33,8 @@ type ArmClient struct {
 	sasToken           string
 }
 
-func buildArmClient(config BackendConfig) (*ArmClient, error) {
-	env, err := buildArmEnvironment(config)
+func buildArmClient(ctx context.Context, config BackendConfig) (*ArmClient, error) {
+	env, err := authentication.AzureEnvironmentByNameFromEndpoint(ctx, config.MetadataHost, config.Environment)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/remote-state/azure/helpers_test.go
+++ b/backend/remote-state/azure/helpers_test.go
@@ -73,7 +73,7 @@ func buildTestClient(t *testing.T, res resourceNames) *ArmClient {
 	// Endpoint is optional (only for Stack)
 	endpoint := os.Getenv("ARM_ENDPOINT")
 
-	armClient, err := buildArmClient(BackendConfig{
+	armClient, err := buildArmClient(context.TODO(), BackendConfig{
 		SubscriptionID:                subscriptionID,
 		TenantID:                      tenantID,
 		ClientID:                      clientID,


### PR DESCRIPTION
This should fix an issue when using the metadata host to lookup the environments from.