### PR TITLE
lang/funcs: Make nonsensitive more permissive

### DIFF
--- a/lang/funcs/sensitive.go
+++ b/lang/funcs/sensitive.go
@@ -48,7 +48,7 @@ var NonsensitiveFunc = function.New(&function.Spec{
 		return args[0].Type(), nil
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
-		if !args[0].HasMark("sensitive") {
+		if args[0].IsKnown() && !args[0].HasMark("sensitive") {
 			return cty.DynamicVal, function.NewArgErrorf(0, "the given value is not sensitive, so this call is redundant")
 		}
 		v, marks := args[0].Unmark()

--- a/lang/funcs/sensitive_test.go
+++ b/lang/funcs/sensitive_test.go
@@ -134,16 +134,19 @@ func TestNonsensitive(t *testing.T) {
 			`the given value is not sensitive, so this call is redundant`,
 		},
 		{
-			cty.DynamicVal,
-			`the given value is not sensitive, so this call is redundant`,
-		},
-		{
 			cty.NullVal(cty.String),
 			`the given value is not sensitive, so this call is redundant`,
 		},
+
+		// Unknown values may become sensitive once they are known, so we
+		// permit them to be marked nonsensitive.
+		{
+			cty.DynamicVal,
+			``,
+		},
 		{
 			cty.UnknownVal(cty.String),
-			`the given value is not sensitive, so this call is redundant`,
+			``,
 		},
 	}
 


### PR DESCRIPTION
Calling the `nonsensitive` function with values which are not sensitive will result in an error. This restriction was added with the goal of preventing confusingly redundant use of this function.

Unfortunately, this breaks when using `nonsensitive` to reveal the value of sensitive resource attributes. This is because the validate walk does not (and cannot) mark attributes as sensitive based on the schema, because the resource value itself is unknown.

This commit therefore alters this restriction such that it permits nonsensitive unknown values, and adds a test case to cover this specific scenario.

Fixes #28321.