### PR TITLE
Add env and envexists functions

### DIFF
--- a/lang/funcs/env.go
+++ b/lang/funcs/env.go
@@ -1,0 +1,55 @@
+package funcs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// EnvFunc constructs a function that takes a key string and returns the value
+// of the environment variable named by the key, or an error if it doesn't exist.
+var EnvFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "key",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		if val, exists := os.LookupEnv(args[0].AsString()); exists {
+			return cty.StringVal(val), nil
+		}
+		return cty.NilVal, fmt.Errorf("environment variable doesn't exist")
+	},
+})
+
+// EnvExistsFunc constructs a function that takes a key string and returns a
+// boolean value reflecting whether an environment variable named by the key exists.
+var EnvExistsFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "key",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.Bool),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		_, exists := os.LookupEnv(args[0].AsString())
+		return cty.BoolVal(exists), nil
+	},
+})
+
+// Env retrieves the value of the environment variable named by the key.
+// It returns the value, or an error if the variable is not present.
+func Env(key cty.Value) (cty.Value, error) {
+	return EnvFunc.Call([]cty.Value{key})
+}
+
+// EnvExists takes a key string and returns a boolean value reflecting whether
+// an environment variable named by the key exists.
+func EnvExists(key cty.Value) (cty.Value, error) {
+	return EnvExistsFunc.Call([]cty.Value{key})
+}

--- a/lang/funcs/env_test.go
+++ b/lang/funcs/env_test.go
@@ -1,0 +1,103 @@
+package funcs
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestEnv(t *testing.T) {
+	const envKeySet, envValueSet = "ENV_KEY_SET", "ENV_VALUE_SET"
+	const envKeyEmpty, envValueEmpty = "ENV_KEY_EMPTY", ""
+	const envKeyUnset = "ENV_KEY_UNSET"
+
+	tests := []struct {
+		Value cty.Value
+		Want  cty.Value
+		Err   bool
+	}{
+		{
+			cty.StringVal(envKeySet),
+			cty.StringVal(envValueSet),
+			false,
+		},
+		{
+			cty.StringVal(envKeyEmpty),
+			cty.StringVal(envValueEmpty),
+			false,
+		},
+		{
+			cty.StringVal(envKeyUnset),
+			cty.StringVal(""),
+			true,
+		},
+	}
+
+	os.Setenv(envKeySet, envValueSet)
+	defer os.Unsetenv(envKeySet)
+	os.Setenv(envKeyEmpty, envValueEmpty)
+	defer os.Unsetenv(envValueEmpty)
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Env(%#v...)", test.Value), func(t *testing.T) {
+			got, err := Env(test.Value)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
+func TestEnvExists(t *testing.T) {
+	const envKeySet, envValueSet = "ENVEXISTS_KEY_SET", "ENVEXISTS_VALUE_SET"
+	const envKeyEmpty, envValueEmpty = "ENVEXISTS_KEY_EMPTY", ""
+	const envKeyUnset = "ENVEXISTS_KEY_UNSET"
+
+	tests := []struct {
+		Value cty.Value
+		Want  cty.Value
+	}{
+		{
+			cty.StringVal(envKeySet),
+			cty.BoolVal(true),
+		},
+		{
+			cty.StringVal(envKeyEmpty),
+			cty.BoolVal(true),
+		},
+		{
+			cty.StringVal(envKeyUnset),
+			cty.BoolVal(false),
+		},
+	}
+
+	os.Setenv(envKeySet, envValueSet)
+	defer os.Unsetenv(envKeySet)
+	os.Setenv(envKeyEmpty, envValueEmpty)
+	defer os.Unsetenv(envValueEmpty)
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("EnvExists(%#v...)", test.Value), func(t *testing.T) {
+			got, err := EnvExists(test.Value)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}

--- a/lang/funcs/env_test.go
+++ b/lang/funcs/env_test.go
@@ -61,8 +61,8 @@ func TestEnv(t *testing.T) {
 }
 
 func TestEnvExists(t *testing.T) {
-	const envKeySet, envValueSet = "ENVEXISTS_KEY_SET", "ENVEXISTS_VALUE_SET"
-	const envKeyEmpty, envValueEmpty = "ENVEXISTS_KEY_EMPTY", ""
+	const envKeySet = "ENVEXISTS_KEY_SET"
+	const envKeyEmpty = "ENVEXISTS_KEY_EMPTY"
 	const envKeyUnset = "ENVEXISTS_KEY_UNSET"
 
 	tests := []struct {

--- a/lang/funcs/env_test.go
+++ b/lang/funcs/env_test.go
@@ -61,8 +61,8 @@ func TestEnv(t *testing.T) {
 }
 
 func TestEnvExists(t *testing.T) {
-	const envKeySet = "ENVEXISTS_KEY_SET"
-	const envKeyEmpty = "ENVEXISTS_KEY_EMPTY"
+	const envKeySet, envValueSet = "ENVEXISTS_KEY_SET", "ENVEXISTS_VALUE_SET"
+	const envKeyEmpty, envValueEmpty = "ENVEXISTS_KEY_EMPTY", ""
 	const envKeyUnset = "ENVEXISTS_KEY_UNSET"
 
 	tests := []struct {

--- a/lang/funcs/env_test.go
+++ b/lang/funcs/env_test.go
@@ -38,7 +38,7 @@ func TestEnv(t *testing.T) {
 	os.Setenv(envKeySet, envValueSet)
 	defer os.Unsetenv(envKeySet)
 	os.Setenv(envKeyEmpty, envValueEmpty)
-	defer os.Unsetenv(envValueEmpty)
+	defer os.Unsetenv(envKeyEmpty)
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("Env(%#v...)", test.Value), func(t *testing.T) {
@@ -86,7 +86,7 @@ func TestEnvExists(t *testing.T) {
 	os.Setenv(envKeySet, envValueSet)
 	defer os.Unsetenv(envKeySet)
 	os.Setenv(envKeyEmpty, envValueEmpty)
-	defer os.Unsetenv(envValueEmpty)
+	defer os.Unsetenv(envKeyEmpty)
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("EnvExists(%#v...)", test.Value), func(t *testing.T) {

--- a/lang/functions.go
+++ b/lang/functions.go
@@ -57,6 +57,8 @@ func (s *Scope) Functions() map[string]function.Function {
 			"dirname":          funcs.DirnameFunc,
 			"distinct":         stdlib.DistinctFunc,
 			"element":          stdlib.ElementFunc,
+			"env":              funcs.EnvFunc,
+			"envexists":        funcs.EnvExistsFunc,
 			"chunklist":        stdlib.ChunklistFunc,
 			"file":             funcs.MakeFileFunc(s.BaseDir, false),
 			"fileexists":       funcs.MakeFileExistsFunc(s.BaseDir),

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -305,6 +305,24 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"env": {
+			{
+				`env("ephemeral_test_var")`,
+				cty.StringVal("test value"),
+			},
+		},
+
+		"envexists": {
+			{
+				`envexists("ephemeral_test_var")`,
+				cty.BoolVal(true),
+			},
+			{
+				`envexists("no_such_var")`,
+				cty.BoolVal(false),
+			},
+		},
+
 		"file": {
 			{
 				`file("hello.txt")`,
@@ -1047,6 +1065,11 @@ func TestFunctions(t *testing.T) {
 			t.Errorf("Missing test for function %s\n", f)
 		}
 	}
+
+	// Set (and defer unset) an environment variable to allow "env" and
+	// "envexists" to be tested. Surely there's a better place to put this.
+	os.Setenv("ephemeral_test_var", "test value")
+	defer os.Unsetenv("ephemeral_test_var")
 
 	for funcName, funcTests := range tests {
 		t.Run(funcName, func(t *testing.T) {

--- a/website/docs/configuration/functions/env.html.md
+++ b/website/docs/configuration/functions/env.html.md
@@ -1,0 +1,23 @@
+---
+layout: "functions"
+page_title: "env - Functions - Configuration Language"
+sidebar_current: "docs-funcs-env-env"
+description: |-
+  The env function provides the value of a given environment
+  variable.
+---
+
+# `env` Function
+
+`env` provides the string value of a specified environment variable.
+
+If the environment variable doesn't exist, this function will generate an
+error. Use the `envexists` function to test for the existence of an 
+environment variable.
+
+## Examples
+
+```
+> env("environment")
+development
+```

--- a/website/docs/configuration/functions/envexists.html.md
+++ b/website/docs/configuration/functions/envexists.html.md
@@ -1,0 +1,20 @@
+---
+layout: "functions"
+page_title: "envexists - Functions - Configuration Language"
+sidebar_current: "docs-funcs-env-envexists"
+description: |-
+  The envexists function determines whether a specified environment variable exists.
+---
+
+# `envexists` Function
+
+`envexists` determines whether a specified environment variable exists.
+
+The `env` function can be used to retrieve the string value of an environment variable.
+
+## Examples
+
+```
+> envexists("environment")
+true
+```

--- a/website/layouts/functions.erb
+++ b/website/layouts/functions.erb
@@ -499,6 +499,21 @@
             </ul>
           </li>
 
+          <li id="docs-funcs-env">
+            <a href="#docs-funcs-env">Environment Functions</a>
+            <ul class="nav">
+
+              <li>
+                <a href="/docs/configuration/functions/env.html">env</a>
+              </li>
+
+              <li>
+                <a href="/docs/configuration/functions/envexists.html">envexists</a>
+              </li>
+
+            </ul>
+          </li>
+
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
This PR adds two functions, `env` and `envexists`. These will be analogous to `file` and `fileexists`, except that they would provide the value and existence, respectively, of an environment value.

I have also contributed an issue for this PR: https://github.com/hashicorp/terraform/issues/26477

I understand that I should have allowed for a thorough discussion in the issue first, and I apologize for not doing so, but I'll admit that I was excited to implement the feature and got a little ahead of myself. 🙂 