### PR TITLE
Fix terraform_remote_state backend version check

### DIFF
--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/backend/remote"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/tfdiags"
@@ -213,6 +214,12 @@ func getBackend(cfg cty.Value) (backend.Backend, tfdiags.Diagnostics) {
 	if configureDiags.HasErrors() {
 		diags = diags.Append(configureDiags.Err())
 		return nil, diags
+	}
+
+	// If this is the enhanced remote backend, we want to disable the version
+	// check, because this is a read-only operation
+	if rb, ok := b.(*remote.Remote); ok {
+		rb.IgnoreVersionConflict()
 	}
 
 	return b, diags


### PR DESCRIPTION
The change recently introduced to ensure that remote backend users do not accidentally upgrade their state file (#26947) needs to be disabled for all read-only uses, including the builtin `terraform_remote_state` data source. Without doing this, the remote state data source fails to read state from `remote` backend sources which do not have an exactly matching Terraform version.

Backport of #27197.