### PR TITLE
check errors before using configSnap

### DIFF
--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -95,6 +95,10 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, *configload.
 		}
 		log.Printf("[TRACE] backend/local: building context from plan file")
 		tfCtx, configSnap, ctxDiags = b.contextFromPlanFile(op.PlanFile, opts, stateMeta)
+		if ctxDiags.HasErrors() {
+			return nil, nil, nil, ctxDiags
+		}
+
 		// Write sources into the cache of the main loader so that they are
 		// available if we need to generate diagnostic message snippets.
 		op.ConfigLoader.ImportSourcesFromSnapshot(configSnap)


### PR DESCRIPTION
configSnap may be nil if there are errors loading it from the plan file.

This does not address any potential regressions or errors when loading the config, it only adds a missing error check leading to a nil pointer dereference.

Fixes #27924