### PR TITLE
Fix duplicate default state

### DIFF
--- a/backend/remote-state/etcdv3/backend_state.go
+++ b/backend/remote-state/etcdv3/backend_state.go
@@ -23,7 +23,9 @@ func (b *Backend) Workspaces() ([]string, error) {
 	result := make([]string, 1, len(res.Kvs)+1)
 	result[0] = backend.DefaultStateName
 	for _, kv := range res.Kvs {
-		result = append(result, strings.TrimPrefix(string(kv.Key), b.prefix))
+		if strings.TrimPrefix(string(kv.Key), b.prefix) != backend.DefaultStateName {
+			result = append(result, strings.TrimPrefix(string(kv.Key), b.prefix))
+		}
 	}
 	sort.Strings(result[1:])
 


### PR DESCRIPTION
The default state is already explicitly added to the result slice. Added
a guard to prevent it being added a second time.

Fixes https://github.com/hashicorp/terraform/issues/28098