### PR TITLE
Backport of core: Fix crash for marked data source prior value into v0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 
 * core: Fix "Invalid planned change" error when planning tainted resource which no longer exists [GH-27563]
+* core: Fix panic when refreshing data source which contains sensitive values [GH-27567]
 
 ## 0.14.5 (January 20, 2021)
 

--- a/terraform/eval_read_data_plan.go
+++ b/terraform/eval_read_data_plan.go
@@ -112,10 +112,15 @@ func (n *evalReadDataPlan) Eval(ctx EvalContext) (interface{}, error) {
 
 	// if we have a prior value, we can check for any irregularities in the response
 	if !priorVal.IsNull() {
+		// We drop marks on the values used here as the result is only
+		// temporarily used for validation.
+		unmarkedConfigVal, _ := configVal.UnmarkDeep()
+		unmarkedPriorVal, _ := priorVal.UnmarkDeep()
+
 		// While we don't propose planned changes for data sources, we can
 		// generate a proposed value for comparison to ensure the data source
 		// is returning a result following the rules of the provider contract.
-		proposedVal := objchange.ProposedNewObject(schema, priorVal, configVal)
+		proposedVal := objchange.ProposedNewObject(schema, unmarkedPriorVal, unmarkedConfigVal)
 		if errs := objchange.AssertObjectCompatible(schema, proposedVal, newVal); len(errs) > 0 {
 			// Resources have the LegacyTypeSystem field to signal when they are
 			// using an SDK which may not produce precise values. While data


### PR DESCRIPTION
When planning a data source change, the object compatibility verification step should be performed with unmarked values. This value is transient and preserving marks is not necessary, and the object change code is not fully marks-aware.

Fixes #27565, backport of #27567