### PR TITLE
Mildwonkey/providers interface renaming

### DIFF
--- a/backend/local/backend_refresh_test.go
+++ b/backend/local/backend_refresh_test.go
@@ -81,7 +81,7 @@ func TestLocal_refreshInput(t *testing.T) {
 	p.ReadResourceResponse = &providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
 		"id": cty.StringVal("yes"),
 	})}
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		val := req.Config.GetAttr("value")
 		if val.IsNull() || val.AsString() != "bar" {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("incorrect value %#v", val))
@@ -183,8 +183,8 @@ func TestLocal_refreshValidateProviderConfigured(t *testing.T) {
 	}
 	<-run.Done()
 
-	if !p.PrepareProviderConfigCalled {
-		t.Fatal("Prepare provider config should be called")
+	if !p.ValidateProviderConfigCalled {
+		t.Fatal("Validate provider config should be called")
 	}
 
 	checkState(t, b.StateOutPath, `

--- a/backend/local/testing.go
+++ b/backend/local/testing.go
@@ -52,20 +52,20 @@ func TestLocalProvider(t *testing.T, b *Local, name string, schema *terraform.Pr
 	if schema == nil {
 		schema = &terraform.ProviderSchema{} // default schema is empty
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider:      providers.Schema{Block: schema.Provider},
 		ProviderMeta:  providers.Schema{Block: schema.ProviderMeta},
 		ResourceTypes: map[string]providers.Schema{},
 		DataSources:   map[string]providers.Schema{},
 	}
 	for name, res := range schema.ResourceTypes {
-		p.GetSchemaResponse.ResourceTypes[name] = providers.Schema{
+		p.GetProviderSchemaResponse.ResourceTypes[name] = providers.Schema{
 			Block:   res,
 			Version: int64(schema.ResourceTypeSchemaVersions[name]),
 		}
 	}
 	for name, dat := range schema.DataSources {
-		p.GetSchemaResponse.DataSources[name] = providers.Schema{Block: dat}
+		p.GetProviderSchemaResponse.DataSources[name] = providers.Schema{Block: dat}
 	}
 
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {

--- a/builtin/providers/terraform/provider.go
+++ b/builtin/providers/terraform/provider.go
@@ -22,8 +22,8 @@ func NewProvider() providers.Interface {
 }
 
 // GetSchema returns the complete schema for the provider.
-func (p *Provider) GetSchema() providers.GetSchemaResponse {
-	return providers.GetSchemaResponse{
+func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
+	return providers.GetProviderSchemaResponse{
 		DataSources: map[string]providers.Schema{
 			"terraform_remote_state": dataSourceRemoteStateGetSchema(),
 		},
@@ -31,10 +31,10 @@ func (p *Provider) GetSchema() providers.GetSchemaResponse {
 }
 
 // ValidateProviderConfig is used to validate the configuration values.
-func (p *Provider) PrepareProviderConfig(req providers.PrepareProviderConfigRequest) providers.PrepareProviderConfigResponse {
+func (p *Provider) ValidateProviderConfig(req providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
 	// At this moment there is nothing to configure for the terraform provider,
 	// so we will happily return without taking any action
-	var res providers.PrepareProviderConfigResponse
+	var res providers.ValidateProviderConfigResponse
 	res.PreparedConfig = req.Config
 	return res
 }
@@ -59,10 +59,10 @@ func (p *Provider) ValidateDataSourceConfig(req providers.ValidateDataSourceConf
 }
 
 // Configure configures and initializes the provider.
-func (p *Provider) Configure(providers.ConfigureRequest) providers.ConfigureResponse {
+func (p *Provider) ConfigureProvider(providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 	// At this moment there is nothing to configure for the terraform provider,
 	// so we will happily return without taking any action
-	var res providers.ConfigureResponse
+	var res providers.ConfigureProviderResponse
 	return res
 }
 
@@ -126,11 +126,11 @@ func (p *Provider) ImportResourceState(providers.ImportResourceStateRequest) pro
 	panic("unimplemented - terraform_remote_state has no resources")
 }
 
-// ValidateResourceTypeConfig is used to to validate the resource configuration values.
-func (p *Provider) ValidateResourceTypeConfig(providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
+// ValidateResourceConfig is used to to validate the resource configuration values.
+func (p *Provider) ValidateResourceConfig(providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 	// At this moment there is nothing to configure for the terraform provider,
 	// so we will happily return without taking any action
-	var res providers.ValidateResourceTypeConfigResponse
+	var res providers.ValidateResourceConfigResponse
 	return res
 }
 

--- a/command/apply_destroy_test.go
+++ b/command/apply_destroy_test.go
@@ -44,7 +44,7 @@ func TestApply_destroy(t *testing.T) {
 	statePath := testStateFile(t, originalState)
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -416,7 +416,7 @@ func TestApply_destroyTargetedDependencies(t *testing.T) {
 	statePath := testStateFile(t, originalState)
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -567,7 +567,7 @@ func TestApply_destroyTargeted(t *testing.T) {
 	statePath := testStateFile(t, originalState)
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -302,7 +302,7 @@ func TestApply_parallelism(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		name := fmt.Sprintf("test%d", i)
 		provider := &terraform.MockProvider{}
-		provider.GetSchemaResponse = &providers.GetSchemaResponse{
+		provider.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				name + "_instance": {Block: &configschema.Block{}},
 			},
@@ -492,7 +492,7 @@ func TestApply_error(t *testing.T) {
 		resp.PlannedState = cty.ObjectVal(s)
 		return
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1075,7 +1075,7 @@ func TestApply_shutdown(t *testing.T) {
 		return
 	}
 
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1291,7 +1291,7 @@ func TestApply_vars(t *testing.T) {
 	}
 
 	actual := ""
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1354,7 +1354,7 @@ func TestApply_varFile(t *testing.T) {
 	}
 
 	actual := ""
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1417,7 +1417,7 @@ func TestApply_varFileDefault(t *testing.T) {
 	}
 
 	actual := ""
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1479,7 +1479,7 @@ func TestApply_varFileDefaultJSON(t *testing.T) {
 	}
 
 	actual := ""
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1777,7 +1777,7 @@ func TestApply_targeted(t *testing.T) {
 	defer testChdir(t, td)()
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1862,8 +1862,8 @@ func TestApply_targetFlagsDiags(t *testing.T) {
 // applyFixtureSchema returns a schema suitable for processing the
 // configuration in testdata/apply . This schema should be
 // assigned to a mock provider named "test".
-func applyFixtureSchema() *providers.GetSchemaResponse {
-	return &providers.GetSchemaResponse{
+func applyFixtureSchema() *providers.GetProviderSchemaResponse {
+	return &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1884,7 +1884,7 @@ func applyFixtureSchema() *providers.GetSchemaResponse {
 // Terraform Core.
 func applyFixtureProvider() *terraform.MockProvider {
 	p := testProvider()
-	p.GetSchemaResponse = applyFixtureSchema()
+	p.GetProviderSchemaResponse = applyFixtureSchema()
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: req.ProposedNewState,

--- a/command/console_test.go
+++ b/command/console_test.go
@@ -66,7 +66,7 @@ func TestConsole_tfvars(t *testing.T) {
 	}
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -119,7 +119,7 @@ func TestConsole_unsetRequiredVars(t *testing.T) {
 	defer testChdir(t, td)()
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{

--- a/command/format/state_test.go
+++ b/command/format/state_test.go
@@ -86,13 +86,13 @@ func testProvider() *terraform.MockProvider {
 		return providers.ReadResourceResponse{NewState: req.PriorState}
 	}
 
-	p.GetSchemaResponse = testProviderSchema()
+	p.GetProviderSchemaResponse = testProviderSchema()
 
 	return p
 }
 
-func testProviderSchema() *providers.GetSchemaResponse {
-	return &providers.GetSchemaResponse{
+func testProviderSchema() *providers.GetProviderSchemaResponse {
+	return &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{

--- a/command/import_test.go
+++ b/command/import_test.go
@@ -44,7 +44,7 @@ func TestImport(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -99,7 +99,7 @@ func TestImport_providerConfig(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -119,22 +119,22 @@ func TestImport_providerConfig(t *testing.T) {
 	}
 
 	configured := false
-	p.ConfigureFn = func(req providers.ConfigureRequest) providers.ConfigureResponse {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 		configured = true
 
 		cfg := req.Config
 		if !cfg.Type().HasAttribute("foo") {
-			return providers.ConfigureResponse{
+			return providers.ConfigureProviderResponse{
 				Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("configuration has no foo argument")),
 			}
 		}
 		if got, want := cfg.GetAttr("foo"), cty.StringVal("bar"); !want.RawEquals(got) {
-			return providers.ConfigureResponse{
+			return providers.ConfigureProviderResponse{
 				Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("foo argument is %#v, but want %#v", got, want)),
 			}
 		}
 
-		return providers.ConfigureResponse{}
+		return providers.ConfigureProviderResponse{}
 	}
 
 	args := []string{
@@ -213,7 +213,7 @@ func TestImport_remoteState(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -233,13 +233,13 @@ func TestImport_remoteState(t *testing.T) {
 	}
 
 	configured := false
-	p.ConfigureFn = func(req providers.ConfigureRequest) providers.ConfigureResponse {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 		var diags tfdiags.Diagnostics
 		configured = true
 		if got, want := req.Config.GetAttr("foo"), cty.StringVal("bar"); !want.RawEquals(got) {
 			diags = diags.Append(fmt.Errorf("wrong \"foo\" value %#v; want %#v", got, want))
 		}
-		return providers.ConfigureResponse{
+		return providers.ConfigureProviderResponse{
 			Diagnostics: diags,
 		}
 	}
@@ -369,7 +369,7 @@ func TestImport_providerConfigWithVar(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -389,13 +389,13 @@ func TestImport_providerConfigWithVar(t *testing.T) {
 	}
 
 	configured := false
-	p.ConfigureFn = func(req providers.ConfigureRequest) providers.ConfigureResponse {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 		var diags tfdiags.Diagnostics
 		configured = true
 		if got, want := req.Config.GetAttr("foo"), cty.StringVal("bar"); !want.RawEquals(got) {
 			diags = diags.Append(fmt.Errorf("wrong \"foo\" value %#v; want %#v", got, want))
 		}
-		return providers.ConfigureResponse{
+		return providers.ConfigureProviderResponse{
 			Diagnostics: diags,
 		}
 	}
@@ -449,7 +449,7 @@ func TestImport_providerConfigWithDataSource(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -514,7 +514,7 @@ func TestImport_providerConfigWithVarDefault(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -534,13 +534,13 @@ func TestImport_providerConfigWithVarDefault(t *testing.T) {
 	}
 
 	configured := false
-	p.ConfigureFn = func(req providers.ConfigureRequest) providers.ConfigureResponse {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 		var diags tfdiags.Diagnostics
 		configured = true
 		if got, want := req.Config.GetAttr("foo"), cty.StringVal("bar"); !want.RawEquals(got) {
 			diags = diags.Append(fmt.Errorf("wrong \"foo\" value %#v; want %#v", got, want))
 		}
-		return providers.ConfigureResponse{
+		return providers.ConfigureProviderResponse{
 			Diagnostics: diags,
 		}
 	}
@@ -593,7 +593,7 @@ func TestImport_providerConfigWithVarFile(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -613,13 +613,13 @@ func TestImport_providerConfigWithVarFile(t *testing.T) {
 	}
 
 	configured := false
-	p.ConfigureFn = func(req providers.ConfigureRequest) providers.ConfigureResponse {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 		var diags tfdiags.Diagnostics
 		configured = true
 		if got, want := req.Config.GetAttr("foo"), cty.StringVal("bar"); !want.RawEquals(got) {
 			diags = diags.Append(fmt.Errorf("wrong \"foo\" value %#v; want %#v", got, want))
 		}
-		return providers.ConfigureResponse{
+		return providers.ConfigureProviderResponse{
 			Diagnostics: diags,
 		}
 	}
@@ -673,7 +673,7 @@ func TestImport_allowMissingResourceConfig(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -808,7 +808,7 @@ func TestImportModuleVarFile(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -883,7 +883,7 @@ func TestImportModuleInputVariableEvaluation(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -187,7 +187,7 @@ func TestPlan_noState(t *testing.T) {
 
 	// Verify that the provider was called with the existing state
 	actual := p.PlanResourceChangeRequest.PriorState
-	expected := cty.NullVal(p.GetSchemaResponse.ResourceTypes["test_instance"].Block.ImpliedType())
+	expected := cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["test_instance"].Block.ImpliedType())
 	if !expected.RawEquals(actual) {
 		t.Fatalf("wrong prior state\ngot:  %#v\nwant: %#v", actual, expected)
 	}
@@ -314,7 +314,7 @@ func TestPlan_outBackend(t *testing.T) {
 
 	outPath := "foo"
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -510,7 +510,7 @@ func TestPlan_validate(t *testing.T) {
 	defer testChdir(t, td)()
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -637,7 +637,7 @@ func TestPlan_providerArgumentUnset(t *testing.T) {
 
 	p := planFixtureProvider()
 	// override the planFixtureProvider schema to include a required provider argument
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -895,7 +895,7 @@ func TestPlan_shutdown(t *testing.T) {
 		return
 	}
 
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -953,7 +953,7 @@ func TestPlan_targeted(t *testing.T) {
 	defer testChdir(t, td)()
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1036,8 +1036,8 @@ func TestPlan_targetFlagsDiags(t *testing.T) {
 // planFixtureSchema returns a schema suitable for processing the
 // configuration in testdata/plan . This schema should be
 // assigned to a mock provider named "test".
-func planFixtureSchema() *providers.GetSchemaResponse {
-	return &providers.GetSchemaResponse{
+func planFixtureSchema() *providers.GetProviderSchemaResponse {
+	return &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1068,7 +1068,7 @@ func planFixtureSchema() *providers.GetSchemaResponse {
 // step just passing through the new object proposed by Terraform Core.
 func planFixtureProvider() *terraform.MockProvider {
 	p := testProvider()
-	p.GetSchemaResponse = planFixtureSchema()
+	p.GetProviderSchemaResponse = planFixtureSchema()
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: req.ProposedNewState,
@@ -1080,8 +1080,8 @@ func planFixtureProvider() *terraform.MockProvider {
 // planVarsFixtureSchema returns a schema suitable for processing the
 // configuration in testdata/plan-vars . This schema should be
 // assigned to a mock provider named "test".
-func planVarsFixtureSchema() *providers.GetSchemaResponse {
-	return &providers.GetSchemaResponse{
+func planVarsFixtureSchema() *providers.GetProviderSchemaResponse {
+	return &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1101,7 +1101,7 @@ func planVarsFixtureSchema() *providers.GetSchemaResponse {
 // step just passing through the new object proposed by Terraform Core.
 func planVarsFixtureProvider() *terraform.MockProvider {
 	p := testProvider()
-	p.GetSchemaResponse = planVarsFixtureSchema()
+	p.GetProviderSchemaResponse = planVarsFixtureSchema()
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		return providers.PlanResourceChangeResponse{
 			PlannedState: req.ProposedNewState,

--- a/command/plugins_test.go
+++ b/command/plugins_test.go
@@ -36,7 +36,7 @@ func TestInternalProviders(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	schema := tfProvider.GetSchema()
+	schema := tfProvider.GetProviderSchema()
 	_, found := schema.DataSources["terraform_remote_state"]
 	if !found {
 		t.Errorf("didn't find terraform_remote_state in internal \"terraform\" provider")

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -47,7 +47,7 @@ func TestRefresh(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaResponse = refreshFixtureSchema()
+	p.GetProviderSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
@@ -146,7 +146,7 @@ func TestRefresh_lockedState(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaResponse = refreshFixtureSchema()
+	p.GetProviderSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
@@ -192,7 +192,7 @@ func TestRefresh_cwd(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaResponse = refreshFixtureSchema()
+	p.GetProviderSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
@@ -272,7 +272,7 @@ func TestRefresh_defaultState(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaResponse = refreshFixtureSchema()
+	p.GetProviderSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
@@ -342,7 +342,7 @@ func TestRefresh_outPath(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaResponse = refreshFixtureSchema()
+	p.GetProviderSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
@@ -402,7 +402,7 @@ func TestRefresh_var(t *testing.T) {
 			View:             view,
 		},
 	}
-	p.GetSchemaResponse = refreshVarFixtureSchema()
+	p.GetProviderSchemaResponse = refreshVarFixtureSchema()
 
 	args := []string{
 		"-var", "foo=bar",
@@ -412,10 +412,10 @@ func TestRefresh_var(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 
-	if !p.ConfigureCalled {
+	if !p.ConfigureProviderCalled {
 		t.Fatal("configure should be called")
 	}
-	if got, want := p.ConfigureRequest.Config.GetAttr("value"), cty.StringVal("bar"); !want.RawEquals(got) {
+	if got, want := p.ConfigureProviderRequest.Config.GetAttr("value"), cty.StringVal("bar"); !want.RawEquals(got) {
 		t.Fatalf("wrong provider configuration\ngot:  %#v\nwant: %#v", got, want)
 	}
 }
@@ -440,7 +440,7 @@ func TestRefresh_varFile(t *testing.T) {
 			View:             view,
 		},
 	}
-	p.GetSchemaResponse = refreshVarFixtureSchema()
+	p.GetProviderSchemaResponse = refreshVarFixtureSchema()
 
 	varFilePath := testTempFile(t)
 	if err := ioutil.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
@@ -455,10 +455,10 @@ func TestRefresh_varFile(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 
-	if !p.ConfigureCalled {
+	if !p.ConfigureProviderCalled {
 		t.Fatal("configure should be called")
 	}
-	if got, want := p.ConfigureRequest.Config.GetAttr("value"), cty.StringVal("bar"); !want.RawEquals(got) {
+	if got, want := p.ConfigureProviderRequest.Config.GetAttr("value"), cty.StringVal("bar"); !want.RawEquals(got) {
 		t.Fatalf("wrong provider configuration\ngot:  %#v\nwant: %#v", got, want)
 	}
 }
@@ -483,7 +483,7 @@ func TestRefresh_varFileDefault(t *testing.T) {
 			View:             view,
 		},
 	}
-	p.GetSchemaResponse = refreshVarFixtureSchema()
+	p.GetProviderSchemaResponse = refreshVarFixtureSchema()
 
 	varFilePath := filepath.Join(td, "terraform.tfvars")
 	if err := ioutil.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
@@ -497,10 +497,10 @@ func TestRefresh_varFileDefault(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 
-	if !p.ConfigureCalled {
+	if !p.ConfigureProviderCalled {
 		t.Fatal("configure should be called")
 	}
-	if got, want := p.ConfigureRequest.Config.GetAttr("value"), cty.StringVal("bar"); !want.RawEquals(got) {
+	if got, want := p.ConfigureProviderRequest.Config.GetAttr("value"), cty.StringVal("bar"); !want.RawEquals(got) {
 		t.Fatalf("wrong provider configuration\ngot:  %#v\nwant: %#v", got, want)
 	}
 }
@@ -531,7 +531,7 @@ func TestRefresh_varsUnset(t *testing.T) {
 			View:             view,
 		},
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -597,7 +597,7 @@ func TestRefresh_backup(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaResponse = refreshFixtureSchema()
+	p.GetProviderSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
@@ -668,7 +668,7 @@ func TestRefresh_disableBackup(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaResponse = refreshFixtureSchema()
+	p.GetProviderSchemaResponse = refreshFixtureSchema()
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.ObjectVal(map[string]cty.Value{
@@ -734,7 +734,7 @@ func TestRefresh_displaysOutputs(t *testing.T) {
 			View:             view,
 		},
 	}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -773,7 +773,7 @@ func TestRefresh_targeted(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -859,8 +859,8 @@ func TestRefresh_targetFlagsDiags(t *testing.T) {
 
 // configuration in testdata/refresh . This schema should be
 // assigned to a mock provider named "test".
-func refreshFixtureSchema() *providers.GetSchemaResponse {
-	return &providers.GetSchemaResponse{
+func refreshFixtureSchema() *providers.GetProviderSchemaResponse {
+	return &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -877,8 +877,8 @@ func refreshFixtureSchema() *providers.GetSchemaResponse {
 // refreshVarFixtureSchema returns a schema suitable for processing the
 // configuration in testdata/refresh-var . This schema should be
 // assigned to a mock provider named "test".
-func refreshVarFixtureSchema() *providers.GetSchemaResponse {
-	return &providers.GetSchemaResponse{
+func refreshVarFixtureSchema() *providers.GetProviderSchemaResponse {
+	return &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -428,8 +428,8 @@ func TestShow_json_output_state(t *testing.T) {
 // showFixtureSchema returns a schema suitable for processing the configuration
 // in testdata/show. This schema should be assigned to a mock provider
 // named "test".
-func showFixtureSchema() *providers.GetSchemaResponse {
-	return &providers.GetSchemaResponse{
+func showFixtureSchema() *providers.GetProviderSchemaResponse {
+	return &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -457,7 +457,7 @@ func showFixtureSchema() *providers.GetSchemaResponse {
 // Terraform Core.
 func showFixtureProvider() *terraform.MockProvider {
 	p := testProvider()
-	p.GetSchemaResponse = showFixtureSchema()
+	p.GetProviderSchemaResponse = showFixtureSchema()
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		idVal := req.ProposedNewState.GetAttr("id")
 		amiVal := req.ProposedNewState.GetAttr("ami")

--- a/command/state_show_test.go
+++ b/command/state_show_test.go
@@ -33,7 +33,7 @@ func TestStateShow(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -108,7 +108,7 @@ func TestStateShow_multi(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -216,7 +216,7 @@ func TestStateShow_configured_provider(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -19,7 +19,7 @@ import (
 func setupTest(fixturepath string, args ...string) (*cli.MockUi, int) {
 	ui := new(cli.MockUi)
 	p := testProvider()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -52,7 +52,7 @@ var (
 
 func init() {
 	configureDiscoveryRetry()
-	ConfigureProviderRequestTimeout()
+	configureRequestTimeout()
 }
 
 var SupportedPluginProtocols = MustParseVersionConstraints("~> 5")
@@ -492,9 +492,9 @@ func maxRetryErrorHandler(resp *http.Response, err error, numTries int) (*http.R
 	return resp, fmt.Errorf("the request failed, please try again later%s", errMsg)
 }
 
-// ConfigureProviderRequestTimeout configures the registry client request timeout from
+// configureRequestTimeout configures the registry client request timeout from
 // environment variables
-func ConfigureProviderRequestTimeout() {
+func configureRequestTimeout() {
 	requestTimeout = defaultRequestTimeout
 
 	if v := os.Getenv(registryClientTimeoutEnvName); v != "" {

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -52,7 +52,7 @@ var (
 
 func init() {
 	configureDiscoveryRetry()
-	configureRequestTimeout()
+	ConfigureProviderRequestTimeout()
 }
 
 var SupportedPluginProtocols = MustParseVersionConstraints("~> 5")
@@ -492,9 +492,9 @@ func maxRetryErrorHandler(resp *http.Response, err error, numTries int) (*http.R
 	return resp, fmt.Errorf("the request failed, please try again later%s", errMsg)
 }
 
-// configureRequestTimeout configures the registry client request timeout from
+// ConfigureProviderRequestTimeout configures the registry client request timeout from
 // environment variables
-func configureRequestTimeout() {
+func ConfigureProviderRequestTimeout() {
 	requestTimeout = defaultRequestTimeout
 
 	if v := os.Getenv(registryClientTimeoutEnvName); v != "" {

--- a/internal/getproviders/registry_client_test.go
+++ b/internal/getproviders/registry_client_test.go
@@ -75,7 +75,7 @@ func TestConfigureRegistryClientTimeout(t *testing.T) {
 		}(os.Getenv(registryClientTimeoutEnvName))
 		os.Setenv(registryClientTimeoutEnvName, "20")
 
-		ConfigureProviderRequestTimeout()
+		configureRequestTimeout()
 		expected := 20 * time.Second
 		if requestTimeout != expected {
 			t.Fatalf("expected timeout %q, got %q",

--- a/internal/getproviders/registry_client_test.go
+++ b/internal/getproviders/registry_client_test.go
@@ -75,7 +75,7 @@ func TestConfigureRegistryClientTimeout(t *testing.T) {
 		}(os.Getenv(registryClientTimeoutEnvName))
 		os.Setenv(registryClientTimeoutEnvName, "20")
 
-		configureRequestTimeout()
+		ConfigureProviderRequestTimeout()
 		expected := 20 * time.Second
 		if requestTimeout != expected {
 			t.Fatalf("expected timeout %q, got %q",

--- a/internal/grpcwrap/provider.go
+++ b/internal/grpcwrap/provider.go
@@ -17,13 +17,13 @@ import (
 func Provider(p providers.Interface) tfplugin5.ProviderServer {
 	return &provider{
 		provider: p,
-		schema:   p.GetSchema(),
+		schema:   p.GetProviderSchema(),
 	}
 }
 
 type provider struct {
 	provider providers.Interface
-	schema   providers.GetSchemaResponse
+	schema   providers.GetProviderSchemaResponse
 }
 
 func (p *provider) GetSchema(_ context.Context, req *tfplugin5.GetProviderSchema_Request) (*tfplugin5.GetProviderSchema_Response, error) {
@@ -75,7 +75,7 @@ func (p *provider) PrepareProviderConfig(_ context.Context, req *tfplugin5.Prepa
 		return resp, nil
 	}
 
-	prepareResp := p.provider.PrepareProviderConfig(providers.PrepareProviderConfigRequest{
+	prepareResp := p.provider.ValidateProviderConfig(providers.ValidateProviderConfigRequest{
 		Config: configVal,
 	})
 
@@ -94,7 +94,7 @@ func (p *provider) ValidateResourceTypeConfig(_ context.Context, req *tfplugin5.
 		return resp, nil
 	}
 
-	validateResp := p.provider.ValidateResourceTypeConfig(providers.ValidateResourceTypeConfigRequest{
+	validateResp := p.provider.ValidateResourceConfig(providers.ValidateResourceConfigRequest{
 		TypeName: req.TypeName,
 		Config:   configVal,
 	})
@@ -158,7 +158,7 @@ func (p *provider) Configure(_ context.Context, req *tfplugin5.Configure_Request
 		return resp, nil
 	}
 
-	configureResp := p.provider.Configure(providers.ConfigureRequest{
+	configureResp := p.provider.ConfigureProvider(providers.ConfigureProviderRequest{
 		TerraformVersion: req.TerraformVersion,
 		Config:           configVal,
 	})

--- a/internal/legacy/terraform/provider_mock.go
+++ b/internal/legacy/terraform/provider_mock.go
@@ -22,18 +22,18 @@ type MockProvider struct {
 	Meta interface{}
 
 	GetSchemaCalled bool
-	GetSchemaReturn *ProviderSchema // This is using ProviderSchema directly rather than providers.GetSchemaResponse for compatibility with old tests
+	GetSchemaReturn *ProviderSchema // This is using ProviderSchema directly rather than providers.GetProviderSchemaResponse for compatibility with old tests
 
-	PrepareProviderConfigCalled   bool
-	PrepareProviderConfigResponse providers.PrepareProviderConfigResponse
-	PrepareProviderConfigRequest  providers.PrepareProviderConfigRequest
-	PrepareProviderConfigFn       func(providers.PrepareProviderConfigRequest) providers.PrepareProviderConfigResponse
+	ValidateProviderConfigCalled   bool
+	ValidateProviderConfigResponse providers.ValidateProviderConfigResponse
+	ValidateProviderConfigRequest  providers.ValidateProviderConfigRequest
+	ValidateProviderConfigFn       func(providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse
 
-	ValidateResourceTypeConfigCalled   bool
-	ValidateResourceTypeConfigTypeName string
-	ValidateResourceTypeConfigResponse providers.ValidateResourceTypeConfigResponse
-	ValidateResourceTypeConfigRequest  providers.ValidateResourceTypeConfigRequest
-	ValidateResourceTypeConfigFn       func(providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse
+	ValidateResourceConfigCalled   bool
+	ValidateResourceConfigTypeName string
+	ValidateResourceConfigResponse providers.ValidateResourceConfigResponse
+	ValidateResourceConfigRequest  providers.ValidateResourceConfigRequest
+	ValidateResourceConfigFn       func(providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse
 
 	ValidateDataSourceConfigCalled   bool
 	ValidateDataSourceConfigTypeName string
@@ -47,10 +47,10 @@ type MockProvider struct {
 	UpgradeResourceStateRequest  providers.UpgradeResourceStateRequest
 	UpgradeResourceStateFn       func(providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse
 
-	ConfigureCalled   bool
-	ConfigureResponse providers.ConfigureResponse
-	ConfigureRequest  providers.ConfigureRequest
-	ConfigureFn       func(providers.ConfigureRequest) providers.ConfigureResponse
+	ConfigureProviderCalled   bool
+	ConfigureProviderResponse providers.ConfigureProviderResponse
+	ConfigureProviderRequest  providers.ConfigureProviderRequest
+	ConfigureProviderFn       func(providers.ConfigureProviderRequest) providers.ConfigureProviderResponse
 
 	StopCalled   bool
 	StopFn       func() error
@@ -88,19 +88,19 @@ type MockProvider struct {
 	CloseError  error
 }
 
-func (p *MockProvider) GetSchema() providers.GetSchemaResponse {
+func (p *MockProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
 	p.Lock()
 	defer p.Unlock()
 	p.GetSchemaCalled = true
 	return p.getSchema()
 }
 
-func (p *MockProvider) getSchema() providers.GetSchemaResponse {
+func (p *MockProvider) getSchema() providers.GetProviderSchemaResponse {
 	// This version of getSchema doesn't do any locking, so it's suitable to
 	// call from other methods of this mock as long as they are already
 	// holding the lock.
 
-	ret := providers.GetSchemaResponse{
+	ret := providers.GetProviderSchemaResponse{
 		Provider:      providers.Schema{},
 		DataSources:   map[string]providers.Schema{},
 		ResourceTypes: map[string]providers.Schema{},
@@ -124,31 +124,30 @@ func (p *MockProvider) getSchema() providers.GetSchemaResponse {
 	return ret
 }
 
-func (p *MockProvider) PrepareProviderConfig(r providers.PrepareProviderConfigRequest) providers.PrepareProviderConfigResponse {
+func (p *MockProvider) ValidateProviderConfig(r providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
 	p.Lock()
 	defer p.Unlock()
 
-	p.PrepareProviderConfigCalled = true
-	p.PrepareProviderConfigRequest = r
-	if p.PrepareProviderConfigFn != nil {
-		return p.PrepareProviderConfigFn(r)
+	p.ValidateProviderConfigCalled = true
+	p.ValidateProviderConfigRequest = r
+	if p.ValidateProviderConfigFn != nil {
+		return p.ValidateProviderConfigFn(r)
 	}
-	p.PrepareProviderConfigResponse.PreparedConfig = r.Config
-	return p.PrepareProviderConfigResponse
+	return p.ValidateProviderConfigResponse
 }
 
-func (p *MockProvider) ValidateResourceTypeConfig(r providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
+func (p *MockProvider) ValidateResourceConfig(r providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 	p.Lock()
 	defer p.Unlock()
 
-	p.ValidateResourceTypeConfigCalled = true
-	p.ValidateResourceTypeConfigRequest = r
+	p.ValidateResourceConfigCalled = true
+	p.ValidateResourceConfigRequest = r
 
-	if p.ValidateResourceTypeConfigFn != nil {
-		return p.ValidateResourceTypeConfigFn(r)
+	if p.ValidateResourceConfigFn != nil {
+		return p.ValidateResourceConfigFn(r)
 	}
 
-	return p.ValidateResourceTypeConfigResponse
+	return p.ValidateResourceConfigResponse
 }
 
 func (p *MockProvider) ValidateDataSourceConfig(r providers.ValidateDataSourceConfigRequest) providers.ValidateDataSourceConfigResponse {
@@ -204,18 +203,18 @@ func (p *MockProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequ
 	return resp
 }
 
-func (p *MockProvider) Configure(r providers.ConfigureRequest) providers.ConfigureResponse {
+func (p *MockProvider) ConfigureProvider(r providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 	p.Lock()
 	defer p.Unlock()
 
-	p.ConfigureCalled = true
-	p.ConfigureRequest = r
+	p.ConfigureProviderCalled = true
+	p.ConfigureProviderRequest = r
 
-	if p.ConfigureFn != nil {
-		return p.ConfigureFn(r)
+	if p.ConfigureProviderFn != nil {
+		return p.ConfigureProviderFn(r)
 	}
 
-	return p.ConfigureResponse
+	return p.ConfigureProviderResponse
 }
 
 func (p *MockProvider) Stop() error {

--- a/internal/legacy/terraform/resource_provider_mock.go
+++ b/internal/legacy/terraform/resource_provider_mock.go
@@ -33,7 +33,7 @@ type MockResourceProvider struct {
 	ApplyReturnError               error
 	ConfigureCalled                bool
 	ConfigureConfig                *ResourceConfig
-	ConfigureFn                    func(*ResourceConfig) error
+	ConfigureProviderFn            func(*ResourceConfig) error
 	ConfigureReturnError           error
 	DiffCalled                     bool
 	DiffInfo                       *InstanceInfo
@@ -154,8 +154,8 @@ func (p *MockResourceProvider) Configure(c *ResourceConfig) error {
 	p.ConfigureCalled = true
 	p.ConfigureConfig = c
 
-	if p.ConfigureFn != nil {
-		return p.ConfigureFn(c)
+	if p.ConfigureProviderFn != nil {
+		return p.ConfigureProviderFn(c)
 	}
 
 	return p.ConfigureReturnError

--- a/internal/legacy/terraform/schemas.go
+++ b/internal/legacy/terraform/schemas.go
@@ -114,7 +114,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			provider.Close()
 		}()
 
-		resp := provider.GetSchema()
+		resp := provider.GetProviderSchema()
 		if resp.Diagnostics.HasErrors() {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls.

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -12,7 +12,7 @@ import (
 )
 
 type simple struct {
-	schema providers.GetSchemaResponse
+	schema providers.GetProviderSchemaResponse
 }
 
 func Provider() providers.Interface {
@@ -32,7 +32,7 @@ func Provider() providers.Interface {
 	}
 
 	return simple{
-		schema: providers.GetSchemaResponse{
+		schema: providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
 				Block: nil,
 			},
@@ -46,15 +46,15 @@ func Provider() providers.Interface {
 	}
 }
 
-func (s simple) GetSchema() providers.GetSchemaResponse {
+func (s simple) GetProviderSchema() providers.GetProviderSchemaResponse {
 	return s.schema
 }
 
-func (s simple) PrepareProviderConfig(req providers.PrepareProviderConfigRequest) (resp providers.PrepareProviderConfigResponse) {
+func (s simple) ValidateProviderConfig(req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 	return resp
 }
 
-func (s simple) ValidateResourceTypeConfig(req providers.ValidateResourceTypeConfigRequest) (resp providers.ValidateResourceTypeConfigResponse) {
+func (s simple) ValidateResourceConfig(req providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
 	return resp
 }
 
@@ -70,7 +70,7 @@ func (p simple) UpgradeResourceState(req providers.UpgradeResourceStateRequest) 
 	return resp
 }
 
-func (s simple) Configure(providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+func (s simple) ConfigureProvider(providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 	return resp
 }
 

--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -39,7 +39,7 @@ func (p *GRPCProviderPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Serve
 
 // GRPCProvider handles the client, or core side of the plugin rpc connection.
 // The GRPCProvider methods are mostly a translation layer between the
-// terraform provioders types and the grpc proto types, directly converting
+// terraform providers types and the grpc proto types, directly converting
 // between the two.
 type GRPCProvider struct {
 	// PluginClient provides a reference to the plugin.Client which controls the plugin process.
@@ -60,13 +60,13 @@ type GRPCProvider struct {
 	// schema stores the schema for this provider. This is used to properly
 	// serialize the state for requests.
 	mu      sync.Mutex
-	schemas providers.GetSchemaResponse
+	schemas providers.GetProviderSchemaResponse
 }
 
 // getSchema is used internally to get the saved provider schema.  The schema
 // should have already been fetched from the provider, but we have to
 // synchronize access to avoid being called concurrently with GetSchema.
-func (p *GRPCProvider) getSchema() providers.GetSchemaResponse {
+func (p *GRPCProvider) getSchema() providers.GetProviderSchemaResponse {
 	p.mu.Lock()
 	// unlock inline in case GetSchema needs to be called
 	if p.schemas.Provider.Block != nil {
@@ -78,7 +78,7 @@ func (p *GRPCProvider) getSchema() providers.GetSchemaResponse {
 	// the schema should have been fetched already, but give it another shot
 	// just in case things are being called out of order. This may happen for
 	// tests.
-	schemas := p.GetSchema()
+	schemas := p.GetProviderSchema()
 	if schemas.Diagnostics.HasErrors() {
 		panic(schemas.Diagnostics.Err())
 	}
@@ -115,8 +115,8 @@ func (p *GRPCProvider) getProviderMetaSchema() providers.Schema {
 	return schema.ProviderMeta
 }
 
-func (p *GRPCProvider) GetSchema() (resp providers.GetSchemaResponse) {
-	logger.Trace("GRPCProvider: GetSchema")
+func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResponse) {
+	logger.Trace("GRPCProvider: GetProviderSchema")
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -166,8 +166,8 @@ func (p *GRPCProvider) GetSchema() (resp providers.GetSchemaResponse) {
 	return resp
 }
 
-func (p *GRPCProvider) PrepareProviderConfig(r providers.PrepareProviderConfigRequest) (resp providers.PrepareProviderConfigResponse) {
-	logger.Trace("GRPCProvider: PrepareProviderConfig")
+func (p *GRPCProvider) ValidateProviderConfig(r providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
+	logger.Trace("GRPCProvider: ValidateProviderConfig")
 
 	schema := p.getSchema()
 	ty := schema.Provider.Block.ImpliedType()
@@ -199,8 +199,8 @@ func (p *GRPCProvider) PrepareProviderConfig(r providers.PrepareProviderConfigRe
 	return resp
 }
 
-func (p *GRPCProvider) ValidateResourceTypeConfig(r providers.ValidateResourceTypeConfigRequest) (resp providers.ValidateResourceTypeConfigResponse) {
-	logger.Trace("GRPCProvider: ValidateResourceTypeConfig")
+func (p *GRPCProvider) ValidateResourceConfig(r providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
+	logger.Trace("GRPCProvider: ValidateResourceConfig")
 	resourceSchema := p.getResourceSchema(r.TypeName)
 
 	mp, err := msgpack.Marshal(r.Config, resourceSchema.Block.ImpliedType())
@@ -286,8 +286,8 @@ func (p *GRPCProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequ
 	return resp
 }
 
-func (p *GRPCProvider) Configure(r providers.ConfigureRequest) (resp providers.ConfigureResponse) {
-	logger.Trace("GRPCProvider: Configure")
+func (p *GRPCProvider) ConfigureProvider(r providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
+	logger.Trace("GRPCProvider: ConfigureProvider")
 
 	schema := p.getSchema()
 

--- a/plugin/grpc_provider_test.go
+++ b/plugin/grpc_provider_test.go
@@ -88,7 +88,7 @@ func TestGRPCProvider_GetSchema(t *testing.T) {
 		client: mockProviderClient(t),
 	}
 
-	resp := p.GetSchema()
+	resp := p.GetProviderSchema()
 	checkDiags(t, resp.Diagnostics)
 }
 
@@ -104,11 +104,11 @@ func TestGRPCProvider_PrepareProviderConfig(t *testing.T) {
 	).Return(&proto.PrepareProviderConfig_Response{}, nil)
 
 	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
-	resp := p.PrepareProviderConfig(providers.PrepareProviderConfigRequest{Config: cfg})
+	resp := p.ValidateProviderConfig(providers.ValidateProviderConfigRequest{Config: cfg})
 	checkDiags(t, resp.Diagnostics)
 }
 
-func TestGRPCProvider_ValidateResourceTypeConfig(t *testing.T) {
+func TestGRPCProvider_ValidateResourceConfig(t *testing.T) {
 	client := mockProviderClient(t)
 	p := &GRPCProvider{
 		client: client,
@@ -120,7 +120,7 @@ func TestGRPCProvider_ValidateResourceTypeConfig(t *testing.T) {
 	).Return(&proto.ValidateResourceTypeConfig_Response{}, nil)
 
 	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
-	resp := p.ValidateResourceTypeConfig(providers.ValidateResourceTypeConfigRequest{
+	resp := p.ValidateResourceConfig(providers.ValidateResourceConfigRequest{
 		TypeName: "resource",
 		Config:   cfg,
 	})
@@ -219,7 +219,7 @@ func TestGRPCProvider_Configure(t *testing.T) {
 		gomock.Any(),
 	).Return(&proto.Configure_Response{}, nil)
 
-	resp := p.Configure(providers.ConfigureRequest{
+	resp := p.ConfigureProvider(providers.ConfigureProviderRequest{
 		Config: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
 		}),

--- a/plugin6/grpc_provider.go
+++ b/plugin6/grpc_provider.go
@@ -60,7 +60,7 @@ type GRPCProvider struct {
 	// schema stores the schema for this provider. This is used to properly
 	// serialize the state for requests.
 	mu      sync.Mutex
-	schemas providers.GetSchemaResponse
+	schemas providers.GetProviderSchemaResponse
 }
 
 func New(client proto6.ProviderClient, ctx context.Context) GRPCProvider {
@@ -73,7 +73,7 @@ func New(client proto6.ProviderClient, ctx context.Context) GRPCProvider {
 // getSchema is used internally to get the saved provider schema.  The schema
 // should have already been fetched from the provider, but we have to
 // synchronize access to avoid being called concurrently with GetSchema.
-func (p *GRPCProvider) getSchema() providers.GetSchemaResponse {
+func (p *GRPCProvider) getSchema() providers.GetProviderSchemaResponse {
 	p.mu.Lock()
 	// unlock inline in case GetSchema needs to be called
 	if p.schemas.Provider.Block != nil {
@@ -122,7 +122,7 @@ func (p *GRPCProvider) getProviderMetaSchema() providers.Schema {
 	return schema.ProviderMeta
 }
 
-func (p *GRPCProvider) GetSchema() (resp providers.GetSchemaResponse) {
+func (p *GRPCProvider) GetSchema() (resp providers.GetProviderSchemaResponse) {
 	logger.Trace("GRPCProvider.v6: GetSchema")
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -173,7 +173,7 @@ func (p *GRPCProvider) GetSchema() (resp providers.GetSchemaResponse) {
 	return resp
 }
 
-func (p *GRPCProvider) ValidateProviderConfig(r providers.PrepareProviderConfigRequest) (resp providers.PrepareProviderConfigResponse) {
+func (p *GRPCProvider) ValidateProviderConfig(r providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 	logger.Trace("GRPCProvider.v6: ValidateProviderConfig")
 
 	schema := p.getSchema()
@@ -199,8 +199,8 @@ func (p *GRPCProvider) ValidateProviderConfig(r providers.PrepareProviderConfigR
 	return resp
 }
 
-func (p *GRPCProvider) ValidateResourceTypeConfig(r providers.ValidateResourceTypeConfigRequest) (resp providers.ValidateResourceTypeConfigResponse) {
-	logger.Trace("GRPCProvider.v6: ValidateResourceTypeConfig")
+func (p *GRPCProvider) ValidateResourceConfig(r providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
+	logger.Trace("GRPCProvider.v6: ValidateResourceConfig")
 	resourceSchema := p.getResourceSchema(r.TypeName)
 
 	mp, err := msgpack.Marshal(r.Config, resourceSchema.Block.ImpliedType())
@@ -286,7 +286,7 @@ func (p *GRPCProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequ
 	return resp
 }
 
-func (p *GRPCProvider) Configure(r providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+func (p *GRPCProvider) Configure(r providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 	logger.Trace("GRPCProvider.v6: Configure")
 
 	schema := p.getSchema()

--- a/providers/factory.go
+++ b/providers/factory.go
@@ -31,7 +31,7 @@ func FactoryFixed(p Interface) Factory {
 // a subsequent call to do anything with the resource type would fail
 // anyway.
 func ProviderHasResource(provider Interface, typeName string) bool {
-	resp := provider.GetSchema()
+	resp := provider.GetProviderSchema()
 	if resp.Diagnostics.HasErrors() {
 		return false
 	}
@@ -53,7 +53,7 @@ func ProviderHasResource(provider Interface, typeName string) bool {
 // a subsequent call to do anything with the data source would fail
 // anyway.
 func ProviderHasDataSource(provider Interface, dataSourceName string) bool {
-	resp := provider.GetSchema()
+	resp := provider.GetProviderSchema()
 	if resp.Diagnostics.HasErrors() {
 		return false
 	}

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -12,17 +12,17 @@ import (
 // provider plugin.
 type Interface interface {
 	// GetSchema returns the complete schema for the provider.
-	GetSchema() GetSchemaResponse
+	GetProviderSchema() GetProviderSchemaResponse
 
-	// PrepareProviderConfig allows the provider to validate the configuration.
-	// The PrepareProviderConfigResponse.PreparedConfig field is unused. The
+	// ValidateProviderConfig allows the provider to validate the configuration.
+	// The ValidateProviderConfigResponse.PreparedConfig field is unused. The
 	// final configuration is not stored in the state, and any modifications
 	// that need to be made must be made during the Configure method call.
-	PrepareProviderConfig(PrepareProviderConfigRequest) PrepareProviderConfigResponse
+	ValidateProviderConfig(ValidateProviderConfigRequest) ValidateProviderConfigResponse
 
-	// ValidateResourceTypeConfig allows the provider to validate the resource
+	// ValidateResourceConfig allows the provider to validate the resource
 	// configuration values.
-	ValidateResourceTypeConfig(ValidateResourceTypeConfigRequest) ValidateResourceTypeConfigResponse
+	ValidateResourceConfig(ValidateResourceConfigRequest) ValidateResourceConfigResponse
 
 	// ValidateDataSource allows the provider to validate the data source
 	// configuration values.
@@ -35,7 +35,7 @@ type Interface interface {
 	UpgradeResourceState(UpgradeResourceStateRequest) UpgradeResourceStateResponse
 
 	// Configure configures and initialized the provider.
-	Configure(ConfigureRequest) ConfigureResponse
+	ConfigureProvider(ConfigureProviderRequest) ConfigureProviderResponse
 
 	// Stop is called when the provider should halt any in-flight actions.
 	//
@@ -71,7 +71,7 @@ type Interface interface {
 	Close() error
 }
 
-type GetSchemaResponse struct {
+type GetProviderSchemaResponse struct {
 	// Provider is the schema for the provider itself.
 	Provider Schema
 
@@ -95,19 +95,19 @@ type Schema struct {
 	Block   *configschema.Block
 }
 
-type PrepareProviderConfigRequest struct {
+type ValidateProviderConfigRequest struct {
 	// Config is the raw configuration value for the provider.
 	Config cty.Value
 }
 
-type PrepareProviderConfigResponse struct {
-	// PreparedConfig is unused.
+type ValidateProviderConfigResponse struct {
+	// PreparedConfig is unused and will be removed with support for plugin protocol v5.
 	PreparedConfig cty.Value
 	// Diagnostics contains any warnings or errors from the method call.
 	Diagnostics tfdiags.Diagnostics
 }
 
-type ValidateResourceTypeConfigRequest struct {
+type ValidateResourceConfigRequest struct {
 	// TypeName is the name of the resource type to validate.
 	TypeName string
 
@@ -116,7 +116,7 @@ type ValidateResourceTypeConfigRequest struct {
 	Config cty.Value
 }
 
-type ValidateResourceTypeConfigResponse struct {
+type ValidateResourceConfigResponse struct {
 	// Diagnostics contains any warnings or errors from the method call.
 	Diagnostics tfdiags.Diagnostics
 }
@@ -160,7 +160,7 @@ type UpgradeResourceStateResponse struct {
 	Diagnostics tfdiags.Diagnostics
 }
 
-type ConfigureRequest struct {
+type ConfigureProviderRequest struct {
 	// Terraform version is the version string from the running instance of
 	// terraform. Providers can use TerraformVersion to verify compatibility,
 	// and to store for informational purposes.
@@ -170,7 +170,7 @@ type ConfigureRequest struct {
 	Config cty.Value
 }
 
-type ConfigureResponse struct {
+type ConfigureProviderResponse struct {
 	// Diagnostics contains any warnings or errors from the method call.
 	Diagnostics tfdiags.Diagnostics
 }

--- a/registry/client.go
+++ b/registry/client.go
@@ -54,7 +54,7 @@ var (
 
 func init() {
 	configureDiscoveryRetry()
-	configureRequestTimeout()
+	ConfigureProviderRequestTimeout()
 }
 
 // Client provides methods to query Terraform Registries.
@@ -309,9 +309,9 @@ func maxRetryErrorHandler(resp *http.Response, err error, numTries int) (*http.R
 	return resp, fmt.Errorf("the request failed, please try again later%s", errMsg)
 }
 
-// configureRequestTimeout configures the registry client request timeout from
+// ConfigureProviderRequestTimeout configures the registry client request timeout from
 // environment variables
-func configureRequestTimeout() {
+func ConfigureProviderRequestTimeout() {
 	requestTimeout = defaultRequestTimeout
 
 	if v := os.Getenv(registryClientTimeoutEnvName); v != "" {

--- a/registry/client.go
+++ b/registry/client.go
@@ -54,7 +54,7 @@ var (
 
 func init() {
 	configureDiscoveryRetry()
-	ConfigureProviderRequestTimeout()
+	configureRequestTimeout()
 }
 
 // Client provides methods to query Terraform Registries.
@@ -309,9 +309,9 @@ func maxRetryErrorHandler(resp *http.Response, err error, numTries int) (*http.R
 	return resp, fmt.Errorf("the request failed, please try again later%s", errMsg)
 }
 
-// ConfigureProviderRequestTimeout configures the registry client request timeout from
+// configureRequestTimeout configures the registry client request timeout from
 // environment variables
-func ConfigureProviderRequestTimeout() {
+func configureRequestTimeout() {
 	requestTimeout = defaultRequestTimeout
 
 	if v := os.Getenv(registryClientTimeoutEnvName); v != "" {

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -72,7 +72,7 @@ func TestConfigureRegistryClientTimeout(t *testing.T) {
 		}(os.Getenv(registryClientTimeoutEnvName))
 		os.Setenv(registryClientTimeoutEnvName, "20")
 
-		configureRequestTimeout()
+		ConfigureProviderRequestTimeout()
 		expected := 20 * time.Second
 		if requestTimeout != expected {
 			t.Fatalf("expected timeout %q, got %q",

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -72,7 +72,7 @@ func TestConfigureRegistryClientTimeout(t *testing.T) {
 		}(os.Getenv(registryClientTimeoutEnvName))
 		os.Setenv(registryClientTimeoutEnvName, "20")
 
-		ConfigureProviderRequestTimeout()
+		configureRequestTimeout()
 		expected := 20 * time.Second
 		if requestTimeout != expected {
 			t.Fatalf("expected timeout %q, got %q",

--- a/repl/session_test.go
+++ b/repl/session_test.go
@@ -184,7 +184,7 @@ func testSession(t *testing.T, test testSessionTest) {
 	t.Helper()
 
 	p := &terraform.MockProvider{}
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -93,7 +93,7 @@ func TestContext2Apply_unstable(t *testing.T) {
 		Type: "test_resource",
 		Name: "foo",
 	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
-	schema := p.GetSchemaResponse.ResourceTypes["test_resource"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Block
 	rds := plan.Changes.ResourceInstance(addr)
 	rd, err := rds.Decode(schema.ImpliedType())
 	if err != nil {
@@ -656,7 +656,7 @@ func TestContext2Apply_providerAliasConfigure(t *testing.T) {
 
 	// Configure to record calls AFTER Plan above
 	var configCount int32
-	p2.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p2.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		atomic.AddInt32(&configCount, 1)
 
 		foo := req.Config.GetAttr("foo").AsString()
@@ -689,7 +689,7 @@ func TestContext2Apply_providerWarning(t *testing.T) {
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
-	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) (resp providers.ValidateResourceTypeConfigResponse) {
+	p.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
 		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.SimpleWarning("just a warning"))
 		return
 	}
@@ -720,7 +720,7 @@ aws_instance.foo:
 		t.Fatalf("got: \n%s\n\nexpected:\n%s", actual, expected)
 	}
 
-	if !p.ConfigureCalled {
+	if !p.ConfigureProviderCalled {
 		t.Fatalf("provider Configure() was never called!")
 	}
 }
@@ -1588,7 +1588,7 @@ func TestContext2Apply_destroyCrossProviders(t *testing.T) {
 	p_aws := testProvider("aws")
 	p_aws.ApplyResourceChangeFn = testApplyFn
 	p_aws.PlanResourceChangeFn = testDiffFn
-	p_aws.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p_aws.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1927,7 +1927,7 @@ func TestContext2Apply_compute(t *testing.T) {
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -2423,7 +2423,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 		return resp
 	}
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -2494,7 +2494,7 @@ func TestContext2Apply_moduleInheritAlias(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
 
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		val := req.Config.GetAttr("value")
 		if val.IsNull() {
 			return
@@ -2544,7 +2544,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 	p := testProvider("test")
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -2619,7 +2619,7 @@ func TestContext2Apply_moduleOrphanInheritAlias(t *testing.T) {
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
 
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		val := req.Config.GetAttr("value")
 		if val.IsNull() {
 			return
@@ -2662,7 +2662,7 @@ func TestContext2Apply_moduleOrphanInheritAlias(t *testing.T) {
 		t.Fatalf("diags: %s", diags.Err())
 	}
 
-	if !p.ConfigureCalled {
+	if !p.ConfigureProviderCalled {
 		t.Fatal("must call configure")
 	}
 
@@ -2674,7 +2674,7 @@ func TestContext2Apply_moduleOrphanProvider(t *testing.T) {
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
 
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		val := req.Config.GetAttr("value")
 		if val.IsNull() {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("value is not found"))
@@ -2717,7 +2717,7 @@ func TestContext2Apply_moduleOrphanGrandchildProvider(t *testing.T) {
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
 
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		val := req.Config.GetAttr("value")
 		if val.IsNull() {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("value is not found"))
@@ -2762,7 +2762,7 @@ func TestContext2Apply_moduleGrandchildProvider(t *testing.T) {
 
 	var callLock sync.Mutex
 	called := false
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		val := req.Config.GetAttr("value")
 		if val.IsNull() {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("value is not found"))
@@ -3149,7 +3149,7 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 	m := testModule(t, "apply-multi-provider-destroy")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"addr": {Type: cty.String, Optional: true},
@@ -3168,7 +3168,7 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 	p2 := testProvider("vault")
 	p2.ApplyResourceChangeFn = testApplyFn
 	p2.PlanResourceChangeFn = testDiffFn
-	p2.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p2.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"vault_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3269,7 +3269,7 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 	m := testModule(t, "apply-multi-provider-destroy-child")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"value": {Type: cty.String, Optional: true},
@@ -3288,7 +3288,7 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 	p2 := testProvider("vault")
 	p2.ApplyResourceChangeFn = testApplyFn
 	p2.PlanResourceChangeFn = testDiffFn
-	p2.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p2.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"vault_instance": {
@@ -3504,7 +3504,7 @@ func TestContext2Apply_multiVarComprehensive(t *testing.T) {
 		}
 	}
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3851,7 +3851,7 @@ func TestContext2Apply_multiVarMissingState(t *testing.T) {
 	m := testModule(t, "apply-multi-var-missing-state")
 	p := testProvider("test")
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3987,7 +3987,7 @@ func TestContext2Apply_providerComputedVar(t *testing.T) {
 		},
 	})
 
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		val := req.Config.GetAttr("value")
 		if val.IsNull() {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("value is not found"))
@@ -4010,7 +4010,7 @@ func TestContext2Apply_providerConfigureDisabled(t *testing.T) {
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
 
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		val := req.Config.GetAttr("value")
 		if val.IsNull() {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("value is not found"))
@@ -4034,7 +4034,7 @@ func TestContext2Apply_providerConfigureDisabled(t *testing.T) {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
-	if !p.ConfigureCalled {
+	if !p.ConfigureProviderCalled {
 		t.Fatal("configure never called")
 	}
 }
@@ -4414,7 +4414,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 	m := testModule(t, "apply-multi-depose-create-before-destroy")
 	p := testProvider("aws")
 	ps := map[addrs.Provider]providers.Factory{addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p)}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6275,7 +6275,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 	m := testModule(t, "empty")
 	p := testProvider("test")
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6348,7 +6348,7 @@ func TestContext2Apply_errorCreateInvalidNew(t *testing.T) {
 	m := testModule(t, "apply-error")
 
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6412,7 +6412,7 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 	m := testModule(t, "apply-error")
 
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -7653,7 +7653,7 @@ func TestContext2Apply_unknownAttribute(t *testing.T) {
 	}
 	p.ApplyResourceChangeFn = testApplyFn
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -8012,7 +8012,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 func TestContext2Apply_issue7824(t *testing.T) {
 	p := testProvider("template")
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"template_file": {
 				Attributes: map[string]*configschema.Attribute{
@@ -8068,7 +8068,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 	p := testProvider("template")
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"template_file": {
 				Attributes: map[string]*configschema.Attribute{
@@ -8235,7 +8235,7 @@ func TestContext2Apply_ignoreChangesCreate(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
 
-	instanceSchema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	instanceSchema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	instanceSchema.Attributes["required_field"] = &configschema.Attribute{
 		Type:     cty.String,
 		Required: true,
@@ -8378,7 +8378,7 @@ func TestContext2Apply_ignoreChangesWildcard(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
 
-	instanceSchema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	instanceSchema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	instanceSchema.Attributes["required_field"] = &configschema.Attribute{
 		Type:     cty.String,
 		Required: true,
@@ -8797,7 +8797,7 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 
 	providerRegion := ""
 	// this should not be overridden during destroy
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		val := req.Config.GetAttr("region")
 		if !val.IsNull() {
 			providerRegion = val.AsString()
@@ -9176,7 +9176,7 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 func TestContext2Apply_inconsistentWithPlan(t *testing.T) {
 	m := testModule(t, "apply-inconsistent-with-plan")
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test": {
 				Attributes: map[string]*configschema.Attribute{
@@ -9229,7 +9229,7 @@ func TestContext2Apply_inconsistentWithPlan(t *testing.T) {
 func TestContext2Apply_issue19908(t *testing.T) {
 	m := testModule(t, "apply-issue19908")
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test": {
 				Attributes: map[string]*configschema.Attribute{
@@ -9310,7 +9310,7 @@ func TestContext2Apply_issue19908(t *testing.T) {
 
 func TestContext2Apply_invalidIndexRef(t *testing.T) {
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -9367,7 +9367,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 			},
 		}
 
-		p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+		p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 			ResourceTypes: map[string]*configschema.Block{
 				"aws_instance": instanceSchema,
 			},
@@ -9598,7 +9598,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 		t.Fatalf("failed to create context for plan: %s", diags.Err())
 	}
 
-	tp.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	tp.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		foo := req.Config.GetAttr("foo")
 		if !foo.IsKnown() {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unknown config value foo"))
@@ -9640,7 +9640,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 
 		return testApplyFn(req)
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -9991,7 +9991,7 @@ func TestContext2Apply_ProviderMeta_apply_set(t *testing.T) {
 			NewState: cty.ObjectVal(s),
 		}
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10072,7 +10072,7 @@ func TestContext2Apply_ProviderMeta_apply_unset(t *testing.T) {
 			NewState: cty.ObjectVal(s),
 		}
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10122,7 +10122,7 @@ func TestContext2Apply_ProviderMeta_plan_set(t *testing.T) {
 			PlannedState: req.ProposedNewState,
 		}
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10190,7 +10190,7 @@ func TestContext2Apply_ProviderMeta_plan_unset(t *testing.T) {
 			PlannedState: req.ProposedNewState,
 		}
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10270,7 +10270,7 @@ func TestContext2Apply_ProviderMeta_plan_setInvalid(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10326,14 +10326,14 @@ func TestContext2Apply_ProviderMeta_refresh_set(t *testing.T) {
 	rrcPMs := map[string]cty.Value{}
 	p.ReadResourceFn = func(req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
 		rrcPMs[req.TypeName] = req.ProviderMeta
-		newState, err := p.GetSchemaResponse.ResourceTypes[req.TypeName].Block.CoerceValue(req.PriorState)
+		newState, err := p.GetProviderSchemaResponse.ResourceTypes[req.TypeName].Block.CoerceValue(req.PriorState)
 		if err != nil {
 			panic(err)
 		}
 		resp.NewState = newState
 		return resp
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10403,7 +10403,7 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10419,7 +10419,7 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 
 	// drop the schema before refresh, to test that it errors
 	schema.ProviderMeta = nil
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx = testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10471,7 +10471,7 @@ func TestContext2Apply_ProviderMeta_refresh_setInvalid(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10494,7 +10494,7 @@ func TestContext2Apply_ProviderMeta_refresh_setInvalid(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx = testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10548,7 +10548,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_set(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10643,7 +10643,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_unset(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -10756,7 +10756,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setInvalid(t *testing.T) {
 			},
 		},
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 	ctx := testContext2(t, &ContextOpts{
 		Config: m,
 		Providers: map[addrs.Provider]providers.Factory{
@@ -11378,10 +11378,10 @@ output "output" {
 	testP.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
 		return providers.ReadResourceResponse{NewState: req.PriorState}
 	}
-	testP.GetSchemaResponse = getSchemaResponseFromProviderSchema(schemaFn("test"))
+	testP.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schemaFn("test"))
 
 	providerConfig := ""
-	testP.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	testP.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		value := req.Config.GetAttr("value")
 		if value.IsKnown() && !value.IsNull() {
 			providerConfig = value.AsString()
@@ -11403,7 +11403,7 @@ output "output" {
 	nullP.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
 		return providers.ReadResourceResponse{NewState: req.PriorState}
 	}
-	nullP.GetSchemaResponse = getSchemaResponseFromProviderSchema(schemaFn("null"))
+	nullP.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schemaFn("null"))
 
 	nullP.ApplyResourceChangeFn = testApplyFn
 	nullP.PlanResourceChangeFn = testDiffFn
@@ -11788,7 +11788,7 @@ resource "test_resource" "foo" {
 	p.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
 		return providers.ReadResourceResponse{NewState: req.PriorState}
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"test_resource": {
@@ -12292,7 +12292,7 @@ resource "test_instance" "a" {
 		return resp
 	}
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{

--- a/terraform/context_import_test.go
+++ b/terraform/context_import_test.go
@@ -216,7 +216,7 @@ func TestContextImport_moduleProvider(t *testing.T) {
 		},
 	}
 
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		foo := req.Config.GetAttr("foo").AsString()
 		if foo != "bar" {
 			resp.Diagnostics = resp.Diagnostics.Append(errors.New("not bar"))
@@ -247,7 +247,7 @@ func TestContextImport_moduleProvider(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	if !p.ConfigureCalled {
+	if !p.ConfigureProviderCalled {
 		t.Fatal("didn't configure provider")
 	}
 
@@ -280,7 +280,7 @@ func TestContextImport_providerModule(t *testing.T) {
 		},
 	}
 
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		foo := req.Config.GetAttr("foo").AsString()
 		if foo != "bar" {
 			resp.Diagnostics = resp.Diagnostics.Append(errors.New("not bar"))
@@ -303,7 +303,7 @@ func TestContextImport_providerModule(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	if !p.ConfigureCalled {
+	if !p.ConfigureProviderCalled {
 		t.Fatal("didn't configure provider")
 	}
 }
@@ -366,11 +366,11 @@ func TestContextImport_providerConfig(t *testing.T) {
 				t.Fatalf("unexpected errors: %s", diags.Err())
 			}
 
-			if !p.ConfigureCalled {
+			if !p.ConfigureProviderCalled {
 				t.Fatal("didn't configure provider")
 			}
 
-			if foo := p.ConfigureRequest.Config.GetAttr("foo").AsString(); foo != test.value {
+			if foo := p.ConfigureProviderRequest.Config.GetAttr("foo").AsString(); foo != test.value {
 				t.Fatalf("bad value %#v; want %#v", foo, test.value)
 			}
 
@@ -654,7 +654,7 @@ func TestContextImport_multiState(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "import-provider")
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {Type: cty.String, Optional: true},
@@ -723,7 +723,7 @@ func TestContextImport_multiStateSame(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "import-provider")
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {Type: cty.String, Optional: true},
@@ -829,7 +829,7 @@ resource "test_resource" "unused" {
 `,
 	})
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {Type: cty.String, Optional: true},

--- a/terraform/context_input_test.go
+++ b/terraform/context_input_test.go
@@ -17,7 +17,7 @@ import (
 func TestContext2Input_provider(t *testing.T) {
 	m := testModule(t, "input-provider")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {
@@ -54,7 +54,7 @@ func TestContext2Input_provider(t *testing.T) {
 	})
 
 	var actual interface{}
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		actual = req.Config.GetAttr("foo").AsString()
 		return
 	}
@@ -87,7 +87,7 @@ func TestContext2Input_providerMulti(t *testing.T) {
 	m := testModule(t, "input-provider-multi")
 
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {
@@ -135,7 +135,7 @@ func TestContext2Input_providerMulti(t *testing.T) {
 		t.Fatalf("plan errors: %s", diags.Err())
 	}
 
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		lock.Lock()
 		defer lock.Unlock()
 		actual = append(actual, req.Config.GetAttr("foo").AsString())
@@ -172,7 +172,7 @@ func TestContext2Input_providerId(t *testing.T) {
 	m := testModule(t, "input-provider")
 
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {
@@ -203,7 +203,7 @@ func TestContext2Input_providerId(t *testing.T) {
 	})
 
 	var actual interface{}
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		actual = req.Config.GetAttr("foo").AsString()
 		return
 	}
@@ -234,7 +234,7 @@ func TestContext2Input_providerOnly(t *testing.T) {
 
 	m := testModule(t, "input-provider-vars")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {
@@ -273,7 +273,7 @@ func TestContext2Input_providerOnly(t *testing.T) {
 	}
 
 	var actual interface{}
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		actual = req.Config.GetAttr("foo").AsString()
 		return
 	}
@@ -325,7 +325,7 @@ func TestContext2Input_providerVars(t *testing.T) {
 	}
 
 	var actual interface{}
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		actual = req.Config.GetAttr("foo").AsString()
 		return
 	}
@@ -388,7 +388,7 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 	p := testProvider("null")
 	m := testModule(t, "input-module-data-vars")
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		DataSources: map[string]*configschema.Block{
 			"null_data_source": {
 				Attributes: map[string]*configschema.Attribute{

--- a/terraform/context_plan2_test.go
+++ b/terraform/context_plan2_test.go
@@ -74,7 +74,7 @@ data "test_data_source" "foo" {
 	})
 
 	p := new(MockProvider)
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		DataSources: map[string]*configschema.Block{
 			"test_data_source": {
 				Attributes: map[string]*configschema.Attribute{
@@ -230,7 +230,7 @@ resource "test_object" "a" {
 
 	// The resource within the module should be using the provider configured
 	// from the root module. We should never see an empty configuration.
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		if req.Config.GetAttr("test_string").IsNull() {
 			resp.Diagnostics = resp.Diagnostics.Append(errors.New("missing test_string value"))
 		}

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -55,7 +55,7 @@ func TestContext2Plan_basic(t *testing.T) {
 		t.Fatalf("expected empty state, got %#v\n", ctx.State())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 	for _, r := range plan.Changes.Resources {
 		ric, err := r.Decode(ty)
@@ -79,7 +79,7 @@ func TestContext2Plan_basic(t *testing.T) {
 		}
 	}
 
-	if !p.PrepareProviderConfigCalled {
+	if !p.ValidateProviderConfigCalled {
 		t.Fatal("provider config was not checked before Configure")
 	}
 
@@ -135,7 +135,7 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 		t.Fatalf("\nexpected: %q\ngot:      %q\n", expectedState, ctx.State().String())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	type InstanceGen struct {
@@ -299,7 +299,7 @@ func TestContext2Plan_escapedVar(t *testing.T) {
 		t.Fatalf("expected resource creation, got %s", res.Action)
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	ric, err := res.Decode(ty)
@@ -374,7 +374,7 @@ func TestContext2Plan_modules(t *testing.T) {
 		t.Error("expected 3 resource in plan, got", len(plan.Changes.Resources))
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	expectFoo := objectVal(t, schema, map[string]cty.Value{
@@ -429,7 +429,7 @@ func TestContext2Plan_moduleExpand(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	expected := map[string]struct{}{
@@ -466,7 +466,7 @@ func TestContext2Plan_moduleExpand(t *testing.T) {
 func TestContext2Plan_moduleCycle(t *testing.T) {
 	m := testModule(t, "plan-module-cycle")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -490,7 +490,7 @@ func TestContext2Plan_moduleCycle(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -545,7 +545,7 @@ func TestContext2Plan_moduleDeadlock(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+		schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 		ty := schema.ImpliedType()
 
 		for _, res := range plan.Changes.Resources {
@@ -590,7 +590,7 @@ func TestContext2Plan_moduleInput(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -645,7 +645,7 @@ func TestContext2Plan_moduleInputComputed(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -703,7 +703,7 @@ func TestContext2Plan_moduleInputFromVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -741,7 +741,7 @@ func TestContext2Plan_moduleInputFromVar(t *testing.T) {
 func TestContext2Plan_moduleMultiVar(t *testing.T) {
 	m := testModule(t, "plan-module-multi-var")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -765,7 +765,7 @@ func TestContext2Plan_moduleMultiVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 5 {
@@ -840,7 +840,7 @@ func TestContext2Plan_moduleOrphans(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -936,7 +936,7 @@ func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -1002,7 +1002,7 @@ func TestContext2Plan_moduleProviderInherit(t *testing.T) {
 				defer l.Unlock()
 
 				p := testProvider("aws")
-				p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+				p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 					Provider: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"from": {Type: cty.String, Optional: true},
@@ -1016,7 +1016,7 @@ func TestContext2Plan_moduleProviderInherit(t *testing.T) {
 						},
 					},
 				})
-				p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+				p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 					from := req.Config.GetAttr("from")
 					if from.IsNull() || from.AsString() != "root" {
 						resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("not root"))
@@ -1066,7 +1066,7 @@ func TestContext2Plan_moduleProviderInheritDeep(t *testing.T) {
 				var from string
 				p := testProvider("aws")
 
-				p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+				p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 					Provider: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"from": {Type: cty.String, Optional: true},
@@ -1079,7 +1079,7 @@ func TestContext2Plan_moduleProviderInheritDeep(t *testing.T) {
 					},
 				})
 
-				p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+				p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 					v := req.Config.GetAttr("from")
 					if v.IsNull() || v.AsString() != "root" {
 						resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("not root"))
@@ -1121,7 +1121,7 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 				defer l.Unlock()
 
 				p := testProvider("aws")
-				p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+				p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 					Provider: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"to":   {Type: cty.String, Optional: true},
@@ -1136,7 +1136,7 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 						},
 					},
 				})
-				p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+				p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 					var buf bytes.Buffer
 					from := req.Config.GetAttr("from")
 					if !from.IsNull() {
@@ -1182,7 +1182,7 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 func TestContext2Plan_moduleProviderVar(t *testing.T) {
 	m := testModule(t, "plan-module-provider-var")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"value": {Type: cty.String, Optional: true},
@@ -1209,7 +1209,7 @@ func TestContext2Plan_moduleProviderVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -1252,7 +1252,7 @@ func TestContext2Plan_moduleVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -1354,7 +1354,7 @@ func TestContext2Plan_moduleVarComputed(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -1503,7 +1503,7 @@ func TestContext2Plan_preventDestroy_countBad(t *testing.T) {
 func TestContext2Plan_preventDestroy_countGood(t *testing.T) {
 	m := testModule(t, "plan-prevent-destroy-count-good")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1555,7 +1555,7 @@ func TestContext2Plan_preventDestroy_countGoodNoChange(t *testing.T) {
 	m := testModule(t, "plan-prevent-destroy-count-good")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1667,7 +1667,7 @@ func TestContext2Plan_computed(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -1707,7 +1707,7 @@ func TestContext2Plan_computed(t *testing.T) {
 func TestContext2Plan_blockNestingGroup(t *testing.T) {
 	m := testModule(t, "plan-block-nesting-group")
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test": {
 				BlockTypes: map[string]*configschema.NestedBlock{
@@ -1779,7 +1779,7 @@ func TestContext2Plan_blockNestingGroup(t *testing.T) {
 func TestContext2Plan_computedDataResource(t *testing.T) {
 	m := testModule(t, "plan-computed-data-resource")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1809,7 +1809,7 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.DataSources["aws_vpc"].Block
+	schema := p.GetProviderSchemaResponse.DataSources["aws_vpc"].Block
 	ty := schema.ImpliedType()
 
 	if rc := plan.Changes.ResourceInstance(addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "aws_instance", Name: "foo"}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)); rc == nil {
@@ -1840,7 +1840,7 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 func TestContext2Plan_computedInFunction(t *testing.T) {
 	m := testModule(t, "plan-computed-in-function")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1885,7 +1885,7 @@ func TestContext2Plan_computedInFunction(t *testing.T) {
 func TestContext2Plan_computedDataCountResource(t *testing.T) {
 	m := testModule(t, "plan-computed-data-count")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1963,7 +1963,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 	m := testModule(t, "plan-data-resource-becomes-computed")
 	p := testProvider("aws")
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1993,7 +1993,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 		}
 	}
 
-	schema := p.GetSchemaResponse.DataSources["aws_data_source"].Block
+	schema := p.GetProviderSchemaResponse.DataSources["aws_data_source"].Block
 	ty := schema.ImpliedType()
 
 	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
@@ -2057,7 +2057,7 @@ func TestContext2Plan_computedList(t *testing.T) {
 	m := testModule(t, "plan-computed-list")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -2082,7 +2082,7 @@ func TestContext2Plan_computedList(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -2122,7 +2122,7 @@ func TestContext2Plan_computedMultiIndex(t *testing.T) {
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -2146,7 +2146,7 @@ func TestContext2Plan_computedMultiIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -2201,7 +2201,7 @@ func TestContext2Plan_count(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 6 {
@@ -2312,7 +2312,7 @@ func TestContext2Plan_countModuleStatic(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -2366,7 +2366,7 @@ func TestContext2Plan_countModuleStaticGrandchild(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -2420,7 +2420,7 @@ func TestContext2Plan_countIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -2476,7 +2476,7 @@ func TestContext2Plan_countVar(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2526,7 +2526,7 @@ func TestContext2Plan_countVar(t *testing.T) {
 func TestContext2Plan_countZero(t *testing.T) {
 	m := testModule(t, "plan-count-zero")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -2554,7 +2554,7 @@ func TestContext2Plan_countZero(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -2596,7 +2596,7 @@ func TestContext2Plan_countOneIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -2675,7 +2675,7 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2761,7 +2761,7 @@ func TestContext2Plan_countIncreaseFromNotSet(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2840,7 +2840,7 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2933,7 +2933,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 5 {
@@ -3000,7 +3000,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 	m := testModule(t, "plan-count-splat-reference")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3060,7 +3060,7 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 6 {
@@ -3115,7 +3115,7 @@ func TestContext2Plan_forEach(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 8 {
@@ -3202,7 +3202,7 @@ func TestContext2Plan_destroy(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3264,7 +3264,7 @@ func TestContext2Plan_moduleDestroy(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3328,7 +3328,7 @@ func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3390,7 +3390,7 @@ func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3423,7 +3423,7 @@ func TestContext2Plan_pathVar(t *testing.T) {
 
 	m := testModule(t, "plan-path-var")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3447,7 +3447,7 @@ func TestContext2Plan_pathVar(t *testing.T) {
 		t.Fatalf("err: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -3504,7 +3504,7 @@ func TestContext2Plan_diffVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3623,7 +3623,7 @@ func TestContext2Plan_orphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3704,7 +3704,7 @@ func TestContext2Plan_state(t *testing.T) {
 	if len(plan.Changes.Resources) < 2 {
 		t.Fatalf("bad: %#v", plan.Changes.Resources)
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3783,7 +3783,7 @@ func TestContext2Plan_taint(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3819,7 +3819,7 @@ func TestContext2Plan_taint(t *testing.T) {
 func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 	m := testModule(t, "plan-taint-ignore-changes")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -3855,7 +3855,7 @@ func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -3935,7 +3935,7 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			t.Fatalf("unexpected errors: %s", diags.Err())
 		}
 
-		schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+		schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 		ty := schema.ImpliedType()
 
 		if len(plan.Changes.Resources) != 3 {
@@ -3992,7 +3992,7 @@ func TestContext2Plan_targeted(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4041,7 +4041,7 @@ func TestContext2Plan_targetedCrossModule(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -4078,7 +4078,7 @@ func TestContext2Plan_targetedCrossModule(t *testing.T) {
 func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
 	m := testModule(t, "plan-targeted-module-with-provider")
 	p := testProvider("null")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"key": {Type: cty.String, Optional: true},
@@ -4106,7 +4106,7 @@ func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["null_resource"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["null_resource"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4166,7 +4166,7 @@ func TestContext2Plan_targetedOrphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4233,7 +4233,7 @@ func TestContext2Plan_targetedModuleOrphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4276,7 +4276,7 @@ func TestContext2Plan_targetedModuleUntargetedVariable(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -4382,7 +4382,7 @@ func TestContext2Plan_targetedOverTen(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	for _, res := range plan.Changes.Resources {
@@ -4401,7 +4401,7 @@ func TestContext2Plan_provider(t *testing.T) {
 	p := testProvider("aws")
 
 	var value interface{}
-	p.ConfigureFn = func(req providers.ConfigureRequest) (resp providers.ConfigureResponse) {
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		value = req.Config.GetAttr("foo").AsString()
 		return
 	}
@@ -4480,7 +4480,7 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4553,7 +4553,7 @@ func TestContext2Plan_ignoreChangesWildcard(t *testing.T) {
 func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 	p := testProvider("test")
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_ignore_changes_map": {
 				Attributes: map[string]*configschema.Attribute{
@@ -4600,7 +4600,7 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["test_ignore_changes_map"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_ignore_changes_map"].Block
 	ty := schema.ImpliedType()
 
 	if got, want := len(plan.Changes.Resources), 1; got != want {
@@ -4663,7 +4663,7 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4690,7 +4690,7 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 func TestContext2Plan_moduleMapLiteral(t *testing.T) {
 	m := testModule(t, "plan-module-map-literal")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -4730,7 +4730,7 @@ func TestContext2Plan_moduleMapLiteral(t *testing.T) {
 func TestContext2Plan_computedValueInMap(t *testing.T) {
 	m := testModule(t, "plan-computed-value-in-map")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -4774,7 +4774,7 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 	}
 
 	for _, res := range plan.Changes.Resources {
-		schema := p.GetSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
+		schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
 
 		ric, err := res.Decode(schema.ImpliedType())
 		if err != nil {
@@ -4803,7 +4803,7 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 	m := testModule(t, "plan-module-variable-from-splat")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -4830,7 +4830,7 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 	}
 
 	for _, res := range plan.Changes.Resources {
-		schema := p.GetSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
+		schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
 
 		ric, err := res.Decode(schema.ImpliedType())
 		if err != nil {
@@ -4858,7 +4858,7 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 func TestContext2Plan_createBeforeDestroy_depends_datasource(t *testing.T) {
 	m := testModule(t, "plan-cbd-depends-datasource")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -4913,9 +4913,9 @@ func TestContext2Plan_createBeforeDestroy_depends_datasource(t *testing.T) {
 		var schema *configschema.Block
 		switch res.Addr.Resource.Resource.Mode {
 		case addrs.DataResourceMode:
-			schema = p.GetSchemaResponse.DataSources[res.Addr.Resource.Resource.Type].Block
+			schema = p.GetProviderSchemaResponse.DataSources[res.Addr.Resource.Resource.Type].Block
 		case addrs.ManagedResourceMode:
-			schema = p.GetSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
+			schema = p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
 		}
 
 		ric, err := res.Decode(schema.ImpliedType())
@@ -4962,7 +4962,7 @@ func TestContext2Plan_createBeforeDestroy_depends_datasource(t *testing.T) {
 func TestContext2Plan_listOrder(t *testing.T) {
 	m := testModule(t, "plan-list-order")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5007,7 +5007,7 @@ func TestContext2Plan_listOrder(t *testing.T) {
 func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 	m := testModule(t, "plan-ignore-changes-with-flatmaps")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5058,7 +5058,7 @@ func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 	}
 
 	res := plan.Changes.Resources[0]
-	schema := p.GetSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
 
 	ric, err := res.Decode(schema.ImpliedType())
 	if err != nil {
@@ -5190,7 +5190,7 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 func TestContext2Plan_computedAttrRefTypeMismatch(t *testing.T) {
 	m := testModule(t, "plan-computed-attr-ref-type-mismatch")
 	p := testProvider("aws")
-	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
+	p.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 		var diags tfdiags.Diagnostics
 		if req.TypeName == "aws_instance" {
 			amiVal := req.Config.GetAttr("ami")
@@ -5198,7 +5198,7 @@ func TestContext2Plan_computedAttrRefTypeMismatch(t *testing.T) {
 				diags = diags.Append(fmt.Errorf("Expected ami to be cty.String, got %#v", amiVal))
 			}
 		}
-		return providers.ValidateResourceTypeConfigResponse{
+		return providers.ValidateResourceConfigResponse{
 			Diagnostics: diags,
 		}
 	}
@@ -5237,7 +5237,7 @@ func TestContext2Plan_computedAttrRefTypeMismatch(t *testing.T) {
 
 func TestContext2Plan_selfRef(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5274,7 +5274,7 @@ func TestContext2Plan_selfRef(t *testing.T) {
 
 func TestContext2Plan_selfRefMulti(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5311,7 +5311,7 @@ func TestContext2Plan_selfRefMulti(t *testing.T) {
 
 func TestContext2Plan_selfRefMultiAll(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5449,7 +5449,7 @@ resource "aws_instance" "foo" {
 	})
 
 	p := testProvider("aws")
-	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) (resp providers.ValidateResourceTypeConfigResponse) {
+	p.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
 		foo := req.Config.GetAttr("foo").AsString()
 		if foo == "bar" {
 			resp.Diagnostics = resp.Diagnostics.Append(errors.New("foo cannot be bar"))
@@ -5497,7 +5497,7 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -5564,7 +5564,7 @@ func TestContext2Plan_variableSensitivityModule(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -5637,7 +5637,7 @@ func objectVal(t *testing.T, schema *configschema.Block, m map[string]cty.Value)
 func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 	m := testModule(t, "plan-required-output")
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_resource": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5660,7 +5660,7 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["test_resource"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -5701,7 +5701,7 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 func TestContext2Plan_requiredModuleObject(t *testing.T) {
 	m := testModule(t, "plan-required-whole-mod")
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_resource": {
 				Attributes: map[string]*configschema.Attribute{
@@ -5724,7 +5724,7 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetSchemaResponse.ResourceTypes["test_resource"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -6040,7 +6040,7 @@ data "test_data_source" "foo" {}
 	})
 
 	p := new(MockProvider)
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		DataSources: map[string]*configschema.Block{
 			"test_data_source": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6165,7 +6165,7 @@ func TestContext2Plan_targetedModuleInstance(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -6394,7 +6394,7 @@ resource "test_instance" "a" {
 		return resp
 	}
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6451,7 +6451,7 @@ resource "test_instance" "a" {
 		return resp
 	}
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6505,7 +6505,7 @@ resource "test_instance" "a" {
 	})
 
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -6515,14 +6515,14 @@ resource "test_instance" "a" {
 			},
 		},
 	})
-	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
+	p.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 		var diags tfdiags.Diagnostics
 		if req.TypeName == "test_instance" {
 			if !req.Config.GetAttr("id").IsNull() {
 				diags = diags.Append(errors.New("id cannot be set in config"))
 			}
 		}
-		return providers.ValidateResourceTypeConfigResponse{
+		return providers.ValidateResourceConfigResponse{
 			Diagnostics: diags,
 		}
 	}

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -41,7 +41,7 @@ func TestContext2Refresh(t *testing.T) {
 		State: state,
 	})
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 	readState, err := hcl2shim.HCL2ValueFromFlatmap(map[string]string{"id": "foo", "foo": "baz"}, ty)
 	if err != nil {
@@ -103,7 +103,7 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 	})
 
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -130,7 +130,7 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 		State: startingState,
 	})
 
-	schema := p.GetSchemaResponse.ResourceTypes["test_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_instance"].Block
 	ty := schema.ImpliedType()
 
 	s, diags := ctx.Refresh()
@@ -167,7 +167,7 @@ func TestContext2Refresh_dataComputedModuleVar(t *testing.T) {
 		return resp
 	}
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -218,7 +218,7 @@ func TestContext2Refresh_dataComputedModuleVar(t *testing.T) {
 
 func TestContext2Refresh_targeted(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_elb": {
@@ -294,7 +294,7 @@ func TestContext2Refresh_targeted(t *testing.T) {
 
 func TestContext2Refresh_targetedCount(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_elb": {
@@ -380,7 +380,7 @@ func TestContext2Refresh_targetedCount(t *testing.T) {
 
 func TestContext2Refresh_targetedCountIndex(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_elb": {
@@ -458,7 +458,7 @@ func TestContext2Refresh_targetedCountIndex(t *testing.T) {
 
 func TestContext2Refresh_moduleComputedVar(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -508,7 +508,7 @@ func TestContext2Refresh_delete(t *testing.T) {
 	})
 
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
-		NewState: cty.NullVal(p.GetSchemaResponse.ResourceTypes["aws_instance"].Block.ImpliedType()),
+		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block.ImpliedType()),
 	}
 
 	s, diags := ctx.Refresh()
@@ -628,7 +628,7 @@ func TestContext2Refresh_modules(t *testing.T) {
 func TestContext2Refresh_moduleInputComputedOutput(t *testing.T) {
 	m := testModule(t, "refresh-module-input-computed-output")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -699,7 +699,7 @@ func TestContext2Refresh_noState(t *testing.T) {
 func TestContext2Refresh_output(t *testing.T) {
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -753,7 +753,7 @@ func TestContext2Refresh_outputPartial(t *testing.T) {
 	// remote objects yet, to get stub values for interpolation. Therefore
 	// we need to make DiffFn available to let that complete.
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -768,7 +768,7 @@ func TestContext2Refresh_outputPartial(t *testing.T) {
 	})
 
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
-		NewState: cty.NullVal(p.GetSchemaResponse.ResourceTypes["aws_instance"].Block.ImpliedType()),
+		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block.ImpliedType()),
 	}
 
 	state := states.NewState()
@@ -811,7 +811,7 @@ func TestContext2Refresh_stateBasic(t *testing.T) {
 		State: state,
 	})
 
-	schema := p.GetSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
 	ty := schema.ImpliedType()
 
 	readStateVal, err := schema.CoerceValue(cty.ObjectVal(map[string]cty.Value{
@@ -855,7 +855,7 @@ func TestContext2Refresh_dataCount(t *testing.T) {
 		resp.PlannedState = cty.ObjectVal(m)
 		return resp
 	}
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test": {
 				Attributes: map[string]*configschema.Attribute{
@@ -904,7 +904,7 @@ func TestContext2Refresh_dataState(t *testing.T) {
 	}
 
 	p := testProvider("null")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		DataSources: map[string]*configschema.Block{
 			"null_data_source": schema,
@@ -953,7 +953,7 @@ func TestContext2Refresh_dataState(t *testing.T) {
 
 func TestContext2Refresh_dataStateRefData(t *testing.T) {
 	p := testProvider("null")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		DataSources: map[string]*configschema.Block{
 			"null_data_source": {
@@ -1089,7 +1089,7 @@ func TestContext2Refresh_vars(t *testing.T) {
 		},
 	}
 
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider:      &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{"aws_instance": schema},
 	})
@@ -1219,7 +1219,7 @@ func TestContext2Refresh_orphanModule(t *testing.T) {
 
 func TestContext2Validate(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{},
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
@@ -1286,7 +1286,7 @@ aws_instance.bar:
 func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
 	m := testModule(t, "refresh-schema-upgrade")
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1372,7 +1372,7 @@ test_thing.bar:
 func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
 	m := testModule(t, "refresh-schema-upgrade")
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_thing": {
 				Attributes: map[string]*configschema.Attribute{
@@ -1492,7 +1492,7 @@ data "aws_data_source" "foo" {
 func TestContext2Refresh_dataResourceDependsOn(t *testing.T) {
 	m := testModule(t, "plan-data-depends-on")
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"test_resource": {
 				Attributes: map[string]*configschema.Attribute{

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -401,7 +401,7 @@ func testDiffFn(req providers.PlanResourceChangeRequest) (resp providers.PlanRes
 
 func testProvider(prefix string) *MockProvider {
 	p := new(MockProvider)
-	p.GetSchemaResponse = testProviderSchema(prefix)
+	p.GetProviderSchemaResponse = testProviderSchema(prefix)
 
 	return p
 }
@@ -461,8 +461,8 @@ func testCheckDeadlock(t *testing.T, f func()) {
 	}
 }
 
-func testProviderSchema(name string) *providers.GetSchemaResponse {
-	return getSchemaResponseFromProviderSchema(&ProviderSchema{
+func testProviderSchema(name string) *providers.GetProviderSchemaResponse {
+	return getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"region": {

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestContext2Validate_badCount(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{},
@@ -42,7 +42,7 @@ func TestContext2Validate_badCount(t *testing.T) {
 
 func TestContext2Validate_badResource_reference(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{},
@@ -66,7 +66,7 @@ func TestContext2Validate_badResource_reference(t *testing.T) {
 
 func TestContext2Validate_badVar(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
@@ -94,7 +94,7 @@ func TestContext2Validate_badVar(t *testing.T) {
 func TestContext2Validate_varMapOverrideOld(t *testing.T) {
 	m := testModule(t, "validate-module-pc-vars")
 	p := testProvider("aws")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(&ProviderSchema{
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		Provider: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"foo": {Type: cty.String, Optional: true},
@@ -133,7 +133,7 @@ func TestContext2Validate_varNoDefaultExplicitType(t *testing.T) {
 
 func TestContext2Validate_computedVar(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -150,7 +150,7 @@ func TestContext2Validate_computedVar(t *testing.T) {
 		},
 	}
 	pt := testProvider("test")
-	pt.GetSchemaResponse = &providers.GetSchemaResponse{
+	pt.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -172,7 +172,7 @@ func TestContext2Validate_computedVar(t *testing.T) {
 		},
 	})
 
-	p.PrepareProviderConfigFn = func(req providers.PrepareProviderConfigRequest) (resp providers.PrepareProviderConfigResponse) {
+	p.ValidateProviderConfigFn = func(req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 		val := req.Config.GetAttr("value")
 		if val.IsKnown() {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("value isn't computed"))
@@ -185,14 +185,14 @@ func TestContext2Validate_computedVar(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
-	if p.ConfigureCalled {
+	if p.ConfigureProviderCalled {
 		t.Fatal("Configure should not be called for provider")
 	}
 }
 
 func TestContext2Validate_computedInFunction(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -233,7 +233,7 @@ func TestContext2Validate_computedInFunction(t *testing.T) {
 // can be realized during a plan.
 func TestContext2Validate_countComputed(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -269,7 +269,7 @@ func TestContext2Validate_countComputed(t *testing.T) {
 
 func TestContext2Validate_countNegative(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -294,7 +294,7 @@ func TestContext2Validate_countNegative(t *testing.T) {
 
 func TestContext2Validate_countVariable(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -322,7 +322,7 @@ func TestContext2Validate_countVariable(t *testing.T) {
 func TestContext2Validate_countVariableNoDefault(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "validate-count-variable")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -347,7 +347,7 @@ func TestContext2Validate_countVariableNoDefault(t *testing.T) {
 
 func TestContext2Validate_moduleBadOutput(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -374,7 +374,7 @@ func TestContext2Validate_moduleBadOutput(t *testing.T) {
 
 func TestContext2Validate_moduleGood(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -402,7 +402,7 @@ func TestContext2Validate_moduleGood(t *testing.T) {
 func TestContext2Validate_moduleBadResource(t *testing.T) {
 	m := testModule(t, "validate-module-bad-rc")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -419,7 +419,7 @@ func TestContext2Validate_moduleBadResource(t *testing.T) {
 		},
 	})
 
-	p.ValidateResourceTypeConfigResponse = &providers.ValidateResourceTypeConfigResponse{
+	p.ValidateResourceConfigResponse = &providers.ValidateResourceConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
@@ -432,7 +432,7 @@ func TestContext2Validate_moduleBadResource(t *testing.T) {
 func TestContext2Validate_moduleDepsShouldNotCycle(t *testing.T) {
 	m := testModule(t, "validate-module-deps-cycle")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -460,7 +460,7 @@ func TestContext2Validate_moduleDepsShouldNotCycle(t *testing.T) {
 func TestContext2Validate_moduleProviderVar(t *testing.T) {
 	m := testModule(t, "validate-module-pc-vars")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -492,7 +492,7 @@ func TestContext2Validate_moduleProviderVar(t *testing.T) {
 		},
 	})
 
-	p.PrepareProviderConfigFn = func(req providers.PrepareProviderConfigRequest) (resp providers.PrepareProviderConfigResponse) {
+	p.ValidateProviderConfigFn = func(req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 		if req.Config.GetAttr("foo").IsNull() {
 			resp.Diagnostics = resp.Diagnostics.Append(errors.New("foo is null"))
 		}
@@ -508,7 +508,7 @@ func TestContext2Validate_moduleProviderVar(t *testing.T) {
 func TestContext2Validate_moduleProviderInheritUnused(t *testing.T) {
 	m := testModule(t, "validate-module-pc-inherit-unused")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -534,7 +534,7 @@ func TestContext2Validate_moduleProviderInheritUnused(t *testing.T) {
 		},
 	})
 
-	p.PrepareProviderConfigFn = func(req providers.PrepareProviderConfigRequest) (resp providers.PrepareProviderConfigResponse) {
+	p.ValidateProviderConfigFn = func(req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 		if req.Config.GetAttr("foo").IsNull() {
 			resp.Diagnostics = resp.Diagnostics.Append(errors.New("foo is null"))
 		}
@@ -549,7 +549,7 @@ func TestContext2Validate_moduleProviderInheritUnused(t *testing.T) {
 
 func TestContext2Validate_orphans(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -576,12 +576,12 @@ func TestContext2Validate_orphans(t *testing.T) {
 		State: state,
 	})
 
-	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
+	p.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 		var diags tfdiags.Diagnostics
 		if req.Config.GetAttr("foo").IsNull() {
 			diags = diags.Append(errors.New("foo is not set"))
 		}
-		return providers.ValidateResourceTypeConfigResponse{
+		return providers.ValidateResourceConfigResponse{
 			Diagnostics: diags,
 		}
 	}
@@ -595,7 +595,7 @@ func TestContext2Validate_orphans(t *testing.T) {
 func TestContext2Validate_providerConfig_bad(t *testing.T) {
 	m := testModule(t, "validate-bad-pc")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -619,7 +619,7 @@ func TestContext2Validate_providerConfig_bad(t *testing.T) {
 		},
 	})
 
-	p.PrepareProviderConfigResponse = &providers.PrepareProviderConfigResponse{
+	p.ValidateProviderConfigResponse = &providers.ValidateProviderConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
@@ -635,7 +635,7 @@ func TestContext2Validate_providerConfig_bad(t *testing.T) {
 func TestContext2Validate_providerConfig_skippedEmpty(t *testing.T) {
 	m := testModule(t, "validate-skipped-pc-empty")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -659,7 +659,7 @@ func TestContext2Validate_providerConfig_skippedEmpty(t *testing.T) {
 		},
 	})
 
-	p.PrepareProviderConfigResponse = &providers.PrepareProviderConfigResponse{
+	p.ValidateProviderConfigResponse = &providers.ValidateProviderConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("should not be called")),
 	}
 
@@ -672,7 +672,7 @@ func TestContext2Validate_providerConfig_skippedEmpty(t *testing.T) {
 func TestContext2Validate_providerConfig_good(t *testing.T) {
 	m := testModule(t, "validate-bad-pc")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -708,7 +708,7 @@ func TestContext2Validate_requiredProviderConfig(t *testing.T) {
 	m := testModule(t, "validate-required-provider-config")
 	p := testProvider("aws")
 
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -741,7 +741,7 @@ func TestContext2Validate_requiredProviderConfig(t *testing.T) {
 func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 	m := testModule(t, "validate-bad-prov-conf")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -765,7 +765,7 @@ func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 		},
 	})
 
-	p.PrepareProviderConfigResponse = &providers.PrepareProviderConfigResponse{
+	p.ValidateProviderConfigResponse = &providers.ValidateProviderConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
@@ -778,7 +778,7 @@ func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 func TestContext2Validate_badResourceConnection(t *testing.T) {
 	m := testModule(t, "validate-bad-resource-connection")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -812,7 +812,7 @@ func TestContext2Validate_badResourceConnection(t *testing.T) {
 func TestContext2Validate_badProvisionerConnection(t *testing.T) {
 	m := testModule(t, "validate-bad-prov-connection")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -846,7 +846,7 @@ func TestContext2Validate_badProvisionerConnection(t *testing.T) {
 func TestContext2Validate_provisionerConfig_good(t *testing.T) {
 	m := testModule(t, "validate-bad-prov-conf")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
 			Block: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -895,7 +895,7 @@ func TestContext2Validate_provisionerConfig_good(t *testing.T) {
 func TestContext2Validate_requiredVar(t *testing.T) {
 	m := testModule(t, "validate-required-var")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -921,7 +921,7 @@ func TestContext2Validate_requiredVar(t *testing.T) {
 func TestContext2Validate_resourceConfig_bad(t *testing.T) {
 	m := testModule(t, "validate-bad-rc")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -939,7 +939,7 @@ func TestContext2Validate_resourceConfig_bad(t *testing.T) {
 		},
 	})
 
-	p.ValidateResourceTypeConfigResponse = &providers.ValidateResourceTypeConfigResponse{
+	p.ValidateResourceConfigResponse = &providers.ValidateResourceConfigResponse{
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
@@ -952,7 +952,7 @@ func TestContext2Validate_resourceConfig_bad(t *testing.T) {
 func TestContext2Validate_resourceConfig_good(t *testing.T) {
 	m := testModule(t, "validate-bad-rc")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -978,7 +978,7 @@ func TestContext2Validate_resourceConfig_good(t *testing.T) {
 
 func TestContext2Validate_tainted(t *testing.T) {
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -1004,12 +1004,12 @@ func TestContext2Validate_tainted(t *testing.T) {
 		State: state,
 	})
 
-	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
+	p.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 		var diags tfdiags.Diagnostics
 		if req.Config.GetAttr("foo").IsNull() {
 			diags = diags.Append(errors.New("foo is not set"))
 		}
-		return providers.ValidateResourceTypeConfigResponse{
+		return providers.ValidateResourceConfigResponse{
 			Diagnostics: diags,
 		}
 	}
@@ -1024,7 +1024,7 @@ func TestContext2Validate_targetedDestroy(t *testing.T) {
 	m := testModule(t, "validate-targeted")
 	p := testProvider("aws")
 	pr := simpleMockProvisioner()
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -1068,7 +1068,7 @@ func TestContext2Validate_targetedDestroy(t *testing.T) {
 func TestContext2Validate_varRefUnknown(t *testing.T) {
 	m := testModule(t, "validate-variable-ref")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -1093,9 +1093,9 @@ func TestContext2Validate_varRefUnknown(t *testing.T) {
 	})
 
 	var value cty.Value
-	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
+	p.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 		value = req.Config.GetAttr("foo")
-		return providers.ValidateResourceTypeConfigResponse{}
+		return providers.ValidateResourceConfigResponse{}
 	}
 
 	c.Validate()
@@ -1115,7 +1115,7 @@ func TestContext2Validate_interpolateVar(t *testing.T) {
 
 	m := testModule(t, "input-interpolate-var")
 	p := testProvider("null")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"template_file": {
 				Block: &configschema.Block{
@@ -1148,7 +1148,7 @@ func TestContext2Validate_interpolateComputedModuleVarDef(t *testing.T) {
 
 	m := testModule(t, "validate-computed-module-var-ref")
 	p := testProvider("aws")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
 				Block: &configschema.Block{
@@ -1219,12 +1219,12 @@ resource "aws_instance" "foo" {
 	})
 
 	p := testProvider("aws")
-	p.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
+	p.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 		// Providers receive unmarked values
 		if got, want := req.Config.GetAttr("foo"), cty.UnknownVal(cty.String); !got.RawEquals(want) {
 			t.Fatalf("wrong value for foo\ngot:  %#v\nwant: %#v", got, want)
 		}
-		return providers.ValidateResourceTypeConfigResponse{}
+		return providers.ValidateResourceConfigResponse{}
 	}
 	p.ValidateDataSourceConfigFn = func(req providers.ValidateDataSourceConfigRequest) (resp providers.ValidateDataSourceConfigResponse) {
 		if got, want := req.Config.GetAttr("foo"), cty.UnknownVal(cty.String); !got.RawEquals(want) {
@@ -1251,8 +1251,8 @@ resource "aws_instance" "foo" {
 		t.Fatal(diags.Err())
 	}
 
-	if !p.ValidateResourceTypeConfigCalled {
-		t.Fatal("expected ValidateResourceTypeConfigFn to be called")
+	if !p.ValidateResourceConfigCalled {
+		t.Fatal("expected ValidateResourceConfigFn to be called")
 	}
 
 	if !p.ValidateDataSourceConfigCalled {
@@ -1927,7 +1927,7 @@ resource "test_instance" "a" {
 	})
 
 	p := testProvider("test")
-	p.GetSchemaResponse = &providers.GetSchemaResponse{
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Block: &configschema.Block{
@@ -1939,7 +1939,7 @@ resource "test_instance" "a" {
 		},
 	}
 
-	p.ValidateResourceTypeConfigResponse = &providers.ValidateResourceTypeConfigResponse{
+	p.ValidateResourceConfigResponse = &providers.ValidateResourceConfigResponse{
 		Diagnostics: tfdiags.Diagnostics(nil).Append(tfdiags.SimpleWarning("don't frobble")),
 	}
 

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -187,12 +187,12 @@ func (ctx *BuiltinEvalContext) ConfigureProvider(addr addrs.AbsProviderConfig, c
 		return diags
 	}
 
-	req := providers.ConfigureRequest{
+	req := providers.ConfigureProviderRequest{
 		TerraformVersion: version.String(),
 		Config:           cfg,
 	}
 
-	resp := p.Configure(req)
+	resp := p.ConfigureProvider(req)
 	return resp.Diagnostics
 }
 

--- a/terraform/graph_builder_plan_test.go
+++ b/terraform/graph_builder_plan_test.go
@@ -16,7 +16,7 @@ func TestPlanGraphBuilder_impl(t *testing.T) {
 
 func TestPlanGraphBuilder(t *testing.T) {
 	awsProvider := &MockProvider{
-		GetSchemaResponse: &providers.GetSchemaResponse{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{Block: simpleTestSchema()},
 			ResourceTypes: map[string]providers.Schema{
 				"aws_security_group": {Block: simpleTestSchema()},

--- a/terraform/node_provider.go
+++ b/terraform/node_provider.go
@@ -56,7 +56,7 @@ func (n *NodeApplyableProvider) ValidateProvider(ctx EvalContext, provider provi
 		return nil
 	}
 
-	resp := provider.GetSchema()
+	resp := provider.GetProviderSchema()
 	diags = diags.Append(resp.Diagnostics)
 	if diags.HasErrors() {
 		return diags
@@ -80,11 +80,11 @@ func (n *NodeApplyableProvider) ValidateProvider(ctx EvalContext, provider provi
 	// stripped out before sending this to the provider
 	unmarkedConfigVal, _ := configVal.UnmarkDeep()
 
-	req := providers.PrepareProviderConfigRequest{
+	req := providers.ValidateProviderConfigRequest{
 		Config: unmarkedConfigVal,
 	}
 
-	validateResp := provider.PrepareProviderConfig(req)
+	validateResp := provider.ValidateProviderConfig(req)
 	diags = diags.Append(validateResp.Diagnostics)
 
 	return diags
@@ -98,7 +98,7 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, provider prov
 
 	configBody := buildProviderConfig(ctx, n.Addr, config)
 
-	resp := provider.GetSchema()
+	resp := provider.GetProviderSchema()
 	diags = diags.Append(resp.Diagnostics)
 	if diags.HasErrors() {
 		return diags
@@ -127,13 +127,13 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, provider prov
 
 	// Allow the provider to validate and insert any defaults into the full
 	// configuration.
-	req := providers.PrepareProviderConfigRequest{
+	req := providers.ValidateProviderConfigRequest{
 		Config: unmarkedConfigVal,
 	}
 
-	// PrepareProviderConfig is only used for validation. We are intentionally
+	// ValidateProviderConfig is only used for validation. We are intentionally
 	// ignoring the PreparedConfig field to maintain existing behavior.
-	prepareResp := provider.PrepareProviderConfig(req)
+	prepareResp := provider.ValidateProviderConfig(req)
 	if prepareResp.Diagnostics.HasErrors() {
 		if config == nil {
 			// If there isn't an explicit "provider" block in the configuration,
@@ -155,7 +155,7 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, provider prov
 	// indicate to provider developers that the value is not used.
 	preparedCfg := prepareResp.PreparedConfig
 	if preparedCfg != cty.NilVal && !preparedCfg.IsNull() && !preparedCfg.RawEquals(unmarkedConfigVal) {
-		log.Printf("[WARN] PrepareProviderConfig from %q changed the config value, but that value is unused", n.Addr)
+		log.Printf("[WARN] ValidateProviderConfig from %q changed the config value, but that value is unused", n.Addr)
 	}
 
 	configDiags := ctx.ConfigureProvider(n.Addr, unmarkedConfigVal)

--- a/terraform/node_provider_test.go
+++ b/terraform/node_provider_test.go
@@ -183,11 +183,11 @@ func TestNodeApplyableProviderExecute_sensitiveValidate(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if !provider.PrepareProviderConfigCalled {
+	if !provider.ValidateProviderConfigCalled {
 		t.Fatal("should be called")
 	}
 
-	gotObj := provider.PrepareProviderConfigRequest.Config
+	gotObj := provider.ValidateProviderConfigRequest.Config
 	if !gotObj.Type().HasAttribute("test_string") {
 		t.Fatal("configuration object does not have \"test_string\" attribute")
 	}
@@ -299,9 +299,9 @@ func TestNodeApplyableProvider_Validate(t *testing.T) {
 }
 
 //This test specifically tests responses from the
-//providers.PrepareProviderConfigFn. See
+//providers.ValidateProviderConfigFn. See
 //TestNodeApplyableProvider_ConfigProvider_config_fn_err for
-//providers.ConfigureRequest responses.
+//providers.ConfigureProviderRequest responses.
 func TestNodeApplyableProvider_ConfigProvider(t *testing.T) {
 	provider := mockProviderWithConfigSchema(&configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
@@ -313,7 +313,7 @@ func TestNodeApplyableProvider_ConfigProvider(t *testing.T) {
 	})
 	// For this test, we're returning an error for an optional argument. This
 	// can happen for example if an argument is only conditionally required.
-	provider.PrepareProviderConfigFn = func(req providers.PrepareProviderConfigRequest) (resp providers.PrepareProviderConfigResponse) {
+	provider.ValidateProviderConfigFn = func(req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 		region := req.Config.GetAttr("region")
 		if region.IsNull() {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("value is not found"))
@@ -383,7 +383,7 @@ func TestNodeApplyableProvider_ConfigProvider(t *testing.T) {
 
 }
 
-//This test is similar to TestNodeApplyableProvider_ConfigProvider, but tests responses from the providers.ConfigureRequest
+//This test is similar to TestNodeApplyableProvider_ConfigProvider, but tests responses from the providers.ConfigureProviderRequest
 func TestNodeApplyableProvider_ConfigProvider_config_fn_err(t *testing.T) {
 	provider := mockProviderWithConfigSchema(&configschema.Block{
 		Attributes: map[string]*configschema.Attribute{

--- a/terraform/node_resource_abstract_instance.go
+++ b/terraform/node_resource_abstract_instance.go
@@ -627,8 +627,8 @@ func (n *NodeAbstractResourceInstance) plan(
 	// TODO: It would be more correct to validate the config after
 	// ignore_changes has been applied, but the current implementation cannot
 	// exclude computed-only attributes when given the `all` option.
-	validateResp := provider.ValidateResourceTypeConfig(
-		providers.ValidateResourceTypeConfigRequest{
+	validateResp := provider.ValidateResourceConfig(
+		providers.ValidateResourceConfigRequest{
 			TypeName: n.Addr.Resource.Resource.Type,
 			Config:   unmarkedConfigVal,
 		},

--- a/terraform/node_resource_destroy_deposed_test.go
+++ b/terraform/node_resource_destroy_deposed_test.go
@@ -99,7 +99,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_Execute(t *testing.T) {
 	}
 
 	p := testProvider("test")
-	p.GetSchemaResponse = getSchemaResponseFromProviderSchema(schema)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
 
 	p.UpgradeResourceStateResponse = &providers.UpgradeResourceStateResponse{
 		UpgradedState: cty.ObjectVal(map[string]cty.Value{

--- a/terraform/node_resource_validate.go
+++ b/terraform/node_resource_validate.go
@@ -373,12 +373,12 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 
 		// Use unmarked value for validate request
 		unmarkedConfigVal, _ := configVal.UnmarkDeep()
-		req := providers.ValidateResourceTypeConfigRequest{
+		req := providers.ValidateResourceConfigRequest{
 			TypeName: n.Config.Type,
 			Config:   unmarkedConfigVal,
 		}
 
-		resp := provider.ValidateResourceTypeConfig(req)
+		resp := provider.ValidateResourceConfig(req)
 		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config))
 
 	case addrs.DataResourceMode:

--- a/terraform/node_resource_validate_test.go
+++ b/terraform/node_resource_validate_test.go
@@ -155,7 +155,7 @@ func TestNodeValidatableResource_ValidateProvisioner__conntectionInvalid(t *test
 
 func TestNodeValidatableResource_ValidateResource_managedResource(t *testing.T) {
 	mp := simpleMockProvider()
-	mp.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
+	mp.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 		if got, want := req.TypeName, "test_object"; got != want {
 			t.Fatalf("wrong resource type\ngot:  %#v\nwant: %#v", got, want)
 		}
@@ -165,7 +165,7 @@ func TestNodeValidatableResource_ValidateResource_managedResource(t *testing.T) 
 		if got, want := req.Config.GetAttr("test_number"), cty.NumberIntVal(2); !got.RawEquals(want) {
 			t.Fatalf("wrong value for test_number\ngot:  %#v\nwant: %#v", got, want)
 		}
-		return providers.ValidateResourceTypeConfigResponse{}
+		return providers.ValidateResourceConfigResponse{}
 	}
 
 	p := providers.Interface(mp)
@@ -196,22 +196,22 @@ func TestNodeValidatableResource_ValidateResource_managedResource(t *testing.T) 
 		t.Fatalf("err: %s", err)
 	}
 
-	if !mp.ValidateResourceTypeConfigCalled {
-		t.Fatal("Expected ValidateResourceTypeConfig to be called, but it was not!")
+	if !mp.ValidateResourceConfigCalled {
+		t.Fatal("Expected ValidateResourceConfig to be called, but it was not!")
 	}
 }
 
 func TestNodeValidatableResource_ValidateResource_managedResourceCount(t *testing.T) {
 	// Setup
 	mp := simpleMockProvider()
-	mp.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
+	mp.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 		if got, want := req.TypeName, "test_object"; got != want {
 			t.Fatalf("wrong resource type\ngot:  %#v\nwant: %#v", got, want)
 		}
 		if got, want := req.Config.GetAttr("test_string"), cty.StringVal("bar"); !got.RawEquals(want) {
 			t.Fatalf("wrong value for test_string\ngot:  %#v\nwant: %#v", got, want)
 		}
-		return providers.ValidateResourceTypeConfigResponse{}
+		return providers.ValidateResourceConfigResponse{}
 	}
 
 	p := providers.Interface(mp)
@@ -259,8 +259,8 @@ func TestNodeValidatableResource_ValidateResource_managedResourceCount(t *testin
 				t.Fatalf("err: %s", diags.Err())
 			}
 
-			if !mp.ValidateResourceTypeConfigCalled {
-				t.Fatal("Expected ValidateResourceTypeConfig to be called, but it was not!")
+			if !mp.ValidateResourceConfigCalled {
+				t.Fatal("Expected ValidateResourceConfig to be called, but it was not!")
 			}
 		})
 	}
@@ -317,8 +317,8 @@ func TestNodeValidatableResource_ValidateResource_dataSource(t *testing.T) {
 
 func TestNodeValidatableResource_ValidateResource_valid(t *testing.T) {
 	mp := simpleMockProvider()
-	mp.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
-		return providers.ValidateResourceTypeConfigResponse{}
+	mp.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+		return providers.ValidateResourceConfigResponse{}
 	}
 
 	p := providers.Interface(mp)
@@ -349,11 +349,11 @@ func TestNodeValidatableResource_ValidateResource_valid(t *testing.T) {
 
 func TestNodeValidatableResource_ValidateResource_warningsAndErrorsPassedThrough(t *testing.T) {
 	mp := simpleMockProvider()
-	mp.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
+	mp.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 		var diags tfdiags.Diagnostics
 		diags = diags.Append(tfdiags.SimpleWarning("warn"))
 		diags = diags.Append(errors.New("err"))
-		return providers.ValidateResourceTypeConfigResponse{
+		return providers.ValidateResourceConfigResponse{
 			Diagnostics: diags,
 		}
 	}
@@ -397,8 +397,8 @@ func TestNodeValidatableResource_ValidateResource_warningsAndErrorsPassedThrough
 
 func TestNodeValidatableResource_ValidateResource_invalidDependsOn(t *testing.T) {
 	mp := simpleMockProvider()
-	mp.ValidateResourceTypeConfigFn = func(req providers.ValidateResourceTypeConfigRequest) providers.ValidateResourceTypeConfigResponse {
-		return providers.ValidateResourceTypeConfigResponse{}
+	mp.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+		return providers.ValidateResourceConfigResponse{}
 	}
 
 	// We'll check a _valid_ config first, to make sure we're not failing

--- a/terraform/resource_provider_mock_test.go
+++ b/terraform/resource_provider_mock_test.go
@@ -10,7 +10,7 @@ import (
 // provider with the given schema for its own configuration.
 func mockProviderWithConfigSchema(schema *configschema.Block) *MockProvider {
 	return &MockProvider{
-		GetSchemaResponse: &providers.GetSchemaResponse{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{Block: schema},
 		},
 	}
@@ -20,7 +20,7 @@ func mockProviderWithConfigSchema(schema *configschema.Block) *MockProvider {
 // provider with a schema containing a single resource type.
 func mockProviderWithResourceTypeSchema(name string, schema *configschema.Block) *MockProvider {
 	return &MockProvider{
-		GetSchemaResponse: &providers.GetSchemaResponse{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
 				Block: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
@@ -50,7 +50,7 @@ func mockProviderWithResourceTypeSchema(name string, schema *configschema.Block)
 // from an existing ProviderSchema.
 func mockProviderWithProviderSchema(providerSchema ProviderSchema) *MockProvider {
 	p := &MockProvider{
-		GetSchemaResponse: &providers.GetSchemaResponse{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
 				Block: providerSchema.Provider,
 			},
@@ -60,23 +60,23 @@ func mockProviderWithProviderSchema(providerSchema ProviderSchema) *MockProvider
 	}
 
 	for name, schema := range providerSchema.ResourceTypes {
-		p.GetSchemaResponse.ResourceTypes[name] = providers.Schema{
+		p.GetProviderSchemaResponse.ResourceTypes[name] = providers.Schema{
 			Block:   schema,
 			Version: int64(providerSchema.ResourceTypeSchemaVersions[name]),
 		}
 	}
 
 	for name, schema := range providerSchema.DataSources {
-		p.GetSchemaResponse.DataSources[name] = providers.Schema{Block: schema}
+		p.GetProviderSchemaResponse.DataSources[name] = providers.Schema{Block: schema}
 	}
 
 	return p
 }
 
-// getSchemaResponseFromProviderSchema is a test helper to convert a
-// ProviderSchema to a GetSchemaResponse for use when building a mock provider.
-func getSchemaResponseFromProviderSchema(providerSchema *ProviderSchema) *providers.GetSchemaResponse {
-	resp := &providers.GetSchemaResponse{
+// getProviderSchemaResponseFromProviderSchema is a test helper to convert a
+// ProviderSchema to a GetProviderSchemaResponse for use when building a mock provider.
+func getProviderSchemaResponseFromProviderSchema(providerSchema *ProviderSchema) *providers.GetProviderSchemaResponse {
+	resp := &providers.GetProviderSchemaResponse{
 		Provider:      providers.Schema{Block: providerSchema.Provider},
 		ProviderMeta:  providers.Schema{Block: providerSchema.ProviderMeta},
 		ResourceTypes: map[string]providers.Schema{},
@@ -116,7 +116,7 @@ func getSchemaResponseFromProviderSchema(providerSchema *ProviderSchema) *provid
 // objects so that callers can mutate without affecting mock objects.
 func simpleMockProvider() *MockProvider {
 	return &MockProvider{
-		GetSchemaResponse: &providers.GetSchemaResponse{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{Block: simpleTestSchema()},
 			ResourceTypes: map[string]providers.Schema{
 				"test_object": providers.Schema{Block: simpleTestSchema()},

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -114,7 +114,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			provider.Close()
 		}()
 
-		resp := provider.GetSchema()
+		resp := provider.GetProviderSchema()
 		if resp.Diagnostics.HasErrors() {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls.


### PR DESCRIPTION
This PR builds on #27793 and will be merged only after that is reviewed and merged.

This PR renamed several functions and types in `providers.Interface`, and weaves that change throughout terraform. I put the interface change in a separate commit to aid in reviewing; I will squash these commits together when merging.

This is a purely aesthetic change, updating our internal names to match the _new_ protocol v6. There is no expected impact on providers written against protocol v5 - nothing has changed in the v5 protocol definition, only in the conversion from that package to internal terraform types.