### PR TITLE
Disable visual error hierarchy in -no-color mode

### DIFF
--- a/command/e2etest/strip_ansi.go
+++ b/command/e2etest/strip_ansi.go
@@ -1,0 +1,13 @@
+package e2etest
+
+import (
+	"regexp"
+)
+
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
+var ansiRe = regexp.MustCompile(ansi)
+
+func stripAnsi(str string) string {
+	return ansiRe.ReplaceAllString(str, "")
+}

--- a/command/format/state_test.go
+++ b/command/format/state_test.go
@@ -9,14 +9,8 @@ import (
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/mitchellh/colorstring"
 	"github.com/zclconf/go-cty/cty"
 )
-
-var disabledColorize = &colorstring.Colorize{
-	Colors:  colorstring.DefaultColors,
-	Disable: true,
-}
 
 func TestState(t *testing.T) {
 	tests := []struct {

--- a/command/meta.go
+++ b/command/meta.go
@@ -656,14 +656,20 @@ func (m *Meta) showDiagnostics(vals ...interface{}) {
 	}
 
 	for _, diag := range diags {
-		msg := format.Diagnostic(diag, m.configSources(), m.Colorize(), outputWidth)
+		var msg string
+		if m.Color {
+			msg = format.Diagnostic(diag, m.configSources(), m.Colorize(), outputWidth)
+		} else {
+			msg = format.DiagnosticPlain(diag, m.configSources(), outputWidth)
+		}
+
 		switch diag.Severity() {
 		case tfdiags.Error:
-			m.Ui.Error(strings.TrimSpace(msg))
+			m.Ui.Error(msg)
 		case tfdiags.Warning:
-			m.Ui.Warn(strings.TrimSpace(msg))
+			m.Ui.Warn(msg)
 		default:
-			m.Ui.Output(strings.TrimSpace(msg))
+			m.Ui.Output(msg)
 		}
 	}
 }

--- a/command/state_mv_test.go
+++ b/command/state_mv_test.go
@@ -4,15 +4,20 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/mitchellh/cli"
+	"github.com/mitchellh/colorstring"
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/states"
 )
+
+var disabledColorize = &colorstring.Colorize{
+	Colors:  colorstring.DefaultColors,
+	Disable: true,
+}
 
 func TestStateMv(t *testing.T) {
 	state := states.BuildState(func(s *states.SyncState) {
@@ -270,7 +275,8 @@ func TestStateMv_resourceToInstanceErr(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := cli.NewMockUi()
+
 	c := &StateMvCommand{
 		StateMeta{
 			Meta: Meta{
@@ -290,19 +296,88 @@ func TestStateMv_resourceToInstanceErr(t *testing.T) {
 		t.Fatalf("expected error output, got:\n%s", ui.OutputWriter.String())
 	}
 
-	expectedErr := `╷
-│ Error: Invalid target address
-│
-│ Cannot move test_instance.foo to test_instance.bar[0]: the source is a
-│ whole resource (not a resource instance) so the target must also be a whole
-│ resource.
-╵
+	expectedErr := `
+Error: Invalid target address
+
+Cannot move test_instance.foo to test_instance.bar[0]: the source is a whole
+resource (not a resource instance) so the target must also be a whole
+resource.
+
 `
 	errOutput := ui.ErrorWriter.String()
 	if errOutput != expectedErr {
 		t.Errorf("wrong output\n%s", cmp.Diff(errOutput, expectedErr))
 	}
 }
+
+func TestStateMv_resourceToInstanceErrInAutomation(t *testing.T) {
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_instance",
+				Name: "foo",
+			}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
+				Status:    states.ObjectReady,
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			},
+		)
+		s.SetResourceProvider(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_instance",
+				Name: "bar",
+			}.Absolute(addrs.RootModuleInstance),
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			},
+		)
+	})
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &StateMvCommand{
+		StateMeta{
+			Meta: Meta{
+				testingOverrides:    metaOverridesForProvider(p),
+				Ui:                  ui,
+				RunningInAutomation: true,
+			},
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"test_instance.foo",
+		"test_instance.bar[0]",
+	}
+
+	if code := c.Run(args); code == 0 {
+		t.Fatalf("expected error output, got:\n%s", ui.OutputWriter.String())
+	}
+
+	expectedErr := `
+Error: Invalid target address
+
+Cannot move test_instance.foo to test_instance.bar[0]: the source is a whole
+resource (not a resource instance) so the target must also be a whole
+resource.
+
+`
+	errOutput := ui.ErrorWriter.String()
+	if errOutput != expectedErr {
+		t.Errorf("Unexpected diff.\ngot:\n%s\nwant:\n%s\n", errOutput, expectedErr)
+		t.Errorf("%s", cmp.Diff(errOutput, expectedErr))
+	}
+}
+
 func TestStateMv_instanceToResource(t *testing.T) {
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -502,13 +577,14 @@ func TestStateMv_differentResourceTypes(t *testing.T) {
 		t.Fatalf("expected error output, got:\n%s", ui.OutputWriter.String())
 	}
 
-	gotErr := strings.TrimSpace(ui.ErrorWriter.String())
-	wantErr := strings.TrimSpace(`╷
-│ Error: Invalid state move request
-│
-│ Cannot move test_instance.foo to test_network.bar: resource types don't
-│ match.
-╵`)
+	gotErr := ui.ErrorWriter.String()
+	wantErr := `
+Error: Invalid state move request
+
+Cannot move test_instance.foo to test_network.bar: resource types don't
+match.
+
+`
 	if gotErr != wantErr {
 		t.Fatalf("expected initialization error\ngot:\n%s\n\nwant:%s", gotErr, wantErr)
 	}

--- a/command/taint_test.go
+++ b/command/taint_test.go
@@ -361,12 +361,12 @@ func TestTaint_missingAllow(t *testing.T) {
 
 	// Check for the warning
 	actual := strings.TrimSpace(ui.ErrorWriter.String())
-	expected := strings.TrimSpace(`╷
-│ Warning: No such resource instance
-│
-│ Resource instance test_instance.bar was not found, but this is not an error
-│ because -allow-missing was set.
-╵
+	expected := strings.TrimSpace(`
+Warning: No such resource instance
+
+Resource instance test_instance.bar was not found, but this is not an error
+because -allow-missing was set.
+
 `)
 	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Fatalf("wrong output\n%s", diff)

--- a/command/untaint_test.go
+++ b/command/untaint_test.go
@@ -389,12 +389,12 @@ func TestUntaint_missingAllow(t *testing.T) {
 
 	// Check for the warning
 	actual := strings.TrimSpace(ui.ErrorWriter.String())
-	expected := strings.TrimSpace(`╷
-│ Warning: No such resource instance
-│
-│ Resource instance test_instance.bar was not found, but this is not an error
-│ because -allow-missing was set.
-╵
+	expected := strings.TrimSpace(`
+Warning: No such resource instance
+
+Resource instance test_instance.bar was not found, but this is not an error
+because -allow-missing was set.
+
 `)
 	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Fatalf("wrong output\n%s", diff)


### PR DESCRIPTION
Commit e865faf adds visual indentation for diagnostic messages using various vertical line characters. This PR disables this behaviour when running in automation, adding `format.DiagnosticPlain` to preserve the legacy behaviour.

While the contents of stderr are not intended to be part of the Terraform API, this is currently how terraform-exec detects certain error types in order to present them as well-known Go errors to the user. Such detection is complicated when vertical lines are added to the CLI output at unpredictable points.

I expect this change will also be helpful for screen reader users.