### PR TITLE
getproviders: Normalize versions before dedupe

### DIFF
--- a/internal/getproviders/types_test.go
+++ b/internal/getproviders/types_test.go
@@ -53,6 +53,10 @@ func TestVersionConstraintsString(t *testing.T) {
 			MustParseVersionConstraints(">= 1.2.3, 1.2.3, ~> 1.2, 1.2.3"),
 			"~> 1.2, >= 1.2.3, 1.2.3",
 		},
+		"equivalent duplicates removed": {
+			MustParseVersionConstraints(">= 2.68, >= 2.68.0"),
+			">= 2.68.0",
+		},
 		"consistent ordering, exhaustive": {
 			// This weird jumble is just to exercise the different sort
 			// ordering codepaths. Hopefully nothing quite this horrific


### PR DESCRIPTION
When rendering a set of version constraints to a string, we normalize partially-constrained versions. This means converting a version like `2.68.*` to `2.68.0`.

Prior to this commit, this normalization was done after deduplication. This could result in a version constraints string with duplicate entries, if multiple partially-constrained versions are equivalent. This commit fixes this by normalizing before deduplicating and sorting.

Fixes #26772