### PR TITLE
Fix support link (mailto is not supported in GitHub template URLs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Terraform Cloud/Enterprise Troubleshooting and Feature Requests
-    url: mailto:tf-cloud@hashicorp.support
-    about: For issues and feature requests related to the Terraform Cloud/Enterprise platform, please contact tf-cloud@hashicorp.support
+    url: https://support.hashicorp.com/hc/en-us/requests/new
+    about: For issues and feature requests related to the Terraform Cloud/Enterprise platform, please submit a HashiCorp support request or email tf-cloud@hashicorp.support
   - name: Provider-related Feedback and Questions
     url: https://github.com/terraform-providers
     about: Each provider (e.g. AWS, Azure, GCP, Oracle, K8S, etc.) has its own repository, any provider related issues or questions should be directed to appropriate provider repository.


### PR DESCRIPTION
Interestingly, I just learned that the GitHub template config.yml `url` doesn't support `mailto` prefixes. Oops! Let's use the support form instead, which is probably better anyway.

Fixes #28865  😅 