### PR TITLE
Emit ProviderAlreadyInstalled when provider installed

### DIFF
--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -314,6 +314,9 @@ NeedProvider:
 		if installed := i.targetDir.ProviderVersion(provider, version); installed != nil {
 			if len(preferredHashes) > 0 {
 				if matches, _ := installed.MatchesAnyHash(preferredHashes); matches {
+					if cb := evts.ProviderAlreadyInstalled; cb != nil {
+						cb(provider, version)
+					}
 					continue
 				}
 			}

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apparentlymart/go-versions/versions"
 	"github.com/apparentlymart/go-versions/versions/constraints"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
@@ -645,6 +646,11 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Event:    "QueryPackagesSuccess",
 							Provider: beepProvider,
 							Args:     "2.0.0",
+						},
+						{
+							Event:    "ProviderAlreadyInstalled",
+							Provider: beepProvider,
+							Args:     versions.Version{Major: 2, Minor: 0, Patch: 0},
 						},
 					},
 				}


### PR DESCRIPTION
Emit the ProviderAlreadyInstalled event when we successfully verify that we've already installed this provider and are skipping installation.

Before:
```
$ terraform init

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of providerland/foo from the dependency lock file

Terraform has been successfully initialized!

```

After:
```
$ terraform init

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of providerland/foo from the dependency lock file
- Using previously-installed providerland/foo v0.0.8

Terraform has been successfully initialized!
```

