### PR TITLE
New login success output for TFC/E

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -237,13 +237,15 @@ func (c *LoginCommand) Run(args []string) int {
 
 		motdServiceURL, err := host.ServiceURL("motd.v1")
 		if err != nil {
-			c.outputDefaultTFCLoginSuccess(err)
+			c.logMOTDError(err)
+			c.outputDefaultTFCLoginSuccess()
 			return 0
 		}
 
 		req, err := http.NewRequest("GET", motdServiceURL.String(), nil)
 		if err != nil {
-			c.outputDefaultTFCLoginSuccess(err)
+			c.logMOTDError(err)
+			c.outputDefaultTFCLoginSuccess()
 			return 0
 		}
 
@@ -251,13 +253,15 @@ func (c *LoginCommand) Run(args []string) int {
 
 		resp, err := httpclient.New().Do(req)
 		if err != nil {
-			c.outputDefaultTFCLoginSuccess(err)
+			c.logMOTDError(err)
+			c.outputDefaultTFCLoginSuccess()
 			return 0
 		}
 
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			c.outputDefaultTFCLoginSuccess(err)
+			c.logMOTDError(err)
+			c.outputDefaultTFCLoginSuccess()
 			return 0
 		}
 
@@ -270,7 +274,8 @@ func (c *LoginCommand) Run(args []string) int {
 			)
 			return 0
 		} else {
-			c.outputDefaultTFCLoginSuccess(fmt.Errorf("platform responded with errors or an empty message"))
+			c.logMOTDError(fmt.Errorf("platform responded with errors or an empty message"))
+			c.outputDefaultTFCLoginSuccess()
 			return 0
 		}
 	}
@@ -305,8 +310,7 @@ func (c *LoginCommand) outputDefaultTFELoginSuccess(dispHostname string) {
 	)
 }
 
-func (c *LoginCommand) outputDefaultTFCLoginSuccess(err error) {
-	log.Printf("[TRACE] login: An error occurred attempting to fetch a message of the day for Terraform Cloud: %s", err)
+func (c *LoginCommand) outputDefaultTFCLoginSuccess() {
 	c.Ui.Output(
 		fmt.Sprintf(
 			c.Colorize().Color(strings.TrimSpace(`
@@ -314,6 +318,10 @@ func (c *LoginCommand) outputDefaultTFCLoginSuccess(err error) {
 `)),
 		) + "\n",
 	)
+}
+
+func (c *LoginCommand) logMOTDError(err error) {
+	log.Printf("[TRACE] login: An error occurred attempting to fetch a message of the day for Terraform Cloud: %s", err)
 }
 
 // Help implements cli.Command.

--- a/command/login.go
+++ b/command/login.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -131,9 +133,9 @@ func (c *LoginCommand) Run(args []string) int {
 	}
 
 	// If login service is unavailable, check for a TFE v2 API as fallback
-	var service *url.URL
+	var tfeservice *url.URL
 	if clientConfig == nil {
-		service, err = host.ServiceURL("tfe.v2")
+		tfeservice, err = host.ServiceURL("tfe.v2")
 		switch err.(type) {
 		case nil:
 			// Success!
@@ -184,6 +186,8 @@ func (c *LoginCommand) Run(args []string) int {
 			oauthToken, tokenDiags = c.interactiveGetTokenByCode(hostname, credsCtx, clientConfig)
 		case clientConfig.SupportedGrantTypes.Has(disco.OAuthOwnerPasswordGrant) && hostname == svchost.Hostname("app.terraform.io"):
 			// The password grant type is allowed only for Terraform Cloud SaaS.
+			// Note this case is purely theoretical at this point, as TFC currently uses
+			// its own bespoke login protocol (tfe)
 			oauthToken, tokenDiags = c.interactiveGetTokenByPassword(hostname, credsCtx, clientConfig)
 		default:
 			tokenDiags = tokenDiags.Append(tfdiags.Sourceless(
@@ -195,8 +199,8 @@ func (c *LoginCommand) Run(args []string) int {
 		if oauthToken != nil {
 			token = svcauth.HostCredentialsToken(oauthToken.AccessToken)
 		}
-	} else if service != nil {
-		token, tokenDiags = c.interactiveGetTokenByUI(hostname, credsCtx, service)
+	} else if tfeservice != nil {
+		token, tokenDiags = c.interactiveGetTokenByUI(hostname, credsCtx, tfeservice)
 	}
 
 	diags = diags.Append(tokenDiags)
@@ -220,19 +224,96 @@ func (c *LoginCommand) Run(args []string) int {
 	}
 
 	c.Ui.Output("\n---------------------------------------------------------------------------------\n")
-	c.Ui.Output(
-		fmt.Sprintf(
-			c.Colorize().Color(strings.TrimSpace(`
+	if hostname == "app.terraform.io" { // Terraform Cloud
+		var motd struct {
+			Message string        `json:"msg"`
+			Errors  []interface{} `json:"errors"`
+		}
+
+		// Throughout the entire process of fetching a MOTD from TFC, use a default
+		// message if the platform-provided message is unavailable for any reason -
+		// be it the service isn't provided, the request failed, or any sort of
+		// platform error returned.
+
+		motdServiceURL, err := host.ServiceURL("motd.v1")
+		if err != nil {
+			c.outputDefaultTFCLoginSuccess(err)
+			return 0
+		}
+
+		req, err := http.NewRequest("GET", motdServiceURL.String(), nil)
+		if err != nil {
+			c.outputDefaultTFCLoginSuccess(err)
+			return 0
+		}
+
+		req.Header.Set("Authorization", "Bearer "+token.Token())
+
+		resp, err := httpclient.New().Do(req)
+		if err != nil {
+			c.outputDefaultTFCLoginSuccess(err)
+			return 0
+		}
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			c.outputDefaultTFCLoginSuccess(err)
+			return 0
+		}
+
+		defer resp.Body.Close()
+		json.Unmarshal(body, &motd)
+
+		if motd.Errors == nil && motd.Message != "" {
+			c.Ui.Output(
+				c.Colorize().Color(motd.Message),
+			)
+			return 0
+		} else {
+			c.outputDefaultTFCLoginSuccess(fmt.Errorf("platform responded with errors or an empty message"))
+			return 0
+		}
+	}
+
+	if tfeservice != nil { // Terraform Enterprise
+		c.outputDefaultTFELoginSuccess(dispHostname)
+	} else {
+		c.Ui.Output(
+			fmt.Sprintf(
+				c.Colorize().Color(strings.TrimSpace(`
 [green][bold]Success![reset] [bold]Terraform has obtained and saved an API token.[reset]
 
 The new API token will be used for any future Terraform command that must make
 authenticated requests to %s.
 `)),
+				dispHostname,
+			) + "\n",
+		)
+	}
+
+	return 0
+}
+
+func (c *LoginCommand) outputDefaultTFELoginSuccess(dispHostname string) {
+	c.Ui.Output(
+		fmt.Sprintf(
+			c.Colorize().Color(strings.TrimSpace(`
+[green][bold]Success![reset] [bold]Logged in to Terraform Enterprise (%s)[reset]
+`)),
 			dispHostname,
 		) + "\n",
 	)
+}
 
-	return 0
+func (c *LoginCommand) outputDefaultTFCLoginSuccess(err error) {
+	log.Printf("[TRACE] login: An error occurred attempting to fetch a message of the day for Terraform Cloud: %s", err)
+	c.Ui.Output(
+		fmt.Sprintf(
+			c.Colorize().Color(strings.TrimSpace(`
+[green][bold]Success![reset] [bold]Logged in to Terraform Cloud[reset]
+`)),
+		) + "\n",
+	)
 }
 
 // Help implements cli.Command.

--- a/command/meta.go
+++ b/command/meta.go
@@ -250,8 +250,14 @@ func (m *Meta) StateOutPath() string {
 
 // Colorize returns the colorization structure for a command.
 func (m *Meta) Colorize() *colorstring.Colorize {
+	colors := make(map[string]string)
+	for k, v := range colorstring.DefaultColors {
+		colors[k] = v
+	}
+	colors["purple"] = "38;5;57"
+
 	return &colorstring.Colorize{
-		Colors:  colorstring.DefaultColors,
+		Colors:  colors,
 		Disable: !m.color,
 		Reset:   true,
 	}

--- a/command/testdata/login-tfe-server/tfeserver.go
+++ b/command/testdata/login-tfe-server/tfeserver.go
@@ -11,6 +11,7 @@ import (
 const (
 	goodToken      = "good-token"
 	accountDetails = `{"data":{"id":"user-abc123","type":"users","attributes":{"username":"testuser","email":"testuser@example.com"}}}`
+	MOTD           = `{"msg":"Welcome to Terraform Cloud!"}`
 )
 
 // Handler is an implementation of net/http.Handler that provides a stub
@@ -29,6 +30,8 @@ func (h handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		h.servePing(resp, req)
 	case "/api/v2/account/details":
 		h.serveAccountDetails(resp, req)
+	case "/api/terraform/motd":
+		h.serveMOTD(resp, req)
 	default:
 		fmt.Printf("404 when fetching %s\n", req.URL.String())
 		http.Error(resp, `{"errors":[{"status":"404","title":"not found"}]}`, http.StatusNotFound)
@@ -47,6 +50,11 @@ func (h handler) serveAccountDetails(resp http.ResponseWriter, req *http.Request
 
 	resp.WriteHeader(http.StatusOK)
 	resp.Write([]byte(accountDetails))
+}
+
+func (h handler) serveMOTD(resp http.ResponseWriter, req *http.Request) {
+	resp.WriteHeader(http.StatusOK)
+	resp.Write([]byte(MOTD))
 }
 
 func init() {


### PR DESCRIPTION
When logging in to Terraform Cloud or Terraform Enterprise, this changes the success output to be a bit more customized for the platform. For Terraform Cloud, fetch a dynamic welcome banner that intentionally fails open and defaults to a hardcoded message if it's not available for any reason.

Additionally, after some research to ensure that adding a code for 256 color terminals shouldn't be a problem, I've added a Terraform purple color code to the default list of colorstring codes.

### Screenshots

_Logging in to Terraform Cloud:_

![image](https://user-images.githubusercontent.com/2430490/115647974-6118e300-a2ea-11eb-9e84-5422f9b9ec4a.png)

_Logging in to Terraform Cloud (a failure case with trace logging enabled):_

![image](https://user-images.githubusercontent.com/2430490/115648125-902f5480-a2ea-11eb-9d7f-25611aa078a1.png)

_Logging in to Terraform Enterprise:_

![image](https://user-images.githubusercontent.com/2430490/115648369-eb614700-a2ea-11eb-8d78-d90da11b2875.png)

