### PR TITLE
Fix yamldecode example from json to yaml

### DIFF
--- a/website/docs/language/functions/yamldecode.html.md
+++ b/website/docs/language/functions/yamldecode.html.md
@@ -57,24 +57,9 @@ supports only a subset of YAML 1.2, with restrictions including the following:
 ## Examples
 
 ```
-> yamldecode(<<EOF
-    foo:
-      bar: Hello world!
-      stuff:
-      - one
-      - two
-      - three
-  EOF
-  )
+> yamldecode("hello: world")
 {
-  "foo" = {
-    "bar" = "Hello world!"
-    "stuff" = [
-      "one",
-      "two",
-      "three",
-    ]
-  }
+  "hello" = "world"
 }
 
 > yamldecode("true")

--- a/website/docs/language/functions/yamldecode.html.md
+++ b/website/docs/language/functions/yamldecode.html.md
@@ -57,9 +57,24 @@ supports only a subset of YAML 1.2, with restrictions including the following:
 ## Examples
 
 ```
-> yamldecode("{\"hello\": \"world\"}")
+> yamldecode(<<EOF
+    foo:
+      bar: Hello world!
+      stuff:
+      - one
+      - two
+      - three
+  EOF
+  )
 {
-  "hello" = "world"
+  "foo" = {
+    "bar" = "Hello world!"
+    "stuff" = [
+      "one",
+      "two",
+      "three",
+    ]
+  }
 }
 
 > yamldecode("true")


### PR DESCRIPTION
The `yamldecode` example it's a little bit confusing because it's using a `json` instead of `yaml`. So for better suit I change it to a yaml.