### PR TITLE
Guard against double marking in other locations in evaluate

### DIFF
--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -433,7 +433,7 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 
 			instance[cfg.Name] = outputState
 
-			if cfg.Sensitive {
+			if cfg.Sensitive && !outputState.HasMark("sensitive") {
 				instance[cfg.Name] = outputState.Mark("sensitive")
 			}
 		}
@@ -462,7 +462,7 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 
 			instance[cfg.Name] = change.After
 
-			if change.Sensitive {
+			if change.Sensitive && !change.After.HasMark("sensitive") {
 				instance[cfg.Name] = change.After.Mark("sensitive")
 			}
 		}


### PR DESCRIPTION
Add checks for double marking elsewhere in the evaluate code -- this is tough to test for, so submitting this as a cautionary patch, carrying the fix for https://github.com/hashicorp/terraform/pull/27131 over to output values without waiting for a bug report of "how" this can happen.