### PR TITLE
backport changes to refresh error message to v1.0

### DIFF
--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -721,6 +721,10 @@ func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend
 		f = b.opPlan
 	case backend.OperationTypeApply:
 		f = b.opApply
+	case backend.OperationTypeRefresh:
+		return nil, fmt.Errorf(
+			"\n\nThe \"refresh\" operation is not supported when using the \"remote\" backend. " +
+				"Use \"terraform apply -refresh-only\" instead.")
 	default:
 		return nil, fmt.Errorf(
 			"\n\nThe \"remote\" backend does not support the %q operation.", op.Type)


### PR DESCRIPTION
Backporting this small change from https://github.com/hashicorp/terraform/pull/28820 into the 1.0 branch since I foolishly merged that PR into main without applying a backport label.