### PR TITLE
core: Fix double-marked sensitive attributes

### DIFF
--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -782,9 +782,15 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 
 		val := ios.Value
 
-		// If our schema contains sensitive values, mark those as sensitive
+		// If our schema contains sensitive values, mark those as sensitive.
+		// Since decoding the instance object can also apply sensitivity marks,
+		// we must remove and combine those before remarking to avoid a double-
+		// mark error.
 		if schema.ContainsSensitive() {
-			val = markProviderSensitiveAttributes(schema, val)
+			var marks []cty.PathValueMarks
+			val, marks = val.UnmarkDeepWithPaths()
+			marks = append(marks, getValMarks(schema, val, nil)...)
+			val = val.MarkWithPaths(marks)
 		}
 		instances[key] = val
 	}
@@ -952,12 +958,6 @@ func moduleDisplayAddr(addr addrs.ModuleInstance) string {
 	default:
 		return addr.String()
 	}
-}
-
-// markProviderSensitiveAttributes returns an updated value
-// where attributes that are Sensitive are marked
-func markProviderSensitiveAttributes(schema *configschema.Block, val cty.Value) cty.Value {
-	return val.MarkWithPaths(getValMarks(schema, val, nil))
 }
 
 func getValMarks(schema *configschema.Block, val cty.Value, path cty.Path) []cty.PathValueMarks {

--- a/terraform/evaluate_test.go
+++ b/terraform/evaluate_test.go
@@ -563,7 +563,7 @@ func evaluatorForModule(stateSync *states.SyncState, changesSync *plans.ChangesS
 	}
 }
 
-func TestMarkProviderSensitive(t *testing.T) {
+func TestGetValMarks(t *testing.T) {
 	schema := &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"unsensitive": {
@@ -647,7 +647,7 @@ func TestMarkProviderSensitive(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("%#v", tc.given), func(t *testing.T) {
-			got := markProviderSensitiveAttributes(schema, tc.given)
+			got := tc.given.MarkWithPaths(getValMarks(schema, tc.given, nil))
 			if !got.RawEquals(tc.expect) {
 				t.Fatalf("\nexpected: %#v\ngot:      %#v\n", tc.expect, got)
 			}


### PR DESCRIPTION
If a resource has a writeable attribute which is sensitive in the schema, which is bound to a marked sensitive value, reading the resource from state would previously crash due to double-marking the value. To fix this, we need to unmark the value from state, merge its marks with the schema-derived marks, and re-apply the merged marks.

Fixes #28370.