### PR TITLE
cli: Remove dead code for output -module flag

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/repl"
 	"github.com/hashicorp/terraform/states"
@@ -178,7 +177,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	}
 
 	if !c.Destroy {
-		if outputs := outputsAsString(op.State, addrs.RootModuleInstance, true); outputs != "" {
+		if outputs := outputsAsString(op.State, true); outputs != "" {
 			c.Ui.Output(c.Colorize().Color(outputs))
 		}
 	}
@@ -315,16 +314,12 @@ Options:
 	return strings.TrimSpace(helpText)
 }
 
-func outputsAsString(state *states.State, modPath addrs.ModuleInstance, includeHeader bool) string {
+func outputsAsString(state *states.State, includeHeader bool) string {
 	if state == nil {
 		return ""
 	}
 
-	ms := state.Module(modPath)
-	if ms == nil {
-		return ""
-	}
-
+	ms := state.RootModule()
 	outputs := ms.OutputValues
 	outputBuf := new(bytes.Buffer)
 	if len(outputs) > 0 {

--- a/command/output_test.go
+++ b/command/output_test.go
@@ -268,35 +268,6 @@ func TestOutput_jsonEmptyOutputs(t *testing.T) {
 	}
 }
 
-func TestMissingModuleOutput(t *testing.T) {
-	originalState := states.BuildState(func(s *states.SyncState) {
-		s.SetOutputValue(
-			addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
-			cty.StringVal("bar"),
-			false,
-		)
-	})
-	statePath := testStateFile(t, originalState)
-
-	ui := new(cli.MockUi)
-	c := &OutputCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(testProvider()),
-			Ui:               ui,
-		},
-	}
-
-	args := []string{
-		"-state", statePath,
-		"-module", "not_existing_module",
-		"blah",
-	}
-
-	if code := c.Run(args); code != 1 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
-	}
-}
-
 func TestOutput_badVar(t *testing.T) {
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetOutputValue(

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/tfdiags"
 )
@@ -96,7 +95,7 @@ func (c *RefreshCommand) Run(args []string) int {
 		return op.Result.ExitStatus()
 	}
 
-	if outputs := outputsAsString(op.State, addrs.RootModuleInstance, true); outputs != "" {
+	if outputs := outputsAsString(op.State, true); outputs != "" {
 		c.Ui.Output(c.Colorize().Color(outputs))
 	}
 


### PR DESCRIPTION
The `-module` flag to `terraform output` has been unimplemented since 0.12 (removed in 025540789). This commit removes some dead code and the specific error message for this flag.

[The website documentation for `output`](https://www.terraform.io/docs/cli/commands/output.html) does not mention this flag, so it is unchanged.