### PR TITLE
Use a global sequence to create the IDs for each workspace

### DIFF
--- a/backend/remote-state/pg/backend.go
+++ b/backend/remote-state/pg/backend.go
@@ -105,10 +105,14 @@ func (b *Backend) configure(ctx context.Context) error {
 	}
 
 	if !data.Get("skip_table_creation").(bool) {
+		if _, err := db.Exec("CREATE SEQUENCE IF NOT EXISTS public.global_states_id_seq AS bigint"); err != nil {
+			return err
+		}
+
 		query = `CREATE TABLE IF NOT EXISTS %s.%s (
-			id SERIAL PRIMARY KEY,
-			name TEXT,
-			data TEXT
+			id bigint NOT NULL DEFAULT nextval('public.global_states_id_seq') PRIMARY KEY,
+			name text,
+			data text
 			)`
 		if _, err := db.Exec(fmt.Sprintf(query, b.schemaName, statesTableName)); err != nil {
 			return err


### PR DESCRIPTION
Until now the default workspace for every project would have the ID 1,
which would make it impossible to lock them at the same time since we
use the ID to identify the lock. With a global sequence to generate the
IDs, the default workspace will now have a different ID for each project
and it will be possible to lock multiple unrelated projects at the same
time.

If an old version of Terraform tries to get the lock on a project created
with this new version it will work as we continue to use the ID of the
workspace, we just change the way we generate them.

If this version tries to get a lock on a project created by an old
version of Terraform it will work as usual, but we may encounter a
conflict with another unrelated project. This is already the current
behavior so it's not an issue to persist this behavior. As users migrate
to an up-to-date version of Terraform this will stop.

Projects already present in the database will keep their conflicting IDs,
I did not wanted to change them as users may be reading the states
directly in the database for some reason. They can if they want change
them manually to remove conflicts, newly created projects will work
without manual intervention.

Closes https://github.com/hashicorp/terraform/issues/22833