### PR TITLE
cli: Migrate plan to command views

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -89,7 +89,7 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 	}
 
 	// Build the operation request
-	opReq, opDiags := c.OperationRequest(be, view, planFile, args.Operation)
+	opReq, opDiags := c.OperationRequest(be, view, planFile, args.Operation, args.AutoApprove)
 	diags = diags.Append(opDiags)
 
 	// Collect variable value and add them to the operation request
@@ -226,7 +226,12 @@ func (c *ApplyCommand) PrepareBackend(planFile *planfile.Reader, args *arguments
 	return be, diags
 }
 
-func (c *ApplyCommand) OperationRequest(be backend.Enhanced, view views.Apply, planFile *planfile.Reader, args *arguments.Operation,
+func (c *ApplyCommand) OperationRequest(
+	be backend.Enhanced,
+	view views.Apply,
+	planFile *planfile.Reader,
+	args *arguments.Operation,
+	autoApprove bool,
 ) (*backend.Operation, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
@@ -237,7 +242,7 @@ func (c *ApplyCommand) OperationRequest(be backend.Enhanced, view views.Apply, p
 
 	// Build the operation
 	opReq := c.Operation(be)
-	opReq.AutoApprove = args.AutoApprove
+	opReq.AutoApprove = autoApprove
 	opReq.ConfigDir = "."
 	opReq.Destroy = c.Destroy
 	opReq.Hooks = view.Hooks()

--- a/command/arguments/apply.go
+++ b/command/arguments/apply.go
@@ -11,6 +11,9 @@ type Apply struct {
 	Operation *Operation
 	Vars      *Vars
 
+	// AutoApprove skips the manual verification step for the apply operation.
+	AutoApprove bool
+
 	// InputEnabled is used to disable interactive input for unspecified
 	// variable and backend config values. Default is true.
 	InputEnabled bool
@@ -34,6 +37,7 @@ func ParseApply(args []string) (*Apply, tfdiags.Diagnostics) {
 	}
 
 	cmdFlags := extendedFlagSet("apply", apply.State, apply.Operation, apply.Vars)
+	cmdFlags.BoolVar(&apply.AutoApprove, "auto-approve", false, "auto-approve")
 	cmdFlags.BoolVar(&apply.InputEnabled, "input", true, "input")
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/command/arguments/apply_test.go
+++ b/command/arguments/apply_test.go
@@ -16,14 +16,16 @@ func TestParseApply_basicValid(t *testing.T) {
 		"defaults": {
 			nil,
 			&Apply{
+				AutoApprove:  false,
 				InputEnabled: true,
 				PlanPath:     "",
 				ViewType:     ViewHuman,
 			},
 		},
-		"disabled input and plan path": {
-			[]string{"-input=false", "saved.tfplan"},
+		"auto-approve, disabled input, and plan path": {
+			[]string{"-auto-approve", "-input=false", "saved.tfplan"},
 			&Apply{
+				AutoApprove:  true,
 				InputEnabled: false,
 				PlanPath:     "saved.tfplan",
 				ViewType:     ViewHuman,

--- a/command/arguments/extended.go
+++ b/command/arguments/extended.go
@@ -45,9 +45,6 @@ type State struct {
 // Operation describes arguments which are used to configure how a Terraform
 // operation such as a plan or apply executes.
 type Operation struct {
-	// AutoApprove skips the manual verification step for the apply operation.
-	AutoApprove bool
-
 	// Parallelism is the limit Terraform places on total parallel operations
 	// as it walks the dependency graph.
 	Parallelism int
@@ -141,7 +138,6 @@ func extendedFlagSet(name string, state *State, operation *Operation, vars *Vars
 	}
 
 	if operation != nil {
-		f.BoolVar(&operation.AutoApprove, "auto-approve", false, "auto-approve")
 		f.IntVar(&operation.Parallelism, "parallelism", DefaultParallelism, "parallelism")
 		f.BoolVar(&operation.Refresh, "refresh", true, "refresh")
 		f.Var((*flagStringSlice)(&operation.targetsRaw), "target", "target")

--- a/command/arguments/plan.go
+++ b/command/arguments/plan.go
@@ -1,0 +1,75 @@
+package arguments
+
+import (
+	"github.com/hashicorp/terraform/tfdiags"
+)
+
+// Plan represents the command-line arguments for the plan command.
+type Plan struct {
+	// State, Operation, and Vars are the common extended flags
+	State     *State
+	Operation *Operation
+	Vars      *Vars
+
+	// Destroy can be set to generate a plan to destroy all infrastructure.
+	Destroy bool
+
+	// DetailedExitCode enables different exit codes for error, success with
+	// changes, and success with no changes.
+	DetailedExitCode bool
+
+	// InputEnabled is used to disable interactive input for unspecified
+	// variable and backend config values. Default is true.
+	InputEnabled bool
+
+	// OutPath contains an optional path to store the plan file
+	OutPath string
+
+	// ViewType specifies which output format to use
+	ViewType ViewType
+}
+
+// ParsePlan processes CLI arguments, returning a Plan value and errors.
+// If errors are encountered, a Plan value is still returned representing
+// the best effort interpretation of the arguments.
+func ParsePlan(args []string) (*Plan, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	plan := &Plan{
+		State:     &State{},
+		Operation: &Operation{},
+		Vars:      &Vars{},
+	}
+
+	cmdFlags := extendedFlagSet("plan", plan.State, plan.Operation, plan.Vars)
+	cmdFlags.BoolVar(&plan.Destroy, "destroy", false, "destroy")
+	cmdFlags.BoolVar(&plan.DetailedExitCode, "detailed-exitcode", false, "detailed-exitcode")
+	cmdFlags.BoolVar(&plan.InputEnabled, "input", true, "input")
+	cmdFlags.StringVar(&plan.OutPath, "out", "", "out")
+
+	if err := cmdFlags.Parse(args); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line flags",
+			err.Error(),
+		))
+	}
+
+	args = cmdFlags.Args()
+
+	if len(args) > 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Too many command line arguments",
+			"To specify a working directory for the plan, use the global -chdir flag.",
+		))
+	}
+
+	diags = diags.Append(plan.Operation.Parse())
+
+	switch {
+	default:
+		plan.ViewType = ViewHuman
+	}
+
+	return plan, diags
+}

--- a/command/arguments/plan_test.go
+++ b/command/arguments/plan_test.go
@@ -1,0 +1,179 @@
+package arguments
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/addrs"
+)
+
+func TestParsePlan_basicValid(t *testing.T) {
+	testCases := map[string]struct {
+		args []string
+		want *Plan
+	}{
+		"defaults": {
+			nil,
+			&Plan{
+				Destroy:          false,
+				DetailedExitCode: false,
+				InputEnabled:     true,
+				OutPath:          "",
+				ViewType:         ViewHuman,
+			},
+		},
+		"setting all options": {
+			[]string{"-destroy", "-detailed-exitcode", "-input=false", "-out=saved.tfplan"},
+			&Plan{
+				Destroy:          true,
+				DetailedExitCode: true,
+				InputEnabled:     false,
+				OutPath:          "saved.tfplan",
+				ViewType:         ViewHuman,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, diags := ParsePlan(tc.args)
+			if len(diags) > 0 {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+			// Ignore the extended arguments for simplicity
+			got.State = nil
+			got.Operation = nil
+			got.Vars = nil
+			if *got != *tc.want {
+				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParsePlan_invalid(t *testing.T) {
+	got, diags := ParsePlan([]string{"-frob"})
+	if len(diags) == 0 {
+		t.Fatal("expected diags but got none")
+	}
+	if got, want := diags.Err().Error(), "flag provided but not defined"; !strings.Contains(got, want) {
+		t.Fatalf("wrong diags\n got: %s\nwant: %s", got, want)
+	}
+	if got.ViewType != ViewHuman {
+		t.Fatalf("wrong view type, got %#v, want %#v", got.ViewType, ViewHuman)
+	}
+}
+
+func TestParsePlan_tooManyArguments(t *testing.T) {
+	got, diags := ParsePlan([]string{"saved.tfplan"})
+	if len(diags) == 0 {
+		t.Fatal("expected diags but got none")
+	}
+	if got, want := diags.Err().Error(), "Too many command line arguments"; !strings.Contains(got, want) {
+		t.Fatalf("wrong diags\n got: %s\nwant: %s", got, want)
+	}
+	if got.ViewType != ViewHuman {
+		t.Fatalf("wrong view type, got %#v, want %#v", got.ViewType, ViewHuman)
+	}
+}
+
+func TestParsePlan_targets(t *testing.T) {
+	foobarbaz, _ := addrs.ParseTargetStr("foo_bar.baz")
+	boop, _ := addrs.ParseTargetStr("module.boop")
+	testCases := map[string]struct {
+		args    []string
+		want    []addrs.Targetable
+		wantErr string
+	}{
+		"no targets by default": {
+			args: nil,
+			want: nil,
+		},
+		"one target": {
+			args: []string{"-target=foo_bar.baz"},
+			want: []addrs.Targetable{foobarbaz.Subject},
+		},
+		"two targets": {
+			args: []string{"-target=foo_bar.baz", "-target", "module.boop"},
+			want: []addrs.Targetable{foobarbaz.Subject, boop.Subject},
+		},
+		"invalid traversal": {
+			args:    []string{"-target=foo."},
+			want:    nil,
+			wantErr: "Dot must be followed by attribute name",
+		},
+		"invalid target": {
+			args:    []string{"-target=data[0].foo"},
+			want:    nil,
+			wantErr: "A data source name is required",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, diags := ParsePlan(tc.args)
+			if len(diags) > 0 {
+				if tc.wantErr == "" {
+					t.Fatalf("unexpected diags: %v", diags)
+				} else if got := diags.Err().Error(); !strings.Contains(got, tc.wantErr) {
+					t.Fatalf("wrong diags\n got: %s\nwant: %s", got, tc.wantErr)
+				}
+			}
+			if !cmp.Equal(got.Operation.Targets, tc.want) {
+				t.Fatalf("unexpected result\n%s", cmp.Diff(got.Operation.Targets, tc.want))
+			}
+		})
+	}
+}
+
+func TestParsePlan_vars(t *testing.T) {
+	testCases := map[string]struct {
+		args []string
+		want []FlagNameValue
+	}{
+		"no var flags by default": {
+			args: nil,
+			want: nil,
+		},
+		"one var": {
+			args: []string{"-var", "foo=bar"},
+			want: []FlagNameValue{
+				{Name: "-var", Value: "foo=bar"},
+			},
+		},
+		"one var-file": {
+			args: []string{"-var-file", "cool.tfvars"},
+			want: []FlagNameValue{
+				{Name: "-var-file", Value: "cool.tfvars"},
+			},
+		},
+		"ordering preserved": {
+			args: []string{
+				"-var", "foo=bar",
+				"-var-file", "cool.tfvars",
+				"-var", "boop=beep",
+			},
+			want: []FlagNameValue{
+				{Name: "-var", Value: "foo=bar"},
+				{Name: "-var-file", Value: "cool.tfvars"},
+				{Name: "-var", Value: "boop=beep"},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, diags := ParsePlan(tc.args)
+			if len(diags) > 0 {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+			if vars := got.Vars.All(); !cmp.Equal(vars, tc.want) {
+				t.Fatalf("unexpected result\n%s", cmp.Diff(vars, tc.want))
+			}
+			if got, want := got.Vars.Empty(), len(tc.want) == 0; got != want {
+				t.Fatalf("expected Empty() to return %t, but was %t", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR refactors the plan command to use the new command/arguments and command/views structure. There should be no effect on the functionality of plan.

Follow-up to #27841. See also #27865.