### PR TITLE
terraform: Unmark provider configuration arguments

### DIFF
--- a/terraform/node_provider_test.go
+++ b/terraform/node_provider_test.go
@@ -115,3 +115,77 @@ func TestNodeApplyableProviderExecute_unknownApply(t *testing.T) {
 		t.Errorf("wrong configuration value\ngot:  %#v\nwant: %#v", got, want)
 	}
 }
+
+func TestNodeApplyableProviderExecute_sensitive(t *testing.T) {
+	config := &configs.Provider{
+		Name: "foo",
+		Config: configs.SynthBody("", map[string]cty.Value{
+			"test_string": cty.StringVal("hello").Mark("sensitive"),
+		}),
+	}
+	provider := mockProviderWithConfigSchema(simpleTestSchema())
+	providerAddr := addrs.AbsProviderConfig{
+		Module:   addrs.RootModule,
+		Provider: addrs.NewDefaultProvider("foo"),
+	}
+
+	n := &NodeApplyableProvider{&NodeAbstractProvider{
+		Addr:   providerAddr,
+		Config: config,
+	}}
+
+	ctx := &MockEvalContext{ProviderProvider: provider}
+	ctx.installSimpleEval()
+	if err := n.Execute(ctx, walkApply); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !ctx.ConfigureProviderCalled {
+		t.Fatal("should be called")
+	}
+
+	gotObj := ctx.ConfigureProviderConfig
+	if !gotObj.Type().HasAttribute("test_string") {
+		t.Fatal("configuration object does not have \"test_string\" attribute")
+	}
+	if got, want := gotObj.GetAttr("test_string"), cty.StringVal("hello"); !got.RawEquals(want) {
+		t.Errorf("wrong configuration value\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestNodeApplyableProviderExecute_sensitiveValidate(t *testing.T) {
+	config := &configs.Provider{
+		Name: "foo",
+		Config: configs.SynthBody("", map[string]cty.Value{
+			"test_string": cty.StringVal("hello").Mark("sensitive"),
+		}),
+	}
+	provider := mockProviderWithConfigSchema(simpleTestSchema())
+	providerAddr := addrs.AbsProviderConfig{
+		Module:   addrs.RootModule,
+		Provider: addrs.NewDefaultProvider("foo"),
+	}
+
+	n := &NodeApplyableProvider{&NodeAbstractProvider{
+		Addr:   providerAddr,
+		Config: config,
+	}}
+
+	ctx := &MockEvalContext{ProviderProvider: provider}
+	ctx.installSimpleEval()
+	if err := n.Execute(ctx, walkValidate); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !provider.PrepareProviderConfigCalled {
+		t.Fatal("should be called")
+	}
+
+	gotObj := provider.PrepareProviderConfigRequest.Config
+	if !gotObj.Type().HasAttribute("test_string") {
+		t.Fatal("configuration object does not have \"test_string\" attribute")
+	}
+	if got, want := gotObj.GetAttr("test_string"), cty.StringVal("hello"); !got.RawEquals(want) {
+		t.Errorf("wrong configuration value\ngot:  %#v\nwant: %#v", got, want)
+	}
+}


### PR DESCRIPTION
Before configuring a provider, we need to unmark the configuration object, in case it includes any sensitive values. This is required because configuration occurs over gRPC, which doesn't support sensitive marks.

Fixes #26922