### PR TITLE
Give suggestions & remind users to use required_providers when provider not in registry

### DIFF
--- a/addrs/provider.go
+++ b/addrs/provider.go
@@ -23,6 +23,9 @@ type Provider struct {
 // not have an explicit hostname.
 const DefaultRegistryHost = svchost.Hostname("registry.terraform.io")
 
+// DefaultNamespace is the default namespace for providers
+const DefaultNamespace = "hashicorp"
+
 // BuiltInProviderHost is the pseudo-hostname used for the "built-in" provider
 // namespace. Built-in provider addresses must also have their namespace set
 // to BuiltInProviderNamespace in order to be considered as built-in.
@@ -214,7 +217,7 @@ func (pt Provider) IsDefault() bool {
 		panic("called IsDefault() on zero-value addrs.Provider")
 	}
 
-	return pt.Hostname == DefaultRegistryHost && pt.Namespace == "hashicorp"
+	return pt.Hostname == DefaultRegistryHost && pt.Namespace == DefaultNamespace
 }
 
 // Equals returns true if the receiver and other provider have the same attributes.

--- a/addrs/provider.go
+++ b/addrs/provider.go
@@ -23,9 +23,6 @@ type Provider struct {
 // not have an explicit hostname.
 const DefaultRegistryHost = svchost.Hostname("registry.terraform.io")
 
-// DefaultNamespace is the default namespace for providers
-const DefaultNamespace = "hashicorp"
-
 // BuiltInProviderHost is the pseudo-hostname used for the "built-in" provider
 // namespace. Built-in provider addresses must also have their namespace set
 // to BuiltInProviderNamespace in order to be considered as built-in.
@@ -217,7 +214,7 @@ func (pt Provider) IsDefault() bool {
 		panic("called IsDefault() on zero-value addrs.Provider")
 	}
 
-	return pt.Hostname == DefaultRegistryHost && pt.Namespace == DefaultNamespace
+	return pt.Hostname == DefaultRegistryHost && pt.Namespace == "hashicorp"
 }
 
 // Equals returns true if the receiver and other provider have the same attributes.

--- a/command/e2etest/init_test.go
+++ b/command/e2etest/init_test.go
@@ -345,7 +345,7 @@ func TestInitProviderNotFound(t *testing.T) {
 			t.Errorf("expected error message is missing from output:\n%s", stderr)
 		}
 
-		if !strings.Contains(oneLineStderr, "If you meant to install a provider from the registry that is not in the hashicorp namespace, the required_providers block for your module is not optional") {
+		if !strings.Contains(oneLineStderr, "All modules should specify their required_providers") {
 			t.Errorf("expected error message is missing from output:\n%s", stderr)
 		}
 	})
@@ -380,56 +380,11 @@ func TestInitProviderNotFound(t *testing.T) {
 │ hashicorp/nonexist: provider registry registry.terraform.io does not have a
 │ provider named registry.terraform.io/hashicorp/nonexist
 │ 
-│ If you meant to install a provider from the registry that is not in the
-│ hashicorp namespace, the required_providers block for your module is not
-│ optional. All modules should specify their required_providers so that
-│ external consumers will get the correct providers when using a module.
-╵
-
-`
-		if stripAnsi(stderr) != expectedErr {
-			t.Errorf("wrong output:\n%s", cmp.Diff(stripAnsi(stderr), expectedErr))
-		}
-	})
-}
-
-func TestInitProviderNotFoundNonDefault(t *testing.T) {
-	t.Parallel()
-
-	// This test will reach out to registry.terraform.io as one of the possible
-	// installation locations for teamterraform/nonexist, which should not exist,
-	// so long as no one publishes a provider under teamterraform/nonexist
-	skipIfCannotAccessNetwork(t)
-
-	fixturePath := filepath.Join("testdata", "provider-not-found-non-default")
-	tf := e2e.NewBinary(terraformBin, fixturePath)
-	defer tf.Close()
-
-	t.Run("registry provider not found", func(t *testing.T) {
-		_, stderr, err := tf.Run("init", "-no-color")
-		if err == nil {
-			t.Fatal("expected error, got success")
-		}
-
-		oneLineStderr := strings.ReplaceAll(stderr, "\n", " ")
-
-		if strings.Contains(oneLineStderr, "If you meant to install a provider from the registry that is not in the hashicorp namespace, the required_providers block for your module is not optional") {
-			t.Errorf("error message contains required_providers suggestion and should not:\n%s", stderr)
-		}
-	})
-
-	t.Run("special characters enabled", func(t *testing.T) {
-		_, stderr, err := tf.Run("init")
-		if err == nil {
-			t.Fatal("expected error, got success")
-		}
-
-		expectedErr := `╷
-│ Error: Failed to query available provider packages
-│` + ` ` + `
-│ Could not retrieve the list of available versions for provider
-│ teamterraform/nonexist: provider registry registry.terraform.io does not
-│ have a provider named registry.terraform.io/teamterraform/nonexist
+│ All modules should specify their required_providers so that external
+│ consumers will get the correct providers when using a module. To see which
+│ modules are currently depending on hashicorp/nonexist, run the following
+│ command:
+│     terraform providers
 ╵
 
 `

--- a/command/e2etest/testdata/provider-not-found-non-default/main.tf
+++ b/command/e2etest/testdata/provider-not-found-non-default/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    nonexist = {
+      source = "teamterraform/nonexist"
+    }
+  }
+}

--- a/command/init.go
+++ b/command/init.go
@@ -519,6 +519,13 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 						"\n\nDid you intend to use %s? If so, you must specify that source address in each module which requires that provider. To see which modules are currently depending on %s, run the following command:\n    terraform providers",
 						alternative.ForDisplay(), provider.ForDisplay(),
 					)
+				} else if provider.IsDefault() {
+					// If the provider uses the default namespace let's give a suggestion that the user may want
+					// to use required_providers. (all modules should do this, but the default namespace behavior
+					// was intended to allow a smoother transition)
+					// In the future, it would be helpful if this could suggest providers based on existing known
+					// non-default domain [hashicorp] providers
+					suggestion = "\n\nIf you meant to install a provider from the registry that is not in the hashicorp namespace, the required_providers block for your module is not optional. All modules should specify their required_providers so that external consumers will get the correct providers when using a module."
 				}
 
 				diags = diags.Append(tfdiags.Sourceless(

--- a/command/init.go
+++ b/command/init.go
@@ -512,17 +512,13 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 			case getproviders.ErrRegistryProviderNotKnown:
 				// We might be able to suggest an alternative provider to use
 				// instead of this one.
-				var suggestion string
-				alternative := getproviders.MissingProviderSuggestion(ctx, provider, inst.ProviderSource())
+				suggestion := fmt.Sprintf("\n\nAll modules should specify their required_providers so that external consumers will get the correct providers when using a module. To see which modules are currently depending on %s, run the following command:\n    terraform providers", provider.ForDisplay())
+				alternative := getproviders.MissingProviderSuggestion(ctx, provider, inst.ProviderSource(), reqs)
 				if alternative != provider {
 					suggestion = fmt.Sprintf(
 						"\n\nDid you intend to use %s? If so, you must specify that source address in each module which requires that provider. To see which modules are currently depending on %s, run the following command:\n    terraform providers",
 						alternative.ForDisplay(), provider.ForDisplay(),
 					)
-				} else {
-					// In the future, it would be helpful if this could suggest providers based on existing known
-					// similarly-named providers required by other modules in the configuration
-					suggestion = fmt.Sprintf("\n\nAll modules should specify their required_providers so that external consumers will get the correct providers when using a module. To see which modules are currently depending on %s, run the following command:\n    terraform providers", provider.ForDisplay())
 				}
 
 				diags = diags.Append(tfdiags.Sourceless(

--- a/command/init.go
+++ b/command/init.go
@@ -519,13 +519,10 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 						"\n\nDid you intend to use %s? If so, you must specify that source address in each module which requires that provider. To see which modules are currently depending on %s, run the following command:\n    terraform providers",
 						alternative.ForDisplay(), provider.ForDisplay(),
 					)
-				} else if provider.IsDefault() {
-					// If the provider uses the default namespace let's give a suggestion that the user may want
-					// to use required_providers. (all modules should do this, but the default namespace behavior
-					// was intended to allow a smoother transition)
+				} else {
 					// In the future, it would be helpful if this could suggest providers based on existing known
-					// non-default domain [hashicorp] providers
-					suggestion = "\n\nIf you meant to install a provider from the registry that is not in the hashicorp namespace, the required_providers block for your module is not optional. All modules should specify their required_providers so that external consumers will get the correct providers when using a module."
+					// similarly-named providers required by other modules in the configuration
+					suggestion = fmt.Sprintf("\n\nAll modules should specify their required_providers so that external consumers will get the correct providers when using a module. To see which modules are currently depending on %s, run the following command:\n    terraform providers", provider.ForDisplay())
 				}
 
 				diags = diags.Append(tfdiags.Sourceless(

--- a/internal/getproviders/didyoumean.go
+++ b/internal/getproviders/didyoumean.go
@@ -30,17 +30,29 @@ import (
 // careful to give it only as a possibility and not necessarily a suitable
 // replacement for the given provider.
 //
-// In practice today this function only knows how to suggest alternatives for
-// "default" providers, which is to say ones that are in the hashicorp
-// namespace in the Terraform registry. It will always return no result for
-// any other provider. That might change in future if we introduce other ways
-// to discover provider suggestions.
-//
 // If the given context is cancelled then this function might not return a
 // renaming suggestion even if one would've been available for a completed
 // request.
-func MissingProviderSuggestion(ctx context.Context, addr addrs.Provider, source Source) addrs.Provider {
-	if !addr.IsDefault() {
+func MissingProviderSuggestion(ctx context.Context, addr addrs.Provider, source Source, reqs Requirements) addrs.Provider {
+	// If the missing provider is in a non-default [hashicorp] namespace,
+	// don't do further processing
+	if addr.Namespace != addrs.DefaultNamespace {
+		return addr
+	}
+
+	// Before possibly looking up legacy naming, see if the user has another provider
+	// named in their requirements that is of the same type, and offer that
+	// as a suggestion
+	for req := range reqs {
+		if req != addr && req.Type == addr.Type {
+			return req
+		}
+	}
+
+	// If no provider from existing requirements is suggested, if
+	// we aren't using the default registry, go ahead and return the addr
+	// as we cannot guarantee the other registry implements this lookup
+	if addr.Hostname != addrs.DefaultRegistryHost {
 		return addr
 	}
 

--- a/internal/getproviders/didyoumean.go
+++ b/internal/getproviders/didyoumean.go
@@ -30,13 +30,17 @@ import (
 // careful to give it only as a possibility and not necessarily a suitable
 // replacement for the given provider.
 //
+// In practice today this function only knows how to suggest alternatives for
+// "default" providers, which is to say ones that are in the hashicorp
+// namespace in the Terraform registry. It will always return no result for
+// any other provider. That might change in future if we introduce other ways
+// to discover provider suggestions.
+//
 // If the given context is cancelled then this function might not return a
 // renaming suggestion even if one would've been available for a completed
 // request.
 func MissingProviderSuggestion(ctx context.Context, addr addrs.Provider, source Source, reqs Requirements) addrs.Provider {
-	// If the missing provider is in a non-default [hashicorp] namespace,
-	// don't do further processing
-	if addr.Namespace != addrs.DefaultNamespace {
+	if !addr.IsDefault() {
 		return addr
 	}
 
@@ -47,13 +51,6 @@ func MissingProviderSuggestion(ctx context.Context, addr addrs.Provider, source 
 		if req != addr && req.Type == addr.Type {
 			return req
 		}
-	}
-
-	// If no provider from existing requirements is suggested, if
-	// we aren't using the default registry, go ahead and return the addr
-	// as we cannot guarantee the other registry implements this lookup
-	if addr.Hostname != addrs.DefaultRegistryHost {
-		return addr
 	}
 
 	// Our strategy here, for a default provider, is to use the default

--- a/internal/getproviders/didyoumean_test.go
+++ b/internal/getproviders/didyoumean_test.go
@@ -21,10 +21,14 @@ func TestMissingProviderSuggestion(t *testing.T) {
 
 		// testRegistrySource handles -/legacy as a valid legacy provider
 		// lookup mapping to legacycorp/legacy.
+		legacyAddr := addrs.NewDefaultProvider("legacy")
 		got := MissingProviderSuggestion(
 			ctx,
 			addrs.NewDefaultProvider("legacy"),
 			source,
+			Requirements{
+				legacyAddr: MustParseVersionConstraints(">= 1.0.0"),
+			},
 		)
 
 		want := addrs.Provider{
@@ -48,19 +52,48 @@ func TestMissingProviderSuggestion(t *testing.T) {
 		// copy in some other namespace for v0.13 or later to use. Our naming
 		// suggestions ignore the v0.12-compatible one and suggest the
 		// other one.
-		got := MissingProviderSuggestion(
-			ctx,
-			addrs.NewDefaultProvider("moved"),
-			source,
-		)
-
+		moved := addrs.NewDefaultProvider("moved")
 		want := addrs.Provider{
 			Hostname:  defaultRegistryHost,
 			Namespace: "acme",
 			Type:      "moved",
 		}
+
+		got := MissingProviderSuggestion(
+			ctx,
+			moved,
+			source,
+			Requirements{
+				moved: MustParseVersionConstraints(">= 1.0.0"),
+			},
+		)
+
 		if got != want {
 			t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
+		}
+
+		// If a provider has moved, but there's provider requirements
+		// for something of the same type, we'll return that one
+		// and skip the legacy lookup process. In practice,
+		// hopefully this is also "acme" but it's "zcme" here to
+		// exercise the codepath
+		want2 := addrs.Provider{
+			Hostname:  defaultRegistryHost,
+			Namespace: "zcme",
+			Type:      "moved",
+		}
+		got2 := MissingProviderSuggestion(
+			ctx,
+			moved,
+			source,
+			Requirements{
+				moved: MustParseVersionConstraints(">= 1.0.0"),
+				want2: MustParseVersionConstraints(">= 1.0.0"),
+			},
+		)
+
+		if got2 != want2 {
+			t.Errorf("wrong result\ngot:  %s\nwant: %s", got2, want2)
 		}
 	})
 	t.Run("invalid response", func(t *testing.T) {
@@ -76,6 +109,9 @@ func TestMissingProviderSuggestion(t *testing.T) {
 			ctx,
 			want,
 			source,
+			Requirements{
+				want: MustParseVersionConstraints(">= 1.0.0"),
+			},
 		)
 		if got != want {
 			t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
@@ -98,9 +134,35 @@ func TestMissingProviderSuggestion(t *testing.T) {
 			ctx,
 			want,
 			source,
+			Requirements{
+				want: MustParseVersionConstraints(">= 1.0.0"),
+			},
 		)
 		if got != want {
 			t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
+		}
+
+		// Checking the case where we have a default namespace
+		// but a provider in the requirements that can fulfill it
+		wantDiffNamespace := addrs.Provider{
+			Hostname:  svchost.Hostname("example.com"),
+			Namespace: "nuhuh",
+			Type:      "foo",
+		}
+		gotDiffNamespace := MissingProviderSuggestion(
+			ctx,
+			addrs.Provider{
+				Hostname:  svchost.Hostname("example.com"),
+				Namespace: "hashicorp",
+				Type:      "foo",
+			},
+			source,
+			Requirements{
+				wantDiffNamespace: MustParseVersionConstraints(">= 1.0.0"),
+			},
+		)
+		if gotDiffNamespace != wantDiffNamespace {
+			t.Errorf("wrong result\ngot:  %s\nwant: %s", gotDiffNamespace, wantDiffNamespace)
 		}
 	})
 	t.Run("another namespace", func(t *testing.T) {
@@ -109,8 +171,8 @@ func TestMissingProviderSuggestion(t *testing.T) {
 		defer close()
 
 		// Because this provider address isn't in
-		// registry.terraform.io/hashicorp/..., MissingProviderSuggestion won't
-		// even attempt to make a suggestion for it.
+		// registry.terraform.io/hashicorp/..., MissingProviderSuggestion
+		// will provide the same addr since there's no alternative in Requirements
 		want := addrs.Provider{
 			Hostname:  defaultRegistryHost,
 			Namespace: "whatever",
@@ -120,9 +182,37 @@ func TestMissingProviderSuggestion(t *testing.T) {
 			ctx,
 			want,
 			source,
+			Requirements{
+				want: MustParseVersionConstraints(">= 1.0.0"),
+			},
 		)
 		if got != want {
 			t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
+		}
+
+		// If there is a provider required that has the same type,
+		// but different namespace, we can suggest that
+		foo := addrs.Provider{
+			Hostname:  defaultRegistryHost,
+			Namespace: "hashicorp",
+			Type:      "foo",
+		}
+		realFoo := addrs.Provider{
+			Hostname:  defaultRegistryHost,
+			Namespace: "acme",
+			Type:      "foo",
+		}
+		got2 := MissingProviderSuggestion(
+			ctx,
+			foo,
+			source,
+			Requirements{
+				foo:     MustParseVersionConstraints(">= 1.0.0"),
+				realFoo: MustParseVersionConstraints(">= 1.0.0"),
+			},
+		)
+		if got2 != realFoo {
+			t.Errorf("wrong result\ngot:  %s\nwant: %s", got2, realFoo)
 		}
 	})
 }

--- a/internal/getproviders/didyoumean_test.go
+++ b/internal/getproviders/didyoumean_test.go
@@ -141,29 +141,6 @@ func TestMissingProviderSuggestion(t *testing.T) {
 		if got != want {
 			t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
 		}
-
-		// Checking the case where we have a default namespace
-		// but a provider in the requirements that can fulfill it
-		wantDiffNamespace := addrs.Provider{
-			Hostname:  svchost.Hostname("example.com"),
-			Namespace: "nuhuh",
-			Type:      "foo",
-		}
-		gotDiffNamespace := MissingProviderSuggestion(
-			ctx,
-			addrs.Provider{
-				Hostname:  svchost.Hostname("example.com"),
-				Namespace: "hashicorp",
-				Type:      "foo",
-			},
-			source,
-			Requirements{
-				wantDiffNamespace: MustParseVersionConstraints(">= 1.0.0"),
-			},
-		)
-		if gotDiffNamespace != wantDiffNamespace {
-			t.Errorf("wrong result\ngot:  %s\nwant: %s", gotDiffNamespace, wantDiffNamespace)
-		}
 	})
 	t.Run("another namespace", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
When a user has any module, or child module, that has a `ErrRegistryProviderNotKnown` error, users are often confused why they don't get inheritance from other modules. 

Because Terraform explicitly loads modules as units with their own provider requirements (`required_providers`), and adds a suggestion of a provider "did you mean" if they have a provider of the same type (but not the default namespace) in their requirements.

This is what the new suggestion looks like in practice (with suggestion):

<img width="1552" alt="Screen Shot 2021-03-10 at 11 09 08 AM" src="https://user-images.githubusercontent.com/204372/110660197-4ef74100-8191-11eb-8c7c-3a99100ab4aa.png">


This is what the new suggestion looks like in practice (without suggestion/no existing provider requirements):

<img width="1259" alt="Screen Shot 2021-03-08 at 3 12 47 PM" src="https://user-images.githubusercontent.com/204372/110376077-c3f73900-8020-11eb-8b72-44ce7c5b6778.png">


Open to comments on improving this suggestion to be more user-friendly (for lack of a better term)

My hope is that this can address the (very valid!) concerns and comments surrounding issues like https://github.com/hashicorp/terraform/issues/27920 and https://github.com/hashicorp/terraform/issues/27701 . In #27920, Martin suggests an improvement where we could suggest a similar-name provider we may know about, but because of how the code is currently structured, I don't have confidence in picking an accurate (successful) name, so I am suggesting a more general suggestion here.

Fixes #27920
Fixes #27701