### PR TITLE
core: Fix sensitive value variable validation

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -6725,3 +6725,23 @@ resource "test_resource" "foo" {
 		}
 	}
 }
+
+func TestContext2Plan_variableCustomValidationsSensitive(t *testing.T) {
+	m := testModule(t, "validate-variable-custom-validations-child-sensitive")
+
+	p := testProvider("test")
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan()
+	if !diags.HasErrors() {
+		t.Fatal("succeeded; want errors")
+	}
+	if got, want := diags.Err().Error(), `Invalid value for variable: Value must not be "nope".`; !strings.Contains(got, want) {
+		t.Fatalf("wrong error:\ngot:  %s\nwant: message containing %q", got, want)
+	}
+}

--- a/terraform/eval_variable.go
+++ b/terraform/eval_variable.go
@@ -81,6 +81,11 @@ func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *config
 			continue
 		}
 
+		// Validation condition may be marked if the input variable is bound to
+		// a sensitive value. This is irrelevant to the validation process, so
+		// we discard the marks now.
+		result, _ = result.Unmark()
+
 		if result.False() {
 			if expr != nil {
 				diags = diags.Append(&hcl.Diagnostic{

--- a/terraform/testdata/validate-variable-custom-validations-child-sensitive/child/child.tf
+++ b/terraform/testdata/validate-variable-custom-validations-child-sensitive/child/child.tf
@@ -1,0 +1,8 @@
+variable "test" {
+  type = string
+
+  validation {
+    condition     = var.test != "nope"
+    error_message = "Value must not be \"nope\"."
+  }
+}

--- a/terraform/testdata/validate-variable-custom-validations-child-sensitive/validate-variable-custom-validations.tf
+++ b/terraform/testdata/validate-variable-custom-validations-child-sensitive/validate-variable-custom-validations.tf
@@ -1,0 +1,10 @@
+variable "test" {
+  sensitive = true
+  default = "nope"
+}
+
+module "child" {
+  source = "./child"
+
+  test = var.test
+}


### PR DESCRIPTION
Binding a sensitive value to a variable with custom validation rules would cause a panic, as the validation expression carries the sensitive mark when it is evaluated for truthiness. This commit drops the marks before testing, which fixes the issue.

Fixes #27375