### PR TITLE
modify ProvidedBy to indicate no provider needed for orphaned data sources

### DIFF
--- a/terraform/node_resource_plan_orphan.go
+++ b/terraform/node_resource_plan_orphan.go
@@ -27,6 +27,7 @@ var (
 	_ GraphNodeAttachResourceConfig = (*NodePlannableResourceInstanceOrphan)(nil)
 	_ GraphNodeAttachResourceState  = (*NodePlannableResourceInstanceOrphan)(nil)
 	_ GraphNodeExecutable           = (*NodePlannableResourceInstanceOrphan)(nil)
+	_ GraphNodeProviderConsumer     = (*NodePlannableResourceInstanceOrphan)(nil)
 )
 
 func (n *NodePlannableResourceInstanceOrphan) Name() string {
@@ -46,6 +47,14 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))
 	}
+}
+
+func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() (addr addrs.ProviderConfig, exact bool) {
+	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
+		// indicate that this node does not require a configured provider
+		return nil, true
+	}
+	return n.NodeAbstractResourceInstance.ProvidedBy()
 }
 
 func (n *NodePlannableResourceInstanceOrphan) dataResourceExecute(ctx EvalContext) tfdiags.Diagnostics {


### PR DESCRIPTION
Because of the composition pattern used within core, we can't easily remove a behavior from an embedded type. Rather than trying to re-implement all necessary methods on the `NodePlannableResourceInstnaceOrphan` to exclude orphaned data resources from `GraphNodeProviderConsumer`, we can modify `ProvidedBy` to indicate when there is no provider required.

Overloading the meaning of the returned values of this method is definitely not optimal, but it already requires careful handling due to it being overloaded in this way. It also is only called in one location, and immediately checked for the new condition. This seems overall safer than the alternatives of yet another optional interface, or proxying all required methods which are not guaranteed to be statically checked and can be missed. 

Fixes #26833