### PR TITLE
Unmark values in count before go conversion

### DIFF
--- a/terraform/eval_count.go
+++ b/terraform/eval_count.go
@@ -60,6 +60,10 @@ func evaluateCountExpressionValue(expr hcl.Expression, ctx EvalContext) (cty.Val
 		return nullCount, diags
 	}
 
+	// Unmark the count value, sensitive values are allowed in count but not for_each,
+	// as using it here will not disclose the sensitive value
+	countVal, _ = countVal.Unmark()
+
 	switch {
 	case countVal.IsNull():
 		diags = diags.Append(&hcl.Diagnostic{

--- a/terraform/eval_count_test.go
+++ b/terraform/eval_count_test.go
@@ -1,0 +1,45 @@
+package terraform
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestEvaluateCountExpression(t *testing.T) {
+	tests := map[string]struct {
+		Expr  hcl.Expression
+		Count int
+	}{
+		"zero": {
+			hcltest.MockExprLiteral(cty.NumberIntVal(0)),
+			0,
+		},
+		"expression with marked value": {
+			hcltest.MockExprLiteral(cty.NumberIntVal(8).Mark("sensitive")),
+			8,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := &MockEvalContext{}
+			ctx.installSimpleEval()
+			countVal, diags := evaluateCountExpression(test.Expr, ctx)
+
+			if len(diags) != 0 {
+				t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
+			}
+
+			if !reflect.DeepEqual(countVal, test.Count) {
+				t.Errorf(
+					"wrong map value\ngot:  %swant: %s",
+					spew.Sdump(countVal), spew.Sdump(test.Count),
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When evaluating count values, we need to unmark the cty value before passing the value for conversion into a go int value.

This PR adds a test file/some coverage for the `evaluateCountExpression` function, but selfishly limits this addition to the basic level pluss adding a test case specific to this marking.