### PR TITLE
Stop printing tfce error message log

### DIFF
--- a/backend/remote/backend_common.go
+++ b/backend/remote/backend_common.go
@@ -321,8 +321,7 @@ func (b *Remote) costEstimate(stopCtx, cancelCtx context.Context, op *backend.Op
 			b.CLI.Output("\n------------------------------------------------------------------------")
 			return nil
 		case tfe.CostEstimateErrored:
-			b.CLI.Output(msgPrefix + " errored:\n")
-			b.CLI.Output(ce.ErrorMessage)
+			b.CLI.Output(msgPrefix + " errored.\n")
 			b.CLI.Output("\n------------------------------------------------------------------------")
 			return nil
 		case tfe.CostEstimateCanceled:


### PR DESCRIPTION
Reverts part of #26618

We'll just have the error continuation bug fix in for now. Improved error messaging will come later once it's refactored in our cost-estimation library.