### PR TITLE
website: v0.15 Upgrade Guide entry for Azure Backend arguments

### DIFF
--- a/website/upgrade-guides/0-15.html.markdown
+++ b/website/upgrade-guides/0-15.html.markdown
@@ -52,6 +52,7 @@ Upgrade guide sections:
 * [Commands Accepting a Configuration Directory Argument](#commands-accepting-a-configuration-directory-argument)
 * [Microsoft Windows Terminal Support](#microsoft-windows-terminal-support)
 * [Other Minor Command Line Behavior Changes](#other-minor-command-line-behavior-changes)
+* [Azure Backend `arm_`-prefixed Arguments](#azure-backend-removed-arguments)
 
 ## Sensitive Output Values
 
@@ -493,3 +494,44 @@ cleanup of obsolete features and improved consistency:
 
     If you are using `-force` in an automated call to `terraform destroy`,
     change to using `-auto-approve` instead.
+
+## Azure Backend Removed Arguments
+
+In an earlier release the `azure` backend changed to remove the `arm_` prefix
+from a number of the configuration arguments:
+
+| Old Name              | New Name          |
+|-----------------------|-------------------|
+| `arm_client_id`       | `client_id`       |
+| `arm_client_secret`   | `client_secret`   |
+| `arm_subscription_id` | `subscription_id` |
+| `arm_tenant_id`       | `tenant_id`       |
+
+The old names were previously deprecated, but we've removed them altogether
+in Terraform v0.15 in order to conclude that deprecation cycle.
+
+If you have a backend configuration using the old names then you may see
+errors like the following when upgrading to Terraform v0.15:
+
+```
+╷
+│ Error: Invalid backend configuration argument
+│
+│ The backend configuration argument "arm_client_id" given on
+│ the command line is not expected for the selected backend type.
+╵
+```
+
+If you see errors like this, rename the arguments in your backend configuration
+as shown in the table above and then run the following to re-initialize your
+backend configuration:
+
+```
+terraform init -reconfigure
+```
+
+The `-reconfigure` argument instructs Terraform to just replace the old
+configuration with the new configuration directly, rather than offering to
+migrate the latest state snapshots from the old to the new configuration.
+Migration would not be appropriate in this case because the old and new
+configurations are equivalent and refer to the same remote objects.


### PR DESCRIPTION
Terraform v0.15 includes the conclusion of the deprecation cycle for some renamed arguments in the "azure" backend.

We missed this on the first draft of the upgrade guide because this change arrived along with various other more innocuous updates in #28181 and so we didn't spot it during our change review.

This closes #28378.
