### PR TITLE
views: Fix missing source in diagnostic output

### DIFF
--- a/command/plan.go
+++ b/command/plan.go
@@ -30,7 +30,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
-		view.HelpPrompt("plan")
+		view.HelpPrompt()
 		return 1
 	}
 

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -543,6 +543,9 @@ func TestPlan_validate(t *testing.T) {
 	if want := "Error: Invalid count argument"; !strings.Contains(actual, want) {
 		t.Fatalf("unexpected error output\ngot:\n%s\n\nshould contain: %s", actual, want)
 	}
+	if want := "9:   count = timestamp()"; !strings.Contains(actual, want) {
+		t.Fatalf("unexpected error output\ngot:\n%s\n\nshould contain: %s", actual, want)
+	}
 }
 
 func TestPlan_vars(t *testing.T) {

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -31,7 +31,7 @@ func (c *RefreshCommand) Run(rawArgs []string) int {
 
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
-		view.HelpPrompt("refresh")
+		view.HelpPrompt()
 		return 1
 	}
 

--- a/command/views/apply.go
+++ b/command/views/apply.go
@@ -27,7 +27,7 @@ func NewApply(vt arguments.ViewType, destroy bool, runningInAutomation bool, vie
 	switch vt {
 	case arguments.ViewHuman:
 		return &ApplyHuman{
-			View:         *view,
+			view:         view,
 			destroy:      destroy,
 			inAutomation: runningInAutomation,
 			countHook:    &countHook{},
@@ -40,7 +40,7 @@ func NewApply(vt arguments.ViewType, destroy bool, runningInAutomation bool, vie
 // The ApplyHuman implementation renders human-readable text logs, suitable for
 // a scrolling terminal.
 type ApplyHuman struct {
-	View
+	view *View
 
 	destroy      bool
 	inAutomation bool
@@ -52,40 +52,44 @@ var _ Apply = (*ApplyHuman)(nil)
 
 func (v *ApplyHuman) ResourceCount(stateOutPath string) {
 	if v.destroy {
-		v.streams.Printf(
-			v.colorize.Color("[reset][bold][green]\nDestroy complete! Resources: %d destroyed.\n"),
+		v.view.streams.Printf(
+			v.view.colorize.Color("[reset][bold][green]\nDestroy complete! Resources: %d destroyed.\n"),
 			v.countHook.Removed,
 		)
 	} else {
-		v.streams.Printf(
-			v.colorize.Color("[reset][bold][green]\nApply complete! Resources: %d added, %d changed, %d destroyed.\n"),
+		v.view.streams.Printf(
+			v.view.colorize.Color("[reset][bold][green]\nApply complete! Resources: %d added, %d changed, %d destroyed.\n"),
 			v.countHook.Added,
 			v.countHook.Changed,
 			v.countHook.Removed,
 		)
 	}
 	if (v.countHook.Added > 0 || v.countHook.Changed > 0) && stateOutPath != "" {
-		v.streams.Printf("\n%s\n\n", format.WordWrap(stateOutPathPostApply, v.View.outputColumns()))
-		v.streams.Printf("State path: %s\n", stateOutPath)
+		v.view.streams.Printf("\n%s\n\n", format.WordWrap(stateOutPathPostApply, v.view.outputColumns()))
+		v.view.streams.Printf("State path: %s\n", stateOutPath)
 	}
 }
 
 func (v *ApplyHuman) Outputs(outputValues map[string]*states.OutputValue) {
 	if len(outputValues) > 0 {
-		v.streams.Print(v.colorize.Color("[reset][bold][green]\nOutputs:\n\n"))
-		NewOutput(arguments.ViewHuman, &v.View).Output("", outputValues)
+		v.view.streams.Print(v.view.colorize.Color("[reset][bold][green]\nOutputs:\n\n"))
+		NewOutput(arguments.ViewHuman, v.view).Output("", outputValues)
 	}
 }
 
 func (v *ApplyHuman) Operation() Operation {
-	return NewOperation(arguments.ViewHuman, v.inAutomation, &v.View)
+	return NewOperation(arguments.ViewHuman, v.inAutomation, v.view)
 }
 
 func (v *ApplyHuman) Hooks() []terraform.Hook {
 	return []terraform.Hook{
 		v.countHook,
-		NewUiHook(&v.View),
+		NewUiHook(v.view),
 	}
+}
+
+func (v *ApplyHuman) Diagnostics(diags tfdiags.Diagnostics) {
+	v.view.Diagnostics(diags)
 }
 
 func (v *ApplyHuman) HelpPrompt() {
@@ -93,7 +97,7 @@ func (v *ApplyHuman) HelpPrompt() {
 	if v.destroy {
 		command = "destroy"
 	}
-	v.View.HelpPrompt(command)
+	v.view.HelpPrompt(command)
 }
 
 const stateOutPathPostApply = "The state of your infrastructure has been saved to the path below. This state is required to modify and destroy your infrastructure, so keep it safe. To inspect the complete state use the `terraform show` command."

--- a/command/views/operation.go
+++ b/command/views/operation.go
@@ -32,14 +32,14 @@ type Operation interface {
 func NewOperation(vt arguments.ViewType, inAutomation bool, view *View) Operation {
 	switch vt {
 	case arguments.ViewHuman:
-		return &OperationHuman{View: *view, inAutomation: inAutomation}
+		return &OperationHuman{view: view, inAutomation: inAutomation}
 	default:
 		panic(fmt.Sprintf("unknown view type %v", vt))
 	}
 }
 
 type OperationHuman struct {
-	View
+	view *View
 
 	// inAutomation indicates that commands are being run by an
 	// automated system rather than directly at a command prompt.
@@ -54,11 +54,11 @@ type OperationHuman struct {
 var _ Operation = (*OperationHuman)(nil)
 
 func (v *OperationHuman) Interrupted() {
-	v.streams.Println(format.WordWrap(interrupted, v.outputColumns()))
+	v.view.streams.Println(format.WordWrap(interrupted, v.view.outputColumns()))
 }
 
 func (v *OperationHuman) FatalInterrupt() {
-	v.streams.Eprintln(format.WordWrap(fatalInterrupt, v.errorColumns()))
+	v.view.streams.Eprintln(format.WordWrap(fatalInterrupt, v.view.errorColumns()))
 }
 
 const fatalInterrupt = `
@@ -72,14 +72,14 @@ Gracefully shutting down...
 `
 
 func (v *OperationHuman) Stopping() {
-	v.streams.Println("Stopping operation...")
+	v.view.streams.Println("Stopping operation...")
 }
 
 func (v *OperationHuman) Cancelled(destroy bool) {
 	if destroy {
-		v.streams.Println("Destroy cancelled.")
+		v.view.streams.Println("Destroy cancelled.")
 	} else {
-		v.streams.Println("Apply cancelled.")
+		v.view.streams.Println("Apply cancelled.")
 	}
 }
 
@@ -89,17 +89,17 @@ func (v *OperationHuman) EmergencyDumpState(stateFile *statefile.File) error {
 	if jsonErr != nil {
 		return jsonErr
 	}
-	v.streams.Eprintln(stateBuf)
+	v.view.streams.Eprintln(stateBuf)
 	return nil
 }
 
 func (v *OperationHuman) PlanNoChanges() {
-	v.streams.Println("\n" + v.colorize.Color(strings.TrimSpace(planNoChanges)))
-	v.streams.Println("\n" + strings.TrimSpace(format.WordWrap(planNoChangesDetail, v.outputColumns())))
+	v.view.streams.Println("\n" + v.view.colorize.Color(strings.TrimSpace(planNoChanges)))
+	v.view.streams.Println("\n" + strings.TrimSpace(format.WordWrap(planNoChangesDetail, v.view.outputColumns())))
 }
 
 func (v *OperationHuman) Plan(plan *plans.Plan, baseState *states.State, schemas *terraform.Schemas) {
-	renderPlan(plan, baseState, schemas, &v.View)
+	renderPlan(plan, baseState, schemas, v.view)
 }
 
 // PlanNextStep gives the user some next-steps, unless we're running in an
@@ -108,18 +108,22 @@ func (v *OperationHuman) PlanNextStep(planPath string) {
 	if v.inAutomation {
 		return
 	}
-	v.outputHorizRule()
+	v.view.outputHorizRule()
 
 	if planPath == "" {
-		v.streams.Print(
-			"\n" + strings.TrimSpace(format.WordWrap(planHeaderNoOutput, v.outputColumns())) + "\n",
+		v.view.streams.Print(
+			"\n" + strings.TrimSpace(format.WordWrap(planHeaderNoOutput, v.view.outputColumns())) + "\n",
 		)
 	} else {
-		v.streams.Printf(
-			"\n"+strings.TrimSpace(format.WordWrap(planHeaderYesOutput, v.outputColumns()))+"\n",
+		v.view.streams.Printf(
+			"\n"+strings.TrimSpace(format.WordWrap(planHeaderYesOutput, v.view.outputColumns()))+"\n",
 			planPath, planPath,
 		)
 	}
+}
+
+func (v *OperationHuman) Diagnostics(diags tfdiags.Diagnostics) {
+	v.view.Diagnostics(diags)
 }
 
 const planNoChanges = `

--- a/command/views/state_locker.go
+++ b/command/views/state_locker.go
@@ -17,7 +17,7 @@ type StateLocker interface {
 func NewStateLocker(vt arguments.ViewType, view *View) StateLocker {
 	switch vt {
 	case arguments.ViewHuman:
-		return &StateLockerHuman{View: *view}
+		return &StateLockerHuman{view: view}
 	default:
 		panic(fmt.Sprintf("unknown view type %v", vt))
 	}
@@ -26,15 +26,15 @@ func NewStateLocker(vt arguments.ViewType, view *View) StateLocker {
 // StateLockerHuman is an implementation of StateLocker which prints status to
 // a terminal.
 type StateLockerHuman struct {
-	View
+	view *View
 }
 
 var _ StateLocker = (*StateLockerHuman)(nil)
 
 func (v *StateLockerHuman) Locking() {
-	v.streams.Println("Acquiring state lock. This may take a few moments...")
+	v.view.streams.Println("Acquiring state lock. This may take a few moments...")
 }
 
 func (v *StateLockerHuman) Unlocking() {
-	v.streams.Println("Releasing state lock. This may take a few moments...")
+	v.view.streams.Println("Releasing state lock. This may take a few moments...")
 }


### PR DESCRIPTION
The previous implementation of views was copying and embedding the base `View` struct in each individual view. While this allowed for easy access to the interface of that struct (both in the view and externally), it more importantly completely broke the ability of the diagnostic printer to output source code snippets.

This is because the `configSources` field on the base view is lazily set after the config loader is initialized. In the commands ported to use views, this happens after the base `View` struct is copied, so we are updating the wrong copy of the struct.

This commit fixes this with a simple mechanical refactor: keep a pointer to the base `View` struct instead, and update all of the individual views to explicitly refer to that struct to access its fields and methods.

This is not a particularly satisfying solution, but I can't find anything clearly better. It might be worth exploring the alternative approach in the view for the new `test` command, which explicitly pulls its dependencies out of the base view, rather than retaining a full reference. Maybe there's a third way which is better still.

## Screenshots

Before:
<img width="938" alt="before" src="https://user-images.githubusercontent.com/68917/109358546-ee433c80-7851-11eb-80c8-352a98d9ec8a.png">

After:
<img width="938" alt="after" src="https://user-images.githubusercontent.com/68917/109358549-eedbd300-7851-11eb-8a09-ae29ae74c7c2.png">
