### PR TITLE
docs: correct spelling of normally

### DIFF
--- a/website/docs/cli/commands/apply.html.md
+++ b/website/docs/cli/commands/apply.html.md
@@ -86,7 +86,7 @@ plan to remove it in Terraform v0.15. If your workflow relies on overriding
 the root module directory, use
 [the `-chdir` global option](./#switching-working-directory-with-chdir)
 instead, which works across all commands and makes Terraform consistently look
-in the given directory for all files it would normaly read or write in the
+in the given directory for all files it would normally read or write in the
 current working directory.
 
 If your previous use of this legacy pattern was also relying on Terraform

--- a/website/docs/cli/commands/init.html.md
+++ b/website/docs/cli/commands/init.html.md
@@ -189,7 +189,7 @@ plan to remove it in Terraform v0.15. If your workflow relies on overriding
 the root module directory, use
 [the `-chdir` global option](./#switching-working-directory-with-chdir)
 instead, which works across all commands and makes Terraform consistently look
-in the given directory for all files it would normaly read or write in the
+in the given directory for all files it would normally read or write in the
 current working directory.
 
 If your previous use of this legacy pattern was also relying on Terraform

--- a/website/docs/cli/commands/plan.html.md
+++ b/website/docs/cli/commands/plan.html.md
@@ -148,7 +148,7 @@ plan to remove it in Terraform v0.15. If your workflow relies on overriding
 the root module directory, use
 [the `-chdir` global option](./#switching-working-directory-with-chdir)
 instead, which works across all commands and makes Terraform consistently look
-in the given directory for all files it would normaly read or write in the
+in the given directory for all files it would normally read or write in the
 current working directory.
 
 If your previous use of this legacy pattern was also relying on Terraform


### PR DESCRIPTION
**Reasoning for docs update**: fix spelling of "normally" in the sentence which is found in `init`, `plan`, `apply` docs
**Relevant Terraform version**: current