### PR TITLE
Remove get-plugins flag

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -34,7 +34,7 @@ type InitCommand struct {
 
 func (c *InitCommand) Run(args []string) int {
 	var flagFromModule string
-	var flagBackend, flagGet, flagUpgrade, getPlugins bool
+	var flagBackend, flagGet, flagUpgrade bool
 	var flagPluginPath FlagStringSlice
 	var flagVerifyPlugins bool
 	flagConfigExtra := newRawFlags("-backend-config")
@@ -45,7 +45,6 @@ func (c *InitCommand) Run(args []string) int {
 	cmdFlags.Var(flagConfigExtra, "backend-config", "")
 	cmdFlags.StringVar(&flagFromModule, "from-module", "", "copy the source of the given module into the directory before init")
 	cmdFlags.BoolVar(&flagGet, "get", true, "")
-	cmdFlags.BoolVar(&getPlugins, "get-plugins", true, "no-op flag, use provider_installation blocks to customize provider installation")
 	cmdFlags.BoolVar(&c.forceInitCopy, "force-copy", false, "suppress prompts about copying state data")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
@@ -62,16 +61,6 @@ func (c *InitCommand) Run(args []string) int {
 
 	if len(flagPluginPath) > 0 {
 		c.pluginPath = flagPluginPath
-	}
-
-	// If users are setting the no-op get-plugins command, give them a warning,
-	// this should allow us to remove the flag in the future.
-	if !getPlugins {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Warning,
-			"No-op -get-plugins flag used",
-			`As of Terraform 0.13+, the -get-plugins=false command is a no-op flag. If you would like to customize provider installation, use a provider_installation block or other available Terraform settings.`,
-		))
 	}
 
 	// Validate the arg count
@@ -979,11 +968,6 @@ Options:
                        directory before initialization.
 
   -get=true            Download any modules for this configuration.
-
-  -get-plugins=true    Download any missing plugins for this configuration.
-                       This command is a no-op in Terraform 0.13+: use
-                       -plugin-dir settings or provider_installation blocks
-                       instead.
 
   -input=true          Ask for input if necessary. If false, will error if
                        input was required.

--- a/website/docs/commands/init.html.markdown
+++ b/website/docs/commands/init.html.markdown
@@ -147,7 +147,8 @@ You can modify `terraform init`'s plugin behavior with the following options:
     -> Note: Since Terraform 0.13, this option has been superseded by the
     [`provider_installation`](./cli-config.html#provider-installation) and
     [`plugin_cache_dir`](./cli-config.html#plugin_cache_dir) settings.
-    It should not be used in Terraform versions 0.13+.
+    It should not be used in Terraform versions 0.13+, and this option
+    was removed in Terraform 0.15.
 - `-plugin-dir=PATH` — Force plugin installation to read plugins _only_ from
   the specified directory, as if it had been configured as a `filesystem_mirror`
   in the CLI configuration. If you intend to routinely use a particular


### PR DESCRIPTION
Remove the no-op get-plugins flag, this follows through on a deprecation notice released in the 0.14 series.