### PR TITLE
Fix command/state_mv_test.go

### DIFF
--- a/command/state_mv_test.go
+++ b/command/state_mv_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"


### PR DESCRIPTION
Missing import appeared due to base branch drift when merging https://github.com/hashicorp/terraform/pull/27536.