### PR TITLE
document that destroy provisioners don't run with create_before_destroy

### DIFF
--- a/website/docs/language/meta-arguments/lifecycle.html.md
+++ b/website/docs/language/meta-arguments/lifecycle.html.md
@@ -45,6 +45,10 @@ The following arguments can be used within a `lifecycle` block:
     such features, so you must understand the constraints for each resource
     type before using `create_before_destroy` with it.
 
+    Destroy provisioners of this resource will not run if `create_before_destroy`
+    is used. This limitation may be addressed in the future, see
+    [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) for details.
+
 * `prevent_destroy` (bool) - This meta-argument, when set to `true`, will
   cause Terraform to reject with an error any plan that would destroy the
   infrastructure object associated with the resource, as long as the argument

--- a/website/docs/language/meta-arguments/lifecycle.html.md
+++ b/website/docs/language/meta-arguments/lifecycle.html.md
@@ -46,8 +46,7 @@ The following arguments can be used within a `lifecycle` block:
     type before using `create_before_destroy` with it.
 
     Destroy provisioners of this resource will not run if `create_before_destroy`
-    is used. This limitation may be addressed in the future, see
-    [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) for details.
+    is set to `true`. We may address this in the future, and this [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) contains more details.
 
 * `prevent_destroy` (bool) - This meta-argument, when set to `true`, will
   cause Terraform to reject with an error any plan that would destroy the

--- a/website/docs/language/resources/provisioners/syntax.html.md
+++ b/website/docs/language/resources/provisioners/syntax.html.md
@@ -237,10 +237,8 @@ fail, Terraform will error and rerun the provisioners again on the next
 `terraform apply`. Due to this behavior, care should be taken for destroy
 provisioners to be safe to run multiple times.
 
-Destroy provisioners will not run if the lifecycle Meta-Argument
-[`create_before_destroy`](/docs/language/meta-arguments/lifecycle.html) is used
-in the resource. This limitation may be addressed in the future, see
-[GitHub issue](https://github.com/hashicorp/terraform/issues/13549) for details.
+    Destroy provisioners of this resource will not run if `create_before_destroy`
+    is set to `true`. We may address this in the future, and this [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) contains more details.
 
 Destroy-time provisioners can only run if they remain in the configuration
 at the time a resource is destroyed. If a resource block with a destroy-time

--- a/website/docs/language/resources/provisioners/syntax.html.md
+++ b/website/docs/language/resources/provisioners/syntax.html.md
@@ -237,6 +237,11 @@ fail, Terraform will error and rerun the provisioners again on the next
 `terraform apply`. Due to this behavior, care should be taken for destroy
 provisioners to be safe to run multiple times.
 
+Destroy provisioners will not run if the lifecycle Meta-Argument
+[`create_before_destroy`](/docs/language/meta-arguments/lifecycle.html) is used
+in the resource. This limitation may be addressed in the future, see
+[GitHub issue](https://github.com/hashicorp/terraform/issues/13549) for details.
+
 Destroy-time provisioners can only run if they remain in the configuration
 at the time a resource is destroyed. If a resource block with a destroy-time
 provisioner is removed entirely from the configuration, its provisioner


### PR DESCRIPTION
Documents issue https://github.com/hashicorp/terraform/issues/13549

Ran in this today again after first running into it a year ago and forgetting about it...
I think it's better to document this so people don't try to use this and then just end up disappointed because it doesn't work.