### PR TITLE
commands: `terraform add`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -110,6 +110,12 @@ func initCommands(
 	// that to match.
 
 	Commands = map[string]cli.CommandFactory{
+		"add": func() (cli.Command, error) {
+			return &command.AddCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"apply": func() (cli.Command, error) {
 			return &command.ApplyCommand{
 				Meta: meta,

--- a/internal/command/add.go
+++ b/internal/command/add.go
@@ -1,0 +1,278 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/backend"
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// AddCommand is a Command implementation that generates resource configuration templates.
+type AddCommand struct {
+	Meta
+}
+
+func (c *AddCommand) Run(rawArgs []string) int {
+	// Parse and apply global view arguments
+	common, rawArgs := arguments.ParseView(rawArgs)
+	c.View.Configure(common)
+	args, diags := arguments.ParseAdd(rawArgs)
+	view := views.NewAdd(args.ViewType, c.View, args)
+	if diags.HasErrors() {
+		view.Diagnostics(diags)
+		return 1
+	}
+
+	// Check for user-supplied plugin path
+	var err error
+	if c.pluginPath, err = c.loadPluginPath(); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Error loading plugin path",
+			err.Error(),
+		))
+		view.Diagnostics(diags)
+		return 1
+	}
+
+	// Apply the state arguments to the meta object here because they are later
+	// used when initializing the backend.
+	c.Meta.applyStateArguments(args.State)
+
+	// Load the backend
+	b, backendDiags := c.Backend(nil)
+	diags = diags.Append(backendDiags)
+	if backendDiags.HasErrors() {
+		view.Diagnostics(diags)
+		return 1
+	}
+
+	// We require a local backend
+	local, ok := b.(backend.Local)
+	if !ok {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Unsupported backend",
+			ErrUnsupportedLocalOp,
+		))
+		view.Diagnostics(diags)
+		return 1
+	}
+
+	// This is a read-only command (until -import is implemented)
+	c.ignoreRemoteBackendVersionConflict(b)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Error determining current working directory",
+			err.Error(),
+		))
+		view.Diagnostics(diags)
+		return 1
+	}
+
+	// Build the operation
+	opReq := c.Operation(b)
+	opReq.AllowUnsetVariables = true
+	opReq.ConfigDir = cwd
+	opReq.ConfigLoader, err = c.initConfigLoader()
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Error initializing config loader",
+			err.Error(),
+		))
+		view.Diagnostics(diags)
+		return 1
+	}
+
+	// Get the context
+	ctx, _, ctxDiags := local.Context(opReq)
+	diags = diags.Append(ctxDiags)
+	if ctxDiags.HasErrors() {
+		view.Diagnostics(diags)
+		return 1
+	}
+
+	// load the configuration to verify that the resource address doesn't
+	// already exist in the config.
+	var module *configs.Module
+	if args.Addr.Module.IsRoot() {
+		module = ctx.Config().Module
+	} else {
+		// This is weird, but users can potentially specify non-existant module names
+		cfg := ctx.Config().Root.Descendent(args.Addr.Module.Module())
+		if cfg != nil {
+			module = cfg.Module
+		}
+	}
+
+	if module == nil {
+		// It's fine if the module doesn't actually exist; we don't need to check if the resource exists.
+	} else {
+		if rs, ok := module.ManagedResources[args.Addr.ContainingResource().Config().String()]; ok {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Resource already in configuration",
+				Detail:   fmt.Sprintf("The resource %s is already in this configuration at %s. Resource names must be unique per type in each module.", args.Addr, rs.DeclRange),
+				Subject:  &rs.DeclRange,
+			})
+			c.View.Diagnostics(diags)
+			return 1
+		}
+	}
+
+	// Get the schemas from the context
+	schemas := ctx.Schemas()
+	rs := args.Addr.Resource.Resource
+
+	// If the provider was set on the command line, find the local name for that provider.
+	var providerLocalName string
+	var absProvider addrs.Provider
+	if !args.Provider.IsZero() {
+		absProvider = args.Provider
+		providerLocalName = module.LocalNameForProvider(absProvider)
+	} else {
+		provider := rs.ImpliedProvider()
+		if module != nil {
+			absProvider = module.ImpliedProviderForUnqualifiedType(provider)
+		} else {
+			// lacking any indication otherwise, we'll go with a default provider.
+			absProvider = addrs.NewDefaultProvider(provider)
+		}
+	}
+
+	if _, exists := schemas.Providers[absProvider]; !exists {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Missing schema for provider",
+			fmt.Sprintf("No schema found for provider %s. Please verify that this provider exists in the configuration.", absProvider.String()),
+		))
+		c.View.Diagnostics(diags)
+		return 1
+	}
+
+	schema, schemaVersion := schemas.ResourceTypeConfig(absProvider, rs.Mode, rs.Type)
+	if schema == nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Missing resource schema from provider",
+			fmt.Sprintf("No resource schema found for %s.", rs.Type),
+		))
+		c.View.Diagnostics(diags)
+		return 1
+	}
+
+	var rio *states.ResourceInstanceObject
+	if args.FromResourceAddr != nil {
+		// Get the state
+		env, err := c.Workspace()
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+			return 1
+		}
+		stateMgr, err := b.StateMgr(env)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
+			return 1
+		}
+		if err := stateMgr.RefreshState(); err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to refresh state: %s", err))
+			return 1
+		}
+
+		state := stateMgr.State()
+		if state == nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"No state",
+				"There is no state found for the current configuration, so add cannot populate values.",
+			))
+			c.View.Diagnostics(diags)
+			return 1
+		}
+		ri := state.ResourceInstance(*args.FromResourceAddr)
+		if ri.Current == nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"No state for resource",
+				fmt.Sprintf("There is no state found for the resource %s, so add cannot populate values.", rs.String()),
+			))
+			c.View.Diagnostics(diags)
+			return 1
+		}
+		rio, err = ri.Current.Decode(schema.ImpliedType())
+		if err != nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Error decoding state",
+				fmt.Sprintf("Error decoding state for resource %s: %s", rs.String(), err.Error()),
+			))
+			c.View.Diagnostics(diags)
+			return 1
+		}
+
+		if ri.Current.SchemaVersion != schemaVersion {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Schema version mismatch",
+				fmt.Sprintf("schema version %d for %s in state does not match version %d from the provider", ri.Current.SchemaVersion, rs.String(), schemaVersion),
+			))
+			c.View.Diagnostics(diags)
+			return 1
+		}
+	}
+
+	var val cty.Value
+	if rio != nil {
+		val = rio.Value
+	} else {
+		val = cty.NilVal
+	}
+
+	diags = diags.Append(view.Resource(args.Addr, schema, providerLocalName, val))
+	if diags.HasErrors() {
+		c.View.Diagnostics(diags)
+		return 1
+	}
+
+	return 0
+}
+
+func (c *AddCommand) Help() string {
+	helpText := `
+Usage: terraform [global options] add [options] ADDRESS
+
+  Generates a blank resource template. With no additional flags,
+  the template will be displayed in the terminal. 
+
+Options:
+
+-from-state=ADDRESS		Fill the template with values from an existing resource.
+                        The resource must be the same type as the target address
+						and exist in state.
+
+-out=string 			Write the template to a file. If the file already
+						exists, the template will be appended to the file.
+
+-optional=false			Include optional attributes. Defaults to false.
+
+-provider=provider		Override the configured provider for the resource.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *AddCommand) Synopsis() string {
+	return "Generate a blank resource configuration template"
+}

--- a/internal/command/add.go
+++ b/internal/command/add.go
@@ -260,7 +260,7 @@ func (c *AddCommand) Help() string {
 	helpText := `
 Usage: terraform [global options] add [options] ADDRESS
 
-  Generates a blank resource template. With no additional flags,
+  Generates a blank resource template. With no additional options,
   the template will be displayed in the terminal. 
 
 Options:
@@ -272,7 +272,7 @@ Options:
 -out=string 			Write the template to a file. If the file already
                         exists, the template will be appended to the file.
 
--optional=false			Include optional attributes. Defaults to false.
+-optional=true          Include optional attributes. Defaults to false.
 
 -provider=provider		Override the configured provider for the resource. Conflicts
                         with -from-state

--- a/internal/command/add.go
+++ b/internal/command/add.go
@@ -280,7 +280,7 @@ Options:
 }
 
 func (c *AddCommand) Synopsis() string {
-	return "Generate a blank resource configuration template"
+	return "Generate a resource configuration template"
 }
 
 func (c *AddCommand) getResource(b backend.Enhanced, addr addrs.AbsResource) (*states.Resource, tfdiags.Diagnostics) {

--- a/internal/command/add.go
+++ b/internal/command/add.go
@@ -143,12 +143,12 @@ func (c *AddCommand) Run(rawArgs []string) int {
 	var providerLocalName string
 	rs := args.Addr.Resource.Resource
 
-	// If there is a FromResourceAddr, get the AbsProviderConfig directly from
-	// state.
+	// If we are getting the values from state, get the AbsProviderConfig
+	// directly from state as well.
 	var resource *states.Resource
 	var moreDiags tfdiags.Diagnostics
-	if args.FromResourceAddr != nil {
-		resource, moreDiags = c.getResource(b, args.FromResourceAddr.ContainingResource())
+	if args.FromState {
+		resource, moreDiags = c.getResource(b, args.Addr.ContainingResource())
 		if moreDiags.HasErrors() {
 			diags = diags.Append(moreDiags)
 			c.View.Diagnostics(diags)
@@ -211,8 +211,8 @@ func (c *AddCommand) Run(rawArgs []string) int {
 
 	stateVal := cty.NilVal
 	// Now that we have the schema, we can decode the previously-acquired resource state
-	if args.FromResourceAddr != nil {
-		ri := resource.Instance(args.FromResourceAddr.Resource.Key)
+	if args.FromState {
+		ri := resource.Instance(args.Addr.Resource.Key)
 		if ri.Current == nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
@@ -265,9 +265,8 @@ Usage: terraform [global options] add [options] ADDRESS
 
 Options:
 
--from-state=ADDRESS		Fill the template with values from an existing resource.
-                        The resource must be the same type as the target address
-                        and exist in state.
+-from-state=true		Fill the template with values from an existing resource.
+                        Defaults to false.
 
 -out=string 			Write the template to a file. If the file already
                         exists, the template will be appended to the file.

--- a/internal/command/add_test.go
+++ b/internal/command/add_test.go
@@ -1,0 +1,531 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/mitchellh/cli"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// simple test cases with a simple resource schema
+func TestAdd_basic(t *testing.T) {
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("add/basic"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	p := testProvider()
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
+			"test_instance": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":    {Type: cty.String, Optional: true, Computed: true},
+						"ami":   {Type: cty.String, Optional: true, Description: "the ami to use"},
+						"value": {Type: cty.String, Required: true, Description: "a value of a thing"},
+					},
+				},
+			},
+		},
+	}
+
+	overrides := &testingOverrides{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"):                                providers.FactoryFixed(p),
+			addrs.NewProvider("registry.terraform.io", "happycorp", "test"): providers.FactoryFixed(p),
+		},
+	}
+
+	t.Run("basic", func(t *testing.T) {
+		view, done := testView(t)
+		c := &AddCommand{
+			Meta: Meta{
+				testingOverrides: overrides,
+				View:             view,
+			},
+		}
+		args := []string{"test_instance.new"}
+		code := c.Run(args)
+		output := done(t)
+		if code != 0 {
+			fmt.Println(output.Stderr())
+			t.Fatalf("wrong exit status. Got %d, want 0", code)
+		}
+		expected := `resource "test_instance" "new" {
+  value = null # REQUIRED string
+}
+`
+
+		if !cmp.Equal(output.Stdout(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, output.Stdout()))
+		}
+	})
+
+	t.Run("basic to file", func(t *testing.T) {
+		view, done := testView(t)
+		c := &AddCommand{
+			Meta: Meta{
+				testingOverrides: overrides,
+				View:             view,
+			},
+		}
+		outPath := "add.tf"
+		args := []string{fmt.Sprintf("-out=%s", outPath), "test_instance.new"}
+		code := c.Run(args)
+		output := done(t)
+		if code != 0 {
+			fmt.Println(output.Stderr())
+			t.Fatalf("wrong exit status. Got %d, want 0", code)
+		}
+		expected := `resource "test_instance" "new" {
+  value = null # REQUIRED string
+}
+`
+		result, err := os.ReadFile(outPath)
+		if err != nil {
+			t.Fatalf("error reading result file %s: %s", outPath, err.Error())
+		}
+		// While the entire directory will get removed once the whole test suite
+		// is done, we remove this lest it gets in the way of another (not yet
+		// written) test.
+		os.Remove(outPath)
+
+		if !cmp.Equal(expected, string(result)) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, string(result)))
+		}
+	})
+
+	t.Run("optionals", func(t *testing.T) {
+		view, done := testView(t)
+		c := &AddCommand{
+			Meta: Meta{
+				testingOverrides: overrides,
+				View:             view,
+			},
+		}
+		args := []string{"-optional", "test_instance.new"}
+		code := c.Run(args)
+		if code != 0 {
+			t.Fatalf("wrong exit status. Got %d, want 0", code)
+		}
+		output := done(t)
+		expected := `resource "test_instance" "new" {
+  ami   = null # OPTIONAL string
+  id    = null # OPTIONAL string
+  value = null # REQUIRED string
+}
+`
+
+		if !cmp.Equal(output.Stdout(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, output.Stdout()))
+		}
+	})
+
+	t.Run("alternate provider for resource", func(t *testing.T) {
+		view, done := testView(t)
+		c := &AddCommand{
+			Meta: Meta{
+				testingOverrides: overrides,
+				View:             view,
+			},
+		}
+		args := []string{"-provider=happycorp/test", "test_instance.new"}
+		code := c.Run(args)
+		if code != 0 {
+			t.Fatalf("wrong exit status. Got %d, want 0", code)
+		}
+		output := done(t)
+
+		// The provider happycorp/test has a localname "othertest" in the provider configuration.
+		expected := `resource "test_instance" "new" {
+  provider = othertest
+  value    = null # REQUIRED string
+}
+`
+
+		if !cmp.Equal(output.Stdout(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, output.Stdout()))
+		}
+	})
+
+	t.Run("resource exists error", func(t *testing.T) {
+		view, done := testView(t)
+		c := &AddCommand{
+			Meta: Meta{
+				testingOverrides: overrides,
+				View:             view,
+			},
+		}
+		args := []string{"test_instance.exists"}
+		code := c.Run(args)
+		if code != 1 {
+			t.Fatalf("wrong exit status. Got %d, want 0", code)
+		}
+
+		output := done(t)
+		if !strings.Contains(output.Stderr(), "The resource test_instance.exists is already in this configuration") {
+			t.Fatalf("missing expected error message: %s", output.Stderr())
+		}
+	})
+
+	t.Run("provider not in configuration", func(t *testing.T) {
+		view, done := testView(t)
+		c := &AddCommand{
+			Meta: Meta{
+				testingOverrides: overrides,
+				View:             view,
+			},
+		}
+		args := []string{"toast_instance.new"}
+		code := c.Run(args)
+		if code != 1 {
+			t.Fatalf("wrong exit status. Got %d, want 0", code)
+		}
+
+		output := done(t)
+		if !strings.Contains(output.Stderr(), "No schema found for provider registry.terraform.io/hashicorp/toast.") {
+			t.Fatalf("missing expected error message: %s", output.Stderr())
+		}
+	})
+
+	t.Run("no schema for resource", func(t *testing.T) {
+		view, done := testView(t)
+		c := &AddCommand{
+			Meta: Meta{
+				testingOverrides: overrides,
+				View:             view,
+			},
+		}
+		args := []string{"test_pet.meow"}
+		code := c.Run(args)
+		if code != 1 {
+			t.Fatalf("wrong exit status. Got %d, want 0", code)
+		}
+
+		output := done(t)
+		if !strings.Contains(output.Stderr(), "No resource schema found for test_pet.") {
+			t.Fatalf("missing expected error message: %s", output.Stderr())
+		}
+	})
+}
+
+func TestAdd(t *testing.T) {
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("add/module"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	// a simple hashicorp/test provider, and a more complex happycorp/test provider
+	p := testProvider()
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
+			"test_instance": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Required: true},
+					},
+				},
+			},
+		},
+	}
+
+	happycorp := testProvider()
+	happycorp.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
+			"test_instance": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":    {Type: cty.String, Optional: true, Computed: true},
+						"ami":   {Type: cty.String, Optional: true, Description: "the ami to use"},
+						"value": {Type: cty.String, Required: true, Description: "a value of a thing"},
+						"disks": {
+							NestedType: &configschema.Object{
+								Nesting: configschema.NestingList,
+								Attributes: map[string]*configschema.Attribute{
+									"size":        {Type: cty.String, Optional: true},
+									"mount_point": {Type: cty.String, Required: true},
+								},
+							},
+							Optional: true,
+						},
+					},
+					BlockTypes: map[string]*configschema.NestedBlock{
+						"network_interface": {
+							Nesting:  configschema.NestingList,
+							MinItems: 1,
+							Block: configschema.Block{
+								Attributes: map[string]*configschema.Attribute{
+									"device_index": {Type: cty.String, Optional: true},
+									"description":  {Type: cty.String, Optional: true},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	providerSource, psClose := newMockProviderSource(t, map[string][]string{
+		"registry.terraform.io/happycorp/test": {"1.0.0"},
+		"registry.terraform.io/hashicorp/test": {"1.0.0"},
+	})
+	defer psClose()
+
+	overrides := &testingOverrides{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewProvider("registry.terraform.io", "happycorp", "test"): providers.FactoryFixed(happycorp),
+			addrs.NewDefaultProvider("test"):                                providers.FactoryFixed(p),
+		},
+	}
+
+	// the test fixture uses a module, so we need to run init.
+	m := Meta{
+		testingOverrides: overrides,
+		ProviderSource:   providerSource,
+		Ui:               new(cli.MockUi),
+	}
+
+	init := &InitCommand{
+		Meta: m,
+	}
+
+	code := init.Run([]string{})
+	if code != 0 {
+		t.Fatal("init failed")
+	}
+
+	t.Run("optional", func(t *testing.T) {
+		view, done := testView(t)
+		c := &AddCommand{
+			Meta: Meta{
+				testingOverrides: overrides,
+				View:             view,
+			},
+		}
+		args := []string{"-optional", "test_instance.new"}
+		code := c.Run(args)
+		output := done(t)
+		if code != 0 {
+			t.Fatalf("wrong exit status. Got %d, want 0", code)
+		}
+
+		expected := `resource "test_instance" "new" {
+  ami = null           # OPTIONAL string
+  disks = [{           # OPTIONAL list of object
+    mount_point = null # REQUIRED string
+    size        = null # OPTIONAL string
+  }]
+  id    = null # OPTIONAL string
+  value = null # REQUIRED string
+  network_interface {
+    description  = null # OPTIONAL string
+    device_index = null # OPTIONAL string
+  }
+}
+`
+
+		if !cmp.Equal(output.Stdout(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, output.Stdout()))
+		}
+
+	})
+
+	t.Run("chooses correct provider for root module", func(t *testing.T) {
+		// in the root module of this test fixture, "test" is the local name for "happycorp/test"
+		view, done := testView(t)
+		c := &AddCommand{
+			Meta: Meta{
+				testingOverrides: overrides,
+				View:             view,
+			},
+		}
+		args := []string{"test_instance.new"}
+		code := c.Run(args)
+		output := done(t)
+		if code != 0 {
+			t.Fatalf("wrong exit status. Got %d, want 0", code)
+		}
+
+		expected := `resource "test_instance" "new" {
+  value = null # REQUIRED string
+  network_interface {
+  }
+}
+`
+
+		if !cmp.Equal(output.Stdout(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, output.Stdout()))
+		}
+	})
+
+	t.Run("chooses correct provider for child module", func(t *testing.T) {
+		// in the child module of this test fixture, "test" is a default "hashicorp/test" provider
+		view, done := testView(t)
+		c := &AddCommand{
+			Meta: Meta{
+				testingOverrides: overrides,
+				View:             view,
+			},
+		}
+		args := []string{"module.child.test_instance.new"}
+		code := c.Run(args)
+		output := done(t)
+		if code != 0 {
+			t.Fatalf("wrong exit status. Got %d, want 0", code)
+		}
+
+		expected := `resource "test_instance" "new" {
+  id = null # REQUIRED string
+}
+`
+
+		if !cmp.Equal(output.Stdout(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, output.Stdout()))
+		}
+	})
+
+	t.Run("chooses correct provider for an unknown module", func(t *testing.T) {
+		// it's weird but ok to use a new/unknown module name; terraform will
+		// fall back on default providers (unless a -provider argument is
+		// supplied)
+		view, done := testView(t)
+		c := &AddCommand{
+			Meta: Meta{
+				testingOverrides: overrides,
+				View:             view,
+			},
+		}
+		args := []string{"module.madeup.test_instance.new"}
+		code := c.Run(args)
+		output := done(t)
+		if code != 0 {
+			t.Fatalf("wrong exit status. Got %d, want 0", code)
+		}
+
+		expected := `resource "test_instance" "new" {
+  id = null # REQUIRED string
+}
+`
+
+		if !cmp.Equal(output.Stdout(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, output.Stdout()))
+		}
+	})
+}
+
+func TestAdd_from_state(t *testing.T) {
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("add/basic"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	// write some state
+	testState := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_instance",
+				Name: "old",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON:    []byte("{\"id\":\"bar\",\"ami\":\"ami-123456\",\"disks\":[{\"mount_point\":\"diska\",\"size\":null}],\"value\":\"bloop\"}"),
+				Status:       states.ObjectReady,
+				Dependencies: []addrs.ConfigResource{},
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	})
+	f, err := os.Create("terraform.tfstate")
+	if err != nil {
+		t.Fatalf("failed to create temporary state file: %s", err)
+	}
+	defer f.Close()
+	err = writeStateForTesting(testState, f)
+	if err != nil {
+		t.Fatalf("failed to write state file: %s", err)
+	}
+
+	p := testProvider()
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
+			"test_instance": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":    {Type: cty.String, Optional: true, Computed: true},
+						"ami":   {Type: cty.String, Optional: true, Description: "the ami to use"},
+						"value": {Type: cty.String, Required: true, Description: "a value of a thing"},
+						"disks": {
+							NestedType: &configschema.Object{
+								Nesting: configschema.NestingList,
+								Attributes: map[string]*configschema.Attribute{
+									"size":        {Type: cty.String, Optional: true},
+									"mount_point": {Type: cty.String, Required: true},
+								},
+							},
+							Optional: true,
+						},
+					},
+					BlockTypes: map[string]*configschema.NestedBlock{
+						"network_interface": {
+							Nesting:  configschema.NestingList,
+							MinItems: 1,
+							Block: configschema.Block{
+								Attributes: map[string]*configschema.Attribute{
+									"device_index": {Type: cty.String, Optional: true},
+									"description":  {Type: cty.String, Optional: true},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	overrides := &testingOverrides{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"):                                providers.FactoryFixed(p),
+			addrs.NewProvider("registry.terraform.io", "happycorp", "test"): providers.FactoryFixed(p),
+		},
+	}
+	view, done := testView(t)
+	c := &AddCommand{
+		Meta: Meta{
+			testingOverrides: overrides,
+			View:             view,
+		},
+	}
+
+	args := []string{"-from-state=test_instance.old", "-optional", "test_instance.new"}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		fmt.Println(output.Stderr())
+		t.Fatalf("wrong exit status. Got %d, want 0", code)
+	}
+
+	expected := `resource "test_instance" "new" {
+  ami = "ami-123456"
+  disks = [
+    {
+      mount_point = "diska"
+      size        = null
+    },
+  ]
+  id    = "bar"
+  value = "bloop"
+}
+`
+
+	if !cmp.Equal(output.Stdout(), expected) {
+		t.Fatalf("wrong output:\n%s", cmp.Diff(expected, output.Stdout()))
+	}
+
+}

--- a/internal/command/add_test.go
+++ b/internal/command/add_test.go
@@ -433,7 +433,7 @@ func TestAdd_from_state(t *testing.T) {
 			addrs.Resource{
 				Mode: addrs.ManagedResourceMode,
 				Type: "test_instance",
-				Name: "old",
+				Name: "new",
 			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 			&states.ResourceInstanceObjectSrc{
 				AttrsJSON:    []byte("{\"id\":\"bar\",\"ami\":\"ami-123456\",\"disks\":[{\"mount_point\":\"diska\",\"size\":null}],\"value\":\"bloop\"}"),
@@ -503,7 +503,7 @@ func TestAdd_from_state(t *testing.T) {
 		},
 	}
 
-	args := []string{"-from-state=test_instance.old", "test_instance.new"}
+	args := []string{"-from-state", "test_instance.new"}
 	code := c.Run(args)
 	output := done(t)
 	if code != 0 {

--- a/internal/command/add_test.go
+++ b/internal/command/add_test.go
@@ -137,16 +137,16 @@ func TestAdd_basic(t *testing.T) {
 				View:             view,
 			},
 		}
-		args := []string{"-provider=happycorp/test", "test_instance.new"}
+		args := []string{"-provider=provider[\"registry.terraform.io/happycorp/test\"].alias", "test_instance.new"}
 		code := c.Run(args)
+		output := done(t)
 		if code != 0 {
 			t.Fatalf("wrong exit status. Got %d, want 0", code)
 		}
-		output := done(t)
 
 		// The provider happycorp/test has a localname "othertest" in the provider configuration.
 		expected := `resource "test_instance" "new" {
-  provider = othertest
+  provider = othertest.alias
   value    = null # REQUIRED string
 }
 `

--- a/internal/command/add_test.go
+++ b/internal/command/add_test.go
@@ -323,9 +323,9 @@ func TestAdd(t *testing.T) {
     mount_point = null # REQUIRED string
     size        = null # OPTIONAL string
   }]
-  id    = null # OPTIONAL string
-  value = null # REQUIRED string
-  network_interface {
+  id    = null          # OPTIONAL string
+  value = null          # REQUIRED string
+  network_interface {   # REQUIRED block
     description  = null # OPTIONAL string
     device_index = null # OPTIONAL string
   }
@@ -355,8 +355,8 @@ func TestAdd(t *testing.T) {
 		}
 
 		expected := `resource "test_instance" "new" {
-  value = null # REQUIRED string
-  network_interface {
+  value = null        # REQUIRED string
+  network_interface { # REQUIRED block
   }
 }
 `
@@ -503,7 +503,7 @@ func TestAdd_from_state(t *testing.T) {
 		},
 	}
 
-	args := []string{"-from-state=test_instance.old", "-optional", "test_instance.new"}
+	args := []string{"-from-state=test_instance.old", "test_instance.new"}
 	code := c.Run(args)
 	output := done(t)
 	if code != 0 {

--- a/internal/command/arguments/add.go
+++ b/internal/command/arguments/add.go
@@ -1,0 +1,129 @@
+package arguments
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// Add represents the command-line arguments for the Add command.
+type Add struct {
+	// Addr specifies which resource to generate configuration for.
+	Addr addrs.AbsResourceInstance
+
+	// FromResourceAddr specifies the address of an existing resource in state
+	// which should be used to populate the template.
+	FromResourceAddr *addrs.AbsResourceInstance
+
+	// OutPath contains an optional path to store the generated configuration.
+	OutPath string
+
+	// Optional specifies whether or not to include optional attributes in the
+	// generated configuration. Defaults to false.
+	Optional bool
+
+	// Provider specifies the provider for the target.
+	Provider addrs.Provider
+
+	// State from the common extended flags
+	State *State
+
+	// ViewType specifies which output format to use
+	ViewType ViewType
+}
+
+func ParseAdd(args []string) (*Add, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	add := &Add{State: &State{}, ViewType: ViewHuman}
+
+	var provider string
+	var fromAddr string
+
+	cmdFlags := extendedFlagSet("add", add.State, nil, nil)
+	cmdFlags.StringVar(&fromAddr, "from-state", "", "fill attribute values from a resource already managed by terraform")
+	cmdFlags.BoolVar(&add.Optional, "optional", false, "include optional attributes")
+	cmdFlags.StringVar(&add.OutPath, "out", "", "out")
+	cmdFlags.StringVar(&provider, "provider", "", "provider")
+
+	if err := cmdFlags.Parse(args); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line flags",
+			err.Error(),
+		))
+		return add, diags
+	}
+
+	if provider != "" {
+		absProvider, providerDiags := addrs.ParseProviderSourceString(provider)
+		if providerDiags.HasErrors() {
+			// The diagnostics returned from ParseProviderSourceString are
+			// specific to the "source" attribute and not suitable for this use
+			// case.
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				fmt.Sprintf("Invalid provider string: %s", provider),
+				`The "provider" argument must be in the format "[hostname/][namespace/]name"`,
+			))
+			return add, diags
+		}
+		add.Provider = absProvider
+	}
+
+	args = cmdFlags.Args()
+
+	if len(args) == 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Too few command line arguments",
+			"Expected exactly one positional argument.",
+		))
+		return add, diags
+	}
+
+	if len(args) > 1 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Too many command line arguments",
+			"Expected exactly one positional argument.",
+		))
+		return add, diags
+	}
+
+	// parse address from the argument
+	addr, addrDiags := addrs.ParseAbsResourceInstanceStr(args[0])
+	if addrDiags.HasErrors() {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			fmt.Sprintf("Error parsing resource address: %s", args[0]),
+			"This command requires that the address argument references one specific resource instance.",
+		))
+		return add, diags
+	}
+	add.Addr = addr
+
+	if fromAddr != "" {
+		stateAddr, addrDiags := addrs.ParseAbsResourceInstanceStr(fromAddr)
+		if addrDiags.HasErrors() {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				fmt.Sprintf("Error parsing resource address: %s", stateAddr),
+				fmt.Sprintf("Error parsing -from-state resource address: %s", addrDiags.Err().Error()),
+			))
+			return add, diags
+		}
+		add.FromResourceAddr = &stateAddr
+
+		if stateAddr.Resource.Resource.Type != addr.Resource.Resource.Type {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Resource type mismatch",
+				"The target address and -from-state address must have the same resource type.",
+			))
+			return add, diags
+		}
+	}
+
+	return add, diags
+}

--- a/internal/command/arguments/add.go
+++ b/internal/command/arguments/add.go
@@ -76,7 +76,7 @@ func ParseAdd(args []string) (*Add, tfdiags.Diagnostics) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Too few command line arguments",
-			"Expected exactly one positional argument.",
+			"Expected exactly one positional argument, giving the address of the resource configuration to generate.",
 		))
 		return add, diags
 	}
@@ -96,7 +96,7 @@ func ParseAdd(args []string) (*Add, tfdiags.Diagnostics) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			fmt.Sprintf("Error parsing resource address: %s", args[0]),
-			"This command requires that the address argument references one specific resource instance.",
+			"This command requires that the address argument specifies one resource instance.",
 		))
 		return add, diags
 	}
@@ -106,8 +106,8 @@ func ParseAdd(args []string) (*Add, tfdiags.Diagnostics) {
 		if add.Provider != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
-				"Conflicting command flags",
-				"Cannot use both -from-resource and -provider. The provider will be determined from the resource's state.",
+				"Incompatible command-line options",
+				"Cannot use both -from-state and -provider. The provider will be determined from the resource's state.",
 			))
 			return add, diags
 		}

--- a/internal/command/arguments/add.go
+++ b/internal/command/arguments/add.go
@@ -26,19 +26,19 @@ type Add struct {
 	// Provider specifies the provider for the target.
 	Provider addrs.Provider
 
-	// State from the common extended flags
+	// State from the common extended flags.
 	State *State
 
-	// ViewType specifies which output format to use
+	// ViewType specifies which output format to use. ViewHuman is currently the
+	// only supported view type.
 	ViewType ViewType
 }
 
 func ParseAdd(args []string) (*Add, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
 	add := &Add{State: &State{}, ViewType: ViewHuman}
 
-	var provider string
-	var fromAddr string
+	var diags tfdiags.Diagnostics
+	var provider, fromAddr string
 
 	cmdFlags := extendedFlagSet("add", add.State, nil, nil)
 	cmdFlags.StringVar(&fromAddr, "from-state", "", "fill attribute values from a resource already managed by terraform")
@@ -72,7 +72,6 @@ func ParseAdd(args []string) (*Add, tfdiags.Diagnostics) {
 	}
 
 	args = cmdFlags.Args()
-
 	if len(args) == 0 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -108,7 +107,7 @@ func ParseAdd(args []string) (*Add, tfdiags.Diagnostics) {
 		if addrDiags.HasErrors() {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
-				fmt.Sprintf("Error parsing resource address: %s", stateAddr),
+				"Invalid resource addrses",
 				fmt.Sprintf("Error parsing -from-state resource address: %s", addrDiags.Err().Error()),
 			))
 			return add, diags

--- a/internal/command/arguments/add_test.go
+++ b/internal/command/arguments/add_test.go
@@ -1,0 +1,136 @@
+package arguments
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestParseAdd(t *testing.T) {
+	// need a pointer value for the -from-resource-addr tests
+	fromResource := mustResourceInstanceAddr("test_foo.bar")
+
+	tests := map[string]struct {
+		args      []string
+		want      *Add
+		wantError string
+	}{
+		"defaults": {
+			[]string{"test_foo.bar"},
+			&Add{
+				Addr:     mustResourceInstanceAddr("test_foo.bar"),
+				State:    &State{Lock: true},
+				ViewType: ViewHuman,
+			},
+			``,
+		},
+		"some flags": {
+			[]string{"-optional=true", "test_foo.bar"},
+			&Add{
+				Addr:     mustResourceInstanceAddr("test_foo.bar"),
+				State:    &State{Lock: true},
+				Optional: true,
+				ViewType: ViewHuman,
+			},
+			``,
+		},
+		"-from-state": {
+			[]string{"-from-state=test_foo.bar", "module.foo.test_foo.baz"},
+			&Add{
+				Addr:             mustResourceInstanceAddr("module.foo.test_foo.baz"),
+				State:            &State{Lock: true},
+				ViewType:         ViewHuman,
+				FromResourceAddr: &fromResource,
+			},
+			``,
+		},
+		"-provider": {
+			[]string{"-provider=example.com/happycorp/test", "test_foo.bar"},
+			&Add{
+				Addr:     mustResourceInstanceAddr("test_foo.bar"),
+				State:    &State{Lock: true},
+				ViewType: ViewHuman,
+				Provider: addrs.NewProvider("example.com", "happycorp", "test"),
+			},
+			``,
+		},
+
+		// Error cases
+		"missing required argument": {
+			nil,
+			&Add{
+				ViewType: ViewHuman,
+				State:    &State{Lock: true},
+			},
+			`Too few command line arguments`,
+		},
+		"too many arguments": {
+			[]string{"-from-state=resource_foo.baz", "resource_foo.bar", "module.foo.resource_foo.baz"},
+			&Add{
+				ViewType: ViewHuman,
+				State:    &State{Lock: true},
+			},
+			`Too many command line arguments`,
+		},
+		"invalid target address": {
+			[]string{"definitely-not_a-VALID-resource"},
+			&Add{
+				ViewType: ViewHuman,
+				State:    &State{Lock: true},
+			},
+			`Error parsing resource address: definitely-not_a-VALID-resource`,
+		},
+		"invalid provider flag": {
+			[]string{"-provider=/this/isn't/quite/correct", "resource_foo.bar"},
+			&Add{
+				ViewType: ViewHuman,
+				State:    &State{Lock: true},
+			},
+			`Invalid provider string: /this/isn't/quite/correct`,
+		},
+		"resource type mismatch": {
+			[]string{"-from-state=test_foo.bar", "test_compute.bar"},
+			&Add{ViewType: ViewHuman,
+				Addr:             mustResourceInstanceAddr("test_compute.bar"),
+				State:            &State{Lock: true},
+				FromResourceAddr: &fromResource,
+			},
+			`Resource type mismatch`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, diags := ParseAdd(test.args)
+			if test.wantError != "" {
+				if len(diags) != 1 {
+					t.Fatalf("got %d diagnostics; want exactly 1\n", len(diags))
+				}
+				if diags[0].Severity() != tfdiags.Error {
+					t.Fatalf("got a warning; want an error\n%s", diags.ErrWithWarnings())
+				}
+				if desc := diags[0].Description(); desc.Summary != test.wantError {
+					t.Fatalf("wrong error\ngot:  %s\nwant: %s", desc.Summary, test.wantError)
+				}
+			} else {
+				if len(diags) != 0 {
+					t.Fatalf("got %d diagnostics; want none\n%s", len(diags), diags.Err().Error())
+				}
+			}
+
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
+			}
+		})
+	}
+}
+
+func mustResourceInstanceAddr(s string) addrs.AbsResourceInstance {
+	addr, diags := addrs.ParseAbsResourceInstanceStr(s)
+	if diags.HasErrors() {
+		panic(diags.Err())
+	}
+	return addr
+}

--- a/internal/command/arguments/add_test.go
+++ b/internal/command/arguments/add_test.go
@@ -47,12 +47,14 @@ func TestParseAdd(t *testing.T) {
 			``,
 		},
 		"-provider": {
-			[]string{"-provider=example.com/happycorp/test", "test_foo.bar"},
+			[]string{"-provider=provider[\"example.com/happycorp/test\"]", "test_foo.bar"},
 			&Add{
 				Addr:     mustResourceInstanceAddr("test_foo.bar"),
 				State:    &State{Lock: true},
 				ViewType: ViewHuman,
-				Provider: addrs.NewProvider("example.com", "happycorp", "test"),
+				Provider: &addrs.AbsProviderConfig{
+					Provider: addrs.NewProvider("example.com", "happycorp", "test"),
+				},
 			},
 			``,
 		},
@@ -107,6 +109,18 @@ func TestParseAdd(t *testing.T) {
 				FromResourceAddr: &fromResource,
 			},
 			`Resource type mismatch`,
+		},
+		"conflicting -provider and -from-state flags": {
+			[]string{"-from-state=test_foo.bar", "-provider=provider[\"example.com/happycorp/test\"]", "test_compute.bar"},
+			&Add{ViewType: ViewHuman,
+				Addr:             mustResourceInstanceAddr("test_compute.bar"),
+				State:            &State{Lock: true},
+				FromResourceAddr: nil,
+				Provider: &addrs.AbsProviderConfig{
+					Provider: addrs.NewProvider("example.com", "happycorp", "test"),
+				},
+			},
+			`Conflicting command flags`,
 		},
 	}
 

--- a/internal/command/arguments/add_test.go
+++ b/internal/command/arguments/add_test.go
@@ -56,6 +56,15 @@ func TestParseAdd(t *testing.T) {
 			},
 			``,
 		},
+		"state options from extended flag set": {
+			[]string{"-state=local.tfstate", "test_foo.bar"},
+			&Add{
+				Addr:     mustResourceInstanceAddr("test_foo.bar"),
+				State:    &State{Lock: true, StatePath: "local.tfstate"},
+				ViewType: ViewHuman,
+			},
+			``,
+		},
 
 		// Error cases
 		"missing required argument": {

--- a/internal/command/arguments/add_test.go
+++ b/internal/command/arguments/add_test.go
@@ -110,7 +110,7 @@ func TestParseAdd(t *testing.T) {
 			},
 			`Resource type mismatch`,
 		},
-		"conflicting -provider and -from-state flags": {
+		"incompatible options": {
 			[]string{"-from-state=test_foo.bar", "-provider=provider[\"example.com/happycorp/test\"]", "test_compute.bar"},
 			&Add{ViewType: ViewHuman,
 				Addr:             mustResourceInstanceAddr("test_compute.bar"),
@@ -120,7 +120,7 @@ func TestParseAdd(t *testing.T) {
 					Provider: addrs.NewProvider("example.com", "happycorp", "test"),
 				},
 			},
-			`Conflicting command flags`,
+			`Incompatible command-line options`,
 		},
 	}
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -935,6 +935,14 @@ func mustResourceAddr(s string) addrs.ConfigResource {
 	return addr.Config()
 }
 
+func mustProviderConfig(s string) addrs.AbsProviderConfig {
+	p, diags := addrs.ParseAbsProviderConfigStr(s)
+	if diags.HasErrors() {
+		panic(diags.Err())
+	}
+	return p
+}
+
 // This map from provider type name to namespace is used by the fake registry
 // when called via LookupLegacyProvider. Providers not in this map will return
 // a 404 Not Found error.

--- a/internal/command/testdata/add/basic/main.tf
+++ b/internal/command/testdata/add/basic/main.tf
@@ -1,0 +1,14 @@
+terraform {
+    required_providers  {
+        test = {
+            source = "hashicorp/test"
+        }
+        othertest = {
+            source = "happycorp/test"
+        }
+    }
+}
+
+resource "test_instance" "exists" {
+    // I exist!
+}

--- a/internal/command/testdata/add/module/main.tf
+++ b/internal/command/testdata/add/module/main.tf
@@ -1,0 +1,17 @@
+terraform {
+    required_providers  {
+        // This is deliberately odd, so we can test that the correct happycorp
+        // provider is selected for any test_ resource added for this module
+        test = {
+            source = "happycorp/test"
+        }
+    }
+}
+
+resource "test_instance" "exists" {
+    // I exist!
+}
+
+module "child" {
+    source = "./module"
+}

--- a/internal/command/testdata/add/module/module/main.tf
+++ b/internal/command/testdata/add/module/module/main.tf
@@ -1,0 +1,9 @@
+terraform {
+    required_providers {
+        test = {
+            source = "hashicorp/test"
+        }
+    }
+}
+
+resource "test_instance" "exists" {}

--- a/internal/command/views/add.go
+++ b/internal/command/views/add.go
@@ -1,0 +1,496 @@
+package views
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Add is the view interface for the "terraform add" command.
+type Add interface {
+	Resource(addrs.AbsResourceInstance, *configschema.Block, string, cty.Value) error
+	Diagnostics(tfdiags.Diagnostics)
+}
+
+// NewAdd returns an initialized Validate implementation for the given ViewType.
+func NewAdd(vt arguments.ViewType, view *View, args *arguments.Add) Add {
+	return &addHuman{
+		view:     view,
+		optional: args.Optional,
+		outPath:  args.OutPath,
+	}
+}
+
+type addHuman struct {
+	view     *View
+	optional bool
+	outPath  string
+}
+
+func (v *addHuman) Resource(addr addrs.AbsResourceInstance, schema *configschema.Block, provider string, stateVal cty.Value) error {
+	var buf strings.Builder
+	buf.WriteString(fmt.Sprintf("resource %q %q {\n", addr.Resource.Resource.Type, addr.Resource.Resource.Name))
+	if provider != "" {
+		buf.WriteString(strings.Repeat(" ", 2))
+		buf.WriteString(fmt.Sprintf("provider = %s\n", provider))
+	}
+
+	if stateVal.RawEquals(cty.NilVal) {
+		if err := v.writeConfigAttributes(&buf, schema.Attributes, 2); err != nil {
+			return err
+		}
+		if err := v.writeConfigBlocks(&buf, schema.BlockTypes, 2); err != nil {
+			return err
+		}
+	} else {
+		if err := v.writeConfigAttributesFromExisting(&buf, stateVal, schema.Attributes, 2); err != nil {
+			return err
+		}
+		if err := v.writeConfigBlocksFromExisting(&buf, stateVal, schema.BlockTypes, 2); err != nil {
+			return err
+		}
+	}
+
+	buf.WriteString("}")
+
+	// The output better be valid HCL which can be parsed and formatted.
+	formatted := hclwrite.Format([]byte(buf.String()))
+
+	var err error
+	if v.outPath == "" {
+		_, err = v.view.streams.Println(string(formatted))
+		return err
+	} else {
+		// The Println call above adds this newline automatically; we add it manually here.
+		formatted = append(formatted, '\n')
+		return os.WriteFile(v.outPath, formatted, 0600)
+	}
+}
+
+func (v *addHuman) Diagnostics(diags tfdiags.Diagnostics) {
+	v.view.Diagnostics(diags)
+}
+
+func (v *addHuman) writeConfigAttributes(buf *strings.Builder, attrs map[string]*configschema.Attribute, indent int) error {
+	if len(attrs) == 0 {
+		return nil
+	}
+
+	// Get a list of sorted attribute names so the output will be consistent between runs.
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for i := range keys {
+		name := keys[i]
+		attrS := attrs[name]
+		if attrS.NestedType != nil {
+			if err := v.writeConfigNestedTypeAttribute(buf, name, attrS, indent); err != nil {
+				return err
+			}
+			continue
+		}
+		if attrS.Required {
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString(fmt.Sprintf("%s = ", name))
+			tok := hclwrite.TokensForValue(attrS.EmptyValue())
+			if _, err := tok.WriteTo(buf); err != nil {
+				return err
+			}
+			writeAttrTypeConstraint(buf, attrS)
+		} else if attrS.Optional && v.optional {
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString(fmt.Sprintf("%s = ", name))
+			tok := hclwrite.TokensForValue(attrS.EmptyValue())
+			if _, err := tok.WriteTo(buf); err != nil {
+				return err
+			}
+			writeAttrTypeConstraint(buf, attrS)
+		}
+	}
+	return nil
+}
+
+func (v *addHuman) writeConfigAttributesFromExisting(buf *strings.Builder, stateVal cty.Value, attrs map[string]*configschema.Attribute, indent int) error {
+	if len(attrs) == 0 {
+		return nil
+	}
+
+	// Get a list of sorted attribute names so the output will be consistent between runs.
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for i := range keys {
+		name := keys[i]
+		attrS := attrs[name]
+		if attrS.NestedType != nil {
+			if err := v.writeConfigNestedTypeAttributeFromExisting(buf, name, attrS, stateVal, indent); err != nil {
+				return err
+			}
+			continue
+		}
+		if attrS.Required {
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString(fmt.Sprintf("%s = ", name))
+
+			var val cty.Value
+			if stateVal.Type().HasAttribute(name) {
+				val = stateVal.GetAttr(name)
+			} else {
+				val = attrS.EmptyValue()
+			}
+			if attrS.Sensitive || val.IsMarked() {
+				buf.WriteString("null # sensitive")
+			} else {
+				tok := hclwrite.TokensForValue(val)
+				if _, err := tok.WriteTo(buf); err != nil {
+					return err
+				}
+			}
+
+			buf.WriteString("\n")
+
+		} else if attrS.Optional && v.optional {
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString(fmt.Sprintf("%s = ", name))
+
+			var val cty.Value
+			if !stateVal.RawEquals(cty.NilVal) && stateVal.Type().HasAttribute(name) {
+				val = stateVal.GetAttr(name)
+			} else {
+				val = attrS.EmptyValue()
+			}
+			if attrS.Sensitive || val.IsMarked() {
+				buf.WriteString("null # sensitive")
+			} else {
+				tok := hclwrite.TokensForValue(val)
+				if _, err := tok.WriteTo(buf); err != nil {
+					return err
+				}
+			}
+
+			buf.WriteString("\n")
+		}
+	}
+	return nil
+}
+
+func (v *addHuman) writeConfigBlocks(buf *strings.Builder, blocks map[string]*configschema.NestedBlock, indent int) error {
+	if len(blocks) == 0 {
+		return nil
+	}
+
+	// Get a list of sorted block names so the output will be consistent between runs.
+	names := make([]string, 0, len(blocks))
+	for k := range blocks {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	for i := range names {
+		name := names[i]
+		blockS := blocks[name]
+
+		if blockS.MinItems > 0 {
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString(fmt.Sprintf("%s {\n", name))
+			if len(blockS.Attributes) > 0 {
+				if err := v.writeConfigAttributes(buf, blockS.Attributes, indent+2); err != nil {
+					return err
+				}
+			}
+			if len(blockS.BlockTypes) > 0 {
+				if err := v.writeConfigBlocks(buf, blockS.BlockTypes, indent+2); err != nil {
+					return err
+				}
+			}
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString("}\n")
+		}
+	}
+	return nil
+}
+
+func (v *addHuman) writeConfigNestedTypeAttribute(buf *strings.Builder, name string, schema *configschema.Attribute, indent int) error {
+	if schema.Required == false && v.optional == false {
+		return nil
+	}
+
+	buf.WriteString(strings.Repeat(" ", indent))
+	buf.WriteString(fmt.Sprintf("%s = ", name))
+
+	switch schema.NestedType.Nesting {
+	case configschema.NestingSingle:
+		buf.WriteString("{")
+		writeAttrTypeConstraint(buf, schema)
+		if err := v.writeConfigAttributes(buf, schema.NestedType.Attributes, indent+2); err != nil {
+			return err
+		}
+		buf.WriteString(strings.Repeat(" ", indent))
+		buf.WriteString("}\n")
+		return nil
+	case configschema.NestingList, configschema.NestingSet:
+		buf.WriteString("[{")
+		writeAttrTypeConstraint(buf, schema)
+		if err := v.writeConfigAttributes(buf, schema.NestedType.Attributes, indent+2); err != nil {
+			return err
+		}
+		buf.WriteString(strings.Repeat(" ", indent))
+		buf.WriteString("}]\n")
+		return nil
+	case configschema.NestingMap:
+		buf.WriteString("{")
+		writeAttrTypeConstraint(buf, schema)
+		buf.WriteString(strings.Repeat(" ", indent+2))
+		buf.WriteString("key = {\n")
+		if err := v.writeConfigAttributes(buf, schema.NestedType.Attributes, indent+4); err != nil {
+			return err
+		}
+		buf.WriteString(strings.Repeat(" ", indent+2))
+		buf.WriteString("}\n")
+		buf.WriteString(strings.Repeat(" ", indent))
+		buf.WriteString("}\n")
+		return nil
+	default:
+		// This should not happen, the above should be exhaustive.
+		return fmt.Errorf("unsupported NestingMode %s", schema.NestedType.Nesting.String())
+	}
+}
+
+func (v *addHuman) writeConfigBlocksFromExisting(buf *strings.Builder, stateVal cty.Value, blocks map[string]*configschema.NestedBlock, indent int) error {
+	if len(blocks) == 0 {
+		return nil
+	}
+
+	// Get a list of sorted block names so the output will be consistent between runs.
+	names := make([]string, 0, len(blocks))
+	for k := range blocks {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		blockS := blocks[name]
+		// This shouldn't happen in real usage; state always has all values (set
+		// to null as needed), but it protects against panics in tests (and any
+		// really weird and unlikely cases).
+		if !stateVal.Type().HasAttribute(name) {
+			continue
+		}
+		blockVal := stateVal.GetAttr(name)
+		if err := v.writeConfigNestedBlockFromExisting(buf, name, blockS, blockVal, indent); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (v *addHuman) writeConfigNestedTypeAttributeFromExisting(buf *strings.Builder, name string, schema *configschema.Attribute, stateVal cty.Value, indent int) error {
+	switch schema.NestedType.Nesting {
+	case configschema.NestingSingle:
+		if schema.Sensitive {
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString(fmt.Sprintf("%s = {} # sensitive\n", name))
+			return nil
+		}
+		buf.WriteString(strings.Repeat(" ", indent))
+		buf.WriteString(fmt.Sprintf("%s = {\n", name))
+
+		// This shouldn't happen in real usage; state always has all values (set
+		// to null as needed), but it protects against panics in tests (and any
+		// really weird and unlikely cases).
+		if !stateVal.Type().HasAttribute(name) {
+			return nil
+		}
+		nestedVal := stateVal.GetAttr(name)
+		if err := v.writeConfigAttributesFromExisting(buf, nestedVal, schema.NestedType.Attributes, indent+2); err != nil {
+			return err
+		}
+		buf.WriteString("}\n")
+		return nil
+	case configschema.NestingList, configschema.NestingSet:
+		buf.WriteString(strings.Repeat(" ", indent))
+		buf.WriteString(fmt.Sprintf("%s = [\n", name))
+
+		if schema.Sensitive || stateVal.IsMarked() {
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString("] # sensitive\n")
+			return nil
+		}
+
+		listVals := ctyCollectionValues(stateVal.GetAttr(name))
+		for i := range listVals {
+			buf.WriteString(strings.Repeat(" ", indent+2))
+			buf.WriteString("{\n")
+			if err := v.writeConfigAttributesFromExisting(buf, listVals[i], schema.NestedType.Attributes, indent+4); err != nil {
+				return err
+			}
+			buf.WriteString(strings.Repeat(" ", indent+2))
+			buf.WriteString("},\n")
+		}
+		buf.WriteString(strings.Repeat(" ", indent))
+		buf.WriteString("]\n")
+		return nil
+	case configschema.NestingMap:
+		buf.WriteString(strings.Repeat(" ", indent))
+		buf.WriteString(fmt.Sprintf("%s = {\n", name))
+
+		if schema.Sensitive || stateVal.IsMarked() {
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString("} # sensitive\n")
+			return nil
+		}
+
+		vals := stateVal.GetAttr(name).AsValueMap()
+		keys := make([]string, 0, len(vals))
+		for key := range vals {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			buf.WriteString(strings.Repeat(" ", indent+2))
+			buf.WriteString(fmt.Sprintf("%s = {\n", key))
+			if err := v.writeConfigAttributesFromExisting(buf, vals[key], schema.NestedType.Attributes, indent+4); err != nil {
+				return err
+			}
+			buf.WriteString(strings.Repeat(" ", indent+2))
+			buf.WriteString("},\n")
+		}
+		buf.WriteString(strings.Repeat(" ", indent))
+		buf.WriteString("}\n")
+		return nil
+	default:
+		// This should not happen, the above should be exhaustive.
+		return fmt.Errorf("unsupported NestingMode %s", schema.NestedType.Nesting.String())
+	}
+}
+
+func (v *addHuman) writeConfigNestedBlockFromExisting(buf *strings.Builder, name string, schema *configschema.NestedBlock, stateVal cty.Value, indent int) error {
+	switch schema.Nesting {
+	case configschema.NestingSingle, configschema.NestingGroup:
+		buf.WriteString(strings.Repeat(" ", indent))
+		buf.WriteString(fmt.Sprintf("%s {", name))
+
+		// If the entire value is marked, don't print any nested attributes
+		if stateVal.IsMarked() {
+			buf.WriteString("} # sensitive\n")
+			return nil
+		}
+		buf.WriteString("\n")
+		if err := v.writeConfigAttributesFromExisting(buf, stateVal, schema.Attributes, indent+2); err != nil {
+			return err
+		}
+		if err := v.writeConfigBlocksFromExisting(buf, stateVal, schema.BlockTypes, indent+2); err != nil {
+			return err
+		}
+		buf.WriteString("}\n")
+		return nil
+	case configschema.NestingList, configschema.NestingSet:
+		if stateVal.IsMarked() {
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString(fmt.Sprintf("%s {} # sensitive\n", name))
+			return nil
+		}
+		listVals := ctyCollectionValues(stateVal)
+		for i := range listVals {
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString(fmt.Sprintf("%s {\n", name))
+			if err := v.writeConfigAttributesFromExisting(buf, listVals[i], schema.Attributes, indent+2); err != nil {
+				return err
+			}
+			if err := v.writeConfigBlocksFromExisting(buf, listVals[i], schema.BlockTypes, indent+2); err != nil {
+				return err
+			}
+			buf.WriteString("}\n")
+		}
+		return nil
+	case configschema.NestingMap:
+		// If the entire value is marked, don't print any nested attributes
+		if stateVal.IsMarked() {
+			buf.WriteString(fmt.Sprintf("%s {} # sensitive\n", name))
+			return nil
+		}
+
+		vals := stateVal.AsValueMap()
+		keys := make([]string, 0, len(vals))
+		for key := range vals {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString(fmt.Sprintf("%s %q {", name, key))
+			// This entire map element is marked
+			if vals[key].IsMarked() {
+				buf.WriteString("} # sensitive\n")
+				return nil
+			}
+			buf.WriteString("\n")
+
+			if err := v.writeConfigAttributesFromExisting(buf, vals[key], schema.Attributes, indent+2); err != nil {
+				return err
+			}
+			if err := v.writeConfigBlocksFromExisting(buf, vals[key], schema.BlockTypes, indent+2); err != nil {
+				return err
+			}
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString("}\n")
+		}
+		return nil
+	default:
+		// This should not happen, the above should be exhaustive.
+		return fmt.Errorf("unsupported NestingMode %s", schema.Nesting.String())
+	}
+}
+
+func writeAttrTypeConstraint(buf *strings.Builder, schema *configschema.Attribute) {
+	if schema.Required {
+		buf.WriteString(" # REQUIRED ")
+	} else {
+		buf.WriteString(" # OPTIONAL ")
+	}
+
+	if schema.NestedType != nil {
+		buf.WriteString(fmt.Sprintf("%s\n", schema.NestedType.ImpliedType().FriendlyName()))
+	} else {
+		buf.WriteString(fmt.Sprintf("%s\n", schema.Type.FriendlyName()))
+	}
+	return
+}
+
+// copied from command/format/diff
+func ctyCollectionValues(val cty.Value) []cty.Value {
+	if !val.IsKnown() || val.IsNull() {
+		return nil
+	}
+
+	var len int
+	if val.IsMarked() {
+		val, _ = val.Unmark()
+		len = val.LengthInt()
+	} else {
+		len = val.LengthInt()
+	}
+
+	ret := make([]cty.Value, 0, len)
+	for it := val.ElementIterator(); it.Next(); {
+		_, value := it.Element()
+		ret = append(ret, value)
+	}
+
+	return ret
+}

--- a/internal/command/views/add_test.go
+++ b/internal/command/views/add_test.go
@@ -1,0 +1,732 @@
+package views
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/terminal"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// The output is tested in detail in other tests; this is a minimal test of the entrypoint.
+func TestAddResource(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	defer done(t)
+	v := addHuman{view: NewView(streams), optional: true}
+	val := cty.ObjectVal(map[string]cty.Value{
+		"disks": cty.ObjectVal(map[string]cty.Value{
+			"mount_point": cty.StringVal("/mnt/foo"),
+			"size":        cty.StringVal("50GB"),
+		}),
+	})
+	err := v.Resource(
+		mustResourceInstanceAddr("test_instance.foo"),
+		addTestSchemaSensitive(configschema.NestingSingle),
+		"", val,
+	)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+func TestAdd_writeConfigAttributes(t *testing.T) {
+	tests := map[string]struct {
+		attrs    map[string]*configschema.Attribute
+		expected string
+	}{
+		"empty returns nil": {
+			map[string]*configschema.Attribute{},
+			"",
+		},
+		"attributes": {
+			map[string]*configschema.Attribute{
+				"ami": {
+					Type:     cty.Number,
+					Required: true,
+				},
+				"boot_disk": {
+					Type:     cty.String,
+					Optional: true,
+				},
+				"password": {
+					Type:      cty.String,
+					Optional:  true,
+					Sensitive: true, // sensitivity is ignored when printing blank templates
+				},
+			},
+			`ami = null # REQUIRED number
+boot_disk = null # OPTIONAL string
+password = null # OPTIONAL string
+`,
+		},
+		"attributes with nested types": {
+			map[string]*configschema.Attribute{
+				"ami": {
+					Type:     cty.Number,
+					Required: true,
+				},
+				"disks": {
+					NestedType: &configschema.Object{
+						Nesting: configschema.NestingSingle,
+						Attributes: map[string]*configschema.Attribute{
+							"size": {
+								Type:     cty.Number,
+								Optional: true,
+							},
+							"mount_point": {
+								Type:     cty.String,
+								Required: true,
+							},
+						},
+					},
+					Optional: true,
+				},
+			},
+			`ami = null # REQUIRED number
+disks = { # OPTIONAL object
+  mount_point = null # REQUIRED string
+  size = null # OPTIONAL number
+}
+`,
+		},
+	}
+
+	v := addHuman{optional: true}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := v.writeConfigAttributes(&buf, test.attrs, 0); err != nil {
+				t.Errorf("unexpected error")
+			}
+			if buf.String() != test.expected {
+				fmt.Println(buf.String())
+				t.Errorf("wrong result: %s", cmp.Diff(test.expected, buf.String()))
+			}
+		})
+	}
+}
+
+func TestAdd_writeConfigAttributesFromExisting(t *testing.T) {
+	attrs := map[string]*configschema.Attribute{
+		"ami": {
+			Type:     cty.Number,
+			Required: true,
+		},
+		"boot_disk": {
+			Type:     cty.String,
+			Optional: true,
+		},
+		"password": {
+			Type:      cty.String,
+			Optional:  true,
+			Sensitive: true,
+		},
+		"disks": {
+			NestedType: &configschema.Object{
+				Nesting: configschema.NestingSingle,
+				Attributes: map[string]*configschema.Attribute{
+					"size": {
+						Type:     cty.Number,
+						Optional: true,
+					},
+					"mount_point": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+			},
+			Optional: true,
+		},
+	}
+
+	tests := map[string]struct {
+		attrs    map[string]*configschema.Attribute
+		val      cty.Value
+		expected string
+	}{
+		"empty returns nil": {
+			map[string]*configschema.Attribute{},
+			cty.NilVal,
+			"",
+		},
+		"mixed attributes": {
+			attrs,
+			cty.ObjectVal(map[string]cty.Value{
+				"ami":       cty.NumberIntVal(123456),
+				"boot_disk": cty.NullVal(cty.String),
+				"password":  cty.StringVal("i am secret"),
+				"disks": cty.ObjectVal(map[string]cty.Value{
+					"size":        cty.NumberIntVal(50),
+					"mount_point": cty.NullVal(cty.String),
+				}),
+			}),
+			`ami = 123456
+boot_disk = null
+disks = {
+  mount_point = null
+  size = 50
+}
+password = null # sensitive
+`,
+		},
+	}
+
+	v := addHuman{optional: true}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := v.writeConfigAttributesFromExisting(&buf, test.val, test.attrs, 0); err != nil {
+				t.Errorf("unexpected error")
+			}
+			if buf.String() != test.expected {
+				t.Errorf("wrong result: %s", cmp.Diff(test.expected, buf.String()))
+			}
+		})
+	}
+}
+
+func TestAdd_writeConfigBlocksFromExisting(t *testing.T) {
+
+	t.Run("NestingSingle", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.ObjectVal(map[string]cty.Value{
+				"volume_type": cty.StringVal("foo"),
+			}),
+		})
+		schema := addTestSchema(configschema.NestingSingle)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		expected := `root_block_device {
+  volume_type = "foo"
+}
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Errorf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingSingle_marked_attr", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.ObjectVal(map[string]cty.Value{
+				"volume_type": cty.StringVal("foo").Mark("bar"),
+			}),
+		})
+		schema := addTestSchema(configschema.NestingSingle)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		expected := `root_block_device {
+  volume_type = null # sensitive
+}
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Errorf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingSingle_entirely_marked", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.ObjectVal(map[string]cty.Value{
+				"volume_type": cty.StringVal("foo"),
+			}),
+		}).Mark("bar")
+		schema := addTestSchema(configschema.NestingSingle)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		expected := `root_block_device {} # sensitive
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Errorf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingList", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("foo"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("bar"),
+				}),
+			}),
+		})
+		schema := addTestSchema(configschema.NestingList)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		expected := `root_block_device {
+  volume_type = "foo"
+}
+root_block_device {
+  volume_type = "bar"
+}
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingList_marked_attr", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("foo").Mark("sensitive"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("bar"),
+				}),
+			}),
+		})
+		schema := addTestSchema(configschema.NestingList)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		expected := `root_block_device {
+  volume_type = null # sensitive
+}
+root_block_device {
+  volume_type = "bar"
+}
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingList_entirely_marked", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("foo"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("bar"),
+				}),
+			}).Mark("mark"),
+		})
+		schema := addTestSchema(configschema.NestingList)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		expected := `root_block_device {} # sensitive
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingSet", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("foo"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("bar"),
+				}),
+			}),
+		})
+		schema := addTestSchema(configschema.NestingSet)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		expected := `root_block_device {
+  volume_type = "bar"
+}
+root_block_device {
+  volume_type = "foo"
+}
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingSet_marked", func(t *testing.T) {
+		v := addHuman{optional: true}
+		// In cty.Sets, the entire set ends up marked if any element is marked.
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("foo"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("bar"),
+				}),
+			}).Mark("sensitive"),
+		})
+		schema := addTestSchema(configschema.NestingSet)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		// When the entire set of blocks is sensitive, we only print one block.
+		expected := `root_block_device {} # sensitive
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingMap", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.MapVal(map[string]cty.Value{
+				"1": cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("foo"),
+				}),
+				"2": cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("bar"),
+				}),
+			}),
+		})
+		schema := addTestSchema(configschema.NestingMap)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		expected := `root_block_device "1" {
+  volume_type = "foo"
+}
+root_block_device "2" {
+  volume_type = "bar"
+}
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingMap_marked", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.MapVal(map[string]cty.Value{
+				"1": cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("foo").Mark("sensitive"),
+				}),
+				"2": cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("bar"),
+				}),
+			}),
+		})
+		schema := addTestSchema(configschema.NestingMap)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		expected := `root_block_device "1" {
+  volume_type = null # sensitive
+}
+root_block_device "2" {
+  volume_type = "bar"
+}
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingMap_entirely_marked", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.MapVal(map[string]cty.Value{
+				"1": cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("foo"),
+				}),
+				"2": cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("bar"),
+				}),
+			}).Mark("sensitive"),
+		})
+		schema := addTestSchema(configschema.NestingMap)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		expected := `root_block_device {} # sensitive
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingMap_marked_elem", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"root_block_device": cty.MapVal(map[string]cty.Value{
+				"1": cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("foo"),
+				}),
+				"2": cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("bar"),
+				}).Mark("sensitive"),
+			}),
+		})
+		schema := addTestSchema(configschema.NestingMap)
+		var buf strings.Builder
+		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
+
+		expected := `root_block_device "1" {
+  volume_type = "foo"
+}
+root_block_device "2" {} # sensitive
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+}
+
+func TestAdd_WriteConfigNestedTypeAttributeFromExisting(t *testing.T) {
+	t.Run("NestingSingle", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"disks": cty.ObjectVal(map[string]cty.Value{
+				"mount_point": cty.StringVal("/mnt/foo"),
+				"size":        cty.StringVal("50GB"),
+			}),
+		})
+		schema := addTestSchema(configschema.NestingSingle)
+		var buf strings.Builder
+		v.writeConfigNestedTypeAttributeFromExisting(&buf, "disks", schema.Attributes["disks"], val, 0)
+
+		expected := `disks = {
+  mount_point = "/mnt/foo"
+  size = "50GB"
+}
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingSingle_sensitive", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"disks": cty.ObjectVal(map[string]cty.Value{
+				"mount_point": cty.StringVal("/mnt/foo"),
+				"size":        cty.StringVal("50GB"),
+			}),
+		})
+		schema := addTestSchemaSensitive(configschema.NestingSingle)
+		var buf strings.Builder
+		v.writeConfigNestedTypeAttributeFromExisting(&buf, "disks", schema.Attributes["disks"], val, 0)
+
+		expected := `disks = {} # sensitive
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingList", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"disks": cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.StringVal("/mnt/foo"),
+					"size":        cty.StringVal("50GB"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.StringVal("/mnt/bar"),
+					"size":        cty.StringVal("250GB"),
+				}),
+			}),
+		})
+
+		schema := addTestSchema(configschema.NestingList)
+		var buf strings.Builder
+		v.writeConfigNestedTypeAttributeFromExisting(&buf, "disks", schema.Attributes["disks"], val, 0)
+
+		expected := `disks = [
+  {
+    mount_point = "/mnt/foo"
+    size = "50GB"
+  },
+  {
+    mount_point = "/mnt/bar"
+    size = "250GB"
+  },
+]
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			fmt.Println(buf.String())
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingList - marked", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"disks": cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.StringVal("/mnt/foo"),
+					"size":        cty.StringVal("50GB").Mark("hi"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.StringVal("/mnt/bar"),
+					"size":        cty.StringVal("250GB").Mark("bye"),
+				}),
+			}),
+		})
+
+		schema := addTestSchema(configschema.NestingList)
+		var buf strings.Builder
+		v.writeConfigNestedTypeAttributeFromExisting(&buf, "disks", schema.Attributes["disks"], val, 0)
+
+		expected := `disks = [
+  {
+    mount_point = "/mnt/foo"
+    size = null # sensitive
+  },
+  {
+    mount_point = "/mnt/bar"
+    size = null # sensitive
+  },
+]
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			fmt.Println(buf.String())
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+
+	t.Run("NestingMap", func(t *testing.T) {
+		v := addHuman{optional: true}
+		val := cty.ObjectVal(map[string]cty.Value{
+			"disks": cty.MapVal(map[string]cty.Value{
+				"foo": cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.StringVal("/mnt/foo"),
+					"size":        cty.StringVal("50GB"),
+				}),
+				"bar": cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.StringVal("/mnt/bar"),
+					"size":        cty.StringVal("250GB"),
+				}),
+			}),
+		})
+		schema := addTestSchema(configschema.NestingMap)
+		var buf strings.Builder
+		v.writeConfigNestedTypeAttributeFromExisting(&buf, "disks", schema.Attributes["disks"], val, 0)
+
+		expected := `disks = {
+  bar = {
+    mount_point = "/mnt/bar"
+    size = "250GB"
+  },
+  foo = {
+    mount_point = "/mnt/foo"
+    size = "50GB"
+  },
+}
+`
+
+		if !cmp.Equal(buf.String(), expected) {
+			fmt.Println(buf.String())
+			t.Fatalf("wrong output:\n%s", cmp.Diff(expected, buf.String()))
+		}
+	})
+}
+
+func addTestSchema(nesting configschema.NestingMode) *configschema.Block {
+	return &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id":  {Type: cty.String, Optional: true, Computed: true},
+			"ami": {Type: cty.String, Optional: true},
+			"disks": {
+				NestedType: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"mount_point": {Type: cty.String, Optional: true},
+						"size":        {Type: cty.String, Optional: true},
+					},
+					Nesting: nesting,
+				},
+			},
+		},
+		BlockTypes: map[string]*configschema.NestedBlock{
+			"root_block_device": {
+				Block: configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"volume_type": {
+							Type:     cty.String,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+				Nesting: nesting,
+			},
+		},
+	}
+}
+
+// addTestSchemaSensitive returns a schema with a sensitive NestedType and a
+// NestedBlock with sensitive attributes.
+func addTestSchemaSensitive(nesting configschema.NestingMode) *configschema.Block {
+	return &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id":  {Type: cty.String, Optional: true, Computed: true},
+			"ami": {Type: cty.String, Optional: true},
+			"disks": {
+				NestedType: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"mount_point": {Type: cty.String, Optional: true},
+						"size":        {Type: cty.String, Optional: true},
+					},
+					Nesting: nesting,
+				},
+				Sensitive: true,
+			},
+		},
+		BlockTypes: map[string]*configschema.NestedBlock{
+			"root_block_device": {
+				Block: configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"volume_type": {
+							Type:      cty.String,
+							Optional:  true,
+							Computed:  true,
+							Sensitive: true,
+						},
+					},
+				},
+				Nesting: nesting,
+			},
+		},
+	}
+}
+
+func mustResourceInstanceAddr(s string) addrs.AbsResourceInstance {
+	addr, diags := addrs.ParseAbsResourceInstanceStr(s)
+	if diags.HasErrors() {
+		panic(diags.Err())
+	}
+	return addr
+}

--- a/internal/command/views/add_test.go
+++ b/internal/command/views/add_test.go
@@ -20,7 +20,7 @@ func TestAddResource(t *testing.T) {
 		err := v.Resource(
 			mustResourceInstanceAddr("test_instance.foo"),
 			addTestSchemaSensitive(configschema.NestingSingle),
-			"mytest", cty.NilVal,
+			addrs.NewDefaultLocalProviderConfig("mytest"), cty.NilVal,
 		)
 		if err != nil {
 			t.Fatal(err.Error())
@@ -55,10 +55,11 @@ func TestAddResource(t *testing.T) {
 				"size":        cty.StringVal("50GB"),
 			}),
 		})
+
 		err := v.Resource(
 			mustResourceInstanceAddr("test_instance.foo"),
 			addTestSchemaSensitive(configschema.NestingSingle),
-			"mytest", val,
+			addrs.NewDefaultLocalProviderConfig("mytest"), val,
 		)
 		if err != nil {
 			t.Fatal(err.Error())
@@ -909,8 +910,10 @@ func TestAdd_WriteConfigNestedTypeAttributeFromExisting(t *testing.T) {
 func addTestSchema(nesting configschema.NestingMode) *configschema.Block {
 	return &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
-			"id":  {Type: cty.String, Optional: true, Computed: true},
-			"ami": {Type: cty.String, Optional: true},
+			"id": {Type: cty.String, Optional: true, Computed: true},
+			// Attributes which are neither optional nor required should not print.
+			"uuid": {Type: cty.String, Computed: true},
+			"ami":  {Type: cty.String, Optional: true},
 			"disks": {
 				NestedType: &configschema.Object{
 					Attributes: map[string]*configschema.Attribute{
@@ -956,8 +959,10 @@ func addTestSchema(nesting configschema.NestingMode) *configschema.Block {
 func addTestSchemaSensitive(nesting configschema.NestingMode) *configschema.Block {
 	return &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
-			"id":  {Type: cty.String, Optional: true, Computed: true},
-			"ami": {Type: cty.String, Optional: true},
+			"id": {Type: cty.String, Optional: true, Computed: true},
+			// Attributes which are neither optional nor required should not print.
+			"uuid": {Type: cty.String, Computed: true},
+			"ami":  {Type: cty.String, Optional: true},
 			"disks": {
 				NestedType: &configschema.Object{
 					Attributes: map[string]*configschema.Attribute{

--- a/website/docs/cli/commands/add.html.md
+++ b/website/docs/cli/commands/add.html.md
@@ -13,6 +13,10 @@ The `terraform add` command generates a resource configuration template with
 used. By default, the template only includes required resource attributes; the
 `-optional` flag tells Terraform to also include any optional attributes. 
 
+When `terraform add` used with the `-from-state` will _not_ print sensitive
+values. You can use `terraform show ADDRESS` to see all values, including
+sensitive values, recorded in state for the given resource address.
+
 ## Usage
 
 Usage: `terraform add [options] ADDRESS`

--- a/website/docs/cli/commands/add.html.md
+++ b/website/docs/cli/commands/add.html.md
@@ -21,7 +21,7 @@ This command requires an address that points to a resource which does not
 already exist in the configuration. Addresses are in 
 [resource addressing format](/docs/cli/state/resource-addressing.html).
 
-The command-line flags are all optional. The list of available flags are:
+This command accepts the following options:
 
 `-from-state=ADDRESS` - populate the template with values from a resource
 already in state. Sensitive values are redacted.

--- a/website/docs/cli/commands/add.html.md
+++ b/website/docs/cli/commands/add.html.md
@@ -27,7 +27,7 @@ already exist in the configuration. Addresses are in
 
 This command accepts the following options:
 
-`-from-state=ADDRESS` - populate the template with values from a resource
+`-from-state` - populate the template with values from a resource
 already in state. Sensitive values are redacted.
 
 `-optional` - include optional attributes in the template.

--- a/website/docs/cli/commands/add.html.md
+++ b/website/docs/cli/commands/add.html.md
@@ -1,0 +1,36 @@
+---
+layout: "docs"
+page_title: "Command: add"
+sidebar_current: "docs-commands-add"
+description: |-
+  The `terraform add` command generates resource configuration templates.
+---
+
+# Command: add
+
+The `terraform add` command generates a resource configuration template with
+`null` placeholder values for all attributes, unless the `-from-state` flag is
+used. By default, the template only includes required resource attributes; the
+`-optional` flag tells Terraform to also include any optional attributes. 
+
+## Usage
+
+Usage: `terraform add [options] ADDRESS`
+
+This command requires an address that points to a resource which does not
+already exist in the configuration. Addresses are in 
+[resource addressing format](/docs/cli/state/resource-addressing.html).
+
+The command-line flags are all optional. The list of available flags are:
+
+`-from-state=ADDRESS` - populate the template with values from a resource
+already in state. Sensitive values are redacted.
+
+`-optional` - include optional attributes in the template.
+
+`-out=FILENAME` - writes the template to the given filename. If the file already
+exists, the template will be added to the end of the file.
+
+`-provider=provider` - override the configured provider for the resource. By
+default, Terraform will use the configured provider for the given resource type,
+and that is the best behavior in most cases.

--- a/website/docs/cli/commands/index.html.md
+++ b/website/docs/cli/commands/index.html.md
@@ -40,6 +40,7 @@ Main commands:
   destroy       Destroy previously-created infrastructure
 
 All other commands:
+  add           Generate a resource configuration template
   console       Try Terraform expressions at an interactive command prompt
   fmt           Reformat your configuration in the standard style
   force-unlock  Release a stuck lock on the current workspace

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -75,6 +75,10 @@
           </li>
 
           <li>
+            <a href="/docs/cli/commands/add.html"><code>add</code></a>
+          </li>
+
+          <li>
             <a href="/docs/cli/commands/console.html"><code>console</code></a>
           </li>
 
@@ -356,6 +360,10 @@
       <li>
         <a href="#">Alphabetical List of Commands</a>
         <ul class="nav">
+
+          <li>
+            <a href="/docs/cli/commands/add.html"><code>add</code></a>
+          </li>
 
           <li>
             <a href="/docs/cli/commands/apply.html"><code>apply</code></a>


### PR DESCRIPTION
`terraform add` generates resource configuration templates which can be filled out and used to create resources. 

The template is output in stdout unless the `-out` flag is used. By default, only required attributes are included and the values all set to `null`, with a comment indicating the expect value type (`string`, `list of object`, etc). The `-optional` flag  tells `add` to include all optional attributes as well. 

When the `-from-state=ADDRESS` flag is used, `add` will copy the values from that resource's state into the template. For this initial release, terraform does not copy any values that are `sensitive` according to the provider schema; a future release may add a mechanism to overrides this behavior. (`-from-state` currently ignores the `-optional` flag and prints all attributes; this may change depending on user feedback).

The most-likely workflow with `-from-state` is using `terraform import` to import a resource's state, and then `terraform add -from-state=ADDRESS NEW_ADDRESS`. 

The generated configuration is not likely to be precisely what's needed, and I expect that users will still need to modify the generated configuration block to suit their needs. Users will need to manage dependencies, replace hard-coded values with expressions (for e.g. references to variables), and make other manual adjustments.

While I wouldn't call this a fully experimental feature, its stability is not guaranteed. It is likely that flags will change once we start getting user feedback.

Here are some example outputs, using my perennial favorite `random_pet` resource: 

```
» terraform add random_pet.meow 
resource "random_pet" "meow" {
}

» terraform add -optional random_pet.meow
resource "random_pet" "meow" {
  keepers   = null
  length    = 3
  prefix    = "add"
  separator = "-"
}

 terraform add -from-state=random_pet.example random_pet.meow
resource "random_pet" "meow" {
  id        = "add-vigorously-refined-doe"
  keepers   = null
  length    = 3
  prefix    = "add"
  separator = "-"
}
```