### PR TITLE
Update state when sensitivity changes

### DIFF
--- a/states/module.go
+++ b/states/module.go
@@ -76,16 +76,14 @@ func (ms *Module) RemoveResource(addr addrs.Resource) {
 
 // SetResourceInstanceCurrent saves the given instance object as the current
 // generation of the resource instance with the given address, simultaneously
-// updating the recorded provider configuration address, dependencies, and
-// resource EachMode.
+// updating the recorded provider configuration address and dependencies.
 //
 // Any existing current instance object for the given resource is overwritten.
 // Set obj to nil to remove the primary generation object altogether. If there
 // are no deposed objects then the instance will be removed altogether.
 //
-// The provider address and "each mode" are resource-wide settings and so they
-// are updated for all other instances of the same resource as a side-effect of
-// this call.
+// The provider address is a resource-wide setting and is updated for all other
+// instances of the same resource as a side-effect of this call.
 func (ms *Module) SetResourceInstanceCurrent(addr addrs.ResourceInstance, obj *ResourceInstanceObjectSrc, provider addrs.AbsProviderConfig) {
 	rs := ms.Resource(addr.Resource)
 	// if the resource is nil and the object is nil, don't do anything!

--- a/states/sync.go
+++ b/states/sync.go
@@ -316,9 +316,8 @@ func (s *SyncState) MaybeFixUpResourceInstanceAddressForCount(addr addrs.ConfigR
 // concurrently mutated during this call, but may be freely used again once
 // this function returns.
 //
-// The provider address and "each mode" are resource-wide settings and so they
-// are updated for all other instances of the same resource as a side-effect of
-// this call.
+// The provider address is a resource-wide settings and is updated
+// for all other instances of the same resource as a side-effect of this call.
 //
 // If the containing module for this resource or the resource itself are not
 // already tracked in state then they will be added as a side-effect.

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
@@ -118,7 +119,7 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 	// and we should not communicate with the provider or perform further action.
 	eqV := unmarkedBefore.Equals(unmarkedAfter)
 	eq := eqV.IsKnown() && eqV.True()
-	if change.Action == plans.Update && eq && (len(beforePaths) != len(afterPaths)) {
+	if change.Action == plans.Update && eq && !reflect.DeepEqual(beforePaths, afterPaths) {
 		return nil, diags.ErrWithWarnings()
 	}
 

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -109,20 +109,17 @@ func (n *EvalApply) Eval(ctx EvalContext) (interface{}, error) {
 	// If our config, Before or After value contain any marked values,
 	// ensure those are stripped out before sending
 	// this to the provider
-	unmarkedConfigVal := configVal
-	if configVal.ContainsMarked() {
-		unmarkedConfigVal, _ = configVal.UnmarkDeep()
-	}
+	unmarkedConfigVal, _ := configVal.UnmarkDeep()
+	unmarkedBefore, beforePaths := change.Before.UnmarkDeepWithPaths()
+	unmarkedAfter, afterPaths := change.After.UnmarkDeepWithPaths()
 
-	unmarkedBefore := change.Before
-	if change.Before.ContainsMarked() {
-		unmarkedBefore, _ = change.Before.UnmarkDeep()
-	}
-
-	unmarkedAfter := change.After
-	var afterPaths []cty.PathValueMarks
-	if change.After.ContainsMarked() {
-		unmarkedAfter, afterPaths = change.After.UnmarkDeepWithPaths()
+	// If we have an Update action, our before and after values are equal,
+	// and only differ on their sensitivity, the newVal is the after val
+	// and we should not communicate with the provider or perform further action.
+	eqV := unmarkedBefore.Equals(unmarkedAfter)
+	eq := eqV.IsKnown() && eqV.True()
+	if change.Action == plans.Update && eq && (len(beforePaths) != len(afterPaths)) {
+		return nil, diags.ErrWithWarnings()
 	}
 
 	resp := provider.ApplyResourceChange(providers.ApplyResourceChangeRequest{

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -484,7 +485,7 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 
 	// If we plan to write or delete sensitive paths from state,
 	// this is an Update action
-	if action == plans.NoOp && len(priorPaths) != len(unmarkedPaths) {
+	if action == plans.NoOp && !reflect.DeepEqual(priorPaths, unmarkedPaths) {
 		action = plans.Update
 	}
 

--- a/terraform/eval_variable.go
+++ b/terraform/eval_variable.go
@@ -12,7 +12,7 @@ import (
 	"github.com/zclconf/go-cty/cty/convert"
 )
 
-// evalVariableValidations ensures ta all of the configured custom validations
+// evalVariableValidations ensures that all of the configured custom validations
 // for a variable are passing.
 //
 // This must be used only after any side-effects that make the value of the


### PR DESCRIPTION
When sensitivity changes (but values do not) we still want to show an "Update" informational to the user, so we should have the `action` be Update in this (otherwise NoOp) scenario. However, when this happens, we should _not_ follow through with communicating with the provider and the following scenarios, because it is a no-op change from the provider's (value-only) perspective.

There are a few commits in here where I updated comments to reflect current state of the world (no EachMode) or simple typos. They are extraneous to this PR, but maybe it'll prevent some future "Fixed a typo" PRs.