### PR TITLE
null check in ValueMarks

### DIFF
--- a/configs/configschema/marks.go
+++ b/configs/configschema/marks.go
@@ -24,6 +24,9 @@ func (b *Block) ValueMarks(val cty.Value, path cty.Path) []cty.PathValueMarks {
 		}
 	}
 
+	if val.IsNull() {
+		return pvm
+	}
 	for name, blockS := range b.BlockTypes {
 		// If our block doesn't contain any sensitive attributes, skip inspecting it
 		if !blockS.Block.ContainsSensitive() {

--- a/configs/configschema/marks_test.go
+++ b/configs/configschema/marks_test.go
@@ -48,6 +48,10 @@ func TestBlockValueMarks(t *testing.T) {
 			cty.UnknownVal(schema.ImpliedType()),
 		},
 		{
+			cty.NullVal(schema.ImpliedType()),
+			cty.NullVal(schema.ImpliedType()),
+		},
+		{
 			cty.ObjectVal(map[string]cty.Value{
 				"sensitive":   cty.UnknownVal(cty.String),
 				"unsensitive": cty.UnknownVal(cty.String),


### PR DESCRIPTION
When comparing values in a plan, the prior value can be null.