### PR TITLE
terraform: Fix missing deposed key for PreApply

### DIFF
--- a/terraform/context_apply2_test.go
+++ b/terraform/context_apply2_test.go
@@ -1,1 +1,71 @@
 package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/providers"
+	"github.com/hashicorp/terraform/states"
+)
+
+// Test that the PreApply hook is called with the correct deposed key
+func TestContext2Apply_createBeforeDestroy_deposedKeyPreApply(t *testing.T) {
+	m := testModule(t, "apply-cbd-deposed-only")
+	p := testProvider("aws")
+	p.PlanResourceChangeFn = testDiffFn
+	p.ApplyResourceChangeFn = testApplyFn
+
+	deposedKey := states.NewDeposedKey()
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("aws_instance.bar").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"bar"}`),
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
+	)
+	root.SetResourceInstanceDeposed(
+		mustResourceInstanceAddr("aws_instance.bar").Resource,
+		deposedKey,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectTainted,
+			AttrsJSON: []byte(`{"id":"foo"}`),
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
+	)
+
+	hook := new(MockHook)
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		Hooks:  []Hook{hook},
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+		State: state,
+	})
+
+	if p, diags := ctx.Plan(); diags.HasErrors() {
+		t.Fatalf("diags: %s", diags.Err())
+	} else {
+		t.Logf(legacyDiffComparisonString(p.Changes))
+	}
+
+	state, diags := ctx.Apply()
+	if diags.HasErrors() {
+		t.Fatalf("diags: %s", diags.Err())
+	}
+
+	// Verify PreApply was called correctly
+	if !hook.PreApplyCalled {
+		t.Fatalf("PreApply hook not called")
+	}
+	if addr, wantAddr := hook.PreApplyAddr, mustResourceInstanceAddr("aws_instance.bar"); !addr.Equal(wantAddr) {
+		t.Errorf("expected addr to be %s, but was %s", wantAddr, addr)
+	}
+	if gen := hook.PreApplyGen; gen != deposedKey {
+		t.Errorf("expected gen to be %q, but was %q", deposedKey, gen)
+	}
+}

--- a/terraform/node_resource_abstract_instance.go
+++ b/terraform/node_resource_abstract_instance.go
@@ -221,7 +221,7 @@ func (n *NodeAbstractResourceInstance) preApplyHook(ctx EvalContext, change *pla
 		plannedNewState := change.After
 
 		diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
-			return h.PreApply(n.Addr, nil, change.Action, priorState, plannedNewState)
+			return h.PreApply(n.Addr, change.DeposedKey.Generation(), change.Action, priorState, plannedNewState)
 		}))
 		if diags.HasErrors() {
 			return diags


### PR DESCRIPTION
The `PreApply` hook was always being called with a `nil` generation argument, instead of the deposed key of the resource (if present). This commit passes the deposed key from the change to the `PreApply` hook, and adds a context test to cover this.

## New behavior

The resulting behavior of Terraform after this change makes sense to me, but I'm not completely confident that this is the right fix. Below is my understanding of what this changes.

Apply logs now display the generation of any resource which is destroyed as a result of a `create_before_destroy` setting. For example, with this configuration:

```hcl
resource "random_id" "foo" {
  byte_length = 16

  keepers = { uuid = uuid() }

  lifecycle {
    create_before_destroy = true
  }
}
```

Repeated applies now look like:

```shellsession
$ terraform apply -auto-approve
random_id.foo: Refreshing state... [id=gphYpJjXisv5x2rEo27i-A]
random_id.foo: Creating...
random_id.foo: Creation complete after 0s [id=TCEcr3binSLpnN7itZeDEQ]
random_id.foo (ab75b70e): Destroying... [id=gphYpJjXisv5x2rEo27i-A]
random_id.foo: Destruction complete after 0s

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

If the state file contains a deposed key for the resource, an interactive plan shows this key, and it is later rendered in the apply logs:

```shellsession
$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  - destroy

Terraform will perform the following actions:

  # random_id.foo will be created
  + resource "random_id" "foo" {
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 16
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
      + keepers     = (known after apply)
    }

  # random_id.foo (deposed object ABCDEFGH) will be destroyed
  - resource "random_id" "foo" {
      - b64_std     = "TCEcr3binSLpnN7itZeDEQ==" -> null
      - b64_url     = "TCEcr3binSLpnN7itZeDEQ" -> null
      - byte_length = 16 -> null
      - dec         = "101193255285175788345174100269323485969" -> null
      - hex         = "4c211caf76e29d22e99cdee2b5978311" -> null
      - id          = "TCEcr3binSLpnN7itZeDEQ" -> null
      - keepers     = {
          - "uuid" = "617931a8-42da-5b66-fc17-b437e0e23f33"
        } -> null
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

random_id.foo: Creating...
random_id.foo: Creation complete after 0s [id=8pdk8uVDCP_4MIIRFb-1MQ]
random_id.foo (ABCDEFGH): Destroying... [id=TCEcr3binSLpnN7itZeDEQ]
random_id.foo: Destruction complete after 0s

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

With a create-after-destroy configuration, the deposed key is not shown in the plan rendering, which simplifies this to "replaced".