### PR TITLE
cli: Remove -var/-var-file flags from validate

### DIFF
--- a/command/validate.go
+++ b/command/validate.go
@@ -19,19 +19,10 @@ type ValidateCommand struct {
 
 func (c *ValidateCommand) Run(args []string) int {
 	args = c.Meta.process(args)
-	// TODO: The `var` and `var-file` options are not actually used, and should
-	// be removed in the next major release.
-	if c.Meta.variableArgs.items == nil {
-		c.Meta.variableArgs = newRawFlags("-var")
-	}
-	varValues := c.Meta.variableArgs.Alias("-var")
-	varFiles := c.Meta.variableArgs.Alias("-var-file")
 
 	var jsonOutput bool
 	cmdFlags := c.Meta.defaultFlagSet("validate")
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "produce JSON output")
-	cmdFlags.Var(varValues, "var", "variables")
-	cmdFlags.Var(varFiles, "var-file", "variable file")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
@@ -39,15 +30,6 @@ func (c *ValidateCommand) Run(args []string) int {
 	}
 
 	var diags tfdiags.Diagnostics
-
-	// If set, output a warning indicating that these values are not used.
-	if !varValues.Empty() || !varFiles.Empty() {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Warning,
-			"The -var and -var-file flags are not used in validate. Setting them has no effect.",
-			"These flags will be removed in a future version of Terraform.",
-		))
-	}
 
 	// After this point, we must only produce JSON output if JSON mode is
 	// enabled, so all errors should be accumulated into diags and we'll


### PR DESCRIPTION
These flags are not used and have been deprecated since 0.12.11.