### PR TITLE
Decode change values with marks

### DIFF
--- a/command/format/diff.go
+++ b/command/format/diff.go
@@ -125,14 +125,6 @@ func ResourceChange(
 	changeV.Change.Before = objchange.NormalizeObjectFromLegacySDK(changeV.Change.Before, schema)
 	changeV.Change.After = objchange.NormalizeObjectFromLegacySDK(changeV.Change.After, schema)
 
-	// Now that the change is decoded, add back the marks at the defined paths
-	if len(change.BeforeValMarks) > 0 {
-		changeV.Change.Before = changeV.Change.Before.MarkWithPaths(change.BeforeValMarks)
-	}
-	if len(change.AfterValMarks) > 0 {
-		changeV.Change.After = changeV.Change.After.MarkWithPaths(change.AfterValMarks)
-	}
-
 	result := p.writeBlockBodyDiff(schema, changeV.Before, changeV.After, 6, path)
 	if result.bodyWritten {
 		buf.WriteString("\n")

--- a/command/jsonplan/plan.go
+++ b/command/jsonplan/plan.go
@@ -212,10 +212,15 @@ func (p *plan) marshalResourceChanges(changes *plans.Changes, schemas *terraform
 		if err != nil {
 			return err
 		}
+		// We drop the marks from the change, as decoding is only an
+		// intermediate step to re-encode the values as json
+		changeV.Before, _ = changeV.Before.UnmarkDeep()
+		changeV.After, _ = changeV.After.UnmarkDeep()
 
 		var before, after []byte
 		var beforeSensitive, afterSensitive []byte
 		var afterUnknown cty.Value
+
 		if changeV.Before != cty.NilVal {
 			before, err = ctyjson.Marshal(changeV.Before, changeV.Before.Type())
 			if err != nil {
@@ -338,6 +343,10 @@ func (p *plan) marshalOutputChanges(changes *plans.Changes) error {
 		if err != nil {
 			return err
 		}
+		// We drop the marks from the change, as decoding is only an
+		// intermediate step to re-encode the values as json
+		changeV.Before, _ = changeV.Before.UnmarkDeep()
+		changeV.After, _ = changeV.After.UnmarkDeep()
 
 		var before, after []byte
 		afterUnknown := cty.False

--- a/command/jsonplan/values.go
+++ b/command/jsonplan/values.go
@@ -60,13 +60,15 @@ func marshalPlannedOutputs(changes *plans.Changes) (map[string]output, error) {
 		if err != nil {
 			return ret, err
 		}
+		// The values may be marked, but we must rely on the Sensitive flag
+		// as the decoded value is only an intermediate step in transcoding
+		// this to a json format.
+		changeV.After, _ = changeV.After.UnmarkDeep()
 
-		if changeV.After != cty.NilVal {
-			if changeV.After.IsWhollyKnown() {
-				after, err = ctyjson.Marshal(changeV.After, changeV.After.Type())
-				if err != nil {
-					return ret, err
-				}
+		if changeV.After != cty.NilVal && changeV.After.IsWhollyKnown() {
+			after, err = ctyjson.Marshal(changeV.After, changeV.After.Type())
+			if err != nil {
+				return ret, err
 			}
 		}
 
@@ -193,6 +195,11 @@ func marshalPlanResources(changes *plans.Changes, ris []addrs.AbsResourceInstanc
 		if err != nil {
 			return nil, err
 		}
+		// The values may be marked, but we must rely on the Sensitive flag
+		// as the decoded value is only an intermediate step in transcoding
+		// this to a json format.
+		changeV.Before, _ = changeV.Before.UnmarkDeep()
+		changeV.After, _ = changeV.After.UnmarkDeep()
 
 		if changeV.After != cty.NilVal {
 			if changeV.After.IsWhollyKnown() {

--- a/plans/changes_src.go
+++ b/plans/changes_src.go
@@ -200,9 +200,10 @@ func (cs *ChangeSrc) Decode(ty cty.Type) (*Change, error) {
 			return nil, fmt.Errorf("error decoding 'after' value: %s", err)
 		}
 	}
+
 	return &Change{
 		Action: cs.Action,
-		Before: before,
-		After:  after,
+		Before: before.MarkWithPaths(cs.BeforeValMarks),
+		After:  after.MarkWithPaths(cs.AfterValMarks),
 	}, nil
 }

--- a/plans/changes_test.go
+++ b/plans/changes_test.go
@@ -1,0 +1,41 @@
+package plans
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestChangeEncodeSensitive(t *testing.T) {
+	testVals := []cty.Value{
+		cty.ObjectVal(map[string]cty.Value{
+			"ding": cty.StringVal("dong").Mark("sensitive"),
+		}),
+		cty.StringVal("bleep").Mark("bloop"),
+		cty.ListVal([]cty.Value{cty.UnknownVal(cty.String).Mark("sup?")}),
+	}
+
+	for _, v := range testVals {
+		t.Run(fmt.Sprintf("%#v", v), func(t *testing.T) {
+			change := Change{
+				Before: cty.NullVal(v.Type()),
+				After:  v,
+			}
+
+			encoded, err := change.Encode(v.Type())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			decoded, err := encoded.Decode(v.Type())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !v.RawEquals(decoded.After) {
+				t.Fatalf("%#v != %#v\n", decoded.After, v)
+			}
+		})
+	}
+}

--- a/terraform/evaluate.go
+++ b/terraform/evaluate.go
@@ -459,7 +459,7 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 				continue
 			}
 
-			instance[cfg.Name] = change.After.MarkWithPaths(changeSrc.AfterValMarks)
+			instance[cfg.Name] = change.After
 
 			if change.Sensitive && !change.After.HasMark("sensitive") {
 				instance[cfg.Name] = change.After.Mark("sensitive")

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -259,9 +259,11 @@ func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags 
 	// we we have a change recorded, we don't need to re-evaluate if the value
 	// was known
 	if changeRecorded {
-		var err error
-		val, err = n.Change.After.Decode(cty.DynamicPseudoType)
+		change, err := n.Change.Decode()
 		diags = diags.Append(err)
+		if err == nil {
+			val = change.After
+		}
 	}
 
 	// If there was no change recorded, or the recorded change was not wholly


### PR DESCRIPTION
When decoding change values, the stored marks should be applied to the decoded value, as this is the direct inverse of the `Encode` operation. The missing marks were not noticed in most cases because they would be correctly re-evaluated on demand, however some cases like module output values can rely on the change source alone, resulting in the marks being lost during apply.

Many call sites which were aware that the marks were missing would manually apply the marks after decoding. After removing the duplicate marking and verifying tests, `Decode` call sites were again statically located and checked for mark handling. Any locations found that were relying on the _absence_ of marks now must manually strip the marks before processing the values.

Fixes #28671