### PR TITLE
return error for invalid resource import

### DIFF
--- a/internal/terraform/transform_import_state.go
+++ b/internal/terraform/transform_import_state.go
@@ -282,6 +282,25 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (di
 		return diags
 	}
 
+	// Verify the existance of the imported resource
+	if state.Value.IsNull() {
+		var diags tfdiags.Diagnostics
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Cannot import non-existent remote object",
+			fmt.Sprintf(
+				"While attempting to import an existing object to %q, "+
+					"the provider detected that no object exists with the given id. "+
+					"Only pre-existing objects can be imported; check that the id "+
+					"is correct and that it is associated with the provider's "+
+					"configured region or endpoint, or use \"terraform apply\" to "+
+					"create a new remote object for this resource.",
+				n.TargetAddr,
+			),
+		))
+		return diags
+	}
+
 	diags = diags.Append(riNode.writeResourceInstanceState(ctx, state, workingState))
 	return diags
 }


### PR DESCRIPTION
Most legacy provider resources do not implement any import functionality
other than returning an empty object with the given ID, relying on core
to later read that resource and obtain the complete state. Because of
this, we need to check the response from ReadResource for a null value,
and use that as an indication the import ID was invalid.

Fixes #28637