### PR TITLE
Urlparse function

### DIFF
--- a/lang/funcs/url.go
+++ b/lang/funcs/url.go
@@ -1,0 +1,67 @@
+package funcs
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// URLParseFunc constructs a function that parses a url in its parts: [scheme:][//[userinfo@]host:port][/]path[?query][#fragment]
+var URLParseFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "url",
+			Type: cty.String,
+		},
+	},
+	Type: func(args []cty.Value) (cty.Type, error) {
+		if args[0].IsNull() {
+			return cty.NilType, function.NewArgErrorf(0, "URL cannot be empty")
+		}
+		return cty.DynamicPseudoType, nil
+	},
+	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
+		urlStr := args[0].AsString()
+
+		u, err := url.Parse(urlStr)
+		if err != nil {
+			return cty.NilVal, fmt.Errorf("Failed to parse url '%s' error: %v", urlStr, err)
+		}
+
+		pw, pwSet := u.User.Password()
+		result := map[string]cty.Value{
+			"scheme": cty.StringVal(u.Scheme),
+			"user": cty.ObjectVal(map[string]cty.Value{
+				"username":     cty.StringVal(u.User.Username()),
+				"password":     cty.StringVal(pw),
+				"password_set": cty.BoolVal(pwSet),
+			}),
+			"host":     cty.StringVal(u.Host),
+			"hostname": cty.StringVal(u.Hostname()),
+			"port":     cty.StringVal(u.Port()),
+			"path":     cty.StringVal(u.Path),
+			"fragment": cty.StringVal(u.Fragment),
+		}
+		q := u.Query()
+		if len(q) > 0 {
+			query := make(map[string]cty.Value)
+			for k, v := range q {
+				vals := make([]cty.Value, len(v))
+				for i := range v {
+					vals[i] = cty.StringVal(v[i])
+				}
+				query[k] = cty.ListVal(vals)
+			}
+			result["query"] = cty.MapVal(query)
+		}
+		return cty.ObjectVal(result), nil
+	},
+})
+
+// URLParse searches a given string for another
+// given substring and return the index of the start of the first ocurrence.
+func URLParse(url cty.Value) (cty.Value, error) {
+	return URLParseFunc.Call([]cty.Value{url})
+}

--- a/lang/funcs/url_test.go
+++ b/lang/funcs/url_test.go
@@ -1,0 +1,78 @@
+package funcs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestURLParse(t *testing.T) {
+	tests := []struct {
+		URL  cty.Value
+		Want cty.Value
+		Err  bool
+	}{
+		{ // valid url
+			cty.StringVal("mongodb://username:password@hostN:123/path/?query=query#fragment"),
+			cty.ObjectVal(map[string]cty.Value{
+				"scheme": cty.StringVal("mongodb"),
+				"user": cty.ObjectVal(map[string]cty.Value{
+					"username":     cty.StringVal("username"),
+					"password":     cty.StringVal("password"),
+					"password_set": cty.BoolVal(true),
+				}),
+				"host":     cty.StringVal("hostN:123"),
+				"hostname": cty.StringVal("hostN"),
+				"port":     cty.StringVal("123"),
+				"path":     cty.StringVal("/path/"),
+				"fragment": cty.StringVal("fragment"),
+				"query": cty.MapVal(map[string]cty.Value{
+					"query": cty.ListVal([]cty.Value{cty.StringVal("query")}),
+				}),
+			}),
+			false,
+		},
+		{ // valid url no query
+			cty.StringVal("http://hostname/path/"),
+			cty.ObjectVal(map[string]cty.Value{
+				"scheme": cty.StringVal("http"),
+				"user": cty.ObjectVal(map[string]cty.Value{
+					"username":     cty.StringVal(""),
+					"password":     cty.StringVal(""),
+					"password_set": cty.BoolVal(false),
+				}),
+				"host":     cty.StringVal("hostname"),
+				"hostname": cty.StringVal("hostname"),
+				"port":     cty.StringVal(""),
+				"path":     cty.StringVal("/path/"),
+				"fragment": cty.StringVal(""),
+			}),
+			false,
+		},
+		{ // invalid url
+			cty.StringVal("https://test:port"),
+			cty.NilVal,
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("url_decode(%#v)", test.URL), func(t *testing.T) {
+			got, err := URLParse(test.URL)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}

--- a/lang/functions.go
+++ b/lang/functions.go
@@ -36,16 +36,17 @@ func (s *Scope) Functions() map[string]function.Function {
 			"abspath":          funcs.AbsPathFunc,
 			"alltrue":          funcs.AllTrueFunc,
 			"anytrue":          funcs.AnyTrueFunc,
-			"basename":         funcs.BasenameFunc,
 			"base64decode":     funcs.Base64DecodeFunc,
 			"base64encode":     funcs.Base64EncodeFunc,
 			"base64gzip":       funcs.Base64GzipFunc,
 			"base64sha256":     funcs.Base64Sha256Func,
 			"base64sha512":     funcs.Base64Sha512Func,
+			"basename":         funcs.BasenameFunc,
 			"bcrypt":           funcs.BcryptFunc,
 			"can":              tryfunc.CanFunc,
 			"ceil":             stdlib.CeilFunc,
 			"chomp":            stdlib.ChompFunc,
+			"chunklist":        stdlib.ChunklistFunc,
 			"cidrhost":         funcs.CidrHostFunc,
 			"cidrnetmask":      funcs.CidrNetmaskFunc,
 			"cidrsubnet":       funcs.CidrSubnetFunc,
@@ -60,14 +61,13 @@ func (s *Scope) Functions() map[string]function.Function {
 			"dirname":          funcs.DirnameFunc,
 			"distinct":         stdlib.DistinctFunc,
 			"element":          stdlib.ElementFunc,
-			"chunklist":        stdlib.ChunklistFunc,
 			"file":             funcs.MakeFileFunc(s.BaseDir, false),
-			"fileexists":       funcs.MakeFileExistsFunc(s.BaseDir),
-			"fileset":          funcs.MakeFileSetFunc(s.BaseDir),
 			"filebase64":       funcs.MakeFileFunc(s.BaseDir, true),
 			"filebase64sha256": funcs.MakeFileBase64Sha256Func(s.BaseDir),
 			"filebase64sha512": funcs.MakeFileBase64Sha512Func(s.BaseDir),
+			"fileexists":       funcs.MakeFileExistsFunc(s.BaseDir),
 			"filemd5":          funcs.MakeFileMd5Func(s.BaseDir),
+			"fileset":          funcs.MakeFileSetFunc(s.BaseDir),
 			"filesha1":         funcs.MakeFileSha1Func(s.BaseDir),
 			"filesha256":       funcs.MakeFileSha256Func(s.BaseDir),
 			"filesha512":       funcs.MakeFileSha512Func(s.BaseDir),
@@ -118,15 +118,15 @@ func (s *Scope) Functions() map[string]function.Function {
 			"sum":              funcs.SumFunc,
 			"textdecodebase64": funcs.TextDecodeBase64Func,
 			"textencodebase64": funcs.TextEncodeBase64Func,
-			"timestamp":        funcs.TimestampFunc,
 			"timeadd":          stdlib.TimeAddFunc,
+			"timestamp":        funcs.TimestampFunc,
 			"title":            stdlib.TitleFunc,
-			"tostring":         funcs.MakeToFunc(cty.String),
-			"tonumber":         funcs.MakeToFunc(cty.Number),
 			"tobool":           funcs.MakeToFunc(cty.Bool),
-			"toset":            funcs.MakeToFunc(cty.Set(cty.DynamicPseudoType)),
 			"tolist":           funcs.MakeToFunc(cty.List(cty.DynamicPseudoType)),
 			"tomap":            funcs.MakeToFunc(cty.Map(cty.DynamicPseudoType)),
+			"tonumber":         funcs.MakeToFunc(cty.Number),
+			"toset":            funcs.MakeToFunc(cty.Set(cty.DynamicPseudoType)),
+			"tostring":         funcs.MakeToFunc(cty.String),
 			"transpose":        funcs.TransposeFunc,
 			"trim":             stdlib.TrimFunc,
 			"trimprefix":       stdlib.TrimPrefixFunc,
@@ -135,6 +135,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"try":              tryfunc.TryFunc,
 			"upper":            stdlib.UpperFunc,
 			"urlencode":        funcs.URLEncodeFunc,
+			"urlparse":         funcs.URLParseFunc,
 			"uuid":             funcs.UUIDFunc,
 			"uuidv5":           funcs.UUIDV5Func,
 			"values":           stdlib.ValuesFunc,
@@ -161,6 +162,15 @@ func (s *Scope) Functions() map[string]function.Function {
 
 	return s.funcs
 }
+
+var unimplFunc = function.New(&function.Spec{
+	Type: func([]cty.Value) (cty.Type, error) {
+		return cty.DynamicPseudoType, fmt.Errorf("function not yet implemented")
+	},
+	Impl: func([]cty.Value, cty.Type) (cty.Value, error) {
+		return cty.DynamicVal, fmt.Errorf("function not yet implemented")
+	},
+})
 
 // experimentalFunction checks whether the given experiment is enabled for
 // the recieving scope. If so, it will return the given function verbatim.

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -972,6 +972,25 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"urlparse": {
+			{
+				`urlparse("http://hostname/path/")`,
+				cty.ObjectVal(map[string]cty.Value{
+					"scheme": cty.StringVal("http"),
+					"user": cty.ObjectVal(map[string]cty.Value{
+						"username":     cty.StringVal(""),
+						"password":     cty.StringVal(""),
+						"password_set": cty.BoolVal(false),
+					}),
+					"host":     cty.StringVal("hostname"),
+					"hostname": cty.StringVal("hostname"),
+					"port":     cty.StringVal(""),
+					"path":     cty.StringVal("/path/"),
+					"fragment": cty.StringVal(""),
+				}),
+			},
+		},
+
 		"urlencode": {
 			{
 				`urlencode("foo:bar@localhost?foo=bar&bar=baz")`,


### PR DESCRIPTION
# What was done?

- Sorted the functions in the functions.go file.
- Added a urlparse function that allows the user to access it parts.
> The format of the parts are the defined in net/url package of go: [scheme:][//[userinfo@]host:port][/]path[?query][#fragment]

I believe this could be useful when parsing different urls from git, mongo db and etc. to get details that are usually passed by query or other formats. Please let me know if I need to write more tests or fix something.