### PR TITLE
Add time conversion functions to Terraform HCL

### DIFF
--- a/lang/funcs/time_conv.go
+++ b/lang/funcs/time_conv.go
@@ -1,0 +1,90 @@
+package funcs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+var inSeconds = map[string]float64{
+	"seconds": 1,
+	"minutes": 60,
+	"hours":   60 * 60,
+	"days":    60 * 60 * 24,
+	"weeks":   60 * 60 * 24 * 7,
+}
+
+type interval struct {
+	Magnitude float64
+	Unit      string
+}
+
+// ValidIntervalUnits returns the intervals that can be used in the to_* time conversion functions.
+// It shadows the keys of the inSeconds map, and is largely just a convenience
+// Intentionally missing from ValidIntervalUnits are any measures of time which may have a variable length.
+// For example, a year could be either 365 or 366 days (or other lengths in other calendars!), and a similar situation
+// exists for months. Because of this, we omit them entirely, as this grey area could cause confusion for the user.
+func ValidIntervalUnits() []string {
+	valids := make([]string, 0, len(inSeconds))
+	for k := range inSeconds {
+		valids = append(valids, k)
+	}
+
+	return valids
+}
+
+func validIntervalUnitsWithSingulars() []string {
+	valids := ValidIntervalUnits()
+	withPlurals := make([]string, 0, len(valids)*2)
+	for _, unit := range valids {
+		withPlurals = append(withPlurals, strings.TrimSuffix(unit, "s"))
+		withPlurals = append(withPlurals, unit)
+	}
+	return withPlurals
+}
+
+func parseInterval(intervalStr, caller string) (interval, error) {
+	split := strings.Split(strings.ToLower(intervalStr), " ")
+	magnitude, floatParseErr := strconv.ParseFloat(split[0], 64)
+	unit := split[1]
+	if !strings.HasSuffix(unit, "s") { // If it's not a plural, pluralise it
+		unit += "s"
+	}
+	_, isValidInterval := inSeconds[unit]
+
+	if len(split) != 2 || floatParseErr != nil || !isValidInterval {
+		return interval{}, fmt.Errorf("The argument to %s must be a non-zero number and a valid unit, separated by a single space. Valid units are: %v. Singular and plural units are equivalent", caller, validIntervalUnitsWithSingulars())
+	}
+
+	return interval{Magnitude: magnitude, Unit: unit}, nil
+}
+
+// NewTimeConvFunc returns a cty.Function that will convert a time interval (represented as a string such as "1 day", "127 hours" or "36 minutes")
+// into the given unit. NewTimeConvFunc will panic if it's passed a unit that's not in funcs.ValidIntervalUnits
+func NewTimeConvFunc(toUnit string) function.Function {
+	if _, ok := inSeconds[toUnit]; !ok {
+		panic(fmt.Sprintf("The interval passed to NewTimeConvFunc (%s) must be a valid interval. Valid intervals are %v", toUnit, ValidIntervalUnits()))
+	}
+
+	return function.New(&function.Spec{
+		Params: []function.Parameter{{
+			Name: "interval",
+			Type: cty.String,
+		}},
+		Type: function.StaticReturnType(cty.Number),
+		Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+			intervalStr := args[0].AsString()
+
+			interval, err := parseInterval(intervalStr, "to_seconds")
+			if err != nil {
+				return cty.UnknownVal(cty.String), err
+			}
+
+			result := (interval.Magnitude * inSeconds[interval.Unit]) / inSeconds[toUnit]
+			return cty.NumberFloatVal(result), nil
+		},
+	})
+}

--- a/lang/funcs/time_conv_test.go
+++ b/lang/funcs/time_conv_test.go
@@ -1,0 +1,246 @@
+package funcs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+type testCase struct {
+	Interval cty.Value
+	Want     cty.Value
+	Err      bool
+}
+
+func TestToSeconds(t *testing.T) {
+	tests := []testCase{
+		{
+			cty.StringVal("30 seconds"),
+			cty.NumberIntVal(30),
+			false,
+		},
+		{
+			cty.StringVal("1 minute"),
+			cty.NumberIntVal(60),
+			false,
+		},
+		{
+			cty.StringVal("1 minutes"),
+			cty.NumberIntVal(60),
+			false,
+		},
+		{
+			cty.StringVal("1 MiNuTe"),
+			cty.NumberIntVal(60),
+			false,
+		},
+		{
+			cty.StringVal("1.5 minutes"),
+			cty.NumberIntVal(90),
+			false,
+		},
+		{
+			cty.StringVal("1 hour"),
+			cty.NumberIntVal(3600),
+			false,
+		},
+		{
+			cty.StringVal("9 years"),
+			cty.UnknownVal(cty.String),
+			true,
+		},
+		{
+			cty.StringVal("not a real interval"),
+			cty.UnknownVal(cty.String),
+			true,
+		},
+	}
+	run(t, "to_seconds", NewTimeConvFunc("seconds"), tests)
+}
+
+func TestToMinutes(t *testing.T) {
+	tests := []testCase{
+		{
+			cty.StringVal("30 minute"),
+			cty.NumberFloatVal(30),
+			false,
+		},
+		{
+			cty.StringVal("60 seconds"),
+			cty.NumberFloatVal(1),
+			false,
+		},
+		{
+			cty.StringVal("60 SeCoNdS"),
+			cty.NumberFloatVal(1),
+			false,
+		},
+		{
+			cty.StringVal("1.5 hours"),
+			cty.NumberIntVal(90),
+			false,
+		},
+		{
+			cty.StringVal("1 day"),
+			cty.NumberIntVal(1440),
+			false,
+		},
+		{
+			cty.StringVal("9 years"),
+			cty.UnknownVal(cty.String),
+			true,
+		},
+		{
+			cty.StringVal("not a real interval"),
+			cty.UnknownVal(cty.String),
+			true,
+		},
+	}
+	run(t, "to_minutes", NewTimeConvFunc("minutes"), tests)
+}
+
+func TestToHours(t *testing.T) {
+	tests := []testCase{
+		{
+			cty.StringVal("2 hours"),
+			cty.NumberFloatVal(2),
+			false,
+		},
+		{
+			cty.StringVal("30 minute"),
+			cty.NumberFloatVal(0.5),
+			false,
+		},
+		{
+			cty.StringVal("30 minutes"),
+			cty.NumberFloatVal(0.5),
+			false,
+		},
+		{
+			cty.StringVal("30 MiNuTeS"),
+			cty.NumberFloatVal(0.5),
+			false,
+		},
+		{
+			cty.StringVal("1.5 days"),
+			cty.NumberIntVal(36),
+			false,
+		},
+		{
+			cty.StringVal("1 week"),
+			cty.NumberIntVal(168),
+			false,
+		},
+		{
+			cty.StringVal("9 years"),
+			cty.UnknownVal(cty.String),
+			true,
+		},
+		{
+			cty.StringVal("not a real interval"),
+			cty.UnknownVal(cty.String),
+			true,
+		},
+	}
+	run(t, "to_hours", NewTimeConvFunc("hours"), tests)
+}
+
+func TestToDays(t *testing.T) {
+	tests := []testCase{
+		{
+			cty.StringVal("7 days"),
+			cty.NumberFloatVal(7),
+			false,
+		},
+		{
+			cty.StringVal("24 hours"),
+			cty.NumberFloatVal(1),
+			false,
+		},
+		{
+			cty.StringVal("36 hours"),
+			cty.NumberFloatVal(1.5),
+			false,
+		},
+		{
+			cty.StringVal("36 HoUrS"),
+			cty.NumberFloatVal(1.5),
+			false,
+		},
+		{
+			cty.StringVal("1.5 weeks"),
+			cty.NumberFloatVal(10.5),
+			false,
+		},
+		{
+			cty.StringVal("1 week"),
+			cty.NumberIntVal(7),
+			false,
+		},
+		{
+			cty.StringVal("9 years"),
+			cty.UnknownVal(cty.String),
+			true,
+		},
+		{
+			cty.StringVal("not a real interval"),
+			cty.UnknownVal(cty.String),
+			true,
+		},
+	}
+	run(t, "to_days", NewTimeConvFunc("days"), tests)
+}
+
+func TestToWeeks(t *testing.T) {
+	tests := []testCase{
+		{
+			cty.StringVal("1 week"),
+			cty.NumberFloatVal(1),
+			false,
+		},
+		{
+			cty.StringVal("7 days"),
+			cty.NumberFloatVal(1),
+			false,
+		},
+		{
+			cty.StringVal("364 days"),
+			cty.NumberFloatVal(52),
+			false,
+		},
+		{
+			cty.StringVal("9 years"),
+			cty.UnknownVal(cty.String),
+			true,
+		},
+		{
+			cty.StringVal("not a real interval"),
+			cty.UnknownVal(cty.String),
+			true,
+		},
+	}
+	run(t, "to_weeks", NewTimeConvFunc("weeks"), tests)
+}
+
+func run(t *testing.T, funcName string, callable function.Function, tests []testCase) {
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s(%q)", funcName, test.Interval.AsString()), func(t *testing.T) {
+			got, err := callable.Call([]cty.Value{test.Interval})
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}

--- a/lang/functions.go
+++ b/lang/functions.go
@@ -149,6 +149,10 @@ func (s *Scope) Functions() map[string]function.Function {
 			return s.funcs
 		})
 
+		for _, interval := range funcs.ValidIntervalUnits() {
+			s.funcs[fmt.Sprintf("to_%s", interval)] = funcs.NewTimeConvFunc(interval)
+		}
+
 		if s.PureOnly {
 			// Force our few impure functions to return unknown so that we
 			// can defer evaluating them until a later pass.

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -853,6 +853,41 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"to_seconds": {
+			{
+				`to_seconds("1 minute")`,
+				cty.NumberIntVal(60),
+			},
+		},
+
+		"to_days": {
+			{
+				`to_days("52 weeks")`,
+				cty.NumberIntVal(364),
+			},
+		},
+
+		"to_hours": {
+			{
+				`to_hours("90 minutes")`,
+				cty.NumberFloatVal(1.5),
+			},
+		},
+
+		"to_minutes": {
+			{
+				`to_minutes("2 hours")`,
+				cty.NumberIntVal(120),
+			},
+		},
+
+		"to_weeks": {
+			{
+				`to_weeks("3.5 days")`,
+				cty.NumberFloatVal(0.5),
+			},
+		},
+
 		"tobool": {
 			{
 				`tobool("false")`,


### PR DESCRIPTION
## Rationale
Many terraform resources express time intervals as integers, but this often leaves the actual unit of the interval unclear. Consider the following example:
```HCL
resource "provider_imaginary_queue" "message_queue" {
  name              = "bmosky's queue"
  message_retention = 1209600
}
```

Given the information on hand, without looking at the docs (or commenting your terraform code), it's impossible to actually know how long messages are retained for. 

## Summary
This PR adds builtin functions to terraform to allow users to input declarative time intervals. This allows us to replace the above code with:
```HCL
resource "provider_imaginary_queue" "message_queue" {
  name              = "bmosky's queue"
  message_retention = to_seconds("2 weeks")
}
```

It's now very clear from looking just at the resource that:
  a. The unit for message retention is seconds
  b. That we've set it to 2 weeks aka 1,209,600 seconds.

This PR includes methods for conversion to and from seconds, minutes, hours, days and weeks. 
```HCL
to_seconds("2 weeks")   # => 1_209_600
to_minutes("1.5 hours") # => 90
to_hours("1.7 weeks")   # => 2_448
to_days("24 hours")     # => 1
to_weeks("28 Days")     # => 4
```
If we decide to add other time periods, this should be as simple as adding them to the `toSeconds` map in the `funcs` package 

## Implementation Notes
I've set up the interval parsing to intentionally be as straightforward as possible - an interval string is always a number (float or int), followed by a unit, which must be one of `[second minute hour day week]`, allowing plurals. I've left the door open to add more units as we see fit. Explicitly out of scope is doing any more advanced parsing of interval strings - ie, trying to run 
```HCL
to_seconds("five hours")
// or
to_seconds("5 hours and 7 minutes")
```
will always fail, by design. Doing any sort of complex string parsing like that would cause problems, I think.

## Open Questions
- Though I've named the functions `to_$units`, I'm not 100% happy with this name - I think there's possible cognitive overlap with the `to$type` functions - `tolist()`, `tomap()` etc. Perhaps something like `in_units` eg `in_seconds`, `in_minutes` might remove that overlap, but it's also slightly harder to parse when reading. Very keen to get input on this.

# #TODO
- [ ] Write docs for the docs website - I'll do this once the code is reviewed and the API is confirmed