### PR TITLE
New IP Network function cidrnet(ip_address, netmask) and cidrbitmask(netmask)

### DIFF
--- a/lang/funcs/cidr.go
+++ b/lang/funcs/cidr.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"strconv"
+	"strings"
 
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/zclconf/go-cty/cty"
@@ -186,6 +188,68 @@ var CidrSubnetsFunc = function.New(&function.Spec{
 	},
 })
 
+// CidrNetFunc constructs a cidr notation for a subnet provided a network address
+// in "subnet" "netmask" notation
+var CidrNetFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "subnet",
+			Type: cty.String,
+		},
+		{
+			Name: "netmask",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
+		netmaskslice := strings.Split(args[1].AsString(), ".")
+		var netmaskBytes []byte
+
+		for _, s := range netmaskslice {
+			i, _ := strconv.ParseInt(s, 10, 16)
+			netmaskBytes = append(netmaskBytes, byte(i))
+		}
+
+		ipmask := net.IPv4Mask(netmaskBytes[0], netmaskBytes[1], netmaskBytes[2], netmaskBytes[3])
+
+		cidrmask, _ := ipmask.Size()
+		cidrsubnet := fmt.Sprintf("%s/%v", args[0].AsString(), cidrmask)
+		_, network, err := net.ParseCIDR(cidrsubnet)
+		if err != nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("invalid Subnet expression: %s", err)
+		}
+
+		return cty.StringVal(network.String()), nil
+	},
+})
+
+// CidrBitmaskFunc returns the bitmask size given a octet notation
+var CidrBitmaskFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "netmask",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.Number),
+	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
+		netmaskslice := strings.Split(args[0].AsString(), ".")
+		var netmaskBytes []byte
+
+		for _, s := range netmaskslice {
+			i, _ := strconv.ParseInt(s, 10, 16)
+			netmaskBytes = append(netmaskBytes, byte(i))
+		}
+
+		ipmask := net.IPv4Mask(netmaskBytes[0], netmaskBytes[1], netmaskBytes[2], netmaskBytes[3])
+
+		cidrmask, _ := ipmask.Size()
+
+		return cty.NumberIntVal(int64(cidrmask)), nil
+	},
+})
+
 // CidrHost calculates a full host IP address within a given IP network address prefix.
 func CidrHost(prefix, hostnum cty.Value) (cty.Value, error) {
 	return CidrHostFunc.Call([]cty.Value{prefix, hostnum})
@@ -208,4 +272,14 @@ func CidrSubnets(prefix cty.Value, newbits ...cty.Value) (cty.Value, error) {
 	args[0] = prefix
 	copy(args[1:], newbits)
 	return CidrSubnetsFunc.Call(args)
+}
+
+// CidrNet converts legacy "Subnet" "Netmask" notation into CIDR notation
+func CidrNet(subnet, netmask cty.Value) (cty.Value, error) {
+	return CidrNetFunc.Call([]cty.Value{subnet, netmask})
+}
+
+// CidrNet converts legacy "Subnet" "Netmask" notation into CIDR notation
+func CidrBitmask(netmask cty.Value) (cty.Value, error) {
+	return CidrBitmaskFunc.Call([]cty.Value{netmask})
 }

--- a/lang/funcs/cidr.go
+++ b/lang/funcs/cidr.go
@@ -203,7 +203,11 @@ var CidrNetFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.String),
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
-		netmaskslice := strings.Split(args[1].AsString(), ".")
+		netmask := args[1].AsString()
+		if net.ParseIP(netmask) == nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("invalid Netmask expression: %s", netmask)
+		}
+		netmaskslice := strings.Split(netmask, ".")
 		var netmaskBytes []byte
 
 		for _, s := range netmaskslice {
@@ -234,7 +238,11 @@ var CidrBitmaskFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.Number),
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
-		netmaskslice := strings.Split(args[0].AsString(), ".")
+		netmask := args[0].AsString()
+		if net.ParseIP(netmask) == nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("invalid Netmask expression: %s", err)
+		}
+		netmaskslice := strings.Split(netmask, ".")
 		var netmaskBytes []byte
 
 		for _, s := range netmaskslice {

--- a/lang/funcs/cidr_test.go
+++ b/lang/funcs/cidr_test.go
@@ -338,3 +338,93 @@ func TestCidrSubnets(t *testing.T) {
 		})
 	}
 }
+
+func TestCidrNet(t *testing.T) {
+	tests := []struct {
+		Subnet  cty.Value
+		Netmask cty.Value
+		Want    cty.Value
+		Err     bool
+	}{
+		{
+			cty.StringVal("192.168.1.0"),
+			cty.StringVal("255.255.255.0"),
+			cty.StringVal("192.168.1.0/24"),
+			false,
+		},
+		{
+			cty.StringVal("10.10.10.6"),
+			cty.StringVal("255.255.254.0"),
+			cty.StringVal("10.10.10.0/23"),
+			false,
+		},
+		{
+			cty.StringVal("192.168.0.200"),
+			cty.StringVal("255.255.255.128"),
+			cty.StringVal("192.168.0.128/25"),
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("cidrnet(%#v, %#v)", test.Subnet, test.Netmask), func(t *testing.T) {
+			got, err := CidrNet(test.Subnet, test.Netmask)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
+func TestCidrBitmask(t *testing.T) {
+	tests := []struct {
+		Netmask cty.Value
+		Want    cty.Value
+		Err     bool
+	}{
+		{
+			cty.StringVal("255.255.255.0"),
+			cty.NumberIntVal(24),
+			false,
+		},
+		{
+			cty.StringVal("255.255.254.0"),
+			cty.NumberIntVal(23),
+			false,
+		},
+		{
+			cty.StringVal("255.255.255.128"),
+			cty.NumberIntVal(25),
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("cidrbitmask(%#v)", test.Netmask), func(t *testing.T) {
+			got, err := CidrBitmask(test.Netmask)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}

--- a/lang/funcs/cidr_test.go
+++ b/lang/funcs/cidr_test.go
@@ -353,9 +353,9 @@ func TestCidrNet(t *testing.T) {
 			false,
 		},
 		{
-			cty.StringVal("10.10.10.6"),
+			cty.StringVal("192.168.1.6"),
 			cty.StringVal("255.255.254.0"),
-			cty.StringVal("10.10.10.0/23"),
+			cty.StringVal("192.168.0.0/23"),
 			false,
 		},
 		{
@@ -363,6 +363,36 @@ func TestCidrNet(t *testing.T) {
 			cty.StringVal("255.255.255.128"),
 			cty.StringVal("192.168.0.128/25"),
 			false,
+		},
+		{
+			cty.StringVal("192.168.1.6"),
+			cty.StringVal("255.255.255.255"),
+			cty.StringVal("192.168.1.6/32"),
+			false,
+		},
+		{
+			cty.StringVal("192.168.1.6"),
+			cty.StringVal("0.0.0.0"),
+			cty.StringVal("0.0.0.0/0"),
+			false,
+		},
+		{
+			cty.StringVal("192.168.1.6"),
+			cty.StringVal("255.255.355.0"),
+			cty.NumberIntVal(0),
+			true,
+		},
+		{
+			cty.StringVal("192.168.1.6"),
+			cty.StringVal("not-a-netmask"),
+			cty.NumberIntVal(0),
+			true,
+		},
+		{
+			cty.StringVal("not-an-ip"),
+			cty.StringVal("255.255.255.0"),
+			cty.NumberIntVal(0),
+			true,
 		},
 	}
 
@@ -406,6 +436,31 @@ func TestCidrBitmask(t *testing.T) {
 			cty.StringVal("255.255.255.128"),
 			cty.NumberIntVal(25),
 			false,
+		},
+		{
+			cty.StringVal("255.255.255.255"),
+			cty.NumberIntVal(32),
+			false,
+		},
+		{
+			cty.StringVal("0.0.0.0"),
+			cty.NumberIntVal(0),
+			false,
+		},
+		{
+			cty.StringVal("255.255.355.0"),
+			cty.NumberIntVal(0),
+			true,
+		},
+		{
+			cty.StringVal("not-a-netmask"),
+			cty.NumberIntVal(0),
+			true,
+		},
+		{
+			cty.StringVal("fe80::/48"),
+			cty.NumberIntVal(0),
+			true,
 		},
 	}
 

--- a/lang/functions.go
+++ b/lang/functions.go
@@ -50,6 +50,8 @@ func (s *Scope) Functions() map[string]function.Function {
 			"cidrnetmask":      funcs.CidrNetmaskFunc,
 			"cidrsubnet":       funcs.CidrSubnetFunc,
 			"cidrsubnets":      funcs.CidrSubnetsFunc,
+			"cidrnet":          funcs.CidrNetFunc,
+			"cidrbitmask":      funcs.CidrBitmaskFunc,
 			"coalesce":         funcs.CoalesceFunc,
 			"coalescelist":     stdlib.CoalesceListFunc,
 			"compact":          stdlib.CompactFunc,

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -209,6 +209,20 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"cidrnet": {
+			{
+				`cidrsubnet("192.168.1.6", "255.255.254.0")`,
+				cty.StringVal("192.168.0.0/23"),
+			},
+		},
+
+		"cidrbitmask": {
+			{
+				`cidrsubnet("255.255.255.0")`,
+				cty.NumberIntVal(24),
+			},
+		},
+
 		"coalesce": {
 			{
 				`coalesce("first", "second", "third")`,

--- a/website/docs/language/functions/cidrbitmask.html.md
+++ b/website/docs/language/functions/cidrbitmask.html.md
@@ -1,0 +1,43 @@
+---
+layout: "language"
+page_title: "cidrbitmask - Functions - Configuration Language"
+sidebar_current: "docs-funcs-ipnet-cidrbitmask"
+description: |-
+  The cidrbitmask function converts an IPv4 subnet mask in decimal dot
+  notation into a CIDR mask size
+---
+
+# `cidrbitmask` Function
+
+`cidrbitmask` converts an IPv4 subnet mask in conventional dotted-decimal 
+IPv4 address syntax into a CIDR mask size
+
+```hcl
+cidrbitmask(subnetmask)
+```
+
+`subnetmask` must be given in conventional dotted-decimal IPv4 address syntax
+```
+"255.255.255.255"
+```
+
+The result is a CIDR mask size as an integer
+
+CIDR notation is the only valid notation for IPv6 addresses, so `cidrbitmask`
+produces an error if given an IPv6 address.
+
+## Examples
+
+```
+> cidrbitmask("255.240.0.0")
+12
+> cidrbitmask("255.255.255.0")
+24
+> cidrbitmask("255.255.255.255")
+32
+```
+
+## Related Functions
+
+* [`cidrnet`](./cidrnet.html) calculates the CIDR prefix given an address
+and subnet mask in conventional dotted-decimal IPv4 address syntax

--- a/website/docs/language/functions/cidrnet.html.md
+++ b/website/docs/language/functions/cidrnet.html.md
@@ -1,0 +1,50 @@
+---
+layout: "language"
+page_title: "cidrnet - Functions - Configuration Language"
+sidebar_current: "docs-funcs-ipnet-cidrnet"
+description: |-
+  The cidrnet function converts an IPv4 address
+  and subnet mask in conventional dotted-decimal
+  notation into a CIDR prefix
+---
+
+# `cidrnet` Function
+
+`cidrnet` converts an IPv4 address and subnet mask in conventional dotted-decimal 
+IPv4 address syntax into it's CIDR prefix
+
+```hcl
+cidrnet(address, subnetmask)
+```
+
+`address` must be given in conventional dotted-decimal IPv4 address syntax
+```
+"192.168.1.0"
+```
+
+`subnetmask` must be given in conventional dotted-decimal IPv4 address syntax
+```
+"255.255.255.255"
+```
+
+The result is the CIDR prefix for the given subnet
+
+CIDR notation is the only valid notation for IPv6 addresses, so `cidrnet`
+has no support for IPv6
+
+## Examples
+
+```
+> cidrnet("192.168.1.6", "255.255.254.0")
+192.168.0.0/23
+> cidrnet("192.168.0.200", "255.255.255.128")
+192.168.0.128/25
+> cidrnet("192.168.1.6", "255.255.255.255")
+192.168.1.6/32
+```
+
+
+## Related Functions
+
+* [`cidrbitmask`](./cidrbitmask.html) calculates the prefix size
+given a subnet mask in conventional dotted-decimal IPv4 address syntax

--- a/website/layouts/language.erb
+++ b/website/layouts/language.erb
@@ -778,6 +778,14 @@
                 <a href="/docs/language/functions/cidrsubnets.html">cidrsubnets</a>
               </li>
 
+              <li>
+                <a href="/docs/language/functions/cidrnet.html">cidrnet</a>
+              </li>
+
+              <li>
+                <a href="/docs/language/functions/cidrbitmask.html">cidrbitmask</a>
+              </li>
+
             </ul>
           </li>
 


### PR DESCRIPTION
As proposed in [Issue #23905](https://github.com/hashicorp/terraform/issues/23905) 

### Use-cases
Some providers of network equipment will represent return IP data in conventional dotted-decimal IPv4 notation where as most resource definitions require CIDR notation. This can make it cumbersome to work with these devices. This is can add an unnecessary level of complexity when applying to a brown-field environment.

### Proposed Solution
adding two new functions:

> cidrnet("10.10.10.10", "255.255.255.0")
10.10.10.0/24
> cidrnet("192.168.0.200", "255.255.255.128")
192.168.0.128/25
> cidrbitmask("255.255.255.0")
24
> cidrbitmask("255.255.192.0")
18


These functions can be used with the other CIDR functions present for complete convertibility between notations