### PR TITLE
Update docs and add warning for -get-plugins

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -31,14 +31,11 @@ import (
 // module and clones it to the working directory.
 type InitCommand struct {
 	Meta
-
-	// getPlugins is for the -get-plugins flag
-	getPlugins bool
 }
 
 func (c *InitCommand) Run(args []string) int {
 	var flagFromModule string
-	var flagBackend, flagGet, flagUpgrade bool
+	var flagBackend, flagGet, flagUpgrade, getPlugins bool
 	var flagPluginPath FlagStringSlice
 	var flagVerifyPlugins bool
 	flagConfigExtra := newRawFlags("-backend-config")
@@ -49,7 +46,7 @@ func (c *InitCommand) Run(args []string) int {
 	cmdFlags.Var(flagConfigExtra, "backend-config", "")
 	cmdFlags.StringVar(&flagFromModule, "from-module", "", "copy the source of the given module into the directory before init")
 	cmdFlags.BoolVar(&flagGet, "get", true, "")
-	cmdFlags.BoolVar(&c.getPlugins, "get-plugins", true, "")
+	cmdFlags.BoolVar(&getPlugins, "get-plugins", true, "no-op flag, use provider_installation blocks to customize provider installation")
 	cmdFlags.BoolVar(&c.forceInitCopy, "force-copy", false, "suppress prompts about copying state data")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
@@ -66,7 +63,16 @@ func (c *InitCommand) Run(args []string) int {
 
 	if len(flagPluginPath) > 0 {
 		c.pluginPath = flagPluginPath
-		c.getPlugins = false
+	}
+
+	// If users are setting the no-op get-plugins command, give them a warning,
+	// this should allow us to remove the flag in the future.
+	if !getPlugins {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"No-op -get-plugins flag used",
+			`As of Terraform 0.13+, the -get-plugins=false command is a no-op flag. If you would like to customize provider installation, use a provider_installation block or other available Terraform settings.`,
+		))
 	}
 
 	// Validate the arg count
@@ -971,7 +977,6 @@ func (c *InitCommand) AutocompleteFlags() complete.Flags {
 		"-force-copy":     complete.PredictNothing,
 		"-from-module":    completePredictModuleSource,
 		"-get":            completePredictBoolean,
-		"-get-plugins":    completePredictBoolean,
 		"-input":          completePredictBoolean,
 		"-lock":           completePredictBoolean,
 		"-lock-timeout":   complete.PredictAnything,
@@ -1024,6 +1029,9 @@ Options:
   -get=true            Download any modules for this configuration.
 
   -get-plugins=true    Download any missing plugins for this configuration.
+                       This command is a no-op in Terraform 0.13+: use
+                       -plugin-dir settings or provider_installation blocks
+                       instead.
 
   -input=true          Ask for input if necessary. If false, will error if
                        input was required.
@@ -1042,8 +1050,8 @@ Options:
   -reconfigure         Reconfigure the backend, ignoring any saved
                        configuration.
 
-  -upgrade=false       If installing modules (-get) or plugins (-get-plugins),
-                       ignore previously-downloaded objects and install the
+  -upgrade=false       If installing modules (-get) or plugins, ignore
+                       previously-downloaded objects and install the
                        latest version allowed within configured constraints.
 
   -verify-plugins=true Verify the authenticity and integrity of automatically

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -226,7 +226,6 @@ func TestInit_getUpgradeModules(t *testing.T) {
 
 	args := []string{
 		"-get=true",
-		"-get-plugins=false",
 		"-upgrade",
 		testFixturePath("init-get"),
 	}

--- a/tools/terraform-bundle/README.md
+++ b/tools/terraform-bundle/README.md
@@ -171,9 +171,7 @@ Therefore if automatic installation is not desired, it is important to ensure
 that version constraints within Terraform configurations do not exclude all
 of the versions available from the bundle. If a suitable version cannot be
 found in the bundle, Terraform _will_ attempt to satisfy that dependency by
-automatic installation from the official repository. If you want
-`terraform init` to explicitly fail instead of contacting the repository, pass
-the `-get-plugins=false` option.
+automatic installation from the official repository.
 
 For full details about provider resolution, see
 [How Terraform Works: Plugin Discovery](https://www.terraform.io/docs/extend/how-terraform-works.html#discovery).

--- a/website/docs/commands/init.html.markdown
+++ b/website/docs/commands/init.html.markdown
@@ -142,11 +142,10 @@ You can modify `terraform init`'s plugin behavior with the following options:
   cause Terraform to ignore any selections recorded in the dependency lock
   file, and to take the newest available version matching the configured
   version constraints.
-- `-get-plugins=false` — Skip plugin installation. If you previously ran
-  `terraform init` without this option, the previously-installed plugins will
-  remain available in your current working directory. If you have not
-  previously run without this option, subsequent Terraform commands will
-  fail due to the needed provider plugins being unavailable.
+- `-get-plugins=false` — Skip plugin installation. _Note: Since Terraform 0.13, this
+  command has been superseded by [`provider_installation`](./cli-config.html#provider-installation)
+  blocks or using the [`plugin_cache_dir`](./cli-config.html#plugin_cache_dir) setting.
+  It should not be used in Terraform versions 0.13+.
 - `-plugin-dir=PATH` — Force plugin installation to read plugins _only_ from
   the specified directory, as if it had been configured as a `filesystem_mirror`
   in the CLI configuration. If you intend to routinely use a particular


### PR DESCRIPTION
As of Terraform 0.13+, the get-plugins command has been superseded by new provider installation mechanisms, and general philosophy (providers are always installed, but the sources may be customized). Update the init command to give users a warning if they are setting this flag, to encourage them to remove it from their workflow, and update relevant docs and docstrings as well.

Fixes https://github.com/hashicorp/terraform/issues/27092

Looking to backport to 0.14 (which would give 0.14.1+ users a warning when using this flag), and remove the flag completely in 0.15 after this.

Also looking for:

- Are the reccs here the preferred recommendations for people using this flag?
- Approval/Nay-saying on the "add a warning, then remove completely" plan
- Should this be backported to 0.13 as well?