### PR TITLE
Unmark values before showing in JSON

### DIFF
--- a/command/jsonstate/state.go
+++ b/command/jsonstate/state.go
@@ -9,7 +9,6 @@ import (
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/hashicorp/terraform/addrs"
-	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statefile"
 	"github.com/hashicorp/terraform/terraform"
@@ -100,7 +99,10 @@ type resource struct {
 // resource, whose structure depends on the resource type schema.
 type attributeValues map[string]interface{}
 
-func marshalAttributeValues(value cty.Value, schema *configschema.Block) attributeValues {
+func marshalAttributeValues(value cty.Value) attributeValues {
+	// unmark our value to show all values
+	value, _ = value.UnmarkDeep()
+
 	if value == cty.NilVal || value.IsNull() {
 		return nil
 	}
@@ -295,7 +297,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 					return nil, err
 				}
 
-				current.AttributeValues = marshalAttributeValues(riObj.Value, schema)
+				current.AttributeValues = marshalAttributeValues(riObj.Value)
 
 				if len(riObj.Dependencies) > 0 {
 					dependencies := make([]string, len(riObj.Dependencies))
@@ -327,7 +329,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 					return nil, err
 				}
 
-				deposed.AttributeValues = marshalAttributeValues(riObj.Value, schema)
+				deposed.AttributeValues = marshalAttributeValues(riObj.Value)
 
 				if len(riObj.Dependencies) > 0 {
 					dependencies := make([]string, len(riObj.Dependencies))

--- a/command/testdata/show-json-state/sensitive-variables/output.json
+++ b/command/testdata/show-json-state/sensitive-variables/output.json
@@ -1,0 +1,22 @@
+{
+    "format_version": "0.1",
+    "terraform_version": "0.14.0",
+    "values": {
+        "root_module": {
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
+                    "schema_version": 0,
+                    "values": {
+                        "id": "621124146446964903",
+                        "ami": "abc"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/command/testdata/show-json-state/sensitive-variables/terraform.tfstate
+++ b/command/testdata/show-json-state/sensitive-variables/terraform.tfstate
@@ -1,0 +1,33 @@
+{
+  "version": 4,
+  "terraform_version": "0.14.0",
+  "serial": 1,
+  "lineage": "d7a6880b-6875-288f-13a9-696a65c73036",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "test_instance",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "621124146446964903",
+            "ami": "abc"
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "ami"
+              }
+            ]
+          ],
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This prevents "sensitive" values from unintentionally showing as nil when running terraform show -json. Also adjusts the signature of a function to remove an unused argument.

Closes #26737