### PR TITLE
Obfuscate sensitive vals in console

### DIFF
--- a/command/testdata/variables/main.tf
+++ b/command/testdata/variables/main.tf
@@ -1,0 +1,20 @@
+terraform {
+    experiments = [sensitive_variables]
+}
+
+variable "foo" {
+    default = "bar"
+}
+
+variable "snack" {
+    default = "popcorn"
+}
+
+variable "secret_snack" {
+    default   = "seaweed snacks"
+    sensitive = true
+}
+
+locals {
+    snack_bar = [var.snack, var.secret_snack]
+}

--- a/repl/format.go
+++ b/repl/format.go
@@ -16,6 +16,9 @@ func FormatValue(v cty.Value, indent int) string {
 	if !v.IsKnown() {
 		return "(known after apply)"
 	}
+	if v.IsMarked() {
+		return "(sensitive)"
+	}
 	if v.IsNull() {
 		ty := v.Type()
 		switch {
@@ -36,9 +39,6 @@ func FormatValue(v cty.Value, indent int) string {
 		default:
 			return fmt.Sprintf("null /* %s */", ty.FriendlyName())
 		}
-	}
-	if v.IsMarked() {
-		return "(sensitive)"
 	}
 
 	ty := v.Type()

--- a/repl/format.go
+++ b/repl/format.go
@@ -37,6 +37,9 @@ func FormatValue(v cty.Value, indent int) string {
 			return fmt.Sprintf("null /* %s */", ty.FriendlyName())
 		}
 	}
+	if v.IsMarked() {
+		return "(sensitive)"
+	}
 
 	ty := v.Type()
 	switch {

--- a/repl/format_test.go
+++ b/repl/format_test.go
@@ -136,6 +136,10 @@ func TestFormatValue(t *testing.T) {
 			cty.SetValEmpty(cty.String),
 			`toset([])`,
 		},
+		{
+			cty.StringVal("sensitive value").Mark("sensitive"),
+			"(sensitive)",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Updates `terraform console` to show `(sensitive)` when a value is marked as sensitive.