### PR TITLE
website: Reword confusing statement about module sources in TFE

### DIFF
--- a/website/docs/modules/sources.html.markdown
+++ b/website/docs/modules/sources.html.markdown
@@ -116,9 +116,10 @@ module "consul" {
 ```
 
 If you are using the SaaS version of Terraform Cloud, its private
-registry hostname is `app.terraform.io`. If you are using a Terraform Enterprise
-instance, its private registry hostname is the same hostname you use to
-access the Terraform Cloud application.
+registry hostname is `app.terraform.io`. If you use a self-hosted Terraform
+Enterprise instance, its private registry hostname is the same as the host
+where you'd access the web UI and the host you'd use when configuring
+the `remote` backend.
 
 Registry modules support versioning. You can provide a specific version as shown
 in the above examples, or use flexible


### PR DESCRIPTION
As written previously this seemed to suggest using `app.terraform.io` (the "hostname you use to access the Terraform Cloud application) to access a private registry in Terraform Enterprise, but that isn't true and I assume isn't what was intended.

Instead, the hostname for a Terraform Enterprise instance is the hostname where the Terraform Enterprise application is running, which is both the hostname where users would find its web UI and the hostname they'd use to configure the `remote` backend for remote operations and state storage.

This is motivated by and closes #26154.