### PR TITLE
support force-unlock for remote http backends. Fixes #28421

### DIFF
--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -114,11 +114,20 @@ func (c *httpClient) Lock(info *statemgr.LockInfo) (string, error) {
 }
 
 func (c *httpClient) Unlock(id string) error {
+	var info statemgr.LockInfo
+
 	if c.UnlockURL == nil {
 		return nil
 	}
 
-	resp, err := c.httpRequest(c.UnlockMethod, c.UnlockURL, &c.jsonLockInfo, "unlock")
+	if err := json.Unmarshal(c.jsonLockInfo, &info); err != nil {
+		return err
+	}
+
+	info.ID = id
+	jsonLockInfo := info.Marshal()
+
+	resp, err := c.httpRequest(c.UnlockMethod, c.UnlockURL, &jsonLockInfo, "unlock")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The PR ensures the LockInfo body is sent to a http remote backend. This is currently missing when using the force-unlock command. Unlocking works fine in the happy flow as the body from the lock command is still available and replayed.