### PR TITLE
Fix possible nil pointer dereference in azure sdk

### DIFF
--- a/backend/remote-state/azure/client.go
+++ b/backend/remote-state/azure/client.go
@@ -39,7 +39,7 @@ func (c *RemoteClient) Get() (*remote.Payload, error) {
 	ctx := context.TODO()
 	blob, err := c.giovanniBlobClient.Get(ctx, c.accountName, c.containerName, c.keyName, options)
 	if err != nil {
-		if blob.Response.StatusCode == 404 {
+		if blob.Response.Response != nil && blob.Response.StatusCode == 404 {
 			return nil, nil
 		}
 		return nil, err

--- a/backend/remote-state/azure/client.go
+++ b/backend/remote-state/azure/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"

--- a/backend/remote-state/azure/client.go
+++ b/backend/remote-state/azure/client.go
@@ -39,7 +39,7 @@ func (c *RemoteClient) Get() (*remote.Payload, error) {
 	ctx := context.TODO()
 	blob, err := c.giovanniBlobClient.Get(ctx, c.accountName, c.containerName, c.keyName, options)
 	if err != nil {
-		if blob.Response.Response != nil && blob.Response.StatusCode == 404 {
+		if blob.Response.IsHTTPStatus(http.StatusNotFound) {
 			return nil, nil
 		}
 		return nil, err


### PR DESCRIPTION
Fix for bug desribed in #27511. Value of `blob.Response.Response` could be `nil` if error occurred on early stages of calling `c.giovanniBlobClient.Get(...)` method.