### PR TITLE
Added clarity: File connection requirement

### DIFF
--- a/website/docs/language/resources/provisioners/file.html.md
+++ b/website/docs/language/resources/provisioners/file.html.md
@@ -10,7 +10,8 @@ description: |-
 
 The `file` provisioner is used to copy files or directories from the machine
 executing Terraform to the newly created resource. The `file` provisioner
-supports both `ssh` and `winrm` type [connections](/docs/language/resources/provisioners/connection.html).
+requires a [connection](/docs/language/resources/provisioners/connection.html)
+and supports both `ssh` and `winrm`.
 
 -> **Note:** Provisioners should only be used as a last resort. For most
 common situations there are better alternatives. For more information, see
@@ -21,6 +22,15 @@ common situations there are better alternatives. For more information, see
 ```hcl
 resource "aws_instance" "web" {
   # ...
+
+  # Establishes connection to be used by all 
+  # generic remote provisioners (i.e. file/remote-exec)
+  connection {
+    type     = "ssh"
+    user     = "root"
+    password = var.root_password
+    host     = self.public_ip
+  }
 
   # Copies the myapp.conf file to /etc/myapp.conf
   provisioner "file" {


### PR DESCRIPTION
This is the first of two similar commits, the second is PR #28579

According to the [Provisioner Connection](https://www.terraform.io/docs/language/resources/provisioners/connection.html) page, provisioners require the connection block.

This change of behavior is shown prominently within a note on the [Provisioner Connection](https://www.terraform.io/docs/language/resources/provisioners/connection.html) page:

> Note: In Terraform 0.11 and earlier, providers could set default values for some connection settings, so that connection blocks could sometimes be omitted. This feature was removed in 0.12 in order to make Terraform's behavior more predictable.

However, this behavioral change is omitted from the [File Provisioner](https://www.terraform.io/docs/language/resources/provisioners/file.html) page which is where a user will be if they are attempting to follow the prior behavior when this was permissible in versions prior to 0.12. This change prompts the user of that change and directs to the connection page.