### PR TITLE
Improve marks support for `length` and `lookup`

### DIFF
--- a/lang/funcs/collection.go
+++ b/lang/funcs/collection.go
@@ -20,6 +20,7 @@ var LengthFunc = function.New(&function.Spec{
 			Type:             cty.DynamicPseudoType,
 			AllowDynamicType: true,
 			AllowUnknown:     true,
+			AllowMarked:      true,
 		},
 	},
 	Type: func(args []cty.Value) (cty.Type, error) {
@@ -34,15 +35,16 @@ var LengthFunc = function.New(&function.Spec{
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		coll := args[0]
 		collTy := args[0].Type()
+		marks := coll.Marks()
 		switch {
 		case collTy == cty.DynamicPseudoType:
-			return cty.UnknownVal(cty.Number), nil
+			return cty.UnknownVal(cty.Number).WithMarks(marks), nil
 		case collTy.IsTupleType():
 			l := len(collTy.TupleElementTypes())
-			return cty.NumberIntVal(int64(l)), nil
+			return cty.NumberIntVal(int64(l)).WithMarks(marks), nil
 		case collTy.IsObjectType():
 			l := len(collTy.AttributeTypes())
-			return cty.NumberIntVal(int64(l)), nil
+			return cty.NumberIntVal(int64(l)).WithMarks(marks), nil
 		case collTy == cty.String:
 			// We'll delegate to the cty stdlib strlen function here, because
 			// it deals with all of the complexities of tokenizing unicode

--- a/lang/funcs/collection_test.go
+++ b/lang/funcs/collection_test.go
@@ -122,6 +122,54 @@ func TestLength(t *testing.T) {
 			cty.DynamicVal,
 			cty.UnknownVal(cty.Number),
 		},
+		{ // Marked collections return a marked length
+			cty.ListVal([]cty.Value{
+				cty.StringVal("hello"),
+				cty.StringVal("world"),
+			}).Mark("secret"),
+			cty.NumberIntVal(2).Mark("secret"),
+		},
+		{ // Marks on values in unmarked collections do not propagate
+			cty.ListVal([]cty.Value{
+				cty.StringVal("hello").Mark("a"),
+				cty.StringVal("world").Mark("b"),
+			}),
+			cty.NumberIntVal(2),
+		},
+		{ // Marked strings return a marked length
+			cty.StringVal("hello world").Mark("secret"),
+			cty.NumberIntVal(11).Mark("secret"),
+		},
+		{ // Marked tuples return a marked length
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("hello"),
+				cty.StringVal("world"),
+			}).Mark("secret"),
+			cty.NumberIntVal(2).Mark("secret"),
+		},
+		{ // Marks on values in unmarked tuples do not propagate
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("hello").Mark("a"),
+				cty.StringVal("world").Mark("b"),
+			}),
+			cty.NumberIntVal(2),
+		},
+		{ // Marked objects return a marked length
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("hello"),
+				"b": cty.StringVal("world"),
+				"c": cty.StringVal("nice to meet you"),
+			}).Mark("secret"),
+			cty.NumberIntVal(3).Mark("secret"),
+		},
+		{ // Marks on object attribute values do not propagate
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("hello").Mark("a"),
+				"b": cty.StringVal("world").Mark("b"),
+				"c": cty.StringVal("nice to meet you").Mark("c"),
+			}),
+			cty.NumberIntVal(3),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
We improved marks support for these two functions in https://github.com/zclconf/go-cty/pull/98, not realizing that Terraform has its own separate and incompatible implementations. These commits bring across essentially the same changes, re-applied to these local versions.

### functions: Improve marks support for `length`

Similar to cty's implementation, we only need to preserve marks from the value itself, not any nested values it may contain. This means that taking the length of an umarked list with marked elements results in an unmarked number.

### functions: Improve marks support for `lookup`

Several changes to `lookup` to improve how we handle marked values:

- If the entire collection is marked, preserve the marks on any result (whether successful or fallback)
- If a returned value from the collection is marked, preserve the marks from only that value, combined with any overall collection marks
- Retain marks on the fallback value when it is returned, combined with any overall collection marks
- Include marks on the key in the result, as otherwise the result it ends up selecting could imply what the sensitive value was
- Retain collection marks when returning an unknown value for a not wholly-known collection


Fixes #28638