### PR TITLE
More precise handling of lists and maps within sets for ProposedNewObject

### DIFF
--- a/plans/objchange/objchange.go
+++ b/plans/objchange/objchange.go
@@ -357,13 +357,13 @@ func setElementCompareValue(schema *configschema.Block, v cty.Value, isConfig bo
 					// set and we've not changed the types of any elements here.
 					attrs[name] = cty.SetVal(elems)
 				} else {
-					attrs[name] = cty.TupleVal(elems)
+					attrs[name] = cty.ListVal(elems)
 				}
 			} else {
 				if blockType.Nesting == configschema.NestingSet {
 					attrs[name] = cty.SetValEmpty(blockType.Block.ImpliedType())
 				} else {
-					attrs[name] = cty.EmptyTupleVal
+					attrs[name] = cty.ListValEmpty(blockType.Block.ImpliedType())
 				}
 			}
 

--- a/plans/objchange/objchange_test.go
+++ b/plans/objchange/objchange_test.go
@@ -799,6 +799,61 @@ func TestProposedNewObject(t *testing.T) {
 				}),
 			}),
 		},
+		"empty nested map in set": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							BlockTypes: map[string]*configschema.NestedBlock{
+								"bar": {
+									Nesting: configschema.NestingMap,
+									Block: configschema.Block{
+										Attributes: map[string]*configschema.Attribute{
+											"baz": {
+												Type:     cty.String,
+												Optional: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+							"baz": cty.String,
+						})),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.MapVal(map[string]cty.Value{
+							"bing": cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("true"),
+							}),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.MapVal(map[string]cty.Value{
+							"bing": cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("true"),
+							}),
+						}),
+					}),
+				}),
+			}),
+		},
 	}
 
 	for name, test := range tests {

--- a/plans/objchange/objchange_test.go
+++ b/plans/objchange/objchange_test.go
@@ -572,6 +572,70 @@ func TestProposedNewObject(t *testing.T) {
 				}),
 			}),
 		},
+		"nested list in sed": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							BlockTypes: map[string]*configschema.NestedBlock{
+								"bar": {
+									Nesting: configschema.NestingList,
+									Block: configschema.Block{
+										Attributes: map[string]*configschema.Attribute{
+											"baz": {
+												Type: cty.String,
+											},
+											"qux": {
+												Type:     cty.String,
+												Computed: true,
+												Optional: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("beep"),
+								"qux": cty.StringVal("boop"),
+							}),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("beep"),
+								"qux": cty.NullVal(cty.String),
+							}),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("beep"),
+								"qux": cty.StringVal("boop"),
+							}),
+						}),
+					}),
+				}),
+			}),
+		},
 	}
 
 	for name, test := range tests {

--- a/plans/objchange/objchange_test.go
+++ b/plans/objchange/objchange_test.go
@@ -440,7 +440,7 @@ func TestProposedNewObject(t *testing.T) {
 					}),
 					"b": cty.ObjectVal(map[string]cty.Value{
 						"bar": cty.StringVal("blep"),
-						"baz": cty.StringVal("boot"),
+						"baz": cty.ListVal([]cty.Value{cty.StringVal("boot")}),
 					}),
 				}),
 			}),
@@ -452,7 +452,7 @@ func TestProposedNewObject(t *testing.T) {
 					}),
 					"c": cty.ObjectVal(map[string]cty.Value{
 						"bar": cty.StringVal("bosh"),
-						"baz": cty.NullVal(cty.String),
+						"baz": cty.NullVal(cty.List(cty.String)),
 					}),
 				}),
 			}),
@@ -464,7 +464,7 @@ func TestProposedNewObject(t *testing.T) {
 					}),
 					"c": cty.ObjectVal(map[string]cty.Value{
 						"bar": cty.StringVal("bosh"),
-						"baz": cty.NullVal(cty.String),
+						"baz": cty.NullVal(cty.List(cty.String)),
 					}),
 				}),
 			}),
@@ -670,6 +670,131 @@ func TestProposedNewObject(t *testing.T) {
 				"foo": cty.SetVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"bar": cty.ListValEmpty((&configschema.Block{}).ImpliedType()),
+					}),
+				}),
+			}),
+		},
+		"nested list with dynamic in set": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							BlockTypes: map[string]*configschema.NestedBlock{
+								"bar": {
+									Nesting: configschema.NestingList,
+									Block: configschema.Block{
+										Attributes: map[string]*configschema.Attribute{
+											"baz": {
+												Type: cty.DynamicPseudoType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.TupleVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("true"),
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.ListVal([]cty.Value{cty.StringVal("true")}),
+							}),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.TupleVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("true"),
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.ListVal([]cty.Value{cty.StringVal("true")}),
+							}),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.TupleVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("true"),
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.ListVal([]cty.Value{cty.StringVal("true")}),
+							}),
+						}),
+					}),
+				}),
+			}),
+		},
+		"nested map with dynamic in set": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							BlockTypes: map[string]*configschema.NestedBlock{
+								"bar": {
+									Nesting: configschema.NestingMap,
+									Block: configschema.Block{
+										Attributes: map[string]*configschema.Attribute{
+											"baz": {
+												Type:     cty.DynamicPseudoType,
+												Optional: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ObjectVal(map[string]cty.Value{
+							"bing": cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.StringVal("true"),
+							}),
+							"bang": cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.ListVal([]cty.Value{cty.StringVal("true")}),
+							}),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ObjectVal(map[string]cty.Value{
+							"bing": cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.ListVal([]cty.Value{cty.StringVal("true")}),
+							}),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ObjectVal(map[string]cty.Value{
+							"bing": cty.ObjectVal(map[string]cty.Value{
+								"baz": cty.ListVal([]cty.Value{cty.StringVal("true")}),
+							}),
+						}),
 					}),
 				}),
 			}),

--- a/plans/objchange/objchange_test.go
+++ b/plans/objchange/objchange_test.go
@@ -572,7 +572,7 @@ func TestProposedNewObject(t *testing.T) {
 				}),
 			}),
 		},
-		"nested list in sed": {
+		"nested list in set": {
 			&configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"foo": {
@@ -632,6 +632,44 @@ func TestProposedNewObject(t *testing.T) {
 								"qux": cty.StringVal("boop"),
 							}),
 						}),
+					}),
+				}),
+			}),
+		},
+		"empty nested list in set": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							BlockTypes: map[string]*configschema.NestedBlock{
+								"bar": {
+									Nesting: configschema.NestingList,
+									Block:   configschema.Block{},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListValEmpty((&configschema.Block{}).ImpliedType()),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListValEmpty((&configschema.Block{}).ImpliedType()),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.ListValEmpty((&configschema.Block{}).ImpliedType()),
 					}),
 				}),
 			}),


### PR DESCRIPTION
When generating set elements for comparison for a `ProposedNewObject`, we want to use the most accurate type possible for lists and maps within the sets. This ensures distinct values within lists and maps are compared correctly, while also still allowing nested lists and maps containing dynamic types in sets.

Based on #26133