### PR TITLE
core: Unmark provisioner config before validation

### DIFF
--- a/terraform/node_resource_validate.go
+++ b/terraform/node_resource_validate.go
@@ -90,8 +90,10 @@ func (n *NodeValidatableResource) validateProvisioner(ctx EvalContext, p *config
 		return diags.Append(fmt.Errorf("EvaluateBlock returned nil value"))
 	}
 
+	// Use unmarked value for validate request
+	unmarkedConfigVal, _ := configVal.UnmarkDeep()
 	req := provisioners.ValidateProvisionerConfigRequest{
-		Config: configVal,
+		Config: unmarkedConfigVal,
 	}
 
 	resp := provisioner.ValidateProvisionerConfig(req)

--- a/terraform/testdata/validate-sensitive-provisioner-config/main.tf
+++ b/terraform/testdata/validate-sensitive-provisioner-config/main.tf
@@ -1,0 +1,11 @@
+variable "secret" {
+  type      = string
+  default   = " password123"
+  sensitive = true
+}
+
+resource "aws_instance" "foo" {
+  provisioner "test" {
+    test_string = var.secret
+  }
+}


### PR DESCRIPTION
Sensitive values in provisioner configuration would cause errors in the validate phase. We need to unmark these value before serializing the config value for the provisioner plugin.

Reported in #27763. There will be a separate PR for the 0.14 branch as this won't backport cleanly.