### PR TITLE
lang/funcs: Fix alltrue/anytrue with unknowns

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -70,6 +70,9 @@ var AllTrueFunc = function.New(&function.Spec{
 		result := cty.True
 		for it := args[0].ElementIterator(); it.Next(); {
 			_, v := it.Element()
+			if !v.IsKnown() {
+				return cty.UnknownVal(cty.Bool), nil
+			}
 			if v.IsNull() {
 				return cty.False, nil
 			}
@@ -94,8 +97,13 @@ var AnyTrueFunc = function.New(&function.Spec{
 	Type: function.StaticReturnType(cty.Bool),
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
 		result := cty.False
+		var hasUnknown bool
 		for it := args[0].ElementIterator(); it.Next(); {
 			_, v := it.Element()
+			if !v.IsKnown() {
+				hasUnknown = true
+				continue
+			}
 			if v.IsNull() {
 				continue
 			}
@@ -103,6 +111,9 @@ var AnyTrueFunc = function.New(&function.Spec{
 			if result.True() {
 				return cty.True, nil
 			}
+		}
+		if hasUnknown {
+			return cty.UnknownVal(cty.Bool), nil
 		}
 		return result, nil
 	},

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -170,9 +170,27 @@ func TestAllTrue(t *testing.T) {
 			false,
 		},
 		{
+			cty.ListVal([]cty.Value{cty.True, cty.NullVal(cty.Bool)}),
+			cty.False,
+			false,
+		},
+		{
 			cty.ListVal([]cty.Value{cty.UnknownVal(cty.Bool)}),
 			cty.UnknownVal(cty.Bool),
-			true,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{
+				cty.UnknownVal(cty.Bool),
+				cty.UnknownVal(cty.Bool),
+			}),
+			cty.UnknownVal(cty.Bool),
+			false,
+		},
+		{
+			cty.UnknownVal(cty.List(cty.Bool)),
+			cty.UnknownVal(cty.Bool),
+			false,
 		},
 		{
 			cty.NullVal(cty.List(cty.Bool)),
@@ -233,9 +251,35 @@ func TestAnyTrue(t *testing.T) {
 			false,
 		},
 		{
+			cty.ListVal([]cty.Value{cty.NullVal(cty.Bool), cty.True}),
+			cty.True,
+			false,
+		},
+		{
 			cty.ListVal([]cty.Value{cty.UnknownVal(cty.Bool)}),
 			cty.UnknownVal(cty.Bool),
-			true,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{
+				cty.UnknownVal(cty.Bool),
+				cty.False,
+			}),
+			cty.UnknownVal(cty.Bool),
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{
+				cty.UnknownVal(cty.Bool),
+				cty.True,
+			}),
+			cty.True,
+			false,
+		},
+		{
+			cty.UnknownVal(cty.List(cty.Bool)),
+			cty.UnknownVal(cty.Bool),
+			false,
 		},
 		{
 			cty.NullVal(cty.List(cty.Bool)),


### PR DESCRIPTION
The `alltrue`/`anytrue` functions did not correctly handle unknown values. This commit changes these functions so that the result is unknown if:

- The list argument is unknown
- For `alltrue`: any elements are unknown
- For `anytrue`: any elements are unknown and no known elements are true

The last change is a little subtle, so there are test cases to cover it specifically. Examples:

- `anytrue(unknown)` = `unknown`
- `anytrue(false, unknown)` = `unknown`
- `anytrue(false, unknown, true)` = `true`

Intended for backport to a future 0.14 patch release.

Fixes #27236