### PR TITLE
docs: `sensitive` and `nonsensitive` is not available in 0.14.x

### DIFF
--- a/website/docs/language/functions/nonsensitive.html.md
+++ b/website/docs/language/functions/nonsensitive.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # `nonsensitive` Function
 
--> **Note:** This function is only available in Terraform v0.14 and later.
+-> **Note:** This function is only available in Terraform v0.15 and later.
 
 `nonsensitive` takes a sensitive value and returns a copy of that value with
 the sensitive marking removed, thereby exposing the sensitive value.

--- a/website/docs/language/functions/sensitive.html.md
+++ b/website/docs/language/functions/sensitive.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # `sensitive` Function
 
--> **Note:** This function is only available in Terraform v0.14 and later.
+-> **Note:** This function is only available in Terraform v0.15 and later.
 
 `sensitive` takes any value and returns a copy of it marked so that Terraform
 will treat it as sensitive, with the same meaning and behavior as for


### PR DESCRIPTION
The `sensitive` function was introduced here: https://github.com/hashicorp/terraform/pull/27341

And made available in `0.15-beta2`, see: https://github.com/hashicorp/terraform/pull/27341#issuecomment-800678499

```
Terraform v0.14.11
```
yields:
```
There is no function named "sensitive".
```


cc @alloveras