### PR TITLE
Make sure state blob is created before locking or snapshotting is attempted in azurerm backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+.vscode
 
 website/vendor
 


### PR DESCRIPTION
This fixes https://github.com/hashicorp/terraform/issues/27771

Current implementation attempts to create a new state blob in several different places:

1. In the Backend.StateMgr() function, but only if state name is not a default one (not clear why)
2. In the RemoteClient.Lock() function, if it doesn't find the blob it tries to lock. While this works in most cases, it fails if you use `-lock=false` CLI option. 
3. In the RemoteClient.Put() function, if blob is not found it will ignore the 404 error from `GetProperties` and let the new blob to be created, but if you configure your azurerm backend with `snapshot=true` it may try to snapshot a blob that doesn't exist yet.

One question I have is how to indicate a condition that should never happen in the `RemoteClient.Lock()` function. Basically if a blob doesn't exist at this point, something went really wrong or someone deleted the blob manually. Right now I just return an empty `lockId` and the `err`, but may be there is a better way to handle such conditions?

I'd like to make this solution better aligned with other backend implementations, notable S3 and PostgreSQL. Those implementations use `Backend.Workspaces()` function to get a list of existing states and then proceed to create new empty states
if there is no existing one. With azurerm implementation the `Workspaces()` function doesn't seem to return an existing state because of some strangeness in how it constructs a prefix. This function probably needs to be refactored as well, but I think that would be a separate PR since I haven't spent any time understanding the workspaces related code base. 


