### PR TITLE
Bumping AWS GO SDK to 1.38.42 to fix AWS SSO auth woes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/aws/aws-sdk-go v1.37.0
+	github.com/aws/aws-sdk-go v1.38.42
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3A
 github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.37.0 h1:GzFnhOIsrGyQ69s7VgqtrG2BG8v7X7vwB3Xpbd/DBBk=
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.38.42 h1:94blpbGDe2q5e0Xoop7131uzI2CH2qitQoptSMrkJP8=
+github.com/aws/aws-sdk-go v1.38.42/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f h1:ZNv7On9kyUzm7fvRZumSyy/IUiSC7AzL0I1jKKtwooA=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
AWS SSO is used in many organizations to authenticate users for access to their AWS accounts. It's the same scale organizations that would very likely also use Terraform to manage their infrastructure. However, proper support for using this authentication scheme landed in the CLI and SDKs only over time, with features like interactive re-authentication (as may be needed when temporary credentials expire) still not universally supported. It's because of this that **many people**, including myself, will **configure their profiles** in their local AWS config **such that in addition to the SSO configuration, there is a** `credential_process`, which provides backwards compatibility for applications not supporting SSO as well as helps trigger an interactive re-auth as needed (such as [aws-sso-util](https://github.com/benkehoe/aws-sso-util)).

**For a while the AWS GO SDK derived from the behaviour of all the other AWS SDKs when it comes to handling profiles with this configuration. This has been addressed in** [aws/aws-sdk-go #3763](https://github.com/aws/aws-sdk-go/issues/3763) and a fix to that merged in [aws/aws-sdk-go PR#3763](https://github.com/aws/aws-sdk-go/pull/3905), which landed in [aws/aws-sdk-go v1.38.42](https://github.com/aws/aws-sdk-go/releases/tag/v1.38.42) and subsequently **[hashicorp/terraform-provider-aws v3.41.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.41.0)**.

**However, this issue** not only affected [hashicorp/terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws) (as initially brought up in #24133) but **also affects Terraform itself**, specifically when using AWS for storing the state, for example in S3. When using this common profile configuration of both SSO and `credential_process` simultaneously, `terraform init` will - because of its outdated AWS GO SDK dependency - fail with
```
Error: error configuring S3 Backend: Error creating AWS session:
       SharedConfigErr: only one credential type may be specified per profile:
       source profile, credential source, credential process, web identity token, or sso
```

**This pull requests is to** bump this dependency to the minimum version needed to fix this issue and **achieve consistent behaviour between Terraform itself and its AWS Provider as well compared to most other locally run tools that require AWS authentication**.

---


FYI: The current workaround is to create a separate named profile with only a credentials_process configured to point to the actual SSO profile. This works but it also means essentially duplicating all required profiles which is far from ideal.

