### PR TITLE
Allow runs to continue on TFCE error

### DIFF
--- a/backend/remote/backend_common.go
+++ b/backend/remote/backend_common.go
@@ -321,7 +321,9 @@ func (b *Remote) costEstimate(stopCtx, cancelCtx context.Context, op *backend.Op
 			b.CLI.Output("\n------------------------------------------------------------------------")
 			return nil
 		case tfe.CostEstimateErrored:
-			return fmt.Errorf(msgPrefix + " errored.")
+			b.CLI.Output(msgPrefix + " errored.\n")
+			b.CLI.Output("\n------------------------------------------------------------------------")
+			return nil
 		case tfe.CostEstimateCanceled:
 			return fmt.Errorf(msgPrefix + " canceled.")
 		default:


### PR DESCRIPTION
A cost estimation error does not actually stop a run, so the run was continuing in the background after the cli exits, causing confusion. This change matches the UI behavior.

We'd like to include this in the 0.14 release. I've created this PR in anticipation of inclusion once we get approval.