### PR TITLE
website: Give example plugin location when using XDG Base Directory

### DIFF
--- a/website/docs/cli/config/config-file.html.md
+++ b/website/docs/cli/config/config-file.html.md
@@ -272,12 +272,13 @@ The set of directories Terraform can select as filesystem mirrors depends on
 the operating system where you are running Terraform:
 
 * **Windows:** `%APPDATA%/terraform.d/plugins` and `%APPDATA%/HashiCorp/Terraform/plugins`
-* **Mac OS X:** `$HOME/.terraform.d/plugins/`,
+* **Mac OS X:** `$HOME/.terraform.d/plugins`,
   `~/Library/Application Support/io.terraform/plugins`, and
   `/Library/Application Support/io.terraform/plugins`
-* **Linux and other Unix-like systems**:`$HOME/.terraform.d/plugins/`, and
+* **Linux and other Unix-like systems**:`$HOME/.terraform.d/plugins` and
+  `terraform/plugins` located within a valid
   [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
-  data directories as configured, after appending `terraform/plugins`.
+  data directory such as `$XDG_DATA_HOME/terraform/plugins`.
   Without any XDG environment variables set, Terraform will use
   `~/.local/share/terraform/plugins`,
   `/usr/local/share/terraform/plugins`, and `/usr/share/terraform/plugins`.


### PR DESCRIPTION
The current documention was unclear about the full path of local mirrors
when using the XDG Base Directory Specification.

Also removed the trailing slashes for the other paths in this section.
