### PR TITLE
fix test case on windows

### DIFF
--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -63,7 +63,7 @@ func TestFunctions(t *testing.T) {
 					if err != nil {
 						panic(err)
 					}
-					return cwd
+					return filepath.ToSlash(cwd)
 				})()),
 			},
 		},


### PR DESCRIPTION
in the implementation of `abspath` func, the separator character in the results will be replaced with a slash ('/') character.

the test case in windows will fail