### PR TITLE
cli: Migrate Terraform UI hook to command views

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -183,6 +183,10 @@ type Operation struct {
 	// configuration from ConfigDir.
 	ConfigLoader *configload.Loader
 
+	// Hooks can be used to perform actions triggered by various events during
+	// the operation's lifecycle.
+	Hooks []terraform.Hook
+
 	// Plan is a plan that was passed as an argument. This is valid for
 	// plan and apply arguments but may not work for all backends.
 	PlanFile *planfile.Reader

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -40,12 +40,7 @@ func (b *Local) opApply(
 	}
 
 	stateHook := new(StateHook)
-	if b.ContextOpts == nil {
-		b.ContextOpts = new(terraform.ContextOpts)
-	}
-	old := b.ContextOpts.Hooks
-	defer func() { b.ContextOpts.Hooks = old }()
-	b.ContextOpts.Hooks = append(b.ContextOpts.Hooks, stateHook)
+	op.Hooks = append(op.Hooks, stateHook)
 
 	// Get our context
 	tfCtx, _, opState, contextDiags := b.context(op)

--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -77,6 +77,7 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, *configload.
 	opts.Destroy = op.Destroy
 	opts.Targets = op.Targets
 	opts.UIInput = op.UIIn
+	opts.Hooks = op.Hooks
 
 	opts.SkipRefresh = op.Type != backend.OperationTypeRefresh && !op.PlanRefresh
 	if opts.SkipRefresh {

--- a/command/apply.go
+++ b/command/apply.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/command/arguments"
 	"github.com/hashicorp/terraform/command/views"
 	"github.com/hashicorp/terraform/plans/planfile"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
@@ -110,7 +111,6 @@ func (c *ApplyCommand) Run(args []string) int {
 
 	// Set up our count hook that keeps track of resource changes
 	countHook := new(CountHook)
-	c.ExtraHooks = append(c.ExtraHooks, countHook)
 
 	// Load the backend
 	var be backend.Enhanced
@@ -171,6 +171,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	opReq.AutoApprove = autoApprove
 	opReq.ConfigDir = configPath
 	opReq.Destroy = c.Destroy
+	opReq.Hooks = []terraform.Hook{countHook, c.uiHook()}
 	opReq.PlanFile = planFile
 	opReq.PlanRefresh = refresh
 	opReq.ShowDiagnostics = c.showDiagnostics

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -941,10 +941,12 @@ func TestApply_planNoModuleFiles(t *testing.T) {
 	p := applyFixtureProvider()
 	planPath := applyFixturePlanFile(t)
 
+	view, _ := testView(t)
 	apply := &ApplyCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               new(cli.MockUi),
+			View:             view,
 		},
 	}
 	args := []string{

--- a/command/import.go
+++ b/command/import.go
@@ -189,6 +189,7 @@ func (c *ImportCommand) Run(args []string) int {
 		c.showDiagnostics(diags)
 		return 1
 	}
+	opReq.Hooks = []terraform.Hook{c.uiHook()}
 	{
 		var moreDiags tfdiags.Diagnostics
 		opReq.Variables, moreDiags = c.collectVariableValues()

--- a/command/import_test.go
+++ b/command/import_test.go
@@ -24,10 +24,12 @@ func TestImport(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -77,10 +79,12 @@ func TestImport_providerConfig(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -170,9 +174,11 @@ func TestImport_remoteState(t *testing.T) {
 
 	// init our backend
 	ui := cli.NewMockUi()
+	view, _ := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
 		Ui:               ui,
+		View:             view,
 		ProviderSource:   providerSource,
 	}
 
@@ -192,6 +198,7 @@ func TestImport_remoteState(t *testing.T) {
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -280,9 +287,11 @@ func TestImport_initializationErrorShouldUnlock(t *testing.T) {
 
 	// init our backend
 	ui := cli.NewMockUi()
+	view, _ := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
 		Ui:               ui,
+		View:             view,
 		ProviderSource:   providerSource,
 	}
 
@@ -305,6 +314,7 @@ func TestImport_initializationErrorShouldUnlock(t *testing.T) {
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -339,10 +349,12 @@ func TestImport_providerConfigWithVar(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -417,10 +429,12 @@ func TestImport_providerConfigWithDataSource(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -480,10 +494,12 @@ func TestImport_providerConfigWithVarDefault(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -557,10 +573,12 @@ func TestImport_providerConfigWithVarFile(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -635,10 +653,12 @@ func TestImport_allowMissingResourceConfig(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -690,10 +710,12 @@ func TestImport_emptyConfig(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -720,10 +742,12 @@ func TestImport_missingResourceConfig(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -750,10 +774,12 @@ func TestImport_missingModuleConfig(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -801,9 +827,11 @@ func TestImportModuleVarFile(t *testing.T) {
 
 	// init to install the module
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
 		Ui:               ui,
+		View:             view,
 		ProviderSource:   providerSource,
 	}
 
@@ -820,6 +848,7 @@ func TestImportModuleVarFile(t *testing.T) {
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 	args := []string{
@@ -873,9 +902,11 @@ func TestImportModuleInputVariableEvaluation(t *testing.T) {
 
 	// init to install the module
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
 		Ui:               ui,
+		View:             view,
 		ProviderSource:   providerSource,
 	}
 
@@ -892,6 +923,7 @@ func TestImportModuleInputVariableEvaluation(t *testing.T) {
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 	args := []string{
@@ -912,10 +944,12 @@ func TestImport_dataResource(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -942,10 +976,12 @@ func TestImport_invalidResourceAddr(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -972,10 +1008,12 @@ func TestImport_targetIsModule(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 

--- a/command/plan.go
+++ b/command/plan.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/plans"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
@@ -82,6 +83,7 @@ func (c *PlanCommand) Run(args []string) int {
 	opReq := c.Operation(b)
 	opReq.ConfigDir = configPath
 	opReq.Destroy = destroy
+	opReq.Hooks = []terraform.Hook{c.uiHook()}
 	opReq.PlanOutPath = outPath
 	opReq.PlanRefresh = refresh
 	opReq.ShowDiagnostics = c.showDiagnostics

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -32,10 +32,12 @@ func TestPlan(t *testing.T) {
 
 	p := planFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -59,10 +61,12 @@ func TestPlan_lockedState(t *testing.T) {
 
 	p := planFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -85,10 +89,12 @@ func TestPlan_plan(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -126,10 +132,12 @@ func TestPlan_destroy(t *testing.T) {
 
 	p := planFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -158,10 +166,12 @@ func TestPlan_noState(t *testing.T) {
 
 	p := planFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -193,10 +203,12 @@ func TestPlan_outPath(t *testing.T) {
 
 	p := planFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -246,10 +258,12 @@ func TestPlan_outPathNoChange(t *testing.T) {
 
 	p := planFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -324,10 +338,12 @@ func TestPlan_outBackend(t *testing.T) {
 		}
 	}
 	ui := cli.NewMockUi()
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -376,10 +392,12 @@ func TestPlan_refreshFalse(t *testing.T) {
 
 	p := planFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -407,10 +425,12 @@ func TestPlan_state(t *testing.T) {
 
 	p := planFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -450,10 +470,12 @@ func TestPlan_stateDefault(t *testing.T) {
 
 	p := planFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -505,10 +527,12 @@ func TestPlan_validate(t *testing.T) {
 		}
 	}
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -532,10 +556,12 @@ func TestPlan_vars(t *testing.T) {
 
 	p := planVarsFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -577,10 +603,12 @@ func TestPlan_varsUnset(t *testing.T) {
 
 	p := planVarsFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -640,10 +668,12 @@ func TestPlan_providerArgumentUnset(t *testing.T) {
 		},
 	}
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -667,10 +697,12 @@ func TestPlan_varFile(t *testing.T) {
 
 	p := planVarsFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -707,10 +739,12 @@ func TestPlan_varFileDefault(t *testing.T) {
 
 	p := planVarsFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -745,10 +779,12 @@ func TestPlan_varFileWithDecls(t *testing.T) {
 
 	p := planVarsFixtureProvider()
 	ui := cli.NewMockUi()
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -773,10 +809,12 @@ func TestPlan_detailedExitcode(t *testing.T) {
 
 	p := planFixtureProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -794,10 +832,12 @@ func TestPlan_detailedExitcode_emptyDiff(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -819,10 +859,12 @@ func TestPlan_shutdown(t *testing.T) {
 
 	p := testProvider()
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 			ShutdownCh:       shutdownCh,
 		},
 	}
@@ -884,10 +926,12 @@ func TestPlan_init_required(t *testing.T) {
 	defer testChdir(t, td)()
 
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			// Running plan without setting testingOverrides is similar to plan without init
-			Ui: ui,
+			Ui:   ui,
+			View: view,
 		},
 	}
 
@@ -927,10 +971,12 @@ func TestPlan_targeted(t *testing.T) {
 	}
 
 	ui := new(cli.MockUi)
+	view, _ := testView(t)
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
+			View:             view,
 		},
 	}
 
@@ -961,9 +1007,11 @@ func TestPlan_targetFlagsDiags(t *testing.T) {
 			defer testChdir(t, td)()
 
 			ui := new(cli.MockUi)
+			view, _ := testView(t)
 			c := &PlanCommand{
 				Meta: Meta{
-					Ui: ui,
+					Ui:   ui,
+					View: view,
 				},
 			}
 

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/command/arguments"
 	"github.com/hashicorp/terraform/command/views"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
@@ -75,6 +76,7 @@ func (c *RefreshCommand) Run(args []string) int {
 	// Build the operation
 	opReq := c.Operation(b)
 	opReq.ConfigDir = configPath
+	opReq.Hooks = []terraform.Hook{c.uiHook()}
 	opReq.ShowDiagnostics = c.showDiagnostics
 	opReq.Type = backend.OperationTypeRefresh
 

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -791,7 +791,7 @@ func TestRefresh_targeted(t *testing.T) {
 	}
 
 	ui := new(cli.MockUi)
-	view, _ := testView(t)
+	view, done := testView(t)
 	c := &RefreshCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -808,7 +808,7 @@ func TestRefresh_targeted(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 
-	got := ui.OutputWriter.String()
+	got := done(t).Stdout()
 	if want := "test_instance.foo: Refreshing"; !strings.Contains(got, want) {
 		t.Fatalf("expected output to contain %q, got:\n%s", want, got)
 	}

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -255,9 +255,11 @@ func TestShow_json_output(t *testing.T) {
 
 			p := showFixtureProvider()
 			ui := new(cli.MockUi)
+			view, _ := testView(t)
 			m := Meta{
 				testingOverrides: metaOverridesForProvider(p),
 				Ui:               ui,
+				View:             view,
 				ProviderSource:   providerSource,
 			}
 


### PR DESCRIPTION
Move the code which renders Terraform hook callbacks as UI into the views package, backed by a `views.View` instead of a `cli.Ui`. Update test setup accordingly.

To allow commands to control this hook, we add a hooks member on the backend `Operation` struct. This supersedes the hooks in the Terraform context, which is not directly controlled by the command logic.

There is a little bit of refactoring of the UI hook in this change:

- Use an explicit initializer instead of the calls to `h.once.Do(h.init)`, and rename some fields so that they are unexported
- Inline the locking around calls to `output`, rather than wrapping the entire `views.View` as was done with `cli.Ui`

I intentionally did not fix the misuse of `Color` on the entire output string rather than the format string in order to minimize the diff, but I'm happy to go back and do that as part of this PR if it seems like a good time.

This commit should not change how Terraform works, and is refactoring in preparation for more changes which move UI code out of the backend.