### PR TITLE
do not evaluate module variables during import

### DIFF
--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -153,7 +153,7 @@ func (n *nodeModuleVariable) Execute(ctx EvalContext, op walkOperation) error {
 	var err error
 
 	switch op {
-	case walkPlan, walkApply, walkDestroy, walkImport:
+	case walkPlan, walkApply, walkDestroy:
 		vals, err = n.EvalModuleCallArgument(ctx, false)
 		if err != nil {
 			return err


### PR DESCRIPTION
We do not currently need to evaluate module variables in order to
import a resource.

This will likely change once we can select the import provider
automatically, and have a more dynamic method for dispatching providers
to module instances. In the meantime we can avoid the evaluation for now
and prevent a certain class of import errors.

Fixes #26258 by rolling back #25890. Note the test from 25890 is not removed,
because other evaluation improvements in the meantime now prevent the
need to evaluate the variables in the first place.