### PR TITLE
jsonstate: do not use the current schema to encode prior state

### DIFF
--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -120,7 +120,7 @@ func Marshal(
 
 	// output.PriorState
 	if sf != nil && !sf.State.Empty() {
-		output.PriorState, err = jsonstate.Marshal(sf, schemas)
+		output.PriorState, err = jsonstate.Marshal(sf)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling prior state: %s", err)
 		}

--- a/command/jsonstate/state_test.go
+++ b/command/jsonstate/state_test.go
@@ -73,83 +73,14 @@ func TestMarshalOutputs(t *testing.T) {
 	}
 }
 
-func TestMarshalAttributeValues(t *testing.T) {
-	tests := []struct {
-		Attr cty.Value
-		Want attributeValues
-	}{
-		{
-			cty.NilVal,
-			nil,
-		},
-		{
-			cty.NullVal(cty.String),
-			nil,
-		},
-		{
-			cty.ObjectVal(map[string]cty.Value{
-				"foo": cty.StringVal("bar"),
-			}),
-			attributeValues{"foo": json.RawMessage(`"bar"`)},
-		},
-		{
-			cty.ObjectVal(map[string]cty.Value{
-				"foo": cty.NullVal(cty.String),
-			}),
-			attributeValues{"foo": json.RawMessage(`null`)},
-		},
-		{
-			cty.ObjectVal(map[string]cty.Value{
-				"bar": cty.MapVal(map[string]cty.Value{
-					"hello": cty.StringVal("world"),
-				}),
-				"baz": cty.ListVal([]cty.Value{
-					cty.StringVal("goodnight"),
-					cty.StringVal("moon"),
-				}),
-			}),
-			attributeValues{
-				"bar": json.RawMessage(`{"hello":"world"}`),
-				"baz": json.RawMessage(`["goodnight","moon"]`),
-			},
-		},
-		// Marked values
-		{
-			cty.ObjectVal(map[string]cty.Value{
-				"bar": cty.MapVal(map[string]cty.Value{
-					"hello": cty.StringVal("world"),
-				}),
-				"baz": cty.ListVal([]cty.Value{
-					cty.StringVal("goodnight"),
-					cty.StringVal("moon").Mark("sensitive"),
-				}),
-			}),
-			attributeValues{
-				"bar": json.RawMessage(`{"hello":"world"}`),
-				"baz": json.RawMessage(`["goodnight","moon"]`),
-			},
-		},
-	}
-
-	for _, test := range tests {
-		got := marshalAttributeValues(test.Attr)
-		eq := reflect.DeepEqual(got, test.Want)
-		if !eq {
-			t.Fatalf("wrong result:\nGot: %#v\nWant: %#v\n", got, test.Want)
-		}
-	}
-}
-
 func TestMarshalResources(t *testing.T) {
 	deposedKey := states.NewDeposedKey()
 	tests := map[string]struct {
 		Resources map[string]*states.Resource
-		Schemas   *terraform.Schemas
 		Want      []resource
 		Err       bool
 	}{
 		"nil": {
-			nil,
 			nil,
 			nil,
 			false,
@@ -179,20 +110,16 @@ func TestMarshalResources(t *testing.T) {
 					},
 				},
 			},
-			testSchemas(),
 			[]resource{
 				resource{
-					Address:       "test_thing.bar",
-					Mode:          "managed",
-					Type:          "test_thing",
-					Name:          "bar",
-					Index:         addrs.InstanceKey(nil),
-					ProviderName:  "registry.terraform.io/hashicorp/test",
-					SchemaVersion: 1,
-					AttributeValues: attributeValues{
-						"foozles": json.RawMessage(`null`),
-						"woozles": json.RawMessage(`"confuzles"`),
-					},
+					Address:         "test_thing.bar",
+					Mode:            "managed",
+					Type:            "test_thing",
+					Name:            "bar",
+					Index:           addrs.InstanceKey(nil),
+					ProviderName:    "registry.terraform.io/hashicorp/test",
+					SchemaVersion:   1,
+					AttributeValues: json.RawMessage(`{"woozles":"confuzles"}`),
 				},
 			},
 			false,
@@ -222,20 +149,16 @@ func TestMarshalResources(t *testing.T) {
 					},
 				},
 			},
-			testSchemas(),
 			[]resource{
 				resource{
-					Address:       "test_thing.bar[0]",
-					Mode:          "managed",
-					Type:          "test_thing",
-					Name:          "bar",
-					Index:         addrs.IntKey(0),
-					ProviderName:  "registry.terraform.io/hashicorp/test",
-					SchemaVersion: 1,
-					AttributeValues: attributeValues{
-						"foozles": json.RawMessage(`null`),
-						"woozles": json.RawMessage(`"confuzles"`),
-					},
+					Address:         "test_thing.bar[0]",
+					Mode:            "managed",
+					Type:            "test_thing",
+					Name:            "bar",
+					Index:           addrs.IntKey(0),
+					ProviderName:    "registry.terraform.io/hashicorp/test",
+					SchemaVersion:   1,
+					AttributeValues: json.RawMessage(`{"woozles":"confuzles"}`),
 				},
 			},
 			false,
@@ -265,20 +188,16 @@ func TestMarshalResources(t *testing.T) {
 					},
 				},
 			},
-			testSchemas(),
 			[]resource{
 				resource{
-					Address:       "test_thing.bar[\"rockhopper\"]",
-					Mode:          "managed",
-					Type:          "test_thing",
-					Name:          "bar",
-					Index:         addrs.StringKey("rockhopper"),
-					ProviderName:  "registry.terraform.io/hashicorp/test",
-					SchemaVersion: 1,
-					AttributeValues: attributeValues{
-						"foozles": json.RawMessage(`null`),
-						"woozles": json.RawMessage(`"confuzles"`),
-					},
+					Address:         "test_thing.bar[\"rockhopper\"]",
+					Mode:            "managed",
+					Type:            "test_thing",
+					Name:            "bar",
+					Index:           addrs.StringKey("rockhopper"),
+					ProviderName:    "registry.terraform.io/hashicorp/test",
+					SchemaVersion:   1,
+					AttributeValues: json.RawMessage(`{"woozles":"confuzles"}`),
 				},
 			},
 			false,
@@ -310,20 +229,16 @@ func TestMarshalResources(t *testing.T) {
 					},
 				},
 			},
-			testSchemas(),
 			[]resource{
 				resource{
-					Address:      "test_thing.bar",
-					Mode:         "managed",
-					Type:         "test_thing",
-					Name:         "bar",
-					Index:        addrs.InstanceKey(nil),
-					ProviderName: "registry.terraform.io/hashicorp/test",
-					DeposedKey:   deposedKey.String(),
-					AttributeValues: attributeValues{
-						"foozles": json.RawMessage(`null`),
-						"woozles": json.RawMessage(`"confuzles"`),
-					},
+					Address:         "test_thing.bar",
+					Mode:            "managed",
+					Type:            "test_thing",
+					Name:            "bar",
+					Index:           addrs.InstanceKey(nil),
+					ProviderName:    "registry.terraform.io/hashicorp/test",
+					DeposedKey:      deposedKey.String(),
+					AttributeValues: json.RawMessage(`{"woozles":"confuzles"}`),
 				},
 			},
 			false,
@@ -360,33 +275,26 @@ func TestMarshalResources(t *testing.T) {
 					},
 				},
 			},
-			testSchemas(),
 			[]resource{
 				resource{
-					Address:       "test_thing.bar",
-					Mode:          "managed",
-					Type:          "test_thing",
-					Name:          "bar",
-					Index:         addrs.InstanceKey(nil),
-					ProviderName:  "registry.terraform.io/hashicorp/test",
-					SchemaVersion: 1,
-					AttributeValues: attributeValues{
-						"foozles": json.RawMessage(`null`),
-						"woozles": json.RawMessage(`"confuzles"`),
-					},
+					Address:         "test_thing.bar",
+					Mode:            "managed",
+					Type:            "test_thing",
+					Name:            "bar",
+					Index:           addrs.InstanceKey(nil),
+					ProviderName:    "registry.terraform.io/hashicorp/test",
+					SchemaVersion:   1,
+					AttributeValues: json.RawMessage(`{"woozles":"confuzles"}`),
 				},
 				resource{
-					Address:      "test_thing.bar",
-					Mode:         "managed",
-					Type:         "test_thing",
-					Name:         "bar",
-					Index:        addrs.InstanceKey(nil),
-					ProviderName: "registry.terraform.io/hashicorp/test",
-					DeposedKey:   deposedKey.String(),
-					AttributeValues: attributeValues{
-						"foozles": json.RawMessage(`null`),
-						"woozles": json.RawMessage(`"confuzles"`),
-					},
+					Address:         "test_thing.bar",
+					Mode:            "managed",
+					Type:            "test_thing",
+					Name:            "bar",
+					Index:           addrs.InstanceKey(nil),
+					ProviderName:    "registry.terraform.io/hashicorp/test",
+					DeposedKey:      deposedKey.String(),
+					AttributeValues: json.RawMessage(`{"woozles":"confuzles"}`),
 				},
 			},
 			false,
@@ -395,7 +303,7 @@ func TestMarshalResources(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := marshalResources(test.Resources, addrs.RootModuleInstance, test.Schemas)
+			got, err := marshalResources(test.Resources, addrs.RootModuleInstance)
 			if test.Err {
 				if err == nil {
 					t.Fatal("succeeded; want error")
@@ -465,7 +373,7 @@ func TestMarshalModules_basic(t *testing.T) {
 	moduleMap := make(map[string][]addrs.ModuleInstance)
 	moduleMap[""] = []addrs.ModuleInstance{childModule, subModule}
 
-	got, err := marshalModules(testState, testSchemas(), moduleMap[""], moduleMap)
+	got, err := marshalModules(testState, moduleMap[""], moduleMap)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
@@ -535,7 +443,7 @@ func TestMarshalModules_nested(t *testing.T) {
 	moduleMap[""] = []addrs.ModuleInstance{childModule}
 	moduleMap[childModule.String()] = []addrs.ModuleInstance{subModule}
 
-	got, err := marshalModules(testState, testSchemas(), moduleMap[""], moduleMap)
+	got, err := marshalModules(testState, moduleMap[""], moduleMap)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
@@ -588,7 +496,7 @@ func TestMarshalModules_parent_no_resources(t *testing.T) {
 			},
 		)
 	})
-	got, err := marshalRootModule(testState, testSchemas())
+	got, err := marshalRootModule(testState)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())

--- a/command/show.go
+++ b/command/show.go
@@ -167,7 +167,7 @@ func (c *ShowCommand) Run(args []string) int {
 	if jsonOutput {
 		// At this point, it is possible that there is neither state nor a plan.
 		// That's ok, we'll just return an empty object.
-		jsonState, err := jsonstate.Marshal(stateFile, schemas)
+		jsonState, err := jsonstate.Marshal(stateFile)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Failed to marshal state to json: %s", err))
 			return 1

--- a/command/testdata/show-json-state/basic/output.json
+++ b/command/testdata/show-json-state/basic/output.json
@@ -13,7 +13,6 @@
                     "provider_name": "registry.terraform.io/hashicorp/test",
                     "schema_version": 0,
                     "values": {
-                        "ami": null,
                         "id": "621124146446964903"
                     }
                 },
@@ -26,7 +25,6 @@
                     "provider_name": "registry.terraform.io/hashicorp/test",
                     "schema_version": 0,
                     "values": {
-                        "ami": null,
                         "id": "4330206298367988603"
                     }
                 }

--- a/command/testdata/show-json-state/modules/output.json
+++ b/command/testdata/show-json-state/modules/output.json
@@ -20,8 +20,7 @@
                             "provider_name": "registry.terraform.io/hashicorp/test",
                             "schema_version": 0,
                             "values": {
-                                "ami": "bar-var",
-                                "id": null
+                                "ami": "bar-var"
                             }
                         }
                     ],
@@ -38,8 +37,7 @@
                             "provider_name": "registry.terraform.io/hashicorp/test",
                             "schema_version": 0,
                             "values": {
-                                "ami": "foo-var",
-                                "id": null
+                                "ami": "foo-var"
                             }
                         }
                     ],


### PR DESCRIPTION
Technically there is no schema for the prior state, and we cannot use the current schema to operate on the state values. Rather than trying to decode and re-encode the state, transfer the attributes json directly to the output structure.

This appears in tests as missing `nil` values were there are computed attributes not present in the prior state. However, the only way these values would appear is if the schema had added new computed values since the state was saved, but using the wrong schema to decode and re-encode the state is incorrect in the first place, and these values are invalid in the context of the original state.

Fixes #27065