### PR TITLE
core: If we refresh during orphan processing, use the result for planning

### DIFF
--- a/terraform/node_resource_plan_orphan.go
+++ b/terraform/node_resource_plan_orphan.go
@@ -114,6 +114,10 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 		if diags.HasErrors() {
 			return diags
 		}
+
+		// If we refreshed then our subsequent planning should be in terms of
+		// the new object, not the original object.
+		oldState = refreshedState
 	}
 
 	if !n.skipPlanChanges {

--- a/terraform/node_resource_plan_orphan_test.go
+++ b/terraform/node_resource_plan_orphan_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/hashicorp/terraform/configs/configschema"
 	"github.com/hashicorp/terraform/instances"
 	"github.com/hashicorp/terraform/plans"
+	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/states"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodeResourcePlanOrphanExecute(t *testing.T) {
@@ -63,4 +65,82 @@ func TestNodeResourcePlanOrphanExecute(t *testing.T) {
 	if !state.Empty() {
 		t.Fatalf("expected empty state, got %s", state.String())
 	}
+}
+
+func TestNodeResourcePlanOrphanExecute_alreadyDeleted(t *testing.T) {
+	addr := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "test_object",
+		Name: "foo",
+	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
+
+	state := states.NewState()
+	state.Module(addrs.RootModuleInstance).SetResourceInstanceCurrent(
+		addr.Resource,
+		&states.ResourceInstanceObjectSrc{
+			AttrsFlat: map[string]string{
+				"test_string": "foo",
+			},
+			Status: states.ObjectReady,
+		},
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   addrs.RootModule,
+		},
+	)
+	refreshState := state.DeepCopy()
+	prevRunState := state.DeepCopy()
+	changes := plans.NewChanges()
+
+	p := simpleMockProvider()
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
+		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["test_string"].Block.ImpliedType()),
+	}
+	ctx := &MockEvalContext{
+		StateState:               state.SyncWrapper(),
+		RefreshStateState:        refreshState.SyncWrapper(),
+		PrevRunStateState:        prevRunState.SyncWrapper(),
+		InstanceExpanderExpander: instances.NewExpander(),
+		ProviderProvider:         p,
+		ProviderSchemaSchema: &ProviderSchema{
+			ResourceTypes: map[string]*configschema.Block{
+				"test_object": simpleTestSchema(),
+			},
+		},
+		ChangesChanges: changes.SyncWrapper(),
+	}
+
+	node := NodePlannableResourceInstanceOrphan{
+		NodeAbstractResourceInstance: &NodeAbstractResourceInstance{
+			NodeAbstractResource: NodeAbstractResource{
+				ResolvedProvider: addrs.AbsProviderConfig{
+					Provider: addrs.NewDefaultProvider("test"),
+					Module:   addrs.RootModule,
+				},
+			},
+			Addr: mustResourceInstanceAddr("test_object.foo"),
+		},
+	}
+	diags := node.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %s", diags.Err())
+	}
+	if !state.Empty() {
+		t.Fatalf("expected empty state, got %s", state.String())
+	}
+
+	if got := prevRunState.ResourceInstance(addr); got == nil {
+		t.Errorf("no entry for %s in the prev run state; should still be present", addr)
+	}
+	if got := refreshState.ResourceInstance(addr); got != nil {
+		t.Errorf("refresh state has entry for %s; should've been removed", addr)
+	}
+	if got := changes.ResourceInstance(addr); got == nil {
+		t.Errorf("no entry for %s in the planned changes; should have a NoOp change", addr)
+	} else {
+		if got, want := got.Action, plans.NoOp; got != want {
+			t.Errorf("planned change for %s has wrong action\ngot:  %s\nwant: %s", addr, got, want)
+		}
+	}
+
 }


### PR DESCRIPTION
If we don't do this then we can create a situation where refresh detects that an object already doesn't exist but we plan to destroy it anyway, rather than returning "no changes" as expected. Often that's harmless because deleting is idempotent anyway, but there are also many APIs that treat deleting a non-existing object as special sort of error which would then cause a failure during apply.

By writing the unit test for this I also noticed that we were failing to generate a `NoOp` plan for the resource in that case. Again, that's not something that's a _major_ big deal, but for our JSON plan output we produce plans for every resource instance we considered during planning so that certain external consumers can distinguish "we've confirmed that this instance needs to changes" from "this instance was excluded from planning altogether, e.g. by `-target`".
