### PR TITLE
validate provider_meta contains no interpolations

### DIFF
--- a/configs/testdata/invalid-modules/provider-meta/invalid-interpolation.tf
+++ b/configs/testdata/invalid-modules/provider-meta/invalid-interpolation.tf
@@ -1,0 +1,10 @@
+terraform {
+  provider_meta "my-provider" {
+    hello = var.name
+  }
+}
+
+variable "name" {
+  type = string
+}
+

--- a/configs/testdata/valid-modules/provider-meta/main.tf
+++ b/configs/testdata/valid-modules/provider-meta/main.tf
@@ -1,0 +1,5 @@
+terraform {
+  provider_meta "my-provider" {
+    hello = "test-module"
+  }
+}


### PR DESCRIPTION
The `provider_meta` specification does not allow interpolation, but we were not preventing it in the configuration. The `provider_meta` block does not have a defined lifecycle during evaluation, and cannot be correctly ordered to ensure any references have been evaluated. Since `provider_meta` must be an entirely static map, we can validate this early on while loading the configuration. 

Preventing interpolations could be a breaking change for existing modules that were successfully using this undefined behavior, but as demonstrated in #28061 success is not deterministic between releases.

Resolves #28061