### PR TITLE
website: Fix formatting of v1 compatibility promises

### DIFF
--- a/website/docs/language/v1-compatibility-promises.html.md
+++ b/website/docs/language/v1-compatibility-promises.html.md
@@ -101,6 +101,7 @@ whose behavior may change as part of future changes to the workspace model.
 
 We intend to retain broad compatibility with Terraform language features, with
 a few specific caveats:
+
 * We consider a configuration to be valid if Terraform can create and apply
   a plan for it without reporting any errors.
   


### PR DESCRIPTION
Seems like we lost a newline in some of the shuffling it took to get this into the live website, and so it's formatting oddly in the rendered website. This restores the intended formatting of this as the start of a bullet list, rather than as a continuation of the previous paragraph.
