### PR TITLE
command/version: Report the current platform

### DIFF
--- a/command/version.go
+++ b/command/version.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders"
 )
 
 // VersionCommand is a Command implementation prints the version.
@@ -19,11 +20,13 @@ type VersionCommand struct {
 	Version           string
 	VersionPrerelease string
 	CheckFunc         VersionCheckFunc
+	Platform          getproviders.Platform
 }
 
 type VersionOutput struct {
 	Version            string            `json:"terraform_version"`
 	Revision           string            `json:"terraform_revision"`
+	Platform           string            `json:"platform"`
 	ProviderSelections map[string]string `json:"provider_selections"`
 	Outdated           bool              `json:"terraform_outdated"`
 }
@@ -137,6 +140,7 @@ func (c *VersionCommand) Run(args []string) int {
 		output := VersionOutput{
 			Version:            versionOutput,
 			Revision:           c.Revision,
+			Platform:           c.Platform.String(),
 			ProviderSelections: selectionsOutput,
 			Outdated:           outdated,
 		}
@@ -150,6 +154,8 @@ func (c *VersionCommand) Run(args []string) int {
 		return 0
 	} else {
 		c.Ui.Output(versionString.String())
+		c.Ui.Output(fmt.Sprintf("on %s", c.Platform))
+
 		if len(providerVersions) != 0 {
 			sort.Strings(providerVersions)
 			for _, str := range providerVersions {

--- a/command/version_test.go
+++ b/command/version_test.go
@@ -49,6 +49,7 @@ func TestVersion(t *testing.T) {
 		},
 		Version:           "4.5.6",
 		VersionPrerelease: "foo",
+		Platform:          getproviders.Platform{OS: "aros", Arch: "riscv64"},
 	}
 	if err := c.replaceLockedDependencies(locks); err != nil {
 		t.Fatal(err)
@@ -58,7 +59,7 @@ func TestVersion(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(ui.OutputWriter.String())
-	expected := "Terraform v4.5.6-foo\n+ provider registry.terraform.io/hashicorp/test1 v7.8.9-beta.2\n+ provider registry.terraform.io/hashicorp/test2 v1.2.3"
+	expected := "Terraform v4.5.6-foo\non aros_riscv64\n+ provider registry.terraform.io/hashicorp/test1 v7.8.9-beta.2\n+ provider registry.terraform.io/hashicorp/test2 v1.2.3"
 	if actual != expected {
 		t.Fatalf("wrong output\ngot:\n%s\nwant:\n%s", actual, expected)
 	}
@@ -76,6 +77,7 @@ func TestVersion_flags(t *testing.T) {
 		Meta:              m,
 		Version:           "4.5.6",
 		VersionPrerelease: "foo",
+		Platform:          getproviders.Platform{OS: "aros", Arch: "riscv64"},
 	}
 
 	if code := c.Run([]string{"-v", "-version"}); code != 0 {
@@ -83,7 +85,7 @@ func TestVersion_flags(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(ui.OutputWriter.String())
-	expected := "Terraform v4.5.6-foo"
+	expected := "Terraform v4.5.6-foo\non aros_riscv64"
 	if actual != expected {
 		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actual, expected)
 	}
@@ -99,6 +101,7 @@ func TestVersion_outdated(t *testing.T) {
 		Meta:      m,
 		Version:   "4.5.6",
 		CheckFunc: mockVersionCheckFunc(true, "4.5.7"),
+		Platform:  getproviders.Platform{OS: "aros", Arch: "riscv64"},
 	}
 
 	if code := c.Run([]string{}); code != 0 {
@@ -106,7 +109,7 @@ func TestVersion_outdated(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(ui.OutputWriter.String())
-	expected := "Terraform v4.5.6\n\nYour version of Terraform is out of date! The latest version\nis 4.5.7. You can update by downloading from https://www.terraform.io/downloads.html"
+	expected := "Terraform v4.5.6\non aros_riscv64\n\nYour version of Terraform is out of date! The latest version\nis 4.5.7. You can update by downloading from https://www.terraform.io/downloads.html"
 	if actual != expected {
 		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actual, expected)
 	}
@@ -127,8 +130,9 @@ func TestVersion_json(t *testing.T) {
 
 	// `terraform version -json` without prerelease
 	c := &VersionCommand{
-		Meta:    meta,
-		Version: "4.5.6",
+		Meta:     meta,
+		Version:  "4.5.6",
+		Platform: getproviders.Platform{OS: "aros", Arch: "riscv64"},
 	}
 	if code := c.Run([]string{"-json"}); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
@@ -139,6 +143,7 @@ func TestVersion_json(t *testing.T) {
 {
   "terraform_version": "4.5.6",
   "terraform_revision": "",
+  "platform": "aros_riscv64",
   "provider_selections": {},
   "terraform_outdated": false
 }
@@ -172,6 +177,7 @@ func TestVersion_json(t *testing.T) {
 		Meta:              meta,
 		Version:           "4.5.6",
 		VersionPrerelease: "foo",
+		Platform:          getproviders.Platform{OS: "aros", Arch: "riscv64"},
 	}
 	if err := c.replaceLockedDependencies(locks); err != nil {
 		t.Fatal(err)
@@ -185,6 +191,7 @@ func TestVersion_json(t *testing.T) {
 {
   "terraform_version": "4.5.6-foo",
   "terraform_revision": "",
+  "platform": "aros_riscv64",
   "provider_selections": {
     "registry.terraform.io/hashicorp/test1": "7.8.9-beta.2",
     "registry.terraform.io/hashicorp/test2": "1.2.3"
@@ -208,6 +215,7 @@ func TestVersion_jsonoutdated(t *testing.T) {
 		Meta:      m,
 		Version:   "4.5.6",
 		CheckFunc: mockVersionCheckFunc(true, "4.5.7"),
+		Platform:  getproviders.Platform{OS: "aros", Arch: "riscv64"},
 	}
 
 	if code := c.Run([]string{"-json"}); code != 0 {
@@ -215,7 +223,7 @@ func TestVersion_jsonoutdated(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(ui.OutputWriter.String())
-	expected := "{\n  \"terraform_version\": \"4.5.6\",\n  \"terraform_revision\": \"\",\n  \"provider_selections\": {},\n  \"terraform_outdated\": true\n}"
+	expected := "{\n  \"terraform_version\": \"4.5.6\",\n  \"terraform_revision\": \"\",\n  \"platform\": \"aros_riscv64\",\n  \"provider_selections\": {},\n  \"terraform_outdated\": true\n}"
 	if actual != expected {
 		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actual, expected)
 	}

--- a/commands.go
+++ b/commands.go
@@ -284,6 +284,7 @@ func initCommands(
 				Revision:          GitCommit,
 				Version:           Version,
 				VersionPrerelease: VersionPrerelease,
+				Platform:          getproviders.CurrentPlatform,
 				CheckFunc:         commandVersionCheck,
 			}, nil
 		},

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // The main version number that is being run at the moment.
-var Version = "0.14.0"
+var Version = "0.15.0"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
Along with all of the other information we previously reported in the `terraform version` output, we'll now include the name of the current platform as our provider installation mechanisms represent it.

This is addressing a long-standing minor annoyance where we sometimes can't tell from an incomplete bug report which platform Terraform was running on, and incomplete bug reporters do tend to at least include the requested `terraform version` output even if they don't also include the requested full trace log.

However, what motivated doing this _now_ is that anyone building a provider registry or mirror needs to have some awareness of these platform identifiers which have been, until v0.13, mostly an implementation detail. This additional information is a small thing we can do to help registry builders (or folks publishing providers for more esoteric platforms) find out what the platform identifier ought to be for each of the platforms they aim to support, even if some of them are platforms which the Go compiler allows but which HashiCorp doesn't officially support.

The new information is on a line of its own in the output as a pragmatic way to avoid breaking anyone who might be using something like `$(terraform version | head -n1)` to print a brief Terraform version identifier into some logs. That's not an interface we officially support for machine consumption, but it's easy to avoid breaking it here and so we won't do so. (If you _do_ want an interface for machine consumption, use `terraform version -json` instead.)

```
Terraform v0.15.0-dev
on linux_amd64
+ provider registry.terraform.io/apparentlymart/testing v0.0.2
+ provider registry.terraform.io/hashicorp/azurerm v2.1.0
+ provider registry.terraform.io/hashicorp/null v3.0.0
+ provider registry.terraform.io/newrelic/newrelic v2.1.2
```

```json
{
  "terraform_version": "0.15.0-dev",
  "terraform_revision": "",
  "platform": "linux_amd64",
  "provider_selections": {
    "registry.terraform.io/apparentlymart/testing": "0.0.2",
    "registry.terraform.io/hashicorp/azurerm": "2.1.0",
    "registry.terraform.io/hashicorp/null": "3.0.0",
    "registry.terraform.io/newrelic/newrelic": "2.1.2"
  },
  "terraform_outdated": false
}
```

---

While I was working on this I also noticed that we forgot to update the `version` package to report the current development as being `0.15.0`, so there's another commit in this PR to update that.
