### PR TITLE
Added clarity: remote-exec connection requirement

### DIFF
--- a/website/docs/language/resources/provisioners/remote-exec.html.md
+++ b/website/docs/language/resources/provisioners/remote-exec.html.md
@@ -12,7 +12,8 @@ The `remote-exec` provisioner invokes a script on a remote resource after it
 is created. This can be used to run a configuration management tool, bootstrap
 into a cluster, etc. To invoke a local process, see the `local-exec`
 [provisioner](/docs/language/resources/provisioners/local-exec.html) instead. The `remote-exec`
-provisioner supports both `ssh` and `winrm` type [connections](/docs/language/resources/provisioners/connection.html).
+provisioner requires a [connection](/docs/language/resources/provisioners/connection.html)
+and supports both `ssh` and `winrm`.
 
 -> **Note:** Provisioners should only be used as a last resort. For most
 common situations there are better alternatives. For more information, see
@@ -23,6 +24,15 @@ common situations there are better alternatives. For more information, see
 ```hcl
 resource "aws_instance" "web" {
   # ...
+
+  # Establishes connection to be used by all 
+  # generic remote provisioners (i.e. file/remote-exec)
+  connection {
+    type     = "ssh"
+    user     = "root"
+    password = var.root_password
+    host     = self.public_ip
+  }
 
   provisioner "remote-exec" {
     inline = [


### PR DESCRIPTION
This is a secondary change to PR #28578 

Details:
According to the [Provisioner Connection](https://www.terraform.io/docs/language/resources/provisioners/connection.html) page, provisioners require the connection block.

This change of behavior is shown prominently within a note on the [Provisioner Connection](https://www.terraform.io/docs/language/resources/provisioners/connection.html) page:

> Note: In Terraform 0.11 and earlier, providers could set default values for some connection settings, so that connection blocks could sometimes be omitted. This feature was removed in 0.12 in order to make Terraform's behavior more predictable.

However, this behavioral change is omitted from the [remote-exec provisioner](https://www.terraform.io/docs/language/resources/provisioners/remote-exec.html) page which is where a user will be if they are attempting to follow the prior behavior when this was permissible in versions prior to 0.12. This change prompts the user of that change and directs to the connection page.