### PR TITLE
Check for stale plan if either current _or_ prior state have lineage

### DIFF
--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -219,7 +219,7 @@ func (b *Local) contextFromPlanFile(pf *planfile.Reader, opts terraform.ContextO
 		// has changed since the plan was created. (All of the "real-world"
 		// state manager implementations support this, but simpler test backends
 		// may not.)
-		if currentStateMeta.Lineage != "" && priorStateFile.Lineage != "" {
+		if currentStateMeta.Lineage != "" || priorStateFile.Lineage != "" {
 			if priorStateFile.Serial != currentStateMeta.Serial || priorStateFile.Lineage != currentStateMeta.Lineage {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -174,16 +174,18 @@ func testPlan(t *testing.T) *plans.Plan {
 	}
 }
 
-func testPlanFile(t *testing.T, configSnap *configload.Snapshot, state *states.State, plan *plans.Plan) string {
+func testPlanFile(t *testing.T, configSnap *configload.Snapshot, state *states.State, plan *plans.Plan, lineage string) string {
 	t.Helper()
 
 	stateFile := &statefile.File{
-		Lineage:          "",
+		Lineage:          lineage,
+		Serial:           1,
 		State:            state,
 		TerraformVersion: version.SemVer,
 	}
 	prevStateFile := &statefile.File{
-		Lineage:          "",
+		Lineage:          lineage,
+		Serial:           1,
 		State:            state, // we just assume no changes detected during refresh
 		TerraformVersion: version.SemVer,
 	}
@@ -213,7 +215,7 @@ func testPlanFileNoop(t *testing.T) string {
 	}
 	state := states.NewState()
 	plan := testPlan(t)
-	return testPlanFile(t, snap, state, plan)
+	return testPlanFile(t, snap, state, plan, "")
 }
 
 func testReadPlan(t *testing.T, path string) *plans.Plan {

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -139,7 +139,7 @@ func TestGraph_plan(t *testing.T) {
 	}
 	_, configSnap := testModuleWithSnapshot(t, "graph")
 
-	planPath := testPlanFile(t, configSnap, states.NewState(), plan)
+	planPath := testPlanFile(t, configSnap, states.NewState(), plan, "")
 
 	ui := new(cli.MockUi)
 	c := &GraphCommand{

--- a/command/show_test.go
+++ b/command/show_test.go
@@ -237,6 +237,7 @@ func TestShow_planWithForceReplaceChange(t *testing.T) {
 		snap,
 		states.NewState(),
 		plan,
+		"",
 	)
 
 	ui := cli.NewMockUi()
@@ -746,6 +747,7 @@ func showFixturePlanFile(t *testing.T, action plans.Action) string {
 		snap,
 		states.NewState(),
 		plan,
+		"",
 	)
 }
 


### PR DESCRIPTION
There is currently a check that informs you when your plan is stale, this check is only run when current state **and** prior state have a `lineage` set. However this won't catch a particular scenario:

1. Start out with no state
2. Make 2x plans for given config
3. Apply plan 1 -> Changes applied -> State saved
4. Apply plan 2 -> Changes applied again -> State saved again (first state lost)

I think at step 4 above you should be told the plan is stale. After all, the state of the world has changed since this plan was created. If the code were to check if current state **or** prior state have a `lineage` instead of only when both do, this will work.

I've run into this when running Terraform in automation and a plan job happened concurrently with another apply job saving a new plan, then when later applying the second plan (which failed because resources already existing) I then lost state of all existing resources.

There's also an inverse situation covered in this change where you have a plan with lineage in the prior state but you have no lineage in current state, this should also give a stale warning I think. If not I can modify the PR to cover only the first case.

~I'm aware this breaks 1 existing test related to state backup (I think it's unrelated to the test intention though)~, if the change sounds good I will add additional coverage for this change.

Related issues:
- https://github.com/hashicorp/terraform/issues/24078
- https://github.com/hashicorp/terraform/issues/23345

---
Current workaround I'm using is as below:
```sh
CURRENT_STATE_LINEAGE=$(terraform state pull | jq -r '.lineage')    
PRIOR_PLAN_STATE=$(terraform show -json tenant.plan | jq '.prior_state')    
if ! [[ -z "${CURRENT_STATE_LINEAGE}" ]] && [[ "${PRIOR_PLAN_STATE}" == "null" ]]; then        
  echo "Stale plan detected (has no lineage). State lineage is ${CURRENT_STATE_LINEAGE}"        
  exit 1    
fi
```