### PR TITLE
Fixes for sensitive values used as input to provisioners

### DIFF
--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -683,10 +683,17 @@ func (n *EvalApplyProvisioners) apply(ctx EvalContext, provs []*configs.Provisio
 			})
 		}
 
+		// If our config or connection info contains any marked values, ensure
+		// those are stripped out before sending to the provisioner. Unlike
+		// resources, we have no need to capture the marked paths and reapply
+		// later.
+		unmarkedConfig, _ := config.UnmarkDeep()
+		unmarkedConnInfo, _ := connInfo.UnmarkDeep()
+
 		output := CallbackUIOutput{OutputFn: outputFn}
 		resp := provisioner.ProvisionResource(provisioners.ProvisionResourceRequest{
-			Config:     config,
-			Connection: connInfo,
+			Config:     unmarkedConfig,
+			Connection: unmarkedConnInfo,
 			UIOutput:   &output,
 		})
 		applyDiags := resp.Diagnostics.InConfigBody(prov.Config)

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -687,8 +687,21 @@ func (n *EvalApplyProvisioners) apply(ctx EvalContext, provs []*configs.Provisio
 		// those are stripped out before sending to the provisioner. Unlike
 		// resources, we have no need to capture the marked paths and reapply
 		// later.
-		unmarkedConfig, _ := config.UnmarkDeep()
+		unmarkedConfig, configMarks := config.UnmarkDeep()
 		unmarkedConnInfo, _ := connInfo.UnmarkDeep()
+
+		// Marks on the config might result in leaking sensitive values through
+		// provisioner logging, so we conservatively suppress all output in
+		// this case. This should not apply to connection info values, which
+		// provisioners ought not to be logging anyway.
+		if len(configMarks) > 0 {
+			outputFn = func(msg string) {
+				ctx.Hook(func(h Hook) (HookAction, error) {
+					h.ProvisionOutput(absAddr, prov.Type, "(output suppressed due to sensitive value in config)")
+					return HookActionContinue, nil
+				})
+			}
+		}
 
 		output := CallbackUIOutput{OutputFn: outputFn}
 		resp := provisioner.ProvisionResource(provisioners.ProvisionResourceRequest{

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -866,6 +866,13 @@ aws_instance.bar:
   type = aws_instance
 `
 
+const testTerraformApplyProvisionerSensitiveStr = `
+aws_instance.foo:
+  ID = foo
+  provider = provider["registry.terraform.io/hashicorp/aws"]
+  type = aws_instance
+`
+
 const testTerraformApplyDestroyStr = `
 <no state>
 `

--- a/terraform/testdata/apply-provisioner-sensitive/main.tf
+++ b/terraform/testdata/apply-provisioner-sensitive/main.tf
@@ -1,0 +1,18 @@
+variable "password" {
+  type      = string
+  sensitive = true
+}
+
+resource "aws_instance" "foo" {
+  connection {
+    host     = "localhost"
+    type     = "telnet"
+    user     = "superuser"
+    port     = 2222
+    password = var.password
+  }
+
+  provisioner "shell" {
+    command = "echo ${var.password} > secrets"
+  }
+}

--- a/website/docs/provisioners/index.html.markdown
+++ b/website/docs/provisioners/index.html.markdown
@@ -186,6 +186,10 @@ that resource's attributes. For example, use `self.public_ip` to reference an
 references create dependencies. Referring to a resource by name within its own
 block would create a dependency cycle.
 
+## Suppressing Provisioner Logs in CLI Output
+
+The configuration for a `provisioner` block may use sensitive values, such as [`sensitive` variables](../configuration/variables.html#suppressing-values-in-cli-output) or [`sensitive` output values](../outputs.html#sensitive-suppressing-values-in-cli-output). In this case, all log output from the provider is automatically suppressed to prevent the sensitive values from being displayed.
+
 ## Creation-Time Provisioners
 
 By default, provisioners run when the resource they are defined within is


### PR DESCRIPTION
Two separate commits in this pull request, which I'd suggest reviewing separately. The first is a bug fix which I'm pretty confident about, and the second is a UI change that I'd really appreciate feedback on.

## Unmark provisioner arguments

If provisioner configuration or connection info includes sensitive values, we need to unmark them before calling the provisioner. Failing to do so causes serialization to error.

Unlike resources, we do not need to capture marked paths here, so we just discard the marks.

## Hide maybe-sensitive provisioner output

If the provisioner configuration includes sensitive values, it's a reasonable assumption that we should suppress its log output. Obvious examples where this makes sense include echoing a secret to a file using local-exec or remote-exec.

This commit adds tests for both logging output from provisioners with non-sensitive configuration, and suppressing logs for provisioners with sensitive values in configuration.

Note that we do not suppress logs if connection info contains sensitive information, as provisioners should not be logging connection information under any circumstances.

### Screenshot

<img width="932" alt="after" src="https://user-images.githubusercontent.com/68917/96302627-1f1f8500-0fc7-11eb-956a-f684854a731a.png">
