### PR TITLE
command/views: remove extra newline in validate output

### DIFF
--- a/internal/command/views/validate.go
+++ b/internal/command/views/validate.go
@@ -60,9 +60,9 @@ func (v *ValidateHuman) Results(diags tfdiags.Diagnostics) int {
 	return 0
 }
 
-const validateSuccess = "[green][bold]Success![reset] The configuration is valid.\n"
+const validateSuccess = "[green][bold]Success![reset] The configuration is valid."
 
-const validateWarnings = "[green][bold]Success![reset] The configuration is valid, but there were some validation warnings as shown above.\n"
+const validateWarnings = "[green][bold]Success![reset] The configuration is valid, but there were some validation warnings as shown above."
 
 func (v *ValidateHuman) Diagnostics(diags tfdiags.Diagnostics) {
 	v.view.Diagnostics(diags)


### PR DESCRIPTION
Fixes #28996

Remove extra newline from validate ouput, e.g.,
```
% tf validate                             
Success! The configuration is valid.
%
```
vs
```
% tf validate                             
Success! The configuration is valid.

%
```
Let me know if this isn't safe to remove the newlines here and if a different fix is needed.

It seems like in 0.14.x, this is also an issue when there are validation errors (with, or without, color output), however, building off latest git version, that doesn't seem to be an issue.