### PR TITLE
Enable single address locking in HTTP backend, fixes #23777

### DIFF
--- a/backend/remote-state/http/backend.go
+++ b/backend/remote-state/http/backend.go
@@ -55,6 +55,12 @@ func New() backend.Backend {
 				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_UNLOCK_METHOD", "UNLOCK"),
 				Description: "The HTTP method to use when unlocking",
 			},
+			"locking": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_LOCKING", false),
+				Description: "Wether to enable locking use on REST endpoint",
+			},
 			"username": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -146,6 +152,18 @@ func (b *Backend) configure(ctx context.Context) error {
 	}
 
 	unlockMethod := data.Get("unlock_method").(string)
+
+	if data.Get("locking").(bool) {
+		// Use default address if no lock_address is provided
+		if lockURL == nil {
+			lockURL = updateURL
+		}
+
+		// Use default address if no unlock_address is provided
+		if unlockURL == nil {
+			unlockURL = updateURL
+		}
+	}
 
 	client := cleanhttp.DefaultPooledClient()
 

--- a/backend/remote-state/http/backend_test.go
+++ b/backend/remote-state/http/backend_test.go
@@ -99,6 +99,7 @@ func TestHTTPClientFactoryWithEnv(t *testing.T) {
 		"lock_method":    "BLIP",
 		"unlock_address": "http://127.0.0.1:8888/baz",
 		"unlock_method":  "BLOOP",
+		"locking":        "false",
 		"username":       "user",
 		"password":       "pass",
 		"retry_max":      "999",
@@ -112,6 +113,7 @@ func TestHTTPClientFactoryWithEnv(t *testing.T) {
 	defer testWithEnv(t, "TF_HTTP_UNLOCK_ADDRESS", conf["unlock_address"])()
 	defer testWithEnv(t, "TF_HTTP_LOCK_METHOD", conf["lock_method"])()
 	defer testWithEnv(t, "TF_HTTP_UNLOCK_METHOD", conf["unlock_method"])()
+	defer testWithEnv(t, "TF_HTTP_LOCKING", conf["locking"])()
 	defer testWithEnv(t, "TF_HTTP_USERNAME", conf["username"])()
 	defer testWithEnv(t, "TF_HTTP_PASSWORD", conf["password"])()
 	defer testWithEnv(t, "TF_HTTP_RETRY_MAX", conf["retry_max"])()

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -661,6 +661,7 @@ func TestApply_plan_remoteState(t *testing.T) {
 		"unlock_address":         cty.NullVal(cty.String),
 		"lock_method":            cty.NullVal(cty.String),
 		"unlock_method":          cty.NullVal(cty.String),
+		"locking":                cty.NullVal(cty.Bool),
 		"username":               cty.NullVal(cty.String),
 		"password":               cty.NullVal(cty.String),
 		"skip_cert_verification": cty.NullVal(cty.Bool),


### PR DESCRIPTION
Hi,

This enable single remote endpoint locking, trying to fix https://github.com/hashicorp/terraform/issues/23777.

Now an HTTP backend can just be
```hcl
terraform {
  backend "http" {
    address = "http://myrestapi.example.com/foo"
    locking = true
  }
}
```
And the address will then be used for both `LOCK` and `UNLOCK` operations.

If `lock_address` or `unlock_address` are specified, the HTTP backend use them accordingly as usual, enabling one to override them if required.

Kind regards,
