### PR TITLE
website: Fix a stray broken link to 0.8 -> 0.9 backend upgrade doc

### DIFF
--- a/website/upgrade-guides/0-9.html.markdown
+++ b/website/upgrade-guides/0-9.html.markdown
@@ -26,7 +26,8 @@ Remote state has been overhauled to be easier and safer to configure and use.
 you'll be prompted to migrate to the new remote backend system.
 
 An in-depth guide for migrating to the new backend system
-[is available here](/docs/backends/legacy-0-8.html). This includes
+[is available here](https://github.com/hashicorp/terraform/blob/v0.9.11/website/source/docs/backends/legacy-0-8.html.md).
+This includes
 backing up your existing remote state and also rolling back if necessary.
 
 The only non-backwards compatible change is in the CLI: the existing


### PR DESCRIPTION
I missed this earlier because my link checker was collapsing the two links from
this page to that page into a single report.

For posterity's sake, I'm linking directly to the markdown file in GitHub at an
appropriate tag version. I do not expect anyone to ever click this link again,
though.