### PR TITLE
Use hashicorp/terraform-registry-address as a decoupled library

### DIFF
--- a/addrs/provider.go
+++ b/addrs/provider.go
@@ -1,32 +1,25 @@
 package addrs
 
 import (
-	"fmt"
-	"strings"
+	"errors"
 
-	"golang.org/x/net/idna"
-
-	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform-registry-address"
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // Provider encapsulates a single provider type. In the future this will be
 // extended to include additional fields including Namespace and SourceHost
-type Provider struct {
-	Type      string
-	Namespace string
-	Hostname  svchost.Hostname
-}
+type Provider = tfaddr.Provider
 
 // DefaultRegistryHost is the hostname used for provider addresses that do
 // not have an explicit hostname.
-const DefaultRegistryHost = svchost.Hostname("registry.terraform.io")
+const DefaultRegistryHost = tfaddr.DefaultRegistryHost
 
 // BuiltInProviderHost is the pseudo-hostname used for the "built-in" provider
 // namespace. Built-in provider addresses must also have their namespace set
 // to BuiltInProviderNamespace in order to be considered as built-in.
-const BuiltInProviderHost = svchost.Hostname("terraform.io")
+const BuiltInProviderHost = tfaddr.BuiltInProviderHost
 
 // BuiltInProviderNamespace is the provider namespace used for "built-in"
 // providers. Built-in provider addresses must also have their hostname
@@ -35,35 +28,14 @@ const BuiltInProviderHost = svchost.Hostname("terraform.io")
 // The this namespace is literally named "builtin", in the hope that users
 // who see FQNs containing this will be able to infer the way in which they are
 // special, even if they haven't encountered the concept formally yet.
-const BuiltInProviderNamespace = "builtin"
+const BuiltInProviderNamespace = tfaddr.BuiltInProviderNamespace
 
 // LegacyProviderNamespace is the special string used in the Namespace field
 // of type Provider to mark a legacy provider address. This special namespace
 // value would normally be invalid, and can be used only when the hostname is
 // DefaultRegistryHost because that host owns the mapping from legacy name to
 // FQN.
-const LegacyProviderNamespace = "-"
-
-// String returns an FQN string, indended for use in machine-readable output.
-func (pt Provider) String() string {
-	if pt.IsZero() {
-		panic("called String on zero-value addrs.Provider")
-	}
-	return pt.Hostname.ForDisplay() + "/" + pt.Namespace + "/" + pt.Type
-}
-
-// ForDisplay returns a user-friendly FQN string, simplified for readability. If
-// the provider is using the default hostname, the hostname is omitted.
-func (pt Provider) ForDisplay() string {
-	if pt.IsZero() {
-		panic("called ForDisplay on zero-value addrs.Provider")
-	}
-
-	if pt.Hostname == DefaultRegistryHost {
-		return pt.Namespace + "/" + pt.Type
-	}
-	return pt.Hostname.ForDisplay() + "/" + pt.Namespace + "/" + pt.Type
-}
+const LegacyProviderNamespace = tfaddr.LegacyProviderNamespace
 
 // NewProvider constructs a provider address from its parts, and normalizes
 // the namespace and type parts to lowercase using unicode case folding rules
@@ -77,18 +49,7 @@ func (pt Provider) ForDisplay() string {
 // When accepting namespace or type values from outside the program, use
 // ParseProviderPart first to check that the given value is valid.
 func NewProvider(hostname svchost.Hostname, namespace, typeName string) Provider {
-	if namespace == LegacyProviderNamespace {
-		// Legacy provider addresses must always be created via
-		// NewLegacyProvider so that we can use static analysis to find
-		// codepaths still working with those.
-		panic("attempt to create legacy provider address using NewProvider; use NewLegacyProvider instead")
-	}
-
-	return Provider{
-		Type:      MustParseProviderPart(typeName),
-		Namespace: MustParseProviderPart(namespace),
-		Hostname:  hostname,
-	}
+	return Provider(tfaddr.NewProvider(hostname, namespace, typeName))
 }
 
 // ImpliedProviderForUnqualifiedType represents the rules for inferring what
@@ -102,124 +63,25 @@ func NewProvider(hostname svchost.Hostname, namespace, typeName string) Provider
 // intent than the now-unmaintained "registry.terraform.io/hashicorp/terraform"
 // which remains only for compatibility with older Terraform versions.
 func ImpliedProviderForUnqualifiedType(typeName string) Provider {
-	switch typeName {
-	case "terraform":
-		// Note for future maintainers: any additional strings we add here
-		// as implied to be builtin must never also be use as provider names
-		// in the registry.terraform.io/hashicorp/... namespace, because
-		// otherwise older versions of Terraform could implicitly select
-		// the registry name instead of the internal one.
-		return NewBuiltInProvider(typeName)
-	default:
-		return NewDefaultProvider(typeName)
-	}
+	return Provider(tfaddr.ImpliedProviderForUnqualifiedType(typeName))
 }
 
 // NewDefaultProvider returns the default address of a HashiCorp-maintained,
 // Registry-hosted provider.
 func NewDefaultProvider(name string) Provider {
-	return Provider{
-		Type:      MustParseProviderPart(name),
-		Namespace: "hashicorp",
-		Hostname:  DefaultRegistryHost,
-	}
+	return Provider(tfaddr.NewDefaultProvider(name))
 }
 
 // NewBuiltInProvider returns the address of a "built-in" provider. See
 // the docs for Provider.IsBuiltIn for more information.
 func NewBuiltInProvider(name string) Provider {
-	return Provider{
-		Type:      MustParseProviderPart(name),
-		Namespace: BuiltInProviderNamespace,
-		Hostname:  BuiltInProviderHost,
-	}
+	return Provider(tfaddr.NewBuiltInProvider(name))
 }
 
 // NewLegacyProvider returns a mock address for a provider.
 // This will be removed when ProviderType is fully integrated.
 func NewLegacyProvider(name string) Provider {
-	return Provider{
-		// We intentionally don't normalize and validate the legacy names,
-		// because existing code expects legacy provider names to pass through
-		// verbatim, even if not compliant with our new naming rules.
-		Type:      name,
-		Namespace: LegacyProviderNamespace,
-		Hostname:  DefaultRegistryHost,
-	}
-}
-
-// LegacyString returns the provider type, which is frequently used
-// interchangeably with provider name. This function can and should be removed
-// when provider type is fully integrated. As a safeguard for future
-// refactoring, this function panics if the Provider is not a legacy provider.
-func (pt Provider) LegacyString() string {
-	if pt.IsZero() {
-		panic("called LegacyString on zero-value addrs.Provider")
-	}
-	if pt.Namespace != LegacyProviderNamespace && pt.Namespace != BuiltInProviderNamespace {
-		panic(pt.String() + " cannot be represented as a legacy string")
-	}
-	return pt.Type
-}
-
-// IsZero returns true if the receiver is the zero value of addrs.Provider.
-//
-// The zero value is not a valid addrs.Provider and calling other methods on
-// such a value is likely to either panic or otherwise misbehave.
-func (pt Provider) IsZero() bool {
-	return pt == Provider{}
-}
-
-// IsBuiltIn returns true if the receiver is the address of a "built-in"
-// provider. That is, a provider under terraform.io/builtin/ which is
-// included as part of the Terraform binary itself rather than one to be
-// installed from elsewhere.
-//
-// These are ignored by the provider installer because they are assumed to
-// already be available without any further installation.
-func (pt Provider) IsBuiltIn() bool {
-	return pt.Hostname == BuiltInProviderHost && pt.Namespace == BuiltInProviderNamespace
-}
-
-// LessThan returns true if the receiver should sort before the other given
-// address in an ordered list of provider addresses.
-//
-// This ordering is an arbitrary one just to allow deterministic results from
-// functions that would otherwise have no natural ordering. It's subject
-// to change in future.
-func (pt Provider) LessThan(other Provider) bool {
-	switch {
-	case pt.Hostname != other.Hostname:
-		return pt.Hostname < other.Hostname
-	case pt.Namespace != other.Namespace:
-		return pt.Namespace < other.Namespace
-	default:
-		return pt.Type < other.Type
-	}
-}
-
-// IsLegacy returns true if the provider is a legacy-style provider
-func (pt Provider) IsLegacy() bool {
-	if pt.IsZero() {
-		panic("called IsLegacy() on zero-value addrs.Provider")
-	}
-
-	return pt.Hostname == DefaultRegistryHost && pt.Namespace == LegacyProviderNamespace
-
-}
-
-// IsDefault returns true if the provider is a default hashicorp provider
-func (pt Provider) IsDefault() bool {
-	if pt.IsZero() {
-		panic("called IsDefault() on zero-value addrs.Provider")
-	}
-
-	return pt.Hostname == DefaultRegistryHost && pt.Namespace == "hashicorp"
-}
-
-// Equals returns true if the receiver and other provider have the same attributes.
-func (pt Provider) Equals(other Provider) bool {
-	return pt == other
+	return Provider(tfaddr.NewLegacyProvider(name))
 }
 
 // ParseProviderSourceString parses the source attribute and returns a provider.
@@ -231,145 +93,23 @@ func (pt Provider) Equals(other Provider) bool {
 // 		namespace/name
 // 		hostname/namespace/name
 func ParseProviderSourceString(str string) (Provider, tfdiags.Diagnostics) {
-	var ret Provider
-	var diags tfdiags.Diagnostics
+	diags := make(tfdiags.Diagnostics, 0)
 
-	// split the source string into individual components
-	parts := strings.Split(str, "/")
-	if len(parts) == 0 || len(parts) > 3 {
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid provider source string",
-			Detail:   `The "source" attribute must be in the format "[hostname/][namespace/]name"`,
-		})
-		return ret, diags
-	}
-
-	// check for an invalid empty string in any part
-	for i := range parts {
-		if parts[i] == "" {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid provider source string",
-				Detail:   `The "source" attribute must be in the format "[hostname/][namespace/]name"`,
-			})
-			return ret, diags
-		}
-	}
-
-	// check the 'name' portion, which is always the last part
-	givenName := parts[len(parts)-1]
-	name, err := ParseProviderPart(givenName)
+	pAddr, err := tfaddr.ParseAndInferProviderSourceString(str)
 	if err != nil {
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid provider type",
-			Detail:   fmt.Sprintf(`Invalid provider type %q in source %q: %s"`, givenName, str, err),
-		})
-		return ret, diags
-	}
-	ret.Type = name
-	ret.Hostname = DefaultRegistryHost
-
-	if len(parts) == 1 {
-		return NewDefaultProvider(parts[0]), diags
-	}
-
-	if len(parts) >= 2 {
-		// the namespace is always the second-to-last part
-		givenNamespace := parts[len(parts)-2]
-		if givenNamespace == LegacyProviderNamespace {
-			// For now we're tolerating legacy provider addresses until we've
-			// finished updating the rest of the codebase to no longer use them,
-			// or else we'd get errors round-tripping through legacy subsystems.
-			ret.Namespace = LegacyProviderNamespace
+		parserErr := &tfaddr.ParserError{}
+		if errors.As(err, &parserErr) {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				parserErr.Summary,
+				parserErr.Detail,
+			))
 		} else {
-			namespace, err := ParseProviderPart(givenNamespace)
-			if err != nil {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Invalid provider namespace",
-					Detail:   fmt.Sprintf(`Invalid provider namespace %q in source %q: %s"`, namespace, str, err),
-				})
-				return Provider{}, diags
-			}
-			ret.Namespace = namespace
+			diags = diags.Append(tfdiags.FormatError(err))
 		}
 	}
 
-	// Final Case: 3 parts
-	if len(parts) == 3 {
-		// the namespace is always the first part in a three-part source string
-		hn, err := svchost.ForComparison(parts[0])
-		if err != nil {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid provider source hostname",
-				Detail:   fmt.Sprintf(`Invalid provider source hostname namespace %q in source %q: %s"`, hn, str, err),
-			})
-			return Provider{}, diags
-		}
-		ret.Hostname = hn
-	}
-
-	if ret.Namespace == LegacyProviderNamespace && ret.Hostname != DefaultRegistryHost {
-		// Legacy provider addresses must always be on the default registry
-		// host, because the default registry host decides what actual FQN
-		// each one maps to.
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid provider namespace",
-			Detail:   "The legacy provider namespace \"-\" can be used only with hostname " + DefaultRegistryHost.ForDisplay() + ".",
-		})
-		return Provider{}, diags
-	}
-
-	// Due to how plugin executables are named and provider git repositories
-	// are conventionally named, it's a reasonable and
-	// apparently-somewhat-common user error to incorrectly use the
-	// "terraform-provider-" prefix in a provider source address. There is
-	// no good reason for a provider to have the prefix "terraform-" anyway,
-	// so we've made that invalid from the start both so we can give feedback
-	// to provider developers about the terraform- prefix being redundant
-	// and give specialized feedback to folks who incorrectly use the full
-	// terraform-provider- prefix to help them self-correct.
-	const redundantPrefix = "terraform-"
-	const userErrorPrefix = "terraform-provider-"
-	if strings.HasPrefix(ret.Type, redundantPrefix) {
-		if strings.HasPrefix(ret.Type, userErrorPrefix) {
-			// Likely user error. We only return this specialized error if
-			// whatever is after the prefix would otherwise be a
-			// syntactically-valid provider type, so we don't end up advising
-			// the user to try something that would be invalid for another
-			// reason anyway.
-			// (This is mainly just for robustness, because the validation
-			// we already did above should've rejected most/all ways for
-			// the suggestedType to end up invalid here.)
-			suggestedType := ret.Type[len(userErrorPrefix):]
-			if _, err := ParseProviderPart(suggestedType); err == nil {
-				suggestedAddr := ret
-				suggestedAddr.Type = suggestedType
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Error,
-					"Invalid provider type",
-					fmt.Sprintf("Provider source %q has a type with the prefix %q, which isn't valid. Although that prefix is often used in the names of version control repositories for Terraform providers, provider source strings should not include it.\n\nDid you mean %q?", ret.ForDisplay(), userErrorPrefix, suggestedAddr.ForDisplay()),
-				))
-				return Provider{}, diags
-			}
-		}
-		// Otherwise, probably instead an incorrectly-named provider, perhaps
-		// arising from a similar instinct to what causes there to be
-		// thousands of Python packages on PyPI with "python-"-prefixed
-		// names.
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid provider type",
-			fmt.Sprintf("Provider source %q has a type with the prefix %q, which isn't allowed because it would be redundant to name a Terraform provider with that prefix. If you are the author of this provider, rename it to not include the prefix.", ret, redundantPrefix),
-		))
-		return Provider{}, diags
-	}
-
-	return ret, diags
+	return Provider(pAddr), diags
 }
 
 // MustParseProviderSourceString is a wrapper around ParseProviderSourceString that panics if
@@ -409,56 +149,16 @@ func MustParseProviderSourceString(str string) Provider {
 // It's valid to pass the result of this function as the argument to a
 // subsequent call, in which case the result will be identical.
 func ParseProviderPart(given string) (string, error) {
-	if len(given) == 0 {
-		return "", fmt.Errorf("must have at least one character")
-	}
-
-	// We're going to process the given name using the same "IDNA" library we
-	// use for the hostname portion, since it already implements the case
-	// folding rules we want.
-	//
-	// The idna library doesn't expose individual label parsing directly, but
-	// once we've verified it doesn't contain any dots we can just treat it
-	// like a top-level domain for this library's purposes.
-	if strings.ContainsRune(given, '.') {
-		return "", fmt.Errorf("dots are not allowed")
-	}
-
-	// We don't allow names containing multiple consecutive dashes, just as
-	// a matter of preference: they look weird, confusing, or incorrect.
-	// This also, as a side-effect, prevents the use of the "punycode"
-	// indicator prefix "xn--" that would cause the IDNA library to interpret
-	// the given name as punycode, because that would be weird and unexpected.
-	if strings.Contains(given, "--") {
-		return "", fmt.Errorf("cannot use multiple consecutive dashes")
-	}
-
-	result, err := idna.Lookup.ToUnicode(given)
-	if err != nil {
-		return "", fmt.Errorf("must contain only letters, digits, and dashes, and may not use leading or trailing dashes")
-	}
-
-	return result, nil
+	return tfaddr.ParseProviderPart(given)
 }
 
 // MustParseProviderPart is a wrapper around ParseProviderPart that panics if
 // it returns an error.
 func MustParseProviderPart(given string) string {
-	result, err := ParseProviderPart(given)
-	if err != nil {
-		panic(err.Error())
-	}
-	return result
+	return tfaddr.MustParseProviderPart(given)
 }
 
 // IsProviderPartNormalized compares a given string to the result of ParseProviderPart(string)
 func IsProviderPartNormalized(str string) (bool, error) {
-	normalized, err := ParseProviderPart(str)
-	if err != nil {
-		return false, err
-	}
-	if str == normalized {
-		return true, nil
-	}
-	return false, nil
+	return tfaddr.IsProviderPartNormalized(str)
 }

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/gofrs/uuid v3.3.0+incompatible // indirect
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
-	github.com/google/go-cmp v0.5.2
+	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.2.0
 	github.com/gophercloud/gophercloud v0.10.1-0.20200424014253-c3bfe50899e5
 	github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d
@@ -69,6 +69,7 @@ require (
 	github.com/hashicorp/memberlist v0.1.0 // indirect
 	github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb // indirect
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2
+	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/jmespath/go-jmespath v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,9 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -318,8 +319,6 @@ github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuD
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-getter v1.5.1 h1:lM9sM02nvEApQGFgkXxWbhfqtyN+AyhQmi+MaMdBDOI=
-github.com/hashicorp/go-getter v1.5.1/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
 github.com/hashicorp/go-getter v1.5.2 h1:XDo8LiAcDisiqZdv0TKgz+HtX3WN7zA2JD1R1tjsabE=
 github.com/hashicorp/go-getter v1.5.2/go.mod h1:orNH3BTYLu/fIxGIdLjLoAJHWMDQ/UKQr5O4m3iBuoo=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -368,6 +367,8 @@ github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb h1:ZbgmOQt8DOg796fi
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2 h1:l+bLFvHjqtgNQwWxwrFX9PemGAAO2P1AGZM7zlMNvCs=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2/go.mod h1:Z0Nnk4+3Cy89smEbrq+sl1bxc9198gIP4I7wcQF6Kqs=
+github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 h1:1FGtlkJw87UsTMg5s8jrekrHmUPUJaMcu6ELiVhQrNw=
+github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -703,6 +704,7 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=


### PR DESCRIPTION
This PR proposes replacement of some of the internal logic of `addrs` package which handles parsing and representation of the provider registry address.

As discussed earlier there is now a decoupled library at https://github.com/hashicorp/terrafom-registry-address , which effectively commits to that API there and replacing the internals here ensures that no breaking changes are introduced without other external consumers noticing - soon to be Terraform LS, and likely the plugin SDK too.

--- 

I originally wanted to replace all imports throughout the codebase but later realized how many there are, so I decided to just leave the existing functions, constants and types in place and just "proxy" it to the library. I'm willing to do a more thorough replacing if desired though.

Also I do plan to tag `terraform-registry-address@v1.0.0`, but I thought I'd raise this PR first to double check with you all before formally/externally committing to that API.