### PR TITLE
states: new `Move` funcs for Resource, ResourceInstance, and ModuleInstances

### DIFF
--- a/internal/addrs/module_instance.go
+++ b/internal/addrs/module_instance.go
@@ -496,14 +496,26 @@ func (m ModuleInstance) absMoveableSigil() {
 	// ModuleInstance is moveable
 }
 
-// IsCallInstance returns true if the receiver is an instance of the given
+// IsDeclaredByCall returns true if the receiver is an instance of the given
 // AbsModuleCall.
-func (m ModuleInstance) IsCallInstance(other AbsModuleCall) bool {
-	if len(m) == 0 {
+func (m ModuleInstance) IsDeclaredByCall(other AbsModuleCall) bool {
+	// Compare len(m) to len(other.Module+1) because the final module instance
+	// step in other is stored in the AbsModuleCall.Call
+	if len(m) > len(other.Module)+1 || len(m) == 0 && len(other.Module) == 0 {
 		return false
 	}
-	s := m[len(m)-1]
-	return s.Name == other.Call.Name
+
+	// Verify that the other's ModuleInstance matches the receiver.
+	inst, lastStep := other.Module, other.Call
+	for i := range inst {
+		if inst[i] != m[i] {
+			return false
+		}
+	}
+
+	// Now compare the final step of the received with the other Call, where
+	// only the name needs to match.
+	return lastStep.Name == m[len(m)-1].Name
 }
 
 func (s ModuleInstanceStep) String() string {

--- a/internal/addrs/module_instance.go
+++ b/internal/addrs/module_instance.go
@@ -496,6 +496,16 @@ func (m ModuleInstance) absMoveableSigil() {
 	// ModuleInstance is moveable
 }
 
+// IsCallInstance returns true if the receiver is an instance of the given
+// AbsModuleCall.
+func (m ModuleInstance) IsCallInstance(other AbsModuleCall) bool {
+	if len(m) == 0 {
+		return false
+	}
+	s := m[len(m)-1]
+	return s.Name == other.Call.Name
+}
+
 func (s ModuleInstanceStep) String() string {
 	if s.InstanceKey != NoKey {
 		return s.Name + s.InstanceKey.String()

--- a/internal/addrs/module_instance_test.go
+++ b/internal/addrs/module_instance_test.go
@@ -91,3 +91,53 @@ func BenchmarkStringLong(b *testing.B) {
 		addr.String()
 	}
 }
+
+func TestModuleInstance_IsCallInstance(t *testing.T) {
+	tests := []struct {
+		instance ModuleInstance
+		call     AbsModuleCall
+		want     bool
+	}{
+		{
+			mustParseModuleInstanceStr("module.child"),
+			AbsModuleCall{
+				mustParseModuleInstanceStr(`module.child["a"]`),
+				ModuleCall{Name: "child"},
+			},
+			true,
+		},
+		{
+			mustParseModuleInstanceStr("module.child"),
+			AbsModuleCall{
+				mustParseModuleInstanceStr(`module.child`),
+				ModuleCall{Name: "child"},
+			},
+			true,
+		},
+		{
+			mustParseModuleInstanceStr("module.child"),
+			AbsModuleCall{
+				mustParseModuleInstanceStr(`module.kinder["a"]`),
+				ModuleCall{Name: "kinder"},
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s.IsCallInstance(%s)", test.instance, test.call.String()), func(t *testing.T) {
+			got := test.instance.IsCallInstance(test.call)
+			if got != test.want {
+				t.Fatal("wrong result")
+			}
+		})
+	}
+}
+
+func mustParseModuleInstanceStr(str string) ModuleInstance {
+	mi, err := ParseModuleInstanceStr(str)
+	if err != nil {
+		panic(err)
+	}
+	return mi
+}

--- a/internal/addrs/module_instance_test.go
+++ b/internal/addrs/module_instance_test.go
@@ -92,7 +92,7 @@ func BenchmarkStringLong(b *testing.B) {
 	}
 }
 
-func TestModuleInstance_IsCallInstance(t *testing.T) {
+func TestModuleInstance_IsDeclaredByCall(t *testing.T) {
 	tests := []struct {
 		instance ModuleInstance
 		call     AbsModuleCall

--- a/internal/states/state.go
+++ b/internal/states/state.go
@@ -524,7 +524,7 @@ func (s *State) MoveModule(src, dst addrs.AbsModuleCall) {
 	for _, ms := range srcMIs {
 		newInst := make(addrs.ModuleInstance, len(ms.Addr))
 		copy(newInst, ms.Addr)
-		if ms.Addr.IsCallInstance(src) {
+		if ms.Addr.IsDeclaredByCall(src) {
 			// Easy case: we just need to update the last step with the new name
 			newInst[len(newInst)-1].Name = dst.Call.Name
 		} else {

--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -582,3 +582,17 @@ func (s *SyncState) MaybeMoveResourceInstance(src, dst addrs.AbsResourceInstance
 
 	return s.state.MaybeMoveAbsResourceInstance(src, dst)
 }
+
+func (s *SyncState) MoveModuleInstance(src, dst addrs.ModuleInstance) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.state.MoveModuleInstance(src, dst)
+}
+
+func (s *SyncState) MaybeMoveModuleInstance(src, dst addrs.ModuleInstance) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.state.MaybeMoveModuleInstance(src, dst)
+}

--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -554,3 +554,31 @@ func (s *SyncState) maybePruneModule(addr addrs.ModuleInstance) {
 		s.state.RemoveModule(addr)
 	}
 }
+
+func (s *SyncState) MoveAbsResource(src, dst addrs.AbsResource) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.state.MoveAbsResource(src, dst)
+}
+
+func (s *SyncState) MaybeMoveAbsResource(src, dst addrs.AbsResource) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.state.MaybeMoveAbsResource(src, dst)
+}
+
+func (s *SyncState) MoveResourceInstance(src, dst addrs.AbsResourceInstance) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.state.MoveAbsResourceInstance(src, dst)
+}
+
+func (s *SyncState) MaybeMoveResourceInstance(src, dst addrs.AbsResourceInstance) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.state.MaybeMoveAbsResourceInstance(src, dst)
+}


### PR DESCRIPTION
This PR adds `Move` functions for `AbsResouce`s, `AbsResouceInstance`s, and `ModuleInstance`s. The code was loosely inspired by the functionality in `internal/command/state_mv.go`, though these functions are all limited to a single state.

It is the caller's responsibility to confirm the validity of the moves. The functions will panic if the `src` does not exist or the `dst` does exist; I've added a `MaybeMove` version of each function which will succeed if the opposite is true. The return value of the `MaybeMove` functions indicates whether or not a move actually occurred. (Having said that, I'm less convinced of the utility of the `MaybeMove` funcs and have no qualms about dropping them)

Finally, I've added `SyncState` wrappers for all of these functions for good measure.

These are currently unused functions, which will be used in the configuration-based state moves. (It's entirely plausible that these functions will change during the development cycle.) 