### PR TITLE
Add a missing new line

### DIFF
--- a/website/docs/commands/output.html.markdown
+++ b/website/docs/commands/output.html.markdown
@@ -61,6 +61,7 @@ password = <sensitive>
 ```
 
 Note that outputs with the `sensitive` attribute will be redacted:
+
 ```shellsession
 $ terraform output password
 password = <sensitive>


### PR DESCRIPTION
The missing new line doesn't permit the code block to show up in the generated documentation