### PR TITLE
fixed terraform etcdv3 backend ca certificate path

### DIFF
--- a/internal/backend/remote-state/etcdv3/backend.go
+++ b/internal/backend/remote-state/etcdv3/backend.go
@@ -140,7 +140,7 @@ func (b *Backend) rawClient() (*etcdv3.Client, error) {
 
 	if tlsCfg, err := tlsInfo.ClientConfig(); err != nil {
 		return nil, err
-	} else if !tlsInfo.Empty() {
+	} else if !tlsInfo.Empty() || tlsInfo.TrustedCAFile != "" {
 		config.TLS = tlsCfg // Assign TLS configuration only if it valid and non-empty.
 	}
 


### PR DESCRIPTION
Terraform tries to check if the tls configuration is provided but the etcd transport packages `TLSInfo.Empty()` function only checks for certificate and key, not ca certificate:
https://github.com/etcd-io/etcd/blob/2c834459e1aab78a5d5219c7dfe42335fc4b617a/pkg/transport/listener.go#L100-L102

If you specify `cacert_path` without `cert_path` or `key_path` you are not able to connect to an endpoint with a self signed certificate. You can import it in your global ca certificates keystore, but sometimes this is not an option and you have to specify it directly. So `cacert_path` should not be ignored.

This pull request is a fix for this issue and tested.
Terraform installed from repository:
```bash
/usr/bin/terraform init

Initializing the backend...
│ Error: rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: x509: certificate signed by unknown authority"
```

Terraform build in the pull request branch:
```bash
~/git/terraform/terraform init

Initializing the backend...

Successfully configured the backend "etcdv3"! Terraform will automatically
use this backend unless the backend configuration changes.
```

I am not a go programmer and I do not understand the testing setup. Can someone help me if a test is required for this pull request?
Maybe someone can explain, how to setup and run etcdv3 backend tests so I can execute them and provide the results.

Fix for this issue:
#19185