### PR TITLE
simplify the backend interface; promote locking to a first class citizen

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform/plans"
 	"github.com/hashicorp/terraform/plans/planfile"
 	"github.com/hashicorp/terraform/states"
+	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statemgr"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
@@ -51,6 +52,9 @@ type InitFn func() Backend
 
 // Backend is the minimal interface that must be implemented to enable Terraform.
 type Backend interface {
+	// Can later pull the methods out directly in this interface, and potentially remove these interfaces.
+	// Support basic implementation of write, put, lock, get, delete.
+	remote.ClientLocker
 	// ConfigSchema returns a description of the expected configuration
 	// structure for the receiving backend.
 	//
@@ -92,26 +96,7 @@ type Backend interface {
 	// is undefined and no other methods may be called.
 	Configure(cty.Value) tfdiags.Diagnostics
 
-	// StateMgr returns the state manager for the given workspace name.
-	//
-	// If the returned state manager also implements statemgr.Locker then
-	// it's the caller's responsibility to call Lock and Unlock as appropriate.
-	//
-	// If the named workspace doesn't exist, or if it has no state, it will
-	// be created either immediately on this call or the first time
-	// PersistState is called, depending on the state manager implementation.
-	StateMgr(workspace string) (statemgr.Full, error)
-
-	// DeleteWorkspace removes the workspace with the given name if it exists.
-	//
-	// DeleteWorkspace cannot prevent deleting a state that is in use. It is
-	// the responsibility of the caller to hold a Lock for the state manager
-	// belonging to this workspace before calling this method.
-	DeleteWorkspace(name string) error
-
-	// States returns a list of the names of all of the workspaces that exist
-	// in this backend.
-	Workspaces() ([]string, error)
+	// Remove statemgr.. make workspaces a first class citizen
 }
 
 // Enhanced implements additional behavior on top of a normal backend.

--- a/states/remote/remote.go
+++ b/states/remote/remote.go
@@ -10,9 +10,11 @@ import (
 // driver. It supports dumb put/get/delete, and the higher level structs
 // handle persisting the state properly here.
 type Client interface {
-	Get() (*Payload, error)
-	Put([]byte) error
-	Delete() error
+	Get(workspace string) (*Payload, error)
+	Put(workspace string, data []byte) error
+	Delete(workspace string) error
+	// List worksapces.
+	List() (string, error)
 }
 
 // ClientForcePusher is an optional interface that allows a remote


### PR DESCRIPTION
Hi there,

Looking at promoting locking to a first class function for terraform backends. See https://github.com/hashicorp/terraform/issues/26422

Starting a draft here to allow a fail-fast, in case this is a non-starter or undesirable (this would result in a large refactor, and changes to each backend implementation).

Anyways, I'm thinking that backends should support simple operations, and place the complexity of calling, locking, and coordinating various operations in the main terraform code. The result is backends will only need to implement the following:

```
// Backend is the minimal interface that must be implemented to enable Terraform.
type Backend interface {
        // Basic state operations a backend must implement.
	Get(workspace string) (*Payload, error)
	Put(workspace string, data []byte) error
	Delete(workspace string) error
	// List worksapces.
	List() (string, error)
	Lock(info *LockInfo) (string, error)
	Unlock(id string) error

        // Meta operations required to validate and create backends
	ConfigSchema() *configschema.Block
	PrepareConfig(cty.Value) (cty.Value, tfdiags.Diagnostics)
	Configure(cty.Value) tfdiags.Diagnostics
}
```

I understand there are some implementations (consul, any others?) that require a live session for locking, however it is feasible to implement locking without that. For now I'd like to stray away from *how* we will achieve this, and those specific implementation details, but whether this is desirable for the calling code within terraform, or if there are any other non-starters.