### PR TITLE
Clarify that pull will match state file to locally installed terraform version

### DIFF
--- a/website/docs/cli/commands/state/pull.html.md
+++ b/website/docs/cli/commands/state/pull.html.md
@@ -17,8 +17,8 @@ works with local state.
 Usage: `terraform state pull`
 
 This command will download the state from its current location, upgrade the
-local copy to the latest state file version, and output the raw format to
-stdout.
+local copy to the latest state file version that is compatible with
+locally-installed Terraform, and output the raw format to stdout.
 
 This is useful for reading values out of state (potentially pairing this
 command with something like [jq](https://stedolan.github.io/jq/)). It is


### PR DESCRIPTION
This PR clarifies the version that `terraform state pull` will upgrade the local version of the state file to, in reference to [this discussion](https://github.com/hashicorp/terraform/pull/27572/files#r600928348). One open question I had is what happens if the local terraform version is earlier than the remote version; will pull downgrade the local state file? 