### PR TITLE
setsubtract doc: use "Relative Complement" correctly

### DIFF
--- a/website/docs/language/functions/setsubtract.html.md
+++ b/website/docs/language/functions/setsubtract.html.md
@@ -10,7 +10,7 @@ description: |-
 # `setsubtract` Function
 
 The `setsubtract` function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the
-[relative complement](https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement) of the second set in the first set.
+[relative complement](https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement) of the second set.
 
 ```hcl
 setsubtract(a, b)

--- a/website/docs/language/functions/setsubtract.html.md
+++ b/website/docs/language/functions/setsubtract.html.md
@@ -10,7 +10,7 @@ description: |-
 # `setsubtract` Function
 
 The `setsubtract` function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the
-[relative complement](https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement) of the first set in the second set.
+[relative complement](https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement) of the second set in the first set.
 
 ```hcl
 setsubtract(a, b)


### PR DESCRIPTION
The explanation of the setsubtract function confuses the first and second sets when using the term "Relative Complement".  Fixing it.