### PR TITLE
Add name to untaint missing warning

### DIFF
--- a/command/untaint.go
+++ b/command/untaint.go
@@ -236,7 +236,7 @@ func (c *UntaintCommand) allowMissingExit(name addrs.AbsResourceInstance) int {
 	c.showDiagnostics(tfdiags.Sourceless(
 		tfdiags.Warning,
 		"No such resource instance",
-		"Resource instance %s was not found, but this is not an error because -allow-missing was set.",
+		fmt.Sprintf("Resource instance %s was not found, but this is not an error because -allow-missing was set.", name),
 	))
 	return 0
 }

--- a/command/untaint_test.go
+++ b/command/untaint_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/states"
 	"github.com/mitchellh/cli"
@@ -384,6 +385,18 @@ func TestUntaint_missingAllow(t *testing.T) {
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Check for the warning
+	actual := strings.TrimSpace(ui.ErrorWriter.String())
+	expected := strings.TrimSpace(`
+Warning: No such resource instance
+
+Resource instance test_instance.bar was not found, but this is not an error
+because -allow-missing was set.
+`)
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Fatalf("wrong output\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
Ensure the name shows when running `untaint -allow-missing`