### PR TITLE
Add link to Modules in Package Sub-directories

### DIFF
--- a/website/docs/language/modules/sources.html.md
+++ b/website/docs/language/modules/sources.html.md
@@ -32,6 +32,8 @@ types, as listed below.
   * [S3 buckets](#s3-bucket)
 
   * [GCS buckets](#gcs-bucket)
+  
+  * [Modules in Package Sub-directories](#modules-in-package-sub-directories)
 
 Each of these is described in the following sections. Module source addresses
 use a _URL-like_ syntax, but with extensions to support unambiguous selection


### PR DESCRIPTION
Add link to "Modules in Package Sub-directories" section at top of page.
This will make it easier for readers to find that section which is important if they want to be able to directly reference a nested module from inside another module.