### PR TITLE
functions: Fix panics in defaults

### DIFF
--- a/lang/funcs/defaults.go
+++ b/lang/funcs/defaults.go
@@ -127,9 +127,11 @@ func defaultsApply(input, fallback cty.Value) cty.Value {
 		case wantTy.IsMapType():
 			newVals := map[string]cty.Value{}
 
-			for it := input.ElementIterator(); it.Next(); {
-				k, v := it.Element()
-				newVals[k.AsString()] = defaultsApply(v, fallback)
+			if !input.IsNull() {
+				for it := input.ElementIterator(); it.Next(); {
+					k, v := it.Element()
+					newVals[k.AsString()] = defaultsApply(v, fallback)
+				}
 			}
 
 			if len(newVals) == 0 {
@@ -139,10 +141,12 @@ func defaultsApply(input, fallback cty.Value) cty.Value {
 		case wantTy.IsListType(), wantTy.IsSetType():
 			var newVals []cty.Value
 
-			for it := input.ElementIterator(); it.Next(); {
-				_, v := it.Element()
-				newV := defaultsApply(v, fallback)
-				newVals = append(newVals, newV)
+			if !input.IsNull() {
+				for it := input.ElementIterator(); it.Next(); {
+					_, v := it.Element()
+					newV := defaultsApply(v, fallback)
+					newVals = append(newVals, newV)
+				}
 			}
 
 			if len(newVals) == 0 {

--- a/lang/funcs/defaults.go
+++ b/lang/funcs/defaults.go
@@ -187,7 +187,7 @@ func defaultsAssertSuitableFallback(wantTy, fallbackTy cty.Type, fallbackPath ct
 		if fallbackTy.Equals(wantTy) {
 			return nil
 		}
-		conversion := convert.GetConversionUnsafe(fallbackTy, wantTy)
+		conversion := convert.GetConversion(fallbackTy, wantTy)
 		if conversion == nil {
 			msg := convert.MismatchMessage(fallbackTy, wantTy)
 			return fallbackPath.NewErrorf("invalid default value for %s: %s", wantTy.FriendlyName(), msg)

--- a/lang/funcs/defaults_test.go
+++ b/lang/funcs/defaults_test.go
@@ -370,6 +370,25 @@ func TestDefaults(t *testing.T) {
 			Defaults: cty.StringVal("hello"),
 			WantErr:  `only object types and collections of object types can have defaults applied`,
 		},
+		// When applying default values to collection types, null collections in the
+		// input should result in empty collections in the output.
+		{
+			Input: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NullVal(cty.List(cty.String)),
+				"b": cty.NullVal(cty.Map(cty.String)),
+				"c": cty.NullVal(cty.Set(cty.String)),
+			}),
+			Defaults: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("hello"),
+				"b": cty.StringVal("hi"),
+				"c": cty.StringVal("greetings"),
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.ListValEmpty(cty.String),
+				"b": cty.MapValEmpty(cty.String),
+				"c": cty.SetValEmpty(cty.String),
+			}),
+		},
 	}
 
 	for _, test := range tests {

--- a/lang/funcs/defaults_test.go
+++ b/lang/funcs/defaults_test.go
@@ -389,6 +389,38 @@ func TestDefaults(t *testing.T) {
 				"c": cty.SetValEmpty(cty.String),
 			}),
 		},
+		// When specifying fallbacks, we allow mismatched primitive attribute
+		// types so long as a safe conversion is possible. This means that we
+		// can accept number or boolean values for string attributes.
+		{
+			Input: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NullVal(cty.String),
+				"b": cty.NullVal(cty.String),
+				"c": cty.NullVal(cty.String),
+			}),
+			Defaults: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NumberIntVal(5),
+				"b": cty.True,
+				"c": cty.StringVal("greetings"),
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("5"),
+				"b": cty.StringVal("true"),
+				"c": cty.StringVal("greetings"),
+			}),
+		},
+		// Fallbacks with mismatched primitive attribute types which do not
+		// have safe conversions must not pass the suitable fallback check,
+		// even if unsafe conversion would be possible.
+		{
+			Input: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NullVal(cty.Bool),
+			}),
+			Defaults: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("5"),
+			}),
+			WantErr: ".a: invalid default value for bool: bool required",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Two commits, addressing the two separate issues in #27385:

## functions: Fix defaults null collections panic

When applying default values to collection types, null collections in the input should result in empty collections in the output.

Fixes #27385 (original report)

## functions: Fix defaults mismatched types fallback

We allow primitive fallback values which have mismatched types, but only if there is a conversion to the target type. Previously we would allow unsafe conversions (e.g. string to bool), but later had no capacity to return an error if the conversion failed due to the value of the fallback being unable to convert to the target type.

This commit makes the more conservative requirement that default fallback values must have a safe conversion.

Fixes #27385 (follow-up reports)