### PR TITLE
configs: Specialized warning for single-interpolation object keys

### DIFF
--- a/configs/compat_shim_test.go
+++ b/configs/compat_shim_test.go
@@ -1,0 +1,61 @@
+package configs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestWarnForDeprecatedInterpolationsInExpr(t *testing.T) {
+	tests := []struct {
+		Expr       string
+		WantSubstr string
+	}{
+		{
+			`"${foo}"`,
+			"leaving just the inner expression",
+		},
+		{
+			`{"${foo}" = 1}`,
+			// Special message for object key expressions, because just
+			// removing the interpolation markers would change the meaning
+			// in that context.
+			"opening and closing parentheses respectively",
+		},
+		{
+			`{upper("${foo}") = 1}`,
+			// But no special message if the template is just descended from an
+			// object key, because the special interpretation applies only to
+			// a naked reference in te object key position.
+			"leaving just the inner expression",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Expr, func(t *testing.T) {
+			expr, diags := hclsyntax.ParseExpression([]byte(test.Expr), "", hcl.InitialPos)
+			if diags.HasErrors() {
+				t.Fatalf("parse error: %s", diags.Error())
+			}
+
+			diags = warnForDeprecatedInterpolationsInExpr(expr)
+			if !diagWarningsContainSubstring(diags, test.WantSubstr) {
+				t.Errorf("wrong warning message\nwant detail substring: %s\ngot: %s", test.WantSubstr, diags.Error())
+			}
+		})
+	}
+}
+
+func diagWarningsContainSubstring(diags hcl.Diagnostics, want string) bool {
+	for _, diag := range diags {
+		if diag.Severity != hcl.DiagWarning {
+			continue
+		}
+		if strings.Contains(diag.Detail, want) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
We have an existing warning message to encourage moving away from the old 0.11-and-earlier style of redundantly wrapping standalone expressions in templates, but due to the special rules for object keys the warning message was giving misleading advice in that context: a user following the advice as given would then encounter an error about the object key being ambiguous.

```hcl
locals {
  foo = {
    a = "b"
    "${local.bar}" = "c"
  }
}
```

```
Warning: Interpolation-only expressions are deprecated

  on interp-map-keys.tf line 4, in locals:
   4:     "${local.bar}" = "c"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```

```hcl
locals {
  foo = {
    a = "b"
    local.bar = "c"
  }
}
```

```
Error: Ambiguous attribute key

  on interp-map-keys.tf line 4, in locals:
   4:     local.bar = "c"

If this expression is intended to be a reference, wrap it in parentheses. If
it's instead intended as a literal name containing periods, wrap it in quotes
to create a string literal.
```

To account for that, this introduces a special alternative version of the warning just for that particular position, directing the user to replace the template interpolation markers with parenthesis instead. That will then get the same result as the former interpolation sequence, rather than producing the ambiguity error.

```
Warning: Interpolation-only expressions are deprecated

  on interp-map-keys.tf line 4, in locals:
   4:     "${local.bar}" = "c"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated.

To silence this warning, replace the "${ opening sequence and the }" closing
sequence with opening and closing parentheses respectively. Parentheses are
needed here to mark this as an expression to be evaluated, rather than as a
literal string key.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```

```hcl
locals {
  foo = {
    a = "b"
    (local.bar) = "c"
  }
}
```

```shellsession
$ terraform apply

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

My goal here is essentially to combine the two previous messages into a single message that leads directly to the working result. As with the other version of this warning, it's not super easy to explain what's needed here in prose because of the need to refer to specific punctuation in the message, but I hope this gets a similar point across as the "Ambiguous attribute key" error message.

This closes #26512, by hopefully making the initial warning message clearer and thus avoiding the misdirection that led to that bug report.
