### PR TITLE
lang/funcs: Conversion functions can handle sensitive values

### DIFF
--- a/lang/funcs/conversion_test.go
+++ b/lang/funcs/conversion_test.go
@@ -33,6 +33,18 @@ func TestTo(t *testing.T) {
 			``,
 		},
 		{
+			cty.StringVal("a").Mark("boop"),
+			cty.String,
+			cty.StringVal("a").Mark("boop"),
+			``,
+		},
+		{
+			cty.NullVal(cty.String).Mark("boop"),
+			cty.String,
+			cty.NullVal(cty.String).Mark("boop"),
+			``,
+		},
+		{
 			cty.True,
 			cty.String,
 			cty.StringVal("true"),
@@ -45,10 +57,22 @@ func TestTo(t *testing.T) {
 			`cannot convert "a" to bool; only the strings "true" or "false" are allowed`,
 		},
 		{
+			cty.StringVal("a").Mark("boop"),
+			cty.Bool,
+			cty.DynamicVal,
+			`cannot convert this sensitive string to bool`,
+		},
+		{
 			cty.StringVal("a"),
 			cty.Number,
 			cty.DynamicVal,
 			`cannot convert "a" to number; given string must be a decimal representation of a number`,
+		},
+		{
+			cty.StringVal("a").Mark("boop"),
+			cty.Number,
+			cty.DynamicVal,
+			`cannot convert this sensitive string to number`,
 		},
 		{
 			cty.NullVal(cty.String),
@@ -84,6 +108,30 @@ func TestTo(t *testing.T) {
 			cty.ObjectVal(map[string]cty.Value{"foo": cty.StringVal("hello"), "bar": cty.True}),
 			cty.Map(cty.String),
 			cty.MapVal(map[string]cty.Value{"foo": cty.StringVal("hello"), "bar": cty.StringVal("true")}),
+			``,
+		},
+		{
+			cty.ObjectVal(map[string]cty.Value{"foo": cty.StringVal("hello"), "bar": cty.StringVal("world").Mark("boop")}),
+			cty.Map(cty.String),
+			cty.MapVal(map[string]cty.Value{"foo": cty.StringVal("hello"), "bar": cty.StringVal("world").Mark("boop")}),
+			``,
+		},
+		{
+			cty.ObjectVal(map[string]cty.Value{"foo": cty.StringVal("hello"), "bar": cty.StringVal("world")}).Mark("boop"),
+			cty.Map(cty.String),
+			cty.MapVal(map[string]cty.Value{"foo": cty.StringVal("hello"), "bar": cty.StringVal("world")}).Mark("boop"),
+			``,
+		},
+		{
+			cty.TupleVal([]cty.Value{cty.StringVal("hello"), cty.StringVal("world").Mark("boop")}),
+			cty.List(cty.String),
+			cty.ListVal([]cty.Value{cty.StringVal("hello"), cty.StringVal("world").Mark("boop")}),
+			``,
+		},
+		{
+			cty.TupleVal([]cty.Value{cty.StringVal("hello"), cty.StringVal("world")}).Mark("boop"),
+			cty.List(cty.String),
+			cty.ListVal([]cty.Value{cty.StringVal("hello"), cty.StringVal("world")}).Mark("boop"),
 			``,
 		},
 		{


### PR DESCRIPTION
In order to avoid updating every one of our existing functions with explicit support for sensitive values, there's a default rule in the
functions system which makes the result of a function sensitive if any of its arguments contain sensitive values.

We were applying that default to the various type conversion functions, like `tomap` and `tolist`, which meant that converting a complex-typed value with a sensitive value anywhere inside it would result in a wholly-sensitive result.

That's unnecessarily conservative because the `cty` conversion layer (which these functions are wrapping) already knows how to handle sensitivity in a more precise way. Therefore we can opt in to handling marked values (which Terraform uses for sensitivity) here and the only special thing we need to do is handle errors related to sensitive values differently, so we won't print their values out literally in case of an error (and so that the attempt to print them out literally won't panic trying to extract the marked values).

---

The more-conservative-than-needed sensitivity here was mainly just a cosmetic annoyance, but it has a more practical implication when using `tomap` or `toset` to prepare a partially-sensitive collection for use in `for_each`:

```hcl
locals {
  sensitive_parts = tomap({
    boop = "hello"
    beep = sensitive("goodbye")
  })
}

resource "null_resource" "example" {
  for_each = local.sensitive_parts
}
```

Without this PR, the `for_each` in `null_resource.example` is invalid because the whole map is marked as sensitive. After this PR it works because the map itself is known and only `local.sensitive_parts["beep"]` returns an unknown value.
