### PR TITLE
remote provisioners require a connection config

### DIFF
--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -74,6 +74,11 @@ func (p *provisioner) ValidateProvisionerConfig(req provisioners.ValidateProvisi
 }
 
 func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	if req.Connection.IsNull() {
+		resp.Diagnostics = resp.Diagnostics.Append(errors.New("missing connection configuration for provisioner"))
+		return resp
+	}
+
 	comm, err := communicator.New(req.Connection)
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)

--- a/builtin/provisioners/file/resource_provisioner_test.go
+++ b/builtin/provisioners/file/resource_provisioner_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/provisioners"
@@ -101,4 +102,17 @@ func TestResourceProvisioner_StopClose(t *testing.T) {
 	p := New()
 	p.Stop()
 	p.Close()
+}
+
+func TestResourceProvisioner_connectionRequired(t *testing.T) {
+	p := New()
+	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{})
+	if !resp.Diagnostics.HasErrors() {
+		t.Fatal("expected error")
+	}
+
+	got := resp.Diagnostics.Err().Error()
+	if !strings.Contains(got, "missing connection") {
+		t.Fatalf("expected 'missing connection' error: got %q", got)
+	}
 }

--- a/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -85,6 +85,11 @@ func (p *provisioner) ValidateProvisionerConfig(req provisioners.ValidateProvisi
 }
 
 func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	if req.Connection.IsNull() {
+		resp.Diagnostics = resp.Diagnostics.Append(errors.New("missing connection configuration for provisioner"))
+		return resp
+	}
+
 	comm, err := communicator.New(req.Connection)
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)

--- a/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -261,3 +261,16 @@ func TestResourceProvisioner_StopClose(t *testing.T) {
 	p.Stop()
 	p.Close()
 }
+
+func TestResourceProvisioner_connectionRequired(t *testing.T) {
+	p := New()
+	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{})
+	if !resp.Diagnostics.HasErrors() {
+		t.Fatal("expected error")
+	}
+
+	got := resp.Diagnostics.Err().Error()
+	if !strings.Contains(got, "missing connection") {
+		t.Fatalf("expected 'missing connection' error: got %q", got)
+	}
+}


### PR DESCRIPTION
The new provisioner implementation did not validate that there was a connection configuration.

There should probably be a way to catch this ahead of time during static validation, but we need to prevent the communicator from panicking. 