### PR TITLE
do not panic if there is no deposed state

### DIFF
--- a/terraform/node_resource_destroy_deposed.go
+++ b/terraform/node_resource_destroy_deposed.go
@@ -159,6 +159,11 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		return diags.Append(err)
 	}
 
+	if state == nil {
+		diags = diags.Append(fmt.Errorf("missing deposed state for %s (%s)", n.Addr, n.DeposedKey))
+		return diags
+	}
+
 	change, destroyPlanDiags := n.planDestroy(ctx, state, n.DeposedKey)
 	diags = diags.Append(destroyPlanDiags)
 	if diags.HasErrors() {

--- a/terraform/node_resource_destroy_deposed_test.go
+++ b/terraform/node_resource_destroy_deposed_test.go
@@ -176,3 +176,28 @@ aws_instance.foo: (1 deposed)
   Deposed ID 1 = i-abc123
 	`)
 }
+
+func TestNodeDestroyDeposedResourceInstanceObject_ExecuteMissingState(t *testing.T) {
+	p := simpleMockProvider()
+	ctx := &MockEvalContext{
+		StateState:           states.NewState().SyncWrapper(),
+		ProviderProvider:     simpleMockProvider(),
+		ProviderSchemaSchema: p.ProviderSchema(),
+		ChangesChanges:       plans.NewChanges().SyncWrapper(),
+	}
+
+	node := NodeDestroyDeposedResourceInstanceObject{
+		NodeAbstractResourceInstance: &NodeAbstractResourceInstance{
+			Addr: mustResourceInstanceAddr("test_object.foo"),
+			NodeAbstractResource: NodeAbstractResource{
+				ResolvedProvider: mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+			},
+		},
+		DeposedKey: states.NewDeposedKey(),
+	}
+	err := node.Execute(ctx, walkApply)
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
NodeDestroyDeposedResourceInstanceObject should not panic if the deposed
state no longer exists.

While we have not confirmed if we can still get into this situation with the current codebase, Execute should not pass a nil state to a function that will panic. Returning an error here will let us better diagnose if this does happen again.

Fixes #27475