### PR TITLE
add implied data depends_on caveat

### DIFF
--- a/website/docs/configuration/data-sources.html.md
+++ b/website/docs/configuration/data-sources.html.md
@@ -118,6 +118,12 @@ Data resources have the same dependency resolution behavior
 Setting the `depends_on` meta-argument within `data` blocks defers reading of
 the data source until after all changes to the dependencies have been applied.
 
+In order to ensure that data sources are accessing the most up to date
+information possible in a wide variety of use cases, arguments directly
+referencing managed resources are treated the same as if the resource was
+listed in `depends_on`. This behavior can be avoided when desired by indirectly
+referencing the managed resource values through a `local` value.
+
 ~> **NOTE:** **In Terraform 0.12 and earlier**, due to the data resource behavior of deferring the read until the apply phase when depending on values that are not yet known, using `depends_on` with `data` resources will force the read to always be deferred to the apply phase, and therefore a configuration that uses `depends_on` with a `data` resource can never converge. Due to this behavior, we do not recommend using `depends_on` with data resources.
 
 


### PR DESCRIPTION
Trying to find a way to better document the implied `depends_on` behavior with data resources, as seen in #27171. 

This behavior was re-introduced in order to satisfy #25961, and remain compatible with a large base of existing provider acceptance tests. The original behavior however only worked on the first apply, and could return incorrect results on subsequent changes. Making this work in all cases has the unfortunate side effect of causing data sources to be deferred until apply far more often, hence the workaround presented here.