### PR TITLE
command/cliconfig: Allow development overrides for providers

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -131,6 +131,11 @@ func (c *ApplyCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Applying changes with dev overrides in effect could make it impossible
+	// to switch back to a release version if the schema isn't compatible,
+	// so we'll warn about it.
+	diags = diags.Append(c.providerDevOverrideWarnings())
+
 	// Before we delegate to the backend, we'll print any warning diagnostics
 	// we've accumulated here, since the backend will start fresh with its own
 	// diagnostics.

--- a/command/cliconfig/provider_installation_test.go
+++ b/command/cliconfig/provider_installation_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/internal/getproviders"
 )
 
 func TestLoadConfig_providerInstallation(t *testing.T) {
@@ -35,6 +37,11 @@ func TestLoadConfig_providerInstallation(t *testing.T) {
 								Location: ProviderInstallationDirect,
 								Exclude:  []string{"example.com/*/*"},
 							},
+						},
+
+						DevOverrides: map[addrs.Provider]getproviders.PackageLocalDir{
+							addrs.MustParseProviderSourceString("hashicorp/boop"):  getproviders.PackageLocalDir(filepath.FromSlash("/tmp/boop")),
+							addrs.MustParseProviderSourceString("hashicorp/blorp"): getproviders.PackageLocalDir(filepath.FromSlash("/tmp/blorp")),
 						},
 					},
 				},

--- a/command/cliconfig/testdata/provider-installation
+++ b/command/cliconfig/testdata/provider-installation
@@ -1,4 +1,8 @@
 provider_installation {
+  dev_overrides {
+    "hashicorp/boop" = "/tmp/bloop/../boop"
+    "hashicorp/blorp" = "/tmp/blorp"
+  }
   filesystem_mirror {
     path    = "/tmp/example1"
     include = ["example.com/*/*"]

--- a/command/cliconfig/testdata/provider-installation.json
+++ b/command/cliconfig/testdata/provider-installation.json
@@ -1,5 +1,9 @@
 {
   "provider_installation": {
+    "dev_overrides": {
+      "hashicorp/boop": "/tmp/bloop/../boop",
+      "hashicorp/blorp": "/tmp/blorp"
+    },
     "filesystem_mirror": [{
       "path": "/tmp/example1",
       "include": ["example.com/*/*"]

--- a/command/e2etest/provider_dev_test.go
+++ b/command/e2etest/provider_dev_test.go
@@ -1,0 +1,76 @@
+package e2etest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/e2e"
+)
+
+// TestProviderDevOverrides is a test for the special dev_overrides setting
+// in the provider_installation section of the CLI configuration file, which
+// is our current answer to smoothing provider development by allowing
+// developers to opt out of the version number and checksum verification
+// we normally do, so they can just overwrite the same local executable
+// in-place to iterate faster.
+func TestProviderDevOverrides(t *testing.T) {
+	t.Parallel()
+
+	tf := e2e.NewBinary(terraformBin, "testdata/provider-dev-override")
+	defer tf.Close()
+
+	// In order to do a decent end-to-end test for this case we will need a
+	// real enough provider plugin to try to run and make sure we are able
+	// to actually run it. For now we'll use the "test" provider for that,
+	// because it happens to be in this repository and therefore allows
+	// us to avoid drawing in anything external, but we might revisit this
+	// strategy in future if other needs cause us to evolve the test
+	// provider in a way that makes it less suitable for this particular test,
+	// such as if it stops being buildable into an independent executable.
+	providerExeDir := filepath.Join(tf.WorkDir(), "pkgdir")
+	providerExePrefix := filepath.Join(providerExeDir, "terraform-provider-test_")
+	providerExe := e2e.GoBuild("github.com/hashicorp/terraform/builtin/bins/provider-test", providerExePrefix)
+	t.Logf("temporary provider executable is %s", providerExe)
+
+	err := ioutil.WriteFile(filepath.Join(tf.WorkDir(), "dev.tfrc"), []byte(fmt.Sprintf(`
+		provider_installation {
+			dev_overrides {
+				"example.com/test/test" = %q
+			}
+		}
+	`, providerExeDir)), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tf.AddEnv("TF_CLI_CONFIG_FILE=dev.tfrc")
+
+	stdout, stderr, err := tf.Run("providers")
+	if err != nil {
+		t.Fatalf("unexpected error: %s\n%s", err, stderr)
+	}
+	if got, want := stdout, `provider[example.com/test/test]`; !strings.Contains(got, want) {
+		t.Errorf("configuration should depend on %s, but doesn't\n%s", want, got)
+	}
+
+	// NOTE: We're intentionally not running "terraform init" here, because
+	// dev overrides are always ready to use and don't need any special action
+	// to "install" them. This test is mimicking the a happy path of going
+	// directly from "go build" to validate/plan/apply without interacting
+	// with any registries, mirrors, lock files, etc.
+	stdout, stderr, err = tf.Run("validate")
+	if err != nil {
+		t.Fatalf("unexpected error: %s\n%s", err, stderr)
+	}
+
+	if got, want := stdout, `The configuration is valid, but`; !strings.Contains(got, want) {
+		t.Errorf("stdout doesn't include the success message\nwant: %s\n%s", want, got)
+	}
+	if got, want := stdout, `Provider development overrides are in effect`; !strings.Contains(got, want) {
+		t.Errorf("stdout doesn't include the warning about development overrides\nwant: %s\n%s", want, got)
+	}
+}

--- a/command/e2etest/testdata/provider-dev-override/pkgdir/.exists
+++ b/command/e2etest/testdata/provider-dev-override/pkgdir/.exists
@@ -1,0 +1,1 @@
+This is where the test will place the temporary build of the test provider.

--- a/command/e2etest/testdata/provider-dev-override/provider-dev-override.tf
+++ b/command/e2etest/testdata/provider-dev-override/provider-dev-override.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    test = {
+      source  = "example.com/test/test"
+      version = "2.0.0"
+    }
+  }
+}
+
+provider "test" {
+}
+
+data "test_data_source" "test" {
+}

--- a/command/init.go
+++ b/command/init.go
@@ -730,6 +730,12 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 		},
 	}
 
+	// Dev overrides cause the result of "terraform init" to be irrelevant for
+	// any overridden providers, so we'll warn about it to avoid later
+	// confusion when Terraform ends up using a different provider than the
+	// lock file called for.
+	diags = diags.Append(c.providerDevOverrideWarnings())
+
 	mode := providercache.InstallNewProvidersOnly
 	if upgrade {
 		mode = providercache.InstallUpgrades

--- a/command/meta.go
+++ b/command/meta.go
@@ -50,10 +50,9 @@ type Meta struct {
 	// for some reason.
 	OriginalWorkingDir string
 
-	Color            bool             // True if output should be colored
-	GlobalPluginDirs []string         // Additional paths to search for plugins
-	PluginOverrides  *PluginOverrides // legacy overrides from .terraformrc file
-	Ui               cli.Ui           // Ui for output
+	Color            bool     // True if output should be colored
+	GlobalPluginDirs []string // Additional paths to search for plugins
+	Ui               cli.Ui   // Ui for output
 
 	// ExtraHooks are extra hooks to add to the context.
 	ExtraHooks []terraform.Hook
@@ -104,7 +103,21 @@ type Meta struct {
 	// When this channel is closed, the command will be cancelled.
 	ShutdownCh <-chan struct{}
 
-	// UnmanagedProviders are a set of providers that exist as processes predating Terraform, which Terraform should use but not worry about the lifecycle of.
+	// ProviderDevOverrides are providers where we ignore the lock file, the
+	// configured version constraints, and the local cache directory and just
+	// always use exactly the path specified. This is intended to allow
+	// provider developers to easily test local builds without worrying about
+	// what version number they might eventually be released as, or what
+	// checksums they have.
+	ProviderDevOverrides map[addrs.Provider]getproviders.PackageLocalDir
+
+	// UnmanagedProviders are a set of providers that exist as processes
+	// predating Terraform, which Terraform should use but not worry about the
+	// lifecycle of.
+	//
+	// This is essentially a more extreme version of ProviderDevOverrides where
+	// Terraform doesn't even worry about how the provider server gets launched,
+	// just trusting that someone else did it before running Terraform.
 	UnmanagedProviders map[addrs.Provider]*plugin.ReattachConfig
 
 	//----------------------------------------------------------
@@ -192,11 +205,6 @@ type Meta struct {
 
 	// Used with the import command to allow import of state when no matching config exists.
 	allowMissingConfig bool
-}
-
-type PluginOverrides struct {
-	Providers    map[string]string
-	Provisioners map[string]string
 }
 
 type testingOverrides struct {

--- a/command/validate.go
+++ b/command/validate.go
@@ -77,6 +77,12 @@ func (c *ValidateCommand) Run(args []string) int {
 	validateDiags := c.validate(dir)
 	diags = diags.Append(validateDiags)
 
+	// Validating with dev overrides in effect means that the result might
+	// not be valid for a stable release, so we'll warn about that in case
+	// the user is trying to use "terraform validate" as a sort of pre-flight
+	// check before submitting a change.
+	diags = diags.Append(c.providerDevOverrideWarnings())
+
 	return c.showResults(diags, jsonOutput)
 }
 

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -254,7 +254,8 @@ func (b *binary) Close() {
 }
 
 func GoBuild(pkgPath, tmpPrefix string) string {
-	tmpFile, err := ioutil.TempFile("", tmpPrefix)
+	dir, prefix := filepath.Split(tmpPrefix)
+	tmpFile, err := ioutil.TempFile(dir, prefix)
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -195,6 +195,7 @@ func wrappedMain() int {
 			// We continue to run anyway, because most commands don't do provider installation.
 		}
 	}
+	providerDevOverrides := providerDevOverrides(config.ProviderInstallation)
 
 	// The user can declare that certain providers are being managed on
 	// Terraform's behalf using this environment variable. Thsi is used
@@ -241,7 +242,7 @@ func wrappedMain() int {
 		// in case they need to refer back to it for any special reason, though
 		// they should primarily be working with the override working directory
 		// that we've now switched to above.
-		initCommands(originalWd, config, services, providerSrc, unmanagedProviders)
+		initCommands(originalWd, config, services, providerSrc, providerDevOverrides, unmanagedProviders)
 	}
 
 	// Run checkpoint
@@ -299,10 +300,6 @@ func wrappedMain() int {
 		AutocompleteInstall:   "install-autocomplete",
 		AutocompleteUninstall: "uninstall-autocomplete",
 	}
-
-	// Pass in the overriding plugin paths from config
-	PluginOverrides.Providers = config.Providers
-	PluginOverrides.Provisioners = config.Provisioners
 
 	exitCode, err := cliRunner.Run()
 	if err != nil {

--- a/provider_source.go
+++ b/provider_source.go
@@ -225,3 +225,14 @@ func providerSourceForCLIConfigLocation(loc cliconfig.ProviderInstallationLocati
 		panic(fmt.Sprintf("unexpected provider source location type %T", loc))
 	}
 }
+
+func providerDevOverrides(configs []*cliconfig.ProviderInstallation) map[addrs.Provider]getproviders.PackageLocalDir {
+	if len(configs) == 0 {
+		return nil
+	}
+
+	// There should only be zero or one configurations, which is checked by
+	// the validation logic in the cliconfig package. Therefore we'll just
+	// ignore any additional configurations in here.
+	return configs[0].DevOverrides
+}


### PR DESCRIPTION
For normal provider installation we want to associate each provider with a selected version number and find a suitable package for that version that conforms to the official hashes for that release. Those requirements are very onerous for a provider developer currently testing a not-yet-released build, though.

To allow for that case this new CLI configuration feature allows overriding specific providers to refer to give local filesystem directories. Any provider overridden in this way is not subject to the usual restrictions about selected versions or checksum conformance, and activating an override won't cause any changes to the selections recorded in the lock file because it's intended to be a temporary setting for one developer only. In the typical case of just working with a single provider to test it this even avoids the need to run `terraform init`, so developers can just overwrite an executable and re-test without any further admin work.

This is, in a sense, a spiritual successor of an old capability we had to override specific plugins in the CLI configuration file, via the `providers` top-level argument. It's likely that we'll want to revisit this mechanism again in a future release once we learn from the mechanism implemented here, but the main goal of this was to do something close to the known-pretty-good solution from earlier Terraform releases in order to reduce provider developer friction in the short term, rather than making provider developers wait for a possible deeper design effort later. I've explicitly marked this mechanism as subject to change in later releases to allow for later improvement, although it's _possible_ that later design effort will conclude that this interim design is actually adequate.

There were some vestiges of the _old_ CLI config settings `providers` and `provisioners` left in the main package and CLI config package, but nothing has actually been honoring them for several versions now -- they were just silently ignored. This commit removes the remaining dead code for them to avoid confusion with the new mechanism. Due to how `command/cliconfig` is designed to silently ignore top-level items it doesn't expect, it will continue to ignore the `providers` and `provisioners` setting in any existing CLI config files even after we merge this.
