### PR TITLE
[tests] Roll back test schema expansion and isolate

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -6701,10 +6701,10 @@ resource "test_resource" "foo" {
 				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 				&states.ResourceInstanceObjectSrc{
 					Status:    states.ObjectReady,
-					AttrsJSON: []byte(`{"id":"foo", "value":"hello", "sensitive_value":"hello", "network_interface":[]}`),
+					AttrsJSON: []byte(`{"id":"foo", "value":"hello", "sensitive_value":"hello"}`),
 					AttrSensitivePaths: []cty.PathValueMarks{
-						cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "value"}}, Marks: cty.NewValueMarks("sensitive")},
-						cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "sensitive_value"}}, Marks: cty.NewValueMarks("sensitive")},
+						{Path: cty.Path{cty.GetAttrStep{Name: "value"}}, Marks: cty.NewValueMarks("sensitive")},
+						{Path: cty.Path{cty.GetAttrStep{Name: "sensitive_value"}}, Marks: cty.NewValueMarks("sensitive")},
 					},
 				},
 				addrs.AbsProviderConfig{

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -599,15 +599,6 @@ func testProviderSchema(name string) *ProviderSchema {
 					},
 				},
 				BlockTypes: map[string]*configschema.NestedBlock{
-					"network_interface": {
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"network_interface_id": {Type: cty.String, Optional: true},
-								"device_index":         {Type: cty.Number, Optional: true},
-							},
-						},
-						Nesting: configschema.NestingSet,
-					},
 					"nesting_single": {
 						Block: configschema.Block{
 							Attributes: map[string]*configschema.Attribute{


### PR DESCRIPTION
Isolate the test schema expansion, because having NestingSet in the schema actually necessitates [] values in the AttrsJson.
While this didn't fail any tests on its addition, that is scary and so isolate this to the one test using it.

This block was added in https://github.com/hashicorp/terraform/pull/26379/, but the fact that it is actually more of a sweeping change than expected was discovered recently, which necessitated the change (that has been reverted) in `TestContext2Plan_noSensitivityChange` and `TestContext2Apply_variableSensitivityChange`