### PR TITLE
Made shebang same

### DIFF
--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script rewrites [GH-nnnn]-style references in the CHANGELOG.md file to
 # be Markdown links to the given github issues.

--- a/scripts/gogetcookie.sh
+++ b/scripts/gogetcookie.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 touch ~/.gitcookies
 chmod 0600 ~/.gitcookies
 


### PR DESCRIPTION
The two different shebang can point to two different bash, specially in MacOS.