### PR TITLE
command/views: Add reason to JSON planned change

### DIFF
--- a/command/views/json/change.go
+++ b/command/views/json/change.go
@@ -10,6 +10,7 @@ func NewResourceInstanceChange(change *plans.ResourceInstanceChangeSrc) *Resourc
 	c := &ResourceInstanceChange{
 		Resource: newResourceAddr(change.Addr),
 		Action:   changeAction(change.Action),
+		Reason:   changeReason(change.ActionReason),
 	}
 
 	return c
@@ -18,6 +19,7 @@ func NewResourceInstanceChange(change *plans.ResourceInstanceChangeSrc) *Resourc
 type ResourceInstanceChange struct {
 	Resource ResourceAddr `json:"resource"`
 	Action   ChangeAction `json:"action"`
+	Reason   ChangeReason `json:"reason,omitempty"`
 }
 
 func (c *ResourceInstanceChange) String() string {
@@ -51,5 +53,33 @@ func changeAction(action plans.Action) ChangeAction {
 		return ActionDelete
 	default:
 		return ActionNoOp
+	}
+}
+
+type ChangeReason string
+
+const (
+	ReasonNone         ChangeReason = ""
+	ReasonTainted      ChangeReason = "tainted"
+	ReasonRequested    ChangeReason = "requested"
+	ReasonCannotUpdate ChangeReason = "cannot_update"
+	ReasonUnknown      ChangeReason = "unknown"
+)
+
+func changeReason(reason plans.ResourceInstanceChangeActionReason) ChangeReason {
+	switch reason {
+	case plans.ResourceInstanceChangeNoReason:
+		return ReasonNone
+	case plans.ResourceInstanceReplaceBecauseTainted:
+		return ReasonTainted
+	case plans.ResourceInstanceReplaceByRequest:
+		return ReasonRequested
+	case plans.ResourceInstanceReplaceBecauseCannotUpdate:
+		return ReasonCannotUpdate
+	default:
+		// This should never happen, but there's no good way to guarantee
+		// exhaustive handling of the enum, so a generic fall back is better
+		// than a misleading result or a panic
+		return ReasonUnknown
 	}
 }


### PR DESCRIPTION
Now that we have extra information about the reason for a given resource action, include that in the JSON log output for planned changes.