### PR TITLE
configs: Emit a warning for backends in nested modules

### DIFF
--- a/configs/config_build.go
+++ b/configs/config_build.go
@@ -78,6 +78,15 @@ func buildChildModules(parent *Config, walker ModuleWalker) (map[string]*Config,
 		child.Children, modDiags = buildChildModules(child, walker)
 		diags = append(diags, modDiags...)
 
+		if mod.Backend != nil {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Backend configuration ignored",
+				Detail:   "Any selected backend applies to the entire configuration, so Terraform expects provider configurations only in the root module.\n\nThis is a warning rather than an error because it's sometimes convenient to temporarily call a root module as a child module for testing purposes, but this backend configuration block will have no effect.",
+				Subject:  mod.Backend.DeclRange.Ptr(),
+			})
+		}
+
 		ret[call.Name] = child
 	}
 

--- a/configs/config_build_test.go
+++ b/configs/config_build_test.go
@@ -114,3 +114,43 @@ func TestBuildConfigDiags(t *testing.T) {
 		t.Fatalf("wrong result\ngot: %swant: %s", spew.Sdump(got), spew.Sdump(want))
 	}
 }
+
+func TestBuildConfigChildModuleBackend(t *testing.T) {
+	parser := NewParser(nil)
+	mod, diags := parser.LoadConfigDir("testdata/nested-backend-warning")
+	assertNoDiagnostics(t, diags)
+	if mod == nil {
+		t.Fatal("got nil root module; want non-nil")
+	}
+
+	cfg, diags := BuildConfig(mod, ModuleWalkerFunc(
+		func(req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {
+			// For the sake of this test we're going to just treat our
+			// SourceAddr as a path relative to our fixture directory.
+			// A "real" implementation of ModuleWalker should accept the
+			// various different source address syntaxes Terraform supports.
+			sourcePath := filepath.Join("testdata/nested-backend-warning", req.SourceAddr)
+
+			mod, diags := parser.LoadConfigDir(sourcePath)
+			version, _ := version.NewVersion("1.0.0")
+			return mod, version, diags
+		},
+	))
+
+	assertDiagnosticSummary(t, diags, "Backend configuration ignored")
+
+	// we should still have module structure loaded
+	var got []string
+	cfg.DeepEach(func(c *Config) {
+		got = append(got, fmt.Sprintf("%s %s", strings.Join(c.Path, "."), c.Version))
+	})
+	sort.Strings(got)
+	want := []string{
+		" <nil>",
+		"child 1.0.0",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("wrong result\ngot: %swant: %s", spew.Sdump(got), spew.Sdump(want))
+	}
+}

--- a/configs/testdata/nested-backend-warning/child/child.tf
+++ b/configs/testdata/nested-backend-warning/child/child.tf
@@ -1,0 +1,6 @@
+terraform {
+  # Only the root module can declare a backend. Terraform should emit a warning
+  # about this child module backend declaration.
+  backend "ignored" {
+  }
+}

--- a/configs/testdata/nested-backend-warning/root.tf
+++ b/configs/testdata/nested-backend-warning/root.tf
@@ -1,0 +1,3 @@
+module "child" {
+  source = "./child"
+}


### PR DESCRIPTION
Terraform considers backend configurations only in the root module, so any declarations in child modules are entirely ignored.

To avoid users mistakenly thinking that a root module backend configuration has taken effect, we'll now emit a warning about it. This is a warning rather than an error because it's reasonable to call a module that would normally be a root module instead as a child module when writing a wrapper module to handle integration testing.

```
Warning: Backend configuration ignored

  on child/nested-backend-config-child.tf line 2, in terraform:
   2:   backend "ignored" {}

The selected backend applies to the entire configuration, so Terraform expects
provider configurations only in the root module.

This is a warning rather than an error because it's sometimes convenient to
temporarily call a root module as a child module for testing purposes, but
this backend configuration block will have no effect.
```

This closes #25933, by giving better feedback that ignoring the child module backends is by design.
