### PR TITLE
terraform: validate providers' schemas during NewContext

### DIFF
--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -940,7 +940,7 @@ func TestPlan_init_required(t *testing.T) {
 		t.Fatalf("expected error, got success")
 	}
 	got := output.Stderr()
-	if !strings.Contains(got, `Plugin reinitialization required. Please run "terraform init".`) {
+	if !strings.Contains(got, `Error: Could not load plugin`) {
 		t.Fatal("wrong error message in output:", got)
 	}
 }

--- a/configs/configschema/decoder_spec.go
+++ b/configs/configschema/decoder_spec.go
@@ -92,10 +92,10 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 
 	for name, blockS := range b.BlockTypes {
 		if _, exists := ret[name]; exists {
-			// This indicates an invalid schema, since it's not valid to
-			// define both an attribute and a block type of the same name.
-			// However, we don't raise this here since it's checked by
-			// InternalValidate.
+			// This indicates an invalid schema, since it's not valid to define
+			// both an attribute and a block type of the same name. We assume
+			// that the provider has already used something like
+			// InternalValidate to validate their schema.
 			continue
 		}
 
@@ -104,7 +104,7 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 		// We can only validate 0 or 1 for MinItems, because a dynamic block
 		// may satisfy any number of min items while only having a single
 		// block in the config. We cannot validate MaxItems because a
-		// configuration may have any number of dynamic blocks
+		// configuration may have any number of dynamic blocks.
 		minItems := 0
 		if blockS.MinItems > 1 {
 			minItems = 1
@@ -145,10 +145,12 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 			}
 		case NestingSet:
 			// We forbid dynamically-typed attributes inside NestingSet in
-			// InternalValidate, so we don't do anything special to handle
-			// that here. (There is no set analog to tuple and object types,
-			// because cty's set implementation depends on knowing the static
-			// type in order to properly compute its internal hashes.)
+			// InternalValidate, so we don't do anything special to handle that
+			// here. (There is no set analog to tuple and object types, because
+			// cty's set implementation depends on knowing the static type in
+			// order to properly compute its internal hashes.)  We assume that
+			// the provider has already used something like InternalValidate to
+			// validate their schema.
 			ret[name] = &hcldec.BlockSetSpec{
 				TypeName: name,
 				Nested:   childSpec,
@@ -174,7 +176,8 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 			}
 		default:
 			// Invalid nesting type is just ignored. It's checked by
-			// InternalValidate.
+			// InternalValidate.  We assume that the provider has already used
+			// something like InternalValidate to validate their schema.
 			continue
 		}
 	}
@@ -190,9 +193,10 @@ func (a *Attribute) decoderSpec(name string) hcldec.Spec {
 	}
 
 	if a.NestedType != nil {
-		// FIXME: a panic() is a bad UX. Fix this, probably by extending
-		// InternalValidate() to check Attribute schemas as well and calling it
-		// when we get the schema from the provider in Context().
+		// FIXME: a panic() is a bad UX. InternalValidate() can check Attribute
+		// schemas as well so a fix might be to call it when we get the schema
+		// from the provider in Context(). Since this could be a breaking
+		// change, we'd need to communicate well before adding that call.
 		if a.Type != cty.NilType {
 			panic("Invalid attribute schema: NestedType and Type cannot both be set. This is a bug in the provider.")
 		}

--- a/configs/configschema/internal_validate.go
+++ b/configs/configschema/internal_validate.go
@@ -21,50 +21,51 @@ func (b *Block) InternalValidate() error {
 	if b == nil {
 		return fmt.Errorf("top-level block schema is nil")
 	}
-	return b.internalValidate("", nil)
-
+	return b.internalValidate("")
 }
 
-func (b *Block) internalValidate(prefix string, err error) error {
+func (b *Block) internalValidate(prefix string) error {
+	var multiErr *multierror.Error
+
 	for name, attrS := range b.Attributes {
 		if attrS == nil {
-			err = multierror.Append(err, fmt.Errorf("%s%s: attribute schema is nil", prefix, name))
+			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: attribute schema is nil", prefix, name))
 			continue
 		}
-		err = multierror.Append(err, attrS.internalValidate(name, prefix))
+		multiErr = multierror.Append(multiErr, attrS.internalValidate(name, prefix))
 	}
 
 	for name, blockS := range b.BlockTypes {
 		if blockS == nil {
-			err = multierror.Append(err, fmt.Errorf("%s%s: block schema is nil", prefix, name))
+			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: block schema is nil", prefix, name))
 			continue
 		}
 
 		if _, isAttr := b.Attributes[name]; isAttr {
-			err = multierror.Append(err, fmt.Errorf("%s%s: name defined as both attribute and child block type", prefix, name))
+			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: name defined as both attribute and child block type", prefix, name))
 		} else if !validName.MatchString(name) {
-			err = multierror.Append(err, fmt.Errorf("%s%s: name may contain only lowercase letters, digits and underscores", prefix, name))
+			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: name may contain only lowercase letters, digits and underscores", prefix, name))
 		}
 
 		if blockS.MinItems < 0 || blockS.MaxItems < 0 {
-			err = multierror.Append(err, fmt.Errorf("%s%s: MinItems and MaxItems must both be greater than zero", prefix, name))
+			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must both be greater than zero", prefix, name))
 		}
 
 		switch blockS.Nesting {
 		case NestingSingle:
 			switch {
 			case blockS.MinItems != blockS.MaxItems:
-				err = multierror.Append(err, fmt.Errorf("%s%s: MinItems and MaxItems must match in NestingSingle mode", prefix, name))
+				multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must match in NestingSingle mode", prefix, name))
 			case blockS.MinItems < 0 || blockS.MinItems > 1:
-				err = multierror.Append(err, fmt.Errorf("%s%s: MinItems and MaxItems must be set to either 0 or 1 in NestingSingle mode", prefix, name))
+				multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must be set to either 0 or 1 in NestingSingle mode", prefix, name))
 			}
 		case NestingGroup:
 			if blockS.MinItems != 0 || blockS.MaxItems != 0 {
-				err = multierror.Append(err, fmt.Errorf("%s%s: MinItems and MaxItems cannot be used in NestingGroup mode", prefix, name))
+				multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems cannot be used in NestingGroup mode", prefix, name))
 			}
 		case NestingList, NestingSet:
 			if blockS.MinItems > blockS.MaxItems && blockS.MaxItems != 0 {
-				err = multierror.Append(err, fmt.Errorf("%s%s: MinItems must be less than or equal to MaxItems in %s mode", prefix, name, blockS.Nesting))
+				multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems must be less than or equal to MaxItems in %s mode", prefix, name, blockS.Nesting))
 			}
 			if blockS.Nesting == NestingSet {
 				ety := blockS.Block.ImpliedType()
@@ -72,22 +73,22 @@ func (b *Block) internalValidate(prefix string, err error) error {
 					// This is not permitted because the HCL (cty) set implementation
 					// needs to know the exact type of set elements in order to
 					// properly hash them, and so can't support mixed types.
-					err = multierror.Append(err, fmt.Errorf("%s%s: NestingSet blocks may not contain attributes of cty.DynamicPseudoType", prefix, name))
+					multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: NestingSet blocks may not contain attributes of cty.DynamicPseudoType", prefix, name))
 				}
 			}
 		case NestingMap:
 			if blockS.MinItems != 0 || blockS.MaxItems != 0 {
-				err = multierror.Append(err, fmt.Errorf("%s%s: MinItems and MaxItems must both be 0 in NestingMap mode", prefix, name))
+				multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must both be 0 in NestingMap mode", prefix, name))
 			}
 		default:
-			err = multierror.Append(err, fmt.Errorf("%s%s: invalid nesting mode %s", prefix, name, blockS.Nesting))
+			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: invalid nesting mode %s", prefix, name, blockS.Nesting))
 		}
 
 		subPrefix := prefix + name + "."
-		err = blockS.Block.internalValidate(subPrefix, err)
+		multiErr = multierror.Append(multiErr, blockS.Block.internalValidate(subPrefix))
 	}
 
-	return err
+	return multiErr.ErrorOrNil()
 }
 
 // InternalValidate returns an error if the receiving attribute and its child
@@ -101,11 +102,13 @@ func (a *Attribute) InternalValidate(name string) error {
 }
 
 func (a *Attribute) internalValidate(name, prefix string) error {
-	var err error
+	var err *multierror.Error
 
+	/* FIXME: this validation breaks certain existing providers and cannot be enforced without coordination.
 	if !validName.MatchString(name) {
 		err = multierror.Append(err, fmt.Errorf("%s%s: name may contain only lowercase letters, digits and underscores", prefix, name))
 	}
+	*/
 	if !a.Optional && !a.Required && !a.Computed {
 		err = multierror.Append(err, fmt.Errorf("%s%s: must set Optional, Required or Computed", prefix, name))
 	}
@@ -164,5 +167,5 @@ func (a *Attribute) internalValidate(name, prefix string) error {
 		}
 	}
 
-	return err
+	return err.ErrorOrNil()
 }

--- a/configs/configschema/internal_validate.go
+++ b/configs/configschema/internal_validate.go
@@ -11,12 +11,12 @@ import (
 
 var validName = regexp.MustCompile(`^[a-z0-9_]+$`)
 
-// InternalValidate returns an error if the receiving block and its child
-// schema definitions have any inconsistencies with the documented rules for
-// valid schema.
+// InternalValidate returns an error if the receiving block and its child schema
+// definitions have any inconsistencies with the documented rules for valid
+// schema.
 //
-// This is intended to be used within unit tests to detect when a given
-// schema is invalid.
+// This can be used within unit tests to detect when a given schema is invalid,
+// and is run when terraform loads provider schemas during NewContext.
 func (b *Block) InternalValidate() error {
 	if b == nil {
 		return fmt.Errorf("top-level block schema is nil")

--- a/configs/configschema/internal_validate_test.go
+++ b/configs/configschema/internal_validate_test.go
@@ -131,17 +131,18 @@ func TestBlockInternalValidate(t *testing.T) {
 			},
 			[]string{"foo: either Type or NestedType must be defined"},
 		},
-		"attribute with invalid name": {
-			&Block{
-				Attributes: map[string]*Attribute{
-					"fooBar": {
-						Type:     cty.String,
-						Optional: true,
-					},
-				},
-			},
-			[]string{"fooBar: name may contain only lowercase letters, digits and underscores"},
+		/* FIXME: This caused errors when applied to existing providers (oci)
+		and cannot be enforced without coordination.
+
+		"attribute with invalid name": {&Block{Attributes:
+		    map[string]*Attribute{"fooBar": {Type:     cty.String, Optional:
+		    true,
+		            },
+		        },
+		    },
+		    []string{"fooBar: name may contain only lowercase letters, digits and underscores"},
 		},
+		*/
 		"attribute with invalid NestedType nesting": {
 			&Block{
 				Attributes: map[string]*Attribute{

--- a/configs/configschema/internal_validate_test.go
+++ b/configs/configschema/internal_validate_test.go
@@ -20,54 +20,54 @@ func TestBlockInternalValidate(t *testing.T) {
 		"valid": {
 			&Block{
 				Attributes: map[string]*Attribute{
-					"foo": &Attribute{
+					"foo": {
 						Type:     cty.String,
 						Required: true,
 					},
-					"bar": &Attribute{
+					"bar": {
 						Type:     cty.String,
 						Optional: true,
 					},
-					"baz": &Attribute{
+					"baz": {
 						Type:     cty.String,
 						Computed: true,
 					},
-					"baz_maybe": &Attribute{
+					"baz_maybe": {
 						Type:     cty.String,
 						Optional: true,
 						Computed: true,
 					},
 				},
 				BlockTypes: map[string]*NestedBlock{
-					"single": &NestedBlock{
+					"single": {
 						Nesting: NestingSingle,
 						Block:   Block{},
 					},
-					"single_required": &NestedBlock{
+					"single_required": {
 						Nesting:  NestingSingle,
 						Block:    Block{},
 						MinItems: 1,
 						MaxItems: 1,
 					},
-					"list": &NestedBlock{
+					"list": {
 						Nesting: NestingList,
 						Block:   Block{},
 					},
-					"list_required": &NestedBlock{
+					"list_required": {
 						Nesting:  NestingList,
 						Block:    Block{},
 						MinItems: 1,
 					},
-					"set": &NestedBlock{
+					"set": {
 						Nesting: NestingSet,
 						Block:   Block{},
 					},
-					"set_required": &NestedBlock{
+					"set_required": {
 						Nesting:  NestingSet,
 						Block:    Block{},
 						MinItems: 1,
 					},
-					"map": &NestedBlock{
+					"map": {
 						Nesting: NestingMap,
 						Block:   Block{},
 					},
@@ -78,7 +78,7 @@ func TestBlockInternalValidate(t *testing.T) {
 		"attribute with no flags set": {
 			&Block{
 				Attributes: map[string]*Attribute{
-					"foo": &Attribute{
+					"foo": {
 						Type: cty.String,
 					},
 				},
@@ -88,7 +88,7 @@ func TestBlockInternalValidate(t *testing.T) {
 		"attribute required and optional": {
 			&Block{
 				Attributes: map[string]*Attribute{
-					"foo": &Attribute{
+					"foo": {
 						Type:     cty.String,
 						Required: true,
 						Optional: true,
@@ -100,7 +100,7 @@ func TestBlockInternalValidate(t *testing.T) {
 		"attribute required and computed": {
 			&Block{
 				Attributes: map[string]*Attribute{
-					"foo": &Attribute{
+					"foo": {
 						Type:     cty.String,
 						Required: true,
 						Computed: true,
@@ -112,7 +112,7 @@ func TestBlockInternalValidate(t *testing.T) {
 		"attribute optional and computed": {
 			&Block{
 				Attributes: map[string]*Attribute{
-					"foo": &Attribute{
+					"foo": {
 						Type:     cty.String,
 						Optional: true,
 						Computed: true,
@@ -124,17 +124,17 @@ func TestBlockInternalValidate(t *testing.T) {
 		"attribute with missing type": {
 			&Block{
 				Attributes: map[string]*Attribute{
-					"foo": &Attribute{
+					"foo": {
 						Optional: true,
 					},
 				},
 			},
-			[]string{"foo: Type must be set to something other than cty.NilType"},
+			[]string{"foo: either Type or NestedType must be defined"},
 		},
 		"attribute with invalid name": {
 			&Block{
 				Attributes: map[string]*Attribute{
-					"fooBar": &Attribute{
+					"fooBar": {
 						Type:     cty.String,
 						Optional: true,
 					},
@@ -142,10 +142,45 @@ func TestBlockInternalValidate(t *testing.T) {
 			},
 			[]string{"fooBar: name may contain only lowercase letters, digits and underscores"},
 		},
+		"attribute with invalid NestedType nesting": {
+			&Block{
+				Attributes: map[string]*Attribute{
+					"foo": {
+						NestedType: &Object{
+							Nesting:  NestingSingle,
+							MinItems: 10,
+							MaxItems: 10,
+						},
+						Optional: true,
+					},
+				},
+			},
+			[]string{"foo: MinItems and MaxItems must be set to either 0 or 1 in NestingSingle mode"},
+		},
+		"attribute with invalid NestedType attribute": {
+			&Block{
+				Attributes: map[string]*Attribute{
+					"foo": {
+						NestedType: &Object{
+							Nesting: NestingSingle,
+							Attributes: map[string]*Attribute{
+								"foo": {
+									Type:     cty.String,
+									Required: true,
+									Optional: true,
+								},
+							},
+						},
+						Optional: true,
+					},
+				},
+			},
+			[]string{"foo: cannot set both Optional and Required"},
+		},
 		"block type with invalid name": {
 			&Block{
 				BlockTypes: map[string]*NestedBlock{
-					"fooBar": &NestedBlock{
+					"fooBar": {
 						Nesting: NestingSingle,
 					},
 				},
@@ -155,13 +190,13 @@ func TestBlockInternalValidate(t *testing.T) {
 		"colliding names": {
 			&Block{
 				Attributes: map[string]*Attribute{
-					"foo": &Attribute{
+					"foo": {
 						Type:     cty.String,
 						Optional: true,
 					},
 				},
 				BlockTypes: map[string]*NestedBlock{
-					"foo": &NestedBlock{
+					"foo": {
 						Nesting: NestingSingle,
 					},
 				},
@@ -171,11 +206,11 @@ func TestBlockInternalValidate(t *testing.T) {
 		"nested block with badness": {
 			&Block{
 				BlockTypes: map[string]*NestedBlock{
-					"bad": &NestedBlock{
+					"bad": {
 						Nesting: NestingSingle,
 						Block: Block{
 							Attributes: map[string]*Attribute{
-								"nested_bad": &Attribute{
+								"nested_bad": {
 									Type:     cty.String,
 									Required: true,
 									Optional: true,
@@ -190,11 +225,11 @@ func TestBlockInternalValidate(t *testing.T) {
 		"nested list block with dynamically-typed attribute": {
 			&Block{
 				BlockTypes: map[string]*NestedBlock{
-					"bad": &NestedBlock{
+					"bad": {
 						Nesting: NestingList,
 						Block: Block{
 							Attributes: map[string]*Attribute{
-								"nested_bad": &Attribute{
+								"nested_bad": {
 									Type:     cty.DynamicPseudoType,
 									Optional: true,
 								},
@@ -208,11 +243,11 @@ func TestBlockInternalValidate(t *testing.T) {
 		"nested set block with dynamically-typed attribute": {
 			&Block{
 				BlockTypes: map[string]*NestedBlock{
-					"bad": &NestedBlock{
+					"bad": {
 						Nesting: NestingSet,
 						Block: Block{
 							Attributes: map[string]*Attribute{
-								"nested_bad": &Attribute{
+								"nested_bad": {
 									Type:     cty.DynamicPseudoType,
 									Optional: true,
 								},
@@ -253,11 +288,12 @@ func TestBlockInternalValidate(t *testing.T) {
 				for _, err := range errs {
 					t.Logf("- %s", err.Error())
 				}
-			}
-			if len(errs) > 0 {
-				for i := range errs {
-					if errs[i].Error() != test.Errs[i] {
-						t.Errorf("wrong error: got %s, want %s", errs[i].Error(), test.Errs[i])
+			} else {
+				if len(errs) > 0 {
+					for i := range errs {
+						if errs[i].Error() != test.Errs[i] {
+							t.Errorf("wrong error: got %s, want %s", errs[i].Error(), test.Errs[i])
+						}
 					}
 				}
 			}

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -1,8 +1,6 @@
 package terraform
 
 const errPluginInit = `
-Plugin reinitialization required. Please run "terraform init".
-
 Plugins are external binaries that Terraform uses to access and manipulate
 resources. The configuration provided requires plugins which can't be located,
 don't satisfy the version constraints, or are otherwise incompatible.
@@ -12,4 +10,7 @@ configuration, including providers used in child modules. To see the
 requirements and constraints, run "terraform providers".
 
 %s
+
+Plugin reinitialization required. Please address the above error(s) and run
+"terraform init".
 `

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -143,9 +143,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 
 		for t, r := range resp.ResourceTypes {
 			if err := r.Block.InternalValidate(); err != nil {
-				diags = diags.Append(
-					fmt.Errorf("Internal validation of the provider failed! This is always a bug with the provider itself, and not a user issue. Please report this bug:\n\n%s", fmt.Errorf("resource %s: %s", t, err)),
-				)
+				diags = diags.Append(fmt.Errorf(errProviderSchemaInvalid, name, "resource", t, err))
 			}
 			s.ResourceTypes[t] = r.Block
 			s.ResourceTypeSchemaVersions[t] = uint64(r.Version)
@@ -158,9 +156,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 
 		for t, d := range resp.DataSources {
 			if err := d.Block.InternalValidate(); err != nil {
-				diags = diags.Append(
-					fmt.Errorf("Internal validation of the provider failed! This is always a bug with the provider itself, and not a user issue. Please report this bug:\n\n%s", err),
-				)
+				diags = diags.Append(fmt.Errorf(errProviderSchemaInvalid, name, "data source", t, err))
 			}
 			s.DataSources[t] = d.Block
 			if d.Version < 0 {
@@ -284,3 +280,11 @@ func (ps *ProviderSchema) SchemaForResourceType(mode addrs.ResourceMode, typeNam
 func (ps *ProviderSchema) SchemaForResourceAddr(addr addrs.Resource) (schema *configschema.Block, version uint64) {
 	return ps.SchemaForResourceType(addr.Mode, addr.Type)
 }
+
+const errProviderSchemaInvalid = `
+Internal validation of the provider failed! This is always a bug with the 
+provider itself, and not a user issue. Please report this bug to the 
+maintainers of the %q provider:
+
+%s %s: %s
+`

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -142,6 +142,11 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 		}
 
 		for t, r := range resp.ResourceTypes {
+			if err := r.Block.InternalValidate(); err != nil {
+				diags = diags.Append(
+					fmt.Errorf("invalid schema for resource type %s provider %q: %s", t, name, err.Error()),
+				)
+			}
 			s.ResourceTypes[t] = r.Block
 			s.ResourceTypeSchemaVersions[t] = uint64(r.Version)
 			if r.Version < 0 {
@@ -152,6 +157,11 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 		}
 
 		for t, d := range resp.DataSources {
+			if err := d.Block.InternalValidate(); err != nil {
+				diags = diags.Append(
+					fmt.Errorf("invalid schema for data source type %s provider %q: %s", t, name, err.Error()),
+				)
+			}
 			s.DataSources[t] = d.Block
 			if d.Version < 0 {
 				// We're not using the version numbers here yet, but we'll check

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -144,7 +144,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 		for t, r := range resp.ResourceTypes {
 			if err := r.Block.InternalValidate(); err != nil {
 				diags = diags.Append(
-					fmt.Errorf("invalid schema for resource type %s provider %q: %s", t, name, err.Error()),
+					fmt.Errorf("Internal validation of the provider failed! This is always a bug with the provider itself, and not a user issue. Please report this bug:\n\n%s", fmt.Errorf("resource %s: %s", t, err)),
 				)
 			}
 			s.ResourceTypes[t] = r.Block
@@ -159,7 +159,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 		for t, d := range resp.DataSources {
 			if err := d.Block.InternalValidate(); err != nil {
 				diags = diags.Append(
-					fmt.Errorf("invalid schema for data source type %s provider %q: %s", t, name, err.Error()),
+					fmt.Errorf("Internal validation of the provider failed! This is always a bug with the provider itself, and not a user issue. Please report this bug:\n\n%s", err),
 				)
 			}
 			s.DataSources[t] = d.Block


### PR DESCRIPTION
Hello! This PR comes with a lead-in question before you look at the code: should we even do this? I think so, but if there's any controversy I can step back and RFC this. [updated with improved error message] ~If agreed, I will have at least one more commit to improve the error message; I didn't want to spend any more time on it before confirming if this is a good idea in the first place.~ 

----

The terraform-plugin-sdk has a lovely series of InternalValidate functions that verify the validity of the providers' schemas during `Configure` (entrypoint [here](https://github.com/hashicorp/terraform-plugin-sdk/blob/dcaac684c7fe179d35d2ff34f9f1de99ea129c6c/helper/schema/provider.go#L109)). Terraform _assumes_ that this is run for every provider. 

This is not a safe assumption, unfortunately: for example a provider not using our sdk might not implement something like `InternalValidate`. Most of the mistakes that the validation would catch will result in errors in terraform (for e.g.: if an attribute is both required and computed, we'll get an invalid result after apply error). There's a _new_ potential issue that will result in a panic: an attribute with both a non-nil `Type` and a `NestedType`. (this is not yet included in `InternalValidate`; the sdk doesn't support the new `NestedType`s yet).

I started down this path because I wanted Terraform to validate the schema too, so we could catch errors at the beginning of a command instead of during plan or apply (apply being the worst case scenario). I tested this change with a config that used all of our top official providers (aws, azure, google, alicloud, oci, k8s), after which I removed one of the original checks that was in `configschema.InternalValidate` (only called by our builtin providers), since that caused an error with the `oci` provider (invalid attribute names - that's a project for another day). 

If you prefer to review this commit-by-commit, this commentary on each might be helpful:

*  c5a903b updates the existing InternalValidate test to verify specific errors instead of the number of errors; the `Attribute.InternalValidate` function in this commit is incomplete (and buggy) so please ignore that.
* 9f669b5 extracts the attribute validation into a function and refactors Block.InternalValidate to use it. One test error message changed. 
* 02c31cd adds the call to InternalValidate into `loadProviderSchemas` (called during `terraform.NewContext`) and fixes a bug with the error message returned by InternalValidate
* 2dc6960 tweaks the error message so it's closer to the sdk's current error (spoiler: it's not as good)


I don't like this error message as much as the one from the provider, but I am not sure how much I can improve it (I'm sure I can get the specific resource name in!), since in this case the error could be one of a series of diagnostics. I shouldn't just throw everything else away in favor of returning exactly/only the same message as the SDK does (I don't think I'm putting this into words very well; hit me up in slack if you want to talk through it). 

Now for the pictures! Here's the current error message from the SDK if a provider has an invalid schema:

<img width="908" alt="Screen Shot 2021-03-16 at 8 30 42 AM" src="https://user-images.githubusercontent.com/6210214/111474777-c59cbd00-8702-11eb-947d-3e3187b0c012.png">

Here's the same error, caught by Terraform during NewContext. UPDATED VERSION ~It's not as nice, and also notice that the failing resource name is missing~:

<img width="914" alt="Screen Shot 2021-03-18 at 9 16 29 AM" src="https://user-images.githubusercontent.com/6210214/111632878-4de69500-87cb-11eb-855e-da2d77ca5ab4.png">


