### PR TITLE
command/views/json: Never generate invalid diagnostic snippet offsets

### DIFF
--- a/internal/command/format/diagnostic.go
+++ b/internal/command/format/diagnostic.go
@@ -250,6 +250,21 @@ func appendSourceSnippets(buf *bytes.Buffer, diag *viewsjson.Diagnostic, color *
 			}
 		}
 
+		// If either start or end is out of range for the code buffer then
+		// we'll cap them at the bounds just to avoid a panic, although
+		// this would happen only if there's a bug in the code generating
+		// the snippet objects.
+		if start < 0 {
+			start = 0
+		} else if start > len(code) {
+			start = len(code)
+		}
+		if end < 0 {
+			end = 0
+		} else if end > len(code) {
+			end = len(code)
+		}
+
 		before, highlight, after := code[0:start], code[start:end], code[end:]
 		code = fmt.Sprintf(color.Color("%s[underline]%s[reset]%s"), before, highlight, after)
 

--- a/internal/command/views/json/diagnostic.go
+++ b/internal/command/views/json/diagnostic.go
@@ -221,12 +221,23 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 			// to the code snippet string.
 			start := highlightRange.Start.Byte - codeStartByte
 			end := start + (highlightRange.End.Byte - highlightRange.Start.Byte)
-			if start > len(codeStr) {
+
+			// We can end up with some quirky results here in edge cases like
+			// when a source range starts or ends at a newline character,
+			// so we'll cap the results at the bounds of the highlight range
+			// so that consumers of this data don't need to contend with
+			// out-of-bounds errors themselves.
+			if start < 0 {
+				start = 0
+			} else if start > len(codeStr) {
 				start = len(codeStr)
 			}
-			if end > len(codeStr) {
+			if end < 0 {
+				end = 0
+			} else if end > len(codeStr) {
 				end = len(codeStr)
 			}
+
 			diagnostic.Snippet.HighlightStartOffset = start
 			diagnostic.Snippet.HighlightEndOffset = end
 

--- a/internal/command/views/json/testdata/diagnostic/error-whose-range-starts-at-a-newline.json
+++ b/internal/command/views/json/testdata/diagnostic/error-whose-range-starts-at-a-newline.json
@@ -1,0 +1,26 @@
+{
+  "severity": "error",
+  "summary": "Invalid newline",
+  "detail": "How awkward!",
+  "range": {
+    "filename": "odd-comment.tf",
+    "start": {
+      "line": 2,
+      "column": 5,
+      "byte": 4
+    },
+    "end": {
+      "line": 3,
+      "column": 1,
+      "byte": 6
+    }
+  },
+  "snippet": {
+    "context": null,
+    "code": "#",
+    "start_line": 2,
+    "highlight_start_offset": 0,
+    "highlight_end_offset": 1,
+    "values": []
+  }
+}


### PR DESCRIPTION
Because our snippet generator is trying to select whole lines to include in the snippet, it has some edge cases for odd situations where the relevant source range starts or ends directly at a newline, which were previously causing this logic to return out-of-bounds offsets into the code snippet string.

Newlines at the bounds of source ranges are inevitably a bit of an edge case when thinking about the line/column representation of positions rather than byte offsets, because newlines don't really exist as far as line/column representation is concerned: they are the boundary between the lines, not part of the lines themselves, and they therefore don't really have a real "column". Therefore we somewhat arbitrarily just decide to shift the range over to the start of the following line instead when presenting it, so we can still show _something_ even if it's not exactly what the parser was gesturing at.

For completeness here I also added some similar logic to the human-oriented diagnostic formatter, which consumes the result of the JSON diagnostic builder. That's not really needed with the additional checks in the JSON diagnostic builder, but it's nice to reinforce that this code can't panic (in this way, at least) even if its input isn't valid.

This fixes #29041, making it no longer crash.

Arguably the source range of the error it is trying to return is also a bit off, but syntax errors are often like that because the HCL parser is just making a best guess about what the author's intention was. In any case if we want to improve that we'd be doing it over in HCL rather than in Terraform, so I've focused just on avoiding a crash here.
