### PR TITLE
command: New -replace=... planning option

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -266,6 +266,7 @@ func (c *ApplyCommand) OperationRequest(
 	opReq.PlanFile = planFile
 	opReq.PlanRefresh = args.Refresh
 	opReq.Targets = args.Targets
+	opReq.ForceReplace = args.ForceReplace
 	opReq.Type = backend.OperationTypeApply
 	opReq.View = view.Operation()
 

--- a/command/arguments/extended.go
+++ b/command/arguments/extended.go
@@ -63,11 +63,24 @@ type Operation struct {
 	// their dependencies.
 	Targets []addrs.Targetable
 
+	// ForceReplace addresses cause Terraform to force a particular set of
+	// resource instances to generate "replace" actions in any plan where they
+	// would normally have generated "no-op" or "update" actions.
+	//
+	// This is currently limited to specific instances because typical uses
+	// of replace are associated with only specific remote objects that the
+	// user has somehow learned to be malfunctioning, in which case it
+	// would be unusual and potentially dangerous to replace everything under
+	// a module all at once. We could potentially loosen this later if we
+	// learn a use-case for broader matching.
+	ForceReplace []addrs.AbsResourceInstance
+
 	// These private fields are used only temporarily during decoding. Use
 	// method Parse to populate the exported fields from these, validating
 	// the raw values in the process.
-	targetsRaw []string
-	destroyRaw bool
+	targetsRaw      []string
+	forceReplaceRaw []string
+	destroyRaw      bool
 }
 
 // Parse must be called on Operation after initial flag parse. This processes
@@ -100,6 +113,39 @@ func (o *Operation) Parse() tfdiags.Diagnostics {
 		}
 
 		o.Targets = append(o.Targets, target.Subject)
+	}
+
+	for _, raw := range o.forceReplaceRaw {
+		traversal, syntaxDiags := hclsyntax.ParseTraversalAbs([]byte(raw), "", hcl.Pos{Line: 1, Column: 1})
+		if syntaxDiags.HasErrors() {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				fmt.Sprintf("Invalid force-replace address %q", raw),
+				syntaxDiags[0].Detail,
+			))
+			continue
+		}
+
+		addr, addrDiags := addrs.ParseAbsResourceInstance(traversal)
+		if addrDiags.HasErrors() {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				fmt.Sprintf("Invalid force-replace address %q", raw),
+				addrDiags[0].Description().Detail,
+			))
+			continue
+		}
+
+		if addr.Resource.Resource.Mode != addrs.ManagedResourceMode {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				fmt.Sprintf("Invalid force-replace address %q", raw),
+				"Only managed resources can be used with the -replace=... option.",
+			))
+			continue
+		}
+
+		o.ForceReplace = append(o.ForceReplace, addr)
 	}
 
 	// If you add a new possible value for o.PlanMode here, consider also
@@ -161,6 +207,7 @@ func extendedFlagSet(name string, state *State, operation *Operation, vars *Vars
 		f.BoolVar(&operation.Refresh, "refresh", true, "refresh")
 		f.BoolVar(&operation.destroyRaw, "destroy", false, "destroy")
 		f.Var((*flagStringSlice)(&operation.targetsRaw), "target", "target")
+		f.Var((*flagStringSlice)(&operation.forceReplaceRaw), "replace", "replace")
 	}
 
 	// Gather all -var and -var-file arguments into one heterogenous structure

--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -60,6 +60,8 @@ func ResourceChange(
 		switch change.ActionReason {
 		case plans.ResourceInstanceReplaceBecauseTainted:
 			buf.WriteString(color.Color(fmt.Sprintf("[bold]  # %s[reset] is tainted, so must be [bold][red]replaced", dispAddr)))
+		case plans.ResourceInstanceReplaceByRequest:
+			buf.WriteString(color.Color(fmt.Sprintf("[bold]  # %s[reset] will be [bold][red]replaced[reset], as requested", dispAddr)))
 		default:
 			buf.WriteString(color.Color(fmt.Sprintf("[bold]  # %s[reset] must be [bold][red]replaced", dispAddr)))
 		}

--- a/command/plan.go
+++ b/command/plan.go
@@ -149,6 +149,7 @@ func (c *PlanCommand) OperationRequest(
 	opReq.PlanRefresh = args.Refresh
 	opReq.PlanOutPath = planOutPath
 	opReq.Targets = args.Targets
+	opReq.ForceReplace = args.ForceReplace
 	opReq.Type = backend.OperationTypePlan
 	opReq.View = view.Operation()
 
@@ -204,11 +205,21 @@ Plan Customization Options:
   -destroy            If set, a plan will be generated to destroy all resources
                       managed by the given configuration and state.
 
-  -refresh=true       Update state prior to checking for differences.
+  -refresh=false      Skip checking for changes to remote objects while
+                      creating the plan. This can potentially make planning
+                      faster, but at the expense of possibly planning against
+                      a stale record of the remote system state.
 
-  -target=resource    Resource to target. Operation will be limited to this
-                      resource and its dependencies. This flag can be used
-                      multiple times.
+  -replace=resource   Force replacement of a particular resource instance using
+                      its resource address. If the plan would've normally
+                      produced an update or no-op action for this instance,
+                      Terraform will plan to replace it instead.
+
+  -target=resource    Limit the planning operation to only the given module,
+                      resource, or resource instance and all of its
+                      dependencies. You can use this option multiple times to
+                      include more than one object. This is for exceptional
+                      use only.
 
   -var 'foo=bar'      Set a variable in the Terraform configuration. This
                       flag can be set multiple times.

--- a/command/testdata/apply-replace/main.tf
+++ b/command/testdata/apply-replace/main.tf
@@ -1,0 +1,2 @@
+resource "test_instance" "a" {
+}

--- a/command/testdata/plan-replace/main.tf
+++ b/command/testdata/plan-replace/main.tf
@@ -1,0 +1,2 @@
+resource "test_instance" "a" {
+}

--- a/terraform/node_resource_abstract_instance.go
+++ b/terraform/node_resource_abstract_instance.go
@@ -824,22 +824,12 @@ func (n *NodeAbstractResourceInstance) plan(
 			matchedForceReplace = true
 			break
 		}
+
 		// For "force replace" purposes we require an exact resource instance
-		// address to match, but just in case a user forgets to include the
-		// instance key for a multi-instance resource we'll give them a
-		// warning hint.
-		if n.Addr.Resource.Key != addrs.NoKey && candidateAddr.Resource.Key == addrs.NoKey {
-			if n.Addr.Resource.Resource.Equal(candidateAddr.Resource.Resource) {
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Warning,
-					"Incompletely-matched force-replace resource instance",
-					fmt.Sprintf(
-						"Your force-replace request for %s didn't match %s because it lacks the instance key.\n\nTo force replacement of this particular instance, use -replace=%q .",
-						candidateAddr, n.Addr, n.Addr,
-					),
-				))
-			}
-		}
+		// address to match. If a user forgets to include the instance key
+		// for a multi-instance resource then it won't match here, but we
+		// have an earlier check in NodePlannableResource.Execute that should
+		// prevent us from getting here in that case.
 	}
 
 	// Unmark for this test for value equality.

--- a/website/docs/cli/commands/plan.html.md
+++ b/website/docs/cli/commands/plan.html.md
@@ -135,6 +135,23 @@ the previous section, are also available with the same meanings on
     it would effectively disable the entirety of the planning operation in that
     case.
 
+* `-replace=ADDRESS` - Instructs Terraform to plan to replace the single
+  resource instance with the given address. If the given instance would
+  normally have caused only an "update" action, or no action at all, then
+  Terraform will choose a "replace" action instead.
+
+    You can use this option if you have learned that a particular remote object
+    has become degraded in some way. If you are using immutable infrastructure
+    patterns then you may wish to respond to that by replacing the
+    malfunctioning object with a new object that has the same configuration.
+
+    This option is allowed only in the normal planning mode, so this option
+    is incompatible with the `-destroy` option.
+
+    The `-replace=...` option is available only from Terraform v1.0 onwards.
+    For earlier versions, you can achieve a similar effect (with some caveats)
+    using [`terraform taint`](./taint.html).
+
 * `-target=ADDRESS` - Instructs Terraform to focus its planning efforts only
   on resource instances which match the given address and on any objects that
   those instances depend on.

--- a/website/docs/cli/commands/taint.html.md
+++ b/website/docs/cli/commands/taint.html.md
@@ -14,6 +14,30 @@ become degraded or damaged. Terraform represents this by marking the
 object as "tainted" in the Terraform state, in which case Terraform will
 propose to replace it in the next plan you create.
 
+~> *Warning:* This command is deprecated, because there are better alternatives
+available in Terraform v1.0 and later. See below for more details.
+
+If your intent is to force replacement of a particular object even though
+there are no configuration changes that would require it, we recommend instead
+to use the `-replace` option with [`terraform apply`](./apply.html).
+For example:
+
+```
+terraform apply -replace="aws_instance.example[0]"
+```
+
+Creating a plan with the "replace" option is superior to using `terraform taint`
+because it will allow you to see the full effect of that change before you take
+any externally-visible action. When you use `terraform taint` to get a similar
+effect, you risk someone else on your team creating a new plan against your
+tainted object before you've had a chance to review the consequences of that
+change yourself.
+
+The `-replace=...` option to `terraform apply` is only available from
+Terraform v1.0 onwards, so if you are using an earlier version you will need to
+use `terraform taint` to force object replacement, while considering the
+caveats described above.
+
 ## Usage
 
 Usage: `terraform taint [options] address`

--- a/website/docs/cli/commands/untaint.html.md
+++ b/website/docs/cli/commands/untaint.html.md
@@ -28,6 +28,14 @@ you can use `terraform untaint` to remove the taint marker from that object.
 This command _will not_ modify any real remote objects, but will modify the
 state in order to remove the tainted status.
 
+If you remove the taint marker from an object but then later discover that it
+was degraded after all, you can create and apply a plan to replace it without
+first re-tainting the object, by using a command like the following:
+
+```
+terraform apply -replace="aws_instance.example[0]"
+```
+
 ## Usage
 
 Usage: `terraform untaint [options] address`


### PR DESCRIPTION
This allows a similar effect to pre-tainting an object but does the action within the context of a normal plan and apply, avoiding the need for an intermediate state where the old object still exists but is marked as tainted.

```
terraform plan -replace=null_resource.blah
terraform apply -replace=null_resource.blah
```

The core functionality for this was already present from #28560, so this commit is just the UI-level changes to make that option available for use and to explain how it contributed to the resulting plan in Terraform's output. It does include one little tweak to the core-level implementation to respond to some error reporting feedback I deferred in #28560.

As with instances that are marked as tainted in the prior state, an instance that is forced for replacement gets a special annotation in the plan to acknowledge that this replace was in response to an explicit user request, rather than in response to tainting or as directed by the provider.

![](https://user-images.githubusercontent.com/20180/116764767-07de3d00-a9d7-11eb-8c7a-2a615e970355.png)

```
Terraform used the selected providers to generate the following execution plan.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # null_resource.blah will be replaced, as requested
-/+ resource "null_resource" "blah" {
      ~ id = "2748831065994947069" -> (known after apply)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

The source information needed to replicate that special annotation in another external UI was already included in the `terraform show -json` plan output as part of #28544, so there's no additional work for that here.
