### PR TITLE
Fix crash with deposed instances in orphaned resources

### DIFF
--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -399,7 +399,6 @@ func (n *NodeAbstractResourceInstance) planDestroy(ctx EvalContext, currentState
 				Before: cty.NullVal(cty.DynamicPseudoType),
 				After:  cty.NullVal(cty.DynamicPseudoType),
 			},
-			Private:      currentState.Private,
 			ProviderAddr: n.ResolvedProvider,
 		}
 		return noop, nil

--- a/internal/terraform/transform_orphan_resource.go
+++ b/internal/terraform/transform_orphan_resource.go
@@ -79,7 +79,12 @@ func (t *OrphanResourceInstanceTransformer) transform(g *Graph, ms *states.Modul
 			}
 		}
 
-		for key := range rs.Instances {
+		for key, inst := range rs.Instances {
+			// deposed instances will be taken care of separately
+			if inst.Current == nil {
+				continue
+			}
+
 			addr := rs.Addr.Instance(key)
 			abstract := NewNodeAbstractResourceInstance(addr)
 			var node dag.Vertex = abstract

--- a/internal/terraform/transform_orphan_resource_test.go
+++ b/internal/terraform/transform_orphan_resource_test.go
@@ -50,6 +50,26 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 				Module:   addrs.RootModule,
 			},
 		)
+
+		// A deposed orphan should not be handled by this transformer
+		s.SetResourceInstanceDeposed(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_instance",
+				Name: "deposed",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			states.NewDeposedKey(),
+			&states.ResourceInstanceObjectSrc{
+				AttrsFlat: map[string]string{
+					"id": "foo",
+				},
+				Status: states.ObjectReady,
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			},
+		)
 	})
 
 	g := Graph{Path: addrs.RootModuleInstance}


### PR DESCRIPTION
If an orphaned resource only consists of deposed instances, there will be no current state with which to plan, causing a panic when accessing the stored private data. There is no reason however to access this private field for a noop change in a destroyed instance, so avoid the field altogether since we accept that the state may be nil here anyway. 

We also should not have been planning to delete an orphan here in the first place, since there is no current instance state to plan. We can skip any instances with no current state when adding orphan nodes to the graph.

Fixes #28763