### PR TITLE
website: Add new learn links, improve legacy landing pages

### DIFF
--- a/website/docs/configuration/blocks/providers/index.html.md
+++ b/website/docs/configuration/blocks/providers/index.html.md
@@ -69,6 +69,8 @@ and commit it to version control along with your configuration. If a lock file
 is present, Terraform Cloud, CLI, and Enterprise will all obey it when
 installing providers.
 
+> **Hands-on:** Try the [Lock and Upgrade Provider Versions](https://learn.hashicorp.com/tutorials/terraform/provider-versioning?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+
 ## How to Find Providers
 
 To find providers for the infrastructure platforms you use, browse

--- a/website/docs/configuration/dependency-lock.html.md
+++ b/website/docs/configuration/dependency-lock.html.md
@@ -9,6 +9,8 @@ page_title: "Dependency Lock File (.terraform.lock.hcl) - Configuration Language
 versions of Terraform did not track dependency selections at all, so the
 information here is not relevant to those versions.
 
+> **Hands-on:** Try the [Lock and Upgrade Provider Versions](https://learn.hashicorp.com/tutorials/terraform/provider-versioning?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+
 A Terraform configuration may refer to two different kinds of external
 dependency that come from outside of its own codebase:
 

--- a/website/docs/configuration/expressions.html.md
+++ b/website/docs/configuration/expressions.html.md
@@ -23,6 +23,10 @@ Terraform's types are `string`, `number`, `bool`, `list`, `tuple`, `map`,
 This information has moved to
 [Types and Values](/docs/configuration/expressions/types.html).
 
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
+
 <a id="references-to-named-values"></a>
 <a id="local-named-values"></a>
 <a id="named-values-and-dependencies"></a>
@@ -38,6 +42,10 @@ You can refer to certain values by name, like `var.some_variable` or
 This information has moved to
 [References to Values](/docs/configuration/expressions/references.html).
 
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
+
 <a id="arithmetic-operators"></a>
 <a id="equality-operators"></a>
 <a id="comparison-operators"></a>
@@ -51,6 +59,10 @@ numbers (`+`) or comparing two values to get a bool (`==`, `>=`, etc.).
 This information has moved to
 [Operators](/docs/configuration/expressions/references.html).
 
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
+
 ## Conditional Expressions
 
 The `condition ? true_val : false_val` expression chooses between two
@@ -58,6 +70,10 @@ expressions based on a bool condition.
 
 This information has moved to
 [Conditional Expressions](/docs/configuration/expressions/conditionals.html).
+
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
 
 <a id="expanding-function-arguments"></a>
 <a id="available-functions"></a>
@@ -69,6 +85,10 @@ Terraform's functions can be called like `function_name(arg1, arg2)`.
 This information has moved to
 [Function Calls](/docs/configuration/expressions/function-calls.html).
 
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
+
 <a id="for-expressions"></a>
 
 ## `for` Expressions
@@ -78,6 +98,10 @@ value into another complex type value.
 
 This information has moved to
 [For Expressions](/docs/configuration/expressions/for.html).
+
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
 
 <a id="splat-expressions"></a>
 <a id="legacy-attribute-only-splat-expressions"></a>
@@ -90,6 +114,10 @@ collections.
 This information has moved to
 [Splat Expressions](/docs/configuration/expressions/splat.html).
 
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
+
 <a id="dynamic-blocks"></a>
 <a id="best-practices-for-dynamic-blocks"></a>
 
@@ -100,6 +128,10 @@ except it creates multiple repeatable nested blocks instead of a complex value.
 
 This information has moved to
 [Dynamic Blocks](/docs/configuration/expressions/dynamic-blocks.html).
+
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
 
 <a id="string-literals"></a>
 <a id="string-templates"></a>
@@ -121,3 +153,5 @@ Strings can also include escape sequences like `\n`, interpolation sequences
 
 This information has moved to
 [Strings and Templates](/docs/configuration/expressions/strings.html).
+
+<div style="height: 100vh; margin: 0; padding: 0;"></div>

--- a/website/docs/configuration/expressions/conditionals.html.md
+++ b/website/docs/configuration/expressions/conditionals.html.md
@@ -5,6 +5,8 @@ page_title: "Conditional Expressions - Configuration Language"
 
 # Conditional Expressions
 
+> **Hands-on:** Try the [Create Dynamic Expressions](https://learn.hashicorp.com/tutorials/terraform/expressions?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+
 A _conditional expression_ uses the value of a bool expression to select one of
 two values.
 

--- a/website/docs/configuration/expressions/function-calls.html.md
+++ b/website/docs/configuration/expressions/function-calls.html.md
@@ -5,6 +5,8 @@ page_title: "Function Calls - Configuration Language"
 
 # Function Calls
 
+> **Hands-on:** Try the [Perform Dynamic Operations with Functions](https://learn.hashicorp.com/tutorials/terraform/functions?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+
 The Terraform language has a number of
 [built-in functions](/docs/configuration/functions.html) that can be used
 in expressions to transform and combine values. These

--- a/website/docs/configuration/expressions/index.html.md
+++ b/website/docs/configuration/expressions/index.html.md
@@ -5,6 +5,8 @@ page_title: "Expressions - Configuration Language"
 
 # Expressions
 
+> **Hands-on:** Try the [Create Dynamic Expressions](https://learn.hashicorp.com/tutorials/terraform/expressions?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+
 _Expressions_ are used to refer to or compute values within a configuration.
 The simplest expressions are just literal values, like `"hello"` or `5`,
 but the Terraform language also allows more complex expressions such as

--- a/website/docs/configuration/expressions/references.html.md
+++ b/website/docs/configuration/expressions/references.html.md
@@ -5,6 +5,8 @@ page_title: "References to Values - Configuration Language"
 
 # References to Named Values
 
+> **Hands-on:** Try the [Create Dynamic Expressions](https://learn.hashicorp.com/tutorials/terraform/expressions?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+
 Terraform makes several kinds of named values available. Each of these names is
 an expression that references the associated value; you can use them as
 standalone expressions, or combine them with other expressions to compute new

--- a/website/docs/configuration/expressions/splat.html.md
+++ b/website/docs/configuration/expressions/splat.html.md
@@ -5,6 +5,8 @@ page_title: "Splat Expressions - Configuration Language"
 
 # Splat Expressions
 
+> **Hands-on:** Try the [Create Dynamic Expressions](https://learn.hashicorp.com/tutorials/terraform/expressions?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+
 A _splat expression_ provides a more concise way to express a common
 operation that could otherwise be performed with a `for` expression.
 

--- a/website/docs/configuration/functions.html.md
+++ b/website/docs/configuration/functions.html.md
@@ -13,6 +13,8 @@ description: |-
 earlier, see
 [0.11 Configuration Language: Interpolation Syntax](../configuration-0-11/interpolation.html).
 
+> **Hands-on:** Try the [Perform Dynamic Operations with Functions](https://learn.hashicorp.com/tutorials/terraform/functions?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+
 The Terraform language includes a number of built-in functions that you can
 call from within expressions to transform and combine values. The general
 syntax for function calls is a function name followed by comma-separated

--- a/website/docs/configuration/modules.html.md
+++ b/website/docs/configuration/modules.html.md
@@ -20,6 +20,10 @@ pages.
 This information has moved to
 [Module Blocks](/docs/configuration/blocks/modules/syntax.html).
 
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
+
 <a id="multiple-instances-of-a-module"></a>
 
 ## Multiple Instances with `count` and `for_each`
@@ -27,6 +31,10 @@ This information has moved to
 This information has moved to
 [`count`](/docs/configuration/meta-arguments/count.html) and
 [`for_each`](/docs/configuration/meta-arguments/for_each.html).
+
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
 
 <a id="providers-within-modules"></a>
 <a id="provider-version-constraints-in-modules"></a>
@@ -42,3 +50,5 @@ This information has moved to
 (for users of re-usable modules) and
 [Providers Within Modules](/docs/modules/providers.html)
 (for module developers).
+
+<div style="height: 100vh; margin: 0; padding: 0;"></div>

--- a/website/docs/configuration/provider-requirements.html.md
+++ b/website/docs/configuration/provider-requirements.html.md
@@ -217,6 +217,15 @@ The `version` argument is optional; if omitted, Terraform will accept any
 version of the provider as compatible. However, we strongly recommend specifying
 a version constraint for every provider your module depends on.
 
+To ensure Terraform always installs the same provider versions for a given
+configuration, you can use Terraform CLI to create a
+[dependency lock file](/docs/configuration/dependency-lock.html)
+and commit it to version control along with your configuration. If a lock file
+is present, Terraform Cloud, CLI, and Enterprise will all obey it when
+installing providers.
+
+> **Hands-on:** Try the [Lock and Upgrade Provider Versions](https://learn.hashicorp.com/tutorials/terraform/provider-versioning?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+
 ### Best Practices for Provider Versions
 
 Each module should at least declare the minimum provider version it is known

--- a/website/docs/configuration/resources.html.md
+++ b/website/docs/configuration/resources.html.md
@@ -21,6 +21,10 @@ pages.
 This information has moved to
 [Resource Blocks](/docs/configuration/blocks/resources/syntax.html).
 
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
+
 <a id="resource-behavior"></a>
 <a id="accessing-resource-attributes"></a>
 <a id="resource-dependencies"></a>
@@ -31,9 +35,24 @@ This information has moved to
 This information has moved to
 [Resource Behavior](/docs/configuration/blocks/resources/behavior.html).
 
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
+
 ## Resource Meta-Arguments
 
-Each resource meta-argument has moved to its own page.
+Each resource meta-argument has moved to its own page:
+
+- [`depends_on`](/docs/configuration/meta-arguments/depends_on.html)
+- [`count`](/docs/configuration/meta-arguments/count.html)
+- [`for_each`](/docs/configuration/meta-arguments/for_each.html)
+- [`provider`](/docs/configuration/meta-arguments/resource-provider.html)
+- [`lifecycle`](/docs/configuration/meta-arguments/lifecycle.html)
+- [Provisioners](/docs/configuration/blocks/resources/provisioners/index.html)
+
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
 
 <a id="depends_on-explicit-resource-dependencies"></a>
 
@@ -41,6 +60,10 @@ Each resource meta-argument has moved to its own page.
 
 This information has moved to
 [`depends_on`](/docs/configuration/meta-arguments/depends_on.html).
+
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
 
 <a id="count-multiple-resource-instances-by-count"></a>
 <a id="the-count-object"></a>
@@ -53,6 +76,10 @@ This information has moved to
 This information has moved to
 [`count`](/docs/configuration/meta-arguments/count.html).
 
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
+
 <a id="for_each-multiple-resource-instances-defined-by-a-map-or-set-of-strings"></a>
 <a id="the-each-object"></a>
 <a id="using-expressions-in-for_each"></a>
@@ -64,12 +91,20 @@ This information has moved to
 This information has moved to
 [`for_each`](/docs/configuration/meta-arguments/for_each.html).
 
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
+
 <a id="provider-selecting-a-non-default-provider-configuration"></a>
 
 ### `provider`
 
 This information has moved to
 [`provider`](/docs/configuration/meta-arguments/resource-provider.html).
+
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
 
 <a id="lifecycle-lifecycle-customizations"></a>
 
@@ -78,9 +113,15 @@ This information has moved to
 This information has moved to
 [`lifecycle`](/docs/configuration/meta-arguments/lifecycle.html).
 
+<div style="height: 100vh; margin: 0; padding: 0;"></div>
+
+
+
 <a id="provisioner-and-connection-resource-provisioners"></a>
 
 ### Provisioners
 
 This information has moved to
 [Provisioners](/docs/configuration/blocks/resources/provisioners/index.html).
+
+<div style="height: 100vh; margin: 0; padding: 0;"></div>

--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -211,7 +211,9 @@ using a sentence structure similar to the above examples.
 
 [inpage-sensitive]: #suppressing-values-in-cli-output
 
--> This feature was introduced in Terraform CLI v0.14.0.
+-> This feature was introduced in Terraform v0.14.0.
+
+> **Hands-on:** Try the [Protect Sensitive Input Variables](https://learn.hashicorp.com/tutorials/terraform/sensitive-variables?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Setting a variable as `sensitive` prevents Terraform from showing its value in the `plan` or `apply` output, when that variable is used within a configuration.
 


### PR DESCRIPTION
A collection of really tiny docs fixes for the last little run-up to 0.14. 

The one about spacing out the landing pages makes it so that if you clicked an old deep link into the expressions page, the summary and link to the relevant _new_ page is the **only** thing you'll see in the initial page view. (You can, of course, scroll to see more if you really want to.) 

![image](https://user-images.githubusercontent.com/484309/100810072-77320f80-33ec-11eb-9d55-16f976b02d96.png)
