### PR TITLE
website: Dynamic blocks can for_each any collection type

### DIFF
--- a/website/docs/language/expressions/dynamic-blocks.html.md
+++ b/website/docs/language/expressions/dynamic-blocks.html.md
@@ -78,7 +78,7 @@ to generate meta-argument blocks such as `lifecycle` and `provisioner`
 blocks, since Terraform must process these before it is safe to evaluate
 expressions.
 
-The `for_each` value must be a map or set with one element per desired
+The `for_each` value must be a collection with one element per desired
 nested block. If you need to declare resource instances based on a nested
 data structure or combinations of elements from multiple data structures you
 can use Terraform expressions and functions to derive a suitable value.


### PR DESCRIPTION
We previously added a hint to both resource `for_each` and `dynamic` blocks about using the `flatten` and `setproduct` situations to construct suitable collections to repeat over.

However, we used the same text in both places which ended up stating that `dynamic` blocks can only accept map or set values, which is a constraint that applies to resource `for_each` (because we need to assign a unique identifier to each instance) and not to `dynamic` blocks (which don't have any uniqueness enforced by Terraform Core itself).

To remove that contradiction, I've just generalized this to say "collection", because the primary point of this paragraph is the "one element per desired nested block" part, not specifically what sort of collections are permitted in this location. (Earlier text on the page describes the supported types.)
