### PR TITLE
Improve ModuleInstance String() performance

### DIFF
--- a/addrs/module_instance.go
+++ b/addrs/module_instance.go
@@ -1,8 +1,8 @@
 package addrs
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -251,7 +251,17 @@ func (m ModuleInstance) Parent() ModuleInstance {
 //
 // The address of the root module has the empty string as its representation.
 func (m ModuleInstance) String() string {
-	var buf bytes.Buffer
+	if len(m) == 0 {
+		return ""
+	}
+	// Calculate minimal necessary space (no instance keys).
+	l := 0
+	for _, step := range m {
+		l += len(step.Name)
+	}
+	buf := strings.Builder{}
+	// 8 is len(".module.") which separates entries.
+	buf.Grow(l + len(m)*8)
 	sep := ""
 	for _, step := range m {
 		buf.WriteString(sep)

--- a/addrs/module_instance_test.go
+++ b/addrs/module_instance_test.go
@@ -77,3 +77,17 @@ func TestModuleInstanceEqual_false(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkStringShort(b *testing.B) {
+        addr, _ := ParseModuleInstanceStr(`module.foo`)
+        for n := 0; n < b.N; n++ {
+                addr.String()
+        }
+}
+
+func BenchmarkStringLong(b *testing.B) {
+        addr, _ := ParseModuleInstanceStr(`module.southamerica-brazil-region.module.user-regional-desktops.module.user-name`)
+        for n := 0; n < b.N; n++ {
+                addr.String()
+        }
+}

--- a/addrs/module_instance_test.go
+++ b/addrs/module_instance_test.go
@@ -79,15 +79,15 @@ func TestModuleInstanceEqual_false(t *testing.T) {
 }
 
 func BenchmarkStringShort(b *testing.B) {
-        addr, _ := ParseModuleInstanceStr(`module.foo`)
-        for n := 0; n < b.N; n++ {
-                addr.String()
-        }
+	addr, _ := ParseModuleInstanceStr(`module.foo`)
+	for n := 0; n < b.N; n++ {
+		addr.String()
+	}
 }
 
 func BenchmarkStringLong(b *testing.B) {
-        addr, _ := ParseModuleInstanceStr(`module.southamerica-brazil-region.module.user-regional-desktops.module.user-name`)
-        for n := 0; n < b.N; n++ {
-                addr.String()
-        }
+	addr, _ := ParseModuleInstanceStr(`module.southamerica-brazil-region.module.user-regional-desktops.module.user-name`)
+	for n := 0; n < b.N; n++ {
+		addr.String()
+	}
 }


### PR DESCRIPTION
`bytes.Buffer` always allocates when converting to a string. `strings.Builder` does not.

Preallocating the memory is beneficial as well, note that the new code only does a single allocation per operation

Results, first this branch, then main:

```
$ go test -bench=String ./addrs -benchmem 
BenchmarkStringShort-12         18271692                56.52 ns/op           16 B/op          1 allocs/op
BenchmarkStringLong-12           8057071               158.5 ns/op            96 B/op          1 allocs/op
PASS
$ git checkout main addrs/module_instance.go
$ go test -bench=String ./addrs -benchmem 
BenchmarkStringShort-12          7690818               162.0 ns/op            80 B/op          2 allocs/op
BenchmarkStringLong-12           2922117               414.1 ns/op           288 B/op          3 allocs/op
```

This improves running `terraform validate` of some large configuration by ~15% of wall time