### PR TITLE
cli: Fix fmt output for multi-line value exprs

### DIFF
--- a/command/testdata/fmt/general_in.tf
+++ b/command/testdata/fmt/general_in.tf
@@ -42,3 +42,12 @@ resource "foo_instance" /* ... */ "baz" {
 
   provider "" {
 }
+
+locals {
+  name = "${contains(["foo"], var.my_var) ? "${var.my_var}-bar" :
+    contains(["baz"], var.my_var) ? "baz-${var.my_var}" :
+  file("ERROR: unsupported type ${var.my_var}")}"
+  wrapped = "${(var.my_var == null ? 1 :
+    var.your_var == null ? 2 :
+  3)}"
+}

--- a/command/testdata/fmt/general_out.tf
+++ b/command/testdata/fmt/general_out.tf
@@ -42,3 +42,12 @@ resource "foo_instance" "baz" {
 
 provider "" {
 }
+
+locals {
+  name = (contains(["foo"], var.my_var) ? "${var.my_var}-bar" :
+    contains(["baz"], var.my_var) ? "baz-${var.my_var}" :
+  file("ERROR: unsupported type ${var.my_var}"))
+  wrapped = (var.my_var == null ? 1 :
+    var.your_var == null ? 2 :
+  3)
+}


### PR DESCRIPTION
The formatter for value expressions which use legacy interpolation syntax was previously behaving incorrectly with some multi-line expressions. Any HCL expression which requires parenthesis to be allowed to span multiple lines could skip those parens if already inside string interpolation (`"${}"`).

When removing string interpolation, we now check for a resulting multi-line expression, and conservatively ensure that it starts and ends with parenthesis. These may be redundant, as not all expressions require parens to permit spanning multiple lines, but at least it will be valid output.

Fixes #28199.