### PR TITLE
Remote backend: Stop setting message when creating runs

### DIFF
--- a/internal/backend/remote/backend_plan.go
+++ b/internal/backend/remote/backend_plan.go
@@ -273,14 +273,8 @@ in order to capture the filesystem context the remote workspace expects:
 			"Failed to upload configuration files", errors.New("operation timed out"))
 	}
 
-	queueMessage := "Queued manually using Terraform"
-	if op.Targets != nil {
-		queueMessage = "Queued manually via Terraform using -target"
-	}
-
 	runOptions := tfe.RunCreateOptions{
 		ConfigurationVersion: cv,
-		Message:              tfe.String(queueMessage),
 		Refresh:              tfe.Bool(op.PlanRefresh),
 		Workspace:            w,
 	}

--- a/internal/backend/remote/backend_plan_test.go
+++ b/internal/backend/remote/backend_plan_test.go
@@ -482,10 +482,6 @@ func TestRemote_planWithTarget(t *testing.T) {
 		if diff := cmp.Diff([]string{"null_resource.foo"}, run.TargetAddrs); diff != "" {
 			t.Errorf("wrong TargetAddrs in the created run\n%s", diff)
 		}
-
-		if !strings.Contains(run.Message, "using -target") {
-			t.Errorf("incorrect Message on the created run: %s", run.Message)
-		}
 	}
 }
 


### PR DESCRIPTION
Historically, we've used TFC's default run messages as a sort of dumping
ground for metadata about the run. We've recently decided to mostly stop
doing that, in favor of:

- Only specifying the run's source in the default message.
- Letting TFC itself handle the default messages.

Today, the remote backend explicitly sets a run message, overriding
any default that TFC might set. This commit removes that explicit message
so we can allow TFC to sort it out.

This shouldn't have any bad effect on TFE out in the wild, because it's
known how to set a default message for remote backend runs since late 2018.