### PR TITLE
Show resource name in taint -allow-missing warning

### DIFF
--- a/command/taint.go
+++ b/command/taint.go
@@ -267,7 +267,7 @@ func (c *TaintCommand) allowMissingExit(name addrs.AbsResourceInstance) int {
 	c.showDiagnostics(tfdiags.Sourceless(
 		tfdiags.Warning,
 		"No such resource instance",
-		"Resource instance %s was not found, but this is not an error because -allow-missing was set.",
+		fmt.Sprintf("Resource instance %s was not found, but this is not an error because -allow-missing was set.", name),
 	))
 	return 0
 }

--- a/command/taint_test.go
+++ b/command/taint_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/mitchellh/cli"
 
 	"github.com/hashicorp/terraform/addrs"
@@ -356,6 +357,18 @@ func TestTaint_missingAllow(t *testing.T) {
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Check for the warning
+	actual := strings.TrimSpace(ui.ErrorWriter.String())
+	expected := strings.TrimSpace(`
+Warning: No such resource instance
+
+Resource instance test_instance.bar was not found, but this is not an error
+because -allow-missing was set.
+`)
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Fatalf("wrong output\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
Show the resource name in the warning when allow-missing is used and no resource matches.