### PR TITLE
Allow for source override from registry URL to local path in module call

### DIFF
--- a/configs/module_merge.go
+++ b/configs/module_merge.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/internal/earlyconfig"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
@@ -152,6 +153,11 @@ func (mc *ModuleCall) merge(omc *ModuleCall) hcl.Diagnostics {
 		mc.SourceAddr = omc.SourceAddr
 		mc.SourceAddrRange = omc.SourceAddrRange
 		mc.SourceSet = omc.SourceSet
+		// The Version attribute needs to be empty if overriding SourceAddr to a local addr
+		// If omc.Version isn't empty, that's user error
+		if earlyconfig.IsLocalSourceAddr(omc.SourceAddr) {
+			mc.Version = omc.Version
+		}
 	}
 
 	if omc.Count != nil {

--- a/configs/module_merge_test.go
+++ b/configs/module_merge_test.go
@@ -313,3 +313,18 @@ func TestModuleOverrideResourceFQNs(t *testing.T) {
 		t.Fatalf("wrong result: found provider config ref %s, expected nil", got.ProviderConfigRef)
 	}
 }
+
+func TestModuleOverrideSourceToLocal(t *testing.T) {
+	moduleName := "example"
+	mod, diags := testModuleFromDir("testdata/valid-modules/override-module-source-local")
+
+	assertNoDiagnostics(t, diags)
+	if mod == nil {
+		t.Fatalf("module is nil")
+	}
+	if _, ok := mod.ModuleCalls[moduleName]; !ok {
+		t.Fatalf("module call \"%s\" not found", moduleName)
+	}
+	// We expect the version attribute to be unset when changing source to a local path
+	assertResultDeepEqual(t, mod.ModuleCalls[moduleName].Version, VersionConstraint{})
+}

--- a/configs/testdata/valid-modules/override-module-source-local/override.tf
+++ b/configs/testdata/valid-modules/override-module-source-local/override.tf
@@ -1,0 +1,6 @@
+# This is testing a module source override use case. The source does not need to
+# be a valid module, but it must be set to a local path.
+
+module "example" {
+  source = "../"
+}

--- a/configs/testdata/valid-modules/override-module-source-local/primary.tf
+++ b/configs/testdata/valid-modules/override-module-source-local/primary.tf
@@ -1,0 +1,8 @@
+# This fixture depends on a registry module. However, the test that uses it
+# is testing the source and version override functionality. The registry does
+# not need to be accessed, and the source can be any registry URL.
+
+module "example" {
+  source  = "hashicorp/subnets/cidr"
+  version = "1.0.0"
+}

--- a/internal/earlyconfig/config.go
+++ b/internal/earlyconfig/config.go
@@ -3,6 +3,7 @@ package earlyconfig
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
@@ -207,4 +208,21 @@ func (c *Config) ProviderDependencies() (*moduledeps.Module, tfdiags.Diagnostics
 	}
 
 	return ret, diags
+}
+
+var localSourcePrefixes = []string{
+	"./",
+	"../",
+	".\\",
+	"..\\",
+}
+
+// IsLocalSourceAddr detects if the given SourceAddr is a local path or not
+func IsLocalSourceAddr(addr string) bool {
+	for _, prefix := range localSourcePrefixes {
+		if strings.HasPrefix(addr, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/initwd/getter.go
+++ b/internal/initwd/getter.go
@@ -174,22 +174,6 @@ func splitAddrSubdir(addr string) (packageAddr, subDir string) {
 	return getter.SourceDirSubdir(addr)
 }
 
-var localSourcePrefixes = []string{
-	"./",
-	"../",
-	".\\",
-	"..\\",
-}
-
-func isLocalSourceAddr(addr string) bool {
-	for _, prefix := range localSourcePrefixes {
-		if strings.HasPrefix(addr, prefix) {
-			return true
-		}
-	}
-	return false
-}
-
 func isRegistrySourceAddr(addr string) bool {
 	_, err := regsrc.ParseModuleSource(addr)
 	return err == nil

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -197,7 +197,7 @@ func (i *ModuleInstaller) installDescendentModules(rootMod *tfconfig.Module, roo
 			// on what type of module source address we have.
 			switch {
 
-			case isLocalSourceAddr(req.SourceAddr):
+			case earlyconfig.IsLocalSourceAddr(req.SourceAddr):
 				log.Printf("[TRACE] ModuleInstaller: %s has local path %q", key, req.SourceAddr)
 				mod, mDiags := i.installLocalModule(req, key, manifest, hooks)
 				diags = append(diags, mDiags...)


### PR DESCRIPTION
This change allows for overriding the source attribute on a module call from a registry URL to a local path when a version attribute is also set. Currently there is no way to delete an attribute when doing an override, and so without this change the source override will fail due to a version attribute being set when the source is set to a local path. See #27368 or the included tests for a full example.

**Feedback requested**: For this change I decided to move and export the `isLocalSourceAddr` function out of the `initwd` package because the `configs` package is imported by `initwd` (leading to circular dependencies if trying to call `initwd.IsLocalSourceAddr` from `configs`). I don't know if this is the preferable way to handle this situation.

The included test can be quickly triggered using
```shell
go test -run ^TestModuleOverrideSourceToLocal$ github.com/hashicorp/terraform/configs -v
```

Closes #27368 