### PR TITLE
provide more memory for builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,7 @@ jobs:
   # build all distros
   build-distros: &build-distros
     executor: go
+    resource_class: medium+
     environment: &build-env
       TF_RELEASE: 1
     steps:


### PR DESCRIPTION
Cross-platform builds are running out of resources. Try using a little
more memory.