### PR TITLE
cli: Remove legacy positional path arguments

### DIFF
--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -26,6 +26,12 @@ import (
 )
 
 func TestApply(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	statePath := testTempFile(t)
 
 	p := applyFixtureProvider()
@@ -41,7 +47,6 @@ func TestApply(t *testing.T) {
 	args := []string{
 		"-state", statePath,
 		"-auto-approve",
-		testFixturePath("apply"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -59,6 +64,12 @@ func TestApply(t *testing.T) {
 
 // test apply with locked state
 func TestApply_lockedState(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	statePath := testTempFile(t)
 
 	unlock, err := testLockState(testDataDir, statePath)
@@ -79,7 +90,6 @@ func TestApply_lockedState(t *testing.T) {
 	args := []string{
 		"-state", statePath,
 		"-auto-approve",
-		testFixturePath("apply"),
 	}
 	if code := c.Run(args); code == 0 {
 		t.Fatal("expected error")
@@ -93,6 +103,12 @@ func TestApply_lockedState(t *testing.T) {
 
 // test apply with locked state, waiting for unlock
 func TestApply_lockedStateWait(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	statePath := testTempFile(t)
 
 	unlock, err := testLockState(testDataDir, statePath)
@@ -121,7 +137,6 @@ func TestApply_lockedStateWait(t *testing.T) {
 		"-state", statePath,
 		"-lock-timeout", "4s",
 		"-auto-approve",
-		testFixturePath("apply"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("lock should have succeeded in less than 3s: %s", ui.ErrorWriter)
@@ -157,6 +172,12 @@ func (t *hwm) Max() int {
 }
 
 func TestApply_parallelism(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("parallelism"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	statePath := testTempFile(t)
 
 	par := 4
@@ -217,7 +238,6 @@ func TestApply_parallelism(t *testing.T) {
 		"-state", statePath,
 		"-auto-approve",
 		fmt.Sprintf("-parallelism=%d", par),
-		testFixturePath("parallelism"),
 	}
 
 	// Run in a goroutine. We can get any errors from the ui.OutputWriter
@@ -258,6 +278,12 @@ func TestApply_parallelism(t *testing.T) {
 }
 
 func TestApply_configInvalid(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply-config-invalid"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &ApplyCommand{
@@ -270,7 +296,6 @@ func TestApply_configInvalid(t *testing.T) {
 	args := []string{
 		"-state", testTempFile(t),
 		"-auto-approve",
-		testFixturePath("apply-config-invalid"),
 	}
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("bad: \n%s", ui.OutputWriter.String())
@@ -278,7 +303,12 @@ func TestApply_configInvalid(t *testing.T) {
 }
 
 func TestApply_defaultState(t *testing.T) {
-	td := testTempDir(t)
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	statePath := filepath.Join(td, DefaultStateFilename)
 
 	// Change to the temporary directory
@@ -308,7 +338,6 @@ func TestApply_defaultState(t *testing.T) {
 
 	args := []string{
 		"-auto-approve",
-		testFixturePath("apply"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -325,6 +354,12 @@ func TestApply_defaultState(t *testing.T) {
 }
 
 func TestApply_error(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply-error"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	statePath := testTempFile(t)
 
 	p := testProvider()
@@ -376,7 +411,6 @@ func TestApply_error(t *testing.T) {
 	args := []string{
 		"-state", statePath,
 		"-auto-approve",
-		testFixturePath("apply-error"),
 	}
 	if ui.ErrorWriter != nil {
 		t.Logf("stdout:\n%s", ui.OutputWriter.String())
@@ -400,6 +434,12 @@ func TestApply_error(t *testing.T) {
 }
 
 func TestApply_input(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply-input"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	// Disable test mode so input would be asked
 	test = false
 	defer func() { test = true }()
@@ -426,7 +466,6 @@ func TestApply_input(t *testing.T) {
 	args := []string{
 		"-state", statePath,
 		"-auto-approve",
-		testFixturePath("apply-input"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -444,6 +483,12 @@ result = foo
 // When only a partial set of the variables are set, Terraform
 // should still ask for the unset ones by default (with -input=true)
 func TestApply_inputPartial(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply-input-partial"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	// Disable test mode so input would be asked
 	test = false
 	defer func() { test = true }()
@@ -467,7 +512,6 @@ func TestApply_inputPartial(t *testing.T) {
 		"-state", statePath,
 		"-auto-approve",
 		"-var", "foo=foovalue",
-		testFixturePath("apply-input-partial"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -484,14 +528,11 @@ foo = foovalue
 }
 
 func TestApply_noArgs(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(testFixturePath("apply")); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
 
 	statePath := testTempFile(t)
 
@@ -517,9 +558,6 @@ func TestApply_noArgs(t *testing.T) {
 	}
 
 	state := testStateRead(t, statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
 	if state == nil {
 		t.Fatal("state should not be nil")
 	}
@@ -800,6 +838,12 @@ func TestApply_planNoModuleFiles(t *testing.T) {
 }
 
 func TestApply_refresh(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -831,7 +875,6 @@ func TestApply_refresh(t *testing.T) {
 	args := []string{
 		"-state", statePath,
 		"-auto-approve",
-		testFixturePath("apply"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -861,6 +904,12 @@ func TestApply_refresh(t *testing.T) {
 }
 
 func TestApply_shutdown(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply-shutdown"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	cancelled := make(chan struct{})
 	shutdownCh := make(chan struct{})
 
@@ -920,7 +969,6 @@ func TestApply_shutdown(t *testing.T) {
 	args := []string{
 		"-state", statePath,
 		"-auto-approve",
-		testFixturePath("apply-shutdown"),
 	}
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -943,6 +991,12 @@ func TestApply_shutdown(t *testing.T) {
 }
 
 func TestApply_state(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -986,7 +1040,6 @@ func TestApply_state(t *testing.T) {
 	args := []string{
 		"-state", statePath,
 		"-auto-approve",
-		testFixturePath("apply"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -1031,6 +1084,12 @@ func TestApply_state(t *testing.T) {
 }
 
 func TestApply_stateNoExist(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	p := applyFixtureProvider()
 	ui := new(cli.MockUi)
 	c := &ApplyCommand{
@@ -1042,7 +1101,6 @@ func TestApply_stateNoExist(t *testing.T) {
 
 	args := []string{
 		"idontexist.tfstate",
-		testFixturePath("apply"),
 	}
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("bad: \n%s", ui.OutputWriter.String())
@@ -1050,6 +1108,12 @@ func TestApply_stateNoExist(t *testing.T) {
 }
 
 func TestApply_sensitiveOutput(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply-sensitive-output"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &ApplyCommand{
@@ -1064,7 +1128,6 @@ func TestApply_sensitiveOutput(t *testing.T) {
 	args := []string{
 		"-state", statePath,
 		"-auto-approve",
-		testFixturePath("apply-sensitive-output"),
 	}
 
 	if code := c.Run(args); code != 0 {
@@ -1081,6 +1144,12 @@ func TestApply_sensitiveOutput(t *testing.T) {
 }
 
 func TestApply_vars(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply-vars"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	statePath := testTempFile(t)
 
 	p := testProvider()
@@ -1120,7 +1189,6 @@ func TestApply_vars(t *testing.T) {
 		"-auto-approve",
 		"-var", "foo=bar",
 		"-state", statePath,
-		testFixturePath("apply-vars"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -1132,6 +1200,12 @@ func TestApply_vars(t *testing.T) {
 }
 
 func TestApply_varFile(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply-vars"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	varFilePath := testTempFile(t)
 	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
@@ -1176,7 +1250,6 @@ func TestApply_varFile(t *testing.T) {
 		"-auto-approve",
 		"-var-file", varFilePath,
 		"-state", statePath,
-		testFixturePath("apply-vars"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -1188,22 +1261,18 @@ func TestApply_varFile(t *testing.T) {
 }
 
 func TestApply_varFileDefault(t *testing.T) {
-	varFileDir := testTempDir(t)
-	varFilePath := filepath.Join(varFileDir, "terraform.tfvars")
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply-vars"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	varFilePath := filepath.Join(td, "terraform.tfvars")
 	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	statePath := testTempFile(t)
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(varFileDir); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
 
 	p := testProvider()
 	ui := new(cli.MockUi)
@@ -1241,7 +1310,6 @@ func TestApply_varFileDefault(t *testing.T) {
 	args := []string{
 		"-auto-approve",
 		"-state", statePath,
-		testFixturePath("apply-vars"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -1253,22 +1321,18 @@ func TestApply_varFileDefault(t *testing.T) {
 }
 
 func TestApply_varFileDefaultJSON(t *testing.T) {
-	varFileDir := testTempDir(t)
-	varFilePath := filepath.Join(varFileDir, "terraform.tfvars.json")
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply-vars"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	varFilePath := filepath.Join(td, "terraform.tfvars.json")
 	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFileJSON), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	statePath := testTempFile(t)
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(varFileDir); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
 
 	p := testProvider()
 	ui := new(cli.MockUi)
@@ -1306,7 +1370,6 @@ func TestApply_varFileDefaultJSON(t *testing.T) {
 	args := []string{
 		"-auto-approve",
 		"-state", statePath,
-		testFixturePath("apply-vars"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -1318,6 +1381,12 @@ func TestApply_varFileDefaultJSON(t *testing.T) {
 }
 
 func TestApply_backup(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -1358,7 +1427,6 @@ func TestApply_backup(t *testing.T) {
 		"-auto-approve",
 		"-state", statePath,
 		"-backup", backupPath,
-		testFixturePath("apply"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -1389,6 +1457,12 @@ func TestApply_backup(t *testing.T) {
 }
 
 func TestApply_disableBackup(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	originalState := testState()
 	statePath := testStateFile(t, originalState)
 
@@ -1412,7 +1486,6 @@ func TestApply_disableBackup(t *testing.T) {
 		"-auto-approve",
 		"-state", statePath,
 		"-backup", "-",
-		testFixturePath("apply"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -1462,6 +1535,12 @@ func TestApply_disableBackup(t *testing.T) {
 
 // Test that the Terraform env is passed through
 func TestApply_terraformEnv(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply-terraform-env"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	statePath := testTempFile(t)
 
 	p := testProvider()
@@ -1476,7 +1555,6 @@ func TestApply_terraformEnv(t *testing.T) {
 	args := []string{
 		"-auto-approve",
 		"-state", statePath,
-		testFixturePath("apply-terraform-env"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -1495,7 +1573,7 @@ output = default
 func TestApply_terraformEnvNonDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := tempDir(t)
-	os.MkdirAll(td, 0755)
+	testCopyDir(t, testFixturePath("apply-terraform-env"), td)
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
@@ -1531,7 +1609,6 @@ func TestApply_terraformEnvNonDefault(t *testing.T) {
 
 	args := []string{
 		"-auto-approve",
-		testFixturePath("apply-terraform-env"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())

--- a/command/command.go
+++ b/command/command.go
@@ -47,29 +47,25 @@ is configured to use a non-local backend. This backend doesn't support this
 operation.
 `
 
-// ModulePath returns the path to the root module from the CLI args.
+// ModulePath returns the path to the root module and validates CLI arguments.
 //
-// This centralizes the logic for any commands that expect a module path
-// on their CLI args. This will verify that only one argument is given
-// and that it is a path to configuration.
+// This centralizes the logic for any commands that previously accepted
+// a module path via CLI arguments. This will error if any extraneous arguments
+// are given and suggest using the -chdir flag instead.
 //
 // If your command accepts more than one arg, then change the slice bounds
 // to pass validation.
 func ModulePath(args []string) (string, error) {
 	// TODO: test
 
-	if len(args) > 1 {
-		return "", fmt.Errorf("Too many command line arguments. Configuration path expected.")
+	if len(args) > 0 {
+		return "", fmt.Errorf("Too many command line arguments. Did you mean to use -chdir?")
 	}
 
-	if len(args) == 0 {
-		path, err := os.Getwd()
-		if err != nil {
-			return "", fmt.Errorf("Error getting pwd: %s", err)
-		}
-
-		return path, nil
+	path, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("Error getting pwd: %s", err)
 	}
 
-	return args[0], nil
+	return path, nil
 }

--- a/command/console.go
+++ b/command/console.go
@@ -175,7 +175,7 @@ func (c *ConsoleCommand) modePiped(session *repl.Session, ui cli.Ui) int {
 
 func (c *ConsoleCommand) Help() string {
 	helpText := `
-Usage: terraform console [options] [DIR]
+Usage: terraform console [options]
 
   Starts an interactive console for experimenting with Terraform
   interpolations.
@@ -186,9 +186,6 @@ Usage: terraform console [options] [DIR]
   using them in future configurations.
 
   This command will never modify your state.
-
-  DIR can be set to a directory with a Terraform state to load. By
-  default, this will default to the current working directory.
 
 Options:
 

--- a/command/get_test.go
+++ b/command/get_test.go
@@ -9,8 +9,10 @@ import (
 )
 
 func TestGet(t *testing.T) {
-	tmp, cwd := testCwd(t)
-	defer testFixCwd(t, tmp, cwd)
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("get"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
 
 	ui := new(cli.MockUi)
 	c := &GetCommand{
@@ -21,9 +23,7 @@ func TestGet(t *testing.T) {
 		},
 	}
 
-	args := []string{
-		testFixturePath("get"),
-	}
+	args := []string{}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
@@ -53,7 +53,7 @@ func TestGet_multipleArgs(t *testing.T) {
 	}
 }
 
-func TestGet_noArgs(t *testing.T) {
+func TestGet_update(t *testing.T) {
 	td := tempDir(t)
 	testCopyDir(t, testFixturePath("get"), td)
 	defer os.RemoveAll(td)
@@ -68,33 +68,8 @@ func TestGet_noArgs(t *testing.T) {
 		},
 	}
 
-	args := []string{}
-	if code := c.Run(args); code != 0 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
-	}
-
-	output := ui.OutputWriter.String()
-	if !strings.Contains(output, "- foo in") {
-		t.Fatalf("doesn't look like get: %s", output)
-	}
-}
-
-func TestGet_update(t *testing.T) {
-	tmp, cwd := testCwd(t)
-	defer testFixCwd(t, tmp, cwd)
-
-	ui := new(cli.MockUi)
-	c := &GetCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(testProvider()),
-			Ui:               ui,
-			dataDir:          tempDir(t),
-		},
-	}
-
 	args := []string{
 		"-update",
-		testFixturePath("get"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())

--- a/command/graph.go
+++ b/command/graph.go
@@ -23,6 +23,7 @@ func (c *GraphCommand) Run(args []string) int {
 	var graphTypeStr string
 	var moduleDepth int
 	var verbose bool
+	var planPath string
 
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("graph")
@@ -30,19 +31,14 @@ func (c *GraphCommand) Run(args []string) int {
 	cmdFlags.StringVar(&graphTypeStr, "type", "", "type")
 	cmdFlags.IntVar(&moduleDepth, "module-depth", -1, "module-depth")
 	cmdFlags.BoolVar(&verbose, "verbose", false, "verbose")
+	cmdFlags.StringVar(&planPath, "plan", "", "plan")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
-	args = cmdFlags.Args()
-	var planPath string
-	if len(args) > 0 {
-		planPath = args[0]
-		args = args[1:]
-	}
-	configPath, err := ModulePath(args)
+	configPath, err := ModulePath(cmdFlags.Args())
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -170,7 +166,7 @@ func (c *GraphCommand) Help() string {
 Usage: terraform graph [options]
 
   Outputs the visual execution graph of Terraform resources according to
-  configuration files in the current directory.
+  either the current configuration or an execution plan.
 
   The graph is outputted in DOT format. The typical program that can
   read this format is GraphViz, but many web services are also available
@@ -183,6 +179,9 @@ Usage: terraform graph [options]
   argument.
 
 Options:
+
+  -plan=tfplan     Render graph using the specified plan file instead of the
+                   configuration in the current directory.
 
   -draw-cycles     Highlight any cycles in the graph with colored edges.
                    This helps when diagnosing cycle errors.

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 func TestGraph(t *testing.T) {
-	tmp, cwd := testCwd(t)
-	defer testFixCwd(t, tmp, cwd)
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("graph"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
 
 	ui := new(cli.MockUi)
 	c := &GraphCommand{
@@ -25,9 +27,7 @@ func TestGraph(t *testing.T) {
 		},
 	}
 
-	args := []string{
-		testFixturePath("graph"),
-	}
+	args := []string{}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
@@ -57,14 +57,10 @@ func TestGraph_multipleArgs(t *testing.T) {
 }
 
 func TestGraph_noArgs(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(testFixturePath("graph")); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("graph"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
 
 	ui := new(cli.MockUi)
 	c := &GraphCommand{

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -150,7 +150,7 @@ func TestGraph_plan(t *testing.T) {
 	}
 
 	args := []string{
-		planPath,
+		"-plan", planPath,
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())

--- a/command/plan.go
+++ b/command/plan.go
@@ -47,21 +47,6 @@ func (c *PlanCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Check if the path is a plan, which is not permitted
-	planFileReader, err := c.PlanFile(configPath)
-	if err != nil {
-		c.Ui.Error(err.Error())
-		return 1
-	}
-	if planFileReader != nil {
-		c.showDiagnostics(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid configuration directory",
-			fmt.Sprintf("Cannot pass a saved plan file to the 'terraform plan' command. To apply a saved plan, use: terraform apply %s", configPath),
-		))
-		return 1
-	}
-
 	var diags tfdiags.Diagnostics
 
 	var backendConfig *configs.Backend
@@ -191,7 +176,7 @@ func (c *PlanCommand) Run(args []string) int {
 
 func (c *PlanCommand) Help() string {
 	helpText := `
-Usage: terraform plan [options] [DIR]
+Usage: terraform plan [options]
 
   Generates a speculative execution plan, showing what actions Terraform
   would take to apply the current configuration. This command will not

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -104,7 +104,7 @@ func (c *RefreshCommand) Run(args []string) int {
 
 func (c *RefreshCommand) Help() string {
 	helpText := `
-Usage: terraform refresh [options] [dir]
+Usage: terraform refresh [options]
 
   Update the state file of your infrastructure with metadata that matches
   the physical resources they are tracking.

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -27,6 +27,12 @@ import (
 var equateEmpty = cmpopts.EquateEmpty()
 
 func TestRefresh(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("refresh"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	state := testState()
 	statePath := testStateFile(t, state)
 
@@ -49,7 +55,6 @@ func TestRefresh(t *testing.T) {
 
 	args := []string{
 		"-state", statePath,
-		testFixturePath("refresh"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -100,9 +105,7 @@ func TestRefresh_empty(t *testing.T) {
 		}),
 	}
 
-	args := []string{
-		td,
-	}
+	args := []string{}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
@@ -113,6 +116,12 @@ func TestRefresh_empty(t *testing.T) {
 }
 
 func TestRefresh_lockedState(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("refresh"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	state := testState()
 	statePath := testStateFile(t, state)
 
@@ -141,7 +150,6 @@ func TestRefresh_lockedState(t *testing.T) {
 
 	args := []string{
 		"-state", statePath,
-		testFixturePath("refresh"),
 	}
 
 	if code := c.Run(args); code == 0 {
@@ -214,6 +222,12 @@ func TestRefresh_cwd(t *testing.T) {
 }
 
 func TestRefresh_defaultState(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("refresh"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	originalState := testState()
 
 	// Write the state file in a temporary directory with the
@@ -258,7 +272,6 @@ func TestRefresh_defaultState(t *testing.T) {
 
 	args := []string{
 		"-state", statePath,
-		testFixturePath("refresh"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -290,6 +303,12 @@ func TestRefresh_defaultState(t *testing.T) {
 }
 
 func TestRefresh_outPath(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("refresh"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	state := testState()
 	statePath := testStateFile(t, state)
 
@@ -322,7 +341,6 @@ func TestRefresh_outPath(t *testing.T) {
 	args := []string{
 		"-state", statePath,
 		"-state-out", outPath,
-		testFixturePath("refresh"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -353,6 +371,12 @@ func TestRefresh_outPath(t *testing.T) {
 }
 
 func TestRefresh_var(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("refresh-var"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	state := testState()
 	statePath := testStateFile(t, state)
 
@@ -369,7 +393,6 @@ func TestRefresh_var(t *testing.T) {
 	args := []string{
 		"-var", "foo=bar",
 		"-state", statePath,
-		testFixturePath("refresh-var"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -384,6 +407,12 @@ func TestRefresh_var(t *testing.T) {
 }
 
 func TestRefresh_varFile(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("refresh-var"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	state := testState()
 	statePath := testStateFile(t, state)
 
@@ -405,7 +434,6 @@ func TestRefresh_varFile(t *testing.T) {
 	args := []string{
 		"-var-file", varFilePath,
 		"-state", statePath,
-		testFixturePath("refresh-var"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -420,6 +448,12 @@ func TestRefresh_varFile(t *testing.T) {
 }
 
 func TestRefresh_varFileDefault(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("refresh-var"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	state := testState()
 	statePath := testStateFile(t, state)
 
@@ -433,24 +467,13 @@ func TestRefresh_varFileDefault(t *testing.T) {
 	}
 	p.GetSchemaResponse = refreshVarFixtureSchema()
 
-	varFileDir := testTempDir(t)
-	varFilePath := filepath.Join(varFileDir, "terraform.tfvars")
+	varFilePath := filepath.Join(td, "terraform.tfvars")
 	if err := ioutil.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(varFileDir); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
-
 	args := []string{
 		"-state", statePath,
-		testFixturePath("refresh-var"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -465,6 +488,12 @@ func TestRefresh_varFileDefault(t *testing.T) {
 }
 
 func TestRefresh_varsUnset(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("refresh-unset-var"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	// Disable test mode so input would be asked
 	test = false
 	defer func() { test = true }()
@@ -497,7 +526,6 @@ func TestRefresh_varsUnset(t *testing.T) {
 
 	args := []string{
 		"-state", statePath,
-		testFixturePath("refresh-unset-var"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -505,6 +533,12 @@ func TestRefresh_varsUnset(t *testing.T) {
 }
 
 func TestRefresh_backup(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("refresh"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	state := testState()
 	statePath := testStateFile(t, state)
 
@@ -553,7 +587,6 @@ func TestRefresh_backup(t *testing.T) {
 		"-state", statePath,
 		"-state-out", outPath,
 		"-backup", backupPath,
-		testFixturePath("refresh"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -584,6 +617,12 @@ func TestRefresh_backup(t *testing.T) {
 }
 
 func TestRefresh_disableBackup(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("refresh"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	state := testState()
 	statePath := testStateFile(t, state)
 
@@ -617,7 +656,6 @@ func TestRefresh_disableBackup(t *testing.T) {
 		"-state", statePath,
 		"-state-out", outPath,
 		"-backup", "-",
-		testFixturePath("refresh"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
@@ -653,6 +691,12 @@ func TestRefresh_disableBackup(t *testing.T) {
 }
 
 func TestRefresh_displaysOutputs(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("refresh-output"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
 	state := testState()
 	statePath := testStateFile(t, state)
 
@@ -679,7 +723,6 @@ func TestRefresh_displaysOutputs(t *testing.T) {
 
 	args := []string{
 		"-state", statePath,
-		testFixturePath("refresh-output"),
 	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())

--- a/command/unlock.go
+++ b/command/unlock.go
@@ -30,8 +30,8 @@ func (c *UnlockCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	if len(args) == 0 {
-		c.Ui.Error("unlock requires a lock id argument")
+	if len(args) != 1 {
+		c.Ui.Error("Expected a single argument: LOCK_ID")
 		return cli.RunResultHelp
 	}
 
@@ -116,7 +116,7 @@ func (c *UnlockCommand) Run(args []string) int {
 
 func (c *UnlockCommand) Help() string {
 	helpText := `
-Usage: terraform force-unlock LOCK_ID [DIR]
+Usage: terraform force-unlock LOCK_ID
 
   Manually unlock the state for the defined configuration.
 

--- a/command/unlock_test.go
+++ b/command/unlock_test.go
@@ -56,7 +56,7 @@ func TestUnlock(t *testing.T) {
 		"-force",
 	}
 
-	if code := c.Run(args); code != 1 {
+	if code := c.Run(args); code != cli.RunResultHelp {
 		t.Fatalf("bad: %d\n%s\n%s", code, ui.OutputWriter.String(), ui.ErrorWriter.String())
 	}
 }

--- a/command/workspace_delete.go
+++ b/command/workspace_delete.go
@@ -35,8 +35,8 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	if len(args) == 0 {
-		c.Ui.Error("expected NAME.\n")
+	if len(args) != 1 {
+		c.Ui.Error("Expected a single argument: NAME.\n")
 		return cli.RunResultHelp
 	}
 
@@ -182,7 +182,7 @@ func (c *WorkspaceDeleteCommand) AutocompleteFlags() complete.Flags {
 
 func (c *WorkspaceDeleteCommand) Help() string {
 	helpText := `
-Usage: terraform workspace delete [OPTIONS] NAME [DIR]
+Usage: terraform workspace delete [OPTIONS] NAME
 
   Delete a Terraform workspace
 

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -91,7 +91,7 @@ func (c *WorkspaceListCommand) AutocompleteFlags() complete.Flags {
 
 func (c *WorkspaceListCommand) Help() string {
 	helpText := `
-Usage: terraform workspace list [DIR]
+Usage: terraform workspace list
 
   List Terraform workspaces.
 

--- a/command/workspace_new.go
+++ b/command/workspace_new.go
@@ -37,7 +37,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	if len(args) == 0 {
+	if len(args) != 1 {
 		c.Ui.Error("Expected a single argument: NAME.\n")
 		return cli.RunResultHelp
 	}
@@ -176,7 +176,7 @@ func (c *WorkspaceNewCommand) AutocompleteFlags() complete.Flags {
 
 func (c *WorkspaceNewCommand) Help() string {
 	helpText := `
-Usage: terraform workspace new [OPTIONS] NAME [DIR]
+Usage: terraform workspace new [OPTIONS] NAME
 
   Create a new Terraform workspace.
 

--- a/command/workspace_select.go
+++ b/command/workspace_select.go
@@ -26,7 +26,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	if len(args) == 0 {
+	if len(args) != 1 {
 		c.Ui.Error("Expected a single argument: NAME.\n")
 		return cli.RunResultHelp
 	}
@@ -129,7 +129,7 @@ func (c *WorkspaceSelectCommand) AutocompleteFlags() complete.Flags {
 
 func (c *WorkspaceSelectCommand) Help() string {
 	helpText := `
-Usage: terraform workspace select NAME [DIR]
+Usage: terraform workspace select NAME
 
   Select a different Terraform workspace.
 

--- a/website/docs/cli/commands/graph.html.md
+++ b/website/docs/cli/commands/graph.html.md
@@ -18,20 +18,23 @@ The output is in the DOT format, which can be used by
 
 Usage: `terraform graph [options]`
 
-Outputs the visual dependency graph of Terraform resources represented by the
-configuration in the current working directory.
+Outputs the visual execution graph of Terraform resources according to
+either the current configuration or an execution plan.
 
 The graph is outputted in DOT format. The typical program that can
 read this format is GraphViz, but many web services are also available
 to read this format.
 
-The -type flag can be used to control the type of graph shown. Terraform
+The `-type` flag can be used to control the type of graph shown. Terraform
 creates different graphs for different operations. See the options below
 for the list of types supported. The default type is "plan" if a
 configuration is given, and "apply" if a plan file is passed as an
 argument.
 
 Options:
+
+* `-plan=tfplan`    - Render graph using the specified plan file instead of the
+                      configuration in the current directory.
 
 * `-draw-cycles`    - Highlight any cycles in the graph with colored edges.
                       This helps when diagnosing cycle errors.
@@ -48,7 +51,7 @@ The output of `terraform graph` is in the DOT format, which can
 easily be converted to an image by making use of `dot` provided
 by GraphViz:
 
-```shell
+```shellsession
 $ terraform graph | dot -Tsvg > graph.svg
 ```
 


### PR DESCRIPTION
Several commands continued to support the legacy positional path argument to specify a working directory. This functionality has been replaced with the global `-chdir` flag (#26087), which is specified before any other arguments, including the sub-command name.

This commit removes support for the trailing path parameter from most commands. The only command which still supports a path argument is `fmt`, which also supports "-" to indicate receiving configuration from standard input.

Any invocation of a command with an invalid trailing path parameter will result in a short error message, pointing at the `-chdir` alternative.

There are many test updates in this commit, almost all of which are migrations from using positional arguments to specify a working directory. Because of the layer at which these tests run, we are unable to use the `-chdir` argument, so the churn in test files is larger than ideal. Sorry!