### PR TITLE
command/e2etest: do not leave incomplete provider installation directories behind

### DIFF
--- a/command/e2etest/init_test.go
+++ b/command/e2etest/init_test.go
@@ -142,6 +142,12 @@ func TestInitProvidersLocalOnly(t *testing.T) {
 
 	fixturePath := filepath.Join("testdata", "local-only-provider")
 	tf := e2e.NewBinary(terraformBin, fixturePath)
+	// If you run this test on a workstation with a plugin-cache directory
+	// configured, it will leave a bad directory behind and terraform init will
+	// not work until you remove it.
+	//
+	// To avoid this, we will  "zero out" any existing cli config file.
+	tf.AddEnv("TF_CLI_CONFIG_FILE=\"\"")
 	defer tf.Close()
 
 	// Our fixture dir has a generic os_arch dir, which we need to customize


### PR DESCRIPTION
If you run the e2e tests locally and use a configured plugin_cache_dir,
`TestInitProvidersLocalOnly` will leave a bad (incomplete) directory behind in your cache dir that causes
later `init`s to fail. To circumvent this, pass an explicitly-empty CLI
config file.

This is a nicety for local developers and not required, but
it happens to me often enough that I'd like to fix it. It's probably not
a *bad* idea to pass an explicit cli config to all e2e tests, honestly,
but this is the only one that causes active problems for the local workstation (that I have encountered, at least) so I limited this PR to that one test.

Here's the error which occurs on subsequent `init` if this test is run on a
machine that uses a plugin cache dir:

```
2020/10/13 10:41:05 [TRACE] providercache.fillMetaCache: error while scanning directory /Users/mildwonkey/.terraform.d/plugin-cache: failed to read metadata about /Users/mildwonkey/.terraform.d/plugin-cache/example.com/awesomecorp/happycloud/1.2.0/darwin_amd64: stat /Users/mildwonkey/.terraform.d/plugin-cache/example.com/awesomecorp/happycloud/1.2.0/darwin_amd64: no such file or directory
```