### PR TITLE
Allow runs to continue on tfce error

### DIFF
--- a/backend/remote/backend_common.go
+++ b/backend/remote/backend_common.go
@@ -321,7 +321,10 @@ func (b *Remote) costEstimate(stopCtx, cancelCtx context.Context, op *backend.Op
 			b.CLI.Output("\n------------------------------------------------------------------------")
 			return nil
 		case tfe.CostEstimateErrored:
-			return fmt.Errorf(msgPrefix + " errored.")
+			b.CLI.Output(msgPrefix + " errored:\n")
+			b.CLI.Output(ce.ErrorMessage)
+			b.CLI.Output("\n------------------------------------------------------------------------")
+			return nil
 		case tfe.CostEstimateCanceled:
 			return fmt.Errorf(msgPrefix + " canceled.")
 		default:


### PR DESCRIPTION
A cost estimation error does not actually stop a run, so the run was continuing in the background after the cli exits, causing confusion. This change matches the UI behavior.