### PR TITLE
terraform: use hcl.MergeBodies instead of configs.MergeBodies for pro…

### DIFF
--- a/internal/command/testdata/plan-provider-input/main.tf
+++ b/internal/command/testdata/plan-provider-input/main.tf
@@ -1,0 +1,20 @@
+variable "users" {
+    default = {
+        one = "onepw"
+        two = "twopw"
+    }
+}
+
+provider "test" {
+    url = "example.com"
+    
+    dynamic "auth" {
+        for_each = var.users
+        content {
+            user     = auth.key
+            password = auth.value
+        }
+    }
+}
+
+resource "test_instance" "test" {}

--- a/internal/terraform/eval_provider.go
+++ b/internal/terraform/eval_provider.go
@@ -26,13 +26,7 @@ func buildProviderConfig(ctx EvalContext, addr addrs.AbsProviderConfig, config *
 	switch {
 	case configBody != nil && inputBody != nil:
 		log.Printf("[TRACE] buildProviderConfig for %s: merging explicit config and input", addr)
-		// Note that the inputBody is the _base_ here, because configs.MergeBodies
-		// expects the base have all of the required fields, while these are
-		// forced to be optional for the override. The input process should
-		// guarantee that we have a value for each of the required arguments and
-		// that in practice the sets of attributes in each body will be
-		// disjoint.
-		return configs.MergeBodies(inputBody, configBody)
+		return hcl.MergeBodies([]hcl.Body{inputBody, configBody})
 	case configBody != nil:
 		log.Printf("[TRACE] buildProviderConfig for %s: using explicit config only", addr)
 		return configBody

--- a/internal/terraform/node_provider_test.go
+++ b/internal/terraform/node_provider_test.go
@@ -18,10 +18,23 @@ func TestNodeApplyableProviderExecute(t *testing.T) {
 	config := &configs.Provider{
 		Name: "foo",
 		Config: configs.SynthBody("", map[string]cty.Value{
-			"test_string": cty.StringVal("hello"),
+			"user": cty.StringVal("hello"),
 		}),
 	}
-	provider := mockProviderWithConfigSchema(simpleTestSchema())
+
+	schema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"user": {
+				Type:     cty.String,
+				Required: true,
+			},
+			"pw": {
+				Type:     cty.String,
+				Required: true,
+			},
+		},
+	}
+	provider := mockProviderWithConfigSchema(schema)
 	providerAddr := addrs.AbsProviderConfig{
 		Module:   addrs.RootModule,
 		Provider: addrs.NewDefaultProvider("foo"),
@@ -34,8 +47,12 @@ func TestNodeApplyableProviderExecute(t *testing.T) {
 
 	ctx := &MockEvalContext{ProviderProvider: provider}
 	ctx.installSimpleEval()
-	if err := n.Execute(ctx, walkApply); err != nil {
-		t.Fatalf("err: %s", err)
+	ctx.ProviderInputValues = map[string]cty.Value{
+		"pw": cty.StringVal("so secret"),
+	}
+
+	if diags := n.Execute(ctx, walkApply); diags.HasErrors() {
+		t.Fatalf("err: %s", diags.Err())
 	}
 
 	if !ctx.ConfigureProviderCalled {
@@ -43,10 +60,17 @@ func TestNodeApplyableProviderExecute(t *testing.T) {
 	}
 
 	gotObj := ctx.ConfigureProviderConfig
-	if !gotObj.Type().HasAttribute("test_string") {
-		t.Fatal("configuration object does not have \"test_string\" attribute")
+	if !gotObj.Type().HasAttribute("user") {
+		t.Fatal("configuration object does not have \"user\" attribute")
 	}
-	if got, want := gotObj.GetAttr("test_string"), cty.StringVal("hello"); !got.RawEquals(want) {
+	if got, want := gotObj.GetAttr("user"), cty.StringVal("hello"); !got.RawEquals(want) {
+		t.Errorf("wrong configuration value\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	if !gotObj.Type().HasAttribute("pw") {
+		t.Fatal("configuration object does not have \"pw\" attribute")
+	}
+	if got, want := gotObj.GetAttr("pw"), cty.StringVal("so secret"); !got.RawEquals(want) {
 		t.Errorf("wrong configuration value\ngot:  %#v\nwant: %#v", got, want)
 	}
 }


### PR DESCRIPTION
…vider configuration

Previously, Terraform would return an error if the user supplied provider configuration via interactive input iff the configuration provided on the command line was missing any required attributes - even if those attributes were already set in config.

That error came from configs.MergeBody, which was designed for overriding valid configuration. It expects that the first ("base") body has all required attributes. However in the case of interactive input for provider configuration, it is perfectly valid if either or both bodies are missing required attributes, as long as the final body has all required attributes. hcl.MergeBodies works very similarly to configs.MergeBodies, with a key difference being that it only checks that all required attributes are present after the two bodies are merged.

I've updated the existing test to use interactive input vars and a schema with all required attributes. This test failed before switching from configs.MergeBodies to hcl.MergeBodies.

Fixes #28956