### PR TITLE
Eval diagnostics

### DIFF
--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -924,7 +924,7 @@ func TestApply_shutdown(t *testing.T) {
 		"-auto-approve",
 		testFixturePath("apply-shutdown"),
 	}
-	if code := c.Run(args); code != 0 {
+	if code := c.Run(args); code != 1 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -845,12 +845,8 @@ func TestPlan_shutdown(t *testing.T) {
 		"-state=nonexistent.tfstate",
 		testFixturePath("apply-shutdown"),
 	})
-	if code != 0 {
-		// FIXME: In retrospect cancellation ought to be an unsuccessful exit
-		// case, but we need to do that cautiously in case it impacts automation
-		// wrappers. See the note about this in the terraform.stopHook
-		// implementation for more.
-		t.Errorf("wrong exit code %d; want 0\noutput:\n%s", code, ui.OutputWriter.String())
+	if code != 1 {
+		t.Errorf("wrong exit code %d; want 1\noutput:\n%s", code, ui.OutputWriter.String())
 	}
 
 	select {

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -1734,8 +1734,16 @@ func TestContext2Apply_cancel(t *testing.T) {
 	}()
 
 	state := <-stateCh
-	if applyDiags.HasErrors() {
-		t.Fatalf("unexpected errors: %s", applyDiags.Err())
+	// only expecting an early exit error
+	if !applyDiags.HasErrors() {
+		t.Fatal("expected early exit error")
+	}
+
+	for _, d := range applyDiags {
+		desc := d.Description()
+		if desc.Summary != "execution halted" {
+			t.Fatalf("unexpected error: %v", applyDiags.Err())
+		}
 	}
 
 	actual := strings.TrimSpace(state.String())
@@ -1812,8 +1820,16 @@ func TestContext2Apply_cancelBlock(t *testing.T) {
 
 	// Wait for apply to complete
 	state := <-stateCh
-	if applyDiags.HasErrors() {
-		t.Fatalf("unexpected error: %s", applyDiags.Err())
+	// only expecting an early exit error
+	if !applyDiags.HasErrors() {
+		t.Fatal("expected early exit error")
+	}
+
+	for _, d := range applyDiags {
+		desc := d.Description()
+		if desc.Summary != "execution halted" {
+			t.Fatalf("unexpected error: %v", applyDiags.Err())
+		}
 	}
 
 	checkStateString(t, state, `
@@ -1882,7 +1898,18 @@ func TestContext2Apply_cancelProvisioner(t *testing.T) {
 
 	// Wait for completion
 	state := <-stateCh
-	assertNoErrors(t, applyDiags)
+
+	// we are expecting only an early exit error
+	if !applyDiags.HasErrors() {
+		t.Fatal("expected early exit error")
+	}
+
+	for _, d := range applyDiags {
+		desc := d.Description()
+		if desc.Summary != "execution halted" {
+			t.Fatalf("unexpected error: %v", applyDiags.Err())
+		}
+	}
 
 	checkStateString(t, state, `
 aws_instance.foo: (tainted)

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -107,7 +107,7 @@ func (ctx *BuiltinEvalContext) Hook(fn func(Hook) (HookAction, error)) error {
 		case HookActionHalt:
 			// Return an early exit error to trigger an early exit
 			log.Printf("[WARN] Early exit triggered by hook: %T", h)
-			return EvalEarlyExitError{}
+			return nil
 		}
 	}
 

--- a/terraform/eval_error.go
+++ b/terraform/eval_error.go
@@ -1,7 +1,0 @@
-package terraform
-
-// EvalEarlyExitError is a special error return value that can be returned
-// by eval nodes that does an early exit.
-type EvalEarlyExitError struct{}
-
-func (EvalEarlyExitError) Error() string { return "early exit" }

--- a/terraform/eval_refresh.go
+++ b/terraform/eval_refresh.go
@@ -29,7 +29,7 @@ type EvalRefresh struct {
 }
 
 // TODO: test
-func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
+func (n *EvalRefresh) Eval(ctx EvalContext) tfdiags.Diagnostics {
 	state := *n.State
 	absAddr := n.Addr.Absolute(ctx.Path())
 
@@ -38,13 +38,14 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 	// If we have no state, we don't do any refreshing
 	if state == nil {
 		log.Printf("[DEBUG] refresh: %s: no state, so not refreshing", n.Addr.Absolute(ctx.Path()))
-		return nil, diags.ErrWithWarnings()
+		return diags
 	}
 
 	schema, _ := (*n.ProviderSchema).SchemaForResourceAddr(n.Addr.ContainingResource())
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
-		return nil, fmt.Errorf("provider does not support resource type %q", n.Addr.Resource.Type)
+		diags = diags.Append(fmt.Errorf("provider does not support resource type %q", n.Addr.Resource.Type))
+		return diags
 	}
 
 	metaConfigVal := cty.NullVal(cty.DynamicPseudoType)
@@ -66,18 +67,18 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 				metaConfigVal, _, configDiags = ctx.EvaluateBlock(m.Config, (*n.ProviderSchema).ProviderMeta, nil, EvalDataForNoInstanceKey)
 				diags = diags.Append(configDiags)
 				if configDiags.HasErrors() {
-					return nil, diags.Err()
+					return diags
 				}
 			}
 		}
 	}
 
 	// Call pre-refresh hook
-	err := ctx.Hook(func(h Hook) (HookAction, error) {
+	diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
 		return h.PreRefresh(absAddr, states.CurrentGen, state.Value)
-	})
-	if err != nil {
-		return nil, diags.ErrWithWarnings()
+	}))
+	if diags.HasErrors() {
+		return diags
 	}
 
 	// Refresh!
@@ -100,7 +101,7 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 	resp := provider.ReadResource(req)
 	diags = diags.Append(resp.Diagnostics)
 	if diags.HasErrors() {
-		return nil, diags.Err()
+		return diags
 	}
 
 	if resp.NewState == cty.NilVal {
@@ -121,7 +122,7 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 		))
 	}
 	if diags.HasErrors() {
-		return nil, diags.Err()
+		return diags
 	}
 
 	// We have no way to exempt provider using the legacy SDK from this check,
@@ -142,11 +143,11 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 	newState.CreateBeforeDestroy = state.CreateBeforeDestroy
 
 	// Call post-refresh hook
-	err = ctx.Hook(func(h Hook) (HookAction, error) {
+	diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
 		return h.PostRefresh(absAddr, states.CurrentGen, priorVal, newState.Value)
-	})
-	if err != nil {
-		return nil, err
+	}))
+	if diags.HasErrors() {
+		return diags
 	}
 
 	// Mark the value if necessary
@@ -158,5 +159,5 @@ func (n *EvalRefresh) Eval(ctx EvalContext) (interface{}, error) {
 		*n.Output = newState
 	}
 
-	return nil, diags.ErrWithWarnings()
+	return diags
 }

--- a/terraform/eval_state_test.go
+++ b/terraform/eval_state_test.go
@@ -67,15 +67,12 @@ func TestEvalReadState(t *testing.T) {
 			ctx.StateState = state.SyncWrapper()
 			ctx.PathPath = addrs.RootModuleInstance
 
-			result, err := c.Node.Eval(ctx)
-			if err != nil {
-				t.Fatalf("[%s] Got err: %#v", k, err)
+			diags := c.Node.Eval(ctx)
+			if diags.HasErrors() {
+				t.Fatalf("[%s] Got err: %#v", k, diags.ErrWithWarnings())
 			}
 
 			expected := c.ExpectedInstanceId
-			if !(result != nil && instanceObjectIdForTests(result.(*states.ResourceInstanceObject)) == expected) {
-				t.Fatalf("[%s] Expected return with ID %#v, got: %#v", k, expected, result)
-			}
 
 			if !(output != nil && output.Value.GetAttr("id") == cty.StringVal(expected)) {
 				t.Fatalf("[%s] Expected output with ID %#v, got: %#v", k, expected, output)
@@ -141,15 +138,12 @@ func TestEvalReadStateDeposed(t *testing.T) {
 			ctx.StateState = state.SyncWrapper()
 			ctx.PathPath = addrs.RootModuleInstance
 
-			result, err := c.Node.Eval(ctx)
-			if err != nil {
-				t.Fatalf("[%s] Got err: %#v", k, err)
+			diags := c.Node.Eval(ctx)
+			if diags.HasErrors() {
+				t.Fatalf("[%s] Got err: %#v", k, diags.ErrWithWarnings())
 			}
 
 			expected := c.ExpectedInstanceId
-			if !(result != nil && instanceObjectIdForTests(result.(*states.ResourceInstanceObject)) == expected) {
-				t.Fatalf("[%s] Expected return with ID %#v, got: %#v", k, expected, result)
-			}
 
 			if !(output != nil && output.Value.GetAttr("id") == cty.StringVal(expected)) {
 				t.Fatalf("[%s] Expected output with ID %#v, got: %#v", k, expected, output)
@@ -194,9 +188,9 @@ func TestEvalWriteState(t *testing.T) {
 		ProviderSchema: &providerSchema,
 		ProviderAddr:   addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewDefaultProvider("aws")),
 	}
-	_, err := node.Eval(ctx)
-	if err != nil {
-		t.Fatalf("Got err: %#v", err)
+	diags := node.Eval(ctx)
+	if diags.HasErrors() {
+		t.Fatalf("Got err: %#v", diags.ErrWithWarnings())
 	}
 
 	checkStateString(t, state, `
@@ -241,9 +235,9 @@ func TestEvalWriteStateDeposed(t *testing.T) {
 		ProviderSchema: &providerSchema,
 		ProviderAddr:   addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewDefaultProvider("aws")),
 	}
-	_, err := node.Eval(ctx)
-	if err != nil {
-		t.Fatalf("Got err: %#v", err)
+	diags := node.Eval(ctx)
+	if diags.HasErrors() {
+		t.Fatalf("Got err: %#v", diags.ErrWithWarnings())
 	}
 
 	checkStateString(t, state, `

--- a/terraform/eval_validate_selfref.go
+++ b/terraform/eval_validate_selfref.go
@@ -20,7 +20,7 @@ type EvalValidateSelfRef struct {
 	ProviderSchema **ProviderSchema
 }
 
-func (n *EvalValidateSelfRef) Eval(ctx EvalContext) (interface{}, error) {
+func (n *EvalValidateSelfRef) Eval(ctx EvalContext) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	addr := n.Addr
 
@@ -33,7 +33,8 @@ func (n *EvalValidateSelfRef) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	if n.ProviderSchema == nil || *n.ProviderSchema == nil {
-		return nil, fmt.Errorf("provider schema unavailable while validating %s for self-references; this is a bug in Terraform and should be reported", addr)
+		diags = diags.Append(fmt.Errorf("provider schema unavailable while validating %s for self-references; this is a bug in Terraform and should be reported", addr))
+		return diags
 	}
 
 	providerSchema := *n.ProviderSchema
@@ -46,7 +47,8 @@ func (n *EvalValidateSelfRef) Eval(ctx EvalContext) (interface{}, error) {
 	}
 
 	if schema == nil {
-		return nil, fmt.Errorf("no schema available for %s to validate for self-references; this is a bug in Terraform and should be reported", addr)
+		diags = diags.Append(fmt.Errorf("no schema available for %s to validate for self-references; this is a bug in Terraform and should be reported", addr))
+		return diags
 	}
 
 	refs, _ := lang.ReferencesInBlock(n.Config, schema)
@@ -63,5 +65,5 @@ func (n *EvalValidateSelfRef) Eval(ctx EvalContext) (interface{}, error) {
 		}
 	}
 
-	return nil, diags.NonFatalErr()
+	return diags
 }

--- a/terraform/eval_validate_selfref_test.go
+++ b/terraform/eval_validate_selfref_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/configs/configschema"
-	"github.com/hashicorp/terraform/tfdiags"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcltest"
@@ -98,11 +97,7 @@ func TestEvalValidateSelfRef(t *testing.T) {
 				Config:         body,
 				ProviderSchema: &ps,
 			}
-			result, err := n.Eval(nil)
-			if result != nil {
-				t.Fatal("result should always be nil")
-			}
-			diags := tfdiags.Diagnostics(nil).Append(err)
+			diags := n.Eval(nil)
 			if diags.HasErrors() != test.Err {
 				if test.Err {
 					t.Errorf("unexpected success; want error")

--- a/terraform/eval_variable.go
+++ b/terraform/eval_variable.go
@@ -18,13 +18,11 @@ import (
 // This must be used only after any side-effects that make the value of the
 // variable available for use in expression evaluation, such as
 // EvalModuleCallArgument for variables in descendent modules.
-func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *configs.Variable, expr hcl.Expression, ctx EvalContext) error {
+func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *configs.Variable, expr hcl.Expression, ctx EvalContext) (diags tfdiags.Diagnostics) {
 	if config == nil || len(config.Validations) == 0 {
 		log.Printf("[TRACE] evalVariableValidations: not active for %s, so skipping", addr)
 		return nil
 	}
-
-	var diags tfdiags.Diagnostics
 
 	// Variable nodes evaluate in the parent module to where they were declared
 	// because the value expression (n.Expr, if set) comes from the calling
@@ -105,5 +103,5 @@ func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *config
 		}
 	}
 
-	return diags.ErrWithWarnings()
+	return diags
 }

--- a/terraform/execute.go
+++ b/terraform/execute.go
@@ -1,9 +1,11 @@
 package terraform
 
+import "github.com/hashicorp/terraform/tfdiags"
+
 // GraphNodeExecutable is the interface that graph nodes must implement to
 // enable execution. This is an alternative to GraphNodeEvalable, which is in
 // the process of being removed. A given graph node should _not_ implement both
 // GraphNodeExecutable and GraphNodeEvalable.
 type GraphNodeExecutable interface {
-	Execute(EvalContext, walkOperation) error
+	Execute(EvalContext, walkOperation) tfdiags.Diagnostics
 }

--- a/terraform/graph_walk_context.go
+++ b/terraform/graph_walk_context.go
@@ -145,7 +145,6 @@ func (w *ContextGraphWalker) Execute(ctx EvalContext, n GraphNodeExecutable) tfd
 		return nil
 	}
 
-	//  If we early exit, it isn't an error.
 	if _, isEarlyExit := err.(EvalEarlyExitError); isEarlyExit {
 		return nil
 	}

--- a/terraform/graph_walk_context.go
+++ b/terraform/graph_walk_context.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"
@@ -145,16 +146,34 @@ func (w *ContextGraphWalker) Execute(ctx EvalContext, n GraphNodeExecutable) tfd
 		return nil
 	}
 
-	if _, isEarlyExit := err.(EvalEarlyExitError); isEarlyExit {
+	var diags tfdiags.Diagnostics
+
+	// Handle a simple early exit error
+	if errors.Is(err, EvalEarlyExitError{}) {
 		return nil
+	}
+
+	// we need to see if this wraps only EarlyExitErrors
+	if wrapper, ok := err.(interface{ WrappedErrors() []error }); ok {
+		//WrappedErrors only returns native error values, so we can't extract
+		//them from diagnostics. Just return the whole thing if we have a
+		//combination.
+		errs := wrapper.WrappedErrors()
+		earlyExit := true
+		for _, err := range errs {
+			if err != (EvalEarlyExitError{}) {
+				earlyExit = false
+			}
+		}
+		if len(errs) > 0 && earlyExit {
+			return nil
+		}
 	}
 
 	// Otherwise, we'll let our usual diagnostics machinery figure out how to
 	// unpack this as one or more diagnostic messages and return that. If we
 	// get down here then the returned diagnostics will contain at least one
 	// error, causing the graph walk to halt.
-	var diags tfdiags.Diagnostics
 	diags = diags.Append(err)
 	return diags
-
 }

--- a/terraform/hook_stop.go
+++ b/terraform/hook_stop.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"errors"
 	"sync/atomic"
 
 	"github.com/zclconf/go-cty/cty"
@@ -76,11 +77,7 @@ func (h *stopHook) PostStateUpdate(new *states.State) (HookAction, error) {
 
 func (h *stopHook) hook() (HookAction, error) {
 	if h.Stopped() {
-		// FIXME: This should really return an error since stopping partway
-		// through is not a successful run-to-completion, but we'll need to
-		// introduce that cautiously since existing automation solutions may
-		// be depending on this behavior.
-		return HookActionHalt, nil
+		return HookActionHalt, errors.New("execution halted")
 	}
 
 	return HookActionContinue, nil

--- a/terraform/node_count_boundary_test.go
+++ b/terraform/node_count_boundary_test.go
@@ -53,9 +53,9 @@ func TestNodeCountBoundaryExecute(t *testing.T) {
 	}
 	node := NodeCountBoundary{Config: config}
 
-	err := node.Execute(ctx, walkApply)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err.Error())
+	diags := node.Execute(ctx, walkApply)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %s", diags.Err())
 	}
 	if !state.HasResources() {
 		t.Fatal("resources missing from state")

--- a/terraform/node_data_destroy.go
+++ b/terraform/node_data_destroy.go
@@ -1,6 +1,10 @@
 package terraform
 
-import "log"
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/tfdiags"
+)
 
 // NodeDestroyableDataResourceInstance represents a resource that is "destroyable":
 // it is ready to be destroyed.
@@ -13,7 +17,7 @@ var (
 )
 
 // GraphNodeExecutable
-func (n *NodeDestroyableDataResourceInstance) Execute(ctx EvalContext, op walkOperation) error {
+func (n *NodeDestroyableDataResourceInstance) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	log.Printf("[TRACE] NodeDestroyableDataResourceInstance: removing state object for %s", n.Addr)
 	ctx.State().SetResourceInstanceCurrent(n.Addr, nil, n.ResolvedProvider)
 	return nil

--- a/terraform/node_data_destroy_test.go
+++ b/terraform/node_data_destroy_test.go
@@ -36,9 +36,9 @@ func TestNodeDataDestroyExecute(t *testing.T) {
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 	}}
 
-	err := node.Execute(ctx, walkApply)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err.Error())
+	diags := node.Execute(ctx, walkApply)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %v", diags.Err())
 	}
 
 	// verify resource removed from state

--- a/terraform/node_module_expand_test.go
+++ b/terraform/node_module_expand_test.go
@@ -42,9 +42,9 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 			StateState: state.SyncWrapper(),
 		}
 		node := nodeCloseModule{addrs.Module{"child"}}
-		err := node.Execute(ctx, walkApply)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err.Error())
+		diags := node.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
 		}
 
 		// Since module.child has no resources, it should be removed
@@ -62,9 +62,9 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 		}
 		node := nodeCloseModule{addrs.Module{"child"}}
 
-		err := node.Execute(ctx, walkImport)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err.Error())
+		diags := node.Execute(ctx, walkImport)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
 		}
 		if _, ok := state.Modules["module.child"]; !ok {
 			t.Fatal("module.child was removed from state, expected no-op")
@@ -87,9 +87,9 @@ func TestNodeValidateModuleExecute(t *testing.T) {
 			},
 		}
 
-		err := node.Execute(ctx, walkApply)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err.Error())
+		diags := node.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %v", diags.Err())
 		}
 	})
 

--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/dag"
 	"github.com/hashicorp/terraform/instances"
 	"github.com/hashicorp/terraform/lang"
+	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 )
@@ -141,7 +142,7 @@ func (n *nodeModuleVariable) ModulePath() addrs.Module {
 }
 
 // GraphNodeExecutable
-func (n *nodeModuleVariable) Execute(ctx EvalContext, op walkOperation) error {
+func (n *nodeModuleVariable) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	// If we have no value, do nothing
 	if n.Expr == nil {
 		return nil
@@ -155,13 +156,15 @@ func (n *nodeModuleVariable) Execute(ctx EvalContext, op walkOperation) error {
 	switch op {
 	case walkValidate:
 		vals, err = n.EvalModuleCallArgument(ctx, true)
-		if err != nil {
-			return err
+		diags = diags.Append(err)
+		if diags.HasErrors() {
+			return diags
 		}
 	default:
 		vals, err = n.EvalModuleCallArgument(ctx, false)
-		if err != nil {
-			return err
+		diags = diags.Append(err)
+		if diags.HasErrors() {
+			return diags
 		}
 	}
 

--- a/terraform/node_output_test.go
+++ b/terraform/node_output_test.go
@@ -81,11 +81,11 @@ func TestNodeApplyableOutputExecute_invalidDependsOn(t *testing.T) {
 	})
 	ctx.EvaluateExprResult = val
 
-	err := node.Execute(ctx, walkApply)
-	if err == nil {
+	diags := node.Execute(ctx, walkApply)
+	if !diags.HasErrors() {
 		t.Fatal("expected execute error, but there was none")
 	}
-	if got, want := err.Error(), "Invalid depends_on reference"; !strings.Contains(got, want) {
+	if got, want := diags.Err().Error(), "Invalid depends_on reference"; !strings.Contains(got, want) {
 		t.Errorf("expected error to include %q, but was: %s", want, got)
 	}
 }
@@ -102,11 +102,11 @@ func TestNodeApplyableOutputExecute_sensitiveValueNotOutput(t *testing.T) {
 	})
 	ctx.EvaluateExprResult = val
 
-	err := node.Execute(ctx, walkApply)
-	if err == nil {
+	diags := node.Execute(ctx, walkApply)
+	if !diags.HasErrors() {
 		t.Fatal("expected execute error, but there was none")
 	}
-	if got, want := err.Error(), "Output refers to sensitive values"; !strings.Contains(got, want) {
+	if got, want := diags.Err().Error(), "Output refers to sensitive values"; !strings.Contains(got, want) {
 		t.Errorf("expected error to include %q, but was: %s", want, got)
 	}
 }
@@ -151,9 +151,9 @@ func TestNodeDestroyableOutputExecute(t *testing.T) {
 	}
 	node := NodeDestroyableOutput{Addr: outputAddr}
 
-	err := node.Execute(ctx, walkApply)
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err.Error())
+	diags := node.Execute(ctx, walkApply)
+	if diags.HasErrors() {
+		t.Fatalf("Unexpected error: %s", diags.Err())
 	}
 	if state.OutputValue(outputAddr) != nil {
 		t.Fatal("Unexpected outputs in state after removal")

--- a/terraform/node_provider_eval.go
+++ b/terraform/node_provider_eval.go
@@ -1,5 +1,7 @@
 package terraform
 
+import "github.com/hashicorp/terraform/tfdiags"
+
 // NodeEvalableProvider represents a provider during an "eval" walk.
 // This special provider node type just initializes a provider and
 // fetches its schema, without configuring it or otherwise interacting
@@ -8,8 +10,10 @@ type NodeEvalableProvider struct {
 	*NodeAbstractProvider
 }
 
+var _ GraphNodeExecutable = (*NodeEvalableProvider)(nil)
+
 // GraphNodeExecutable
-func (n *NodeEvalableProvider) Execute(ctx EvalContext, op walkOperation) error {
+func (n *NodeEvalableProvider) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	_, err := ctx.InitProvider(n.Addr)
-	return err
+	return diags.Append(err)
 }

--- a/terraform/node_provider_test.go
+++ b/terraform/node_provider_test.go
@@ -65,13 +65,13 @@ func TestNodeApplyableProviderExecute_unknownImport(t *testing.T) {
 	ctx := &MockEvalContext{ProviderProvider: provider}
 	ctx.installSimpleEval()
 
-	err := n.Execute(ctx, walkImport)
-	if err == nil {
+	diags := n.Execute(ctx, walkImport)
+	if !diags.HasErrors() {
 		t.Fatal("expected error, got success")
 	}
 
 	detail := `Invalid provider configuration: The configuration for provider["registry.terraform.io/hashicorp/foo"] depends on values that cannot be determined until apply.`
-	if got, want := err.Error(), detail; got != want {
+	if got, want := diags.Err().Error(), detail; got != want {
 		t.Errorf("wrong diagnostic detail\n got: %q\nwant: %q", got, want)
 	}
 

--- a/terraform/node_provisioner.go
+++ b/terraform/node_provisioner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // NodeProvisioner represents a provider that has no associated operations.
@@ -39,6 +40,6 @@ func (n *NodeProvisioner) ProvisionerName() string {
 }
 
 // GraphNodeExecutable impl.
-func (n *NodeProvisioner) Execute(ctx EvalContext, op walkOperation) error {
-	return ctx.InitProvisioner(n.NameValue)
+func (n *NodeProvisioner) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+	return diags.Append(ctx.InitProvisioner(n.NameValue))
 }

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -305,8 +305,7 @@ func (n *NodeAbstractResource) DotNode(name string, opts *dag.DotOpts) *dag.DotN
 // eval is the only change we get to set the resource "each mode" to list
 // in that case, allowing expression evaluation to see it as a zero-element list
 // rather than as not set at all.
-func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.AbsResource) error {
-	var diags tfdiags.Diagnostics
+func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.AbsResource) (diags tfdiags.Diagnostics) {
 	state := ctx.State()
 
 	// We'll record our expansion decision in the shared "expander" object
@@ -320,7 +319,7 @@ func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.Ab
 		count, countDiags := evaluateCountExpression(n.Config.Count, ctx)
 		diags = diags.Append(countDiags)
 		if countDiags.HasErrors() {
-			return diags.Err()
+			return diags
 		}
 
 		state.SetResourceProvider(addr, n.ResolvedProvider)
@@ -330,7 +329,7 @@ func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.Ab
 		forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx)
 		diags = diags.Append(forEachDiags)
 		if forEachDiags.HasErrors() {
-			return diags.Err()
+			return diags
 		}
 
 		// This method takes care of all of the business logic of updating this
@@ -343,7 +342,7 @@ func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.Ab
 		expander.SetResourceSingle(addr.Module, n.Addr.Resource)
 	}
 
-	return nil
+	return diags
 }
 
 // ReadResourceInstanceState reads the current object for a specific instance in

--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/dag"
 	"github.com/hashicorp/terraform/lang"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // nodeExpandApplyableResource handles the first layer of resource
@@ -102,13 +103,12 @@ func (n *NodeApplyableResource) References() []*addrs.Reference {
 }
 
 // GraphNodeExecutable
-func (n *NodeApplyableResource) Execute(ctx EvalContext, op walkOperation) error {
+func (n *NodeApplyableResource) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	if n.Config == nil {
 		// Nothing to do, then.
 		log.Printf("[TRACE] NodeApplyableResource: no configuration present for %s", n.Name())
 		return nil
 	}
 
-	err := n.writeResourceState(ctx, n.Addr)
-	return err
+	return n.writeResourceState(ctx, n.Addr)
 }

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -187,9 +187,9 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) err
 		ProviderSchema: &providerSchema,
 		Change:         nil,
 	}
-	_, err = writeDiff.Eval(ctx)
-	if err != nil {
-		return err
+	diags := writeDiff.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	UpdateStateHook(ctx)
@@ -276,9 +276,9 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		OutputChange:   &diffApply,
 		OutputState:    &state,
 	}
-	_, err = evalDiff.Eval(ctx)
-	if err != nil {
-		return err
+	diags = evalDiff.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	// Compare the diffs
@@ -289,9 +289,9 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		Planned:        &diff,
 		Actual:         &diffApply,
 	}
-	_, err = checkPlannedChange.Eval(ctx)
-	if err != nil {
-		return err
+	diags = checkPlannedChange.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	readState = &EvalReadState{
@@ -312,9 +312,9 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		Destroy:   false,
 		OutChange: &diffApply,
 	}
-	_, err = reduceDiff.Eval(ctx)
-	if err != nil {
-		return err
+	diags = reduceDiff.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	// EvalReduceDiff may have simplified our planned change
@@ -361,9 +361,9 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		ProviderSchema: &providerSchema,
 		Change:         nil,
 	}
-	_, err = writeDiff.Eval(ctx)
-	if err != nil {
-		return err
+	diags = writeDiff.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	evalMaybeTainted := &EvalMaybeTainted{

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -178,9 +178,9 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) err
 		ProviderSchema: &providerSchema,
 		State:          &state,
 	}
-	_, err = writeState.Eval(ctx)
-	if err != nil {
-		return err
+	diags = writeState.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	writeDiff := &EvalWriteDiff{
@@ -239,9 +239,9 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			ForceKey:  n.PreallocatedDeposedKey,
 			OutputKey: &deposedKey,
 		}
-		_, err = deposeState.Eval(ctx)
-		if err != nil {
-			return err
+		diags = deposeState.Eval(ctx)
+		if diags.HasErrors() {
+			return diags.ErrWithWarnings()
 		}
 	}
 
@@ -252,9 +252,9 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 
 		Output: &state,
 	}
-	_, err = readState.Eval(ctx)
-	if err != nil {
-		return err
+	diags = readState.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	// Get the saved diff
@@ -302,9 +302,9 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 
 		Output: &state,
 	}
-	_, err = readState.Eval(ctx)
-	if err != nil {
-		return err
+	diags = readState.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	reduceDiff := &EvalReduceDiff{
@@ -385,9 +385,9 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		State:          &state,
 		Dependencies:   &n.Dependencies,
 	}
-	_, err = writeState.Eval(ctx)
-	if err != nil {
-		return err
+	diags = writeState.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	applyProvisioners := &EvalApplyProvisioners{
@@ -421,9 +421,9 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		State:          &state,
 		Dependencies:   &n.Dependencies,
 	}
-	_, err = writeState.Eval(ctx)
-	if err != nil {
-		return err
+	diags = writeState.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	if createBeforeDestroyEnabled && applyError != nil {
@@ -432,9 +432,9 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			PlannedChange: &diffApply,
 			Key:           &deposedKey,
 		}
-		_, err := maybeRestoreDesposedObject.Eval(ctx)
-		if err != nil {
-			return err
+		diags := maybeRestoreDesposedObject.Eval(ctx)
+		if diags.HasErrors() {
+			return diags.ErrWithWarnings()
 		}
 	}
 

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -148,7 +148,6 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 	}
 	// Stop early if we don't actually have a diff
 	if change == nil {
-		diags = diags.Append(EvalEarlyExitError{})
 		return diags
 	}
 
@@ -223,7 +222,6 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	// We don't want to do any destroys
 	// (these are handled by NodeDestroyResourceInstance instead)
 	if diffApply == nil || diffApply.Action == plans.Delete {
-		diags = diags.Append(EvalEarlyExitError{})
 		return diags
 	}
 
@@ -325,7 +323,6 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	// into a NoOp if it only requires destroying, since destroying
 	// is handled by NodeDestroyResourceInstance.
 	if diffApply == nil || diffApply.Action == plans.NoOp {
-		diags = diags.Append(EvalEarlyExitError{})
 		return diags
 	}
 

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -134,6 +134,7 @@ func (n *NodeApplyableResourceInstance) Execute(ctx EvalContext, op walkOperatio
 }
 
 func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) error {
+	var diags tfdiags.Diagnostics
 	addr := n.ResourceInstanceAddr().Resource
 
 	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
@@ -166,9 +167,9 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) err
 			State:          &state,
 		},
 	}
-	_, err = readDataApply.Eval(ctx)
-	if err != nil {
-		return err
+	diags = readDataApply.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	writeState := &EvalWriteState{
@@ -187,7 +188,7 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) err
 		ProviderSchema: &providerSchema,
 		Change:         nil,
 	}
-	diags := writeDiff.Eval(ctx)
+	diags = writeDiff.Eval(ctx)
 	if diags.HasErrors() {
 		return diags.ErrWithWarnings()
 	}

--- a/terraform/node_resource_apply_test.go
+++ b/terraform/node_resource_apply_test.go
@@ -23,9 +23,9 @@ func TestNodeApplyableResourceExecute(t *testing.T) {
 			},
 			Addr: mustAbsResourceAddr("test_instance.foo"),
 		}
-		err := node.Execute(ctx, walkApply)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err.Error())
+		diags := node.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
 		}
 		if !state.Empty() {
 			t.Fatalf("expected no state, got:\n %s", state.String())
@@ -48,9 +48,9 @@ func TestNodeApplyableResourceExecute(t *testing.T) {
 			},
 			Addr: mustAbsResourceAddr("test_instance.foo"),
 		}
-		err := node.Execute(ctx, walkApply)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err.Error())
+		diags := node.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
 		}
 		if state.Empty() {
 			t.Fatal("expected resources in state, got empty state")

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -155,9 +155,9 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 		Destroy:   true,
 		OutChange: &changeApply,
 	}
-	_, err = evalReduceDiff.Eval(ctx)
-	if err != nil {
-		return err
+	diags = evalReduceDiff.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	// EvalReduceDiff may have simplified our planned change

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -163,7 +163,6 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 	// EvalReduceDiff may have simplified our planned change
 	// into a NoOp if it does not require destroying.
 	if changeApply == nil || changeApply.Action == plans.NoOp {
-		diags = diags.Append(EvalEarlyExitError{})
 		return diags
 	}
 
@@ -175,7 +174,6 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 
 	// Exit early if the state object is null after reading the state
 	if state == nil || state.Value.IsNull() {
-		diags = diags.Append(EvalEarlyExitError{})
 		return diags
 	}
 

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -240,9 +240,9 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 			ProviderSchema: &providerSchema,
 			State:          &state,
 		}
-		_, err = evalWriteState.Eval(ctx)
-		if err != nil {
-			return err
+		diags = evalWriteState.Eval(ctx)
+		if diags.HasErrors() {
+			return diags.ErrWithWarnings()
 		}
 	} else {
 		log.Printf("[TRACE] NodeDestroyResourceInstance: removing state object for %s", n.Addr)

--- a/terraform/node_resource_destroy_deposed.go
+++ b/terraform/node_resource_destroy_deposed.go
@@ -65,6 +65,8 @@ func (n *NodePlanDeposedResourceInstanceObject) References() []*addrs.Reference 
 
 // GraphNodeEvalable impl.
 func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) error {
+	var diags tfdiags.Diagnostics
+
 	addr := n.ResourceInstanceAddr()
 
 	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
@@ -84,9 +86,9 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walk
 		Provider:       &provider,
 		ProviderSchema: &providerSchema,
 	}
-	_, err = readStateDeposed.Eval(ctx)
-	if err != nil {
-		return err
+	diags = readStateDeposed.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	diffDestroy := &EvalDiffDestroy{
@@ -96,7 +98,7 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walk
 		State:        &state,
 		Output:       &change,
 	}
-	diags := diffDestroy.Eval(ctx)
+	diags = diffDestroy.Eval(ctx)
 	if diags.HasErrors() {
 		return diags.ErrWithWarnings()
 	}
@@ -203,9 +205,9 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		Provider:       &provider,
 		ProviderSchema: &providerSchema,
 	}
-	_, err = readStateDeposed.Eval(ctx)
-	if err != nil {
-		return err
+	diags = readStateDeposed.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	diffDestroy := &EvalDiffDestroy{
@@ -256,9 +258,9 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		ProviderSchema: &providerSchema,
 		State:          &state,
 	}
-	_, err = writeStateDeposed.Eval(ctx)
-	if err != nil {
-		return err
+	diags = writeStateDeposed.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	applyPost := &EvalApplyPost{

--- a/terraform/node_resource_destroy_deposed.go
+++ b/terraform/node_resource_destroy_deposed.go
@@ -96,9 +96,9 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walk
 		State:        &state,
 		Output:       &change,
 	}
-	_, err = diffDestroy.Eval(ctx)
-	if err != nil {
-		return err
+	diags := diffDestroy.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	writeDiff := &EvalWriteDiff{
@@ -107,9 +107,9 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walk
 		ProviderSchema: &providerSchema,
 		Change:         &change,
 	}
-	_, err = writeDiff.Eval(ctx)
-	if err != nil {
-		return err
+	diags = writeDiff.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	return nil
@@ -214,9 +214,9 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		State:        &state,
 		Output:       &change,
 	}
-	_, err = diffDestroy.Eval(ctx)
-	if err != nil {
-		return err
+	diags = diffDestroy.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	// Call pre-apply hook

--- a/terraform/node_resource_destroy_deposed.go
+++ b/terraform/node_resource_destroy_deposed.go
@@ -64,14 +64,13 @@ func (n *NodePlanDeposedResourceInstanceObject) References() []*addrs.Reference 
 }
 
 // GraphNodeEvalable impl.
-func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) error {
-	var diags tfdiags.Diagnostics
-
+func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
 	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
-	if err != nil {
-		return err
+	diags = diags.Append(err)
+	if diags.HasErrors() {
+		return diags
 	}
 
 	// During the plan walk we always produce a planned destroy change, because
@@ -86,9 +85,9 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walk
 		Provider:       &provider,
 		ProviderSchema: &providerSchema,
 	}
-	diags = readStateDeposed.Eval(ctx)
+	diags = diags.Append(readStateDeposed.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	diffDestroy := &EvalDiffDestroy{
@@ -98,9 +97,9 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walk
 		State:        &state,
 		Output:       &change,
 	}
-	diags = diffDestroy.Eval(ctx)
+	diags = diags.Append(diffDestroy.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	writeDiff := &EvalWriteDiff{
@@ -109,12 +108,8 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walk
 		ProviderSchema: &providerSchema,
 		Change:         &change,
 	}
-	diags = writeDiff.Eval(ctx)
-	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
-	}
-
-	return nil
+	diags = diags.Append(writeDiff.Eval(ctx))
+	return diags
 }
 
 // NodeDestroyDeposedResourceInstanceObject represents deposed resource
@@ -184,9 +179,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) ModifyCreateBeforeDestroy(v b
 }
 
 // GraphNodeExecutable impl.
-func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) error {
-	var diags tfdiags.Diagnostics
-
+func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr().Resource
 
 	var state *states.ResourceInstanceObject
@@ -194,8 +187,9 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 	var applyError error
 
 	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
-	if err != nil {
-		return err
+	diags = diags.Append(err)
+	if diags.HasErrors() {
+		return diags
 	}
 
 	readStateDeposed := &EvalReadStateDeposed{
@@ -205,9 +199,9 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		Provider:       &provider,
 		ProviderSchema: &providerSchema,
 	}
-	diags = readStateDeposed.Eval(ctx)
+	diags = diags.Append(readStateDeposed.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	diffDestroy := &EvalDiffDestroy{
@@ -216,9 +210,9 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		State:        &state,
 		Output:       &change,
 	}
-	diags = diffDestroy.Eval(ctx)
+	diags = diags.Append(diffDestroy.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	// Call pre-apply hook
@@ -227,9 +221,9 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		State:  &state,
 		Change: &change,
 	}
-	diags = applyPre.Eval(ctx)
+	diags = diags.Append(applyPre.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	apply := &EvalApply{
@@ -243,9 +237,9 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		Output:         &state,
 		Error:          &applyError,
 	}
-	diags = apply.Eval(ctx)
+	diags = diags.Append(apply.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	// Always write the resource back to the state deposed. If it
@@ -258,9 +252,9 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		ProviderSchema: &providerSchema,
 		State:          &state,
 	}
-	diags = writeStateDeposed.Eval(ctx)
+	diags = diags.Append(writeStateDeposed.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	applyPost := &EvalApplyPost{
@@ -268,15 +262,16 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		State: &state,
 		Error: &applyError,
 	}
-	diags = applyPost.Eval(ctx)
+	diags = diags.Append(applyPost.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 	if applyError != nil {
-		return applyError
+		diags = diags.Append(applyError)
+		return diags
 	}
-	UpdateStateHook(ctx)
-	return nil
+	diags = diags.Append(UpdateStateHook(ctx))
+	return diags
 }
 
 // GraphNodeDeposer is an optional interface implemented by graph nodes that

--- a/terraform/node_resource_plan.go
+++ b/terraform/node_resource_plan.go
@@ -178,15 +178,14 @@ func (n *NodePlannableResource) ModuleInstance() addrs.ModuleInstance {
 }
 
 // GraphNodeExecutable
-func (n *NodePlannableResource) Execute(ctx EvalContext, op walkOperation) error {
+func (n *NodePlannableResource) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	if n.Config == nil {
 		// Nothing to do, then.
 		log.Printf("[TRACE] NodeApplyableResource: no configuration present for %s", n.Name())
 		return nil
 	}
 
-	err := n.writeResourceState(ctx, n.Addr)
-	return err
+	return n.writeResourceState(ctx, n.Addr)
 }
 
 // GraphNodeDestroyerCBD

--- a/terraform/node_resource_plan_destroy.go
+++ b/terraform/node_resource_plan_destroy.go
@@ -57,9 +57,9 @@ func (n *NodePlanDestroyableResourceInstance) Execute(ctx EvalContext, op walkOp
 		State:        &state,
 		Output:       &change,
 	}
-	_, err = diffDestroy.Eval(ctx)
-	if err != nil {
-		return err
+	diags := diffDestroy.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	err = n.checkPreventDestroy(change)
@@ -72,6 +72,6 @@ func (n *NodePlanDestroyableResourceInstance) Execute(ctx EvalContext, op walkOp
 		ProviderSchema: &providerSchema,
 		Change:         &change,
 	}
-	_, err = writeDiff.Eval(ctx)
-	return err
+	diags = writeDiff.Eval(ctx)
+	return diags.ErrWithWarnings()
 }

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -119,8 +119,8 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 		ProviderSchema: &providerSchema,
 		Change:         &change,
 	}
-	_, err = writeDiff.Eval(ctx)
-	return err
+	diags := writeDiff.Eval(ctx)
+	return diags.ErrWithWarnings()
 }
 
 func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) error {
@@ -204,9 +204,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		OutputChange:        &change,
 		OutputState:         &instancePlanState,
 	}
-	_, err = diff.Eval(ctx)
-	if err != nil {
-		return err
+	diags := diff.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	err = n.checkPreventDestroy(change)
@@ -230,6 +230,6 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		ProviderSchema: &providerSchema,
 		Change:         &change,
 	}
-	_, err = writeDiff.Eval(ctx)
-	return err
+	diags = writeDiff.Eval(ctx)
+	return diags.ErrWithWarnings()
 }

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -68,9 +68,9 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 		Config:         config.Config,
 		ProviderSchema: &providerSchema,
 	}
-	_, err = validateSelfRef.Eval(ctx)
-	if err != nil {
-		return err
+	diags = validateSelfRef.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	readDataPlan := &evalReadDataPlan{
@@ -144,9 +144,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		Config:         config.Config,
 		ProviderSchema: &providerSchema,
 	}
-	_, err = validateSelfRef.Eval(ctx)
-	if err != nil {
-		return err
+	diags = validateSelfRef.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	instanceRefreshState, err = n.ReadResourceInstanceState(ctx, addr)

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -174,9 +174,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			State:          &instanceRefreshState,
 			Output:         &instanceRefreshState,
 		}
-		_, err = refresh.Eval(ctx)
-		if err != nil {
-			return err
+		diags := refresh.Eval(ctx)
+		if diags.HasErrors() {
+			return diags.ErrWithWarnings()
 		}
 
 		writeRefreshState := &EvalWriteState{

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -31,7 +31,7 @@ var (
 )
 
 // GraphNodeEvalable
-func (n *NodePlannableResourceInstance) Execute(ctx EvalContext, op walkOperation) error {
+func (n *NodePlannableResourceInstance) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	addr := n.ResourceInstanceAddr()
 
 	// Eval info is different depending on what kind of resource this is
@@ -45,8 +45,7 @@ func (n *NodePlannableResourceInstance) Execute(ctx EvalContext, op walkOperatio
 	}
 }
 
-func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) error {
-	var diags tfdiags.Diagnostics
+func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {
 	config := n.Config
 	addr := n.ResourceInstanceAddr()
 
@@ -54,13 +53,15 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 	var state *states.ResourceInstanceObject
 
 	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
-	if err != nil {
-		return err
+	diags = diags.Append(err)
+	if diags.HasErrors() {
+		return diags
 	}
 
 	state, err = n.ReadResourceInstanceState(ctx, addr)
-	if err != nil {
-		return err
+	diags = diags.Append(err)
+	if diags.HasErrors() {
+		return diags
 	}
 
 	validateSelfRef := &EvalValidateSelfRef{
@@ -68,9 +69,9 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 		Config:         config.Config,
 		ProviderSchema: &providerSchema,
 	}
-	diags = validateSelfRef.Eval(ctx)
+	diags = diags.Append(validateSelfRef.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	readDataPlan := &evalReadDataPlan{
@@ -86,9 +87,9 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 			dependsOn:      n.dependsOn,
 		},
 	}
-	diags = readDataPlan.Eval(ctx)
+	diags = diags.Append(readDataPlan.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	// write the data source into both the refresh state and the
@@ -100,9 +101,9 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 		State:          &state,
 		targetState:    refreshState,
 	}
-	diags = writeRefreshState.Eval(ctx)
+	diags = diags.Append(writeRefreshState.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	writeState := &EvalWriteState{
@@ -111,9 +112,9 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 		ProviderSchema: &providerSchema,
 		State:          &state,
 	}
-	diags = writeState.Eval(ctx)
+	diags = diags.Append(writeState.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	writeDiff := &EvalWriteDiff{
@@ -121,12 +122,11 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 		ProviderSchema: &providerSchema,
 		Change:         &change,
 	}
-	diags = writeDiff.Eval(ctx)
-	return diags.ErrWithWarnings()
+	diags = diags.Append(writeDiff.Eval(ctx))
+	return diags
 }
 
-func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) error {
-	var diags tfdiags.Diagnostics
+func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {
 	config := n.Config
 	addr := n.ResourceInstanceAddr()
 
@@ -135,8 +135,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	var instancePlanState *states.ResourceInstanceObject
 
 	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
-	if err != nil {
-		return err
+	diags = diags.Append(err)
+	if diags.HasErrors() {
+		return diags
 	}
 
 	validateSelfRef := &EvalValidateSelfRef{
@@ -144,14 +145,15 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		Config:         config.Config,
 		ProviderSchema: &providerSchema,
 	}
-	diags = validateSelfRef.Eval(ctx)
+	diags = diags.Append(validateSelfRef.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	instanceRefreshState, err = n.ReadResourceInstanceState(ctx, addr)
-	if err != nil {
-		return err
+	diags = diags.Append(err)
+	if diags.HasErrors() {
+		return diags
 	}
 	refreshLifecycle := &EvalRefreshLifecycle{
 		Addr:                     addr,
@@ -159,9 +161,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		State:                    &instanceRefreshState,
 		ForceCreateBeforeDestroy: n.ForceCreateBeforeDestroy,
 	}
-	diags = refreshLifecycle.Eval(ctx)
+	diags = diags.Append(refreshLifecycle.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	// Refresh, maybe
@@ -175,9 +177,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			State:          &instanceRefreshState,
 			Output:         &instanceRefreshState,
 		}
-		diags := refresh.Eval(ctx)
+		diags := diags.Append(refresh.Eval(ctx))
 		if diags.HasErrors() {
-			return diags.ErrWithWarnings()
+			return diags
 		}
 
 		writeRefreshState := &EvalWriteState{
@@ -188,9 +190,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			targetState:    refreshState,
 			Dependencies:   &n.Dependencies,
 		}
-		diags = writeRefreshState.Eval(ctx)
+		diags = diags.Append(writeRefreshState.Eval(ctx))
 		if diags.HasErrors() {
-			return diags.ErrWithWarnings()
+			return diags
 		}
 	}
 
@@ -207,14 +209,14 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		OutputChange:        &change,
 		OutputState:         &instancePlanState,
 	}
-	diags = diff.Eval(ctx)
+	diags = diags.Append(diff.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
-	err = n.checkPreventDestroy(change)
-	if err != nil {
-		return err
+	diags = diags.Append(n.checkPreventDestroy(change))
+	if diags.HasErrors() {
+		return diags
 	}
 
 	writeState := &EvalWriteState{
@@ -223,9 +225,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		State:          &instancePlanState,
 		ProviderSchema: &providerSchema,
 	}
-	diags = writeState.Eval(ctx)
+	diags = diags.Append(writeState.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	writeDiff := &EvalWriteDiff{
@@ -233,6 +235,6 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		ProviderSchema: &providerSchema,
 		Change:         &change,
 	}
-	diags = writeDiff.Eval(ctx)
-	return diags.ErrWithWarnings()
+	diags = diags.Append(writeDiff.Eval(ctx))
+	return diags
 }

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -100,9 +100,9 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 		State:          &state,
 		targetState:    refreshState,
 	}
-	_, err = writeRefreshState.Eval(ctx)
-	if err != nil {
-		return err
+	diags = writeRefreshState.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	writeState := &EvalWriteState{
@@ -111,9 +111,9 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 		ProviderSchema: &providerSchema,
 		State:          &state,
 	}
-	_, err = writeState.Eval(ctx)
-	if err != nil {
-		return err
+	diags = writeState.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	writeDiff := &EvalWriteDiff{
@@ -126,6 +126,7 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) err
 }
 
 func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) error {
+	var diags tfdiags.Diagnostics
 	config := n.Config
 	addr := n.ResourceInstanceAddr()
 
@@ -158,9 +159,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		State:                    &instanceRefreshState,
 		ForceCreateBeforeDestroy: n.ForceCreateBeforeDestroy,
 	}
-	_, err = refreshLifecycle.Eval(ctx)
-	if err != nil {
-		return err
+	diags = refreshLifecycle.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	// Refresh, maybe
@@ -187,9 +188,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			targetState:    refreshState,
 			Dependencies:   &n.Dependencies,
 		}
-		_, err = writeRefreshState.Eval(ctx)
-		if err != nil {
-			return err
+		diags = writeRefreshState.Eval(ctx)
+		if diags.HasErrors() {
+			return diags.ErrWithWarnings()
 		}
 	}
 
@@ -206,7 +207,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		OutputChange:        &change,
 		OutputState:         &instancePlanState,
 	}
-	diags := diff.Eval(ctx)
+	diags = diff.Eval(ctx)
 	if diags.HasErrors() {
 		return diags.ErrWithWarnings()
 	}
@@ -222,9 +223,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		State:          &instancePlanState,
 		ProviderSchema: &providerSchema,
 	}
-	_, err = writeState.Eval(ctx)
-	if err != nil {
-		return err
+	diags = writeState.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	writeDiff := &EvalWriteDiff{

--- a/terraform/node_resource_plan_orphan.go
+++ b/terraform/node_resource_plan_orphan.go
@@ -104,9 +104,9 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 			State:          &state,
 			targetState:    refreshState,
 		}
-		_, err = writeRefreshState.Eval(ctx)
-		if err != nil {
-			return err
+		diags = writeRefreshState.Eval(ctx)
+		if diags.HasErrors() {
+			return diags.ErrWithWarnings()
 		}
 	}
 
@@ -143,9 +143,9 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 		ProviderSchema: &providerSchema,
 		State:          &state,
 	}
-	_, err = writeState.Eval(ctx)
-	if err != nil {
-		return err
+	diags = writeState.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 	return nil
 }

--- a/terraform/node_resource_plan_orphan.go
+++ b/terraform/node_resource_plan_orphan.go
@@ -114,9 +114,9 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 		Output:       &change,
 		OutputState:  &state, // Will point to a nil state after this complete, signalling destroyed
 	}
-	_, err = diffDestroy.Eval(ctx)
+	diags := diffDestroy.Eval(ctx)
 	if err != nil {
-		return err
+		return diags.ErrWithWarnings()
 	}
 
 	err = n.checkPreventDestroy(change)
@@ -129,9 +129,9 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 		ProviderSchema: &providerSchema,
 		Change:         &change,
 	}
-	_, err = writeDiff.Eval(ctx)
-	if err != nil {
-		return err
+	diags = writeDiff.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	writeState := &EvalWriteState{

--- a/terraform/node_resource_plan_orphan_test.go
+++ b/terraform/node_resource_plan_orphan_test.go
@@ -55,9 +55,9 @@ func TestNodeResourcePlanOrphanExecute(t *testing.T) {
 			Addr: mustResourceInstanceAddr("test_object.foo"),
 		},
 	}
-	err := node.Execute(ctx, walkApply)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err.Error())
+	diags := node.Execute(ctx, walkApply)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %s", diags.Err())
 	}
 	if !state.Empty() {
 		t.Fatalf("expected empty state, got %s", state.String())

--- a/terraform/node_resource_plan_test.go
+++ b/terraform/node_resource_plan_test.go
@@ -23,9 +23,9 @@ func TestNodePlannableResourceExecute(t *testing.T) {
 			},
 			Addr: mustAbsResourceAddr("test_instance.foo"),
 		}
-		err := node.Execute(ctx, walkApply)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err.Error())
+		diags := node.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
 		}
 		if !state.Empty() {
 			t.Fatalf("expected no state, got:\n %s", state.String())
@@ -48,9 +48,9 @@ func TestNodePlannableResourceExecute(t *testing.T) {
 			},
 			Addr: mustAbsResourceAddr("test_instance.foo"),
 		}
-		err := node.Execute(ctx, walkApply)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err.Error())
+		diags := node.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
 		}
 		if state.Empty() {
 			t.Fatal("expected resources in state, got empty state")

--- a/terraform/node_root_variable.go
+++ b/terraform/node_root_variable.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/dag"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // NodeRootVariable represents a root variable input.
@@ -36,7 +37,7 @@ func (n *NodeRootVariable) ReferenceableAddrs() []addrs.Referenceable {
 }
 
 // GraphNodeExecutable
-func (n *NodeRootVariable) Execute(ctx EvalContext, op walkOperation) error {
+func (n *NodeRootVariable) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	// We don't actually need to _evaluate_ a root module variable, because
 	// its value is always constant and already stashed away in our EvalContext.
 	// However, we might need to run some user-defined validation rules against

--- a/terraform/node_root_variable_test.go
+++ b/terraform/node_root_variable_test.go
@@ -17,9 +17,9 @@ func TestNodeRootVariableExecute(t *testing.T) {
 		},
 	}
 
-	err := n.Execute(ctx, walkApply)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err.Error())
+	diags := n.Execute(ctx, walkApply)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %s", diags.Err())
 	}
 
 }

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -116,25 +116,25 @@ func (n *graphNodeImportState) ModulePath() addrs.Module {
 }
 
 // GraphNodeExecutable impl.
-func (n *graphNodeImportState) Execute(ctx EvalContext, op walkOperation) error {
+func (n *graphNodeImportState) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	// Reset our states
 	n.states = nil
 
 	provider, _, err := GetProvider(ctx, n.ResolvedProvider)
-	if err != nil {
-		return err
+	diags = diags.Append(err)
+	if diags.HasErrors() {
+		return diags
 	}
 
 	// import state
 	absAddr := n.Addr.Resource.Absolute(ctx.Path())
-	var diags tfdiags.Diagnostics
 
 	// Call pre-import hook
-	err = ctx.Hook(func(h Hook) (HookAction, error) {
+	diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
 		return h.PreImportState(absAddr, n.ID)
-	})
-	if err != nil {
-		return err
+	}))
+	if diags.HasErrors() {
+		return diags
 	}
 
 	resp := provider.ImportResourceState(providers.ImportResourceStateRequest{
@@ -143,7 +143,7 @@ func (n *graphNodeImportState) Execute(ctx EvalContext, op walkOperation) error 
 	})
 	diags = diags.Append(resp.Diagnostics)
 	if diags.HasErrors() {
-		return diags.Err()
+		return diags
 	}
 
 	imported := resp.ImportedResources
@@ -153,10 +153,10 @@ func (n *graphNodeImportState) Execute(ctx EvalContext, op walkOperation) error 
 	n.states = imported
 
 	// Call post-import hook
-	err = ctx.Hook(func(h Hook) (HookAction, error) {
+	diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
 		return h.PostImportState(absAddr, imported)
-	})
-	return err
+	}))
+	return diags
 }
 
 // GraphNodeDynamicExpandable impl.
@@ -259,17 +259,18 @@ func (n *graphNodeImportStateSub) Path() addrs.ModuleInstance {
 }
 
 // GraphNodeExecutable impl.
-func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) error {
-	var diags tfdiags.Diagnostics
+func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	// If the Ephemeral type isn't set, then it is an error
 	if n.State.TypeName == "" {
-		return fmt.Errorf("import of %s didn't set type", n.TargetAddr.String())
+		diags = diags.Append(fmt.Errorf("import of %s didn't set type", n.TargetAddr.String()))
+		return diags
 	}
 
 	state := n.State.AsInstanceObject()
 	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
-	if err != nil {
-		return err
+	diags = diags.Append(err)
+	if diags.HasErrors() {
+		return diags
 	}
 
 	// EvalRefresh
@@ -281,9 +282,9 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) err
 		State:          &state,
 		Output:         &state,
 	}
-	diags = evalRefresh.Eval(ctx)
+	diags = diags.Append(evalRefresh.Eval(ctx))
 	if diags.HasErrors() {
-		return diags.ErrWithWarnings()
+		return diags
 	}
 
 	// Verify the existance of the imported resource
@@ -296,7 +297,7 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) err
 				n.TargetAddr.Resource.String(),
 			),
 		))
-		return diags.Err()
+		return diags
 	}
 
 	//EvalWriteState
@@ -307,5 +308,5 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) err
 		State:          &state,
 	}
 	diags = diags.Append(evalWriteState.Eval(ctx))
-	return diags.ErrWithWarnings()
+	return diags
 }

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -280,9 +280,9 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) err
 		State:          &state,
 		Output:         &state,
 	}
-	_, err = evalRefresh.Eval(ctx)
-	if err != nil {
-		return err
+	diags := evalRefresh.Eval(ctx)
+	if diags.HasErrors() {
+		return diags.ErrWithWarnings()
 	}
 
 	// Verify the existance of the imported resource

--- a/terraform/transform_import_state_test.go
+++ b/terraform/transform_import_state_test.go
@@ -41,9 +41,9 @@ func TestGraphNodeImportStateExecute(t *testing.T) {
 		},
 	}
 
-	err := node.Execute(ctx, walkImport)
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err.Error())
+	diags := node.Execute(ctx, walkImport)
+	if diags.HasErrors() {
+		t.Fatalf("Unexpected error: %s", diags.Err())
 	}
 
 	if len(node.states) != 1 {
@@ -93,9 +93,9 @@ func TestGraphNodeImportStateSubExecute(t *testing.T) {
 			Module:   addrs.RootModule,
 		},
 	}
-	err := node.Execute(ctx, walkImport)
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err.Error())
+	diags := node.Execute(ctx, walkImport)
+	if diags.HasErrors() {
+		t.Fatalf("Unexpected error: %s", diags.Err())
 	}
 
 	// check for resource in state

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -449,6 +449,7 @@ type graphNodeCloseProvider struct {
 
 var (
 	_ GraphNodeCloseProvider = (*graphNodeCloseProvider)(nil)
+	_ GraphNodeExecutable    = (*graphNodeCloseProvider)(nil)
 )
 
 func (n *graphNodeCloseProvider) Name() string {
@@ -461,8 +462,8 @@ func (n *graphNodeCloseProvider) ModulePath() addrs.Module {
 }
 
 // GraphNodeExecutable impl.
-func (n *graphNodeCloseProvider) Execute(ctx EvalContext, op walkOperation) error {
-	return ctx.CloseProvider(n.Addr)
+func (n *graphNodeCloseProvider) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+	return diags.Append(ctx.CloseProvider(n.Addr))
 }
 
 // GraphNodeDependable impl.

--- a/terraform/transform_provisioner.go
+++ b/terraform/transform_provisioner.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/dag"
+	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // GraphNodeProvisioner is an interface that nodes that can be a provisioner
@@ -165,13 +166,15 @@ type graphNodeCloseProvisioner struct {
 	ProvisionerNameValue string
 }
 
+var _ GraphNodeExecutable = (*graphNodeCloseProvisioner)(nil)
+
 func (n *graphNodeCloseProvisioner) Name() string {
 	return fmt.Sprintf("provisioner.%s (close)", n.ProvisionerNameValue)
 }
 
 // GraphNodeExecutable impl.
-func (n *graphNodeCloseProvisioner) Execute(ctx EvalContext, op walkOperation) error {
-	return ctx.CloseProvisioner(n.ProvisionerNameValue)
+func (n *graphNodeCloseProvisioner) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+	return diags.Append(ctx.CloseProvisioner(n.ProvisionerNameValue))
 }
 
 func (n *graphNodeCloseProvisioner) CloseProvisionerName() string {


### PR DESCRIPTION
This completes the diagnostics portion of the Eval node refactor. Diagnostics are now maintained from the RPC calls all the way through core error handling. The most noticeable external benefit to this is that warnings from plugins can now be passed all the way through to the UI even when there are no accompanying errors for them to piggy-back on.

We do have a change in behavior to note however. Not using raw errors during eval makes it much harder to hide the error that was being used to stop execution when there's an interrupt. This however may not be an issue, since a partial execution should not result in a 0 exit code, and most unix process in general exit with a non-0 code when interrupted. Merging this early in the 0.15 development cycle gives us time to evaluate the change, and assess if we need to work on another method to hide that error.

Also closes #26680