### PR TITLE
Fix error handling in instance apply methods

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -12553,13 +12553,13 @@ func TestContext2Apply_errorRestoreStatus(t *testing.T) {
 
 	state, diags = ctx.Apply()
 
-	if len(diags) != 2 {
-		t.Fatal("expected 1 error and 1 warning")
-	}
-
 	errString := diags.ErrWithWarnings().Error()
 	if !strings.Contains(errString, "oops") || !strings.Contains(errString, "warned") {
 		t.Fatalf("error missing expected info: %q", errString)
+	}
+
+	if len(diags) != 2 {
+		t.Fatalf("expected 1 error and 1 warning, got: %q", errString)
 	}
 
 	res := state.ResourceInstance(addr)

--- a/terraform/node_resource_abstract_instance.go
+++ b/terraform/node_resource_abstract_instance.go
@@ -232,7 +232,7 @@ func (n *NodeAbstractResourceInstance) preApplyHook(ctx EvalContext, change *pla
 }
 
 // postApplyHook calls the post-Apply hook
-func (n *NodeAbstractResourceInstance) postApplyHook(ctx EvalContext, state *states.ResourceInstanceObject, err *error) tfdiags.Diagnostics {
+func (n *NodeAbstractResourceInstance) postApplyHook(ctx EvalContext, state *states.ResourceInstanceObject, err error) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	// Only managed resources have user-visible apply actions.
@@ -244,7 +244,7 @@ func (n *NodeAbstractResourceInstance) postApplyHook(ctx EvalContext, state *sta
 			newState = cty.NullVal(cty.DynamicPseudoType)
 		}
 		diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
-			return h.PostApply(n.Addr, nil, newState, *err)
+			return h.PostApply(n.Addr, nil, newState, err)
 		}))
 	}
 

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -326,7 +326,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		}
 	}
 
-	diags = diags.Append(n.postApplyHook(ctx, state, &applyErr))
+	diags = diags.Append(n.postApplyHook(ctx, state, diags.Err()))
 	diags = diags.Append(applyDiags)
 	diags = diags.Append(updateStateHook(ctx))
 	return diags

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -264,8 +264,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		return diags
 	}
 
-	var applyError error
-	state, applyDiags, applyError := n.apply(ctx, state, diffApply, n.Config, n.CreateBeforeDestroy(), applyError)
+	state, applyDiags, applyError := n.apply(ctx, state, diffApply, n.Config, n.CreateBeforeDestroy())
 	diags = diags.Append(applyDiags)
 	if diags.HasErrors() {
 		return diags

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -191,8 +191,8 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 		// we pass a nil configuration to apply because we are destroying
 		s, d := n.apply(ctx, state, changeApply, nil, false)
 		state, diags = s, diags.Append(d)
-		// we must keep applyDiags separate until returning in order to process
-		// the error independently
+		// we don't return immediately here on error, so that the state can be
+		// finalized
 
 		err := n.writeResourceInstanceState(ctx, state, n.Dependencies, workingState)
 		if err != nil {

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -182,7 +182,7 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 		if provisionerErr != nil {
 			// If we have a provisioning error, then we just call
 			// the post-apply hook now.
-			diags = diags.Append(n.postApplyHook(ctx, state, &provisionerErr))
+			diags = diags.Append(n.postApplyHook(ctx, state, provisionerErr))
 			return diags.Append(applyProvisionersDiags)
 		}
 	}
@@ -210,8 +210,7 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 	}
 
 	// create the err value for postApplyHook
-	applyErr := applyDiags.Err()
-	diags = diags.Append(n.postApplyHook(ctx, state, &applyErr))
+	diags = diags.Append(n.postApplyHook(ctx, state, applyDiags.Err()))
 
 	diags = diags.Append(applyDiags)
 	diags = diags.Append(updateStateHook(ctx))

--- a/terraform/node_resource_destroy_deposed.go
+++ b/terraform/node_resource_destroy_deposed.go
@@ -185,8 +185,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		return diags.Append(applyDiags)
 	}
 
-	applyErr := applyDiags.Err()
-	diags = diags.Append(n.postApplyHook(ctx, state, &applyErr))
+	diags = diags.Append(n.postApplyHook(ctx, state, applyDiags.Err()))
 	diags = diags.Append(applyDiags)
 
 	return diags.Append(updateStateHook(ctx))

--- a/terraform/node_resource_destroy_deposed.go
+++ b/terraform/node_resource_destroy_deposed.go
@@ -152,7 +152,6 @@ func (n *NodeDestroyDeposedResourceInstanceObject) ModifyCreateBeforeDestroy(v b
 // GraphNodeExecutable impl.
 func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	var change *plans.ResourceInstanceChange
-	var applyError error
 
 	// Read the state for the deposed resource instance
 	state, err := n.readResourceInstanceStateDeposed(ctx, n.Addr, n.DeposedKey)
@@ -174,7 +173,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 	}
 
 	// we pass a nil configuration to apply because we are destroying
-	state, applyDiags, applyError := n.apply(ctx, state, change, nil, false, applyError)
+	state, applyDiags, applyError := n.apply(ctx, state, change, nil, false)
 	diags = diags.Append(applyDiags)
 	if diags.HasErrors() {
 		return diags


### PR DESCRIPTION
The error handling here was very convoluted, passing multiple error values and error pointers around, which was a remnant of the old eval-node pattern. This caused diagnostics to be dropped in some cases, and made the code extremely fragile in general.

Get rid of the separate error parameters and return value in the apply methods, and reorganize the diagnostic handling to use a single set of diagnostics that flows through each Execute method.