### PR TITLE
Mechanisms to allow for future language extension

### DIFF
--- a/addrs/parse_ref.go
+++ b/addrs/parse_ref.go
@@ -239,6 +239,18 @@ func parseRef(traversal hcl.Traversal) (*Reference, tfdiags.Diagnostics) {
 			Remaining:   remain,
 		}, diags
 
+	case "template", "lazy", "arg":
+		// These names are all pre-emptively reserved in the hope of landing
+		// some version of "template values" or "lazy expressions" feature
+		// before the next opt-in language edition, but don't yet do anything.
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Reserved symbol name",
+			Detail:   fmt.Sprintf("The symbol name %q is reserved for use in a future Terraform version. If you are using a provider that already uses this as a resource type name, add the prefix \"resource.\" to force interpretation as a resource type name.", root),
+			Subject:  rootRange.Ptr(),
+		})
+		return nil, diags
+
 	default:
 		return parseResourceRef(ManagedResourceMode, rootRange, traversal)
 	}

--- a/addrs/parse_ref_test.go
+++ b/addrs/parse_ref_test.go
@@ -605,6 +605,25 @@ func TestParseRef(t *testing.T) {
 			``,
 		},
 
+		// We have some names reserved which might be used by a
+		// still-under-discussion proposal for template values or lazy
+		// expressions.
+		{
+			`template.foo`,
+			nil,
+			`The symbol name "template" is reserved for use in a future Terraform version. If you are using a provider that already uses this as a resource type name, add the prefix "resource." to force interpretation as a resource type name.`,
+		},
+		{
+			`lazy.foo`,
+			nil,
+			`The symbol name "lazy" is reserved for use in a future Terraform version. If you are using a provider that already uses this as a resource type name, add the prefix "resource." to force interpretation as a resource type name.`,
+		},
+		{
+			`arg.foo`,
+			nil,
+			`The symbol name "arg" is reserved for use in a future Terraform version. If you are using a provider that already uses this as a resource type name, add the prefix "resource." to force interpretation as a resource type name.`,
+		},
+
 		// anything else, interpreted as a managed resource reference
 		{
 			`boop_instance.foo`,

--- a/addrs/parse_ref_test.go
+++ b/addrs/parse_ref_test.go
@@ -584,6 +584,27 @@ func TestParseRef(t *testing.T) {
 			`The "var" object does not support this operation.`,
 		},
 
+		// the "resource" prefix forces interpreting the next name as a
+		// resource type name. This is an alias for just using a resource
+		// type name at the top level, to be used only if a later edition
+		// of the Terraform language introduces a new reserved word that
+		// overlaps with a resource type name.
+		{
+			`resource.boop_instance.foo`,
+			&Reference{
+				Subject: Resource{
+					Mode: ManagedResourceMode,
+					Type: "boop_instance",
+					Name: "foo",
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 27, Byte: 26},
+				},
+			},
+			``,
+		},
+
 		// anything else, interpreted as a managed resource reference
 		{
 			`boop_instance.foo`,

--- a/configs/escaping_blocks_test.go
+++ b/configs/escaping_blocks_test.go
@@ -1,0 +1,308 @@
+package configs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// "Escaping Blocks" are a special mechanism we have inside our block types
+// that accept a mixture of meta-arguments and externally-defined arguments,
+// which allow an author to force particular argument names to be interpreted
+// as externally-defined even if they have the same name as a meta-argument.
+//
+// An escaping block is a block with the special type name "_" (just an
+// underscore), and is allowed at the top-level of any resource, data, or
+// module block. It intentionally has a rather "odd" look so that it stands
+// out as something special and rare.
+//
+// This is not something we expect to see used a lot, but it's an important
+// part of our strategy to evolve the Terraform language in future using
+// editions, so that later editions can define new meta-arguments without
+// blocking access to externally-defined arguments of the same name.
+//
+// We should still define new meta-arguments with care to avoid squatting on
+// commonly-used names, but we can't see all modules and all providers in
+// the world and so this is an escape hatch for edge cases. Module migration
+// tools for future editions that define new meta-arguments should detect
+// collisions and automatically migrate existing arguments into an escaping
+// block.
+
+func TestEscapingBlockResource(t *testing.T) {
+	// (this also tests escaping blocks in provisioner blocks, because
+	// they only appear nested inside resource blocks.)
+
+	parser := NewParser(nil)
+	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/resource")
+	assertNoDiagnostics(t, diags)
+	if mod == nil {
+		t.Fatal("got nil root module; want non-nil")
+	}
+
+	rc := mod.ManagedResources["foo.bar"]
+	if rc == nil {
+		t.Fatal("no managed resource named foo.bar")
+	}
+
+	t.Run("resource body", func(t *testing.T) {
+		if got := rc.Count; got == nil {
+			t.Errorf("count not set; want count = 2")
+		} else {
+			got, diags := got.Value(nil)
+			assertNoDiagnostics(t, diags)
+			if want := cty.NumberIntVal(2); !want.RawEquals(got) {
+				t.Errorf("wrong count\ngot:  %#v\nwant: %#v", got, want)
+			}
+		}
+		if got, want := rc.ForEach, hcl.Expression(nil); got != want {
+			// Shouldn't have any count because our test fixture only has
+			// for_each in the escaping block.
+			t.Errorf("wrong for_each\ngot:  %#v\nwant: %#v", got, want)
+		}
+
+		schema := &hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{Name: "normal", Required: true},
+				{Name: "count", Required: true},
+				{Name: "for_each", Required: true},
+			},
+			Blocks: []hcl.BlockHeaderSchema{
+				{Type: "normal_block"},
+				{Type: "lifecycle"},
+				{Type: "_"},
+			},
+		}
+		content, diags := rc.Config.Content(schema)
+		assertNoDiagnostics(t, diags)
+
+		normalVal, diags := content.Attributes["normal"].Expr.Value(nil)
+		assertNoDiagnostics(t, diags)
+		if got, want := normalVal, cty.StringVal("yes"); !want.RawEquals(got) {
+			t.Errorf("wrong value for 'normal'\ngot:  %#v\nwant: %#v", got, want)
+		}
+
+		countVal, diags := content.Attributes["count"].Expr.Value(nil)
+		assertNoDiagnostics(t, diags)
+		if got, want := countVal, cty.StringVal("not actually count"); !want.RawEquals(got) {
+			t.Errorf("wrong value for 'count'\ngot:  %#v\nwant: %#v", got, want)
+		}
+
+		var gotBlockTypes []string
+		for _, block := range content.Blocks {
+			gotBlockTypes = append(gotBlockTypes, block.Type)
+		}
+		wantBlockTypes := []string{"normal_block", "lifecycle", "_"}
+		if diff := cmp.Diff(gotBlockTypes, wantBlockTypes); diff != "" {
+			t.Errorf("wrong block types\n%s", diff)
+		}
+	})
+	t.Run("provisioner body", func(t *testing.T) {
+		if got, want := len(rc.Managed.Provisioners), 1; got != want {
+			t.Fatalf("wrong number of provisioners %d; want %d", got, want)
+		}
+		pc := rc.Managed.Provisioners[0]
+
+		schema := &hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{Name: "when", Required: true},
+				{Name: "normal", Required: true},
+			},
+			Blocks: []hcl.BlockHeaderSchema{
+				{Type: "normal_block"},
+				{Type: "lifecycle"},
+				{Type: "_"},
+			},
+		}
+		content, diags := pc.Config.Content(schema)
+		assertNoDiagnostics(t, diags)
+
+		normalVal, diags := content.Attributes["normal"].Expr.Value(nil)
+		assertNoDiagnostics(t, diags)
+		if got, want := normalVal, cty.StringVal("yep"); !want.RawEquals(got) {
+			t.Errorf("wrong value for 'normal'\ngot:  %#v\nwant: %#v", got, want)
+		}
+		whenVal, diags := content.Attributes["when"].Expr.Value(nil)
+		assertNoDiagnostics(t, diags)
+		if got, want := whenVal, cty.StringVal("hell freezes over"); !want.RawEquals(got) {
+			t.Errorf("wrong value for 'normal'\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+}
+
+func TestEscapingBlockData(t *testing.T) {
+	parser := NewParser(nil)
+	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/data")
+	assertNoDiagnostics(t, diags)
+	if mod == nil {
+		t.Fatal("got nil root module; want non-nil")
+	}
+
+	rc := mod.DataResources["data.foo.bar"]
+	if rc == nil {
+		t.Fatal("no data resource named data.foo.bar")
+	}
+
+	if got := rc.Count; got == nil {
+		t.Errorf("count not set; want count = 2")
+	} else {
+		got, diags := got.Value(nil)
+		assertNoDiagnostics(t, diags)
+		if want := cty.NumberIntVal(2); !want.RawEquals(got) {
+			t.Errorf("wrong count\ngot:  %#v\nwant: %#v", got, want)
+		}
+	}
+	if got, want := rc.ForEach, hcl.Expression(nil); got != want {
+		// Shouldn't have any count because our test fixture only has
+		// for_each in the escaping block.
+		t.Errorf("wrong for_each\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	schema := &hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{Name: "normal", Required: true},
+			{Name: "count", Required: true},
+			{Name: "for_each", Required: true},
+		},
+		Blocks: []hcl.BlockHeaderSchema{
+			{Type: "normal_block"},
+			{Type: "lifecycle"},
+			{Type: "_"},
+		},
+	}
+	content, diags := rc.Config.Content(schema)
+	assertNoDiagnostics(t, diags)
+
+	normalVal, diags := content.Attributes["normal"].Expr.Value(nil)
+	assertNoDiagnostics(t, diags)
+	if got, want := normalVal, cty.StringVal("yes"); !want.RawEquals(got) {
+		t.Errorf("wrong value for 'normal'\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	countVal, diags := content.Attributes["count"].Expr.Value(nil)
+	assertNoDiagnostics(t, diags)
+	if got, want := countVal, cty.StringVal("not actually count"); !want.RawEquals(got) {
+		t.Errorf("wrong value for 'count'\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	var gotBlockTypes []string
+	for _, block := range content.Blocks {
+		gotBlockTypes = append(gotBlockTypes, block.Type)
+	}
+	wantBlockTypes := []string{"normal_block", "lifecycle", "_"}
+	if diff := cmp.Diff(gotBlockTypes, wantBlockTypes); diff != "" {
+		t.Errorf("wrong block types\n%s", diff)
+	}
+
+}
+
+func TestEscapingBlockModule(t *testing.T) {
+	parser := NewParser(nil)
+	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/module")
+	assertNoDiagnostics(t, diags)
+	if mod == nil {
+		t.Fatal("got nil root module; want non-nil")
+	}
+
+	mc := mod.ModuleCalls["foo"]
+	if mc == nil {
+		t.Fatal("no module call named foo")
+	}
+
+	if got := mc.Count; got == nil {
+		t.Errorf("count not set; want count = 2")
+	} else {
+		got, diags := got.Value(nil)
+		assertNoDiagnostics(t, diags)
+		if want := cty.NumberIntVal(2); !want.RawEquals(got) {
+			t.Errorf("wrong count\ngot:  %#v\nwant: %#v", got, want)
+		}
+	}
+	if got, want := mc.ForEach, hcl.Expression(nil); got != want {
+		// Shouldn't have any count because our test fixture only has
+		// for_each in the escaping block.
+		t.Errorf("wrong for_each\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	schema := &hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{Name: "normal", Required: true},
+			{Name: "count", Required: true},
+			{Name: "for_each", Required: true},
+		},
+		Blocks: []hcl.BlockHeaderSchema{
+			{Type: "normal_block"},
+			{Type: "lifecycle"},
+			{Type: "_"},
+		},
+	}
+	content, diags := mc.Config.Content(schema)
+	assertNoDiagnostics(t, diags)
+
+	normalVal, diags := content.Attributes["normal"].Expr.Value(nil)
+	assertNoDiagnostics(t, diags)
+	if got, want := normalVal, cty.StringVal("yes"); !want.RawEquals(got) {
+		t.Errorf("wrong value for 'normal'\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	countVal, diags := content.Attributes["count"].Expr.Value(nil)
+	assertNoDiagnostics(t, diags)
+	if got, want := countVal, cty.StringVal("not actually count"); !want.RawEquals(got) {
+		t.Errorf("wrong value for 'count'\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	var gotBlockTypes []string
+	for _, block := range content.Blocks {
+		gotBlockTypes = append(gotBlockTypes, block.Type)
+	}
+	wantBlockTypes := []string{"normal_block", "lifecycle", "_"}
+	if diff := cmp.Diff(gotBlockTypes, wantBlockTypes); diff != "" {
+		t.Errorf("wrong block types\n%s", diff)
+	}
+
+}
+
+func TestEscapingBlockProvider(t *testing.T) {
+	parser := NewParser(nil)
+	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/provider")
+	assertNoDiagnostics(t, diags)
+	if mod == nil {
+		t.Fatal("got nil root module; want non-nil")
+	}
+
+	pc := mod.ProviderConfigs["foo.bar"]
+	if pc == nil {
+		t.Fatal("no provider configuration named foo.bar")
+	}
+
+	if got, want := pc.Alias, "bar"; got != want {
+		t.Errorf("wrong alias\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	schema := &hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{Name: "normal", Required: true},
+			{Name: "alias", Required: true},
+			{Name: "version", Required: true},
+		},
+	}
+	content, diags := pc.Config.Content(schema)
+	assertNoDiagnostics(t, diags)
+
+	normalVal, diags := content.Attributes["normal"].Expr.Value(nil)
+	assertNoDiagnostics(t, diags)
+	if got, want := normalVal, cty.StringVal("yes"); !want.RawEquals(got) {
+		t.Errorf("wrong value for 'normal'\ngot:  %#v\nwant: %#v", got, want)
+	}
+	aliasVal, diags := content.Attributes["alias"].Expr.Value(nil)
+	assertNoDiagnostics(t, diags)
+	if got, want := aliasVal, cty.StringVal("not actually alias"); !want.RawEquals(got) {
+		t.Errorf("wrong value for 'alias'\ngot:  %#v\nwant: %#v", got, want)
+	}
+	versionVal, diags := content.Attributes["version"].Expr.Value(nil)
+	assertNoDiagnostics(t, diags)
+	if got, want := versionVal, cty.StringVal("not actually version"); !want.RawEquals(got) {
+		t.Errorf("wrong value for 'version'\ngot:  %#v\nwant: %#v", got, want)
+	}
+}

--- a/configs/testdata/escaping-blocks/data/data-escaping-block.tf
+++ b/configs/testdata/escaping-blocks/data/data-escaping-block.tf
@@ -1,0 +1,35 @@
+
+data "foo" "bar" {
+  count = 2
+
+  normal = "yes"
+
+  normal_block {}
+
+  _ {
+    # This "escaping block" is an escape hatch for when a resource
+    # type declares argument names that collide with meta-argument
+    # names. The examples below are not really realistic because they
+    # are long-standing names that predate the need for escaping,
+    # but we're using them as a proxy for new meta-arguments we might
+    # add in future language editions which might collide with
+    # names defined in pre-existing providers.
+
+    # note that count is set both as a meta-argument above _and_ as
+    # an resource-type-specific argument here, which is valid and
+    # should result in both being populated.
+    count = "not actually count"
+
+    # for_each is only set in here, not as a meta-argument
+    for_each = "not actually for_each"
+
+    lifecycle {
+      # This is a literal lifecycle block, not a meta-argument block
+    }
+
+    _ {
+        # It would be pretty weird for a resource type to define its own
+        # "_" block type, but that's valid to escape in here too.
+    }
+  }
+}

--- a/configs/testdata/escaping-blocks/module/module-escaping-block.tf
+++ b/configs/testdata/escaping-blocks/module/module-escaping-block.tf
@@ -1,0 +1,36 @@
+
+module "foo" {
+  source = "./child"
+  count = 2
+
+  normal = "yes"
+
+  normal_block {}
+
+  _ {
+    # This "escaping block" is an escape hatch for when a module
+    # declares input variable names that collide with meta-argument
+    # names. The examples below are not really realistic because they
+    # are long-standing names that predate the need for escaping,
+    # but we're using them as a proxy for new meta-arguments we might
+    # add in future language editions which might collide with
+    # names defined in pre-existing modules.
+
+    # note that count is set both as a meta-argument above _and_ as
+    # an resource-type-specific argument here, which is valid and
+    # should result in both being populated.
+    count = "not actually count"
+
+    # for_each is only set in here, not as a meta-argument
+    for_each = "not actually for_each"
+
+    lifecycle {
+      # This is a literal lifecycle block, not a meta-argument block
+    }
+
+    _ {
+        # It would be pretty weird for a resource type to define its own
+        # "_" block type, but that's valid to escape in here too.
+    }
+  }
+}

--- a/configs/testdata/escaping-blocks/provider/provider-escaping-block.tf
+++ b/configs/testdata/escaping-blocks/provider/provider-escaping-block.tf
@@ -1,0 +1,23 @@
+
+provider "foo" {
+  alias = "bar"
+
+  normal = "yes"
+
+  _ {
+    # This "escaping block" is an escape hatch for when a provider
+    # declares argument names that collide with meta-argument
+    # names. The examples below are not really realistic because they
+    # are long-standing names that predate the need for escaping,
+    # but we're using them as a proxy for new meta-arguments we might
+    # add in future language editions which might collide with
+    # names defined in pre-existing providers.
+
+    # alias is set both as a meta-argument above _and_
+    # as a provider-type-specific argument
+    alias = "not actually alias"
+
+    # version is only set in here, not as a meta-argument
+    version = "not actually version"
+  }
+}

--- a/configs/testdata/escaping-blocks/resource/resource-escaping-block.tf
+++ b/configs/testdata/escaping-blocks/resource/resource-escaping-block.tf
@@ -1,0 +1,43 @@
+
+resource "foo" "bar" {
+  count = 2
+
+  normal = "yes"
+
+  normal_block {}
+
+  _ {
+    # This "escaping block" is an escape hatch for when a resource
+    # type declares argument names that collide with meta-argument
+    # names. The examples below are not really realistic because they
+    # are long-standing names that predate the need for escaping,
+    # but we're using them as a proxy for new meta-arguments we might
+    # add in future language editions which might collide with
+    # names defined in pre-existing providers.
+
+    # note that count is set both as a meta-argument above _and_ as
+    # an resource-type-specific argument here, which is valid and
+    # should result in both being populated.
+    count = "not actually count"
+
+    # for_each is only set in here, not as a meta-argument
+    for_each = "not actually for_each"
+
+    lifecycle {
+      # This is a literal lifecycle block, not a meta-argument block
+    }
+
+    _ {
+        # It would be pretty weird for a resource type to define its own
+        # "_" block type, but that's valid to escape in here too.
+    }
+  }
+
+  provisioner "boop" {
+    when = destroy
+    _ {
+      when = "hell freezes over"
+    }
+    normal = "yep"
+  }
+}

--- a/lang/eval.go
+++ b/lang/eval.go
@@ -407,9 +407,16 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 		}
 	}
 
+	// Managed resources are exposed in two different locations. The primary
+	// is at the top level where the resource type name is the root of the
+	// traversal, but we also expose them under "resource" as an escaping
+	// technique if we add a reserved name in a future language edition which
+	// conflicts with someone's existing provider.
 	for k, v := range buildResourceObjects(managedResources) {
 		vals[k] = v
 	}
+	vals["resource"] = cty.ObjectVal(buildResourceObjects(managedResources))
+
 	vals["data"] = cty.ObjectVal(buildResourceObjects(dataResources))
 	vals["module"] = cty.ObjectVal(wholeModules)
 	vals["var"] = cty.ObjectVal(inputVariables)

--- a/lang/eval_test.go
+++ b/lang/eval_test.go
@@ -120,6 +120,13 @@ func TestScopeEvalContext(t *testing.T) {
 						"attr": cty.StringVal("bar"),
 					}),
 				}),
+				"resource": cty.ObjectVal(map[string]cty.Value{
+					"null_resource": cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("bar"),
+						}),
+					}),
+				}),
 			},
 		},
 		{
@@ -128,6 +135,13 @@ func TestScopeEvalContext(t *testing.T) {
 				"null_resource": cty.ObjectVal(map[string]cty.Value{
 					"foo": cty.ObjectVal(map[string]cty.Value{
 						"attr": cty.StringVal("bar"),
+					}),
+				}),
+				"resource": cty.ObjectVal(map[string]cty.Value{
+					"null_resource": cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.ObjectVal(map[string]cty.Value{
+							"attr": cty.StringVal("bar"),
+						}),
 					}),
 				}),
 			},
@@ -142,6 +156,18 @@ func TestScopeEvalContext(t *testing.T) {
 						}),
 						cty.ObjectVal(map[string]cty.Value{
 							"attr": cty.StringVal("multi1"),
+						}),
+					}),
+				}),
+				"resource": cty.ObjectVal(map[string]cty.Value{
+					"null_resource": cty.ObjectVal(map[string]cty.Value{
+						"multi": cty.TupleVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"attr": cty.StringVal("multi0"),
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"attr": cty.StringVal("multi1"),
+							}),
 						}),
 					}),
 				}),
@@ -161,6 +187,18 @@ func TestScopeEvalContext(t *testing.T) {
 						}),
 					}),
 				}),
+				"resource": cty.ObjectVal(map[string]cty.Value{
+					"null_resource": cty.ObjectVal(map[string]cty.Value{
+						"multi": cty.TupleVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"attr": cty.StringVal("multi0"),
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"attr": cty.StringVal("multi1"),
+							}),
+						}),
+					}),
+				}),
 			},
 		},
 		{
@@ -174,6 +212,18 @@ func TestScopeEvalContext(t *testing.T) {
 						}),
 						"each1": cty.ObjectVal(map[string]cty.Value{
 							"attr": cty.StringVal("each1"),
+						}),
+					}),
+				}),
+				"resource": cty.ObjectVal(map[string]cty.Value{
+					"null_resource": cty.ObjectVal(map[string]cty.Value{
+						"each": cty.ObjectVal(map[string]cty.Value{
+							"each0": cty.ObjectVal(map[string]cty.Value{
+								"attr": cty.StringVal("each0"),
+							}),
+							"each1": cty.ObjectVal(map[string]cty.Value{
+								"attr": cty.StringVal("each1"),
+							}),
 						}),
 					}),
 				}),
@@ -193,6 +243,18 @@ func TestScopeEvalContext(t *testing.T) {
 						}),
 					}),
 				}),
+				"resource": cty.ObjectVal(map[string]cty.Value{
+					"null_resource": cty.ObjectVal(map[string]cty.Value{
+						"each": cty.ObjectVal(map[string]cty.Value{
+							"each0": cty.ObjectVal(map[string]cty.Value{
+								"attr": cty.StringVal("each0"),
+							}),
+							"each1": cty.ObjectVal(map[string]cty.Value{
+								"attr": cty.StringVal("each1"),
+							}),
+						}),
+					}),
+				}),
 			},
 		},
 		{
@@ -205,6 +267,18 @@ func TestScopeEvalContext(t *testing.T) {
 						}),
 						cty.ObjectVal(map[string]cty.Value{
 							"attr": cty.StringVal("multi1"),
+						}),
+					}),
+				}),
+				"resource": cty.ObjectVal(map[string]cty.Value{
+					"null_resource": cty.ObjectVal(map[string]cty.Value{
+						"multi": cty.TupleVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"attr": cty.StringVal("multi0"),
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"attr": cty.StringVal("multi1"),
+							}),
 						}),
 					}),
 				}),


### PR DESCRIPTION
The Terraform language has always had a number of situations where reserved words defined in the language can appear in the same location as externally-defined names provided by either providers or modules. These are:
* In `provider`, `resource`, and `data` blocks Terraform overlays reserved meta-arguments onto the relevant provider schema, effectively masking any provider-defined argument with a conflicting name.
* In `module` blocks Terraform overlays reserved meta-arguments onto the set of input variable names defined in the module. Currently we block modules from declaring such conflicting names, but that means that adding any new meta-arguments here is a breaking change for existing modules, as we previously saw when we reserved `count` in the v0.12 release.
* In `provisioner` blocks Terraform overlays reserved meta-arguments onto the provisioner configuration schema, likewise masking any provisioner-defined argument with a conflicting name.
* References to managed resources use the resource type name with no prefix, like `aws_instance.foo`, but certain prefixes are reserved for other purposes (such as `var.`, `local.`, `path.`, etc) which means that a managed resource of that name would not be referenceable.

Each of these situations is a liability for future language expansion because it makes any additional reserved word a potential breaking change. While we would always do research to select a name not used in any commonly-used providers or modules, there are lots of providers and modules kept private within organizations and so there is always a risk that we'd pick a name that collides with a provider or module used only within a single organization.

In #27941 we reserved a mechanism which we intend to use in future to allow per-module opt-in to new "editions" of the Terraform language that may have breaking changes such as these, which does at least allow for a gradual module-by-module migration up to a new edition. However, our intent is that there should usually be an largely-automated process for upgrading a module to a newer edition without changing its behavior, and that means that we must provide a way to continue using module and provider features that have been newly-masked by reserved words until there's a newer version of the provider or module that supports a non-reserved alternative name.

This PR, then, proposes two new language additions that will together serve as an escape hatch for all of the situations described earlier, so that if we _do_ introduce a new reserved word that is in use by a provider or module we cannot see we can offer a graceful migration path to still opt in to the new language edition without having to wait for the provider or module to be updated.

## The `resource.` Prefix

When we refer to data resources, we write `data.type.name` which means that there's no ambiguity that the second component `type` is _always_ the name of a data resource type. The `resource.` prefix aims to get the same result for managed resources, so that `resource.aws_instance.foo` is just an equivalent alias for `aws_instance.foo` as long as `aws_instance` is never a reserved word (which would be weird!).

My intent is that we'd use this as part of the module upgrade tool for any new language edition which introduces a new reserved reference prefix. For example, if we'd introduced a new prefix `foo.` then the upgrade tool would search the module for any references that seem to refer to a resource type called "foo" and rewrite them to have the `resource.` prefix, leaving all other references unchanged. For example, `foo.bar.baz` would be come `resource.foo.bar.baz`, but `aws_instance.foo` would remain just `aws_instance.foo`.

I don't intend to recommend using this prefix in cases where it isn't needed, because it'll make such references unnecessarily long. Although I didn't implement this here yet, I could imagine a future version of `terraform fmt` automatically trimming off a `resource.` prefix for any reference where the resource type name isn't a reserved word in the currently-selected language edition, to help reinforce that this is for upgrade path use only.

## Meta-argument Escaping Blocks

The idea of "escaping blocks" aims to address all of the variants above which involve a mixture of meta-arguments and normal arguments inside a single HCL block body. This applies to `resource`, `data`, `provider`, and `module` blocks at the top level, and also to `provisioner` blocks nested directly inside `resource` blocks.

This mechanism reserves the special and intentionally-odd-looking block type name `_` (just a single underscore) to contain block body items for which the author intends to avoid interpretation as meta-arguments. For example, if a later language edition introduced a new meta-argument `only_if` (though there is no current plan to do so), it might be the case that there's an existing resource type or module that already has an argument named `only_if` which could be "escaped" using an escaping block, like this:

```hcl
resource "example" "foo" {
  # most arguments stay out here to be
  # processed as normal
  beep = "boop"

  _ {
    # Arguments that conflict with a later-added
    # meta-argument can move in here to
    # retain the old interpretation.
    only_if = var.something
  }
}
```

Terraform interprets the content of the escaping block as if it were written outside of the escaping block except for bypassing the usual pre-processing to handle meta-arguments, and thus `only_if` above would always be understood as an argument of the resource type `example` rather than as a meta-argument.

Again, my intent is that we'd use this as part of a module upgrade tool for a new language edition which introduces a new meta-argument. It would search the module configuration for any argument names that are now shadowed by the new reserved word and move them into an escaping block to allow the module to retain its existing functionality.

I don't intend to recommend using escaping blocks in situations where they aren't needed, because it's an intentionally-odd-looking syntax to try to help make it obviously distinct from "normal" blocks. Although I didn't implement this here yet, I could imagine a future version of `terraform fmt` automatically hoisting items out of an escaping block if they don't conflict with any relevant meta-argument names in the currently-selected language edition, to help reinforce that this is for upgrade path use only.

It's interesting to note here that `dynamic` blocks actually already serve as a funny sort of escaping block which works only for reserved nested block types: a `resource` block containing a `dynamic "lifecycle"` block can produce an equivalent effect as an escaping block with a plain `lifecycle` block inside of it. Escaping blocks generalize that idea to include attributes too, and they offer a syntax that is easier to directly map from the normal syntax (retaining attached comments and all) in an upgrade tool.

---

## Some Other Loose Ends

Over in #28700 there's an early proposal for a new feature to allow separating template definition from template evaluation, which if accepted would require adding a new reserved reference prefix. It seems unlikely that we'll fully accept and implement that proposal before we adopt a stricter compatibility promise, but it would also be a shame to hold it all the way to a new language edition that's likely at least a year away, and so out of a sense of pragmatism here I've also pre-emptively reserved some prefixes that seem unlikely to already be used as resource type names and that might be what we choose as the prefix for the template proposal, if accepted.

These reserved prefixes are `template.`, `lazy.`, and `arg.`. Only zero or one of these will ultimately be used, depending on the outcome of the proposal, so the unused ones can be un-reserved later and become available for use as unescaped resource type names again.

These additions also serve as a way to "rehearse" the use of the `resource.` escaping prefix to resolve any collisions: in the unlikely event that there's a private provider out there which has a resource type name which conflicts with one of these three, a module using that resource type can be rewritten to say e.g. `resource.template.` instead of just `template.` and otherwise retain the existing behavior. Since we are prior to stricter compatibility promises there is no explicit opt-in here, but I'd like to make this tradeoff as a compromise to allow a discussion already in progress to conclude relatively promptly, rather than retroactively become subject to a new blocker on its implementation.

The `resource.` prefix here does, of course, also theoretically conflict with a resource type literally named "resource". That also seems very unlikely in practice, but if it _does_ arise then users can escape it by writing `resource.resource.`, which looks silly but will buy some time to select a more reasonable resource type name without being blocked from upgrading Terraform.

Nothing in this PR actually requires the addition of meta-argument escaping blocks yet -- they could in principle be added by the first future language edition that needs them -- but having this mechanism in place will give us some peace of mind that this path is available and also represent concretely in code our intentions for future language expansion.

It's pretty irregular to introduce stuff like this in a patch release, but with stricter compatibility promises imminent I think it's a worthwhile compromise to give us necessarily flexibility for both work currently in progress and future work we've not yet imagined. Therefore I'm proposing to backport this to the v0.15 branch.
