### PR TITLE
Chage backend.tmpl to config.tmpl in Maps example,

### DIFF
--- a/website/docs/configuration/functions/templatefile.html.md
+++ b/website/docs/configuration/functions/templatefile.html.md
@@ -78,7 +78,7 @@ The `templatefile` function renders the template:
 
 ```
 > templatefile(
-               "${path.module}/backends.tmpl",
+               "${path.module}/config.tmpl",
                {
                  config = {
                    "x"   = "y"


### PR DESCRIPTION
Reference file in Maps example is named config.tmpl, example references non existent file called backend.tmpl,
likely a cut and paste error from the above example.