### PR TITLE
backend: Only show root module output changes

### DIFF
--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -314,8 +314,18 @@ func RenderPlan(plan *plans.Plan, baseState *states.State, schemas *terraform.Sc
 
 	// If there is at least one planned change to the root module outputs
 	// then we'll render a summary of those too.
-	if len(plan.Changes.Outputs) > 0 {
-		ui.Output(colorize.Color("[reset]\n[bold]Changes to Outputs:[reset]" + format.OutputChanges(plan.Changes.Outputs, colorize)))
+	var changedRootModuleOutputs []*plans.OutputChangeSrc
+	for _, output := range plan.Changes.Outputs {
+		if !output.Addr.Module.IsRoot() {
+			continue
+		}
+		if output.ChangeSrc.Action == plans.NoOp {
+			continue
+		}
+		changedRootModuleOutputs = append(changedRootModuleOutputs, output)
+	}
+	if len(changedRootModuleOutputs) > 0 {
+		ui.Output(colorize.Color("[reset]\n[bold]Changes to Outputs:[reset]" + format.OutputChanges(changedRootModuleOutputs, colorize)))
 	}
 }
 

--- a/backend/local/testdata/plan-outputs-changed/main.tf
+++ b/backend/local/testdata/plan-outputs-changed/main.tf
@@ -1,3 +1,7 @@
+module "submodule" {
+  source = "./submodule"
+}
+
 output "changed" {
   value = "after"
 }

--- a/backend/local/testdata/plan-outputs-changed/submodule/main.tf
+++ b/backend/local/testdata/plan-outputs-changed/submodule/main.tf
@@ -1,0 +1,3 @@
+output "foo" {
+  value = "bar"
+}


### PR DESCRIPTION
When rendering planned output changes, we need to filter the plan's output changes to ensure that only root module outputs which have changed are rendered. Otherwise we will render changes for submodule outputs, and (with concise diff disabled) render unchanged outputs also.

Fixes #26776