### PR TITLE
backend: Refresh azure state outside of grabbing the lock

### DIFF
--- a/backend/remote-state/azure/backend_state.go
+++ b/backend/remote-state/azure/backend_state.go
@@ -118,19 +118,28 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 			return parent
 		}
 
-		// If we have no state, we have to create an empty state
-		if err := stateMgr.WriteState(states.NewState()); err != nil {
+		// Grab the value
+		if err := stateMgr.RefreshState(); err != nil {
 			err = lockUnlock(err)
 			return nil, err
 		}
-		if err := stateMgr.PersistState(); err != nil {
-			err = lockUnlock(err)
-			return nil, err
-		}
+		//if this isn't the default state name, we need to create the object so
+		//it's listed by States.
+		if v := stateMgr.State(); v == nil {
+			// If we have no state, we have to create an empty state
+			if err := stateMgr.WriteState(states.NewState()); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
+			if err := stateMgr.PersistState(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
 
-		// Unlock, the state should now be initialized
-		if err := lockUnlock(nil); err != nil {
-			return nil, err
+			// Unlock, the state should now be initialized
+			if err := lockUnlock(nil); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/backend/remote-state/azure/backend_test.go
+++ b/backend/remote-state/azure/backend_test.go
@@ -258,6 +258,9 @@ func TestBackendAccessKeyLocked(t *testing.T) {
 
 	backend.TestBackendStateLocks(t, b1, b2)
 	backend.TestBackendStateForceUnlock(t, b1, b2)
+
+	backend.TestBackendStateLocksInWS(t, b1, b2, "foo")
+	backend.TestBackendStateForceUnlockInWS(t, b1, b2, "foo")
 }
 
 func TestBackendServicePrincipalLocked(t *testing.T) {
@@ -301,4 +304,7 @@ func TestBackendServicePrincipalLocked(t *testing.T) {
 
 	backend.TestBackendStateLocks(t, b1, b2)
 	backend.TestBackendStateForceUnlock(t, b1, b2)
+
+	backend.TestBackendStateLocksInWS(t, b1, b2, "foo")
+	backend.TestBackendStateForceUnlockInWS(t, b1, b2, "foo")
 }

--- a/backend/testing.go
+++ b/backend/testing.go
@@ -279,7 +279,27 @@ func TestBackendStateForceUnlock(t *testing.T, b1, b2 Backend) {
 	testLocks(t, b1, b2, true)
 }
 
+// TestBackendStateLocksInWS will test the locking functionality of the remote
+// state backend.
+func TestBackendStateLocksInWS(t *testing.T, b1, b2 Backend, ws string) {
+	t.Helper()
+	testLocksInWorkspace(t, b1, b2, false, ws)
+}
+
+// TestBackendStateForceUnlockInWS verifies that the lock error is the expected
+// type, and the lock can be unlocked using the ID reported in the error.
+// Remote state backends that support -force-unlock should call this in at
+// least one of the acceptance tests.
+func TestBackendStateForceUnlockInWS(t *testing.T, b1, b2 Backend, ws string) {
+	t.Helper()
+	testLocksInWorkspace(t, b1, b2, true, ws)
+}
+
 func testLocks(t *testing.T, b1, b2 Backend, testForceUnlock bool) {
+	testLocksInWorkspace(t, b1, b2, testForceUnlock, DefaultStateName)
+}
+
+func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, workspace string) {
 	t.Helper()
 
 	// Get the default state for each


### PR DESCRIPTION
Refresh state outside of grabbing the lock; only grab the lock on provisioning if the state file doesn't exist; this is similar to the GCS backend.

This fixes the broken force-unlock command for the nominal case, where the backend state is locked and already exists.

This was previuosly done for the purpose of creating a new workspace, and simultaneously creating the resulting state file. This PR simply gets the state outside of the lock, but attempts to grab the lock when creating, so still avoids any potential race conditions.