### PR TITLE
cli: Add reference to global options to help text

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -261,7 +261,7 @@ func (c *ApplyCommand) Synopsis() string {
 
 func (c *ApplyCommand) helpApply() string {
 	helpText := `
-Usage: terraform apply [options] [PLAN]
+Usage: terraform [global options] apply [options] [PLAN]
 
   Creates or updates infrastructure according to Terraform configuration
   files in the current directory.
@@ -323,7 +323,7 @@ Options:
 
 func (c *ApplyCommand) helpDestroy() string {
 	helpText := `
-Usage: terraform destroy [options]
+Usage: terraform [global options] destroy [options]
 
   Destroy Terraform-managed infrastructure.
 

--- a/command/console.go
+++ b/command/console.go
@@ -175,7 +175,7 @@ func (c *ConsoleCommand) modePiped(session *repl.Session, ui cli.Ui) int {
 
 func (c *ConsoleCommand) Help() string {
 	helpText := `
-Usage: terraform console [options]
+Usage: terraform [global options] console [options]
 
   Starts an interactive console for experimenting with Terraform
   interpolations.

--- a/command/fmt.go
+++ b/command/fmt.go
@@ -494,7 +494,7 @@ func (c *FmtCommand) trimNewlines(tokens hclwrite.Tokens) hclwrite.Tokens {
 
 func (c *FmtCommand) Help() string {
 	helpText := `
-Usage: terraform fmt [options] [DIR]
+Usage: terraform [global options] fmt [options] [DIR]
 
 	Rewrites all Terraform configuration files to a canonical format. Both
 	configuration files (.tf) and variables files (.tfvars) are updated.

--- a/command/get.go
+++ b/command/get.go
@@ -44,7 +44,7 @@ func (c *GetCommand) Run(args []string) int {
 
 func (c *GetCommand) Help() string {
 	helpText := `
-Usage: terraform get [options] PATH
+Usage: terraform [global options] get [options] PATH
 
   Downloads and installs modules needed for the configuration given by
   PATH.

--- a/command/graph.go
+++ b/command/graph.go
@@ -163,7 +163,7 @@ func (c *GraphCommand) Run(args []string) int {
 
 func (c *GraphCommand) Help() string {
 	helpText := `
-Usage: terraform graph [options]
+Usage: terraform [global options] graph [options]
 
   Outputs the visual execution graph of Terraform resources according to
   either the current configuration or an execution plan.

--- a/command/import.go
+++ b/command/import.go
@@ -271,7 +271,7 @@ func (c *ImportCommand) Run(args []string) int {
 
 func (c *ImportCommand) Help() string {
 	helpText := `
-Usage: terraform import [options] ADDR ID
+Usage: terraform [global options] import [options] ADDR ID
 
   Import existing infrastructure into your Terraform state.
 

--- a/command/init.go
+++ b/command/init.go
@@ -909,7 +909,7 @@ func (c *InitCommand) AutocompleteFlags() complete.Flags {
 
 func (c *InitCommand) Help() string {
 	helpText := `
-Usage: terraform init [options]
+Usage: terraform [global options] init [options]
 
   Initialize a new or existing Terraform working directory by creating
   initial files, loading any remote state, downloading modules, etc.

--- a/command/login.go
+++ b/command/login.go
@@ -249,7 +249,7 @@ func (c *LoginCommand) Help() string {
 	}
 
 	helpText := fmt.Sprintf(`
-Usage: terraform login [hostname]
+Usage: terraform [global options] login [hostname]
 
   Retrieves an authentication token for the given hostname, if it supports
   automatic login, and saves it in a credentials file in your home directory.

--- a/command/logout.go
+++ b/command/logout.go
@@ -132,7 +132,7 @@ func (c *LogoutCommand) Help() string {
 	}
 
 	helpText := `
-Usage: terraform logout [hostname]
+Usage: terraform [global options] logout [hostname]
 
   Removes locally-stored credentials for specified hostname.
 

--- a/command/output.go
+++ b/command/output.go
@@ -97,7 +97,7 @@ func (c *OutputCommand) Outputs(statePath string) (map[string]*states.OutputValu
 
 func (c *OutputCommand) Help() string {
 	helpText := `
-Usage: terraform output [options] [NAME]
+Usage: terraform [global options] output [options] [NAME]
 
   Reads an output variable from a Terraform state file and prints
   the value. With no additional arguments, output will display all

--- a/command/plan.go
+++ b/command/plan.go
@@ -187,7 +187,7 @@ func (c *PlanCommand) Run(args []string) int {
 
 func (c *PlanCommand) Help() string {
 	helpText := `
-Usage: terraform plan [options]
+Usage: terraform [global options] plan [options]
 
   Generates a speculative execution plan, showing what actions Terraform
   would take to apply the current configuration. This command will not

--- a/command/providers.go
+++ b/command/providers.go
@@ -149,7 +149,7 @@ func (c *ProvidersCommand) populateTreeNode(tree treeprint.Tree, node *configs.M
 }
 
 const providersCommandHelp = `
-Usage: terraform providers [dir]
+Usage: terraform [global options] providers [dir]
 
   Prints out a tree of modules in the referenced configuration annotated with
   their provider requirements.

--- a/command/providers_lock.go
+++ b/command/providers_lock.go
@@ -301,7 +301,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 
 func (c *ProvidersLockCommand) Help() string {
 	return `
-Usage: terraform providers lock [options] [providers...]
+Usage: terraform [global options] providers lock [options] [providers...]
 
   Normally the dependency lock file (.terraform.lock.hcl) is updated
   automatically by "terraform init", but the information available to the

--- a/command/providers_mirror.go
+++ b/command/providers_mirror.go
@@ -329,7 +329,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 
 func (c *ProvidersMirrorCommand) Help() string {
 	return `
-Usage: terraform providers mirror [options] <target-dir>
+Usage: terraform [global options] providers mirror [options] <target-dir>
 
   Populates a local directory with copies of the provider plugins needed for
   the current configuration, so that the directory can be used either directly

--- a/command/providers_schema.go
+++ b/command/providers_schema.go
@@ -108,7 +108,7 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 }
 
 const providersSchemaCommandHelp = `
-Usage: terraform providers schema -json
+Usage: terraform [global options] providers schema -json
 
   Prints out a json representation of the schemas for all providers used 
   in the current configuration.

--- a/command/push.go
+++ b/command/push.go
@@ -23,7 +23,7 @@ func (c *PushCommand) Run(args []string) int {
 
 func (c *PushCommand) Help() string {
 	helpText := `
-Usage: terraform push [options] [DIR]
+Usage: terraform [global options] push [options] [DIR]
 
   This command was for the legacy version of Terraform Enterprise (v1), which
   has now reached end-of-life. Therefore this command is no longer supported.

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -120,7 +120,7 @@ func (c *RefreshCommand) Run(args []string) int {
 
 func (c *RefreshCommand) Help() string {
 	helpText := `
-Usage: terraform refresh [options]
+Usage: terraform [global options] refresh [options]
 
   Update the state file of your infrastructure with metadata that matches
   the physical resources they are tracking.

--- a/command/show.go
+++ b/command/show.go
@@ -190,7 +190,7 @@ func (c *ShowCommand) Run(args []string) int {
 
 func (c *ShowCommand) Help() string {
 	helpText := `
-Usage: terraform show [options] [path]
+Usage: terraform [global options] show [options] [path]
 
   Reads and outputs a Terraform state or plan file in a human-readable
   form. If no path is specified, the current state will be shown.

--- a/command/state_command.go
+++ b/command/state_command.go
@@ -18,7 +18,7 @@ func (c *StateCommand) Run(args []string) int {
 
 func (c *StateCommand) Help() string {
 	helpText := `
-Usage: terraform state <subcommand> [options] [args]
+Usage: terraform [global options] state <subcommand> [options] [args]
 
   This command has subcommands for advanced state management.
 

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -92,7 +92,7 @@ func (c *StateListCommand) Run(args []string) int {
 
 func (c *StateListCommand) Help() string {
 	helpText := `
-Usage: terraform state list [options] [address...]
+Usage: terraform [global options] state list [options] [address...]
 
   List resources in the Terraform state.
 

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -454,7 +454,7 @@ func (c *StateMvCommand) validateResourceMove(addrFrom, addrTo addrs.AbsResource
 
 func (c *StateMvCommand) Help() string {
 	helpText := `
-Usage: terraform state mv [options] SOURCE DESTINATION
+Usage: terraform [global options] state mv [options] SOURCE DESTINATION
 
  This command will move an item matched by the address given to the
  destination address. This command can also move to a destination address

--- a/command/state_pull.go
+++ b/command/state_pull.go
@@ -68,7 +68,7 @@ func (c *StatePullCommand) Run(args []string) int {
 
 func (c *StatePullCommand) Help() string {
 	helpText := `
-Usage: terraform state pull [options]
+Usage: terraform [global options] state pull [options]
 
   Pull the state from its location, upgrade the local copy, and output it
   to stdout.

--- a/command/state_push.go
+++ b/command/state_push.go
@@ -135,7 +135,7 @@ func (c *StatePushCommand) Run(args []string) int {
 
 func (c *StatePushCommand) Help() string {
 	helpText := `
-Usage: terraform state push [options] PATH
+Usage: terraform [global options] state push [options] PATH
 
   Update remote state from a local state file at PATH.
 

--- a/command/state_replace_provider.go
+++ b/command/state_replace_provider.go
@@ -171,7 +171,7 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 
 func (c *StateReplaceProviderCommand) Help() string {
 	helpText := `
-Usage: terraform state replace-provider [options] FROM_PROVIDER_FQN TO_PROVIDER_FQN
+Usage: terraform [global options] state replace-provider [options] FROM_PROVIDER_FQN TO_PROVIDER_FQN
 
   Replace provider for resources in the Terraform state.
 

--- a/command/state_replace_provider_test.go
+++ b/command/state_replace_provider_test.go
@@ -285,7 +285,7 @@ func TestStateReplaceProvider(t *testing.T) {
 func TestStateReplaceProvider_docs(t *testing.T) {
 	c := &StateReplaceProviderCommand{}
 
-	if got, want := c.Help(), "Usage: terraform state replace-provider"; !strings.Contains(got, want) {
+	if got, want := c.Help(), "Usage: terraform [global options] state replace-provider"; !strings.Contains(got, want) {
 		t.Fatalf("unexpected help text\nwant: %s\nfull output:\n%s", want, got)
 	}
 

--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -134,7 +134,7 @@ func (c *StateRmCommand) Run(args []string) int {
 
 func (c *StateRmCommand) Help() string {
 	helpText := `
-Usage: terraform state rm [options] ADDRESS...
+Usage: terraform [global options] state rm [options] ADDRESS...
 
   Remove one or more items from the Terraform state, causing Terraform to
   "forget" those items without first destroying them in the remote system.

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -145,7 +145,7 @@ func (c *StateShowCommand) Run(args []string) int {
 
 func (c *StateShowCommand) Help() string {
 	helpText := `
-Usage: terraform state show [options] ADDRESS
+Usage: terraform [global options] state show [options] ADDRESS
 
   Shows the attributes of a resource in the Terraform state.
 

--- a/command/taint.go
+++ b/command/taint.go
@@ -207,7 +207,7 @@ func (c *TaintCommand) Run(args []string) int {
 
 func (c *TaintCommand) Help() string {
 	helpText := `
-Usage: terraform taint [options] <address>
+Usage: terraform [global options] taint [options] <address>
 
   Terraform uses the term "tainted" to describe a resource instance
   which may not be fully functional, either because its creation

--- a/command/unlock.go
+++ b/command/unlock.go
@@ -116,7 +116,7 @@ func (c *UnlockCommand) Run(args []string) int {
 
 func (c *UnlockCommand) Help() string {
 	helpText := `
-Usage: terraform force-unlock LOCK_ID
+Usage: terraform [global options] force-unlock LOCK_ID
 
   Manually unlock the state for the defined configuration.
 

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -181,7 +181,7 @@ func (c *UntaintCommand) Run(args []string) int {
 
 func (c *UntaintCommand) Help() string {
 	helpText := `
-Usage: terraform untaint [options] name
+Usage: terraform [global options] untaint [options] name
 
   Terraform uses the term "tainted" to describe a resource instance
   which may not be fully functional, either because its creation

--- a/command/validate.go
+++ b/command/validate.go
@@ -240,7 +240,7 @@ func (c *ValidateCommand) Synopsis() string {
 
 func (c *ValidateCommand) Help() string {
 	helpText := `
-Usage: terraform validate [options] [dir]
+Usage: terraform [global options] validate [options] [dir]
 
   Validate the configuration files in a directory, referring only to the
   configuration and not accessing any remote services such as remote state,

--- a/command/version.go
+++ b/command/version.go
@@ -44,7 +44,7 @@ type VersionCheckInfo struct {
 
 func (c *VersionCommand) Help() string {
 	helpText := `
-Usage: terraform version [options]
+Usage: terraform [global options] version [options]
 
   Displays the version of Terraform and all installed plugins
 

--- a/command/workspace_command.go
+++ b/command/workspace_command.go
@@ -27,7 +27,7 @@ func (c *WorkspaceCommand) Run(args []string) int {
 
 func (c *WorkspaceCommand) Help() string {
 	helpText := `
-Usage: terraform workspace
+Usage: terraform [global options] workspace
 
   new, list, show, select and delete Terraform workspaces.
 

--- a/command/workspace_delete.go
+++ b/command/workspace_delete.go
@@ -183,7 +183,7 @@ func (c *WorkspaceDeleteCommand) AutocompleteFlags() complete.Flags {
 
 func (c *WorkspaceDeleteCommand) Help() string {
 	helpText := `
-Usage: terraform workspace delete [OPTIONS] NAME
+Usage: terraform [global options] workspace delete [OPTIONS] NAME
 
   Delete a Terraform workspace
 

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -91,7 +91,7 @@ func (c *WorkspaceListCommand) AutocompleteFlags() complete.Flags {
 
 func (c *WorkspaceListCommand) Help() string {
 	helpText := `
-Usage: terraform workspace list
+Usage: terraform [global options] workspace list
 
   List Terraform workspaces.
 

--- a/command/workspace_new.go
+++ b/command/workspace_new.go
@@ -181,7 +181,7 @@ func (c *WorkspaceNewCommand) AutocompleteFlags() complete.Flags {
 
 func (c *WorkspaceNewCommand) Help() string {
 	helpText := `
-Usage: terraform workspace new [OPTIONS] NAME
+Usage: terraform [global options] workspace new [OPTIONS] NAME
 
   Create a new Terraform workspace.
 

--- a/command/workspace_select.go
+++ b/command/workspace_select.go
@@ -129,7 +129,7 @@ func (c *WorkspaceSelectCommand) AutocompleteFlags() complete.Flags {
 
 func (c *WorkspaceSelectCommand) Help() string {
 	helpText := `
-Usage: terraform workspace select NAME
+Usage: terraform [global options] workspace select NAME
 
   Select a different Terraform workspace.
 

--- a/command/workspace_show.go
+++ b/command/workspace_show.go
@@ -40,7 +40,7 @@ func (c *WorkspaceShowCommand) AutocompleteFlags() complete.Flags {
 
 func (c *WorkspaceShowCommand) Help() string {
 	helpText := `
-Usage: terraform workspace show
+Usage: terraform [global options] workspace show
 
   Show the name of the current workspace.
 `


### PR DESCRIPTION
When a spurious trailing argument is passed to commands, we suggest the global `-chdir` should be used, but don't explain in the individual command help text where global options go. This commit tries to address that.