### PR TITLE
backend/gcs: remove deprecated "path" config argument

### DIFF
--- a/backend/remote-state/gcs/backend.go
+++ b/backend/remote-state/gcs/backend.go
@@ -27,9 +27,8 @@ type Backend struct {
 	storageClient  *storage.Client
 	storageContext context.Context
 
-	bucketName       string
-	prefix           string
-	defaultStateFile string
+	bucketName string
+	prefix     string
 
 	encryptionKey []byte
 }

--- a/backend/remote-state/gcs/backend.go
+++ b/backend/remote-state/gcs/backend.go
@@ -45,13 +45,6 @@ func New() backend.Backend {
 				Description: "The name of the Google Cloud Storage bucket",
 			},
 
-			"path": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Path of the default state file",
-				Deprecated:  "Use the \"prefix\" option instead",
-			},
-
 			"prefix": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/backend/remote-state/gcs/backend.go
+++ b/backend/remote-state/gcs/backend.go
@@ -114,8 +114,6 @@ func (b *Backend) configure(ctx context.Context) error {
 		b.prefix = b.prefix + "/"
 	}
 
-	b.defaultStateFile = strings.TrimLeft(data.Get("path").(string), "/")
-
 	var opts []option.ClientOption
 
 	// Add credential source

--- a/backend/remote-state/gcs/backend_state.go
+++ b/backend/remote-state/gcs/backend_state.go
@@ -146,15 +146,9 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 }
 
 func (b *Backend) stateFile(name string) string {
-	if name == backend.DefaultStateName && b.defaultStateFile != "" {
-		return b.defaultStateFile
-	}
 	return path.Join(b.prefix, name+stateFileSuffix)
 }
 
 func (b *Backend) lockFile(name string) string {
-	if name == backend.DefaultStateName && b.defaultStateFile != "" {
-		return strings.TrimSuffix(b.defaultStateFile, stateFileSuffix) + lockFileSuffix
-	}
 	return path.Join(b.prefix, name+lockFileSuffix)
 }

--- a/backend/remote-state/gcs/backend_test.go
+++ b/backend/remote-state/gcs/backend_test.go
@@ -25,23 +25,19 @@ func TestStateFile(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		prefix           string
-		defaultStateFile string
-		name             string
-		wantStateFile    string
-		wantLockFile     string
+		prefix        string
+		name          string
+		wantStateFile string
+		wantLockFile  string
 	}{
-		{"state", "", "default", "state/default.tfstate", "state/default.tflock"},
-		{"state", "", "test", "state/test.tfstate", "state/test.tflock"},
-		{"state", "legacy.tfstate", "default", "legacy.tfstate", "legacy.tflock"},
-		{"state", "legacy.tfstate", "test", "state/test.tfstate", "state/test.tflock"},
-		{"state", "legacy.state", "default", "legacy.state", "legacy.state.tflock"},
-		{"state", "legacy.state", "test", "state/test.tfstate", "state/test.tflock"},
+		{"state", "default", "state/default.tfstate", "state/default.tflock"},
+		{"state", "test", "state/test.tfstate", "state/test.tflock"},
+		{"state", "test", "state/test.tfstate", "state/test.tflock"},
+		{"state", "test", "state/test.tfstate", "state/test.tflock"},
 	}
 	for _, c := range cases {
 		b := &Backend{
-			prefix:           c.prefix,
-			defaultStateFile: c.defaultStateFile,
+			prefix: c.prefix,
 		}
 
 		if got := b.stateFile(c.name); got != c.wantStateFile {

--- a/website/docs/backends/types/gcs.html.md
+++ b/website/docs/backends/types/gcs.html.md
@@ -70,8 +70,6 @@ The following configuration options are supported:
    `credentials` field.
  *  `prefix` - (Optional) GCS prefix inside the bucket. Named states for
     workspaces are stored in an object called `<prefix>/<name>.tfstate`.
- *  `path` - (Deprecated) GCS path to the state file of the default state. For
-    backwards compatibility only, use `prefix` instead.
  *  `encryption_key` / `GOOGLE_ENCRYPTION_KEY` - (Optional) A 32 byte base64
     encoded 'customer supplied encryption key' used to encrypt all state. For
     more information see [Customer Supplied Encryption


### PR DESCRIPTION
Path was deprecated more than 3 years ago.

This removes it from the code.

Spotted while working on #26700 