### PR TITLE
Allow to override global token in the remote backend

### DIFF
--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -266,12 +266,9 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 		return diags
 	}
 
-	// Get the token from the config if no token was configured for this
-	// host in credentials section of the CLI Config File.
-	if token == "" {
-		if val := obj.GetAttr("token"); !val.IsNull() {
-			token = val.AsString()
-		}
+	// Override token from the config if it is set
+	if val := obj.GetAttr("token"); !val.IsNull() {
+		token = val.AsString()
 	}
 
 	// Return an error if we still don't have a token at this point.


### PR DESCRIPTION
This PR allows to override token in the backend or data source configuration. This should allow to use different tokens, e.g. in the multi-org setup when main token will be used for the state storage and data source will set own token set.

This unblocks multi-org data sources in TFE using `remote_state` data source. 

This should fix https://github.com/hashicorp/terraform/issues/23093 issue

testcase:

```hcl
variable "tftoken" {
  type    = string
  default = "<token1>"
}

data "terraform_remote_state" "foo" {
  backend = "remote"

  config = {
    organization = "ORG1"
    hostname = "terraform.example.cloud"
    token =  var.tftoken

    workspaces = {
      name = "test1"
    }
  }
}

data "terraform_remote_state" "bar" {
  backend = "remote"

  config = {
    token = var.tftoken


    organization = "ORG1"
    hostname = "terraform.example.cloud"

    workspaces = {
      name = "test2"
    }
  }
}

data "terraform_remote_state" "neworg" {
  backend = "remote"

  config = {
    token = <token2>

    organization = "ORG2"
    hostname = "terraform.example.cloud"

    workspaces = {
      name = "test"
    }
  }
}
output "foo" {
  value=data.terraform_remote_state.foo.outputs
}

output "bar" {
  value=data.terraform_remote_state.bar.outputs
}

output "neworg" {
  value=data.terraform_remote_state.neworg.outputs
}
```