### PR TITLE
cli: Better diagnostics for apply positional args

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -74,10 +74,21 @@ func (c *ApplyCommand) Run(args []string) int {
 			c.Ui.Error(err.Error())
 			return 1
 		}
-	}
-	if c.Destroy && planFile != nil {
-		c.Ui.Error("Destroy can't be called with a plan file.")
-		return 1
+
+		// If the path doesn't look like a plan, both planFile and err will be
+		// nil. In that case, the user is probably trying to use the positional
+		// argument to specify a configuration path. Point them at -chdir.
+		if planFile == nil {
+			c.Ui.Error(fmt.Sprintf("Failed to load %q as a plan file. Did you mean to use -chdir?", planPath))
+			return 1
+		}
+
+		// If we successfully loaded a plan but this is a destroy operation,
+		// explain that this is not supported.
+		if c.Destroy {
+			c.Ui.Error("Destroy can't be called with a plan file.")
+			return 1
+		}
 	}
 	if planFile != nil {
 		// Reset the config path for backend loading

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -63,6 +63,36 @@ func TestApply(t *testing.T) {
 	}
 }
 
+func TestApply_path(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("apply"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	p := applyFixtureProvider()
+
+	ui := new(cli.MockUi)
+	c := &ApplyCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+		},
+	}
+
+	args := []string{
+		"-auto-approve",
+		testFixturePath("apply"),
+	}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+	output := ui.ErrorWriter.String()
+	if !strings.Contains(output, "-chdir") {
+		t.Fatal("expected command output to refer to -chdir flag, but got:", output)
+	}
+}
+
 func TestApply_approveNo(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := tempDir(t)


### PR DESCRIPTION
[The previous changes removing support for using the trailing positional argument as a working directory](https://github.com/hashicorp/terraform/pull/27664) missed a spot in the `apply`/`destroy` command implementation. We still support this argument for applying a saved plan:

    terraform apply foo.tfplan

However, if you pass a positional path which doesn't "look like" a plan (for example, the path to a configuration directory), Terraform would silently ignore it and continue.

This commit fixes that by adding an error message if the user specifies a path which the plan loader rejects as not "looking like" a plan. This message includes a reference to the `-chdir` flag as a pointer about what to do next.

We also rearrange the error message when calling `terraform destroy` with a plan file argument, and add test coverage for the above. While we're here, update the destroy tests to copy the fixture directory, chdir, and defer cleanup.