### PR TITLE
documentation: Clarify JSON diagnostic values traversal semantics

### DIFF
--- a/website/docs/cli/commands/validate.html.md
+++ b/website/docs/cli/commands/validate.html.md
@@ -202,7 +202,11 @@ part of the expression which triggered the diagnostic. This is especially
 useful when using `for_each` or similar constructs, in order to identify
 exactly which values are responsible for an error. The object has two properties:
 
-* `traversal` (string): An HCL traversal string, such as `var.instance_count`.
+* `traversal` (string): An HCL-like traversal string, such as
+  `var.instance_count`. Complex index key values may be elided, so this will
+  not always be valid, parseable HCL. The contents of this string are intended
+  to be human-readable and are subject to change in future versions of
+  Terraform.
 
 * `statement` (string): A short English-language fragment describing the value
   of the expression when the diagnostic was triggered. The contents of this


### PR DESCRIPTION
The traversal value is normally a valid HCL string, but can be simplified if a traversal step has a complex index value (e.g. an
object). This means it is not always parseable HCL, so this commit updates the documentation to clarify this and explicitly record that we do not guarantee its contents are stable. The purpose of these values is purely for building human-readable UI.

Here's the code which generates this value: https://github.com/hashicorp/terraform/blob/53739f0aacf6e8251a977f2038bb61b9f1a1a3c3/command/views/json/diagnostic.go#L373-L401