### PR TITLE
restore saved dependencies on delete error

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -12467,9 +12467,10 @@ func TestContext2Apply_errorRestoreStatus(t *testing.T) {
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
-			Status:    states.ObjectTainted,
-			AttrsJSON: []byte(`{"test_string":"foo"}`),
-			Private:   []byte("private"),
+			Status:       states.ObjectTainted,
+			AttrsJSON:    []byte(`{"test_string":"foo"}`),
+			Private:      []byte("private"),
+			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.b")},
 		}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
 	})
 
@@ -12504,6 +12505,10 @@ func TestContext2Apply_errorRestoreStatus(t *testing.T) {
 
 	if res.Current.Status != states.ObjectTainted {
 		t.Fatal("resource should still be tainted in the state")
+	}
+
+	if len(res.Current.Dependencies) != 1 || !res.Current.Dependencies[0].Equal(mustConfigResourceAddr("test_object.b")) {
+		t.Fatalf("incorrect dependencies, got %q", res.Current.Dependencies)
 	}
 
 	if string(res.Current.Private) != "private" {

--- a/terraform/node_resource_abstract_instance.go
+++ b/terraform/node_resource_abstract_instance.go
@@ -2102,6 +2102,13 @@ func (n *NodeAbstractResourceInstance) apply(
 			Private:             resp.Private,
 			CreateBeforeDestroy: createBeforeDestroy,
 		}
+
+		// if the resource was being deleted, the dependencies are not going to
+		// be recalculated and we need to restore those as well.
+		if change.Action == plans.Delete {
+			newState.Dependencies = state.Dependencies
+		}
+
 		return newState, diags
 
 	case !newVal.IsNull():


### PR DESCRIPTION
Is a resource delete action fails and the provider returned a new state,
we need to ensure the stored dependencies are retained.

Fixes #28315