### PR TITLE
backend: Replace payload struct with byte slice

### DIFF
--- a/backend/remote-state/artifactory/client.go
+++ b/backend/remote-state/artifactory/client.go
@@ -1,11 +1,9 @@
 package artifactory
 
 import (
-	"crypto/md5"
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform/states/remote"
 	artifactory "github.com/lusis/go-artifactory/src/artifactory.v401"
 )
 
@@ -20,7 +18,7 @@ type ArtifactoryClient struct {
 	subpath      string
 }
 
-func (c *ArtifactoryClient) Get() (*remote.Payload, error) {
+func (c *ArtifactoryClient) Get() ([]byte, error) {
 	p := fmt.Sprintf("%s/%s/%s", c.repo, c.subpath, ARTIF_TFSTATE_NAME)
 	output, err := c.nativeClient.Get(p, make(map[string]string))
 	if err != nil {
@@ -30,21 +28,12 @@ func (c *ArtifactoryClient) Get() (*remote.Payload, error) {
 		return nil, err
 	}
 
-	// TODO: migrate to using X-Checksum-Md5 header from artifactory
-	// needs to be exposed by go-artifactory first
-
-	hash := md5.Sum(output)
-	payload := &remote.Payload{
-		Data: output,
-		MD5:  hash[:md5.Size],
-	}
-
 	// If there was no data, then return nil
-	if len(payload.Data) == 0 {
+	if len(output) == 0 {
 		return nil, nil
 	}
 
-	return payload, nil
+	return output, nil
 }
 
 func (c *ArtifactoryClient) Put(data []byte) error {

--- a/backend/remote-state/azure/client.go
+++ b/backend/remote-state/azure/client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
 
-	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statemgr"
 )
 
@@ -30,7 +29,7 @@ type RemoteClient struct {
 	snapshot           bool
 }
 
-func (c *RemoteClient) Get() (*remote.Payload, error) {
+func (c *RemoteClient) Get() ([]byte, error) {
 	options := blobs.GetInput{}
 	if c.leaseID != "" {
 		options.LeaseID = &c.leaseID
@@ -45,16 +44,14 @@ func (c *RemoteClient) Get() (*remote.Payload, error) {
 		return nil, err
 	}
 
-	payload := &remote.Payload{
-		Data: blob.Contents,
-	}
+	data := blob.Contents
 
 	// If there was no data, then return nil
-	if len(payload.Data) == 0 {
+	if len(data) == 0 {
 		return nil, nil
 	}
 
-	return payload, nil
+	return data, nil
 }
 
 func (c *RemoteClient) Put(data []byte) error {

--- a/backend/remote-state/consul/client.go
+++ b/backend/remote-state/consul/client.go
@@ -15,7 +15,6 @@ import (
 
 	consulapi "github.com/hashicorp/consul/api"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statemgr"
 )
 
@@ -68,7 +67,7 @@ type RemoteClient struct {
 	sessionCancel context.CancelFunc
 }
 
-func (c *RemoteClient) Get() (*remote.Payload, error) {
+func (c *RemoteClient) Get() ([]byte, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -114,10 +113,7 @@ func (c *RemoteClient) Get() (*remote.Payload, error) {
 		return nil, fmt.Errorf("The remote state does not match the expected hash")
 	}
 
-	return &remote.Payload{
-		Data: payload,
-		MD5:  md5[:],
-	}, nil
+	return payload, nil
 }
 
 func (c *RemoteClient) Put(data []byte) error {

--- a/backend/remote-state/consul/client_test.go
+++ b/backend/remote-state/consul/client_test.go
@@ -141,7 +141,7 @@ func TestConsul_largeState(t *testing.T) {
 		// 	t.Fatal("the md5 sums do not match")
 		// }
 
-		if !bytes.Equal(payload, remote.Data) {
+		if !bytes.Equal(payload, remote) {
 			t.Fatal("the data do not match")
 		}
 

--- a/backend/remote-state/cos/client.go
+++ b/backend/remote-state/cos/client.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statemgr"
 	tag "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813"
 	"github.com/tencentyun/cos-go-sdk-v5"
@@ -37,10 +36,10 @@ type remoteClient struct {
 }
 
 // Get returns remote state file
-func (c *remoteClient) Get() (*remote.Payload, error) {
+func (c *remoteClient) Get() ([]byte, error) {
 	log.Printf("[DEBUG] get remote state file %s", c.stateFile)
 
-	exists, data, checksum, err := c.getObject(c.stateFile)
+	exists, data, _, err := c.getObject(c.stateFile)
 	if err != nil {
 		return nil, err
 	}
@@ -49,12 +48,7 @@ func (c *remoteClient) Get() (*remote.Payload, error) {
 		return nil, nil
 	}
 
-	payload := &remote.Payload{
-		Data: data,
-		MD5:  []byte(checksum),
-	}
-
-	return payload, nil
+	return data, nil
 }
 
 // Put put state file to remote

--- a/backend/remote-state/etcdv2/client.go
+++ b/backend/remote-state/etcdv2/client.go
@@ -2,11 +2,9 @@ package etcdv2
 
 import (
 	"context"
-	"crypto/md5"
 	"fmt"
 
 	etcdapi "github.com/coreos/etcd/client"
-	"github.com/hashicorp/terraform/states/remote"
 )
 
 // EtcdClient is a remote client that stores data in etcd.
@@ -15,7 +13,7 @@ type EtcdClient struct {
 	Path   string
 }
 
-func (c *EtcdClient) Get() (*remote.Payload, error) {
+func (c *EtcdClient) Get() ([]byte, error) {
 	resp, err := etcdapi.NewKeysAPI(c.Client).Get(context.Background(), c.Path, &etcdapi.GetOptions{Quorum: true})
 	if err != nil {
 		if err, ok := err.(etcdapi.Error); ok && err.Code == etcdapi.ErrorCodeKeyNotFound {
@@ -27,12 +25,7 @@ func (c *EtcdClient) Get() (*remote.Payload, error) {
 		return nil, fmt.Errorf("path is a directory")
 	}
 
-	data := []byte(resp.Node.Value)
-	md5 := md5.Sum(data)
-	return &remote.Payload{
-		Data: data,
-		MD5:  md5[:],
-	}, nil
+	return []byte(resp.Node.Value), nil
 }
 
 func (c *EtcdClient) Put(data []byte) error {

--- a/backend/remote-state/etcdv3/client.go
+++ b/backend/remote-state/etcdv3/client.go
@@ -2,7 +2,6 @@ package etcd
 
 import (
 	"context"
-	"crypto/md5"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -11,7 +10,6 @@ import (
 	etcdv3 "github.com/coreos/etcd/clientv3"
 	etcdv3sync "github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statemgr"
 )
 
@@ -33,7 +31,7 @@ type RemoteClient struct {
 	modRevision int64
 }
 
-func (c *RemoteClient) Get() (*remote.Payload, error) {
+func (c *RemoteClient) Get() ([]byte, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -50,13 +48,7 @@ func (c *RemoteClient) Get() (*remote.Payload, error) {
 
 	c.modRevision = res.Kvs[0].ModRevision
 
-	payload := res.Kvs[0].Value
-	md5 := md5.Sum(payload)
-
-	return &remote.Payload{
-		Data: payload,
-		MD5:  md5[:],
-	}, nil
+	return res.Kvs[0].Value, nil
 }
 
 func (c *RemoteClient) Put(data []byte) error {

--- a/backend/remote-state/inmem/client.go
+++ b/backend/remote-state/inmem/client.go
@@ -1,41 +1,30 @@
 package inmem
 
 import (
-	"crypto/md5"
-
-	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statemgr"
 )
 
 // RemoteClient is a remote client that stores data in memory for testing.
 type RemoteClient struct {
 	Data []byte
-	MD5  []byte
 	Name string
 }
 
-func (c *RemoteClient) Get() (*remote.Payload, error) {
+func (c *RemoteClient) Get() ([]byte, error) {
 	if c.Data == nil {
 		return nil, nil
 	}
 
-	return &remote.Payload{
-		Data: c.Data,
-		MD5:  c.MD5,
-	}, nil
+	return c.Data, nil
 }
 
 func (c *RemoteClient) Put(data []byte) error {
-	md5 := md5.Sum(data)
-
 	c.Data = data
-	c.MD5 = md5[:]
 	return nil
 }
 
 func (c *RemoteClient) Delete() error {
 	c.Data = nil
-	c.MD5 = nil
 	return nil
 }
 

--- a/backend/remote-state/kubernetes/client.go
+++ b/backend/remote-state/kubernetes/client.go
@@ -3,14 +3,12 @@ package kubernetes
 import (
 	"bytes"
 	"compress/gzip"
-	"crypto/md5"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statemgr"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +38,7 @@ type RemoteClient struct {
 	workspace              string
 }
 
-func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
+func (c *RemoteClient) Get() (payload []byte, err error) {
 	secretName, err := c.createSecretName()
 	if err != nil {
 		return nil, err
@@ -67,13 +65,7 @@ func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 		return nil, err
 	}
 
-	md5 := md5.Sum(state)
-
-	p := &remote.Payload{
-		Data: state,
-		MD5:  md5[:],
-	}
-	return p, nil
+	return state, nil
 }
 
 func (c *RemoteClient) Put(data []byte) error {

--- a/backend/remote-state/manta/client.go
+++ b/backend/remote-state/manta/client.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	uuid "github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statemgr"
 	tritonErrors "github.com/joyent/triton-go/errors"
 	"github.com/joyent/triton-go/storage"
@@ -28,7 +27,7 @@ type RemoteClient struct {
 	statePath     string
 }
 
-func (c *RemoteClient) Get() (*remote.Payload, error) {
+func (c *RemoteClient) Get() ([]byte, error) {
 	output, err := c.storageClient.Objects().Get(context.Background(), &storage.GetObjectInput{
 		ObjectPath: path.Join(mantaDefaultRootStore, c.directoryName, c.keyName),
 	})
@@ -45,16 +44,14 @@ func (c *RemoteClient) Get() (*remote.Payload, error) {
 		return nil, fmt.Errorf("Failed to read remote state: %s", err)
 	}
 
-	payload := &remote.Payload{
-		Data: buf.Bytes(),
-	}
+	data := buf.Bytes()
 
 	// If there was no data, then return nil
-	if len(payload.Data) == 0 {
+	if len(data) == 0 {
 		return nil, nil
 	}
 
-	return payload, nil
+	return data, nil
 
 }
 

--- a/backend/remote-state/pg/client.go
+++ b/backend/remote-state/pg/client.go
@@ -1,12 +1,10 @@
 package pg
 
 import (
-	"crypto/md5"
 	"database/sql"
 	"fmt"
 
 	uuid "github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statemgr"
 	_ "github.com/lib/pq"
 )
@@ -20,7 +18,7 @@ type RemoteClient struct {
 	info *statemgr.LockInfo
 }
 
-func (c *RemoteClient) Get() (*remote.Payload, error) {
+func (c *RemoteClient) Get() ([]byte, error) {
 	query := `SELECT data FROM %s.%s WHERE name = $1`
 	row := c.Client.QueryRow(fmt.Sprintf(query, c.SchemaName, statesTableName), c.Name)
 	var data []byte
@@ -32,11 +30,7 @@ func (c *RemoteClient) Get() (*remote.Payload, error) {
 	case err != nil:
 		return nil, err
 	default:
-		md5 := md5.Sum(data)
-		return &remote.Payload{
-			Data: data,
-			MD5:  md5[:],
-		}, nil
+		return data, nil
 	}
 }
 

--- a/backend/remote-state/s3/client.go
+++ b/backend/remote-state/s3/client.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	multierror "github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statemgr"
 )
 
@@ -53,23 +52,26 @@ var (
 // test hook called when checksums don't match
 var testChecksumHook func()
 
-func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
+func (c *RemoteClient) Get() (payload []byte, err error) {
 	deadline := time.Now().Add(consistencyRetryTimeout)
 
+	var data []byte
 	// If we have a checksum, and the returned payload doesn't match, we retry
 	// up until deadline.
 	for {
-		payload, err = c.get()
+		var err error
+		data, err = c.get()
 		if err != nil {
 			return nil, err
 		}
 
-		// If the remote state was manually removed the payload will be nil,
+		// If the remote state was manually removed the data will be nil,
 		// but if there's still a digest entry for that state we will still try
 		// to compare the MD5 below.
 		var digest []byte
-		if payload != nil {
-			digest = payload.MD5
+		if data != nil {
+			checksum := md5.Sum(data)
+			digest = checksum[:]
 		}
 
 		// verify that this state is what we expect
@@ -94,10 +96,10 @@ func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 		break
 	}
 
-	return payload, err
+	return data, nil
 }
 
-func (c *RemoteClient) get() (*remote.Payload, error) {
+func (c *RemoteClient) get() ([]byte, error) {
 	var output *s3.GetObjectOutput
 	var err error
 
@@ -133,18 +135,14 @@ func (c *RemoteClient) get() (*remote.Payload, error) {
 		return nil, fmt.Errorf("Failed to read remote state: %s", err)
 	}
 
-	sum := md5.Sum(buf.Bytes())
-	payload := &remote.Payload{
-		Data: buf.Bytes(),
-		MD5:  sum[:],
-	}
+	data := buf.Bytes()
 
 	// If there was no data, then return nil
-	if len(payload.Data) == 0 {
+	if len(data) == 0 {
 		return nil, nil
 	}
 
-	return payload, nil
+	return data, nil
 }
 
 func (c *RemoteClient) Put(data []byte) error {

--- a/backend/remote/backend_state.go
+++ b/backend/remote/backend_state.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	tfe "github.com/hashicorp/go-tfe"
-	"github.com/hashicorp/terraform/states/remote"
 	"github.com/hashicorp/terraform/states/statefile"
 	"github.com/hashicorp/terraform/states/statemgr"
 )
@@ -24,7 +23,7 @@ type remoteClient struct {
 }
 
 // Get the remote state.
-func (r *remoteClient) Get() (*remote.Payload, error) {
+func (r *remoteClient) Get() ([]byte, error) {
 	ctx := context.Background()
 
 	sv, err := r.client.StateVersions.Current(ctx, r.workspace.ID)
@@ -46,13 +45,7 @@ func (r *remoteClient) Get() (*remote.Payload, error) {
 		return nil, nil
 	}
 
-	// Get the MD5 checksum of the state.
-	sum := md5.Sum(state)
-
-	return &remote.Payload{
-		Data: state,
-		MD5:  sum[:],
-	}, nil
+	return state, nil
 }
 
 // Put the remote state.

--- a/states/remote/remote.go
+++ b/states/remote/remote.go
@@ -10,7 +10,7 @@ import (
 // driver. It supports dumb put/get/delete, and the higher level structs
 // handle persisting the state properly here.
 type Client interface {
-	Get() (*Payload, error)
+	Get() ([]byte, error)
 	Put([]byte) error
 	Delete() error
 }
@@ -28,12 +28,6 @@ type ClientForcePusher interface {
 type ClientLocker interface {
 	Client
 	statemgr.Locker
-}
-
-// Payload is the return value from the remote state storage.
-type Payload struct {
-	MD5  []byte
-	Data []byte
 }
 
 // Factory is the factory function to create a remote client.

--- a/states/remote/remote_test.go
+++ b/states/remote/remote_test.go
@@ -2,7 +2,6 @@ package remote
 
 import (
 	"bytes"
-	"crypto/md5"
 	"encoding/json"
 	"testing"
 
@@ -28,7 +27,7 @@ func testClient(t *testing.T, c Client) {
 	if err != nil {
 		t.Fatalf("get: %s", err)
 	}
-	if !bytes.Equal(p.Data, data) {
+	if !bytes.Equal(p, data) {
 		t.Fatalf("bad: %#v", p)
 	}
 
@@ -57,7 +56,7 @@ func TestRemoteClient_noPayload(t *testing.T) {
 // nilClient returns nil for everything
 type nilClient struct{}
 
-func (nilClient) Get() (*Payload, error) { return nil, nil }
+func (nilClient) Get() ([]byte, error) { return nil, nil }
 
 func (c nilClient) Put([]byte) error { return nil }
 
@@ -76,16 +75,12 @@ type mockClientRequest struct {
 	Content map[string]interface{}
 }
 
-func (c *mockClient) Get() (*Payload, error) {
+func (c *mockClient) Get() ([]byte, error) {
 	c.appendLog("Get", c.current)
 	if c.current == nil {
 		return nil, nil
 	}
-	checksum := md5.Sum(c.current)
-	return &Payload{
-		Data: c.current,
-		MD5:  checksum[:],
-	}, nil
+	return c.current, nil
 }
 
 func (c *mockClient) Put(data []byte) error {
@@ -125,16 +120,12 @@ type mockClientForcePusher struct {
 	log     []mockClientRequest
 }
 
-func (c *mockClientForcePusher) Get() (*Payload, error) {
+func (c *mockClientForcePusher) Get() ([]byte, error) {
 	c.appendLog("Get", c.current)
 	if c.current == nil {
 		return nil, nil
 	}
-	checksum := md5.Sum(c.current)
-	return &Payload{
-		Data: c.current,
-		MD5:  checksum[:],
-	}, nil
+	return c.current, nil
 }
 
 func (c *mockClientForcePusher) Put(data []byte) error {

--- a/states/remote/state.go
+++ b/states/remote/state.go
@@ -121,7 +121,7 @@ func (s *State) refreshState() error {
 		return nil
 	}
 
-	stateFile, err := statefile.Read(bytes.NewReader(payload.Data))
+	stateFile, err := statefile.Read(bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/states/remote/testing.go
+++ b/states/remote/testing.go
@@ -27,8 +27,8 @@ func TestClient(t *testing.T, c Client) {
 	if err != nil {
 		t.Fatalf("get: %s", err)
 	}
-	if !bytes.Equal(p.Data, data) {
-		t.Fatalf("expected full state %q\n\ngot: %q", string(p.Data), string(data))
+	if !bytes.Equal(p, data) {
+		t.Fatalf("expected full state %q\n\ngot: %q", string(p), string(data))
 	}
 
 	if err := c.Delete(); err != nil {
@@ -40,7 +40,7 @@ func TestClient(t *testing.T, c Client) {
 		t.Fatalf("get: %s", err)
 	}
 	if p != nil {
-		t.Fatalf("expected empty state, got: %q", string(p.Data))
+		t.Fatalf("expected empty state, got: %q", string(p))
 	}
 }
 


### PR DESCRIPTION
The various remote state backend clients were required to include an MD5 digest of the state data as part of the `remote.Payload` struct. This was not used by anything else, and most of the backends simply computed the digest locally, which is pointless.

Some of the backends do verify a locally-computed digest against a known-good one from the source. This is useful and has been retained.

This commit replaces the struct with a byte slice representing the data, stops computing local digests which would immediately be discarded, and adds client-internal digest verification to backends which can easily support it: `atlas`, `http`, and `gcs`.