### PR TITLE
Add documentation page for version

### DIFF
--- a/website/docs/cli/plugins/index.html.md
+++ b/website/docs/cli/plugins/index.html.md
@@ -37,6 +37,10 @@ more information, see [CLI Config File](/docs/commands/cli-config.html).
 Use the [`terraform providers`](/docs/commands/providers.html) command to get information
 about the providers required by the current working directory's configuration.
 
+Use the [`terraform version`](/docs/commands/version.html) command (or
+`terraform -version`) to show the specific provider versions installed for the
+current working directory.
+
 Use the [`terraform providers schema`](/docs/commands/providers/schema.html) command to
 get machine-readable information about the resources and configuration options
 offered by each provider.

--- a/website/docs/commands/version.html.markdown
+++ b/website/docs/commands/version.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "docs"
+page_title: "Command: version"
+sidebar_current: "docs-commands-version"
+description: |-
+  The `terraform version` command displays the version of Terraform and all installed plugins.
+---
+
+# Command: version
+
+The `terraform version` displays the current version of Terraform and all
+installed plugins.
+
+## Usage
+
+Usage: `terraform version [options]`
+
+With no additional arguments, `version` will display the version of Terraform,
+the platform it's installed on, installed providers, and the results of upgrade
+and security checks [unless disabled](/docs/commands/index.html#upgrade-and-security-bulletin-checks).
+
+This command has one optional flag:
+
+* `-json` - If specified, the version information is formatted as a JSON object, 
+    and no upgrade or security information is included.
+
+-> **Note:** Platform information was added to the `version` command in Terraform 0.15. 
+
+## Example
+
+Basic usage, with upgrade and security information shown if relevant:
+
+```shellsession
+$ terraform version
+Terraform v0.15.0
+on darwin_amd64
++ provider registry.terraform.io/hashicorp/null v3.0.0
+
+Your version of Terraform is out of date! The latest version
+is X.Y.Z. You can update by downloading from https://www.terraform.io/downloads.html
+```
+
+As JSON:
+
+```shellsession
+$ terraform version -json
+{
+  "terraform_version": "0.15.0",
+  "platform": "darwin_amd64",
+  "provider_selections": {
+    "registry.terraform.io/hashicorp/null": "3.0.0"
+  },
+  "terraform_outdated": true
+}
+```

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -462,11 +462,11 @@
           </li>
 
           <li>
-            <a href="/docs/commands/validate.html"><code>validate</code></a>
+            <a href="/docs/commands/untaint.html"><code>untaint</code></a>
           </li>
 
           <li>
-            <a href="/docs/commands/untaint.html"><code>untaint</code></a>
+            <a href="/docs/commands/validate.html"><code>validate</code></a>
           </li>
 
           <li>

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -292,6 +292,10 @@
           </li>
 
           <li>
+            <a href="/docs/commands/version.html"><code>version</code></a>
+          </li>
+
+          <li>
             <a href="/docs/commands/providers/lock.html"><code>providers lock</code></a>
           </li>
 
@@ -467,6 +471,10 @@
 
           <li>
             <a href="/docs/commands/validate.html"><code>validate</code></a>
+          </li>
+
+          <li>
+            <a href="/docs/commands/version.html"><code>version</code></a>
           </li>
 
           <li>


### PR DESCRIPTION
The version command, although not the mightiest of our commands, did not have a page among our docs. This means that it's not present on the site in the alphabetical listing of commands.