### PR TITLE
configs: A better error message for custom variable validation

### DIFF
--- a/configs/named_values.go
+++ b/configs/named_values.go
@@ -382,7 +382,7 @@ func decodeVariableValidationBlock(varName string, block *hcl.Block, override bo
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  errSummary,
-					Detail:   "Validation error message must be at least one full English sentence starting with an uppercase letter and ending with a period or question mark.",
+					Detail:   "The validation error message must be at least one full sentence starting with an uppercase letter and ending with a period or question mark.\n\nYour given message will be included as part of a larger Terraform error message, written as English prose. For broadly-shared modules we suggest using a similar writing style so that the overall result will be consistent.",
 					Subject:  attr.Expr.Range().Ptr(),
 				})
 			}


### PR DESCRIPTION
Our previous message conflated the requirement for a full sentence with the suggestion to write in a style similar to Terraform's built-in error messages, which created a sense that the system would actively reject an error message written in another language.

There's no intent here to block writing error messages in other languages, but there is a practical consideration that Terraform's UI output is currently not localized and so consistency with Terraform's other output, if that's important to a module author, will typically mean writing the error message in English.

This is the new error message implemented here:

```
╷
│ Error: Invalid validation error message
│ 
│   on variable-validation.tf line 4, in variable "foo":
│    4:     error_message = "not valid"
│ 
│ The validation error message must be at least one full sentence
│ starting with an uppercase letter and ending with a period or
│ question mark.
│ 
│ Your given message will be included as part of a larger Terraform
│ error message, written as English prose. For broadly-shared modules
│ we suggest using a similar writing style so that the overall result
│ will be consistent.
╵
```

Hopefully one day we'll be able to offer a localized UI, and as part of that some way to deal with modules whose messages are written in other languages too, but that is a much bigger task than correcting a poorly-written error message, and so my focus is on the latter for the sake of this PR.

---

The backport here is not for any specific technical reason but rather that we happen to be right at the start of the next release period and so it'd be a shame for something like this with low technical risk to only be released months from now in the next major/minor.
