### PR TITLE
website: add example of multiple var cli

### DIFF
--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -343,7 +343,7 @@ when running the `terraform plan` and `terraform apply` commands:
 
 ```
 terraform apply -var="image_id=ami-abc123"
-terraform apply -var='image_id_list=["ami-abc123","ami-def456"]'
+terraform apply -var='image_id_list=["ami-abc123","ami-def456"]' -var="instance_type=t2.micro"
 terraform apply -var='image_id_map={"us-east-1":"ami-abc123","us-east-2":"ami-def456"}'
 ```
 


### PR DESCRIPTION
This PR updates the documentation of input variable of terraform. It's
mentioned that multiple `-var` is possible, but no example is given.
This PR adds an example of multiple `-var` option