### PR TITLE
builtin/provider/terraform: Add field descriptions

### DIFF
--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -18,24 +18,42 @@ func dataSourceRemoteStateGetSchema() providers.Schema {
 		Block: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"backend": {
-					Type:     cty.String,
-					Required: true,
+					Type:            cty.String,
+					Description:     "The remote backend to use, e.g. `remote` or `http`.",
+					DescriptionKind: configschema.StringMarkdown,
+					Required:        true,
 				},
 				"config": {
-					Type:     cty.DynamicPseudoType,
-					Optional: true,
+					Type: cty.DynamicPseudoType,
+					Description: "The configuration of the remote backend. " +
+						"Although this is optional, most backends require " +
+						"some configuration.\n\n" +
+						"The object can use any arguments that would be valid " +
+						"in the equivalent `terraform { backend \"<TYPE>\" { ... } }` " +
+						"block.",
+					DescriptionKind: configschema.StringMarkdown,
+					Optional:        true,
 				},
 				"defaults": {
-					Type:     cty.DynamicPseudoType,
-					Optional: true,
+					Type: cty.DynamicPseudoType,
+					Description: "Default values for outputs, in case " +
+						"the state file is empty or lacks a required output.",
+					DescriptionKind: configschema.StringMarkdown,
+					Optional:        true,
 				},
 				"outputs": {
-					Type:     cty.DynamicPseudoType,
-					Computed: true,
+					Type: cty.DynamicPseudoType,
+					Description: "An object containing every root-level " +
+						"output in the remote state.",
+					DescriptionKind: configschema.StringMarkdown,
+					Computed:        true,
 				},
 				"workspace": {
-					Type:     cty.String,
-					Optional: true,
+					Type: cty.String,
+					Description: "The Terraform workspace to use, if " +
+						"the backend supports workspaces.",
+					DescriptionKind: configschema.StringMarkdown,
+					Optional:        true,
 				},
 			},
 		},


### PR DESCRIPTION
These fields are well documented [in the docs](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state), but this provides descriptions for the schema export (`terraform providers schema -json`) which is in turn used by the language server.

In other words this enhances the user experience of user editing configuration with the Terraform language server - we can display these descriptions e.g. in completion selectbox or on hover.

--- 

I have mostly copy-pasted these from the linked docs and it seems that we use dot at the end of every description. I'm assuming this is intended, even though in most cases it's not a full sentence? Someone with better english grammar knowledge please confirm or correct me if I'm wrong. cc @nfagerlund 