### PR TITLE
Hide sensitive outputs in terraform show

### DIFF
--- a/command/format/state.go
+++ b/command/format/state.go
@@ -74,7 +74,11 @@ func State(opts *StateOpts) string {
 		for _, k := range ks {
 			v := m.OutputValues[k]
 			p.buf.WriteString(fmt.Sprintf("%s = ", k))
-			p.writeValue(v.Value, plans.NoOp, 0)
+			if v.Sensitive {
+				p.buf.WriteString("(sensitive value)")
+			} else {
+				p.writeValue(v.Value, plans.NoOp, 0)
+			}
 			p.buf.WriteString("\n")
 		}
 	}

--- a/command/format/state_test.go
+++ b/command/format/state_test.go
@@ -219,7 +219,7 @@ map_var = {
     "first"  = "foo"
     "second" = "bar"
 }
-sensitive_var = "secret!!!"
+sensitive_var = (sensitive value)
 string_var = "string value"`
 
 func basicState(t *testing.T) *states.State {


### PR DESCRIPTION
`terraform show -json` is intended to be the means to view _all_ values in state, but previously, `terraform show` would still show outputs that were designated as `sensitive`. This adjusts that behavior.

Before:
```
$ terraform show 
# random_pet.bar:
resource "random_pet" "bar" {
    id        = "cat-quick-sunbird"
    length    = 2
    prefix    = (sensitive)
    separator = "-"
}


Outputs:

out = "cat"
```
After:
```
$ terraform show 
# random_pet.bar:
resource "random_pet" "bar" {
    id        = "cat-quick-sunbird"
    length    = 2
    prefix    = (sensitive)
    separator = "-"
}


Outputs:

out = (sensitive value)
```