### PR TITLE
command: new cache directory .terraform/providers for providers

### DIFF
--- a/command/e2etest/init_test.go
+++ b/command/e2etest/init_test.go
@@ -263,7 +263,7 @@ func TestInitProviders_pluginCache(t *testing.T) {
 		t.Errorf("unexpected stderr output:\n%s\n", stderr)
 	}
 
-	path := filepath.FromSlash(fmt.Sprintf(".terraform/plugins/registry.terraform.io/hashicorp/template/2.1.0/%s_%s/terraform-provider-template_v2.1.0_x4", runtime.GOOS, runtime.GOARCH))
+	path := filepath.FromSlash(fmt.Sprintf(".terraform/providers/registry.terraform.io/hashicorp/template/2.1.0/%s_%s/terraform-provider-template_v2.1.0_x4", runtime.GOOS, runtime.GOARCH))
 	content, err := tf.ReadFile(path)
 	if err != nil {
 		t.Fatalf("failed to read installed plugin from %s: %s", path, err)
@@ -272,7 +272,7 @@ func TestInitProviders_pluginCache(t *testing.T) {
 		t.Errorf("template plugin was not installed from local cache")
 	}
 
-	nullLinkPath := filepath.FromSlash(fmt.Sprintf(".terraform/plugins/registry.terraform.io/hashicorp/null/2.1.0/%s_%s/terraform-provider-null_v2.1.0_x4", runtime.GOOS, runtime.GOARCH))
+	nullLinkPath := filepath.FromSlash(fmt.Sprintf(".terraform/providers/registry.terraform.io/hashicorp/null/2.1.0/%s_%s/terraform-provider-null_v2.1.0_x4", runtime.GOOS, runtime.GOARCH))
 	if runtime.GOOS == "windows" {
 		nullLinkPath = nullLinkPath + ".exe"
 	}

--- a/command/init.go
+++ b/command/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -475,6 +476,7 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 	// things relatively concise. Later it'd be nice to have a progress UI
 	// where statuses update in-place, but we can't do that as long as we
 	// are shimming our vt100 output to the legacy console API on Windows.
+	missingProviders := make(map[addrs.Provider]struct{})
 	evts := &providercache.InstallerEvents{
 		PendingProviders: func(reqs map[addrs.Provider]getproviders.VersionConstraints) {
 			c.Ui.Output(c.Colorize().Color(
@@ -512,6 +514,10 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 			c.Ui.Info(fmt.Sprintf("- Installing %s v%s...", provider.ForDisplay(), version))
 		},
 		QueryPackagesFailure: func(provider addrs.Provider, err error) {
+			// We track providers that had missing metadata because we might
+			// generate additional hints for some of them at the end.
+			missingProviders[provider] = struct{}{}
+
 			switch errorTy := err.(type) {
 			case getproviders.ErrProviderNotFound:
 				sources := errorTy.Sources
@@ -741,6 +747,60 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 		c.showDiagnostics(diags)
 		c.Ui.Error("Provider installation was canceled by an interrupt signal.")
 		return true, true, diags
+	}
+	if len(missingProviders) > 0 {
+		// If we encountered requirements for one or more providers where we
+		// weren't able to find any metadata, that _might_ be because a
+		// user had previously (before 0.14) been incorrectly using the
+		// .terraform/plugins directory as if it were a local filesystem
+		// mirror, rather than as the main cache directory.
+		//
+		// We no longer allow that because it'd be ambiguous whether plugins in
+		// there are explictly intended to be a local mirror or if they are
+		// just leftover cache entries from provider installation in
+		// Terraform 0.13.
+		//
+		// To help those users migrate we have a specialized warning message
+		// for it, which we'll produce only if one of the missing providers can
+		// be seen in the "legacy" cache directory, which is what we're now
+		// considering .terraform/plugins to be. (The _current_ cache directory
+		// is .terraform/providers.)
+		//
+		// This is only a heuristic, so it might potentially produce false
+		// positives if a user happens to encounter another sort of error
+		// while they are upgrading from Terraform 0.13 to 0.14. Aside from
+		// upgrading users should not end up in here because they won't
+		// have a legacy cache directory at all.
+		legacyDir := c.providerLegacyCacheDir()
+		if legacyDir != nil { // if the legacy directory is present at all
+			for missingProvider := range missingProviders {
+				if missingProvider.IsDefault() {
+					// If we get here for a default provider then it's more
+					// likely that something _else_ went wrong, like a network
+					// problem, so we'll skip the warning in this case to
+					// avoid potentially misleading the user into creating an
+					// unnecessary local mirror for an official provider.
+					continue
+				}
+				entry := legacyDir.ProviderLatestVersion(missingProvider)
+				if entry == nil {
+					continue
+				}
+				// If we get here then the missing provider was cached, which
+				// implies that it might be an in-house provider the user
+				// placed manually to try to make Terraform use it as if it
+				// were a local mirror directory.
+				wantDir := filepath.FromSlash(fmt.Sprintf("terraform.d/plugins/%s/%s/%s", missingProvider, entry.Version, getproviders.CurrentPlatform))
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Warning,
+					"Missing provider is in legacy cache directory",
+					fmt.Sprintf(
+						"Terraform supports a number of local directories that can serve as automatic local filesystem mirrors, but .terraform/plugins is not one of them because Terraform v0.13 and earlier used this directory to cache copies of provider plugins retrieved from elsewhere.\n\nIf you intended to use this directory as a filesystem mirror for %s, place it instead in the following directory:\n  %s",
+						missingProvider, wantDir,
+					),
+				))
+			}
+		}
 	}
 	if err != nil {
 		// The errors captured in "err" should be redundant with what we

--- a/command/testdata/init-legacy-provider-cache/.terraform/plugins/example.com/test/b/1.1.0/os_arch/terraform-provider-b
+++ b/command/testdata/init-legacy-provider-cache/.terraform/plugins/example.com/test/b/1.1.0/os_arch/terraform-provider-b
@@ -1,0 +1,2 @@
+# This is not a real provider executable. It's just here to be discovered
+# during installation and produce a warning about it being in the wrong place.

--- a/command/testdata/init-legacy-provider-cache/.terraform/plugins/registry.terraform.io/hashicorp/c/2.0.0/os_arch/terraform-provider-c
+++ b/command/testdata/init-legacy-provider-cache/.terraform/plugins/registry.terraform.io/hashicorp/c/2.0.0/os_arch/terraform-provider-c
@@ -1,0 +1,2 @@
+# This is not a real provider executable. It's just here to be discovered
+# during installation and produce a warning about it being in the wrong place.

--- a/command/testdata/init-legacy-provider-cache/versions.tf
+++ b/command/testdata/init-legacy-provider-cache/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    a = {
+      # This one is just not available at all
+      source = "example.com/test/a"
+    }
+    b = {
+      # This one is unavailable but happens to be cached in the legacy
+      # cache directory, under .terraform/plugins
+      source = "example.com/test/b"
+    }
+    c = {
+      # This one is also cached in the legacy cache directory, but it's
+      # an official provider so init will assume it got there via normal
+      # automatic installation and not generate a warning about it.
+      # This one is also not available at all, but it's an official
+      # provider so we don't expect to see a warning about it.
+      source = "hashicorp/c"
+    }
+  }
+}

--- a/website/upgrade-guides/0-14.html.markdown
+++ b/website/upgrade-guides/0-14.html.markdown
@@ -223,6 +223,52 @@ modules being altered in-place without your knowledge, we recommend using
 modules only from sources directly under your control, such as a private
 Terraform module registry.
 
+### The local provider cache directory
+
+As an implementation detail of automatic provider installation, Terraform
+has historically unpacked auto-installed plugins under the local cache
+directory in `.terraform/plugins`. That directory was only intended for
+Terraform's internal use, but unfortunately due to a miscommunication within
+our team it was inadvertently documented as if it were a "filesystem mirror"
+directory that you could place local providers in to upload them to
+Terraform Cloud.
+
+Unfortunately the implementation details have changed in Terraform v0.14 in
+order to move the authority for provider version selection to the new dependency
+lock file, and so manually placing extra plugins into that local cache directory
+is no longer effective in Terraform v0.14.
+
+We've included a heuristic in `terraform init` for Terraform v0.14 which should
+detect situations where you're relying on an unofficial provider manually
+installed into the cache directory and generate a warning like the following:
+
+```
+Warning: Missing provider is in legacy cache directory
+
+Terraform supports a number of local directories that can serve as automatic
+local filesystem mirrors, but .terraform/plugins is not one of them because
+Terraform v0.13 and earlier used this directory to cache copies of provider
+plugins retrieved from elsewhere.
+
+If you intended to use this directory as a filesystem mirror for
+tf.example.com/awesomecorp/happycloud, place it instead in the following
+directory:
+  terraform.d/plugins/tf.example.com/awesomecorp/happycloud/1.1.0/linux_amd64
+```
+
+The error message suggests using the `terraform.d` directory, which is a
+local search directory originally introduced in Terraform v0.10 in order to
+allow sending bundled providers along with your configuration up to Terraform
+Cloud. The error message assumes that use-case because it was for Terraform
+Cloud in particular that this approach was previously mis-documented.
+
+If you aren't intending to upload the provider plugin to Terraform Cloud as
+part of your configuration, we recommend instead installing to one of
+[the other implied mirror directories](/docs/commands/cli-config.html#implied-local-mirror-directories),
+or you can explicitly configure some
+[custom provider installation methods](/docs/commands/cli-config.html#provider-installation)
+if your needs are more complicated.
+
 ## Concise Terraform Plan Output
 
 In Terraform v0.11 and earlier, the output from `terraform plan` was designed


### PR DESCRIPTION
Terraform v0.10 introduced `.terraform/plugins` as a cache directory for plugins installed automatically over the network. Terraform v0.13 later reorganized the directory structure inside but retained its purpose as a cache for the provider plugins used by the current configuration.

The local cache used to also serve as an implicit record of specifically which packages were selected in a particular working directory, with the intent that a second run of `terraform init` would always select the same packages again. That meant that in some sense it behaved a bit like a local filesystem mirror directory, even though that wasn't its intended purpose.

Due to some unfortunate miscommunications, somewhere a long the line we published some documentation that _recommended_ using the cache directory as if it were a filesystem mirror directory when working with Terraform
Cloud. That was really only working as an accident of implementation details, and Terraform v0.14 is now going to break that usage pattern because the source of record for the currently-selected provider versions is now the public-facing dependency lock file (probably under version control) rather than the contents of an existing local cache directory on disk on a particular computer.

After some consideration of how to move forward here, this commit implements a compromise that tries to avoid silently doing anything surprising while still giving useful guidance to folks who were previously using the unsupported strategy. Specifically:

- The local cache directory will now be `.terraform/providers` rather than `.terraform/plugins`, because `.terraform/plugins` is effectively "poisoned" by the incorrect usage; we can't reliably distinguish it from files created through _correct_ usage of Terraform v0.13, because the directory contents would be the same either way.

- The `.terraform/plugins` directory is now the "legacy cache directory". It is intentionally _not_ now a filesystem mirror directory, because that would risk incorrectly interpreting providers automatically installed by Terraform v0.13 as if they were a local mirror, and thus upgrades and checksum fetches from the origin registry would be blocked with no explanation.

    It's important that we start "fresh" on the first run after upgrading to Terraform v0.14 because we need an opportunity to fetch the metadata from the origin registry or real mirror in order to seed the initial dependency lock file. Picking up existing providers in the `.terraform/plugins` directory as local mirrors would cause us to lock only what's available there, which would make the generated lock file not portable to other platforms because the cache directory contains only a package for the current platform.

- Because of the previous two points, someone who _was_ trying to use the legacy cache directory as a filesystem mirror would see installation fail for any providers they manually added to the legacy directory.

  To avoid leaving that user stumped as to what went wrong, there's a heuristic for the case where a non-official provider fails installation and yet we can see it in the legacy cache directory. If that heuristic matches then we'll produce a warning message hinting to move the provider under the `terraform.d/plugins` directory, which is a _correct_ location for "bundled" provider plugins (albeit one we no longer actively recommend aside from Terraform Cloud usage) that belong only to a single configuration.

This does unfortunately mean that anyone who was following the incorrectly-documented pattern will now encounter an error (and the aforementioned warning hint) after upgrading to Terraform v0.14. This seems like the safest compromise because Terraform can't automatically infer the intent of files it finds in `.terraform/plugins` in order to decide automatically how best to handle them. Instead, we prompt the user to decide how to resolve it, giving them a hint for one possible solution.

The internals of the `.terraform` directory are always considered an implementation detail for a particular Terraform version and so switching to a new directory for the _actual_ cache directory fits within our usual set of guarantees, though it's definitely non-ideal in isolation. It seems better when taken in the broader context of this problem, where the alternative would be potential silent misbehavior when upgrading due to the ambiguity of `.terraform/plugins` usage.
