### PR TITLE
command/views: Remove unused drift summary message

### DIFF
--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -11,7 +11,6 @@ const (
 	// Operation results
 	MessagePlannedChange MessageType = "planned_change"
 	MessageChangeSummary MessageType = "change_summary"
-	MessageDriftSummary  MessageType = "drift_summary"
 	MessageOutputs       MessageType = "outputs"
 
 	// Hook-driven messages

--- a/internal/command/views/json_view.go
+++ b/internal/command/views/json_view.go
@@ -103,14 +103,6 @@ func (v *JSONView) ChangeSummary(cs *json.ChangeSummary) {
 	)
 }
 
-func (v *JSONView) DriftSummary(cs *json.ChangeSummary) {
-	v.log.Info(
-		cs.String(),
-		"type", json.MessageDriftSummary,
-		"changes", cs,
-	)
-}
-
 func (v *JSONView) Hook(h json.Hook) {
 	v.log.Info(
 		h.String(),


### PR DESCRIPTION
This was dead code, and there is no clear way to retrieve this information, as we currently only derive the drift information as part of the plan rendering process.