### PR TITLE
hide provider crashes from panicwrap when logging

### DIFF
--- a/internal/logging/panic_test.go
+++ b/internal/logging/panic_test.go
@@ -1,9 +1,12 @@
 package logging
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 func TestPanicRecorder(t *testing.T) {
@@ -48,4 +51,32 @@ func TestPanicLimit(t *testing.T) {
 			t.Fatalf("expected no more than %d lines, got: %d", max, found)
 		}
 	}
+}
+
+func TestLogPanicWrapper(t *testing.T) {
+	var buf bytes.Buffer
+	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
+		Name:        "test",
+		Level:       hclog.Debug,
+		Output:      &buf,
+		DisableTime: true,
+	})
+
+	wrapped := (&logPanicWrapper{
+		Logger: logger,
+	}).Named("test")
+
+	wrapped.Debug("panic: invalid foo of bar")
+	wrapped.Debug("\tstack trace")
+
+	expected := `[DEBUG] test.test: PANIC: invalid foo of bar
+[DEBUG] test.test: 	stack trace
+`
+
+	got := buf.String()
+
+	if expected != got {
+		t.Fatalf("Expected:\n%q\nGot:\n%q", expected, got)
+	}
+
 }


### PR DESCRIPTION
When logging is turned on, panicwrap will still see provider crashes and
falsely report them as core crashes, hiding the formatted provider error.
We can trick panicwrap by slightly obfuscating the error line.