### PR TITLE
docs: fix incorrect link on index function reference

### DIFF
--- a/website/docs/language/functions/element.html.md
+++ b/website/docs/language/functions/element.html.md
@@ -46,5 +46,5 @@ c
 
 ## Related Functions
 
-* [`index`](./index.html) finds the index for a particular element value.
+* [`index`](./index_function.html) finds the index for a particular element value.
 * [`lookup`](./lookup.html) retrieves a value from a _map_ given its _key_.


### PR DESCRIPTION
The current link to the related function `index` is redirecting to the index page of all functions. The `index` function has a special filename in order to not interfer with the HTML index one.

The correct page to link is `index_function.html`.