### PR TITLE
Prototype: "expandnull" function

### DIFF
--- a/lang/functions.go
+++ b/lang/functions.go
@@ -60,6 +60,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"dirname":          funcs.DirnameFunc,
 			"distinct":         stdlib.DistinctFunc,
 			"element":          stdlib.ElementFunc,
+			"expandnull":       funcs.ExpandNullFunc,
 			"chunklist":        stdlib.ChunklistFunc,
 			"file":             funcs.MakeFileFunc(s.BaseDir, false),
 			"fileexists":       funcs.MakeFileExistsFunc(s.BaseDir),


### PR DESCRIPTION
This is intended to complement the `defaults` function as part of the optional attributes experiment, to give module authors a way to concisely declare that they don't care to distinguish between null objects/tuples and objects/tuples _containing_ nulls, and that they don't care to distinguish between null collections and empty collections, and thus they can avoid needing to do conditional traversals and focus only on handling the leaf primitive-typed values as being null.

This is just a prototype to see what this might look like and how it will interact with the `defaults` function. It's not yet ready to be merged because it lacks tests and documentation.

This is one candidate answer to the concern raised in #28344:

```hcl
terraform {
  experiments      = [module_variable_optional_attrs]
}

variable "my_var" {
  type = object({
    some_config1 = optional(object({
      my_something = optional(bool)
    }))

    deep_config = optional(object({
      deep_1 = optional(object({
        something_1 = string
        something_2 = number
      }))

      deep_2 = optional(object({
        something_1 = string
        something_2 = number
      }))
    }))
  })
}

locals {
  my_var = defaults(expandnull(var.my_var), {
    some_config1 = {
      my_something = true
    }

    deep_config = {
      deep_1 = {
        something_1 = "asdf"
        something_2 = 1
      }

      deep_2 = {
        something_1 = "fdsa"
        something_2 = 5
      }
    }
  })
}

output "my_var" {
  value = local.my_var
}
```

```
Outputs:

my_var = {
  "deep_config" = {
    "deep_1" = {
      "something_1" = "asdf"
      "something_2" = 1
    }
    "deep_2" = {
      "something_1" = "fdsa"
      "something_2" = 5
    }
  }
  "some_config1" = {
    "my_something" = true
  }
}
```

However, it does come at the expense of adding another very specialized function with a limited use-case, so we'll likely consider other designs too.
