### PR TITLE
Separate loggers

### DIFF
--- a/command/meta_providers.go
+++ b/command/meta_providers.go
@@ -335,7 +335,7 @@ func providerFactory(meta *providercache.CachedProvider) providers.Factory {
 
 		config := &plugin.ClientConfig{
 			HandshakeConfig:  tfplugin.Handshake,
-			Logger:           logging.NewProviderLogger(),
+			Logger:           logging.NewProviderLogger(""),
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 			Managed:          true,
 			Cmd:              exec.Command(execFile),
@@ -383,7 +383,7 @@ func unmanagedProviderFactory(provider addrs.Provider, reattach *plugin.Reattach
 
 		config := &plugin.ClientConfig{
 			HandshakeConfig:  tfplugin.Handshake,
-			Logger:           logging.NewHCLogger("unmanaged-plugin"),
+			Logger:           logging.NewProviderLogger("unmanaged."),
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 			Managed:          false,
 			Reattach:         reattach,

--- a/command/plugins.go
+++ b/command/plugins.go
@@ -169,7 +169,7 @@ func internalPluginClient(kind, name string) (*plugin.Client, error) {
 		VersionedPlugins: tfplugin.VersionedPlugins,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		AutoMTLS:         enableProviderAutoMTLS,
-		Logger:           logging.NewProviderLogger(),
+		Logger:           logging.NewLogger(kind),
 	}
 
 	return plugin.NewClient(cfg), nil
@@ -182,7 +182,7 @@ func provisionerFactory(meta discovery.PluginMeta) terraform.ProvisionerFactory 
 			HandshakeConfig:  tfplugin.Handshake,
 			VersionedPlugins: tfplugin.VersionedPlugins,
 			Managed:          true,
-			Logger:           logging.NewHCLogger("provisioner"),
+			Logger:           logging.NewLogger("provisioner"),
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 			AutoMTLS:         enableProviderAutoMTLS,
 		}

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-getter v1.4.2-0.20200106182914-9813cbd4eb02
-	github.com/hashicorp/go-hclog v0.14.2-0.20201019183805-6b377870ae4a
+	github.com/hashicorp/go-hclog v0.14.2-0.20201022192508-e59fd7e11108
 	github.com/hashicorp/go-immutable-radix v0.0.0-20180129170900-7f3cd4390caa // indirect
 	github.com/hashicorp/go-msgpack v0.5.4 // indirect
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,10 @@ github.com/hashicorp/go-hclog v0.14.1 h1:nQcJDQwIAGnmoUWp8ubocEX40cCml/17YkF6csQ
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.14.2-0.20201019183805-6b377870ae4a h1:jMdSTm5U2cMM2Z0y+tiSTsMAinefoMZyXGj3Gap+JmE=
 github.com/hashicorp/go-hclog v0.14.2-0.20201019183805-6b377870ae4a/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v0.14.2-0.20201022165706-5774f3f2f293 h1:l/xQmH6wg6Z8nRuoMcm/bx3o3nWwy0dLKy9QNKfB2+c=
+github.com/hashicorp/go-hclog v0.14.2-0.20201022165706-5774f3f2f293/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v0.14.2-0.20201022192508-e59fd7e11108 h1:njjwC6QCapHoavbrnzrenpovKeHauePE1wPVdflPvRU=
+github.com/hashicorp/go-hclog v0.14.2-0.20201022192508-e59fd7e11108/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v0.0.0-20180129170900-7f3cd4390caa h1:0nA8i+6Rwqaq9xlpmVxxTwk6rxiEhX+E6Wh4vPNHiS8=
 github.com/hashicorp/go-immutable-radix v0.0.0-20180129170900-7f3cd4390caa/go.mod h1:6ij3Z20p+OhOkCSrA0gImAWoHYQRGbnlcuk6XYTiaRw=
 github.com/hashicorp/go-msgpack v0.5.4 h1:SFT72YqIkOcLdWJUYcriVX7hbrZpwc/f7h8aW2NUqrA=

--- a/internal/logging/panic.go
+++ b/internal/logging/panic.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/mitchellh/panicwrap"
 )
@@ -67,6 +66,6 @@ func PanicHandler(tmpLogPath string) panicwrap.HandlerFunc {
 		// Tell the user a crash occurred in some helpful way that
 		// they'll hopefully notice.
 		fmt.Printf("\n\n")
-		fmt.Printf(strings.TrimSpace(panicOutput), f.Name())
+		fmt.Printf(panicOutput, f.Name())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -95,7 +95,6 @@ func wrappedMain() int {
 	if tmpLogPath != "" {
 		f, err := os.OpenFile(tmpLogPath, os.O_RDWR|os.O_APPEND, 0666)
 		if err == nil {
-			defer os.Remove(f.Name())
 			defer f.Close()
 
 			log.Printf("[DEBUG] Adding temp file log sink: %s", f.Name())

--- a/website/docs/commands/environment-variables.html.md
+++ b/website/docs/commands/environment-variables.html.md
@@ -16,16 +16,16 @@ for debugging.
 
 ## TF_LOG
 
-If set to any value, enables detailed logs to appear on stderr which is useful for debugging. For example:
+Enables detailed logs to appear on stderr which is useful for debugging. For example:
 
 ```shell
-export TF_LOG=TRACE
+export TF_LOG=trace
 ```
 
-To disable, either unset it or set it to empty. When unset, logging will default to stderr. For example:
+To disable, either unset it, or set it to `off`. For example:
 
 ```shell
-export TF_LOG=
+export TF_LOG=off
 ```
 
 For more on debugging Terraform, check out the section on [Debugging](/docs/internals/debugging.html).

--- a/website/docs/internals/debugging.html.md
+++ b/website/docs/internals/debugging.html.md
@@ -10,7 +10,11 @@ description: |-
 
 Terraform has detailed logs which can be enabled by setting the `TF_LOG` environment variable to any value. This will cause detailed logs to appear on stderr.
 
-You can set `TF_LOG` to one of the log levels `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR` to change the verbosity of the logs. `TRACE` is the most verbose and it is the default if `TF_LOG` is set to something other than a log level name.
+You can set `TF_LOG` to one of the log levels `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR` to change the verbosity of the logs.
+
+Logging can be enabled separately for terraform itself and the provider plugins
+using the `TF_LOG_CORE` or `TF_LOG_PROVIDER` environment variables. These take
+the same level arguments as `TF_LOG`, but only activate a subset of the logs.
 
 To persist logged output you can set `TF_LOG_PATH` in order to force the log to always be appended to a specific file when logging is enabled. Note that even when `TF_LOG_PATH` is set, `TF_LOG` must be set in order for any logging to be enabled.
 


### PR DESCRIPTION
Both core and provider logs can be quite verbose, and it is often difficult to debug one or the other while sifting through the combination of their logs.

Here we introduce two new environment variables for more control over logging:

    TF_LOG_CORE=level
    TF_LOG_PROVIDER=level

The existing `TF_LOG` environment variable remains to set the global log level, but these new variables allow the viewing of the subsystem logs independently. 