### PR TITLE
Add staticcheck to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
     steps:
       - checkout
       - run: go mod verify
-      - run: make fmtcheck generate
+      - run: go install honnef.co/go/tools/cmd/staticcheck
+      - run: make fmtcheck generate staticcheck
       - run:
           name: verify no code was generated
           command: |

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ protobuf:
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
+staticcheck:
+	@sh -c "'$(CURDIR)/scripts/staticcheck.sh'"
+
 website:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
@@ -70,4 +73,4 @@ endif
 # under parallel conditions.
 .NOTPARALLEL:
 
-.PHONY: fmtcheck generate protobuf website website-test
+.PHONY: fmtcheck generate protobuf website website-test staticcheck

--- a/backend/local/cli.go
+++ b/backend/local/cli.go
@@ -56,6 +56,8 @@ func (b *Local) outputColumns() int {
 //
 // This is the number of columns to use if you are calling b.CLI.Error or
 // b.CLI.Warn.
+//
+//lint:ignore U1000 TODO
 func (b *Local) errorColumns() int {
 	if b.Streams == nil {
 		// We can potentially get here in tests, if they don't populate the

--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -905,7 +905,7 @@ func (b *Remote) VerifyWorkspaceTerraformVersion(workspaceName string) tfdiags.D
 
 	// If the workspace has remote operations disabled, the remote Terraform
 	// version is effectively meaningless, so we'll skip version verification.
-	if workspace.Operations == false {
+	if !workspace.Operations {
 		return nil
 	}
 

--- a/command/state_meta.go
+++ b/command/state_meta.go
@@ -121,7 +121,7 @@ func (c *StateMeta) lookupResourceInstanceAddr(state *states.State, allowMissing
 			}
 		}
 
-		if found == false && !allowMissing {
+		if !found && !allowMissing {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Unknown module",

--- a/go.mod
+++ b/go.mod
@@ -130,6 +130,7 @@ require (
 	google.golang.org/grpc v1.31.1
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/ini.v1 v1.42.0 // indirect
+	honnef.co/go/tools v0.0.1-2020.1.4
 	k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v10.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4 h1:pSm8mp0T2OH2CP
 github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c h1:/IBSNwUN8+eKzUzbJPqhK839ygXJ82sde8x3ogr6R28=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022 h1:y8Gs8CzNfDF5AZvjr+5UyGQvQEBL7pwo+v+wX6q9JI8=
@@ -934,6 +935,7 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.0.0-20190620084959-7cf5895f2711 h1:BblVYz/wE5WtBsD/Gvu54KyBUTJMflolzc5I2DTvh50=
 k8s.io/api v0.0.0-20190620084959-7cf5895f2711/go.mod h1:TBhBqb1AWbBQbW3XRusr7n7E4v2+5ZY8r8sAMnyFC5A=

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-# Check gofmt
-echo "==> Checking that code complies with gofmt requirements..."
-gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor`)
+# Check go fmt
+echo "==> Checking that code complies with go fmt requirements..."
+gofmt_files=$(go fmt ./...)
 if [[ -n ${gofmt_files} ]]; then
     echo 'gofmt needs running on the following files:'
     echo "${gofmt_files}"
-    echo "You can use the command: \`gofmt -w .\` to reformat code."
+    echo "You can use the command: \`go fmt\` to reformat code."
     exit 1
 fi
 

--- a/scripts/staticcheck.sh
+++ b/scripts/staticcheck.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+echo "==> Checking that code complies with static analysis requirements..."
+# The legacy code is frozen, and should not be updated. It will be removed once
+# we can refactor the remote backends to no longer require it.
+skip="internal/legacy|backend/remote-state/"
+packages=$(go list ./... | egrep -v ${skip})
+
+# We are skipping style-related checks, since terraform intentionally breaks
+# some of these. The goal here is to find issues that reduce code clarity, or
+# may result in bugs.
+staticcheck -checks 'all,-ST*' ${packages}

--- a/terraform/resource_provider_mock_test.go
+++ b/terraform/resource_provider_mock_test.go
@@ -46,33 +46,6 @@ func mockProviderWithResourceTypeSchema(name string, schema *configschema.Block)
 	}
 }
 
-// mockProviderWithProviderSchema is a test helper to create a mock provider
-// from an existing ProviderSchema.
-func mockProviderWithProviderSchema(providerSchema ProviderSchema) *MockProvider {
-	p := &MockProvider{
-		GetSchemaResponse: &providers.GetSchemaResponse{
-			Provider: providers.Schema{
-				Block: providerSchema.Provider,
-			},
-			ResourceTypes: map[string]providers.Schema{},
-			DataSources:   map[string]providers.Schema{},
-		},
-	}
-
-	for name, schema := range providerSchema.ResourceTypes {
-		p.GetSchemaResponse.ResourceTypes[name] = providers.Schema{
-			Block:   schema,
-			Version: int64(providerSchema.ResourceTypeSchemaVersions[name]),
-		}
-	}
-
-	for name, schema := range providerSchema.DataSources {
-		p.GetSchemaResponse.DataSources[name] = providers.Schema{Block: schema}
-	}
-
-	return p
-}
-
 // getSchemaResponseFromProviderSchema is a test helper to convert a
 // ProviderSchema to a GetSchemaResponse for use when building a mock provider.
 func getSchemaResponseFromProviderSchema(providerSchema *ProviderSchema) *providers.GetSchemaResponse {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -7,4 +7,5 @@ import (
 	_ "github.com/mitchellh/gox"
 	_ "golang.org/x/tools/cmd/cover"
 	_ "golang.org/x/tools/cmd/stringer"
+	_ "honnef.co/go/tools/cmd/staticcheck"
 )


### PR DESCRIPTION
Add `staticcheck -checks 'all,-ST*'` to the CI config.

This tool was used extensively during refactoring, and has proven to be quite useful for catching common mistakes. 
While we skip the stylistic checks here for now, we can work towards those too (or at least a subset of those, since we intentionally break some conventions like error string format). 