### PR TITLE
S3 backend documentation update - DynamoDB uses Partition keys, not primary keys

### DIFF
--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -18,7 +18,7 @@ the `dynamodb_table` field to an existing DynamoDB table name.
 A single DynamoDB table can be used to lock multiple remote state files. Terraform generates key names that include the values of the `bucket` and `key` variables.
 
 ~> **Warning!** It is highly recommended that you enable
-[Bucket Versioning](http://docs.aws.amazon.com/AmazonS3/latest/UG/enable-bucket-versioning.html)
+[Bucket Versioning](https://docs.aws.amazon.com/AmazonS3/latest/UG/enable-bucket-versioning.html)
 on the S3 bucket to allow for state recovery in the case of accidental deletions and human error.
 
 ## Example Configuration
@@ -239,15 +239,15 @@ gain access to the (usually more privileged) administrative infrastructure.
 
 Your administrative AWS account will contain at least the following items:
 
-* One or more [IAM user](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_users.html)
+* One or more [IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users.html)
   for system administrators that will log in to maintain infrastructure in
   the other accounts.
-* Optionally, one or more [IAM groups](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups.html)
+* Optionally, one or more [IAM groups](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups.html)
   to differentiate between different groups of users that have different
   levels of access to the other AWS accounts.
-* An [S3 bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html)
+* An [S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html)
   that will contain the Terraform state files for each workspace.
-* A [DynamoDB table](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.TablesItemsAttributes)
+* A [DynamoDB table](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.TablesItemsAttributes)
   that will be used for locking to prevent concurrent operations on a single
   workspace.
 
@@ -265,7 +265,7 @@ administrative account described above.
 
 Your environment accounts will eventually contain your own product-specific
 infrastructure. Along with this it must contain one or more
-[IAM roles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)
+[IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)
 that grant sufficient access for Terraform to perform the desired management
 tasks.
 
@@ -273,7 +273,7 @@ tasks.
 
 Each Administrator will run Terraform using credentials for their IAM user
 in the administrative account.
-[IAM Role Delegation](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html)
+[IAM Role Delegation](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html)
 is used to grant these users access to the roles created in each environment
 account.
 
@@ -368,7 +368,7 @@ tend to require.
 
 When running Terraform in an automation tool running on an Amazon EC2 instance,
 consider running this instance in the administrative account and using an
-[instance profile](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html)
+[instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html)
 in place of the various administrator IAM users suggested above. An IAM
 instance profile can also be granted cross-account delegation access via
 an IAM policy, giving this instance the access it needs to run Terraform.

--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -199,7 +199,7 @@ The following configuration is optional:
 The following configuration is optional:
 
 * `dynamodb_endpoint` - (Optional) Custom endpoint for the AWS DynamoDB API. This can also be sourced from the `AWS_DYNAMODB_ENDPOINT` environment variable.
-* `dynamodb_table` - (Optional) Name of DynamoDB Table to use for state locking and consistency. The table must have a primary key named `LockID` with type of `string`. If not configured, state locking will be disabled.
+* `dynamodb_table` - (Optional) Name of DynamoDB Table to use for state locking and consistency. The table must have a Partition key named `LockID` with type of `String`. If not configured, state locking will be disabled.
 
 ## Multi-account AWS Architecture
 

--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -18,7 +18,7 @@ the `dynamodb_table` field to an existing DynamoDB table name.
 A single DynamoDB table can be used to lock multiple remote state files. Terraform generates key names that include the values of the `bucket` and `key` variables.
 
 ~> **Warning!** It is highly recommended that you enable
-[Bucket Versioning](https://docs.aws.amazon.com/AmazonS3/latest/UG/enable-bucket-versioning.html)
+[Bucket Versioning](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-versioning.html)
 on the S3 bucket to allow for state recovery in the case of accidental deletions and human error.
 
 ## Example Configuration


### PR DESCRIPTION
Very minor update to the S3 backend documentation.

Refers to a DynamoDB "primary key" - when it should be "Partition key".