### PR TITLE
http remote backend initialization fails due to unescaped username

### DIFF
--- a/backend/remote-state/http/client.go
+++ b/backend/remote-state/http/client.go
@@ -37,7 +37,7 @@ type httpClient struct {
 	jsonLockInfo []byte
 }
 
-func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what string) (*http.Response, error) {
+func (c *httpClient) httpRequest(method string, remoteUrl *url.URL, data *[]byte, what string) (*http.Response, error) {
 	// If we have data we need a reader
 	var reader io.Reader = nil
 	if data != nil {
@@ -45,13 +45,13 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	}
 
 	// Create the request
-	req, err := retryablehttp.NewRequest(method, url.String(), reader)
+	req, err := retryablehttp.NewRequest(method, url.QueryEscape(remoteUrl.String()), reader)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to make %s HTTP request: %s", what, err)
 	}
 	// Set up basic auth
 	if c.Username != "" {
-		req.SetBasicAuth(c.Username, c.Password)
+		req.SetBasicAuth(url.QueryEscape(c.Username), url.QueryEscape(c.Password))
 	}
 
 	// Work with data/body

--- a/backend/remote-state/http/client.go
+++ b/backend/remote-state/http/client.go
@@ -45,7 +45,7 @@ func (c *httpClient) httpRequest(method string, remoteUrl *url.URL, data *[]byte
 	}
 
 	// Create the request
-	req, err := retryablehttp.NewRequest(method, url.QueryEscape(remoteUrl.String()), reader)
+	req, err := retryablehttp.NewRequest(method, remoteUrl.String(), reader)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to make %s HTTP request: %s", what, err)
 	}


### PR DESCRIPTION
Backend initialization fails if the username contains a `.`

The problem is the setting of the basic auth header without escaping the parameters:

[https://github.com/hashicorp/terraform/blob/6697245c18dad6848e7647598dda1ab04c2680ca/backend/remote-state/http/client.go#L53-L56](https://github.com/hashicorp/terraform/blob/6697245c18dad6848e7647598dda1ab04c2680ca/backend/remote-state/http/client.go#L53-L56)

In that PR I escaped the url, username and password using `url.EscapeQuery`, now it works:

```bash
$> terraform init \
-backend-config="address=url" \
-backend-config="lock_address=url" \
-backend-config="unlock_address=url" \
-backend-config="password=foo" \
-backend-config="lock_method=POST" \
-backend-config="unlock_method=DELETE" \
-backend-config="retry_wait_min=5" \
-backend-config="username=user.name"
Terraform initialized in an empty directory!
```

related Issues:
* [https://github.com/gitlabhq/terraform-provider-gitlab/issues/476](https://github.com/gitlabhq/terraform-provider-gitlab/issues/476)
