### PR TITLE
terraform: Fix sensitive values in ignore changes

### DIFF
--- a/terraform/testdata/plan-ignore-changes-sensitive/ignore-changes-sensitive.tf
+++ b/terraform/testdata/plan-ignore-changes-sensitive/ignore-changes-sensitive.tf
@@ -1,0 +1,11 @@
+variable "foo" {
+  sensitive = true
+}
+
+resource "aws_instance" "foo" {
+  ami = var.foo
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
+}


### PR DESCRIPTION
Because `ignore_changes` configuration can refer to resource arguments which are assigned sensitive values, we need to unmark the resource object before processing.

Fixes #26633