### PR TITLE
Fix type conversion panic

### DIFF
--- a/backend/remote-state/etcdv3/backend_test.go
+++ b/backend/remote-state/etcdv3/backend_test.go
@@ -60,12 +60,12 @@ func TestBackend(t *testing.T) {
 
 	// Get the backend. We need two to test locking.
 	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"endpoints": etcdv3Endpoints,
+		"endpoints": stringsToInterfaces(etcdv3Endpoints),
 		"prefix":    prefix,
 	}))
 
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"endpoints": etcdv3Endpoints,
+		"endpoints": stringsToInterfaces(etcdv3Endpoints),
 		"prefix":    prefix,
 	}))
 
@@ -83,17 +83,25 @@ func TestBackend_lockDisabled(t *testing.T) {
 
 	// Get the backend. We need two to test locking.
 	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"endpoints": etcdv3Endpoints,
+		"endpoints": stringsToInterfaces(etcdv3Endpoints),
 		"prefix":    prefix,
 		"lock":      false,
 	}))
 
 	b2 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"endpoints": etcdv3Endpoints,
+		"endpoints": stringsToInterfaces(etcdv3Endpoints),
 		"prefix":    prefix + "/" + "different", // Diff so locking test would fail if it was locking
 		"lock":      false,
 	}))
 
 	// Test
 	backend.TestBackendStateLocks(t, b1, b2)
+}
+
+func stringsToInterfaces(strSlice []string) []interface{} {
+	var interfaceSlice []interface{}
+	for _, v := range strSlice {
+		interfaceSlice = append(interfaceSlice, v)
+	}
+	return interfaceSlice
 }

--- a/backend/remote-state/etcdv3/client_test.go
+++ b/backend/remote-state/etcdv3/client_test.go
@@ -23,7 +23,7 @@ func TestRemoteClient(t *testing.T) {
 
 	// Get the backend
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"endpoints": etcdv3Endpoints,
+		"endpoints": stringsToInterfaces(etcdv3Endpoints),
 		"prefix":    prefix,
 	}))
 
@@ -45,7 +45,7 @@ func TestEtcdv3_stateLock(t *testing.T) {
 
 	// Get the backend
 	s1, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"endpoints": etcdv3Endpoints,
+		"endpoints": stringsToInterfaces(etcdv3Endpoints),
 		"prefix":    prefix,
 	})).StateMgr(backend.DefaultStateName)
 	if err != nil {
@@ -53,7 +53,7 @@ func TestEtcdv3_stateLock(t *testing.T) {
 	}
 
 	s2, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"endpoints": etcdv3Endpoints,
+		"endpoints": stringsToInterfaces(etcdv3Endpoints),
 		"prefix":    prefix,
 	})).StateMgr(backend.DefaultStateName)
 	if err != nil {
@@ -71,7 +71,7 @@ func TestEtcdv3_destroyLock(t *testing.T) {
 
 	// Get the backend
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"endpoints": etcdv3Endpoints,
+		"endpoints": stringsToInterfaces(etcdv3Endpoints),
 		"prefix":    prefix,
 	}))
 


### PR DESCRIPTION
etcdv3 acceptance tests fail due to attempting to pass slices of strings
for the endpoints config to HCL2ValueFromConfigValue() which does not
handle that type.

Not a pretty solution but a helper function that converts the endpoints to a slice of
empty interfaces satisfies the requirements of the
HCL2ValueFromConfigValue function.

fixes https://github.com/hashicorp/terraform/issues/28096