### PR TITLE
Providers: Fix init with broken link in plugin_cache_dir

### DIFF
--- a/internal/getproviders/filesystem_search.go
+++ b/internal/getproviders/filesystem_search.go
@@ -120,7 +120,8 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 		// filesystem object below.
 		info, err = os.Stat(fullPath)
 		if err != nil {
-			return fmt.Errorf("failed to read metadata about %s: %s", fullPath, err)
+			log.Printf("[WARN] failed to read metadata about %s: %s", fullPath, err)
+			return nil
 		}
 
 		switch len(parts) {


### PR DESCRIPTION
Hello

Fixes https://github.com/hashicorp/terraform/issues/27445.

Instead of raising and error, it display a warning (TF_LOG=trace) and continue analyzing the next providers.

Cheers
Romain