### PR TITLE
Unmark values in couldHaveUnknownBlockPlaceholder before iteration

### DIFF
--- a/plans/objchange/compatible.go
+++ b/plans/objchange/compatible.go
@@ -357,6 +357,10 @@ func couldHaveUnknownBlockPlaceholder(v cty.Value, blockS *configschema.NestedBl
 			return false // treated as if the list were empty, so we would see zero iterations below
 		}
 
+		// Unmark before we call ElementIterator in case this iterable is marked sensitive.
+		// This can arise in the case where a member of a Set is sensitive, and thus the
+		// whole Set is marked sensitive
+		v, _ := v.Unmark()
 		// For all other nesting modes, our value should be something iterable.
 		for it := v.ElementIterator(); it.Next(); {
 			_, ev := it.Element()


### PR DESCRIPTION
This is needed for cases where a variable may be fetched and become a member of a set, and thus the whole set is marked, which means ElementIterator will panic on unmarked values.

Fixes https://github.com/hashicorp/terraform/issues/27596