### PR TITLE
jsonconfig: properly unwind and enumerate references

### DIFF
--- a/internal/command/jsonconfig/expression_test.go
+++ b/internal/command/jsonconfig/expression_test.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hcltest"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 )
 
 func TestMarshalExpressions(t *testing.T) {
 	tests := []struct {
-		Input  hcl.Body
-		Schema *configschema.Block
-		Want   expressions
+		Input hcl.Body
+		Want  expressions
 	}{
 		{
 			&hclsyntax.Body{
@@ -28,14 +28,6 @@ func TestMarshalExpressions(t *testing.T) {
 					},
 				},
 			},
-			&configschema.Block{
-				Attributes: map[string]*configschema.Attribute{
-					"foo": {
-						Type:     cty.String,
-						Optional: true,
-					},
-				},
-			},
 			expressions{
 				"foo": expression{
 					ConstantValue: json.RawMessage([]byte(`"bar"`)),
@@ -43,12 +35,66 @@ func TestMarshalExpressions(t *testing.T) {
 				},
 			},
 		},
+		{
+			hcltest.MockBody(&hcl.BodyContent{
+				Attributes: hcl.Attributes{
+					"foo": {
+						Name: "foo",
+						Expr: hcltest.MockExprTraversalSrc(`var.list[1]`),
+					},
+				},
+			}),
+			expressions{
+				"foo": expression{
+					References: []string{"var.list[1]", "var.list"},
+				},
+			},
+		},
+		{
+			hcltest.MockBody(&hcl.BodyContent{
+				Attributes: hcl.Attributes{
+					"foo": {
+						Name: "foo",
+						Expr: hcltest.MockExprTraversalSrc(`data.template_file.foo[1].vars["baz"]`),
+					},
+				},
+			}),
+			expressions{
+				"foo": expression{
+					References: []string{"data.template_file.foo[1].vars[\"baz\"]", "data.template_file.foo[1].vars", "data.template_file.foo[1]", "data.template_file.foo"},
+				},
+			},
+		},
+		{
+			hcltest.MockBody(&hcl.BodyContent{
+				Attributes: hcl.Attributes{
+					"foo": {
+						Name: "foo",
+						Expr: hcltest.MockExprTraversalSrc(`module.foo.bar`),
+					},
+				},
+			}),
+			expressions{
+				"foo": expression{
+					References: []string{"module.foo.bar", "module.foo"},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
-		got := marshalExpressions(test.Input, test.Schema)
+		schema := &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"foo": {
+					Type:     cty.String,
+					Optional: true,
+				},
+			},
+		}
+
+		got := marshalExpressions(test.Input, schema)
 		if !reflect.DeepEqual(got, test.Want) {
-			t.Fatalf("wrong result:\nGot: %#v\nWant: %#v\n", got, test.Want)
+			t.Errorf("wrong result:\nGot: %#v\nWant: %#v\n", got, test.Want)
 		}
 	}
 }

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -334,7 +334,7 @@ func TestShow_json_output(t *testing.T) {
 			expectError := strings.Contains(entry.Name(), "error")
 
 			providerSource, close := newMockProviderSource(t, map[string][]string{
-				"test": []string{"1.2.3"},
+				"test": {"1.2.3"},
 			})
 			defer close()
 

--- a/internal/command/testdata/show-json/modules/output.json
+++ b/internal/command/testdata/show-json/modules/output.json
@@ -192,7 +192,8 @@
                 "test": {
                     "expression": {
                         "references": [
-                            "module.module_test_foo.test"
+                            "module.module_test_foo.test",
+                            "module.module_test_foo"
                         ]
                     },
                     "depends_on": [

--- a/internal/command/testdata/show-json/sensitive-values/output.json
+++ b/internal/command/testdata/show-json/sensitive-values/output.json
@@ -83,6 +83,7 @@
                 "test": {
                     "expression": {
                         "references": [
+                            "test_instance.test.ami",
                             "test_instance.test"
                         ]
                     },


### PR DESCRIPTION
The "references" included in the expression representation now properly unwrap for each traversal step, to match what was documented.

This fixes https://github.com/hashicorp/terraform/issues/28860

[update: I made the version bump in a later PR] There isn't a format version specific to the configuration representation, and we're not changing the overall format of the plan representation, so I did not increase the plan's format version. I'm not confident about that, I will do so if anyone disagrees! 