### PR TITLE
terraform-bundle: return an error if "versions" argument is omitted

### DIFF
--- a/tools/terraform-bundle/config.go
+++ b/tools/terraform-bundle/config.go
@@ -72,10 +72,14 @@ func (c *Config) validate() error {
 				return fmt.Errorf("providers.%s: %s", k, diags.Err().Error())
 			}
 		}
-		for _, c := range cs.Versions {
-			if _, err := getproviders.ParseVersionConstraints(c); err != nil {
-				return fmt.Errorf("providers.%s: %s", k, err)
+		if len(cs.Versions) > 0 {
+			for _, c := range cs.Versions {
+				if _, err := getproviders.ParseVersionConstraints(c); err != nil {
+					return fmt.Errorf("providers.%s: %s", k, err)
+				}
 			}
+		} else {
+			return fmt.Errorf("provider.%s: required \"versions\" argument not found", k)
 		}
 	}
 


### PR DESCRIPTION
terraform-bundle would happily install no providers if the "version" argument was omitted, so this PR adds an error in that situation. I'll backport this to 0.13 - 0.15, since we tell users to build terraform-bundle from the latest commit of a given version tag. ("backport" here is low-risk; terraform-bundle is not part of a terraform release so it's no impact, whether or not there is a terraform release from those branches)

Closes #28091

<img width="927" alt="Screen Shot 2021-03-22 at 9 42 19 AM" src="https://user-images.githubusercontent.com/6210214/111999575-7fc16980-8af3-11eb-9622-7fd4d0bf3468.png">
