### PR TITLE
return diagnostics from provisioners

### DIFF
--- a/internal/builtin/provisioners/file/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/file/resource_provisioner_test.go
@@ -112,7 +112,7 @@ func TestResourceProvisioner_connectionRequired(t *testing.T) {
 	}
 
 	got := resp.Diagnostics.Err().Error()
-	if !strings.Contains(got, "missing connection") {
-		t.Fatalf("expected 'missing connection' error: got %q", got)
+	if !strings.Contains(got, "Missing connection") {
+		t.Fatalf("expected 'Missing connection' error: got %q", got)
 	}
 }

--- a/internal/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -271,8 +271,8 @@ func TestResourceProvisioner_connectionRequired(t *testing.T) {
 	}
 
 	got := resp.Diagnostics.Err().Error()
-	if !strings.Contains(got, "missing connection") {
-		t.Fatalf("expected 'missing connection' error: got %q", got)
+	if !strings.Contains(got, "Missing connection") {
+		t.Fatalf("expected 'Missing connection' error: got %q", got)
 	}
 }
 


### PR DESCRIPTION
The calls to resource provisioners were still converting diagnostics to error, which was losing any detail information. We also need to ensure that the builtin provisioners return diagnostics which can be annotated with config context.

Fixes #28707