### PR TITLE
ensure plans always have a stored state

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -604,7 +604,9 @@ func (c *Context) plan() (*plans.Plan, tfdiags.Diagnostics) {
 
 func (c *Context) destroyPlan() (*plans.Plan, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	destroyPlan := &plans.Plan{}
+	destroyPlan := &plans.Plan{
+		State: c.state.DeepCopy(),
+	}
 	c.changes = plans.NewChanges()
 
 	// A destroy plan starts by running Refresh to read any pending data

--- a/terraform/context_plan2_test.go
+++ b/terraform/context_plan2_test.go
@@ -249,3 +249,47 @@ resource "test_object" "a" {
 		t.Fatal(diags.Err())
 	}
 }
+
+func TestContext2Plan_destroySkipRefresh(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "a" {
+}
+`,
+	})
+
+	p := simpleMockProvider()
+
+	addr := mustResourceInstanceAddr("test_object.a")
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{"test_string":"foo"}`),
+			Status:    states.ObjectReady,
+		}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		State:  state,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+		Destroy:     true,
+		SkipRefresh: true,
+	})
+
+	plan, diags := ctx.Plan()
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+
+	if plan.State == nil {
+		t.Fatal("missing plan state")
+	}
+
+	for _, c := range plan.Changes.Resources {
+		if c.Action != plans.Delete {
+			t.Errorf("unexpected %s change for %s", c.Action, c.Addr)
+		}
+	}
+}


### PR DESCRIPTION
0.15 back port of #28272

When refresh was skipped for a destroy plan, there was no state stored
in the plan.