### PR TITLE
cli: Improve sensitivity change warning output

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -1722,11 +1722,21 @@ func (p *blockBodyDiffPrinter) writeSensitivityWarning(old, new cty.Value, inden
 		diffType = "block"
 	}
 
+	// If only attribute sensitivity is changing, clarify that the value is unchanged
+	var valueUnchangedSuffix string
+	if !isBlock {
+		oldUnmarked, _ := old.UnmarkDeep()
+		newUnmarked, _ := new.UnmarkDeep()
+		if oldUnmarked.RawEquals(newUnmarked) {
+			valueUnchangedSuffix = " The value is unchanged."
+		}
+	}
+
 	if new.IsMarked() && !old.IsMarked() {
 		p.buf.WriteString(strings.Repeat(" ", indent))
-		p.buf.WriteString(p.color.Color(fmt.Sprintf("# [yellow]Warning:[reset] this %s will be marked as sensitive and will\n", diffType)))
+		p.buf.WriteString(p.color.Color(fmt.Sprintf("# [yellow]Warning:[reset] this %s will be marked as sensitive and will not\n", diffType)))
 		p.buf.WriteString(strings.Repeat(" ", indent))
-		p.buf.WriteString(p.color.Color("# not display in UI output after applying this change\n"))
+		p.buf.WriteString(fmt.Sprintf("# display in UI output after applying this change.%s\n", valueUnchangedSuffix))
 	}
 
 	// Note if changing this attribute will change its sensitivity
@@ -1734,7 +1744,7 @@ func (p *blockBodyDiffPrinter) writeSensitivityWarning(old, new cty.Value, inden
 		p.buf.WriteString(strings.Repeat(" ", indent))
 		p.buf.WriteString(p.color.Color(fmt.Sprintf("# [yellow]Warning:[reset] this %s will no longer be marked as sensitive\n", diffType)))
 		p.buf.WriteString(strings.Repeat(" ", indent))
-		p.buf.WriteString(p.color.Color("# after applying this change\n"))
+		p.buf.WriteString(fmt.Sprintf("# after applying this change.%s\n", valueUnchangedSuffix))
 	}
 }
 

--- a/internal/command/format/diff_test.go
+++ b/internal/command/format/diff_test.go
@@ -3402,7 +3402,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
       # Warning: this attribute value will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change.
       ~ ami         = (sensitive)
         id          = "i-02ae66f368e8518a9"
       ~ list_field  = [
@@ -3413,29 +3413,29 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
         ]
       ~ map_key     = {
           # Warning: this attribute value will no longer be marked as sensitive
-          # after applying this change
+          # after applying this change.
           ~ "dinner"    = (sensitive)
             # (1 unchanged element hidden)
         }
       # Warning: this attribute value will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change.
       ~ map_whole   = (sensitive)
       # Warning: this attribute value will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change.
       ~ some_number = (sensitive)
       # Warning: this attribute value will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change.
       ~ special     = (sensitive)
 
       # Warning: this block will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change.
       ~ nested_block {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
 
       # Warning: this block will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change.
       ~ nested_block_set {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
@@ -3533,16 +3533,16 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
         ]
       ~ map_key    = {
           ~ "breakfast" = 800 -> 700
-          # Warning: this attribute value will be marked as sensitive and will
-          # not display in UI output after applying this change
+          # Warning: this attribute value will be marked as sensitive and will not
+          # display in UI output after applying this change.
           ~ "dinner"    = (sensitive)
         }
-      # Warning: this attribute value will be marked as sensitive and will
-      # not display in UI output after applying this change
+      # Warning: this attribute value will be marked as sensitive and will not
+      # display in UI output after applying this change.
       ~ map_whole  = (sensitive)
 
-      # Warning: this block will be marked as sensitive and will
-      # not display in UI output after applying this change
+      # Warning: this block will be marked as sensitive and will not
+      # display in UI output after applying this change.
       ~ nested_block_single {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
@@ -3809,7 +3809,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
       # Warning: this attribute value will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change. The value is unchanged.
       ~ ami         = (sensitive)
         id          = "i-02ae66f368e8518a9"
       ~ list_field  = [
@@ -3820,29 +3820,29 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
         ]
       ~ map_key     = {
           # Warning: this attribute value will no longer be marked as sensitive
-          # after applying this change
+          # after applying this change. The value is unchanged.
           ~ "dinner"    = (sensitive)
             # (1 unchanged element hidden)
         }
       # Warning: this attribute value will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change. The value is unchanged.
       ~ map_whole   = (sensitive)
       # Warning: this attribute value will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change. The value is unchanged.
       ~ some_number = (sensitive)
       # Warning: this attribute value will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change. The value is unchanged.
       ~ special     = (sensitive)
 
       # Warning: this block will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change.
       ~ nested_block {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
 
       # Warning: this block will no longer be marked as sensitive
-      # after applying this change
+      # after applying this change.
       ~ nested_block_set {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.


### PR DESCRIPTION
When an attribute value changes in sensitivity, we previously rendered this in the diff with a `~` update action and a note about the consequence of the sensitivity change. Since we also suppress the attribute value, this made it impossible to know if the underlying value was changing, too, which has significant consequences on the meaning of the plan.

This commit adds an equality check of the old/new underlying values. If these are unchanged, we add a note to the sensitivity warning to clarify that only sensitivity is changing.

Fixes #28593. This is a more conservative change that the one I originally proposed in that issue, but I think it's a reasonable step forward.

### Screenshot

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/68917/118670168-5d329080-b7c4-11eb-80e9-c33d24b5a950.png">
