### PR TITLE
command: Revert local patch for pkg/browser

### DIFF
--- a/command/webbrowser/native.go
+++ b/command/webbrowser/native.go
@@ -2,8 +2,6 @@ package webbrowser
 
 import (
 	"github.com/pkg/browser"
-	"os/exec"
-	"strings"
 )
 
 // NewNativeLauncher creates and returns a Launcher that will attempt to interact
@@ -15,18 +13,6 @@ func NewNativeLauncher() Launcher {
 
 type nativeLauncher struct{}
 
-func hasProgram(name string) bool {
-	_, err := exec.LookPath(name)
-	return err == nil
-}
-
 func (l nativeLauncher) OpenURL(url string) error {
-	// Windows Subsystem for Linux (bash for Windows) doesn't have xdg-open available
-	// but you can execute cmd.exe from there; try to identify it
-	if !hasProgram("xdg-open") && hasProgram("cmd.exe") {
-		r := strings.NewReplacer("&", "^&")
-		exec.Command("cmd.exe", "/c", "start", r.Replace(url)).Run()
-	}
-
 	return browser.OpenURL(url)
 }

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db
 	github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c // indirect
-	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
+	github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect

--- a/go.sum
+++ b/go.sum
@@ -494,6 +494,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
+github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23 h1:dofHuld+js7eKSemxqTVIo8yRlpRw+H1SdpzZxWruBc=
+github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
The upstream bug with opening a browser on Windows Subsystem for Linux has been fixed, so this reverts our local patch for this. [The approach upstream](https://github.com/pkg/browser/pull/26) adds fallback support for `x-www-browser` and `www-browser` if `xdg-open` fails, and this fixes the problem on WSL installations of common Linux distros.

This reverts commit 12e090ce48f17e970cd7ba5de129f638ae296303.

Tested (using `terraform login`) on Windows 10, both the windows/amd64 build with cmd.exe and Powershell and the linux/amd64 build on WSL with Ubuntu 18.04.