### PR TITLE
Remote backend: look up canonical capitalization of organization names

### DIFF
--- a/internal/backend/remote/backend_plan_test.go
+++ b/internal/backend/remote/backend_plan_test.go
@@ -90,6 +90,28 @@ func TestRemote_planBasic(t *testing.T) {
 	}
 }
 
+func TestRemote_planMisspelled(t *testing.T) {
+	b, bCleanup := testBackendMisspelled(t)
+	defer bCleanup()
+
+	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
+	defer configCleanup()
+	defer done(t)
+
+	op.Workspace = backend.DefaultStateName
+
+	run, err := b.Operation(context.Background(), op)
+	if err != nil {
+		t.Fatalf("error starting operation: %v", err)
+	}
+
+	<-run.Done()
+	output := b.CLI.(*cli.MockUi).OutputWriter.String()
+	if !strings.Contains(output, "https://app.terraform.io/app/hashicorp/prod/runs/") {
+		t.Fatalf("expected canonical capitalization of 'hashicorp' (not 'hashiCorp') in output: %s", output)
+	}
+}
+
 func TestRemote_planCanceled(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -222,6 +222,25 @@ func testServer(t *testing.T) *httptest.Server {
 }`)
 	})
 
+	// Respond to the initial query to read the hashicorp org. Only checks for name, so omit most attrs.
+	mux.HandleFunc("/api/v2/organizations/hashicorp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		io.WriteString(w, `{
+  "data": {
+    "id": "hashicorp",
+    "type": "organizations",
+    "attributes": {
+      "external-id": "org-GExadygjSbKP8hsY",
+      "name": "hashicorp"
+    },
+    "relationships": {},
+    "links": {
+      "self": "/api/v2/organizations/hashicorp"
+    }
+  }
+}`)
+	})
+
 	// Respond to the initial query to read the no-operations org entitlements.
 	mux.HandleFunc("/api/v2/organizations/no-operations/entitlement-set", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")
@@ -236,6 +255,25 @@ func testServer(t *testing.T) *httptest.Server {
       "state-storage": true,
       "teams": true,
       "vcs-integrations": true
+    }
+  }
+}`)
+	})
+
+	// Respond to the initial query to read the no-operations org. Only checks for name, so omit most attrs.
+	mux.HandleFunc("/api/v2/organizations/no-operations", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		io.WriteString(w, `{
+  "data": {
+    "id": "no-operations",
+    "type": "organizations",
+    "attributes": {
+      "external-id": "org-ufxa3y8jSbKP8hsT",
+      "name": "no-operations"
+    },
+    "relationships": {},
+    "links": {
+      "self": "/api/v2/organizations/no-operations"
     }
   }
 }`)


### PR DESCRIPTION
- Org names and workspace names in TFC/TFE have to be case-insensitively unique,
and if you look one up using the wrong caps you still get the correct resource
back.

- When Terraform starts a remote run, it prints a URL for viewing the run in
TFC/TFE. It discovers the canonical capitalization for the workspace name, but
uses the organization name from the remote backend config block verbatim.

- Older TFE versions (prior to May 2021) would 404 if you clicked a run link
with a miscapitalized organization name.

- But:
    - We fixed that and now TFC/TFE handles org names case-insensitively.
    - Also you could easily avoid that by spelling it correctly in the backend
    config block.

- Regardless, this commit does an extra HTTP request to ensure we use the
correct capitalization of the organization name after configuring the backend.

This way, it matches what we already do for workspaces, and we should hopefully never print a "wrong" organization name, regardless of whether it would cause any harm or not. (After all, "beauty works better.")