### PR TITLE
backend: Faster remote backend tests

### DIFF
--- a/backend/remote/backend_apply_test.go
+++ b/backend/remote/backend_apply_test.go
@@ -542,8 +542,8 @@ func TestRemote_applyApprovedExternally(t *testing.T) {
 		t.Fatalf("error starting operation: %v", err)
 	}
 
-	// Wait 2 seconds to make sure the run started.
-	time.Sleep(2 * time.Second)
+	// Wait 50 milliseconds to make sure the run started.
+	time.Sleep(50 * time.Millisecond)
 
 	wl, err := b.client.Workspaces.List(
 		ctx,
@@ -617,8 +617,8 @@ func TestRemote_applyDiscardedExternally(t *testing.T) {
 		t.Fatalf("error starting operation: %v", err)
 	}
 
-	// Wait 2 seconds to make sure the run started.
-	time.Sleep(2 * time.Second)
+	// Wait 50 milliseconds to make sure the run started.
+	time.Sleep(50 * time.Millisecond)
 
 	wl, err := b.client.Workspaces.List(
 		ctx,
@@ -871,7 +871,7 @@ func TestRemote_applyLockTimeout(t *testing.T) {
 		"approve": "yes",
 	})
 
-	op.StateLockTimeout = 5 * time.Second
+	op.StateLockTimeout = 50 * time.Millisecond
 	op.UIIn = input
 	op.UIOut = b.CLI
 	op.Workspace = backend.DefaultStateName
@@ -887,8 +887,8 @@ func TestRemote_applyLockTimeout(t *testing.T) {
 	case <-sigint:
 		// Stop redirecting SIGINT signals.
 		signal.Stop(sigint)
-	case <-time.After(10 * time.Second):
-		t.Fatalf("expected lock timeout after 5 seconds, waited 10 seconds")
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("expected lock timeout after 50 milliseconds, waited 200 milliseconds")
 	}
 
 	if len(input.answers) != 2 {

--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -360,7 +360,7 @@ func (m *mockLogReader) Read(l []byte) (int, error) {
 		if written, err := m.read(l); err != io.ErrNoProgress {
 			return written, err
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(1 * time.Millisecond)
 	}
 }
 

--- a/backend/remote/backend_plan.go
+++ b/backend/remote/backend_plan.go
@@ -20,6 +20,8 @@ import (
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
+var planConfigurationVersionsPollInterval = 500 * time.Millisecond
+
 func (b *Remote) opPlan(stopCtx, cancelCtx context.Context, op *backend.Operation, w *tfe.Workspace) (*tfe.Run, error) {
 	log.Printf("[INFO] backend/remote: starting Plan operation")
 
@@ -213,7 +215,7 @@ in order to capture the filesystem context the remote workspace expects:
 			return nil, context.Canceled
 		case <-cancelCtx.Done():
 			return nil, context.Canceled
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(planConfigurationVersionsPollInterval):
 			cv, err = b.client.ConfigurationVersions.Read(stopCtx, cv.ID)
 			if err != nil {
 				return nil, generalError("Failed to retrieve configuration version", err)

--- a/backend/remote/backend_plan_test.go
+++ b/backend/remote/backend_plan_test.go
@@ -620,7 +620,7 @@ func TestRemote_planLockTimeout(t *testing.T) {
 		"approve": "yes",
 	})
 
-	op.StateLockTimeout = 5 * time.Second
+	op.StateLockTimeout = 50 * time.Millisecond
 	op.UIIn = input
 	op.UIOut = b.CLI
 	op.Workspace = backend.DefaultStateName
@@ -636,8 +636,8 @@ func TestRemote_planLockTimeout(t *testing.T) {
 	case <-sigint:
 		// Stop redirecting SIGINT signals.
 		signal.Stop(sigint)
-	case <-time.After(10 * time.Second):
-		t.Fatalf("expected lock timeout after 5 seconds, waited 10 seconds")
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("expected lock timeout after 50 milliseconds, waited 200 milliseconds")
 	}
 
 	if len(input.answers) != 2 {

--- a/backend/remote/remote_test.go
+++ b/backend/remote/remote_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"testing"
+	"time"
 
 	_ "github.com/hashicorp/terraform/internal/logging"
 )
@@ -13,6 +14,12 @@ func TestMain(m *testing.M) {
 
 	// Make sure TF_FORCE_LOCAL_BACKEND is unset
 	os.Unsetenv("TF_FORCE_LOCAL_BACKEND")
+
+	// Reduce delays to make tests run faster
+	backoffMin = 1.0
+	backoffMax = 1.0
+	planConfigurationVersionsPollInterval = 1 * time.Millisecond
+	runPollInterval = 1 * time.Millisecond
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
The remote backend tests spent most of their execution time sleeping in various polling and backoff waits. This is unnecessary when testing against a mock server, so reduce all of these delays when under test to much lower values.

Only one remaining test has an artificial delay: verifying the discovery of services against an unknown hostname. This times out at DNS resolution, which is more difficult to fix than seems worth it at this time.

The only change to production code is unifying the network backoff when waiting for the run and waiting for the cost estimate. The latter is now an exponential backoff between 1 and 3 seconds, instead of constant 1 second.

From my reading of these tests, I don't think this should cause flaky tests due to timing. I'm going to rerun the CircleCI job a few times until I feel more certain about this. Edit: five runs, all passing ✅ 

## Comparison

Total test run times for the package are dominated by these delays.

Before:

```shellsession
$ go test -count=1 ./backend/remote
ok  	github.com/hashicorp/terraform/backend/remote	78.589s
```

After:

```shellsession
$ go test -count=1 ./backend/remote
ok  	github.com/hashicorp/terraform/backend/remote	6.084s
```