### PR TITLE
Better planing of unknown dynamic blocks

### DIFF
--- a/configs/configschema/decoder_spec.go
+++ b/configs/configschema/decoder_spec.go
@@ -101,15 +101,6 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 
 		childSpec := blockS.Block.DecoderSpec()
 
-		// We can only validate 0 or 1 for MinItems, because a dynamic block
-		// may satisfy any number of min items while only having a single
-		// block in the config. We cannot validate MaxItems because a
-		// configuration may have any number of dynamic blocks.
-		minItems := 0
-		if blockS.MinItems > 1 {
-			minItems = 1
-		}
-
 		switch blockS.Nesting {
 		case NestingSingle, NestingGroup:
 			ret[name] = &hcldec.BlockSpec{
@@ -134,13 +125,15 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 				ret[name] = &hcldec.BlockTupleSpec{
 					TypeName: name,
 					Nested:   childSpec,
-					MinItems: minItems,
+					MinItems: blockS.MinItems,
+					MaxItems: blockS.MaxItems,
 				}
 			} else {
 				ret[name] = &hcldec.BlockListSpec{
 					TypeName: name,
 					Nested:   childSpec,
-					MinItems: minItems,
+					MinItems: blockS.MinItems,
+					MaxItems: blockS.MaxItems,
 				}
 			}
 		case NestingSet:
@@ -154,7 +147,8 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 			ret[name] = &hcldec.BlockSetSpec{
 				TypeName: name,
 				Nested:   childSpec,
-				MinItems: minItems,
+				MinItems: blockS.MinItems,
+				MaxItems: blockS.MaxItems,
 			}
 		case NestingMap:
 			// We prefer to use a list where possible, since it makes our

--- a/configs/configschema/decoder_spec_test.go
+++ b/configs/configschema/decoder_spec_test.go
@@ -344,15 +344,12 @@ func TestBlockDecoderSpec(t *testing.T) {
 					},
 					&hcl.Block{
 						Type: "foo",
-						Body: hcl.EmptyBody(),
+						Body: unknownBody{hcl.EmptyBody()},
 					},
 				},
 			}),
 			cty.ObjectVal(map[string]cty.Value{
-				"foo": cty.ListVal([]cty.Value{
-					cty.EmptyObjectVal,
-					cty.EmptyObjectVal,
-				}),
+				"foo": cty.UnknownVal(cty.List(cty.EmptyObject)),
 			}),
 			0, // max items cannot be validated during decode
 		},
@@ -372,14 +369,12 @@ func TestBlockDecoderSpec(t *testing.T) {
 				Blocks: hcl.Blocks{
 					&hcl.Block{
 						Type: "foo",
-						Body: hcl.EmptyBody(),
+						Body: unknownBody{hcl.EmptyBody()},
 					},
 				},
 			}),
 			cty.ObjectVal(map[string]cty.Value{
-				"foo": cty.ListVal([]cty.Value{
-					cty.EmptyObjectVal,
-				}),
+				"foo": cty.UnknownVal(cty.List(cty.EmptyObject)),
 			}),
 			0,
 		},
@@ -401,6 +396,7 @@ func TestBlockDecoderSpec(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			spec := test.Schema.DecoderSpec()
+
 			got, diags := hcldec.Decode(test.TestBody, spec, nil)
 			if len(diags) != test.DiagCount {
 				t.Errorf("wrong number of diagnostics %d; want %d", len(diags), test.DiagCount)
@@ -425,6 +421,16 @@ func TestBlockDecoderSpec(t *testing.T) {
 			}
 		})
 	}
+}
+
+// this satisfies hcldec.UnknownBody to simulate a dynamic block with an
+// unknown number of values.
+type unknownBody struct {
+	hcl.Body
+}
+
+func (b unknownBody) Unknown() bool {
+	return true
 }
 
 func TestAttributeDecoderSpec(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl/v2 v2.9.1
+	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/hashicorp/memberlist v0.1.0 // indirect
 	github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb // indirect
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,6 @@ github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuD
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-getter v1.5.1 h1:lM9sM02nvEApQGFgkXxWbhfqtyN+AyhQmi+MaMdBDOI=
-github.com/hashicorp/go-getter v1.5.1/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
 github.com/hashicorp/go-getter v1.5.2 h1:XDo8LiAcDisiqZdv0TKgz+HtX3WN7zA2JD1R1tjsabE=
 github.com/hashicorp/go-getter v1.5.2/go.mod h1:orNH3BTYLu/fIxGIdLjLoAJHWMDQ/UKQr5O4m3iBuoo=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -360,8 +358,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
-github.com/hashicorp/hcl/v2 v2.9.1 h1:eOy4gREY0/ZQHNItlfuEZqtcQbXIxzojlP301hDpnac=
-github.com/hashicorp/hcl/v2 v2.9.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
+github.com/hashicorp/hcl/v2 v2.10.0 h1:1S1UnuhDGlv3gRFV4+0EdwB+znNP5HmcGbIqwnSCByg=
+github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/memberlist v0.1.0 h1:qSsCiC0WYD39lbSitKNt40e30uorm2Ss/d4JGU1hzH8=
 github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc3W6JvZwjxxsE=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb h1:ZbgmOQt8DOg796figP87/EFCVx2v2h9yRvwHF/zceX4=

--- a/lang/blocktoattr/fixup.go
+++ b/lang/blocktoattr/fixup.go
@@ -41,6 +41,17 @@ type fixupBody struct {
 	names    map[string]struct{}
 }
 
+type unknownBlock interface {
+	Unknown() bool
+}
+
+func (b *fixupBody) Unknown() bool {
+	if u, ok := b.original.(unknownBlock); ok {
+		return u.Unknown()
+	}
+	return false
+}
+
 // Content decodes content from the body. The given schema must be the lower-level
 // representation of the same schema that was previously passed to FixUpBlockAttrs,
 // or else the result is undefined.

--- a/plans/objchange/compatible_test.go
+++ b/plans/objchange/compatible_test.go
@@ -30,10 +30,6 @@ func TestAssertObjectCompatible(t *testing.T) {
 		"foo": cty.StringVal("bar"),
 		"bar": cty.NullVal(cty.String), // simulating the situation where bar isn't set in the config at all
 	})
-	fooBarBlockDynamicPlaceholder := cty.ObjectVal(map[string]cty.Value{
-		"foo": cty.UnknownVal(cty.String),
-		"bar": cty.NullVal(cty.String), // simulating the situation where bar isn't set in the config at all
-	})
 
 	tests := []struct {
 		Schema   *configschema.Block
@@ -919,13 +915,11 @@ func TestAssertObjectCompatible(t *testing.T) {
 					},
 				},
 			},
-			cty.ObjectVal(map[string]cty.Value{
-				"key": cty.ObjectVal(map[string]cty.Value{
-					// One wholly unknown block is what "dynamic" blocks
-					// generate when the for_each expression is unknown.
-					"foo": cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.Object(map[string]cty.Type{
+				"key": cty.Object(map[string]cty.Type{
+					"foo": cty.String,
 				}),
-			}),
+			})),
 			cty.ObjectVal(map[string]cty.Value{
 				"key": cty.NullVal(cty.Object(map[string]cty.Type{
 					"foo": cty.String,
@@ -1011,11 +1005,9 @@ func TestAssertObjectCompatible(t *testing.T) {
 					},
 				},
 			},
-			cty.ObjectVal(map[string]cty.Value{
-				"key": cty.ListVal([]cty.Value{
-					fooBarBlockDynamicPlaceholder, // the presence of this disables some of our checks
-				}),
-			}),
+			cty.UnknownVal(cty.Object(map[string]cty.Type{
+				"key": cty.List(fooBarBlockValue.Type()),
+			})),
 			cty.ObjectVal(map[string]cty.Value{
 				"key": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
@@ -1026,35 +1018,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 					}),
 				}),
 			}),
-			nil, // a single block whose attrs are all unknown is allowed to expand into multiple, because that's how dynamic blocks behave when for_each is unknown
-		},
-		{
-			&configschema.Block{
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"key": {
-						Nesting: configschema.NestingList,
-						Block:   schemaWithFooBar,
-					},
-				},
-			},
-			cty.ObjectVal(map[string]cty.Value{
-				"key": cty.ListVal([]cty.Value{
-					fooBarBlockValue,              // the presence of one static block does not negate that the following element looks like a dynamic placeholder
-					fooBarBlockDynamicPlaceholder, // the presence of this disables some of our checks
-				}),
-			}),
-			cty.ObjectVal(map[string]cty.Value{
-				"key": cty.ListVal([]cty.Value{
-					fooBlockValue,
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.StringVal("hello"),
-					}),
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.StringVal("world"),
-					}),
-				}),
-			}),
-			nil, // as above, the presence of a block whose attrs are all unknown indicates dynamic block expansion, so our usual count checks don't apply
+			nil, // an unknown block is allowed to expand into multiple, because that's how dynamic blocks behave when for_each is unknown
 		},
 		{
 			&configschema.Block{
@@ -1195,14 +1159,11 @@ func TestAssertObjectCompatible(t *testing.T) {
 				},
 			},
 			cty.ObjectVal(map[string]cty.Value{
-				"block": cty.SetVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.UnknownVal(cty.String),
+				"block": cty.UnknownVal(cty.Set(
+					cty.Object(map[string]cty.Type{
+						"foo": cty.String,
 					}),
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.UnknownVal(cty.String),
-					}),
-				}),
+				)),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
 				"block": cty.SetVal([]cty.Value{
@@ -1214,47 +1175,6 @@ func TestAssertObjectCompatible(t *testing.T) {
 					}),
 					cty.ObjectVal(map[string]cty.Value{
 						"foo": cty.StringVal("nope"),
-					}),
-				}),
-			}),
-			// there is no error here, because the presence of unknowns
-			// indicates this may be a dynamic block, and the length is unknown
-			nil,
-		},
-		{
-			&configschema.Block{
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"block": {
-						Nesting: configschema.NestingSet,
-						Block:   schemaWithFooBar,
-					},
-				},
-			},
-			// The legacy SDK cannot handle missing strings in sets, and will
-			// insert empty strings to the planned value. Empty strings should
-			// be handled as nulls, and this object should represent a possible
-			// dynamic block.
-			cty.ObjectVal(map[string]cty.Value{
-				"block": cty.SetVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.UnknownVal(cty.String),
-						"bar": cty.StringVal(""),
-					}),
-				}),
-			}),
-			cty.ObjectVal(map[string]cty.Value{
-				"block": cty.SetVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.StringVal("hello"),
-						"bar": cty.StringVal(""),
-					}),
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.StringVal("world"),
-						"bar": cty.StringVal(""),
-					}),
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.StringVal("nope"),
-						"bar": cty.StringVal(""),
 					}),
 				}),
 			}),
@@ -1335,11 +1255,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 				},
 			},
 			cty.ObjectVal(map[string]cty.Value{
-				"block": cty.SetVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.UnknownVal(cty.String),
-					}),
-				}),
+				"block": cty.UnknownVal(cty.Set(fooBlockValue.Type())),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
 				"block": cty.SetVal([]cty.Value{
@@ -1364,11 +1280,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 				},
 			},
 			cty.ObjectVal(map[string]cty.Value{
-				"block2": cty.SetVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.UnknownVal(cty.String),
-					}),
-				}),
+				"block2": cty.UnknownVal(cty.Set(fooBlockValue.Type())),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
 				"block2": cty.SetValEmpty(cty.Object(map[string]cty.Type{
@@ -1401,37 +1313,6 @@ func TestAssertObjectCompatible(t *testing.T) {
 				"block3": cty.SetVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"foo": cty.StringVal("a"),
-					}),
-				}),
-			}),
-			nil,
-		},
-		{
-			&configschema.Block{
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"block": {
-						Nesting: configschema.NestingSet,
-						Block:   schemaWithFooBar,
-					},
-				},
-			},
-			cty.ObjectVal(map[string]cty.Value{
-				"block": cty.SetVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.UnknownVal(cty.String),
-						"bar": cty.NullVal(cty.String),
-					}),
-				}),
-			}),
-			cty.ObjectVal(map[string]cty.Value{
-				"block": cty.SetVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.StringVal("a"),
-						"bar": cty.StringVal(""),
-					}),
-					cty.ObjectVal(map[string]cty.Value{
-						"foo": cty.StringVal("b"),
-						"bar": cty.StringVal(""),
 					}),
 				}),
 			}),

--- a/plans/objchange/objchange.go
+++ b/plans/objchange/objchange.go
@@ -93,6 +93,12 @@ func proposedNew(schema *configschema.Block, prior, config cty.Value) cty.Value 
 }
 
 func proposedNewNestedBlock(schema *configschema.NestedBlock, prior, config cty.Value) cty.Value {
+	// The only time we should encounter an entirely unknown block is from the
+	// use of dynamic with an unknown for_each expression.
+	if !config.IsKnown() {
+		return config
+	}
+
 	var newV cty.Value
 
 	switch schema.Nesting {
@@ -103,7 +109,7 @@ func proposedNewNestedBlock(schema *configschema.NestedBlock, prior, config cty.
 	case configschema.NestingList:
 		// Nested blocks are correlated by index.
 		configVLen := 0
-		if config.IsKnown() && !config.IsNull() {
+		if !config.IsNull() {
 			configVLen = config.LengthInt()
 		}
 		if configVLen > 0 {

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -2008,3 +2008,95 @@ func TestContext2Validate_sensitiveProvisionerConfig(t *testing.T) {
 		t.Fatal("ValidateProvisionerConfig not called")
 	}
 }
+
+func TestContext2Plan_validateMinMaxDynamicBlock(t *testing.T) {
+	p := new(MockProvider)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_instance": {
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Computed: true,
+					},
+					"things": {
+						Type:     cty.List(cty.String),
+						Computed: true,
+					},
+				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"foo": {
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"bar": {Type: cty.String, Optional: true},
+							},
+						},
+						Nesting:  configschema.NestingList,
+						MinItems: 2,
+						MaxItems: 3,
+					},
+				},
+			},
+		},
+	})
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "a" {
+  // MinItems 2
+  foo {
+    bar = "a"
+  }
+  foo {
+    bar = "b"
+  }
+}
+
+resource "test_instance" "b" {
+  // one dymamic block can satisfy MinItems of 2
+  dynamic "foo" {
+	for_each = test_instance.a.things
+	content {
+	  bar = foo.value
+	}
+  }
+}
+
+resource "test_instance" "c" {
+  // we may have more than MaxItems dynamic blocks when they are unknown
+  foo {
+    bar = "b"
+  }
+  dynamic "foo" {
+    for_each = test_instance.a.things
+    content {
+      bar = foo.value
+    }
+  }
+  dynamic "foo" {
+    for_each = test_instance.a.things
+    content {
+      bar = "${foo.value}-2"
+    }
+  }
+  dynamic "foo" {
+    for_each = test_instance.b.things
+    content {
+      bar = foo.value
+    }
+  }
+}
+`})
+
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate()
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+}


### PR DESCRIPTION
Make use of the new `hcldec.UnknownBody` feature in HCL to allow unknown `dynamic` blocks to be decoded as entirely unknown values. A more complete description of this new feature is in https://github.com/hashicorp/hcl/pull/461

Now that the dynamic sentinel values are no longer a factor, the logic around `couldHaveUnknownBlockPlaceholder` is no longer needed, as `AssertObjectCompatible` can directly check of the entire block container is unknown.

The `hcldec` package will also now no longer need terraform to change `MinItems` and `MaxItems` to account for dynamic blocks, because they will no longer be compared at all when dealing with unknown dynamic blocks.

The end result here is that providers will now be able to correctly customize (within the constraints of the [Resource Instance Change Lifecycle](https://github.com/hashicorp/terraform/blob/main/docs/resource-instance-change-lifecycle.md)) any proposed block values during `PlanResourceChange`. 

Fixes #28340