### PR TITLE
0.14 backport of 27563

### DIFF
--- a/terraform/context_plan2_test.go
+++ b/terraform/context_plan2_test.go
@@ -1,0 +1,57 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/plans"
+	"github.com/hashicorp/terraform/providers"
+	"github.com/hashicorp/terraform/states"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestContext2Plan_removedDuringRefresh(t *testing.T) {
+	// The resource was added to state but actually failed to create and was
+	// left tainted. This should be removed during plan and result in a Create
+	// action.
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "a" {
+}
+`,
+	})
+
+	p := simpleMockProvider()
+	p.ReadResourceFn = func(req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
+		resp.NewState = cty.NullVal(req.PriorState.Type())
+		return resp
+	}
+	p.PlanResourceChangeFn = testDiffFn
+
+	addr := mustResourceInstanceAddr("test_object.a")
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{"test_string":"foo"}`),
+			Status:    states.ObjectTainted,
+		}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		State:  state,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan()
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+
+	for _, c := range plan.Changes.Resources {
+		if c.Action != plans.Create {
+			t.Fatalf("expected Create action for missing %s, got %s", c.Addr, c.Action)
+		}
+	}
+}

--- a/terraform/eval_diff.go
+++ b/terraform/eval_diff.go
@@ -493,7 +493,7 @@ func (n *EvalDiff) Eval(ctx EvalContext) (interface{}, error) {
 	// If our prior value was tainted then we actually want this to appear
 	// as a replace change, even though so far we've been treating it as a
 	// create.
-	if action == plans.Create && priorValTainted != cty.NilVal {
+	if action == plans.Create && !priorValTainted.IsNull() {
 		if createBeforeDestroy {
 			action = plans.CreateThenDelete
 		} else {


### PR DESCRIPTION
fix null check for tainted state during plan

The tainted state was checked against `cty.NilVal`, however it was
always being set to a null value.

Backport of #27563