### PR TITLE
jsonplan: Add replace_paths

### DIFF
--- a/command/testdata/show-json/requires-replace/output.json
+++ b/command/testdata/show-json/requires-replace/output.json
@@ -40,7 +40,8 @@
                     "id": true
                 },
                 "after_sensitive": {},
-                "before_sensitive": {}
+                "before_sensitive": {},
+                "replace_paths": [["ami"]]
             },
             "action_reason": "replace_because_cannot_update"
         }

--- a/website/docs/internals/json-format.html.md
+++ b/website/docs/internals/json-format.html.md
@@ -490,7 +490,7 @@ A `<change-representation>` describes the change that will be made to the indica
   // e.g. just scan the list for "delete" to recognize all three situations
   // where the object will be deleted, allowing for any new deletion
   // combinations that might be added in future.
-  "actions": ["update"]
+  "actions": ["update"],
 
   // "before" and "after" are representations of the object value both before
   // and after the action. For ["create"] and ["delete"] actions, either
@@ -498,6 +498,35 @@ A `<change-representation>` describes the change that will be made to the indica
   // after values are identical. The "after" value will be incomplete if there
   // are values within it that won't be known until after apply.
   "before": <value-representation>,
-  "after": <value-representation>
+  "after": <value-representation>,
+
+  // "after_unknown" is an object value with similar structure to "after", but
+  // with all unknown leaf values replaced with "true", and all known leaf
+  // values omitted. This can be combined with "after" to reconstruct a full
+  // value after the action, including values which will only be known after
+  // apply.
+  "after_unknown": {
+    "id": true
+  },
+
+  // "before_sensitive" and "after_sensitive" are object values with similar
+  // structure to "before" and "after", but with all sensitive leaf values
+  // replaced with true, and all non-sensitive leaf values omitted. These
+  // objects should be combined with "before" and "after" to prevent accidental
+  // display of sensitive values in user interfaces.
+  "before_sensitive": {},
+  "after_sensitive": {
+    "triggers": {
+      "boop": true
+    }
+  },
+
+  // "replace_paths" is an array of arrays representing a set of paths into the
+  // object value which resulted in the action being "replace". This will be
+  // omitted if the action is not replace, or if no paths caused the
+  // replacement (for example, if the resource was tainted). Each path
+  // consists of one or more steps, each of which will be a number or a
+  // string.
+  "replace_paths": [["triggers"]]
 }
 ```


### PR DESCRIPTION
The set of paths which caused a resource update to require replacement has been stored in the plan since 0.15.0 (#28201). This commit adds a simple JSON representation of these paths, allowing consumers of this format to determine exactly which paths caused the resource to be replaced.

This representation is intentionally more loosely encoded than the JSON state serialization of paths used for sensitive attributes. Instead of a path step being represented by an object with type and value, we use a more-JavaScripty heterogenous array of numbers and strings. Any practical consumer of this format will likely traverse an object tree using the index operator, which should work more easily with this format. It also allows easy prefix comparison for consumers which are tracking paths.

While updating the documentation to include this new field, I noticed that some others were missing, so added them too.

This is the last missing piece of the JSON plan format that I'm aware of, so we might want to bump the output format to 1.0 soon. If so that can be a separate decision from this PR.