### PR TITLE
Corrected minor typo

### DIFF
--- a/website/docs/commands/cli-config.html.markdown
+++ b/website/docs/commands/cli-config.html.markdown
@@ -18,7 +18,7 @@ which apply across all Terraform working directories. This is separate from
 The configuration is placed in a single file whose location depends on the
 host operating system:
 
-* On Windows, the file must be named named `terraform.rc` and placed
+* On Windows, the file must be named `terraform.rc` and placed
   in the relevant user's `%APPDATA%` directory. The physical location
   of this directory depends on your Windows version and system configuration;
   use `$env:APPDATA` in PowerShell to find its location on your system.


### PR DESCRIPTION
On Windows, the file must be named named terraform.rc => On Windows, the file must be named terraform.rc