### PR TITLE
getproviders: Don't log if EvalSymlinks changes nothing

### DIFF
--- a/internal/getproviders/filesystem_search.go
+++ b/internal/getproviders/filesystem_search.go
@@ -30,7 +30,9 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 	// symlink to help Terraform find them anyway.
 	originalBaseDir := baseDir
 	if finalDir, err := filepath.EvalSymlinks(baseDir); err == nil {
-		log.Printf("[TRACE] getproviders.SearchLocalDirectory: %s is a symlink to %s", baseDir, finalDir)
+		if finalDir != filepath.Clean(baseDir) {
+			log.Printf("[TRACE] getproviders.SearchLocalDirectory: using %s instead of %s", finalDir, baseDir)
+		}
 		baseDir = finalDir
 	} else {
 		// We'll eat this particular error because if we're somehow able to


### PR DESCRIPTION
Previously this codepath was generating a confusing message in the absense of any symlinks, because `filepath.EvalSymlinks` returns a successful result if the target isn't a symlink.

Now we'll emit the log line only if `filepath.EvalSymlinks` returns a result that's different in a way that isn't purely syntactic (which
`filepath.Clean` would "fix").

The new message is a little more generic because technically we've not actually ensured that a difference here was caused by a symlink and so we shouldn't over-promise and generate something potentially misleading.