### PR TITLE
Use recorded changes for outputs and plan root output removals

### DIFF
--- a/command/testdata/show-json/basic-update/output.json
+++ b/command/testdata/show-json/basic-update/output.json
@@ -55,9 +55,9 @@
     "output_changes": {
         "test": {
             "actions": [
-                "create"
+                "no-op"
             ],
-            "before": null,
+            "before": "bar",
             "after": "bar",
             "after_unknown": false
         }

--- a/command/testdata/show-json/basic-update/terraform.tfstate
+++ b/command/testdata/show-json/basic-update/terraform.tfstate
@@ -3,7 +3,12 @@
     "terraform_version": "0.12.0",
     "serial": 7,
     "lineage": "configuredUnchanged",
-    "outputs": {},
+    "outputs": {
+        "test": {
+            "value": "bar",
+            "type": "string"
+        }
+    },
     "resources": [
         {
             "mode": "managed",

--- a/command/testdata/show-json/multi-resource-update/output.json
+++ b/command/testdata/show-json/multi-resource-update/output.json
@@ -90,9 +90,9 @@
     "output_changes": {
         "test": {
             "actions": [
-                "create"
+                "no-op"
             ],
-            "before": null,
+            "before": "bar",
             "after": "bar",
             "after_unknown": false
         }

--- a/command/testdata/show-json/multi-resource-update/terraform.tfstate
+++ b/command/testdata/show-json/multi-resource-update/terraform.tfstate
@@ -3,7 +3,12 @@
     "terraform_version": "0.12.0",
     "serial": 7,
     "lineage": "configuredUnchanged",
-    "outputs": {},
+    "outputs": {
+        "test": {
+            "value": "bar",
+            "type": "string"
+        }
+    },
     "resources": [
         {
             "mode": "managed",

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -277,7 +277,6 @@ func (c *Context) Graph(typ GraphType, opts *ContextGraphOpts) (*Graph, tfdiags.
 			Components: c.components,
 			Schemas:    c.schemas,
 			Targets:    c.targets,
-			Destroy:    c.destroy,
 			Validate:   opts.Validate,
 		}).Build(addrs.RootModuleInstance)
 

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -9142,9 +9142,12 @@ func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
 	}
 
 	// Applying the plan should now succeed
-	_, diags = ctx.Apply()
+	state, diags = ctx.Apply()
 	if diags.HasErrors() {
 		t.Fatalf("apply failed: %s", diags.Err())
+	}
+	if !state.Empty() {
+		t.Fatalf("state not empty: %s\n", state)
 	}
 }
 

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -40,9 +40,6 @@ type ApplyGraphBuilder struct {
 	// outputs should go into the diff so that this is unnecessary.
 	Targets []addrs.Targetable
 
-	// Destroy, if true, represents a pure destroy operation
-	Destroy bool
-
 	// Validate will do structural validation of the graph.
 	Validate bool
 }

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -91,7 +91,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&RootVariableTransformer{Config: b.Config},
 		&ModuleVariableTransformer{Config: b.Config},
 		&LocalTransformer{Config: b.Config},
-		&OutputTransformer{Config: b.Config},
+		&OutputTransformer{Config: b.Config, Changes: b.Changes},
 
 		// Creates all the resource instances represented in the diff, along
 		// with dependency edges against the whole-resource nodes added by

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -150,17 +150,6 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 			Schemas: b.Schemas,
 		},
 
-		// Create a destroy node for root outputs to remove them from the
-		// state.  This does nothing unless invoked via the destroy command
-		// directly.  A destroy is identical to a normal apply, except for the
-		// fact that we also have configuration to evaluate. While the rest of
-		// the unused nodes can be programmatically pruned (via
-		// pruneUnusedNodesTransformer), root module outputs always have an
-		// implied dependency on remote state. This means that if they exist in
-		// the configuration, the only signal to remove them is via the destroy
-		// command itself.
-		&destroyRootOutputTransformer{Destroy: b.Destroy},
-
 		// We need to remove configuration nodes that are not used at all, as
 		// they may not be able to evaluate, especially during destroy.
 		// These include variables, locals, and instance expanders.

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -468,7 +468,6 @@ func TestApplyGraphBuilder_provisionerDestroy(t *testing.T) {
 	}
 
 	b := &ApplyGraphBuilder{
-		Destroy:    true,
 		Config:     testModule(t, "graph-builder-apply-provisioner"),
 		Changes:    changes,
 		Components: simpleMockComponentFactory(),

--- a/terraform/graph_builder_destroy_plan.go
+++ b/terraform/graph_builder_destroy_plan.go
@@ -72,6 +72,11 @@ func (b *DestroyPlanGraphBuilder) Steps() []GraphTransformer {
 			State:           b.State,
 		},
 
+		&OutputTransformer{
+			Config:  b.Config,
+			Destroy: true,
+		},
+
 		// Attach the state
 		&AttachStateTransformer{State: b.State},
 

--- a/terraform/graph_builder_plan_test.go
+++ b/terraform/graph_builder_plan_test.go
@@ -288,10 +288,10 @@ local.instance_id (expand)
   aws_instance.web (expand)
 meta.count-boundary (EachMode fixup)
   aws_load_balancer.weblb (expand)
-  output.instance_id (expand)
+  output.instance_id
 openstack_floating_ip.random (expand)
   provider["registry.terraform.io/hashicorp/openstack"]
-output.instance_id (expand)
+output.instance_id
   local.instance_id (expand)
 provider["registry.terraform.io/hashicorp/aws"]
   openstack_floating_ip.random (expand)

--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -26,7 +26,8 @@ var (
 	_ GraphNodeTargetable           = (*nodeExpandApplyableResource)(nil)
 )
 
-func (n *nodeExpandApplyableResource) expandsInstances() {}
+func (n *nodeExpandApplyableResource) expandsInstances() {
+}
 
 func (n *nodeExpandApplyableResource) References() []*addrs.Reference {
 	return (&NodeApplyableResource{NodeAbstractResource: n.NodeAbstractResource}).References()

--- a/terraform/transform_output.go
+++ b/terraform/transform_output.go
@@ -64,31 +64,24 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			}
 		}
 
+		destroy := t.Destroy
+		if rootChange != nil {
+			destroy = rootChange.Action == plans.Delete
+		}
+
 		var node dag.Vertex
 		switch {
-		case c.Path.IsRoot() && t.Destroy:
+		case c.Path.IsRoot() && destroy:
 			node = &NodeDestroyableOutput{
 				Addr:   addr.Absolute(addrs.RootModuleInstance),
 				Config: o,
 			}
-		case c.Path.IsRoot():
-			destroy := t.Destroy
-			if rootChange != nil {
-				destroy = rootChange.Action == plans.Delete
-			}
 
-			switch {
-			case destroy:
-				node = &NodeDestroyableOutput{
-					Addr:   addr.Absolute(addrs.RootModuleInstance),
-					Config: o,
-				}
-			default:
-				node = &NodeApplyableOutput{
-					Addr:   addr.Absolute(addrs.RootModuleInstance),
-					Config: o,
-					Change: rootChange,
-				}
+		case c.Path.IsRoot():
+			node = &NodeApplyableOutput{
+				Addr:   addr.Absolute(addrs.RootModuleInstance),
+				Config: o,
+				Change: rootChange,
 			}
 
 		default:

--- a/terraform/transform_output.go
+++ b/terraform/transform_output.go
@@ -47,8 +47,6 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 	// into NodeApplyableOutputs to reflect possible expansion
 	// through the presence of "count" or "for_each" on the modules.
 
-	// if this is a root output, we add the apply or destroy node directly, as
-	// the root modules does not expand
 	var changes []*plans.OutputChangeSrc
 	if t.Changes != nil {
 		changes = t.Changes.Outputs
@@ -68,6 +66,9 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 		if rootChange != nil {
 			destroy = rootChange.Action == plans.Delete
 		}
+
+		// If this is a root output, we add the apply or destroy node directly,
+		// as the root modules does not expand.
 
 		var node dag.Vertex
 		switch {

--- a/terraform/transform_targets_test.go
+++ b/terraform/transform_targets_test.go
@@ -122,7 +122,7 @@ module.child.module.grandchild.output.id (expand)
   module.child.module.grandchild.aws_instance.foo
 module.child.output.grandchild_id (expand)
   module.child.module.grandchild.output.id (expand)
-output.grandchild_id (expand)
+output.grandchild_id
   module.child.output.grandchild_id (expand)
 	`)
 	if actual != expected {
@@ -193,7 +193,7 @@ module.child.module.grandchild.output.id (expand)
   module.child.module.grandchild.aws_instance.foo
 module.child.output.grandchild_id (expand)
   module.child.module.grandchild.output.id (expand)
-output.grandchild_id (expand)
+output.grandchild_id
   module.child.output.grandchild_id (expand)
 	`)
 	if actual != expected {


### PR DESCRIPTION
We record output changes in the plan, but don't currently use them for anything other than display. If we have a wholly known output value stored in the plan, we should prefer that for apply in order to ensure consistency with the planned values. This also avoids cases where evaluation during apply cannot happen correctly, like when all resources are being removed or we are executing a destroy.

Recording all change in the state also lets us remove the need for the special destroy root output transformer. That was always a stop-gap until we could plan the outputs, since it was the last usage of the apply graph `Destroy` flag.

`Before` values are now stored correctly in the plan changes too, and the change `Action` is updated to use `NoOp` when there is no change,  and `Update` when the `Before` value was not null. This PR does not yet go into updating the plan rendering, which likely has some changes that could be made to make use of the new more detailed change entries. 