### PR TITLE
don't use legacy import for the terraform.UIInput interface

### DIFF
--- a/plugin/ui_input.go
+++ b/plugin/ui_input.go
@@ -5,7 +5,7 @@ import (
 	"net/rpc"
 
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/terraform/internal/legacy/terraform"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 // UIInput is an implementation of terraform.UIInput that communicates

--- a/plugin/ui_input_test.go
+++ b/plugin/ui_input_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/terraform/internal/legacy/terraform"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestUIInput_impl(t *testing.T) {

--- a/plugin/ui_output.go
+++ b/plugin/ui_output.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"net/rpc"
 
-	"github.com/hashicorp/terraform/internal/legacy/terraform"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 // UIOutput is an implementatin of terraform.UIOutput that communicates

--- a/plugin/ui_output_test.go
+++ b/plugin/ui_output_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/terraform/internal/legacy/terraform"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestUIOutput_impl(t *testing.T) {


### PR DESCRIPTION
The import was switched for other types which have since been removed.
Point this at the correct package.