### PR TITLE
Remove -module option for taint and untaint

### DIFF
--- a/command/taint.go
+++ b/command/taint.go
@@ -21,14 +21,12 @@ type TaintCommand struct {
 
 func (c *TaintCommand) Run(args []string) int {
 	args = c.Meta.process(args)
-	var module string
 	var allowMissing bool
 	cmdFlags := c.Meta.ignoreRemoteVersionFlagSet("taint")
-	cmdFlags.BoolVar(&allowMissing, "allow-missing", false, "module")
+	cmdFlags.BoolVar(&allowMissing, "allow-missing", false, "allow missing")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
-	cmdFlags.StringVar(&module, "module", "", "module")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
@@ -44,11 +42,6 @@ func (c *TaintCommand) Run(args []string) int {
 	if len(args) != 1 {
 		c.Ui.Error("The taint command expects exactly one argument.")
 		cmdFlags.Usage()
-		return 1
-	}
-
-	if module != "" {
-		c.Ui.Error("The -module option is no longer used. Instead, include the module path in the main resource address, like \"module.foo.module.bar.null_resource.baz\".")
 		return 1
 	}
 

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -19,14 +19,12 @@ type UntaintCommand struct {
 
 func (c *UntaintCommand) Run(args []string) int {
 	args = c.Meta.process(args)
-	var module string
 	var allowMissing bool
 	cmdFlags := c.Meta.ignoreRemoteVersionFlagSet("untaint")
-	cmdFlags.BoolVar(&allowMissing, "allow-missing", false, "module")
+	cmdFlags.BoolVar(&allowMissing, "allow-missing", false, "allow missing")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
-	cmdFlags.StringVar(&module, "module", "", "module")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
@@ -42,11 +40,6 @@ func (c *UntaintCommand) Run(args []string) int {
 	if len(args) != 1 {
 		c.Ui.Error("The untaint command expects exactly one argument.")
 		cmdFlags.Usage()
-		return 1
-	}
-
-	if module != "" {
-		c.Ui.Error("The -module option is no longer used. Instead, include the module path in the main resource address, like \"module.foo.module.bar.null_resource.baz\".")
 		return 1
 	}
 
@@ -209,10 +202,6 @@ Options:
   -lock=true              Lock the state file when locking is supported.
 
   -lock-timeout=0s        Duration to retry a state lock.
-
-  -module=path            The module path where the resource lives. By default
-						  this will be root. Child modules can be specified by
-						  names. Ex. "consul" or "consul.vpc" (nested modules).
 
   -state=path             Path to read and save state (unless state-out
                           is specified). Defaults to "terraform.tfstate".

--- a/website/docs/cli/commands/untaint.html.md
+++ b/website/docs/cli/commands/untaint.html.md
@@ -43,12 +43,6 @@ certain cases, see above note). The list of available flags are:
 
 * `-lock-timeout=0s` - Duration to retry a state lock.
 
-* `-module=path` - The module path where the resource to untaint exists.
-    By default this is the root path. Other modules can be specified by
-    a period-separated list. Example: "foo" would reference the module
-    "foo" but "foo.bar" would reference the "bar" module in the "foo"
-    module.
-
 * `-no-color` - Disables output with coloring
 
 * `-state=path` - Path to read and write the state file to. Defaults to "terraform.tfstate".


### PR DESCRIPTION
This has been an error with help text, and can be removed. A "while I was here" to update the usage text for `-allow-missing` is here as well.

The `untaint` command currently has this option in its help string and its web docs, and I'll be opening a v0.14 specific PR for that.