### PR TITLE
Staticcheck fixes in terraform package

### DIFF
--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -1094,7 +1094,7 @@ func TestContext2Refresh_unknownProvider(t *testing.T) {
 		t.Fatal("successfully created context; want error")
 	}
 
-	if !regexp.MustCompile(`Failed to instantiate provider ".+"`).MatchString(diags.Err().Error()) {
+	if !regexp.MustCompile(`failed to instantiate provider ".+"`).MatchString(diags.Err().Error()) {
 		t.Fatalf("wrong error: %s", diags.Err())
 	}
 }

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -233,7 +233,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 
 	// Make a new diff, in case we've learned new values in the state
 	// during apply which we can now incorporate.
-	diffApply, state, planDiags := n.plan(ctx, diff, state, false)
+	diffApply, _, planDiags := n.plan(ctx, diff, state, false)
 	diags = diags.Append(planDiags)
 	if diags.HasErrors() {
 		return diags
@@ -265,7 +265,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	}
 
 	var applyError error
-	state, applyError, applyDiags := n.apply(ctx, state, diffApply, n.Config, n.CreateBeforeDestroy(), applyError)
+	state, applyDiags, applyError := n.apply(ctx, state, diffApply, n.Config, n.CreateBeforeDestroy(), applyError)
 	diags = diags.Append(applyDiags)
 	if diags.HasErrors() {
 		return diags
@@ -283,7 +283,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	}
 
 	createNew := (diffApply.Action == plans.Create || diffApply.Action.IsReplace())
-	applyError, applyProvisionersDiags := n.evalApplyProvisioners(ctx, state, createNew, configs.ProvisionerWhenCreate, applyError)
+	applyProvisionersDiags, applyError := n.evalApplyProvisioners(ctx, state, createNew, configs.ProvisionerWhenCreate, applyError)
 	diags = diags.Append(applyProvisionersDiags)
 	if diags.HasErrors() {
 		return diags

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -175,7 +175,7 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 	// Run destroy provisioners if not tainted
 	if state != nil && state.Status != states.ObjectTainted {
 		var applyProvisionersDiags tfdiags.Diagnostics
-		provisionerErr, applyProvisionersDiags = n.evalApplyProvisioners(ctx, state, false, configs.ProvisionerWhenDestroy, provisionerErr)
+		applyProvisionersDiags, provisionerErr = n.evalApplyProvisioners(ctx, state, false, configs.ProvisionerWhenDestroy, provisionerErr)
 		diags = diags.Append(applyProvisionersDiags)
 		if diags.HasErrors() {
 			return diags
@@ -195,7 +195,7 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 	if addr.Resource.Resource.Mode == addrs.ManagedResourceMode {
 		var applyDiags tfdiags.Diagnostics
 		// we pass a nil configuration to apply because we are destroying
-		state, provisionerErr, applyDiags = n.apply(ctx, state, changeApply, nil, false, provisionerErr)
+		state, applyDiags, provisionerErr = n.apply(ctx, state, changeApply, nil, false, provisionerErr)
 		diags.Append(applyDiags)
 		if diags.HasErrors() {
 			return diags

--- a/terraform/node_resource_destroy_deposed.go
+++ b/terraform/node_resource_destroy_deposed.go
@@ -174,7 +174,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 	}
 
 	// we pass a nil configuration to apply because we are destroying
-	state, applyError, applyDiags := n.apply(ctx, state, change, nil, false, applyError)
+	state, applyDiags, applyError := n.apply(ctx, state, change, nil, false, applyError)
 	diags = diags.Append(applyDiags)
 	if diags.HasErrors() {
 		return diags

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -106,7 +106,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to instantiate provider %q to obtain schema: %s", name, err),
+				fmt.Errorf("failed to instantiate provider %q to obtain schema: %s", name, err),
 			)
 			return
 		}
@@ -120,7 +120,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to retrieve schema from provider %q: %s", name, resp.Diagnostics.Err()),
+				fmt.Errorf("failed to retrieve schema from provider %q: %s", name, resp.Diagnostics.Err()),
 			)
 			return
 		}
@@ -200,7 +200,7 @@ func loadProvisionerSchemas(schemas map[string]*configschema.Block, config *conf
 			// future calls.
 			schemas[name] = &configschema.Block{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to instantiate provisioner %q to obtain schema: %s", name, err),
+				fmt.Errorf("failed to instantiate provisioner %q to obtain schema: %s", name, err),
 			)
 			return
 		}
@@ -214,7 +214,7 @@ func loadProvisionerSchemas(schemas map[string]*configschema.Block, config *conf
 			// future calls.
 			schemas[name] = &configschema.Block{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to retrieve schema from provisioner %q: %s", name, resp.Diagnostics.Err()),
+				fmt.Errorf("failed to retrieve schema from provisioner %q: %s", name, resp.Diagnostics.Err()),
 			)
 			return
 		}

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -22,13 +22,13 @@ func (t *ImportStateTransformer) Transform(g *Graph) error {
 
 		// This is only likely to happen in misconfigured tests
 		if t.Config == nil {
-			return fmt.Errorf("Cannot import into an empty configuration.")
+			return fmt.Errorf("cannot import into an empty configuration")
 		}
 
 		// Get the module config
 		modCfg := t.Config.Descendent(target.Addr.Module.Module())
 		if modCfg == nil {
-			return fmt.Errorf("Module %s not found.", target.Addr.Module.Module())
+			return fmt.Errorf("module %s not found", target.Addr.Module.Module())
 		}
 
 		providerAddr := addrs.AbsProviderConfig{

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -255,8 +255,7 @@ func (t *CloseProviderTransformer) Transform(g *Graph) error {
 	cpm := make(map[string]*graphNodeCloseProvider)
 	var err error
 
-	for _, v := range pm {
-		p := v.(GraphNodeProvider)
+	for _, p := range pm {
 		key := p.ProviderAddr().String()
 
 		// get the close provider of this type if we alread created it

--- a/terraform/transform_vertex.go
+++ b/terraform/transform_vertex.go
@@ -31,7 +31,7 @@ func (t *VertexTransformer) Transform(g *Graph) error {
 			if ok := g.Replace(v, newV); !ok {
 				// This should never happen, big problem
 				return fmt.Errorf(
-					"Failed to replace %s with %s!\n\nSource: %#v\n\nTarget: %#v",
+					"failed to replace %s with %s!\n\nSource: %#v\n\nTarget: %#v",
 					dag.VertexName(v), dag.VertexName(newV), v, newV)
 			}
 


### PR DESCRIPTION
Fixes within the terraform package to remove staticcheck errors from running `staticcheck github.com/hashicorp/terraform/terraform`. 

The following notices were fixed:

- Makes error last return
- Unused value
- Unnecessary type transformation
- Errors are lowercase and don't end in punctuation

On the last item, it means that some error appearances will change:

```
        Plugin reinitialization required. Please run "terraform init".
        
        [... cut for brevity...]
        
        2 problems:
        
        - failed to instantiate provider "registry.terraform.io/hashicorp/unknown" to obtain schema: unknown provider "registry.terraform.io/hashicorp/unknown"
 ```

(These bulleted items are now lowercase)