### PR TITLE
Update the MockProvider to use correct types and allow default behaviors

### DIFF
--- a/backend/local/backend_apply_test.go
+++ b/backend/local/backend_apply_test.go
@@ -27,7 +27,7 @@ func TestLocal_applyBasic(t *testing.T) {
 	defer cleanup()
 
 	p := TestLocalProvider(t, b, "test", applyFixtureSchema())
-	p.ApplyResourceChangeResponse = providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{
 		"id":  cty.StringVal("yes"),
 		"ami": cty.StringVal("bar"),
 	})}
@@ -70,7 +70,7 @@ func TestLocal_applyEmptyDir(t *testing.T) {
 	defer cleanup()
 
 	p := TestLocalProvider(t, b, "test", &terraform.ProviderSchema{})
-	p.ApplyResourceChangeResponse = providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("yes")})}
+	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("yes")})}
 
 	op, configCleanup := testOperationApply(t, "./testdata/empty")
 	defer configCleanup()
@@ -101,7 +101,7 @@ func TestLocal_applyEmptyDirDestroy(t *testing.T) {
 	defer cleanup()
 
 	p := TestLocalProvider(t, b, "test", &terraform.ProviderSchema{})
-	p.ApplyResourceChangeResponse = providers.ApplyResourceChangeResponse{}
+	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{}
 
 	op, configCleanup := testOperationApply(t, "./testdata/empty")
 	defer configCleanup()
@@ -193,7 +193,7 @@ func TestLocal_applyBackendFail(t *testing.T) {
 	defer cleanup()
 
 	p := TestLocalProvider(t, b, "test", applyFixtureSchema())
-	p.ApplyResourceChangeResponse = providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{
 		"id":  cty.StringVal("yes"),
 		"ami": cty.StringVal("bar"),
 	})}

--- a/backend/local/backend_refresh_test.go
+++ b/backend/local/backend_refresh_test.go
@@ -24,7 +24,7 @@ func TestLocal_refresh(t *testing.T) {
 	testStateFile(t, b.StatePath, testRefreshState())
 
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
 		"id": cty.StringVal("yes"),
 	})}
 
@@ -76,7 +76,7 @@ func TestLocal_refreshInput(t *testing.T) {
 	testStateFile(t, b.StatePath, testRefreshState())
 
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
 		"id": cty.StringVal("yes"),
 	})}
 	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
@@ -119,7 +119,7 @@ func TestLocal_refreshValidate(t *testing.T) {
 	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
 	testStateFile(t, b.StatePath, testRefreshState())
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
 		"id": cty.StringVal("yes"),
 	})}
 
@@ -165,7 +165,7 @@ func TestLocal_refreshValidateProviderConfigured(t *testing.T) {
 	p := TestLocalProvider(t, b, "test", schema)
 	testStateFile(t, b.StatePath, testRefreshState())
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
 		"id": cty.StringVal("yes"),
 	})}
 

--- a/backend/local/testing.go
+++ b/backend/local/testing.go
@@ -72,7 +72,21 @@ func TestLocalProvider(t *testing.T, b *Local, name string, schema *terraform.Pr
 	if schema == nil {
 		schema = &terraform.ProviderSchema{} // default schema is empty
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider:      providers.Schema{Block: schema.Provider},
+		ProviderMeta:  providers.Schema{Block: schema.ProviderMeta},
+		ResourceTypes: map[string]providers.Schema{},
+		DataSources:   map[string]providers.Schema{},
+	}
+	for name, res := range schema.ResourceTypes {
+		p.GetSchemaResponse.ResourceTypes[name] = providers.Schema{
+			Block:   res,
+			Version: int64(schema.ResourceTypeSchemaVersions[name]),
+		}
+	}
+	for name, dat := range schema.DataSources {
+		p.GetSchemaResponse.DataSources[name] = providers.Schema{Block: dat}
+	}
 
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		rSchema, _ := schema.SchemaForResourceType(addrs.ManagedResourceMode, req.TypeName)

--- a/backend/remote/testing.go
+++ b/backend/remote/testing.go
@@ -175,7 +175,7 @@ func testLocalBackend(t *testing.T, remote *Remote) backend.Enhanced {
 			},
 		},
 	})
-	p.ApplyResourceChangeResponse = providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{
 		"id": cty.StringVal("yes"),
 	})}
 

--- a/command/apply_destroy_test.go
+++ b/command/apply_destroy_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statefile"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestApply_destroy(t *testing.T) {
@@ -38,12 +37,14 @@ func TestApply_destroy(t *testing.T) {
 	statePath := testStateFile(t, originalState)
 
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":  {Type: cty.String, Computed: true},
+						"ami": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -225,17 +226,21 @@ func TestApply_destroyTargeted(t *testing.T) {
 	statePath := testStateFile(t, originalState)
 
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Computed: true},
+					},
 				},
 			},
 			"test_load_balancer": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":        {Type: cty.String, Computed: true},
-					"instances": {Type: cty.List(cty.String), Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":        {Type: cty.String, Computed: true},
+						"instances": {Type: cty.List(cty.String), Optional: true},
+					},
 				},
 			},
 		},

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -177,9 +177,9 @@ func TestApply_parallelism(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		name := fmt.Sprintf("test%d", i)
 		provider := &terraform.MockProvider{}
-		provider.GetSchemaReturn = &terraform.ProviderSchema{
-			ResourceTypes: map[string]*configschema.Block{
-				name + "_instance": {},
+		provider.GetSchemaResponse = &providers.GetSchemaResponse{
+			ResourceTypes: map[string]providers.Schema{
+				name + "_instance": {Block: &configschema.Block{}},
 			},
 		}
 		provider.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
@@ -359,13 +359,15 @@ func TestApply_error(t *testing.T) {
 		resp.PlannedState = cty.ObjectVal(s)
 		return
 	}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":    {Type: cty.String, Optional: true, Computed: true},
-					"ami":   {Type: cty.String, Optional: true},
-					"error": {Type: cty.Bool, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":    {Type: cty.String, Optional: true, Computed: true},
+						"ami":   {Type: cty.String, Optional: true},
+						"error": {Type: cty.Bool, Optional: true},
+					},
 				},
 			},
 		},
@@ -903,11 +905,13 @@ func TestApply_shutdown(t *testing.T) {
 		return
 	}
 
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"ami": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"ami": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -959,12 +963,12 @@ func TestApply_state(t *testing.T) {
 	statePath := testStateFile(t, originalState)
 
 	p := applyFixtureProvider()
-	p.PlanResourceChangeResponse = providers.PlanResourceChangeResponse{
+	p.PlanResourceChangeResponse = &providers.PlanResourceChangeResponse{
 		PlannedState: cty.ObjectVal(map[string]cty.Value{
 			"ami": cty.StringVal("bar"),
 		}),
 	}
-	p.ApplyResourceChangeResponse = providers.ApplyResourceChangeResponse{
+	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"ami": cty.StringVal("bar"),
 		}),
@@ -1089,11 +1093,13 @@ func TestApply_vars(t *testing.T) {
 	}
 
 	actual := ""
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"value": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"value": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -1143,11 +1149,13 @@ func TestApply_varFile(t *testing.T) {
 	}
 
 	actual := ""
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"value": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"value": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -1207,11 +1215,13 @@ func TestApply_varFileDefault(t *testing.T) {
 	}
 
 	actual := ""
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"value": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"value": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -1270,11 +1280,13 @@ func TestApply_varFileDefaultJSON(t *testing.T) {
 	}
 
 	actual := ""
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"value": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"value": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -1327,7 +1339,7 @@ func TestApply_backup(t *testing.T) {
 	backupPath := testTempFile(t)
 
 	p := applyFixtureProvider()
-	p.PlanResourceChangeResponse = providers.PlanResourceChangeResponse{
+	p.PlanResourceChangeResponse = &providers.PlanResourceChangeResponse{
 		PlannedState: cty.ObjectVal(map[string]cty.Value{
 			"ami": cty.StringVal("bar"),
 		}),
@@ -1381,7 +1393,7 @@ func TestApply_disableBackup(t *testing.T) {
 	statePath := testStateFile(t, originalState)
 
 	p := applyFixtureProvider()
-	p.PlanResourceChangeResponse = providers.PlanResourceChangeResponse{
+	p.PlanResourceChangeResponse = &providers.PlanResourceChangeResponse{
 		PlannedState: cty.ObjectVal(map[string]cty.Value{
 			"ami": cty.StringVal("bar"),
 		}),
@@ -1538,13 +1550,15 @@ output = test
 // applyFixtureSchema returns a schema suitable for processing the
 // configuration in testdata/apply . This schema should be
 // assigned to a mock provider named "test".
-func applyFixtureSchema() *terraform.ProviderSchema {
-	return &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+func applyFixtureSchema() *providers.GetSchemaResponse {
+	return &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":  {Type: cty.String, Optional: true, Computed: true},
+						"ami": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -1553,12 +1567,12 @@ func applyFixtureSchema() *terraform.ProviderSchema {
 
 // applyFixtureProvider returns a mock provider that is configured for basic
 // operation with the configuration in testdata/apply. This mock has
-// GetSchemaReturn, PlanResourceChangeFn, and ApplyResourceChangeFn populated,
+// GetSchemaResponse, PlanResourceChangeFn, and ApplyResourceChangeFn populated,
 // with the plan/apply steps just passing through the data determined by
 // Terraform Core.
 func applyFixtureProvider() *terraform.MockProvider {
 	p := testProvider()
-	p.GetSchemaReturn = applyFixtureSchema()
+	p.GetSchemaResponse = applyFixtureSchema()
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: req.ProposedNewState,

--- a/command/console_test.go
+++ b/command/console_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/configs/configschema"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/providers"
 	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -62,16 +62,17 @@ func TestConsole_tfvars(t *testing.T) {
 	}
 
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"value": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"value": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
 	}
-
 	ui := cli.NewMockUi()
 	c := &ConsoleCommand{
 		Meta: Meta{
@@ -110,11 +111,13 @@ func TestConsole_unsetRequiredVars(t *testing.T) {
 	defer testFixCwd(t, tmp, cwd)
 
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"value": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"value": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},

--- a/command/format/state_test.go
+++ b/command/format/state_test.go
@@ -92,43 +92,49 @@ func testProvider() *terraform.MockProvider {
 		return providers.ReadResourceResponse{NewState: req.PriorState}
 	}
 
-	p.GetSchemaReturn = testProviderSchema()
+	p.GetSchemaResponse = testProviderSchema()
 
 	return p
 }
 
-func testProviderSchema() *terraform.ProviderSchema {
-	return &terraform.ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"region": {Type: cty.String, Optional: true},
+func testProviderSchema() *providers.GetSchemaResponse {
+	return &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"region": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"test_resource": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":      {Type: cty.String, Computed: true},
-					"foo":     {Type: cty.String, Optional: true},
-					"woozles": {Type: cty.String, Optional: true},
-				},
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"nested": {
-						Nesting: configschema.NestingList,
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"compute": {Type: cty.String, Optional: true},
-								"value":   {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":      {Type: cty.String, Computed: true},
+						"foo":     {Type: cty.String, Optional: true},
+						"woozles": {Type: cty.String, Optional: true},
+					},
+					BlockTypes: map[string]*configschema.NestedBlock{
+						"nested": {
+							Nesting: configschema.NestingList,
+							Block: configschema.Block{
+								Attributes: map[string]*configschema.Attribute{
+									"compute": {Type: cty.String, Optional: true},
+									"value":   {Type: cty.String, Optional: true},
+								},
 							},
 						},
 					},
 				},
 			},
 		},
-		DataSources: map[string]*configschema.Block{
+		DataSources: map[string]providers.Schema{
 			"test_data_source": {
-				Attributes: map[string]*configschema.Attribute{
-					"compute": {Type: cty.String, Optional: true},
-					"value":   {Type: cty.String, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"compute": {Type: cty.String, Optional: true},
+						"value":   {Type: cty.String, Computed: true},
+					},
 				},
 			},
 		},
@@ -139,7 +145,7 @@ func testSchemas() *terraform.Schemas {
 	provider := testProvider()
 	return &terraform.Schemas{
 		Providers: map[addrs.Provider]*terraform.ProviderSchema{
-			addrs.NewDefaultProvider("test"): provider.GetSchemaReturn,
+			addrs.NewDefaultProvider("test"): provider.ProviderSchema(),
 		},
 	}
 }

--- a/command/import_test.go
+++ b/command/import_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/internal/copy"
 	"github.com/hashicorp/terraform/providers"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
@@ -33,7 +32,7 @@ func TestImport(t *testing.T) {
 	}
 
 	p.ImportResourceStateFn = nil
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "test_instance",
@@ -43,11 +42,13 @@ func TestImport(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Optional: true, Computed: true},
+					},
 				},
 			},
 		},
@@ -84,7 +85,7 @@ func TestImport_providerConfig(t *testing.T) {
 	}
 
 	p.ImportResourceStateFn = nil
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "test_instance",
@@ -94,16 +95,20 @@ func TestImport_providerConfig(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Optional: true, Computed: true},
+					},
 				},
 			},
 		},
@@ -191,7 +196,7 @@ func TestImport_remoteState(t *testing.T) {
 	}
 
 	p.ImportResourceStateFn = nil
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "test_instance",
@@ -201,16 +206,20 @@ func TestImport_remoteState(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Optional: true, Computed: true},
+					},
 				},
 			},
 		},
@@ -338,7 +347,7 @@ func TestImport_providerConfigWithVar(t *testing.T) {
 	}
 
 	p.ImportResourceStateFn = nil
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "test_instance",
@@ -348,16 +357,20 @@ func TestImport_providerConfigWithVar(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Optional: true, Computed: true},
+					},
 				},
 			},
 		},
@@ -412,7 +425,7 @@ func TestImport_providerConfigWithDataSource(t *testing.T) {
 	}
 
 	p.ImportResourceStateFn = nil
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "test_instance",
@@ -422,23 +435,29 @@ func TestImport_providerConfigWithDataSource(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
-			},
-		},
-		ResourceTypes: map[string]*configschema.Block{
-			"test_instance": {
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true, Computed: true},
+					"foo": {Type: cty.String, Optional: true},
 				},
 			},
 		},
-		DataSources: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
+			"test_instance": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Optional: true, Computed: true},
+					},
+				},
+			},
+		},
+		DataSources: map[string]providers.Schema{
 			"test_data": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -469,7 +488,7 @@ func TestImport_providerConfigWithVarDefault(t *testing.T) {
 	}
 
 	p.ImportResourceStateFn = nil
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "test_instance",
@@ -479,16 +498,20 @@ func TestImport_providerConfigWithVarDefault(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Optional: true, Computed: true},
+					},
 				},
 			},
 		},
@@ -542,7 +565,7 @@ func TestImport_providerConfigWithVarFile(t *testing.T) {
 	}
 
 	p.ImportResourceStateFn = nil
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "test_instance",
@@ -552,16 +575,20 @@ func TestImport_providerConfigWithVarFile(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Optional: true, Computed: true},
+					},
 				},
 			},
 		},
@@ -616,7 +643,7 @@ func TestImport_allowMissingResourceConfig(t *testing.T) {
 	}
 
 	p.ImportResourceStateFn = nil
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "test_instance",
@@ -626,11 +653,13 @@ func TestImport_allowMissingResourceConfig(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Optional: true, Computed: true},
+					},
 				},
 			},
 		},
@@ -753,11 +782,13 @@ func TestImportModuleVarFile(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -823,11 +854,13 @@ func TestImportModuleInputVariableEvaluation(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -172,7 +172,7 @@ func TestPlan_noState(t *testing.T) {
 
 	// Verify that the provider was called with the existing state
 	actual := p.PlanResourceChangeRequest.PriorState
-	expected := cty.NullVal(p.GetSchemaReturn.ResourceTypes["test_instance"].ImpliedType())
+	expected := cty.NullVal(p.GetSchemaResponse.ResourceTypes["test_instance"].Block.ImpliedType())
 	if !expected.RawEquals(actual) {
 		t.Fatalf("wrong prior state\ngot:  %#v\nwant: %#v", actual, expected)
 	}
@@ -194,7 +194,7 @@ func TestPlan_outPath(t *testing.T) {
 		},
 	}
 
-	p.PlanResourceChangeResponse = providers.PlanResourceChangeResponse{
+	p.PlanResourceChangeResponse = &providers.PlanResourceChangeResponse{
 		PlannedState: cty.NullVal(cty.EmptyObject),
 	}
 
@@ -292,17 +292,19 @@ func TestPlan_outBackend(t *testing.T) {
 
 	outPath := "foo"
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {
-						Type:     cty.String,
-						Computed: true,
-					},
-					"ami": {
-						Type:     cty.String,
-						Optional: true,
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {
+							Type:     cty.String,
+							Computed: true,
+						},
+						"ami": {
+							Type:     cty.String,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -476,11 +478,13 @@ func TestPlan_validate(t *testing.T) {
 	defer testChdir(t, td)()
 
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Optional: true, Computed: true},
+					},
 				},
 			},
 		},
@@ -589,25 +593,29 @@ func TestPlan_providerArgumentUnset(t *testing.T) {
 
 	p := planFixtureProvider()
 	// override the planFixtureProvider schema to include a required provider argument
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"region": {Type: cty.String, Required: true},
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"region": {Type: cty.String, Required: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true, Computed: true},
-				},
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"network_interface": {
-						Nesting: configschema.NestingList,
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"device_index": {Type: cty.String, Optional: true},
-								"description":  {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":  {Type: cty.String, Optional: true, Computed: true},
+						"ami": {Type: cty.String, Optional: true, Computed: true},
+					},
+					BlockTypes: map[string]*configschema.NestedBlock{
+						"network_interface": {
+							Nesting: configschema.NestingList,
+							Block: configschema.Block{
+								Attributes: map[string]*configschema.Attribute{
+									"device_index": {Type: cty.String, Optional: true},
+									"description":  {Type: cty.String, Optional: true},
+								},
 							},
 						},
 					},
@@ -827,11 +835,13 @@ func TestPlan_shutdown(t *testing.T) {
 		return
 	}
 
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"ami": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"ami": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -883,21 +893,23 @@ func TestPlan_init_required(t *testing.T) {
 // planFixtureSchema returns a schema suitable for processing the
 // configuration in testdata/plan . This schema should be
 // assigned to a mock provider named "test".
-func planFixtureSchema() *terraform.ProviderSchema {
-	return &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+func planFixtureSchema() *providers.GetSchemaResponse {
+	return &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
-				},
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"network_interface": {
-						Nesting: configschema.NestingList,
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"device_index": {Type: cty.String, Optional: true},
-								"description":  {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":  {Type: cty.String, Optional: true, Computed: true},
+						"ami": {Type: cty.String, Optional: true},
+					},
+					BlockTypes: map[string]*configschema.NestedBlock{
+						"network_interface": {
+							Nesting: configschema.NestingList,
+							Block: configschema.Block{
+								Attributes: map[string]*configschema.Attribute{
+									"device_index": {Type: cty.String, Optional: true},
+									"description":  {Type: cty.String, Optional: true},
+								},
 							},
 						},
 					},
@@ -909,11 +921,11 @@ func planFixtureSchema() *terraform.ProviderSchema {
 
 // planFixtureProvider returns a mock provider that is configured for basic
 // operation with the configuration in testdata/plan. This mock has
-// GetSchemaReturn and PlanResourceChangeFn populated, with the plan
+// GetSchemaResponse and PlanResourceChangeFn populated, with the plan
 // step just passing through the new object proposed by Terraform Core.
 func planFixtureProvider() *terraform.MockProvider {
 	p := testProvider()
-	p.GetSchemaReturn = planFixtureSchema()
+	p.GetSchemaResponse = planFixtureSchema()
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: req.ProposedNewState,
@@ -925,13 +937,15 @@ func planFixtureProvider() *terraform.MockProvider {
 // planVarsFixtureSchema returns a schema suitable for processing the
 // configuration in testdata/plan-vars . This schema should be
 // assigned to a mock provider named "test".
-func planVarsFixtureSchema() *terraform.ProviderSchema {
-	return &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+func planVarsFixtureSchema() *providers.GetSchemaResponse {
+	return &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":    {Type: cty.String, Optional: true, Computed: true},
-					"value": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":    {Type: cty.String, Optional: true, Computed: true},
+						"value": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -940,11 +954,11 @@ func planVarsFixtureSchema() *terraform.ProviderSchema {
 
 // planVarsFixtureProvider returns a mock provider that is configured for basic
 // operation with the configuration in testdata/plan-vars. This mock has
-// GetSchemaReturn and PlanResourceChangeFn populated, with the plan
+// GetSchemaResponse and PlanResourceChangeFn populated, with the plan
 // step just passing through the new object proposed by Terraform Core.
 func planVarsFixtureProvider() *terraform.MockProvider {
 	p := testProvider()
-	p.GetSchemaReturn = planVarsFixtureSchema()
+	p.GetSchemaResponse = planVarsFixtureSchema()
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: req.ProposedNewState,

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statefile"
 	"github.com/hashicorp/terraform/states/statemgr"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 var equateEmpty = cmpopts.EquateEmpty()
@@ -40,9 +39,9 @@ func TestRefresh(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaReturn = refreshFixtureSchema()
+	p.GetSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("yes"),
 		}),
@@ -95,7 +94,7 @@ func TestRefresh_empty(t *testing.T) {
 	}
 
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("yes"),
 		}),
@@ -132,9 +131,9 @@ func TestRefresh_lockedState(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaReturn = refreshFixtureSchema()
+	p.GetSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("yes"),
 		}),
@@ -177,9 +176,9 @@ func TestRefresh_cwd(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaReturn = refreshFixtureSchema()
+	p.GetSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("yes"),
 		}),
@@ -249,9 +248,9 @@ func TestRefresh_defaultState(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaReturn = refreshFixtureSchema()
+	p.GetSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("yes"),
 		}),
@@ -312,9 +311,9 @@ func TestRefresh_outPath(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaReturn = refreshFixtureSchema()
+	p.GetSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("yes"),
 		}),
@@ -365,7 +364,7 @@ func TestRefresh_var(t *testing.T) {
 			Ui:               ui,
 		},
 	}
-	p.GetSchemaReturn = refreshVarFixtureSchema()
+	p.GetSchemaResponse = refreshVarFixtureSchema()
 
 	args := []string{
 		"-var", "foo=bar",
@@ -396,7 +395,7 @@ func TestRefresh_varFile(t *testing.T) {
 			Ui:               ui,
 		},
 	}
-	p.GetSchemaReturn = refreshVarFixtureSchema()
+	p.GetSchemaResponse = refreshVarFixtureSchema()
 
 	varFilePath := testTempFile(t)
 	if err := ioutil.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
@@ -432,7 +431,7 @@ func TestRefresh_varFileDefault(t *testing.T) {
 			Ui:               ui,
 		},
 	}
-	p.GetSchemaReturn = refreshVarFixtureSchema()
+	p.GetSchemaResponse = refreshVarFixtureSchema()
 
 	varFileDir := testTempDir(t)
 	varFilePath := filepath.Join(varFileDir, "terraform.tfvars")
@@ -483,12 +482,14 @@ func TestRefresh_varsUnset(t *testing.T) {
 			Ui:               ui,
 		},
 	}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":  {Type: cty.String, Optional: true, Computed: true},
+						"ami": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -540,9 +541,9 @@ func TestRefresh_backup(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaReturn = refreshFixtureSchema()
+	p.GetSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("changed"),
 		}),
@@ -604,9 +605,9 @@ func TestRefresh_disableBackup(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaReturn = refreshFixtureSchema()
+	p.GetSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("yes"),
 		}),
@@ -663,12 +664,14 @@ func TestRefresh_displaysOutputs(t *testing.T) {
 			Ui:               ui,
 		},
 	}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":  {Type: cty.String, Optional: true, Computed: true},
+						"ami": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -692,13 +695,15 @@ func TestRefresh_displaysOutputs(t *testing.T) {
 
 // configuration in testdata/refresh . This schema should be
 // assigned to a mock provider named "test".
-func refreshFixtureSchema() *terraform.ProviderSchema {
-	return &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+func refreshFixtureSchema() *providers.GetSchemaResponse {
+	return &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":  {Type: cty.String, Optional: true, Computed: true},
+						"ami": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -708,17 +713,21 @@ func refreshFixtureSchema() *terraform.ProviderSchema {
 // refreshVarFixtureSchema returns a schema suitable for processing the
 // configuration in testdata/refresh-var . This schema should be
 // assigned to a mock provider named "test".
-func refreshVarFixtureSchema() *terraform.ProviderSchema {
-	return &terraform.ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"value": {Type: cty.String, Optional: true},
+func refreshVarFixtureSchema() *providers.GetSchemaResponse {
+	return &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Optional: true, Computed: true},
+					},
 				},
 			},
 		},

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -408,18 +408,22 @@ func TestShow_json_output_state(t *testing.T) {
 // showFixtureSchema returns a schema suitable for processing the configuration
 // in testdata/show. This schema should be assigned to a mock provider
 // named "test".
-func showFixtureSchema() *terraform.ProviderSchema {
-	return &terraform.ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"region": {Type: cty.String, Optional: true},
+func showFixtureSchema() *providers.GetSchemaResponse {
+	return &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"region": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":  {Type: cty.String, Optional: true, Computed: true},
+						"ami": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -428,12 +432,12 @@ func showFixtureSchema() *terraform.ProviderSchema {
 
 // showFixtureProvider returns a mock provider that is configured for basic
 // operation with the configuration in testdata/show. This mock has
-// GetSchemaReturn, PlanResourceChangeFn, and ApplyResourceChangeFn populated,
+// GetSchemaResponse, PlanResourceChangeFn, and ApplyResourceChangeFn populated,
 // with the plan/apply steps just passing through the data determined by
 // Terraform Core.
 func showFixtureProvider() *terraform.MockProvider {
 	p := testProvider()
-	p.GetSchemaReturn = showFixtureSchema()
+	p.GetSchemaResponse = showFixtureSchema()
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		idVal := req.ProposedNewState.GetAttr("id")
 		amiVal := req.ProposedNewState.GetAttr("ami")

--- a/command/state_show_test.go
+++ b/command/state_show_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/states"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -34,13 +33,15 @@ func TestStateShow(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"foo": {Type: cty.String, Optional: true},
-					"bar": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":  {Type: cty.String, Optional: true, Computed: true},
+						"foo": {Type: cty.String, Optional: true},
+						"bar": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -107,13 +108,15 @@ func TestStateShow_multi(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"foo": {Type: cty.String, Optional: true},
-					"bar": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":  {Type: cty.String, Optional: true, Computed: true},
+						"foo": {Type: cty.String, Optional: true},
+						"bar": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -213,13 +216,15 @@ func TestStateShow_configured_provider(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"foo": {Type: cty.String, Optional: true},
-					"bar": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":  {Type: cty.String, Optional: true, Computed: true},
+						"foo": {Type: cty.String, Optional: true},
+						"bar": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -13,26 +13,28 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/configs/configschema"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/providers"
 )
 
 func setupTest(fixturepath string, args ...string) (*cli.MockUi, int) {
 	ui := new(cli.MockUi)
 	p := testProvider()
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"ami": {Type: cty.String, Optional: true},
-				},
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"network_interface": {
-						Nesting: configschema.NestingList,
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"device_index": {Type: cty.String, Optional: true},
-								"description":  {Type: cty.String, Optional: true},
-								"name":         {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"ami": {Type: cty.String, Optional: true},
+					},
+					BlockTypes: map[string]*configschema.NestedBlock{
+						"network_interface": {
+							Nesting: configschema.NestingList,
+							Block: configschema.Block{
+								Attributes: map[string]*configschema.Attribute{
+									"device_index": {Type: cty.String, Optional: true},
+									"description":  {Type: cty.String, Optional: true},
+									"name":         {Type: cty.String, Optional: true},
+								},
 							},
 						},
 					},

--- a/configs/configschema/path.go
+++ b/configs/configschema/path.go
@@ -1,0 +1,29 @@
+package configschema
+
+import (
+	"github.com/zclconf/go-cty/cty"
+)
+
+// AttributeByPath looks up the Attribute schema which corresponds to the given
+// cty.Path. A nil value is returned if the given path does not correspond to a
+// specific attribute.
+// TODO: this will need to be updated for nested attributes
+func (b *Block) AttributeByPath(path cty.Path) *Attribute {
+	block := b
+	for _, step := range path {
+		switch step := step.(type) {
+		case cty.GetAttrStep:
+			if attr := block.Attributes[step.Name]; attr != nil {
+				return attr
+			}
+
+			if nestedBlock := block.BlockTypes[step.Name]; nestedBlock != nil {
+				block = &nestedBlock.Block
+				continue
+			}
+
+			return nil
+		}
+	}
+	return nil
+}

--- a/configs/configschema/path_test.go
+++ b/configs/configschema/path_test.go
@@ -1,0 +1,121 @@
+package configschema
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestAttributeByPath(t *testing.T) {
+	schema := &Block{
+		Attributes: map[string]*Attribute{
+			"a1": {Description: "a1"},
+			"a2": {Description: "a2"},
+		},
+		BlockTypes: map[string]*NestedBlock{
+			"b1": {
+				Nesting: NestingList,
+				Block: Block{
+					Attributes: map[string]*Attribute{
+						"a3": {Description: "a3"},
+						"a4": {Description: "a4"},
+					},
+					BlockTypes: map[string]*NestedBlock{
+						"b2": {
+							Nesting: NestingMap,
+							Block: Block{
+								Attributes: map[string]*Attribute{
+									"a5": {Description: "a5"},
+									"a6": {Description: "a6"},
+								},
+							},
+						},
+					},
+				},
+			},
+			"b3": {
+				Nesting: NestingMap,
+				Block: Block{
+					Attributes: map[string]*Attribute{
+						"a7": {Description: "a7"},
+						"a8": {Description: "a8"},
+					},
+					BlockTypes: map[string]*NestedBlock{
+						"b4": {
+							Nesting: NestingSet,
+							Block: Block{
+								Attributes: map[string]*Attribute{
+									"a9":  {Description: "a9"},
+									"a10": {Description: "a10"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		path            cty.Path
+		attrDescription string
+		exists          bool
+	}{
+		{
+			cty.GetAttrPath("a2"),
+			"a2",
+			true,
+		},
+		{
+			cty.GetAttrPath("b1"),
+			"block",
+			false,
+		},
+		{
+			cty.GetAttrPath("b1").IndexInt(1).GetAttr("a3"),
+			"a3",
+			true,
+		},
+		{
+			cty.GetAttrPath("b1").IndexInt(1).GetAttr("b2").IndexString("foo").GetAttr("a7"),
+			"missing",
+			false,
+		},
+		{
+			cty.GetAttrPath("b1").IndexInt(1).GetAttr("b2").IndexString("foo").GetAttr("a6"),
+			"a6",
+			true,
+		},
+		{
+			cty.GetAttrPath("b3").IndexString("foo").GetAttr("b2").IndexString("foo").GetAttr("a7"),
+			"missing_block",
+			false,
+		},
+		{
+			cty.GetAttrPath("b3").IndexString("foo").GetAttr("a7"),
+			"a7",
+			true,
+		},
+		{
+			// Index steps don't apply to the schema, so the set Index value doesn't matter.
+			cty.GetAttrPath("b3").IndexString("foo").GetAttr("b4").Index(cty.EmptyObjectVal).GetAttr("a9"),
+			"a9",
+			true,
+		},
+	} {
+		t.Run(tc.attrDescription, func(t *testing.T) {
+			attr := schema.AttributeByPath(tc.path)
+			if !tc.exists && attr == nil {
+				return
+			}
+
+			if attr == nil {
+				t.Fatalf("missing attribute from path %#v\n", tc.path)
+			}
+
+			if attr.Description != tc.attrDescription {
+				t.Fatalf("expected Attribute for %q, got %#v\n", tc.attrDescription, attr)
+			}
+		})
+	}
+}

--- a/repl/session_test.go
+++ b/repl/session_test.go
@@ -184,11 +184,13 @@ func testSession(t *testing.T, test testSessionTest) {
 	t.Helper()
 
 	p := &terraform.MockProvider{}
-	p.GetSchemaReturn = &terraform.ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Computed: true},
+					},
 				},
 			},
 		},

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -1418,7 +1418,7 @@ func TestContext2Apply_dataBasic(t *testing.T) {
 	p := testProvider("null")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
 			"id":  cty.StringVal("yo"),
 			"foo": cty.NullVal(cty.String),
@@ -10402,13 +10402,12 @@ func TestContext2Apply_ProviderMeta_refresh_set(t *testing.T) {
 		},
 	}
 	rrcPMs := map[string]cty.Value{}
-	p.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
+	p.ReadResourceFn = func(req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
 		rrcPMs[req.TypeName] = req.ProviderMeta
-		newState, err := p.GetSchemaReturn.ResourceTypes[req.TypeName].CoerceValue(p.ReadResourceResponse.NewState)
+		newState, err := p.GetSchemaReturn.ResourceTypes[req.TypeName].CoerceValue(req.PriorState)
 		if err != nil {
 			panic(err)
 		}
-		resp := p.ReadResourceResponse
 		resp.NewState = newState
 		return resp
 	}
@@ -10792,7 +10791,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setNoSchema(t *testing.T) {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
 			"id":  cty.StringVal("yo"),
 			"foo": cty.StringVal("bar"),
@@ -10848,7 +10847,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setInvalid(t *testing.T) {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
 			"id":  cty.StringVal("yo"),
 			"foo": cty.StringVal("bar"),
@@ -11497,7 +11496,7 @@ output "output" {
 	nullP.ApplyResourceChangeFn = testApplyFn
 	nullP.PlanResourceChangeFn = testDiffFn
 
-	nullP.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+	nullP.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
 			"id":     cty.StringVal("ID"),
 			"output": cty.StringVal("valid"),

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -94,7 +94,7 @@ func TestContext2Apply_unstable(t *testing.T) {
 		Type: "test_resource",
 		Name: "foo",
 	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
-	schema := p.GetSchemaReturn.ResourceTypes["test_resource"] // automatically available in mock
+	schema := p.GetSchemaResponse.ResourceTypes["test_resource"].Block
 	rds := plan.Changes.ResourceInstance(addr)
 	rd, err := rds.Decode(schema.ImpliedType())
 	if err != nil {
@@ -1600,7 +1600,7 @@ func TestContext2Apply_destroyCrossProviders(t *testing.T) {
 	p_aws := testProvider("aws")
 	p_aws.ApplyResourceChangeFn = testApplyFn
 	p_aws.PlanResourceChangeFn = testDiffFn
-	p_aws.GetSchemaReturn = &ProviderSchema{
+	p_aws.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1623,7 +1623,7 @@ func TestContext2Apply_destroyCrossProviders(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	providers := map[addrs.Provider]providers.Factory{
 		addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p_aws),
@@ -1939,7 +1939,7 @@ func TestContext2Apply_compute(t *testing.T) {
 	p := testProvider("aws")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1974,7 +1974,7 @@ func TestContext2Apply_compute(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -2438,7 +2438,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 		return resp
 	}
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -2448,7 +2448,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	state := states.NewState()
 	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
@@ -2559,7 +2559,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -2568,7 +2568,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	// Step 1: create the resources and instances
 	m := testModule(t, "apply-orphan-resource")
@@ -3172,7 +3172,7 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 	p := testProvider("aws")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"addr": {Type: cty.String, Optional: true},
@@ -3186,12 +3186,12 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	p2 := testProvider("vault")
 	p2.ApplyResourceChangeFn = testApplyFn
 	p2.PlanResourceChangeFn = testDiffFn
-	p2.GetSchemaReturn = &ProviderSchema{
+	p2.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"vault_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3199,7 +3199,7 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	var state *states.State
 
@@ -3293,7 +3293,7 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 	p := testProvider("aws")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"value": {Type: cty.String, Optional: true},
@@ -3307,12 +3307,12 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	p2 := testProvider("vault")
 	p2.ApplyResourceChangeFn = testApplyFn
 	p2.PlanResourceChangeFn = testDiffFn
-	p2.GetSchemaReturn = &ProviderSchema{
+	p2.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"vault_instance": {
@@ -3321,7 +3321,7 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	var state *states.State
 
@@ -3530,7 +3530,7 @@ func TestContext2Apply_multiVarComprehensive(t *testing.T) {
 		}
 	}
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3552,7 +3552,7 @@ func TestContext2Apply_multiVarComprehensive(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	// First, apply with a count of 3
 	ctx := testContext2(t, &ContextOpts{
@@ -3880,7 +3880,7 @@ func TestContext2Apply_multiVarMissingState(t *testing.T) {
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3889,7 +3889,7 @@ func TestContext2Apply_multiVarMissingState(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	// First, apply with a count of 3
 	ctx := testContext2(t, &ContextOpts{
@@ -4447,7 +4447,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 	m := testModule(t, "apply-multi-depose-create-before-destroy")
 	p := testProvider("aws")
 	ps := map[addrs.Provider]providers.Factory{addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p)}
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -4456,7 +4456,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -6328,7 +6328,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 	m := testModule(t, "empty")
 	p := testProvider("test")
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6336,7 +6336,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		// Should actually be called for this test, because Terraform Core
 		// constructs the plan for a destroy operation itself.
@@ -6401,7 +6401,7 @@ func TestContext2Apply_errorCreateInvalidNew(t *testing.T) {
 	m := testModule(t, "apply-error")
 
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6410,7 +6410,7 @@ func TestContext2Apply_errorCreateInvalidNew(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: req.ProposedNewState,
@@ -6465,7 +6465,7 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 	m := testModule(t, "apply-error")
 
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6474,7 +6474,7 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: req.ProposedNewState,
@@ -7713,7 +7713,7 @@ func TestContext2Apply_unknownAttribute(t *testing.T) {
 		return resp
 	}
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -7724,7 +7724,7 @@ func TestContext2Apply_unknownAttribute(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -8074,7 +8074,7 @@ func TestContext2Apply_issue7824(t *testing.T) {
 	p := testProvider("template")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"template_file": {
 				Attributes: map[string]*configschema.Attribute{
@@ -8083,7 +8083,7 @@ func TestContext2Apply_issue7824(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	m, snap := testModuleWithSnapshot(t, "issue-7824")
 
@@ -8130,7 +8130,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 	p := testProvider("template")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"template_file": {
 				Attributes: map[string]*configschema.Attribute{
@@ -8141,7 +8141,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	// Apply cleanly step 0
 	ctx := testContext2(t, &ContextOpts{
@@ -8297,7 +8297,7 @@ func TestContext2Apply_ignoreChangesCreate(t *testing.T) {
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
 
-	instanceSchema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	instanceSchema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	instanceSchema.Attributes["required_field"] = &configschema.Attribute{
 		Type:     cty.String,
 		Required: true,
@@ -8441,7 +8441,7 @@ func TestContext2Apply_ignoreChangesWildcard(t *testing.T) {
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
 
-	instanceSchema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	instanceSchema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	instanceSchema.Attributes["required_field"] = &configschema.Attribute{
 		Type:     cty.String,
 		Required: true,
@@ -9248,7 +9248,7 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 func TestContext2Apply_inconsistentWithPlan(t *testing.T) {
 	m := testModule(t, "apply-inconsistent-with-plan")
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test": {
 				Attributes: map[string]*configschema.Attribute{
@@ -9256,7 +9256,7 @@ func TestContext2Apply_inconsistentWithPlan(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: cty.ObjectVal(map[string]cty.Value{
@@ -9301,7 +9301,7 @@ func TestContext2Apply_inconsistentWithPlan(t *testing.T) {
 func TestContext2Apply_issue19908(t *testing.T) {
 	m := testModule(t, "apply-issue19908")
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test": {
 				Attributes: map[string]*configschema.Attribute{
@@ -9309,7 +9309,7 @@ func TestContext2Apply_issue19908(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: req.ProposedNewState,
@@ -9382,7 +9382,7 @@ func TestContext2Apply_issue19908(t *testing.T) {
 
 func TestContext2Apply_invalidIndexRef(t *testing.T) {
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -9390,7 +9390,7 @@ func TestContext2Apply_invalidIndexRef(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	m := testModule(t, "apply-invalid-index")
@@ -9440,11 +9440,11 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 			},
 		}
 
-		p.GetSchemaReturn = &ProviderSchema{
+		p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 			ResourceTypes: map[string]*configschema.Block{
 				"aws_instance": instanceSchema,
 			},
-		}
+		})
 
 		state := states.NewState()
 		modA := state.EnsureModule(addrs.RootModuleInstance.Child("a", addrs.NoKey))
@@ -9715,7 +9715,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 
 		return testApplyFn(req)
 	}
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -9730,7 +9730,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -10037,7 +10037,7 @@ func TestContext2Apply_ProviderMeta_apply_set(t *testing.T) {
 	m := testModule(t, "provider-meta-set")
 	p := testProvider("test")
 	p.PlanResourceChangeFn = testDiffFn
-	schema := p.GetSchemaReturn
+	schema := p.ProviderSchema()
 	schema.ProviderMeta = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"baz": {
@@ -10064,7 +10064,7 @@ func TestContext2Apply_ProviderMeta_apply_set(t *testing.T) {
 			NewState: cty.ObjectVal(s),
 		}
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10120,7 +10120,7 @@ func TestContext2Apply_ProviderMeta_apply_unset(t *testing.T) {
 	m := testModule(t, "provider-meta-unset")
 	p := testProvider("test")
 	p.PlanResourceChangeFn = testDiffFn
-	schema := p.GetSchemaReturn
+	schema := p.ProviderSchema()
 	schema.ProviderMeta = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"baz": {
@@ -10145,7 +10145,7 @@ func TestContext2Apply_ProviderMeta_apply_unset(t *testing.T) {
 			NewState: cty.ObjectVal(s),
 		}
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10180,7 +10180,7 @@ func TestContext2Apply_ProviderMeta_plan_set(t *testing.T) {
 	m := testModule(t, "provider-meta-set")
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
-	schema := p.GetSchemaReturn
+	schema := p.ProviderSchema()
 	schema.ProviderMeta = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"baz": {
@@ -10196,7 +10196,7 @@ func TestContext2Apply_ProviderMeta_plan_set(t *testing.T) {
 			PlannedState: req.ProposedNewState,
 		}
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10249,7 +10249,7 @@ func TestContext2Apply_ProviderMeta_plan_unset(t *testing.T) {
 	m := testModule(t, "provider-meta-unset")
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
-	schema := p.GetSchemaReturn
+	schema := p.ProviderSchema()
 	schema.ProviderMeta = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"baz": {
@@ -10265,7 +10265,7 @@ func TestContext2Apply_ProviderMeta_plan_unset(t *testing.T) {
 			PlannedState: req.ProposedNewState,
 		}
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10338,7 +10338,7 @@ func TestContext2Apply_ProviderMeta_plan_setInvalid(t *testing.T) {
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	schema := p.GetSchemaReturn
+	schema := p.ProviderSchema()
 	schema.ProviderMeta = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"quux": {
@@ -10347,7 +10347,7 @@ func TestContext2Apply_ProviderMeta_plan_setInvalid(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10392,7 +10392,7 @@ func TestContext2Apply_ProviderMeta_refresh_set(t *testing.T) {
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	schema := p.GetSchemaReturn
+	schema := p.ProviderSchema()
 	schema.ProviderMeta = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"baz": {
@@ -10404,14 +10404,14 @@ func TestContext2Apply_ProviderMeta_refresh_set(t *testing.T) {
 	rrcPMs := map[string]cty.Value{}
 	p.ReadResourceFn = func(req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
 		rrcPMs[req.TypeName] = req.ProviderMeta
-		newState, err := p.GetSchemaReturn.ResourceTypes[req.TypeName].CoerceValue(req.PriorState)
+		newState, err := p.GetSchemaResponse.ResourceTypes[req.TypeName].Block.CoerceValue(req.PriorState)
 		if err != nil {
 			panic(err)
 		}
 		resp.NewState = newState
 		return resp
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10473,7 +10473,7 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 
 	// we need a schema for plan/apply so they don't error
-	schema := p.GetSchemaReturn
+	schema := p.ProviderSchema()
 	schema.ProviderMeta = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"baz": {
@@ -10482,7 +10482,7 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10498,7 +10498,7 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 
 	// drop the schema before refresh, to test that it errors
 	schema.ProviderMeta = nil
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx = testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10542,7 +10542,7 @@ func TestContext2Apply_ProviderMeta_refresh_setInvalid(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 
 	// we need a matching schema for plan/apply so they don't error
-	schema := p.GetSchemaReturn
+	schema := p.ProviderSchema()
 	schema.ProviderMeta = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"baz": {
@@ -10551,7 +10551,7 @@ func TestContext2Apply_ProviderMeta_refresh_setInvalid(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10574,7 +10574,7 @@ func TestContext2Apply_ProviderMeta_refresh_setInvalid(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx = testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10620,7 +10620,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_set(t *testing.T) {
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	schema := p.GetSchemaReturn
+	schema := p.ProviderSchema()
 	schema.ProviderMeta = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"baz": {
@@ -10629,7 +10629,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_set(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10716,7 +10716,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_unset(t *testing.T) {
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	schema := p.GetSchemaReturn
+	schema := p.ProviderSchema()
 	schema.ProviderMeta = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"baz": {
@@ -10725,7 +10725,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_unset(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10831,7 +10831,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setInvalid(t *testing.T) {
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	schema := p.GetSchemaReturn
+	schema := p.ProviderSchema()
 	schema.ProviderMeta = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"quux": {
@@ -10840,7 +10840,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setInvalid(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaReturn = schema
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -11466,7 +11466,7 @@ output "output" {
 	testP.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
 		return providers.ReadResourceResponse{NewState: req.PriorState}
 	}
-	testP.GetSchemaReturn = schemaFn("test")
+	testP.GetSchemaResponse = getSchemaResponseFromProviderSchema(schemaFn("test"))
 
 	providerConfig := ""
 	testP.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
@@ -11491,7 +11491,7 @@ output "output" {
 	nullP.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
 		return providers.ReadResourceResponse{NewState: req.PriorState}
 	}
-	nullP.GetSchemaReturn = schemaFn("null")
+	nullP.GetSchemaResponse = getSchemaResponseFromProviderSchema(schemaFn("null"))
 
 	nullP.ApplyResourceChangeFn = testApplyFn
 	nullP.PlanResourceChangeFn = testDiffFn
@@ -11880,7 +11880,7 @@ resource "test_resource" "foo" {
 	p.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
 		return providers.ReadResourceResponse{NewState: req.PriorState}
 	}
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"test_resource": {
@@ -11908,7 +11908,7 @@ resource "test_resource" "foo" {
 				},
 			},
 		},
-	}
+	})
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
 
@@ -12384,7 +12384,7 @@ resource "test_instance" "a" {
 		return resp
 	}
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -12392,7 +12392,7 @@ resource "test_instance" "a" {
 				},
 			},
 		},
-	}
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -22,7 +22,7 @@ func TestContextImport_basic(t *testing.T) {
 		},
 	})
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -63,7 +63,7 @@ func TestContextImport_countIndex(t *testing.T) {
 		},
 	})
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -125,7 +125,7 @@ func TestContextImport_collision(t *testing.T) {
 		}),
 	})
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -164,7 +164,7 @@ func TestContextImport_missingType(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "import-provider")
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				State: cty.ObjectVal(map[string]cty.Value{
@@ -205,7 +205,7 @@ func TestContextImport_missingType(t *testing.T) {
 func TestContextImport_moduleProvider(t *testing.T) {
 	p := testProvider("aws")
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -269,7 +269,7 @@ func TestContextImport_providerModule(t *testing.T) {
 		},
 	})
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -341,7 +341,7 @@ func TestContextImport_providerConfig(t *testing.T) {
 				},
 			})
 
-			p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+			p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 				ImportedResources: []providers.ImportedResource{
 					{
 						TypeName: "aws_instance",
@@ -396,7 +396,7 @@ func TestContextImport_providerConfigResources(t *testing.T) {
 		},
 	})
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -435,7 +435,7 @@ func TestContextImport_refresh(t *testing.T) {
 		},
 	})
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -448,7 +448,7 @@ func TestContextImport_refresh(t *testing.T) {
 
 	p.ReadResourceFn = nil
 
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"id":  cty.StringVal("foo"),
 			"foo": cty.StringVal("bar"),
@@ -486,7 +486,7 @@ func TestContextImport_refreshNil(t *testing.T) {
 		},
 	})
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -534,7 +534,7 @@ func TestContextImport_module(t *testing.T) {
 		},
 	})
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -576,7 +576,7 @@ func TestContextImport_moduleDepth2(t *testing.T) {
 		},
 	})
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -618,7 +618,7 @@ func TestContextImport_moduleDiff(t *testing.T) {
 		},
 	})
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -674,7 +674,7 @@ func TestContextImport_multiState(t *testing.T) {
 		},
 	}
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -743,7 +743,7 @@ func TestContextImport_multiStateSame(t *testing.T) {
 		},
 	}
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",
@@ -844,7 +844,7 @@ resource "test_resource" "unused" {
 		},
 	}
 
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "test_resource",
@@ -854,7 +854,7 @@ resource "test_resource" "unused" {
 			},
 		},
 	}
-	p.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "test_resource",

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -654,7 +654,7 @@ func TestContextImport_multiState(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "import-provider")
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {Type: cty.String, Optional: true},
@@ -672,7 +672,7 @@ func TestContextImport_multiState(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
@@ -723,7 +723,7 @@ func TestContextImport_multiStateSame(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "import-provider")
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {Type: cty.String, Optional: true},
@@ -741,7 +741,7 @@ func TestContextImport_multiStateSame(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
@@ -829,7 +829,7 @@ resource "test_resource" "unused" {
 `,
 	})
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {Type: cty.String, Optional: true},
@@ -842,7 +842,7 @@ resource "test_resource" "unused" {
 				},
 			},
 		},
-	}
+	})
 
 	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{

--- a/terraform/context_input_test.go
+++ b/terraform/context_input_test.go
@@ -19,7 +19,7 @@ func TestContext2Input_provider(t *testing.T) {
 	p := testProvider("aws")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {
@@ -39,7 +39,7 @@ func TestContext2Input_provider(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	inp := &MockUIInput{
 		InputReturnMap: map[string]string{
@@ -91,7 +91,7 @@ func TestContext2Input_providerMulti(t *testing.T) {
 	p := testProvider("aws")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {
@@ -111,7 +111,7 @@ func TestContext2Input_providerMulti(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	inp := &MockUIInput{
 		InputReturnMap: map[string]string{
@@ -180,7 +180,7 @@ func TestContext2Input_providerId(t *testing.T) {
 	p := testProvider("aws")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {
@@ -200,7 +200,7 @@ func TestContext2Input_providerId(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -245,7 +245,7 @@ func TestContext2Input_providerOnly(t *testing.T) {
 	p := testProvider("aws")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {
@@ -263,7 +263,7 @@ func TestContext2Input_providerOnly(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -405,7 +405,7 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 	p := testProvider("null")
 	m := testModule(t, "input-module-data-vars")
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		DataSources: map[string]*configschema.Block{
 			"null_data_source": {
 				Attributes: map[string]*configschema.Attribute{
@@ -413,7 +413,7 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
 		return providers.ReadDataSourceResponse{
 			State: req.Config,

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -56,7 +56,7 @@ func TestContext2Plan_basic(t *testing.T) {
 		t.Fatalf("expected empty state, got %#v\n", ctx.State())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 	for _, r := range plan.Changes.Resources {
 		ric, err := r.Decode(ty)
@@ -136,7 +136,7 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 		t.Fatalf("\nexpected: %q\ngot:      %q\n", expectedState, ctx.State().String())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	type InstanceGen struct {
@@ -301,7 +301,7 @@ func TestContext2Plan_escapedVar(t *testing.T) {
 		t.Fatalf("expected resource creation, got %s", res.Action)
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	ric, err := res.Decode(ty)
@@ -377,7 +377,7 @@ func TestContext2Plan_modules(t *testing.T) {
 		t.Error("expected 3 resource in plan, got", len(plan.Changes.Resources))
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	expectFoo := objectVal(t, schema, map[string]cty.Value{
@@ -433,7 +433,7 @@ func TestContext2Plan_moduleExpand(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	expected := map[string]struct{}{
@@ -470,7 +470,7 @@ func TestContext2Plan_moduleExpand(t *testing.T) {
 func TestContext2Plan_moduleCycle(t *testing.T) {
 	m := testModule(t, "plan-module-cycle")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -480,7 +480,7 @@ func TestContext2Plan_moduleCycle(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
@@ -495,7 +495,7 @@ func TestContext2Plan_moduleCycle(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -550,7 +550,7 @@ func TestContext2Plan_moduleDeadlock(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+		schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 		ty := schema.ImpliedType()
 
 		for _, res := range plan.Changes.Resources {
@@ -595,7 +595,7 @@ func TestContext2Plan_moduleInput(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -650,7 +650,7 @@ func TestContext2Plan_moduleInputComputed(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -708,7 +708,7 @@ func TestContext2Plan_moduleInputFromVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -746,7 +746,7 @@ func TestContext2Plan_moduleInputFromVar(t *testing.T) {
 func TestContext2Plan_moduleMultiVar(t *testing.T) {
 	m := testModule(t, "plan-module-multi-var")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -756,7 +756,7 @@ func TestContext2Plan_moduleMultiVar(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
@@ -771,7 +771,7 @@ func TestContext2Plan_moduleMultiVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 5 {
@@ -846,7 +846,7 @@ func TestContext2Plan_moduleOrphans(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -942,7 +942,7 @@ func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -1008,7 +1008,7 @@ func TestContext2Plan_moduleProviderInherit(t *testing.T) {
 				defer l.Unlock()
 
 				p := testProvider("aws")
-				p.GetSchemaReturn = &ProviderSchema{
+				p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 					Provider: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"from": {Type: cty.String, Optional: true},
@@ -1021,7 +1021,7 @@ func TestContext2Plan_moduleProviderInherit(t *testing.T) {
 							},
 						},
 					},
-				}
+				})
 				p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
 					from := req.Config.GetAttr("from")
 					if from.IsNull() || from.AsString() != "root" {
@@ -1072,7 +1072,7 @@ func TestContext2Plan_moduleProviderInheritDeep(t *testing.T) {
 				var from string
 				p := testProvider("aws")
 
-				p.GetSchemaReturn = &ProviderSchema{
+				p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 					Provider: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"from": {Type: cty.String, Optional: true},
@@ -1083,7 +1083,7 @@ func TestContext2Plan_moduleProviderInheritDeep(t *testing.T) {
 							Attributes: map[string]*configschema.Attribute{},
 						},
 					},
-				}
+				})
 
 				p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
 					v := req.Config.GetAttr("from")
@@ -1127,7 +1127,7 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 				defer l.Unlock()
 
 				p := testProvider("aws")
-				p.GetSchemaReturn = &ProviderSchema{
+				p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 					Provider: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"to":   {Type: cty.String, Optional: true},
@@ -1141,7 +1141,7 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 							},
 						},
 					},
-				}
+				})
 				p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
 					var buf bytes.Buffer
 					from := req.Config.GetAttr("from")
@@ -1189,7 +1189,7 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 func TestContext2Plan_moduleProviderVar(t *testing.T) {
 	m := testModule(t, "plan-module-provider-var")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"value": {Type: cty.String, Optional: true},
@@ -1202,7 +1202,7 @@ func TestContext2Plan_moduleProviderVar(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1217,7 +1217,7 @@ func TestContext2Plan_moduleProviderVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -1260,7 +1260,7 @@ func TestContext2Plan_moduleVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -1365,7 +1365,7 @@ func TestContext2Plan_moduleVarComputed(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -1515,7 +1515,7 @@ func TestContext2Plan_preventDestroy_countBad(t *testing.T) {
 func TestContext2Plan_preventDestroy_countGood(t *testing.T) {
 	m := testModule(t, "plan-prevent-destroy-count-good")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1524,7 +1524,7 @@ func TestContext2Plan_preventDestroy_countGood(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
@@ -1567,7 +1567,7 @@ func TestContext2Plan_preventDestroy_countGood(t *testing.T) {
 func TestContext2Plan_preventDestroy_countGoodNoChange(t *testing.T) {
 	m := testModule(t, "plan-prevent-destroy-count-good")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1577,7 +1577,7 @@ func TestContext2Plan_preventDestroy_countGoodNoChange(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
@@ -1682,7 +1682,7 @@ func TestContext2Plan_computed(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -1722,7 +1722,7 @@ func TestContext2Plan_computed(t *testing.T) {
 func TestContext2Plan_blockNestingGroup(t *testing.T) {
 	m := testModule(t, "plan-block-nesting-group")
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test": {
 				BlockTypes: map[string]*configschema.NestedBlock{
@@ -1737,7 +1737,7 @@ func TestContext2Plan_blockNestingGroup(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: req.ProposedNewState,
@@ -1794,7 +1794,7 @@ func TestContext2Plan_blockNestingGroup(t *testing.T) {
 func TestContext2Plan_computedDataResource(t *testing.T) {
 	m := testModule(t, "plan-computed-data-resource")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1811,7 +1811,7 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1825,7 +1825,7 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.DataSources["aws_vpc"]
+	schema := p.GetSchemaResponse.DataSources["aws_vpc"].Block
 	ty := schema.ImpliedType()
 
 	if rc := plan.Changes.ResourceInstance(addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "aws_instance", Name: "foo"}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)); rc == nil {
@@ -1856,7 +1856,7 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 func TestContext2Plan_computedInFunction(t *testing.T) {
 	m := testModule(t, "plan-computed-in-function")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1871,7 +1871,7 @@ func TestContext2Plan_computedInFunction(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
@@ -1902,7 +1902,7 @@ func TestContext2Plan_computedInFunction(t *testing.T) {
 func TestContext2Plan_computedDataCountResource(t *testing.T) {
 	m := testModule(t, "plan-computed-data-count")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1919,7 +1919,7 @@ func TestContext2Plan_computedDataCountResource(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1982,7 +1982,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 	m := testModule(t, "plan-data-resource-becomes-computed")
 	p := testProvider("aws")
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1999,7 +1999,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		fooVal := req.ProposedNewState.GetAttr("foo")
@@ -2012,7 +2012,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 		}
 	}
 
-	schema := p.GetSchemaReturn.DataSources["aws_data_source"]
+	schema := p.GetSchemaResponse.DataSources["aws_data_source"].Block
 	ty := schema.ImpliedType()
 
 	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
@@ -2075,7 +2075,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 func TestContext2Plan_computedList(t *testing.T) {
 	m := testModule(t, "plan-computed-list")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -2086,7 +2086,7 @@ func TestContext2Plan_computedList(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2101,7 +2101,7 @@ func TestContext2Plan_computedList(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -2141,7 +2141,7 @@ func TestContext2Plan_computedMultiIndex(t *testing.T) {
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -2151,7 +2151,7 @@ func TestContext2Plan_computedMultiIndex(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	p.PlanResourceChangeFn = testDiffFn
 
@@ -2167,7 +2167,7 @@ func TestContext2Plan_computedMultiIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -2222,7 +2222,7 @@ func TestContext2Plan_count(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 6 {
@@ -2334,7 +2334,7 @@ func TestContext2Plan_countModuleStatic(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -2388,7 +2388,7 @@ func TestContext2Plan_countModuleStaticGrandchild(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -2442,7 +2442,7 @@ func TestContext2Plan_countIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -2498,7 +2498,7 @@ func TestContext2Plan_countVar(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2548,7 +2548,7 @@ func TestContext2Plan_countVar(t *testing.T) {
 func TestContext2Plan_countZero(t *testing.T) {
 	m := testModule(t, "plan-count-zero")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -2556,7 +2556,7 @@ func TestContext2Plan_countZero(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	// This schema contains a DynamicPseudoType, and therefore can't go through any shim functions
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
@@ -2576,7 +2576,7 @@ func TestContext2Plan_countZero(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -2618,7 +2618,7 @@ func TestContext2Plan_countOneIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -2697,7 +2697,7 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2783,7 +2783,7 @@ func TestContext2Plan_countIncreaseFromNotSet(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2862,7 +2862,7 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2955,7 +2955,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 5 {
@@ -3022,7 +3022,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 	m := testModule(t, "plan-count-splat-reference")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3032,7 +3032,7 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
@@ -3083,7 +3083,7 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 6 {
@@ -3139,7 +3139,7 @@ func TestContext2Plan_forEach(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 8 {
@@ -3228,7 +3228,7 @@ func TestContext2Plan_destroy(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3291,7 +3291,7 @@ func TestContext2Plan_moduleDestroy(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3356,7 +3356,7 @@ func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3419,7 +3419,7 @@ func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3452,7 +3452,7 @@ func TestContext2Plan_pathVar(t *testing.T) {
 
 	m := testModule(t, "plan-path-var")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3462,7 +3462,7 @@ func TestContext2Plan_pathVar(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3477,7 +3477,7 @@ func TestContext2Plan_pathVar(t *testing.T) {
 		t.Fatalf("err: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -3535,7 +3535,7 @@ func TestContext2Plan_diffVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3656,7 +3656,7 @@ func TestContext2Plan_orphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3738,7 +3738,7 @@ func TestContext2Plan_state(t *testing.T) {
 	if len(plan.Changes.Resources) < 2 {
 		t.Fatalf("bad: %#v", plan.Changes.Resources)
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3817,7 +3817,7 @@ func TestContext2Plan_taint(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3853,7 +3853,7 @@ func TestContext2Plan_taint(t *testing.T) {
 func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 	m := testModule(t, "plan-taint-ignore-changes")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3863,7 +3863,7 @@ func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
 
@@ -3891,7 +3891,7 @@ func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -3971,7 +3971,7 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			t.Fatalf("unexpected errors: %s", diags.Err())
 		}
 
-		schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+		schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 		ty := schema.ImpliedType()
 
 		if len(plan.Changes.Resources) != 3 {
@@ -4028,7 +4028,7 @@ func TestContext2Plan_targeted(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4077,7 +4077,7 @@ func TestContext2Plan_targetedCrossModule(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -4114,7 +4114,7 @@ func TestContext2Plan_targetedCrossModule(t *testing.T) {
 func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
 	m := testModule(t, "plan-targeted-module-with-provider")
 	p := testProvider("null")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"key": {Type: cty.String, Optional: true},
@@ -4125,7 +4125,7 @@ func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
 				Attributes: map[string]*configschema.Attribute{},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4143,7 +4143,7 @@ func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["null_resource"]
+	schema := p.GetSchemaResponse.ResourceTypes["null_resource"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4204,7 +4204,7 @@ func TestContext2Plan_targetedOrphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4272,7 +4272,7 @@ func TestContext2Plan_targetedModuleOrphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4315,7 +4315,7 @@ func TestContext2Plan_targetedModuleUntargetedVariable(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -4422,7 +4422,7 @@ func TestContext2Plan_targetedOverTen(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	for _, res := range plan.Changes.Resources {
@@ -4521,7 +4521,7 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4594,7 +4594,7 @@ func TestContext2Plan_ignoreChangesWildcard(t *testing.T) {
 func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 	p := testProvider("test")
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_ignore_changes_map": {
 				Attributes: map[string]*configschema.Attribute{
@@ -4602,7 +4602,7 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: req.ProposedNewState,
@@ -4643,7 +4643,7 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["test_ignore_changes_map"]
+	schema := p.GetSchemaResponse.ResourceTypes["test_ignore_changes_map"].Block
 	ty := schema.ImpliedType()
 
 	if got, want := len(plan.Changes.Resources), 1; got != want {
@@ -4706,7 +4706,7 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4733,7 +4733,7 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 func TestContext2Plan_moduleMapLiteral(t *testing.T) {
 	m := testModule(t, "plan-module-map-literal")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -4742,7 +4742,7 @@ func TestContext2Plan_moduleMapLiteral(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
 		s := req.ProposedNewState.AsValueMap()
@@ -4774,7 +4774,7 @@ func TestContext2Plan_moduleMapLiteral(t *testing.T) {
 func TestContext2Plan_computedValueInMap(t *testing.T) {
 	m := testModule(t, "plan-computed-value-in-map")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -4787,7 +4787,7 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
 		resp = testDiffFn(req)
@@ -4819,7 +4819,7 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 	}
 
 	for _, res := range plan.Changes.Resources {
-		schema := p.GetSchemaReturn.ResourceTypes[res.Addr.Resource.Resource.Type]
+		schema := p.GetSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
 
 		ric, err := res.Decode(schema.ImpliedType())
 		if err != nil {
@@ -4849,7 +4849,7 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 	m := testModule(t, "plan-module-variable-from-splat")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -4857,7 +4857,7 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -4876,7 +4876,7 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 	}
 
 	for _, res := range plan.Changes.Resources {
-		schema := p.GetSchemaReturn.ResourceTypes[res.Addr.Resource.Resource.Type]
+		schema := p.GetSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
 
 		ric, err := res.Decode(schema.ImpliedType())
 		if err != nil {
@@ -4904,7 +4904,7 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 func TestContext2Plan_createBeforeDestroy_depends_datasource(t *testing.T) {
 	m := testModule(t, "plan-cbd-depends-datasource")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -4921,7 +4921,7 @@ func TestContext2Plan_createBeforeDestroy_depends_datasource(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		computedVal := req.ProposedNewState.GetAttr("computed")
 		if computedVal.IsNull() {
@@ -4959,9 +4959,9 @@ func TestContext2Plan_createBeforeDestroy_depends_datasource(t *testing.T) {
 		var schema *configschema.Block
 		switch res.Addr.Resource.Resource.Mode {
 		case addrs.DataResourceMode:
-			schema = p.GetSchemaReturn.DataSources[res.Addr.Resource.Resource.Type]
+			schema = p.GetSchemaResponse.DataSources[res.Addr.Resource.Resource.Type].Block
 		case addrs.ManagedResourceMode:
-			schema = p.GetSchemaReturn.ResourceTypes[res.Addr.Resource.Resource.Type]
+			schema = p.GetSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
 		}
 
 		ric, err := res.Decode(schema.ImpliedType())
@@ -5010,7 +5010,7 @@ func TestContext2Plan_listOrder(t *testing.T) {
 	p := testProvider("aws")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5018,7 +5018,7 @@ func TestContext2Plan_listOrder(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -5056,7 +5056,7 @@ func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 	m := testModule(t, "plan-ignore-changes-with-flatmaps")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5072,7 +5072,7 @@ func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -5107,7 +5107,7 @@ func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 	}
 
 	res := plan.Changes.Resources[0]
-	schema := p.GetSchemaReturn.ResourceTypes[res.Addr.Resource.Resource.Type]
+	schema := p.GetSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
 
 	ric, err := res.Decode(schema.ImpliedType())
 	if err != nil {
@@ -5288,7 +5288,7 @@ func TestContext2Plan_computedAttrRefTypeMismatch(t *testing.T) {
 
 func TestContext2Plan_selfRef(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5296,7 +5296,7 @@ func TestContext2Plan_selfRef(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	m := testModule(t, "plan-self-ref")
 	c := testContext2(t, &ContextOpts{
@@ -5325,7 +5325,7 @@ func TestContext2Plan_selfRef(t *testing.T) {
 
 func TestContext2Plan_selfRefMulti(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5333,7 +5333,7 @@ func TestContext2Plan_selfRefMulti(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	m := testModule(t, "plan-self-ref-multi")
 	c := testContext2(t, &ContextOpts{
@@ -5362,7 +5362,7 @@ func TestContext2Plan_selfRefMulti(t *testing.T) {
 
 func TestContext2Plan_selfRefMultiAll(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5370,7 +5370,7 @@ func TestContext2Plan_selfRefMultiAll(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	m := testModule(t, "plan-self-ref-multi-all")
 	c := testContext2(t, &ContextOpts{
@@ -5548,7 +5548,7 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -5615,7 +5615,7 @@ func TestContext2Plan_variableSensitivityModule(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -5688,7 +5688,7 @@ func objectVal(t *testing.T, schema *configschema.Block, m map[string]cty.Value)
 func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 	m := testModule(t, "plan-required-output")
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_resource": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5697,7 +5697,7 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5712,7 +5712,7 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["test_resource"]
+	schema := p.GetSchemaResponse.ResourceTypes["test_resource"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -5753,7 +5753,7 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 func TestContext2Plan_requiredModuleObject(t *testing.T) {
 	m := testModule(t, "plan-required-whole-mod")
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_resource": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5762,7 +5762,7 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5777,7 +5777,7 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaReturn.ResourceTypes["test_resource"]
+	schema := p.GetSchemaResponse.ResourceTypes["test_resource"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -6097,7 +6097,7 @@ data "test_data_source" "foo" {}
 	})
 
 	p := new(MockProvider)
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		DataSources: map[string]*configschema.Block{
 			"test_data_source": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6112,7 +6112,7 @@ data "test_data_source" "foo" {}
 				},
 			},
 		},
-	}
+	})
 
 	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
@@ -6224,7 +6224,7 @@ func TestContext2Plan_targetedModuleInstance(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -6458,7 +6458,7 @@ resource "test_instance" "a" {
 		return resp
 	}
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6466,7 +6466,7 @@ resource "test_instance" "a" {
 				},
 			},
 		},
-	}
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -6515,7 +6515,7 @@ resource "test_instance" "a" {
 		return resp
 	}
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6524,7 +6524,7 @@ resource "test_instance" "a" {
 				},
 			},
 		},
-	}
+	})
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -6569,7 +6569,7 @@ resource "test_instance" "a" {
 	})
 
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6578,7 +6578,7 @@ resource "test_instance" "a" {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
 		var diags tfdiags.Diagnostics

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -28,7 +28,6 @@ import (
 func TestContext2Plan_basic(t *testing.T) {
 	m := testModule(t, "plan-good")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -204,7 +203,6 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 func TestContext2Plan_createBefore_maintainRoot(t *testing.T) {
 	m := testModule(t, "plan-cbd-maintain-root")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -321,7 +319,6 @@ func TestContext2Plan_escapedVar(t *testing.T) {
 func TestContext2Plan_minimal(t *testing.T) {
 	m := testModule(t, "plan-empty")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -420,7 +417,6 @@ func TestContext2Plan_moduleExpand(t *testing.T) {
 	// Test a smattering of plan expansion behavior
 	m := testModule(t, "plan-modules-expand")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -481,7 +477,6 @@ func TestContext2Plan_moduleCycle(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -757,7 +752,6 @@ func TestContext2Plan_moduleMultiVar(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -894,8 +888,8 @@ module.child:
 func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 	m := testModule(t, "plan-modules-remove-provisioners")
 	p := testProvider("aws")
-	pr := testProvisioner()
 	p.PlanResourceChangeFn = testDiffFn
+	pr := testProvisioner()
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -1159,7 +1153,6 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 					return
 				}
 
-				p.PlanResourceChangeFn = testDiffFn
 				return p, nil
 			},
 		},
@@ -1203,7 +1196,6 @@ func TestContext2Plan_moduleProviderVar(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -1302,7 +1294,6 @@ func TestContext2Plan_moduleVar(t *testing.T) {
 func TestContext2Plan_moduleVarWrongTypeBasic(t *testing.T) {
 	m := testModule(t, "plan-module-wrong-var-type")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -1319,7 +1310,6 @@ func TestContext2Plan_moduleVarWrongTypeBasic(t *testing.T) {
 func TestContext2Plan_moduleVarWrongTypeNested(t *testing.T) {
 	m := testModule(t, "plan-module-wrong-var-type-nested")
 	p := testProvider("null")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -1336,7 +1326,6 @@ func TestContext2Plan_moduleVarWrongTypeNested(t *testing.T) {
 func TestContext2Plan_moduleVarWithDefaultValue(t *testing.T) {
 	m := testModule(t, "plan-module-var-with-default-value")
 	p := testProvider("null")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -1472,7 +1461,6 @@ func TestContext2Plan_preventDestroy_good(t *testing.T) {
 func TestContext2Plan_preventDestroy_countBad(t *testing.T) {
 	m := testModule(t, "plan-prevent-destroy-count-bad")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -1525,7 +1513,6 @@ func TestContext2Plan_preventDestroy_countGood(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -1567,6 +1554,7 @@ func TestContext2Plan_preventDestroy_countGood(t *testing.T) {
 func TestContext2Plan_preventDestroy_countGoodNoChange(t *testing.T) {
 	m := testModule(t, "plan-prevent-destroy-count-good")
 	p := testProvider("aws")
+	p.PlanResourceChangeFn = testDiffFn
 	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -1578,7 +1566,6 @@ func TestContext2Plan_preventDestroy_countGoodNoChange(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -1612,7 +1599,6 @@ func TestContext2Plan_preventDestroy_countGoodNoChange(t *testing.T) {
 func TestContext2Plan_preventDestroy_destroyPlan(t *testing.T) {
 	m := testModule(t, "plan-prevent-destroy-good")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -1648,7 +1634,6 @@ func TestContext2Plan_preventDestroy_destroyPlan(t *testing.T) {
 func TestContext2Plan_provisionerCycle(t *testing.T) {
 	m := testModule(t, "plan-provisioner-cycle")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	pr := testProvisioner()
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -1812,7 +1797,6 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -1872,7 +1856,6 @@ func TestContext2Plan_computedInFunction(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
 			"computed": cty.ListVal([]cty.Value{
@@ -1920,7 +1903,6 @@ func TestContext2Plan_computedDataCountResource(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -1951,7 +1933,6 @@ func TestContext2Plan_computedDataCountResource(t *testing.T) {
 func TestContext2Plan_localValueCount(t *testing.T) {
 	m := testModule(t, "plan-local-value-count")
 	p := testProvider("test")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -2075,6 +2056,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 func TestContext2Plan_computedList(t *testing.T) {
 	m := testModule(t, "plan-computed-list")
 	p := testProvider("aws")
+	p.PlanResourceChangeFn = testDiffFn
 	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -2087,7 +2069,6 @@ func TestContext2Plan_computedList(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -2152,8 +2133,6 @@ func TestContext2Plan_computedMultiIndex(t *testing.T) {
 			},
 		},
 	})
-
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -2284,7 +2263,6 @@ func TestContext2Plan_count(t *testing.T) {
 func TestContext2Plan_countComputed(t *testing.T) {
 	m := testModule(t, "plan-count-computed")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -3033,7 +3011,6 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -3126,7 +3103,6 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 func TestContext2Plan_forEach(t *testing.T) {
 	m := testModule(t, "plan-for-each")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -3162,7 +3138,6 @@ func TestContext2Plan_forEachUnknownValue(t *testing.T) {
 	// expect this to produce an error, but not to panic.
 	m := testModule(t, "plan-for-each-unknown-value")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -3193,7 +3168,6 @@ func TestContext2Plan_forEachUnknownValue(t *testing.T) {
 func TestContext2Plan_destroy(t *testing.T) {
 	m := testModule(t, "plan-destroy")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -3256,7 +3230,6 @@ func TestContext2Plan_destroy(t *testing.T) {
 func TestContext2Plan_moduleDestroy(t *testing.T) {
 	m := testModule(t, "plan-module-destroy")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -3320,7 +3293,6 @@ func TestContext2Plan_moduleDestroy(t *testing.T) {
 func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 	m := testModule(t, "plan-module-destroy-gh-1835")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	aModule := state.EnsureModule(addrs.RootModuleInstance.Child("a_module", addrs.NoKey))
@@ -3384,7 +3356,6 @@ func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
 	m := testModule(t, "plan-module-destroy-multivar")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
@@ -3463,7 +3434,6 @@ func TestContext2Plan_pathVar(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -3509,6 +3479,7 @@ func TestContext2Plan_pathVar(t *testing.T) {
 func TestContext2Plan_diffVar(t *testing.T) {
 	m := testModule(t, "plan-diffvar")
 	p := testProvider("aws")
+	p.PlanResourceChangeFn = testDiffFn
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
 	root.SetResourceInstanceCurrent(
@@ -3527,8 +3498,6 @@ func TestContext2Plan_diffVar(t *testing.T) {
 		},
 		State: state,
 	})
-
-	p.PlanResourceChangeFn = testDiffFn
 
 	plan, diags := ctx.Plan()
 	if diags.HasErrors() {
@@ -3582,7 +3551,6 @@ func TestContext2Plan_hook(t *testing.T) {
 	m := testModule(t, "plan-good")
 	h := new(MockHook)
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Hooks:  []Hook{h},
@@ -3610,7 +3578,6 @@ func TestContext2Plan_closeProvider(t *testing.T) {
 	// "provider.aws".
 	m := testModule(t, "plan-close-module-provider")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -3694,7 +3661,6 @@ func TestContext2Plan_orphan(t *testing.T) {
 func TestContext2Plan_shadowUuid(t *testing.T) {
 	m := testModule(t, "plan-shadow-uuid")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -3865,7 +3831,6 @@ func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 		},
 	})
 	p.ApplyResourceChangeFn = testApplyFn
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -4126,7 +4091,6 @@ func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -4164,7 +4128,6 @@ func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
 func TestContext2Plan_targetedOrphan(t *testing.T) {
 	m := testModule(t, "plan-targeted-orphan")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -4232,7 +4195,6 @@ func TestContext2Plan_targetedOrphan(t *testing.T) {
 func TestContext2Plan_targetedModuleOrphan(t *testing.T) {
 	m := testModule(t, "plan-targeted-module-orphan")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
@@ -4353,7 +4315,6 @@ func TestContext2Plan_targetedModuleUntargetedVariable(t *testing.T) {
 func TestContext2Plan_outputContainsTargetedResource(t *testing.T) {
 	m := testModule(t, "plan-untargeted-resource-output")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -4439,7 +4400,6 @@ func TestContext2Plan_targetedOverTen(t *testing.T) {
 func TestContext2Plan_provider(t *testing.T) {
 	m := testModule(t, "plan-provider")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	var value interface{}
 	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
@@ -4608,8 +4568,6 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 			PlannedState: req.ProposedNewState,
 		}
 	}
-
-	p.PlanResourceChangeFn = testDiffFn
 
 	s := states.BuildState(func(ss *states.SyncState) {
 		ss.SetResourceInstanceCurrent(
@@ -4788,7 +4746,6 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
 		resp = testDiffFn(req)
 
@@ -4848,7 +4805,6 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 	m := testModule(t, "plan-module-variable-from-splat")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -5009,7 +4965,6 @@ func TestContext2Plan_listOrder(t *testing.T) {
 	m := testModule(t, "plan-list-order")
 	p := testProvider("aws")
 	p.ApplyResourceChangeFn = testApplyFn
-	p.PlanResourceChangeFn = testDiffFn
 	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -5055,7 +5010,6 @@ func TestContext2Plan_listOrder(t *testing.T) {
 func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 	m := testModule(t, "plan-ignore-changes-with-flatmaps")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -5239,7 +5193,6 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 func TestContext2Plan_computedAttrRefTypeMismatch(t *testing.T) {
 	m := testModule(t, "plan-computed-attr-ref-type-mismatch")
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
 		var diags tfdiags.Diagnostics
 		if req.TypeName == "aws_instance" {
@@ -5252,7 +5205,6 @@ func TestContext2Plan_computedAttrRefTypeMismatch(t *testing.T) {
 			Diagnostics: diags,
 		}
 	}
-	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
 		if req.TypeName != "aws_ami_list" {
 			t.Fatalf("Reached apply for unexpected resource type! %s", req.TypeName)
@@ -5698,7 +5650,6 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -5763,7 +5714,6 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -5910,7 +5860,6 @@ output"out" {
 	})
 
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -5940,7 +5889,6 @@ resource "aws_instance" "foo" {
 	})
 
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	targets := []addrs.Targetable{}
 	target, diags := addrs.ParseTargetStr("module.mod[1].aws_instance.foo[0]")
@@ -6004,7 +5952,6 @@ resource "aws_instance" "foo" {
 	})
 
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	target, diags := addrs.ParseTargetStr("module.mod[1].aws_instance.foo")
 	if diags.HasErrors() {
@@ -6074,7 +6021,6 @@ resource "aws_instance" "foo" {
 	})
 
 	p := testProvider("aws")
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -6156,7 +6102,6 @@ data "test_data_source" "foo" {}
 func TestContext2Plan_scaleInForEach(t *testing.T) {
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
-	p.PlanResourceChangeFn = testDiffFn
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -6293,7 +6238,6 @@ data "test_data_source" "d" {
 func TestContext2Plan_dataReferencesResource(t *testing.T) {
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
-	p.PlanResourceChangeFn = testDiffFn
 
 	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("data source should not be read"))
@@ -6388,7 +6332,6 @@ resource "test_instance" "a" {
 func TestContext2Plan_dataInModuleDependsOn(t *testing.T) {
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
-	p.PlanResourceChangeFn = testDiffFn
 
 	readDataSourceB := false
 	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
@@ -6579,7 +6522,6 @@ resource "test_instance" "a" {
 			},
 		},
 	})
-	p.PlanResourceChangeFn = testDiffFn
 	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
 		var diags tfdiags.Diagnostics
 		if req.TypeName == "test_instance" {
@@ -6626,7 +6568,6 @@ resource "test_instance" "a" {
 	})
 
 	p := testProvider("test")
-	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -6685,7 +6626,6 @@ resource "test_resource" "foo" {
 
 	p := testProvider("test")
 	p.ApplyResourceChangeFn = testApplyFn
-	p.PlanResourceChangeFn = testDiffFn
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -1873,7 +1873,7 @@ func TestContext2Plan_computedInFunction(t *testing.T) {
 		},
 	}
 	p.PlanResourceChangeFn = testDiffFn
-	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
 			"computed": cty.ListVal([]cty.Value{
 				cty.StringVal("foo"),
@@ -2015,7 +2015,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 	schema := p.GetSchemaReturn.DataSources["aws_data_source"]
 	ty := schema.ImpliedType()
 
-	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		// This should not be called, because the configuration for the
 		// data resource contains an unknown value for "foo".
 		Diagnostics: tfdiags.Diagnostics(nil).Append(fmt.Errorf("ReadDataSource called, but should not have been")),
@@ -5412,7 +5412,7 @@ output "out" {
 	})
 
 	p := testProvider("aws")
-	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
 			"id":  cty.StringVal("data_id"),
 			"foo": cty.StringVal("foo"),
@@ -5459,7 +5459,7 @@ resource "aws_instance" "foo" {
 	})
 
 	p := testProvider("aws")
-	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
 			"id":  cty.StringVal("data_id"),
 			"foo": cty.StringVal("foo"),
@@ -6114,7 +6114,7 @@ data "test_data_source" "foo" {}
 		},
 	}
 
-	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
 			"id":  cty.StringVal("data_id"),
 			"foo": cty.StringVal("foo"),
@@ -6261,7 +6261,7 @@ data "test_data_source" "d" {
 `})
 
 	p := testProvider("test")
-	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
 			"id":  cty.StringVal("this"),
 			"foo": cty.NullVal(cty.String),

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -41,7 +41,7 @@ func TestContext2Refresh(t *testing.T) {
 		State: state,
 	})
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 	readState, err := hcl2shim.HCL2ValueFromFlatmap(map[string]string{"id": "foo", "foo": "baz"}, ty)
 	if err != nil {
@@ -105,7 +105,7 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 	})
 
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -113,7 +113,7 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
 		return providers.ReadResourceResponse{
 			NewState: readStateVal,
@@ -132,7 +132,7 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 		State: startingState,
 	})
 
-	schema := p.GetSchemaReturn.ResourceTypes["test_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["test_instance"].Block
 	ty := schema.ImpliedType()
 
 	s, diags := ctx.Refresh()
@@ -169,7 +169,7 @@ func TestContext2Refresh_dataComputedModuleVar(t *testing.T) {
 		return resp
 	}
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -199,7 +199,7 @@ func TestContext2Refresh_dataComputedModuleVar(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -220,7 +220,7 @@ func TestContext2Refresh_dataComputedModuleVar(t *testing.T) {
 
 func TestContext2Refresh_targeted(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_elb": {
@@ -252,7 +252,7 @@ func TestContext2Refresh_targeted(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -297,7 +297,7 @@ func TestContext2Refresh_targeted(t *testing.T) {
 
 func TestContext2Refresh_targetedCount(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_elb": {
@@ -329,7 +329,7 @@ func TestContext2Refresh_targetedCount(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -384,7 +384,7 @@ func TestContext2Refresh_targetedCount(t *testing.T) {
 
 func TestContext2Refresh_targetedCountIndex(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_elb": {
@@ -416,7 +416,7 @@ func TestContext2Refresh_targetedCountIndex(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -463,7 +463,7 @@ func TestContext2Refresh_targetedCountIndex(t *testing.T) {
 
 func TestContext2Refresh_moduleComputedVar(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -479,7 +479,7 @@ func TestContext2Refresh_moduleComputedVar(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	m := testModule(t, "refresh-module-computed-var")
@@ -515,7 +515,7 @@ func TestContext2Refresh_delete(t *testing.T) {
 
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
-		NewState: cty.NullVal(p.GetSchemaReturn.ResourceTypes["aws_instance"].ImpliedType()),
+		NewState: cty.NullVal(p.GetSchemaResponse.ResourceTypes["aws_instance"].Block.ImpliedType()),
 	}
 	p.PlanResourceChangeFn = testDiffFn
 
@@ -641,7 +641,7 @@ func TestContext2Refresh_moduleInputComputedOutput(t *testing.T) {
 	m := testModule(t, "refresh-module-input-computed-output")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -658,7 +658,7 @@ func TestContext2Refresh_moduleInputComputedOutput(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -714,7 +714,7 @@ func TestContext2Refresh_noState(t *testing.T) {
 
 func TestContext2Refresh_output(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -731,7 +731,7 @@ func TestContext2Refresh_output(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	m := testModule(t, "refresh-output")
@@ -770,7 +770,7 @@ func TestContext2Refresh_outputPartial(t *testing.T) {
 	// we need to make DiffFn available to let that complete.
 	p.PlanResourceChangeFn = testDiffFn
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -782,11 +782,11 @@ func TestContext2Refresh_outputPartial(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
-		NewState: cty.NullVal(p.GetSchemaReturn.ResourceTypes["aws_instance"].ImpliedType()),
+		NewState: cty.NullVal(p.GetSchemaResponse.ResourceTypes["aws_instance"].Block.ImpliedType()),
 	}
 
 	state := states.NewState()
@@ -829,7 +829,7 @@ func TestContext2Refresh_stateBasic(t *testing.T) {
 		State: state,
 	})
 
-	schema := p.GetSchemaReturn.ResourceTypes["aws_instance"]
+	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	readStateVal, err := schema.CoerceValue(cty.ObjectVal(map[string]cty.Value{
@@ -875,7 +875,7 @@ func TestContext2Refresh_dataCount(t *testing.T) {
 		resp.PlannedState = cty.ObjectVal(m)
 		return resp
 	}
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test": {
 				Attributes: map[string]*configschema.Attribute{
@@ -887,7 +887,7 @@ func TestContext2Refresh_dataCount(t *testing.T) {
 		DataSources: map[string]*configschema.Block{
 			"test": {},
 		},
-	}
+	})
 
 	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
 		return providers.ReadDataSourceResponse{
@@ -924,12 +924,12 @@ func TestContext2Refresh_dataState(t *testing.T) {
 	}
 
 	p := testProvider("null")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		DataSources: map[string]*configschema.Block{
 			"null_data_source": schema,
 		},
-	}
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
@@ -974,7 +974,7 @@ func TestContext2Refresh_dataState(t *testing.T) {
 
 func TestContext2Refresh_dataStateRefData(t *testing.T) {
 	p := testProvider("null")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		DataSources: map[string]*configschema.Block{
 			"null_data_source": {
@@ -994,7 +994,7 @@ func TestContext2Refresh_dataStateRefData(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	m := testModule(t, "refresh-data-ref-data")
 	state := states.NewState()
@@ -1115,10 +1115,10 @@ func TestContext2Refresh_vars(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider:      &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{"aws_instance": schema},
-	}
+	})
 
 	m := testModule(t, "refresh-vars")
 	state := states.NewState()
@@ -1248,7 +1248,7 @@ func TestContext2Refresh_orphanModule(t *testing.T) {
 
 func TestContext2Validate(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -1264,7 +1264,7 @@ func TestContext2Validate(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 
 	m := testModule(t, "validate-good")
@@ -1318,7 +1318,7 @@ aws_instance.bar:
 func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
 	m := testModule(t, "refresh-schema-upgrade")
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1332,7 +1332,7 @@ func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
 		ResourceTypeSchemaVersions: map[string]uint64{
 			"test_thing": 5,
 		},
-	}
+	})
 	p.UpgradeResourceStateResponse = &providers.UpgradeResourceStateResponse{
 		UpgradedState: cty.ObjectVal(map[string]cty.Value{
 			"name": cty.StringVal("foo"),
@@ -1405,7 +1405,7 @@ test_thing.bar:
 func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
 	m := testModule(t, "refresh-schema-upgrade")
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1419,7 +1419,7 @@ func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
 		ResourceTypeSchemaVersions: map[string]uint64{
 			"test_thing": 5,
 		},
-	}
+	})
 	p.UpgradeResourceStateResponse = &providers.UpgradeResourceStateResponse{
 		UpgradedState: cty.ObjectVal(map[string]cty.Value{
 			"name": cty.StringVal("foo"),
@@ -1527,7 +1527,7 @@ data "aws_data_source" "foo" {
 func TestContext2Refresh_dataResourceDependsOn(t *testing.T) {
 	m := testModule(t, "plan-data-depends-on")
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_resource": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1543,7 +1543,7 @@ func TestContext2Refresh_dataResourceDependsOn(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	p.PlanResourceChangeFn = testDiffFn
 	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -49,7 +49,7 @@ func TestContext2Refresh(t *testing.T) {
 	}
 
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: readState,
 	}
 	p.PlanResourceChangeFn = testDiffFn
@@ -514,7 +514,7 @@ func TestContext2Refresh_delete(t *testing.T) {
 	})
 
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.NullVal(p.GetSchemaReturn.ResourceTypes["aws_instance"].ImpliedType()),
 	}
 	p.PlanResourceChangeFn = testDiffFn
@@ -542,7 +542,7 @@ func TestContext2Refresh_ignoreUncreated(t *testing.T) {
 	})
 
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("foo"),
 		}),
@@ -700,7 +700,7 @@ func TestContext2Refresh_noState(t *testing.T) {
 	})
 
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("foo"),
 		}),
@@ -785,7 +785,7 @@ func TestContext2Refresh_outputPartial(t *testing.T) {
 	}
 
 	p.ReadResourceFn = nil
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.NullVal(p.GetSchemaReturn.ResourceTypes["aws_instance"].ImpliedType()),
 	}
 
@@ -841,7 +841,7 @@ func TestContext2Refresh_stateBasic(t *testing.T) {
 
 	p.ReadResourceFn = nil
 	p.PlanResourceChangeFn = testDiffFn
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: readStateVal,
 	}
 
@@ -1142,7 +1142,7 @@ func TestContext2Refresh_vars(t *testing.T) {
 
 	p.ReadResourceFn = nil
 	p.PlanResourceChangeFn = testDiffFn
-	p.ReadResourceResponse = providers.ReadResourceResponse{
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: readStateVal,
 	}
 
@@ -1333,7 +1333,7 @@ func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
 			"test_thing": 5,
 		},
 	}
-	p.UpgradeResourceStateResponse = providers.UpgradeResourceStateResponse{
+	p.UpgradeResourceStateResponse = &providers.UpgradeResourceStateResponse{
 		UpgradedState: cty.ObjectVal(map[string]cty.Value{
 			"name": cty.StringVal("foo"),
 		}),
@@ -1420,7 +1420,7 @@ func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
 			"test_thing": 5,
 		},
 	}
-	p.UpgradeResourceStateResponse = providers.UpgradeResourceStateResponse{
+	p.UpgradeResourceStateResponse = &providers.UpgradeResourceStateResponse{
 		UpgradedState: cty.ObjectVal(map[string]cty.Value{
 			"name": cty.StringVal("foo"),
 		}),
@@ -1545,7 +1545,7 @@ func TestContext2Refresh_dataResourceDependsOn(t *testing.T) {
 		},
 	}
 	p.PlanResourceChangeFn = testDiffFn
-	p.ReadDataSourceResponse = providers.ReadDataSourceResponse{
+	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		State: cty.ObjectVal(map[string]cty.Value{
 			"compute": cty.StringVal("value"),
 		}),

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -401,10 +401,6 @@ func testDiffFn(req providers.PlanResourceChangeRequest) (resp providers.PlanRes
 
 func testProvider(prefix string) *MockProvider {
 	p := new(MockProvider)
-	p.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
-		return providers.ReadResourceResponse{NewState: req.PriorState}
-	}
-
 	p.GetSchemaResponse = testProviderSchema(prefix)
 
 	return p

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -405,7 +405,7 @@ func testProvider(prefix string) *MockProvider {
 		return providers.ReadResourceResponse{NewState: req.PriorState}
 	}
 
-	p.GetSchemaReturn = testProviderSchema(prefix)
+	p.GetSchemaResponse = testProviderSchema(prefix)
 
 	return p
 }
@@ -465,8 +465,8 @@ func testCheckDeadlock(t *testing.T, f func()) {
 	}
 }
 
-func testProviderSchema(name string) *ProviderSchema {
-	return &ProviderSchema{
+func testProviderSchema(name string) *providers.GetSchemaResponse {
+	return getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"region": {
@@ -708,8 +708,7 @@ func testProviderSchema(name string) *ProviderSchema {
 				},
 			},
 		},
-	}
-
+	})
 }
 
 // contextForPlanViaFile is a helper that creates a temporary plan file, then

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -18,13 +18,13 @@ import (
 
 func TestContext2Validate_badCount(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{},
 			},
 		},
-	}
+	})
 
 	m := testModule(t, "validate-bad-count")
 	c := testContext2(t, &ContextOpts{
@@ -42,13 +42,13 @@ func TestContext2Validate_badCount(t *testing.T) {
 
 func TestContext2Validate_badResource_reference(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{},
 			},
 		},
-	}
+	})
 
 	m := testModule(t, "validate-bad-resource-count")
 	c := testContext2(t, &ContextOpts{
@@ -66,7 +66,7 @@ func TestContext2Validate_badResource_reference(t *testing.T) {
 
 func TestContext2Validate_badVar(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -75,7 +75,7 @@ func TestContext2Validate_badVar(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	m := testModule(t, "validate-bad-var")
 	c := testContext2(t, &ContextOpts{
@@ -94,7 +94,7 @@ func TestContext2Validate_badVar(t *testing.T) {
 func TestContext2Validate_varMapOverrideOld(t *testing.T) {
 	m := testModule(t, "validate-module-pc-vars")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
+	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {Type: cty.String, Optional: true},
@@ -105,7 +105,7 @@ func TestContext2Validate_varMapOverrideOld(t *testing.T) {
 				Attributes: map[string]*configschema.Attribute{},
 			},
 		},
-	}
+	})
 
 	_, diags := NewContext(&ContextOpts{
 		Config: m,
@@ -133,25 +133,31 @@ func TestContext2Validate_varNoDefaultExplicitType(t *testing.T) {
 
 func TestContext2Validate_computedVar(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"value": {Type: cty.String, Optional: true},
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
 			},
 		},
 	}
 	pt := testProvider("test")
-	pt.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	pt.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id":    {Type: cty.String, Computed: true},
-					"value": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":    {Type: cty.String, Computed: true},
+						"value": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -186,19 +192,23 @@ func TestContext2Validate_computedVar(t *testing.T) {
 
 func TestContext2Validate_computedInFunction(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"attr": {Type: cty.Number, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"attr": {Type: cty.Number, Optional: true},
+					},
 				},
 			},
 		},
-		DataSources: map[string]*configschema.Block{
+		DataSources: map[string]providers.Schema{
 			"aws_data_source": {
-				Attributes: map[string]*configschema.Attribute{
-					"optional_attr": {Type: cty.String, Optional: true},
-					"computed":      {Type: cty.String, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"optional_attr": {Type: cty.String, Optional: true},
+						"computed":      {Type: cty.String, Computed: true},
+					},
 				},
 			},
 		},
@@ -223,17 +233,21 @@ func TestContext2Validate_computedInFunction(t *testing.T) {
 // can be realized during a plan.
 func TestContext2Validate_countComputed(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
 			},
 		},
-		DataSources: map[string]*configschema.Block{
+		DataSources: map[string]providers.Schema{
 			"aws_data_source": {
-				Attributes: map[string]*configschema.Attribute{
-					"compute": {Type: cty.String, Optional: true},
-					"value":   {Type: cty.String, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"compute": {Type: cty.String, Optional: true},
+						"value":   {Type: cty.String, Computed: true},
+					},
 				},
 			},
 		},
@@ -255,14 +269,15 @@ func TestContext2Validate_countComputed(t *testing.T) {
 
 func TestContext2Validate_countNegative(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
 			},
 		},
 	}
-
 	m := testModule(t, "validate-count-negative")
 	c := testContext2(t, &ContextOpts{
 		Config: m,
@@ -279,16 +294,17 @@ func TestContext2Validate_countNegative(t *testing.T) {
 
 func TestContext2Validate_countVariable(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
 	}
-
 	m := testModule(t, "apply-count-variable")
 	c := testContext2(t, &ContextOpts{
 		Config: m,
@@ -306,16 +322,17 @@ func TestContext2Validate_countVariable(t *testing.T) {
 func TestContext2Validate_countVariableNoDefault(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "validate-count-variable")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
 	}
-
 	_, diags := NewContext(&ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -330,16 +347,17 @@ func TestContext2Validate_countVariableNoDefault(t *testing.T) {
 
 func TestContext2Validate_moduleBadOutput(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
 	}
-
 	m := testModule(t, "validate-bad-module-output")
 	c := testContext2(t, &ContextOpts{
 		Config: m,
@@ -356,16 +374,17 @@ func TestContext2Validate_moduleBadOutput(t *testing.T) {
 
 func TestContext2Validate_moduleGood(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
 	}
-
 	m := testModule(t, "validate-good-module")
 	c := testContext2(t, &ContextOpts{
 		Config: m,
@@ -383,10 +402,12 @@ func TestContext2Validate_moduleGood(t *testing.T) {
 func TestContext2Validate_moduleBadResource(t *testing.T) {
 	m := testModule(t, "validate-module-bad-rc")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
 			},
 		},
 	}
@@ -411,11 +432,13 @@ func TestContext2Validate_moduleBadResource(t *testing.T) {
 func TestContext2Validate_moduleDepsShouldNotCycle(t *testing.T) {
 	m := testModule(t, "validate-module-deps-cycle")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -437,16 +460,20 @@ func TestContext2Validate_moduleDepsShouldNotCycle(t *testing.T) {
 func TestContext2Validate_moduleProviderVar(t *testing.T) {
 	m := testModule(t, "validate-module-pc-vars")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
-			},
-		},
-		ResourceTypes: map[string]*configschema.Block{
-			"aws_instance": {
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
+				},
+			},
+		},
+		ResourceTypes: map[string]providers.Schema{
+			"aws_instance": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -481,16 +508,20 @@ func TestContext2Validate_moduleProviderVar(t *testing.T) {
 func TestContext2Validate_moduleProviderInheritUnused(t *testing.T) {
 	m := testModule(t, "validate-module-pc-inherit-unused")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
-			},
-		},
-		ResourceTypes: map[string]*configschema.Block{
-			"aws_instance": {
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
+				},
+			},
+		},
+		ResourceTypes: map[string]providers.Schema{
+			"aws_instance": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -518,12 +549,14 @@ func TestContext2Validate_moduleProviderInheritUnused(t *testing.T) {
 
 func TestContext2Validate_orphans(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
-					"num": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+						"num": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -562,15 +595,19 @@ func TestContext2Validate_orphans(t *testing.T) {
 func TestContext2Validate_providerConfig_bad(t *testing.T) {
 	m := testModule(t, "validate-bad-pc")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
 			},
 		},
 	}
@@ -598,15 +635,19 @@ func TestContext2Validate_providerConfig_bad(t *testing.T) {
 func TestContext2Validate_providerConfig_skippedEmpty(t *testing.T) {
 	m := testModule(t, "validate-skipped-pc-empty")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
 			},
 		},
 	}
@@ -631,15 +672,19 @@ func TestContext2Validate_providerConfig_skippedEmpty(t *testing.T) {
 func TestContext2Validate_providerConfig_good(t *testing.T) {
 	m := testModule(t, "validate-bad-pc")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {Type: cty.String, Optional: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
 			},
 		},
 	}
@@ -663,15 +708,19 @@ func TestContext2Validate_requiredProviderConfig(t *testing.T) {
 	m := testModule(t, "validate-required-provider-config")
 	p := testProvider("aws")
 
-	p.GetSchemaReturn = &ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"required_attribute": {Type: cty.String, Required: true},
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"required_attribute": {Type: cty.String, Required: true},
+				},
 			},
 		},
-		ResourceTypes: map[string]*configschema.Block{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
 			},
 		},
 	}
@@ -692,11 +741,13 @@ func TestContext2Validate_requiredProviderConfig(t *testing.T) {
 func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 	m := testModule(t, "validate-bad-prov-conf")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -727,11 +778,13 @@ func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 func TestContext2Validate_badResourceConnection(t *testing.T) {
 	m := testModule(t, "validate-bad-resource-connection")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -759,11 +812,13 @@ func TestContext2Validate_badResourceConnection(t *testing.T) {
 func TestContext2Validate_badProvisionerConnection(t *testing.T) {
 	m := testModule(t, "validate-bad-prov-connection")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -791,16 +846,20 @@ func TestContext2Validate_badProvisionerConnection(t *testing.T) {
 func TestContext2Validate_provisionerConfig_good(t *testing.T) {
 	m := testModule(t, "validate-bad-prov-conf")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		Provider: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"foo": {Type: cty.String, Optional: true},
-			},
-		},
-		ResourceTypes: map[string]*configschema.Block{
-			"aws_instance": {
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
+				},
+			},
+		},
+		ResourceTypes: map[string]providers.Schema{
+			"aws_instance": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -836,16 +895,17 @@ func TestContext2Validate_provisionerConfig_good(t *testing.T) {
 func TestContext2Validate_requiredVar(t *testing.T) {
 	m := testModule(t, "validate-required-var")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"ami": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"ami": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
 	}
-
 	_, diags := NewContext(&ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -861,16 +921,17 @@ func TestContext2Validate_requiredVar(t *testing.T) {
 func TestContext2Validate_resourceConfig_bad(t *testing.T) {
 	m := testModule(t, "validate-bad-rc")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
 	}
-
 	c := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -891,16 +952,17 @@ func TestContext2Validate_resourceConfig_bad(t *testing.T) {
 func TestContext2Validate_resourceConfig_good(t *testing.T) {
 	m := testModule(t, "validate-bad-rc")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
 	}
-
 	c := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -916,12 +978,14 @@ func TestContext2Validate_resourceConfig_good(t *testing.T) {
 
 func TestContext2Validate_tainted(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
-					"num": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+						"num": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -962,12 +1026,14 @@ func TestContext2Validate_targetedDestroy(t *testing.T) {
 	pr := simpleMockProvisioner()
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
-					"num": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+						"num": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -1004,11 +1070,13 @@ func TestContext2Validate_targetedDestroy(t *testing.T) {
 func TestContext2Validate_varRefUnknown(t *testing.T) {
 	m := testModule(t, "validate-variable-ref")
 	p := testProvider("aws")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -1051,11 +1119,13 @@ func TestContext2Validate_interpolateVar(t *testing.T) {
 	p := testProvider("null")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"template_file": {
-				Attributes: map[string]*configschema.Attribute{
-					"template": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"template": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -1084,11 +1154,13 @@ func TestContext2Validate_interpolateComputedModuleVarDef(t *testing.T) {
 	p := testProvider("aws")
 	p.ApplyResourceChangeFn = testApplyFn
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"attr": {Type: cty.String, Optional: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"attr": {Type: cty.String, Optional: true},
+					},
 				},
 			},
 		},
@@ -1867,11 +1939,13 @@ resource "test_instance" "a" {
 	})
 
 	p := testProvider("test")
-	p.GetSchemaReturn = &ProviderSchema{
-		ResourceTypes: map[string]*configschema.Block{
+	p.GetSchemaResponse = &providers.GetSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Computed: true},
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Computed: true},
+					},
 				},
 			},
 		},

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -398,7 +398,7 @@ func TestContext2Validate_moduleBadResource(t *testing.T) {
 		},
 	})
 
-	p.ValidateResourceTypeConfigResponse = providers.ValidateResourceTypeConfigResponse{
+	p.ValidateResourceTypeConfigResponse = &providers.ValidateResourceTypeConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
@@ -582,7 +582,7 @@ func TestContext2Validate_providerConfig_bad(t *testing.T) {
 		},
 	})
 
-	p.PrepareProviderConfigResponse = providers.PrepareProviderConfigResponse{
+	p.PrepareProviderConfigResponse = &providers.PrepareProviderConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
@@ -618,7 +618,7 @@ func TestContext2Validate_providerConfig_skippedEmpty(t *testing.T) {
 		},
 	})
 
-	p.PrepareProviderConfigResponse = providers.PrepareProviderConfigResponse{
+	p.PrepareProviderConfigResponse = &providers.PrepareProviderConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("should not be called")),
 	}
 
@@ -714,7 +714,7 @@ func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 		},
 	})
 
-	p.PrepareProviderConfigResponse = providers.PrepareProviderConfigResponse{
+	p.PrepareProviderConfigResponse = &providers.PrepareProviderConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
@@ -878,7 +878,7 @@ func TestContext2Validate_resourceConfig_bad(t *testing.T) {
 		},
 	})
 
-	p.ValidateResourceTypeConfigResponse = providers.ValidateResourceTypeConfigResponse{
+	p.ValidateResourceTypeConfigResponse = &providers.ValidateResourceTypeConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
@@ -1877,7 +1877,7 @@ resource "test_instance" "a" {
 		},
 	}
 
-	p.ValidateResourceTypeConfigResponse = providers.ValidateResourceTypeConfigResponse{
+	p.ValidateResourceTypeConfigResponse = &providers.ValidateResourceTypeConfigResponse{
 		Diagnostics: tfdiags.Diagnostics(nil).Append(tfdiags.SimpleWarning("don't frobble")),
 	}
 

--- a/terraform/graph_builder_plan_test.go
+++ b/terraform/graph_builder_plan_test.go
@@ -16,23 +16,16 @@ func TestPlanGraphBuilder_impl(t *testing.T) {
 
 func TestPlanGraphBuilder(t *testing.T) {
 	awsProvider := &MockProvider{
-		GetSchemaReturn: &ProviderSchema{
-			Provider: simpleTestSchema(),
-			ResourceTypes: map[string]*configschema.Block{
-				"aws_security_group": simpleTestSchema(),
-				"aws_instance":       simpleTestSchema(),
-				"aws_load_balancer":  simpleTestSchema(),
+		GetSchemaResponse: &providers.GetSchemaResponse{
+			Provider: providers.Schema{Block: simpleTestSchema()},
+			ResourceTypes: map[string]providers.Schema{
+				"aws_security_group": {Block: simpleTestSchema()},
+				"aws_instance":       {Block: simpleTestSchema()},
+				"aws_load_balancer":  {Block: simpleTestSchema()},
 			},
 		},
 	}
-	openstackProvider := &MockProvider{
-		GetSchemaReturn: &ProviderSchema{
-			Provider: simpleTestSchema(),
-			ResourceTypes: map[string]*configschema.Block{
-				"openstack_floating_ip": simpleTestSchema(),
-			},
-		},
-	}
+	openstackProvider := mockProviderWithResourceTypeSchema("openstack_floating_ip", simpleTestSchema())
 	components := &basicComponentFactory{
 		providers: map[addrs.Provider]providers.Factory{
 			addrs.NewDefaultProvider("aws"):       providers.FactoryFixed(awsProvider),
@@ -45,8 +38,8 @@ func TestPlanGraphBuilder(t *testing.T) {
 		Components: components,
 		Schemas: &Schemas{
 			Providers: map[addrs.Provider]*ProviderSchema{
-				addrs.NewDefaultProvider("aws"):       awsProvider.GetSchemaReturn,
-				addrs.NewDefaultProvider("openstack"): openstackProvider.GetSchemaReturn,
+				addrs.NewDefaultProvider("aws"):       awsProvider.ProviderSchema(),
+				addrs.NewDefaultProvider("openstack"): openstackProvider.ProviderSchema(),
 			},
 		},
 	}
@@ -68,28 +61,22 @@ func TestPlanGraphBuilder(t *testing.T) {
 }
 
 func TestPlanGraphBuilder_dynamicBlock(t *testing.T) {
-	provider := &MockProvider{
-		GetSchemaReturn: &ProviderSchema{
-			ResourceTypes: map[string]*configschema.Block{
-				"test_thing": {
+	provider := mockProviderWithResourceTypeSchema("test_thing", &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id":   {Type: cty.String, Computed: true},
+			"list": {Type: cty.List(cty.String), Computed: true},
+		},
+		BlockTypes: map[string]*configschema.NestedBlock{
+			"nested": {
+				Nesting: configschema.NestingList,
+				Block: configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
-						"id":   {Type: cty.String, Computed: true},
-						"list": {Type: cty.List(cty.String), Computed: true},
-					},
-					BlockTypes: map[string]*configschema.NestedBlock{
-						"nested": {
-							Nesting: configschema.NestingList,
-							Block: configschema.Block{
-								Attributes: map[string]*configschema.Attribute{
-									"foo": {Type: cty.String, Optional: true},
-								},
-							},
-						},
+						"foo": {Type: cty.String, Optional: true},
 					},
 				},
 			},
 		},
-	}
+	})
 	components := &basicComponentFactory{
 		providers: map[addrs.Provider]providers.Factory{
 			addrs.NewDefaultProvider("test"): providers.FactoryFixed(provider),
@@ -101,7 +88,7 @@ func TestPlanGraphBuilder_dynamicBlock(t *testing.T) {
 		Components: components,
 		Schemas: &Schemas{
 			Providers: map[addrs.Provider]*ProviderSchema{
-				addrs.NewDefaultProvider("test"): provider.GetSchemaReturn,
+				addrs.NewDefaultProvider("test"): provider.ProviderSchema(),
 			},
 		},
 	}
@@ -144,23 +131,17 @@ test_thing.c (expand)
 }
 
 func TestPlanGraphBuilder_attrAsBlocks(t *testing.T) {
-	provider := &MockProvider{
-		GetSchemaReturn: &ProviderSchema{
-			ResourceTypes: map[string]*configschema.Block{
-				"test_thing": {
-					Attributes: map[string]*configschema.Attribute{
-						"id": {Type: cty.String, Computed: true},
-						"nested": {
-							Type: cty.List(cty.Object(map[string]cty.Type{
-								"foo": cty.String,
-							})),
-							Optional: true,
-						},
-					},
-				},
+	provider := mockProviderWithResourceTypeSchema("test_thing", &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id": {Type: cty.String, Computed: true},
+			"nested": {
+				Type: cty.List(cty.Object(map[string]cty.Type{
+					"foo": cty.String,
+				})),
+				Optional: true,
 			},
 		},
-	}
+	})
 	components := &basicComponentFactory{
 		providers: map[addrs.Provider]providers.Factory{
 			addrs.NewDefaultProvider("test"): providers.FactoryFixed(provider),
@@ -172,7 +153,7 @@ func TestPlanGraphBuilder_attrAsBlocks(t *testing.T) {
 		Components: components,
 		Schemas: &Schemas{
 			Providers: map[addrs.Provider]*ProviderSchema{
-				addrs.NewDefaultProvider("test"): provider.GetSchemaReturn,
+				addrs.NewDefaultProvider("test"): provider.ProviderSchema(),
 			},
 		},
 	}
@@ -233,14 +214,7 @@ func TestPlanGraphBuilder_targetModule(t *testing.T) {
 }
 
 func TestPlanGraphBuilder_forEach(t *testing.T) {
-	awsProvider := &MockProvider{
-		GetSchemaReturn: &ProviderSchema{
-			Provider: simpleTestSchema(),
-			ResourceTypes: map[string]*configschema.Block{
-				"aws_instance": simpleTestSchema(),
-			},
-		},
-	}
+	awsProvider := mockProviderWithResourceTypeSchema("aws_instance", simpleTestSchema())
 
 	components := &basicComponentFactory{
 		providers: map[addrs.Provider]providers.Factory{
@@ -253,7 +227,7 @@ func TestPlanGraphBuilder_forEach(t *testing.T) {
 		Components: components,
 		Schemas: &Schemas{
 			Providers: map[addrs.Provider]*ProviderSchema{
-				addrs.NewDefaultProvider("aws"): awsProvider.GetSchemaReturn,
+				addrs.NewDefaultProvider("aws"): awsProvider.ProviderSchema(),
 			},
 		},
 	}

--- a/terraform/node_provider_test.go
+++ b/terraform/node_provider_test.go
@@ -231,18 +231,14 @@ func TestNodeApplyableProviderExecute_emptyValidate(t *testing.T) {
 }
 
 func TestNodeApplyableProvider_Validate(t *testing.T) {
-	provider := &MockProvider{
-		GetSchemaReturn: &ProviderSchema{
-			Provider: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{
-					"region": {
-						Type:     cty.String,
-						Required: true,
-					},
-				},
+	provider := mockProviderWithConfigSchema(&configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"region": {
+				Type:     cty.String,
+				Required: true,
 			},
 		},
-	}
+	})
 	ctx := &MockEvalContext{ProviderProvider: provider}
 	ctx.installSimpleEval()
 
@@ -307,18 +303,14 @@ func TestNodeApplyableProvider_Validate(t *testing.T) {
 //TestNodeApplyableProvider_ConfigProvider_config_fn_err for
 //providers.ConfigureRequest responses.
 func TestNodeApplyableProvider_ConfigProvider(t *testing.T) {
-	provider := &MockProvider{
-		GetSchemaReturn: &ProviderSchema{
-			Provider: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{
-					"region": {
-						Type:     cty.String,
-						Optional: true,
-					},
-				},
+	provider := mockProviderWithConfigSchema(&configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"region": {
+				Type:     cty.String,
+				Optional: true,
 			},
 		},
-	}
+	})
 	// For this test, we're returning an error for an optional argument. This
 	// can happen for example if an argument is only conditionally required.
 	provider.PrepareProviderConfigFn = func(req providers.PrepareProviderConfigRequest) (resp providers.PrepareProviderConfigResponse) {
@@ -393,18 +385,14 @@ func TestNodeApplyableProvider_ConfigProvider(t *testing.T) {
 
 //This test is similar to TestNodeApplyableProvider_ConfigProvider, but tests responses from the providers.ConfigureRequest
 func TestNodeApplyableProvider_ConfigProvider_config_fn_err(t *testing.T) {
-	provider := &MockProvider{
-		GetSchemaReturn: &ProviderSchema{
-			Provider: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{
-					"region": {
-						Type:     cty.String,
-						Optional: true,
-					},
-				},
+	provider := mockProviderWithConfigSchema(&configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"region": {
+				Type:     cty.String,
+				Optional: true,
 			},
 		},
-	}
+	})
 	ctx := &MockEvalContext{ProviderProvider: provider}
 	ctx.installSimpleEval()
 	// For this test, provider.PrepareConfigFn will succeed every time but the

--- a/terraform/node_resource_abstract_instance_test.go
+++ b/terraform/node_resource_abstract_instance_test.go
@@ -143,7 +143,7 @@ func TestNodeAbstractResourceInstance_WriteResourceInstanceState(t *testing.T) {
 		},
 	}
 	ctx.ProviderProvider = mockProvider
-	ctx.ProviderSchemaSchema = mockProvider.GetSchemaReturn
+	ctx.ProviderSchemaSchema = mockProvider.ProviderSchema()
 
 	err := node.writeResourceInstanceState(ctx, obj, nil, workingState)
 	if err != nil {

--- a/terraform/node_resource_abstract_test.go
+++ b/terraform/node_resource_abstract_test.go
@@ -157,7 +157,7 @@ func TestNodeAbstractResource_ReadResourceInstanceState(t *testing.T) {
 			ctx := new(MockEvalContext)
 			ctx.StateState = test.State.SyncWrapper()
 			ctx.PathPath = addrs.RootModuleInstance
-			ctx.ProviderSchemaSchema = mockProvider.GetSchemaReturn
+			ctx.ProviderSchemaSchema = mockProvider.ProviderSchema()
 			ctx.ProviderProvider = providers.Interface(mockProvider)
 
 			got, err := test.Node.readResourceInstanceState(ctx, test.Node.Addr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance))
@@ -218,7 +218,7 @@ func TestNodeAbstractResource_ReadResourceInstanceStateDeposed(t *testing.T) {
 			ctx := new(MockEvalContext)
 			ctx.StateState = test.State.SyncWrapper()
 			ctx.PathPath = addrs.RootModuleInstance
-			ctx.ProviderSchemaSchema = mockProvider.GetSchemaReturn
+			ctx.ProviderSchemaSchema = mockProvider.ProviderSchema()
 			ctx.ProviderProvider = providers.Interface(mockProvider)
 
 			key := states.DeposedKey("00000001") // shim from legacy state assigns 0th deposed index this key

--- a/terraform/node_resource_destroy_deposed_test.go
+++ b/terraform/node_resource_destroy_deposed_test.go
@@ -143,7 +143,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_WriteResourceInstanceState(t *
 		},
 	})
 	ctx.ProviderProvider = mockProvider
-	ctx.ProviderSchemaSchema = mockProvider.GetSchemaReturn
+	ctx.ProviderSchemaSchema = mockProvider.ProviderSchema()
 
 	obj := &states.ResourceInstanceObject{
 		Value: cty.ObjectVal(map[string]cty.Value{

--- a/terraform/node_resource_destroy_deposed_test.go
+++ b/terraform/node_resource_destroy_deposed_test.go
@@ -26,7 +26,7 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 	)
 
 	p := testProvider("test")
-	p.UpgradeResourceStateResponse = providers.UpgradeResourceStateResponse{
+	p.UpgradeResourceStateResponse = &providers.UpgradeResourceStateResponse{
 		UpgradedState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("bar"),
 		}),
@@ -86,7 +86,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_Execute(t *testing.T) {
 	)
 
 	p := testProvider("test")
-	p.UpgradeResourceStateResponse = providers.UpgradeResourceStateResponse{
+	p.UpgradeResourceStateResponse = &providers.UpgradeResourceStateResponse{
 		UpgradedState: cty.ObjectVal(map[string]cty.Value{
 			"id": cty.StringVal("bar"),
 		}),

--- a/terraform/node_resource_validate_test.go
+++ b/terraform/node_resource_validate_test.go
@@ -188,7 +188,7 @@ func TestNodeValidatableResource_ValidateResource_managedResource(t *testing.T) 
 
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
-	ctx.ProviderSchemaSchema = mp.GetSchemaReturn
+	ctx.ProviderSchemaSchema = mp.ProviderSchema()
 	ctx.ProviderProvider = p
 
 	err := node.validateResource(ctx)
@@ -218,7 +218,7 @@ func TestNodeValidatableResource_ValidateResource_managedResourceCount(t *testin
 
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
-	ctx.ProviderSchemaSchema = mp.GetSchemaReturn
+	ctx.ProviderSchemaSchema = mp.ProviderSchema()
 	ctx.ProviderProvider = p
 
 	tests := []struct {
@@ -302,7 +302,7 @@ func TestNodeValidatableResource_ValidateResource_dataSource(t *testing.T) {
 
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
-	ctx.ProviderSchemaSchema = mp.GetSchemaReturn
+	ctx.ProviderSchemaSchema = mp.ProviderSchema()
 	ctx.ProviderProvider = p
 
 	diags := node.validateResource(ctx)
@@ -338,7 +338,7 @@ func TestNodeValidatableResource_ValidateResource_valid(t *testing.T) {
 
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
-	ctx.ProviderSchemaSchema = mp.GetSchemaReturn
+	ctx.ProviderSchemaSchema = mp.ProviderSchema()
 	ctx.ProviderProvider = p
 
 	diags := node.validateResource(ctx)
@@ -375,7 +375,7 @@ func TestNodeValidatableResource_ValidateResource_warningsAndErrorsPassedThrough
 
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
-	ctx.ProviderSchemaSchema = mp.GetSchemaReturn
+	ctx.ProviderSchemaSchema = mp.ProviderSchema()
 	ctx.ProviderProvider = p
 
 	diags := node.validateResource(ctx)
@@ -437,7 +437,8 @@ func TestNodeValidatableResource_ValidateResource_invalidDependsOn(t *testing.T)
 
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
-	ctx.ProviderSchemaSchema = mp.GetSchemaReturn
+
+	ctx.ProviderSchemaSchema = mp.ProviderSchema()
 	ctx.ProviderProvider = p
 
 	diags := node.validateResource(ctx)

--- a/terraform/resource_provider_mock_test.go
+++ b/terraform/resource_provider_mock_test.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/providers"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -9,8 +10,8 @@ import (
 // provider with the given schema for its own configuration.
 func mockProviderWithConfigSchema(schema *configschema.Block) *MockProvider {
 	return &MockProvider{
-		GetSchemaReturn: &ProviderSchema{
-			Provider: schema,
+		GetSchemaResponse: &providers.GetSchemaResponse{
+			Provider: providers.Schema{Block: schema},
 		},
 	}
 }
@@ -19,28 +20,81 @@ func mockProviderWithConfigSchema(schema *configschema.Block) *MockProvider {
 // provider with a schema containing a single resource type.
 func mockProviderWithResourceTypeSchema(name string, schema *configschema.Block) *MockProvider {
 	return &MockProvider{
-		GetSchemaReturn: &ProviderSchema{
-			Provider: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{
-					"string": {
-						Type:     cty.String,
-						Optional: true,
-					},
-					"list": {
-						Type:     cty.List(cty.String),
-						Optional: true,
-					},
-					"root": {
-						Type:     cty.Map(cty.String),
-						Optional: true,
+		GetSchemaResponse: &providers.GetSchemaResponse{
+			Provider: providers.Schema{
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"string": {
+							Type:     cty.String,
+							Optional: true,
+						},
+						"list": {
+							Type:     cty.List(cty.String),
+							Optional: true,
+						},
+						"root": {
+							Type:     cty.Map(cty.String),
+							Optional: true,
+						},
 					},
 				},
 			},
-			ResourceTypes: map[string]*configschema.Block{
-				name: schema,
+			ResourceTypes: map[string]providers.Schema{
+				name: providers.Schema{Block: schema},
 			},
 		},
 	}
+}
+
+// mockProviderWithProviderSchema is a test helper to create a mock provider
+// from an existing ProviderSchema.
+func mockProviderWithProviderSchema(providerSchema ProviderSchema) *MockProvider {
+	p := &MockProvider{
+		GetSchemaResponse: &providers.GetSchemaResponse{
+			Provider: providers.Schema{
+				Block: providerSchema.Provider,
+			},
+			ResourceTypes: map[string]providers.Schema{},
+			DataSources:   map[string]providers.Schema{},
+		},
+	}
+
+	for name, schema := range providerSchema.ResourceTypes {
+		p.GetSchemaResponse.ResourceTypes[name] = providers.Schema{
+			Block:   schema,
+			Version: int64(providerSchema.ResourceTypeSchemaVersions[name]),
+		}
+	}
+
+	for name, schema := range providerSchema.DataSources {
+		p.GetSchemaResponse.DataSources[name] = providers.Schema{Block: schema}
+	}
+
+	return p
+}
+
+// getSchemaResponseFromProviderSchema is a test helper to convert a
+// ProviderSchema to a GetSchemaResponse for use when building a mock provider.
+func getSchemaResponseFromProviderSchema(providerSchema *ProviderSchema) *providers.GetSchemaResponse {
+	resp := &providers.GetSchemaResponse{
+		Provider:      providers.Schema{Block: providerSchema.Provider},
+		ProviderMeta:  providers.Schema{Block: providerSchema.ProviderMeta},
+		ResourceTypes: map[string]providers.Schema{},
+		DataSources:   map[string]providers.Schema{},
+	}
+
+	for name, schema := range providerSchema.ResourceTypes {
+		resp.ResourceTypes[name] = providers.Schema{
+			Block:   schema,
+			Version: int64(providerSchema.ResourceTypeSchemaVersions[name]),
+		}
+	}
+
+	for name, schema := range providerSchema.DataSources {
+		resp.DataSources[name] = providers.Schema{Block: schema}
+	}
+
+	return resp
 }
 
 // simpleMockProvider returns a MockProvider that is pre-configured
@@ -62,13 +116,13 @@ func mockProviderWithResourceTypeSchema(name string, schema *configschema.Block)
 // objects so that callers can mutate without affecting mock objects.
 func simpleMockProvider() *MockProvider {
 	return &MockProvider{
-		GetSchemaReturn: &ProviderSchema{
-			Provider: simpleTestSchema(),
-			ResourceTypes: map[string]*configschema.Block{
-				"test_object": simpleTestSchema(),
+		GetSchemaResponse: &providers.GetSchemaResponse{
+			Provider: providers.Schema{Block: simpleTestSchema()},
+			ResourceTypes: map[string]providers.Schema{
+				"test_object": providers.Schema{Block: simpleTestSchema()},
 			},
-			DataSources: map[string]*configschema.Block{
-				"test_object": simpleTestSchema(),
+			DataSources: map[string]providers.Schema{
+				"test_object": providers.Schema{Block: simpleTestSchema()},
 			},
 		},
 	}

--- a/terraform/schemas_test.go
+++ b/terraform/schemas_test.go
@@ -8,9 +8,10 @@ import (
 func simpleTestSchemas() *Schemas {
 	provider := simpleMockProvider()
 	provisioner := simpleMockProvisioner()
+
 	return &Schemas{
 		Providers: map[addrs.Provider]*ProviderSchema{
-			addrs.NewDefaultProvider("test"): provider.GetSchemaReturn,
+			addrs.NewDefaultProvider("test"): provider.ProviderSchema(),
 		},
 		Provisioners: map[string]*configschema.Block{
 			"test": provisioner.GetSchemaResponse.Provisioner,

--- a/terraform/transform_import_state_test.go
+++ b/terraform/transform_import_state_test.go
@@ -14,7 +14,7 @@ import (
 func TestGraphNodeImportStateExecute(t *testing.T) {
 	state := states.NewState()
 	provider := testProvider("aws")
-	provider.ImportResourceStateResponse = providers.ImportResourceStateResponse{
+	provider.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
 		ImportedResources: []providers.ImportedResource{
 			{
 				TypeName: "aws_instance",


### PR DESCRIPTION
These are some basic fixes to the much used `terraform.MockProvider`, which unfortunately create a lot of churn in the test codebase. The end result here is that the `MockProvider` can implement default behaviors as well as easily be allowed to implement invalid behavior for testing. Unifying the mock with the actual types used in the protocol, and providing some baseline expected behavior should allow for easier maintenance and use of the mock in new tests.

The terraform `MockProvider` now uses pointers for the response type fields, so that unset values can be differentiated from zero values. We also will use `providers.GetSchemaResponse` as the schema response type, to ensure that the mock provider is in parity with actual providers. 

Default behaviors are aded to the `MockProvider`, so that simple tests do not need to always assign plan and apply functions. This behavior is based directly upon the documented resource lifecycle, rather than be an ad-hoc collection of behaviors from old tests.

In order to easily create the mock `PlanResourceChange` behavior, there is a new method in `configschema` called `Block.AttributeByPath`.  This should be be useful in other situations where one would use a `cty.Transform` function to modify a `cty.Value`, but need to query the schema. The current implementation only handles absolute paths to Attributes, which is sufficient for our use case here.
