### PR TITLE
Don't try to build the config is there were errors loading

### DIFF
--- a/configs/configload/loader_load.go
+++ b/configs/configload/loader_load.go
@@ -20,7 +20,7 @@ import (
 // required to process the individual modules
 func (l *Loader) LoadConfig(rootDir string) (*configs.Config, hcl.Diagnostics) {
 	rootMod, diags := l.parser.LoadConfigDir(rootDir)
-	if rootMod == nil {
+	if rootMod == nil || diags.HasErrors() {
 		return nil, diags
 	}
 

--- a/configs/configload/loader_load_test.go
+++ b/configs/configload/loader_load_test.go
@@ -80,3 +80,19 @@ func TestLoaderLoadConfig_addVersion(t *testing.T) {
 		t.Fatalf("wrong error\ngot:\n%s\n\nwant: containing %q", got, want)
 	}
 }
+
+func TestLoaderLoadConfig_loadDiags(t *testing.T) {
+	// building a config which didn't load correctly may cause configs to panic
+	fixtureDir := filepath.Clean("testdata/invalid-names")
+	loader, err := NewLoader(&Config{
+		ModulesDir: filepath.Join(fixtureDir, ".terraform/modules"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from NewLoader: %s", err)
+	}
+
+	_, diags := loader.LoadConfig(fixtureDir)
+	if !diags.HasErrors() {
+		t.Fatalf("success; want error")
+	}
+}

--- a/configs/configload/testdata/invalid-names/main.tf
+++ b/configs/configload/testdata/invalid-names/main.tf
@@ -1,0 +1,3 @@
+provider "42_bad!" {
+  invalid_provider_name = "yes"
+}


### PR DESCRIPTION
If the config did not load properly, the config builder may panic.
Check for diagnostics before building. 

Fixes #28577