### PR TITLE
Fix docs on nonsensitive version availability

### DIFF
--- a/website/docs/language/functions/nonsensitive.html.md
+++ b/website/docs/language/functions/nonsensitive.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # `nonsensitive` Function
 
--> **Note:** This function is only available in Terraform v0.14 and later.
+-> **Note:** This function is only available in Terraform v0.15 and later.
 
 `nonsensitive` takes a sensitive value and returns a copy of that value with
 the sensitive marking removed, thereby exposing the sensitive value.


### PR DESCRIPTION
`nonsensitive` is only available in 0.15 and later, not 0.14.