### PR TITLE
save apply diagnostics on backend failure

### DIFF
--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -165,6 +165,7 @@ func (b *Local) opApply(
 	if b.opWait(doneCh, stopCtx, cancelCtx, tfCtx, opState, op.View) {
 		return
 	}
+	diags = diags.Append(applyDiags)
 
 	// Store the final state
 	runningOp.State = applyState
@@ -183,7 +184,6 @@ func (b *Local) opApply(
 		return
 	}
 
-	diags = diags.Append(applyDiags)
 	if applyDiags.HasErrors() {
 		op.ReportResult(runningOp, diags)
 		return


### PR DESCRIPTION
Make sure to collect apply diagnostics before persisting the backend
state so runtime errors are not lost.

Closes #28708