### PR TITLE
command/jsonprovider: bump format version

### DIFF
--- a/command/jsonprovider/provider.go
+++ b/command/jsonprovider/provider.go
@@ -9,7 +9,7 @@ import (
 // FormatVersion represents the version of the json format and will be
 // incremented for any change to this format that requires changes to a
 // consuming parser.
-const FormatVersion = "0.1"
+const FormatVersion = "0.2"
 
 // providers is the top-level object returned when exporting provider schemas
 type providers struct {

--- a/command/testdata/providers-schema/basic/output.json
+++ b/command/testdata/providers-schema/basic/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.1",
+    "format_version": "0.2",
     "provider_schemas": {
         "registry.terraform.io/hashicorp/test": {
             "provider": {

--- a/command/testdata/providers-schema/empty/output.json
+++ b/command/testdata/providers-schema/empty/output.json
@@ -1,3 +1,3 @@
 {
-    "format_version": "0.1"
+    "format_version": "0.2"
 }

--- a/command/testdata/providers-schema/required/output.json
+++ b/command/testdata/providers-schema/required/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.1",
+    "format_version": "0.2",
     "provider_schemas": {
         "registry.terraform.io/hashicorp/test": {
             "provider": {


### PR DESCRIPTION
Support for attributes with NestedTypes was added in https://github.com/hashicorp/terraform/pull/28055, and that PR should have included a format version bump: this is a backwards-compatible change, but consumers will need to be updated in order to properly decode attributes (with NestedTypes) going forward.

Thanks @bflad for the nudge! 

@vancluever , I am sorry I did not include you on the last PR (#28055); if you have questions / see any problems / have any requests I'll get right on 'em. 