### PR TITLE
objchange: catch invalidly planned attributes earlier

### DIFF
--- a/plans/objchange/plan_valid_test.go
+++ b/plans/objchange/plan_valid_test.go
@@ -1077,7 +1077,7 @@ func TestAssertPlanValid(t *testing.T) {
 					}),
 				}),
 			}),
-			[]string{".bloop: planned for existence but config wants absense"},
+			[]string{`.bloop: planned value cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"blop":cty.StringVal("ok")})}) for a non-computed attribute`},
 		},
 		"NestedType nested set attribute to null": {
 			&configschema.Block{
@@ -1116,7 +1116,7 @@ func TestAssertPlanValid(t *testing.T) {
 					}),
 				}),
 			}),
-			[]string{".bloop: planned for existence but config wants absense"},
+			[]string{`.bloop: planned value cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"blop":cty.StringVal("ok")})}) for a non-computed attribute`},
 		},
 	}
 


### PR DESCRIPTION
Catch attributes which are planed but not computed separately to provide
a clearer error to provider developers.

The error conditions were previously caught, however it was unclear from
the error text as to _why_ the change was an error. The statements about
value inequality would be incorrect when planning no changes for a value
which should not have been set in the first place.

Previous errors could have text like:
```
.length: planned value cty.NumberIntVal(2) does not match config value cty.NullVal(cty.Number) nor prior value cty.NumberIntVal(2)
```

Which is replaced by:

```
.length: planned value cty.NumberIntVal(2) for a non-computed attribute
```