### PR TITLE
backend/remote: clearer error when we fail to read the organization

### DIFF
--- a/backend/remote/backend.go
+++ b/backend/remote/backend.go
@@ -321,15 +321,16 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	entitlements, err := b.client.Organizations.Entitlements(context.Background(), b.organization)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
-			err = fmt.Errorf("organization %s does not exist", b.organization)
+			err = fmt.Errorf("organization %q at host %s not found.\n\n"+
+				"Please ensure that the organization and hostname are correct "+
+				"and that your API token for %s is valid.",
+				b.organization, b.hostname, b.hostname)
 		}
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,
-			"Failed to read organization entitlements",
-			fmt.Sprintf(
-				`The "remote" backend encountered an unexpected error while reading the `+
-					`organization settings: %s.`, err,
-			),
+			fmt.Sprintf("Failed to read organization %q at host %s", b.organization, b.hostname),
+			fmt.Sprintf("The \"remote\" backend encountered an unexpected error while reading the "+
+				"organization settings: %s", err),
 			cty.Path{cty.GetAttrStep{Name: "organization"}},
 		))
 		return diags

--- a/backend/remote/backend_test.go
+++ b/backend/remote/backend_test.go
@@ -55,7 +55,7 @@ func TestRemote_config(t *testing.T) {
 					"prefix": cty.NullVal(cty.String),
 				}),
 			}),
-			confErr: "organization nonexisting does not exist",
+			confErr: "organization \"nonexisting\" at host app.terraform.io not found",
 		},
 		"with_an_unknown_host": {
 			config: cty.ObjectVal(map[string]cty.Value{


### PR DESCRIPTION
Currently, the error when we fail to read the organization entitlements while configuring the remote backend is a little cryptic:

<img width="792" alt="Screen Shot 2021-05-11 at 11 34 01 PM" src="https://user-images.githubusercontent.com/17039873/117932765-9f843b00-b2b5-11eb-8d2a-65809353bbb7.png">

It implies that the organization definitely does not exist, but in practice, there are any number of reasons why we might get an error there: the user may have misspelled the organization name, forgotten to specify the hostname (causing it to default to `app.terraform.io`), or be using an API token that's been revoked.

Surfacing more information and common debugging steps should help users resolve this problem more easily.

<img width="788" alt="Screen Shot 2021-05-11 at 11 30 42 PM" src="https://user-images.githubusercontent.com/17039873/117932738-97c49680-b2b5-11eb-872a-305ebdac04c4.png">