### PR TITLE
backend/azurerm: Restore Azure Stack Hub support

### DIFF
--- a/backend/remote-state/azure/helpers_test.go
+++ b/backend/remote-state/azure/helpers_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
-	armStorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-01-01/storage"
+	armStorage "github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/storage/mgmt/storage"
 	"github.com/Azure/go-autorest/autorest"
 	sasStorage "github.com/hashicorp/go-azure-helpers/storage"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/containers"
@@ -156,10 +156,7 @@ func (c *ArmClient) buildTestResources(ctx context.Context, names *resourceNames
 		Location: &names.location,
 	}
 	if names.useAzureADAuth {
-		allowSharedKeyAccess := false
-		storageProps.AccountPropertiesCreateParameters = &armStorage.AccountPropertiesCreateParameters{
-			AllowSharedKeyAccess: &allowSharedKeyAccess,
-		}
+		storageProps.AccountPropertiesCreateParameters = &armStorage.AccountPropertiesCreateParameters{}
 	}
 	future, err := c.storageAccountsClient.Create(ctx, names.resourceGroup, names.storageAccountName, storageProps)
 	if err != nil {
@@ -176,7 +173,7 @@ func (c *ArmClient) buildTestResources(ctx context.Context, names *resourceNames
 		containersClient.Client.Authorizer = *c.azureAdStorageAuth
 	} else {
 		log.Printf("fetching access key for storage account")
-		resp, err := c.storageAccountsClient.ListKeys(ctx, names.resourceGroup, names.storageAccountName, "")
+		resp, err := c.storageAccountsClient.ListKeys(ctx, names.resourceGroup, names.storageAccountName)
 		if err != nil {
 			return fmt.Errorf("failed to list storage account keys %s:", err)
 		}

--- a/website/docs/language/settings/backends/azurerm.html.md
+++ b/website/docs/language/settings/backends/azurerm.html.md
@@ -203,7 +203,7 @@ The following configuration options are supported:
 
 * `key` - (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.
 
-* `environment` - (Optional) The Azure Environment which should be used. This can also be sourced from the `ARM_ENVIRONMENT` environment variable. Possible values are `public`, `china`, `german`, `stack` and `usgovernment`. Defaults to `public`.
+* `environment` - (Optional) The Azure Environment which should be used. This can also be sourced from the `ARM_ENVIRONMENT` environment variable. Possible values are `public`, `china`, `german` and `usgovernment`. Defaults to `public`.
 
 * `endpoint` - (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the `ARM_ENDPOINT` environment variable.
 


### PR DESCRIPTION
This PR restores support for Azure Stack Hub in the azurerm remote
backend. It seems that support was first broken by #26463 and then
later in #28181 the storage package was updated to an API profile
incompatible with Azure Stack Hub.

I've removed the mention of `stack` as a possible value for
environment in the backend configuration documentation, it fails with
a validation error and doesn't seem to be in use.

Resolves #28581.

NOTE:  As is, this PR might break some of the changes that was done in #28181 to resolve #20831. I've simply verified that the azurerm backend works against Azure Stack Hub with the given changes.