### PR TITLE
Update documentation for provider_sensitive_attrs experiment

### DIFF
--- a/website/docs/language/expressions/references.html.md
+++ b/website/docs/language/expressions/references.html.md
@@ -336,12 +336,13 @@ _derive_ from a sensitive resource attribute will not themselves be considered
 sensitive, and so Terraform will include those derived values in its output
 without redacting them.
 
-Terraform v0.14.0 and later has an
-[experimental feature](/docs/language/settings/index.html#experimental-language-features)
-to treat resource attributes that are marked as sensitive in the same way as
-sensitive input variables and output values, so that Terraform will consider
-any derived values as sensitive too. You can activate that experiment for your
-module using the `provider_sensitive_attrs` experiment keyword:
+Terraform v0.15.0 and later treats resource attributes that are marked as
+sensitive (by the provider) in the same way as sensitive input variables and
+output values, so that Terraform will consider any derived values as sensitive too.
+
+If you are using Terraform v0.14.x, this feature is considered experimental.
+You can activate that experiment for your module using the
+`provider_sensitive_attrs` experiment keyword:
 
 ```hcl
 terraform {

--- a/website/docs/language/meta-arguments/for_each.html.md
+++ b/website/docs/language/meta-arguments/for_each.html.md
@@ -109,10 +109,10 @@ main evaluation step.
 
 Sensitive values, such as [sensitive input variables](https://www.terraform.io/docs/language/values/variables.html#suppressing-values-in-cli-output),
 [sensitive outputs](https://www.terraform.io/docs/language/values/outputs.html#sensitive-suppressing-values-in-cli-output),
-or [sensitive resource attributes](https://www.terraform.io/docs/language/expressions/references.html#sensitive-resource-attributes)
-(if the `provider_sensitive_attrs` experiment is enabled), cannot be used as arguments
-to `for_each`. The value used in `for_each` is used to identify the resource instance
-and will always be disclosed in UI output, which is why sensitive values are not allowed.
+or [sensitive resource attributes](https://www.terraform.io/docs/language/expressions/references.html#sensitive-resource-attributes),
+cannot be used as arguments to `for_each`. The value used in `for_each` is used
+to identify the resource instance and will always be disclosed in UI output,
+which is why sensitive values are not allowed.
 Attempts to use sensitive values as `for_each` arguments will result in an error.
 
 If you transform a value containing sensitive data into an argument to be used in `for_each`, be aware that


### PR DESCRIPTION
Update documentation to reference that this experiment is now default in 0.15+. My apologies that these docs updates should have been included in the PR upgrading this experiment.