### PR TITLE
Cost Estimation CLI output unnecessary

### DIFF
--- a/backend/remote/backend_common.go
+++ b/backend/remote/backend_common.go
@@ -276,7 +276,9 @@ func (b *Remote) costEstimate(stopCtx, cancelCtx context.Context, op *backend.Op
 			}
 		}
 
-		if b.CLI != nil {
+		// checking if i == 0 so as to avoid printing this starting horizontal-rule
+		// every retry, and that it only prints it on the first (i=0) attempt.
+		if b.CLI != nil && i == 0 {
 			b.CLI.Output("\n------------------------------------------------------------------------\n")
 		}
 

--- a/backend/remote/backend_common.go
+++ b/backend/remote/backend_common.go
@@ -250,15 +250,7 @@ func (b *Remote) costEstimate(stopCtx, cancelCtx context.Context, op *backend.Op
 		return nil
 	}
 
-	if b.CLI != nil {
-		b.CLI.Output("\n------------------------------------------------------------------------\n")
-	}
-
 	msgPrefix := "Cost estimation"
-	if b.CLI != nil {
-		b.CLI.Output(b.Colorize().Color(msgPrefix + ":\n"))
-	}
-
 	started := time.Now()
 	updated := started
 	for i := 0; ; i++ {
@@ -284,6 +276,10 @@ func (b *Remote) costEstimate(stopCtx, cancelCtx context.Context, op *backend.Op
 			}
 		}
 
+		if b.CLI != nil {
+			b.CLI.Output("\n------------------------------------------------------------------------\n")
+		}
+
 		switch ce.Status {
 		case tfe.CostEstimateFinished:
 			delta, err := strconv.ParseFloat(ce.DeltaMonthlyCost, 64)
@@ -299,6 +295,7 @@ func (b *Remote) costEstimate(stopCtx, cancelCtx context.Context, op *backend.Op
 			deltaRepr := strings.Replace(ce.DeltaMonthlyCost, "-", "", 1)
 
 			if b.CLI != nil {
+				b.CLI.Output(b.Colorize().Color(msgPrefix + ":\n"))
 				b.CLI.Output(b.Colorize().Color(fmt.Sprintf("Resources: %d of %d estimated", ce.MatchedResourcesCount, ce.ResourcesCount)))
 				b.CLI.Output(b.Colorize().Color(fmt.Sprintf("           $%s/mo %s$%s", ce.ProposedMonthlyCost, sign, deltaRepr)))
 
@@ -320,10 +317,12 @@ func (b *Remote) costEstimate(stopCtx, cancelCtx context.Context, op *backend.Op
 					elapsed = fmt.Sprintf(
 						" (%s elapsed)", current.Sub(started).Truncate(30*time.Second))
 				}
+				b.CLI.Output(b.Colorize().Color(msgPrefix + ":\n"))
 				b.CLI.Output(b.Colorize().Color("Waiting for cost estimate to complete..." + elapsed + "\n"))
 			}
 			continue
 		case tfe.CostEstimateSkippedDueToTargeting:
+			b.CLI.Output(b.Colorize().Color(msgPrefix + ":\n"))
 			b.CLI.Output("Not available for this plan, because it was created with the -target option.")
 			b.CLI.Output("\n------------------------------------------------------------------------")
 			return nil


### PR DESCRIPTION
## Problem

When an error occurs during `terraform apply`, the _"Cost Estimation"_ output  appears, even though it shouldn't.

**See Screenshot**

![image](https://user-images.githubusercontent.com/4130121/107538454-ffbdf080-6b91-11eb-9fdd-d714d254a579.png)

## Solution

There is nothing wrong with the specific conditions in the remote backend for cost estimations. Rather, the `CLI.Output` should appear further below depending on the `Status` returned from the `api/v2/cost-estimation` endpoint in the remote backend. 

![image](https://user-images.githubusercontent.com/4130121/107538921-75c25780-6b92-11eb-9b2b-11596ef7358c.png)
