### PR TITLE
backend/remote: No version check for operations

### DIFF
--- a/backend/remote/backend_apply_test.go
+++ b/backend/remote/backend_apply_test.go
@@ -1298,12 +1298,11 @@ func TestRemote_applyVersionCheck(t *testing.T) {
 			remoteVersion: "0.13.5",
 			hasOperations: false,
 		},
-		"error if force local, has remote operations, different versions": {
+		"force local with remote operations and different versions is acceptable": {
 			localVersion:  "0.14.0",
-			remoteVersion: "0.13.5",
+			remoteVersion: "0.14.0-acme-provider-bundle",
 			forceLocal:    true,
 			hasOperations: true,
-			wantErr:       `Remote workspace Terraform version "0.13.5" does not match local Terraform version "0.14.0"`,
 		},
 		"no error if versions are identical": {
 			localVersion:  "0.14.0",


### PR DESCRIPTION
Terraform remote version conflicts are not a concern for operations. We are in one of three states:

- Running remotely, in which case the local version is irrelevant;
- Workspace configured for local operations, in which case the remote version is meaningless;
- Forcing local operations with a remote backend, which should only happen in the Terraform Cloud worker, in which case the Terraform versions by definition match.

This commit therefore disables the version check for operations (plan and apply), which has the consequence of disabling it in Terraform Cloud and Enterprise runs. In turn this enables Terraform Enterprise runs with bundles which have a version that doesn't exactly match the bundled Terraform version.

Intended for back-port to 0.14 for an upcoming release.