### PR TITLE
backend/remote: Fix broken state lock retry

### DIFF
--- a/backend/remote/backend_state.go
+++ b/backend/remote/backend_state.go
@@ -117,6 +117,7 @@ func (r *remoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	})
 	if err != nil {
 		if err == tfe.ErrWorkspaceLocked {
+			lockErr.Info = info
 			err = fmt.Errorf("%s (lock ID: \"%s/%s\")", err, r.organization, r.workspace.Name)
 		}
 		lockErr.Err = err


### PR DESCRIPTION
When using the `-lock-timeout` option with the remote backend configured in local operations mode, Terraform would fail to retry acquiring the lock. This was caused by the lock error message having a missing `Info` field, which the state manager requires to be present in order to attempt retries: https://github.com/hashicorp/terraform/blob/6871d0c991f760eead17dddff874427c8a03eecd/states/statemgr/locker.go#L81-L91

Other remote state storage backends attempt to fetch lock information to populate this field. Because the Terraform Cloud API doesn't really have any lock information exposed, we can't do that here, so we just round-trip the lock info we were passed in to make sure there's something non-nil in the `LockErr`.

While I can't find anywhere to add test coverage for this, I've manually verified that this fixes the problem reported in #27844. Repro steps:

1. Create a Terraform Cloud workspace in local operations mode
2. Start an apply which takes several minutes (e.g. using `time_sleep`)
3. In another session:
    1. Run `terraform plan`: verify that it fails immediately
    2. Run `terraform plan -lock-timeout=10s`: verify that it waits for 10s and then errors
    2. Run `terraform plan -lock-timeout=300s`: verify that it waits long enough for the apply to finish and then runs

Fixes #27844.