### PR TITLE
additional null checks in provisioners

### DIFF
--- a/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/builtin/provisioners/local-exec/resource_provisioner.go
@@ -82,8 +82,10 @@ func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceReques
 
 	if !envVal.IsNull() {
 		for k, v := range envVal.AsValueMap() {
-			entry := fmt.Sprintf("%s=%s", k, v.AsString())
-			env = append(env, entry)
+			if !v.IsNull() {
+				entry := fmt.Sprintf("%s=%s", k, v.AsString())
+				env = append(env, entry)
+			}
 		}
 	}
 
@@ -93,7 +95,9 @@ func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceReques
 	var cmdargs []string
 	if !intrVal.IsNull() && intrVal.LengthInt() > 0 {
 		for _, v := range intrVal.AsValueSlice() {
-			cmdargs = append(cmdargs, v.AsString())
+			if !v.IsNull() {
+				cmdargs = append(cmdargs, v.AsString())
+			}
 		}
 	} else {
 		if runtime.GOOS == "windows" {

--- a/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -128,6 +128,10 @@ func (p *provisioner) Close() error {
 func generateScripts(inline cty.Value) ([]string, error) {
 	var lines []string
 	for _, l := range inline.AsValueSlice() {
+		if l.IsNull() {
+			return nil, errors.New("invalid null string in 'scripts'")
+		}
+
 		s := l.AsString()
 		if s == "" {
 			return nil, errors.New("invalid empty string in 'scripts'")
@@ -169,11 +173,14 @@ func collectScripts(v cty.Value) ([]io.ReadCloser, error) {
 
 	if scriptList := v.GetAttr("scripts"); !scriptList.IsNull() {
 		for _, script := range scriptList.AsValueSlice() {
+			if script.IsNull() {
+				return nil, errors.New("invalid null string in 'script'")
+			}
 			s := script.AsString()
 			if s == "" {
 				return nil, errors.New("invalid empty string in 'script'")
 			}
-			scripts = append(scripts, script.AsString())
+			scripts = append(scripts, s)
 		}
 	}
 


### PR DESCRIPTION
Now that provisioners work directly with the plugin API and cty data
types, we need to add a few null checks to catch invalid input that
would have otherwise been masked by the legacy SDK.

Try to follow the behavior of the legacy SDK as closely as possible,
silently skipping nulls where empty strings would have been ignored,
and returning an error when an empty string would also have errored. 

Fixes #28455