### PR TITLE
Update providers.html.md

### DIFF
--- a/website/docs/language/modules/develop/providers.html.md
+++ b/website/docs/language/modules/develop/providers.html.md
@@ -222,7 +222,7 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 2.7.0"
-      configuration_aliases = [ aws.src, aws.dest ]
+      configuration_aliases = [ "aws.src", "aws.dest" ]
     }
   }
 }


### PR DESCRIPTION
Configuration aliases have to be strings, or else you'll get the following error:  "Variables may not be used here."