### PR TITLE
blocktoattr fixup dropping MissingItemRange

### DIFF
--- a/internal/lang/blocktoattr/fixup.go
+++ b/internal/lang/blocktoattr/fixup.go
@@ -137,6 +137,8 @@ func (b *fixupBody) fixupContent(content *hcl.BodyContent) *hcl.BodyContent {
 			NameRange: blocks[0].TypeRange,
 		}
 	}
+
+	ret.MissingItemRange = b.MissingItemRange()
 	return &ret
 }
 


### PR DESCRIPTION
When `blocktoattr.fixupBody` returned its content, the value for
`MissingItemRange` was omitted, losing the diagnostic Subject.

Fixes #28976