### PR TITLE
Require xterm-style virtual terminal on all platforms, including Windows

### DIFF
--- a/backend/cli.go
+++ b/backend/cli.go
@@ -1,9 +1,11 @@
 package backend
 
 import (
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/colorstring"
+
+	"github.com/hashicorp/terraform/internal/terminal"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 // CLI is an optional interface that can be implemented to be initialized
@@ -47,6 +49,12 @@ type CLIOpts struct {
 	// output will be done. If CLIColor is nil then no coloring will be done.
 	CLI      cli.Ui
 	CLIColor *colorstring.Colorize
+
+	// Streams describes the low-level streams for Stdout, Stderr and Stdin,
+	// including some metadata about whether they are terminals. Most output
+	// should go via the object in field CLI above, but Streams can be useful
+	// for tailoring the output to fit the attached terminal, for example.
+	Streams *terminal.Streams
 
 	// ShowDiagnostics is a function that will format and print diagnostic
 	// messages to the UI.

--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/command/clistate"
 	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/states/statemgr"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
@@ -37,6 +38,10 @@ type Local struct {
 	// output will be done. If CLIColor is nil then no coloring will be done.
 	CLI      cli.Ui
 	CLIColor *colorstring.Colorize
+
+	// If CLI is set then Streams might also be set, to describe the physical
+	// input/output handles that CLI is connected to.
+	Streams *terminal.Streams
 
 	// ShowDiagnostics prints diagnostic messages to the UI.
 	ShowDiagnostics func(vals ...interface{})

--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -32,6 +32,8 @@ func (b *Local) opPlan(
 
 	var diags tfdiags.Diagnostics
 
+	outputColumns := b.outputColumns()
+
 	if op.PlanFile != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -150,6 +152,7 @@ func (b *Local) opPlan(
 
 		if runningOp.PlanEmpty {
 			b.CLI.Output("\n" + b.Colorize().Color(strings.TrimSpace(planNoChanges)))
+			b.CLI.Output("\n" + strings.TrimSpace(format.WordWrap(planNoChangesDetail, outputColumns)))
 			// Even if there are no changes, there still could be some warnings
 			b.ShowDiagnostics(diags)
 			return
@@ -166,15 +169,15 @@ func (b *Local) opPlan(
 		// tool which is presumed to provide its own UI for further actions.
 		if !b.RunningInAutomation {
 
-			b.CLI.Output("\n------------------------------------------------------------------------")
+			b.outputHorizRule()
 
 			if path := op.PlanOutPath; path == "" {
 				b.CLI.Output(fmt.Sprintf(
-					"\n" + strings.TrimSpace(planHeaderNoOutput) + "\n",
+					"\n" + strings.TrimSpace(format.WordWrap(planHeaderNoOutput, outputColumns)) + "\n",
 				))
 			} else {
 				b.CLI.Output(fmt.Sprintf(
-					"\n"+strings.TrimSpace(planHeaderYesOutput)+"\n",
+					"\n"+strings.TrimSpace(format.WordWrap(planHeaderYesOutput, outputColumns))+"\n",
 					path, path,
 				))
 			}
@@ -183,7 +186,7 @@ func (b *Local) opPlan(
 }
 
 func (b *Local) renderPlan(plan *plans.Plan, baseState *states.State, schemas *terraform.Schemas) {
-	RenderPlan(plan, baseState, schemas, b.CLI, b.Colorize())
+	RenderPlan(plan, baseState, schemas, b.CLI, b.Colorize(), b.outputColumns())
 }
 
 // RenderPlan renders the given plan to the given UI.
@@ -206,7 +209,7 @@ func (b *Local) renderPlan(plan *plans.Plan, baseState *states.State, schemas *t
 // output values will not currently be rendered because their prior values
 // are currently stored only in the prior state. (see the docstring for
 // func planHasSideEffects for why this is and when that might change)
-func RenderPlan(plan *plans.Plan, baseState *states.State, schemas *terraform.Schemas, ui cli.Ui, colorize *colorstring.Colorize) {
+func RenderPlan(plan *plans.Plan, baseState *states.State, schemas *terraform.Schemas, ui cli.Ui, colorize *colorstring.Colorize, width int) {
 	counts := map[plans.Action]int{}
 	var rChanges []*plans.ResourceInstanceChangeSrc
 	for _, change := range plan.Changes.Resources {
@@ -220,7 +223,7 @@ func RenderPlan(plan *plans.Plan, baseState *states.State, schemas *terraform.Sc
 	}
 
 	headerBuf := &bytes.Buffer{}
-	fmt.Fprintf(headerBuf, "\n%s\n", strings.TrimSpace(planHeaderIntro))
+	fmt.Fprintf(headerBuf, "\n%s\n", strings.TrimSpace(format.WordWrap(planHeaderIntro, width)))
 	if counts[plans.Create] > 0 {
 		fmt.Fprintf(headerBuf, "%s create\n", format.DiffActionSymbol(plans.Create))
 	}
@@ -330,18 +333,15 @@ func RenderPlan(plan *plans.Plan, baseState *states.State, schemas *terraform.Sc
 }
 
 const planHeaderIntro = `
-An execution plan has been generated and is shown below.
-Resource actions are indicated with the following symbols:
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
 `
 
 const planHeaderNoOutput = `
-Note: You didn't specify an "-out" parameter to save this plan, so Terraform
-can't guarantee that exactly these actions will be performed if
-"terraform apply" is subsequently run.
+Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
 `
 
 const planHeaderYesOutput = `
-This plan was saved to: %s
+Saved the plan to: %s
 
 To perform exactly these actions, run the following command to apply:
     terraform apply %q
@@ -349,8 +349,8 @@ To perform exactly these actions, run the following command to apply:
 
 const planNoChanges = `
 [reset][bold][green]No changes. Infrastructure is up-to-date.[reset][green]
+`
 
-This means that Terraform did not detect any differences between your
-configuration and real physical resources that exist. As a result, no
-actions need to be performed.
+const planNoChangesDetail = `
+That Terraform did not detect any differences between your configuration and the remote system(s). As a result, there are no actions to take.
 `

--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -51,7 +51,7 @@ func TestLocal_planInAutomation(t *testing.T) {
 	defer cleanup()
 	TestLocalProvider(t, b, "test", planFixtureSchema())
 
-	const msg = `You didn't specify an "-out" parameter`
+	const msg = `You didn't use the -out option`
 
 	// When we're "in automation" we omit certain text from the
 	// plan output. However, testing for the absense of text is
@@ -77,7 +77,7 @@ func TestLocal_planInAutomation(t *testing.T) {
 
 		output := b.CLI.(*cli.MockUi).OutputWriter.String()
 		if !strings.Contains(output, msg) {
-			t.Fatalf("missing next-steps message when not in automation")
+			t.Fatalf("missing next-steps message when not in automation\nwant: %s\noutput:\n%s", msg, output)
 		}
 	}
 
@@ -331,8 +331,8 @@ func TestLocal_planTainted(t *testing.T) {
 		t.Fatal("plan should not be empty")
 	}
 
-	expectedOutput := `An execution plan has been generated and is shown below.
-Resource actions are indicated with the following symbols:
+	expectedOutput := `Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
 -/+ destroy and then create replacement
 
 Terraform will perform the following actions:
@@ -433,8 +433,8 @@ func TestLocal_planDeposedOnly(t *testing.T) {
 	// it's also possible for there to be _multiple_ deposed objects, in the
 	// unlikely event that create_before_destroy _keeps_ crashing across
 	// subsequent runs.
-	expectedOutput := `An execution plan has been generated and is shown below.
-Resource actions are indicated with the following symbols:
+	expectedOutput := `Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
   + create
   - destroy
 
@@ -507,8 +507,8 @@ func TestLocal_planTainted_createBeforeDestroy(t *testing.T) {
 		t.Fatal("plan should not be empty")
 	}
 
-	expectedOutput := `An execution plan has been generated and is shown below.
-Resource actions are indicated with the following symbols:
+	expectedOutput := `Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
 +/- create replacement and then destroy
 
 Terraform will perform the following actions:

--- a/backend/local/cli.go
+++ b/backend/local/cli.go
@@ -10,6 +10,7 @@ import (
 func (b *Local) CLIInit(opts *backend.CLIOpts) error {
 	b.CLI = opts.CLI
 	b.CLIColor = opts.CLIColor
+	b.Streams = opts.Streams
 	b.ShowDiagnostics = opts.ShowDiagnostics
 	b.ContextOpts = opts.ContextOpts
 	b.OpInput = opts.Input
@@ -33,4 +34,32 @@ func (b *Local) CLIInit(opts *backend.CLIOpts) error {
 	}
 
 	return nil
+}
+
+// outputColumns returns the number of text character cells any non-error
+// output should be wrapped to.
+//
+// This is the number of columns to use if you are calling b.CLI.Output or
+// b.CLI.Info.
+func (b *Local) outputColumns() int {
+	if b.Streams == nil {
+		// We can potentially get here in tests, if they don't populate the
+		// CLIOpts fully.
+		return 78 // placeholder just so we don't panic
+	}
+	return b.Streams.Stdout.Columns()
+}
+
+// errorColumns returns the number of text character cells any error
+// output should be wrapped to.
+//
+// This is the number of columns to use if you are calling b.CLI.Error or
+// b.CLI.Warn.
+func (b *Local) errorColumns() int {
+	if b.Streams == nil {
+		// We can potentially get here in tests, if they don't populate the
+		// CLIOpts fully.
+		return 78 // placeholder just so we don't panic
+	}
+	return b.Streams.Stderr.Columns()
 }

--- a/backend/local/cli.go
+++ b/backend/local/cli.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/command/format"
 )
 
 // backend.CLI impl.
@@ -62,4 +63,18 @@ func (b *Local) errorColumns() int {
 		return 78 // placeholder just so we don't panic
 	}
 	return b.Streams.Stderr.Columns()
+}
+
+// outputHorizRule will call b.CLI.Output with enough horizontal line
+// characters to fill an entire row of output.
+//
+// This function does nothing if the backend doesn't have a CLI attached.
+//
+// If UI color is enabled, the rule will get a dark grey coloring to try to
+// visually de-emphasize it.
+func (b *Local) outputHorizRule() {
+	if b.CLI == nil {
+		return
+	}
+	b.CLI.Output(format.HorizontalRule(b.CLIColor, b.outputColumns()))
 }

--- a/command/e2etest/primary_test.go
+++ b/command/e2etest/primary_test.go
@@ -59,8 +59,8 @@ func TestPrimarySeparatePlan(t *testing.T) {
 		t.Errorf("incorrect plan tally; want 1 to add:\n%s", stdout)
 	}
 
-	if !strings.Contains(stdout, "This plan was saved to: tfplan") {
-		t.Errorf("missing \"This plan was saved to...\" message in plan output\n%s", stdout)
+	if !strings.Contains(stdout, "Saved the plan to: tfplan") {
+		t.Errorf("missing \"Saved the plan to...\" message in plan output\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "terraform apply \"tfplan\"") {
 		t.Errorf("missing next-step instruction in plan output\n%s", stdout)
@@ -169,8 +169,8 @@ func TestPrimaryChdirOption(t *testing.T) {
 		t.Errorf("incorrect plan tally; want 0 to add:\n%s", stdout)
 	}
 
-	if !strings.Contains(stdout, "This plan was saved to: tfplan") {
-		t.Errorf("missing \"This plan was saved to...\" message in plan output\n%s", stdout)
+	if !strings.Contains(stdout, "Saved the plan to: tfplan") {
+		t.Errorf("missing \"Saved the plan to...\" message in plan output\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "terraform apply \"tfplan\"") {
 		t.Errorf("missing next-step instruction in plan output\n%s", stdout)

--- a/command/format/diagnostic.go
+++ b/command/format/diagnostic.go
@@ -183,11 +183,11 @@ func Diagnostic(diag tfdiags.Diagnostic, sources map[string][]byte, color *color
 	}
 
 	if desc.Detail != "" {
-		if width != 0 {
+		if width > 1 {
 			lines := strings.Split(desc.Detail, "\n")
 			for _, line := range lines {
 				if !strings.HasPrefix(line, " ") {
-					line = wordwrap.WrapString(line, uint(width))
+					line = wordwrap.WrapString(line, uint(width-1))
 				}
 				fmt.Fprintf(&buf, "%s\n", line)
 			}

--- a/command/format/diagnostic.go
+++ b/command/format/diagnostic.go
@@ -172,10 +172,10 @@ func Diagnostic(diag tfdiags.Diagnostic, sources map[string][]byte, color *color
 			sort.Strings(stmts) // FIXME: Should maybe use a traversal-aware sort that can sort numeric indexes properly?
 
 			if len(stmts) > 0 {
-				fmt.Fprint(&buf, color.Color("    [dark_gray]|----------------[reset]\n"))
+				fmt.Fprint(&buf, color.Color("    [dark_gray]├────────────────[reset]\n"))
 			}
 			for _, stmt := range stmts {
-				fmt.Fprintf(&buf, color.Color("    [dark_gray]|[reset] %s\n"), stmt)
+				fmt.Fprintf(&buf, color.Color("    [dark_gray]│[reset] %s\n"), stmt)
 			}
 		}
 

--- a/command/format/diagnostic_test.go
+++ b/command/format/diagnostic_test.go
@@ -94,8 +94,8 @@ Whatever shall we do?
 
   on test.tf line 1:
    1: test [underline]source[reset] code
-    [dark_gray]|----------------[reset]
-    [dark_gray]|[reset] [bold]boop.beep[reset] is "blah"
+    [dark_gray]├────────────────[reset]
+    [dark_gray]│[reset] [bold]boop.beep[reset] is "blah"
 
 Whatever shall we do?
 `,
@@ -127,8 +127,8 @@ Whatever shall we do?
 
   on test.tf line 1:
    1: test [underline]source[reset] code
-    [dark_gray]|----------------[reset]
-    [dark_gray]|[reset] [bold]boop.beep[reset] has a sensitive value
+    [dark_gray]├────────────────[reset]
+    [dark_gray]│[reset] [bold]boop.beep[reset] has a sensitive value
 
 Whatever shall we do?
 `,
@@ -160,8 +160,8 @@ Whatever shall we do?
 
   on test.tf line 1:
    1: test [underline]source[reset] code
-    [dark_gray]|----------------[reset]
-    [dark_gray]|[reset] [bold]boop.beep[reset] is a string, known only after apply
+    [dark_gray]├────────────────[reset]
+    [dark_gray]│[reset] [bold]boop.beep[reset] is a string, known only after apply
 
 Whatever shall we do?
 `,
@@ -193,8 +193,8 @@ Whatever shall we do?
 
   on test.tf line 1:
    1: test [underline]source[reset] code
-    [dark_gray]|----------------[reset]
-    [dark_gray]|[reset] [bold]boop.beep[reset] will be known only after apply
+    [dark_gray]├────────────────[reset]
+    [dark_gray]│[reset] [bold]boop.beep[reset] will be known only after apply
 
 Whatever shall we do?
 `,

--- a/command/format/diagnostic_test.go
+++ b/command/format/diagnostic_test.go
@@ -403,8 +403,8 @@ wrap onto multiple lines. Thank-you very much for listening.
 To fix this, run this very long command:
   terraform read-my-mind -please -thanks -but-do-not-wrap-this-line-because-it-is-prefixed-with-spaces
 
-Here is a coda which is also long enough to wrap and so it should eventually
-make it onto multiple lines. THE END
+Here is a coda which is also long enough to wrap and so it should
+eventually make it onto multiple lines. THE END
 `
 	output := Diagnostic(diags[0], nil, color, 76)
 

--- a/command/format/trivia.go
+++ b/command/format/trivia.go
@@ -16,7 +16,10 @@ import (
 // This is intended for printing to the UI via mitchellh/cli.UI.Output, or
 // similar, which will automatically append a trailing newline too.
 func HorizontalRule(color *colorstring.Colorize, width int) string {
-	rule := strings.Repeat("─", width)
+	if width <= 1 {
+		return "\n"
+	}
+	rule := strings.Repeat("─", width-1)
 	if color == nil { // sometimes unit tests don't populate this properly
 		return "\n" + rule
 	}
@@ -34,7 +37,7 @@ func HorizontalRule(color *colorstring.Colorize, width int) string {
 // unbroken. This allows including literal segments in the output, such as
 // code snippets or filenames, where word wrapping would be confusing.
 func WordWrap(str string, width int) string {
-	if width == 0 {
+	if width <= 1 {
 		// Silly edge case. We'll just return the original string to avoid
 		// panicking or doing other weird stuff.
 		return str
@@ -44,7 +47,7 @@ func WordWrap(str string, width int) string {
 	lines := strings.Split(str, "\n")
 	for i, line := range lines {
 		if !strings.HasPrefix(line, " ") {
-			line = wordwrap.WrapString(line, uint(width))
+			line = wordwrap.WrapString(line, uint(width-1))
 		}
 		if i > 0 {
 			buf.WriteByte('\n') // reintroduce the newlines we skipped in Scan

--- a/command/format/trivia.go
+++ b/command/format/trivia.go
@@ -1,0 +1,55 @@
+package format
+
+import (
+	"strings"
+
+	"github.com/mitchellh/colorstring"
+	wordwrap "github.com/mitchellh/go-wordwrap"
+)
+
+// HorizontalRule returns a newline character followed by a number of
+// horizontal line characters to fill the given width.
+//
+// If the given colorize has colors enabled, the rule will also be given a
+// dark grey color to attempt to visually de-emphasize it for sighted users.
+//
+// This is intended for printing to the UI via mitchellh/cli.UI.Output, or
+// similar, which will automatically append a trailing newline too.
+func HorizontalRule(color *colorstring.Colorize, width int) string {
+	rule := strings.Repeat("─", width)
+	if color == nil { // sometimes unit tests don't populate this properly
+		return "\n" + rule
+	}
+	return color.Color("[dark_gray]\n" + rule)
+}
+
+// WordWrap takes a string containing unbroken lines of text and inserts
+// newline characters to try to make the text fit within the given width.
+//
+// The string can already contain newline characters, for example if you are
+// trying to render multiple paragraphs of text. (In that case, our usual
+// style would be to have _two_ newline characters as the paragraph separator.)
+//
+// As a special case, any line that begins with at least one space will be left
+// unbroken. This allows including literal segments in the output, such as
+// code snippets or filenames, where word wrapping would be confusing.
+func WordWrap(str string, width int) string {
+	if width == 0 {
+		// Silly edge case. We'll just return the original string to avoid
+		// panicking or doing other weird stuff.
+		return str
+	}
+
+	var buf strings.Builder
+	lines := strings.Split(str, "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(line, " ") {
+			line = wordwrap.WrapString(line, uint(width))
+		}
+		if i > 0 {
+			buf.WriteByte('\n') // reintroduce the newlines we skipped in Scan
+		}
+		buf.WriteString(line)
+	}
+	return buf.String()
+}

--- a/command/meta.go
+++ b/command/meta.go
@@ -629,6 +629,8 @@ func (m *Meta) showDiagnostics(vals ...interface{}) {
 		return
 	}
 
+	outputWidth := m.ErrorColumns()
+
 	diags = diags.ConsolidateWarnings(1)
 
 	// Since warning messages are generally competing
@@ -654,11 +656,7 @@ func (m *Meta) showDiagnostics(vals ...interface{}) {
 	}
 
 	for _, diag := range diags {
-		// TODO: Actually measure the terminal width and pass it here.
-		// For now, we don't have easy access to the writer that
-		// ui.Error (etc) are writing to and thus can't interrogate
-		// to see if it's a terminal and what size it is.
-		msg := format.Diagnostic(diag, m.configSources(), m.Colorize(), 78)
+		msg := format.Diagnostic(diag, m.configSources(), m.Colorize(), outputWidth)
 		switch diag.Severity() {
 		case tfdiags.Error:
 			m.Ui.Error(msg)

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -308,6 +308,7 @@ func (m *Meta) backendCLIOpts() (*backend.CLIOpts, error) {
 	return &backend.CLIOpts{
 		CLI:                 m.Ui,
 		CLIColor:            m.Colorize(),
+		Streams:             m.Streams,
 		ShowDiagnostics:     m.showDiagnostics,
 		StatePath:           m.statePath,
 		StateOutPath:        m.stateOutPath,

--- a/command/show.go
+++ b/command/show.go
@@ -166,7 +166,7 @@ func (c *ShowCommand) Run(args []string) int {
 		// package rather than in the backends themselves, but for now we're
 		// accepting this oddity because "terraform show" is a less commonly
 		// used way to render a plan than "terraform plan" is.
-		localBackend.RenderPlan(plan, stateFile.State, schemas, c.Ui, c.Colorize())
+		localBackend.RenderPlan(plan, stateFile.State, schemas, c.Ui, c.Colorize(), c.OutputColumns())
 		return 0
 	}
 

--- a/command/state_mv_test.go
+++ b/command/state_mv_test.go
@@ -435,7 +435,8 @@ func TestStateMv_differentResourceTypes(t *testing.T) {
 		t.Fatalf("expected error output, got:\n%s", ui.OutputWriter.String())
 	}
 
-	if !strings.Contains(ui.ErrorWriter.String(), "resource types don't match") {
+	errOutput := strings.Replace(ui.ErrorWriter.String(), "\n", " ", -1)
+	if !strings.Contains(errOutput, "resource types don't match") {
 		t.Fatalf("expected initialization error, got:\n%s", ui.ErrorWriter.String())
 	}
 }

--- a/commands.go
+++ b/commands.go
@@ -80,6 +80,7 @@ func initCommands(
 
 	meta := command.Meta{
 		OriginalWorkingDir: originalWorkingDir,
+		Streams:            streams,
 
 		Color:            true,
 		GlobalPluginDirs: globalPluginDirs(),

--- a/commands.go
+++ b/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/command/cliconfig"
 	"github.com/hashicorp/terraform/command/webbrowser"
 	"github.com/hashicorp/terraform/internal/getproviders"
+	"github.com/hashicorp/terraform/internal/terminal"
 	pluginDiscovery "github.com/hashicorp/terraform/plugin/discovery"
 )
 
@@ -48,6 +49,7 @@ var Ui cli.Ui
 
 func initCommands(
 	originalWorkingDir string,
+	streams *terminal.Streams,
 	config *cliconfig.Config,
 	services *disco.Disco,
 	providerSrc getproviders.Source,

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,8 @@ require (
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
-	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
+	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf
 	golang.org/x/text v0.3.3
 	golang.org/x/tools v0.0.0-20201028111035-eafbe7b904eb
 	google.golang.org/api v0.34.0

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,6 @@ require (
 	github.com/lusis/go-artifactory v0.0.0-20160115162124-7e4ce345df82
 	github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786 // indirect
 	github.com/masterzen/winrm v0.0.0-20200615185753-c42b5136ff88
-	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mattn/go-shellwords v1.0.4
 	github.com/miekg/dns v1.0.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -420,9 +420,8 @@ github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786/go.mod h1:kCEb
 github.com/masterzen/winrm v0.0.0-20200615185753-c42b5136ff88 h1:cxuVcCvCLD9yYDbRCWw0jSgh1oT6P6mv3aJDKK5o7X4=
 github.com/masterzen/winrm v0.0.0-20200615185753-c42b5136ff88/go.mod h1:a2HXwefeat3evJHxFXSayvRHpYEPJYtErl4uIzfaUqY=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
-github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=

--- a/go.sum
+++ b/go.sum
@@ -746,6 +746,10 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
+golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/terminal/impl_others.go
+++ b/internal/terminal/impl_others.go
@@ -1,0 +1,53 @@
+// +build !windows
+
+package terminal
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+// This is the implementation for all operating systems except Windows, where
+// we don't expect to need to do any special initialization to get a working
+// Virtual Terminal.
+//
+// For this implementation we just delegate everything upstream to
+// golang.org/x/term, since it already has a variety of different
+// implementations for quirks of more esoteric operating systems like plan9,
+// and will hopefully grow to include others as Go is ported to other platforms
+// in future.
+//
+// For operating systems that golang.org/x/term doesn't support either, it
+// defaults to indicating that nothing is a terminal and returns an error when
+// asked for a size, which we'll handle below.
+
+func configureOutputHandle(f *os.File) (*OutputStream, error) {
+	return &OutputStream{
+		File:       f,
+		isTerminal: isTerminalGolangXTerm,
+		getColumns: getColumnsGolangXTerm,
+	}, nil
+}
+
+func configureInputHandle(f *os.File) (*InputStream, error) {
+	return &InputStream{
+		File:       f,
+		isTerminal: isTerminalGolangXTerm,
+	}, nil
+}
+
+func isTerminalGolangXTerm(f *os.File) bool {
+	return term.IsTerminal(int(f.Fd()))
+}
+
+func getColumnsGolangXTerm(f *os.File) int {
+	width, _, err := term.GetSize(int(f.Fd()))
+	if err != nil {
+		// Suggests that it's either not a terminal at all or that we're on
+		// a platform that golang.org/x/term doesn't support. In both cases
+		// we'll just return the placeholder default value.
+		return defaultColumns
+	}
+	return width
+}

--- a/internal/terminal/impl_windows.go
+++ b/internal/terminal/impl_windows.go
@@ -1,0 +1,161 @@
+// +build windows
+
+package terminal
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+
+	// We're continuing to use this third-party library on Windows because it
+	// has the additional IsCygwinTerminal function, which includes some useful
+	// heuristics for recognizing when a pipe seems to be connected to a
+	// legacy terminal emulator on Windows versions that lack true pty support.
+	// We now use golang.org/x/term's functionality on other platforms.
+	isatty "github.com/mattn/go-isatty"
+)
+
+func configureOutputHandle(f *os.File) (*OutputStream, error) {
+	ret := &OutputStream{
+		File: f,
+	}
+
+	if fd := f.Fd(); isatty.IsTerminal(fd) {
+		// We have a few things to deal with here:
+		// - Activating UTF-8 output support (mandatory)
+		// - Activating virtual terminal support (optional)
+		// These will not succeed on Windows 8 or early versions of Windows 10.
+
+		// UTF-8 support means switching the console "code page" to CP_UTF8.
+		// Notice that this doesn't take the specific file descriptor, because
+		// the console is just ambiently associated with our process.
+		err := SetConsoleOutputCP(CP_UTF8)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set the console to UTF-8 mode; you may need to use a newer version of Windows: %s", err)
+		}
+
+		// If the console also allows us to turn on
+		// ENABLE_VIRTUAL_TERMINAL_PROCESSING then we can potentially use VT
+		// output, although the methods of Settings will make the final
+		// determination on that because we might have some handles pointing at
+		// terminals and other handles pointing at files/pipes.
+		ret.getColumns = getColumnsWindowsConsole
+		var mode uint32
+		err = windows.GetConsoleMode(windows.Handle(fd), &mode)
+		if err != nil {
+			return ret, nil // We'll treat this as success but without VT support
+		}
+		mode |= windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING
+		err = windows.SetConsoleMode(windows.Handle(fd), mode)
+		if err != nil {
+			return ret, nil // We'll treat this as success but without VT support
+		}
+
+		// If we get here then we've successfully turned on VT processing, so
+		// we can return an OutputStream that answers true when asked if it
+		// is a Terminal.
+		ret.isTerminal = staticTrue
+		return ret, nil
+
+	} else if isatty.IsCygwinTerminal(fd) {
+		// Cygwin terminals -- and other VT100 "fakers" for older versions of
+		// Windows -- are not really terminals in the usual sense, but rather
+		// are pipes between the child process (Terraform) and the terminal
+		// emulator. isatty.IsCygwinTerminal uses some heuristics to
+		// distinguish those pipes from other pipes we might see if the user
+		// were, for example, using the | operator on the command line.
+		// If we get in here then we'll assume that we can send VT100 sequences
+		// to this stream, even though it isn't a terminal in the usual sense.
+
+		ret.isTerminal = staticTrue
+		// TODO: Is it possible to detect the width of these fake terminals?
+		return ret, nil
+	}
+
+	// If we fall out here then we have a non-terminal filehandle, so we'll
+	// just accept all of the default OutputStream behaviors
+	return ret, nil
+}
+
+func configureInputHandle(f *os.File) (*InputStream, error) {
+	ret := &InputStream{
+		File: f,
+	}
+
+	if fd := f.Fd(); isatty.IsTerminal(fd) {
+		// We have to activate UTF-8 input, or else we fail. This will not
+		// succeed on Windows 8 or early versions of Windows 10.
+		// Notice that this doesn't take the specific file descriptor, because
+		// the console is just ambiently associated with our process.
+		err := SetConsoleCP(CP_UTF8)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set the console to UTF-8 mode; you may need to use a newer version of Windows: %s", err)
+		}
+		ret.isTerminal = staticTrue
+		return ret, nil
+	} else if isatty.IsCygwinTerminal(fd) {
+		// As with the output handles above, we'll use isatty's heuristic to
+		// pretend that a pipe from mintty or a similar userspace terminal
+		// emulator is actually a terminal.
+		ret.isTerminal = staticTrue
+		return ret, nil
+	}
+
+	// If we fall out here then we have a non-terminal filehandle, so we'll
+	// just accept all of the default InputStream behaviors
+	return ret, nil
+}
+
+func getColumnsWindowsConsole(f *os.File) int {
+	// We'll just unconditionally ask the given file for its console buffer
+	// info here, and let it fail if the file isn't actually a console.
+	// (In practice, the init functions above only hook up this function
+	// if the handle looks like a console, so this should succeed.)
+	var info windows.ConsoleScreenBufferInfo
+	err := windows.GetConsoleScreenBufferInfo(windows.Handle(f.Fd()), &info)
+	if err != nil {
+		return defaultColumns
+	}
+	return int(info.Size.X)
+}
+
+// Unfortunately not all of the Windows kernel functions we need are in
+// x/sys/windows at the time of writing, so we need to call some of them
+// directly. (If you're maintaining this in future and have the capacity to
+// test it well, consider checking if these functions have been added upstream
+// yet and switch to their wrapper stubs if so.
+var modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
+var procSetConsoleCP = modkernel32.NewProc("SetConsoleCP")
+var procSetConsoleOutputCP = modkernel32.NewProc("SetConsoleOutputCP")
+
+const CP_UTF8 = 65001
+
+// (These are written in the style of the stubs in x/sys/windows, which is
+// a little non-idiomatic just due to the awkwardness of the low-level syscall
+// interface.)
+
+func SetConsoleCP(codepageID uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procSetConsoleCP.Addr(), 1, uintptr(codepageID), 0, 0)
+	if r1 == 0 {
+		err = e1
+	}
+	return
+}
+
+func SetConsoleOutputCP(codepageID uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procSetConsoleOutputCP.Addr(), 1, uintptr(codepageID), 0, 0)
+	if r1 == 0 {
+		err = e1
+	}
+	return
+}
+
+func staticTrue(f *os.File) bool {
+	return true
+}
+
+func staticFalse(f *os.File) bool {
+	return false
+}

--- a/internal/terminal/panicwrap_ugh.go
+++ b/internal/terminal/panicwrap_ugh.go
@@ -1,0 +1,78 @@
+package terminal
+
+import "os"
+
+// This file has some annoying nonsense to, yet again, work around the
+// panicwrap hack.
+//
+// Specifically, typically when we're running Terraform the stderr handle is
+// not directly connected to the terminal but is instead a pipe into a parent
+// process gathering up the output just in case a panic message appears.
+// However, this package needs to know whether the _real_ stderr is connected
+// to a terminal and what its width is.
+//
+// To work around that, we'll first initialize the terminal in the parent
+// process, and then capture information about stderr into an environment
+// variable so we can pass it down to the child process. The child process
+// will then use the environment variable to pretend that the panicwrap pipe
+// has the same characteristics as the terminal that it's indirectly writing
+// to.
+//
+// This file has some helpers for implementing that awkward handshake, but the
+// handshake itself is in package main, interspersed with all of the other
+// panicwrap machinery.
+//
+// You might think that the code in helper/wrappedstreams could avoid this
+// problem, but that package is broken on Windows: it always fails to recover
+// the real stderr, and it also gets an incorrect result if the user was
+// redirecting or piping stdout/stdin. So... we have this hack instead, which
+// gets a correct result even on Windows and even with I/O redirection.
+
+// StateForAfterPanicWrap is part of the workaround for panicwrap that
+// captures some characteristics of stderr that the caller can pass to the
+// panicwrap child process somehow and then use ReinitInsidePanicWrap.
+func (s *Streams) StateForAfterPanicWrap() *PrePanicwrapState {
+	return &PrePanicwrapState{
+		StderrIsTerminal: s.Stderr.IsTerminal(),
+		StderrWidth:      s.Stderr.Columns(),
+	}
+}
+
+// ReinitInsidePanicwrap is part of the workaround for panicwrap that
+// produces a Streams containing a potentially-lying Stderr that might
+// claim to be a terminal even if it's actually a pipe connected to the
+// parent process.
+//
+// That's an okay lie in practice because the parent process will copy any
+// data it recieves via that pipe verbatim to the real stderr anyway. (The
+// original call to Init in the parent process should've already done any
+// necessary modesetting on the Stderr terminal, if any.)
+//
+// The state argument can be nil if we're not running in panicwrap mode,
+// in which case this function behaves exactly the same as Init.
+func ReinitInsidePanicwrap(state *PrePanicwrapState) (*Streams, error) {
+	ret, err := Init()
+	if err != nil {
+		return ret, err
+	}
+	if state != nil {
+		// A lying stderr, then.
+		ret.Stderr = &OutputStream{
+			File: ret.Stderr.File,
+			isTerminal: func(f *os.File) bool {
+				return state.StderrIsTerminal
+			},
+			getColumns: func(f *os.File) int {
+				return state.StderrWidth
+			},
+		}
+	}
+	return ret, nil
+}
+
+// PrePanicwrapState is a horrible thing we use to work around panicwrap,
+// related to both Streams.StateForAfterPanicWrap and ReinitInsidePanicwrap.
+type PrePanicwrapState struct {
+	StderrIsTerminal bool
+	StderrWidth      int
+}

--- a/internal/terminal/stream.go
+++ b/internal/terminal/stream.go
@@ -1,0 +1,80 @@
+package terminal
+
+import (
+	"os"
+)
+
+const defaultColumns int = 78
+const defaultIsTerminal bool = false
+
+// OutputStream represents an output stream that might or might not be connected
+// to a terminal.
+//
+// There are typically two instances of this: one representing stdout and one
+// representing stderr.
+type OutputStream struct {
+	File *os.File
+
+	// Interacting with a terminal is typically platform-specific, so we
+	// factor out these into virtual functions, although we have default
+	// behaviors suitable for non-Terminal output if any of these isn't
+	// set. (We're using function pointers rather than interfaces for this
+	// because it allows us to mix both normal methods and virtual methods
+	// on the same type, without a bunch of extra complexity.)
+	isTerminal func(*os.File) bool
+	getColumns func(*os.File) int
+}
+
+// Columns returns a number of character cell columns that we expect will
+// fill the width of the terminal that stdout is connected to, or a reasonable
+// placeholder value of 78 if the output doesn't seem to be a terminal.
+//
+// This is a best-effort sort of function which may give an inaccurate result
+// in various cases. For example, callers storing the result will not react
+// to subsequent changes in the terminal width, and indeed this function itself
+// may not be able to either, depending on the constraints of the current
+// execution context.
+func (s *OutputStream) Columns() int {
+	if s.getColumns == nil {
+		return defaultColumns
+	}
+	return s.getColumns(s.File)
+}
+
+// IsTerminal returns true if we expect that the stream is connected to a
+// terminal which supports VT100-style formatting and cursor control sequences.
+func (s *OutputStream) IsTerminal() bool {
+	if s.isTerminal == nil {
+		return defaultIsTerminal
+	}
+	return s.isTerminal(s.File)
+}
+
+// InputStream represents an input stream that might or might not be a terminal.
+//
+// There is typically only one instance of this type, representing stdin.
+type InputStream struct {
+	File *os.File
+
+	// Interacting with a terminal is typically platform-specific, so we
+	// factor out these into virtual functions, although we have default
+	// behaviors suitable for non-Terminal output if any of these isn't
+	// set. (We're using function pointers rather than interfaces for this
+	// because it allows us to mix both normal methods and virtual methods
+	// on the same type, without a bunch of extra complexity.)
+	isTerminal func(*os.File) bool
+}
+
+// IsTerminal returns true if we expect that the stream is connected to a
+// terminal which can support interactive input.
+//
+// If this returns false, callers might prefer to skip elaborate input prompt
+// functionality like tab completion and instead just treat the input as a
+// raw byte stream, or perhaps skip prompting for input at all depending on the
+// situation.
+func (s *InputStream) IsTerminal() bool {
+	if s.isTerminal == nil {
+		return defaultIsTerminal
+	}
+	return s.isTerminal(s.File)
+}

--- a/internal/terminal/streams.go
+++ b/internal/terminal/streams.go
@@ -1,0 +1,74 @@
+// Package terminal encapsulates some platform-specific logic for detecting
+// if we're running in a terminal and, if so, properly configuring that
+// terminal to meet the assumptions that the rest of Terraform makes.
+//
+// Specifically, Terraform requires a Terminal which supports virtual terminal
+// sequences and which accepts UTF-8-encoded text.
+//
+// This is an abstraction only over the platform-specific detection of and
+// possibly initialization of terminals. It's not intended to provide
+// higher-level abstractions of the sort provided by packages like termcap or
+// curses; ultimately we just assume that terminals are "standard" VT100-like
+// terminals and use a subset of control codes that works across the various
+// platforms we support. Our approximate target is "xterm-compatible"
+// virtual terminals.
+package terminal
+
+import (
+	"os"
+)
+
+// Streams represents a collection of three streams that each may or may not
+// be connected to a terminal.
+//
+// If a stream is connected to a terminal then there are more possibilities
+// available, such as detecting the current terminal width. If we're connected
+// to something else, such as a pipe or a file on disk, the stream will
+// typically provide placeholder values or do-nothing stubs for
+// terminal-requiring operatons.
+//
+// Note that it's possible for only a subset of the streams to be connected
+// to a terminal. For example, this happens if the user runs Terraform with
+// I/O redirection where Stdout might refer to a regular disk file while Stderr
+// refers to a terminal, or various other similar combinations.
+type Streams struct {
+	Stdout *OutputStream
+	Stderr *OutputStream
+	Stdin  *InputStream
+}
+
+// Init tries to initialize a terminal, if Terraform is running in one, and
+// returns an object describing what it was able to set up.
+//
+// An error for this function indicates that the current execution context
+// can't meet Terraform's assumptions. For example, on Windows Init will return
+// an error if Terraform is running in a Windows Console that refuses to
+// activate UTF-8 mode, which can happen if we're running on an unsupported old
+// version of Windows.
+//
+// Note that the success of this function doesn't mean that we're actually
+// running in a terminal. It could also represent successfully detecting that
+// one or more of the input/output streams is not a terminal.
+func Init() (*Streams, error) {
+	// These configure* functions are platform-specific functions in other
+	// files that use //+build constraints to vary based on target OS.
+
+	stderr, err := configureOutputHandle(os.Stderr)
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := configureOutputHandle(os.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	stdin, err := configureInputHandle(os.Stdin)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Streams{
+		Stdout: stdout,
+		Stderr: stderr,
+		Stdin:  stdin,
+	}, nil
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform/httpclient"
 	"github.com/hashicorp/terraform/internal/didyoumean"
 	"github.com/hashicorp/terraform/internal/logging"
+	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/version"
 	"github.com/mattn/go-shellwords"
 	"github.com/mitchellh/cli"
@@ -34,6 +35,12 @@ const (
 
 	// The parent process will create a file to collect crash logs
 	envTmpLogPath = "TF_TEMP_LOG_PATH"
+
+	// Environment variable name used for smuggling true stderr terminal
+	// settings into a panicwrap child process. This is an implementation
+	// detail, subject to change in future, and should not ever be directly
+	// set by an end-user.
+	envTerminalPanicwrapWorkaround = "TF_PANICWRAP_STDERR"
 )
 
 // ui wraps the primary output cli.Ui, and redirects Warn calls to Output
@@ -74,6 +81,22 @@ func realMain() int {
 
 		// store the path in the environment for the wrapped executable
 		os.Setenv(envTmpLogPath, logTempFile.Name())
+
+		// We also need to do our terminal initialization before we fork,
+		// because the child process doesn't necessarily have access to
+		// the true stderr in order to initialize it.
+		streams, err := terminal.Init()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to initialize terminal: %s", err)
+			return 1
+		}
+
+		// We need the child process to behave _as if_ connected to the real
+		// stderr, even though panicwrap is about to add a pipe in the way,
+		// so we'll smuggle the true stderr information in an environment
+		// varible.
+		streamState := streams.StateForAfterPanicWrap()
+		os.Setenv(envTerminalPanicwrapWorkaround, fmt.Sprintf("%t:%d", streamState.StderrIsTerminal, streamState.StderrWidth))
 
 		// Create the configuration for panicwrap and wrap our executable
 		wrapConfig.Handler = logging.PanicHandler(logTempFile.Name())
@@ -121,6 +144,39 @@ func wrappedMain() int {
 		Version, VersionPrerelease, GitCommit)
 	log.Printf("[INFO] Go runtime version: %s", runtime.Version())
 	log.Printf("[INFO] CLI args: %#v", os.Args)
+
+	// This is the recieving end of our workaround to retain the metadata
+	// about the real stderr even though we're talking to it via the panicwrap
+	// pipe. See the call to StateForAfterPanicWrap above for the producer
+	// part of this.
+	var streamState *terminal.PrePanicwrapState
+	if raw := os.Getenv(envTerminalPanicwrapWorkaround); raw != "" {
+		streamState = &terminal.PrePanicwrapState{}
+		if _, err := fmt.Sscanf(raw, "%t:%d", &streamState.StderrIsTerminal, &streamState.StderrWidth); err != nil {
+			log.Printf("[WARN] %s is set but is incorrectly-formatted: %s", envTerminalPanicwrapWorkaround, err)
+			streamState = nil // leave it unset for a normal init, then
+		}
+	}
+	streams, err := terminal.ReinitInsidePanicwrap(streamState)
+	if err != nil {
+		Ui.Error(fmt.Sprintf("Failed to configure the terminal: %s", err))
+		return 1
+	}
+	if streams.Stdout.IsTerminal() {
+		log.Printf("[TRACE] Stdout is a terminal of width %d", streams.Stdout.Columns())
+	} else {
+		log.Printf("[TRACE] Stdout is not a terminal")
+	}
+	if streams.Stderr.IsTerminal() {
+		log.Printf("[TRACE] Stderr is a terminal of width %d", streams.Stderr.Columns())
+	} else {
+		log.Printf("[TRACE] Stderr is not a terminal")
+	}
+	if streams.Stdin.IsTerminal() {
+		log.Printf("[TRACE] Stdin is a terminal")
+	} else {
+		log.Printf("[TRACE] Stdin is not a terminal")
+	}
 
 	// NOTE: We're intentionally calling LoadConfig _before_ handling a possible
 	// -chdir=... option on the command line, so that a possible relative
@@ -235,7 +291,7 @@ func wrappedMain() int {
 		// in case they need to refer back to it for any special reason, though
 		// they should primarily be working with the override working directory
 		// that we've now switched to above.
-		initCommands(originalWd, config, services, providerSrc, providerDevOverrides, unmanagedProviders)
+		initCommands(originalWd, streams, config, services, providerSrc, providerDevOverrides, unmanagedProviders)
 	}
 
 	// Run checkpoint


### PR DESCRIPTION
Since very early versions of Terraform we've been supporting colored output from our CLI in the Microsoft Windows console using [go-colorable](https://github.com/mattn/go-colorable), which aims to translate in-band virtual terminal sequences into out-of-band classic Windows Console API calls interspersed with calls to write literal characters to the terminal filehandle.

For several years now Windows 10 updates have supported xterm-style virtual terminal sequences in the Windows console, but only after opting in. Somewhat recently we updated `go-colorable` in #26588 to get a version which would make use of that mechanism if available, but we retained the existing translation layer for console windows where VT mode wasn't available, particularly on Windows 8. However, that effectively meant that we needed to stay constrained by the subset of formatting options supported in the classic console API (which were in turn inspired by the capabilities of VGA text mode) to ensure that the `colorable` translations would work effectively in consoles without VT mode enabled.

[Microsoft now recommends migrating to VT instead of the classic console API](https://docs.microsoft.com/en-us/windows/console/classic-vs-vt), so this change now removes the `colorable` translation layer altogether and imposes some new (breaking) requirements:
* Terraform requires that the attached terminal must support UTF-8 input and output on all platforms. Previously Terraform largely limited its output to ASCII and let any user-supplied non-ASCII characters render incorrectly on Windows, because the classic Windows console can only render characters belonging to the system's current ANSI codepage.
* Terraform assumes that the recipient of its output can understand xterm-style escape sequences on all platforms, unless that's explicitly disabled by setting the `-no-color` option. Previously Terraform made that requirement _except_ on Windows, where it would use `colorable` as a translation layer.

The upshot of the above is that future versions of Terraform will require a new enough version of Windows that its console supports both [the new Unicode text buffer](https://devblogs.microsoft.com/commandline/windows-command-line-unicode-and-utf-8-output-text-buffer/) and [virtual terminal mode](https://devblogs.microsoft.com/commandline/windows-command-line-inside-the-windows-console/#windows-console--vt). These capabilities were introduced and gradually improved throughout the early Windows 10 updates, so we recommend using the latest Windows 10 release for best results. Windows 8 and earlier do not have these new features and so are no longer officially supported, although may still be usable through third-party virtual terminal software or with the `-no-color` option to disable terminal sequences.

(**Nitpicker's Corner:** Technically we already dropped the `go-colorable` translation layer in earlier work in the 0.15 cycle, though it seems that it was unintentional. Prior to this PR we had broken output on Windows even on Windows 10, so this PR could be understood as a fix for that bug, though it's a fix in the form of making the previous behavior obsolete, rather than actually fixing it.)

![](https://user-images.githubusercontent.com/20180/104385903-eff6b200-54e8-11eb-8dde-67af654b67d6.png)

----

The main event in this PR is the introduction of the package `internal/terminal` as a thin abstraction to deal with the special additional console initialization required on Windows. Through that package we can switch opt-in to the modern Windows Console features we need and portably determine whether each of the standard I/O handles is connected to a terminal or to something else.

In order to exercise and test that new implementation, I also did some initial work to start to make use of these new capabilities:

* I changed `command.Meta.StdinPiped` to use `internal/terminal` instead of `helper/wrappedstreams`, because the latter does not implement correct behavior on Windows. This fixes #18242 (both of the main oddities described there) because `terraform console` relies on `Meta.StdinPiped` to decide whether to run in interactive mode or batch mode, and `internal/terminal` will now give it a more reliable answer on Windows.
* I made the diagnostic renderer use the actual terminal width for its text wrapping, where available, thus addressing a long-standing `TODO` in `meta.showDiagnostics`.
* I made the diagnostic renderer use Unicode box drawing characters for the visual separator on the indication of values that are in scope for the related expression, rather than the "ASCII art" we were using before.
* I made the paragraphs of text in the `terraform plan` output respect the terminal width when wrapping, rather than being always hard-wrapped as before.
* I made the `terraform plan` output use Unicode box drawing characters for its horizontal rule rather than ASCII hyphenminus, and made it fill the full with of the terminal when we're able to determine it.

Over time it'd be nice to make fuller use of our new terminal flexibility, but I had to draw the line somewhere for this first iteration and I probably drew it too _late_ here, with more changes in its scope than I ideally would have included, but I wanted to make sure there were a few things here to test with in case others want to test it.

There are not unit tests for `internal/terminal` here because that package interacts with real system calls and therefore can't readily be mocked. If you want to do some interactive testing (either on Windows or elsewhere), here are some ways to observe the above:

* Run `terraform console` both in interactive mode and batch mode and see how it behaves.
* Run `terraform plan` in a configuration which requires at least one change, and observe the new unicode horizontal rule (which should hopefully fill your terminal width) and text wrapping.
* Run `terraform plan` piped into `less` or redirected to a file and see that it selects a reasonable default output width because it's not connected to a terminal. (It still produces colors in that case, because we require an explicit `-no-color` to turn that off. More on that below.)
* Run `terraform plan` in a configuration which produces an error or warning, and hopefully see it wrap at the terminal width rather than at the fixed point as before. Bonus: if you generate an error which includes information about the variables contributing to an expression then you should also see the new Unicode box drawing characters there.
* And of course, anything else you want to test too. It's important that this hasn't regressed any behaviors I _didn't_ intentionally modify! Try piping output and I/O redirection at your shell too, since that should affect whether Terraform detects the output as a terminal.

This closes #22487, and enables the nicer original incarnation of #27343 (which I'll revert back to if we merge _this_ PR).

## Bonus Chatter: Should we disable colors if stdout/stderr isn't a terminal?

While working on this I considered the possibility of having Terraform behave as if `-no-color` were set automatically if it detects that the relevant output stream isn't a real virtual terminal. However, I ultimately decided against that for the following two reasons.

1. Terraform is commonly run in automation systems that capture stdout/stderr and render it to a log with interpretation of terminal _formatting_ characters, even though the output streams are in that case typically connected to pipes rather than to a pseudo-terminal. Disabling our colored output for non-terminals would therefore disable the colors for those systems. We've always had the `-no-color` option to allow _explicitly_ disabling the terminal formatting sequences for situations that don't support them, and so I preserved that precedent here.

    With that said, I hope that in future we'll begin making more extensive use of other terminal capabilities, such as redrawing parts of the output to produce update-in-place progress indicators. Once we start doing things like that, it could be reasonable to enable them only for a true terminal because those operations typically require a real terminal buffer and are thus unlikely to be supported by simple log streamers, even if they happen to support formatting sequences. The metadata about whether stdout and stderr are detected as terminals is available for us to use down the road once we have some real use-cases to evaluate.

2. Part of our story for allowing Terraform to still be used on Windows 8 (albeit only on a best-effort basis) is allowing it to be used inside third-party virtual terminal fakers, like [mintty](https://mintty.github.io/). This PR does include some heuristics (via the upstream `go-isatty`) to try to recognize some of these and pretend they are terminals, but classic Windows has no real concept of a pseudo-terminal and so _really_ we end up connected to pipes and we won't be able to heuristically recognize _all_ such implementations. Continuing to emit terminal formatting sequences even when the output isn't detected as a terminal therefore makes the formatting more likely to work in a faked VT, even if we'd otherwise only recognize it as a pipe.

    A notable downside here is that running `terraform.exe` in a classic Windows Console (_without_ a fake VT) will cause it to emit raw terminal escape sequences into the console buffer, which is not ideal. Terraform running in that context is now a best-effort sort of thing anyway, so that seems like a reasonable compromise. Folks who _do_ want to run Terraform in that context can use `-no-color` to disable the VT formatting sequences and use the uncolored output instead.

Perhaps we can revisit each of these tradeoffs later, but for now I think continuing to emit VT formatting by default, regardless of the type of output handle, is the best compromise to minimize the impact of this change.
