### PR TITLE
build: update comments in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@
 # using the current working directory.
 #
 # This produces a docker image that contains a working Terraform binary along
-# with all of its source code, which is what gets released on hub.docker.com
-# as terraform:full. The main releases (terraform:latest, terraform:light and
-# the release tags) are lighter images including only the officially-released
-# binary from releases.hashicorp.com; these are built instead from
-# scripts/docker-release/Dockerfile-release.
+# with all of its source code. This is not what produces the official releases
+# in the "terraform" namespace on Dockerhub; those images include only
+# the officially-released binary from releases.hashicorp.com and are
+# built by the (closed-source) official release process.
 
 FROM golang:alpine
 LABEL maintainer="HashiCorp Terraform Team <terraform@hashicorp.com>"


### PR DESCRIPTION
Two updates:
- we are going to stop publishing the full docker image , but we will leave the dockerfile and its supporting script in place for users who want to continue using that for development
- the main docker release is handled elsewhere, so drop (outdated) references to it

Closes #26629