### PR TITLE
website: update link to new varibles tutorial

### DIFF
--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -13,7 +13,7 @@ description: |-
 earlier, see
 [0.11 Configuration Language: Input Variables](../configuration-0-11/variables.html).
 
-> **Hands-on:** Try the [Define Input Variables](https://learn.hashicorp.com/tutorials/terraform/aws-variables?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Customize Terraform Configuration with Variables](https://learn.hashicorp.com/tutorials/terraform/variables?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Input variables serve as parameters for a Terraform module, allowing aspects
 of the module to be customized without altering the module's own source code,


### PR DESCRIPTION
Update the link to HashiCorp learn to the new variables tutorial in the configuration language section, rather than the old variables tutorial in the AWS getting started section.