### PR TITLE
cli: Fix state migration remote version check

### DIFF
--- a/command/meta_backend_migrate.go
+++ b/command/meta_backend_migrate.go
@@ -70,6 +70,19 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 	opts.twoEnv = backend.DefaultStateName
 	opts.force = m.forceInitCopy
 
+	// Disregard remote Terraform version for the state source backend. If it's a
+	// Terraform Cloud remote backend, we don't care about the remote version,
+	// as we are migrating away and will not break a remote workspace.
+	m.ignoreRemoteBackendVersionConflict(opts.One)
+
+	// Check the remote Terraform version for the state destination backend. If
+	// it's a Terraform Cloud remote backend, we want to ensure that we don't
+	// break the workspace by uploading an incompatible state file.
+	diags := m.remoteBackendVersionCheck(opts.Two, opts.twoEnv)
+	if diags.HasErrors() {
+		return diags.Err()
+	}
+
 	// Determine migration behavior based on whether the source/destination
 	// supports multi-state.
 	switch {


### PR DESCRIPTION
Previously the state migration process was using the fallback strict error check when migrating to or from a Terraform Cloud workspace. This resulted in an error when running init if the local and remote Terraform versions did not exactly match.

This was excessively strict. When migrating from a remote Terraform Cloud workspace to local state, there is no need for a version check at all, as we cannot break the Terraform Cloud workspace. When migrating to Terraform Cloud, we should use the more forgiving check, rather than the strict equality.

This commit fixes both of these cases accordingly, and allows migrating state to and from Terraform Cloud remote workspaces without errors.

Fixes #27543