### PR TITLE
Add `templatestring` function

### DIFF
--- a/lang/funcs/filesystem_test.go
+++ b/lang/funcs/filesystem_test.go
@@ -157,7 +157,7 @@ func TestTemplateFile(t *testing.T) {
 		},
 	}
 
-	templateFileFn := MakeTemplateFileFunc(".", func() map[string]function.Function {
+	templateFileFn := MakeTemplateFileFunc(".", true, func() map[string]function.Function {
 		return map[string]function.Function{
 			"join":         stdlib.JoinFunc,
 			"templatefile": MakeFileFunc(".", false), // just a placeholder, since templatefile itself overrides this

--- a/lang/functions.go
+++ b/lang/functions.go
@@ -146,9 +146,14 @@ func (s *Scope) Functions() map[string]function.Function {
 			"zipmap":           stdlib.ZipmapFunc,
 		}
 
-		s.funcs["templatefile"] = funcs.MakeTemplateFileFunc(s.BaseDir, func() map[string]function.Function {
+		s.funcs["templatefile"] = funcs.MakeTemplateFileFunc(s.BaseDir, true, func() map[string]function.Function {
 			// The templatefile function prevents recursive calls to itself
 			// by copying this map and overwriting the "templatefile" entry.
+			return s.funcs
+		})
+		s.funcs["templatestring"] = funcs.MakeTemplateFileFunc(s.BaseDir, false, func() map[string]function.Function {
+			// The templatestring function prevents recursive calls to itself
+			// by copying this map and overwriting the "templatestring" entry.
 			return s.funcs
 		})
 

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -869,6 +869,13 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"templatestring": {
+			{
+				`templatestring("Hello, $${name}!", {name = "Jodie"})`,
+				cty.StringVal("Hello, Jodie!"),
+			},
+		},
+
 		"timeadd": {
 			{
 				`timeadd("2017-11-22T00:00:00Z", "1s")`,


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/issues/26838

This allows us to fully deprecate the `template` provider by allowing us to templatize a string.

```shell
✗ go install .
✗ ~/go/bin/terraform console
> templatestring("Hello, $${name}!", { name = "Jodie" })
"Hello, Jodie!"
```

This would be great if we could get this function could be backported to previous versions of terraform to ensure full deprecation of the `template` provider.

Edit: I also found this older PR https://github.com/hashicorp/terraform/pull/24978 that creates the `template` function.