### PR TITLE
Don't force data reads from dependency changes in sibling modules

### DIFF
--- a/terraform/context_apply2_test.go
+++ b/terraform/context_apply2_test.go
@@ -356,8 +356,6 @@ resource "aws_instance" "bin" {
 		t.Fatal(diags.Err())
 	}
 
-	fmt.Println(state)
-
 	bar = state.ResourceInstance(barAddr)
 	if len(bar.Current.Dependencies) == 0 || !bar.Current.Dependencies[0].Equal(fooAddr.ContainingResource().Config()) {
 		t.Fatalf("bar should still depend on foo after apply, but got %s", bar.Current.Dependencies)

--- a/terraform/node_resource_abstract_instance.go
+++ b/terraform/node_resource_abstract_instance.go
@@ -1447,6 +1447,9 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, currentSt
 // immediately reading from the data source where possible, instead forcing us
 // to generate a plan.
 func (n *NodeAbstractResourceInstance) forcePlanReadData(ctx EvalContext) bool {
+	nModInst := n.Addr.Module
+	nMod := nModInst.Module()
+
 	// Check and see if any depends_on dependencies have
 	// changes, since they won't show up as changes in the
 	// configuration.
@@ -1461,6 +1464,18 @@ func (n *NodeAbstractResourceInstance) forcePlanReadData(ctx EvalContext) bool {
 		}
 
 		for _, change := range changes.GetChangesForConfigResource(d) {
+			changeModInst := change.Addr.Module
+			changeMod := changeModInst.Module()
+
+			if changeMod.Equal(nMod) && !changeModInst.Equal(nModInst) {
+				// Dependencies are tracked by configuration address, which
+				// means we may have changes from other instances of parent
+				// modules. The actual reference can only take effect within
+				// the same module instance, so skip any that aren't an exact
+				// match
+				continue
+			}
+
 			if change != nil && change.Action != plans.NoOp {
 				return true
 			}


### PR DESCRIPTION
Dependencies are tracked via configuration addresses, but when dealing with depends_on references they can only apply to resources within the same module instance.

When determining if a data source can be read during planning, verify that the dependency change is coming from the same module instance.

Fixes #28084