### PR TITLE
reverse call to TestConformance in objchange

### DIFF
--- a/plans/objchange/compatible.go
+++ b/plans/objchange/compatible.go
@@ -219,7 +219,7 @@ func assertValueCompatible(planned, actual cty.Value, path cty.Path) []error {
 		// Anything goes, then
 		return errs
 	}
-	if problems := planned.Type().TestConformance(actual.Type()); len(problems) > 0 {
+	if problems := actual.Type().TestConformance(planned.Type()); len(problems) > 0 {
 		errs = append(errs, path.NewErrorf("wrong final value type: %s", convert.MismatchMessage(actual.Type(), planned.Type())))
 		// If the types don't match then we can't do any other comparisons,
 		// so we bail early.

--- a/plans/objchange/compatible_test.go
+++ b/plans/objchange/compatible_test.go
@@ -263,6 +263,28 @@ func TestAssertObjectCompatible(t *testing.T) {
 		{
 			&configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
+					"obj": {
+						Type: cty.Object(map[string]cty.Type{
+							"stuff": cty.DynamicPseudoType,
+						}),
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"obj": cty.ObjectVal(map[string]cty.Value{
+					"stuff": cty.DynamicVal,
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"obj": cty.ObjectVal(map[string]cty.Value{
+					"stuff": cty.NumberIntVal(3),
+				}),
+			}),
+			[]string{},
+		},
+		{
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
 					"id": {
 						Type:     cty.String,
 						Computed: true,


### PR DESCRIPTION
0.14 backport of #27791 

The call to TestConformance needs to be reversed, since we want to
verify that the actual value returned conforms to the planned type.
While the inverse (checking that the planned value conforms to the
applied type) works for everything terraform has been exposed to up
until now, this fails when the planned type has dynamic attributes which
are allowed to become concrete types.