### PR TITLE
Support for remote_exec on Windows SSH

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -360,7 +360,6 @@ func (c *Communicator) Start(cmd *remote.Cmd) error {
 	}
 
 	log.Printf("[DEBUG] starting remote command: %s", cmd.Command)
-
 	err = session.Start(strings.TrimSpace(cmd.Command) + "\n")
 	if err != nil {
 		return err
@@ -424,7 +423,7 @@ func (c *Communicator) Upload(path string, input io.Reader) error {
 
 // UploadScript implementation of communicator.Communicator interface
 func (c *Communicator) UploadScript(path string, input io.Reader) error {
-	// Check if path is specified as windows driveletter, if so: set noPty to true, if not, insert defaultSheBang as first line of the script if it doesn't exist
+	// Check if path is specified as windows driveletter, if so set isWindows to true
 	if isWindowsPath(path) {
 		isWindows = true
 	}

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -345,7 +345,7 @@ func (c *Communicator) Start(cmd *remote.Cmd) error {
 	session.Stdout = cmd.Stdout
 	session.Stderr = cmd.Stderr
 
-	if !c.config.noPty && c.connInfo.TargetPlatform != "windows" {
+	if !c.config.noPty && c.connInfo.TargetPlatform != TargetPlatformWindows {
 		// Request a PTY
 		termModes := ssh.TerminalModes{
 			ssh.ECHO:          0,     // do not echo
@@ -429,7 +429,7 @@ func (c *Communicator) UploadScript(path string, input io.Reader) error {
 	}
 	var script bytes.Buffer
 
-	if string(prefix) != "#!" && c.connInfo.TargetPlatform != "windows" {
+	if string(prefix) != "#!" && c.connInfo.TargetPlatform != TargetPlatformWindows {
 		script.WriteString(DefaultShebang)
 	}
 	script.ReadFrom(reader)
@@ -437,7 +437,7 @@ func (c *Communicator) UploadScript(path string, input io.Reader) error {
 	if err := c.Upload(path, &script); err != nil {
 		return err
 	}
-	if c.connInfo.TargetPlatform != "windows" {
+	if c.connInfo.TargetPlatform != TargetPlatformWindows {
 		var stdout, stderr bytes.Buffer
 		cmd := &remote.Cmd{
 			Command: fmt.Sprintf("chmod 0777 %s", path),

--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -39,8 +39,10 @@ const (
 	// DefaultTimeout is used if there is no timeout given
 	DefaultTimeout = 5 * time.Minute
 
-	// DefaultTargetPlatform is used if no target platform has been specified
-	DefaultTargetPlatform = "unix"
+	// TargetPlatformUnix used for cleaner code, and is used if no target platform has been specified
+	TargetPlatformUnix = "unix"
+	//TargetPlatformWindows used for cleaner code
+	TargetPlatformWindows = "windows"
 )
 
 // connectionInfo is decoded from the ConnInfo of the resource. These are the
@@ -113,14 +115,18 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 	if connInfo.Port == 0 {
 		connInfo.Port = DefaultPort
 	}
-	// Set default targetPlatform to unix
+	// Set default targetPlatform to unix if it's empty
 	if connInfo.TargetPlatform == "" {
-		connInfo.TargetPlatform = DefaultTargetPlatform
+		connInfo.TargetPlatform = TargetPlatformUnix
+	} else if connInfo.TargetPlatform != TargetPlatformUnix && connInfo.TargetPlatform != TargetPlatformWindows {
+		return nil, fmt.Errorf("target_platform for provisioner has to be either %s or %s", TargetPlatformUnix, TargetPlatformWindows)
 	}
-	if connInfo.ScriptPath == "" && connInfo.TargetPlatform == DefaultTargetPlatform {
+	// Choose an appropriate default script path based on the target platform. There is no single
+	// suitable default script path which works on both UNIX and Windows targets.
+	if connInfo.ScriptPath == "" && connInfo.TargetPlatform == TargetPlatformUnix {
 		connInfo.ScriptPath = DefaultUnixScriptPath
 	}
-	if connInfo.ScriptPath == "" && connInfo.TargetPlatform == "windows" {
+	if connInfo.ScriptPath == "" && connInfo.TargetPlatform == TargetPlatformWindows {
 		connInfo.ScriptPath = DefaultWindowsScriptPath
 	}
 	if connInfo.Timeout != "" {

--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -35,23 +35,27 @@ const (
 
 	// DefaultTimeout is used if there is no timeout given
 	DefaultTimeout = 5 * time.Minute
+
+	// DefaultTargetPlatform is used if no target platform has been specified
+	DefaultTargetPlatform = "unix"
 )
 
 // connectionInfo is decoded from the ConnInfo of the resource. These are the
 // only keys we look at. If a PrivateKey is given, that is used instead
 // of a password.
 type connectionInfo struct {
-	User        string
-	Password    string
-	PrivateKey  string `mapstructure:"private_key"`
-	Certificate string `mapstructure:"certificate"`
-	Host        string
-	HostKey     string `mapstructure:"host_key"`
-	Port        int
-	Agent       bool
-	Timeout     string
-	ScriptPath  string        `mapstructure:"script_path"`
-	TimeoutVal  time.Duration `mapstructure:"-"`
+	User           string
+	Password       string
+	PrivateKey     string `mapstructure:"private_key"`
+	Certificate    string `mapstructure:"certificate"`
+	Host           string
+	HostKey        string `mapstructure:"host_key"`
+	Port           int
+	Agent          bool
+	Timeout        string
+	ScriptPath     string        `mapstructure:"script_path"`
+	TimeoutVal     time.Duration `mapstructure:"-"`
+	TargetPlatform string        `mapstructure:"target_platform"`
 
 	BastionUser        string `mapstructure:"bastion_user"`
 	BastionPassword    string `mapstructure:"bastion_password"`
@@ -113,6 +117,11 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 		connInfo.TimeoutVal = safeDuration(connInfo.Timeout, DefaultTimeout)
 	} else {
 		connInfo.TimeoutVal = DefaultTimeout
+	}
+
+	// Set default targetPlatform to unix
+	if connInfo.TargetPlatform == "" {
+		connInfo.TargetPlatform = DefaultTargetPlatform
 	}
 
 	// Default all bastion config attrs to their non-bastion counterparts

--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -29,9 +29,12 @@ const (
 	// DefaultPort is used if there is no port given
 	DefaultPort = 22
 
-	// DefaultScriptPath is used as the path to copy the file to
-	// for remote execution if not provided otherwise.
-	DefaultScriptPath = "/tmp/terraform_%RAND%.sh"
+	// DefaultUnixScriptPath is used as the path to copy the file to
+	// for remote execution on unix if not provided otherwise.
+	DefaultUnixScriptPath = "/tmp/terraform_%RAND%.sh"
+	// DefaultWindowsScriptPath is used as the path to copy the file to
+	// for remote execution on windows if not provided otherwise.
+	DefaultWindowsScriptPath = "C:/windows/temp/terraform_%RAND%.cmd"
 
 	// DefaultTimeout is used if there is no timeout given
 	DefaultTimeout = 5 * time.Minute
@@ -110,18 +113,20 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 	if connInfo.Port == 0 {
 		connInfo.Port = DefaultPort
 	}
-	if connInfo.ScriptPath == "" {
-		connInfo.ScriptPath = DefaultScriptPath
+	// Set default targetPlatform to unix
+	if connInfo.TargetPlatform == "" {
+		connInfo.TargetPlatform = DefaultTargetPlatform
+	}
+	if connInfo.ScriptPath == "" && connInfo.TargetPlatform == DefaultTargetPlatform {
+		connInfo.ScriptPath = DefaultUnixScriptPath
+	}
+	if connInfo.ScriptPath == "" && connInfo.TargetPlatform == "windows" {
+		connInfo.ScriptPath = DefaultWindowsScriptPath
 	}
 	if connInfo.Timeout != "" {
 		connInfo.TimeoutVal = safeDuration(connInfo.Timeout, DefaultTimeout)
 	} else {
 		connInfo.TimeoutVal = DefaultTimeout
-	}
-
-	// Set default targetPlatform to unix
-	if connInfo.TargetPlatform == "" {
-		connInfo.TargetPlatform = DefaultTargetPlatform
 	}
 
 	// Default all bastion config attrs to their non-bastion counterparts

--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -53,7 +53,7 @@ func TestProvisioner_connInfo(t *testing.T) {
 	if conf.ScriptPath != DefaultUnixScriptPath {
 		t.Fatalf("bad: %v", conf)
 	}
-	if conf.TargetPlatform != DefaultTargetPlatform {
+	if conf.TargetPlatform != TargetPlatformUnix {
 		t.Fatalf("bad: %v", conf)
 	}
 	if conf.BastionHost != "127.0.1.1" {

--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -53,6 +53,9 @@ func TestProvisioner_connInfo(t *testing.T) {
 	if conf.ScriptPath != DefaultUnixScriptPath {
 		t.Fatalf("bad: %v", conf)
 	}
+	if conf.TargetPlatform != DefaultTargetPlatform {
+		t.Fatalf("bad: %v", conf)
+	}
 	if conf.BastionHost != "127.0.1.1" {
 		t.Fatalf("bad: %v", conf)
 	}

--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -50,7 +50,7 @@ func TestProvisioner_connInfo(t *testing.T) {
 	if conf.Timeout != "30s" {
 		t.Fatalf("bad: %v", conf)
 	}
-	if conf.ScriptPath != DefaultScriptPath {
+	if conf.ScriptPath != DefaultUnixScriptPath {
 		t.Fatalf("bad: %v", conf)
 	}
 	if conf.BastionHost != "127.0.1.1" {

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -161,7 +161,10 @@ var connectionBlockSupersetSchema = &configschema.Block{
 			Type:     cty.String,
 			Optional: true,
 		},
-
+		"target_platform": {
+			Type:     cty.String,
+			Optional: true,
+		},
 		// For type=ssh only (enforced in ssh communicator)
 		"private_key": {
 			Type:     cty.String,

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -161,11 +161,11 @@ var connectionBlockSupersetSchema = &configschema.Block{
 			Type:     cty.String,
 			Optional: true,
 		},
+		// For type=ssh only (enforced in ssh communicator)
 		"target_platform": {
 			Type:     cty.String,
 			Optional: true,
 		},
-		// For type=ssh only (enforced in ssh communicator)
 		"private_key": {
 			Type:     cty.String,
 			Optional: true,

--- a/website/docs/provisioners/connection.html.markdown
+++ b/website/docs/provisioners/connection.html.markdown
@@ -123,6 +123,8 @@ block would create a dependency cycle.
 
 * `host_key` - The public key from the remote host or the signing CA, used to
   verify the connection.
+* `target_platform` - The target platform to connect to. Valid value are:  
+* `windows` and `unix`. Defaults to `unix` if not set.
 
 **Additional arguments only supported by the `winrm` connection type:**
 

--- a/website/docs/provisioners/connection.html.markdown
+++ b/website/docs/provisioners/connection.html.markdown
@@ -123,10 +123,9 @@ block would create a dependency cycle.
 
 * `host_key` - The public key from the remote host or the signing CA, used to
   verify the connection.
-* `target_platform` - The target platform to connect to. Valid values are: `windows` and `unix`. Defaults to `unix` if not set.  
-  By default the script_path is set to `c:\windows\temp\terraform_%RAND%.cmd` if not provided,  
-  so the SSH DefaultShell on windows is assumed to be CMD, if DefaultShell is set to powershell use `"script_path": "c:/windows/temp/terraform_%RAND%.ps1"`  
-  see: https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows for more details
+* `target_platform` - The target platform to connect to. Valid values are `windows` and `unix`. Defaults to `unix` if not set.
+
+    If the platform is set to `windows`, the default `script_path` is `c:\windows\temp\terraform_%RAND%.cmd`, assuming [the SSH default shell](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows) is `cmd.exe`. If the SSH default shell is PowerShell, set `script_path` to `"c:/windows/temp/terraform_%RAND%.ps1"`  
 
 **Additional arguments only supported by the `winrm` connection type:**
 

--- a/website/docs/provisioners/connection.html.markdown
+++ b/website/docs/provisioners/connection.html.markdown
@@ -123,8 +123,10 @@ block would create a dependency cycle.
 
 * `host_key` - The public key from the remote host or the signing CA, used to
   verify the connection.
-* `target_platform` - The target platform to connect to. Valid value are:  
-* `windows` and `unix`. Defaults to `unix` if not set.
+* `target_platform` - The target platform to connect to. Valid values are: `windows` and `unix`. Defaults to `unix` if not set.  
+  By default the script_path is set to `c:\windows\temp\terraform_%RAND%.cmd` if not provided,  
+  so the SSH DefaultShell on windows is assumed to be CMD, if DefaultShell is set to powershell use `"script_path": "c:/windows/temp/terraform_%RAND%.ps1"`  
+  see: https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows for more details
 
 **Additional arguments only supported by the `winrm` connection type:**
 


### PR DESCRIPTION
EDIT: changed solution to use a target_platform property in the connection block
### Summary
A small fix for #25634 where certain parts of the remote_exec (chmodding, inserting a shebang requesting a pty) are skipped when the target file is a windows path. This is determined by looking at the first 2 runes of the destination path, if the first rune in a range [a-z]:[A-Z] and the second rune is a colon the isWindows var is set to true.

### CMD configuration
```
resource "null_resource" "cmd" {  
    # set HKLM\Software\OpenSSH\DefaultShell value to C:\windows\system32\cmd.exe on your target SSH box
    # https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows
    # script path should end with cmd
  connection {
    type        = "ssh"
    user        = "administrator"
    password    = var.password
    host        = var.host
    script_path = "c:\\windows\\temp\\terraform_%RAND%.cmd"
    target_platform = "windows"
  }

  provisioner "remote-exec" {
    inline = [
      "echo hello there",
      "rmdir /s /q c:\\windows\\temp\\cmd",      
      "mkdir C:\\windows\\temp\\cmd\\testfolder3",
      "mkdir C:\\windows\\temp\\cmd\\testfolder1"
    ]
  }
  // this works
  provisioner "file" {
      source = "testfile.txt"
      destination = "c:/windows/temp/cmd/testfolder3/tesfile.txt"
  }
  provisioner "file" {
      content =  "hello"
      destination = "C:\\windows\\temp\\cmd\\testfolder3\\testfile2.txt"
  }

  provisioner "file" {
      source = "testfolder2"
      destination = "C:\\windows\\temp\\cmd"
  }

  provisioner "file" {
      source = "testfolder2/"
      destination = "C:\\windows\\temp\\cmd\\testfolder1"
  }
}
```
**Output:**

```
C:\Repos\github\terraform\terraform.exe apply --auto-approve
null_resource.cmd: Creating...
null_resource.cmd: Provisioning with 'remote-exec'...
null_resource.cmd (remote-exec): Connecting to remote host via SSH...
null_resource.cmd (remote-exec):   Host: <REMOVED>
null_resource.cmd (remote-exec):   User: administrator
null_resource.cmd (remote-exec):   Password: true
null_resource.cmd (remote-exec):   Private key: false
null_resource.cmd (remote-exec):   Certificate: false
null_resource.cmd (remote-exec):   SSH Agent: false
null_resource.cmd (remote-exec):   Checking Host Key: false
null_resource.cmd (remote-exec): Connected!

null_resource.cmd (remote-exec): administrator@WIN-DOEDDD7IMBU C:\Users\Administrator>echo hello there
null_resource.cmd (remote-exec): hello there

null_resource.cmd (remote-exec): administrator@WIN-DOEDDD7IMBU C:\Users\Administrator>rmdir /s /q c:\windows\temp\cmd

null_resource.cmd (remote-exec): administrator@WIN-DOEDDD7IMBU C:\Users\Administrator>mkdir C:\windows\temp\cmd\testfolder3

null_resource.cmd (remote-exec): administrator@WIN-DOEDDD7IMBU C:\Users\Administrator>mkdir C:\windows\temp\cmd\testfolder1
null_resource.cmd: Provisioning with 'file'...
null_resource.cmd: Provisioning with 'file'...
null_resource.cmd: Provisioning with 'file'...
null_resource.cmd: Provisioning with 'file'...
null_resource.cmd: Creation complete after 1s [id=23905475351768227]
```
### PS1 Configuration
```
resource "null_resource" "ps1" {  
    # set HKLM\Software\OpenSSH\DefaultShell value to C:\windows\system32\windowspowershell\v1.0\powershell.exe on your target SSH box
    # https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows
    # script path should end with ps1
  connection {
    type        = "ssh"
    user        = "administrator"
    password    = var.password
    host        = var.host
    script_path = "c:\\windows\\temp\\terraform_%RAND%.ps1"
   target_platform = "windows"
  }

  provisioner "remote-exec" {
    inline = [
      "Get-Process",
      "Remove-Item -recurse -Path C:\\windows\\temp\\ps1",
      "New-Item -ItemType Directory -Path C:\\windows\\temp\\ps1\\testfolder1",
      "New-Item -ItemType Directory -Path C:\\windows\\temp\\ps1\\testfolder3"
    ]
  }
 
  provisioner "file" {
      source = "testfile.txt"
      destination = "c:/windows/temp/ps1/testfolder3/testfile.txt"
  }
  provisioner "file" {
      content =  "hello"
      destination = "C:\\windows\\temp\\ps1\\testfolder3\\testfile2.txt"
  }

  provisioner "file" {
      source = "testfolder2"
      destination = "C:\\windows\\temp\\ps1"
  }

  provisioner "file" {
      source = "testfolder2/"
      destination = "C:\\windows\\temp\\ps1\\testfolder1"
  }

}
```
**Output**
```
C:\Repos\github\terraform\terraform.exe apply --auto-approve
null_resource.ps1: Creating...
null_resource.ps1: Provisioning with 'remote-exec'...
null_resource.ps1 (remote-exec): Connecting to remote host via SSH...
null_resource.ps1 (remote-exec):   Host: <REMOVED>
null_resource.ps1 (remote-exec):   User: administrator
null_resource.ps1 (remote-exec):   Password: true
null_resource.ps1 (remote-exec):   Private key: false
null_resource.ps1 (remote-exec):   Certificate: false
null_resource.ps1 (remote-exec):   SSH Agent: false
null_resource.ps1 (remote-exec):   Checking Host Key: false
null_resource.ps1 (remote-exec): Connected!

null_resource.ps1 (remote-exec): Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName
null_resource.ps1 (remote-exec): -------  ------    -----      -----     ------     --  -- -----------
null_resource.ps1 (remote-exec):     260      16     4216      23624       0.30   1320   1 ApplicationFrameHost
null_resource.ps1 (remote-exec):     248      12     5484      12456       0.13   1128   0 cmd
null_resource.ps1 (remote-exec):     149      10     6672      12192       0.03   3012   0 conhost
null_resource.ps1 (remote-exec):     149      10     6692      12212       0.03   3348   0 conhost
null_resource.ps1 (remote-exec):     492      19     2248       5432       0.75    384   0 csrss
null_resource.ps1 (remote-exec):     310      14     2396       5340       1.55    460   1 csrss
null_resource.ps1 (remote-exec):     384      16     5836      17380       0.48   4636   1 ctfmon
null_resource.ps1 (remote-exec):     131       8     1464       5988       0.02    212   0 dllhost
null_resource.ps1 (remote-exec):     254      14     3996      13496       0.25   3492   0 dllhost
null_resource.ps1 (remote-exec):     640      40    47104      81004      62.52    972   1 dwm
null_resource.ps1 (remote-exec):    1906     104    38996     116752      34.80   2320   1 explorer
null_resource.ps1 (remote-exec):      49       6     1440       4420       0.03    772   0 fontdrvhost
null_resource.ps1 (remote-exec):      49       7     1864       5776       0.20    780   1 fontdrvhost
null_resource.ps1 (remote-exec):       0       0       56          8                 0   0 Idle
null_resource.ps1 (remote-exec):    1051      23     7144      16928      14.58    620   0 lsass
null_resource.ps1 (remote-exec):     223      13     2948      10404       0.08   3608   0 msdtc
null_resource.ps1 (remote-exec):     570      66   172636     181576     181.64   4744   0 MsMpEng
null_resource.ps1 (remote-exec):     196      10     3476       9948       0.44   3204   0 NisSrv
null_resource.ps1 (remote-exec):     219      12     2340      12476       0.03   4196   0 notepad
null_resource.ps1 (remote-exec):     557      26    49332      54260       0.36   1256   0 powershell
null_resource.ps1 (remote-exec):     224      16     5228      18716       0.98   2780   1 regedit
null_resource.ps1 (remote-exec):       0      12      368      54956       2.77     88   0 Registry
null_resource.ps1 (remote-exec):     224      11     2176      12144       0.13    244   1 RuntimeBroker
null_resource.ps1 (remote-exec):     287      15     5216      16188       0.41   1048   1 RuntimeBroker
null_resource.ps1 (remote-exec):     231      12     2772      16644       0.05   3896   1 RuntimeBroker
null_resource.ps1 (remote-exec):     672      38    20808      63140       0.77   4816   1 SearchUI
null_resource.ps1 (remote-exec):     562      11     4804       9420       7.52    600   0 services
null_resource.ps1 (remote-exec):     806      36    18168      59524       0.73   4356   1 ShellExperienceHost
null_resource.ps1 (remote-exec):     470      18     5324      26388       0.72   2804   1 sihost
null_resource.ps1 (remote-exec):     419      23     9036      26736       0.38    380   1 smartscreen
null_resource.ps1 (remote-exec):      53       3      504       1232       0.27    268   0 smss
null_resource.ps1 (remote-exec):     471      23     5704      16544       0.16   2292   0 spoolsv
null_resource.ps1 (remote-exec):     129       9     2100       7128       0.03   1284   0 sshd
null_resource.ps1 (remote-exec):     136       9     2204       7356       0.02   1408   0 sshd
null_resource.ps1 (remote-exec):     118      12     1796       6720       0.39   2544   0 sshd
null_resource.ps1 (remote-exec):     505      18     4180      12792       0.20    328   0 svchost
null_resource.ps1 (remote-exec):     115       7     1260       5336       0.02    388   0 svchost
null_resource.ps1 (remote-exec):     171       9     1492       7184       0.03    472   0 svchost
null_resource.ps1 (remote-exec):     149       9     1644      11724       0.05    636   0 svchost
null_resource.ps1 (remote-exec):     199      12     1908       9632       0.03    664   0 svchost
null_resource.ps1 (remote-exec):      85       5      900       3856       0.00    724   0 svchost
null_resource.ps1 (remote-exec):     855      20     6872      22636       1.39    744   0 svchost
null_resource.ps1 (remote-exec):     875      17     5496      12180       4.61    856   0 svchost
null_resource.ps1 (remote-exec):     299      12     2356       9920       0.16    912   0 svchost
null_resource.ps1 (remote-exec):     380      13    12120      15456      24.03   1136   0 svchost
null_resource.ps1 (remote-exec):     147       7     1308       5736       0.02   1168   0 svchost
null_resource.ps1 (remote-exec):     184       9     1788       7552       0.11   1208   0 svchost
null_resource.ps1 (remote-exec):     246      12     2876      11400       0.58   1216   0 svchost
null_resource.ps1 (remote-exec):     154       7     1256       5660       0.06   1232   0 svchost
null_resource.ps1 (remote-exec):     428       9     2740       8908       0.33   1240   0 svchost
null_resource.ps1 (remote-exec):     123      17     3808       7860       0.09   1348   0 svchost
null_resource.ps1 (remote-exec):     162       9     1720       7960       0.02   1376   0 svchost
null_resource.ps1 (remote-exec):     213       9     2040       7460       0.17   1396   0 svchost
null_resource.ps1 (remote-exec):     364      18     4928      14108       1.03   1420   0 svchost
null_resource.ps1 (remote-exec):     227      13     2696       7908       0.77   1436   0 svchost
null_resource.ps1 (remote-exec):     300      11     2052       8900       0.05   1444   0 svchost
null_resource.ps1 (remote-exec):     190      12     2188      12100       0.08   1504   0 svchost
null_resource.ps1 (remote-exec):     351      14     3772      10828       0.14   1568   0 svchost
null_resource.ps1 (remote-exec):     140       9     1540       6460       0.06   1576   0 svchost
null_resource.ps1 (remote-exec):     399      32     7912      16724       0.33   1688   0 svchost
null_resource.ps1 (remote-exec):     142       9     1456       6600       0.03   1708   0 svchost
null_resource.ps1 (remote-exec):     194      11     1988       8156       1.36   1760   0 svchost
null_resource.ps1 (remote-exec):     157       9     1968       7352       0.25   1812   0 svchost
null_resource.ps1 (remote-exec):     306      10     2420       8228       0.30   1996   0 svchost
null_resource.ps1 (remote-exec):     193       9     1488       6624       0.03   2020   0 svchost
null_resource.ps1 (remote-exec):     243      14     2244       9216       0.09   2072   0 svchost
null_resource.ps1 (remote-exec):     239      11     2580       9952       0.28   2084   0 svchost
null_resource.ps1 (remote-exec):     138       9     1644       7232       0.03   2304   0 svchost
null_resource.ps1 (remote-exec):     169       9     2912       7720       0.05   2316   0 svchost
null_resource.ps1 (remote-exec):     259      16     2660       9636       0.08   2388   0 svchost
null_resource.ps1 (remote-exec):     262      26     4404      13920       2.77   2404   0 svchost
null_resource.ps1 (remote-exec):     778      21    19616      35332       4.02   2416   0 svchost
null_resource.ps1 (remote-exec):     383      15    13564      23040      88.66   2428   0 svchost
null_resource.ps1 (remote-exec):     136       8     1508       6276       0.03   2512   0 svchost
null_resource.ps1 (remote-exec):     128       7     1232       5484       0.03   2536   0 svchost
null_resource.ps1 (remote-exec):     213      12     1852       7600       0.06   2568   0 svchost
null_resource.ps1 (remote-exec):     210      11     2348       8448       2.44   2584   0 svchost
null_resource.ps1 (remote-exec):     227      13     3428      10876       0.08   2636   0 svchost
null_resource.ps1 (remote-exec):     175      11     2324      13360       0.06   2644   0 svchost
null_resource.ps1 (remote-exec):     462      16     3272      11464       0.11   2676   0 svchost
null_resource.ps1 (remote-exec):     381      19     6364      28748       0.33   2972   1 svchost
null_resource.ps1 (remote-exec):     163      10     2016       7576       0.05   3128   0 svchost
null_resource.ps1 (remote-exec):     250      13     3236      14336       0.19   3392   1 svchost
null_resource.ps1 (remote-exec):     201      15     6180      10248       0.09   3480   0 svchost
null_resource.ps1 (remote-exec):     143       9     1584      10704       0.05   3568   0 svchost
null_resource.ps1 (remote-exec):     251      14     3132      13800       0.06   3772   0 svchost
null_resource.ps1 (remote-exec):     434      19    10216      28284       0.70   3928   0 svchost
null_resource.ps1 (remote-exec):     322      20     9736      14836       0.22   4088   0 svchost
null_resource.ps1 (remote-exec):     356      16     4896      15944       0.34   4160   0 svchost
null_resource.ps1 (remote-exec):     147       8     1728       7592       0.06   4180   0 svchost
null_resource.ps1 (remote-exec):     208      11     2832      12080       1.13   4428   0 svchost
null_resource.ps1 (remote-exec):     272      16     3808      18216       0.19   4496   0 svchost
null_resource.ps1 (remote-exec):     184      10     1912       8708       0.09   4620   0 svchost
null_resource.ps1 (remote-exec):     161       9     4296      11720       0.52   4660   0 svchost
null_resource.ps1 (remote-exec):     314      16    16344      17640      52.92   4864   0 svchost
null_resource.ps1 (remote-exec):    1914       0      192        144      20.34      4   0 System
null_resource.ps1 (remote-exec):     212      21     4360      12948       0.13   3596   1 taskhostw
null_resource.ps1 (remote-exec):     594      28    16580      40148       4.53   3356   1 Taskmgr
null_resource.ps1 (remote-exec):     175      12     3164      10656       0.06   2560   0 VGAuthService
null_resource.ps1 (remote-exec):      96       8     1452       6396       0.05   3824   1 vm3dservice
null_resource.ps1 (remote-exec):     379      22     9736      22112      49.22   2576   0 vmtoolsd
null_resource.ps1 (remote-exec):     265      19     3928      16448      43.91   3344   1 vmtoolsd
null_resource.ps1 (remote-exec):     171      11     1464       6856       0.03    480   0 wininit
null_resource.ps1 (remote-exec):     268      12     2904      11776       0.14    524   1 winlogon
null_resource.ps1 (remote-exec):     341      16    10024      19180      96.14   3716   0 WmiPrvSE
null_resource.ps1 (remote-exec): Remove-Item : Cannot find path 'C:\windows\temp\ps1' because it does not exist.
null_resource.ps1 (remote-exec): At C:\windows\temp\terraform_1529213580.ps1:2 char:1
null_resource.ps1 (remote-exec): + Remove-Item -recurse -Path C:\windows\temp\ps1
null_resource.ps1 (remote-exec): + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
null_resource.ps1 (remote-exec):     + CategoryInfo          : ObjectNotFound: (C:\windows\temp\ps1:String) [Remove-Item], ItemNotFoundException
null_resource.ps1 (remote-exec):     + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.RemoveItemCommand


null_resource.ps1 (remote-exec): PSPath            : Microsoft.PowerShell.Core\FileSystem::C:\windows\temp\ps1\testfolder1
null_resource.ps1 (remote-exec): PSParentPath      : Microsoft.PowerShell.Core\FileSystem::C:\windows\temp\ps1
null_resource.ps1 (remote-exec): PSChildName       : testfolder1
null_resource.ps1 (remote-exec): PSDrive           : C
null_resource.ps1 (remote-exec): PSProvider        : Microsoft.PowerShell.Core\FileSystem
null_resource.ps1 (remote-exec): PSIsContainer     : True
null_resource.ps1 (remote-exec): Name              : testfolder1
null_resource.ps1 (remote-exec): FullName          : C:\windows\temp\ps1\testfolder1
null_resource.ps1 (remote-exec): Parent            : ps1
null_resource.ps1 (remote-exec): Exists            : True
null_resource.ps1 (remote-exec): Root              : C:\
null_resource.ps1 (remote-exec): Extension         :
null_resource.ps1 (remote-exec): CreationTime      : 11/10/2020 1:39:59 PM
null_resource.ps1 (remote-exec): CreationTimeUtc   : 11/10/2020 12:39:59 PM
null_resource.ps1 (remote-exec): LastAccessTime    : 11/10/2020 1:39:59 PM
null_resource.ps1 (remote-exec): LastAccessTimeUtc : 11/10/2020 12:39:59 PM
null_resource.ps1 (remote-exec): LastWriteTime     : 11/10/2020 1:39:59 PM
null_resource.ps1 (remote-exec): LastWriteTimeUtc  : 11/10/2020 12:39:59 PM
null_resource.ps1 (remote-exec): Attributes        : Directory
null_resource.ps1 (remote-exec): Mode              : d-----
null_resource.ps1 (remote-exec): BaseName          : testfolder1
null_resource.ps1 (remote-exec): Target            : {}
null_resource.ps1 (remote-exec): LinkType          :


null_resource.ps1 (remote-exec): PSPath            : Microsoft.PowerShell.Core\FileSystem::C:\windows\temp\ps1\testfolder3
null_resource.ps1 (remote-exec): PSParentPath      : Microsoft.PowerShell.Core\FileSystem::C:\windows\temp\ps1
null_resource.ps1 (remote-exec): PSChildName       : testfolder3
null_resource.ps1 (remote-exec): PSDrive           : C
null_resource.ps1 (remote-exec): PSProvider        : Microsoft.PowerShell.Core\FileSystem
null_resource.ps1 (remote-exec): PSIsContainer     : True
null_resource.ps1 (remote-exec): Name              : testfolder3
null_resource.ps1 (remote-exec): FullName          : C:\windows\temp\ps1\testfolder3
null_resource.ps1 (remote-exec): Parent            : ps1
null_resource.ps1 (remote-exec): Exists            : True
null_resource.ps1 (remote-exec): Root              : C:\
null_resource.ps1 (remote-exec): Extension         :
null_resource.ps1 (remote-exec): CreationTime      : 11/10/2020 1:39:59 PM
null_resource.ps1 (remote-exec): CreationTimeUtc   : 11/10/2020 12:39:59 PM
null_resource.ps1 (remote-exec): LastAccessTime    : 11/10/2020 1:39:59 PM
null_resource.ps1 (remote-exec): LastAccessTimeUtc : 11/10/2020 12:39:59 PM
null_resource.ps1 (remote-exec): LastWriteTime     : 11/10/2020 1:39:59 PM
null_resource.ps1 (remote-exec): LastWriteTimeUtc  : 11/10/2020 12:39:59 PM
null_resource.ps1 (remote-exec): Attributes        : Directory
null_resource.ps1 (remote-exec): Mode              : d-----
null_resource.ps1 (remote-exec): BaseName          : testfolder3
null_resource.ps1 (remote-exec): Target            : {}
null_resource.ps1 (remote-exec): LinkType          :



null_resource.ps1: Provisioning with 'file'...
null_resource.ps1: Provisioning with 'file'...
null_resource.ps1: Provisioning with 'file'...
null_resource.ps1: Provisioning with 'file'...
null_resource.ps1: Creation complete after 4s [id=7624949431424135250]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
