### PR TITLE
plan: handle deposed instances when rendering drift

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -172,6 +172,12 @@ func ResourceInstanceDrift(
 	action := plans.Update
 
 	switch {
+	case before == nil || before.Current == nil:
+		// before should never be nil, but before.Current can be if the
+		// instance was deposed. There is nothing to render for a deposed
+		// instance, since we intend to remove it.
+		return ""
+
 	case after == nil || after.Current == nil:
 		// The object was deleted
 		buf.WriteString(color.Color(fmt.Sprintf("[bold]  # %s[reset] has been deleted", dispAddr)))

--- a/internal/command/views/operation_test.go
+++ b/internal/command/views/operation_test.go
@@ -121,17 +121,80 @@ func TestOperation_planNoChanges(t *testing.T) {
 						state.SetResourceInstanceCurrent(
 							addrs.Resource{
 								Mode: addrs.ManagedResourceMode,
-								Type: "something",
+								Type: "test_resource",
 								Name: "somewhere",
 							}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 							&states.ResourceInstanceObjectSrc{
 								Status:    states.ObjectReady,
 								AttrsJSON: []byte(`{}`),
 							},
-							addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewBuiltInProvider("test")),
+							addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewDefaultProvider("test")),
 						)
 					}),
 					PriorState: states.NewState(),
+				}
+			},
+			"to update the Terraform state to match, create and apply a refresh-only plan",
+		},
+		"drift detected with deposed": {
+			func(schemas *terraform.Schemas) *plans.Plan {
+				return &plans.Plan{
+					UIMode:  plans.NormalMode,
+					Changes: plans.NewChanges(),
+					PrevRunState: states.BuildState(func(state *states.SyncState) {
+						state.SetResourceInstanceCurrent(
+							addrs.Resource{
+								Mode: addrs.ManagedResourceMode,
+								Type: "test_resource",
+								Name: "changes",
+							}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+							&states.ResourceInstanceObjectSrc{
+								Status:    states.ObjectReady,
+								AttrsJSON: []byte(`{"foo":"b"}`),
+							},
+							addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewDefaultProvider("test")),
+						)
+						state.SetResourceInstanceDeposed(
+							addrs.Resource{
+								Mode: addrs.ManagedResourceMode,
+								Type: "test_resource",
+								Name: "broken",
+							}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+							states.NewDeposedKey(),
+							&states.ResourceInstanceObjectSrc{
+								Status:    states.ObjectReady,
+								AttrsJSON: []byte(`{"foo":"c"}`),
+							},
+							addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewDefaultProvider("test")),
+						)
+					}),
+					PriorState: states.BuildState(func(state *states.SyncState) {
+						state.SetResourceInstanceCurrent(
+							addrs.Resource{
+								Mode: addrs.ManagedResourceMode,
+								Type: "test_resource",
+								Name: "changed",
+							}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+							&states.ResourceInstanceObjectSrc{
+								Status:    states.ObjectReady,
+								AttrsJSON: []byte(`{"foo":"b"}`),
+							},
+							addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewDefaultProvider("test")),
+						)
+						state.SetResourceInstanceDeposed(
+							addrs.Resource{
+								Mode: addrs.ManagedResourceMode,
+								Type: "test_resource",
+								Name: "broken",
+							}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+							states.NewDeposedKey(),
+							&states.ResourceInstanceObjectSrc{
+								Status:    states.ObjectReady,
+								AttrsJSON: []byte(`{"foo":"d"}`),
+							},
+							addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewDefaultProvider("test")),
+						)
+					}),
 				}
 			},
 			"to update the Terraform state to match, create and apply a refresh-only plan",
@@ -145,14 +208,14 @@ func TestOperation_planNoChanges(t *testing.T) {
 						state.SetResourceInstanceCurrent(
 							addrs.Resource{
 								Mode: addrs.ManagedResourceMode,
-								Type: "something",
+								Type: "test_resource",
 								Name: "somewhere",
 							}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 							&states.ResourceInstanceObjectSrc{
 								Status:    states.ObjectReady,
 								AttrsJSON: []byte(`{}`),
 							},
-							addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewBuiltInProvider("test")),
+							addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewDefaultProvider("test")),
 						)
 					}),
 					PriorState: states.NewState(),
@@ -169,14 +232,14 @@ func TestOperation_planNoChanges(t *testing.T) {
 						state.SetResourceInstanceCurrent(
 							addrs.Resource{
 								Mode: addrs.ManagedResourceMode,
-								Type: "something",
+								Type: "test_resource",
 								Name: "somewhere",
 							}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 							&states.ResourceInstanceObjectSrc{
 								Status:    states.ObjectReady,
 								AttrsJSON: []byte(`{}`),
 							},
-							addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewBuiltInProvider("test")),
+							addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewDefaultProvider("test")),
 						)
 					}),
 					PriorState: states.NewState(),

--- a/internal/command/views/plan.go
+++ b/internal/command/views/plan.go
@@ -339,7 +339,7 @@ func renderPlan(plan *plans.Plan, schemas *terraform.Schemas, view *View) {
 // line of output, and guarantees to always produce whole lines terminated
 // by newline characters.
 func renderChangesDetectedByRefresh(before, after *states.State, schemas *terraform.Schemas, view *View) bool {
-	// ManagedResourceEqual checks that the state es exactly equal for all
+	// ManagedResourceEqual checks that the state is exactly equal for all
 	// managed resources; but semantically equivalent states, or changes to
 	// deposed instances may not actually represent changes we need to present
 	// to the user, so for now this only serves as a short-circuit to skip

--- a/internal/command/views/plan.go
+++ b/internal/command/views/plan.go
@@ -374,6 +374,10 @@ func renderChangesDetectedByRefresh(before, after *states.State, schemas *terraf
 			}
 
 			for key, bis := range brs.Instances {
+				if bis.Current == nil {
+					// No current instance to render here
+					continue
+				}
 				var pis *states.ResourceInstance
 				if prs != nil {
 					pis = prs.Instance(key)


### PR DESCRIPTION
We need to take into account that resources may not have a current instance, or not have semantically relevant changes to the current instance when rendering drift in the UI.

In the first case, the renderer can panic when attempting to decode a nil current instance. In the latter case, we print the `Objects have changed ...` header because the state has changes to the data, while the current instances may still be unchanged. 

Add checks for missing `Current` instance states, and skip printing empty diffs altogether.

Fixes #28789
Fixes #28776