### PR TITLE
Show which input values are unknown when for_each fails due to being unknown

### DIFF
--- a/lang/eval.go
+++ b/lang/eval.go
@@ -129,10 +129,12 @@ func (s *Scope) EvalExpr(expr hcl.Expression, wantType cty.Type) (cty.Value, tfd
 		if convErr != nil {
 			val = cty.UnknownVal(wantType)
 			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Incorrect value type",
-				Detail:   fmt.Sprintf("Invalid expression value: %s.", tfdiags.FormatError(convErr)),
-				Subject:  expr.Range().Ptr(),
+				Severity:    hcl.DiagError,
+				Summary:     "Incorrect value type",
+				Detail:      fmt.Sprintf("Invalid expression value: %s.", tfdiags.FormatError(convErr)),
+				Subject:     expr.Range().Ptr(),
+				Expression:  expr,
+				EvalContext: ctx,
 			})
 		}
 	}

--- a/terraform/eval_for_each.go
+++ b/terraform/eval_for_each.go
@@ -62,7 +62,7 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext, allowU
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity:    hcl.DiagError,
 			Summary:     "Invalid for_each argument",
-			Detail:      "Sensitive variable, or values derived from sensitive variables, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource instance key.",
+			Detail:      "Sensitive variables, or values derived from sensitive variables, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource instance key.",
 			Subject:     expr.Range().Ptr(),
 			Expression:  expr,
 			EvalContext: hclCtx,

--- a/terraform/eval_for_each_test.go
+++ b/terraform/eval_for_each_test.go
@@ -150,6 +150,16 @@ func TestEvaluateForEachExpression_errors(t *testing.T) {
 			if got, want := diags[0].Description().Detail, test.DetailSubstring; !strings.Contains(got, want) {
 				t.Errorf("wrong diagnostic detail %#v; want %#v", got, want)
 			}
+			if fromExpr := diags[0].FromExpr(); fromExpr != nil {
+				if fromExpr.Expression == nil {
+					t.Errorf("diagnostic does not refer to an expression")
+				}
+				if fromExpr.EvalContext == nil {
+					t.Errorf("diagnostic does not refer to an EvalContext")
+				}
+			} else {
+				t.Errorf("diagnostic does not support FromExpr\ngot: %s", spew.Sdump(diags[0]))
+			}
 		})
 	}
 }
@@ -164,7 +174,7 @@ func TestEvaluateForEachExpressionKnown(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := &MockEvalContext{}
 			ctx.installSimpleEval()
-			forEachVal, diags := evaluateForEachExpressionValue(expr, ctx)
+			forEachVal, diags := evaluateForEachExpressionValue(expr, ctx, true)
 
 			if len(diags) != 0 {
 				t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -519,7 +519,7 @@ func (n *EvalValidateResource) validateCount(ctx EvalContext, expr hcl.Expressio
 }
 
 func (n *EvalValidateResource) validateForEach(ctx EvalContext, expr hcl.Expression) (diags tfdiags.Diagnostics) {
-	val, forEachDiags := evaluateForEachExpressionValue(expr, ctx)
+	val, forEachDiags := evaluateForEachExpressionValue(expr, ctx, true)
 	// If the value isn't known then that's the best we can do for now, but
 	// we'll check more thoroughly during the plan walk
 	if !val.IsKnown() {

--- a/terraform/node_module_expand.go
+++ b/terraform/node_module_expand.go
@@ -232,7 +232,7 @@ func (n *nodeValidateModule) Execute(ctx EvalContext, op walkOperation) (diags t
 			diags = diags.Append(countDiags)
 
 		case n.ModuleCall.ForEach != nil:
-			_, forEachDiags := evaluateForEachExpressionValue(n.ModuleCall.ForEach, ctx)
+			_, forEachDiags := evaluateForEachExpressionValue(n.ModuleCall.ForEach, ctx, true)
 			diags = diags.Append(forEachDiags)
 		}
 


### PR DESCRIPTION
(This is another installment of "I had a little time to kill and this has been annoying me.")

![](https://user-images.githubusercontent.com/20180/97513940-bfbc6000-194a-11eb-97bf-343be4898501.png)

When writing complex `for_each` expressions that collect values from various other places in the configuration, the error message about the value being invalid due to being unknown is particularly frustrating because it has historically not given any guidance as to what might be contributing to the value being unknown.

We typically annotate expression evaluation errors with information about the values that might have contributed to them, but we've not been doing that for the `for_each` expressions because our evaluation codepath was using a sort of "all in one" shortcut method to evaluate the expression and thus didn't have enough information (the `hcl.EvalContext`, to be specific) to properly annotate the errors.

Questions of the form "why is my `for_each` not known during plan?" come up pretty often, so I think it's worth some slight additional complexity of hopping down to the layer below so we can get hold of the `hcl.EvalContext` and improve these error messages, and so that's what this PR does. My focus was on the specific example I've described above, but this actually generalizes to any error message involving an expression making use of unknown values from elsewhere, and may therefore prove useful in some other cases by at least letting the user know what the _type_ of each unknown value is.

While I was in the neighborhood I also noticed that in the case of sensitive values this would potentially disclose that the value is unknown or null, which _might_ (in rare cases) inadvertently indirectly disclose something important in the logs. For that reason, I added an extra check right up front to disable all further presentation for any value that is sensitive. Finally, I realized that we didn't actually have any tests for this formatting codepath (a result of it starting its life as a "shipped prototype", I guess) and so I took this opportunity to write out some basic test cases too, along with verifying the new behaviors I introduced here.

(There's probably some opportunities to do something similar for the corresponding message for unknown `count` values, but I've run out of time to work on this today and so I'd like to save that for another time; my sense is that `for_each` expressions tend to be the more complicated ones, while `count` expressions are often simpler and thus less likely to raise questions about what exactly is unknown in the inputs.)
