### PR TITLE
website: More accurate release versions for new plan options

### DIFF
--- a/website/docs/cli/commands/destroy.html.md
+++ b/website/docs/cli/commands/destroy.html.md
@@ -44,5 +44,5 @@ This will run [`terraform plan`](./plan.html) in _destroy_ mode, showing
 you the proposed destroy changes without executing them.
 
 -> **Note:** The `-destroy` option to `terraform apply` exists only in
-Terraform v1.0 and later. For earlier versions, you _must_ use
+Terraform v0.15.2 and later. For earlier versions, you _must_ use
 `terraform destroy` to get the effect of `terraform apply -destroy`.

--- a/website/docs/cli/commands/plan.html.md
+++ b/website/docs/cli/commands/plan.html.md
@@ -120,6 +120,9 @@ supported only by the `terraform plan` command, and not by the
 `terraform apply` command. To create and apply a plan in destroy mode in
 earlier versions you must run [`terraform destroy`](./destroy.html).
 
+-> **Note:** The `-refresh-only` option is available only in Terraform v0.15.4
+and later.
+
 ## Planning Options
 
 In addition to the planning _modes_ described above, there are also several
@@ -157,7 +160,7 @@ the previous section, are also available with the same meanings on
     This option is allowed only in the normal planning mode, so this option
     is incompatible with the `-destroy` option.
 
-    The `-replace=...` option is available only from Terraform v1.0 onwards.
+    The `-replace=...` option is available only from Terraform v0.15.2 onwards.
     For earlier versions, you can achieve a similar effect (with some caveats)
     using [`terraform taint`](./taint.html).
 

--- a/website/docs/cli/commands/refresh.html.md
+++ b/website/docs/cli/commands/refresh.html.md
@@ -61,7 +61,7 @@ This alternative command will present an interactive prompt for you to confirm
 the detected changes.
 
 The `-refresh-only` option for `terraform plan` and `terraform apply` was
-introduced in Terraform v1.0. For prior versions you must use
+introduced in Terraform v0.15.4. For prior versions you must use
 `terraform refresh` directly if you need this behavior, while taking into
 account the warnings above. Wherever possible, avoid using `terraform refresh`
 explicitly and instead rely on Terraform's behavior of automatically refreshing

--- a/website/docs/cli/commands/taint.html.md
+++ b/website/docs/cli/commands/taint.html.md
@@ -34,8 +34,8 @@ tainted object before you've had a chance to review the consequences of that
 change yourself.
 
 The `-replace=...` option to `terraform apply` is only available from
-Terraform v1.0 onwards, so if you are using an earlier version you will need to
-use `terraform taint` to force object replacement, while considering the
+Terraform v0.15.2 onwards, so if you are using an earlier version you will need
+to use `terraform taint` to force object replacement, while considering the
 caveats described above.
 
 ## Usage


### PR DESCRIPTION
While we were working on and documenting these it wasn't clear exactly which Terraform CLI version they would land in, and so we used "Terraform v1.0" in the docs as a safe bound that was definitely going to include all of them.

With everything now landed though, we can be more specific about which v0.15.x minor release each of these appeared in.
