### PR TITLE
terraform: Compare locks and provider requirements

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -421,6 +421,28 @@ func (m *Meta) contextOpts() (*terraform.ContextOpts, error) {
 		}
 		opts.Providers = providerFactories
 		opts.Provisioners = m.provisionerFactories()
+
+		// Read the dependency locks so that they can be verified against the
+		// provider requirements in the configuration
+		lockedDependencies, diags := m.lockedDependencies()
+
+		// If the locks file is invalid, we should fail early rather than
+		// ignore it. A missing locks file will return no error.
+		if diags.HasErrors() {
+			return nil, diags.Err()
+		}
+		opts.LockedDependencies = lockedDependencies
+
+		// If any unmanaged providers or dev overrides are enabled, they must
+		// be listed in the context so that they can be ignored when verifying
+		// the locks against the configuration
+		opts.ProvidersInDevelopment = make(map[addrs.Provider]struct{})
+		for provider := range m.UnmanagedProviders {
+			opts.ProvidersInDevelopment[provider] = struct{}{}
+		}
+		for provider := range m.ProviderDevOverrides {
+			opts.ProvidersInDevelopment[provider] = struct{}{}
+		}
 	}
 
 	opts.ProviderSHA256s = m.providerPluginsLock().Read()

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 
+	"github.com/apparentlymart/go-versions/versions"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/instances"
@@ -19,6 +21,8 @@ import (
 	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders"
 	_ "github.com/hashicorp/terraform/internal/logging"
 )
 
@@ -66,6 +70,14 @@ type ContextOpts struct {
 	// If non-nil, will apply as additional constraints on the provider
 	// plugins that will be requested from the provider resolver.
 	ProviderSHA256s map[string][]byte
+
+	// If non-nil, will be verified to ensure that provider requirements from
+	// configuration can be satisfied by the set of locked dependencies.
+	LockedDependencies *depsfile.Locks
+
+	// Set of providers to exclude from the requirements check process, as they
+	// are marked as in local development.
+	ProvidersInDevelopment map[addrs.Provider]struct{}
 
 	UIInput UIInput
 }
@@ -210,6 +222,50 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 	config := opts.Config
 	if config == nil {
 		config = configs.NewEmptyConfig()
+	}
+
+	// If we have a configuration and a set of locked dependencies, verify that
+	// the provider requirements from the configuration can be satisfied by the
+	// locked dependencies.
+	if opts.LockedDependencies != nil {
+		reqs, providerDiags := config.ProviderRequirements()
+		diags = diags.Append(providerDiags)
+
+		locked := opts.LockedDependencies.AllProviders()
+		unmetReqs := make(getproviders.Requirements)
+		for provider, versionConstraints := range reqs {
+			// Builtin providers are not listed in the locks file
+			if provider.IsBuiltIn() {
+				continue
+			}
+			// Development providers must be excluded from this check
+			if _, ok := opts.ProvidersInDevelopment[provider]; ok {
+				continue
+			}
+			// If the required provider doesn't exist in the lock, or the
+			// locked version doesn't meet the constraints, mark the
+			// requirement unmet
+			acceptable := versions.MeetingConstraints(versionConstraints)
+			if lock, ok := locked[provider]; !ok || !acceptable.Has(lock.Version()) {
+				unmetReqs[provider] = versionConstraints
+			}
+		}
+
+		if len(unmetReqs) > 0 {
+			var buf strings.Builder
+			for provider, versionConstraints := range unmetReqs {
+				fmt.Fprintf(&buf, "\n- %s", provider)
+				if len(versionConstraints) > 0 {
+					fmt.Fprintf(&buf, " (%s)", getproviders.VersionConstraintsString(versionConstraints))
+				}
+			}
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Provider requirements cannot be satisfied by locked dependencies",
+				fmt.Sprintf("The following required providers are not installed:\n%s\n\nPlease run \"terraform init\".", buf.String()),
+			))
+			return nil, diags
+		}
 	}
 
 	log.Printf("[TRACE] terraform.NewContext: complete")


### PR DESCRIPTION
When building a context, we read the dependency locks and ensure that the provider requirements from the configuration can be satisfied. If the configured requirements change such that the locks need to be updated, we explain this and recommend running "terraform init".

This check is ignored for any providers which are locally marked as in development. This includes unmanaged providers and those listed in the provider installation `dev_overrides` block.

Fixes #26565.

### Screenshot

<img width="885" alt="diags" src="https://user-images.githubusercontent.com/68917/97732204-94518680-1aac-11eb-9c64-7150aef626fe.png">
