### PR TITLE
build: Set Codecov to informational mode again

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,6 +14,11 @@ coverage:
         informational: true
         target: auto
         threshold: "0.5%"
+    patch:
+      default:
+        informational: true
+        target: auto
+        threshold: "0.5%"
 
 github_checks:
     annotations: false


### PR DESCRIPTION
We have informational mode enabled for pull requests. This commit enables it for individual commits, too.

Informational mode registers the result of a Codecov check without ever failing due to low coverage. This is appropriate for Terraform because much of the test coverage comes from cross-package tests, which Codecov misses.

### Screenshot

Here's a commit which does not match our target for diff coverage, and now shows a happy ✅ instead of an angry ❌ :

![image](https://user-images.githubusercontent.com/68917/97049806-4982bc80-154a-11eb-9449-8a9d7c3884bc.png)
