### PR TITLE
website: Adopt a title typo fix from v0.14 branch

### DIFF
--- a/website/docs/commands/providers/lock.html.md
+++ b/website/docs/commands/providers/lock.html.md
@@ -7,7 +7,7 @@ description: |-
   to the dependency lock file without initializing the referenced providers.
 ---
 
-# Command: terraform providers mirror
+# Command: terraform providers lock
 
 The `terraform providers lock` consults upstream registries (by default) in
 order to write provider dependency information into


### PR DESCRIPTION
This was commit 04199a628, and it looks like it might have skipped main and gone straight to 0.14. 