### PR TITLE
Refresh during destroy

### DIFF
--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -559,7 +559,7 @@ func TestLocal_planDestroy(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
 
-	p := TestLocalProvider(t, b, "test", planFixtureSchema())
+	TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState())
 
 	outDir := testTempDir(t)
@@ -593,10 +593,6 @@ func TestLocal_planDestroy(t *testing.T) {
 		t.Fatalf("plan operation failed")
 	}
 
-	if p.ReadResourceCalled {
-		t.Fatal("ReadResource should not be called")
-	}
-
 	if run.PlanEmpty {
 		t.Fatal("plan should not be empty")
 	}
@@ -613,7 +609,7 @@ func TestLocal_planDestroy_withDataSources(t *testing.T) {
 	b, cleanup := TestLocal(t)
 	defer cleanup()
 
-	p := TestLocalProvider(t, b, "test", planFixtureSchema())
+	TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState_withDataSource())
 
 	b.CLI = cli.NewMockUi()
@@ -647,14 +643,6 @@ func TestLocal_planDestroy_withDataSources(t *testing.T) {
 	<-run.Done()
 	if run.Result != backend.OperationSuccess {
 		t.Fatalf("plan operation failed")
-	}
-
-	if p.ReadResourceCalled {
-		t.Fatal("ReadResource should not be called")
-	}
-
-	if p.ReadDataSourceCalled {
-		t.Fatal("ReadDataSourceCalled should not be called")
 	}
 
 	if run.PlanEmpty {

--- a/backend/local/testdata/destroy-with-ds/main.tf
+++ b/backend/local/testdata/destroy-with-ds/main.tf
@@ -1,4 +1,5 @@
 resource "test_instance" "foo" {
+  count = 1
   ami = "bar"
 }
 

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -530,6 +530,20 @@ The -target option is not for routine use, and is provided only for exceptional 
 		))
 	}
 
+	var plan *plans.Plan
+	var planDiags tfdiags.Diagnostics
+	switch {
+	case c.destroy:
+		plan, planDiags = c.destroyPlan()
+	default:
+		plan, planDiags = c.plan()
+	}
+	diags = diags.Append(planDiags)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	// convert the variables into the format expected for the plan
 	varVals := make(map[string]plans.DynamicValue, len(c.variables))
 	for k, iv := range c.variables {
 		// We use cty.DynamicPseudoType here so that we'll save both the
@@ -547,29 +561,22 @@ The -target option is not for routine use, and is provided only for exceptional 
 		varVals[k] = dv
 	}
 
-	plan := &plans.Plan{
-		VariableValues:  varVals,
-		TargetAddrs:     c.targets,
-		ProviderSHA256s: c.providerSHA256s,
-	}
-
-	switch {
-	case c.destroy:
-		diags = diags.Append(c.destroyPlan(plan))
-	default:
-		diags = diags.Append(c.plan(plan))
-	}
+	// insert the run-specific data from the context into the plan; variables,
+	// targets and provider SHAs.
+	plan.VariableValues = varVals
+	plan.TargetAddrs = c.targets
+	plan.ProviderSHA256s = c.providerSHA256s
 
 	return plan, diags
 }
 
-func (c *Context) plan(plan *plans.Plan) tfdiags.Diagnostics {
+func (c *Context) plan() (*plans.Plan, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	graph, graphDiags := c.Graph(GraphTypePlan, nil)
 	diags = diags.Append(graphDiags)
 	if graphDiags.HasErrors() {
-		return diags
+		return nil, diags
 	}
 
 	// Do the walk
@@ -577,9 +584,11 @@ func (c *Context) plan(plan *plans.Plan) tfdiags.Diagnostics {
 	diags = diags.Append(walker.NonFatalDiagnostics)
 	diags = diags.Append(walkDiags)
 	if walkDiags.HasErrors() {
-		return diags
+		return nil, diags
 	}
-	plan.Changes = c.changes
+	plan := &plans.Plan{
+		Changes: c.changes,
+	}
 
 	c.refreshState.SyncWrapper().RemovePlannedResourceInstanceObjects()
 
@@ -590,11 +599,12 @@ func (c *Context) plan(plan *plans.Plan) tfdiags.Diagnostics {
 	// to Apply work as expected.
 	c.state = refreshedState
 
-	return diags
+	return plan, diags
 }
 
-func (c *Context) destroyPlan(destroyPlan *plans.Plan) tfdiags.Diagnostics {
+func (c *Context) destroyPlan() (*plans.Plan, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
+	destroyPlan := &plans.Plan{}
 	c.changes = plans.NewChanges()
 
 	// A destroy plan starts by running Refresh to read any pending data
@@ -602,17 +612,10 @@ func (c *Context) destroyPlan(destroyPlan *plans.Plan) tfdiags.Diagnostics {
 	// a "destroy plan" is only creating delete changes, and is essentially a
 	// local operation.
 	if !c.skipRefresh {
-		refreshPlan := &plans.Plan{
-			VariableValues:  destroyPlan.VariableValues,
-			TargetAddrs:     c.targets,
-			ProviderSHA256s: c.providerSHA256s,
-		}
-
-		refreshDiags := c.plan(refreshPlan)
-
+		refreshPlan, refreshDiags := c.plan()
 		diags = diags.Append(refreshDiags)
 		if diags.HasErrors() {
-			return diags
+			return nil, diags
 		}
 
 		// insert the refreshed state into the destroy plan result, and discard
@@ -624,7 +627,7 @@ func (c *Context) destroyPlan(destroyPlan *plans.Plan) tfdiags.Diagnostics {
 	graph, graphDiags := c.Graph(GraphTypePlanDestroy, nil)
 	diags = diags.Append(graphDiags)
 	if graphDiags.HasErrors() {
-		return diags
+		return nil, diags
 	}
 
 	// Do the walk
@@ -632,11 +635,11 @@ func (c *Context) destroyPlan(destroyPlan *plans.Plan) tfdiags.Diagnostics {
 	diags = diags.Append(walker.NonFatalDiagnostics)
 	diags = diags.Append(walkDiags)
 	if walkDiags.HasErrors() {
-		return diags
+		return nil, diags
 	}
 
 	destroyPlan.Changes = c.changes
-	return diags
+	return destroyPlan, diags
 }
 
 // Refresh goes through all the resources in the state and refreshes them

--- a/terraform/graph_builder_destroy_plan.go
+++ b/terraform/graph_builder_destroy_plan.go
@@ -12,7 +12,10 @@ import (
 // planning a pure-destroy.
 //
 // Planning a pure destroy operation is simple because we can ignore most
-// ordering configuration and simply reverse the state.
+// ordering configuration and simply reverse the state. This graph mainly
+// exists for targeting, because we need to walk the destroy dependencies to
+// ensure we plan the required resources. Without the requirement for
+// targeting, the plan could theoretically be created directly from the state.
 type DestroyPlanGraphBuilder struct {
 	// Config is the configuration tree to build the plan from.
 	Config *configs.Config
@@ -72,6 +75,7 @@ func (b *DestroyPlanGraphBuilder) Steps() []GraphTransformer {
 			State:           b.State,
 		},
 
+		// Create the delete changes for root module outputs.
 		&OutputTransformer{
 			Config:  b.Config,
 			Destroy: true,
@@ -93,8 +97,6 @@ func (b *DestroyPlanGraphBuilder) Steps() []GraphTransformer {
 			Schemas: b.Schemas,
 		},
 
-		// Target. Note we don't set "Destroy: true" here since we already
-		// created proper destroy ordering.
 		&TargetsTransformer{Targets: b.Targets},
 
 		// Close opened plugin connections

--- a/terraform/node_resource_abstract_instance.go
+++ b/terraform/node_resource_abstract_instance.go
@@ -1401,6 +1401,13 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, currentSt
 		return plannedChange, plannedNewState, diags
 	}
 
+	// While this isn't a "diff", continue to call this for data sources.
+	diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
+		return h.PreDiff(n.Addr, states.CurrentGen, priorVal, configVal)
+	}))
+	if diags.HasErrors() {
+		return nil, nil, diags
+	}
 	// We have a complete configuration with no dependencies to wait on, so we
 	// can read the data source into the state.
 	newVal, readDiags := n.readDataSource(ctx, configVal)

--- a/terraform/testdata/apply-destroy-data-cycle/main.tf
+++ b/terraform/testdata/apply-destroy-data-cycle/main.tf
@@ -8,3 +8,7 @@ data "null_data_source" "d" {
 resource "null_resource" "a" {
     count = local.l == "NONE" ? 1 : 0
 }
+
+provider "test" {
+  foo = data.null_data_source.d.id
+}

--- a/terraform/testdata/apply-destroy-data-resource/main.tf
+++ b/terraform/testdata/apply-destroy-data-resource/main.tf
@@ -1,5 +1,3 @@
 data "null_data_source" "testing" {
-  inputs = {
-    test = "yes"
-  }
+  foo = "yes"
 }

--- a/terraform/testdata/plan-module-destroy-gh-1835/b/main.tf
+++ b/terraform/testdata/plan-module-destroy-gh-1835/b/main.tf
@@ -1,5 +1,5 @@
 variable "a_id" {}
 
 resource "aws_instance" "b" {
-  command = "echo ${var.a_id}"
+  foo = "echo ${var.a_id}"
 }


### PR DESCRIPTION
Because the destroy plan only creates the necessary changes for apply to
remove all the resources, it does no reading of resources or data
sources, leading to stale data in the state. In most cases this is not a
problem, but when a provider configuration is using resource values, the
provider may not be able to run correctly during apply. In prior
versions of terraform, the implicit refresh that happened during
`terraform destroy` would update the data sources and remove missing
resources from state as required.

The destroy plan graph has a minimal amount of information, so it is not
feasible to work the reading of resources into the operation without
completely replicating the normal plan graph, and updating the plan
graph and all destroy node implementations is also a considerable amount
of refactoring. Instead, we can run a normal plan which is used to
refresh the state before creating the destroy plan. This brings back
similar behavior to core versions prior to 0.14, and the refresh can
still be skipped using the `-refresh=false` cli flag.

Fixes #27172