### PR TITLE
String templates as values

### DIFF
--- a/lang/functions.go
+++ b/lang/functions.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/experiments"
 	"github.com/hashicorp/terraform/lang/funcs"
+	"github.com/hashicorp/terraform/lang/templatevals"
 )
 
 var impureFunctions = []string{
@@ -60,6 +61,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"dirname":          funcs.DirnameFunc,
 			"distinct":         stdlib.DistinctFunc,
 			"element":          stdlib.ElementFunc,
+			"evaltemplate":     templatevals.EvalTemplateFunc,
 			"chunklist":        stdlib.ChunklistFunc,
 			"file":             funcs.MakeFileFunc(s.BaseDir, false),
 			"fileexists":       funcs.MakeFileExistsFunc(s.BaseDir),
@@ -87,6 +89,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"log":              stdlib.LogFunc,
 			"lookup":           funcs.LookupFunc,
 			"lower":            stdlib.LowerFunc,
+			"maketemplate":     templatevals.MakeTemplateFunc,
 			"map":              funcs.MapFunc,
 			"matchkeys":        funcs.MatchkeysFunc,
 			"max":              stdlib.MaxFunc,

--- a/lang/functions_test.go
+++ b/lang/functions_test.go
@@ -325,6 +325,13 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"evaltemplate": {
+			{
+				`evaltemplate(maketemplate("Hello ${template.a}!"), {a = "world"})`,
+				cty.StringVal("Hello world!"),
+			},
+		},
+
 		"file": {
 			{
 				`file("hello.txt")`,
@@ -547,6 +554,13 @@ func TestFunctions(t *testing.T) {
 			{
 				`lower("HELLO")`,
 				cty.StringVal("hello"),
+			},
+		},
+
+		"maketemplate": {
+			{
+				`evaltemplate(maketemplate("Hello ${template.a}!"), {a = "world"})`,
+				cty.StringVal("Hello world!"),
 			},
 		},
 

--- a/lang/references.go
+++ b/lang/references.go
@@ -30,6 +30,16 @@ func References(traversals []hcl.Traversal) ([]*addrs.Reference, tfdiags.Diagnos
 	refs := make([]*addrs.Reference, 0, len(traversals))
 
 	for _, traversal := range traversals {
+		if traversal.RootName() == "template" {
+			// "template" traversals don't create references. Instead, they
+			// are just part of the template values syntax within the
+			// special "maketemplate" function. We'll ignore references
+			// here to allow maketemplate calls to work, although any use
+			// of these outside of maketemplate will ultimately fail during
+			// evaluation, because we don't define this symbol there.
+			continue
+		}
+
 		ref, refDiags := addrs.ParseRef(traversal)
 		diags = diags.Append(refDiags)
 		if ref == nil {

--- a/lang/templatevals/doc.go
+++ b/lang/templatevals/doc.go
@@ -1,0 +1,5 @@
+// Package templatevals deals with the idea of "template values" in the
+// Terraform language, which allow passing around not-yet-evaluated string
+// templates in a structured way that allows for type checking and avoids
+// confusing additional template escaping.
+package templatevals

--- a/lang/templatevals/funcs.go
+++ b/lang/templatevals/funcs.go
@@ -1,0 +1,163 @@
+package templatevals
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/customdecode"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+var MakeTemplateFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "source",
+			Type: customdecode.ExpressionClosureType,
+		},
+	},
+	Type: func(args []cty.Value) (cty.Type, error) {
+		// Because our parameter is constrained with the special
+		// customdecode.ExpressionClosureType constraint, it's
+		// guaranteed to be a known value of a capsule type
+		// wrapping customdecode.ExpressionClosure.
+		closure := args[0].EncapsulatedValue().(*customdecode.ExpressionClosure)
+		expr := closure.Expression
+		parentCtx := closure.EvalContext
+
+		// Although in principle this lazy evaluation mechanism could
+		// apply to any sort of expression, we intentionally constrain
+		// it only to template expressions here to reinforce that this
+		// is not intended as a general lambda function mechanism.
+		switch expr.(type) {
+		case *hclsyntax.TemplateExpr, *hclsyntax.TemplateWrapExpr:
+			// ok
+		default:
+			return cty.DynamicPseudoType, function.NewArgErrorf(0, "must be a string template expression")
+		}
+
+		// Our initial template type has arguments derived from the references
+		// that have traversals starting with "template".
+		atys := make(map[string]cty.Type)
+		for _, traversal := range expr.Variables() {
+			if traversal.RootName() != "template" {
+				// We don't care about any other traversals
+				continue
+			}
+			var step1 hcl.TraverseAttr
+			if len(traversal) >= 2 {
+				if ta, ok := traversal[1].(hcl.TraverseAttr); ok {
+					step1 = ta
+				}
+			}
+			name := step1.Name
+			if name == "" { // The conditions above didn't match, then
+				return cty.DynamicPseudoType, function.NewArgErrorf(0, "template argument reference at %s must include an attribute lookup representing the argument name", traversal.SourceRange())
+			}
+			// All of our arguments start off with unconstrained types because
+			// we can't walk backwards from an expression to all of the types
+			// that could succeed with it. However, the type conversion
+			// behavior for template values includes a more specific type check
+			// if the destination type has more constrained arguments.
+			atys[name] = cty.DynamicPseudoType
+		}
+
+		// Before we return we'll check to make sure the expression is
+		// evaluable _at all_ (even before we know the argument values)
+		// because that'll help users catch totally-invalid templates early,
+		// even before they try to pass them to another module to be evaluated.
+		ctx := parentCtx.NewChild()
+		ctx.Variables = map[string]cty.Value{
+			"template": cty.UnknownVal(cty.Object(atys)),
+		}
+		v, diags := expr.Value(ctx)
+		if diags.HasErrors() {
+			// It would be nice to have a way to report these diags
+			// directly out to HCL, but unfortunately we're sending them
+			// out through cty and it doesn't understand HCL diagnostics.
+			return cty.DynamicPseudoType, function.NewArgErrorf(0, "invalid template: %s", diags.Error())
+		}
+		if _, err := convert.Convert(v, cty.String); err != nil {
+			// We'll catch this early where possible. It won't always be
+			// possible, because the return type might vary depending on
+			// the input, so we must re-check this in evaltemplate too.
+			return cty.DynamicPseudoType, function.NewArgErrorf(0, "invalid template: must produce a string result")
+		}
+
+		// If all of the above was successful then this template seems valid
+		// and we can determine which type we're returning. (The actual
+		// _value_ of that type will come in Impl.)
+		return Type(atys), nil
+	},
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		// We already did all of our checking inside Type, so our only remaining
+		// job now is to wrap the expression closure up inside a value of
+		// our capsule type.
+		closure := args[0].EncapsulatedValue().(*customdecode.ExpressionClosure)
+		tv := &templateVal{
+			expr: closure.Expression,
+			ctx:  closure.EvalContext,
+		}
+		return cty.CapsuleVal(retType, tv), nil
+	},
+})
+
+// TODO: Consider also a "templatefromfile" function that compiles a separate
+// file as a template in a similar way that "templatefile" does, but which
+// returns a template value rather than immediately evaluating the template.
+// This would then be more convenient for situations where the expected
+// template is quite large in itself and thus worth factoring out into a
+// separate file.
+
+var EvalTemplateFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "template",
+			// We need to type-check this dynamically because there is an
+			// infinite number of possible template types.
+			Type: cty.DynamicPseudoType,
+		},
+		{
+			Name: "args",
+			// We also need to type-check _this_ dynamically, because
+			// we expect an object type whose attributes depend on the
+			// template type.
+			Type:        cty.DynamicPseudoType,
+			AllowMarked: true,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		template := args[0]
+		rawArgsObj, retMarks := args[1].Unmark()
+
+		tv := template.EncapsulatedValue().(*templateVal)
+		atys := TypeArgs(template.Type())
+
+		// The given arguments object must be compatible with the expected
+		// argument types. This'll catch if the call lacks any arguments
+		// that the template requires, or if any of them are of an unsuitable
+		// type.
+		argsObj, err := convert.Convert(rawArgsObj, cty.Object(atys))
+		if err != nil {
+			return cty.NilVal, function.NewArgError(1, err)
+		}
+
+		ctx := tv.ctx.NewChild()
+		ctx.Variables = map[string]cty.Value{
+			"template": argsObj,
+		}
+		v, diags := tv.expr.Value(ctx)
+		if diags.HasErrors() {
+			return cty.NilVal, function.NewArgErrorf(0, "incompatible template: %s", diags.Error())
+		}
+
+		v, err = convert.Convert(v, retType)
+		if err != nil {
+			return cty.NilVal, function.NewArgErrorf(0, "template must produce a string result")
+		}
+
+		return v.WithMarks(retMarks), nil
+	},
+})

--- a/lang/templatevals/types.go
+++ b/lang/templatevals/types.go
@@ -1,0 +1,160 @@
+package templatevals
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+// Type constructs a cty type representing a lazily-evaluated template.
+//
+// Template types are parameterized by their set of required argument names and
+// associated type constraints.
+func Type(atys map[string]cty.Type) cty.Type {
+	var ret cty.Type
+	ops := &cty.CapsuleOps{
+		TypeGoString: func(goTy reflect.Type) string {
+			return fmt.Sprintf("templatevals.Type(%#v)", atys)
+		},
+		GoString: func(rv interface{}) string {
+			tv := rv.(*templateVal)
+			return fmt.Sprintf("templatevals.Val(%#v, %#v, %#v)", atys, tv.expr, tv.ctx)
+		},
+		ConversionFrom: func(dest cty.Type) func(interface{}, cty.Path) (cty.Value, error) {
+			if !IsTemplateType(dest) {
+				// Can only convert between template types
+				return nil
+			}
+
+			// There are some other constraints on successful conversion but
+			// we'll wait until inside the conversion function to deal with
+			// those, so we can return specialized errors.
+			dstAtys := TypeArgs(dest)
+			return func(rv interface{}, path cty.Path) (cty.Value, error) {
+				// Conversion is allowed only if the destination arguments are
+				// all assignable to the source arguments, thus making the
+				// result potentially _more_ constrained in what arguments
+				// the template can accept. To check that we make some
+				// temporary object types to borrow the object type conversion
+				// behavior.
+				srcObjTy := cty.Object(atys)
+				dstObjTy := cty.Object(dstAtys)
+				if srcObjTy.Equals(dstObjTy) {
+					// Easy case then: the two types are equivalent.
+				} else if conv := convert.GetConversionUnsafe(dstObjTy, srcObjTy); conv != nil {
+					// Also valid, from an interface-conformance perspective
+					// (note that dst and src are intentionally inverted above
+					// because we're effectively testing if an object of the
+					// destination type (the final template arguments) would be
+					// assignable to the source type (the arguments that the
+					// template actually expects.)
+				} else {
+					// TODO: A better error message, saying something about
+					// what is wrong.
+					return cty.NilVal, path.NewErrorf("incompatible template arguments")
+				}
+
+				// Even if the static type information suggests compatibility,
+				// our template argument constraints start off very broad
+				// at the point of definition (everything is "any") and
+				// constraining further requires that the template can pass
+				// type checking when given arguments of the destination
+				// types.
+				tv := rv.(*templateVal)
+				expr := tv.expr
+				parentCtx := tv.ctx
+				ctx := parentCtx.NewChild()
+				ctx.Variables = map[string]cty.Value{
+					"template": cty.UnknownVal(dstObjTy),
+				}
+				_, diags := expr.Value(ctx)
+				if diags.HasErrors() {
+					// TODO: Again, a better error message. Doing better here
+					// probably in practice means trying more surgical type
+					// checks with only one argument at a time set to a
+					// specific type constraint, to see which ones fail and
+					// which ones succeed. Although even that wouldn't be
+					// 100% because it might be the combination of two
+					// arguments that makes it invalid!
+					return cty.NilVal, path.NewErrorf("incompatible usage of template arguments")
+				}
+
+				// If we get down here without returning an error then this
+				// conversion seems acceptable from a type-checking standpoint,
+				// and so we can wrap our same templateVal value up in the
+				// destination type.
+				// Note that the resulting template might still fail for
+				// dynamic reasons, e.g. if it's expecting valid JSON but
+				// doesn't _get_ valid JSON, but we'll catch that sort of
+				// problem at evaluation time.
+				return cty.CapsuleVal(dest, tv), nil
+			}
+		},
+		ExtensionData: func(key interface{}) interface{} {
+			switch key {
+			case templateTypeAtys:
+				return atys
+			default:
+				return nil
+			}
+		},
+	}
+	ret = cty.CapsuleWithOps("template", templateValReflect, ops)
+	return ret
+}
+
+// Val constructs a new value of a template type with the given expression and
+// evaluation context.
+//
+// The given type must be a template type, or this function will panic.
+//
+// This function does no validation of whether the given expression and context
+// are compatible with one another or whether the the expression can support
+// the given argument types. The caller must guarantee such compatibility.
+func Val(ty cty.Type, expr hcl.Expression, ctx *hcl.EvalContext) cty.Value {
+	if !IsTemplateType(ty) {
+		panic(fmt.Sprintf("can't construct template value of non-template type %#v", ty))
+	}
+	rv := &templateVal{
+		expr: expr,
+		ctx:  ctx,
+	}
+	return cty.CapsuleVal(ty, rv)
+}
+
+func IsTemplateType(ty cty.Type) bool {
+	if !ty.IsCapsuleType() {
+		return false
+	}
+	return ty.EncapsulatedType() == templateValReflect
+}
+
+// TypeArgs returns the arguments and their associated types for the given
+// type, which must be a template type or this function will panic.
+//
+// Do not modify the returned array. It is part of the internal state of
+// the template type.
+func TypeArgs(ty cty.Type) map[string]cty.Type {
+	if !IsTemplateType(ty) {
+		panic("templatevals.TypeArgs on non-template type")
+	}
+	return ty.CapsuleExtensionData(templateTypeAtys).(map[string]cty.Type)
+}
+
+func IsTemplateVal(v cty.Value) bool {
+	return IsTemplateType(v.Type())
+}
+
+type templateVal struct {
+	expr hcl.Expression
+	ctx  *hcl.EvalContext
+}
+
+var templateValReflect = reflect.TypeOf(templateVal{})
+
+type templateTypeAtysKey int
+
+var templateTypeAtys templateTypeAtysKey = 0


### PR DESCRIPTION
This is a design prototype of one possible way to meet the need of defining a template in a different location from where it will ultimately be evaluated, as discussed in #26838. For example, a generic module might accept a template as an input variable and then evaluate that template using values that are private to the module, thus separating the concern of providing the data from the concern of assembling the data into a particular string shape.

The idea here is to establish a new type of value in the Terraform language that can store a template that has been parsed but not yet evaluated. This is similar in principle to a normal string containing template syntax passed into the deprecated `template_file` data source, but allows use of the real template syntax at the definition site and allows for early evaluation of syntax. It also, _unlike_ a string passed to `template_file`, allows the template to refer to a mixture of template arguments and other values from the surrounding scope.

---

For a small example I put together something admittedly-contrived around constructing log line prefixes. This particular use-case probably doesn't make sense to be done at the Terraform level because log lines tend to incorporate very dynamic data about the specific system generating them, but it serves to show the overall mechanics of this design nonetheless.

The module which consumes the template looks like this:

```hcl
variable "log_prefix_template" {
  type = template({
    level    = string
    app_name = string
    pid      = number
  })
}

output "log_prefix" {
  value = evaltemplate(var.log_prefix_template, {
      app_name = "awesome-app"
      level    = "DEBUG"
      pid      = 2546
  })
}
```

This shows two different aspects of this proposed design:

* The new `template` type constraint syntax, which represents accepting a template that will have a particular set of arguments available to it.
* The new `evaltemplate` function, which takes a value of a template type and an object whose attributes conform to the template's argument types and evaluates the template, returning the resulting string.

The actual _definition_ of the template is left to the calling module, whose source code might look something like this:

```hcl

variable "env_name" {
  type    = string
  default = "PROD"
}

module "child" {
  source = "./child"

  log_prefix_template = maketemplate("${template.app_name}.${var.env_name} ${template.pid}: [${template.level}]")
}

output "result" {
  value = module.child
}
```

Again, this shows an aspect of the proposed design:

* The new `maketemplate` function, which parses its argument as a string template (using a custom argument parser technique, similar to how Terraform currently implements the `try` and `can` functions) and saves it along with the evaluation scope inside a value of a template type, which it returns.

The `maketemplate` function treats its argument as a normal string template, except that it additionally supports special symbols with the `template.` prefix, which serve as the template's arguments. Notice that the `log_prefix_template` template above includes both `template.`-prefixed references _and_ a normal `var.env_name` prefix, which allows it to create a blend of values known both in the calling module and in the called module.

The result of my contrived configuration here is the following:

```
Outputs:

result = {
  "log_prefix" = "awesome-app.PROD 2546: [DEBUG]"
}
```

---

Although this valid example doesn't really show it, having an explicit type for templates (as opposed to just passing them as strings with special characters inside) allows various validity checks on both the side of the template definer and the template evaluator, helping both to cooperate to produce a working result. For example, if I change the template to include a reference to a template argument that the module doesn't provide, we can catch that early at the call site:

```
╷
│ Error: Invalid value for module argument
│ 
│   on templatevals.tf line 10, in module "child":
│   10:   log_prefix_template = maketemplate("${template.appp_name}: ")
│ 
│ The given value is not suitable for child module variable "log_prefix_template" defined at child/templatevals-child.tf:2,1-31: incompatible
│ template arguments.
╵
```

Or, if I change the template to use one of the arguments in a way that isn't compatible with the argument types the module defines:

```
╷
│ Error: Invalid value for module argument
│ 
│   on templatevals.tf line 10, in module "child":
│   10:   log_prefix_template = maketemplate("${template.app_name["boop"]}: ")
│ 
│ The given value is not suitable for child module variable "log_prefix_template" defined at child/templatevals-child.tf:2,1-31: incompatible
│ usage of template arguments.
╵
```

On the evaluator side, similarly we can catch if the `templateeval` call is missing one of the expected arguments or if one has been assigned an incompatible type, even if the currently-passed template value doesn't make use of all of the arguments or if we're just validating the shared module in isolation:

```
╷
│ Error: Invalid function argument
│ 
│   on child/templatevals-child.tf line 11, in output "log_prefix":
│   11:   value = evaltemplate(var.log_prefix_template, {
│   12:       app_name = "awesome-app"
│   13:       level    = "DEBUG"
│   14:   })
│ 
│ Invalid value for "args" parameter: attribute "pid" is required.
╵
```

(The basic error messages above are just placeholders for more detailed messages we should implement if we decide to move forward with this.)

---

This is only just enough to try out the behavior and see how it feels and how intuitive it seems. If we were to move forward with something like this then a real implementation would need some extra care to some other concerns, including but not limited to:

- Generating good error messages when templates don't make valid use of their arguments.

- Properly blocking template values from being used in places where they don't make sense, such as as input to `jsonencode(...)`, as a root module output value, or directly as an argument to a provider. (In all of these situations, it's necessary to first evaluate the template and pass the resulting string.)

- Possibly another function similar to `templatefile` which can create a template value from a file on disk, to allow factoring out larger templates while still being compatible with modules that expect template values.

- Defining default values for variables with template type constraints given that functions aren't available in the `default` argument, and thus it wouldn't naturally work to call `maketemplate` from in there.

There are undoubtedly more things which we'd find with further prototyping and experimentation, if this design seems to have promise.

Before deciding whether to move forward with anything like this we'll need to evaluate it against various use-cases and see which ones it supports and which it doesn't. It doesn't necessarily need to solve _all_ use-cases related to templating, but in order to be a satisfying replacement for `template_file` it should at least address use-cases involving a template being defined in a different module than where it's being evaluated.
