### PR TITLE
Fix handling large states in the Consul backend

### DIFF
--- a/internal/backend/remote-state/consul/client_test.go
+++ b/internal/backend/remote-state/consul/client_test.go
@@ -136,11 +136,6 @@ func TestConsul_largeState(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// md5 := md5.Sum(payload)
-		// if !bytes.Equal(md5[:], remote.MD5) {
-		// 	t.Fatal("the md5 sums do not match")
-		// }
-
 		if !bytes.Equal(payload, remote.Data) {
 			t.Fatal("the data do not match")
 		}
@@ -158,6 +153,19 @@ func TestConsul_largeState(t *testing.T) {
 			"tf-unit/test-large-state",
 			"tf-unit/test-large-state/tfstate.2cb96f52c9fff8e0b56cb786ec4d2bed/0",
 			"tf-unit/test-large-state/tfstate.2cb96f52c9fff8e0b56cb786ec4d2bed/1",
+		},
+	)
+
+	// This payload is just short enough to be stored but will be bigger when
+	// going through the Transaction API as it will be base64 encoded
+	testPayload(
+		t,
+		map[string]string{
+			"foo": strings.Repeat("a", 524288-10),
+		},
+		[]string{
+			"tf-unit/test-large-state",
+			"tf-unit/test-large-state/tfstate.4f407ace136a86521fd0d366972fe5c7/0",
 		},
 	)
 


### PR DESCRIPTION
The logic in e680211bc07d7037a3c6fa5dd869b884ca5a1b3b to determine whether a given state is small enough to fit in a single KV entry in Consul is buggy: because we are using the Transaction API we are base64 encoding it so the payload sent is actually bigger than the raw state, and there is some JSON overhead. This fixes this issue by always trying to store the state in a single entry, and we split it if Consul tells us that is too large. Because we don't try to guess we don't fail anymore.

As far as I know no user as encountered this bug but this patch should be backported to the 0.14 branch as it was the first version to have this feature in the Consul backend.