### PR TITLE
Remove -module from docs for untaint

### DIFF
--- a/command/untaint.go
+++ b/command/untaint.go
@@ -210,10 +210,6 @@ Options:
 
   -lock-timeout=0s        Duration to retry a state lock.
 
-  -module=path            The module path where the resource lives. By default
-						  this will be root. Child modules can be specified by
-						  names. Ex. "consul" or "consul.vpc" (nested modules).
-
   -state=path             Path to read and save state (unless state-out
                           is specified). Defaults to "terraform.tfstate".
 

--- a/website/docs/cli/commands/untaint.html.md
+++ b/website/docs/cli/commands/untaint.html.md
@@ -43,12 +43,6 @@ certain cases, see above note). The list of available flags are:
 
 * `-lock-timeout=0s` - Duration to retry a state lock.
 
-* `-module=path` - The module path where the resource to untaint exists.
-    By default this is the root path. Other modules can be specified by
-    a period-separated list. Example: "foo" would reference the module
-    "foo" but "foo.bar" would reference the "bar" module in the "foo"
-    module.
-
 * `-no-color` - Disables output with coloring
 
 * `-state=path` - Path to read and write the state file to. Defaults to "terraform.tfstate".


### PR DESCRIPTION
This option is an error, and is removed from the docs for taint.
This does the same docs removal for untaint, without changing the current error behavior.