### PR TITLE
command: Add a newline before confirming apply

### DIFF
--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -107,7 +107,7 @@ func (b *Local) opApply(
 
 			v, err := op.UIIn.Input(stopCtx, &terraform.InputOpts{
 				Id:          "approve",
-				Query:       query,
+				Query:       "\n" + query,
 				Description: desc,
 			})
 			if err != nil {


### PR DESCRIPTION
This blank line delineating the plan and the query was accidentally dropped as part of the views migration.

Before:

<img width="1082" alt="before" src="https://user-images.githubusercontent.com/68917/114718704-418b2480-9d04-11eb-9b56-434bda16773c.png">

After:

<img width="1082" alt="after" src="https://user-images.githubusercontent.com/68917/114718712-451eab80-9d04-11eb-8ebd-4e179eb44786.png">
