### PR TITLE
command/views: Remove baseState argument from plan-rendering views

### DIFF
--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -96,7 +96,7 @@ func (b *Local) opApply(
 			}
 
 			if !trivialPlan {
-				op.View.Plan(plan, runningOp.State, tfCtx.Schemas())
+				op.View.Plan(plan, tfCtx.Schemas())
 			}
 
 			// We'll show any accumulated warnings before we display the prompt,

--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -153,7 +153,7 @@ func (b *Local) opPlan(
 	}
 
 	// Render the plan
-	op.View.Plan(plan, plan.PriorState, tfCtx.Schemas())
+	op.View.Plan(plan, tfCtx.Schemas())
 
 	// If we've accumulated any warnings along the way then we'll show them
 	// here just before we show the summary and next steps. If we encountered

--- a/command/show.go
+++ b/command/show.go
@@ -160,7 +160,7 @@ func (c *ShowCommand) Run(args []string) int {
 		}
 
 		view := views.NewShow(arguments.ViewHuman, c.View)
-		view.Plan(plan, stateFile.State, schemas)
+		view.Plan(plan, schemas)
 		return 0
 	}
 

--- a/command/views/operation.go
+++ b/command/views/operation.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform/command/format"
 	"github.com/hashicorp/terraform/command/views/json"
 	"github.com/hashicorp/terraform/plans"
-	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statefile"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
@@ -26,7 +25,7 @@ type Operation interface {
 
 	PlannedChange(change *plans.ResourceInstanceChangeSrc)
 	PlanNoChanges()
-	Plan(plan *plans.Plan, baseState *states.State, schemas *terraform.Schemas)
+	Plan(plan *plans.Plan, schemas *terraform.Schemas)
 	PlanNextStep(planPath string)
 
 	Diagnostics(diags tfdiags.Diagnostics)
@@ -92,8 +91,8 @@ func (v *OperationHuman) PlanNoChanges() {
 	v.view.streams.Println("\n" + strings.TrimSpace(format.WordWrap(planNoChangesDetail, v.view.outputColumns())))
 }
 
-func (v *OperationHuman) Plan(plan *plans.Plan, baseState *states.State, schemas *terraform.Schemas) {
-	renderPlan(plan, baseState, schemas, v.view)
+func (v *OperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
+	renderPlan(plan, schemas, v.view)
 }
 
 func (v *OperationHuman) PlannedChange(change *plans.ResourceInstanceChangeSrc) {
@@ -172,7 +171,7 @@ func (v *OperationJSON) PlanNoChanges() {
 
 // Log a change summary and a series of "planned" messages for the changes in
 // the plan.
-func (v *OperationJSON) Plan(plan *plans.Plan, baseState *states.State, schemas *terraform.Schemas) {
+func (v *OperationJSON) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
 	cs := &json.ChangeSummary{
 		Operation: json.OperationPlanned,
 	}

--- a/command/views/operation_test.go
+++ b/command/views/operation_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform/command/arguments"
 	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/plans"
-	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statefile"
 )
 
@@ -88,9 +87,8 @@ func TestOperation_plan(t *testing.T) {
 	v := NewOperation(arguments.ViewHuman, true, NewView(streams))
 
 	plan := testPlan(t)
-	state := states.NewState()
 	schemas := testSchemas()
-	v.Plan(plan, state, schemas)
+	v.Plan(plan, schemas)
 
 	want := `
 Terraform used the selected providers to generate the following execution
@@ -308,7 +306,7 @@ func TestOperationJSON_plan(t *testing.T) {
 			},
 		},
 	}
-	v.Plan(plan, nil, nil)
+	v.Plan(plan, nil)
 
 	want := []map[string]interface{}{
 		// Create-then-delete should result in replace

--- a/command/views/plan.go
+++ b/command/views/plan.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform/command/arguments"
 	"github.com/hashicorp/terraform/command/format"
 	"github.com/hashicorp/terraform/plans"
-	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/terraform/tfdiags"
 )
@@ -96,7 +95,7 @@ func (v *PlanJSON) HelpPrompt() {
 
 // The plan renderer is used by the Operation view (for plan and apply
 // commands) and the Show view (for the show command).
-func renderPlan(plan *plans.Plan, baseState *states.State, schemas *terraform.Schemas, view *View) {
+func renderPlan(plan *plans.Plan, schemas *terraform.Schemas, view *View) {
 	counts := map[plans.Action]int{}
 	var rChanges []*plans.ResourceInstanceChangeSrc
 	for _, change := range plan.Changes.Resources {

--- a/command/views/show.go
+++ b/command/views/show.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform/command/arguments"
 	"github.com/hashicorp/terraform/plans"
-	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -13,7 +12,7 @@ import (
 // command, in place to allow access to the plan renderer which is now in the
 // views package.
 type Show interface {
-	Plan(plan *plans.Plan, baseState *states.State, schemas *terraform.Schemas)
+	Plan(plan *plans.Plan, schemas *terraform.Schemas)
 }
 
 // FIXME: the show view should support both human and JSON types. This code is
@@ -34,6 +33,6 @@ type ShowHuman struct {
 
 var _ Show = (*ShowHuman)(nil)
 
-func (v *ShowHuman) Plan(plan *plans.Plan, baseState *states.State, schemas *terraform.Schemas) {
-	renderPlan(plan, baseState, schemas, &v.View)
+func (v *ShowHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
+	renderPlan(plan, schemas, &v.View)
 }


### PR DESCRIPTION
In practice the current implementation isn't actually using this, and if we need access to states in future we can access them in either the `plan.PriorState` or `plan.PrevRunState` fields, depending on which stage we want a state snapshot of.

(Technically these two plan fields aren't reliably available until we also merge #28653, but that's moot here because the current view code doesn't access either of them anyway. #28634 will eventually make use of this to produce the "Objects have changed outside of Terraform" bit, though.)
