### PR TITLE
terraform: final eval-related cleanup

### DIFF
--- a/terraform/eval_provider.go
+++ b/terraform/eval_provider.go
@@ -45,8 +45,8 @@ func buildProviderConfig(ctx EvalContext, addr addrs.AbsProviderConfig, config *
 	}
 }
 
-// GetProvider returns the providers.Interface and schema for a given provider.
-func GetProvider(ctx EvalContext, addr addrs.AbsProviderConfig) (providers.Interface, *ProviderSchema, error) {
+// getProvider returns the providers.Interface and schema for a given provider.
+func getProvider(ctx EvalContext, addr addrs.AbsProviderConfig) (providers.Interface, *ProviderSchema, error) {
 	if addr.Provider.Type == "" {
 		// Should never happen
 		panic("GetProvider used with uninitialized provider configuration address")

--- a/terraform/execute.go
+++ b/terraform/execute.go
@@ -3,9 +3,7 @@ package terraform
 import "github.com/hashicorp/terraform/tfdiags"
 
 // GraphNodeExecutable is the interface that graph nodes must implement to
-// enable execution. This is an alternative to GraphNodeEvalable, which is in
-// the process of being removed. A given graph node should _not_ implement both
-// GraphNodeExecutable and GraphNodeEvalable.
+// enable execution.
 type GraphNodeExecutable interface {
 	Execute(EvalContext, walkOperation) tfdiags.Diagnostics
 }

--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -155,13 +155,13 @@ func (n *nodeModuleVariable) Execute(ctx EvalContext, op walkOperation) (diags t
 
 	switch op {
 	case walkValidate:
-		vals, err = n.EvalModuleCallArgument(ctx, true)
+		vals, err = n.evalModuleCallArgument(ctx, true)
 		diags = diags.Append(err)
 		if diags.HasErrors() {
 			return diags
 		}
 	default:
-		vals, err = n.EvalModuleCallArgument(ctx, false)
+		vals, err = n.evalModuleCallArgument(ctx, false)
 		diags = diags.Append(err)
 		if diags.HasErrors() {
 			return diags
@@ -187,7 +187,7 @@ func (n *nodeModuleVariable) DotNode(name string, opts *dag.DotOpts) *dag.DotNod
 	}
 }
 
-// EvalModuleCallArgument produces the value for a particular variable as will
+// evalModuleCallArgument produces the value for a particular variable as will
 // be used by a child module instance.
 //
 // The result is written into a map, with its key set to the local name of the
@@ -199,7 +199,7 @@ func (n *nodeModuleVariable) DotNode(name string, opts *dag.DotOpts) *dag.DotNod
 // validateOnly indicates that this evaluation is only for config
 // validation, and we will not have any expansion module instance
 // repetition data.
-func (n *nodeModuleVariable) EvalModuleCallArgument(ctx EvalContext, validateOnly bool) (map[string]cty.Value, error) {
+func (n *nodeModuleVariable) evalModuleCallArgument(ctx EvalContext, validateOnly bool) (map[string]cty.Value, error) {
 	wantType := n.Config.Type
 	name := n.Addr.Variable.Name
 	expr := n.Expr

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -487,7 +487,7 @@ func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.C
 			// Should never happen, since we just constructed this right above
 			panic(fmt.Sprintf("planned change for %s could not be encoded: %s", n.Addr, err))
 		}
-		log.Printf("[TRACE] ExecuteWriteOutput: Saving %s change for %s in changeset", change.Action, n.Addr)
+		log.Printf("[TRACE] setValue: Saving %s change for %s in changeset", change.Action, n.Addr)
 		changes.RemoveOutputChange(n.Addr) // remove any existing planned change, if present
 		changes.AppendOutputChange(cs)     // add the new planned change
 	}
@@ -496,12 +496,12 @@ func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.C
 		// The state itself doesn't represent unknown values, so we null them
 		// out here and then we'll save the real unknown value in the planned
 		// changeset below, if we have one on this graph walk.
-		log.Printf("[TRACE] EvalWriteOutput: Saving value for %s in state", n.Addr)
+		log.Printf("[TRACE] setValue: Saving value for %s in state", n.Addr)
 		unmarkedVal, _ := val.UnmarkDeep()
 		stateVal := cty.UnknownAsNull(unmarkedVal)
 		state.SetOutputValue(n.Addr, stateVal, n.Config.Sensitive)
 	} else {
-		log.Printf("[TRACE] EvalWriteOutput: Removing %s from state (it is now null)", n.Addr)
+		log.Printf("[TRACE] setValue: Removing %s from state (it is now null)", n.Addr)
 		state.RemoveOutputValue(n.Addr)
 	}
 

--- a/terraform/node_provider.go
+++ b/terraform/node_provider.go
@@ -27,7 +27,7 @@ func (n *NodeApplyableProvider) Execute(ctx EvalContext, op walkOperation) (diag
 	if diags.HasErrors() {
 		return diags
 	}
-	provider, _, err := GetProvider(ctx, n.Addr)
+	provider, _, err := getProvider(ctx, n.Addr)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -348,7 +348,7 @@ func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.Ab
 // readResourceInstanceState reads the current object for a specific instance in
 // the state.
 func (n *NodeAbstractResource) readResourceInstanceState(ctx EvalContext, addr addrs.AbsResourceInstance) (*states.ResourceInstanceObject, error) {
-	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	provider, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +368,7 @@ func (n *NodeAbstractResource) readResourceInstanceState(ctx EvalContext, addr a
 		return nil, fmt.Errorf("no schema available for %s while reading state; this is a bug in Terraform and should be reported", addr)
 	}
 	var diags tfdiags.Diagnostics
-	src, diags = UpgradeResourceState(addr, provider, src, schema, currentVersion)
+	src, diags = upgradeResourceState(addr, provider, src, schema, currentVersion)
 	if diags.HasErrors() {
 		// Note that we don't have any channel to return warnings here. We'll
 		// accept that for now since warnings during a schema upgrade would
@@ -388,7 +388,7 @@ func (n *NodeAbstractResource) readResourceInstanceState(ctx EvalContext, addr a
 // readResourceInstanceStateDeposed reads the deposed object for a specific
 // instance in the state.
 func (n *NodeAbstractResource) readResourceInstanceStateDeposed(ctx EvalContext, addr addrs.AbsResourceInstance, key states.DeposedKey) (*states.ResourceInstanceObject, error) {
-	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	provider, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -413,7 +413,7 @@ func (n *NodeAbstractResource) readResourceInstanceStateDeposed(ctx EvalContext,
 
 	}
 
-	src, diags := UpgradeResourceState(addr, provider, src, schema, currentVersion)
+	src, diags := upgradeResourceState(addr, provider, src, schema, currentVersion)
 	if diags.HasErrors() {
 		// Note that we don't have any channel to return warnings here. We'll
 		// accept that for now since warnings during a schema upgrade would

--- a/terraform/node_resource_abstract_instance.go
+++ b/terraform/node_resource_abstract_instance.go
@@ -273,7 +273,7 @@ const (
 // default is the global working state.
 func (n *NodeAbstractResourceInstance) writeResourceInstanceState(ctx EvalContext, obj *states.ResourceInstanceObject, dependencies []addrs.ConfigResource, targetState phaseState) error {
 	absAddr := n.Addr
-	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return err
 	}
@@ -404,7 +404,7 @@ func (n *NodeAbstractResourceInstance) writeChange(ctx EvalContext, change *plan
 		return nil
 	}
 
-	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return err
 	}
@@ -440,7 +440,7 @@ func (n *NodeAbstractResourceInstance) writeChange(ctx EvalContext, change *plan
 func (n *NodeAbstractResourceInstance) refresh(ctx EvalContext, state *states.ResourceInstanceObject) (*states.ResourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	absAddr := n.Addr
-	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	provider, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return state, diags.Append(err)
 	}
@@ -560,7 +560,7 @@ func (n *NodeAbstractResourceInstance) plan(
 
 	config := *n.Config
 	resource := n.Addr.Resource.Resource
-	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	provider, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return plan, state, diags.Append(err)
 	}
@@ -1173,7 +1173,7 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx EvalContext, configVal
 
 	config := *n.Config
 
-	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	provider, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return newVal, diags
@@ -1277,7 +1277,7 @@ func (n *NodeAbstractResourceInstance) providerMetas(ctx EvalContext) (cty.Value
 	var diags tfdiags.Diagnostics
 	metaConfigVal := cty.NullVal(cty.DynamicPseudoType)
 
-	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return metaConfigVal, diags.Append(err)
 	}
@@ -1317,7 +1317,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, currentSt
 	var diags tfdiags.Diagnostics
 	var configVal cty.Value
 
-	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return nil, nil, diags.Append(err)
 	}
@@ -1466,7 +1466,7 @@ func (n *NodeAbstractResourceInstance) forcePlanReadData(ctx EvalContext) bool {
 func (n *NodeAbstractResourceInstance) applyDataSource(ctx EvalContext, planned *plans.ResourceInstanceChange) (*states.ResourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return nil, diags.Append(err)
 	}
@@ -1808,7 +1808,7 @@ func (n *NodeAbstractResourceInstance) apply(
 		state = &states.ResourceInstanceObject{}
 	}
 	var newState *states.ResourceInstanceObject
-	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	provider, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return newState, applyError, diags.Append(err)
 	}

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -135,7 +135,7 @@ func (n *NodeApplyableResourceInstance) Execute(ctx EvalContext, op walkOperatio
 }
 
 func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {
-	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -168,7 +168,7 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 
 	diags = diags.Append(n.writeChange(ctx, nil, ""))
 
-	diags = diags.Append(UpdateStateHook(ctx))
+	diags = diags.Append(updateStateHook(ctx))
 	return diags
 }
 
@@ -180,7 +180,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	var deposedKey states.DeposedKey
 
 	addr := n.ResourceInstanceAddr().Resource
-	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -323,9 +323,9 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		} else {
 			restored := ctx.State().MaybeRestoreResourceInstanceDeposed(addr.Absolute(ctx.Path()), deposedKey)
 			if restored {
-				log.Printf("[TRACE] EvalMaybeRestoreDeposedObject: %s deposed object %s was restored as the current object", addr, deposedKey)
+				log.Printf("[TRACE] managedResourceExecute: %s deposed object %s was restored as the current object", addr, deposedKey)
 			} else {
-				log.Printf("[TRACE] EvalMaybeRestoreDeposedObject: %s deposed object %s remains deposed", addr, deposedKey)
+				log.Printf("[TRACE] managedResourceExecute: %s deposed object %s remains deposed", addr, deposedKey)
 			}
 		}
 	}
@@ -338,7 +338,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		return diags
 	}
 
-	diags = diags.Append(UpdateStateHook(ctx))
+	diags = diags.Append(updateStateHook(ctx))
 	return diags
 }
 
@@ -361,7 +361,7 @@ func (n *NodeApplyableResourceInstance) checkPlannedChange(ctx EvalContext, plan
 
 	absAddr := addr.Absolute(ctx.Path())
 
-	log.Printf("[TRACE] EvalCheckPlannedChange: Verifying that actual change (action %s) matches planned change (action %s)", actualChange.Action, plannedChange.Action)
+	log.Printf("[TRACE] checkPlannedChange: Verifying that actual change (action %s) matches planned change (action %s)", actualChange.Action, plannedChange.Action)
 
 	if plannedChange.Action != actualChange.Action {
 		switch {

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -137,7 +137,7 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 	var state *states.ResourceInstanceObject
 	var provisionerErr error
 
-	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -215,6 +215,6 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 		return diags
 	}
 
-	diags = diags.Append(UpdateStateHook(ctx))
+	diags = diags.Append(updateStateHook(ctx))
 	return diags
 }

--- a/terraform/node_resource_destroy_deposed.go
+++ b/terraform/node_resource_destroy_deposed.go
@@ -197,7 +197,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		return diags.Append(applyError)
 	}
 
-	return diags.Append(UpdateStateHook(ctx))
+	return diags.Append(updateStateHook(ctx))
 }
 
 // GraphNodeDeposer is an optional interface implemented by graph nodes that
@@ -239,7 +239,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) writeResourceInstanceState(ct
 		return nil
 	}
 
-	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
 		return err
 	}

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -53,7 +53,7 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 	var change *plans.ResourceInstanceChange
 	var state *states.ResourceInstanceObject
 
-	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -99,7 +99,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	var instanceRefreshState *states.ResourceInstanceObject
 	var instancePlanState *states.ResourceInstanceObject
 
-	_, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags

--- a/terraform/node_resource_validate.go
+++ b/terraform/node_resource_validate.go
@@ -260,7 +260,7 @@ var connectionBlockSupersetSchema = &configschema.Block{
 func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	provider, providerSchema, err := GetProvider(ctx, n.ResolvedProvider)
+	provider, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -120,7 +120,7 @@ func (n *graphNodeImportState) Execute(ctx EvalContext, op walkOperation) (diags
 	// Reset our states
 	n.states = nil
 
-	provider, _, err := GetProvider(ctx, n.ResolvedProvider)
+	provider, _, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags

--- a/terraform/update_state_hook.go
+++ b/terraform/update_state_hook.go
@@ -1,7 +1,7 @@
 package terraform
 
-// UpdateStateHook calls the PostStateUpdate hook with the current state.
-func UpdateStateHook(ctx EvalContext) error {
+// updateStateHook calls the PostStateUpdate hook with the current state.
+func updateStateHook(ctx EvalContext) error {
 	// In principle we could grab the lock here just long enough to take a
 	// deep copy and then pass that to our hooks below, but we'll instead
 	// hold the hook for the duration to avoid the potential confusing

--- a/terraform/update_state_hook_test.go
+++ b/terraform/update_state_hook_test.go
@@ -20,7 +20,7 @@ func TestUpdateStateHook(t *testing.T) {
 	ctx.HookHook = mockHook
 	ctx.StateState = state.SyncWrapper()
 
-	if err := UpdateStateHook(ctx); err != nil {
+	if err := updateStateHook(ctx); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/terraform/upgrade_resource_state.go
+++ b/terraform/upgrade_resource_state.go
@@ -13,14 +13,14 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// UpgradeResourceState will, if necessary, run the provider-defined upgrade
+// upgradeResourceState will, if necessary, run the provider-defined upgrade
 // logic against the given state object to make it compliant with the
 // current schema version. This is a no-op if the given state object is
 // already at the latest version.
 //
 // If any errors occur during upgrade, error diagnostics are returned. In that
 // case it is not safe to proceed with using the original state object.
-func UpgradeResourceState(addr addrs.AbsResourceInstance, provider providers.Interface, src *states.ResourceInstanceObjectSrc, currentSchema *configschema.Block, currentVersion uint64) (*states.ResourceInstanceObjectSrc, tfdiags.Diagnostics) {
+func upgradeResourceState(addr addrs.AbsResourceInstance, provider providers.Interface, src *states.ResourceInstanceObjectSrc, currentSchema *configschema.Block, currentVersion uint64) (*states.ResourceInstanceObjectSrc, tfdiags.Diagnostics) {
 	// Remove any attributes from state that are not present in the schema.
 	// This was previously taken care of by the provider, but data sources do
 	// not go through the UpgradeResourceState process.
@@ -42,7 +42,7 @@ func UpgradeResourceState(addr addrs.AbsResourceInstance, provider providers.Int
 	// TODO: This should eventually use a proper FQN.
 	providerType := addr.Resource.Resource.ImpliedProvider()
 	if src.SchemaVersion > currentVersion {
-		log.Printf("[TRACE] UpgradeResourceState: can't downgrade state for %s from version %d to %d", addr, src.SchemaVersion, currentVersion)
+		log.Printf("[TRACE] upgradeResourceState: can't downgrade state for %s from version %d to %d", addr, src.SchemaVersion, currentVersion)
 		var diags tfdiags.Diagnostics
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -62,9 +62,9 @@ func UpgradeResourceState(addr addrs.AbsResourceInstance, provider providers.Int
 	// representation, since only the provider has enough information to
 	// understand a flatmap built against an older schema.
 	if src.SchemaVersion != currentVersion {
-		log.Printf("[TRACE] UpgradeResourceState: upgrading state for %s from version %d to %d using provider %q", addr, src.SchemaVersion, currentVersion, providerType)
+		log.Printf("[TRACE] upgradeResourceState: upgrading state for %s from version %d to %d using provider %q", addr, src.SchemaVersion, currentVersion, providerType)
 	} else {
-		log.Printf("[TRACE] UpgradeResourceState: schema version of %s is still %d; calling provider %q for any other minor fixups", addr, currentVersion, providerType)
+		log.Printf("[TRACE] upgradeResourceState: schema version of %s is still %d; calling provider %q for any other minor fixups", addr, currentVersion, providerType)
 	}
 
 	req := providers.UpgradeResourceStateRequest{


### PR DESCRIPTION
This is a purely mechanical refactor PR: I de-exported a few more
functions which did not need to be exported in the first place, and
fixed a few outdated log outputs.