### PR TITLE
docs: Note that state pull upgrades the state file to current version

### DIFF
--- a/command/state_pull.go
+++ b/command/state_pull.go
@@ -70,9 +70,13 @@ func (c *StatePullCommand) Help() string {
 	helpText := `
 Usage: terraform state pull [options]
 
-  Pull the state from its location and output it to stdout.
+  Pull the state from its location, upgrade the local copy, and output it
+  to stdout.
 
   This command "pulls" the current state and outputs it to stdout.
+  As part of this process, Terraform will upgrade the state format of the
+  local copy to the current version.
+
   The primary use of this is for state stored remotely. This command
   will still work with local state but is less useful for this.
 

--- a/website/docs/cli/commands/state/pull.html.md
+++ b/website/docs/cli/commands/state/pull.html.md
@@ -16,9 +16,14 @@ works with local state.
 
 Usage: `terraform state pull`
 
-This command will download the state from its current location and
-output the raw format to stdout.
+This command will download the state from its current location, upgrade the
+local copy to the latest state file version, and output the raw format to
+stdout.
 
 This is useful for reading values out of state (potentially pairing this
 command with something like [jq](https://stedolan.github.io/jq/)). It is
 also useful if you need to make manual modifications to state.
+
+~> Note: This command cannot be used to inspect the Terraform version of
+the remote state, as it will always be converted to the current Terraform
+version before output.


### PR DESCRIPTION
Some users expect the `state pull` subcommand to retrieve the state file directly from the remote backend and output it unchanged, allowing them to use `jq` to inspect the remote state's Terraform version. Since Terraform upgrades the state on load, this is not the case, which causes confusion.

Changing the behaviour of `state pull` is not a simple task, and is being tracked in enhancement request #25866. For now, I think we can be clearer in the documentation about what `state pull` does, which will hopefully avoid this confusion.

Fixes #27555