### PR TITLE
cli+website: -ignore-remote-version doc elaboration and other cleanup

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -343,7 +343,9 @@ Options:
                          accompanied by errors, show them in a more compact
                          form that includes only the summary messages.
 
-  -lock=true             Lock the state file when locking is supported.
+  -lock=false            Don't hold a state lock during the operation. This is
+                         dangerous if others might concurrently run commands
+                         against the same workspace.
 
   -lock-timeout=0s       Duration to retry a state lock.
 

--- a/command/import.go
+++ b/command/import.go
@@ -309,7 +309,9 @@ Options:
 
   -input=false            Disable interactive input prompts.
 
-  -lock                   Lock the state file when locking is supported.
+  -lock=false             Don't hold a state lock during the operation. This is
+                          dangerous if others might concurrently run commands
+                          against the same workspace.
 
   -lock-timeout=0s        Duration to retry a state lock.
 

--- a/command/import.go
+++ b/command/import.go
@@ -307,9 +307,9 @@ Options:
 
   -allow-missing-config   Allow import when no resource configuration block exists.
 
-  -input=true             Ask for input for variables if not directly set.
+  -input=false            Disable interactive input prompts.
 
-  -lock=true              Lock the state file when locking is supported.
+  -lock                   Lock the state file when locking is supported.
 
   -lock-timeout=0s        Duration to retry a state lock.
 
@@ -323,9 +323,8 @@ Options:
                           a file. If "terraform.tfvars" or any ".auto.tfvars"
                           files are present, they will be automatically loaded.
 
-  -ignore-remote-version  Continue even if remote and local Terraform versions
-                          are incompatible. This may result in an unusable
-                          workspace, and should be used with extreme caution.
+  -ignore-remote-version  A rare option used for the remote backend only. See
+                          the remote backend documentation for more information.
 
   -state, state-out, and -backup are legacy options supported for the local
   backend only. For more information, see the local backend's documentation.

--- a/command/plan.go
+++ b/command/plan.go
@@ -242,7 +242,9 @@ Other Options:
 
   -input=true         Ask for input for variables if not directly set.
 
-  -lock=true          Lock the state file when locking is supported.
+  -lock=false         Don't hold a state lock during the operation. This is
+                      dangerous if others might concurrently run commands
+                      against the same workspace.
 
   -lock-timeout=0s    Duration to retry a state lock.
 

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -187,7 +187,9 @@ Options:
 
   -input=true         Ask for input for variables if not directly set.
 
-  -lock=true          Lock the state file when locking is supported.
+  -lock=false         Don't hold a state lock during the operation. This is
+                      dangerous if others might concurrently run commands
+                      against the same workspace.
 
   -lock-timeout=0s    Duration to retry a state lock.
 

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -477,32 +477,15 @@ Options:
   -dry-run                If set, prints out what would've been moved but doesn't
                           actually move anything.
 
-  -backup=PATH            Path where Terraform should write the backup for the
-                          original state. This can't be disabled. If not set,
-                          Terraform will write it to the same path as the
-                          statefile with a ".backup" extension.
-
-  -backup-out=PATH        Path where Terraform should write the backup for the
-                          destination state. This can't be disabled. If not
-                          set, Terraform will write it to the same path as the
-                          destination state file with a backup extension. This
-                          only needs to be specified if -state-out is set to a
-                          different path than -state.
-
-  -lock=true              Lock the state files when locking is supported.
+  -lock                   Lock the state files when locking is supported.
 
   -lock-timeout=0s        Duration to retry a state lock.
 
-  -state=PATH             Path to the source state file. Defaults to the
-                          configured backend, or "terraform.tfstate"
+  -ignore-remote-version  A rare option used for the remote backend only. See
+                          the remote backend documentation for more information.
 
-  -state-out=PATH         Path to the destination state file to write to. If
-                          this isn't specified, the source state file will be
-                          used. This can be a new or existing path.
-
-  -ignore-remote-version  Continue even if remote and local Terraform versions
-                          are incompatible. This may result in an unusable
-                          workspace, and should be used with extreme caution.
+  -state, state-out, and -backup are legacy options supported for the local
+  backend only. For more information, see the local backend's documentation.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -477,7 +477,9 @@ Options:
   -dry-run                If set, prints out what would've been moved but doesn't
                           actually move anything.
 
-  -lock                   Lock the state files when locking is supported.
+  -lock=false             Don't hold a state lock during the operation. This is
+                          dangerous if others might concurrently run commands
+                          against the same workspace.
 
   -lock-timeout=0s        Duration to retry a state lock.
 

--- a/command/state_push.go
+++ b/command/state_push.go
@@ -156,7 +156,9 @@ Options:
   -force              Write the state even if lineages don't match or the
                       remote serial is higher.
 
-  -lock=true          Lock the state file when locking is supported.
+  -lock=false         Don't hold a state lock during the operation. This is
+                      dangerous if others might concurrently run commands
+                      against the same workspace.
 
   -lock-timeout=0s    Duration to retry a state lock.
 

--- a/command/state_replace_provider.go
+++ b/command/state_replace_provider.go
@@ -179,7 +179,9 @@ Options:
 
   -auto-approve           Skip interactive approval.
 
-  -lock                   Lock the state files when locking is supported.
+  -lock=false             Don't hold a state lock during the operation. This is
+                          dangerous if others might concurrently run commands
+                          against the same workspace.
 
   -lock-timeout=0s        Duration to retry a state lock.
 

--- a/command/state_replace_provider.go
+++ b/command/state_replace_provider.go
@@ -179,21 +179,15 @@ Options:
 
   -auto-approve           Skip interactive approval.
 
-  -backup=PATH            Path where Terraform should write the backup for the
-						  state file. This can't be disabled. If not set,
-						  Terraform will write it to the same path as the state
-						  file with a ".backup" extension.
-
-  -lock=true              Lock the state files when locking is supported.
+  -lock                   Lock the state files when locking is supported.
 
   -lock-timeout=0s        Duration to retry a state lock.
 
-  -state=PATH             Path to the state file to update. Defaults to the
-						  configured backend, or "terraform.tfstate"
+  -ignore-remote-version  A rare option used for the remote backend only. See
+                          the remote backend documentation for more information.
 
-  -ignore-remote-version  Continue even if remote and local Terraform versions
-                          are incompatible. This may result in an unusable
-                          workspace, and should be used with extreme caution.
+  -state, state-out, and -backup are legacy options supported for the local
+  backend only. For more information, see the local backend's documentation.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -157,7 +157,9 @@ Options:
   -backup=PATH            Path where Terraform should write the backup
                           state.
 
-  -lock=true              Lock the state file when locking is supported.
+  -lock=false             Don't hold a state lock during the operation. This is
+                          dangerous if others might concurrently run commands
+                          against the same workspace.
 
   -lock-timeout=0s        Duration to retry a state lock.
 

--- a/command/taint.go
+++ b/command/taint.go
@@ -235,23 +235,15 @@ Options:
   -allow-missing          If specified, the command will succeed (exit code 0)
                           even if the resource is missing.
 
-  -backup=path            Path to backup the existing state file before
-                          modifying. Defaults to the "-state-out" path with
-                          ".backup" extension. Set to "-" to disable backup.
-
-  -lock=true              Lock the state file when locking is supported.
+  -lock                   Lock the state file when locking is supported.
 
   -lock-timeout=0s        Duration to retry a state lock.
 
-  -state=path             Path to read and save state (unless state-out
-                          is specified). Defaults to "terraform.tfstate".
+  -ignore-remote-version  A rare option used for the remote backend only. See
+                          the remote backend documentation for more information.
 
-  -state-out=path         Path to write updated state file. By default, the
-                          "-state" path will be used.
-
-  -ignore-remote-version  Continue even if remote and local Terraform versions
-                          are incompatible. This may result in an unusable
-                          workspace, and should be used with extreme caution.
+  -state, state-out, and -backup are legacy options supported for the local
+  backend only. For more information, see the local backend's documentation.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/taint.go
+++ b/command/taint.go
@@ -235,7 +235,9 @@ Options:
   -allow-missing          If specified, the command will succeed (exit code 0)
                           even if the resource is missing.
 
-  -lock                   Lock the state file when locking is supported.
+  -lock=false             Don't hold a state lock during the operation. This is
+                          dangerous if others might concurrently run commands
+                          against the same workspace.
 
   -lock-timeout=0s        Duration to retry a state lock.
 

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -200,23 +200,15 @@ Options:
   -allow-missing          If specified, the command will succeed (exit code 0)
                           even if the resource is missing.
 
-  -backup=path            Path to backup the existing state file before
-						  modifying. Defaults to the "-state-out" path with
-						  ".backup" extension. Set to "-" to disable backup.
-
-  -lock=true              Lock the state file when locking is supported.
+  -lock                   Lock the state file when locking is supported.
 
   -lock-timeout=0s        Duration to retry a state lock.
 
-  -state=path             Path to read and save state (unless state-out
-                          is specified). Defaults to "terraform.tfstate".
+  -ignore-remote-version  A rare option used for the remote backend only. See
+                          the remote backend documentation for more information.
 
-  -state-out=path         Path to write updated state file. By default, the
-                          "-state" path will be used.
-
-  -ignore-remote-version  Continue even if remote and local Terraform versions
-                          are incompatible. This may result in an unusable
-                          workspace, and should be used with extreme caution.
+  -state, state-out, and -backup are legacy options supported for the local
+  backend only. For more information, see the local backend's documentation.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -200,7 +200,9 @@ Options:
   -allow-missing          If specified, the command will succeed (exit code 0)
                           even if the resource is missing.
 
-  -lock                   Lock the state file when locking is supported.
+  -lock=false             Don't hold a state lock during the operation. This is
+                          dangerous if others might concurrently run commands
+                          against the same workspace.
 
   -lock-timeout=0s        Duration to retry a state lock.
 

--- a/command/workspace_delete.go
+++ b/command/workspace_delete.go
@@ -190,11 +190,13 @@ Usage: terraform [global options] workspace delete [OPTIONS] NAME
 
 Options:
 
-    -force    remove a non-empty workspace.
+  -force             Remove even a non-empty workspace.
 
-    -lock=true          Lock the state file when locking is supported.
+  -lock=false        Don't hold a state lock during the operation. This is
+                     dangerous if others might concurrently run commands
+                     against the same workspace.
 
-    -lock-timeout=0s    Duration to retry a state lock.
+  -lock-timeout=0s   Duration to retry a state lock.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/workspace_new.go
+++ b/command/workspace_new.go
@@ -185,14 +185,15 @@ Usage: terraform [global options] workspace new [OPTIONS] NAME
 
   Create a new Terraform workspace.
 
-
 Options:
 
-    -lock=true          Lock the state file when locking is supported.
+    -lock=false         Don't hold a state lock during the operation. This is
+                        dangerous if others might concurrently run commands
+                        against the same workspace.
 
     -lock-timeout=0s    Duration to retry a state lock.
 
-    -state=path    Copy an existing state file into the new workspace.
+    -state=path         Copy an existing state file into the new workspace.
 
 `
 	return strings.TrimSpace(helpText)

--- a/website/docs/cli/commands/apply.html.md
+++ b/website/docs/cli/commands/apply.html.md
@@ -69,8 +69,9 @@ _in addition to_ the planning modes and planning options described for
   [Running Terraform in Automation](https://learn.hashicorp.com/tutorials/terraform/automate-terraform?in=terraform/automation&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) for some
   different approaches.
 
-* `-lock=false` - Disables Terraform's default behavior of attempting to take
-  a read/write lock on the state for the duration of the operation.
+* `-lock=false` - Don't hold a state lock during the operation. This is
+   dangerous if others might concurrently run commands against the same
+   workspace.
 
 * `-lock-timeout=DURATION` - Unless locking is disabled with `-lock=false`,
   instructs Terraform to retry acquiring a lock for a period of time before

--- a/website/docs/cli/commands/import.html.md
+++ b/website/docs/cli/commands/import.html.md
@@ -77,10 +77,11 @@ in the configuration for the target resource, and that is the best behavior in m
   the working directory. This flag can be used multiple times. This is only
   useful with the `-config` flag.
 
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.
+For configurations using
+[the `remote` backend](/docs/language/settings/backends/remote.html)
+only, `terraform import`
+also accepts the option
+[`-ignore-remote-version`](/docs/language/settings/backends/remote.html#command-line-arguments).
 
 For configurations using
 [the `local` backend](/docs/language/settings/backends/local.html) only,

--- a/website/docs/cli/commands/import.html.md
+++ b/website/docs/cli/commands/import.html.md
@@ -48,7 +48,9 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-input=true` - Whether to ask for input for provider configuration.
 
-* `-lock=true` - Lock the state file when locking is supported.
+* `-lock=false` - Don't hold a state lock during the operation. This is
+   dangerous if others might concurrently run commands against the same
+   workspace.
 
 * `-lock-timeout=0s` - Duration to retry a state lock.
 

--- a/website/docs/cli/commands/plan.html.md
+++ b/website/docs/cli/commands/plan.html.md
@@ -246,8 +246,9 @@ The available options are:
   a value. This option is particular useful when running Terraform in
   non-interactive automation systems.
 
-* `-lock=false` - Disables Terraform's default behavior of attempting to take
-  a read/write lock on the state for the duration of the operation.
+* `-lock=false` - Don't hold a state lock during the operation. This is
+   dangerous if others might concurrently run commands against the same
+   workspace.
 
 * `-lock-timeout=DURATION` - Unless locking is disabled with `-lock=false`,
   instructs Terraform to retry acquiring a lock for a period of time before

--- a/website/docs/cli/commands/state/mv.html.md
+++ b/website/docs/cli/commands/state/mv.html.md
@@ -3,43 +3,60 @@ layout: "docs"
 page_title: "Command: state mv"
 sidebar_current: "docs-commands-state-sub-mv"
 description: |-
-  The `terraform state mv` command moves items in the Terraform state.
+  The `terraform state mv` command changes bindings in Terraform state, associating existing remote objects with new resource instances.
 ---
 
 # Command: state mv
 
-The `terraform state mv` command is used to move items in a
-[Terraform state](/docs/language/state/index.html). This command can move
-single resources, single instances of a resource, entire modules, and more.
-This command can also move items to a completely different state file,
-enabling efficient refactoring.
+The main function of [Terraform state](/docs/language/state/index.html) is
+to track the bindings between resource instance addresses in your configuration
+and the remote objects they represent. Normally Terraform automatically
+updates the state in response to actions taken when applying a plan, such as
+removing a binding for an remote object that has now been deleted.
+
+You can use `terraform state mv` in the less common situation where you wish
+to retain an existing remote object but track it as a different resource
+instance address in Terraform, such as if you have renamed a resource block
+or you have moved it into a different module in your configuration.
 
 ## Usage
 
 Usage: `terraform state mv [options] SOURCE DESTINATION`
 
-This command will move an item matched by the address given to the
-destination address. This command can also move to a destination address
-in a completely different state file.
+Terraform will look in the current state for a resource instance, resource,
+or module that matches the given address, and if successful it will move the
+remote objects currently associated with the source to be tracked instead
+by the destination.
 
-This can be used for simple resource renaming, moving items to and from
-a module, moving entire modules, and more. And because this command can also
-move data to a completely new state, it can also be used for refactoring
-one configuration into multiple separately managed Terraform configurations.
+Both the source and destination addresses must use
+[resource address syntax](/docs/cli/state/resource-addressing.html), and
+they must both refer to the same kind of object: you can only move a resource
+instance to another resource instance, a whole module instance to another
+whole module instance, etc. Furthermore, if you are moving a resource or
+a resource instance then you can only move it to a new address with the
+same resource type.
 
-This command will output a backup copy of the state prior to saving any
-changes. The backup cannot be disabled. Due to the destructive nature
-of this command, backups are required.
+The most common uses for `terraform state mv` are when you have renamed a
+resource block in your configuration or you've moved a resource block into
+a child module, in both cases with the intention of retaining the existing
+object but tracking it under a new name. By default Terraform will understand
+moving or renaming a resource configuration as a request to delete the old
+object and create a new object at the new address, and so `terraform state mv`
+allows you to override that interpretation by pre-emptively attaching the
+existing object to the new address in Terraform.
 
-If you're moving an item to a different state file, a backup will be created
-for each state file.
+~> *Warning:* If you are using Terraform in a collaborative environment, you
+must ensure that when you are using `terraform state mv` for a code refactoring
+purpose you communicate carefully with your coworkers to ensure that nobody
+makes any other changes between your configuration change and your
+`terraform state mv` command, because otherwise they might inadvertently create
+a plan that will destroy the old object and create a new object at the new
+address.
 
-This command requires a source and destination address of the item to move.
-Addresses are
-in [resource addressing format](/docs/cli/state/resource-addressing.html).
+This command also accepts the following option:
 
-This command doesn't normally accept any command line options, except in
-the special situations described in the following paragraphs.
+* `-dry-run` - Report all of the resource instances that match the given
+  address without actually "forgetting" any of them.
 
 For configurations using
 [the `remote` backend](/docs/language/settings/backends/remote.html)
@@ -54,69 +71,107 @@ For configurations using
 
 ## Example: Rename a Resource
 
-The example below renames the `packet_device` resource named `worker` to `helper`:
+Renaming a resource means making a configuration change like the following:
+
+```diff
+-resource "packet_device" "worker" {
++resource "packet_device" "helper" {
+   # ...
+ }
+```
+
+To tell Terraform that it should treat the new "helper" resource as a rename
+of the old "worker" resource, you can pair the above configuration change
+with the following command:
 
 ```shell
-$ terraform state mv 'packet_device.worker' 'packet_device.helper'
+terraform state mv packet_device.worker packet_device.helper
 ```
 
 ## Example: Move a Resource Into a Module
 
-The example below moves the `packet_device` resource named `worker` into a module
-named `app`. The module will be created if it doesn't exist.
+If you originally wrote a resource in your root module but now wish to refactor
+it into a child module, you can move the `resource` block into the child
+module configuration, removing the original in the root module, and then
+run the following command to tell Terraform to treat it as a move:
 
 ```shell
-$ terraform state mv 'packet_device.worker' 'module.app.packet_device.worker'
+terraform state mv packet_device.worker module.worker.packet_device.worker
+```
+
+In the above example the new resource has the same name but a different module
+address. You could also change the resource name at the same time, if the new
+module organization suggests a different naming scheme:
+
+```shell
+terraform state mv packet_device.worker module.worker.packet_device.main
 ```
 
 ## Example: Move a Module Into a Module
 
-The example below moves the module named `app` under the module named `parent`.
+You can also refactor an entire module into a child module. In the
+configuration, move the `module` block representing the module into a different
+module and then pair that change with a command like the following:
 
 ```shell
-$ terraform state mv 'module.app' 'module.parent.module.app'
+terraform state mv module.app module.parent.module.app
 ```
 
-## Example: Move a Module to Another State
+## Example: Move a Particular Instance of a Resource using `count`
 
-The example below moves the module named `app` into another state file. This removes
-the module from the original state file and adds it to the destination.
-The source and destination are the same meaning we're keeping the same name.
-
-```shell
-$ terraform state mv -state-out=other.tfstate 'module.app' 'module.app'
-```
-
-## Example: Move a Resource configured with count
-
-The example below moves the first instance of a `packet_device` resource named `worker` configured with
-[`count`](/docs/language/meta-arguments/count.html) to
-the first instance of a resource named `helper` also configured with `count`:
+A resource defined with [the `count` meta-argument](/docs/language/meta-arguments/count.html)
+has multiple instances that are each identified by an integer. You can
+select a particular instance by including an explicit index in your given
+address:
 
 ```shell
 $ terraform state mv 'packet_device.worker[0]' 'packet_device.helper[0]'
 ```
 
-## Example: Move a Resource configured with for_each
-
-The example below moves the `"example123"` instance of a `packet_device` resource named `worker` configured with
-[`for_each`](/docs/language/meta-arguments/for_each.html)
-to the `"example456"` instance of a resource named `helper` also configuring `for_each`:
-
-Linux, Mac OS, and UNIX:
+A resource that doesn't use `count` or `for_each` has only a single resource
+instance whose address is the same as the resource itself, and so you can
+move from an address not containing an index to an address containing an index,
+or the opposite, as long as the address type you use matches whether and how
+each resource is configured:
 
 ```shell
-$ terraform state mv 'packet_device.worker["example123"]' 'packet_device.helper["example456"]'
+$ terraform state mv 'packet_device.main' 'packet_device.all[0]'
+```
+
+Brackets (`[`, `]`) have a special meaning in some shells, so you may need to
+quote or escape the address in order to pass it literally to Terraform.
+The above examples show the typical quoting syntax for Unix-style shells.
+
+## Example: Move a Resource configured with for_each
+
+A resource defined with [the `for_each` meta-argument](/docs/language/meta-arguments/for_each.html)
+has multiple instances that are each identified by an string. You can
+select a particular instance by including an explicit key in your given
+address.
+
+However, the syntax for strings includes quotes and the quote symbol often
+has special meaning in command shells, so you'll need to use the appropriate
+quoting and/or escaping syntax for the shell you are using. For example:
+
+Unix-style shells, such as on Linux or macOS:
+
+```shell
+terraform state mv 'packet_device.worker["example123"]' 'packet_device.helper["example456"]'
+```
+
+Windows Command Prompt (`cmd.exe`):
+
+```shell
+terraform state mv packet_device.worker[\"example123\"] packet_device.helper[\"example456\"]
 ```
 
 PowerShell:
 
 ```shell
-$ terraform state mv 'packet_device.worker[\"example123\"]' 'packet_device.helper[\"example456\"]'
+terraform state mv 'packet_device.worker[\"example123\"]' 'packet_device.helper[\"example456\"]'
 ```
 
-Windows `cmd.exe`:
-
-```shell
-$ terraform state mv packet_device.worker[\"example123\"] packet_device.helper[\"example456\"]
-```
+Aside from the use of strings instead of integers for instance keys, the
+treatment of `for_each` resources is similar to `count` resources and so
+the same combinations of addresses with and without index components is
+valid as described in the previous section.

--- a/website/docs/cli/commands/state/mv.html.md
+++ b/website/docs/cli/commands/state/mv.html.md
@@ -38,29 +38,19 @@ This command requires a source and destination address of the item to move.
 Addresses are
 in [resource addressing format](/docs/cli/state/resource-addressing.html).
 
-The command-line flags are all optional. The list of available flags are:
+This command doesn't normally accept any command line options, except in
+the special situations described in the following paragraphs.
 
-* `-backup=path` - Path where Terraform should write the backup for the
-  original state. This can't be disabled. If not set, Terraform will write it
-  to the same path as the statefile with a ".backup" extension.
+For configurations using
+[the `remote` backend](/docs/language/settings/backends/remote.html)
+only, `terraform state mv`
+also accepts the option
+[`-ignore-remote-version`](/docs/language/settings/backends/remote.html#command-line-arguments).
 
-* `-backup-out=path` - Path where Terraform should write the backup for the
-  destination state. This can't be disabled. If not set, Terraform will write
-  it to the same path as the destination state file with a backup extension.
-  This only needs to be specified if -state-out is set to a different path than
-  -state.
-
-* `-state=path` - Path to the source state file to read from. Defaults to the
-  configured backend, or "terraform.tfstate".
-
-* `-state-out=path` - Path to the destination state file to write to. If this
-  isn't specified the source state file will be used. This can be a new or
-  existing path.
-
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.
+For configurations using
+[the `local` state mv](/docs/language/settings/backends/local.html) only,
+`terraform taint` also accepts the legacy options
+[`-state`, `-state-out`, and `-backup`](/docs/language/settings/backends/local.html#command-line-arguments).
 
 ## Example: Rename a Resource
 

--- a/website/docs/cli/commands/state/mv.html.md
+++ b/website/docs/cli/commands/state/mv.html.md
@@ -53,10 +53,19 @@ makes any other changes between your configuration change and your
 a plan that will destroy the old object and create a new object at the new
 address.
 
-This command also accepts the following option:
+This command also accepts the following options:
 
 * `-dry-run` - Report all of the resource instances that match the given
   address without actually "forgetting" any of them.
+
+* `-lock=false` - Don't hold a state lock during the operation. This is
+   dangerous if others might concurrently run commands against the same
+   workspace.
+
+* `-lock-timeout=DURATION` - Unless locking is disabled with `-lock=false`,
+  instructs Terraform to retry acquiring a lock for a period of time before
+  returning an error. The duration syntax is a number followed by a time
+  unit letter, such as "3s" for three seconds.
 
 For configurations using
 [the `remote` backend](/docs/language/settings/backends/remote.html)

--- a/website/docs/cli/commands/state/push.html.md
+++ b/website/docs/cli/commands/state/push.html.md
@@ -43,9 +43,8 @@ Both of these safety checks can be disabled with the `-force` flag.
 **This is not recommended.** If you disable the safety checks and are
 pushing state, the destination state will be overwritten.
 
-Other available flags:
-
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.
+For configurations using
+[the `remote` backend](/docs/language/settings/backends/remote.html)
+only, `terraform state push`
+also accepts the option
+[`-ignore-remote-version`](/docs/language/settings/backends/remote.html#command-line-arguments).

--- a/website/docs/cli/commands/state/replace-provider.html.md
+++ b/website/docs/cli/commands/state/replace-provider.html.md
@@ -27,7 +27,9 @@ This command also accepts the following options:
 
 * `-auto-approve` - Skip interactive approval.
 
-* `-lock=true`- Lock the state files when locking is supported.
+* `-lock=false` - Don't hold a state lock during the operation. This is
+   dangerous if others might concurrently run commands against the same
+   workspace.
 
 * `-lock-timeout=0s` - Duration to retry a state lock.
 

--- a/website/docs/cli/commands/state/replace-provider.html.md
+++ b/website/docs/cli/commands/state/replace-provider.html.md
@@ -23,25 +23,25 @@ This command will output a backup copy of the state prior to saving any
 changes. The backup cannot be disabled. Due to the destructive nature
 of this command, backups are required.
 
-The command-line flags are all optional. The list of available flags are:
+This command also accepts the following options:
 
 * `-auto-approve` - Skip interactive approval.
-
-* `-backup=path` - Path where Terraform should write the backup for the
-  original state. This can't be disabled. If not set, Terraform will write it
-  to the same path as the statefile with a ".backup" extension.
 
 * `-lock=true`- Lock the state files when locking is supported.
 
 * `-lock-timeout=0s` - Duration to retry a state lock.
 
-* `-state=path` - Path to the source state file to read from. Defaults to the
-  configured backend, or "terraform.tfstate".
+For configurations using
+[the `remote` backend](/docs/language/settings/backends/remote.html)
+only, `terraform state replace-provider`
+also accepts the option
+[`-ignore-remote-version`](/docs/language/settings/backends/remote.html#command-line-arguments).
 
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.
+For configurations using
+[the `local` state rm](/docs/language/settings/backends/local.html) only,
+`terraform state replace-provider` also accepts the legacy options
+[`-state`, `-state-out`, and `-backup`](/docs/language/settings/backends/local.html#command-line-arguments).
+
 
 ## Example
 

--- a/website/docs/cli/commands/state/rm.html.md
+++ b/website/docs/cli/commands/state/rm.html.md
@@ -41,20 +41,19 @@ This command requires one or more addresses that point to a resources in the
 state. Addresses are
 in [resource addressing format](/docs/cli/state/resource-addressing.html).
 
-The command-line flags are all optional. The list of available flags are:
+This command doesn't normally accept any command line options, except in
+the special situations described in the following paragraphs.
 
-* `-backup=path` - Path where Terraform should write the backup state. This
-  can't be disabled. If not set, Terraform will write it to the same path as
-  the statefile with a backup extension.
+For configurations using
+[the `remote` backend](/docs/language/settings/backends/remote.html)
+only, `terraform state rm`
+also accepts the option
+[`-ignore-remote-version`](/docs/language/settings/backends/remote.html#command-line-arguments).
 
-* `-state=path` - Path to a Terraform state file to use to look up
-  Terraform-managed resources. By default it will use the configured backend,
-  or the default "terraform.tfstate" if it exists.
-
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.
+For configurations using
+[the `local` state rm](/docs/language/settings/backends/local.html) only,
+`terraform state rm` also accepts the legacy options
+[`-state`, `-state-out`, and `-backup`](/docs/language/settings/backends/local.html#command-line-arguments).
 
 ## Example: Remove a Resource
 

--- a/website/docs/cli/commands/state/rm.html.md
+++ b/website/docs/cli/commands/state/rm.html.md
@@ -36,10 +36,19 @@ instances. Depending on the constraints imposed by the remote system, creating
 those objects might fail if their names or other identifiers conflict with
 the old objects still present.
 
-This command also accepts the following option:
+This command also accepts the following options:
 
 * `-dry-run` - Report all of the resource instances that match the given
   address without actually "forgetting" any of them.
+
+* `-lock=false` - Don't hold a state lock during the operation. This is
+   dangerous if others might concurrently run commands against the same
+   workspace.
+
+* `-lock-timeout=DURATION` - Unless locking is disabled with `-lock=false`,
+  instructs Terraform to retry acquiring a lock for a period of time before
+  returning an error. The duration syntax is a number followed by a time
+  unit letter, such as "3s" for three seconds.
 
 For configurations using
 [the `remote` backend](/docs/language/settings/backends/remote.html)

--- a/website/docs/cli/commands/taint.html.md
+++ b/website/docs/cli/commands/taint.html.md
@@ -67,10 +67,11 @@ This command accepts the following options:
   returning an error. The duration syntax is a number followed by a time
   unit letter, such as "3s" for three seconds.
 
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.
+For configurations using
+[the `remote` backend](/docs/language/settings/backends/remote.html)
+only, `terraform taint`
+also accepts the option
+[`-ignore-remote-version`](/docs/language/settings/backends/remote.html#command-line-arguments).
 
 For configurations using
 [the `local` backend](/docs/language/settings/backends/local.html) only,

--- a/website/docs/cli/commands/untaint.html.md
+++ b/website/docs/cli/commands/untaint.html.md
@@ -62,12 +62,13 @@ This command also accepts the following options:
   if you are running Terraform in a context where its output will be
   rendered by a system that cannot interpret terminal formatting.
 
-* `-ignore-remote-version` - When using the enhanced remote backend with
-  Terraform Cloud, continue even if remote and local Terraform versions differ.
-  This may result in an unusable Terraform Cloud workspace, and should be used
-  with extreme caution.
+For configurations using
+[the `remote` backend](/docs/language/settings/backends/remote.html)
+only, `terraform untaint`
+also accepts the option
+[`-ignore-remote-version`](/docs/language/settings/backends/remote.html#command-line-arguments).
 
 For configurations using
 [the `local` backend](/docs/language/settings/backends/local.html) only,
-`terraform taint` also accepts the legacy options
+`terraform untaint` also accepts the legacy options
 [`-state`, `-state-out`, and `-backup`](/docs/language/settings/backends/local.html#command-line-arguments).

--- a/website/docs/cli/commands/untaint.html.md
+++ b/website/docs/cli/commands/untaint.html.md
@@ -50,8 +50,9 @@ This command also accepts the following options:
   for other situations, such as if there is a problem reading or writing
   the state.
 
-* `-lock=false` - Disables Terraform's default behavior of attempting to take
-  a read/write lock on the state for the duration of the operation.
+* `-lock=false` - Don't hold a state lock during the operation. This is
+   dangerous if others might concurrently run commands against the same
+   workspace.
 
 * `-lock-timeout=DURATION` - Unless locking is disabled with `-lock=false`,
   instructs Terraform to retry acquiring a lock for a period of time before

--- a/website/docs/cli/commands/workspace/delete.html.md
+++ b/website/docs/cli/commands/workspace/delete.html.md
@@ -30,8 +30,10 @@ from getting into this situation.
 The command-line flags are all optional. The only supported flag is:
 
 * `-force` - Delete the workspace even if its state is not empty. Defaults to false.
-* `-lock`  - Lock the state file when locking is supported. Defaults to true.
-* `-lock-timeout`   - Duration to retry a state lock. Default 0s.
+* `-lock=false` - Don't hold a state lock during the operation. This is
+   dangerous if others might concurrently run commands against the same
+   workspace.
+* `-lock-timeout=DURATION` - Duration to retry a state lock. Default 0s.
 
 ## Example
 

--- a/website/docs/cli/commands/workspace/new.html.md
+++ b/website/docs/cli/commands/workspace/new.html.md
@@ -22,8 +22,10 @@ will be copied to initialize the state for this new workspace.
 
 The command-line flags are all optional. The supported flags are:
 
-* `-lock`         - Lock the state file when locking is supported. Defaults to true.
-* `-lock-timeout` - Duration to retry a state lock. Default 0s.
+* `-lock=false` - Don't hold a state lock during the operation. This is
+   dangerous if others might concurrently run commands against the same
+   workspace.
+* `-lock-timeout=DURATION` - Duration to retry a state lock. Default 0s.
 * `-state=path`   - Path to an existing state file to initialize the state of this environment.
 
 ## Example: Create

--- a/website/docs/language/settings/backends/remote.html.md
+++ b/website/docs/language/settings/backends/remote.html.md
@@ -195,6 +195,26 @@ The following configuration options are supported:
 data source that retrieves state from another Terraform Cloud workspace. The `prefix` key is only
 intended for use when configuring an instance of the remote backend.
 
+## Command Line Arguments
+
+For configurations that include a `backend "remote"` block, commands that
+make local modifications to Terraform state and then push them back up to
+the remote workspace accept the following option to modify that behavior:
+
+* `-ignore-remote-version` - Override checking that the local and remote
+  Terraform versions agree, making an operation proceed even when there is
+  a mismatch.
+
+    Normally state-modification operations require using a local version of
+    Terraform CLI which is compatible with the Terraform version selected
+    for the remote workspace as part of its settings. This is to avoid the
+    local operation creating a new state snapshot which the workspace's
+    remote execution environment would then be unable to decode.
+
+    Overriding this check can result in a Terraform Cloud workspace that is
+    no longer able to complete remote operations, so we recommend against
+    using this option.
+
 ## Excluding Files from Upload with .terraformignore
 
 -> **Version note:** `.terraformignore` support was added in Terraform 0.12.11.

--- a/website/docs/language/settings/backends/remote.html.md
+++ b/website/docs/language/settings/backends/remote.html.md
@@ -227,7 +227,7 @@ paths to ignore from upload via a `.terraformignore` file at the root of your co
 * .terraform/ directories (exclusive of .terraform/modules)
 
 The `.terraformignore` file can include rules as one would include in a
-[.gitignore file](https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#Ignoring-Files)
+[.gitignore file](https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring)
 
 
 * Comments (starting with `#`) or blank lines are ignored


### PR DESCRIPTION
We previously had only very short descriptions of what `-ignore-remote-version` does due to having the documentation for it inline on many different command pages and `-help` output.

Instead, we'll now centralize the documentation about this argument on the remote backend page, and link to it or refer to it from all other locations. This then allows us to spend more words on discussing what Terraform normally does _without_ this option and warning about the consequences of using it.

This continues earlier precedent for some local-backend-specific options which we also don't recommend for typical use. While this does make these options a little more "buried" than before, that feels justified given that they are all "exceptional use only" sort of options where users ought to learn about various caveats before using them.

While there I also took this opportunity to fix some earlier omissions with the local-backend-specific options and a few other minor consistency tweaks.
