### PR TITLE
Unmark values before provider validate call

### DIFF
--- a/terraform/context_components_test.go
+++ b/terraform/context_components_test.go
@@ -66,15 +66,15 @@ func simpleTestSchema() *configschema.Block {
 				Optional: true,
 			},
 			"test_bool": {
-				Type:     cty.String,
+				Type:     cty.Bool,
 				Optional: true,
 			},
 			"test_list": {
-				Type:     cty.String,
+				Type:     cty.List(cty.String),
 				Optional: true,
 			},
 			"test_map": {
-				Type:     cty.String,
+				Type:     cty.Map(cty.String),
 				Optional: true,
 			},
 		},

--- a/terraform/context_components_test.go
+++ b/terraform/context_components_test.go
@@ -62,7 +62,7 @@ func simpleTestSchema() *configschema.Block {
 				Optional: true,
 			},
 			"test_number": {
-				Type:     cty.String,
+				Type:     cty.Number,
 				Optional: true,
 			},
 			"test_bool": {

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -374,9 +374,11 @@ func (n *EvalValidateResource) Validate(ctx EvalContext) tfdiags.Diagnostics {
 			}
 		}
 
+		// Use unmarked value for validate request
+		unmarkedConfigVal, _ := configVal.UnmarkDeep()
 		req := providers.ValidateResourceTypeConfigRequest{
 			TypeName: cfg.Type,
-			Config:   configVal,
+			Config:   unmarkedConfigVal,
 		}
 
 		resp := provider.ValidateResourceTypeConfig(req)
@@ -404,9 +406,11 @@ func (n *EvalValidateResource) Validate(ctx EvalContext) tfdiags.Diagnostics {
 			return diags
 		}
 
+		// Use unmarked value for validate request
+		unmarkedConfigVal, _ := configVal.UnmarkDeep()
 		req := providers.ValidateDataSourceConfigRequest{
 			TypeName: cfg.Type,
-			Config:   configVal,
+			Config:   unmarkedConfigVal,
 		}
 
 		resp := provider.ValidateDataSourceConfig(req)

--- a/terraform/eval_validate_test.go
+++ b/terraform/eval_validate_test.go
@@ -26,6 +26,9 @@ func TestEvalValidateResource_managedResource(t *testing.T) {
 		if got, want := req.Config.GetAttr("test_string"), cty.StringVal("bar"); !got.RawEquals(want) {
 			t.Fatalf("wrong value for test_string\ngot:  %#v\nwant: %#v", got, want)
 		}
+		if got, want := req.Config.GetAttr("test_number"), cty.NumberIntVal(2); !got.RawEquals(want) {
+			t.Fatalf("wrong value for test_number\ngot:  %#v\nwant: %#v", got, want)
+		}
 		return providers.ValidateResourceTypeConfigResponse{}
 	}
 
@@ -36,6 +39,7 @@ func TestEvalValidateResource_managedResource(t *testing.T) {
 		Name: "foo",
 		Config: configs.SynthBody("", map[string]cty.Value{
 			"test_string": cty.StringVal("bar"),
+			"test_number": cty.NumberIntVal(2).Mark("sensitive"),
 		}),
 	}
 	node := &EvalValidateResource{
@@ -117,6 +121,9 @@ func TestEvalValidateResource_dataSource(t *testing.T) {
 		if got, want := req.Config.GetAttr("test_string"), cty.StringVal("bar"); !got.RawEquals(want) {
 			t.Fatalf("wrong value for test_string\ngot:  %#v\nwant: %#v", got, want)
 		}
+		if got, want := req.Config.GetAttr("test_number"), cty.NumberIntVal(2); !got.RawEquals(want) {
+			t.Fatalf("wrong value for test_number\ngot:  %#v\nwant: %#v", got, want)
+		}
 		return providers.ValidateDataSourceConfigResponse{}
 	}
 
@@ -127,6 +134,7 @@ func TestEvalValidateResource_dataSource(t *testing.T) {
 		Name: "foo",
 		Config: configs.SynthBody("", map[string]cty.Value{
 			"test_string": cty.StringVal("bar"),
+			"test_number": cty.NumberIntVal(2).Mark("sensitive"),
 		}),
 	}
 


### PR DESCRIPTION
Related PR: https://github.com/hashicorp/terraform/pull/26832

Unmark values before sending over to the provider's `ValidateResourceTypeConfig` function -- previously, sending this now (as of PR mentioned above) marked value would fail to be marshalled, and this wasn't covered by our test suite, because the mock provider does not marshall values in its `ValidateResourceTypeConfig`

This PR therefore updates some of the testing infrastructure, ranging from making `test_number` a number, to adding msgpack into the validate functions for the mock provider, to adding some internal methods `getResourceSchema` and `getDatasourceSchema` for that mock provider as well.
