### PR TITLE
internal: Fix lockfile constraint output for 1.2.*

### DIFF
--- a/command/providers_test.go
+++ b/command/providers_test.go
@@ -114,7 +114,7 @@ func TestProviders_modules(t *testing.T) {
 	}
 
 	wantOutput := []string{
-		"provider[registry.terraform.io/hashicorp/foo] 1.0.*", // from required_providers
+		"provider[registry.terraform.io/hashicorp/foo] 1.0.0", // from required_providers
 		"provider[registry.terraform.io/hashicorp/bar] 2.0.0", // from provider config
 		"── module.kiddo",                               // tree node for child module
 		"provider[registry.terraform.io/hashicorp/baz]", // implied by a resource in the child module
@@ -151,7 +151,7 @@ func TestProviders_state(t *testing.T) {
 	}
 
 	wantOutput := []string{
-		"provider[registry.terraform.io/hashicorp/foo] 1.0.*", // from required_providers
+		"provider[registry.terraform.io/hashicorp/foo] 1.0.0", // from required_providers
 		"provider[registry.terraform.io/hashicorp/bar] 2.0.0", // from a provider config block
 		"Providers required by state",                         // header for state providers
 		"provider[registry.terraform.io/hashicorp/baz]",       // from a resouce in state (only)

--- a/internal/depsfile/locks_file_test.go
+++ b/internal/depsfile/locks_file_test.go
@@ -165,10 +165,12 @@ func TestSaveLocksToFile(t *testing.T) {
 	fooProvider := addrs.MustParseProviderSourceString("test/foo")
 	barProvider := addrs.MustParseProviderSourceString("test/bar")
 	bazProvider := addrs.MustParseProviderSourceString("test/baz")
+	booProvider := addrs.MustParseProviderSourceString("test/boo")
 	oneDotOh := getproviders.MustParseVersion("1.0.0")
 	oneDotTwo := getproviders.MustParseVersion("1.2.0")
 	atLeastOneDotOh := getproviders.MustParseVersionConstraints(">= 1.0.0")
 	pessimisticOneDotOh := getproviders.MustParseVersionConstraints("~> 1")
+	abbreviatedOneDotTwo := getproviders.MustParseVersionConstraints("1.2")
 	hashes := []getproviders.Hash{
 		getproviders.MustParseHash("test:cccccccccccccccccccccccccccccccccccccccccccccccc"),
 		getproviders.MustParseHash("test:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
@@ -177,6 +179,7 @@ func TestSaveLocksToFile(t *testing.T) {
 	locks.SetProvider(fooProvider, oneDotOh, atLeastOneDotOh, hashes)
 	locks.SetProvider(barProvider, oneDotTwo, pessimisticOneDotOh, nil)
 	locks.SetProvider(bazProvider, oneDotTwo, nil, nil)
+	locks.SetProvider(booProvider, oneDotTwo, abbreviatedOneDotTwo, nil)
 
 	dir, err := ioutil.TempDir("", "terraform-internal-depsfile-savelockstofile")
 	if err != nil {
@@ -205,6 +208,11 @@ provider "registry.terraform.io/test/bar" {
 
 provider "registry.terraform.io/test/baz" {
   version = "1.2.0"
+}
+
+provider "registry.terraform.io/test/boo" {
+  version     = "1.2.0"
+  constraints = "1.2.0"
 }
 
 provider "registry.terraform.io/test/foo" {


### PR DESCRIPTION
If a configuration requires a partial provider version (with some parts unspecified), Terraform considers this as a constrained-to-zero version. For example, a version constraint of `1.2` will result in an attempt to install version `1.2.0`, even if `1.2.1` is available.

When writing the dependency locks file, we previously would write `1.2.*`, as this is the in-memory representation of `1.2`. This would then cause an error on re-reading the locks file, as this is not a valid constraint format.

Instead, we now explicitly convert the constraint to its zero-filled representation before writing the locks file. This ensures that it correctly round-trips.

Because this change is made in `getproviders.`VersionConstraintsString, it also affects the output of the providers sub-command.

Fixes #26631.