### PR TITLE
ensure plans always have a stored state

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -604,7 +604,9 @@ func (c *Context) plan() (*plans.Plan, tfdiags.Diagnostics) {
 
 func (c *Context) destroyPlan() (*plans.Plan, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	destroyPlan := &plans.Plan{}
+	destroyPlan := &plans.Plan{
+		State: c.state.DeepCopy(),
+	}
 	c.changes = plans.NewChanges()
 
 	// A destroy plan starts by running Refresh to read any pending data


### PR DESCRIPTION
When refresh was skipped for a destroy plan, there was no state stored
in the plan.

Fixes #28271