### PR TITLE
cli: Fix rendering of long integers

### DIFF
--- a/repl/format.go
+++ b/repl/format.go
@@ -52,7 +52,7 @@ func FormatValue(v cty.Value, indent int) string {
 			return strconv.Quote(v.AsString())
 		case cty.Number:
 			bf := v.AsBigFloat()
-			return bf.Text('g', -1)
+			return bf.Text('f', -1)
 		case cty.Bool:
 			if v.True() {
 				return "true"

--- a/repl/format_test.go
+++ b/repl/format_test.go
@@ -90,8 +90,20 @@ EOT_`,
 			`5`,
 		},
 		{
+			cty.NumberIntVal(1234567890),
+			`1234567890`,
+		},
+		{
 			cty.NumberFloatVal(5.2),
 			`5.2`,
+		},
+		{
+			cty.NumberFloatVal(123456789.0),
+			`123456789`,
+		},
+		{
+			cty.NumberFloatVal(123456789.01),
+			`123456789.01`,
 		},
 		{
 			cty.False,


### PR DESCRIPTION
Recent changes to the human-readable rendering of outputs and console values led to long integer values being presented in scientific notation (e.g. 1.2345678e+07). While technically correct, this is an unusual way to present integer values.

This commit checks if a number value is an integer, and if so renders it as a sequence of digits instead (e.g. 12345678).

Fixes #27438.