### PR TITLE
repl: Display multi-line strings as heredocs

### DIFF
--- a/repl/format_test.go
+++ b/repl/format_test.go
@@ -58,7 +58,28 @@ func TestFormatValue(t *testing.T) {
 		},
 		{
 			cty.StringVal("hello\nworld"),
-			`"hello\nworld"`, // Ideally we'd use heredoc syntax here for better readability, but we don't yet
+			`<<EOT
+hello
+world
+EOT`,
+		},
+		{
+			cty.StringVal("EOR\nEOS\nEOT\nEOU"),
+			`<<EOT_
+EOR
+EOS
+EOT
+EOU
+EOT_`,
+		},
+		{
+			cty.ObjectVal(map[string]cty.Value{"foo": cty.StringVal("boop\nbeep")}),
+			`{
+  "foo" = <<-EOT
+  boop
+  beep
+  EOT
+}`,
 		},
 		{
 			cty.Zero,


### PR DESCRIPTION
The console and output formatter previously displayed multi-line strings with escaped newlines, e.g. `"hello\nworld\n"`. While this is a valid way to write the HCL string, it is not as common or as readable as using [the heredoc syntax](https://www.terraform.io/docs/configuration/expressions.html#string-literals), e.g.

```hcl
<<EOF
hello
world
EOF
```

This commit adds heredoc detection and display to this formatter, including support for indented heredocs for nested multi-line strings. This change affects the apply, console, and output sub-commands.

Fixes #27039. Targeting an 0.14.0 backport because this is a fairly narrowly-scoped fix to a problem introduced by changes in the 0.14 release.