### PR TITLE
configs: Accept and minimally validate a "language" argument

### DIFF
--- a/configs/parser_config.go
+++ b/configs/parser_config.go
@@ -58,8 +58,8 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 			content, contentDiags := block.Body.Content(terraformBlockSchema)
 			diags = append(diags, contentDiags...)
 
-			// We ignore the "terraform_version" and "experiments" attributes
-			// here because sniffCoreVersionRequirements and
+			// We ignore the "terraform_version", "language" and "experiments"
+			// attributes here because sniffCoreVersionRequirements and
 			// sniffActiveExperiments already dealt with those above.
 
 			for _, innerBlock := range content.Blocks {
@@ -244,6 +244,7 @@ var terraformBlockSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: "required_version"},
 		{Name: "experiments"},
+		{Name: "language"},
 	},
 	Blocks: []hcl.BlockHeaderSchema{
 		{
@@ -283,8 +284,7 @@ var configFileVersionSniffBlockSchema = &hcl.BodySchema{
 // to decode a single attribute from inside a "terraform" block.
 var configFileExperimentsSniffBlockSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
-		{
-			Name: "experiments",
-		},
+		{Name: "experiments"},
+		{Name: "language"},
 	},
 }

--- a/configs/testdata/error-files/invalid_language_edition.tf
+++ b/configs/testdata/error-files/invalid_language_edition.tf
@@ -1,0 +1,4 @@
+terraform {
+  # The language argument expects a bare keyword, not a string.
+  language = "TF2021" # ERROR: Invalid language edition
+}

--- a/configs/testdata/error-files/unsupported_language_edition.tf
+++ b/configs/testdata/error-files/unsupported_language_edition.tf
@@ -1,0 +1,6 @@
+terraform {
+  # If a future change in this repository happens to make TF2038 a valid
+  # edition then this will start failing; in that case, change this file to
+  # select a different edition that isn't supported.
+  language = TF2038 # ERROR: Unsupported language edition
+}

--- a/configs/testdata/valid-files/valid-language-edition.tf
+++ b/configs/testdata/valid-files/valid-language-edition.tf
@@ -1,0 +1,8 @@
+terraform {
+  # If we drop support for TF2021 in a future Terraform release then this
+  # test will fail. In that case, update this to a newer edition that is
+  # still supported, because the purpose of this test is to verify that
+  # we can successfully decode the language argument, not specifically
+  # that we support TF2021.
+  language = TF2021
+}


### PR DESCRIPTION
We expect that in order to continue to evolve the language without breaking existing modules we will at some point need to have a way to mark when a particular module is expecting a newer interpretation of the language.

Although it's too early to do any deep preparation for that, this commit aims to proactively reserve an argument named "language" inside "terraform" blocks, which currently only accepts the keyword `TF2021` that is intended to represent "the edition of the Terraform language as defined in 2021".

Since `TF2021` represents the language as currently defined _without_ setting `language`, in practice there's no real reason to set this today, but this minimal validation is intended to give better feedback to users of older Terraform versions in the event that we introduce a new language edition later and they try to use an module incompatible with their Terraform version. Specifically, it will recommend that they upgrade to a newer version rather than just reporting that the `language` argument isn't supported.

---

This is a v0.15 backport because this change will meet its goals best if it's included in as early a Terraform CLI release as possible, to minimize the number of pre-0.15 uses of Terraform still around at the point where we might introduce a new edition keyword.