### PR TITLE
Exit with error if UI input scan fails

### DIFF
--- a/command/ui_input.go
+++ b/command/ui_input.go
@@ -179,6 +179,7 @@ func (i *UIInput) Input(ctx context.Context, opts *terraform.InputOpts) (string,
 
 func (i *UIInput) init() {
 	i.result = make(chan string)
+	i.err = make(chan string)
 
 	if i.Colorize == nil {
 		i.Colorize = &colorstring.Colorize{

--- a/command/ui_input_test.go
+++ b/command/ui_input_test.go
@@ -97,3 +97,23 @@ func TestUIInputInput_spaces(t *testing.T) {
 		t.Fatalf("unexpected input: %s", v)
 	}
 }
+
+func TestUIInputInput_Error(t *testing.T) {
+	i := &UIInput{
+		Reader: bytes.NewBuffer(nil),
+		Writer: bytes.NewBuffer(nil),
+	}
+
+	v, err := i.Input(context.Background(), &terraform.InputOpts{})
+	if err == nil {
+		t.Fatalf("Error is not 'nil'")
+	}
+
+	if err.Error() != "EOF" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if v != "" {
+		t.Fatalf("input must be empty")
+	}
+}


### PR DESCRIPTION
**UPDATE**: adding `-input=false` seems to do the trick [as pointed out here](https://www.reddit.com/r/Terraform/comments/j6yk2l/terraform_plan_doesnt_error_out_if_required/g81m2zy?utm_source=share&utm_medium=web2x&context=3). It might still make sense to keep the error handling though?

------------

Fixes: https://github.com/hashicorp/terraform/issues/26508

Sample output:
```
Step 4/4 : RUN TF_LOG=DEBUG /terraform plan /tmp/
 ---> Running in f67cf0c83d8d
2020/10/07 20:12:22 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
2020/10/07 20:12:22 [INFO] Terraform version: 0.14.0 dev 
2020/10/07 20:12:22 [INFO] Go runtime version: go1.15.2
2020/10/07 20:12:22 [INFO] CLI args: []string{"/terraform", "plan", "/tmp/"}
2020/10/07 20:12:22 [DEBUG] Attempting to open CLI config file: /root/.terraformrc
2020/10/07 20:12:22 [DEBUG] File doesn't exist, but doesn't need to. Ignoring.
2020/10/07 20:12:22 [DEBUG] ignoring non-existing provider search directory terraform.d/plugins
2020/10/07 20:12:22 [DEBUG] ignoring non-existing provider search directory /root/.terraform.d/plugins
2020/10/07 20:12:22 [DEBUG] ignoring non-existing provider search directory /root/.local/share/terraform/plugins
2020/10/07 20:12:22 [DEBUG] ignoring non-existing provider search directory /usr/local/share/terraform/plugins
2020/10/07 20:12:22 [DEBUG] ignoring non-existing provider search directory /usr/share/terraform/plugins
2020/10/07 20:12:22 [INFO] CLI command args: []string{"plan", "/tmp/"}
2020/10/07 20:12:22 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
2020/10/07 20:12:22 [DEBUG] New state was assigned lineage "ac8d3306-0318-ef71-e700-fc02993b217c"
2020/10/07 20:12:22 [DEBUG] checking for provisioner in "."
2020/10/07 20:12:22 [DEBUG] checking for provisioner in "/"
2020/10/07 20:12:22 [INFO] Failed to read plugin lock file .terraform/plugins/linux_amd64/lock.json: open .terraform/plugins/linux_amd64/lock.json: no such file or directory
2020/10/07 20:12:22 [INFO] backend/local: starting Plan operation
2020/10/07 20:12:22 [DEBUG] backend/local: will prompt for input of unset required variables [test]
2020/10/07 20:12:22 [DEBUG] command: asking for input: "var.test"
2020/10/07 20:12:22 [ERR] UIInput scan err: EOF
2020/10/07 20:12:22 [WARN] backend/local: Failed to request user input for variable "test": EOF
var.test
  Enter a value: e:
Error: No value for required variable

  on tmp/test.tf line 1:
   1: variable "test"{}

The root module input variable "test" is not set, and has no default value.
Use a -var or -var-file command line argument to provide a value for this
variable.

The command '/bin/sh -c TF_LOG=DEBUG /terraform plan /tmp/' returned a non-zero code: 1

```