### PR TITLE
Remove deprecation on undeclared variable, docs, and summary adjustment

### DIFF
--- a/backend/unparsed_value.go
+++ b/backend/unparsed_value.go
@@ -77,7 +77,7 @@ func ParseVariableValues(vv map[string]UnparsedVariableValue, decls map[string]*
 					diags = diags.Append(tfdiags.Sourceless(
 						tfdiags.Warning,
 						"Value for undeclared variable",
-						fmt.Sprintf("The root module does not declare a variable named %q but a value was found in file %q. If you meant to use this value, add a \"variable\" block to the configuration.\n\nIf you wish to provide certain \"global\" settings to all configurations in your organization, use TF_VAR_... environment variables to set these instead to silence this warning, or use the -compact-warnings option to show warnings in a compact way.", name, val.SourceRange.Filename),
+						fmt.Sprintf("The root module does not declare a variable named %q but a value was found in file %q. If you meant to use this value, add a \"variable\" block to the configuration.\n\nTo silence these warnings, use TF_VAR_... environment variables to provide certain \"global\" settings to all configurations in your organization. To reduce the verbosity of these warnings, use the -compact-warnings option.", name, val.SourceRange.Filename),
 					))
 				}
 				seenUndeclaredInFile++

--- a/backend/unparsed_value.go
+++ b/backend/unparsed_value.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/configs"
@@ -78,7 +77,7 @@ func ParseVariableValues(vv map[string]UnparsedVariableValue, decls map[string]*
 					diags = diags.Append(tfdiags.Sourceless(
 						tfdiags.Warning,
 						"Value for undeclared variable",
-						fmt.Sprintf(strings.TrimSpace(undeclaredVariableWarning), name, val.SourceRange.Filename),
+						fmt.Sprintf("The root module does not declare a variable named %q but a value was found in file %q. If you meant to use this value, add a \"variable\" block to the configuration.\n\nIf you wish to provide certain \"global\" settings to all configurations in your organization, use TF_VAR_... environment variables to set these instead to silence this warning, or use the -compact-warnings option to show warnings in a compact way.", name, val.SourceRange.Filename),
 					))
 				}
 				seenUndeclaredInFile++
@@ -155,14 +154,3 @@ func ParseVariableValues(vv map[string]UnparsedVariableValue, decls map[string]*
 
 	return ret, diags
 }
-
-const undeclaredVariableWarning = `
-The root module does not declare a variable named %q but a value was found in
-file %q. If you meant to use this value, add a "variable" block
-to the configuration.
-
-If you wish to provide certain "global" settings to all configurations in
-your organization, use TF_VAR_... environment variables to set these instead
-to silence this warning, or use the -compact-warnings option to show warnings
-in a compact way.
-`

--- a/backend/unparsed_value.go
+++ b/backend/unparsed_value.go
@@ -74,7 +74,7 @@ func ParseVariableValues(vv map[string]UnparsedVariableValue, decls map[string]*
 				// users have forgotten a variable {} declaration or have a typo in their var name.
 				// Some users will actively ignore this warning because they use a .tfvars file
 				// across multiple configurations.
-				if seenUndeclaredInFile < 3 {
+				if seenUndeclaredInFile < 2 {
 					diags = diags.Append(tfdiags.Sourceless(
 						tfdiags.Warning,
 						"Value for undeclared variable",
@@ -109,7 +109,7 @@ func ParseVariableValues(vv map[string]UnparsedVariableValue, decls map[string]*
 		ret[name] = val
 	}
 
-	if seenUndeclaredInFile >= 3 {
+	if seenUndeclaredInFile > 2 {
 		extras := seenUndeclaredInFile - 2
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagWarning,

--- a/backend/unparsed_value_test.go
+++ b/backend/unparsed_value_test.go
@@ -81,7 +81,7 @@ func TestParseVariableValuesUndeclared(t *testing.T) {
 		t.Errorf("wrong detail for diagnostic 2\ngot:  %s\nmust contain: %s", got, want)
 	}
 	if got, want := diags[3].Description().Summary, missingRequired; got != want {
-		t.Errorf("wrong summary for diagnostic 4\ngot:  %s\nwant: %s", got, want)
+		t.Errorf("wrong summary for diagnostic 3\ngot:  %s\nwant: %s", got, want)
 	}
 
 	wantVals := terraform.InputValues{

--- a/backend/unparsed_value_test.go
+++ b/backend/unparsed_value_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -59,7 +60,7 @@ func TestParseVariableValuesUndeclared(t *testing.T) {
 	for _, diag := range diags {
 		t.Logf("%s: %s", diag.Description().Summary, diag.Description().Detail)
 	}
-	if got, want := len(diags), 5; got != want {
+	if got, want := len(diags), 4; got != want {
 		t.Fatalf("wrong number of diagnostics %d; want %d", got, want)
 	}
 
@@ -73,13 +74,13 @@ func TestParseVariableValuesUndeclared(t *testing.T) {
 	if got, want := diags[1].Description().Summary, undeclSingular; got != want {
 		t.Errorf("wrong summary for diagnostic 1\ngot:  %s\nwant: %s", got, want)
 	}
-	if got, want := diags[2].Description().Summary, undeclSingular; got != want {
+	if got, want := diags[2].Description().Summary, undeclPlural; got != want {
 		t.Errorf("wrong summary for diagnostic 2\ngot:  %s\nwant: %s", got, want)
 	}
-	if got, want := diags[3].Description().Summary, undeclPlural; got != want {
-		t.Errorf("wrong summary for diagnostic 3\ngot:  %s\nwant: %s", got, want)
+	if got, want := diags[2].Description().Detail, "3 other variable(s)"; !strings.Contains(got, want) {
+		t.Errorf("wrong detail for diagnostic 2\ngot:  %s\nmust contain: %s", got, want)
 	}
-	if got, want := diags[4].Description().Summary, missingRequired; got != want {
+	if got, want := diags[3].Description().Summary, missingRequired; got != want {
 		t.Errorf("wrong summary for diagnostic 4\ngot:  %s\nwant: %s", got, want)
 	}
 

--- a/website/docs/language/values/variables.html.md
+++ b/website/docs/language/values/variables.html.md
@@ -437,6 +437,44 @@ $ export TF_VAR_availability_zone_names='["us-west-1b","us-west-1d"]'
 For readability, and to avoid the need to worry about shell escaping, we
 recommend always setting complex variable values via variable definitions files.
 
+### Values for Undeclared Variables
+
+If you have defined a variable value, but not its corresponding `variable {}`
+definition, you may get an error or warning depending on how you have provided
+that value.
+
+If you provide values for undeclared variables defined as [environment variables](#environment-variables)
+you will not get an error or warning. This is because environment variables may
+be declared but not used in all configurations that might be run.
+
+If you provide values for undeclared variables defined [in a file](#variable-definitions-tfvars-files)
+you will get a warning. This is to help in cases where you have provided a variable
+value _meant_ for a variable declaration, but perhaps there is a mistake in the
+value definition. For example, the following configuration:
+
+```terraform
+variable "moose" {
+  type = string
+}
+```
+
+And the following `.tfvars` file:
+
+```hcl
+mosse = "Moose"
+```
+
+Will cause Terraform to warn you that there is no variable declared `"mosse"`, which can help
+you spot this mistake.
+
+If you use `.tfvars` files across multiple configurations and expect to continue to see this warning,
+you can use the [`-compact-warnings`](https://www.terraform.io/docs/cli/commands/plan.html#compact-warnings)
+option to simplify your output.
+
+If you provide values for undeclared variables on the [command line](#variables-on-the-command-line),
+Terraform will error. To avoid this error, either declare a variable block for the value, or remove
+the variable value from your Terraform call.
+
 ### Variable Definition Precedence
 
 The above mechanisms for setting variables can be used together in any


### PR DESCRIPTION
Remove deprecation and add docs specific to the behavior around undeclared variable values. While in the area, I also formatted the error so it'll (more likely, depending on variable names) be the preferred Terraform output width (78).

This also reduces the number of warnings to result in a summary (`In addition to the other similar warnings shown...`) from 3 full warnings to two full warnings. I like this better because then the third warning related to undeclared variables is the summary, rather than the fourth. The math on the `extras` doesn't change because it was off originally (off by 1 issue)

Before:
<img width="1505" alt="Screen Shot 2021-02-16 at 3 35 37 PM" src="https://user-images.githubusercontent.com/204372/108118807-e4a92000-706c-11eb-97d1-d9d6845cf4ac.png">

After:
<img width="768" alt="Screen Shot 2021-02-16 at 3 36 05 PM" src="https://user-images.githubusercontent.com/204372/108118810-e541b680-706c-11eb-84bb-2fba5c647eb0.png">

