### PR TITLE
correct terraform-bundle default plugins dir docs

### DIFF
--- a/tools/terraform-bundle/README.md
+++ b/tools/terraform-bundle/README.md
@@ -124,7 +124,7 @@ bundles contain the same core Terraform version.
 
 ## Custom Plugins
 To include custom plugins in the bundle file, create a local directory named
-`./plugins` and put all the plugins you want to include there, under the
+`./.plugins` and put all the plugins you want to include there, under the
 required [sub directory](#plugins-directory-layout). Optionally, you can use the
 `-plugin-dir` flag to specify a location where to find the plugins. To be
 recognized as a valid plugin, the file must have a name of the form
@@ -135,10 +135,10 @@ Typically this will be `linux` and `amd64`.
 ### Plugins Directory Layout
 To include custom plugins in the bundle file, you must specify a "source"
 attribute in the configuration and place the plugin in the appropriate
-subdirectory under `./plugins`. The directory must have the following layout:
+subdirectory under `./.plugins`. The directory must have the following layout:
 
 ```
-./plugins/$SOURCEHOST/$SOURCENAMESPACE/$NAME/$VERSION/$OS_$ARCH/
+./.plugins/$SOURCEHOST/$SOURCENAMESPACE/$NAME/$VERSION/$OS_$ARCH/
 ```
 
 When installing custom plugins, you may choose any arbitrary identifier for the
@@ -158,7 +158,7 @@ providers {
 The binary must be placed in the following directory:
 
 ```
-./plugins/example.com/myorg/customplugin/0.1/linux_amd64/
+./.plugins/example.com/myorg/customplugin/0.1/linux_amd64/
 ```
 
 ## Provider Resolution Behavior

--- a/tools/terraform-bundle/package.go
+++ b/tools/terraform-bundle/package.go
@@ -130,7 +130,7 @@ func (c *PackageCommand) Run(args []string) int {
 			localSource := getproviders.NewFilesystemMirrorSource(absPluginDir)
 			if available, err := localSource.AllAvailablePackages(); err == nil {
 				for found := range available {
-					c.ui.Info(fmt.Sprintf("Found provider %q in %q. p", found.String(), pluginDir))
+					c.ui.Info(fmt.Sprintf("Found provider %q in %q.", found.String(), pluginDir))
 					foundLocally[found] = struct{}{}
 				}
 			}


### PR DESCRIPTION
Update the `terraform-bundle` tool documentation to use the [correct default location](https://github.com/hashicorp/terraform/blob/master/tools/terraform-bundle/package.go#L31) where the tool will find custom provider plugins.

Consider the following bundle HCL:

```
terraform {
  version = "0.13.5"
}

providers {
  aws = {
    versions = ["~> 2.0"]
  }

  yaml = {
    versions = ["2.1"]
    source = "providers.local/myorg/yaml"
  }
}
```

According to the current README, I should have a tree folder that looks as such:

```
 $ tree -a
.
├── bundle.hcl
└── plugins
    └── providers.local
        └── myorg
            └── yaml
                └── 2.1
                    └── linux_amd64
                        └── terraform-provider-yaml_v2.1.0-linux-amd64
```

Attempting to build this bundle fails, as `terraform-bundle` does not look in `./plugins` by default:

```
 $ terraform-bundle package ./bundle.hcl 
Fetching Terraform 0.13.5 core package...
Local plugin directory ".plugins" found; scanning for provider binaries.
No ".plugins" directory found, skipping local provider discovery.
- Finding hashicorp/aws versions matching "~> 2.0"...
- Installing hashicorp/aws v2.70.0...
- Finding providers.local/myorg/yaml versions matching "2.1.*"...
Could not retrieve the list of available versions for provider providers.local/myorg/yaml: could not connect to providers.local: Failed to request discovery document: Get "https://providers.local/.well-known/terraform.json": dial tcp: lookup providers.local: no such host.
some providers could not be installed:
- providers.local/myorg/yaml: could not connect to providers.local: Failed to request discovery document: Get "https://providers.local/.well-known/terraform.json": dial tcp: lookup providers.local: no such host
```

Providing a custom `-plugin-dir` flag works:

```
 $ terraform-bundle package -plugin-dir=./plugins ./bundle.hcl 
Fetching Terraform 0.13.5 core package...
Local plugin directory "./plugins" found; scanning for provider binaries.
Found provider "providers.local/myorg/yaml" in "./plugins". p
- Finding hashicorp/aws versions matching "~> 2.0"...
- Installing hashicorp/aws v2.70.0...
- Finding providers.local/myorg/yaml versions matching "2.1.*"...
- Installing providers.local/myorg/yaml v2.1.0...
Creating terraform_0.13.5-bundle2020111818_linux_amd64.zip ...
All done!
```

Additionally, moving the plugins directly to the correct directory `./.plugins` works:

```
Fetching Terraform 0.13.5 core package...
Local plugin directory ".plugins" found; scanning for provider binaries.
Found provider "providers.local/myorg/yaml" in ".plugins". p
- Finding providers.local/myorg/yaml versions matching "2.1.*"...
- Installing providers.local/myorg/yaml v2.1.0...
- Finding hashicorp/aws versions matching "~> 2.0"...
- Installing hashicorp/aws v2.70.0...
Creating terraform_0.13.5-bundle2020111818_linux_amd64.zip ...
All done!
```

This PR also fixes a small typo in the log output from fetching from the local plugin directory.