### PR TITLE
Unmark config values when planning a data source read

### DIFF
--- a/terraform/node_resource_abstract_test.go
+++ b/terraform/node_resource_abstract_test.go
@@ -160,9 +160,9 @@ func TestNodeAbstractResource_ReadResourceInstanceState(t *testing.T) {
 			ctx.ProviderSchemaSchema = mockProvider.ProviderSchema()
 			ctx.ProviderProvider = providers.Interface(mockProvider)
 
-			got, err := test.Node.readResourceInstanceState(ctx, test.Node.Addr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance))
-			if err != nil {
-				t.Fatalf("[%s] Got err: %#v", k, err.Error())
+			got, readDiags := test.Node.readResourceInstanceState(ctx, test.Node.Addr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance))
+			if readDiags.HasErrors() {
+				t.Fatalf("[%s] Got err: %#v", k, readDiags.Err())
 			}
 
 			expected := test.ExpectedInstanceId
@@ -223,9 +223,9 @@ func TestNodeAbstractResource_ReadResourceInstanceStateDeposed(t *testing.T) {
 
 			key := states.DeposedKey("00000001") // shim from legacy state assigns 0th deposed index this key
 
-			got, err := test.Node.readResourceInstanceStateDeposed(ctx, test.Node.Addr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance), key)
-			if err != nil {
-				t.Fatalf("[%s] Got err: %#v", k, err.Error())
+			got, readDiags := test.Node.readResourceInstanceStateDeposed(ctx, test.Node.Addr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance), key)
+			if readDiags.HasErrors() {
+				t.Fatalf("[%s] Got err: %#v", k, readDiags.Err())
 			}
 
 			expected := test.ExpectedInstanceId

--- a/terraform/node_resource_apply_instance.go
+++ b/terraform/node_resource_apply_instance.go
@@ -217,8 +217,8 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		log.Printf("[TRACE] managedResourceExecute: prior object for %s now deposed with key %s", n.Addr, deposedKey)
 	}
 
-	state, err = n.readResourceInstanceState(ctx, n.ResourceInstanceAddr())
-	diags = diags.Append(err)
+	state, readDiags := n.readResourceInstanceState(ctx, n.ResourceInstanceAddr())
+	diags = diags.Append(readDiags)
 	if diags.HasErrors() {
 		return diags
 	}
@@ -244,8 +244,8 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		return diags
 	}
 
-	state, err = n.readResourceInstanceState(ctx, n.ResourceInstanceAddr())
-	diags = diags.Append(err)
+	state, readDiags = n.readResourceInstanceState(ctx, n.ResourceInstanceAddr())
+	diags = diags.Append(readDiags)
 	if diags.HasErrors() {
 		return diags
 	}

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -177,8 +177,8 @@ func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext) (d
 		return diags
 	}
 
-	state, err = n.readResourceInstanceState(ctx, addr)
-	diags = diags.Append(err)
+	state, readDiags := n.readResourceInstanceState(ctx, addr)
+	diags = diags.Append(readDiags)
 	if diags.HasErrors() {
 		return diags
 	}

--- a/terraform/node_resource_destroy_deposed.go
+++ b/terraform/node_resource_destroy_deposed.go
@@ -184,9 +184,10 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 	// Always write the resource back to the state deposed. If it
 	// was successfully destroyed it will be pruned. If it was not, it will
 	// be caught on the next run.
-	err = n.writeResourceInstanceState(ctx, state)
-	if err != nil {
-		return diags.Append(err)
+	writeDiags := n.writeResourceInstanceState(ctx, state)
+	diags.Append(writeDiags)
+	if diags.HasErrors() {
+		return diags
 	}
 
 	diags = diags.Append(n.postApplyHook(ctx, state, diags.Err()))

--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -52,7 +52,6 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 	addr := n.ResourceInstanceAddr()
 
 	var change *plans.ResourceInstanceChange
-	var state *states.ResourceInstanceObject
 
 	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
@@ -60,8 +59,8 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 		return diags
 	}
 
-	state, err = n.readResourceInstanceState(ctx, addr)
-	diags = diags.Append(err)
+	state, readDiags := n.readResourceInstanceState(ctx, addr)
+	diags = diags.Append(readDiags)
 	if diags.HasErrors() {
 		return diags
 	}
@@ -97,7 +96,6 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	addr := n.ResourceInstanceAddr()
 
 	var change *plans.ResourceInstanceChange
-	var instanceRefreshState *states.ResourceInstanceObject
 	var instancePlanState *states.ResourceInstanceObject
 
 	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
@@ -111,8 +109,8 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		return diags
 	}
 
-	instanceRefreshState, err = n.readResourceInstanceState(ctx, addr)
-	diags = diags.Append(err)
+	instanceRefreshState, readDiags := n.readResourceInstanceState(ctx, addr)
+	diags = diags.Append(readDiags)
 	if diags.HasErrors() {
 		return diags
 	}

--- a/terraform/node_resource_plan_orphan.go
+++ b/terraform/node_resource_plan_orphan.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/plans"
-	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
@@ -77,11 +76,9 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 	// Declare a bunch of variables that are used for state during
 	// evaluation. These are written to by-address below.
 	var change *plans.ResourceInstanceChange
-	var state *states.ResourceInstanceObject
-	var err error
 
-	state, err = n.readResourceInstanceState(ctx, addr)
-	diags = diags.Append(err)
+	state, readDiags := n.readResourceInstanceState(ctx, addr)
+	diags = diags.Append(readDiags)
 	if diags.HasErrors() {
 		return diags
 	}


### PR DESCRIPTION
If the configuration is storing sensitive values in a data source which cannot be read at plan time, those values must be unmarked before creating a planned read value.

This also updates the `UpgradeResourceState` codepaths to use `Diagnostics`, and add configuration context when possible. 

Fixes #28535