### PR TITLE
Anytrue alltrue docs clarification.

### DIFF
--- a/website/docs/configuration/functions/alltrue.html.md
+++ b/website/docs/configuration/functions/alltrue.html.md
@@ -9,9 +9,7 @@ description: |-
 
 # `alltrue` Function
 
--> **Note:** This page is about Terraform 0.12 and later. For Terraform 0.11 and
-earlier, see
-[0.11 Configuration Language: Interpolation Syntax](../../configuration-0-11/interpolation.html).
+-> **Note:** This function is avaialble in Terraform 0.14 and later.
 
 `alltrue` returns `true` if all elements in a given collection are `true`
 or `"true"`. It also returns `true` if the collection is empty.

--- a/website/docs/configuration/functions/alltrue.html.md
+++ b/website/docs/configuration/functions/alltrue.html.md
@@ -9,7 +9,7 @@ description: |-
 
 # `alltrue` Function
 
--> **Note:** This function is avaialble in Terraform 0.14 and later.
+-> **Note:** This function is available in Terraform 0.14 and later.
 
 `alltrue` returns `true` if all elements in a given collection are `true`
 or `"true"`. It also returns `true` if the collection is empty.

--- a/website/docs/configuration/functions/anytrue.html.md
+++ b/website/docs/configuration/functions/anytrue.html.md
@@ -9,9 +9,7 @@ description: |-
 
 # `anytrue` Function
 
--> **Note:** This page is about Terraform 0.12 and later. For Terraform 0.11 and
-earlier, see
-[0.11 Configuration Language: Interpolation Syntax](../../configuration-0-11/interpolation.html).
+-> **Note:** This function is avaialble in Terraform 0.14 and later.
 
 `anytrue` returns `true` if any element in a given collection is `true`
 or `"true"`. It also returns `false` if the collection is empty.

--- a/website/docs/configuration/functions/anytrue.html.md
+++ b/website/docs/configuration/functions/anytrue.html.md
@@ -9,7 +9,7 @@ description: |-
 
 # `anytrue` Function
 
--> **Note:** This function is avaialble in Terraform 0.14 and later.
+-> **Note:** This function is available in Terraform 0.14 and later.
 
 `anytrue` returns `true` if any element in a given collection is `true`
 or `"true"`. It also returns `false` if the collection is empty.


### PR DESCRIPTION
Fixing a little of the ambiguity due to lack of versioned docs. `anytrue` and `alltrue` functions are available in Terraform `0.14` and later.

Fixes #27098