### PR TITLE
Remove revision from version command

### DIFF
--- a/.tfdev
+++ b/.tfdev
@@ -1,5 +1,4 @@
 version_info {
-  commit_var  =    "main.GitCommit"
   version_var =    "github.com/hashicorp/terraform/version.Version"
   prerelease_var = "github.com/hashicorp/terraform/version.Prerelease"
 }

--- a/command/version.go
+++ b/command/version.go
@@ -16,7 +16,6 @@ import (
 type VersionCommand struct {
 	Meta
 
-	Revision          string
 	Version           string
 	VersionPrerelease string
 	CheckFunc         VersionCheckFunc
@@ -25,7 +24,6 @@ type VersionCommand struct {
 
 type VersionOutput struct {
 	Version            string            `json:"terraform_version"`
-	Revision           string            `json:"terraform_revision"`
 	Platform           string            `json:"platform"`
 	ProviderSelections map[string]string `json:"provider_selections"`
 	Outdated           bool              `json:"terraform_outdated"`
@@ -80,10 +78,6 @@ func (c *VersionCommand) Run(args []string) int {
 	fmt.Fprintf(&versionString, "Terraform v%s", c.Version)
 	if c.VersionPrerelease != "" {
 		fmt.Fprintf(&versionString, "-%s", c.VersionPrerelease)
-
-		if c.Revision != "" {
-			fmt.Fprintf(&versionString, " (%s)", c.Revision)
-		}
 	}
 
 	// We'll also attempt to print out the selected plugin versions. We do
@@ -139,7 +133,6 @@ func (c *VersionCommand) Run(args []string) int {
 
 		output := VersionOutput{
 			Version:            versionOutput,
-			Revision:           c.Revision,
 			Platform:           c.Platform.String(),
 			ProviderSelections: selectionsOutput,
 			Outdated:           outdated,

--- a/command/version_test.go
+++ b/command/version_test.go
@@ -142,7 +142,6 @@ func TestVersion_json(t *testing.T) {
 	expected := strings.TrimSpace(`
 {
   "terraform_version": "4.5.6",
-  "terraform_revision": "",
   "platform": "aros_riscv64",
   "provider_selections": {},
   "terraform_outdated": false
@@ -190,7 +189,6 @@ func TestVersion_json(t *testing.T) {
 	expected = strings.TrimSpace(`
 {
   "terraform_version": "4.5.6-foo",
-  "terraform_revision": "",
   "platform": "aros_riscv64",
   "provider_selections": {
     "registry.terraform.io/hashicorp/test1": "7.8.9-beta.2",
@@ -223,7 +221,7 @@ func TestVersion_jsonoutdated(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(ui.OutputWriter.String())
-	expected := "{\n  \"terraform_version\": \"4.5.6\",\n  \"terraform_revision\": \"\",\n  \"platform\": \"aros_riscv64\",\n  \"provider_selections\": {},\n  \"terraform_outdated\": true\n}"
+	expected := "{\n  \"terraform_version\": \"4.5.6\",\n  \"platform\": \"aros_riscv64\",\n  \"provider_selections\": {},\n  \"terraform_outdated\": true\n}"
 	if actual != expected {
 		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actual, expected)
 	}

--- a/commands.go
+++ b/commands.go
@@ -270,7 +270,6 @@ func initCommands(
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{
 				Meta:              meta,
-				Revision:          GitCommit,
 				Version:           Version,
 				VersionPrerelease: VersionPrerelease,
 				Platform:          getproviders.CurrentPlatform,

--- a/main.go
+++ b/main.go
@@ -117,8 +117,8 @@ func wrappedMain() int {
 	}
 
 	log.Printf(
-		"[INFO] Terraform version: %s %s %s",
-		Version, VersionPrerelease, GitCommit)
+		"[INFO] Terraform version: %s %s",
+		Version, VersionPrerelease)
 	log.Printf("[INFO] Go runtime version: %s", runtime.Version())
 	log.Printf("[INFO] CLI args: %#v", os.Args)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,10 +10,6 @@ DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 # Change into that directory
 cd "$DIR"
 
-# Get the git commit
-GIT_COMMIT=$(git rev-parse HEAD)
-GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
-
 # Determine the arch/os combos we're building for
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
 XC_OS=${XC_OS:-linux darwin windows freebsd openbsd solaris}
@@ -29,9 +25,6 @@ mkdir -p bin/
 if [[ -n "${TF_DEV}" ]]; then
     XC_OS=$(go env GOOS)
     XC_ARCH=$(go env GOARCH)
-
-    # Allow LD_FLAGS to be appended during development compilations
-    LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} $LD_FLAGS"
 fi
 
 if ! which gox > /dev/null; then

--- a/version.go
+++ b/version.go
@@ -4,9 +4,6 @@ import (
 	"github.com/hashicorp/terraform/version"
 )
 
-// The git commit that was compiled. This will be filled in by the compiler.
-var GitCommit string
-
 var Version = version.Version
 
 var VersionPrerelease = version.Prerelease


### PR DESCRIPTION
The revision field is only populated on dev builds so this means most releases of Terraform have an empty "terraform_revision" field in the JSON output. Since we recommend developers use go tooling to `go build` this tool when developing, the revision is not useful data and so it is removed.

The `.tfdev` file is for people who use the [internal] terraform-devtool, and I checked to ensure this removal wouldn't break users who depend on that -- it appears not to (the value going into the devtool should be nil now).