### PR TITLE
backend/remote: Fix new workspace state migration

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -854,6 +854,13 @@ func (b *Remote) VerifyWorkspaceTerraformVersion(workspaceName string) tfdiags.D
 
 	workspace, err := b.getRemoteWorkspace(context.Background(), workspaceName)
 	if err != nil {
+		// If the workspace doesn't exist, there can be no compatibility
+		// problem, so we can return. This is most likely to happen when
+		// migrating state from a local backend to a new workspace.
+		if err == tfe.ErrResourceNotFound {
+			return nil
+		}
+
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Error looking up workspace",

--- a/backend/remote/backend_test.go
+++ b/backend/remote/backend_test.go
@@ -629,8 +629,15 @@ func TestRemote_VerifyWorkspaceTerraformVersion_workspaceErrors(t *testing.T) {
 	defer bCleanup()
 
 	// Attempting to check the version against a workspace which doesn't exist
-	// should fail
+	// should result in no errors
 	diags := b.VerifyWorkspaceTerraformVersion("invalid-workspace")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected error: %s", diags.Err())
+	}
+
+	// Use a special workspace ID to trigger a 500 error, which should result
+	// in a failed check
+	diags = b.VerifyWorkspaceTerraformVersion("network-error")
 	if len(diags) != 1 {
 		t.Fatal("expected diag, but none returned")
 	}


### PR DESCRIPTION
When migrating state to a new workspace, the version check would error due to a 404 error on fetching the workspace record. This would result in failed state migration.

Instead we should look specifically for a 404 error, and allow migration to continue. If we're just about to create the workspace, there can't be a version incompatibility problem.

Fixes #28092, which was introduced in 0.14.5. Proposing backport to 0.14 and 0.15.