### PR TITLE
backend/remote: point refresh users towards -refresh-only

### DIFF
--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -721,6 +721,10 @@ func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend
 		f = b.opPlan
 	case backend.OperationTypeApply:
 		f = b.opApply
+	case backend.OperationTypeRefresh:
+		return nil, fmt.Errorf(
+			"\n\nThe \"refresh\" operation is not supported when using the \"remote\" backend. " +
+				"Use \"terraform apply -refresh-only\" instead.")
 	default:
 		return nil, fmt.Errorf(
 			"\n\nThe \"remote\" backend does not support the %q operation.", op.Type)


### PR DESCRIPTION
Adds a bit more information to the error message when remote backend users attempt to use `terraform refresh` so they know there's another option.

<img width="980" alt="Screen Shot 2021-05-26 at 11 10 51 PM" src="https://user-images.githubusercontent.com/17039873/119774890-b8751a80-be77-11eb-8457-c04b87a0d9a6.png">
