### PR TITLE
core: Loosen output value sensitivity requirement

### DIFF
--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -459,7 +459,7 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 				continue
 			}
 
-			instance[cfg.Name] = change.After
+			instance[cfg.Name] = change.After.MarkWithPaths(changeSrc.AfterValMarks)
 
 			if change.Sensitive && !change.After.HasMark("sensitive") {
 				instance[cfg.Name] = change.After.Mark("sensitive")


### PR DESCRIPTION
Non-root module outputs no longer strip sensitivity marks from their values, allowing dynamically sensitive values to propagate through the configuration. We also remove the requirement for non-root module outputs to be defined as sensitive if the value is marked as sensitive.

This avoids a static/dynamic clash when using shared modules that might unknowingly receive sensitive values via input variables.

Fixes #28431.