### PR TITLE
Validate passing default providers through modules

### DIFF
--- a/configs/testdata/config-diagnostics/pass-inherited-provider/main.tf
+++ b/configs/testdata/config-diagnostics/pass-inherited-provider/main.tf
@@ -1,0 +1,7 @@
+provider "test" {
+  value = "ok"
+}
+
+module "mod" {
+  source = "./mod"
+}

--- a/configs/testdata/config-diagnostics/pass-inherited-provider/mod/main.tf
+++ b/configs/testdata/config-diagnostics/pass-inherited-provider/mod/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+}
+
+module "mod2" {
+  source = "./mod2"
+
+  // the test provider is named here, but a config must be supplied from the
+  // parent module.
+  providers = {
+    test.foo = test
+  }
+}

--- a/configs/testdata/config-diagnostics/pass-inherited-provider/mod2/main.tf
+++ b/configs/testdata/config-diagnostics/pass-inherited-provider/mod2/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+      configuration_aliases = [test.foo]
+    }
+  }
+}
+
+resource "test_resource" "foo" {
+  provider = test.foo
+}

--- a/configs/testdata/config-diagnostics/pass-inherited-provider/warnings
+++ b/configs/testdata/config-diagnostics/pass-inherited-provider/warnings
@@ -1,0 +1,1 @@
+pass-inherited-provider/mod/main.tf:15,16-20: No configuration passed in for provider test in module.mod; Provider test is referenced within module.mod, but no configuration has been supplied

--- a/configs/testdata/config-diagnostics/unknown-root-provider/main.tf
+++ b/configs/testdata/config-diagnostics/unknown-root-provider/main.tf
@@ -1,0 +1,7 @@
+module "mod" {
+  source = "./mod"
+  providers = {
+    // bar may be required by the module, but the name is not defined here
+    bar = bar
+  }
+}

--- a/configs/testdata/config-diagnostics/unknown-root-provider/mod/main.tf
+++ b/configs/testdata/config-diagnostics/unknown-root-provider/mod/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    bar = {
+      version = "~>1.0.0"
+    }
+  }
+}
+
+resource "bar_resource" "x" {
+}

--- a/configs/testdata/config-diagnostics/unknown-root-provider/warnings
+++ b/configs/testdata/config-diagnostics/unknown-root-provider/warnings
@@ -1,0 +1,1 @@
+unknown-root-provider/main.tf:5,11-14: Provider bar is undefined; No provider named bar has been declared in the root module


### PR DESCRIPTION
Add validation for the local side of the providers map assignments in module calls. If these did not actually correspond to a configuration during runtime, the user would be presented with a `missing provider` error with the assumed address of the provider, but no indication how to configure that address. We can detect these during validation, and present a much more precise error

```
╷
│ Warning: No configuration passed in for provider aws in module.mod1
│
│   on mod1/main.tf line 15, in module "mod2":
│   15:     aws.local = aws
│
│ Provider aws is referenced within module.mod1, but no configuration has been supplied.
│ Add a provider named aws to the providers map for module.mod1 in the root module.
```

It was also assumed that inherited providers could be referenced within modules, which is understandable because resources effectively do the same. This inheritance does not work in module calls however, because the provider is looked up in the next child module, one level removed from the inherited provider. Rather than re-work inheritance to account for this edge case, we can direct users to create a more explicit configuration by declaring the name within the module, so that we can follow up with the above recommendation if no configuration is presented.


```
│ Warning: Provider aws is undefined
│
│   on mod1/main.tf line 15, in module "mod2":
│   15:     aws.local = aws
│
│ No provider named aws has been declared in module.mod1.
│ If you wish to refer to the aws provider within the module, add a provider configuration, 
│ or an entry in the required_providers block.
```

Fixes #28565