### PR TITLE
Fix specific version installation instructions

### DIFF
--- a/website/docs/cli/install/apt.html.md
+++ b/website/docs/cli/install/apt.html.md
@@ -123,7 +123,7 @@ You can select a specific version to install by including it in the
 `apt install` command line, as follows:
 
 ```bash
-sudo apt install terraform==0.14.0
+sudo apt install terraform=0.14.0
 ```
 
 If your workflow requires using multiple versions of Terraform at the same


### PR DESCRIPTION
I found that the example to install a specific version of terraform from the APT package repositories was
wrong. To make things easier for future readers of the documentation, fix the syntax error.