### PR TITLE
cli: Only rewrite provider locks file if changed

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -798,15 +798,10 @@ Terraform has made some changes to the provider dependency selections recorded
 in the .terraform.lock.hcl file. Review those changes and commit them to your
 version control system if they represent changes you intended to make.`))
 		}
+
+		moreDiags = c.replaceLockedDependencies(newLocks)
+		diags = diags.Append(moreDiags)
 	}
-
-	// TODO: Check whether newLocks is different from previousLocks and mention
-	// in the UI if so. We should emit a different message if previousLocks was
-	// empty, because that indicates we were creating a lock file for the first
-	// time and so we need to introduce the user to the idea of it.
-
-	moreDiags = c.replaceLockedDependencies(newLocks)
-	diags = diags.Append(moreDiags)
 
 	return true, false, diags
 }

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -1618,6 +1618,13 @@ provider "registry.terraform.io/hashicorp/test" {
 	if diff := cmp.Diff(wantLockFile, string(buf)); diff != "" {
 		t.Errorf("wrong dependency lock file contents\n%s", diff)
 	}
+
+	// Make the local directory read-only, and verify that rerunning init
+	// succeeds, to ensure that we don't try to rewrite an unchanged lock file
+	os.Chmod(".", 0555)
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
 }
 
 func TestInit_providerLockFileReadonly(t *testing.T) {


### PR DESCRIPTION
If the provider locks have not changed, there is no need to rewrite the locks file. Preventing this needless rewrite should allow Terraform to operate in a read-only directory, so long as the provider requirements don't change.

Slightly related to #27630, but serving a different use case. The goal here is to make a smaller change which can be back-ported to 0.14, and still allow being able to run Terraform in a read-only directory to allow upgrade from 0.13 to 0.14.