### PR TITLE
build: revert Dockerfile removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# This Dockerfile builds on golang:alpine by building Terraform from source
+# using the current working directory.
+#
+# This produces a docker image that contains a working Terraform binary along
+# with all of its source code, which is what gets released on hub.docker.com
+# as terraform:full. The main releases (terraform:latest, terraform:light and
+# the release tags) are lighter images including only the officially-released
+# binary from releases.hashicorp.com; these are built instead from
+# scripts/docker-release/Dockerfile-release.
+
+FROM golang:alpine
+LABEL maintainer="HashiCorp Terraform Team <terraform@hashicorp.com>"
+
+RUN apk add --no-cache git bash openssh
+
+ENV TF_DEV=true
+ENV TF_RELEASE=1
+
+WORKDIR $GOPATH/src/github.com/hashicorp/terraform
+COPY . .
+RUN /bin/bash ./scripts/build.sh
+
+WORKDIR $GOPATH
+ENTRYPOINT ["terraform"]


### PR DESCRIPTION
Removing this was a mistake! 

We use two dockerfiles; the one in this PR is used to create the "full" docker image, which includes the source code. The _other_ dockerfile which I removed in [an earlier PR](https://github.com/hashicorp/terraform/pull/26484) is being moved to terraform-releases in https://github.com/hashicorp/terraform-releases/pull/20. 