### PR TITLE
json-output: Omit unchanged resource_drift entries

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -259,6 +259,12 @@ func (p *plan) marshalResourceDrift(oldState, newState *states.State, schemas *t
 				} else {
 					newVal = cty.NullVal(ty)
 				}
+
+				if oldVal.RawEquals(newVal) {
+					// No drift if the two values are semantically equivalent
+					continue
+				}
+
 				oldSensitive := jsonstate.SensitiveAsBool(oldVal)
 				newSensitive := jsonstate.SensitiveAsBool(newVal)
 				oldVal, _ = oldVal.UnmarkDeep()
@@ -290,6 +296,7 @@ func (p *plan) marshalResourceDrift(oldState, newState *states.State, schemas *t
 				}
 
 				change := resourceChange{
+					Address:       addr.String(),
 					ModuleAddress: addr.Module.String(),
 					Mode:          "managed", // drift reporting is only for managed resources
 					Name:          addr.Resource.Resource.Name,

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -636,6 +636,20 @@ func showFixtureSensitiveSchema() *providers.GetProviderSchemaResponse {
 func showFixtureProvider() *terraform.MockProvider {
 	p := testProvider()
 	p.GetProviderSchemaResponse = showFixtureSchema()
+	p.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
+		idVal := req.PriorState.GetAttr("id")
+		amiVal := req.PriorState.GetAttr("ami")
+		if amiVal.RawEquals(cty.StringVal("refresh-me")) {
+			amiVal = cty.StringVal("refreshed")
+		}
+		return providers.ReadResourceResponse{
+			NewState: cty.ObjectVal(map[string]cty.Value{
+				"id":  idVal,
+				"ami": amiVal,
+			}),
+			Private: req.Private,
+		}
+	}
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 		idVal := req.ProposedNewState.GetAttr("id")
 		amiVal := req.ProposedNewState.GetAttr("ami")
@@ -758,6 +772,7 @@ type plan struct {
 	FormatVersion   string                 `json:"format_version,omitempty"`
 	Variables       map[string]interface{} `json:"variables,omitempty"`
 	PlannedValues   map[string]interface{} `json:"planned_values,omitempty"`
+	ResourceDrift   []interface{}          `json:"resource_drift,omitempty"`
 	ResourceChanges []interface{}          `json:"resource_changes,omitempty"`
 	OutputChanges   map[string]interface{} `json:"output_changes,omitempty"`
 	PriorState      priorState             `json:"prior_state,omitempty"`

--- a/internal/command/testdata/show-json/drift/main.tf
+++ b/internal/command/testdata/show-json/drift/main.tf
@@ -1,0 +1,13 @@
+# In state with `ami = "foo"`, so this should be a regular update. The provider
+# should not detect changes on refresh.
+resource "test_instance" "no_refresh" {
+  ami = "bar"
+}
+
+# In state with `ami = "refresh-me"`, but the provider will return
+# `"refreshed"` after the refresh phase. The plan should show the drift
+# (`"refresh-me"` to `"refreshed"`) and plan the update (`"refreshed"` to
+# `"baz"`).
+resource "test_instance" "should_refresh" {
+  ami = "baz"
+}

--- a/internal/command/testdata/show-json/drift/output.json
+++ b/internal/command/testdata/show-json/drift/output.json
@@ -1,26 +1,13 @@
 {
     "format_version": "0.2",
-    "terraform_version": "0.13.0",
-    "variables": {
-        "test_var": {
-            "value": "bar"
-        }
-    },
     "planned_values": {
-        "outputs": {
-            "test": {
-                "sensitive": false,
-                "value": "bar"
-            }
-        },
         "root_module": {
             "resources": [
                 {
-                    "address": "test_instance.test[0]",
+                    "address": "test_instance.no_refresh",
                     "mode": "managed",
                     "type": "test_instance",
-                    "name": "test",
-                    "index": 0,
+                    "name": "no_refresh",
                     "provider_name": "registry.terraform.io/hashicorp/test",
                     "schema_version": 0,
                     "values": {
@@ -30,15 +17,15 @@
                     "sensitive_values": {}
                 },
                 {
-                    "address": "test_instance.test[1]",
+                    "address": "test_instance.should_refresh",
                     "mode": "managed",
                     "type": "test_instance",
-                    "name": "test",
-                    "index": 1,
+                    "name": "should_refresh",
                     "provider_name": "registry.terraform.io/hashicorp/test",
                     "schema_version": 0,
                     "values": {
-                        "ami": "bar"
+                        "ami": "baz",
+                        "id": "placeholder"
                     },
                     "sensitive_values": {}
                 }
@@ -47,39 +34,41 @@
     },
     "resource_drift": [
         {
-            "address": "test_instance.test",
+            "address": "test_instance.should_refresh",
             "mode": "managed",
             "type": "test_instance",
             "provider_name": "registry.terraform.io/hashicorp/test",
-            "name": "test",
+            "name": "should_refresh",
             "change": {
                 "actions": [
-                    "delete"
+                    "update"
                 ],
                 "before": {
-                    "ami": "bar",
+                    "ami": "refresh-me",
                     "id": "placeholder"
                 },
-                "after": null,
-                "before_sensitive": {},
-                "after_sensitive": false
+                "after": {
+                    "ami": "refreshed",
+                    "id": "placeholder"
+                },
+                "after_sensitive": {},
+                "before_sensitive": {}
             }
         }
     ],
     "resource_changes": [
         {
-            "address": "test_instance.test[0]",
+            "address": "test_instance.no_refresh",
             "mode": "managed",
             "type": "test_instance",
-            "name": "test",
-            "index": 0,
             "provider_name": "registry.terraform.io/hashicorp/test",
+            "name": "no_refresh",
             "change": {
                 "actions": [
-                    "no-op"
+                    "update"
                 ],
                 "before": {
-                    "ami": "bar",
+                    "ami": "foo",
                     "id": "placeholder"
                 },
                 "after": {
@@ -92,62 +81,56 @@
             }
         },
         {
-            "address": "test_instance.test[1]",
+            "address": "test_instance.should_refresh",
             "mode": "managed",
             "type": "test_instance",
-            "name": "test",
-            "index": 1,
             "provider_name": "registry.terraform.io/hashicorp/test",
+            "name": "should_refresh",
             "change": {
                 "actions": [
-                    "create"
+                    "update"
                 ],
-                "before": null,
+                "before": {
+                    "ami": "refreshed",
+                    "id": "placeholder"
+                },
                 "after": {
-                    "ami": "bar"
+                    "ami": "baz",
+                    "id": "placeholder"
                 },
-                "after_unknown": {
-                    "id": true
-                },
+                "after_unknown": {},
                 "after_sensitive": {},
-                "before_sensitive": false
+                "before_sensitive": {}
             }
         }
     ],
-    "output_changes": {
-        "test": {
-            "actions": [
-                "no-op"
-            ],
-            "before": "bar",
-            "after": "bar",
-            "after_unknown": false,
-            "before_sensitive": false,
-            "after_sensitive": false
-        }
-    },
     "prior_state": {
         "format_version": "0.2",
-        "terraform_version": "0.13.0",
         "values": {
-            "outputs": {
-                "test": {
-                    "sensitive": false,
-                    "value": "bar"
-                }
-            },
             "root_module": {
                 "resources": [
                     {
-                        "address": "test_instance.test[0]",
+                        "address": "test_instance.no_refresh",
                         "mode": "managed",
                         "type": "test_instance",
-                        "name": "test",
-                        "index": 0,
-                        "provider_name": "registry.terraform.io/hashicorp/test",
+                        "name": "no_refresh",
                         "schema_version": 0,
+                        "provider_name": "registry.terraform.io/hashicorp/test",
                         "values": {
-                            "ami": "bar",
+                            "ami": "foo",
+                            "id": "placeholder"
+                        },
+                        "sensitive_values": {}
+                    },
+                    {
+                        "address": "test_instance.should_refresh",
+                        "mode": "managed",
+                        "type": "test_instance",
+                        "name": "should_refresh",
+                        "schema_version": 0,
+                        "provider_name": "registry.terraform.io/hashicorp/test",
+                        "values": {
+                            "ami": "refreshed",
                             "id": "placeholder"
                         },
                         "sensitive_values": {}
@@ -158,40 +141,34 @@
     },
     "configuration": {
         "root_module": {
-            "outputs": {
-                "test": {
-                    "expression": {
-                        "references": [
-                            "var.test_var"
-                        ]
-                    }
-                }
-            },
             "resources": [
                 {
-                    "address": "test_instance.test",
+                    "address": "test_instance.no_refresh",
                     "mode": "managed",
                     "type": "test_instance",
-                    "name": "test",
+                    "name": "no_refresh",
                     "provider_config_key": "test",
+                    "schema_version": 0,
                     "expressions": {
                         "ami": {
-                            "references": [
-                                "var.test_var"
-                            ]
+                            "constant_value": "bar"
                         }
-                    },
+                    }
+                },
+                {
+                    "address": "test_instance.should_refresh",
+                    "mode": "managed",
+                    "type": "test_instance",
+                    "name": "should_refresh",
+                    "provider_config_key": "test",
                     "schema_version": 0,
-                    "count_expression": {
-                        "constant_value": 2
+                    "expressions": {
+                        "ami": {
+                            "constant_value": "baz"
+                        }
                     }
                 }
-            ],
-            "variables": {
-                "test_var": {
-                    "default": "bar"
-                }
-            }
+            ]
         }
     }
 }

--- a/internal/command/testdata/show-json/drift/terraform.tfstate
+++ b/internal/command/testdata/show-json/drift/terraform.tfstate
@@ -1,0 +1,38 @@
+{
+    "version": 4,
+    "terraform_version": "0.12.0",
+    "serial": 7,
+    "lineage": "configuredUnchanged",
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "no_refresh",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "ami": "foo",
+                        "id": "placeholder"
+                    }
+                }
+            ]
+        },
+        {
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "should_refresh",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "ami": "refresh-me",
+                        "id": "placeholder"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Previously, if any resources were found to have drifted, the JSON plan output would include a drift entry for every resource in state. This commit aligns the JSON plan output with the CLI UI, and only includes those resources where the old value does not equal the new value—i.e. drift has been detected.

Also fixes a bug where the "address" field was missing from the drift output, and adds some test coverage.

(I attempted to refactor the code which determines which resources have drifted into a single location, but got stuck with import cycles. We make the decision about drift very late, after decoding the state values using the provider schema, which means that the implementation needs to refer to the `states`, `plans`, and `terraform` packages, while being called from `command/views` and `command/jsonplan`.)