### PR TITLE
communicator/ssh: Add support for Windows targets

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -139,13 +139,15 @@ func (c *Communicator) Connect(o terraform.UIOutput) (err error) {
 				"  Private key: %t\n"+
 				"  Certificate: %t\n"+
 				"  SSH Agent: %t\n"+
-				"  Checking Host Key: %t",
+				"  Checking Host Key: %t\n"+
+				"  Target Platform: %s\n",
 			c.connInfo.Host, c.connInfo.User,
 			c.connInfo.Password != "",
 			c.connInfo.PrivateKey != "",
 			c.connInfo.Certificate != "",
 			c.connInfo.Agent,
 			c.connInfo.HostKey != "",
+			c.connInfo.TargetPlatform,
 		))
 
 		if c.connInfo.BastionHost != "" {
@@ -343,7 +345,7 @@ func (c *Communicator) Start(cmd *remote.Cmd) error {
 	session.Stdout = cmd.Stdout
 	session.Stderr = cmd.Stderr
 
-	if !c.config.noPty {
+	if !c.config.noPty && c.connInfo.TargetPlatform != TargetPlatformWindows {
 		// Request a PTY
 		termModes := ssh.TerminalModes{
 			ssh.ECHO:          0,     // do not echo
@@ -425,35 +427,35 @@ func (c *Communicator) UploadScript(path string, input io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("Error reading script: %s", err)
 	}
-
 	var script bytes.Buffer
-	if string(prefix) != "#!" {
+
+	if string(prefix) != "#!" && c.connInfo.TargetPlatform != TargetPlatformWindows {
 		script.WriteString(DefaultShebang)
 	}
-
 	script.ReadFrom(reader)
+
 	if err := c.Upload(path, &script); err != nil {
 		return err
 	}
+	if c.connInfo.TargetPlatform != TargetPlatformWindows {
+		var stdout, stderr bytes.Buffer
+		cmd := &remote.Cmd{
+			Command: fmt.Sprintf("chmod 0777 %s", path),
+			Stdout:  &stdout,
+			Stderr:  &stderr,
+		}
+		if err := c.Start(cmd); err != nil {
+			return fmt.Errorf(
+				"Error chmodding script file to 0777 in remote "+
+					"machine: %s", err)
+		}
 
-	var stdout, stderr bytes.Buffer
-	cmd := &remote.Cmd{
-		Command: fmt.Sprintf("chmod 0777 %s", path),
-		Stdout:  &stdout,
-		Stderr:  &stderr,
+		if err := cmd.Wait(); err != nil {
+			return fmt.Errorf(
+				"Error chmodding script file to 0777 in remote "+
+					"machine %v: %s %s", err, stdout.String(), stderr.String())
+		}
 	}
-	if err := c.Start(cmd); err != nil {
-		return fmt.Errorf(
-			"Error chmodding script file to 0777 in remote "+
-				"machine: %s", err)
-	}
-
-	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf(
-			"Error chmodding script file to 0777 in remote "+
-				"machine %v: %s %s", err, stdout.String(), stderr.String())
-	}
-
 	return nil
 }
 

--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -50,7 +50,10 @@ func TestProvisioner_connInfo(t *testing.T) {
 	if conf.Timeout != "30s" {
 		t.Fatalf("bad: %v", conf)
 	}
-	if conf.ScriptPath != DefaultScriptPath {
+	if conf.ScriptPath != DefaultUnixScriptPath {
+		t.Fatalf("bad: %v", conf)
+	}
+	if conf.TargetPlatform != TargetPlatformUnix {
 		t.Fatalf("bad: %v", conf)
 	}
 	if conf.BastionHost != "127.0.1.1" {

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -208,8 +208,11 @@ var connectionBlockSupersetSchema = &configschema.Block{
 			Type:     cty.String,
 			Optional: true,
 		},
-
 		// For type=ssh only (enforced in ssh communicator)
+		"target_platform": {
+			Type:     cty.String,
+			Optional: true,
+		},
 		"private_key": {
 			Type:     cty.String,
 			Optional: true,

--- a/website/docs/language/resources/provisioners/connection.html.md
+++ b/website/docs/language/resources/provisioners/connection.html.md
@@ -123,6 +123,9 @@ block would create a dependency cycle.
 
 * `host_key` - The public key from the remote host or the signing CA, used to
   verify the connection.
+* `target_platform` - The target platform to connect to. Valid values are `windows` and `unix`. Defaults to `unix` if not set.
+
+    If the platform is set to `windows`, the default `script_path` is `c:\windows\temp\terraform_%RAND%.cmd`, assuming [the SSH default shell](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows) is `cmd.exe`. If the SSH default shell is PowerShell, set `script_path` to `"c:/windows/temp/terraform_%RAND%.ps1"`.
 
 **Additional arguments only supported by the `winrm` connection type:**
 


### PR DESCRIPTION
Backport of #26865. Targeting 0.14.1 because we just missed the RC.

Changelog line:

```markdown
* communicator/ssh: Add support for Windows targets. The `remote-exec` provisioner now works correctly when connecting to Windows servers using SSH. Specify the `target_platform` as `"windows"` in the `connection` block. [GH-26865]
```