### PR TITLE
Read orphaned instances during plan

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -267,7 +267,6 @@ func TestContext2Apply_resourceDependsOnModule(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(order, []string{"child", "parent"}) {
-		fmt.Println("ORDER:", order)
 		t.Fatal("resources applied out of order")
 	}
 

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -191,6 +191,7 @@ func (b *PlanGraphBuilder) init() {
 	b.ConcreteResourceOrphan = func(a *NodeAbstractResourceInstance) dag.Vertex {
 		return &NodePlannableResourceInstanceOrphan{
 			NodeAbstractResourceInstance: a,
+			skipRefresh:                  b.skipRefresh,
 		}
 	}
 }

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -36,7 +36,7 @@ func (n *NodePlannableResourceInstance) Execute(ctx EvalContext, op walkOperatio
 	// Eval info is different depending on what kind of resource this is
 	switch addr.Resource.Resource.Mode {
 	case addrs.ManagedResourceMode:
-		return n.managedResourceExecute(ctx, n.skipRefresh)
+		return n.managedResourceExecute(ctx)
 	case addrs.DataResourceMode:
 		return n.dataResourceExecute(ctx)
 	default:
@@ -123,7 +123,7 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 	return err
 }
 
-func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext, skipRefresh bool) error {
+func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) error {
 	config := n.Config
 	addr := n.ResourceInstanceAddr()
 
@@ -162,7 +162,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext, 
 	}
 
 	// Refresh, maybe
-	if !skipRefresh {
+	if !n.skipRefresh {
 		refresh := &EvalRefresh{
 			Addr:           addr.Resource,
 			ProviderAddr:   n.ResolvedProvider,

--- a/terraform/node_resource_plan_orphan_test.go
+++ b/terraform/node_resource_plan_orphan_test.go
@@ -33,6 +33,7 @@ func TestNodeResourcePlanOrphanExecute(t *testing.T) {
 	p := simpleMockProvider()
 	ctx := &MockEvalContext{
 		StateState:               state.SyncWrapper(),
+		RefreshStateState:        state.SyncWrapper(),
 		InstanceExpanderExpander: instances.NewExpander(),
 		ProviderProvider:         p,
 		ProviderSchemaSchema: &ProviderSchema{

--- a/terraform/provider_mock.go
+++ b/terraform/provider_mock.go
@@ -242,14 +242,20 @@ func (p *MockProvider) ReadResource(r providers.ReadResourceRequest) providers.R
 		return p.ReadResourceFn(r)
 	}
 
-	// make sure the NewState fits the schema
-	newState, err := p.GetSchemaReturn.ResourceTypes[r.TypeName].CoerceValue(p.ReadResourceResponse.NewState)
-	if err != nil {
-		panic(err)
-	}
 	resp := p.ReadResourceResponse
-	resp.NewState = newState
+	if resp.NewState != cty.NilVal {
+		// make sure the NewState fits the schema
+		// This isn't always the case for the existing tests
+		newState, err := p.GetSchemaReturn.ResourceTypes[r.TypeName].CoerceValue(resp.NewState)
+		if err != nil {
+			panic(err)
+		}
+		resp.NewState = newState
+		return resp
+	}
 
+	// just return the same state we received
+	resp.NewState = r.PriorState
 	return resp
 }
 


### PR DESCRIPTION
This forces orphaned resources to be re-read during planning, removing
them from the state if they no longer exist.

This needs to be done for a bare `refresh` execution, since Terraform
should remove instances that don't exist and are not in the
configuration from the state. They should also be removed from state so
there is no Delete change planned, as not all providers will gracefully
handle a delete operation on a resource that does not exist.