### PR TITLE
backend/local: Show resource instance drift as part of the plan

### DIFF
--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -70,6 +70,8 @@ func (b *Local) opApply(
 
 	// If we weren't given a plan, then we refresh/plan
 	if op.PlanFile == nil {
+		initialState := tfCtx.State().DeepCopy()
+
 		// Perform the plan
 		log.Printf("[INFO] backend/local: apply calling Plan")
 		plan, planDiags := tfCtx.Plan()
@@ -104,7 +106,7 @@ func (b *Local) opApply(
 
 			if !trivialPlan {
 				// Display the plan of what we are going to apply/destroy.
-				b.renderPlan(plan, runningOp.State, tfCtx.Schemas())
+				b.renderPlan(plan, initialState, plan.State, tfCtx.Schemas())
 				b.CLI.Output("")
 			}
 

--- a/command/show.go
+++ b/command/show.go
@@ -163,7 +163,7 @@ func (c *ShowCommand) Run(args []string) int {
 		// package rather than in the backends themselves, but for now we're
 		// accepting this oddity because "terraform show" is a less commonly
 		// used way to render a plan than "terraform plan" is.
-		localBackend.RenderPlan(plan, stateFile.State, schemas, c.Ui, c.Colorize())
+		localBackend.RenderPlan(plan, stateFile.State, stateFile.State, schemas, c.Ui, c.Colorize())
 		return 0
 	}
 

--- a/states/state_equal.go
+++ b/states/state_equal.go
@@ -16,3 +16,23 @@ func (s *State) Equal(other *State) bool {
 	// more sophisticated comparisons.
 	return reflect.DeepEqual(s, other)
 }
+
+// Equal returns true if the receiver is functionally equivalent to other,
+// including any ephemeral portions of the state that would not be included
+// if the state were saved to files.
+func (s *Resource) Equal(other *Resource) bool {
+	// For the moment this is sufficient, but we may need to do something
+	// more elaborate in future if we have any portions of state that require
+	// more sophisticated comparisons.
+	return reflect.DeepEqual(s, other)
+}
+
+// Equal returns true if the receiver is functionally equivalent to other,
+// including any ephemeral portions of the state that would not be included
+// if the state were saved to files.
+func (s *ResourceInstance) Equal(other *ResourceInstance) bool {
+	// For the moment this is sufficient, but we may need to do something
+	// more elaborate in future if we have any portions of state that require
+	// more sophisticated comparisons.
+	return reflect.DeepEqual(s, other)
+}


### PR DESCRIPTION
For another installment of "I had a little extra time at the end of the week", I noticed a few weeks ago that we now have sufficient information available during planning to detect and report drift explicitly, like we mocked in #15419. This is a prototype of that, mainly focused on seeing what the real UX might be like and how the problem has changed since I filed #15419.

---

When a user edits Terraform-managed objects outside of Terraform it can often prove confusing because Terraform indicates the need to change something even though the configuration hasn't changed.

We retain enough information in the state that we can actually detect when an object has "drifted" since the last apply, so now we'll include that information in the plan output both just to generally make it more visible (in case the drift wasn't actually intentional and so investigation is warranted) and also to potentially serve as an explanation for other changes that appear in the plan that follows.

![](https://user-images.githubusercontent.com/20180/99134531-fc3abd80-25d2-11eb-8cb8-1f9cff0e55d7.png)

---

One way this problem changed since I wrote up #15419 is that we've made sure that `terraform plan` will consider changes to _root module outputs_ as needing to be applied, which was actually the main motivation for #15419, and we've also refined how data resources work so they get processed as part of planning now too.

Because of that, I no longer think it's important to be able to "apply" drift into the state in isolation, if that drift doesn't result in changes to the outputs. Applying it would not result in any significant observable side-effect. With that said, this prototype is therefore just a cosmetic UI thing and doesn't cause Terraform to consider drift as changes to be applied, only as extra context to present _alongside_ changes to be applied.
