### PR TITLE
website: Elaborate the "expressions" sub-pages in the language section

### DIFF
--- a/website/docs/configuration/expressions/conditionals.html.md
+++ b/website/docs/configuration/expressions/conditionals.html.md
@@ -41,3 +41,28 @@ The two result values may be of any type, but they must both
 be of the _same_ type so that Terraform can determine what type the whole
 conditional expression will return without knowing the condition value.
 
+If the two result expressions don't produce the same type then Terraform will
+attempt to find a type that they can both convert to, and make those
+conversions automatically if so.
+
+For example, the following expression is valid and will always return a string,
+because in Terraform all numbers can convert automatically to a string using
+decimal digits:
+
+```hcl
+var.example ? 12 : "hello"
+```
+
+Relying on this automatic conversion behavior can be confusing for those who
+are not familiar with Terraform's conversion rules though, so we recommend
+being explicit using type conversion functions in any situation where there may
+be some uncertainty about the expected result type.
+
+The following example is contrived because it would be easier to write the
+constant `"12"` instead of the type conversion in this case, but shows how to
+use [`tostring`](../functions/tostring.html) to explicitly convert a number to
+a string.
+
+```hcl
+var.example ? tostring(12) : "hello"
+```

--- a/website/docs/configuration/expressions/for.html.md
+++ b/website/docs/configuration/expressions/for.html.md
@@ -10,8 +10,8 @@ another complex type value. Each element in the input value
 can correspond to either one or zero values in the result, and an arbitrary
 expression can be used to transform each input element into an output element.
 
-For example, if `var.list` is a list of strings, then the following expression
-produces a list of strings with all-uppercase letters:
+For example, if `var.list` were a list of strings, then the following expression
+would produce a tuple of strings with all-uppercase letters:
 
 ```hcl
 [for s in var.list : upper(s)]
@@ -22,10 +22,41 @@ evaluates the expression `upper(s)` with `s` set to each respective element.
 It then builds a new tuple value with all of the results of executing that
 expression in the same order.
 
+## Input Types
+
+A `for` expression's input (given after the `in` keyword) can be a list,
+a set, a tuple, a map, or an object.
+
+The above example showed a `for` expression with only a single temporary
+symbol `s`, but a `for` expression can optionally declare a pair of temporary
+symbols in order to use the key or index of each item too:
+
+```hcl
+[for k, v in var.map : length(k) + length(v)]
+```
+
+For a map or object type, like above, the `k` symbol refers to the key or
+attribute name of the current element. You can also use the two-symbol form
+with lists and tuples, in which case the additional symbol is the index
+of each element starting from zero, which conventionally has the symbol name
+`i` or `idx` unless it's helpful to choose a more specific name:
+
+```hcl
+[for i, v in var.list : "${i} is ${v}"]
+```
+
+The index or key symbol is always optional. If you specify only a single
+symbol after the `for` keyword then that symbol will always represent the
+_value_ of each element of the input collection.
+
+## Result Types
+
 The type of brackets around the `for` expression decide what type of result
-it produces. The above example uses `[` and `]`, which produces a tuple. If
-`{` and `}` are used instead, the result is an object, and two result
-expressions must be provided separated by the `=>` symbol:
+it produces.
+
+The above example uses `[` and `]`, which produces a tuple. If you use `{` and
+`}` instead, the result is an object and you must provide two result
+expressions that are separated by the `=>` symbol:
 
 ```hcl
 {for s in var.list : s => upper(s)}
@@ -33,39 +64,146 @@ expressions must be provided separated by the `=>` symbol:
 
 This expression produces an object whose attributes are the original elements
 from `var.list` and their corresponding values are the uppercase versions.
+For example, the resulting value might be as follows:
+
+```hcl
+{
+  foo = "FOO"
+  bar = "BAR"
+  baz = "BAZ"
+}
+```
+
+A `for` expression alone can only produce either an object value or a tuple
+value, but Terraform's automatic type conversion rules mean that you can
+typically use the results in locations where lists, maps, and sets are expected.
+
+## Filtering Elements
 
 A `for` expression can also include an optional `if` clause to filter elements
-from the source collection, which can produce a value with fewer elements than
-the source:
+from the source collection, producing a value with fewer elements than
+the source value:
 
 ```
 [for s in var.list : upper(s) if s != ""]
 ```
 
-The source value can also be an object or map value, in which case two
-temporary variable names can be provided to access the keys and values
-respectively:
+One common reason for filtering collections in `for` expressions is to split
+a single source collection into two separate collections based on some
+criteria. For example, if the input `var.users` is a map of objects where the
+objects each have an attribute `is_admin` then you may wish to produce separate
+maps with admin vs non-admin objects:
 
+```hcl
+variable "users" {
+  type = map(object({
+    is_admin = boolean
+  }))
+}
+
+locals {
+  admin_users = {
+    for name, user in var.users : name => user
+    if user.is_admin
+  }
+  regular_users = {
+    for name, user in var.users : name => user
+    if !user.is_admin
+  }
+}
 ```
-[for k, v in var.map : length(k) + length(v)]
+
+## Element Ordering
+
+Because `for` expressions can convert from unordered types (maps, objects, sets)
+to unordered types (lists, tuples), Terraform must choose an implied ordering
+for the elements of an unordered collection.
+
+For maps and objects, Terraform sorts the elements by key or attribute name,
+using lexical sorting.
+
+For sets of strings, Terraform sorts the elements by their value, using
+lexical sorting.
+
+For sets of other types, Terraform uses an arbitrary ordering that may change
+in future versions of Terraform. For that reason, we recommend converting the
+result of such an expression to itself be a set so that it's clear elsewhere
+in the configuration that the result is unordered. You can use
+[the `toset` function](../functions/toset.html)
+to concisely convert a `for` expression result to be of a set type.
+
+```hcl
+toset([for e in var.set : e.example])
 ```
 
-Finally, if the result type is an object (using `{` and `}` delimiters) then
-the value result expression can be followed by the `...` symbol to group
-together results that have a common key:
+## Grouping Results
 
+If the result type is an object (using `{` and `}` delimiters) then normally
+the given key expression must be unique across all elements in the result,
+or Terraform will return an error.
+
+Sometimes the resulting keys are _not_ unique, and so to support that situation
+Terraform supports a special _grouping mode_ which changes the result to support
+multiple elements per key.
+
+To activate grouping mode, add the symbol `...` after the value expression.
+For example:
+
+```hcl
+variable "users" {
+  type = map(object({
+    role = string
+  }))
+}
+
+locals {
+  users_by_role = {
+    for name, user in var.users : user.role => name...
+  }
+}
 ```
-{for s in var.list : substr(s, 0, 1) => s... if s != ""}
+
+The above represents a situation where a module expects a map describing
+various users who each have a single "role", where the map keys are usernames.
+The usernames are guaranteed unique because they are map keys in the input,
+but many users may all share a single role name.
+
+The `local.users_by_role` expression inverts the input map so that the keys
+are the role names and the values are usernames, but the expression is in
+grouping mode (due to the `...` after `name`) and so the result will be a
+map of lists of strings, such as the following:
+
+```hcl
+{
+  "admin": [
+    "ps",
+  ],
+  "maintainer": [
+    "am",
+    "jb",
+    "kl",
+    "ma",
+  ],
+  "viewer": [
+    "st",
+    "zq",
+  ],
+}
 ```
 
-For expressions are particularly useful when combined with other language
-features to combine collections together in various ways. For example,
-the following two patterns are commonly used when constructing map values
-to use with
-[the `for_each` meta-argument](/docs/configuration/meta-arguments/for_each.html):
+Due to [the element ordering rules](#element-ordering), Terraform will sort
+the users lexically by username as part of evaluating the `for` expression,
+and so the usernames associated with each role will be lexically sorted
+after grouping.
 
-* Transform a multi-level nested structure into a flat list by
-  [using nested `for` expressions with the `flatten` function](/docs/configuration/functions/flatten.html#flattening-nested-structures-for-for_each).
-* Produce an exhaustive list of combinations of elements from two or more
-  collections by
-  [using the `setproduct` function inside a `for` expression](/docs/configuration/functions/setproduct.html#finding-combinations-for-for_each).
+## Repeated Configuration Blocks
+
+The `for` expressions mechanism is for constructing collection values from
+other collection values within expressions, which you can then assign to
+individual resource arguments that expect complex values.
+
+Some resource types also define _nested block types_, which typically represent
+separate objects that belong to the containing resource in some way. You can't
+dynamically generated nested blocks using `for` expressions, but you _can_
+generate nested blocks for a resource dynamically using
+[`dynamic` blocks](dynamic-blocks.html).

--- a/website/docs/configuration/expressions/function-calls.html.md
+++ b/website/docs/configuration/expressions/function-calls.html.md
@@ -30,6 +30,11 @@ min(55, 3453, 2)
 
 A function call expression evaluates to the function's return value.
 
+## Available Functions
+
+For a full list of available functions, see
+[the function reference](/docs/configuration/functions.html).
+
 ## Expanding Function Arguments
 
 If the arguments to pass to a function are available in a list or tuple value,
@@ -43,8 +48,45 @@ min([55, 2453, 2]...)
 The expansion symbol is three periods (`...`), not a Unicode ellipsis character
 (`…`). Expansion is a special syntax that is only available in function calls.
 
-## Available Functions
+## When Terraform Calls Functions
 
-For a full list of available functions, see
-[the function reference](/docs/configuration/functions.html).
+Most of Terraform's built-in functions are, in programming language terms,
+[pure functions](https://en.wikipedia.org/wiki/Pure_function). This means that
+their result is based only on their arguments and so it doesn't make any
+practical difference when Terraform would call them.
 
+However, a small subset of functions interact with outside state and so for
+those it can be helpful to know when Terraform will call them in relation to
+other events that occur in a Terraform run.
+
+The small set of special functions includes
+[`file`](../functions/file.html),
+[`templatefile`](../functions/templatefile.html),
+[`timestamp`](../functions/timestamp.html),
+and [`uuid`](../functions/uuid.html).
+If you are not working with these functions then you don't need
+to read this section, although the information here may still be interesting
+background information.
+
+The `file` and `templatefile` functions are intended for reading files that
+are included as a static part of the configuration and so Terraform will
+execute these functions as part of initial configuration validation, before
+taking any other actions with the configuration. That means you cannot use
+either function to read files that your configuration might generate
+dynamically on disk as part of the plan or apply steps.
+
+The `timestamp` function returns a representation of the current system time
+at the point when Terraform calls it, and the `uuid` function returns a random
+result which differs on each call. Without any special behavior these would
+would both cause the final configuration during the apply step not to match the
+actions shown in the plan, which violates the Terraform execution model.
+
+For that reason, Terraform arranges for both of those functions to produce
+[unknown value](references.html#values-not-yet-known) results during the
+plan step, with the real result being decided only during the apply step.
+For `timestamp` in particular, this means that the recorded time will be
+the instant when Terraform began applying the change, rather than when
+Terraform _planned_ the change.
+
+For more details on the behavior of these functions, refer to their own
+documentation pages.

--- a/website/docs/configuration/expressions/operators.html.md
+++ b/website/docs/configuration/expressions/operators.html.md
@@ -30,15 +30,15 @@ in the following order of operations:
 1. `&&`
 1. `||`
 
-Parentheses can be used to override the default order of operations. Without
-parentheses, higher levels are evaluated first, so `1 + 2 * 3` is interpreted
-as `1 + (2 * 3)` and _not_ as `(1 + 2) * 3`.
+Use parentheses to override the default order of operations. Without
+parentheses, higher levels will be evaluated first, so Terraform will interpret
+`1 + 2 * 3` as `1 + (2 * 3)` and _not_ as `(1 + 2) * 3`.
 
 The different operators can be gathered into a few different groups with
 similar behavior, as described below. Each group of operators expects its
 given values to be of a particular type. Terraform will attempt to convert
 values to the required type automatically, or will produce an error message
-if this automatic conversion is not possible.
+if automatic conversion is impossible.
 
 ## Arithmetic Operators
 
@@ -53,6 +53,11 @@ as results:
   generally useful only when used with whole numbers.
 * `-a` returns the result of multiplying `a` by `-1`.
 
+Terraform supports some other less-common numeric operations as
+[functions](function-calls.html). For example, you can calculate exponents
+using
+[the `pow` function](../functions/pow.html).
+
 ## Equality Operators
 
 The equality operators both take two values of any type and produce boolean
@@ -61,6 +66,18 @@ values as results.
 * `a == b` returns `true` if `a` and `b` both have the same type and the same
   value, or `false` otherwise.
 * `a != b` is the opposite of `a == b`.
+
+Because the equality operators require both arguments to be of exactly the
+same type in order to decide equality, we recommend using these operators only
+with values of primitive types or using explicit type conversion functions
+to indicate which type you are intending to use for comparison.
+
+Comparisons between structural types may produce surprising results if you
+are not sure about the types of each of the arguments. For example,
+`var.list == []` may seem like it would return `true` if `var.list` were an
+empty list, but `[]` actually builds a value of type `tuple([])` and so the
+two values can never match. In this situation it's often clearer to write
+`length(var.list) == 0` instead.
 
 ## Comparison Operators
 
@@ -80,3 +97,7 @@ The logical operators all expect bool values and produce bool values as results.
 * `a || b` returns `true` if either `a` or `b` is `true`, or `false` if both are `false`.
 * `a && b` returns `true` if both `a` and `b` are `true`, or `false` if either one is `false`.
 * `!a` returns `true` if `a` is `false`, and `false` if `a` is `true`.
+
+Terraform does not have an operator for the "exclusive OR" operation. If you
+know that both operators are boolean values then exclusive OR is equivalent
+to the `!=` ("not equal") operator.

--- a/website/docs/configuration/expressions/strings.html.md
+++ b/website/docs/configuration/expressions/strings.html.md
@@ -72,6 +72,20 @@ In the above example, `EOT` is the identifier selected. Any identifier is
 allowed, but conventionally this identifier is in all-uppercase and begins with
 `EO`, meaning "end of". `EOT` in this case stands for "end of text".
 
+### Generating JSON or YAML
+
+Don't use "heredoc" strings to generate JSON or YAML. Instead, use
+[the `jsonencode` function](../functions/jsonencode.html) or
+[the `yamlencode` function](../functions/yamlencode.html) so that Terraform
+can be responsible for guaranteeing valid JSON or YAML syntax.
+
+```hcl
+  example = jsonencode({
+    a = 1
+    b = "hello"
+  })
+```
+
 ### Indented Heredocs
 
 The standard heredoc form (shown above) treats all space characters as literal


### PR DESCRIPTION
When we did the earlier documentation rework for Terraform v0.12 we still had one big "Expressions" page talking about the various operators and constructs, and so we had to be a bit economical with the details about some more complicated constructs in order to avoid the page becoming even more overwhelming.

However, we've recently reorganized the language documentation again so that the expressions section is split across several separate pages, and that gives some freedom to go into some more detail about and show longer examples for certain features.

My changes here are not intended to be an exhaustive rewrite but I did try to focus on some areas I've commonly seen questions about when helping in the community forum and elsewhere, and also to create a little more connectivity between the different content so readers can hopefully find what they are looking for more easily when they're not yet sure what terminology to look for.

While here I also did some more of our ongoing writing style tweaks, such as switching from passive to active voice, but I mostly just kept that for sections I was already revising anyway because I didn't have time today to be thorough with it. More elaboration and more writing style fixes to follow in the future, I'm sure! :grinning: 
