### PR TITLE
cli: Fix for missing provider requirements in JSON plan

### DIFF
--- a/command/testdata/show-json/provider-version-no-config/main.tf
+++ b/command/testdata/show-json/provider-version-no-config/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+      version = ">= 1.2.3"
+    }
+  }
+}
+
+variable "test_var" {
+  default = "bar"
+}
+
+resource "test_instance" "test" {
+  ami   = var.test_var
+  count = 3
+}
+
+output "test" {
+  value = var.test_var
+}

--- a/command/testdata/show-json/provider-version-no-config/output.json
+++ b/command/testdata/show-json/provider-version-no-config/output.json
@@ -1,0 +1,184 @@
+{
+    "format_version": "0.1",
+    "variables": {
+        "test_var": {
+            "value": "bar"
+        }
+    },
+    "planned_values": {
+        "outputs": {
+            "test": {
+                "sensitive": false,
+                "value": "bar"
+            }
+        },
+        "root_module": {
+            "resources": [
+                {
+                    "address": "test_instance.test[0]",
+                    "index": 0,
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
+                    "schema_version": 0,
+                    "values": {
+                        "ami": "bar"
+                    }
+                },
+                {
+                    "address": "test_instance.test[1]",
+                    "index": 1,
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
+                    "schema_version": 0,
+                    "values": {
+                        "ami": "bar"
+                    }
+                },
+                {
+                    "address": "test_instance.test[2]",
+                    "index": 2,
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
+                    "schema_version": 0,
+                    "values": {
+                        "ami": "bar"
+                    }
+                }
+            ]
+        }
+    },
+    "prior_state": {
+        "format_version": "0.1",
+        "values": {
+            "outputs": {
+                "test": {
+                    "sensitive": false,
+                    "value": "bar"
+                }
+            },
+            "root_module": {}
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "test_instance.test[0]",
+            "index": 0,
+            "mode": "managed",
+            "type": "test_instance",
+            "provider_name": "registry.terraform.io/hashicorp/test",
+            "name": "test",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after_unknown": {
+                    "id": true
+                },
+                "after": {
+                    "ami": "bar"
+                }
+            }
+        },
+        {
+            "address": "test_instance.test[1]",
+            "index": 1,
+            "mode": "managed",
+            "type": "test_instance",
+            "provider_name": "registry.terraform.io/hashicorp/test",
+            "name": "test",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after_unknown": {
+                    "id": true
+                },
+                "after": {
+                    "ami": "bar"
+                }
+            }
+        },
+        {
+            "address": "test_instance.test[2]",
+            "index": 2,
+            "mode": "managed",
+            "type": "test_instance",
+            "provider_name": "registry.terraform.io/hashicorp/test",
+            "name": "test",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after_unknown": {
+                    "id": true
+                },
+                "after": {
+                    "ami": "bar"
+                }
+            }
+        }
+    ],
+    "output_changes": {
+        "test": {
+            "actions": [
+                "create"
+            ],
+            "before": null,
+            "after": "bar",
+            "after_unknown": false
+        }
+    },
+    "configuration": {
+        "provider_config": {
+            "test": {
+                "name": "test",
+                "version_constraint": ">= 1.2.3"
+            }
+        },
+        "root_module": {
+            "outputs": {
+                "test": {
+                    "expression": {
+                        "references": [
+                            "var.test_var"
+                        ]
+                    }
+                }
+            },
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_config_key": "test",
+                    "schema_version": 0,
+                    "expressions": {
+                        "ami": {
+                            "references": [
+                                "var.test_var"
+                            ]
+                        }
+                    },
+                    "count_expression": {
+                        "constant_value": 3
+                    }
+                }
+            ],
+            "variables": {
+                "test_var": {
+                    "default": "bar"
+                }
+            }
+        }
+    }
+}

--- a/command/testdata/show-json/provider-version/main.tf
+++ b/command/testdata/show-json/provider-version/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+      version = ">= 1.2.3"
+    }
+  }
+}
+
+provider "test" {
+  region = "somewhere"
+  version = "1.2.3"
+}
+
+variable "test_var" {
+  default = "bar"
+}
+
+resource "test_instance" "test" {
+  ami   = var.test_var
+  count = 3
+}
+
+output "test" {
+  value = var.test_var
+}

--- a/command/testdata/show-json/provider-version/output.json
+++ b/command/testdata/show-json/provider-version/output.json
@@ -1,0 +1,189 @@
+{
+    "format_version": "0.1",
+    "variables": {
+        "test_var": {
+            "value": "bar"
+        }
+    },
+    "planned_values": {
+        "outputs": {
+            "test": {
+                "sensitive": false,
+                "value": "bar"
+            }
+        },
+        "root_module": {
+            "resources": [
+                {
+                    "address": "test_instance.test[0]",
+                    "index": 0,
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
+                    "schema_version": 0,
+                    "values": {
+                        "ami": "bar"
+                    }
+                },
+                {
+                    "address": "test_instance.test[1]",
+                    "index": 1,
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
+                    "schema_version": 0,
+                    "values": {
+                        "ami": "bar"
+                    }
+                },
+                {
+                    "address": "test_instance.test[2]",
+                    "index": 2,
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_name": "registry.terraform.io/hashicorp/test",
+                    "schema_version": 0,
+                    "values": {
+                        "ami": "bar"
+                    }
+                }
+            ]
+        }
+    },
+    "prior_state": {
+        "format_version": "0.1",
+        "values": {
+            "outputs": {
+                "test": {
+                    "sensitive": false,
+                    "value": "bar"
+                }
+            },
+            "root_module": {}
+        }
+    },
+    "resource_changes": [
+        {
+            "address": "test_instance.test[0]",
+            "index": 0,
+            "mode": "managed",
+            "type": "test_instance",
+            "provider_name": "registry.terraform.io/hashicorp/test",
+            "name": "test",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after_unknown": {
+                    "id": true
+                },
+                "after": {
+                    "ami": "bar"
+                }
+            }
+        },
+        {
+            "address": "test_instance.test[1]",
+            "index": 1,
+            "mode": "managed",
+            "type": "test_instance",
+            "provider_name": "registry.terraform.io/hashicorp/test",
+            "name": "test",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after_unknown": {
+                    "id": true
+                },
+                "after": {
+                    "ami": "bar"
+                }
+            }
+        },
+        {
+            "address": "test_instance.test[2]",
+            "index": 2,
+            "mode": "managed",
+            "type": "test_instance",
+            "provider_name": "registry.terraform.io/hashicorp/test",
+            "name": "test",
+            "change": {
+                "actions": [
+                    "create"
+                ],
+                "before": null,
+                "after_unknown": {
+                    "id": true
+                },
+                "after": {
+                    "ami": "bar"
+                }
+            }
+        }
+    ],
+    "output_changes": {
+        "test": {
+            "actions": [
+                "create"
+            ],
+            "before": null,
+            "after": "bar",
+            "after_unknown": false
+        }
+    },
+    "configuration": {
+        "provider_config": {
+            "test": {
+                "name": "test",
+                "expressions": {
+                    "region": {
+                        "constant_value": "somewhere"
+                    }
+                },
+                "version_constraint": ">= 1.2.3, 1.2.3"
+            }
+        },
+        "root_module": {
+            "outputs": {
+                "test": {
+                    "expression": {
+                        "references": [
+                            "var.test_var"
+                        ]
+                    }
+                }
+            },
+            "resources": [
+                {
+                    "address": "test_instance.test",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "test",
+                    "provider_config_key": "test",
+                    "schema_version": 0,
+                    "expressions": {
+                        "ami": {
+                            "references": [
+                                "var.test_var"
+                            ]
+                        }
+                    },
+                    "count_expression": {
+                        "constant_value": 3
+                    }
+                }
+            ],
+            "variables": {
+                "test_var": {
+                    "default": "bar"
+                }
+            }
+        }
+    }
+}

--- a/configs/config.go
+++ b/configs/config.go
@@ -190,6 +190,18 @@ func (c *Config) ProviderRequirements() (getproviders.Requirements, hcl.Diagnost
 	return reqs, diags
 }
 
+// ProviderRequirementsShallow searches only the direct receiver for explicit
+// and implicit dependencies on providers. Descendant modules are ignored.
+//
+// If the returned diagnostics includes errors then the resulting Requirements
+// may be incomplete.
+func (c *Config) ProviderRequirementsShallow() (getproviders.Requirements, hcl.Diagnostics) {
+	reqs := make(getproviders.Requirements)
+	diags := c.addProviderRequirements(reqs, false)
+
+	return reqs, diags
+}
+
 // ProviderRequirementsByModule searches the full tree of modules under the
 // receiver for both explicit and implicit dependencies on providers,
 // constructing a tree where the requirements are broken out by module.


### PR DESCRIPTION
The JSON plan output format includes a serialized, simplified version of the configuration. One component of this config is a map of provider configurations, which includes version constraints.

Until now, only version constraints specified in the provider config blocks were exposed in the JSON plan output. This is a deprecated method of specifying provider versions, and the recommended use of a `required_providers` block resulted in the version constraints being omitted.

This commit fixes this with two changes:

- When processing the provider configurations from a module, output the fully-merged version constraints for the entire module, instead of any constraints set in the provider configuration block itself;
- After all provider configurations are processed, iterate over the `required_providers` entries to ensure that any configuration-less providers are output to the JSON plan too.

No changes are necessary to the structure of the JSON plan output, so this is effectively a semantic level bug fix.