### PR TITLE
Mildwonkey/nested type format

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -328,9 +328,10 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 		return true
 	}
 
-	// TODO: There will need to be an object-specific diff printer, but for now
-	// we will let writeAttrDiff handle attributes with NestedTypes like regular
-	// (object) attributes.
+	// TODO: There will need to be an object-specific diff printer that handles
+	// things like individual attribute sensitivity and pathing into
+	// requiredReplace, but for now we will let writeAttrDiff handle attributes
+	// with NestedTypes like regular (object) attributes.
 	//
 	// To avoid printing any sensitive nested fields inside attributes (until
 	// the above is implemented) we will treat the entire attribute as
@@ -374,7 +375,7 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 }
 
 func (p *blockBodyDiffPrinter) writeNestedAttrDiff(name string, attrS *configschema.Attribute, old, new cty.Value, nameLen, indent int, path cty.Path) bool {
-	return false
+	panic("not implemented")
 }
 
 func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *configschema.NestedBlock, old, new cty.Value, blankBefore bool, indent int, path cty.Path) int {

--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -328,6 +328,18 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 		return true
 	}
 
+	// TODO: There will need to be an object-specific diff printer, but for now
+	// we will let writeAttrDiff handle attributes with NestedTypes like regular
+	// (object) attributes.
+	//
+	// To avoid printing any sensitive nested fields inside attributes (until
+	// the above is implemented) we will treat the entire attribute as
+	// sensitive.
+	var sensitive bool
+	if attrS.NestedType != nil && attrS.NestedType.ContainsSensitive() {
+		sensitive = true
+	}
+
 	p.buf.WriteString("\n")
 
 	p.writeSensitivityWarning(old, new, indent, action, false)
@@ -341,7 +353,7 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 	p.buf.WriteString(strings.Repeat(" ", nameLen-len(name)))
 	p.buf.WriteString(" = ")
 
-	if attrS.Sensitive {
+	if attrS.Sensitive || sensitive {
 		p.buf.WriteString("(sensitive value)")
 	} else {
 		switch {
@@ -358,6 +370,10 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 		}
 	}
 
+	return false
+}
+
+func (p *blockBodyDiffPrinter) writeNestedAttrDiff(name string, attrS *configschema.Attribute, old, new cty.Value, nameLen, indent int, path cty.Path) bool {
 	return false
 }
 

--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -374,6 +374,17 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 	return false
 }
 
+// TODO: writeNestedAttrDiff will be responsible for properly formatting
+// Attributes with NestedTypes in the diff. This function will be called from
+// writeAttrDiff when it recieves attribute with a NestedType. Right now, we are
+// letting the existing formatter "just" print these attributes like regular,
+// object-type attributes. Unlike the regular attribute printer, this function
+// will need to descend into the NestedType to ensure that we are properly
+// handling items such as:
+//   - nested sensitive fields
+//   - which nested field specifically requires replacement
+//
+// Examples of both can be seen in diff_test.go with FIXME comments.
 func (p *blockBodyDiffPrinter) writeNestedAttrDiff(name string, attrS *configschema.Attribute, old, new cty.Value, nameLen, indent int, path cty.Path) bool {
 	panic("not implemented")
 }

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -317,19 +317,36 @@ new line
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":       cty.UnknownVal(cty.String),
 				"password": cty.StringVal("top-secret"),
+				"conn_info": cty.ObjectVal(map[string]cty.Value{
+					"user":     cty.StringVal("not-secret"),
+					"password": cty.StringVal("top-secret"),
+				}),
 			}),
 			Schema: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"id":       {Type: cty.String, Computed: true},
 					"password": {Type: cty.String, Optional: true, Sensitive: true},
+					// TODO: This is a temporary situation; once the NestedType
+					// specific printer is implemented this will need to be
+					// updated so that only the sensitive nested attribute is
+					// hidden.
+					"conn_info": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"user":     {Type: cty.String, Optional: true},
+								"password": {Type: cty.String, Optional: true, Sensitive: true},
+							},
+						},
+					},
 				},
 			},
 			RequiredReplace: cty.NewPathSet(),
 			Tainted:         false,
 			ExpectedOutput: `  # test_instance.example will be created
   + resource "test_instance" "example" {
-      + id       = (known after apply)
-      + password = (sensitive value)
+      + conn_info = (sensitive value)
+      + id        = (known after apply)
+      + password  = (sensitive value)
     }
 `,
 		},

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -326,7 +326,7 @@ new line
 				Attributes: map[string]*configschema.Attribute{
 					"id":       {Type: cty.String, Computed: true},
 					"password": {Type: cty.String, Optional: true, Sensitive: true},
-					// TODO: This is a temporary situation; once the NestedType
+					// FIXME: This is a temporary situation; once the NestedType
 					// specific printer is implemented this will need to be
 					// updated so that only the sensitive nested attribute is
 					// hidden.

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -332,6 +332,7 @@ new line
 					// hidden.
 					"conn_info": {
 						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSingle,
 							Attributes: map[string]*configschema.Attribute{
 								"user":     {Type: cty.String, Optional: true},
 								"password": {Type: cty.String, Optional: true, Sensitive: true},

--- a/command/format/diff_test.go
+++ b/command/format/diff_test.go
@@ -2226,6 +2226,12 @@ func TestResourceChange_nestedList(t *testing.T) {
 						"volume_type": cty.StringVal("gp2"),
 					}),
 				}),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":  cty.StringVal("i-02ae66f368e8518a9"),
@@ -2235,33 +2241,21 @@ func TestResourceChange_nestedList(t *testing.T) {
 						"volume_type": cty.StringVal("gp2"),
 					}),
 				}),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
 			}),
 			RequiredReplace: cty.NewPathSet(),
 			Tainted:         false,
-			Schema: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
-				},
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"root_block_device": {
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"volume_type": {
-									Type:     cty.String,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-						Nesting: configschema.NestingList,
-					},
-				},
-			},
+			Schema:          testSchemaNestingList,
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
-      ~ ami = "ami-BEFORE" -> "ami-AFTER"
-        id  = "i-02ae66f368e8518a9"
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+        id    = "i-02ae66f368e8518a9"
+        # (1 unchanged attribute hidden)
 
         # (1 unchanged block hidden)
     }
@@ -2276,10 +2270,18 @@ func TestResourceChange_nestedList(t *testing.T) {
 				"root_block_device": cty.ListValEmpty(cty.Object(map[string]cty.Type{
 					"volume_type": cty.String,
 				})),
+				"disks": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"mount_point": cty.String,
+					"size":        cty.String,
+				})),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":  cty.StringVal("i-02ae66f368e8518a9"),
 				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.NullVal(cty.String),
+					"size":        cty.NullVal(cty.String),
+				})}),
 				"root_block_device": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"volume_type": cty.NullVal(cty.String),
@@ -2288,30 +2290,17 @@ func TestResourceChange_nestedList(t *testing.T) {
 			}),
 			RequiredReplace: cty.NewPathSet(),
 			Tainted:         false,
-			Schema: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
-				},
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"root_block_device": {
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"volume_type": {
-									Type:     cty.String,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-						Nesting: configschema.NestingList,
-					},
-				},
-			},
+			Schema:          testSchemaNestingList,
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
-      ~ ami = "ami-BEFORE" -> "ami-AFTER"
-        id  = "i-02ae66f368e8518a9"
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+      ~ disks = [] -> [
+          + {
+              + mount_point = null
+              + size        = null
+            },
+        ]
+        id    = "i-02ae66f368e8518a9"
 
       + root_block_device {}
     }
@@ -2326,10 +2315,20 @@ func TestResourceChange_nestedList(t *testing.T) {
 				"root_block_device": cty.ListValEmpty(cty.Object(map[string]cty.Type{
 					"volume_type": cty.String,
 				})),
+				"disks": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"mount_point": cty.String,
+					"size":        cty.String,
+				})),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":  cty.StringVal("i-02ae66f368e8518a9"),
 				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.NullVal(cty.String),
+					}),
+				}),
 				"root_block_device": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"volume_type": cty.StringVal("gp2"),
@@ -2338,30 +2337,17 @@ func TestResourceChange_nestedList(t *testing.T) {
 			}),
 			RequiredReplace: cty.NewPathSet(),
 			Tainted:         false,
-			Schema: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
-				},
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"root_block_device": {
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"volume_type": {
-									Type:     cty.String,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-						Nesting: configschema.NestingList,
-					},
-				},
-			},
+			Schema:          testSchemaNestingList,
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
-      ~ ami = "ami-BEFORE" -> "ami-AFTER"
-        id  = "i-02ae66f368e8518a9"
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+      ~ disks = [] -> [
+          + {
+              + mount_point = "/var/diska"
+              + size        = null
+            },
+        ]
+        id    = "i-02ae66f368e8518a9"
 
       + root_block_device {
           + volume_type = "gp2"
@@ -2375,6 +2361,12 @@ func TestResourceChange_nestedList(t *testing.T) {
 			Before: cty.ObjectVal(map[string]cty.Value{
 				"id":  cty.StringVal("i-02ae66f368e8518a9"),
 				"ami": cty.StringVal("ami-BEFORE"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.NullVal(cty.String),
+					}),
+				}),
 				"root_block_device": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"volume_type": cty.StringVal("gp2"),
@@ -2385,6 +2377,12 @@ func TestResourceChange_nestedList(t *testing.T) {
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":  cty.StringVal("i-02ae66f368e8518a9"),
 				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
 				"root_block_device": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"volume_type": cty.StringVal("gp2"),
@@ -2398,6 +2396,15 @@ func TestResourceChange_nestedList(t *testing.T) {
 				Attributes: map[string]*configschema.Attribute{
 					"id":  {Type: cty.String, Optional: true, Computed: true},
 					"ami": {Type: cty.String, Optional: true},
+					"disks": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"mount_point": {Type: cty.String, Optional: true},
+								"size":        {Type: cty.String, Optional: true},
+							},
+							Nesting: configschema.NestingList,
+						},
+					},
 				},
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"root_block_device": {
@@ -2421,8 +2428,14 @@ func TestResourceChange_nestedList(t *testing.T) {
 			},
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
-      ~ ami = "ami-BEFORE" -> "ami-AFTER"
-        id  = "i-02ae66f368e8518a9"
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+      ~ disks = [
+          ~ {
+              ~ size        = null -> "50GB"
+                # (1 unchanged element hidden)
+            },
+        ]
+        id    = "i-02ae66f368e8518a9"
 
       ~ root_block_device {
           + new_field   = "new_value"
@@ -2431,12 +2444,18 @@ func TestResourceChange_nestedList(t *testing.T) {
     }
 `,
 		},
-		"force-new update (inside block)": {
+		"force-new update (inside blocks)": {
 			Action: plans.DeleteThenCreate,
 			Mode:   addrs.ManagedResourceMode,
 			Before: cty.ObjectVal(map[string]cty.Value{
 				"id":  cty.StringVal("i-02ae66f368e8518a9"),
 				"ami": cty.StringVal("ami-BEFORE"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
 				"root_block_device": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"volume_type": cty.StringVal("gp2"),
@@ -2446,42 +2465,47 @@ func TestResourceChange_nestedList(t *testing.T) {
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":  cty.StringVal("i-02ae66f368e8518a9"),
 				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diskb"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
 				"root_block_device": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"volume_type": cty.StringVal("different"),
 					}),
 				}),
 			}),
-			RequiredReplace: cty.NewPathSet(cty.Path{
-				cty.GetAttrStep{Name: "root_block_device"},
-				cty.IndexStep{Key: cty.NumberIntVal(0)},
-				cty.GetAttrStep{Name: "volume_type"},
-			}),
+			RequiredReplace: cty.NewPathSet(
+				cty.Path{
+					cty.GetAttrStep{Name: "root_block_device"},
+					cty.IndexStep{Key: cty.NumberIntVal(0)},
+					cty.GetAttrStep{Name: "volume_type"},
+				},
+				// FIXME: This is not currently used; when the diff printer is
+				// updated to fully handle NestedTypes this test should fail,
+				// and the expected output should look like this:
+				//
+				// ~ mount_point = "/var/diska" -> "/var/diskb" # forces replacement
+				cty.Path{
+					cty.GetAttrStep{Name: "disks"},
+					cty.IndexStep{Key: cty.NumberIntVal(0)},
+					cty.GetAttrStep{Name: "mount_point"},
+				},
+			),
 			Tainted: false,
-			Schema: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
-				},
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"root_block_device": {
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"volume_type": {
-									Type:     cty.String,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-						Nesting: configschema.NestingList,
-					},
-				},
-			},
+			Schema:  testSchemaNestingList,
 			ExpectedOutput: `  # test_instance.example must be replaced
 -/+ resource "test_instance" "example" {
-      ~ ami = "ami-BEFORE" -> "ami-AFTER"
-        id  = "i-02ae66f368e8518a9"
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+      ~ disks = [
+          ~ {
+              ~ mount_point = "/var/diska" -> "/var/diskb"
+                # (1 unchanged element hidden)
+            },
+        ]
+        id    = "i-02ae66f368e8518a9"
 
       ~ root_block_device {
           ~ volume_type = "gp2" -> "different" # forces replacement
@@ -2495,6 +2519,12 @@ func TestResourceChange_nestedList(t *testing.T) {
 			Before: cty.ObjectVal(map[string]cty.Value{
 				"id":  cty.StringVal("i-02ae66f368e8518a9"),
 				"ami": cty.StringVal("ami-BEFORE"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
 				"root_block_device": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"volume_type": cty.StringVal("gp2"),
@@ -2504,40 +2534,34 @@ func TestResourceChange_nestedList(t *testing.T) {
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":  cty.StringVal("i-02ae66f368e8518a9"),
 				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diskb"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
 				"root_block_device": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"volume_type": cty.StringVal("different"),
 					}),
 				}),
 			}),
-			RequiredReplace: cty.NewPathSet(cty.Path{
-				cty.GetAttrStep{Name: "root_block_device"},
-			}),
+			RequiredReplace: cty.NewPathSet(
+				cty.Path{cty.GetAttrStep{Name: "root_block_device"}},
+				cty.Path{cty.GetAttrStep{Name: "disks"}},
+			),
 			Tainted: false,
-			Schema: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
-				},
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"root_block_device": {
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"volume_type": {
-									Type:     cty.String,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-						Nesting: configschema.NestingList,
-					},
-				},
-			},
+			Schema:  testSchemaNestingList,
 			ExpectedOutput: `  # test_instance.example must be replaced
 -/+ resource "test_instance" "example" {
-      ~ ami = "ami-BEFORE" -> "ami-AFTER"
-        id  = "i-02ae66f368e8518a9"
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+      ~ disks = [ # forces replacement
+          ~ {
+              ~ mount_point = "/var/diska" -> "/var/diskb"
+                # (1 unchanged element hidden)
+            } # forces replacement,
+        ]
+        id    = "i-02ae66f368e8518a9"
 
       ~ root_block_device { # forces replacement
           ~ volume_type = "gp2" -> "different"
@@ -2551,55 +2575,44 @@ func TestResourceChange_nestedList(t *testing.T) {
 			Before: cty.ObjectVal(map[string]cty.Value{
 				"id":  cty.StringVal("i-02ae66f368e8518a9"),
 				"ami": cty.StringVal("ami-BEFORE"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
 				"root_block_device": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"volume_type": cty.StringVal("gp2"),
-						"new_field":   cty.StringVal("new_value"),
 					}),
 				}),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":  cty.StringVal("i-02ae66f368e8518a9"),
 				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"mount_point": cty.String,
+					"size":        cty.String,
+				})),
 				"root_block_device": cty.ListValEmpty(cty.Object(map[string]cty.Type{
 					"volume_type": cty.String,
-					"new_field":   cty.String,
 				})),
 			}),
 			RequiredReplace: cty.NewPathSet(),
 			Tainted:         false,
-			Schema: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Optional: true, Computed: true},
-					"ami": {Type: cty.String, Optional: true},
-				},
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"root_block_device": {
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"volume_type": {
-									Type:     cty.String,
-									Optional: true,
-									Computed: true,
-								},
-								"new_field": {
-									Type:     cty.String,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-						Nesting: configschema.NestingList,
-					},
-				},
-			},
+			Schema:          testSchemaNestingList,
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
-      ~ ami = "ami-BEFORE" -> "ami-AFTER"
-        id  = "i-02ae66f368e8518a9"
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+      ~ disks = [
+          - {
+              - mount_point = "/var/diska"
+              - size        = "50GB"
+            },
+        ] -> []
+        id    = "i-02ae66f368e8518a9"
 
       - root_block_device {
-          - new_field   = "new_value" -> null
           - volume_type = "gp2" -> null
         }
     }
@@ -4327,4 +4340,35 @@ func outputChange(name string, before, after cty.Value, sensitive bool) *plans.O
 	}
 
 	return changeSrc
+}
+
+// A basic test schema using NestingList for one attribute and one block
+var testSchemaNestingList = &configschema.Block{
+	Attributes: map[string]*configschema.Attribute{
+		"id":  {Type: cty.String, Optional: true, Computed: true},
+		"ami": {Type: cty.String, Optional: true},
+		"disks": {
+			NestedType: &configschema.Object{
+				Attributes: map[string]*configschema.Attribute{
+					"mount_point": {Type: cty.String, Optional: true},
+					"size":        {Type: cty.String, Optional: true},
+				},
+				Nesting: configschema.NestingList,
+			},
+		},
+	},
+	BlockTypes: map[string]*configschema.NestedBlock{
+		"root_block_device": {
+			Block: configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"volume_type": {
+						Type:     cty.String,
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+			Nesting: configschema.NestingList,
+		},
+	},
 }

--- a/configs/configschema/implied_type.go
+++ b/configs/configschema/implied_type.go
@@ -62,19 +62,22 @@ func (o *Object) ImpliedType() cty.Type {
 		}
 	}
 	optAttrs := listOptionalAttrsFromObject(o)
-	if len(optAttrs) > 0 {
-		return cty.ObjectWithOptionalAttrs(attrTys, optAttrs)
-	}
 
+	var ret cty.Type
+	if len(optAttrs) > 0 {
+		ret = cty.ObjectWithOptionalAttrs(attrTys, optAttrs)
+	} else {
+		ret = cty.Object(attrTys)
+	}
 	switch o.Nesting {
 	case NestingSingle:
-		return cty.Object(attrTys)
+		return ret
 	case NestingList:
-		return cty.List(cty.Object(attrTys))
+		return cty.List(ret)
 	case NestingMap:
-		return cty.Map(cty.Object(attrTys))
+		return cty.Map(ret)
 	case NestingSet:
-		return cty.Set(cty.Object(attrTys))
+		return cty.Set(ret)
 	default: // Should never happen
 		panic("invalid Nesting")
 	}

--- a/configs/configschema/implied_type_test.go
+++ b/configs/configschema/implied_type_test.go
@@ -134,6 +134,7 @@ func TestObjectImpliedType(t *testing.T) {
 		},
 		"attributes": {
 			&Object{
+				Nesting: NestingSingle,
 				Attributes: map[string]*Attribute{
 					"optional": {
 						Type:     cty.String,
@@ -165,9 +166,11 @@ func TestObjectImpliedType(t *testing.T) {
 		},
 		"nested attributes": {
 			&Object{
+				Nesting: NestingSingle,
 				Attributes: map[string]*Attribute{
 					"nested_type": {
 						NestedType: &Object{
+							Nesting: NestingSingle,
 							Attributes: map[string]*Attribute{
 								"optional": {
 									Type:     cty.String,
@@ -281,6 +284,7 @@ func TestObjectContainsSensitive(t *testing.T) {
 				Attributes: map[string]*Attribute{
 					"nested": {
 						NestedType: &Object{
+							Nesting: NestingSingle,
 							Attributes: map[string]*Attribute{
 								"sensitive": {Sensitive: true},
 							},
@@ -295,6 +299,7 @@ func TestObjectContainsSensitive(t *testing.T) {
 				Attributes: map[string]*Attribute{
 					"nested": {
 						NestedType: &Object{
+							Nesting: NestingSingle,
 							Attributes: map[string]*Attribute{
 								"public": {},
 							},

--- a/configs/configschema/implied_type_test.go
+++ b/configs/configschema/implied_type_test.go
@@ -207,10 +207,10 @@ func TestObjectImpliedType(t *testing.T) {
 			&Object{
 				Nesting: NestingList,
 				Attributes: map[string]*Attribute{
-					"foo": {Type: cty.String},
+					"foo": {Type: cty.String, Optional: true},
 				},
 			},
-			cty.List(cty.Object(map[string]cty.Type{"foo": cty.String})),
+			cty.List(cty.ObjectWithOptionalAttrs(map[string]cty.Type{"foo": cty.String}, []string{"foo"})),
 		},
 		"NestingMap": {
 			&Object{


### PR DESCRIPTION
This PR builds on #27699 . It introduces a small change to the diff formatter, so we don't inadvertently print `NestedType` attributes with _nested_ sensitive attributes. This is a temporary workaround until a bespoke `NestedType` diff format implementation is created. 

I added an attribute with a `NestedType` to the `TestResourceChange_nestedList` test suite, and one test for sensitivity. This pattern needs to be extended to the other tests, and some updated when the bespoke formatter is implemented,  but I think it's a good start that's worth getting into the code base now rather than waiting for the end product.

This work very helpfully uncovered a bug in the `ImpliedType()` function in `configschema`,  which is fixed here. The last commit modifies a test to prove this fix - the issue was specifically with returning an `ObjectWithOptionalAttrs` too early. 