### PR TITLE
Fix terraform_remote_state backend version check

### DIFF
--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/backend/remote"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/tfdiags"
@@ -231,6 +232,12 @@ func getBackend(cfg cty.Value) (backend.Backend, cty.Value, tfdiags.Diagnostics)
 	diags = diags.Append(validateDiags)
 	if validateDiags.HasErrors() {
 		return nil, cty.NilVal, diags
+	}
+
+	// If this is the enhanced remote backend, we want to disable the version
+	// check, because this is a read-only operation
+	if rb, ok := b.(*remote.Remote); ok {
+		rb.IgnoreVersionConflict()
 	}
 
 	return b, newVal, diags


### PR DESCRIPTION
The change recently introduced to ensure that remote backend users do not accidentally upgrade their state file (#26947) needs to be disabled for all read-only uses, including the builtin `terraform_remote_state` data source. Without doing this, the remote state data source fails to read state from `remote` backend sources which do not have an exactly matching Terraform version.

I don't see any reasonable way to add automated tests for this change. Here is an example of the manual verification I'm doing:

<img width="1187" alt="tf15" src="https://user-images.githubusercontent.com/68917/101531416-3f354a00-3961-11eb-855e-85a2e2ef425c.png">

```hcl
data "terraform_remote_state" "sfv" {
  backend = "remote"

  config = {
    workspaces = {
      name = "sfv"
    }
    organization = "alisdair-v2"
  }
}

output "foobar" {
  value = data.terraform_remote_state.sfv.outputs.foobar
}
```

If approved, I intend to backport this change to 0.14, 0.13, and 0.12.

Fixes #27200