### PR TITLE
command/fmt: support formatting multiple files

### DIFF
--- a/internal/command/fmt.go
+++ b/internal/command/fmt.go
@@ -55,11 +55,6 @@ func (c *FmtCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	if len(args) > 1 {
-		c.Ui.Error("The fmt command expects at most one argument.")
-		cmdFlags.Usage()
-		return 1
-	}
 
 	var paths []string
 	if len(args) == 0 {
@@ -68,7 +63,7 @@ func (c *FmtCommand) Run(args []string) int {
 		c.list = false
 		c.write = false
 	} else {
-		paths = []string{args[0]}
+		paths = args
 	}
 
 	var output io.Writer
@@ -528,15 +523,17 @@ func (c *FmtCommand) trimNewlines(tokens hclwrite.Tokens) hclwrite.Tokens {
 
 func (c *FmtCommand) Help() string {
 	helpText := `
-Usage: terraform [global options] fmt [options] [TARGET]
+Usage: terraform [global options] fmt [options] [target...]
 
   Rewrites all Terraform configuration files to a canonical format. Both
   configuration files (.tf) and variables files (.tfvars) are updated.
   JSON files (.tf.json or .tfvars.json) are not modified.
 
-  If TARGET is not specified, the command uses the current working directory.
-  If TARGET is a file, the command only uses the specified file. If TARGET
-  is "-" then the command reads from STDIN.
+  By default, fmt scans the current directory for configuration files. If you
+  provide a directory for the target argument, then fmt will scan that
+  directory instead. If you provide a file, then fmt will process just that
+  file. If you provide a single dash ("-"), then fmt will read from standard
+  input (STDIN).
 
   The content must be in the Terraform language native syntax; JSON is not
   supported.

--- a/website/docs/cli/commands/fmt.mdx
+++ b/website/docs/cli/commands/fmt.mdx
@@ -45,10 +45,13 @@ and the generated files.
 
 ## Usage
 
-Usage: `terraform fmt [options] [TARGET]`
+Usage: `terraform fmt [options] [target...]`
 
-By default, `fmt` scans the current directory for configuration files. If
-you provide a directory for the `target` argument, then `fmt` will scan that directory instead. If you provide a file, then `fmt` will process just that file. If you provide a single dash (`-`), then `fmt` will read from standard input (STDIN).
+By default, `fmt` scans the current directory for configuration files. If you
+provide a directory for the `target` argument, then `fmt` will scan that
+directory instead. If you provide a file, then `fmt` will process just that
+file. If you provide a single dash (`-`), then `fmt` will read from standard
+input (STDIN).
 
 The command-line flags are all optional. The following flags are available:
 


### PR DESCRIPTION
All the code infrastructure was there to support formatting multiple
files already.

This makes `terraform fmt` more flexible and also compliant with the
[treefmt formatted spec](https://numtide.github.io/treefmt/docs/formatters-spec.html)

Fixes https://github.com/numtide/treefmt/issues/97