### PR TITLE
[build] Only run codecov on master

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,6 @@ comment:
   require_head: yes       # [yes :: must have a head report to post]
   branches:               # branch names that can post comment
     - "master"
-    - "v0.12"
 
 coverage:
   status:


### PR DESCRIPTION
Only run codecov on master branches. This will have no effect on the current behavior of the master branch. That will also be true for opening this for the 0.14 branch, so more of a tidying task.