### PR TITLE
Memoize Block.DecoderSpec

### DIFF
--- a/configs/configschema/decoder_spec.go
+++ b/configs/configschema/decoder_spec.go
@@ -1,10 +1,67 @@
 package configschema
 
 import (
+	"runtime"
+	"sync"
+	"unsafe"
+
 	"github.com/hashicorp/hcl/v2/hcldec"
 )
 
 var mapLabelNames = []string{"key"}
+
+// specCache is a global cache of all the generated hcldec.Spec values for
+// Blocks. This cache is used by the Block.DecoderSpec method to memoize calls
+// and prevent unnecessary regeneration of the spec, especially when they are
+// large and deeply nested.
+// Caching these externally rather than within the struct is required because
+// Blocks are used by value and copied when working with NestedBlocks, and the
+// copying of the value prevents any safe synchronisation of the struct itself.
+type specCache struct {
+	sync.Mutex
+	specs map[uintptr]hcldec.Spec
+}
+
+var decoderSpecCache = specCache{
+	specs: map[uintptr]hcldec.Spec{},
+}
+
+// get returns the Spec associated with eth given Block, or nil if non is
+// found.
+func (s *specCache) get(b *Block) hcldec.Spec {
+	s.Lock()
+	defer s.Unlock()
+	k := uintptr(unsafe.Pointer(b))
+	return s.specs[k]
+}
+
+// set stores the given Spec as being the result of b.DecoderSpec().
+func (s *specCache) set(b *Block, spec hcldec.Spec) {
+	s.Lock()
+	defer s.Unlock()
+
+	// the uintptr value gets us a unique identifier for each block, without
+	// tying this to the block value itself.
+	k := uintptr(unsafe.Pointer(b))
+	if _, ok := s.specs[k]; ok {
+		return
+	}
+
+	s.specs[k] = spec
+
+	// This must use a finalizer tied to the Block, otherwise we'll continue to
+	// build up Spec values as the Blocks are recycled.
+	runtime.SetFinalizer(b, s.delete)
+}
+
+// delete removes the spec associated with the given Block.
+func (s *specCache) delete(b *Block) {
+	s.Lock()
+	defer s.Unlock()
+
+	k := uintptr(unsafe.Pointer(b))
+	delete(s.specs, k)
+}
 
 // DecoderSpec returns a hcldec.Spec that can be used to decode a HCL Body
 // using the facilities in the hcldec package.
@@ -16,6 +73,10 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 	ret := hcldec.ObjectSpec{}
 	if b == nil {
 		return ret
+	}
+
+	if spec := decoderSpecCache.get(b); spec != nil {
+		return spec
 	}
 
 	for name, attrS := range b.Attributes {
@@ -111,6 +172,7 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 		}
 	}
 
+	decoderSpecCache.set(b, ret)
 	return ret
 }
 

--- a/configs/configschema/decoder_spec.go
+++ b/configs/configschema/decoder_spec.go
@@ -17,6 +17,12 @@ var mapLabelNames = []string{"key"}
 // Caching these externally rather than within the struct is required because
 // Blocks are used by value and copied when working with NestedBlocks, and the
 // copying of the value prevents any safe synchronisation of the struct itself.
+//
+// While we are using the *Block pointer as the cache key, and the Block
+// contents are mutable, once a Block is created it is treated as immutable for
+// the duration of its life. Because a Block is a representation of a logical
+// schema, which cannot change while it's being used, any modifications to the
+// schema during execution would be an error.
 type specCache struct {
 	sync.Mutex
 	specs map[uintptr]hcldec.Spec
@@ -26,7 +32,7 @@ var decoderSpecCache = specCache{
 	specs: map[uintptr]hcldec.Spec{},
 }
 
-// get returns the Spec associated with the given Block, or nil if none is
+// get returns the Spec associated with eth given Block, or nil if non is
 // found.
 func (s *specCache) get(b *Block) hcldec.Spec {
 	s.Lock()

--- a/configs/configschema/decoder_spec.go
+++ b/configs/configschema/decoder_spec.go
@@ -26,7 +26,7 @@ var decoderSpecCache = specCache{
 	specs: map[uintptr]hcldec.Spec{},
 }
 
-// get returns the Spec associated with eth given Block, or nil if non is
+// get returns the Spec associated with the given Block, or nil if none is
 // found.
 func (s *specCache) get(b *Block) hcldec.Spec {
 	s.Lock()

--- a/lang/blocktoattr/fixup_bench_test.go
+++ b/lang/blocktoattr/fixup_bench_test.go
@@ -1,0 +1,97 @@
+package blocktoattr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcldec"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func ambiguousNestedBlock(nesting int) *configschema.NestedBlock {
+	ret := &configschema.NestedBlock{
+		Nesting: configschema.NestingList,
+		Block: configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"a": {Type: cty.String, Required: true},
+				"b": {Type: cty.String, Optional: true},
+			},
+		},
+	}
+	if nesting > 0 {
+		ret.BlockTypes = map[string]*configschema.NestedBlock{
+			"nested0": ambiguousNestedBlock(nesting - 1),
+			"nested1": ambiguousNestedBlock(nesting - 1),
+			"nested2": ambiguousNestedBlock(nesting - 1),
+			"nested3": ambiguousNestedBlock(nesting - 1),
+			"nested4": ambiguousNestedBlock(nesting - 1),
+			"nested5": ambiguousNestedBlock(nesting - 1),
+			"nested6": ambiguousNestedBlock(nesting - 1),
+			"nested7": ambiguousNestedBlock(nesting - 1),
+			"nested8": ambiguousNestedBlock(nesting - 1),
+			"nested9": ambiguousNestedBlock(nesting - 1),
+		}
+	}
+	return ret
+}
+
+func schemaWithAmbiguousNestedBlock(nesting int) *configschema.Block {
+	return &configschema.Block{
+		BlockTypes: map[string]*configschema.NestedBlock{
+			"maybe_block": ambiguousNestedBlock(nesting),
+		},
+	}
+}
+
+const configForFixupBlockAttrsBenchmark = `
+maybe_block {
+  a = "hello"
+  b = "world"
+  nested0 {
+    a = "the"
+    nested1 {
+	  a = "deeper"
+      nested2 {
+        a = "we"
+        nested3 {
+          a = "go"
+          b = "inside"
+        }
+      }
+    }
+  }
+}
+`
+
+func configBodyForFixupBlockAttrsBenchmark() hcl.Body {
+	f, diags := hclsyntax.ParseConfig([]byte(configForFixupBlockAttrsBenchmark), "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		panic("test configuration is invalid")
+	}
+	return f.Body
+}
+
+func BenchmarkFixUpBlockAttrs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		body := configBodyForFixupBlockAttrsBenchmark()
+		schema := schemaWithAmbiguousNestedBlock(5)
+		b.StartTimer()
+
+		spec := schema.DecoderSpec()
+		fixedBody := FixUpBlockAttrs(body, schema)
+		val, diags := hcldec.Decode(fixedBody, spec, nil)
+		if diags.HasErrors() {
+			b.Fatal("diagnostics during decoding", diags)
+		}
+		if !val.Type().IsObjectType() {
+			b.Fatal("result is not an object")
+		}
+		blockVal := val.GetAttr("maybe_block")
+		if !blockVal.Type().IsListType() || blockVal.LengthInt() != 1 {
+			b.Fatal("result has wrong value for 'maybe_block'")
+		}
+	}
+}


### PR DESCRIPTION
`DecoderSpec` is called many times throughout terraform, and in the process of checking for BlocktoAttr fixups, it may be called n^2 times recursively. While this is not normally a problem for most common resources, with deeply nested schemas this can cause serious performance issues. 

Because of the delicate nature of the BlockToAttr fixup code in dealing with legacy provider schemas, it would be preferable to leave that code as-is for he time being if at all possible. Rather than refactor the BlockToAttr code ((if that's possible at all without subtle breaking changes), we have an easy performance gain here by caching the `Block.DecoderSpec` calls.

The benchmark shown here produced the following results:
```
name               old time/op    new time/op    delta
FixUpBlockAttrs-4     9.13s ± 1%     0.84s ± 3%  -90.78%  (p=0.000 n=10+8)

name               old alloc/op   new alloc/op   delta
FixUpBlockAttrs-4    6.02GB ± 0%    0.41GB ± 0%  -93.24%  (p=0.000 n=10+9)

name               old allocs/op  new allocs/op  delta
FixUpBlockAttrs-4     54.7M ± 0%      3.7M ± 0%  -93.21%  (p=0.000 n=10+9)
```

and testing a simple configuration with a `aws_wafv2_web_acl` resource in the CLI produced roughly a 98% percent speedup.

The less attractive part of this change is the addition of the package-level `specCache`. Normally one would pair the volatile field in the struct with its own mutex, but due to the fact that `Block` is assigned by value to `NestedBlock`, and often copied by assignment, there is no way to insert a mutex without introducing breaking changes in the public API. The package-level mutex used by `specCache` will have no impact, since the number of calls to `DecoderSpec` will be significantly reduced.

Fixes #25889


