### PR TITLE
tiny optimisations of dag.Set

### DIFF
--- a/dag/set.go
+++ b/dag/set.go
@@ -56,13 +56,13 @@ func (s Set) Intersection(other Set) Set {
 // Difference returns a set with the elements that s has but
 // other doesn't.
 func (s Set) Difference(other Set) Set {
+	if other == nil || other.Len() == 0 {
+		return s.Copy()
+	}
+
 	result := make(Set)
 	for k, v := range s {
-		var ok bool
-		if other != nil {
-			_, ok = other[k]
-		}
-		if !ok {
+		if _, ok := other[k]; !ok {
 			result.Add(v)
 		}
 	}
@@ -105,7 +105,7 @@ func (s Set) List() []interface{} {
 
 // Copy returns a shallow copy of the set.
 func (s Set) Copy() Set {
-	c := make(Set)
+	c := make(Set, len(s))
 	for k, v := range s {
 		c[k] = v
 	}

--- a/dag/set_test.go
+++ b/dag/set_test.go
@@ -31,6 +31,12 @@ func TestSetDifference(t *testing.T) {
 			[]interface{}{3, 2, 1, 4},
 			[]interface{}{},
 		},
+		{
+			"B is nil",
+			[]interface{}{1, 2, 3},
+			nil,
+			[]interface{}{1, 2, 3},
+		},
 	}
 
 	for i, tc := range cases {
@@ -43,6 +49,9 @@ func TestSetDifference(t *testing.T) {
 			}
 			for _, v := range tc.B {
 				two.Add(v)
+			}
+			if tc.B == nil {
+				two = nil
 			}
 			for _, v := range tc.Expected {
 				expected.Add(v)


### PR DESCRIPTION
1. Use hint for map size in Set.Copy().
2. Use Set.Copy() if Set.Difference() argument is empty.