### PR TITLE
Fix empty diags not getting associated with source.

### DIFF
--- a/plugin/convert/diagnostics.go
+++ b/plugin/convert/diagnostics.go
@@ -65,7 +65,7 @@ func ProtoToDiagnostics(ds []*proto.Diagnostic) tfdiags.Diagnostics {
 		var newDiag tfdiags.Diagnostic
 
 		// if there's an attribute path, we need to create a AttributeValue diagnostic
-		if d.Attribute != nil {
+		if d.Attribute != nil && len(d.Attribute.Steps) > 0 {
 			path := AttributePathToPath(d.Attribute)
 			newDiag = tfdiags.AttributeValue(severity, d.Summary, d.Detail, path)
 		} else {


### PR DESCRIPTION
Right now, there's a bug that if a diagnostic comes back from the
provider with an AttributePath set, but no steps in the AttributePath,
Terraform _thinks_ it's an attribute-specific diagnostic and not a
whole-resource diagnostic, but then doesn't associate it with any
specific attribute, meaning the diagnostic doesn't get associated with
the config at all.

This PR changes things to check if there are any steps in the
AttributePath before deciding this isn't a whole-resource diagnostic,
and if there aren't, treats it as a whole-resource diagnostic, instead.

See hashicorp/terraform-plugin-sdk#561 for more details on how this
surfaces in the wild.