### PR TITLE
Mark attributes providers mark as sensitive

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -445,6 +445,15 @@ func testProviderSchema(name string) *ProviderSchema {
 						},
 						Nesting: configschema.NestingSet,
 					},
+					"nesting_single": {
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"value":           {Type: cty.String, Optional: true},
+								"sensitive_value": {Type: cty.String, Optional: true, Sensitive: true},
+							},
+						},
+						Nesting: configschema.NestingSingle,
+					},
 				},
 			},
 			name + "_ami_list": {

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -425,6 +425,11 @@ func testProviderSchema(name string) *ProviderSchema {
 						Type:     cty.String,
 						Optional: true,
 					},
+					"sensitive_value": {
+						Type:      cty.String,
+						Sensitive: true,
+						Optional:  true,
+					},
 					"random": {
 						Type:     cty.String,
 						Optional: true,

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -955,6 +955,10 @@ func markProviderSensitiveAttributes(schema *configschema.Block, val cty.Value) 
 func getValMarks(schema *configschema.Block, val cty.Value, path cty.Path) []cty.PathValueMarks {
 	var pvm []cty.PathValueMarks
 	for name, blockS := range schema.BlockTypes {
+		// If our block doesn't contain any sensitive attributes, skip inspecting it
+		if !blockS.Block.ContainsSensitive() {
+			continue
+		}
 		blockV := val.GetAttr(name)
 		blockPath := append(path, cty.GetAttrStep{Name: name})
 		switch blockS.Nesting {

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -974,15 +974,12 @@ func getValMarks(schema *configschema.Block, val cty.Value, path cty.Path) []cty
 		switch blockS.Nesting {
 		case configschema.NestingSingle, configschema.NestingGroup:
 			pvm = append(pvm, getValMarks(&blockS.Block, blockV, blockPath)...)
-		case configschema.NestingList, configschema.NestingMap:
+		case configschema.NestingList, configschema.NestingMap, configschema.NestingSet:
 			for it := blockV.ElementIterator(); it.Next(); {
 				idx, blockEV := it.Element()
 				morePaths := getValMarks(&blockS.Block, blockEV, append(blockPath, cty.IndexStep{Key: idx}))
 				pvm = append(pvm, morePaths...)
 			}
-		case configschema.NestingSet:
-			// TODO
-			continue
 		default:
 			panic(fmt.Sprintf("unsupported nesting mode %s", blockS.Nesting))
 		}

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -954,6 +954,16 @@ func markProviderSensitiveAttributes(schema *configschema.Block, val cty.Value) 
 
 func getValMarks(schema *configschema.Block, val cty.Value, path cty.Path) []cty.PathValueMarks {
 	var pvm []cty.PathValueMarks
+	for name, attrS := range schema.Attributes {
+		if attrS.Sensitive {
+			attrPath := append(path, cty.GetAttrStep{Name: name})
+			pvm = append(pvm, cty.PathValueMarks{
+				Path:  attrPath,
+				Marks: cty.NewValueMarks("sensitive"),
+			})
+		}
+	}
+
 	for name, blockS := range schema.BlockTypes {
 		// If our block doesn't contain any sensitive attributes, skip inspecting it
 		if !blockS.Block.ContainsSensitive() {
@@ -978,16 +988,6 @@ func getValMarks(schema *configschema.Block, val cty.Value, path cty.Path) []cty
 			continue
 		default:
 			panic(fmt.Sprintf("unsupported nesting mode %s", blockS.Nesting))
-		}
-	}
-
-	for name, attrS := range schema.Attributes {
-		if attrS.Sensitive {
-			attrPath := append(path, cty.GetAttrStep{Name: name})
-			pvm = append(pvm, cty.PathValueMarks{
-				Path:  attrPath,
-				Marks: cty.NewValueMarks("sensitive"),
-			})
 		}
 	}
 	return pvm

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -974,15 +974,12 @@ func getValMarks(schema *configschema.Block, val cty.Value, path cty.Path) []cty
 		switch blockS.Nesting {
 		case configschema.NestingSingle, configschema.NestingGroup:
 			pvm = append(pvm, getValMarks(&blockS.Block, blockV, blockPath)...)
-		case configschema.NestingList:
+		case configschema.NestingList, configschema.NestingMap:
 			for it := blockV.ElementIterator(); it.Next(); {
 				idx, blockEV := it.Element()
 				morePaths := getValMarks(&blockS.Block, blockEV, append(blockPath, cty.IndexStep{Key: idx}))
 				pvm = append(pvm, morePaths...)
 			}
-		case configschema.NestingMap:
-			// TODO
-			continue
 		case configschema.NestingSet:
 			// TODO
 			continue

--- a/terraform/evaluate_test.go
+++ b/terraform/evaluate_test.go
@@ -135,7 +135,7 @@ func TestEvaluatorGetResource(t *testing.T) {
 			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 			&states.ResourceInstanceObjectSrc{
 				Status:    states.ObjectReady,
-				AttrsJSON: []byte(`{"id":"foo", "nesting_list": [{"sensitive_value":"abc"}], "nesting_map": {"foo":{"foo":"x"}}, "value":"hello"}`),
+				AttrsJSON: []byte(`{"id":"foo", "nesting_list": [{"sensitive_value":"abc"}], "nesting_map": {"foo":{"foo":"x"}}, "nesting_set": [{"baz":"abc"}], "nesting_single": {"boop":"abc"}, "value":"hello"}`),
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewDefaultProvider("test"),
@@ -206,6 +206,22 @@ func TestEvaluatorGetResource(t *testing.T) {
 									},
 									Nesting: configschema.NestingMap,
 								},
+								"nesting_set": {
+									Block: configschema.Block{
+										Attributes: map[string]*configschema.Attribute{
+											"baz": {Type: cty.String, Optional: true, Sensitive: true},
+										},
+									},
+									Nesting: configschema.NestingSet,
+								},
+								"nesting_single": {
+									Block: configschema.Block{
+										Attributes: map[string]*configschema.Attribute{
+											"boop": {Type: cty.String, Optional: true, Sensitive: true},
+										},
+									},
+									Nesting: configschema.NestingSingle,
+								},
 							},
 						},
 					},
@@ -229,6 +245,14 @@ func TestEvaluatorGetResource(t *testing.T) {
 		}),
 		"nesting_map": cty.MapVal(map[string]cty.Value{
 			"foo": cty.ObjectVal(map[string]cty.Value{"foo": cty.StringVal("x").Mark("sensitive")}),
+		}),
+		"nesting_set": cty.SetVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"baz": cty.StringVal("abc").Mark("sensitive"),
+			}),
+		}),
+		"nesting_single": cty.ObjectVal(map[string]cty.Value{
+			"boop": cty.StringVal("abc").Mark("sensitive"),
 		}),
 		"value": cty.StringVal("hello").Mark("sensitive"),
 	})

--- a/terraform/evaluate_test.go
+++ b/terraform/evaluate_test.go
@@ -135,7 +135,7 @@ func TestEvaluatorGetResource(t *testing.T) {
 			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 			&states.ResourceInstanceObjectSrc{
 				Status:    states.ObjectReady,
-				AttrsJSON: []byte(`{"id":"foo", "value":"hello", "nesting_list": [{"sensitive_value":"abc"}]}`),
+				AttrsJSON: []byte(`{"id":"foo", "nesting_list": [{"sensitive_value":"abc"}], "nesting_map": {"foo":{"foo":"x"}}, "value":"hello"}`),
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewDefaultProvider("test"),
@@ -198,6 +198,14 @@ func TestEvaluatorGetResource(t *testing.T) {
 									},
 									Nesting: configschema.NestingList,
 								},
+								"nesting_map": {
+									Block: configschema.Block{
+										Attributes: map[string]*configschema.Attribute{
+											"foo": {Type: cty.String, Optional: true, Sensitive: true},
+										},
+									},
+									Nesting: configschema.NestingMap,
+								},
 							},
 						},
 					},
@@ -218,6 +226,9 @@ func TestEvaluatorGetResource(t *testing.T) {
 				"sensitive_value": cty.StringVal("abc").Mark("sensitive"),
 				"value":           cty.NullVal(cty.String),
 			}),
+		}),
+		"nesting_map": cty.MapVal(map[string]cty.Value{
+			"foo": cty.ObjectVal(map[string]cty.Value{"foo": cty.StringVal("x").Mark("sensitive")}),
 		}),
 		"value": cty.StringVal("hello").Mark("sensitive"),
 	})


### PR DESCRIPTION
This updates `GetResource` evaluation so that the value returned has marks where the provider's schema has marked an attribute as sensitive. In practice, this means that values will be marked inside a resource when that resource is referenced elsewhere in the config, so that "sensitivity" as defined by the provider on an attribute will follow that value when used elsewhere in Terraform.

Put another way, if we have one resource that has an attribute that is `Sensitive` according to that provider's schema, then referencing that attribute elsewhere will result in derived sensitivity:

```terraform
resource "test_resource" "foo" {
	sensitive_value = "should get marked"
}

resource "test_resource" "bar" {
	value  = test_resource.foo.sensitive_value
}
```

In this scenario, `value` in `test_resource.bar` will be marked by virtue of `Sensitive` being defined in the provider's schema.