### PR TITLE
cli: Fix missing apply summary for remote runs

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -704,6 +704,9 @@ func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend
 
 	// Check if we need to use the local backend to run the operation.
 	if b.forceLocal || !w.Operations {
+		// Record that we're forced to run operations locally to allow the
+		// command package UI to operate correctly
+		b.forceLocal = true
 		return b.local.Operation(ctx, op)
 	}
 
@@ -947,6 +950,10 @@ func (b *Remote) VerifyWorkspaceTerraformVersion(workspaceName string) tfdiags.D
 	))
 
 	return diags
+}
+
+func (b *Remote) IsLocalOperations() bool {
+	return b.forceLocal
 }
 
 // Colorize returns the Colorize structure that can be used for colorizing

--- a/command/apply.go
+++ b/command/apply.go
@@ -124,7 +124,7 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 
 	// Render the resource count and outputs, unless we're using the remote
 	// backend locally, in which case these are rendered remotely
-	if _, isRemoteBackend := be.(*remoteBackend.Remote); !isRemoteBackend || c.RunningInAutomation {
+	if rb, isRemoteBackend := be.(*remoteBackend.Remote); !isRemoteBackend || rb.IsLocalOperations() {
 		view.ResourceCount(args.State.StateOutPath)
 		if !c.Destroy && op.State != nil {
 			view.Outputs(op.State.RootModule().OutputValues)

--- a/command/apply.go
+++ b/command/apply.go
@@ -123,8 +123,8 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 	}
 
 	// Render the resource count and outputs, unless we're using the remote
-	// backend, in which case these are rendered remotely
-	if _, isRemoteBackend := be.(*remoteBackend.Remote); !isRemoteBackend {
+	// backend locally, in which case these are rendered remotely
+	if _, isRemoteBackend := be.(*remoteBackend.Remote); !isRemoteBackend || c.RunningInAutomation {
 		view.ResourceCount(args.State.StateOutPath)
 		if !c.Destroy && op.State != nil {
 			view.Outputs(op.State.RootModule().OutputValues)


### PR DESCRIPTION
Disabling the resource count and outputs rendering when the remote backend is in use causes them to be omitted from Terraform Cloud runs. This PR changes the condition to render these values if either the remote backend is not in use, or it is in local operations mode. The latter is true both for Terraform Cloud workspaces which are for state storage, and when executing Terraform runs remotely on a Terraform Cloud worker.

PR review note: I'm not thrilled with this solution, but I'm at a loss as to how better to solve it. Open to ideas!

Follow-up to #28409.

### Before (running latest main branch locally and in Terraform Cloud)

Missing apply summary:

<img width="902" alt="before" src="https://user-images.githubusercontent.com/68917/115037047-10455c80-9e9c-11eb-9215-27059d76ea20.png">

### After (running this branch locally and in Terraform Cloud)

Apply summary present:

<img width="902" alt="after" src="https://user-images.githubusercontent.com/68917/115036686-bba1e180-9e9b-11eb-8c72-d9aba61c993c.png">

### After (running this branch locally, in local operations mode, against Terraform Cloud)

<img width="857" alt="local-ops" src="https://user-images.githubusercontent.com/68917/115050343-a7fd7780-9ea9-11eb-9da5-e7ceae8643cf.png">
