### PR TITLE
internal/depsfile: Update the dependency lock file atomically

### DIFF
--- a/command/cliconfig/config_unix.go
+++ b/command/cliconfig/config_unix.go
@@ -50,8 +50,3 @@ func homeDir() (string, error) {
 
 	return user.HomeDir, nil
 }
-
-func replaceFileAtomic(source, destination string) error {
-	// On Unix systems, a rename is sufficiently atomic.
-	return os.Rename(source, destination)
-}

--- a/command/cliconfig/config_windows.go
+++ b/command/cliconfig/config_windows.go
@@ -3,12 +3,9 @@
 package cliconfig
 
 import (
-	"os"
 	"path/filepath"
 	"syscall"
 	"unsafe"
-
-	"golang.org/x/sys/windows"
 )
 
 var (
@@ -46,26 +43,4 @@ func homeDir() (string, error) {
 	}
 
 	return syscall.UTF16ToString(b), nil
-}
-
-func replaceFileAtomic(source, destination string) error {
-	// On Windows, renaming one file over another is not atomic and certain
-	// error conditions can result in having only the source file and nothing
-	// at the destination file. Instead, we need to call into the MoveFileEx
-	// Windows API function.
-	srcPtr, err := syscall.UTF16PtrFromString(source)
-	if err != nil {
-		return &os.LinkError{"replace", source, destination, err}
-	}
-	destPtr, err := syscall.UTF16PtrFromString(destination)
-	if err != nil {
-		return &os.LinkError{"replace", source, destination, err}
-	}
-
-	flags := uint32(windows.MOVEFILE_REPLACE_EXISTING | windows.MOVEFILE_WRITE_THROUGH)
-	err = windows.MoveFileEx(srcPtr, destPtr, flags)
-	if err != nil {
-		return &os.LinkError{"replace", source, destination, err}
-	}
-	return nil
 }

--- a/command/cliconfig/credentials.go
+++ b/command/cliconfig/credentials.go
@@ -12,9 +12,10 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
-	"github.com/hashicorp/terraform-svchost"
+	svchost "github.com/hashicorp/terraform-svchost"
 	svcauth "github.com/hashicorp/terraform-svchost/auth"
 	"github.com/hashicorp/terraform/configs/hcl2shim"
+	"github.com/hashicorp/terraform/internal/replacefile"
 	pluginDiscovery "github.com/hashicorp/terraform/plugin/discovery"
 )
 
@@ -336,7 +337,7 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 		// Temporary file now replaces the original file, as atomically as
 		// possible. (At the very least, we should not end up with a file
 		// containing only a partial JSON object.)
-		err = replaceFileAtomic(tmpName, filename)
+		err = replacefile.AtomicRename(tmpName, filename)
 		if err != nil {
 			return fmt.Errorf("failed to replace %s with temporary file %s: %s", filename, tmpName, err)
 		}

--- a/internal/depsfile/locks_file.go
+++ b/internal/depsfile/locks_file.go
@@ -2,7 +2,6 @@ package depsfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 
@@ -15,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/internal/getproviders"
+	"github.com/hashicorp/terraform/internal/replacefile"
 	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/hashicorp/terraform/version"
 )
@@ -108,11 +108,7 @@ func SaveLocksToFile(locks *Locks, filename string) tfdiags.Diagnostics {
 
 	newContent := f.Bytes()
 
-	// TODO: Create the content in a new file and atomically pivot it into
-	// the target, so that there isn't a brief period where an incomplete
-	// file can be seen at the given location.
-	// But for now, this gets us started.
-	err := ioutil.WriteFile(filename, newContent, os.ModePerm)
+	err := replacefile.AtomicWriteFile(filename, newContent, os.ModePerm)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/replacefile/doc.go
+++ b/internal/replacefile/doc.go
@@ -1,0 +1,12 @@
+// Package replacefile is a small helper package focused directly at the
+// problem of atomically "renaming" one file over another one.
+//
+// On Unix systems this is the standard behavior of the rename function, but
+// the equivalent operation on Windows requires some specific operation flags
+// which this package encapsulates.
+//
+// This package uses conditional compilation to select a different
+// implementation for Windows vs. all other platforms. It may therefore
+// require further fiddling in future if Terraform is ported to another
+// OS that is neither Unix-like nor Windows.
+package replacefile

--- a/internal/replacefile/replacefile_unix.go
+++ b/internal/replacefile/replacefile_unix.go
@@ -1,0 +1,24 @@
+// +build !windows
+
+package replacefile
+
+import (
+	"os"
+)
+
+// AtomicRename renames from the source path to the destination path,
+// atomically replacing any file that might already exist at the destination.
+//
+// Typically this operation can succeed only if the source and destination
+// are within the same physical filesystem, so this function is best reserved
+// for cases where the source and destination exist in the same directory and
+// only the local filename differs between them.
+//
+// The Unix implementation of AtomicRename relies on the atomicity of renaming
+// that is required by the ISO C standard, which in turn assumes that Go's
+// implementation of rename is calling into a system call that preserves that
+// guarantee.
+func AtomicRename(source, destination string) error {
+	// On Unix systems, a rename is sufficiently atomic.
+	return os.Rename(source, destination)
+}

--- a/internal/replacefile/replacefile_windows.go
+++ b/internal/replacefile/replacefile_windows.go
@@ -1,0 +1,40 @@
+// +build windows
+
+package replacefile
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// AtomicRename renames from the source path to the destination path,
+// atomically replacing any file that might already exist at the destination.
+//
+// Typically this operation can succeed only if the source and destination
+// are within the same physical filesystem, so this function is best reserved
+// for cases where the source and destination exist in the same directory and
+// only the local filename differs between them.
+func AtomicRename(source, destination string) error {
+	// On Windows, renaming one file over another is not atomic and certain
+	// error conditions can result in having only the source file and nothing
+	// at the destination file. Instead, we need to call into the MoveFileEx
+	// Windows API function, setting two flags to opt in to replacing an
+	// existing file.
+	srcPtr, err := syscall.UTF16PtrFromString(source)
+	if err != nil {
+		return &os.LinkError{"replace", source, destination, err}
+	}
+	destPtr, err := syscall.UTF16PtrFromString(destination)
+	if err != nil {
+		return &os.LinkError{"replace", source, destination, err}
+	}
+
+	flags := uint32(windows.MOVEFILE_REPLACE_EXISTING | windows.MOVEFILE_WRITE_THROUGH)
+	err = windows.MoveFileEx(srcPtr, destPtr, flags)
+	if err != nil {
+		return &os.LinkError{"replace", source, destination, err}
+	}
+	return nil
+}

--- a/internal/replacefile/writefile.go
+++ b/internal/replacefile/writefile.go
@@ -1,0 +1,71 @@
+package replacefile
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// AtomicWriteFile uses a temporary file along with this package's AtomicRename
+// function in order to provide a replacement for ioutil.WriteFile that
+// writes the given file into place as atomically as the underlying operating
+// system can support.
+//
+// The sense of "atomic" meant by this function is that the file at the
+// given filename will either contain the entirety of the previous contents
+// or the entirety of the given data array if opened and read at any point
+// during the execution of the function.
+//
+// On some platforms attempting to overwrite a file that has at least one
+// open filehandle will produce an error. On other platforms, the overwriting
+// will succeed but existing open handles will still refer to the old file,
+// even though its directory entry is no longer present.
+//
+// Although AtomicWriteFile tries its best to avoid leaving behind its
+// temporary file on error, some particularly messy error cases may result
+// in a leftover temporary file.
+func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
+	dir, file := filepath.Split(filename)
+	f, err := ioutil.TempFile(dir, file) // alongside target file and with a similar name
+	if err != nil {
+		return fmt.Errorf("cannot create temporary file to update %s: %s", filename, err)
+	}
+	tmpName := f.Name()
+	moved := false
+	defer func(f *os.File, name string) {
+		// Remove the temporary file if it hasn't been moved yet. We're
+		// ignoring errors here because there's nothing we can do about
+		// them anyway.
+		if !moved {
+			os.Remove(name)
+		}
+	}(f, tmpName)
+
+	// We'll try to apply the requested permissions. This may
+	// not be effective on all platforms, but should at least work on
+	// Unix-like targets and should be harmless elsewhere.
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("cannot set mode for temporary file %s: %s", tmpName, err)
+	}
+
+	// Write the credentials to the temporary file, then immediately close
+	// it, whether or not the write succeeds. Note that closing the file here
+	// is required because on Windows we can't move a file while it's open.
+	_, err = f.Write(data)
+	f.Close()
+	if err != nil {
+		return fmt.Errorf("cannot write to temporary file %s: %s", tmpName, err)
+	}
+
+	// Temporary file now replaces the original file, as atomically as
+	// possible. (At the very least, we should not end up with a file
+	// containing only a partial JSON object.)
+	err = AtomicRename(tmpName, filename)
+	if err != nil {
+		return fmt.Errorf("failed to replace %s with temporary file %s: %s", filename, tmpName, err)
+	}
+
+	moved = true
+	return nil
+}


### PR DESCRIPTION
In this case, "atomic" means that there will be no situation where the file contains only part of the newContent data, and therefore other software monitoring the `.terraform.lock.hcl` file for changes (using a mechanism like inotify) won't risk encountering a truncated file.

It does _not_ mean that there can't be existing filehandles open against the old version of the file. On Windows systems the write will fail in that case, but on Unix systems the write will typically succeed but leave the existing filehandles still pointing at the old version of the file. They'll need to reopen the file in order to see the new content.

This atomic update was already documented as a guarantee in the `depsfile` package documentation, so this change is intended to make the implementation actually match that guarantee and thus enable external software (like the Terraform language server) to rely on it as a way to detect when a configuration's dependencies might have changed.

To get this done I factored out some code we wrote previously for updating the credentials file portion of the CLI configuration, because the Windows implementation of that in particular was fiddly to get right and I don't want to revisit that again at the moment.
