### PR TITLE
functions: Fix defaults for null objects/tuples

### DIFF
--- a/lang/funcs/defaults.go
+++ b/lang/funcs/defaults.go
@@ -94,6 +94,12 @@ func defaultsApply(input, fallback cty.Value) cty.Value {
 		return v
 
 	case wantTy.IsObjectType():
+		// For structural types, a null input value must be passed through. We
+		// do not apply default values for missing optional structural values,
+		// only their contents.
+		if input.IsNull() {
+			return input
+		}
 		atys := wantTy.AttributeTypes()
 		ret := map[string]cty.Value{}
 		for attr, aty := range atys {
@@ -107,6 +113,13 @@ func defaultsApply(input, fallback cty.Value) cty.Value {
 		return cty.ObjectVal(ret)
 
 	case wantTy.IsTupleType():
+		// For structural types, a null input value must be passed through. We
+		// do not apply default values for missing optional structural values,
+		// only their contents.
+		if input.IsNull() {
+			return input
+		}
+
 		l := wantTy.Length()
 		ret := make([]cty.Value, l)
 		for i := 0; i < l; i++ {

--- a/lang/funcs/defaults.go
+++ b/lang/funcs/defaults.go
@@ -97,7 +97,11 @@ func defaultsApply(input, fallback cty.Value) cty.Value {
 		// For structural types, a null input value must be passed through. We
 		// do not apply default values for missing optional structural values,
 		// only their contents.
-		if input.IsNull() {
+		//
+		// We also pass through the input if the fallback value is null. This
+		// can happen if the given defaults do not include a value for this
+		// attribute.
+		if input.IsNull() || fallback.IsNull() {
 			return input
 		}
 		atys := wantTy.AttributeTypes()
@@ -116,7 +120,11 @@ func defaultsApply(input, fallback cty.Value) cty.Value {
 		// For structural types, a null input value must be passed through. We
 		// do not apply default values for missing optional structural values,
 		// only their contents.
-		if input.IsNull() {
+		//
+		// We also pass through the input if the fallback value is null. This
+		// can happen if the given defaults do not include a value for this
+		// attribute.
+		if input.IsNull() || fallback.IsNull() {
 			return input
 		}
 

--- a/lang/funcs/defaults_test.go
+++ b/lang/funcs/defaults_test.go
@@ -370,6 +370,34 @@ func TestDefaults(t *testing.T) {
 			Defaults: cty.StringVal("hello"),
 			WantErr:  `only object types and collections of object types can have defaults applied`,
 		},
+		// When applying default values to structural types, null objects or
+		// tuples in the input should be passed through.
+		{
+			Input: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NullVal(cty.Object(map[string]cty.Type{
+					"x": cty.String,
+					"y": cty.String,
+				})),
+				"b": cty.NullVal(cty.Tuple([]cty.Type{cty.String, cty.String})),
+			}),
+			Defaults: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.ObjectVal(map[string]cty.Value{
+					"x": cty.StringVal("hello"),
+					"y": cty.StringVal("there"),
+				}),
+				"b": cty.TupleVal([]cty.Value{
+					cty.StringVal("how are"),
+					cty.StringVal("you?"),
+				}),
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NullVal(cty.Object(map[string]cty.Type{
+					"x": cty.String,
+					"y": cty.String,
+				})),
+				"b": cty.NullVal(cty.Tuple([]cty.Type{cty.String, cty.String})),
+			}),
+		},
 		// When applying default values to collection types, null collections in the
 		// input should result in empty collections in the output.
 		{

--- a/lang/funcs/defaults_test.go
+++ b/lang/funcs/defaults_test.go
@@ -398,6 +398,51 @@ func TestDefaults(t *testing.T) {
 				"b": cty.NullVal(cty.Tuple([]cty.Type{cty.String, cty.String})),
 			}),
 		},
+		// When applying default values to structural types, we permit null
+		// values in the defaults, and just pass through the input value.
+		{
+			Input: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"p": cty.StringVal("xyz"),
+						"q": cty.StringVal("xyz"),
+					}),
+				}),
+				"b": cty.SetVal([]cty.Value{
+					cty.TupleVal([]cty.Value{
+						cty.NumberIntVal(0),
+						cty.NumberIntVal(2),
+					}),
+					cty.TupleVal([]cty.Value{
+						cty.NumberIntVal(1),
+						cty.NumberIntVal(3),
+					}),
+				}),
+				"c": cty.NullVal(cty.String),
+			}),
+			Defaults: cty.ObjectVal(map[string]cty.Value{
+				"c": cty.StringVal("tada"),
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"p": cty.StringVal("xyz"),
+						"q": cty.StringVal("xyz"),
+					}),
+				}),
+				"b": cty.SetVal([]cty.Value{
+					cty.TupleVal([]cty.Value{
+						cty.NumberIntVal(0),
+						cty.NumberIntVal(2),
+					}),
+					cty.TupleVal([]cty.Value{
+						cty.NumberIntVal(1),
+						cty.NumberIntVal(3),
+					}),
+				}),
+				"c": cty.StringVal("tada"),
+			}),
+		},
 		// When applying default values to collection types, null collections in the
 		// input should result in empty collections in the output.
 		{


### PR DESCRIPTION
When using defaults with a value which contains null objects or tuples, we cannot continue to traverse the value and apply defaults. Instead, when we find an attribute which is null, we return early and stop processing this branch.

Previously this would panic. This behaviour is a little counter-intuitive to me, but I think it's consistent with how defaults work. The alternative I considered was replacing the `null` value with a copy of the given fallback object/tuple, but that wasn't obviously correct either.

Fixes #28046.