### PR TITLE
command/state list: list resources in nested and expanded modules

### DIFF
--- a/command/state_meta.go
+++ b/command/state_meta.go
@@ -103,24 +103,28 @@ func (c *StateMeta) lookupResourceInstanceAddr(state *states.State, allowMissing
 	case addrs.ModuleInstance:
 		// Matches all instances within the indicated module and all of its
 		// descendent modules.
+		found := false
 		ms := state.Module(addr)
-		if ms == nil {
-			if !allowMissing {
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Error,
-					"Unknown module",
-					fmt.Sprintf(`The current state contains no module at %s. If you've just added this module to the configuration, you must run "terraform apply" first to create the module's entry in the state.`, addr),
-				))
-			}
-			break
+		if ms != nil {
+			found = true
+			ret = append(ret, c.collectModuleResourceInstances(ms)...)
 		}
-		ret = append(ret, c.collectModuleResourceInstances(ms)...)
 		for _, cms := range state.Modules {
-			candidateAddr := ms.Addr
-			if len(candidateAddr) > len(addr) && candidateAddr[:len(addr)].Equal(addr) {
-				ret = append(ret, c.collectModuleResourceInstances(cms)...)
+			if !addr.Equal(cms.Addr) {
+				if addr.IsAncestor(cms.Addr) || addr.TargetContains(cms.Addr) {
+					found = true
+					ret = append(ret, c.collectModuleResourceInstances(cms)...)
+				}
 			}
 		}
+		if found == false && !allowMissing {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Unknown module",
+				fmt.Sprintf(`The current state contains no module at %s. If you've just added this module to the configuration, you must run "terraform apply" first to create the module's entry in the state.`, addr),
+			))
+		}
+
 	case addrs.AbsResource:
 		// Matches all instances of the specific selected resource.
 		rs := state.Resource(addr)

--- a/command/state_meta.go
+++ b/command/state_meta.go
@@ -103,6 +103,9 @@ func (c *StateMeta) lookupResourceInstanceAddr(state *states.State, allowMissing
 	case addrs.ModuleInstance:
 		// Matches all instances within the indicated module and all of its
 		// descendent modules.
+
+		// found is used to identify cases where the selected module has no
+		// resources, but one or more of its submodules does.
 		found := false
 		ms := state.Module(addr)
 		if ms != nil {
@@ -117,6 +120,7 @@ func (c *StateMeta) lookupResourceInstanceAddr(state *states.State, allowMissing
 				}
 			}
 		}
+
 		if found == false && !allowMissing {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,

--- a/command/testdata/state-list-nested-modules/terraform.tfstate
+++ b/command/testdata/state-list-nested-modules/terraform.tfstate
@@ -1,0 +1,91 @@
+{
+    "version": 4,
+    "terraform_version": "0.15.0",
+    "serial": 8,
+    "lineage": "00bfda35-ad61-ec8d-c013-14b0320bc416",
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "root",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "attributes": {
+                        "id": "root"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.nest",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "nest",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "attributes": {
+                        "ami": "nested"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.nest.module.subnest",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "subnest",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "attributes": {
+                        "id": "subnested"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.nonexist.module.child",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "child",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "attributes": {
+                        "id": "child"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.count[0]",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "count",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "attributes": {
+                        "id": "zero"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.count[1]",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "count",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "attributes": {
+                        "id": "one"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/website/docs/commands/state/list.html.md
+++ b/website/docs/commands/state/list.html.md
@@ -57,11 +57,12 @@ aws_instance.bar[1]
 
 ## Example: Filtering by Module
 
-This example will only list resources in the given module:
+This example will list resources in the given module and any submodules:
 
 ```
 $ terraform state list module.elb
 module.elb.aws_elb.main
+module.elb.module.secgroups.aws_security_group.sg
 ```
 
 ## Example: Filtering by ID


### PR DESCRIPTION
A few distinct bugs fixed in here:

There was a bug in the logic checking if a given module was the child of
the targetAddr, now fixed. That resolved the basic issue where resources
in nested submodules were not listed.

The logic around `allowMissing` needed some tweaking to allow for empty
modules, as long as those modules had submodules with resources. `state
list` is the only command using `allowMissing` with `false`, so this felt safe
to do.

Finally I extended the logic so `state list` would included expanded modules,
when given a module instance, so for e.g. `list module.foo` would result in resources from
`module.foo[1]`, `module.foo[0]`, etc.

Fixes #26191