### PR TITLE
Skip 10-second periodic updates in automated workflows

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -624,6 +624,7 @@ func (m *Meta) process(args []string) []string {
 		m.View.Configure(&arguments.View{
 			CompactWarnings: m.compactWarnings,
 			NoColor:         !m.Color,
+		    InAutomation:    m.RunningInAutomation,
 		})
 	}
 

--- a/command/views/hook_ui.go
+++ b/command/views/hook_ui.go
@@ -37,6 +37,7 @@ type UiHook struct {
 	viewLock sync.Mutex
 
 	periodicUiTimer time.Duration
+	InAutomation    bool
 
 	resources     map[string]uiResourceState
 	resourcesLock sync.Mutex
@@ -143,6 +144,11 @@ func (h *UiHook) stillApplying(state uiResourceState) {
 
 		case <-time.After(h.periodicUiTimer):
 			// Timer up, show status
+		}
+
+		// Don't return periodic Still... status in automation workflows
+		if h.InAutomation {
+			continue
 		}
 
 		var msg string

--- a/website/docs/cli/config/environment-variables.html.md
+++ b/website/docs/cli/config/environment-variables.html.md
@@ -124,6 +124,9 @@ output more consistent and less confusing in workflows where users don't
 directly execute Terraform commands, like in CI systems or other wrapping
 applications.
 
+It also supresses the 10-second updates given for interactive users, so as to
+minimize unnecessary output for automated workflows.
+
 This is a purely cosmetic change to Terraform's human-readable output, and the
 exact output differences can change between minor Terraform versions.
 


### PR DESCRIPTION
Makes use of the existing `TF_IN_AUTOMATION` environment variable to suppress 10-second updates during command execution added in #6163 which create extremely long, unhelpful logs in automated CI/CD workflows.

Provides relief for needs of #18317 without adding any new configuration options, a goal mentioned by @apparentlymart there