### PR TITLE
command/jsonstate: remove redundant remarking of resource instance

### DIFF
--- a/internal/command/jsonstate/state.go
+++ b/internal/command/jsonstate/state.go
@@ -330,9 +330,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 
 				current.AttributeValues = marshalAttributeValues(riObj.Value)
 
-				// Mark the resource instance value with any marks stored in AttrSensitivePaths so we can build the SensitiveValues object
-				markedVal := riObj.Value.MarkWithPaths(ri.Current.AttrSensitivePaths)
-				s := SensitiveAsBool(markedVal)
+				s := SensitiveAsBool(riObj.Value)
 				v, err := ctyjson.Marshal(s, s.Type())
 				if err != nil {
 					return nil, err
@@ -371,9 +369,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 
 				deposed.AttributeValues = marshalAttributeValues(riObj.Value)
 
-				// Mark the resource instance value with any marks stored in AttrSensitivePaths so we can build the SensitiveValues object
-				markedVal := riObj.Value.MarkWithPaths(rios.AttrSensitivePaths)
-				s := SensitiveAsBool(markedVal)
+				s := SensitiveAsBool(riObj.Value)
 				v, err := ctyjson.Marshal(s, s.Type())
 				if err != nil {
 					return nil, err

--- a/internal/command/jsonstate/state_test.go
+++ b/internal/command/jsonstate/state_test.go
@@ -464,6 +464,51 @@ func TestMarshalResources(t *testing.T) {
 			},
 			false,
 		},
+		"resource with marked map attr": {
+			map[string]*states.Resource{
+				"test_map_attr.bar": {
+					Addr: addrs.AbsResource{
+						Resource: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "test_map_attr",
+							Name: "bar",
+						},
+					},
+					Instances: map[addrs.InstanceKey]*states.ResourceInstance{
+						addrs.NoKey: {
+							Current: &states.ResourceInstanceObjectSrc{
+								Status:    states.ObjectReady,
+								AttrsJSON: []byte(`{"data":{"woozles":"confuzles"}}`),
+								AttrSensitivePaths: []cty.PathValueMarks{{
+									Path:  cty.Path{cty.GetAttrStep{Name: "data"}},
+									Marks: cty.NewValueMarks(marks.Sensitive)},
+								},
+							},
+						},
+					},
+					ProviderConfig: addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+						Module:   addrs.RootModule,
+					},
+				},
+			},
+			testSchemas(),
+			[]resource{
+				{
+					Address:      "test_map_attr.bar",
+					Mode:         "managed",
+					Type:         "test_map_attr",
+					Name:         "bar",
+					Index:        addrs.InstanceKey(nil),
+					ProviderName: "registry.terraform.io/hashicorp/test",
+					AttributeValues: attributeValues{
+						"data": json.RawMessage(`{"woozles":"confuzles"}`),
+					},
+					SensitiveValues: json.RawMessage(`{"data":true}`),
+				},
+			},
+			false,
+		},
 	}
 
 	for name, test := range tests {
@@ -698,6 +743,11 @@ func testSchemas() *terraform.Schemas {
 							"id":  {Type: cty.String, Optional: true, Computed: true},
 							"foo": {Type: cty.String, Optional: true},
 							"bar": {Type: cty.String, Optional: true},
+						},
+					},
+					"test_map_attr": {
+						Attributes: map[string]*configschema.Attribute{
+							"data": {Type: cty.Map(cty.String), Optional: true, Computed: true, Sensitive: true},
 						},
 					},
 				},


### PR DESCRIPTION
`ResourceInstanceObjectSrc.Decode` already handles marking the decoded values with any marks stored in `AttrSensitivePaths`, so re-applying those marks is not necessary and seems to be related to panics seen in the wild, as seen in #29042.

~I have yet to reproduce the reported panic in a test (or locally, for that matter), so I won't close the linked issue until we can get a reproduction/confirmation. The test case I added was not enough to cause a panic, even though the value was already marked.~

Update: @davidalger wrote a test for me, yay! @apparentlymart believes that an upstream fix he recently merged would fix this panic, but the code is still redundant (and yay, more test cases!) so I'd still like this reviewed. 