### PR TITLE
New marks.Sensitive type, and audit of sensitive marks usage

### DIFF
--- a/internal/command/format/diagnostic_test.go
+++ b/internal/command/format/diagnostic_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	viewsjson "github.com/hashicorp/terraform/internal/command/views/json"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -123,7 +124,7 @@ func TestDiagnostic(t *testing.T) {
 				EvalContext: &hcl.EvalContext{
 					Variables: map[string]cty.Value{
 						"boop": cty.ObjectVal(map[string]cty.Value{
-							"beep": cty.StringVal("blah").Mark("sensitive"),
+							"beep": cty.StringVal("blah").Mark(marks.Sensitive),
 						}),
 					},
 				},
@@ -336,7 +337,7 @@ Whatever shall we do?
 				EvalContext: &hcl.EvalContext{
 					Variables: map[string]cty.Value{
 						"boop": cty.ObjectVal(map[string]cty.Value{
-							"beep": cty.StringVal("blah").Mark("sensitive"),
+							"beep": cty.StringVal("blah").Mark(marks.Sensitive),
 						}),
 					},
 				},

--- a/internal/command/format/diff_test.go
+++ b/internal/command/format/diff_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/mitchellh/colorstring"
@@ -3193,28 +3194,28 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			AfterValMarks: []cty.PathValueMarks{
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "ami"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "list_field"}, cty.IndexStep{Key: cty.NumberIntVal(1)}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_whole"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_key"}, cty.IndexStep{Key: cty.StringVal("dinner")}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					// Nested blocks/sets will mark the whole set/block as sensitive
 					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block_list"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block_set"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			RequiredReplace: cty.NewPathSet(),
@@ -3338,35 +3339,35 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			BeforeValMarks: []cty.PathValueMarks{
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "ami"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "special"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "some_number"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "list_field"}, cty.IndexStep{Key: cty.NumberIntVal(2)}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_key"}, cty.IndexStep{Key: cty.StringVal("dinner")}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_whole"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block_set"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			RequiredReplace: cty.NewPathSet(),
@@ -3485,23 +3486,23 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			AfterValMarks: []cty.PathValueMarks{
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "tags"}, cty.IndexStep{Key: cty.StringVal("address")}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "list_field"}, cty.IndexStep{Key: cty.NumberIntVal(0)}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_key"}, cty.IndexStep{Key: cty.StringVal("dinner")}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_whole"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block_single"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			RequiredReplace: cty.NewPathSet(),
@@ -3598,45 +3599,45 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			BeforeValMarks: []cty.PathValueMarks{
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "ami"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "list_field"}, cty.IndexStep{Key: cty.NumberIntVal(0)}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_key"}, cty.IndexStep{Key: cty.StringVal("dinner")}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_whole"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block_map"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			AfterValMarks: []cty.PathValueMarks{
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "ami"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "list_field"}, cty.IndexStep{Key: cty.NumberIntVal(0)}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_key"}, cty.IndexStep{Key: cty.StringVal("dinner")}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_whole"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block_map"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			RequiredReplace: cty.NewPathSet(),
@@ -3745,35 +3746,35 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			BeforeValMarks: []cty.PathValueMarks{
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "ami"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "special"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "some_number"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "list_field"}, cty.IndexStep{Key: cty.NumberIntVal(2)}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_key"}, cty.IndexStep{Key: cty.StringVal("dinner")}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_whole"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block_set"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			RequiredReplace: cty.NewPathSet(),
@@ -3885,27 +3886,27 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			BeforeValMarks: []cty.PathValueMarks{
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "ami"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "list_field"}, cty.IndexStep{Key: cty.NumberIntVal(1)}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_key"}, cty.IndexStep{Key: cty.StringVal("dinner")}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "map_whole"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "nested_block_set"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			RequiredReplace: cty.NewPathSet(),
@@ -3974,21 +3975,21 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			BeforeValMarks: []cty.PathValueMarks{
 				{
 					Path:  cty.GetAttrPath("ami"),
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.GetAttrPath("nested_block_set"),
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			AfterValMarks: []cty.PathValueMarks{
 				{
 					Path:  cty.GetAttrPath("ami"),
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				{
 					Path:  cty.GetAttrPath("nested_block_set"),
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			Schema: &configschema.Block{

--- a/internal/command/jsonstate/state.go
+++ b/internal/command/jsonstate/state.go
@@ -9,6 +9,7 @@ import (
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/terraform"
@@ -404,7 +405,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 }
 
 func SensitiveAsBool(val cty.Value) cty.Value {
-	if val.HasMark("sensitive") {
+	if val.HasMark(marks.Sensitive) {
 		return cty.True
 	}
 

--- a/internal/command/jsonstate/state_test.go
+++ b/internal/command/jsonstate/state_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/zclconf/go-cty/cty"
@@ -122,7 +123,7 @@ func TestMarshalAttributeValues(t *testing.T) {
 				}),
 				"baz": cty.ListVal([]cty.Value{
 					cty.StringVal("goodnight"),
-					cty.StringVal("moon").Mark("sensitive"),
+					cty.StringVal("moon").Mark(marks.Sensitive),
 				}),
 			}),
 			attributeValues{
@@ -660,7 +661,6 @@ func testSchemas() *terraform.Schemas {
 }
 
 func TestSensitiveAsBool(t *testing.T) {
-	sensitive := "sensitive"
 	tests := []struct {
 		Input cty.Value
 		Want  cty.Value
@@ -674,16 +674,16 @@ func TestSensitiveAsBool(t *testing.T) {
 			cty.False,
 		},
 		{
-			cty.StringVal("hello").Mark(sensitive),
+			cty.StringVal("hello").Mark(marks.Sensitive),
 			cty.True,
 		},
 		{
-			cty.NullVal(cty.String).Mark(sensitive),
+			cty.NullVal(cty.String).Mark(marks.Sensitive),
 			cty.True,
 		},
 
 		{
-			cty.NullVal(cty.DynamicPseudoType).Mark(sensitive),
+			cty.NullVal(cty.DynamicPseudoType).Mark(marks.Sensitive),
 			cty.True,
 		},
 		{
@@ -691,7 +691,7 @@ func TestSensitiveAsBool(t *testing.T) {
 			cty.False,
 		},
 		{
-			cty.NullVal(cty.Object(map[string]cty.Type{"test": cty.String})).Mark(sensitive),
+			cty.NullVal(cty.Object(map[string]cty.Type{"test": cty.String})).Mark(marks.Sensitive),
 			cty.True,
 		},
 		{
@@ -699,7 +699,7 @@ func TestSensitiveAsBool(t *testing.T) {
 			cty.False,
 		},
 		{
-			cty.DynamicVal.Mark(sensitive),
+			cty.DynamicVal.Mark(marks.Sensitive),
 			cty.True,
 		},
 
@@ -708,13 +708,13 @@ func TestSensitiveAsBool(t *testing.T) {
 			cty.EmptyTupleVal,
 		},
 		{
-			cty.ListValEmpty(cty.String).Mark(sensitive),
+			cty.ListValEmpty(cty.String).Mark(marks.Sensitive),
 			cty.True,
 		},
 		{
 			cty.ListVal([]cty.Value{
 				cty.StringVal("hello"),
-				cty.StringVal("friend").Mark(sensitive),
+				cty.StringVal("friend").Mark(marks.Sensitive),
 			}),
 			cty.TupleVal([]cty.Value{
 				cty.False,
@@ -726,7 +726,7 @@ func TestSensitiveAsBool(t *testing.T) {
 			cty.EmptyTupleVal,
 		},
 		{
-			cty.SetValEmpty(cty.String).Mark(sensitive),
+			cty.SetValEmpty(cty.String).Mark(marks.Sensitive),
 			cty.True,
 		},
 		{
@@ -734,17 +734,17 @@ func TestSensitiveAsBool(t *testing.T) {
 			cty.TupleVal([]cty.Value{cty.False}),
 		},
 		{
-			cty.SetVal([]cty.Value{cty.StringVal("hello").Mark(sensitive)}),
+			cty.SetVal([]cty.Value{cty.StringVal("hello").Mark(marks.Sensitive)}),
 			cty.True,
 		},
 		{
-			cty.EmptyTupleVal.Mark(sensitive),
+			cty.EmptyTupleVal.Mark(marks.Sensitive),
 			cty.True,
 		},
 		{
 			cty.TupleVal([]cty.Value{
 				cty.StringVal("hello"),
-				cty.StringVal("friend").Mark(sensitive),
+				cty.StringVal("friend").Mark(marks.Sensitive),
 			}),
 			cty.TupleVal([]cty.Value{
 				cty.False,
@@ -756,7 +756,7 @@ func TestSensitiveAsBool(t *testing.T) {
 			cty.EmptyObjectVal,
 		},
 		{
-			cty.MapValEmpty(cty.String).Mark(sensitive),
+			cty.MapValEmpty(cty.String).Mark(marks.Sensitive),
 			cty.True,
 		},
 		{
@@ -769,7 +769,7 @@ func TestSensitiveAsBool(t *testing.T) {
 		{
 			cty.MapVal(map[string]cty.Value{
 				"greeting": cty.StringVal("hello"),
-				"animal":   cty.StringVal("horse").Mark(sensitive),
+				"animal":   cty.StringVal("horse").Mark(marks.Sensitive),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
 				"animal": cty.True,
@@ -778,8 +778,8 @@ func TestSensitiveAsBool(t *testing.T) {
 		{
 			cty.MapVal(map[string]cty.Value{
 				"greeting": cty.StringVal("hello"),
-				"animal":   cty.StringVal("horse").Mark(sensitive),
-			}).Mark(sensitive),
+				"animal":   cty.StringVal("horse").Mark(marks.Sensitive),
+			}).Mark(marks.Sensitive),
 			cty.True,
 		},
 		{
@@ -796,7 +796,7 @@ func TestSensitiveAsBool(t *testing.T) {
 		{
 			cty.ObjectVal(map[string]cty.Value{
 				"greeting": cty.StringVal("hello"),
-				"animal":   cty.StringVal("horse").Mark(sensitive),
+				"animal":   cty.StringVal("horse").Mark(marks.Sensitive),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
 				"animal": cty.True,
@@ -805,8 +805,8 @@ func TestSensitiveAsBool(t *testing.T) {
 		{
 			cty.ObjectVal(map[string]cty.Value{
 				"greeting": cty.StringVal("hello"),
-				"animal":   cty.StringVal("horse").Mark(sensitive),
-			}).Mark(sensitive),
+				"animal":   cty.StringVal("horse").Mark(marks.Sensitive),
+			}).Mark(marks.Sensitive),
 			cty.True,
 		},
 		{
@@ -815,7 +815,7 @@ func TestSensitiveAsBool(t *testing.T) {
 					"a": cty.UnknownVal(cty.String),
 				}),
 				cty.ObjectVal(map[string]cty.Value{
-					"a": cty.StringVal("known").Mark(sensitive),
+					"a": cty.StringVal("known").Mark(marks.Sensitive),
 				}),
 			}),
 			cty.TupleVal([]cty.Value{
@@ -829,7 +829,7 @@ func TestSensitiveAsBool(t *testing.T) {
 			cty.ListVal([]cty.Value{
 				cty.MapValEmpty(cty.String),
 				cty.MapVal(map[string]cty.Value{
-					"a": cty.StringVal("known").Mark(sensitive),
+					"a": cty.StringVal("known").Mark(marks.Sensitive),
 				}),
 				cty.MapVal(map[string]cty.Value{
 					"a": cty.UnknownVal(cty.String),

--- a/internal/command/views/add_test.go
+++ b/internal/command/views/add_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -412,7 +413,7 @@ root_block_device {
 		val := cty.ObjectVal(map[string]cty.Value{
 			"root_block_device": cty.ListVal([]cty.Value{
 				cty.ObjectVal(map[string]cty.Value{
-					"volume_type": cty.StringVal("foo").Mark("sensitive"),
+					"volume_type": cty.StringVal("foo").Mark(marks.Sensitive),
 				}),
 				cty.ObjectVal(map[string]cty.Value{
 					"volume_type": cty.StringVal("bar"),
@@ -500,7 +501,7 @@ root_block_device {
 				cty.ObjectVal(map[string]cty.Value{
 					"volume_type": cty.StringVal("bar"),
 				}),
-			}).Mark("sensitive"),
+			}).Mark(marks.Sensitive),
 		})
 		schema := addTestSchema(configschema.NestingSet)
 		var buf strings.Builder
@@ -549,7 +550,7 @@ root_block_device "2" {
 		val := cty.ObjectVal(map[string]cty.Value{
 			"root_block_device": cty.MapVal(map[string]cty.Value{
 				"1": cty.ObjectVal(map[string]cty.Value{
-					"volume_type": cty.StringVal("foo").Mark("sensitive"),
+					"volume_type": cty.StringVal("foo").Mark(marks.Sensitive),
 				}),
 				"2": cty.ObjectVal(map[string]cty.Value{
 					"volume_type": cty.StringVal("bar"),
@@ -583,7 +584,7 @@ root_block_device "2" {
 				"2": cty.ObjectVal(map[string]cty.Value{
 					"volume_type": cty.StringVal("bar"),
 				}),
-			}).Mark("sensitive"),
+			}).Mark(marks.Sensitive),
 		})
 		schema := addTestSchema(configschema.NestingMap)
 		var buf strings.Builder
@@ -606,7 +607,7 @@ root_block_device "2" {
 				}),
 				"2": cty.ObjectVal(map[string]cty.Value{
 					"volume_type": cty.StringVal("bar"),
-				}).Mark("sensitive"),
+				}).Mark(marks.Sensitive),
 			}),
 		})
 		schema := addTestSchema(configschema.NestingMap)
@@ -825,7 +826,7 @@ func TestAdd_WriteConfigNestedTypeAttributeFromExisting(t *testing.T) {
 					"size":        cty.StringVal("250GB"),
 				}),
 			}),
-		}).Mark("sensitive")
+		}).Mark(marks.Sensitive)
 
 		schema := addTestSchema(configschema.NestingList)
 		var buf strings.Builder
@@ -880,12 +881,12 @@ func TestAdd_WriteConfigNestedTypeAttributeFromExisting(t *testing.T) {
 			"disks": cty.MapVal(map[string]cty.Value{
 				"foo": cty.ObjectVal(map[string]cty.Value{
 					"mount_point": cty.StringVal("/mnt/foo"),
-					"size":        cty.StringVal("50GB").Mark("sensitive"),
+					"size":        cty.StringVal("50GB").Mark(marks.Sensitive),
 				}),
 				"bar": cty.ObjectVal(map[string]cty.Value{
 					"mount_point": cty.StringVal("/mnt/bar"),
 					"size":        cty.StringVal("250GB"),
-				}).Mark("sensitive"),
+				}).Mark(marks.Sensitive),
 			}),
 		})
 		schema := addTestSchema(configschema.NestingMap)

--- a/internal/command/views/add_test.go
+++ b/internal/command/views/add_test.go
@@ -343,7 +343,7 @@ func TestAdd_writeConfigBlocksFromExisting(t *testing.T) {
 		v := addHuman{optional: true}
 		val := cty.ObjectVal(map[string]cty.Value{
 			"root_block_device": cty.ObjectVal(map[string]cty.Value{
-				"volume_type": cty.StringVal("foo").Mark("bar"),
+				"volume_type": cty.StringVal("foo").Mark(marks.Sensitive),
 			}),
 		})
 		schema := addTestSchema(configschema.NestingSingle)
@@ -366,7 +366,7 @@ func TestAdd_writeConfigBlocksFromExisting(t *testing.T) {
 			"root_block_device": cty.ObjectVal(map[string]cty.Value{
 				"volume_type": cty.StringVal("foo"),
 			}),
-		}).Mark("bar")
+		}).Mark(marks.Sensitive)
 		schema := addTestSchema(configschema.NestingSingle)
 		var buf strings.Builder
 		v.writeConfigBlocksFromExisting(&buf, val, schema.BlockTypes, 0)
@@ -447,7 +447,7 @@ root_block_device {
 				cty.ObjectVal(map[string]cty.Value{
 					"volume_type": cty.StringVal("bar"),
 				}),
-			}).Mark("mark"),
+			}).Mark(marks.Sensitive),
 		})
 		schema := addTestSchema(configschema.NestingList)
 		var buf strings.Builder
@@ -784,13 +784,13 @@ func TestAdd_WriteConfigNestedTypeAttributeFromExisting(t *testing.T) {
 			"disks": cty.ListVal([]cty.Value{
 				cty.ObjectVal(map[string]cty.Value{
 					"mount_point": cty.StringVal("/mnt/foo"),
-					"size":        cty.StringVal("50GB").Mark("hi"),
+					"size":        cty.StringVal("50GB").Mark(marks.Sensitive),
 				}),
 				// This is an odd example, where the entire element is marked.
 				cty.ObjectVal(map[string]cty.Value{
 					"mount_point": cty.StringVal("/mnt/bar"),
 					"size":        cty.StringVal("250GB"),
-				}).Mark("bye"),
+				}).Mark(marks.Sensitive),
 			}),
 		})
 

--- a/internal/command/views/apply_test.go
+++ b/internal/command/views/apply_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/zclconf/go-cty/cty"
@@ -228,7 +229,7 @@ func TestApplyJSON_outputs(t *testing.T) {
 
 	v.Outputs(map[string]*states.OutputValue{
 		"boop_count": {Value: cty.NumberIntVal(92)},
-		"password":   {Value: cty.StringVal("horse-battery").Mark("sensitive"), Sensitive: true},
+		"password":   {Value: cty.StringVal("horse-battery").Mark(marks.Sensitive), Sensitive: true},
 	})
 
 	want := []map[string]interface{}{

--- a/internal/command/views/json/diagnostic.go
+++ b/internal/command/views/json/diagnostic.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcled"
 	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -260,7 +261,7 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 							Traversal: traversalStr,
 						}
 						switch {
-						case val.IsMarked():
+						case val.HasMark(marks.Sensitive):
 							// We won't say anything at all about sensitive values,
 							// because we might give away something that was
 							// sensitive about them.
@@ -323,7 +324,7 @@ func compactValueStr(val cty.Value) string {
 	// helpful but concise messages in diagnostics. It is not comprehensive
 	// nor intended to be used for other purposes.
 
-	if val.IsMarked() {
+	if val.HasMark(marks.Sensitive) {
 		// We check this in here just to make sure, but note that the caller
 		// of compactValueStr ought to have already checked this and skipped
 		// calling into compactValueStr anyway, so this shouldn't actually

--- a/internal/command/views/json/diagnostic_test.go
+++ b/internal/command/views/json/diagnostic_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -360,7 +361,7 @@ func TestNewDiagnostic(t *testing.T) {
 					Variables: map[string]cty.Value{
 						"var": cty.ObjectVal(map[string]cty.Value{
 							"boop": cty.MapVal(map[string]cty.Value{
-								"hello!": cty.StringVal("bleurgh").Mark("sensitive"),
+								"hello!": cty.StringVal("bleurgh").Mark(marks.Sensitive),
 							}),
 						}),
 					},
@@ -416,7 +417,7 @@ func TestNewDiagnostic(t *testing.T) {
 					Variables: map[string]cty.Value{
 						"var": cty.ObjectVal(map[string]cty.Value{
 							"boop": cty.MapVal(map[string]cty.Value{
-								"hello!": cty.StringVal("bleurgh").Mark("sensitive"),
+								"hello!": cty.StringVal("bleurgh").Mark(marks.Sensitive),
 							}),
 						}),
 					},
@@ -597,7 +598,7 @@ func TestNewDiagnostic(t *testing.T) {
 							"a": cty.True,
 							"b": cty.NumberFloatVal(123.45),
 							"c": cty.NullVal(cty.String),
-							"d": cty.StringVal("secret").Mark("sensitive"),
+							"d": cty.StringVal("secret").Mark(marks.Sensitive),
 							"e": cty.False,
 							"f": cty.ListValEmpty(cty.String),
 							"g": cty.MapVal(map[string]cty.Value{

--- a/internal/command/views/json/output_test.go
+++ b/internal/command/views/json/output_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -17,7 +18,7 @@ func TestOutputsFromMap(t *testing.T) {
 		},
 		// Sensitive string output
 		"beep": {
-			Value:     cty.StringVal("horse-battery").Mark("sensitive"),
+			Value:     cty.StringVal("horse-battery").Mark(marks.Sensitive),
 			Sensitive: true,
 		},
 		// Sensitive object output which is marked at the leaf
@@ -25,7 +26,7 @@ func TestOutputsFromMap(t *testing.T) {
 			Value: cty.ObjectVal(map[string]cty.Value{
 				"a": cty.ObjectVal(map[string]cty.Value{
 					"b": cty.ObjectVal(map[string]cty.Value{
-						"c": cty.StringVal("oh, hi").Mark("sensitive"),
+						"c": cty.StringVal("oh, hi").Mark(marks.Sensitive),
 					}),
 				}),
 			}),

--- a/internal/command/views/refresh_test.go
+++ b/internal/command/views/refresh_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/zclconf/go-cty/cty"
@@ -80,7 +81,7 @@ func TestRefreshJSON_outputs(t *testing.T) {
 
 	v.Outputs(map[string]*states.OutputValue{
 		"boop_count": {Value: cty.NumberIntVal(92)},
-		"password":   {Value: cty.StringVal("horse-battery").Mark("sensitive"), Sensitive: true},
+		"password":   {Value: cty.StringVal("horse-battery").Mark(marks.Sensitive), Sensitive: true},
 	})
 
 	want := []map[string]interface{}{

--- a/internal/configs/configschema/marks.go
+++ b/internal/configs/configschema/marks.go
@@ -3,6 +3,7 @@ package configschema
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -19,7 +20,7 @@ func (b *Block) ValueMarks(val cty.Value, path cty.Path) []cty.PathValueMarks {
 			attrPath = append(path, cty.GetAttrStep{Name: name})
 			pvm = append(pvm, cty.PathValueMarks{
 				Path:  attrPath,
-				Marks: cty.NewValueMarks("sensitive"),
+				Marks: cty.NewValueMarks(marks.Sensitive),
 			})
 		}
 	}

--- a/internal/configs/configschema/marks_test.go
+++ b/internal/configs/configschema/marks_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -58,7 +59,7 @@ func TestBlockValueMarks(t *testing.T) {
 				"list":        cty.UnknownVal(schema.BlockTypes["list"].ImpliedType()),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
-				"sensitive":   cty.UnknownVal(cty.String).Mark("sensitive"),
+				"sensitive":   cty.UnknownVal(cty.String).Mark(marks.Sensitive),
 				"unsensitive": cty.UnknownVal(cty.String),
 				"list":        cty.UnknownVal(schema.BlockTypes["list"].ImpliedType()),
 			}),
@@ -79,15 +80,15 @@ func TestBlockValueMarks(t *testing.T) {
 				}),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
-				"sensitive":   cty.NullVal(cty.String).Mark("sensitive"),
+				"sensitive":   cty.NullVal(cty.String).Mark(marks.Sensitive),
 				"unsensitive": cty.UnknownVal(cty.String),
 				"list": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
-						"sensitive":   cty.UnknownVal(cty.String).Mark("sensitive"),
+						"sensitive":   cty.UnknownVal(cty.String).Mark(marks.Sensitive),
 						"unsensitive": cty.UnknownVal(cty.String),
 					}),
 					cty.ObjectVal(map[string]cty.Value{
-						"sensitive":   cty.NullVal(cty.String).Mark("sensitive"),
+						"sensitive":   cty.NullVal(cty.String).Mark(marks.Sensitive),
 						"unsensitive": cty.NullVal(cty.String),
 					}),
 				}),

--- a/internal/lang/funcs/conversion.go
+++ b/internal/lang/funcs/conversion.go
@@ -109,7 +109,7 @@ var TypeFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.String),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		return cty.StringVal(TypeString(args[0].Type())).Mark("raw"), nil
+		return cty.StringVal(TypeString(args[0].Type())).Mark(marks.Raw), nil
 	},
 })
 

--- a/internal/lang/funcs/conversion_test.go
+++ b/internal/lang/funcs/conversion_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -61,6 +62,12 @@ func TestTo(t *testing.T) {
 			cty.StringVal("a").Mark("boop"),
 			cty.Bool,
 			cty.DynamicVal,
+			`cannot convert "a" to bool; only the strings "true" or "false" are allowed`,
+		},
+		{
+			cty.StringVal("a").Mark(marks.Sensitive),
+			cty.Bool,
+			cty.DynamicVal,
 			`cannot convert this sensitive string to bool`,
 		},
 		{
@@ -71,6 +78,12 @@ func TestTo(t *testing.T) {
 		},
 		{
 			cty.StringVal("a").Mark("boop"),
+			cty.Number,
+			cty.DynamicVal,
+			`cannot convert "a" to number; given string must be a decimal representation of a number`,
+		},
+		{
+			cty.StringVal("a").Mark(marks.Sensitive),
 			cty.Number,
 			cty.DynamicVal,
 			`cannot convert this sensitive string to number`,

--- a/internal/lang/funcs/sensitive.go
+++ b/internal/lang/funcs/sensitive.go
@@ -1,6 +1,7 @@
 package funcs
 
 import (
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )
@@ -25,7 +26,7 @@ var SensitiveFunc = function.New(&function.Spec{
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
 		val, _ := args[0].Unmark()
-		return val.Mark("sensitive"), nil
+		return val.Mark(marks.Sensitive), nil
 	},
 })
 
@@ -48,12 +49,12 @@ var NonsensitiveFunc = function.New(&function.Spec{
 		return args[0].Type(), nil
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
-		if args[0].IsKnown() && !args[0].HasMark("sensitive") {
+		if args[0].IsKnown() && !args[0].HasMark(marks.Sensitive) {
 			return cty.DynamicVal, function.NewArgErrorf(0, "the given value is not sensitive, so this call is redundant")
 		}
-		v, marks := args[0].Unmark()
-		delete(marks, "sensitive") // remove the sensitive marking
-		return v.WithMarks(marks), nil
+		v, m := args[0].Unmark()
+		delete(m, marks.Sensitive) // remove the sensitive marking
+		return v.WithMarks(m), nil
 	},
 })
 

--- a/internal/lang/funcs/sensitive_test.go
+++ b/internal/lang/funcs/sensitive_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -38,7 +39,7 @@ func TestSensitive(t *testing.T) {
 		},
 		{
 			// A value already marked is allowed and stays marked
-			cty.NumberIntVal(1).Mark("sensitive"),
+			cty.NumberIntVal(1).Mark(marks.Sensitive),
 			``,
 		},
 		{
@@ -52,7 +53,7 @@ func TestSensitive(t *testing.T) {
 		{
 			// A value deep already marked is allowed and stays marked,
 			// _and_ we'll also mark the outer collection as sensitive.
-			cty.ListVal([]cty.Value{cty.NumberIntVal(1).Mark("sensitive")}),
+			cty.ListVal([]cty.Value{cty.NumberIntVal(1).Mark(marks.Sensitive)}),
 			``,
 		},
 	}
@@ -73,7 +74,7 @@ func TestSensitive(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			if !got.HasMark("sensitive") {
+			if !got.HasMark(marks.Sensitive) {
 				t.Errorf("result is not marked sensitive")
 			}
 
@@ -105,24 +106,24 @@ func TestNonsensitive(t *testing.T) {
 		WantErr string
 	}{
 		{
-			cty.NumberIntVal(1).Mark("sensitive"),
+			cty.NumberIntVal(1).Mark(marks.Sensitive),
 			``,
 		},
 		{
-			cty.DynamicVal.Mark("sensitive"),
+			cty.DynamicVal.Mark(marks.Sensitive),
 			``,
 		},
 		{
-			cty.UnknownVal(cty.String).Mark("sensitive"),
+			cty.UnknownVal(cty.String).Mark(marks.Sensitive),
 			``,
 		},
 		{
-			cty.NullVal(cty.EmptyObject).Mark("sensitive"),
+			cty.NullVal(cty.EmptyObject).Mark(marks.Sensitive),
 			``,
 		},
 		{
 			// The inner sensitive remains afterwards
-			cty.ListVal([]cty.Value{cty.NumberIntVal(1).Mark("sensitive")}).Mark("sensitive"),
+			cty.ListVal([]cty.Value{cty.NumberIntVal(1).Mark(marks.Sensitive)}).Mark(marks.Sensitive),
 			``,
 		},
 
@@ -166,7 +167,7 @@ func TestNonsensitive(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			if got.HasMark("sensitive") {
+			if got.HasMark(marks.Sensitive) {
 				t.Errorf("result is still marked sensitive")
 			}
 			wantRaw, _ := test.Input.Unmark()

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/terraform/internal/experiments"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -715,7 +716,7 @@ func TestFunctions(t *testing.T) {
 		"sensitive": {
 			{
 				`sensitive(1)`,
-				cty.NumberIntVal(1).Mark("sensitive"),
+				cty.NumberIntVal(1).Mark(marks.Sensitive),
 			},
 		},
 

--- a/internal/lang/marks/marks.go
+++ b/internal/lang/marks/marks.go
@@ -37,3 +37,7 @@ func Contains(val cty.Value, mark valueMark) bool {
 // Sensitive indicates that this value is marked as sensitive in the context of
 // Terraform.
 var Sensitive = valueMark("sensitive")
+
+// Raw is used to indicate to the repl that the value should be written without
+// any formatting.
+var Raw = valueMark("raw")

--- a/internal/lang/marks/marks.go
+++ b/internal/lang/marks/marks.go
@@ -1,0 +1,13 @@
+package marks
+
+import (
+	"strings"
+)
+
+type valueMark string
+
+func (m valueMark) GoString() string {
+	return "marks." + strings.Title(string(m))
+}
+
+var Sensitive = valueMark("sensitive")

--- a/internal/lang/marks/marks.go
+++ b/internal/lang/marks/marks.go
@@ -2,6 +2,8 @@ package marks
 
 import (
 	"strings"
+
+	"github.com/zclconf/go-cty/cty"
 )
 
 // valueMarks allow creating strictly typed values for use as cty.Value marks.
@@ -11,6 +13,25 @@ type valueMark string
 
 func (m valueMark) GoString() string {
 	return "marks." + strings.Title(string(m))
+}
+
+// Has returns true if and only if the cty.Value has the given mark.
+func Has(val cty.Value, mark valueMark) bool {
+	return val.HasMark(mark)
+}
+
+// Contains returns true if the cty.Value or any any value within it contains
+// the given mark.
+func Contains(val cty.Value, mark valueMark) bool {
+	ret := false
+	cty.Walk(val, func(_ cty.Path, v cty.Value) (bool, error) {
+		if v.HasMark(mark) {
+			ret = true
+			return false, nil
+		}
+		return true, nil
+	})
+	return ret
 }
 
 // Sensitive indicates that this value is marked as sensitive in the context of

--- a/internal/lang/marks/marks.go
+++ b/internal/lang/marks/marks.go
@@ -4,10 +4,15 @@ import (
 	"strings"
 )
 
+// valueMarks allow creating strictly typed values for use as cty.Value marks.
+// The variable name for new values should be the title-cased format of the
+// value to better match the GoString output for debugging.
 type valueMark string
 
 func (m valueMark) GoString() string {
 	return "marks." + strings.Title(string(m))
 }
 
+// Sensitive indicates that this value is marked as sensitive in the context of
+// Terraform.
 var Sensitive = valueMark("sensitive")

--- a/internal/plans/changes_test.go
+++ b/internal/plans/changes_test.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
 
 func TestChangeEncodeSensitive(t *testing.T) {
 	testVals := []cty.Value{
 		cty.ObjectVal(map[string]cty.Value{
-			"ding": cty.StringVal("dong").Mark("sensitive"),
+			"ding": cty.StringVal("dong").Mark(marks.Sensitive),
 		}),
 		cty.StringVal("bleep").Mark("bloop"),
 		cty.ListVal([]cty.Value{cty.UnknownVal(cty.String).Mark("sup?")}),

--- a/internal/plans/objchange/compatible.go
+++ b/internal/plans/objchange/compatible.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zclconf/go-cty/cty/convert"
 
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 )
 
 // AssertObjectCompatible checks whether the given "actual" value is a valid
@@ -57,11 +58,11 @@ func assertObjectCompatible(schema *configschema.Block, planned, actual cty.Valu
 		// exposing a value through errors
 		unmarkedActualV, marksA := actualV.UnmarkDeep()
 		unmarkedPlannedV, marksP := plannedV.UnmarkDeep()
-		_, isMarkedActual := marksA["sensitive"]
-		_, isMarkedPlanned := marksP["sensitive"]
+		_, isSensitiveActual := marksA[marks.Sensitive]
+		_, isSensitivePlanned := marksP[marks.Sensitive]
 
 		moreErrs := assertValueCompatible(unmarkedPlannedV, unmarkedActualV, path)
-		if attrS.Sensitive || isMarkedActual || isMarkedPlanned {
+		if attrS.Sensitive || isSensitiveActual || isSensitivePlanned {
 			if len(moreErrs) > 0 {
 				// Use a vague placeholder message instead, to avoid disclosing
 				// sensitive information.

--- a/internal/plans/objchange/compatible_test.go
+++ b/internal/plans/objchange/compatible_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -155,7 +156,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 			},
 			cty.ObjectVal(map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
-				"name": cty.StringVal("wotsit").Mark("sensitive"),
+				"name": cty.StringVal("wotsit").Mark(marks.Sensitive),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
@@ -184,7 +185,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 			}),
 			cty.ObjectVal(map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
-				"name": cty.StringVal("thingy").Mark("sensitive"),
+				"name": cty.StringVal("thingy").Mark(marks.Sensitive),
 			}),
 			[]string{
 				`.name: inconsistent values for sensitive attribute`,
@@ -216,7 +217,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 							cty.ObjectVal(map[string]cty.Value{
 								"foo": cty.StringVal("secret"),
 							}),
-						}).Mark("sensitive"),
+						}).Mark(marks.Sensitive),
 					}),
 				}),
 			}),
@@ -227,7 +228,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 							cty.ObjectVal(map[string]cty.Value{
 								"foo": cty.StringVal("secret"),
 							}),
-						}).Mark("sensitive"),
+						}).Mark(marks.Sensitive),
 					}),
 				}),
 			}),

--- a/internal/plans/objchange/lcs_test.go
+++ b/internal/plans/objchange/lcs_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -89,16 +90,16 @@ func TestLongestCommonSubsequence(t *testing.T) {
 		},
 		{
 			[]cty.Value{
-				cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x").Mark("sensitive")}),
+				cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x").Mark(marks.Sensitive)}),
 				cty.MapVal(map[string]cty.Value{"b": cty.StringVal("y")}),
 			},
 			[]cty.Value{
-				cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x").Mark("sensitive")}),
+				cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x").Mark(marks.Sensitive)}),
 				cty.MapVal(map[string]cty.Value{"b": cty.StringVal("y")}),
 				cty.MapVal(map[string]cty.Value{"c": cty.StringVal("z")}),
 			},
 			[]cty.Value{
-				cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x").Mark("sensitive")}),
+				cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x").Mark(marks.Sensitive)}),
 				cty.MapVal(map[string]cty.Value{"b": cty.StringVal("y")}),
 			},
 		},

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/plans/internal/planproto"
 	"github.com/hashicorp/terraform/internal/states"
@@ -315,7 +316,7 @@ func changeFromTfplan(rawChange *planproto.Change) (*plans.ChangeSrc, error) {
 		}
 	}
 
-	sensitive := cty.NewValueMarks("sensitive")
+	sensitive := cty.NewValueMarks(marks.Sensitive)
 	beforeValMarks, err := pathValueMarksFromTfplan(rawChange.BeforeSensitivePaths, sensitive)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode before sensitive paths: %s", err)

--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 )
 
@@ -78,7 +79,7 @@ func TestTFPlanRoundTrip(t *testing.T) {
 						AfterValMarks: []cty.PathValueMarks{
 							{
 								Path:  cty.GetAttrPath("boop").IndexInt(1),
-								Marks: cty.NewValueMarks("sensitive"),
+								Marks: cty.NewValueMarks(marks.Sensitive),
 							},
 						},
 					},

--- a/internal/repl/format.go
+++ b/internal/repl/format.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -20,7 +21,7 @@ func FormatValue(v cty.Value, indent int) string {
 		raw, _ := v.Unmark()
 		return raw.AsString()
 	}
-	if v.HasMark("sensitive") {
+	if v.HasMark(marks.Sensitive) {
 		return "(sensitive)"
 	}
 	if v.IsNull() {

--- a/internal/repl/format.go
+++ b/internal/repl/format.go
@@ -17,7 +17,7 @@ func FormatValue(v cty.Value, indent int) string {
 	if !v.IsKnown() {
 		return "(known after apply)"
 	}
-	if v.Type().Equals(cty.String) && v.HasMark("raw") {
+	if v.Type().Equals(cty.String) && v.HasMark(marks.Raw) {
 		raw, _ := v.Unmark()
 		return raw.AsString()
 	}

--- a/internal/repl/format_test.go
+++ b/internal/repl/format_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -170,7 +171,7 @@ EOT_`,
 			`toset([])`,
 		},
 		{
-			cty.StringVal("sensitive value").Mark("sensitive"),
+			cty.StringVal("sensitive value").Mark(marks.Sensitive),
 			"(sensitive)",
 		},
 	}

--- a/internal/states/state_test.go
+++ b/internal/states/state_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 )
 
 func TestState(t *testing.T) {
@@ -262,7 +263,7 @@ func TestStateDeepCopy(t *testing.T) {
 			AttrSensitivePaths: []cty.PathValueMarks{
 				{
 					Path:  cty.Path{cty.GetAttrStep{Name: "woozles"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			Private: []byte("private data"),

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -11,6 +11,7 @@ import (
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -164,7 +165,7 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 				for _, path := range paths {
 					pvm = append(pvm, cty.PathValueMarks{
 						Path:  path,
-						Marks: cty.NewValueMarks("sensitive"),
+						Marks: cty.NewValueMarks(marks.Sensitive),
 					})
 				}
 				obj.AttrSensitivePaths = pvm

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
@@ -420,7 +421,7 @@ resource "test_resource" "b" {
 				AttrSensitivePaths: []cty.PathValueMarks{
 					{
 						Path:  cty.GetAttrPath("sensitive_attr"),
-						Marks: cty.NewValueMarks("sensitive"),
+						Marks: cty.NewValueMarks(marks.Sensitive),
 					},
 				},
 				Status: states.ObjectReady,

--- a/internal/terraform/context_apply_test.go
+++ b/internal/terraform/context_apply_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/configs/hcl2shim"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
@@ -11949,7 +11950,7 @@ resource "test_resource" "foo" {
 		if gotPath, wantPath := pvm.Path, cty.GetAttrPath("value"); !gotPath.Equals(wantPath) {
 			t.Errorf("wrong path\n got: %#v\nwant: %#v", gotPath, wantPath)
 		}
-		if gotMarks, wantMarks := pvm.Marks, cty.NewValueMarks("sensitive"); !gotMarks.Equal(wantMarks) {
+		if gotMarks, wantMarks := pvm.Marks, cty.NewValueMarks(marks.Sensitive); !gotMarks.Equal(wantMarks) {
 			t.Errorf("wrong marks\n got: %#v\nwant: %#v", gotMarks, wantMarks)
 		}
 	}
@@ -12013,7 +12014,7 @@ resource "test_resource" "baz" {
 		if gotPath, wantPath := pvm.Path, cty.GetAttrPath("value"); !gotPath.Equals(wantPath) {
 			t.Errorf("wrong path\n got: %#v\nwant: %#v", gotPath, wantPath)
 		}
-		if gotMarks, wantMarks := pvm.Marks, cty.NewValueMarks("sensitive"); !gotMarks.Equal(wantMarks) {
+		if gotMarks, wantMarks := pvm.Marks, cty.NewValueMarks(marks.Sensitive); !gotMarks.Equal(wantMarks) {
 			t.Errorf("wrong marks\n got: %#v\nwant: %#v", gotMarks, wantMarks)
 		}
 	}
@@ -12098,7 +12099,7 @@ resource "test_resource" "foo" {
 	got := fooState.Current.AttrSensitivePaths[0]
 	want := cty.PathValueMarks{
 		Path:  cty.GetAttrPath("value"),
-		Marks: cty.NewValueMarks("sensitive"),
+		Marks: cty.NewValueMarks(marks.Sensitive),
 	}
 
 	if !got.Equal(want) {
@@ -12399,7 +12400,7 @@ func TestContext2Apply_dataSensitive(t *testing.T) {
 	if gotPath, wantPath := pvm.Path, cty.GetAttrPath("foo"); !gotPath.Equals(wantPath) {
 		t.Errorf("wrong path\n got: %#v\nwant: %#v", gotPath, wantPath)
 	}
-	if gotMarks, wantMarks := pvm.Marks, cty.NewValueMarks("sensitive"); !gotMarks.Equal(wantMarks) {
+	if gotMarks, wantMarks := pvm.Marks, cty.NewValueMarks(marks.Sensitive); !gotMarks.Equal(wantMarks) {
 		t.Errorf("wrong marks\n got: %#v\nwant: %#v", gotMarks, wantMarks)
 	}
 }

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
@@ -175,7 +176,7 @@ data "test_data_source" "foo" {
 			AttrSensitivePaths: []cty.PathValueMarks{
 				{
 					Path:  cty.GetAttrPath("foo"),
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 		},
@@ -1092,7 +1093,7 @@ data "test_data_source" "foo" {
 			AttrSensitivePaths: []cty.PathValueMarks{
 				{
 					Path:  cty.GetAttrPath("foo"),
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 		},
@@ -1106,7 +1107,7 @@ data "test_data_source" "foo" {
 			AttrSensitivePaths: []cty.PathValueMarks{
 				{
 					Path:  cty.GetAttrPath("sensitive"),
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 		},

--- a/internal/terraform/eval_count_test.go
+++ b/internal/terraform/eval_count_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -20,7 +21,7 @@ func TestEvaluateCountExpression(t *testing.T) {
 			0,
 		},
 		"expression with marked value": {
-			hcltest.MockExprLiteral(cty.NumberIntVal(8).Mark("sensitive")),
+			hcltest.MockExprLiteral(cty.NumberIntVal(8).Mark(marks.Sensitive)),
 			8,
 		},
 	}

--- a/internal/terraform/eval_for_each.go
+++ b/internal/terraform/eval_for_each.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -61,7 +62,7 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext, allowU
 
 	// If a whole map is marked, or a set contains marked values (which means the set is then marked)
 	// give an error diagnostic as this value cannot be used in for_each
-	if forEachVal.IsMarked() {
+	if forEachVal.HasMark(marks.Sensitive) {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity:    hcl.DiagError,
 			Summary:     "Invalid for_each argument",

--- a/internal/terraform/eval_for_each_test.go
+++ b/internal/terraform/eval_for_each_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -54,11 +55,11 @@ func TestEvaluateForEachExpression_valid(t *testing.T) {
 		},
 		"map containing sensitive values, but strings are literal": {
 			hcltest.MockExprLiteral(cty.MapVal(map[string]cty.Value{
-				"a": cty.BoolVal(true).Mark("sensitive"),
+				"a": cty.BoolVal(true).Mark(marks.Sensitive),
 				"b": cty.BoolVal(false),
 			})),
 			map[string]cty.Value{
-				"a": cty.BoolVal(true).Mark("sensitive"),
+				"a": cty.BoolVal(true).Mark(marks.Sensitive),
 				"b": cty.BoolVal(false),
 			},
 		},
@@ -124,7 +125,7 @@ func TestEvaluateForEachExpression_errors(t *testing.T) {
 			hcltest.MockExprLiteral(cty.MapVal(map[string]cty.Value{
 				"a": cty.BoolVal(true),
 				"b": cty.BoolVal(false),
-			}).Mark("sensitive")),
+			}).Mark(marks.Sensitive)),
 			"Invalid for_each argument",
 			"Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource instance key.",
 		},
@@ -149,7 +150,7 @@ func TestEvaluateForEachExpression_errors(t *testing.T) {
 			"depends on resource attributes that cannot be determined until apply",
 		},
 		"set containing marked values": {
-			hcltest.MockExprLiteral(cty.SetVal([]cty.Value{cty.StringVal("beep").Mark("sensitive"), cty.StringVal("boop")})),
+			hcltest.MockExprLiteral(cty.SetVal([]cty.Value{cty.StringVal("beep").Mark(marks.Sensitive), cty.StringVal("boop")})),
 			"Invalid for_each argument",
 			"Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource instance key.",
 		},

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -262,7 +262,7 @@ func (d *evaluationStateData) GetInputVariable(addr addrs.InputVariable, rng tfd
 	if d.Operation == walkValidate {
 		// Ensure variable sensitivity is captured in the validate walk
 		if config.Sensitive {
-			return marks.Sensitive(cty.UnknownVal(wantType)), diags
+			return cty.UnknownVal(wantType).Mark(marks.Sensitive), diags
 		}
 		return cty.UnknownVal(wantType), diags
 	}
@@ -299,7 +299,7 @@ func (d *evaluationStateData) GetInputVariable(addr addrs.InputVariable, rng tfd
 
 	// Mark if sensitive
 	if config.Sensitive {
-		val = marks.Sensitive(val)
+		val = val.Mark(marks.Sensitive)
 	}
 
 	return val, diags
@@ -434,7 +434,7 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 			instance[cfg.Name] = outputState
 
 			if cfg.Sensitive {
-				instance[cfg.Name] = marks.Sensitive(outputState)
+				instance[cfg.Name] = outputState.Mark(marks.Sensitive)
 			}
 		}
 
@@ -463,7 +463,7 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 			instance[cfg.Name] = change.After
 
 			if change.Sensitive {
-				instance[cfg.Name] = marks.Sensitive(change.After)
+				instance[cfg.Name] = change.After.Mark(marks.Sensitive)
 			}
 		}
 	}

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -261,7 +262,7 @@ func (d *evaluationStateData) GetInputVariable(addr addrs.InputVariable, rng tfd
 	if d.Operation == walkValidate {
 		// Ensure variable sensitivity is captured in the validate walk
 		if config.Sensitive {
-			return cty.UnknownVal(wantType).Mark("sensitive"), diags
+			return marks.Sensitive(cty.UnknownVal(wantType)), diags
 		}
 		return cty.UnknownVal(wantType), diags
 	}
@@ -296,9 +297,9 @@ func (d *evaluationStateData) GetInputVariable(addr addrs.InputVariable, rng tfd
 		val = cty.UnknownVal(wantType)
 	}
 
-	// Mark if sensitive, and avoid double-marking if this has already been marked
-	if config.Sensitive && !val.HasMark("sensitive") {
-		val = val.Mark("sensitive")
+	// Mark if sensitive
+	if config.Sensitive {
+		val = marks.Sensitive(val)
 	}
 
 	return val, diags
@@ -432,8 +433,8 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 
 			instance[cfg.Name] = outputState
 
-			if cfg.Sensitive && !outputState.HasMark("sensitive") {
-				instance[cfg.Name] = outputState.Mark("sensitive")
+			if cfg.Sensitive {
+				instance[cfg.Name] = marks.Sensitive(outputState)
 			}
 		}
 
@@ -461,8 +462,8 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 
 			instance[cfg.Name] = change.After
 
-			if change.Sensitive && !change.After.HasMark("sensitive") {
-				instance[cfg.Name] = change.After.Mark("sensitive")
+			if change.Sensitive {
+				instance[cfg.Name] = marks.Sensitive(change.After)
 			}
 		}
 	}

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -110,7 +111,7 @@ func TestEvaluatorGetInputVariable(t *testing.T) {
 		VariableValues: map[string]map[string]cty.Value{
 			"": {
 				"some_var":       cty.StringVal("bar"),
-				"some_other_var": cty.StringVal("boop").Mark("sensitive"),
+				"some_other_var": cty.StringVal("boop").Mark(marks.Sensitive),
 			},
 		},
 		VariableValuesLock: &sync.Mutex{},
@@ -121,7 +122,7 @@ func TestEvaluatorGetInputVariable(t *testing.T) {
 	}
 	scope := evaluator.Scope(data, nil)
 
-	want := cty.StringVal("bar").Mark("sensitive")
+	want := cty.StringVal("bar").Mark(marks.Sensitive)
 	got, diags := scope.Data.GetInputVariable(addrs.InputVariable{
 		Name: "some_var",
 	}, tfdiags.SourceRange{})
@@ -133,7 +134,7 @@ func TestEvaluatorGetInputVariable(t *testing.T) {
 		t.Errorf("wrong result %#v; want %#v", got, want)
 	}
 
-	want = cty.StringVal("boop").Mark("sensitive")
+	want = cty.StringVal("boop").Mark(marks.Sensitive)
 	got, diags = scope.Data.GetInputVariable(addrs.InputVariable{
 		Name: "some_other_var",
 	}, tfdiags.SourceRange{})
@@ -276,30 +277,30 @@ func TestEvaluatorGetResource(t *testing.T) {
 		"id": cty.StringVal("foo"),
 		"nesting_list": cty.ListVal([]cty.Value{
 			cty.ObjectVal(map[string]cty.Value{
-				"sensitive_value": cty.StringVal("abc").Mark("sensitive"),
+				"sensitive_value": cty.StringVal("abc").Mark(marks.Sensitive),
 				"value":           cty.NullVal(cty.String),
 			}),
 		}),
 		"nesting_map": cty.MapVal(map[string]cty.Value{
-			"foo": cty.ObjectVal(map[string]cty.Value{"foo": cty.StringVal("x").Mark("sensitive")}),
+			"foo": cty.ObjectVal(map[string]cty.Value{"foo": cty.StringVal("x").Mark(marks.Sensitive)}),
 		}),
 		"nesting_nesting": cty.ObjectVal(map[string]cty.Value{
 			"nesting_list": cty.ListVal([]cty.Value{
 				cty.ObjectVal(map[string]cty.Value{
-					"sensitive_value": cty.StringVal("abc").Mark("sensitive"),
+					"sensitive_value": cty.StringVal("abc").Mark(marks.Sensitive),
 					"value":           cty.NullVal(cty.String),
 				}),
 			}),
 		}),
 		"nesting_set": cty.SetVal([]cty.Value{
 			cty.ObjectVal(map[string]cty.Value{
-				"baz": cty.StringVal("abc").Mark("sensitive"),
+				"baz": cty.StringVal("abc").Mark(marks.Sensitive),
 			}),
 		}),
 		"nesting_single": cty.ObjectVal(map[string]cty.Value{
-			"boop": cty.StringVal("abc").Mark("sensitive"),
+			"boop": cty.StringVal("abc").Mark(marks.Sensitive),
 		}),
-		"value": cty.StringVal("hello").Mark("sensitive"),
+		"value": cty.StringVal("hello").Mark(marks.Sensitive),
 	})
 
 	addr := addrs.Resource{
@@ -354,7 +355,7 @@ func TestEvaluatorGetResource_changes(t *testing.T) {
 			// Provide an After value that contains a marked value
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":              cty.StringVal("foo"),
-				"to_mark_val":     cty.StringVal("pizza").Mark("sensitive"),
+				"to_mark_val":     cty.StringVal("pizza").Mark(marks.Sensitive),
 				"sensitive_value": cty.StringVal("abc"),
 				"sensitive_collection": cty.MapVal(map[string]cty.Value{
 					"boop": cty.StringVal("beep"),
@@ -439,11 +440,11 @@ func TestEvaluatorGetResource_changes(t *testing.T) {
 
 	want := cty.ObjectVal(map[string]cty.Value{
 		"id":              cty.StringVal("foo"),
-		"to_mark_val":     cty.StringVal("pizza").Mark("sensitive"),
-		"sensitive_value": cty.StringVal("abc").Mark("sensitive"),
+		"to_mark_val":     cty.StringVal("pizza").Mark(marks.Sensitive),
+		"sensitive_value": cty.StringVal("abc").Mark(marks.Sensitive),
 		"sensitive_collection": cty.MapVal(map[string]cty.Value{
 			"boop": cty.StringVal("beep"),
-		}).Mark("sensitive"),
+		}).Mark(marks.Sensitive),
 	})
 
 	got, diags := scope.Data.GetResource(addr, tfdiags.SourceRange{})
@@ -471,7 +472,7 @@ func TestEvaluatorGetModule(t *testing.T) {
 		Evaluator: evaluator,
 	}
 	scope := evaluator.Scope(data, nil)
-	want := cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("bar").Mark("sensitive")})
+	want := cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("bar").Mark(marks.Sensitive)})
 	got, diags := scope.Data.GetModule(addrs.ModuleCall{
 		Name: "mod",
 	}, tfdiags.SourceRange{})
@@ -499,7 +500,7 @@ func TestEvaluatorGetModule(t *testing.T) {
 		Evaluator: evaluator,
 	}
 	scope = evaluator.Scope(data, nil)
-	want = cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("baz").Mark("sensitive")})
+	want = cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("baz").Mark(marks.Sensitive)})
 	got, diags = scope.Data.GetModule(addrs.ModuleCall{
 		Name: "mod",
 	}, tfdiags.SourceRange{})
@@ -517,7 +518,7 @@ func TestEvaluatorGetModule(t *testing.T) {
 		Evaluator: evaluator,
 	}
 	scope = evaluator.Scope(data, nil)
-	want = cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("baz").Mark("sensitive")})
+	want = cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("baz").Mark(marks.Sensitive)})
 	got, diags = scope.Data.GetModule(addrs.ModuleCall{
 		Name: "mod",
 	}, tfdiags.SourceRange{})

--- a/internal/terraform/marks_test.go
+++ b/internal/terraform/marks_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -14,32 +15,32 @@ func TestMarksEqual(t *testing.T) {
 	}{
 		{
 			[]cty.PathValueMarks{
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks("sensitive")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
 			},
 			[]cty.PathValueMarks{
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks("sensitive")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
 			},
 			true,
 		},
 		{
 			[]cty.PathValueMarks{
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks("sensitive")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
 			},
 			[]cty.PathValueMarks{
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "A"}}, Marks: cty.NewValueMarks("sensitive")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "A"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
 			},
 			false,
 		},
 		{
 			[]cty.PathValueMarks{
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks("sensitive")},
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "b"}}, Marks: cty.NewValueMarks("sensitive")},
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "c"}}, Marks: cty.NewValueMarks("sensitive")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "b"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "c"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
 			},
 			[]cty.PathValueMarks{
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "b"}}, Marks: cty.NewValueMarks("sensitive")},
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "c"}}, Marks: cty.NewValueMarks("sensitive")},
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks("sensitive")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "b"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "c"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
 			},
 			true,
 		},
@@ -47,31 +48,31 @@ func TestMarksEqual(t *testing.T) {
 			[]cty.PathValueMarks{
 				cty.PathValueMarks{
 					Path:  cty.Path{cty.GetAttrStep{Name: "a"}, cty.GetAttrStep{Name: "b"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				cty.PathValueMarks{
 					Path:  cty.Path{cty.GetAttrStep{Name: "a"}, cty.GetAttrStep{Name: "c"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			[]cty.PathValueMarks{
 				cty.PathValueMarks{
 					Path:  cty.Path{cty.GetAttrStep{Name: "a"}, cty.GetAttrStep{Name: "c"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 				cty.PathValueMarks{
 					Path:  cty.Path{cty.GetAttrStep{Name: "a"}, cty.GetAttrStep{Name: "b"}},
-					Marks: cty.NewValueMarks("sensitive"),
+					Marks: cty.NewValueMarks(marks.Sensitive),
 				},
 			},
 			true,
 		},
 		{
 			[]cty.PathValueMarks{
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks("sensitive")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
 			},
 			[]cty.PathValueMarks{
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "b"}}, Marks: cty.NewValueMarks("sensitive")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "b"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
 			},
 			false,
 		},
@@ -82,7 +83,7 @@ func TestMarksEqual(t *testing.T) {
 		},
 		{
 			[]cty.PathValueMarks{
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks("sensitive")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
 			},
 			nil,
 			false,
@@ -90,7 +91,7 @@ func TestMarksEqual(t *testing.T) {
 		{
 			nil,
 			[]cty.PathValueMarks{
-				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks("sensitive")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
 			},
 			false,
 		},

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -283,9 +283,7 @@ func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags 
 		// a sensitive result, to help avoid accidental exposure in the state
 		// of a sensitive value that the user doesn't want to include there.
 		if n.Addr.Module.IsRoot() {
-			_, m := val.UnmarkDeep()
-			_, hasSensitive := m[marks.Sensitive]
-			if !n.Config.Sensitive && hasSensitive {
+			if !n.Config.Sensitive && marks.Contains(val, marks.Sensitive) {
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Output refers to sensitive values",

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -282,8 +282,9 @@ func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags 
 		// statically declared as sensitive in order to dynamically return
 		// a sensitive result, to help avoid accidental exposure in the state
 		// of a sensitive value that the user doesn't want to include there.
-		hasSensitive := marks.HasSensitive(val)
 		if n.Addr.Module.IsRoot() {
+			_, m := val.UnmarkDeep()
+			_, hasSensitive := m[marks.Sensitive]
 			if !n.Config.Sensitive && hasSensitive {
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -281,8 +282,7 @@ func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags 
 		// statically declared as sensitive in order to dynamically return
 		// a sensitive result, to help avoid accidental exposure in the state
 		// of a sensitive value that the user doesn't want to include there.
-		_, marks := val.UnmarkDeep()
-		_, hasSensitive := marks["sensitive"]
+		hasSensitive := marks.HasSensitive(val)
 		if n.Addr.Module.IsRoot() {
 			if !n.Config.Sensitive && hasSensitive {
 				diags = diags.Append(&hcl.Diagnostic{

--- a/internal/terraform/node_output_test.go
+++ b/internal/terraform/node_output_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -98,7 +99,7 @@ func TestNodeApplyableOutputExecute_sensitiveValueNotOutput(t *testing.T) {
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}
 	val := cty.MapVal(map[string]cty.Value{
-		"a": cty.StringVal("b").Mark("sensitive"),
+		"a": cty.StringVal("b").Mark(marks.Sensitive),
 	})
 	ctx.EvaluateExprResult = val
 
@@ -122,7 +123,7 @@ func TestNodeApplyableOutputExecute_sensitiveValueAndOutput(t *testing.T) {
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}
 	val := cty.MapVal(map[string]cty.Value{
-		"a": cty.StringVal("b").Mark("sensitive"),
+		"a": cty.StringVal("b").Mark(marks.Sensitive),
 	})
 	ctx.EvaluateExprResult = val
 

--- a/internal/terraform/node_provider_test.go
+++ b/internal/terraform/node_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
@@ -126,7 +127,7 @@ func TestNodeApplyableProviderExecute_sensitive(t *testing.T) {
 	config := &configs.Provider{
 		Name: "foo",
 		Config: configs.SynthBody("", map[string]cty.Value{
-			"test_string": cty.StringVal("hello").Mark("sensitive"),
+			"test_string": cty.StringVal("hello").Mark(marks.Sensitive),
 		}),
 	}
 	provider := mockProviderWithConfigSchema(simpleTestSchema())
@@ -163,7 +164,7 @@ func TestNodeApplyableProviderExecute_sensitiveValidate(t *testing.T) {
 	config := &configs.Provider{
 		Name: "foo",
 		Config: configs.SynthBody("", map[string]cty.Value{
-			"test_string": cty.StringVal("hello").Mark("sensitive"),
+			"test_string": cty.StringVal("hello").Mark(marks.Sensitive),
 		}),
 	}
 	provider := mockProviderWithConfigSchema(simpleTestSchema())

--- a/internal/terraform/node_resource_validate_test.go
+++ b/internal/terraform/node_resource_validate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -176,7 +177,7 @@ func TestNodeValidatableResource_ValidateResource_managedResource(t *testing.T) 
 		Name: "foo",
 		Config: configs.SynthBody("", map[string]cty.Value{
 			"test_string": cty.StringVal("bar"),
-			"test_number": cty.NumberIntVal(2).Mark("sensitive"),
+			"test_number": cty.NumberIntVal(2).Mark(marks.Sensitive),
 		}),
 	}
 	node := NodeValidatableResource{
@@ -289,7 +290,7 @@ func TestNodeValidatableResource_ValidateResource_dataSource(t *testing.T) {
 		Name: "foo",
 		Config: configs.SynthBody("", map[string]cty.Value{
 			"test_string": cty.StringVal("bar"),
-			"test_number": cty.NumberIntVal(2).Mark("sensitive"),
+			"test_number": cty.NumberIntVal(2).Mark(marks.Sensitive),
 		}),
 	}
 

--- a/internal/terraform/transform_import_state_test.go
+++ b/internal/terraform/transform_import_state_test.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -163,5 +162,4 @@ func TestGraphNodeImportStateSubExecuteNull(t *testing.T) {
 	if !diags.HasErrors() {
 		t.Fatal("expected error for non-existent resource")
 	}
-	fmt.Println(diags.ErrWithWarnings())
 }


### PR DESCRIPTION
Rather than relying on arbitrary strings for marking sensitivity, use a strictly typed mark values to ensure better control over marks within cty Values. 

Add the typed `marks.Sensitive` as the canonical mark value for sensitivity.
Add the typed `marks.Raw` for use in the repl.

The new `marks` package (which is an independent package to avoid import cycles) also has new `Has` and `Contains` functions for the marks. The `Contains` function may well be better suited as a method in the cty package, and `Has` is quite simple and mostly there for consistency. There may be more useful helpers to add to this package, but these are not that functionally important right now and may be removed in the future if they remain unused. 

This thoroughly audits all usage of marks in the codebase, ensuring that we are not only always looking for the intended mark, but also not using blunt checks like `IsMarked()` as checks for sensitivity.
