### PR TITLE
[website] Update other commands list on commands page

### DIFF
--- a/website/docs/commands/index.html.markdown
+++ b/website/docs/commands/index.html.markdown
@@ -54,8 +54,11 @@ Common commands:
     workspace          Workspace management
 
 All other commands:
+    0.12upgrade        Rewrites pre-0.12 module source code for v0.12
+    0.13upgrade        Rewrites pre-0.13 module source code for v0.13
     debug              Debug output management (experimental)
     force-unlock       Manually unlock the terraform state
+    push               Obsolete command for Terraform Enterprise legacy (v1)
     state              Advanced state management
 
 


### PR DESCRIPTION
Updates the [commands](https://www.terraform.io/docs/commands/) page with `0.12upgrade` and `0.13upgrade` commands.