### PR TITLE
states: Disable Terraform version check

### DIFF
--- a/states/statefile/read.go
+++ b/states/statefile/read.go
@@ -62,15 +62,6 @@ func Read(r io.Reader) (*File, error) {
 		panic("readState returned nil state with no errors")
 	}
 
-	if state.TerraformVersion != nil && state.TerraformVersion.GreaterThan(tfversion.SemVer) {
-		return state, fmt.Errorf(
-			"state snapshot was created by Terraform v%s, which is newer than current v%s; upgrade to Terraform v%s or greater to work with this state",
-			state.TerraformVersion,
-			tfversion.SemVer,
-			state.TerraformVersion,
-		)
-	}
-
 	return state, diags.Err()
 }
 

--- a/states/statefile/testdata/roundtrip/v4-future.in.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-future.in.tfstate
@@ -1,0 +1,60 @@
+{
+    "version": 4,
+    "serial": 0,
+    "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+    "terraform_version": "999.0.0",
+    "outputs": {
+        "numbers": {
+            "type": "string",
+            "value": "0,1"
+        }
+    },
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "bar",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "5388490630832483079",
+                        "triggers.%": "1",
+                        "triggers.whaaat": "0,1"
+                    },
+                    "depends_on": [
+                        "null_resource.foo"
+                    ]
+                }
+            ]
+        },
+        {
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "foo",
+            "provider": "provider[\"registry.terraform.io/-/null\"]",
+            "each": "list",
+            "instances": [
+                {
+                    "index_key": 0,
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "8212585058302700791",
+                        "triggers.%": "1",
+                        "triggers.what": "0"
+                    }
+                },
+                {
+                    "index_key": 1,
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "1523897709610803586",
+                        "triggers.%": "1",
+                        "triggers.what": "0"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/states/statefile/testdata/roundtrip/v4-future.out.tfstate
+++ b/states/statefile/testdata/roundtrip/v4-future.out.tfstate
@@ -1,0 +1,1 @@
+v4-future.in.tfstate


### PR DESCRIPTION
v0.14 backport of #26735

---

For this version of Terraform and forward, we no longer refuse to read compatible state files written by future versions of Terraform. This is a commitment that any changes to the semantics or format of the state file after this commit will require a new state file version 5.

The result of this is that users of this Terraform version will be able to share remote state with users of future versions, and all users will be able to read and write state. This will be true until the next major state file version is required.

This does not affect users of previous versions of Terraform, which will continue to refuse to read state written by later versions.