### PR TITLE
Don't render a plan for module outputs

### DIFF
--- a/backend/local/testdata/plan-module-outputs-changed/main.tf
+++ b/backend/local/testdata/plan-module-outputs-changed/main.tf
@@ -1,0 +1,3 @@
+module "mod" {
+  source = "./mod"
+}

--- a/backend/local/testdata/plan-module-outputs-changed/mod/main.tf
+++ b/backend/local/testdata/plan-module-outputs-changed/mod/main.tf
@@ -1,0 +1,3 @@
+output "changed" {
+  value = "after"
+}

--- a/plans/changes.go
+++ b/plans/changes.go
@@ -39,7 +39,7 @@ func (c *Changes) Empty() bool {
 	}
 
 	for _, out := range c.Outputs {
-		if out.Action != NoOp {
+		if out.Addr.Module.IsRoot() && out.Action != NoOp {
 			return false
 		}
 	}

--- a/plans/plan_test.go
+++ b/plans/plan_test.go
@@ -68,3 +68,28 @@ func TestProviderAddrs(t *testing.T) {
 		t.Error(problem)
 	}
 }
+
+// Module outputs should not effect the result of Empty
+func TestModuleOutputChangesEmpty(t *testing.T) {
+	changes := &Changes{
+		Outputs: []*OutputChangeSrc{
+			{
+				Addr: addrs.AbsOutputValue{
+					Module: addrs.RootModuleInstance.Child("child", addrs.NoKey),
+					OutputValue: addrs.OutputValue{
+						Name: "output",
+					},
+				},
+				ChangeSrc: ChangeSrc{
+					Action: Update,
+					Before: []byte("a"),
+					After:  []byte("b"),
+				},
+			},
+		},
+	}
+
+	if !changes.Empty() {
+		t.Fatal("plan has no visible changes")
+	}
+}


### PR DESCRIPTION
Module outputs should not trigger plan rendering. These are not shown in the plan output, however they were still causing `Changes.Empty()` to return `false`.

Fixes #26899
