### PR TITLE
core: "Did you mean" hint for missing data. prefix in references

### DIFF
--- a/terraform/evaluate_valid_test.go
+++ b/terraform/evaluate_valid_test.go
@@ -33,6 +33,12 @@ func TestStaticValidateReferences(t *testing.T) {
 			`Reference to undeclared resource: A managed resource "aws_instance" "nonexist" has not been declared in the root module.`,
 		},
 		{
+			"beep.boop",
+			`Reference to undeclared resource: A managed resource "beep" "boop" has not been declared in the root module.
+
+Did you mean the data resource data.beep.boop?`,
+		},
+		{
 			"aws_instance.no_count[0]",
 			`Unexpected resource instance key: Because aws_instance.no_count does not have "count" or "for_each" set, references to it must not include an index key. Remove the bracketed index to refer to the single instance of this resource.`,
 		},

--- a/terraform/testdata/static-validate-refs/static-validate-refs.tf
+++ b/terraform/testdata/static-validate-refs/static-validate-refs.tf
@@ -18,3 +18,6 @@ resource "boop_instance" "yep" {
 
 resource "boop_whatever" "nope" {
 }
+
+data "beep" "boop" {
+}


### PR DESCRIPTION
It's a relatively common mistake to try to refer to a data resource without including the data. prefix, making Terraform understand it as a reference to a managed resource.

To help with that case, we'll include an additional suggestion if we can see that there's a data resource declared with the same type and name as in the given address.
