### PR TITLE
Reuse installed target dir providers in init

### DIFF
--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -310,6 +310,15 @@ NeedProvider:
 			preferredHashes = lock.PreferredHashes()
 		}
 
+		// If our target directory already has the provider version that fulfills the lock file, carry on
+		if installed := i.targetDir.ProviderVersion(provider, version); installed != nil {
+			if len(preferredHashes) > 0 {
+				if matches, _ := installed.MatchesAnyHash(preferredHashes); matches {
+					continue
+				}
+			}
+		}
+
 		if i.globalCacheDir != nil {
 			// Step 3a: If our global cache already has this version available then
 			// we'll just link it in.


### PR DESCRIPTION
In init, we can check to see if the target dir already has the provider we are seeking and skip further querying/installing of that provider.

This will help address concerns users are having where they've previously installed a provider (ex. that is in their `.terraform` directory after install) and subsequent installs keep re-fetching the package. While we've been telling users this installation is expected behavior, I think we can make a nicer flow by making things faster by re-using that same provider if it's already installed.

Closes #27534