### PR TITLE
website: Fix broken/wobbly links

### DIFF
--- a/website/docs/backends/state.html.md
+++ b/website/docs/backends/state.html.md
@@ -66,7 +66,7 @@ prior to forcing the overwrite.
 
 Backends are responsible for supporting [state locking](/docs/state/locking.html)
 if possible. Not all backend types support state locking. In the
-[list of supported backend types](/docs/backends/types) we explicitly note
+[list of supported backend types](/docs/backends/types/index.html) we explicitly note
 whether locking is supported.
 
 For more information on state locking, view the

--- a/website/docs/backends/types/azurerm.html.md
+++ b/website/docs/backends/types/azurerm.html.md
@@ -146,9 +146,9 @@ data "terraform_remote_state" "foo" {
 
 The following configuration options are supported:
 
-* `storage_account_name` - (Required) The Name of [the Storage Account](https://www.terraform.io/docs/providers/azurerm/r/storage_account.html).
+* `storage_account_name` - (Required) The Name of [the Storage Account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account).
 
-* `container_name` - (Required) The Name of [the Storage Container](https://www.terraform.io/docs/providers/azurerm/r/storage_container.html) within the Storage Account.
+* `container_name` - (Required) The Name of [the Storage Container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) within the Storage Account.
 
 * `key` - (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.
 

--- a/website/docs/backends/types/cos.html.md
+++ b/website/docs/backends/types/cos.html.md
@@ -28,7 +28,7 @@ terraform {
 }
 ```
 
-This assumes we have a [COS Bucket](https://www.terraform.io/docs/providers/tencentcloud/r/cos_bucket.html) created named `bucket-for-terraform-state-1258798060`,
+This assumes we have a [COS Bucket](https://registry.terraform.io/providers/tencentcloudstack/tencentcloud/latest/docs/resources/cos_bucket) created named `bucket-for-terraform-state-1258798060`,
 Terraform state will be written into the file `terraform/state/terraform.tfstate`.
 
 ## Data Source Configuration

--- a/website/docs/backends/types/oss.html.md
+++ b/website/docs/backends/types/oss.html.md
@@ -33,9 +33,9 @@ terraform {
 }
 ```
 
-This assumes we have a [OSS Bucket](https://www.terraform.io/docs/providers/alicloud/r/oss_bucket.html) created called `bucket-for-terraform-state`,
-a [OTS Instance](https://www.terraform.io/docs/providers/alicloud/r/ots_instance.html) called `terraform-remote` and
-a [OTS TableStore](https://www.terraform.io/docs/providers/alicloud/r/ots_table.html) called `statelock`. The
+This assumes we have a [OSS Bucket](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/oss_bucket) created called `bucket-for-terraform-state`,
+a [OTS Instance](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ots_instance) called `terraform-remote` and
+a [OTS TableStore](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ots_table) called `statelock`. The
 Terraform state will be written into the file `path/mystate/version-1.tfstate`. The `TableStore` must have a primary key named `LockID` of type `String`.
 
 

--- a/website/docs/commands/0.13upgrade.html.markdown
+++ b/website/docs/commands/0.13upgrade.html.markdown
@@ -23,7 +23,7 @@ providers are in use for a module, detect the source address for those
 providers where possible, and record this information in a
 [`required_providers` block][required-providers].
 
-[required-providers]: /docs/configuration/terraform.html#specifying-required-provider-versions
+[required-providers]: /docs/configuration/provider-requirements.html
 
 ~> Note: the command ignores `.tf.json` files and override files in the module.
 

--- a/website/docs/commands/apply.html.markdown
+++ b/website/docs/commands/apply.html.markdown
@@ -72,11 +72,11 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-var 'foo=bar'` - Set a variable in the Terraform configuration. This flag
   can be set multiple times. Variable values are interpreted as
-  [HCL](/docs/configuration/syntax.html#HCL), so list and map values can be
-  specified via this flag.
+  [literal expressions](/docs/configuration/expressions/types.html) in the
+  Terraform language, so list and map values can be specified via this flag.
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
-  a [variable file](/docs/configuration/variables.html#variable-files). If
+  a [variable file](/docs/configuration/variables.html#variable-definitions-tfvars-files). If
   a `terraform.tfvars` or any `.auto.tfvars` files are present in the current
   directory, they will be automatically loaded. `terraform.tfvars` is loaded
   first and the `.auto.tfvars` files after in alphabetical order. Any files
@@ -92,7 +92,7 @@ that directory as the root module instead of the current working directory.
 That usage is still supported in Terraform v0.14, but is now deprecated and we
 plan to remove it in Terraform v0.15. If your workflow relies on overriding
 the root module directory, use
-[the `-chdir` global option](./#switching-working-directory-with--chdir)
+[the `-chdir` global option](./#switching-working-directory-with-chdir)
 instead, which works across all commands and makes Terraform consistently look
 in the given directory for all files it would normaly read or write in the
 current working directory.
@@ -100,6 +100,6 @@ current working directory.
 If your previous use of this legacy pattern was also relying on Terraform
 writing the `.terraform` subdirectory into the current working directory even
 though the root module directory was overridden, use
-[the `TF_DATA_DIR` environment variable](environment-variables.html#TF_DATA_DIR)
+[the `TF_DATA_DIR` environment variable](environment-variables.html#tf_data_dir)
 to direct Terraform to write the `.terraform` directory to a location other
 than the current working directory.

--- a/website/docs/commands/import.html.md
+++ b/website/docs/commands/import.html.md
@@ -75,11 +75,12 @@ in the configuration for the target resource, and that is the best behavior in m
 
 * `-var 'foo=bar'` - Set a variable in the Terraform configuration. This flag
   can be set multiple times. Variable values are interpreted as
-  [HCL](/docs/configuration/syntax.html#HCL), so list and map values can be
-  specified via this flag. This is only useful with the `-config` flag.
+  [literal expressions](/docs/configuration/expressions/types.html) in the
+  Terraform language, so list and map values can be specified via this flag.
+  This is only useful with the `-config` flag.
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
-  a [variable file](/docs/configuration/variables.html#variable-files). If
+  a [variable file](/docs/configuration/variables.html#variable-definitions-tfvars-files). If
   a `terraform.tfvars` or any `.auto.tfvars` files are present in the current
   directory, they will be automatically loaded. `terraform.tfvars` is loaded
   first and the `.auto.tfvars` files after in alphabetical order. Any files

--- a/website/docs/commands/init.html.markdown
+++ b/website/docs/commands/init.html.markdown
@@ -142,10 +142,12 @@ You can modify `terraform init`'s plugin behavior with the following options:
   cause Terraform to ignore any selections recorded in the dependency lock
   file, and to take the newest available version matching the configured
   version constraints.
-- `-get-plugins=false` — Skip plugin installation. _Note: Since Terraform 0.13, this
-  command has been superseded by [`provider_installation`](./cli-config.html#provider-installation)
-  blocks or using the [`plugin_cache_dir`](./cli-config.html#plugin_cache_dir) setting.
-  It should not be used in Terraform versions 0.13+.
+- `-get-plugins=false` — Skip plugin installation.
+
+    -> Note: Since Terraform 0.13, this option has been superseded by the
+    [`provider_installation`](./cli-config.html#provider-installation) and
+    [`plugin_cache_dir`](./cli-config.html#plugin_cache_dir) settings.
+    It should not be used in Terraform versions 0.13+.
 - `-plugin-dir=PATH` — Force plugin installation to read plugins _only_ from
   the specified directory, as if it had been configured as a `filesystem_mirror`
   in the CLI configuration. If you intend to routinely use a particular
@@ -176,7 +178,7 @@ that directory as the root module instead of the current working directory.
 That usage is still supported in Terraform v0.14, but is now deprecated and we
 plan to remove it in Terraform v0.15. If your workflow relies on overriding
 the root module directory, use
-[the `-chdir` global option](./#switching-working-directory-with--chdir)
+[the `-chdir` global option](./#switching-working-directory-with-chdir)
 instead, which works across all commands and makes Terraform consistently look
 in the given directory for all files it would normaly read or write in the
 current working directory.
@@ -184,6 +186,6 @@ current working directory.
 If your previous use of this legacy pattern was also relying on Terraform
 writing the `.terraform` subdirectory into the current working directory even
 though the root module directory was overridden, use
-[the `TF_DATA_DIR` environment variable](environment-variables.html#TF_DATA_DIR)
+[the `TF_DATA_DIR` environment variable](environment-variables.html#tf_data_dir)
 to direct Terraform to write the `.terraform` directory to a location other
 than the current working directory.

--- a/website/docs/commands/plan.html.markdown
+++ b/website/docs/commands/plan.html.markdown
@@ -76,13 +76,13 @@ The available options are:
   Address](/docs/internals/resource-addressing.html) to target. This flag can
   be used multiple times. See below for more information.
 
-* `-var=foo=bar` - Set a variable in the Terraform configuration. This flag
+* `-var 'foo=bar'` - Set a variable in the Terraform configuration. This flag
   can be set multiple times. Variable values are interpreted as
-  [HCL](/docs/configuration/syntax.html#HCL), so list and map values can be
-  specified via this flag.
+  [literal expressions](/docs/configuration/expressions/types.html) in the
+  Terraform language, so list and map values can be specified via this flag.
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
-  a [variable file](/docs/configuration/variables.html#variable-files). If
+  a [variable file](/docs/configuration/variables.html#variable-definitions-tfvars-files). If
   a `terraform.tfvars` or any `.auto.tfvars` files are present in the current
   directory, they will be automatically loaded. `terraform.tfvars` is loaded
   first and the `.auto.tfvars` files after in alphabetical order. Any files
@@ -142,7 +142,7 @@ module instead of the current working directory.
 That usage is still supported in Terraform v0.14, but is now deprecated and we
 plan to remove it in Terraform v0.15. If your workflow relies on overriding
 the root module directory, use
-[the `-chdir` global option](./#switching-working-directory-with--chdir)
+[the `-chdir` global option](./#switching-working-directory-with-chdir)
 instead, which works across all commands and makes Terraform consistently look
 in the given directory for all files it would normaly read or write in the
 current working directory.
@@ -150,6 +150,6 @@ current working directory.
 If your previous use of this legacy pattern was also relying on Terraform
 writing the `.terraform` subdirectory into the current working directory even
 though the root module directory was overridden, use
-[the `TF_DATA_DIR` environment variable](environment-variables.html#TF_DATA_DIR)
+[the `TF_DATA_DIR` environment variable](environment-variables.html#tf_data_dir)
 to direct Terraform to write the `.terraform` directory to a location other
 than the current working directory.

--- a/website/docs/commands/refresh.html.markdown
+++ b/website/docs/commands/refresh.html.markdown
@@ -56,11 +56,11 @@ The `terraform refresh` command accepts the following options:
 
 * `-var 'foo=bar'` - Set a variable in the Terraform configuration. This flag
   can be set multiple times. Variable values are interpreted as
-  [HCL](/docs/configuration/syntax.html#HCL), so list and map values can be
-  specified via this flag.
+  [literal expressions](/docs/configuration/expressions/types.html) in the
+  Terraform language, so list and map values can be specified via this flag.
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
-  a [variable file](/docs/configuration/variables.html#variable-files). If
+  a [variable file](/docs/configuration/variables.html#variable-definitions-tfvars-files). If
   a `terraform.tfvars` or any `.auto.tfvars` files are present in the current
   directory, they will be automatically loaded. `terraform.tfvars` is loaded
   first and the `.auto.tfvars` files after in alphabetical order. Any files

--- a/website/docs/commands/state/push.html.md
+++ b/website/docs/commands/state/push.html.md
@@ -20,7 +20,7 @@ manual intervention is necessary with the remote state.
 Usage: `terraform state push [options] PATH`
 
 This command will push the state specified by PATH to the currently
-configured [backend](/docs/backends).
+configured [backend](/docs/configuration/blocks/backends/index.html).
 
 If PATH is "-" then the state data to push is read from stdin. This data
 is loaded completely into memory and verified prior to being written to

--- a/website/docs/configuration-0-11/interpolation.html.md
+++ b/website/docs/configuration-0-11/interpolation.html.md
@@ -449,7 +449,7 @@ Terraform 0.12 and later.
 ## Templates
 
 Long strings can be managed using templates.
-[Templates](/docs/providers/template/index.html) are
+[Templates](https://registry.terraform.io/providers/hashicorp/template/latest/docs) are
 [data-sources](./data-sources.html) defined by a
 string with interpolation tokens (usually loaded from a file) and some variables
 to use during interpolation. They have a computed `rendered` attribute
@@ -487,7 +487,7 @@ by the surrounding scope of the configuration.
 
 You may use any of the built-in functions in your template. For more
 details on template usage, please see the
-[template_file documentation](/docs/providers/template/d/file.html).
+[template_file documentation](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file).
 
 ### Using Templates with Count
 

--- a/website/docs/configuration-0-11/interpolation.html.md
+++ b/website/docs/configuration-0-11/interpolation.html.md
@@ -409,7 +409,7 @@ The supported built-in functions are:
 
   * `timestamp()` - Returns a UTC timestamp string in RFC 3339 format. This string will change with every
    invocation of the function, so in order to prevent diffs on every plan & apply, it must be used with the
-   [`ignore_changes`](./resources.html#ignore-changes) lifecycle attribute.
+   [`ignore_changes`](./resources.html#ignore_changes) lifecycle attribute.
 
   * `timeadd(time, duration)` - Returns a UTC timestamp string corresponding to adding a given `duration` to `time` in RFC 3339 format.
     For example, `timeadd("2017-11-22T00:00:00Z", "10m")` produces a value `"2017-11-22T00:10:00Z"`.
@@ -424,7 +424,7 @@ The supported built-in functions are:
 
   * `urlencode(string)` - Returns an URL-safe copy of the string.
 
-  * `uuid()` - Returns a random UUID string. This string will change with every invocation of the function, so in order to prevent diffs on every plan & apply, it must be used with the [`ignore_changes`](./resources.html#ignore-changes) lifecycle attribute.
+  * `uuid()` - Returns a random UUID string. This string will change with every invocation of the function, so in order to prevent diffs on every plan & apply, it must be used with the [`ignore_changes`](./resources.html#ignore_changes) lifecycle attribute.
 
   * `values(map)` - Returns a list of the map values, in the order of the keys
     returned by the `keys` function. This function only works on flat maps and

--- a/website/docs/configuration-0-11/modules.html.md
+++ b/website/docs/configuration-0-11/modules.html.md
@@ -233,7 +233,7 @@ resource "aws_s3_bucket" "example" {
 This approach is recommended in the common case where only a single
 configuration is needed for each provider across the entire configuration.
 
-In more complex situations there may be [multiple provider instances](/docs/configuration/providers.html#multiple-provider-instances),
+In more complex situations there may be [multiple provider instances](./providers.html#multiple-provider-instances),
 or a child module may need to use different provider settings than
 its parent. For such situations, it's necessary to pass providers explicitly
 as we will see in the next section.
@@ -272,7 +272,7 @@ module "example" {
 
 The `providers` argument within a `module` block is similar to
 the `provider` argument within a resource as described for
-[multiple provider instances](/docs/configuration/providers.html#multiple-provider-instances),
+[multiple provider instances](./providers.html#multiple-provider-instances),
 but is a map rather than a single string because a module may contain resources
 from many different providers.
 

--- a/website/docs/configuration-0-11/providers.html.md
+++ b/website/docs/configuration-0-11/providers.html.md
@@ -220,7 +220,7 @@ may also be used, but currently may cause errors when running `terraform destroy
 ## Third-party Plugins
 
 Anyone can develop and distribute their own Terraform providers. (See
-[Writing Custom Providers](/docs/extend/writing-custom-providers.html) for more
+[Writing Custom Providers](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE/docs/extend/writing-custom-providers.htmlutm_medium=WEB_IO/docs/extend/writing-custom-providers.htmlutm_offer=ARTICLE_PAGE/docs/extend/writing-custom-providers.htmlutm_content=DOCS) for more
 about provider development.) These third-party providers must be manually
 installed, since `terraform init` cannot automatically download them.
 

--- a/website/docs/configuration-0-11/resources.html.md
+++ b/website/docs/configuration-0-11/resources.html.md
@@ -98,7 +98,7 @@ There are **meta-parameters** available to all resources:
 Individual Resources may provide a `timeouts` block to enable users to configure the
 amount of time a specific operation is allowed to take before being considered
 an error. For example, the
-[aws_db_instance](/docs/providers/aws/r/db_instance.html#timeouts)
+[aws_db_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#timeouts)
 resource provides configurable timeouts for the
 `create`, `update`, and `delete` operations. Any Resource that provides Timeouts
 will document the default values for that operation, and users can overwrite
@@ -211,7 +211,7 @@ You can use the `${count.index}`
 [variable](./variables.html) to accomplish this.
 
 For example, here's how you could create three [AWS
-Instances](/docs/providers/aws/r/instance.html) each with their own
+Instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) each with their own
 static IP address:
 
 ```hcl
@@ -232,7 +232,7 @@ resource "aws_instance" "app" {
 
 To reference a particular instance of a resource you can use `resource.foo.*.id[#]` where `#` is the index number of the instance.
 
-For example, to create a list of all [AWS subnet](/docs/providers/aws/r/subnet.html) ids vs referencing a specific subnet in the list you can use this syntax:
+For example, to create a list of all [AWS subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) ids vs referencing a specific subnet in the list you can use this syntax:
 
 ```hcl
 resource "aws_vpc" "foo" {

--- a/website/docs/configuration-0-11/variables.html.md
+++ b/website/docs/configuration-0-11/variables.html.md
@@ -211,7 +211,7 @@ $ TF_VAR_image=foo terraform apply
 ```
 
 Maps and lists can be specified using environment variables as well using
-[HCL](./syntax.html#HCL) syntax in the value.
+[HCL](./syntax.html) syntax in the value.
 
 For a list variable like so:
 

--- a/website/docs/configuration/blocks/resources/behavior.html.md
+++ b/website/docs/configuration/blocks/resources/behavior.html.md
@@ -95,9 +95,9 @@ types that operate only within Terraform itself, calculating some results and
 saving those results in the state for future use.
 
 For example, local-only resource types exist for
-[generating private keys](/docs/providers/tls/r/private_key.html),
-[issuing self-signed TLS certificates](/docs/providers/tls/r/self_signed_cert.html),
-and even [generating random ids](/docs/providers/random/r/id.html).
+[generating private keys](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key),
+[issuing self-signed TLS certificates](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert),
+and even [generating random ids](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id).
 While these resource types often have a more marginal purpose than those
 managing "real" infrastructure objects, they can be useful as glue to help
 connect together other resources.

--- a/website/docs/configuration/blocks/resources/syntax.html.md
+++ b/website/docs/configuration/blocks/resources/syntax.html.md
@@ -46,7 +46,7 @@ resource and so must be unique within a module.
 Within the block body (between `{` and `}`) are the configuration arguments
 for the resource itself. Most arguments in this section depend on the
 resource type, and indeed in this example both `ami` and `instance_type` are
-arguments defined specifically for [the `aws_instance` resource type](/docs/providers/aws/r/instance.html).
+arguments defined specifically for [the `aws_instance` resource type](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance).
 
 -> **Note:** Resource names must start with a letter or underscore, and may
 contain only letters, digits, underscores, and dashes.
@@ -144,7 +144,7 @@ The following meta-arguments are documented on separate pages:
 Some resource types provide a special `timeouts` nested block argument that
 allows you to customize how long certain operations are allowed to take
 before being considered to have failed.
-For example, [`aws_db_instance`](/docs/providers/aws/r/db_instance.html)
+For example, [`aws_db_instance`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance)
 allows configurable timeouts for `create`, `update` and `delete` operations.
 
 Timeouts are handled entirely by the resource type implementation in the

--- a/website/docs/configuration/data-sources.html.md
+++ b/website/docs/configuration/data-sources.html.md
@@ -49,7 +49,7 @@ resource and so must be unique within a module.
 Within the block body (between `{` and `}`) are query constraints defined by
 the data source. Most arguments in this section depend on the
 data source, and indeed in this example `most_recent`, `owners` and `tags` are
-all arguments defined specifically for [the `aws_ami` data source](/docs/providers/aws/d/ami.html).
+all arguments defined specifically for [the `aws_ami` data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami).
 
 When distinguishing from data resources, the primary kind of resource (as declared
 by a `resource` block) is known as a _managed resource_. Both kinds of resources
@@ -103,9 +103,9 @@ only within Terraform itself, calculating some results and exposing them
 for use elsewhere.
 
 For example, local-only data sources exist for
-[rendering templates](/docs/providers/template/d/file.html),
-[reading local files](/docs/providers/local/d/file.html), and
-[rendering AWS IAM policies](/docs/providers/aws/d/iam_policy_document.html).
+[rendering templates](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file),
+[reading local files](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file), and
+[rendering AWS IAM policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document).
 
 The behavior of local-only data sources is the same as all other data
 sources, but their result data exists only temporarily during a Terraform

--- a/website/docs/configuration/expressions/references.html.md
+++ b/website/docs/configuration/expressions/references.html.md
@@ -213,7 +213,7 @@ resource "aws_instance" "example" {
 }
 ```
 
-The documentation for [`aws_instance`](/docs/providers/aws/r/instance.html)
+The documentation for [`aws_instance`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance)
 lists all of the arguments and nested blocks supported for this resource type,
 and also lists a number of attributes that are _exported_ by this resource
 type. All of these different resource type schema constructs are available

--- a/website/docs/configuration/functions/file.html.md
+++ b/website/docs/configuration/functions/file.html.md
@@ -31,7 +31,7 @@ dependency graph, so this function cannot be used with files that are generated
 dynamically during a Terraform operation. We do not recommend using dynamic
 local files in Terraform configurations, but in rare situations where this is
 necessary you can use
-[the `local_file` data source](/docs/providers/local/d/file.html)
+[the `local_file` data source](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file)
 to read files while respecting resource dependencies.
 
 ## Examples

--- a/website/docs/configuration/functions/uuid.html.md
+++ b/website/docs/configuration/functions/uuid.html.md
@@ -25,11 +25,11 @@ recommend using the `uuid` function in resource configurations, but it can
 be used with care in conjunction with
 [the `ignore_changes` lifecycle meta-argument](/docs/configuration/meta-arguments/lifecycle.html#ignore_changes).
 
-In most cases we recommend using [the `random` provider](/docs/providers/random/index.html)
+In most cases we recommend using [the `random` provider](https://registry.terraform.io/providers/hashicorp/random/latest/docs)
 instead, since it allows the one-time generation of random values that are
 then retained in the Terraform [state](/docs/state/index.html) for use by
 future operations. In particular,
-[`random_id`](/docs/providers/random/r/id.html) can generate results with
+[`random_id`](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) can generate results with
 equivalent randomness to the `uuid` function.
 
 ## Examples

--- a/website/docs/configuration/meta-arguments/resource-provider.html.md
+++ b/website/docs/configuration/meta-arguments/resource-provider.html.md
@@ -51,7 +51,7 @@ ensure that the provider is fully configured before any resource actions
 are taken.
 
 The `provider` meta-argument expects
-[a `<PROVIDER>.<ALIAS>` reference](/docs/configuration/providers.html#referring-to-alternate-providers),
+[a `<PROVIDER>.<ALIAS>` reference](/docs/configuration/providers.html#referring-to-alternate-provider-configurations),
 which does not need to be quoted. Arbitrary expressions are not permitted for
 `provider` because it must be resolved while Terraform is constructing the
 dependency graph, before it is safe to evaluate expressions.

--- a/website/docs/configuration/outputs.html.md
+++ b/website/docs/configuration/outputs.html.md
@@ -66,6 +66,8 @@ value as `module.web_server.instance_ip_addr`.
 
 `output` blocks can optionally include `description`, `sensitive`, and `depends_on` arguments, which are described in the following sections.
 
+<a id="description"></a>
+
 ### `description` — Output Value Documentation
 
 Because the output values of a module are part of its user interface, you can
@@ -84,6 +86,8 @@ purpose of the output and what kind of value is expected. This description
 string might be included in documentation about the module, and so it should be
 written from the perspective of the user of the module rather than its
 maintainer. For commentary for module maintainers, use comments.
+
+<a id="sensitive"></a>
 
 ### `sensitive` — Suppressing Values in CLI Output
 
@@ -150,6 +154,8 @@ Sensitive output values are still recorded in the
 [state](/docs/state/index.html), and so will be visible to anyone who is able
 to access the state data. For more information, see
 [_Sensitive Data in State_](/docs/state/sensitive-data.html).
+
+<a id="depends_on"></a>
 
 ### `depends_on` — Explicit Output Dependencies
 

--- a/website/docs/configuration/providers.html.md
+++ b/website/docs/configuration/providers.html.md
@@ -80,7 +80,7 @@ empty default configuration for any provider that is not explicitly configured.
 
 ## `alias`: Multiple Provider Configurations
 
-[inpage-alias]: #alias-multiple-provider-instances
+[inpage-alias]: #alias-multiple-provider-configurations
 
 You can optionally define multiple configurations for the same provider, and
 select which one to use on a per-resource or per-module basis. The primary

--- a/website/docs/configuration/resources.html.md
+++ b/website/docs/configuration/resources.html.md
@@ -14,6 +14,7 @@ pages.
 <a id="resource-arguments"></a>
 <a id="documentation-for-resource-types"></a>
 <a id="meta-arguments"></a>
+<a id="timeouts"></a>
 <a id="operation-timeouts"></a>
 
 ## Syntax and Elements of Resource Blocks
@@ -66,7 +67,9 @@ This information has moved to
 
 
 <a id="count-multiple-resource-instances-by-count"></a>
+<a id="count-multiple-resource-instances"></a>
 <a id="the-count-object"></a>
+<a id="count-index"></a>
 <a id="referring-to-instances"></a>
 <a id="using-expressions-in-count"></a>
 <a id="when-to-use-for_each-instead-of-count"></a>
@@ -82,6 +85,8 @@ This information has moved to
 
 <a id="for_each-multiple-resource-instances-defined-by-a-map-or-set-of-strings"></a>
 <a id="the-each-object"></a>
+<a id="each-key"></a>
+<a id="each-value"></a>
 <a id="using-expressions-in-for_each"></a>
 <a id="referring-to-instances-1"></a>
 <a id="using-sets"></a>
@@ -107,6 +112,9 @@ This information has moved to
 
 
 <a id="lifecycle-lifecycle-customizations"></a>
+<a id="prevent_destroy"></a>
+<a id="create_before_destroy"></a>
+<a id="ignore_changes"></a>
 
 ### `lifecycle`
 

--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -349,6 +349,8 @@ terraform apply -var='image_id_map={"us-east-1":"ami-abc123","us-east-2":"ami-de
 
 The `-var` option can be used any number of times in a single command.
 
+<a id="variable-files"></a>
+
 ### Variable Definitions (`.tfvars`) Files
 
 To set lots of variables, it is more convenient to specify their values in

--- a/website/docs/import/index.html.md
+++ b/website/docs/import/index.html.md
@@ -31,7 +31,7 @@ behavior. For more information on this assumption, see
 ## Currently State Only
 
 The current implementation of Terraform import can only import resources
-into the [state](/docs/state). It does not generate configuration. A future
+into the [state](/docs/state/). It does not generate configuration. A future
 version of Terraform will also generate configuration.
 
 Because of this, prior to running `terraform import` it is necessary to write

--- a/website/docs/internals/json-format.html.md
+++ b/website/docs/internals/json-format.html.md
@@ -56,7 +56,7 @@ The extra wrapping object here will allow for any extension we may need to add i
 
 A plan consists of a prior state, the configuration that is being applied to that state, and the set of changes Terraform plans to make to achieve that.
 
-For ease of consumption by callers, the plan representation includes a partial representation of the values in the final state (using a [value representation](#value-representation)), allowing callers to easily analyze the planned outcome using similar code as for analyzing the prior state.
+For ease of consumption by callers, the plan representation includes a partial representation of the values in the final state (using a [value representation](#values-representation)), allowing callers to easily analyze the planned outcome using similar code as for analyzing the prior state.
 
 ```javascript
 {

--- a/website/docs/internals/remote-service-discovery.html.md
+++ b/website/docs/internals/remote-service-discovery.html.md
@@ -85,7 +85,7 @@ version 1 of the module registry protocol:
 
 At present, the following service identifiers are in use:
 
-* `login.v1`: [login protocol version 1](/docs/commands/login.html#protocol-v1)
+* `login.v1`: [login protocol version 1](/docs/commands/login.html)
 * `modules.v1`: [module registry API version 1](module-registry-protocol.html)
 * `providers.v1`: [provider registry API version 1](provider-registry-protocol.html)
 

--- a/website/docs/modules/composition.html.markdown
+++ b/website/docs/modules/composition.html.markdown
@@ -345,11 +345,11 @@ module "k8s_cluster" {
 
 The `network` module itself could retrieve this data in a number of different
 ways: it could query the AWS API directly using
-[`aws_vpc`](/docs/providers/aws/d/vpc.html)
+[`aws_vpc`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc)
 and
-[`aws_subnet_ids`](/docs/providers/aws/d/subnet_ids.html)
+[`aws_subnet_ids`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids)
 data sources, or it could read saved information from a Consul cluster using
-[`consul_keys`](https://www.terraform.io/docs/providers/consul/d/keys.html),
+[`consul_keys`](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/data-sources/keys),
 or it might read the outputs directly from the state of the configuration that
 manages the network using
 [`terraform_remote_state`](https://www.terraform.io/docs/providers/terraform/d/remote_state.html).

--- a/website/docs/modules/providers.html.md
+++ b/website/docs/modules/providers.html.md
@@ -80,7 +80,7 @@ however, specify any of the configuration settings that determine what remote
 endpoints the provider will access, such as an AWS region; configuration
 settings come from provider _configurations_, and a particular overall Terraform
 configuration can potentially have
-[several different configurations for the same provider](/docs/configuration/providers.html#alias-multiple-provider-instances).
+[several different configurations for the same provider](/docs/configuration/providers.html#alias-multiple-provider-configurations).
 
 If you are writing a shared Terraform module, constrain only the minimum
 required provider version using a `>=` constraint. This should specify the

--- a/website/docs/plugins/basics.html.md
+++ b/website/docs/plugins/basics.html.md
@@ -43,7 +43,6 @@ directory, located at `%APPDATA%\terraform.d\plugins` on Windows and
 For more information, see:
 
 - [Configuring Providers](/docs/configuration/providers.html)
-- [Configuring Providers: Third-party Plugins](/docs/configuration/providers.html#third-party-plugins)
 
 For developer-centric documentation, see:
 

--- a/website/docs/plugins/provider.html.md
+++ b/website/docs/plugins/provider.html.md
@@ -75,9 +75,8 @@ an official release.
 When constructing a new provider from scratch, it's recommended to follow
 a similar repository structure as for the existing providers, with the main
 package in the repository root and a library package in a subdirectory named
-after the provider. For more information, see
-[Writing Custom Providers](/docs/extend/writing-custom-providers.html) in the
-[Extending Terraform section](/docs/extend/index.html).
+after the provider. For more information, see the
+[Call APIs with Terraform Providers](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE/docs/extend/writing-custom-providers.htmlutm_medium=WEB_IO/docs/extend/writing-custom-providers.htmlutm_offer=ARTICLE_PAGE/docs/extend/writing-custom-providers.htmlutm_content=DOCS) collection on HashiCorp Learn.
 
 When making changes only to files within the provider repository, it is _not_
 necessary to re-build the main Terraform executable. Note that some packages

--- a/website/docs/provisioners/file.html.markdown
+++ b/website/docs/provisioners/file.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 * `content` - This is the content to copy on the destination. If destination is a file,
   the content will be written on that file, in case of a directory a file named
   `tf-file-content` is created. It's recommended to use a file as the destination. A
-  [`template_file`](/docs/providers/template/d/file.html) might be referenced in here, or
+  [`template_file`](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) might be referenced in here, or
   any interpolation syntax. This attribute cannot be specified with `source`.
 
 * `destination` - (Required) This is the destination path. It must be specified as an

--- a/website/docs/provisioners/index.html.markdown
+++ b/website/docs/provisioners/index.html.markdown
@@ -50,25 +50,25 @@ to pass data to instances at the time of their creation such that the data
 is immediately available on system boot. For example:
 
 * Alibaba Cloud: `user_data` on
-  [`alicloud_instance`](/docs/providers/alicloud/r/instance.html)
-  or [`alicloud_launch_template`](/docs/providers/alicloud/r/launch_template.html).
+  [`alicloud_instance`](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/instance)
+  or [`alicloud_launch_template`](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/launch_template).
 * Amazon EC2: `user_data` or `user_data_base64` on
-  [`aws_instance`](/docs/providers/aws/r/instance.html),
-  [`aws_launch_template`](/docs/providers/aws/r/launch_template.html),
-  and [`aws_launch_configuration`](/docs/providers/aws/r/launch_configuration.html).
+  [`aws_instance`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance),
+  [`aws_launch_template`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template),
+  and [`aws_launch_configuration`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration).
 * Amazon Lightsail: `user_data` on
-  [`aws_lightsail_instance`](/docs/providers/aws/r/lightsail_instance.html).
+  [`aws_lightsail_instance`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lightsail_instance).
 * Microsoft Azure: `custom_data` on
-  [`azurerm_virtual_machine`](/docs/providers/azurerm/r/virtual_machine.html)
-  or [`azurerm_virtual_machine_scale_set`](/docs/providers/azurerm/r/virtual_machine_scale_set.html).
+  [`azurerm_virtual_machine`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine)
+  or [`azurerm_virtual_machine_scale_set`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_scale_set).
 * Google Cloud Platform: `metadata` on
-  [`google_compute_instance`](/docs/providers/google/r/compute_instance.html)
-  or [`google_compute_instance_group`](/docs/providers/google/r/compute_instance_group.html).
+  [`google_compute_instance`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance)
+  or [`google_compute_instance_group`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group).
 * Oracle Cloud Infrastructure: `metadata` or `extended_metadata` on
-  [`oci_core_instance`](/docs/providers/oci/r/core_instance.html)
-  or [`oci_core_instance_configuration`](/docs/providers/oci/r/core_instance_configuration.html).
+  [`oci_core_instance`](https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_instance)
+  or [`oci_core_instance_configuration`](https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_instance_configuration).
 * VMware vSphere: Attach a virtual CDROM to
-  [`vsphere_virtual_machine`](/docs/providers/vsphere/r/virtual_machine.html)
+  [`vsphere_virtual_machine`](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/virtual_machine)
   using the `cdrom` block, containing a file called `user-data.txt`.
 
 Many official Linux distribution disk images include software called

--- a/website/docs/provisioners/index.html.markdown
+++ b/website/docs/provisioners/index.html.markdown
@@ -166,8 +166,13 @@ You must include [a `connection` block](./connection.html) so that Terraform
 will know how to communicate with the server.
 
 Terraform includes several built-in provisioners; use the navigation sidebar to
-view their documentation. You can also install third-party provisioners in
-[the user plugins directory](../configuration/providers.html#third-party-plugins).
+view their documentation.
+
+It's also possible to use third-party provisioners as plugins, by placing them
+in `%APPDATA%\terraform.d\plugins`, `~/.terraform.d/plugins`, or the same
+directory where the Terraform binary is installed. However, we do not recommend
+using any provisioners except the built-in `file`, `local-exec`, and
+`remote-exec` provisioners.
 
 All provisioners support the `when` and `on_failure` meta-arguments, which
 are described below (see [Destroy-Time Provisioners](#destroy-time-provisioners)

--- a/website/docs/provisioners/null_resource.html.markdown
+++ b/website/docs/provisioners/null_resource.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 # Provisioners Without a Resource
 
-[null]: /docs/providers/null/resource.html
+[null]: https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource
 
 If you need to run provisioners that aren't directly associated with a specific
 resource, you can associate them with a `null_resource`.

--- a/website/docs/state/locking.html.md
+++ b/website/docs/state/locking.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # State Locking
 
-If supported by your [backend](/docs/backends), Terraform will lock your
+If supported by your [backend](/docs/backends/), Terraform will lock your
 state for all operations that could write state. This prevents
 others from acquiring the lock and potentially corrupting your state.
 
@@ -21,8 +21,8 @@ If acquiring the lock is taking longer than expected, Terraform will output
 a status message. If Terraform doesn't output a message, state locking is
 still occurring if your backend supports it.
 
-Not all [backends](/docs/backends) support locking. Please view the list
-of [backend types](/docs/backends/types) for details on whether a backend
+Not all [backends](/docs/backends/) support locking. Please view the list
+of [backend types](/docs/backends/types/) for details on whether a backend
 supports locking or not.
 
 ## Force Unlock

--- a/website/docs/state/remote.html.md
+++ b/website/docs/state/remote.html.md
@@ -46,9 +46,9 @@ between configurations, you may prefer to use more general stores to
 pass settings both to other configurations and to other consumers. For example,
 if your environment has [HashiCorp Consul](https://www.consul.io/) then you
 can have one Terraform configuration that writes to Consul using
-[`consul_key_prefix`](/docs/providers/consul/r/key_prefix.html) and then
+[`consul_key_prefix`](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/key_prefix) and then
 another that consumes those values using
-[the `consul_keys` data source](/docs/providers/consul/d/keys.html).
+[the `consul_keys` data source](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/data-sources/keys).
 
 ## Locking and Teamwork
 

--- a/website/docs/state/remote.html.md
+++ b/website/docs/state/remote.html.md
@@ -19,7 +19,7 @@ which can then be shared between all members of a team. Terraform supports
 storing state in [Terraform Cloud](https://www.hashicorp.com/products/terraform/),
 [HashiCorp Consul](https://www.consul.io/), Amazon S3, Azure Blob Storage, Google Cloud Storage, Alibaba Cloud OSS, and more.
 
-Remote state is a feature of [backends](/docs/backends), which you can activate
+Remote state is a feature of [backends](/docs/backends/), which you can activate
 in your configuration's root module.
 
 ## Delegation and Teamwork

--- a/website/docs/state/workspaces.html.md
+++ b/website/docs/state/workspaces.html.md
@@ -195,7 +195,7 @@ control, although using a remote backend instead is recommended when there are
 multiple collaborators.
 
 For [remote state](/docs/state/remote.html), the workspaces are stored
-directly in the configured [backend](/docs/backends). For example, if you
+directly in the configured [backend](/docs/backends/). For example, if you
 use [Consul](/docs/backends/types/consul.html), the workspaces are stored
 by appending the workspace name to the state path. To ensure that
 workspace names are stored correctly and safely in all backends, the name

--- a/website/docs/state/workspaces.html.md
+++ b/website/docs/state/workspaces.html.md
@@ -158,20 +158,20 @@ rather than multiple deployments, data can be passed from one component to
 another using paired resources types and data sources. For example:
 
 * Where a shared [Consul](https://consul.io/) cluster is available, use
-  [`consul_key_prefix`](/docs/providers/consul/r/key_prefix.html) to
-  publish to the key/value store and [`consul_keys`](/docs/providers/consul/d/keys.html)
+  [`consul_key_prefix`](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/key_prefix) to
+  publish to the key/value store and [`consul_keys`](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/data-sources/keys)
   to retrieve those values in other configurations.
 
 * In systems that support user-defined labels or tags, use a tagging convention
   to make resources automatically discoverable. For example, use
-  [the `aws_vpc` resource type](/docs/providers/aws/r/vpc.html)
+  [the `aws_vpc` resource type](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc)
   to assign suitable tags and then
-  [the `aws_vpc` data source](/docs/providers/aws/d/vpc.html)
+  [the `aws_vpc` data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc)
   to query by those tags in other configurations.
 
 * For server addresses, use a provider-specific resource to create a DNS
   record with a predictable name and then either use that name directly or
-  use [the `dns` provider](/docs/providers/dns/index.html) to retrieve
+  use [the `dns` provider](https://registry.terraform.io/providers/hashicorp/dns/latest/docs) to retrieve
   the published addresses in other configurations.
 
 * If a Terraform state for one configuration is stored in a remote backend

--- a/website/guides/terraform-provider-development-program.html.md
+++ b/website/guides/terraform-provider-development-program.html.md
@@ -13,7 +13,7 @@ The Verified badge helps users easily identify and discover integrations develop
 
 ![Verified Provider Card](/assets/images/docs/verified-card.png)
 
--> **Building your own provider?** If you're building your own provider and aren't interested in having HashiCorp officially verify and regularly monitor your provider, please refer to the [Writing Custom Providers guide](https://www.terraform.io/docs/extend/writing-custom-providers.html) and the [Extending Terraform](https://www.terraform.io/docs/extend/index.html) section.
+-> **Building your own provider?** If you're building your own provider and aren't interested in having HashiCorp officially verify and regularly monitor your provider, please refer to the [Call APIs with Terraform Providers](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITEhttps://www.terraform.io/docs/extend/writing-custom-providers.htmlutm_medium=WEB_IOhttps://www.terraform.io/docs/extend/writing-custom-providers.htmlutm_offer=ARTICLE_PAGEhttps://www.terraform.io/docs/extend/writing-custom-providers.htmlutm_content=DOCS) collection on HashiCorp Learn and the [Extending Terraform](https://www.terraform.io/docs/extend/index.html) section of the documentation.
 
 
 ## What is a Terraform Provider?
@@ -66,7 +66,7 @@ The provider development process is divided into five steps below. By following 
 ![Provider Development Process](/assets/images/docs/program-steps.png)
 
 1. **Apply**: Initial contact between vendor and HashiCorp
-2. **Prepare**: Follow documentation while developing the provider 
+2. **Prepare**: Follow documentation while developing the provider
 3. **Verify**: Share public GPG key with HashiCorp
 4. **Publish**: Release the provider on the Registry
 5. **Support**: Ongoing maintenance and support of the provider by the vendor.
@@ -112,7 +112,7 @@ We’ve found the provider development process to be fairly straightforward and 
 
 ### 3. Verify
 
-At this stage, it is expected that the provider is fully developed, all tests and documentation are in place, and your provider is ready for publishing. In this step, HashiCorp will verify the source and authenticity of the namespace being used to publish the provider by signing your GPG key with a trust signature. 
+At this stage, it is expected that the provider is fully developed, all tests and documentation are in place, and your provider is ready for publishing. In this step, HashiCorp will verify the source and authenticity of the namespace being used to publish the provider by signing your GPG key with a trust signature.
 
 -> **Important:** This step requires that you have signed and accepted our Technology Partner Agreement. If you have not received this, please see step #1 above.
 
@@ -128,7 +128,7 @@ $ gpg --armor --export "{Key ID or email address}"
 
 Once the verification step is complete please follow the steps on [Publishing a Provider](https://www.terraform.io/docs/registry/providers/publishing.html).  This step does not require additional involvement from HashiCorp as publishing is a fully self-service process in the [Terraform Registry](https://registry.terraform.io).
 
-Once completed, your provider should be visible in the Terraform Registry and usable in Terraform. Please confirm that everything looks good, and that documentation is rendering properly. 
+Once completed, your provider should be visible in the Terraform Registry and usable in Terraform. Please confirm that everything looks good, and that documentation is rendering properly.
 
 ### 5. Maintain & Support
 

--- a/website/intro/use-cases.html.markdown
+++ b/website/intro/use-cases.html.markdown
@@ -91,7 +91,7 @@ This configuration can then be used by Terraform to automatically setup and modi
 settings by interfacing with the control layer. This allows configuration to be
 versioned and changes to be automated. As an example, [AWS VPC](https://aws.amazon.com/vpc/)
 is one of the most commonly used SDN implementations, and [can be configured by
-Terraform](/docs/providers/aws/r/vpc.html).
+Terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc).
 
 ## Resource Schedulers
 

--- a/website/upgrade-guides/0-10.html.markdown
+++ b/website/upgrade-guides/0-10.html.markdown
@@ -60,9 +60,18 @@ eventually support a similar approach for third-party plugins, but we wish
 to ensure the robustness of the installation and versioning mechanisms before
 generalizing this feature.
 
-In the mean time,
-[the prior mechanisms for installing third-party providers](/docs/plugins/basics.html#installing-a-plugin)
-are still supported. Maintainers of third-party providers may optionally
+-> **Note:** As of Terraform 0.13, Terraform can automatically install
+third-party providers released on the Terraform Registry.
+
+In the mean time, third-party providers can be installed by placing them in the
+user plugins directory:
+
+Operating system  | User plugins directory
+------------------|-----------------------
+Windows           | `%APPDATA%\terraform.d\plugins`
+All other systems | `~/.terraform.d/plugins`
+
+Maintainers of third-party providers may optionally
 make use of the new versioning mechanism by naming provider binaries
 using the scheme `terraform-provider-NAME_v0.0.1`, where "0.0.1" is an
 example version. Terraform expects providers to follow the

--- a/website/upgrade-guides/0-13.html.markdown
+++ b/website/upgrade-guides/0-13.html.markdown
@@ -44,7 +44,7 @@ Upgrade guide sections:
 * [New Filesystem Layout for Local Copies of Providers](#new-filesystem-layout-for-local-copies-of-providers)
   * [Special considerations for in-house providers](#in-house-providers)
 * [Destroy-time provisioners may not refer to other resources](#destroy-time-provisioners-may-not-refer-to-other-resources)
-* [Data resource reads can no longer be disabled by `-refresh=false`](#data-resource-reads-can-no-longer-be-disabled-by--refresh-false)
+* [Data resource reads can no longer be disabled by `-refresh=false`](#data-resource-reads-can-no-longer-be-disabled-by-refresh-false)
 * [Frequently Asked Questions](#frequently-asked-questions)
 
 ## Before You Upgrade
@@ -135,7 +135,7 @@ for a module that must remain compatible with both Terraform v0.12 and
 Terraform v0.13; the `terraform 0.13upgrade` result includes a conservative
 version constraint for Terraform v0.13 or later, which you can weaken to
 `>= 0.12.26` if you follow the guidelines in
-[v0.12-Compatible Provider Requirements](/docs/configuration/provider-requirements.html#v012-compatible-provider-requirements).
+[v0.12-Compatible Provider Requirements](/docs/configuration/provider-requirements.html#v0-12-compatible-provider-requirements).
 
 Each module must declare its own set of provider requirements, so if you have
 a configuration which calls other modules then you'll need to run this upgrade
@@ -441,7 +441,7 @@ accurate plan, and so there is no replacement mechanism in Terraform v0.13
 to restore the previous behavior.
 
 ## Frequently Asked Questions
-### Why do I see `-/provider` during init? 
+### Why do I see `-/provider` during init?
 
 Provider source addresses starting with `registry.terraform.io/-/` are a special
 way Terraform marks legacy addresses where the true namespace is unknown. For
@@ -473,7 +473,7 @@ While this does not cause any problems for Terraform, it has been confusing. You
 may circumvent this by using the `terraform state replace-provider` subcommand
 to tell Terraform exactly what provider addresses are required in state.
 Continuing from the example above, the following commands tell Terraform the
-source address for the `null` and `random` providers: 
+source address for the `null` and `random` providers:
 
 ```
 terraform state replace-provider -- -/random registry.terraform.io/hashicorp/random


### PR DESCRIPTION
These links largely still go somewhere useful, but they have some kind of issue
revealed by our new link checker:

- Some of them point to a stale URL that redirects, and can be updated to the
  new destination.
- Some of them point to anchors that don't exist (anymore?) in the destination.
- Some of them end up redirecting unnecessarily due to how the server handles
  directory URLs without trailing slashes. Sorry, I know that's pointless, just,
  humor me for the time being so we can get our CI green. 😭

In a couple cases, I've added invisible anchors to destination pages, either to
preserve an old habit or because the current anchors kind of suck due to being
particularly long or meandering.