### PR TITLE
docs: small update for provider binary locations

### DIFF
--- a/website/docs/cli/config/config-file.html.md
+++ b/website/docs/cli/config/config-file.html.md
@@ -282,14 +282,14 @@ the operating system where you are running Terraform:
   `~/.local/share/terraform/plugins`,
   `/usr/local/share/terraform/plugins`, and `/usr/share/terraform/plugins`.
 
-Terraform will create an implied `filesystem_mirror` method block for each of
-the directories indicated above that exists when Terraform starts up.
-In addition, if a `terraform.d/plugins` directory exists in the current working
-directory, it will be added as a filesystem mirror.
+If a `terraform.d/plugins` directory exists in the current working directory
+then Terraform will also include that directory, regardless of your operating
+system.
 
-Note that providers installed in these directories need to be placed in the
-appropriate nested directory structure described in the
-[filesystem_mirror](#filesystem_mirror) section of this document.
+Terraform will check each of the paths above to see if it exists, and if so
+treat it as a filesystem mirror. The directory structure inside each one must
+therefore match one of the two structures described for `filesystem_mirror`
+blocks.
 
 In addition to the zero or more implied `filesystem_mirror` blocks, Terraform
 also creates an implied `direct` block. Terraform will scan all of the

--- a/website/docs/cli/config/config-file.html.md
+++ b/website/docs/cli/config/config-file.html.md
@@ -289,7 +289,7 @@ system.
 Terraform will check each of the paths above to see if it exists, and if so
 treat it as a filesystem mirror. The directory structure inside each one must
 therefore match one of the two structures described for `filesystem_mirror`
-blocks.
+blocks in [Explicit Installation Method Configuration](#explicit-installation-method-configuration).
 
 In addition to the zero or more implied `filesystem_mirror` blocks, Terraform
 also creates an implied `direct` block. Terraform will scan all of the

--- a/website/docs/cli/config/config-file.html.md
+++ b/website/docs/cli/config/config-file.html.md
@@ -287,6 +287,10 @@ the directories indicated above that exists when Terraform starts up.
 In addition, if a `terraform.d/plugins` directory exists in the current working
 directory, it will be added as a filesystem mirror.
 
+Note that providers installed in these directories need to be placed in the
+appropriate nested directory structure described in the
+[filesystem_mirror](#filesystem_mirror) section of this document.
+
 In addition to the zero or more implied `filesystem_mirror` blocks, Terraform
 also creates an implied `direct` block. Terraform will scan all of the
 filesystem mirror directories to see which providers are placed there and


### PR DESCRIPTION
docs: add note that provider binaries need to be placed in appropriate subdirectories under the default locations

closes #28395 (with a similar PR to terraform-website)

Re-iterate that provider binaries need to be installed _in the proper subdirectory_ rather than just under `.plugins`. 