### PR TITLE
Add null to type conversion docs

### DIFF
--- a/website/docs/language/functions/tobool.html.md
+++ b/website/docs/language/functions/tobool.html.md
@@ -14,7 +14,7 @@ Explicit type conversions are rarely necessary in Terraform because it will
 convert types automatically where required. Use the explicit type conversion
 functions only to normalize types returned in module outputs.
 
-Only boolean values and the exact strings `"true"` and `"false"` can be
+Only boolean values, `null`, and the exact strings `"true"` and `"false"` can be
 converted to boolean. All other values will produce an error.
 
 ## Examples
@@ -24,6 +24,8 @@ converted to boolean. All other values will produce an error.
 true
 > tobool("true")
 true
+> tobool(null)
+null
 > tobool("no")
 Error: Invalid function argument
 

--- a/website/docs/language/functions/tonumber.html.md
+++ b/website/docs/language/functions/tonumber.html.md
@@ -14,7 +14,7 @@ Explicit type conversions are rarely necessary in Terraform because it will
 convert types automatically where required. Use the explicit type conversion
 functions only to normalize types returned in module outputs.
 
-Only numbers and strings containing decimal representations of numbers can be
+Only numbers, `null`, and strings containing decimal representations of numbers can be
 converted to number. All other values will produce an error.
 
 ## Examples
@@ -24,6 +24,8 @@ converted to number. All other values will produce an error.
 1
 > tonumber("1")
 1
+> tonumber(null)
+null
 > tonumber("no")
 Error: Invalid function argument
 

--- a/website/docs/language/functions/tostring.html.md
+++ b/website/docs/language/functions/tostring.html.md
@@ -14,7 +14,7 @@ Explicit type conversions are rarely necessary in Terraform because it will
 convert types automatically where required. Use the explicit type conversion
 functions only to normalize types returned in module outputs.
 
-Only the primitive types (string, number, and bool) can be converted to string.
+Only the primitive types (string, number, and bool) and `null` can be converted to string.
 All other values will produce an error.
 
 ## Examples
@@ -26,6 +26,8 @@ hello
 1
 > tostring(true)
 true
+> tostring(null)
+null
 > tostring([])
 Error: Invalid function argument
 


### PR DESCRIPTION
Noticed this while using `tobool`, it seems to apply to `tonumber` and `tostring` as well, confirmed in console in 0.14, but didn't try any other versions.

```shell
$ terraform console
> tonumber(null)
null
> tostring(null)
null
> tobool(null)
null
> exit
$ terraform version
Terraform v0.14.7
```