### PR TITLE
cli: Fix remote backend UI issues

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/backend"
+	remoteBackend "github.com/hashicorp/terraform/backend/remote"
 	"github.com/hashicorp/terraform/command/arguments"
 	"github.com/hashicorp/terraform/command/views"
 	"github.com/hashicorp/terraform/plans/planfile"
@@ -25,6 +26,11 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 	// Parse and apply global view arguments
 	common, rawArgs := arguments.ParseView(rawArgs)
 	c.View.Configure(common)
+
+	// Propagate -no-color for the remote backend's legacy use of Ui. This
+	// should be removed when the remote backend is migrated to views.
+	c.Meta.color = !common.NoColor
+	c.Meta.Color = c.Meta.color
 
 	// Parse and validate flags
 	args, diags := arguments.ParseApply(rawArgs)
@@ -116,10 +122,13 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 		return op.Result.ExitStatus()
 	}
 
-	// // Render the resource count and outputs
-	view.ResourceCount(args.State.StateOutPath)
-	if !c.Destroy && op.State != nil {
-		view.Outputs(op.State.RootModule().OutputValues)
+	// Render the resource count and outputs, unless we're using the remote
+	// backend, in which case these are rendered remotely
+	if _, isRemoteBackend := be.(*remoteBackend.Remote); !isRemoteBackend {
+		view.ResourceCount(args.State.StateOutPath)
+		if !c.Destroy && op.State != nil {
+			view.Outputs(op.State.RootModule().OutputValues)
+		}
 	}
 
 	view.Diagnostics(diags)

--- a/command/plan.go
+++ b/command/plan.go
@@ -21,6 +21,11 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	common, rawArgs := arguments.ParseView(rawArgs)
 	c.View.Configure(common)
 
+	// Propagate -no-color for the remote backend's legacy use of Ui. This
+	// should be removed when the remote backend is migrated to views.
+	c.Meta.color = !common.NoColor
+	c.Meta.Color = c.Meta.color
+
 	// Parse and validate flags
 	args, diags := arguments.ParsePlan(rawArgs)
 


### PR DESCRIPTION
Fix two bugs which surface when using the remote backend:

- When migrating to views, we removed the call to `(*Meta).process` which initialized the color boolean. This resulted in the legacy UI calls in the remote backend stripping color codes. To fix this, we populate this boolean from the common arguments.
- Remote apply will output the resource summary and output changes, and these are rendered via the remote backend streaming. We need to special case this in the apply command and prevent displaying a zero-change summary line.

Neither of these are coverable by automated tests, as we don't have any command-package level testing for the remote backend. Manually verified.

Fixes #28408.

### Before

<img width="965" alt="before" src="https://user-images.githubusercontent.com/68917/115024810-98bd0080-9e8e-11eb-9909-de8fddab41ad.png">

### After

<img width="965" alt="after" src="https://user-images.githubusercontent.com/68917/115024804-96f33d00-9e8e-11eb-90af-b4fb8196a68d.png">

### After (with `-no-color`)

<img width="965" alt="after-no-color" src="https://user-images.githubusercontent.com/68917/115026730-d589f700-9e90-11eb-9e99-0adca18b0ff5.png">
