### PR TITLE
account for noop deposed instances in json plan

### DIFF
--- a/internal/command/jsonplan/values_test.go
+++ b/internal/command/jsonplan/values_test.go
@@ -204,12 +204,25 @@ func TestMarshalPlanResources(t *testing.T) {
 			}},
 			Err: false,
 		},
-		"delete": {
+		"delete with null and nil": {
 			Action: plans.Delete,
 			Before: cty.NullVal(cty.EmptyObject),
 			After:  cty.NilVal,
 			Want:   nil,
 			Err:    false,
+		},
+		"delete": {
+			Action: plans.Delete,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"woozles": cty.StringVal("foo"),
+				"foozles": cty.StringVal("bar"),
+			}),
+			After: cty.NullVal(cty.Object(map[string]cty.Type{
+				"woozles": cty.String,
+				"foozles": cty.String,
+			})),
+			Want: nil,
+			Err:  false,
 		},
 		"update without unknowns": {
 			Action: plans.Update,
@@ -288,6 +301,39 @@ func TestMarshalPlanResources(t *testing.T) {
 				t.Fatalf("wrong result:\nGot: %#v\nWant: %#v\n", got, test.Want)
 			}
 		})
+	}
+}
+
+func TestMarshalPlanValuesNoopDeposed(t *testing.T) {
+	dynamicNull, err := plans.NewDynamicValue(cty.NullVal(cty.DynamicPseudoType), cty.DynamicPseudoType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testChange := &plans.Changes{
+		Resources: []*plans.ResourceInstanceChangeSrc{
+			{
+				Addr: addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "test_thing",
+					Name: "example",
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+				DeposedKey: "12345678",
+				ProviderAddr: addrs.AbsProviderConfig{
+					Provider: addrs.NewDefaultProvider("test"),
+					Module:   addrs.RootModule,
+				},
+				ChangeSrc: plans.ChangeSrc{
+					Action: plans.NoOp,
+					Before: dynamicNull,
+					After:  dynamicNull,
+				},
+			},
+		},
+	}
+
+	_, err = marshalPlannedValues(testChange, testSchemas())
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
When rendering a json plan, we need to account for deposed instances
that have become a noop rather than a destroy.

Fixes #28903