### PR TITLE
core: Unmark provisioner config before validation

### DIFF
--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -1856,3 +1856,34 @@ output "out" {
 		}
 	}
 }
+
+func TestContext2Validate_sensitiveProvisionerConfig(t *testing.T) {
+	m := testModule(t, "validate-sensitive-provisioner-config")
+	p := testProvider("aws")
+	pr := simpleMockProvisioner()
+
+	c := testContext2(t, &ContextOpts{
+		Config: m,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+		Provisioners: map[string]provisioners.Factory{
+			"test": testProvisionerFuncFixed(pr),
+		},
+	})
+
+	pr.ValidateProvisionerConfigFn = func(r provisioners.ValidateProvisionerConfigRequest) provisioners.ValidateProvisionerConfigResponse {
+		if r.Config.ContainsMarked() {
+			t.Errorf("provisioner config contains marked values")
+		}
+		return pr.ValidateProvisionerConfigResponse
+	}
+
+	diags := c.Validate()
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %s", diags.Err())
+	}
+	if !pr.ValidateProvisionerConfigCalled {
+		t.Fatal("ValidateProvisionerConfig not called")
+	}
+}

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -93,8 +93,10 @@ func (n *EvalValidateProvisioner) Validate(ctx EvalContext) error {
 		return fmt.Errorf("EvaluateBlock returned nil value")
 	}
 
+	// Use unmarked value for validate request
+	unmarkedConfigVal, _ := configVal.UnmarkDeep()
 	req := provisioners.ValidateProvisionerConfigRequest{
-		Config: configVal,
+		Config: unmarkedConfigVal,
 	}
 
 	resp := provisioner.ValidateProvisionerConfig(req)

--- a/terraform/testdata/validate-sensitive-provisioner-config/main.tf
+++ b/terraform/testdata/validate-sensitive-provisioner-config/main.tf
@@ -1,0 +1,11 @@
+variable "secret" {
+  type      = string
+  default   = " password123"
+  sensitive = true
+}
+
+resource "aws_instance" "foo" {
+  provisioner "test" {
+    test_string = var.secret
+  }
+}


### PR DESCRIPTION
Sensitive values in provisioner configuration would cause errors in the validate phase. We need to unmark these value before serializing the config value for the provisioner plugin.

Fixes #27763. Also separately fixed on the main branch.