### PR TITLE
command/output: Raw output mode

### DIFF
--- a/website/docs/commands/output.html.markdown
+++ b/website/docs/commands/output.html.markdown
@@ -24,6 +24,11 @@ The command-line flags are all optional. The list of available flags are:
 * `-json` - If specified, the outputs are formatted as a JSON object, with
     a key per output. If `NAME` is specified, only the output specified will be
     returned. This can be piped into tools such as `jq` for further processing.
+* `-raw` - If specified, Terraform will convert the specified output value to a
+    string and print that string directly to the output, without any special
+    formatting. This can be convenient when working with shell scripts, but
+    it only supports string, number, and boolean values. Use `-json` instead
+    for processing complex data types.
 * `-no-color` - If specified, output won't contain any color.
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
     Ignored when [remote state](/docs/state/remote.html) is used.
@@ -88,21 +93,31 @@ instance_ips = [
 ## Use in automation
 
 The `terraform output` command by default displays in a human-readable format,
-which can change over time to improve clarity. For use in automation, use
-`-json` to output the stable JSON format. You can parse the output using a JSON
-command-line parser such as [jq](https://stedolan.github.io/jq/).
+which can change over time to improve clarity.
 
-For string outputs, you can remove quotes using `jq -r`:
+For scripting and automation, use `-json` to produce the stable JSON format.
+You can parse the output using a JSON command-line parser such as
+[jq](https://stedolan.github.io/jq/):
 
 ```shellsession
-$ terraform output -json lb_address | jq -r .
+$ terraform output -json instance_ips | jq -r '.[0]'
+54.43.114.12
+```
+
+For the common case of directly using a string value in a shell script, you
+can use `-raw` instead, which will print the string directly with no extra
+escaping or whitespace.
+
+```shellsession
+$ terraform output -raw lb_address
 my-app-alb-1657023003.us-east-1.elb.amazonaws.com
 ```
 
-To query for a particular value in a list, use `jq` with an index filter. For
-example, to query for the first instance's IP address:
+The `-raw` option works only with values that Terraform can automatically
+convert to strings. Use `-json` instead, possibly combined with `jq`, to
+work with complex-typed values such as objects.
 
-```shellsession
-$ terraform output -json instance_ips | jq '.[0]'
-"54.43.114.12"
-```
+Terraform strings are sequences of Unicode characters rather than raw bytes,
+so the `-raw` output will be UTF-8 encoded when it contains non-ASCII
+characters. If you need a different character encoding, use a separate command
+such as `iconv` to transcode Terraform's raw output.


### PR DESCRIPTION
So far the output command has had a default output format intended for human consumption and a JSON output format intended for machine consumption.

However, until Terraform v0.14 the default output format for primitive types happened to be _almost_ a raw string representation of the value, and so users started using that as a more convenient way to access primitive-typed output values from shell scripts, avoiding the need to also use a tool like "jq" to decode the JSON. Terraform v0.14 improved the default `terraform output` formatting to be consistent with how we print values in other commands such as `terraform plan`, but consequently it's no longer suitable for direct consumption by shell scripts.

Recognizing that primitive-typed output values are common and that processing them with shell scripts is common, this commit introduces a new `-raw` mode which is explicitly intended for that use-case, guaranteeing that the result will always be the direct result of a string conversion of the output value, or an error if no such conversion is possible.

Our policy elsewhere in Terraform is that we always use JSON for machine-readable output. We adopted that policy because our other machine-readable output has typically been complex data structures rather than single primitive values. A special mode seems justified for output values because it is common for root module output values to be just strings, and so it's pragmatic to offer access to the raw value directly rather than requiring a round-trip through JSON.

I'm not intending this to set any precedent for offering `-raw` options on any other commands. I would also consider any further complexity, such as selecting a deep primitive value out of a nested data structure using an expression/traversal, to be out of scope for this command. `jq` is a far better answer to those more complex cases, because it has a richer query language and various output post-processing options.

---

I've marked this for v0.14 backport in the hope of giving folks who were previously using `terraform output` for machine-readable data an easier upgrade path from v0.13 than installing and learning `jq`.
