### PR TITLE
builtin/providers/terraform: Disable remote state file version checks

### DIFF
--- a/backend/atlas/backend.go
+++ b/backend/atlas/backend.go
@@ -179,6 +179,10 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	return &remote.State{Client: b.stateClient}, nil
 }
 
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.StateMgr(name)
+}
+
 // Colorize returns the Colorize structure that can be used for colorizing
 // output. This is gauranteed to always return a non-nil value and so is useful
 // as a helper to wrap any potentially colored strings.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -103,6 +103,18 @@ type Backend interface {
 	// PersistState is called, depending on the state manager implementation.
 	StateMgr(workspace string) (statemgr.Full, error)
 
+	// StateMgrWithoutCheckVersion returns the state manager for the given
+	// workspace name, while ensuring that Terraform version checks are not
+	// performed if the backend needs to read a state file in order to
+	// initialize the state manager.
+	//
+	// For backends which do not need to read a state file at this point, this
+	// is identical to StateMgr.
+	//
+	// This is used to facilitate reading compatible state files from newer
+	// versions of Terraform.
+	StateMgrWithoutCheckVersion(workspace string) (statemgr.Full, error)
+
 	// DeleteWorkspace removes the workspace with the given name if it exists.
 	//
 	// DeleteWorkspace cannot prevent deleting a state that is in use. It is

--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -279,6 +279,10 @@ func (b *Local) StateMgr(name string) (statemgr.Full, error) {
 	return s, nil
 }
 
+func (b *Local) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.StateMgr(name)
+}
+
 // Operation implements backend.Enhanced
 //
 // This will initialize an in-memory terraform.Context to perform the

--- a/backend/nil.go
+++ b/backend/nil.go
@@ -31,6 +31,10 @@ func (Nil) StateMgr(string) (statemgr.Full, error) {
 	return statemgr.NewFullFake(statemgr.NewTransientInMemory(nil), nil), nil
 }
 
+func (Nil) StateMgrWithoutCheckVersion(string) (statemgr.Full, error) {
+	return statemgr.NewFullFake(statemgr.NewTransientInMemory(nil), nil), nil
+}
+
 func (Nil) DeleteWorkspace(string) error {
 	return nil
 }

--- a/backend/remote-state/artifactory/backend.go
+++ b/backend/remote-state/artifactory/backend.go
@@ -100,3 +100,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		Client: b.client,
 	}, nil
 }
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.StateMgr(name)
+}

--- a/backend/remote-state/azure/backend_state.go
+++ b/backend/remote-state/azure/backend_state.go
@@ -79,6 +79,14 @@ func (b *Backend) DeleteWorkspace(name string) error {
 }
 
 func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, true)
+}
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, false)
+}
+
+func (b *Backend) stateMgr(name string, checkVersion bool) (statemgr.Full, error) {
 	ctx := context.TODO()
 	blobClient, err := b.armClient.getBlobClient(ctx)
 	if err != nil {
@@ -115,9 +123,16 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		}
 
 		// Grab the value
-		if err := stateMgr.RefreshState(); err != nil {
-			err = lockUnlock(err)
-			return nil, err
+		if checkVersion {
+			if err := stateMgr.RefreshState(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
+		} else {
+			if err := stateMgr.RefreshStateWithoutCheckVersion(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
 		}
 
 		// If we have no state, we have to create an empty state

--- a/backend/remote-state/consul/backend_state.go
+++ b/backend/remote-state/consul/backend_state.go
@@ -64,6 +64,14 @@ func (b *Backend) DeleteWorkspace(name string) error {
 }
 
 func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, true)
+}
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, false)
+}
+
+func (b *Backend) stateMgr(name string, checkVersion bool) (statemgr.Full, error) {
 	// Determine the path of the data
 	path := b.path(name)
 
@@ -109,9 +117,16 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	}
 
 	// Grab the value
-	if err := stateMgr.RefreshState(); err != nil {
-		err = lockUnlock(err)
-		return nil, err
+	if checkVersion {
+		if err := stateMgr.RefreshState(); err != nil {
+			err = lockUnlock(err)
+			return nil, err
+		}
+	} else {
+		if err := stateMgr.RefreshStateWithoutCheckVersion(); err != nil {
+			err = lockUnlock(err)
+			return nil, err
+		}
 	}
 
 	// If we have no state, we have to create an empty state

--- a/backend/remote-state/cos/backend_state.go
+++ b/backend/remote-state/cos/backend_state.go
@@ -75,6 +75,14 @@ func (b *Backend) DeleteWorkspace(name string) error {
 
 // StateMgr manage the state, if the named state not exists, a new file will created
 func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, true)
+}
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, false)
+}
+
+func (b *Backend) stateMgr(name string, checkVersion bool) (statemgr.Full, error) {
 	log.Printf("[DEBUG] state manager, current workspace: %v", name)
 
 	c, err := b.client(name)
@@ -108,9 +116,16 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		}
 
 		// Grab the value
-		if err := stateMgr.RefreshState(); err != nil {
-			err = lockUnlock(err)
-			return nil, err
+		if checkVersion {
+			if err := stateMgr.RefreshState(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
+		} else {
+			if err := stateMgr.RefreshStateWithoutCheckVersion(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
 		}
 
 		// If we have no state, we have to create an empty state

--- a/backend/remote-state/etcdv2/backend.go
+++ b/backend/remote-state/etcdv2/backend.go
@@ -94,3 +94,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		},
 	}, nil
 }
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.StateMgr(name)
+}

--- a/backend/remote-state/gcs/backend_state.go
+++ b/backend/remote-state/gcs/backend_state.go
@@ -87,6 +87,14 @@ func (b *Backend) client(name string) (*remoteClient, error) {
 // StateMgr reads and returns the named state from GCS. If the named state does
 // not yet exist, a new state file is created.
 func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, true)
+}
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, false)
+}
+
+func (b *Backend) stateMgr(name string, checkVersion bool) (statemgr.Full, error) {
 	c, err := b.client(name)
 	if err != nil {
 		return nil, err
@@ -95,8 +103,14 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	st := &remote.State{Client: c}
 
 	// Grab the value
-	if err := st.RefreshState(); err != nil {
-		return nil, err
+	if checkVersion {
+		if err := st.RefreshState(); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := st.RefreshStateWithoutCheckVersion(); err != nil {
+			return nil, err
+		}
 	}
 
 	// If we have no state, we have to create an empty state

--- a/backend/remote-state/http/backend.go
+++ b/backend/remote-state/http/backend.go
@@ -188,6 +188,10 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	return &remote.State{Client: b.client}, nil
 }
 
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.StateMgr(name)
+}
+
 func (b *Backend) Workspaces() ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }

--- a/backend/remote-state/inmem/backend.go
+++ b/backend/remote-state/inmem/backend.go
@@ -150,6 +150,10 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	return s, nil
 }
 
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.StateMgr(name)
+}
+
 type stateMap struct {
 	sync.Mutex
 	m map[string]*remote.State

--- a/backend/remote-state/kubernetes/backend_state.go
+++ b/backend/remote-state/kubernetes/backend_state.go
@@ -72,6 +72,14 @@ func (b *Backend) DeleteWorkspace(name string) error {
 }
 
 func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, true)
+}
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, false)
+}
+
+func (b *Backend) stateMgr(name string, checkVersion bool) (statemgr.Full, error) {
 	c, err := b.remoteClient(name)
 	if err != nil {
 		return nil, err
@@ -80,8 +88,14 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	stateMgr := &remote.State{Client: c}
 
 	// Grab the value
-	if err := stateMgr.RefreshState(); err != nil {
-		return nil, err
+	if checkVersion {
+		if err := stateMgr.RefreshState(); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := stateMgr.RefreshStateWithoutCheckVersion(); err != nil {
+			return nil, err
+		}
 	}
 
 	// If we have no state, we have to create an empty state

--- a/backend/remote-state/manta/backend_state.go
+++ b/backend/remote-state/manta/backend_state.go
@@ -65,6 +65,14 @@ func (b *Backend) DeleteWorkspace(name string) error {
 }
 
 func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, true)
+}
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, false)
+}
+
+func (b *Backend) stateMgr(name string, checkVersion bool) (statemgr.Full, error) {
 	if name == "" {
 		return nil, errors.New("missing state name")
 	}
@@ -97,9 +105,16 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		}
 
 		// Grab the value
-		if err := stateMgr.RefreshState(); err != nil {
-			err = lockUnlock(err)
-			return nil, err
+		if checkVersion {
+			if err := stateMgr.RefreshState(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
+		} else {
+			if err := stateMgr.RefreshStateWithoutCheckVersion(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
 		}
 
 		// If we have no state, we have to create an empty state

--- a/backend/remote-state/oss/backend_state.go
+++ b/backend/remote-state/oss/backend_state.go
@@ -107,6 +107,14 @@ func (b *Backend) DeleteWorkspace(name string) error {
 }
 
 func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, true)
+}
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, false)
+}
+
+func (b *Backend) stateMgr(name string, checkVersion bool) (statemgr.Full, error) {
 	client, err := b.remoteClient(name)
 	if err != nil {
 		return nil, err
@@ -147,9 +155,16 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		}
 
 		// Grab the value
-		if err := stateMgr.RefreshState(); err != nil {
-			err = lockUnlock(err)
-			return nil, err
+		if checkVersion {
+			if err := stateMgr.RefreshState(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
+		} else {
+			if err := stateMgr.RefreshStateWithoutCheckVersion(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
 		}
 
 		// If we have no state, we have to create an empty state

--- a/backend/remote-state/pg/backend_state.go
+++ b/backend/remote-state/pg/backend_state.go
@@ -111,3 +111,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 
 	return stateMgr, nil
 }
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.StateMgr(name)
+}

--- a/backend/remote-state/s3/backend_state.go
+++ b/backend/remote-state/s3/backend_state.go
@@ -125,6 +125,14 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 }
 
 func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, true)
+}
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, false)
+}
+
+func (b *Backend) stateMgr(name string, checkVersion bool) (statemgr.Full, error) {
 	client, err := b.remoteClient(name)
 	if err != nil {
 		return nil, err
@@ -173,9 +181,16 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		// Grab the value
 		// This is to ensure that no one beat us to writing a state between
 		// the `exists` check and taking the lock.
-		if err := stateMgr.RefreshState(); err != nil {
-			err = lockUnlock(err)
-			return nil, err
+		if checkVersion {
+			if err := stateMgr.RefreshState(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
+		} else {
+			if err := stateMgr.RefreshStateWithoutCheckVersion(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
 		}
 
 		// If we have no state, we have to create an empty state

--- a/backend/remote-state/swift/backend_state.go
+++ b/backend/remote-state/swift/backend_state.go
@@ -92,6 +92,14 @@ func (b *Backend) DeleteWorkspace(name string) error {
 }
 
 func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, true)
+}
+
+func (b *Backend) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.stateMgr(name, false)
+}
+
+func (b *Backend) stateMgr(name string, checkVersion bool) (statemgr.Full, error) {
 	if name == "" {
 		return nil, fmt.Errorf("missing state name")
 	}
@@ -161,9 +169,16 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		}
 
 		// Grab the value
-		if err := stateMgr.RefreshState(); err != nil {
-			err = lockUnlock(err)
-			return nil, err
+		if checkVersion {
+			if err := stateMgr.RefreshState(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
+		} else {
+			if err := stateMgr.RefreshStateWithoutCheckVersion(); err != nil {
+				err = lockUnlock(err)
+				return nil, err
+			}
 		}
 
 		// If we have no state, we have to create an empty state

--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -641,6 +641,10 @@ func (b *Remote) StateMgr(name string) (statemgr.Full, error) {
 	return &remote.State{Client: client}, nil
 }
 
+func (b *Remote) StateMgrWithoutCheckVersion(name string) (statemgr.Full, error) {
+	return b.StateMgr(name)
+}
+
 // Operation implements backend.Enhanced.
 func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend.RunningOperation, error) {
 	// Get the remote workspace name.

--- a/backend/remote/backend_state.go
+++ b/backend/remote/backend_state.go
@@ -64,6 +64,9 @@ func (r *remoteClient) Put(state []byte) error {
 	if err != nil {
 		return fmt.Errorf("Error reading state: %s", err)
 	}
+	if err := stateFile.CheckTerraformVersion(); err != nil {
+		return fmt.Errorf("Incompatible statefile: %s", err)
+	}
 
 	options := tfe.StateVersionCreateOptions{
 		Lineage: tfe.String(stateFile.Lineage),

--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -107,7 +107,7 @@ func dataSourceRemoteStateRead(d cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		workspaceName = workspaceVal.AsString()
 	}
 
-	state, err := b.StateMgr(workspaceName)
+	state, err := b.StateMgrWithoutCheckVersion(workspaceName)
 	if err != nil {
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,
@@ -118,7 +118,7 @@ func dataSourceRemoteStateRead(d cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		return cty.NilVal, diags
 	}
 
-	if err := state.RefreshState(); err != nil {
+	if err := state.RefreshStateWithoutCheckVersion(); err != nil {
 		diags = diags.Append(err)
 		return cty.NilVal, diags
 	}

--- a/builtin/providers/terraform/data_source_state_test.go
+++ b/builtin/providers/terraform/data_source_state_test.go
@@ -362,6 +362,10 @@ func (b backendFailsConfigure) StateMgr(workspace string) (statemgr.Full, error)
 	return nil, fmt.Errorf("StateMgr not implemented")
 }
 
+func (b backendFailsConfigure) StateMgrWithoutCheckVersion(workspace string) (statemgr.Full, error) {
+	return nil, fmt.Errorf("StateMgrWithoutCheckVersion not implemented")
+}
+
 func (b backendFailsConfigure) DeleteWorkspace(name string) error {
 	return fmt.Errorf("DeleteWorkspace not implemented")
 }

--- a/builtin/providers/terraform/data_source_state_test.go
+++ b/builtin/providers/terraform/data_source_state_test.go
@@ -166,6 +166,26 @@ func TestState_basic(t *testing.T) {
 			}),
 			false,
 		},
+		"future version": {
+			cty.ObjectVal(map[string]cty.Value{
+				"backend": cty.StringVal("local"),
+				"config": cty.ObjectVal(map[string]cty.Value{
+					"path": cty.StringVal("./testdata/future.tfstate"),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"backend": cty.StringVal("local"),
+				"config": cty.ObjectVal(map[string]cty.Value{
+					"path": cty.StringVal("./testdata/future.tfstate"),
+				}),
+				"outputs": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("bar"),
+				}),
+				"defaults":  cty.NullVal(cty.DynamicPseudoType),
+				"workspace": cty.NullVal(cty.String),
+			}),
+			false,
+		},
 		"missing": {
 			cty.ObjectVal(map[string]cty.Value{
 				"backend": cty.StringVal("local"),

--- a/builtin/providers/terraform/testdata/future.tfstate
+++ b/builtin/providers/terraform/testdata/future.tfstate
@@ -1,0 +1,12 @@
+{
+    "version": 4,
+    "terraform_version": "999.0.0",
+    "serial": 0,
+    "lineage": "",
+    "outputs": {
+        "foo": {
+            "value": "bar",
+            "type": "string"
+        }
+    }
+}

--- a/command/show.go
+++ b/command/show.go
@@ -245,6 +245,9 @@ func getStateFromPath(path string) (*statefile.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error reading %s as a statefile: %s", path, err)
 	}
+	if err := stateFile.CheckTerraformVersion(); err != nil {
+		return nil, fmt.Errorf("Incompatible statefile %s: %s", path, err)
+	}
 	return stateFile, nil
 }
 

--- a/command/state_push.go
+++ b/command/state_push.go
@@ -63,6 +63,10 @@ func (c *StatePushCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error reading source state %q: %s", args[0], err))
 		return 1
 	}
+	if err := srcStateFile.CheckTerraformVersion(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Incompatible statefile %q: %s", args[0], err))
+		return 1
+	}
 
 	// Load the backend
 	b, backendDiags := c.Backend(nil)

--- a/command/workspace_new.go
+++ b/command/workspace_new.go
@@ -141,6 +141,10 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		c.Ui.Error(err.Error())
 		return 1
 	}
+	if err := stateFile.CheckTerraformVersion(); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
 
 	// save the existing state in the new Backend.
 	err = stateMgr.WriteState(stateFile.State)

--- a/plans/planfile/reader.go
+++ b/plans/planfile/reader.go
@@ -101,7 +101,11 @@ func (r *Reader) ReadStateFile() (*statefile.File, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to extract state from plan file: %s", err)
 			}
-			return statefile.Read(r)
+			stateFile, err := statefile.Read(r)
+			if err == nil {
+				err = stateFile.CheckTerraformVersion()
+			}
+			return stateFile, err
 		}
 	}
 	return nil, statefile.ErrNoState

--- a/states/remote/state.go
+++ b/states/remote/state.go
@@ -125,6 +125,9 @@ func (s *State) refreshState() error {
 	if err != nil {
 		return err
 	}
+	if err := stateFile.CheckTerraformVersion(); err != nil {
+		return err
+	}
 
 	s.lineage = stateFile.Lineage
 	s.serial = stateFile.Serial

--- a/states/statefile/file.go
+++ b/states/statefile/file.go
@@ -1,6 +1,8 @@
 package statefile
 
 import (
+	"fmt"
+
 	version "github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/terraform/states"
@@ -59,4 +61,16 @@ func (f *File) DeepCopy() *File {
 		Lineage:          f.Lineage,
 		State:            f.State.DeepCopy(),
 	}
+}
+
+func (f *File) CheckTerraformVersion() error {
+	if f.TerraformVersion != nil && f.TerraformVersion.GreaterThan(tfversion.SemVer) {
+		return fmt.Errorf(
+			"state snapshot was created by Terraform v%s, which is newer than current v%s; upgrade to Terraform v%s or greater to work with this state",
+			f.TerraformVersion,
+			tfversion.SemVer,
+			f.TerraformVersion,
+		)
+	}
+	return nil
 }

--- a/states/statefile/read.go
+++ b/states/statefile/read.go
@@ -62,15 +62,6 @@ func Read(r io.Reader) (*File, error) {
 		panic("readState returned nil state with no errors")
 	}
 
-	if state.TerraformVersion != nil && state.TerraformVersion.GreaterThan(tfversion.SemVer) {
-		return state, fmt.Errorf(
-			"state snapshot was created by Terraform v%s, which is newer than current v%s; upgrade to Terraform v%s or greater to work with this state",
-			state.TerraformVersion,
-			tfversion.SemVer,
-			state.TerraformVersion,
-		)
-	}
-
 	return state, diags.Err()
 }
 

--- a/states/statemgr/filesystem.go
+++ b/states/statemgr/filesystem.go
@@ -127,7 +127,7 @@ func (s *Filesystem) WriteState(state *states.State) error {
 	defer s.mutex()()
 
 	if s.readFile == nil {
-		err := s.refreshState()
+		err := s.refreshState(true)
 		if err != nil {
 			return err
 		}
@@ -230,10 +230,15 @@ func (s *Filesystem) PersistState() error {
 // RefreshState is an implementation of Refresher.
 func (s *Filesystem) RefreshState() error {
 	defer s.mutex()()
-	return s.refreshState()
+	return s.refreshState(true)
 }
 
-func (s *Filesystem) refreshState() error {
+func (s *Filesystem) RefreshStateWithoutCheckVersion() error {
+	defer s.mutex()()
+	return s.refreshState(false)
+}
+
+func (s *Filesystem) refreshState(checkVersion bool) error {
 	var reader io.Reader
 
 	// The s.readPath file is only OK to read if we have not written any state out
@@ -280,7 +285,7 @@ func (s *Filesystem) refreshState() error {
 			return err
 		}
 		log.Printf("[TRACE] statemgr.Filesystem: snapshot file has nil snapshot, but that's okay")
-	} else {
+	} else if checkVersion {
 		if err := f.CheckTerraformVersion(); err != nil {
 			return err
 		}
@@ -397,7 +402,7 @@ func (s *Filesystem) WriteStateForMigration(f *statefile.File, force bool) error
 	defer s.mutex()()
 
 	if s.readFile == nil {
-		err := s.refreshState()
+		err := s.refreshState(true)
 		if err != nil {
 			return err
 		}

--- a/states/statemgr/filesystem.go
+++ b/states/statemgr/filesystem.go
@@ -280,6 +280,10 @@ func (s *Filesystem) refreshState() error {
 			return err
 		}
 		log.Printf("[TRACE] statemgr.Filesystem: snapshot file has nil snapshot, but that's okay")
+	} else {
+		if err := f.CheckTerraformVersion(); err != nil {
+			return err
+		}
 	}
 
 	s.file = f
@@ -459,6 +463,10 @@ func (s *Filesystem) createStateFiles() error {
 		}
 		log.Printf("[TRACE] statemgr.Filesystem: no previously-stored snapshot exists")
 	} else {
+		if err := s.backupFile.CheckTerraformVersion(); err != nil {
+			return err
+		}
+
 		log.Printf("[TRACE] statemgr.Filesystem: existing snapshot has lineage %q serial %d", s.backupFile.Lineage, s.backupFile.Serial)
 	}
 

--- a/states/statemgr/lock.go
+++ b/states/statemgr/lock.go
@@ -23,6 +23,10 @@ func (s *LockDisabled) RefreshState() error {
 	return s.Inner.RefreshState()
 }
 
+func (s *LockDisabled) RefreshStateWithoutCheckVersion() error {
+	return s.Inner.RefreshStateWithoutCheckVersion()
+}
+
 func (s *LockDisabled) PersistState() error {
 	return s.Inner.PersistState()
 }

--- a/states/statemgr/persistent.go
+++ b/states/statemgr/persistent.go
@@ -35,7 +35,9 @@ type Persistent interface {
 // PersistState that may be happening in other processes.
 type Refresher interface {
 	// RefreshState retrieves a snapshot of state from persistent storage,
-	// returning an error if this is not possible.
+	// returning an error if this is not possible. If a snapshot is retrieved
+	// but is from an incompatible Terraform version, this will also result
+	// in an error.
 	//
 	// Types that implement RefreshState generally also implement a State
 	// method that returns the result of the latest successful refresh.
@@ -46,6 +48,12 @@ type Refresher interface {
 	// ephemeral portions of the state may be unpopulated after calling
 	// RefreshState.
 	RefreshState() error
+
+	// RefreshStateWithoutCheckVersion is similar to RefreshState, with the
+	// difference that it does not perform a Terraform version check of the
+	// state snapshot. Use with caution, as there is no guarantee that the
+	// state version retrieved is fully compatible.
+	RefreshStateWithoutCheckVersion() error
 }
 
 // Persister is the interface for managers that can write snapshots to

--- a/states/statemgr/statemgr_fake.go
+++ b/states/statemgr/statemgr_fake.go
@@ -61,6 +61,10 @@ func (m *fakeFull) RefreshState() error {
 	return m.t.WriteState(m.fakeP.State())
 }
 
+func (m *fakeFull) RefreshStateWithoutCheckVersion() error {
+	return m.t.WriteState(m.fakeP.State())
+}
+
 func (m *fakeFull) PersistState() error {
 	return m.fakeP.WriteState(m.t.State())
 }
@@ -116,6 +120,10 @@ func (m *fakeErrorFull) WriteState(s *states.State) error {
 }
 
 func (m *fakeErrorFull) RefreshState() error {
+	return errors.New("fake state manager error")
+}
+
+func (m *fakeErrorFull) RefreshStateWithoutCheckVersion() error {
 	return errors.New("fake state manager error")
 }
 


### PR DESCRIPTION
The builtin Terraform provider's remote state data source uses a configured backend to fetch a given state, in order to allow access to its root module outputs. Until this change, this was only possible with remote states which are from the current Terraform version or older, forcing multi-state users to carefully orchestrate Terraform upgrades.

We can now disable this version check, and allow any Terraform state file that the current Terraform version can parse. Since we are only ever accessing root module outputs, this is very likely to be safe for the foreseeable future.

### Notes to reviewers 📝 

I believe this PR will be easier to review one commit at a time. There is some detail in each commit message which may be worth reading. Each commit except the last one should be a no-op, and existing tests pass.

This specific implementation of this idea was intended to be as mechanically simple as possible, because it covers so many files which are difficult to test. The ambition is for reviewers to be confident enough in this change to approve back-porting it to earlier Terraform versions.

The addition of `RefreshStateWithoutCheckVersion` and `StateMgrWithoutCheckVersion` make me a bit uncomfortable, as does the need to remember to call `CheckVersion` after reading a state file wherever appropriate. Ideally I'd like to find another way to achieve this end result before merging this commit, so that we can have a cleaner interface for at least 0.15. That approach could be more invasive, as it would not need to be back-ported. I don't currently have any concrete ideas for this, though—suggestions very welcome!