### PR TITLE
Quoting filesystem path in scp command argument

### DIFF
--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -419,7 +419,7 @@ func (c *Communicator) Upload(path string, input io.Reader) error {
 		return scpUploadFile(targetFile, input, w, stdoutR, size)
 	}
 
-	return c.scpSession("scp -vt "+targetDir, scpFunc)
+	return c.scpSession("scp -vt "+ quoteFilesystemPath(targetDir), scpFunc)
 }
 
 // UploadScript implementation of communicator.Communicator interface
@@ -815,4 +815,9 @@ type bastionConn struct {
 func (c *bastionConn) Close() error {
 	c.Conn.Close()
 	return c.Bastion.Close()
+}
+
+func quoteFilesystemPath(path string) string {
+	replacedQuotes := strings.ReplaceAll(path, "'", "")
+	return fmt.Sprintf("'%s'", replacedQuotes)
 }

--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -420,7 +420,7 @@ func (c *Communicator) Upload(path string, input io.Reader) error {
 		return scpUploadFile(targetFile, input, w, stdoutR, size)
 	}
 
-	cmd, err := QuoteShell([]string{"scp", "-vt", targetDir}, c.connInfo.TargetPlatform)
+	cmd, err := quoteShell([]string{"scp", "-vt", targetDir}, c.connInfo.TargetPlatform)
 	if err != nil {
 		return err
 	}
@@ -493,7 +493,7 @@ func (c *Communicator) UploadDir(dst string, src string) error {
 		return uploadEntries()
 	}
 
-	cmd, err := QuoteShell([]string{"scp", "-rvt", dst}, c.connInfo.TargetPlatform)
+	cmd, err := quoteShell([]string{"scp", "-rvt", dst}, c.connInfo.TargetPlatform)
 	if err != nil {
 		return err
 	}
@@ -826,7 +826,7 @@ func (c *bastionConn) Close() error {
 	return c.Bastion.Close()
 }
 
-func QuoteShell(args []string, targetPlatform string) (string, error) {
+func quoteShell(args []string, targetPlatform string) (string, error) {
 	if targetPlatform == TargetPlatformUnix {
 		return shquot.POSIXShell(args), nil
 	}

--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -420,7 +420,7 @@ func (c *Communicator) Upload(path string, input io.Reader) error {
 		return scpUploadFile(targetFile, input, w, stdoutR, size)
 	}
 
-	return c.scpSession("scp -vt "+ QuoteShell(targetDir), scpFunc)
+	return c.scpSession("scp -vt "+QuoteShell(targetDir), scpFunc)
 }
 
 // UploadScript implementation of communicator.Communicator interface
@@ -489,7 +489,7 @@ func (c *Communicator) UploadDir(dst string, src string) error {
 		return uploadEntries()
 	}
 
-	return c.scpSession("scp -rvt " + QuoteShell(dst), scpFunc)
+	return c.scpSession("scp -rvt "+QuoteShell(dst), scpFunc)
 }
 
 func (c *Communicator) newSession() (session *ssh.Session, err error) {
@@ -826,7 +826,7 @@ func QuoteShell(arg string) string {
 		return "''"
 	}
 
-	if m, _ := regexp.MatchString(`[\w@%+=:,./-]`,arg); m == false {
+	if m, _ := regexp.MatchString(`[\w@%+=:,./-]`, arg); m == false {
 		return arg
 	}
 

--- a/internal/communicator/ssh/communicator_test.go
+++ b/internal/communicator/ssh/communicator_test.go
@@ -642,7 +642,11 @@ func TestAccHugeUploadFile(t *testing.T) {
 		return scpUploadFile(targetFile, source, w, stdoutR, size)
 	}
 
-	err = c.scpSession("scp -vt "+QuoteShell(targetDir), scpFunc)
+	cmd, err := QuoteShell([]string{"scp", "-vt", targetDir}, c.connInfo.TargetPlatform)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.scpSession(cmd, scpFunc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -736,32 +740,5 @@ func acceptPublicKey(keystr string) func(ssh.ConnMetadata, ssh.PublicKey) (*ssh.
 		}
 
 		return nil, fmt.Errorf("public key rejected")
-	}
-}
-
-func TestQuoteShell(t *testing.T) {
-	//unsafe := []string{
-	//	"`subprocess`/",
-	//	"$(subprocess)",
-	//	`' quote escape attempt`,
-	//}
-	if q := QuoteShell(""); q != "''" {
-		t.Fatalf("Expected empty quotes, got: %s", q)
-	}
-
-	if q := QuoteShell("test/some/file"); q != "'test/some/file'" {
-		t.Fatalf("Improperly quoted result: %s", q)
-	}
-
-	if q := QuoteShell("`subprocess call`"); q != "'`subprocess call`'" {
-		t.Fatalf("Improperly quoted result: %s", q)
-	}
-
-	if q := QuoteShell(`$(cat /etc/passwd)`); q != "'$(cat /etc/passwd)'" {
-		t.Fatalf("Improperly quoted result: %s", q)
-	}
-
-	if q := QuoteShell(` '$(echo quote escape) && echo ' `); q != `' '"'"'$(echo quote escape) && echo '"'"' '` {
-		t.Fatalf("Improperly quoted result: %s", q)
 	}
 }

--- a/internal/communicator/ssh/communicator_test.go
+++ b/internal/communicator/ssh/communicator_test.go
@@ -642,7 +642,7 @@ func TestAccHugeUploadFile(t *testing.T) {
 		return scpUploadFile(targetFile, source, w, stdoutR, size)
 	}
 
-	err = c.scpSession("scp -vt "+targetDir, scpFunc)
+	err = c.scpSession("scp -vt "+ QuoteShell(targetDir), scpFunc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -736,5 +736,32 @@ func acceptPublicKey(keystr string) func(ssh.ConnMetadata, ssh.PublicKey) (*ssh.
 		}
 
 		return nil, fmt.Errorf("public key rejected")
+	}
+}
+
+func TestQuoteShell(t *testing.T) {
+	//unsafe := []string{
+	//	"`subprocess`/",
+	//	"$(subprocess)",
+	//	`' quote escape attempt`,
+	//}
+	if q := QuoteShell(""); q != "''" {
+		t.Fatalf("Expected empty quotes, got: %s", q)
+	}
+
+	if q:= QuoteShell("test/some/file"); q != "'test/some/file'" {
+		t.Fatalf("Improperly quoted result: %s", q)
+	}
+
+	if q:= QuoteShell("`subprocess call`"); q != "'`subprocess call`'" {
+		t.Fatalf("Improperly quoted result: %s", q)
+	}
+
+	if q:= QuoteShell(`$(cat /etc/passwd)`); q != "'$(cat /etc/passwd)'" {
+		t.Fatalf("Improperly quoted result: %s", q)
+	}
+
+	if q:= QuoteShell(` '$(echo quote escape) && echo ' `); q != `' '"'"'$(echo quote escape) && echo '"'"' '` {
+		t.Fatalf("Improperly quoted result: %s", q)
 	}
 }

--- a/internal/communicator/ssh/communicator_test.go
+++ b/internal/communicator/ssh/communicator_test.go
@@ -642,7 +642,7 @@ func TestAccHugeUploadFile(t *testing.T) {
 		return scpUploadFile(targetFile, source, w, stdoutR, size)
 	}
 
-	err = c.scpSession("scp -vt "+ QuoteShell(targetDir), scpFunc)
+	err = c.scpSession("scp -vt "+QuoteShell(targetDir), scpFunc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -749,19 +749,19 @@ func TestQuoteShell(t *testing.T) {
 		t.Fatalf("Expected empty quotes, got: %s", q)
 	}
 
-	if q:= QuoteShell("test/some/file"); q != "'test/some/file'" {
+	if q := QuoteShell("test/some/file"); q != "'test/some/file'" {
 		t.Fatalf("Improperly quoted result: %s", q)
 	}
 
-	if q:= QuoteShell("`subprocess call`"); q != "'`subprocess call`'" {
+	if q := QuoteShell("`subprocess call`"); q != "'`subprocess call`'" {
 		t.Fatalf("Improperly quoted result: %s", q)
 	}
 
-	if q:= QuoteShell(`$(cat /etc/passwd)`); q != "'$(cat /etc/passwd)'" {
+	if q := QuoteShell(`$(cat /etc/passwd)`); q != "'$(cat /etc/passwd)'" {
 		t.Fatalf("Improperly quoted result: %s", q)
 	}
 
-	if q:= QuoteShell(` '$(echo quote escape) && echo ' `); q != `' '"'"'$(echo quote escape) && echo '"'"' '` {
+	if q := QuoteShell(` '$(echo quote escape) && echo ' `); q != `' '"'"'$(echo quote escape) && echo '"'"' '` {
 		t.Fatalf("Improperly quoted result: %s", q)
 	}
 }

--- a/internal/communicator/ssh/communicator_test.go
+++ b/internal/communicator/ssh/communicator_test.go
@@ -642,7 +642,7 @@ func TestAccHugeUploadFile(t *testing.T) {
 		return scpUploadFile(targetFile, source, w, stdoutR, size)
 	}
 
-	cmd, err := QuoteShell([]string{"scp", "-vt", targetDir}, c.connInfo.TargetPlatform)
+	cmd, err := quoteShell([]string{"scp", "-vt", targetDir}, c.connInfo.TargetPlatform)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Terraform builds `scp` command used in the ssh communicator directly from user input, without any sort of sanitization or quoting. This allows for command injection via `destination` argument in the provisioner block. 

The security implications of this are minimal, because Terraform provisioners already allow code execution. Regardless, Terraform should quote the user input when constructing the `scp` command, so `destination` is not a vector for code exec. 

This change adds quotes around the user input in the `scp` command. This change is not friendly to filenames that contain a quote - any pre-existing quotes will be removed. In theory this change could break existing Terraform code, but this mechanism of concatenating things into an `scp` command already seems a bit brittle.