### PR TITLE
Downgrade concluded experiment error to warning

### DIFF
--- a/configs/experiments.go
+++ b/configs/experiments.go
@@ -117,9 +117,9 @@ func decodeExperimentsAttr(attr *hcl.Attribute) (experiments.Set, hcl.Diagnostic
 			})
 		case experiments.ConcludedError:
 			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
+				Severity: hcl.DiagWarning,
 				Summary:  "Experiment has concluded",
-				Detail:   fmt.Sprintf("Experiment %q is no longer available. %s", kw, err.Message),
+				Detail:   fmt.Sprintf("Experiment %q is no longer available and you may remove this experiment's keyword from your configuration. %s", kw, err.Message),
 				Subject:  expr.Range().Ptr(),
 			})
 		case nil:

--- a/configs/experiments_test.go
+++ b/configs/experiments_test.go
@@ -55,9 +55,9 @@ func TestExperimentsConfig(t *testing.T) {
 		}
 		got := diags[0]
 		want := &hcl.Diagnostic{
-			Severity: hcl.DiagError,
+			Severity: hcl.DiagWarning,
 			Summary:  `Experiment has concluded`,
-			Detail:   `Experiment "concluded" is no longer available. Reticulate your splines.`,
+			Detail:   `Experiment "concluded" is no longer available and you may remove this experiment's keyword from your configuration. Reticulate your splines.`,
 			Subject: &hcl.Range{
 				Filename: "testdata/experiments/concluded/concluded_experiment.tf",
 				Start:    hcl.Pos{Line: 2, Column: 18, Byte: 29},


### PR DESCRIPTION
This PR is meant as a proposal: Rather than error when users have a concluded experiment remaining in their config, downgrade this error to a warning.

The motivation behind proposing this change is an argument that we should encourage our users to use experiments, and when experiments "graduate", causing our kind testers' configs to error (which can disrupt workflows completely) versus warn (to invite them to update their config).

I understand the trade-off/philosophy is that we should give an error to enforce correct behavior (remove the concluded experiment) but I think this is a case where we can offer users some grace.