### PR TITLE
[build][0.14] only run codecov on main branch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,6 @@ comment:
   require_head: yes       # [yes :: must have a head report to post]
   branches:               # branch names that can post comment
     - "master"
-    - "v0.12"
 
 coverage:
   status:


### PR DESCRIPTION
0.14 sibling to the `master` branch PR