### PR TITLE
docs: fix link to index

### DIFF
--- a/website/docs/language/functions/element.html.md
+++ b/website/docs/language/functions/element.html.md
@@ -46,5 +46,5 @@ c
 
 ## Related Functions
 
-* [`index`](./index.html) finds the index for a particular element value.
+* [`index`](./index_function.html) finds the index for a particular element value.
 * [`lookup`](./lookup.html) retrieves a value from a _map_ given its _key_.


### PR DESCRIPTION
The link from the docs page for function `element` -> function `index` was linking to index.html, but this is the docs homepage.

It now links to index_function.html, the documentation for the related index function.