### PR TITLE
terraform state ls: add alias command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -350,6 +350,13 @@ func initCommands(config *cliconfig.Config, services *disco.Disco, providerSrc g
 			}, nil
 		},
 
+		// Alias for list
+		"state ls": func() (cli.Command, error) {
+			return &command.StateListCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"state rm": func() (cli.Command, error) {
 			return &command.StateRmCommand{
 				StateMeta: command.StateMeta{


### PR DESCRIPTION
Make it more consistent with the other commands:

	terraform state cp
	terraform state rm
	terraform state ls

I always get tripped by this one for some reason. I must not be the only one :)

This is a revival of #18331

This is the new output of the subcommand when running `terraform state --help`:

```
Subcommands:
    list                List resources in the state
    ls                  List resources in the state
    mv                  Move an item in the state
    pull                Pull current state and output to stdout
    push                Update remote state from a local state file
    replace-provider    Replace provider in the state
    rm                  Remove instances from the state
    show                Show a resource in the state
```