### PR TITLE
Set Intersection #performance

### DIFF
--- a/dag/set.go
+++ b/dag/set.go
@@ -38,17 +38,18 @@ func (s Set) Include(v interface{}) bool {
 // Intersection computes the set intersection with other.
 func (s Set) Intersection(other Set) Set {
 	result := make(Set)
-	if s == nil {
+	if s == nil || other == nil {
 		return result
 	}
-	if other != nil {
-		for _, v := range s {
-			if other.Include(v) {
-				result.Add(v)
-			}
+	// Iteration over a smaller set has better performance.
+	if other.Len() < s.Len() {
+		s, other = other, s
+	}
+	for _, v := range s {
+		if other.Include(v) {
+			result.Add(v)
 		}
 	}
-
 	return result
 }
 

--- a/dag/set_test.go
+++ b/dag/set_test.go
@@ -122,7 +122,7 @@ func TestSetCopy(t *testing.T) {
 
 func BenchmarkSetIntersectionLargeToSmall(b *testing.B) {
 	var small, large Set
-	for i := 0; i < b.N; i++ {
+	for i := 0; i < 1000000; i++ {
 		large.Add(i)
 	}
 	small.Add(1)

--- a/dag/set_test.go
+++ b/dag/set_test.go
@@ -119,3 +119,13 @@ func TestSetCopy(t *testing.T) {
 	}
 
 }
+
+func BenchmarkSetIntersectionLargeToSmall(b *testing.B) {
+	var small, large Set
+	for i := 0; i < b.N; i++ {
+		large.Add(i)
+	}
+	small.Add(1)
+	b.ResetTimer()
+	large.Intersection(small)
+}

--- a/dag/set_test.go
+++ b/dag/set_test.go
@@ -120,12 +120,30 @@ func TestSetCopy(t *testing.T) {
 
 }
 
-func BenchmarkSetIntersectionLargeToSmall(b *testing.B) {
-	var small, large Set
-	for i := 0; i < 1000000; i++ {
-		large.Add(i)
+func makeSet(n int) Set {
+	ret := make(Set, n)
+	for i := 0; i < n; i++ {
+		ret.Add(i)
 	}
-	small.Add(1)
+	return ret
+}
+
+func BenchmarkSetIntersection_100_100000(b *testing.B) {
+	small := makeSet(100)
+	large := makeSet(100000)
+
 	b.ResetTimer()
-	large.Intersection(small)
+	for n := 0; n < b.N; n++ {
+		small.Intersection(large)
+	}
+}
+
+func BenchmarkSetIntersection_100000_100(b *testing.B) {
+	small := makeSet(100)
+	large := makeSet(100000)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		large.Intersection(small)
+	}
 }


### PR DESCRIPTION
Intersection is faster for sets of different sizes if one iterates over the shorter set and checks the presence of an element in a larger one. For an edge case consider `s` having 1M entries and `other` no entries at all. In this case original code will iterate over 1M entries in `s` not finding anything and then returning an empty result set. In the patched code the iteration won't happen at all and result is returned immediately.

This change is inspired by profiling a relatively large terraform configuration, where the time to validate was sped up 4x with this change.

This should have no effect other than performance improvement.