### PR TITLE
Add note to upgrade guide about provider sensitivity

### DIFF
--- a/website/upgrade-guides/0-14.html.markdown
+++ b/website/upgrade-guides/0-14.html.markdown
@@ -323,7 +323,7 @@ Terraform will track when you write an expression whose result is derived
 from a
 [sensitive input variable](/docs/configuration/outputs.html#sensitive-suppressing-values-in-cli-output),
 [sensitive output value](/docs/configuration/variables.html#suppressing-values-in-cli-output),
-or an attribute defines as sensitive by a provider,
+or an attribute defined as sensitive by a provider,
 and so after upgrading to Terraform v0.14 you may find that more values are
 obscured in the Terraform plan output than would have been in Terraform v0.13.
 

--- a/website/upgrade-guides/0-14.html.markdown
+++ b/website/upgrade-guides/0-14.html.markdown
@@ -321,9 +321,9 @@ instead of the actual value.
 Terraform v0.14 introduces a more extensive version of that behavior where
 Terraform will track when you write an expression whose result is derived
 from a
-[sensitive input variable](/docs/configuration/outputs.html#sensitive-suppressing-values-in-cli-output)
-or
+[sensitive input variable](/docs/configuration/outputs.html#sensitive-suppressing-values-in-cli-output),
 [sensitive output value](/docs/configuration/variables.html#suppressing-values-in-cli-output),
+or an attribute defines as sensitive by a provider,
 and so after upgrading to Terraform v0.14 you may find that more values are
 obscured in the Terraform plan output than would have been in Terraform v0.13.
 


### PR DESCRIPTION
Now that sensitivity follows attributes providers mark as sensitive, add this note to the upgrade guide.

I couldn't think of other areas of the docs that would need this note (sensitivity for providers appears to be mentioned only in the Extend docs? and then only the comments in the Go code), so pointers are very helpful if there are other locations!