### PR TITLE
Remove documentation on 'CONFIRM_DESTROY'

### DIFF
--- a/website/docs/backends/types/remote.html.md
+++ b/website/docs/backends/types/remote.html.md
@@ -28,7 +28,7 @@ Currently the remote backend supports the following Terraform commands:
 
 - `apply`
 - `console` (supported in Terraform >= v0.11.12)
-- `destroy` (requires manually setting `CONFIRM_DESTROY=1` on the workspace)
+- `destroy`
 - `fmt`
 - `get`
 - `graph` (supported in Terraform >= v0.11.12)


### PR DESCRIPTION
This variable mechanism was replaced long ago with a explicit `Allow destroy plans` setting on a Terraform Cloud workspace, and no longer does anything: https://www.terraform.io/docs/cloud/workspaces/settings.html#destruction-and-deletion

Rather than mention this new mechanism at all though, I've removed the requisite from here entirely - the reason being that a consideration like this is hardly different from other permission concerns (e.g. "You must have Apply permission on a workspace to `apply`"), and without enumerating _all_ of these here - which doesn't seem appropriate - we just remove this concern entirely.