### PR TITLE
resolve provider types when building the config

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -329,6 +329,53 @@ func (c *Config) addProviderRequirements(reqs getproviders.Requirements, recurse
 	return diags
 }
 
+// resolveProviderTypes walks through the providers in the module and ensures
+// the true types are assigned based on the provider requirements for the
+// module.
+func (c *Config) resolveProviderTypes() {
+	for _, child := range c.Children {
+		child.resolveProviderTypes()
+	}
+
+	// collect the required_providers, and then add any missing default providers
+	providers := map[string]addrs.Provider{}
+	for name, p := range c.Module.ProviderRequirements.RequiredProviders {
+		providers[name] = p.Type
+	}
+
+	// ensure all provider configs know their correct type
+	for _, p := range c.Module.ProviderConfigs {
+		addr, required := providers[p.Name]
+		if required {
+			p.providerType = addr
+		} else {
+			addr := addrs.NewDefaultProvider(p.Name)
+			p.providerType = addr
+			providers[p.Name] = addr
+		}
+	}
+
+	// connect module call providers to the correct type
+	for _, mod := range c.Module.ModuleCalls {
+		for _, p := range mod.Providers {
+			if addr, known := providers[p.InParent.Name]; known {
+				p.InParent.providerType = addr
+			}
+		}
+	}
+
+	// fill in parent module calls too
+	if c.Parent != nil {
+		for _, mod := range c.Parent.Module.ModuleCalls {
+			for _, p := range mod.Providers {
+				if addr, known := providers[p.InChild.Name]; known {
+					p.InChild.providerType = addr
+				}
+			}
+		}
+	}
+}
+
 // ProviderTypes returns the FQNs of each distinct provider type referenced
 // in the receiving configuration.
 //

--- a/configs/config_build.go
+++ b/configs/config_build.go
@@ -23,6 +23,10 @@ func BuildConfig(root *Module, walker ModuleWalker) (*Config, hcl.Diagnostics) {
 	cfg.Root = cfg // Root module is self-referential.
 	cfg.Children, diags = buildChildModules(cfg, walker)
 
+	// Now that the config is built, we can connect the provider names to all
+	// the known types for validation.
+	cfg.resolveProviderTypes()
+
 	diags = append(diags, validateProviderConfigs(nil, cfg, false)...)
 
 	return cfg, diags

--- a/configs/provider.go
+++ b/configs/provider.go
@@ -25,6 +25,13 @@ type Provider struct {
 	Config hcl.Body
 
 	DeclRange hcl.Range
+
+	// TODO: this may not be set in some cases, so it is not yet suitable for
+	// use outside of this package. We currently only use it for internal
+	// validation, but once we verify that this can be set in all cases, we can
+	// export this so providers don't need to be re-resolved.
+	// This same field is also added to the ProviderConfigRef struct.
+	providerType addrs.Provider
 }
 
 func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {

--- a/configs/resource.go
+++ b/configs/resource.go
@@ -374,6 +374,13 @@ type ProviderConfigRef struct {
 	NameRange  hcl.Range
 	Alias      string
 	AliasRange *hcl.Range // nil if alias not set
+
+	// TODO: this may not be set in some cases, so it is not yet suitable for
+	// use outside of this package. We currently only use it for internal
+	// validation, but once we verify that this can be set in all cases, we can
+	// export this so providers don't need to be re-resolved.
+	// This same field is also added to the Provider struct.
+	providerType addrs.Provider
 }
 
 func decodeProviderConfigRef(expr hcl.Expression, argName string) (*ProviderConfigRef, hcl.Diagnostics) {

--- a/configs/testdata/valid-modules/nested-providers-fqns/child/main.tf
+++ b/configs/testdata/valid-modules/nested-providers-fqns/child/main.tf
@@ -3,10 +3,12 @@ terraform {
     bar-test = {
       source = "bar/test"
     }
+    foo-test = {
+      source = "foo/test"
+      configuration_aliases = [foo-test.other]
+    }
   }
 }
-
-provider "bar-test" {}
 
 resource "test_instance" "explicit" {
   // explicitly setting provider bar-test
@@ -16,4 +18,8 @@ resource "test_instance" "explicit" {
 resource "test_instance" "implicit" {
   // since the provider type name "test" does not match an entry in
   // required_providers, the default provider "test" should be used
+}
+
+resource "test_instance" "other" {
+  provider = foo-test.other
 }

--- a/configs/testdata/valid-modules/nested-providers-fqns/main.tf
+++ b/configs/testdata/valid-modules/nested-providers-fqns/main.tf
@@ -10,6 +10,9 @@ provider "foo-test" {}
 
 module "child" {
   source = "./child"
+  providers = {
+    foo-test.other = foo-test
+  }
 }
 
 resource "test_instance" "explicit" {


### PR DESCRIPTION
All the information is available to resolve provider types when building
the configuration, but some provider references still had no FQN. This
caused validation to assume a default type, and incorrectly reject valid
module calls with non-default namespaced providers.

Resolve as much provider type information as possible when loading the
config. Only use this internally for now, but this should be useful
outside of the package to avoid re-resolving the providers later on. We
can come back and find where this might be useful elsewhere, but for now
keep the change as small as possible to avoid any changes in behavior.

Fixes #28407