### PR TITLE
docs: Update link to HCL native syntax spec

### DIFF
--- a/website/docs/language/syntax/configuration.html.md
+++ b/website/docs/language/syntax/configuration.html.md
@@ -28,7 +28,7 @@ It is not necessary to know all of the details of HCL syntax in
 order to use Terraform, and so this page summarizes the most important
 details. If you are interested, you can find a full definition of HCL
 syntax in
-[the HCL native syntax specification](https://github.com/hashicorp/hcl/blob/hcl2/hclsyntax/spec.md).
+[the HCL native syntax specification](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md).
 
 ## Arguments and Blocks
 

--- a/website/docs/language/syntax/json.html.md
+++ b/website/docs/language/syntax/json.html.md
@@ -31,7 +31,7 @@ of a specification called _HCL_. It is not necessary to know all of the details
 of HCL syntax or its JSON mapping in order to use Terraform, and so this page
 summarizes the most important differences between native and JSON syntax.
 If you are interested, you can find a full definition of HCL's JSON syntax
-in [its specification](https://github.com/hashicorp/hcl/blob/hcl2/json/spec.md).
+in [its specification](https://github.com/hashicorp/hcl/blob/main/json/spec.md).
 
 ## JSON File Structure
 


### PR DESCRIPTION
The `hcl2` branch doesn't exist anymore, it was renamed to `main`.