### PR TITLE
Update state mv help docs to use spaces instead of tabs

### DIFF
--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -469,27 +469,27 @@ Options:
                           actually move anything.
 
   -backup=PATH            Path where Terraform should write the backup for the
-						  original state. This can't be disabled. If not set,
-						  Terraform will write it to the same path as the
-						  statefile with a ".backup" extension.
+                          original state. This can't be disabled. If not set,
+                          Terraform will write it to the same path as the
+                          statefile with a ".backup" extension.
 
   -backup-out=PATH        Path where Terraform should write the backup for the
-						  destination state. This can't be disabled. If not
-						  set, Terraform will write it to the same path as the
-						  destination state file with a backup extension. This
-						  only needs to be specified if -state-out is set to a
-						  different path than -state.
+                          destination state. This can't be disabled. If not
+                          set, Terraform will write it to the same path as the
+                          destination state file with a backup extension. This
+                          only needs to be specified if -state-out is set to a
+                          different path than -state.
 
   -lock=true              Lock the state files when locking is supported.
 
   -lock-timeout=0s        Duration to retry a state lock.
 
   -state=PATH             Path to the source state file. Defaults to the
-						  configured backend, or "terraform.tfstate"
+                          configured backend, or "terraform.tfstate"
 
   -state-out=PATH         Path to the destination state file to write to. If
-						  this isn't specified, the source state file will be
-						  used. This can be a new or existing path.
+                          this isn't specified, the source state file will be
+                          used. This can be a new or existing path.
 
   -ignore-remote-version  Continue even if remote and local Terraform versions
                           differ. This may result in an unusable workspace, and

--- a/command/state_mv_test.go
+++ b/command/state_mv_test.go
@@ -1317,6 +1317,13 @@ func TestStateMv_onlyResourceInModule(t *testing.T) {
 	testStateOutput(t, backups[0], testStateMvOnlyResourceInModule_original)
 }
 
+func TestStateMvHelp(t *testing.T) {
+	c := &StateMvCommand{}
+	if strings.ContainsRune(c.Help(), '\t') {
+		t.Fatal("help text contains tab character, which will result in poor formatting")
+	}
+}
+
 const testStateMvOutputOriginal = `
 test_instance.baz:
   ID = foo


### PR DESCRIPTION
Update the state mv help docs, there were rogue tab characters causing non-preferred formatting.

Adds a test to make sure that this text doesn't accidentally get tabs added, without having a test that simply direct matches the whole strings (which would be brittle to adding a tab to the test validation)

Before:
<img width="985" alt="Screen Shot 2021-01-26 at 11 27 03 AM" src="https://user-images.githubusercontent.com/204372/105873409-73c09c00-5fc9-11eb-8216-f00b2dd50283.png">

After:
<img width="813" alt="Screen Shot 2021-01-26 at 11 27 09 AM" src="https://user-images.githubusercontent.com/204372/105873441-7b804080-5fc9-11eb-88e1-a1045588ca6f.png">

