### PR TITLE
core: Update working state for resource instances in refresh-only mode

### DIFF
--- a/terraform/node_resource_plan_instance.go
+++ b/terraform/node_resource_plan_instance.go
@@ -226,6 +226,16 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		}
 
 		diags = diags.Append(n.writeChange(ctx, change, ""))
+	} else {
+		// Even if we don't plan changes, we do still need to at least update
+		// the working state to reflect the refresh result. If not, then e.g.
+		// any output values refering to this will not react to the drift.
+		// (Even if we didn't actually refresh above, this will still save
+		// the result of any schema upgrading we did in readResourceInstanceState.)
+		diags = diags.Append(n.writeResourceInstanceState(ctx, instanceRefreshState, workingState))
+		if diags.HasErrors() {
+			return diags
+		}
 	}
 
 	return diags


### PR DESCRIPTION
Previously in refresh-only mode we were skipping making any updates to the working state at all. That's not correct, though: if the state upgrade step detected changes then we need to at least commit _those_ to the working state, because those can then be detected by downstream objects like output values.

Although this incorrect code has been included in a release, it wasn't actually reachable because we haven't made any releases with `-refresh-only` available as an end-user planning mode yet. I found this while working on #28634, where I noticed that refresh-only mode made output values not update until the subsequent plan+apply.
