### PR TITLE
cli: Remove deprecated destroy -force flag

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -188,12 +188,11 @@ type Operation struct {
 
 	// The options below are more self-explanatory and affect the runtime
 	// behavior of the operation.
-	AutoApprove  bool
-	Destroy      bool
-	DestroyForce bool
-	Parallelism  int
-	Targets      []addrs.Targetable
-	Variables    map[string]UnparsedVariableValue
+	AutoApprove bool
+	Destroy     bool
+	Parallelism int
+	Targets     []addrs.Targetable
+	Variables   map[string]UnparsedVariableValue
 
 	// Some operations use root module variables only opportunistically or
 	// don't need them at all. If this flag is set, the backend must treat

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -79,7 +79,7 @@ func (b *Local) opApply(
 
 		trivialPlan := plan.Changes.Empty()
 		hasUI := op.UIOut != nil && op.UIIn != nil
-		mustConfirm := hasUI && ((op.Destroy && (!op.DestroyForce && !op.AutoApprove)) || (!op.Destroy && !op.AutoApprove && !trivialPlan))
+		mustConfirm := hasUI && !op.AutoApprove && !trivialPlan
 		if mustConfirm {
 			var desc, query string
 			if op.Destroy {

--- a/backend/remote/backend_apply.go
+++ b/backend/remote/backend_apply.go
@@ -170,8 +170,7 @@ func (b *Remote) opApply(stopCtx, cancelCtx context.Context, op *backend.Operati
 		return r, diags.Err()
 	}
 
-	mustConfirm := (op.UIIn != nil && op.UIOut != nil) &&
-		((op.Destroy && (!op.DestroyForce && !op.AutoApprove)) || (!op.Destroy && !op.AutoApprove))
+	mustConfirm := (op.UIIn != nil && op.UIOut != nil) && !op.AutoApprove
 
 	if !w.AutoApply {
 		if mustConfirm {

--- a/command/apply.go
+++ b/command/apply.go
@@ -24,7 +24,7 @@ type ApplyCommand struct {
 }
 
 func (c *ApplyCommand) Run(args []string) int {
-	var destroyForce, refresh, autoApprove bool
+	var refresh, autoApprove bool
 	args = c.Meta.process(args)
 	cmdName := "apply"
 	if c.Destroy {
@@ -33,9 +33,6 @@ func (c *ApplyCommand) Run(args []string) int {
 
 	cmdFlags := c.Meta.extendedFlagSet(cmdName)
 	cmdFlags.BoolVar(&autoApprove, "auto-approve", false, "skip interactive approval of plan before applying")
-	if c.Destroy {
-		cmdFlags.BoolVar(&destroyForce, "force", false, "deprecated: same as auto-approve")
-	}
 	cmdFlags.BoolVar(&refresh, "refresh", true, "refresh")
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
@@ -160,7 +157,6 @@ func (c *ApplyCommand) Run(args []string) int {
 	opReq.AutoApprove = autoApprove
 	opReq.ConfigDir = configPath
 	opReq.Destroy = c.Destroy
-	opReq.DestroyForce = destroyForce
 	opReq.PlanFile = planFile
 	opReq.PlanRefresh = refresh
 	opReq.Type = backend.OperationTypeApply
@@ -318,8 +314,6 @@ Options:
                          ".backup" extension. Set to "-" to disable backup.
 
   -auto-approve          Skip interactive approval before destroying.
-
-  -force                 Deprecated: same as auto-approve.
 
   -lock=true             Lock the state file when locking is supported.
 


### PR DESCRIPTION
This dramatically simplifies the logic around auto-approve, which is nice.

Also add test coverage for the manual approve step, for both apply and destroy, answering both yes and no.