### PR TITLE
Validate final provider configuration

### DIFF
--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -798,9 +798,6 @@ func TestApply_planNoModuleFiles(t *testing.T) {
 		planPath,
 	}
 	apply.Run(args)
-	if p.PrepareProviderConfigCalled {
-		t.Fatal("Prepare provider config should not be called with a plan")
-	}
 }
 
 func TestApply_refresh(t *testing.T) {

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -14,8 +14,10 @@ type Interface interface {
 	// GetSchema returns the complete schema for the provider.
 	GetSchema() GetSchemaResponse
 
-	// PrepareProviderConfig allows the provider to validate the configuration
-	// values, and set or override any values with defaults.
+	// PrepareProviderConfig allows the provider to validate the configuration.
+	// The PrepareProviderConfigResponse.PreparedConfig field is unused. The
+	// final configuration is not stored in the state, and any modifications
+	// that need to be made must be made during the Configure method call.
 	PrepareProviderConfig(PrepareProviderConfigRequest) PrepareProviderConfigResponse
 
 	// ValidateResourceTypeConfig allows the provider to validate the resource
@@ -99,7 +101,7 @@ type PrepareProviderConfigRequest struct {
 }
 
 type PrepareProviderConfigResponse struct {
-	// PreparedConfig is the configuration as prepared by the provider.
+	// PreparedConfig is unused.
 	PreparedConfig cty.Value
 	// Diagnostics contains any warnings or errors from the method call.
 	Diagnostics tfdiags.Diagnostics

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -78,6 +78,11 @@ func TestContext2Plan_basic(t *testing.T) {
 			t.Fatal("unknown instance:", i)
 		}
 	}
+
+	if !p.PrepareProviderConfigCalled {
+		t.Fatal("provider config was not checked before Configure")
+	}
+
 }
 
 func TestContext2Plan_createBefore_deposed(t *testing.T) {

--- a/terraform/provider_mock.go
+++ b/terraform/provider_mock.go
@@ -133,6 +133,7 @@ func (p *MockProvider) PrepareProviderConfig(r providers.PrepareProviderConfigRe
 	if p.PrepareProviderConfigFn != nil {
 		return p.PrepareProviderConfigFn(r)
 	}
+	p.PrepareProviderConfigResponse.PreparedConfig = r.Config
 	return p.PrepareProviderConfigResponse
 }
 


### PR DESCRIPTION
The provider was only given the static configuration to validate early on, but that would not contain any variable values that may have been referenced. Add a second call to `PrepareProviderConfig` immediately before `Configure` to allow the provider to validate the final config and not have to repeat its own validation within the `Configure` call. 

Core was also not using the `PreparedConfig` response from `PrepareProviderConfig`, which remains unchanged in this PR. We elect to continue ignoring the `PreparedConfig` here, since there is no useful reason for it at this point, and it would introduce a functional difference between terraform releases that can be avoided. A log warning is added here if the config was altered, as an extra hint to providers that returned value is unused.

The original reason for this returned configuration value was because legacy providers were using a pattern of `Required` attributes with a `DefaultFunc` inserting values from the environment (note that `Required` with a static `Default` value was not allowed). Since `Required` is taken to mean "required to be set in the configuration", the shims worked around this by detecting a possible `DefaultFunc` return value and turning off the `Required` flag in the schema. Even if we were to allow the concept of a `Required` field with defaults, the current architecture of terraform attempts to ask for missing required values before evaluation can happen, so there would be no way to actually use the `PreparedConfig` value for this purpose.