### PR TITLE
StateMgr must be able to return with locked state

### DIFF
--- a/internal/backend/remote-state/etcdv3/backend_state.go
+++ b/internal/backend/remote-state/etcdv3/backend_state.go
@@ -58,16 +58,8 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 
 	lockInfo := statemgr.NewLockInfo()
 	lockInfo.Operation = "init"
-	lockId, err := stateMgr.Lock(lockInfo)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to lock state in etcd: %s.", err)
-	}
-
 	lockUnlock := func(parent error) error {
-		if err := stateMgr.Unlock(lockId); err != nil {
-			return fmt.Errorf(strings.TrimSpace(errStateUnlock), lockId, err)
-		}
-		return parent
+		return nil
 	}
 
 	if err := stateMgr.RefreshState(); err != nil {
@@ -76,6 +68,18 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	}
 
 	if v := stateMgr.State(); v == nil {
+		lockId, err := stateMgr.Lock(lockInfo)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to lock state in etcd: %s.", err)
+		}
+
+		lockUnlock = func(parent error) error {
+			if err := stateMgr.Unlock(lockId); err != nil {
+				return fmt.Errorf(strings.TrimSpace(errStateUnlock), lockId, err)
+			}
+			return parent
+		}
+
 		if err := stateMgr.WriteState(states.NewState()); err != nil {
 			err = lockUnlock(err)
 			return nil, err


### PR DESCRIPTION
The current usage of internal remote state backends requires that
`StateMgr` be able to return an instance of `statemgr.Full` even if the
state is currently locked.

Fixes #28100