### PR TITLE
cli: Show forces replacement for sensitive attrs

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -359,6 +359,9 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 
 	if attrS.Sensitive {
 		p.buf.WriteString("(sensitive value)")
+		if p.pathForcesNewResource(path) {
+			p.buf.WriteString(p.color.Color(forcesNewResourceCaption))
+		}
 	} else {
 		switch {
 		case showJustNew:


### PR DESCRIPTION
When rendering a plan diff, sensitive resource attributes would previously omit the "forces replacement" comment, which can lead to confusion when the only reason for a resource being replaced is a sensitive attribute.

Fixes #28540.