### PR TITLE
Add addresses to diagnostics

### DIFF
--- a/backend/testing.go
+++ b/backend/testing.go
@@ -39,7 +39,7 @@ func TestBackendConfig(t *testing.T, b Backend, c hcl.Body) Backend {
 	diags = diags.Append(decDiags)
 
 	newObj, valDiags := b.PrepareConfig(obj)
-	diags = diags.Append(valDiags.InConfigBody(c))
+	diags = diags.Append(valDiags.InConfigBody(c, ""))
 
 	if len(diags) != 0 {
 		t.Fatal(diags.ErrWithWarnings())
@@ -49,7 +49,7 @@ func TestBackendConfig(t *testing.T, b Backend, c hcl.Body) Backend {
 
 	confDiags := b.Configure(obj)
 	if len(confDiags) != 0 {
-		confDiags = confDiags.InConfigBody(c)
+		confDiags = confDiags.InConfigBody(c, "")
 		t.Fatal(confDiags.ErrWithWarnings())
 	}
 

--- a/command/format/diagnostic.go
+++ b/command/format/diagnostic.go
@@ -214,7 +214,7 @@ func DiagnosticWarningsCompact(diags tfdiags.Diagnostics, color *colorstring.Col
 
 func appendSourceSnippets(buf *bytes.Buffer, diag *viewsjson.Diagnostic, color *colorstring.Colorize) {
 	if diag.Address != "" {
-		fmt.Fprintf(buf, "  (%s)\n", diag.Address)
+		fmt.Fprintf(buf, "  with %s,\n", diag.Address)
 	}
 
 	if diag.Range == nil {

--- a/command/format/diagnostic.go
+++ b/command/format/diagnostic.go
@@ -213,6 +213,10 @@ func DiagnosticWarningsCompact(diags tfdiags.Diagnostics, color *colorstring.Col
 }
 
 func appendSourceSnippets(buf *bytes.Buffer, diag *viewsjson.Diagnostic, color *colorstring.Colorize) {
+	if diag.Address != "" {
+		fmt.Fprintf(buf, "  (%s)\n", diag.Address)
+	}
+
 	if diag.Range == nil {
 		return
 	}

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -1086,13 +1086,13 @@ func (m *Meta) backendInitFromConfig(c *configs.Backend) (backend.Backend, cty.V
 	}
 
 	newVal, validateDiags := b.PrepareConfig(configVal)
-	diags = diags.Append(validateDiags.InConfigBody(c.Config))
+	diags = diags.Append(validateDiags.InConfigBody(c.Config, ""))
 	if validateDiags.HasErrors() {
 		return nil, cty.NilVal, diags
 	}
 
 	configureDiags := b.Configure(newVal)
-	diags = diags.Append(configureDiags.InConfigBody(c.Config))
+	diags = diags.Append(configureDiags.InConfigBody(c.Config, ""))
 
 	return b, configVal, diags
 }

--- a/command/views/json/diagnostic.go
+++ b/command/views/json/diagnostic.go
@@ -30,6 +30,7 @@ type Diagnostic struct {
 	Severity string             `json:"severity"`
 	Summary  string             `json:"summary"`
 	Detail   string             `json:"detail"`
+	Address  string             `json:"address,omitempty"`
 	Range    *DiagnosticRange   `json:"range,omitempty"`
 	Snippet  *DiagnosticSnippet `json:"snippet,omitempty"`
 }
@@ -124,6 +125,7 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 		Severity: sev,
 		Summary:  desc.Summary,
 		Detail:   desc.Detail,
+		Address:  desc.Address,
 	}
 
 	sourceRefs := diag.Source()

--- a/plugin/convert/diagnostics_test.go
+++ b/plugin/convert/diagnostics_test.go
@@ -393,7 +393,7 @@ func TestProtoDiagnostics_emptyAttributePath(t *testing.T) {
 	if parseDiags.HasErrors() {
 		t.Fatal(parseDiags)
 	}
-	diags := tfDiags.InConfigBody(f.Body)
+	diags := tfDiags.InConfigBody(f.Body, "")
 
 	if len(tfDiags) != 1 {
 		t.Fatalf("expected 1 diag, got %d", len(tfDiags))

--- a/plugin/grpc_error.go
+++ b/plugin/grpc_error.go
@@ -45,26 +45,26 @@ func grpcErr(err error) (diags tfdiags.Diagnostics) {
 	case codes.Unavailable:
 		// This case is when the plugin has stopped running for some reason,
 		// and is usually the result of a crash.
-		diags = diags.Append(tfdiags.Sourceless(
+		diags = diags.Append(tfdiags.WholeContainingBody(
 			tfdiags.Error,
 			"Plugin did not respond",
 			fmt.Sprintf("The plugin encountered an error, and failed to respond to the %s call. "+
 				"The plugin logs may contain more details.", requestName),
 		))
 	case codes.Canceled:
-		diags = diags.Append(tfdiags.Sourceless(
+		diags = diags.Append(tfdiags.WholeContainingBody(
 			tfdiags.Error,
 			"Request cancelled",
 			fmt.Sprintf("The %s request was cancelled.", requestName),
 		))
 	case codes.Unimplemented:
-		diags = diags.Append(tfdiags.Sourceless(
+		diags = diags.Append(tfdiags.WholeContainingBody(
 			tfdiags.Error,
 			"Unsupported plugin method",
 			fmt.Sprintf("The %s method is not supported by this plugin.", requestName),
 		))
 	default:
-		diags = diags.Append(tfdiags.Sourceless(
+		diags = diags.Append(tfdiags.WholeContainingBody(
 			tfdiags.Error,
 			"Plugin error",
 			fmt.Sprintf("The plugin returned an unexpected error from %s: %v", requestName, err),

--- a/terraform/node_provider.go
+++ b/terraform/node_provider.go
@@ -167,14 +167,14 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, provider prov
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Invalid provider configuration",
-				fmt.Sprintf(providerConfigErr, configDiags.InConfigBody(configBody).Err(), n.Addr.Provider),
+				fmt.Sprintf(providerConfigErr, configDiags.InConfigBody(configBody, n.Addr.String()).Err(), n.Addr.Provider),
 			))
 			return diags
 		} else {
-			return diags.Append(configDiags.InConfigBody(configBody))
+			return diags.Append(configDiags.InConfigBody(configBody, n.Addr.String()))
 		}
 	}
-	diags = diags.Append(configDiags.InConfigBody(configBody))
+	diags = diags.Append(configDiags.InConfigBody(configBody, n.Addr.String()))
 
 	return diags
 }

--- a/terraform/node_resource_abstract_instance.go
+++ b/terraform/node_resource_abstract_instance.go
@@ -625,8 +625,9 @@ func (n *NodeAbstractResourceInstance) plan(
 			Config:   unmarkedConfigVal,
 		},
 	)
+
 	if validateResp.Diagnostics.HasErrors() {
-		diags = diags.Append(validateResp.Diagnostics.InConfigBody(config.Config))
+		diags = diags.Append(validateResp.Diagnostics.InConfigBody(config.Config, n.Addr.String()))
 		return plan, state, diags
 	}
 
@@ -659,7 +660,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		PriorPrivate:     priorPrivate,
 		ProviderMeta:     metaConfigVal,
 	})
-	diags = diags.Append(resp.Diagnostics.InConfigBody(config.Config))
+	diags = diags.Append(resp.Diagnostics.InConfigBody(config.Config, n.Addr.String()))
 	if diags.HasErrors() {
 		return plan, state, diags
 	}
@@ -869,7 +870,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		// Consequently, we break from the usual pattern here and only
 		// append these new diagnostics if there's at least one error inside.
 		if resp.Diagnostics.HasErrors() {
-			diags = diags.Append(resp.Diagnostics.InConfigBody(config.Config))
+			diags = diags.Append(resp.Diagnostics.InConfigBody(config.Config, n.Addr.String()))
 			return plan, state, diags
 		}
 		plannedNewVal = resp.PlannedState
@@ -1195,7 +1196,7 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx EvalContext, configVal
 		},
 	)
 	if validateResp.Diagnostics.HasErrors() {
-		return newVal, validateResp.Diagnostics.InConfigBody(config.Config)
+		return newVal, validateResp.Diagnostics.InConfigBody(config.Config, n.Addr.String())
 	}
 
 	// If we get down here then our configuration is complete and we're read
@@ -1207,7 +1208,7 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx EvalContext, configVal
 		Config:       configVal,
 		ProviderMeta: metaConfigVal,
 	})
-	diags = diags.Append(resp.Diagnostics.InConfigBody(config.Config))
+	diags = diags.Append(resp.Diagnostics.InConfigBody(config.Config, n.Addr.String()))
 	if diags.HasErrors() {
 		return newVal, diags
 	}
@@ -1741,7 +1742,7 @@ func (n *NodeAbstractResourceInstance) applyProvisioners(ctx EvalContext, state 
 			Connection: unmarkedConnInfo,
 			UIOutput:   &output,
 		})
-		applyDiags := resp.Diagnostics.InConfigBody(prov.Config)
+		applyDiags := resp.Diagnostics.InConfigBody(prov.Config, n.Addr.String())
 
 		// Call post hook
 		hookErr := ctx.Hook(func(h Hook) (HookAction, error) {
@@ -1907,7 +1908,7 @@ func (n *NodeAbstractResourceInstance) apply(
 	})
 	applyDiags := resp.Diagnostics
 	if applyConfig != nil {
-		applyDiags = applyDiags.InConfigBody(applyConfig.Config)
+		applyDiags = applyDiags.InConfigBody(applyConfig.Config, n.Addr.String())
 	}
 	diags = diags.Append(applyDiags)
 

--- a/terraform/node_resource_validate.go
+++ b/terraform/node_resource_validate.go
@@ -381,7 +381,7 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 		}
 
 		resp := provider.ValidateResourceConfig(req)
-		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config))
+		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String()))
 
 	case addrs.DataResourceMode:
 		schema, _ := providerSchema.SchemaForResourceType(n.Config.Mode, n.Config.Type)
@@ -409,7 +409,7 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 		}
 
 		resp := provider.ValidateDataResourceConfig(req)
-		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config))
+		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String()))
 	}
 
 	return diags

--- a/tfdiags/contextual.go
+++ b/tfdiags/contextual.go
@@ -19,17 +19,20 @@ import (
 
 // contextualFromConfig is an interface type implemented by diagnostic types
 // that can elaborate themselves when given information about the configuration
-// body they are embedded in.
+// body they are embedded in, as well as the runtime address associated with
+// that configuration.
 //
 // Usually this entails extracting source location information in order to
 // populate the "Subject" range.
 type contextualFromConfigBody interface {
-	ElaborateFromConfigBody(hcl.Body) Diagnostic
+	ElaborateFromConfigBody(hcl.Body, string) Diagnostic
 }
 
 // InConfigBody returns a copy of the receiver with any config-contextual
-// diagnostics elaborated in the context of the given body.
-func (diags Diagnostics) InConfigBody(body hcl.Body) Diagnostics {
+// diagnostics elaborated in the context of the given body. An optional address
+// argument may be added to indicate which instance of the configuration the
+// error related to.
+func (diags Diagnostics) InConfigBody(body hcl.Body, addr string) Diagnostics {
 	if len(diags) == 0 {
 		return nil
 	}
@@ -37,7 +40,7 @@ func (diags Diagnostics) InConfigBody(body hcl.Body) Diagnostics {
 	ret := make(Diagnostics, len(diags))
 	for i, srcDiag := range diags {
 		if cd, isCD := srcDiag.(contextualFromConfigBody); isCD {
-			ret[i] = cd.ElaborateFromConfigBody(body)
+			ret[i] = cd.ElaborateFromConfigBody(body, addr)
 		} else {
 			ret[i] = srcDiag
 		}
@@ -112,7 +115,12 @@ type attributeDiagnostic struct {
 // source location information is still available, for more accuracy. This
 // is not always possible due to system architecture, so this serves as a
 // "best effort" fallback behavior for such situations.
-func (d *attributeDiagnostic) ElaborateFromConfigBody(body hcl.Body) Diagnostic {
+func (d *attributeDiagnostic) ElaborateFromConfigBody(body hcl.Body, addr string) Diagnostic {
+	// don't change an existing address
+	if d.address == "" {
+		d.address = addr
+	}
+
 	if len(d.attrPath) < 1 {
 		// Should never happen, but we'll allow it rather than crashing.
 		return d
@@ -353,7 +361,12 @@ type wholeBodyDiagnostic struct {
 	subject *SourceRange // populated only after ElaborateFromConfigBody
 }
 
-func (d *wholeBodyDiagnostic) ElaborateFromConfigBody(body hcl.Body) Diagnostic {
+func (d *wholeBodyDiagnostic) ElaborateFromConfigBody(body hcl.Body, addr string) Diagnostic {
+	// don't change an existing address
+	if d.address == "" {
+		d.address = addr
+	}
+
 	if d.subject != nil {
 		// Don't modify an already-elaborated diagnostic.
 		return d

--- a/tfdiags/diagnostic.go
+++ b/tfdiags/diagnostic.go
@@ -25,6 +25,7 @@ const (
 )
 
 type Description struct {
+	Address string
 	Summary string
 	Detail  string
 }

--- a/tfdiags/diagnostic_base.go
+++ b/tfdiags/diagnostic_base.go
@@ -9,6 +9,7 @@ type diagnosticBase struct {
 	severity Severity
 	summary  string
 	detail   string
+	address  string
 }
 
 func (d diagnosticBase) Severity() Severity {
@@ -19,6 +20,7 @@ func (d diagnosticBase) Description() Description {
 	return Description{
 		Summary: d.summary,
 		Detail:  d.detail,
+		Address: d.address,
 	}
 }
 


### PR DESCRIPTION
Diagnostics are most commonly associated with a particular addressable value in terraform, and it would be useful to have some sort of annotation to attribute a diagnostic with a runtime address. This is useful in addition to the configuration body, since the individual resource instance, or containing module instance may be critical to determining the reason for the error.

The result here is that formatted diagnostics will include an address before the configuration details pinpointing the instance:

```
╷
│ Error: something went horribly wrong
│
│   with module.mod["foo"].aws_vpc.a["bar"],
│   on mod/main.tf line 2, in resource "aws_vpc" "a":
```

-- 

We first add an address argument to `tfdiags.InConfigBody`, and store the address string the diagnostics details. Since nearly every place where we want to annotate the diagnostics with the config context we also have some sort of address, we can use the same call to insert them both into the diagnostic.

While the simple `string` type is not very descriptive, the `addrs` package uses `tfdiags` itself, so we cannot use an interface from the `addrs` package as an argument type here. A separate interface could be defines, though that would only amount to being the equivalent of `fmt.Stringer` at the moment, and not really offer much more context. For this reason, the current implementation leaves the address to be represented by a string, and we can follow up with more design around debugging and handling of addresses at a later time. 

All regular provider method diagnostics use types that can be annotated with configuration information, we update the generic grpc errors from a provider to use `WholeContainingBody` so those errors will be annotated as well. This can help troubleshoot problems by narrowing down provider crashes and hangs to a particular configuration or specific resource instance.