### PR TITLE
Revert remote backend version check (v0.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ UPGRADE NOTES:
 
 * The builtin provider's `terraform_remote_state` data source no longer enforces Terraform version checks on the remote state file. This allows Terraform 0.12.30 to access remote state from future Terraform versions, up until a future incompatible state file version upgrade is required. [GH-26692]
 
-ENHANCEMENTS:
-
-* backend/remote: When using the enhanced remote backend with commands which locally modify state, verify that the local Terraform version and the configured remote workspace Terraform version are compatible. This prevents accidentally upgrading the remote state to an incompatible version. The check is skipped for commands which do not write state, and can also be disabled by the use of a new command-line flag, `-ignore-remote-version`. [GH-26947]
-
 ## 0.12.29 (July 22, 2020)
 
 BUG FIXES:

--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -85,12 +85,6 @@ type Remote struct {
 
 	// opLock locks operations
 	opLock sync.Mutex
-
-	// ignoreVersionConflict, if true, will disable the requirement that the
-	// local Terraform version matches the remote workspace's configured
-	// version. This will also cause VerifyWorkspaceTerraformVersion to return
-	// a warning diagnostic instead of an error.
-	ignoreVersionConflict bool
 }
 
 var _ backend.Backend = (*Remote)(nil)
@@ -629,17 +623,6 @@ func (b *Remote) StateMgr(name string) (state.State, error) {
 		}
 	}
 
-	// This is a fallback error check. Most code paths should use other
-	// mechanisms to check the version, then set the ignoreVersionConflict
-	// field to true. This check is only in place to ensure that we don't
-	// accidentally upgrade state with a new code path, and the version check
-	// logic is coarser and simpler.
-	if !b.ignoreVersionConflict {
-		if workspace.TerraformVersion != tfversion.String() {
-			return nil, fmt.Errorf("Remote workspace Terraform version %q does not match local Terraform version %q", workspace.TerraformVersion, tfversion.String())
-		}
-	}
-
 	client := &remoteClient{
 		client:       b.client,
 		organization: b.organization,
@@ -691,16 +674,8 @@ func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend
 
 	// Check if we need to use the local backend to run the operation.
 	if b.forceLocal || !w.Operations {
-		if !w.Operations {
-			// Workspace is explicitly configured for local operations, so its
-			// configured Terraform version is meaningless
-			b.IgnoreVersionConflict()
-		}
 		return b.local.Operation(ctx, op)
 	}
-
-	// Running remotely so we don't care about version conflicts
-	b.IgnoreVersionConflict()
 
 	// Set the remote workspace name.
 	op.Workspace = w.Name
@@ -858,101 +833,6 @@ func (b *Remote) ReportResult(op *backend.RunningOperation, err error) {
 			)
 		}
 	}
-}
-
-// IgnoreVersionConflict allows commands to disable the fall-back check that
-// the local Terraform version matches the remote workspace's configured
-// Terraform version. This should be called by commands where this check is
-// unnecessary, such as those performing remote operations, or read-only
-// operations. It will also be called if the user uses a command-line flag to
-// override this check.
-func (b *Remote) IgnoreVersionConflict() {
-	b.ignoreVersionConflict = true
-}
-
-// VerifyWorkspaceTerraformVersion compares the local Terraform version against
-// the workspace's configured Terraform version. If they are equal, this means
-// that there are no compatibility concerns, so it returns no diagnostics.
-//
-// If the versions differ,
-func (b *Remote) VerifyWorkspaceTerraformVersion(workspaceName string) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-
-	workspace, err := b.getRemoteWorkspace(context.Background(), workspaceName)
-	if err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Error looking up workspace",
-			fmt.Sprintf("Workspace read failed: %s", err),
-		))
-		return diags
-	}
-
-	remoteVersion, err := version.NewSemver(workspace.TerraformVersion)
-	if err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Error looking up workspace",
-			fmt.Sprintf("Invalid Terraform version: %s", err),
-		))
-		return diags
-	}
-
-	v014 := version.Must(version.NewSemver("0.14.0"))
-	if tfversion.SemVer.LessThan(v014) || remoteVersion.LessThan(v014) {
-		// Versions of Terraform prior to 0.14.0 will refuse to load state files
-		// written by a newer version of Terraform, even if it is only a patch
-		// level difference. As a result we require an exact match.
-		if tfversion.SemVer.Equal(remoteVersion) {
-			return diags
-		}
-	}
-	if tfversion.SemVer.GreaterThanOrEqual(v014) && remoteVersion.GreaterThanOrEqual(v014) {
-		// Versions of Terraform after 0.14.0 should be compatible with each
-		// other.  At the time this code was written, the only constraints we
-		// are aware of are:
-		//
-		// - 0.14.0 is guaranteed to be compatible with versions up to but not
-		//   including 1.1.0
-		v110 := version.Must(version.NewSemver("1.1.0"))
-		if tfversion.SemVer.LessThan(v110) && remoteVersion.LessThan(v110) {
-			return diags
-		}
-		// - Any new Terraform state version will require at least minor patch
-		//   increment, so x.y.* will always be compatible with each other
-		tfvs := tfversion.SemVer.Segments64()
-		rwvs := remoteVersion.Segments64()
-		if len(tfvs) == 3 && len(rwvs) == 3 && tfvs[0] == rwvs[0] && tfvs[1] == rwvs[1] {
-			return diags
-		}
-	}
-
-	// Even if ignoring version conflicts, it may still be useful to call this
-	// method and warn the user about a mismatch between the local and remote
-	// Terraform versions.
-	severity := tfdiags.Error
-	if b.ignoreVersionConflict {
-		severity = tfdiags.Warning
-	}
-
-	suggestion := " If you're sure you want to upgrade the state, you can force Terraform to continue using the -ignore-remote-version flag. This may result in an unusable workspace."
-	if b.ignoreVersionConflict {
-		suggestion = ""
-	}
-	diags = diags.Append(tfdiags.Sourceless(
-		severity,
-		"Terraform version mismatch",
-		fmt.Sprintf(
-			"The local Terraform version (%s) does not match the configured version for remote workspace %s/%s (%s).%s",
-			tfversion.String(),
-			b.organization,
-			workspace.Name,
-			workspace.TerraformVersion,
-			suggestion,
-		),
-	))
-
-	return diags
 }
 
 // Colorize returns the Colorize structure that can be used for colorizing

--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -635,10 +635,7 @@ func (b *Remote) StateMgr(name string) (state.State, error) {
 	// accidentally upgrade state with a new code path, and the version check
 	// logic is coarser and simpler.
 	if !b.ignoreVersionConflict {
-		wsv := workspace.TerraformVersion
-		// Explicitly ignore the pseudo-version "latest" here, as it will cause
-		// plan and apply to always fail.
-		if wsv != tfversion.String() && wsv != "latest" {
+		if workspace.TerraformVersion != tfversion.String() {
 			return nil, fmt.Errorf("Remote workspace Terraform version %q does not match local Terraform version %q", workspace.TerraformVersion, tfversion.String())
 		}
 	}
@@ -889,13 +886,6 @@ func (b *Remote) VerifyWorkspaceTerraformVersion(workspaceName string) tfdiags.D
 			fmt.Sprintf("Workspace read failed: %s", err),
 		))
 		return diags
-	}
-
-	// If the workspace has the pseudo-version "latest", all bets are off. We
-	// cannot reasonably determine what the intended Terraform version is, so
-	// we'll skip version verification.
-	if workspace.TerraformVersion == "latest" {
-		return nil
 	}
 
 	remoteVersion, err := version.NewSemver(workspace.TerraformVersion)

--- a/backend/remote/backend_apply_test.go
+++ b/backend/remote/backend_apply_test.go
@@ -11,13 +11,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	tfe "github.com/hashicorp/go-tfe"
-	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/plans/planfile"
 	"github.com/hashicorp/terraform/terraform"
-	tfversion "github.com/hashicorp/terraform/version"
 	"github.com/mitchellh/cli"
 )
 
@@ -1259,135 +1257,5 @@ func TestRemote_applyWithRemoteError(t *testing.T) {
 	output := b.CLI.(*cli.MockUi).OutputWriter.String()
 	if !strings.Contains(output, "null_resource.foo: 1 error") {
 		t.Fatalf("expected apply error in output: %s", output)
-	}
-}
-
-func TestRemote_applyVersionCheck(t *testing.T) {
-	testCases := map[string]struct {
-		localVersion  string
-		remoteVersion string
-		forceLocal    bool
-		hasOperations bool
-		wantErr       string
-	}{
-		"versions can be different for remote apply": {
-			localVersion:  "0.14.0",
-			remoteVersion: "0.13.5",
-			hasOperations: true,
-		},
-		"versions can be different for local apply": {
-			localVersion:  "0.14.0",
-			remoteVersion: "0.13.5",
-			hasOperations: false,
-		},
-		"error if force local, has remote operations, different versions": {
-			localVersion:  "0.14.0",
-			remoteVersion: "0.13.5",
-			forceLocal:    true,
-			hasOperations: true,
-			wantErr:       `Remote workspace Terraform version "0.13.5" does not match local Terraform version "0.14.0"`,
-		},
-		"no error if versions are identical": {
-			localVersion:  "0.14.0",
-			remoteVersion: "0.14.0",
-			forceLocal:    true,
-			hasOperations: true,
-		},
-		"no error if force local but workspace has remote operations disabled": {
-			localVersion:  "0.14.0",
-			remoteVersion: "0.13.5",
-			forceLocal:    true,
-			hasOperations: false,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			b, bCleanup := testBackendDefault(t)
-			defer bCleanup()
-
-			// SETUP: Save original local version state and restore afterwards
-			p := tfversion.Prerelease
-			v := tfversion.Version
-			s := tfversion.SemVer
-			defer func() {
-				tfversion.Prerelease = p
-				tfversion.Version = v
-				tfversion.SemVer = s
-			}()
-
-			// SETUP: Set local version for the test case
-			tfversion.Prerelease = ""
-			tfversion.Version = tc.localVersion
-			tfversion.SemVer = version.Must(version.NewSemver(tc.localVersion))
-
-			// SETUP: Set force local for the test case
-			b.forceLocal = tc.forceLocal
-
-			ctx := context.Background()
-
-			// SETUP: set the operations and Terraform Version fields on the
-			// remote workspace
-			_, err := b.client.Workspaces.Update(
-				ctx,
-				b.organization,
-				b.workspace,
-				tfe.WorkspaceUpdateOptions{
-					Operations:       tfe.Bool(tc.hasOperations),
-					TerraformVersion: tfe.String(tc.remoteVersion),
-				},
-			)
-			if err != nil {
-				t.Fatalf("error creating named workspace: %v", err)
-			}
-
-			// RUN: prepare the apply operation and run it
-			op, configCleanup := testOperationApply(t, "./testdata/apply")
-			defer configCleanup()
-
-			input := testInput(t, map[string]string{
-				"approve": "yes",
-			})
-
-			op.UIIn = input
-			op.UIOut = b.CLI
-			op.Workspace = backend.DefaultStateName
-
-			run, err := b.Operation(ctx, op)
-			if err != nil {
-				t.Fatalf("error starting operation: %v", err)
-			}
-
-			// RUN: wait for completion
-			<-run.Done()
-
-			if tc.wantErr != "" {
-				// ASSERT: if the test case wants an error, check for failure
-				// and the error message
-				if run.Result != backend.OperationFailure {
-					t.Fatalf("expected run to fail, but result was %#v", run.Result)
-				}
-				errOutput := b.CLI.(*cli.MockUi).ErrorWriter.String()
-				if !strings.Contains(errOutput, tc.wantErr) {
-					t.Fatalf("missing error %q\noutput: %s", tc.wantErr, errOutput)
-				}
-			} else {
-				// ASSERT: otherwise, check for success and appropriate output
-				// based on whether the run should be local or remote
-				if run.Result != backend.OperationSuccess {
-					t.Fatalf("operation failed: %s", b.CLI.(*cli.MockUi).ErrorWriter.String())
-				}
-				output := b.CLI.(*cli.MockUi).OutputWriter.String()
-				hasRemote := strings.Contains(output, "Running apply in the remote backend")
-				if !tc.forceLocal && tc.hasOperations && !hasRemote {
-					t.Fatalf("missing remote backend header in output: %s", output)
-				} else if (tc.forceLocal || !tc.hasOperations) && hasRemote {
-					t.Fatalf("unexpected remote backend header in output: %s", output)
-				}
-				if !strings.Contains(output, "1 added, 0 changed, 0 destroyed") {
-					t.Fatalf("expected apply summary in output: %s", output)
-				}
-			}
-		})
 	}
 }

--- a/backend/remote/backend_context.go
+++ b/backend/remote/backend_context.go
@@ -156,20 +156,11 @@ func (b *Remote) getRemoteWorkspaceName(localWorkspaceName string) string {
 	}
 }
 
-func (b *Remote) getRemoteWorkspace(ctx context.Context, localWorkspaceName string) (*tfe.Workspace, error) {
+func (b *Remote) getRemoteWorkspaceID(ctx context.Context, localWorkspaceName string) (string, error) {
 	remoteWorkspaceName := b.getRemoteWorkspaceName(localWorkspaceName)
 
-	log.Printf("[TRACE] backend/remote: looking up workspace for %s/%s", b.organization, remoteWorkspaceName)
+	log.Printf("[TRACE] backend/remote: looking up workspace id for %s/%s", b.organization, remoteWorkspaceName)
 	remoteWorkspace, err := b.client.Workspaces.Read(ctx, b.organization, remoteWorkspaceName)
-	if err != nil {
-		return nil, err
-	}
-
-	return remoteWorkspace, nil
-}
-
-func (b *Remote) getRemoteWorkspaceID(ctx context.Context, localWorkspaceName string) (string, error) {
-	remoteWorkspace, err := b.getRemoteWorkspace(ctx, localWorkspaceName)
 	if err != nil {
 		return "", err
 	}

--- a/backend/remote/backend_mock.go
+++ b/backend/remote/backend_mock.go
@@ -16,7 +16,6 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform/terraform"
-	tfversion "github.com/hashicorp/terraform/version"
 )
 
 type mockClient struct {
@@ -1084,15 +1083,10 @@ func (m *mockWorkspaces) List(ctx context.Context, organization string, options 
 }
 
 func (m *mockWorkspaces) Create(ctx context.Context, organization string, options tfe.WorkspaceCreateOptions) (*tfe.Workspace, error) {
-	if strings.HasSuffix(*options.Name, "no-operations") {
-		options.Operations = tfe.Bool(false)
-	} else if options.Operations == nil {
-		options.Operations = tfe.Bool(true)
-	}
 	w := &tfe.Workspace{
 		ID:         generateID("ws-"),
 		Name:       *options.Name,
-		Operations: *options.Operations,
+		Operations: !strings.HasSuffix(*options.Name, "no-operations"),
 		Permissions: &tfe.WorkspacePermissions{
 			CanQueueApply: true,
 			CanQueueRun:   true,
@@ -1103,11 +1097,6 @@ func (m *mockWorkspaces) Create(ctx context.Context, organization string, option
 	}
 	if options.VCSRepo != nil {
 		w.VCSRepo = &tfe.VCSRepo{}
-	}
-	if options.TerraformVersion != nil {
-		w.TerraformVersion = *options.TerraformVersion
-	} else {
-		w.TerraformVersion = tfversion.String()
 	}
 	m.workspaceIDs[w.ID] = w
 	m.workspaceNames[w.Name] = w
@@ -1141,9 +1130,6 @@ func (m *mockWorkspaces) Update(ctx context.Context, organization, workspace str
 		return nil, tfe.ErrResourceNotFound
 	}
 
-	if options.Operations != nil {
-		w.Operations = *options.Operations
-	}
 	if options.Name != nil {
 		w.Name = *options.Name
 	}

--- a/backend/remote/backend_test.go
+++ b/backend/remote/backend_test.go
@@ -1,18 +1,13 @@
 package remote
 
 import (
-	"context"
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
-	tfe "github.com/hashicorp/go-tfe"
-	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-svchost/disco"
 	"github.com/hashicorp/terraform/backend"
-	"github.com/hashicorp/terraform/tfdiags"
-	tfversion "github.com/hashicorp/terraform/version"
+	"github.com/hashicorp/terraform/version"
 	"github.com/zclconf/go-cty/cty"
 
 	backendLocal "github.com/hashicorp/terraform/backend/local"
@@ -198,11 +193,11 @@ func TestRemote_versionConstraints(t *testing.T) {
 	}
 
 	// Save and restore the actual version.
-	p := tfversion.Prerelease
-	v := tfversion.Version
+	p := version.Prerelease
+	v := version.Version
 	defer func() {
-		tfversion.Prerelease = p
-		tfversion.Version = v
+		version.Prerelease = p
+		version.Version = v
 	}()
 
 	for name, tc := range cases {
@@ -210,8 +205,8 @@ func TestRemote_versionConstraints(t *testing.T) {
 		b := New(testDisco(s))
 
 		// Set the version for this test.
-		tfversion.Prerelease = tc.prerelease
-		tfversion.Version = tc.version
+		version.Prerelease = tc.prerelease
+		version.Version = tc.version
 
 		// Validate
 		_, valDiags := b.PrepareConfig(tc.config)
@@ -430,17 +425,17 @@ func TestRemote_checkConstraints(t *testing.T) {
 	}
 
 	// Save and restore the actual version.
-	p := tfversion.Prerelease
-	v := tfversion.Version
+	p := version.Prerelease
+	v := version.Version
 	defer func() {
-		tfversion.Prerelease = p
-		tfversion.Version = v
+		version.Prerelease = p
+		version.Version = v
 	}()
 
 	for name, tc := range cases {
 		// Set the version for this test.
-		tfversion.Prerelease = tc.prerelease
-		tfversion.Version = tc.version
+		version.Prerelease = tc.prerelease
+		version.Version = tc.version
 
 		// Check the constraints.
 		diags := b.checkConstraints(tc.constraints)
@@ -448,224 +443,5 @@ func TestRemote_checkConstraints(t *testing.T) {
 			(diags.Err() == nil || !strings.Contains(diags.Err().Error(), tc.result)) {
 			t.Fatalf("%s: unexpected constraints result: %v", name, diags.Err())
 		}
-	}
-}
-
-func TestRemote_StateMgr_versionCheck(t *testing.T) {
-	b, bCleanup := testBackendDefault(t)
-	defer bCleanup()
-
-	// Some fixed versions for testing with. This logic is a simple string
-	// comparison, so we don't need many test cases.
-	v0135 := version.Must(version.NewSemver("0.13.5"))
-	v0140 := version.Must(version.NewSemver("0.14.0"))
-
-	// Save original local version state and restore afterwards
-	p := tfversion.Prerelease
-	v := tfversion.Version
-	s := tfversion.SemVer
-	defer func() {
-		tfversion.Prerelease = p
-		tfversion.Version = v
-		tfversion.SemVer = s
-	}()
-
-	// For this test, the local Terraform version is set to 0.14.0
-	tfversion.Prerelease = ""
-	tfversion.Version = v0140.String()
-	tfversion.SemVer = v0140
-
-	// Update the mock remote workspace Terraform version to match the local
-	// Terraform version
-	if _, err := b.client.Workspaces.Update(
-		context.Background(),
-		b.organization,
-		b.workspace,
-		tfe.WorkspaceUpdateOptions{
-			TerraformVersion: tfe.String(v0140.String()),
-		},
-	); err != nil {
-		t.Fatalf("error: %v", err)
-	}
-
-	// This should succeed
-	if _, err := b.StateMgr(backend.DefaultStateName); err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	// Now change the remote workspace to a different Terraform version
-	if _, err := b.client.Workspaces.Update(
-		context.Background(),
-		b.organization,
-		b.workspace,
-		tfe.WorkspaceUpdateOptions{
-			TerraformVersion: tfe.String(v0135.String()),
-		},
-	); err != nil {
-		t.Fatalf("error: %v", err)
-	}
-
-	// This should fail
-	want := `Remote workspace Terraform version "0.13.5" does not match local Terraform version "0.14.0"`
-	if _, err := b.StateMgr(backend.DefaultStateName); err.Error() != want {
-		t.Fatalf("wrong error\n got: %v\nwant: %v", err.Error(), want)
-	}
-}
-
-func TestRemote_VerifyWorkspaceTerraformVersion(t *testing.T) {
-	testCases := []struct {
-		local   string
-		remote  string
-		wantErr bool
-	}{
-		{"0.13.5", "0.13.5", false},
-		{"0.14.0", "0.13.5", true},
-		{"0.14.0", "0.14.1", false},
-		{"0.14.0", "1.0.99", false},
-		{"0.14.0", "1.1.0", true},
-		{"1.2.0", "1.2.99", false},
-		{"1.2.0", "1.3.0", true},
-	}
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("local %s, remote %s", tc.local, tc.remote), func(t *testing.T) {
-			b, bCleanup := testBackendDefault(t)
-			defer bCleanup()
-
-			local := version.Must(version.NewSemver(tc.local))
-			remote := version.Must(version.NewSemver(tc.remote))
-
-			// Save original local version state and restore afterwards
-			p := tfversion.Prerelease
-			v := tfversion.Version
-			s := tfversion.SemVer
-			defer func() {
-				tfversion.Prerelease = p
-				tfversion.Version = v
-				tfversion.SemVer = s
-			}()
-
-			// Override local version as specified
-			tfversion.Prerelease = ""
-			tfversion.Version = local.String()
-			tfversion.SemVer = local
-
-			// Update the mock remote workspace Terraform version to the
-			// specified remote version
-			if _, err := b.client.Workspaces.Update(
-				context.Background(),
-				b.organization,
-				b.workspace,
-				tfe.WorkspaceUpdateOptions{
-					TerraformVersion: tfe.String(remote.String()),
-				},
-			); err != nil {
-				t.Fatalf("error: %v", err)
-			}
-
-			diags := b.VerifyWorkspaceTerraformVersion(backend.DefaultStateName)
-			if tc.wantErr {
-				if len(diags) != 1 {
-					t.Fatal("expected diag, but none returned")
-				}
-				if got := diags.Err().Error(); !strings.Contains(got, "Terraform version mismatch") {
-					t.Fatalf("unexpected error: %s", got)
-				}
-			} else {
-				if len(diags) != 0 {
-					t.Fatalf("unexpected diags: %s", diags.Err())
-				}
-			}
-		})
-	}
-}
-
-func TestRemote_VerifyWorkspaceTerraformVersion_workspaceErrors(t *testing.T) {
-	b, bCleanup := testBackendDefault(t)
-	defer bCleanup()
-
-	// Attempting to check the version against a workspace which doesn't exist
-	// should fail
-	diags := b.VerifyWorkspaceTerraformVersion("invalid-workspace")
-	if len(diags) != 1 {
-		t.Fatal("expected diag, but none returned")
-	}
-	if got := diags.Err().Error(); !strings.Contains(got, "Error looking up workspace: Workspace read failed") {
-		t.Fatalf("unexpected error: %s", got)
-	}
-
-	// Update the mock remote workspace Terraform version to an invalid version
-	if _, err := b.client.Workspaces.Update(
-		context.Background(),
-		b.organization,
-		b.workspace,
-		tfe.WorkspaceUpdateOptions{
-			TerraformVersion: tfe.String("1.0.cheetarah"),
-		},
-	); err != nil {
-		t.Fatalf("error: %v", err)
-	}
-	diags = b.VerifyWorkspaceTerraformVersion(backend.DefaultStateName)
-
-	if len(diags) != 1 {
-		t.Fatal("expected diag, but none returned")
-	}
-	if got := diags.Err().Error(); !strings.Contains(got, "Error looking up workspace: Invalid Terraform version") {
-		t.Fatalf("unexpected error: %s", got)
-	}
-}
-
-func TestRemote_VerifyWorkspaceTerraformVersion_ignoreFlagSet(t *testing.T) {
-	b, bCleanup := testBackendDefault(t)
-	defer bCleanup()
-
-	// If the ignore flag is set, the behaviour changes
-	b.IgnoreVersionConflict()
-
-	// Different local & remote versions to cause an error
-	local := version.Must(version.NewSemver("0.14.0"))
-	remote := version.Must(version.NewSemver("0.13.5"))
-
-	// Save original local version state and restore afterwards
-	p := tfversion.Prerelease
-	v := tfversion.Version
-	s := tfversion.SemVer
-	defer func() {
-		tfversion.Prerelease = p
-		tfversion.Version = v
-		tfversion.SemVer = s
-	}()
-
-	// Override local version as specified
-	tfversion.Prerelease = ""
-	tfversion.Version = local.String()
-	tfversion.SemVer = local
-
-	// Update the mock remote workspace Terraform version to the
-	// specified remote version
-	if _, err := b.client.Workspaces.Update(
-		context.Background(),
-		b.organization,
-		b.workspace,
-		tfe.WorkspaceUpdateOptions{
-			TerraformVersion: tfe.String(remote.String()),
-		},
-	); err != nil {
-		t.Fatalf("error: %v", err)
-	}
-
-	diags := b.VerifyWorkspaceTerraformVersion(backend.DefaultStateName)
-	if len(diags) != 1 {
-		t.Fatal("expected diag, but none returned")
-	}
-
-	if got, want := diags[0].Severity(), tfdiags.Warning; got != want {
-		t.Errorf("wrong severity: got %#v, want %#v", got, want)
-	}
-	if got, want := diags[0].Description().Summary, "Terraform version mismatch"; got != want {
-		t.Errorf("wrong summary: got %s, want %s", got, want)
-	}
-	wantDetail := "The local Terraform version (0.14.0) does not match the configured version for remote workspace hashicorp/prod (0.13.5)."
-	if got := diags[0].Description().Detail; got != wantDetail {
-		t.Errorf("wrong summary: got %s, want %s", got, wantDetail)
 	}
 }

--- a/builtin/providers/terraform/data_source_state.go
+++ b/builtin/providers/terraform/data_source_state.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/backend"
-	"github.com/hashicorp/terraform/backend/remote"
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/tfdiags"
@@ -214,12 +213,6 @@ func getBackend(cfg cty.Value) (backend.Backend, tfdiags.Diagnostics) {
 	if configureDiags.HasErrors() {
 		diags = diags.Append(configureDiags.Err())
 		return nil, diags
-	}
-
-	// If this is the enhanced remote backend, we want to disable the version
-	// check, because this is a read-only operation
-	if rb, ok := b.(*remote.Remote); ok {
-		rb.IgnoreVersionConflict()
 	}
 
 	return b, diags

--- a/command/console.go
+++ b/command/console.go
@@ -73,9 +73,6 @@ func (c *ConsoleCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This is a read-only command
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	// Build the operation
 	opReq := c.Operation(b)
 	opReq.ConfigDir = configPath

--- a/command/graph.go
+++ b/command/graph.go
@@ -91,9 +91,6 @@ func (c *GraphCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This is a read-only command
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	// Build the operation
 	opReq := c.Operation(b)
 	opReq.ConfigDir = configPath

--- a/command/import.go
+++ b/command/import.go
@@ -38,7 +38,6 @@ func (c *ImportCommand) Run(args []string) int {
 	}
 
 	cmdFlags := c.Meta.extendedFlagSet("import")
-	cmdFlags.BoolVar(&c.ignoreRemoteVersion, "ignore-remote-version", false, "continue even if remote and local Terraform versions differ")
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
@@ -232,14 +231,6 @@ func (c *ImportCommand) Run(args []string) int {
 		}
 	}
 
-	// Check remote Terraform version is compatible
-	remoteVersionDiags := c.remoteBackendVersionCheck(b, opReq.Workspace)
-	diags = diags.Append(remoteVersionDiags)
-	c.showDiagnostics(diags)
-	if diags.HasErrors() {
-		return 1
-	}
-
 	// Get the context
 	ctx, state, ctxDiags := local.Context(opReq)
 
@@ -369,9 +360,6 @@ Options:
                           a file. If "terraform.tfvars" or any ".auto.tfvars"
                           files are present, they will be automatically loaded.
 
-  -ignore-remote-version  Continue even if remote and local Terraform versions
-                          differ. This may result in an unusable workspace, and
-                          should be used with extreme caution.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/init.go
+++ b/command/init.go
@@ -325,7 +325,6 @@ func (c *InitCommand) Run(args []string) int {
 	// on a previous run) we'll use the current state as a potential source
 	// of provider dependencies.
 	if back != nil {
-		c.ignoreRemoteBackendVersionConflict(back)
 		sMgr, err := back.StateMgr(c.Workspace())
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error loading state: %s", err))

--- a/command/meta.go
+++ b/command/meta.go
@@ -177,10 +177,6 @@ type Meta struct {
 
 	// Used with the import command to allow import of state when no matching config exists.
 	allowMissingConfig bool
-
-	// Used with commands which write state to allow users to write remote
-	// state even if the remote and local Terraform versions don't match.
-	ignoreRemoteVersion bool
 }
 
 type PluginOverrides struct {
@@ -378,17 +374,6 @@ func (m *Meta) defaultFlagSet(n string) *flag.FlagSet {
 
 	// Set the default Usage to empty
 	f.Usage = func() {}
-
-	return f
-}
-
-// ignoreRemoteVersionFlagSet add the ignore-remote version flag to suppress
-// the error when the configured Terraform version on the remote workspace
-// does not match the local Terraform version.
-func (m *Meta) ignoreRemoteVersionFlagSet(n string) *flag.FlagSet {
-	f := m.defaultFlagSet(n)
-
-	f.BoolVar(&m.ignoreRemoteVersion, "ignore-remote-version", false, "continue even if remote and local Terraform versions differ")
 
 	return f
 }

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/terraform/backend"
-	remoteBackend "github.com/hashicorp/terraform/backend/remote"
 	"github.com/hashicorp/terraform/command/clistate"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/plans"
@@ -1159,33 +1158,6 @@ func (m *Meta) backendInitFromSaved(s *terraform.BackendState) (backend.Backend,
 func (m *Meta) backendInitRequired(reason string) {
 	m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
 		"[reset]"+strings.TrimSpace(errBackendInit)+"\n", reason)))
-}
-
-// Helper method to ignore remote backend version conflicts. Only call this
-// for commands which cannot accidentally upgrade remote state files.
-func (m *Meta) ignoreRemoteBackendVersionConflict(b backend.Backend) {
-	if rb, ok := b.(*remoteBackend.Remote); ok {
-		rb.IgnoreVersionConflict()
-	}
-}
-
-// Helper method to check the local Terraform version against the configured
-// version in the remote workspace, returning diagnostics if they conflict.
-func (m *Meta) remoteBackendVersionCheck(b backend.Backend, workspace string) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-
-	if rb, ok := b.(*remoteBackend.Remote); ok {
-		// Allow user override based on command-line flag
-		if m.ignoreRemoteVersion {
-			rb.IgnoreVersionConflict()
-		}
-		// If the override is set, this check will return a warning instead of
-		// an error
-		versionDiags := rb.VerifyWorkspaceTerraformVersion(workspace)
-		diags = diags.Append(versionDiags)
-	}
-
-	return diags
 }
 
 //-------------------------------------------------------------------

--- a/command/output.go
+++ b/command/output.go
@@ -68,9 +68,6 @@ func (c *OutputCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This is a read-only command
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	env := c.Workspace()
 
 	// Get the state

--- a/command/providers.go
+++ b/command/providers.go
@@ -88,9 +88,6 @@ func (c *ProvidersCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This is a read-only command
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	// Get the state
 	env := c.Workspace()
 	state, err := b.StateMgr(env)

--- a/command/providers_schema.go
+++ b/command/providers_schema.go
@@ -70,9 +70,6 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This is a read-only command
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	// we expect that the config dir is the cwd
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/command/show.go
+++ b/command/show.go
@@ -71,9 +71,6 @@ func (c *ShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This is a read-only command
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	// the show command expects the config dir to always be the cwd
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -44,9 +44,6 @@ func (c *StateListCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This is a read-only command
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	// Get the state
 	env := c.Workspace()
 	stateMgr, err := b.StateMgr(env)

--- a/command/state_meta.go
+++ b/command/state_meta.go
@@ -39,14 +39,6 @@ func (c *StateMeta) State() (state.State, error) {
 		}
 
 		workspace := c.Workspace()
-
-		// Check remote Terraform version is compatible
-		remoteVersionDiags := c.remoteBackendVersionCheck(b, workspace)
-		c.showDiagnostics(remoteVersionDiags)
-		if remoteVersionDiags.HasErrors() {
-			return nil, fmt.Errorf("Error checking remote Terraform version")
-		}
-
 		// Get the state
 		s, err := b.StateMgr(workspace)
 		if err != nil {

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -27,7 +27,7 @@ func (c *StateMvCommand) Run(args []string) int {
 	var backupPathOut, statePathOut string
 
 	var dryRun bool
-	cmdFlags := c.Meta.ignoreRemoteVersionFlagSet("state mv")
+	cmdFlags := c.Meta.defaultFlagSet("state mv")
 	cmdFlags.BoolVar(&dryRun, "dry-run", false, "dry run")
 	cmdFlags.StringVar(&c.backupPath, "backup", "-", "backup")
 	cmdFlags.StringVar(&backupPathOut, "backup-out", "-", "backup")
@@ -490,35 +490,31 @@ Usage: terraform state mv [options] SOURCE DESTINATION
 
 Options:
 
-  -dry-run                If set, prints out what would've been moved but doesn't
-                          actually move anything.
+  -dry-run            If set, prints out what would've been moved but doesn't
+                      actually move anything.
 
-  -backup=PATH            Path where Terraform should write the backup for the
-						  original state. This can't be disabled. If not set,
-						  Terraform will write it to the same path as the
-						  statefile with a ".backup" extension.
+  -backup=PATH        Path where Terraform should write the backup for the original
+                      state. This can't be disabled. If not set, Terraform
+                      will write it to the same path as the statefile with
+                      a ".backup" extension.
 
-  -backup-out=PATH        Path where Terraform should write the backup for the
-						  destination state. This can't be disabled. If not
-						  set, Terraform will write it to the same path as the
-						  destination state file with a backup extension. This
-						  only needs to be specified if -state-out is set to a
-						  different path than -state.
+  -backup-out=PATH    Path where Terraform should write the backup for the destination
+                      state. This can't be disabled. If not set, Terraform
+                      will write it to the same path as the destination state
+                      file with a backup extension. This only needs
+                      to be specified if -state-out is set to a different path
+                      than -state.
 
-  -lock=true              Lock the state files when locking is supported.
+  -lock=true          Lock the state files when locking is supported.
 
-  -lock-timeout=0s        Duration to retry a state lock.
+  -lock-timeout=0s    Duration to retry a state lock.
 
-  -state=PATH             Path to the source state file. Defaults to the
-						  configured backend, or "terraform.tfstate"
+  -state=PATH         Path to the source state file. Defaults to the configured
+                      backend, or "terraform.tfstate"
 
-  -state-out=PATH         Path to the destination state file to write to. If
-						  this isn't specified, the source state file will be
-						  used. This can be a new or existing path.
-
-  -ignore-remote-version  Continue even if remote and local Terraform versions
-                          differ. This may result in an unusable workspace, and
-                          should be used with extreme caution.
+  -state-out=PATH     Path to the destination state file to write to. If this
+                      isn't specified, the source state file will be used. This
+                      can be a new or existing path.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/state_pull.go
+++ b/command/state_pull.go
@@ -35,9 +35,6 @@ func (c *StatePullCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This is a read-only command
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	// Get the state manager for the current workspace
 	env := c.Workspace()
 	stateMgr, err := b.StateMgr(env)

--- a/command/state_push.go
+++ b/command/state_push.go
@@ -26,7 +26,7 @@ func (c *StatePushCommand) Run(args []string) int {
 	}
 
 	var flagForce bool
-	cmdFlags := c.Meta.ignoreRemoteVersionFlagSet("state push")
+	cmdFlags := c.Meta.defaultFlagSet("state push")
 	cmdFlags.BoolVar(&flagForce, "force", false, "")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
@@ -79,18 +79,9 @@ func (c *StatePushCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Determine the workspace name
-	workspace := c.Workspace()
-
-	// Check remote Terraform version is compatible
-	remoteVersionDiags := c.remoteBackendVersionCheck(b, workspace)
-	c.showDiagnostics(remoteVersionDiags)
-	if remoteVersionDiags.HasErrors() {
-		return 1
-	}
-
 	// Get the state manager for the currently-selected workspace
-	stateMgr, err := b.StateMgr(workspace)
+	env := c.Workspace()
+	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load destination state: %s", err))
 		return 1

--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -23,7 +23,7 @@ func (c *StateRmCommand) Run(args []string) int {
 	}
 
 	var dryRun bool
-	cmdFlags := c.Meta.ignoreRemoteVersionFlagSet("state rm")
+	cmdFlags := c.Meta.defaultFlagSet("state rm")
 	cmdFlags.BoolVar(&dryRun, "dry-run", false, "dry run")
 	cmdFlags.StringVar(&c.backupPath, "backup", "-", "backup")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
@@ -144,22 +144,18 @@ Usage: terraform state rm [options] ADDRESS...
 
 Options:
 
-  -dry-run                If set, prints out what would've been removed but
-                          doesn't actually remove anything.
+  -dry-run            If set, prints out what would've been removed but
+                      doesn't actually remove anything.
 
-  -backup=PATH            Path where Terraform should write the backup
-                          state.
+  -backup=PATH        Path where Terraform should write the backup
+                      state.
 
-  -lock=true              Lock the state file when locking is supported.
+  -lock=true          Lock the state file when locking is supported.
 
-  -lock-timeout=0s        Duration to retry a state lock.
+  -lock-timeout=0s    Duration to retry a state lock.
 
-  -state=PATH             Path to the state file to update. Defaults to the
-                          current workspace state.
-
-  -ignore-remote-version  Continue even if remote and local Terraform versions
-                          differ. This may result in an unusable workspace, and
-                          should be used with extreme caution.
+  -state=PATH         Path to the state file to update. Defaults to the current
+                      workspace state.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -56,9 +56,6 @@ func (c *StateShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This is a read-only command
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	// Check if the address can be parsed
 	addr, addrDiags := addrs.ParseAbsResourceInstanceStr(args[0])
 	if addrDiags.HasErrors() {

--- a/command/taint.go
+++ b/command/taint.go
@@ -25,7 +25,7 @@ func (c *TaintCommand) Run(args []string) int {
 
 	var module string
 	var allowMissing bool
-	cmdFlags := c.Meta.ignoreRemoteVersionFlagSet("taint")
+	cmdFlags := c.Meta.defaultFlagSet("taint")
 	cmdFlags.BoolVar(&allowMissing, "allow-missing", false, "module")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
@@ -74,19 +74,9 @@ func (c *TaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Determine the workspace name
-	workspace := c.Workspace()
-
-	// Check remote Terraform version is compatible
-	remoteVersionDiags := c.remoteBackendVersionCheck(b, workspace)
-	diags = diags.Append(remoteVersionDiags)
-	c.showDiagnostics(diags)
-	if diags.HasErrors() {
-		return 1
-	}
-
 	// Get the state
-	stateMgr, err := b.StateMgr(workspace)
+	env := c.Workspace()
+	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
@@ -198,26 +188,22 @@ Usage: terraform taint [options] <address>
 
 Options:
 
-  -allow-missing          If specified, the command will succeed (exit code 0)
-                          even if the resource is missing.
+  -allow-missing      If specified, the command will succeed (exit code 0)
+                      even if the resource is missing.
 
-  -backup=path            Path to backup the existing state file before
-                          modifying. Defaults to the "-state-out" path with
-                          ".backup" extension. Set to "-" to disable backup.
+  -backup=path        Path to backup the existing state file before
+                      modifying. Defaults to the "-state-out" path with
+                      ".backup" extension. Set to "-" to disable backup.
 
-  -lock=true              Lock the state file when locking is supported.
+  -lock=true          Lock the state file when locking is supported.
 
-  -lock-timeout=0s        Duration to retry a state lock.
+  -lock-timeout=0s    Duration to retry a state lock.
 
-  -state=path             Path to read and save state (unless state-out
-                          is specified). Defaults to "terraform.tfstate".
+  -state=path         Path to read and save state (unless state-out
+                      is specified). Defaults to "terraform.tfstate".
 
-  -state-out=path         Path to write updated state file. By default, the
-                          "-state" path will be used.
-
-  -ignore-remote-version  Continue even if remote and local Terraform versions
-                          differ. This may result in an unusable workspace, and
-                          should be used with extreme caution.
+  -state-out=path     Path to write updated state file. By default, the
+                      "-state" path will be used.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -25,7 +25,7 @@ func (c *UntaintCommand) Run(args []string) int {
 
 	var module string
 	var allowMissing bool
-	cmdFlags := c.Meta.ignoreRemoteVersionFlagSet("untaint")
+	cmdFlags := c.Meta.defaultFlagSet("untaint")
 	cmdFlags.BoolVar(&allowMissing, "allow-missing", false, "module")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
@@ -69,18 +69,8 @@ func (c *UntaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Determine the workspace name
-	workspace := c.Workspace()
-
-	// Check remote Terraform version is compatible
-	remoteVersionDiags := c.remoteBackendVersionCheck(b, workspace)
-	diags = diags.Append(remoteVersionDiags)
-	c.showDiagnostics(diags)
-	if diags.HasErrors() {
-		return 1
-	}
-
 	// Get the state
+	workspace := c.Workspace()
 	stateMgr, err := b.StateMgr(workspace)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
@@ -196,30 +186,26 @@ Usage: terraform untaint [options] name
 
 Options:
 
-  -allow-missing          If specified, the command will succeed (exit code 0)
-                          even if the resource is missing.
+  -allow-missing      If specified, the command will succeed (exit code 0)
+                      even if the resource is missing.
 
-  -backup=path            Path to backup the existing state file before
-						  modifying. Defaults to the "-state-out" path with
-						  ".backup" extension. Set to "-" to disable backup.
+  -backup=path        Path to backup the existing state file before
+                      modifying. Defaults to the "-state-out" path with
+                      ".backup" extension. Set to "-" to disable backup.
 
-  -lock=true              Lock the state file when locking is supported.
+  -lock=true          Lock the state file when locking is supported.
 
-  -lock-timeout=0s        Duration to retry a state lock.
+  -lock-timeout=0s    Duration to retry a state lock.
 
-  -module=path            The module path where the resource lives. By default
-						  this will be root. Child modules can be specified by
-						  names. Ex. "consul" or "consul.vpc" (nested modules).
+  -module=path        The module path where the resource lives. By
+                      default this will be root. Child modules can be specified
+                      by names. Ex. "consul" or "consul.vpc" (nested modules).
 
-  -state=path             Path to read and save state (unless state-out
-                          is specified). Defaults to "terraform.tfstate".
+  -state=path         Path to read and save state (unless state-out
+                      is specified). Defaults to "terraform.tfstate".
 
-  -state-out=path         Path to write updated state file. By default, the
-                          "-state" path will be used.
-
-  -ignore-remote-version  Continue even if remote and local Terraform versions
-                          differ. This may result in an unusable workspace, and
-                          should be used with extreme caution.
+  -state-out=path     Path to write updated state file. By default, the
+                      "-state" path will be used.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/workspace_delete.go
+++ b/command/workspace_delete.go
@@ -76,9 +76,6 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This command will not write state
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	workspaces, err := b.Workspaces()
 	if err != nil {
 		c.Ui.Error(err.Error())

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -55,9 +55,6 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This command will not write state
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	states, err := b.Workspaces()
 	if err != nil {
 		c.Ui.Error(err.Error())

--- a/command/workspace_new.go
+++ b/command/workspace_new.go
@@ -85,9 +85,6 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This command will not write state
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	workspaces, err := b.Workspaces()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to get configured named states: %s", err))

--- a/command/workspace_select.go
+++ b/command/workspace_select.go
@@ -71,9 +71,6 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 		return 1
 	}
 
-	// This command will not write state
-	c.ignoreRemoteBackendVersionConflict(b)
-
 	name := args[0]
 	if !validWorkspaceName(name) {
 		c.Ui.Error(fmt.Sprintf(envInvalidName, name))

--- a/website/docs/commands/import.html.md
+++ b/website/docs/commands/import.html.md
@@ -77,11 +77,6 @@ in the configuration for the target resource, and that is the best behavior in m
   the working directory. This flag can be used multiple times. This is only
   useful with the `-config` flag.
 
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.
-
 ## Provider Configuration
 
 Terraform will attempt to load configuration files that configure the

--- a/website/docs/commands/state/mv.html.md
+++ b/website/docs/commands/state/mv.html.md
@@ -57,11 +57,6 @@ The command-line flags are all optional. The list of available flags are:
   isn't specified the source state file will be used. This can be a new or
   existing path.
 
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.
-
 ## Example: Rename a Resource
 
 The example below renames the `packet_device` resource named `worker` to `helper`:

--- a/website/docs/commands/state/push.html.md
+++ b/website/docs/commands/state/push.html.md
@@ -42,10 +42,3 @@ making changes that appear to be unsafe:
 Both of these safety checks can be disabled with the `-force` flag.
 **This is not recommended.** If you disable the safety checks and are
 pushing state, the destination state will be overwritten.
-
-Other available flags:
-
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.

--- a/website/docs/commands/state/rm.html.md
+++ b/website/docs/commands/state/rm.html.md
@@ -51,11 +51,6 @@ The command-line flags are all optional. The list of available flags are:
   Terraform-managed resources. By default it will use the configured backend,
   or the default "terraform.tfstate" if it exists.
 
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.
-
 ## Example: Remove a Resource
 
 The example below removes the `packet_device` resource named `worker`:

--- a/website/docs/commands/taint.html.markdown
+++ b/website/docs/commands/taint.html.markdown
@@ -65,11 +65,6 @@ The command-line flags are all optional. The list of available flags are:
   `-state` path will be used. Ignored when
   [remote state](/docs/state/remote.html) is used.
 
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.
-
 ## Example: Tainting a Single Resource
 
 This example will taint a single resource:

--- a/website/docs/commands/untaint.html.markdown
+++ b/website/docs/commands/untaint.html.markdown
@@ -57,8 +57,3 @@ certain cases, see above note). The list of available flags are:
 * `-state-out=path` - Path to write updated state file. By default, the
   `-state` path will be used. Ignored when
   [remote state](/docs/state/remote.html) is used.
-
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.


### PR DESCRIPTION
We're no longer planning on shipping this feature to legacy versions of Terraform.

