### PR TITLE
cli: Fix double check of remote workspace version

### DIFF
--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -1115,6 +1115,11 @@ func (m *Meta) remoteBackendVersionCheck(b backend.Backend, workspace string) tf
 		// an error
 		versionDiags := rb.VerifyWorkspaceTerraformVersion(workspace)
 		diags = diags.Append(versionDiags)
+		// If there are no errors resulting from this check, we do not need to
+		// check again
+		if !diags.HasErrors() {
+			rb.IgnoreVersionConflict()
+		}
 	}
 
 	return diags


### PR DESCRIPTION
After verifying the remote backend workspace version is compatible with the local Terraform version, we need to record that this check was successful. Otherwise [the fallback error handling path will run a strict version check](https://github.com/hashicorp/terraform/blob/dcf49dc7dd8248cb75799279adbbd8654de3e8f5/backend/remote/backend.go#L638-L650), even if the versions are compatible, which will cause an unexpected failure.

The result of this bug was that compatible remote and local Terraform versions (e.g 0.14.2 and 0.14.4) were prevented from working with commands like `taint`, `import`, `state mv` and so on, unless you use the `-ignore-version-check` override. The same is true for incompatible remote and local versions (e.g. 0.13.5 and 0.14.4) for workspaces in "local" operations mode. This commit fixes both of those cases, which I've verified manually as this cannot be reasonably unit tested.

Fixes #27480.