### PR TITLE
Add compatibility promises to sidebar toc

### DIFF
--- a/website/layouts/language.erb
+++ b/website/layouts/language.erb
@@ -980,6 +980,10 @@
           </li>
 
           <li>
+            <a href="/docs/language/v1-compatibility-promises.html">v1.0 Compatibility Promises</a>
+          </li>
+
+          <li>
             <a href="/upgrade-guides/0-15.html">Upgrading to v0.15</a>
           </li>
 


### PR DESCRIPTION
**Description**
Adding the v1 Compatibility Promises Content to the documentation sidebar in response to this Asana ticket [capability promises isn' in the terraform.io nav](https://app.asana.com/0/1128567758154570/1200539294164951/f).

I think our upgrade guides section could use a larger restructuring, but for now, let's just make sure that this content shows up in the navigation. My thought is that the compatibility promises make the most sense just after the v1.0 upgrade guide (separating it from the v0.x releases that have come before, but please let me know if there are other thoughts!

Requested review scope:
- [x] Content touched by the PR only (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

Review urgency:
- [ ] ASAP (bug fixes, broken content, imminent releases)
- [x] 3 days (small changes, easy reviews)
- [ ] 1 week (default)
- [ ] Best effort (very non-urgent)

I have:
- [x] Verified that all status checks have passed
- [x] Verified that preview environment has successfully deployed.
- [x] Assigned an appropriate label (either Platform or a product name)
- [x] Requested at least one review