### PR TITLE
website: Fix confusing example for local-exec provisioner

### DIFF
--- a/website/docs/provisioners/local-exec.html.markdown
+++ b/website/docs/provisioners/local-exec.html.markdown
@@ -29,7 +29,7 @@ resource "aws_instance" "web" {
   # ...
 
   provisioner "local-exec" {
-    command = "echo ${aws_instance.web.private_ip} >> private_ips.txt"
+    command = "echo ${self.private_ip} >> private_ips.txt"
   }
 }
 ```


### PR DESCRIPTION
The local-exec provisioner documentation includes an example which refers to an attribute of the current resource using its full traversal path, rather than using `self` as we typically expect.

Due to some coincidences in how Terraform builds the dependency graph, referring to the resource in this way happens to work when the resource has only a single instance (the graph builder just skips that self-referential dependency edge), but it fails if the user later tries to add `count` or `for_each` to the resource, because at that point all of the instances become dependent on one another, which creates a dependency cycle.

Using `self` to access the current instance attributes is the usual approach, so I've updated the documentation to show that.

This fixes #25548.