### PR TITLE
Various preparation for Config-driven Move validation

### DIFF
--- a/internal/addrs/module.go
+++ b/internal/addrs/module.go
@@ -150,3 +150,7 @@ func (m Module) Ancestors() []Module {
 	}
 	return ret
 }
+
+func (m Module) configMoveableSigil() {
+	// ModuleInstance is moveable
+}

--- a/internal/addrs/module_call.go
+++ b/internal/addrs/module_call.go
@@ -72,9 +72,9 @@ func (m ModuleCallOutput) String() string {
 	return fmt.Sprintf("%s.%s", m.Call.String(), m.Name)
 }
 
-// AbsModuleCallOutput is the address of a particular named output produced by
+// ModuleCallInstanceOutput is the address of a particular named output produced by
 // an instance of a module call.
-type AbsModuleCallOutput struct {
+type ModuleCallInstanceOutput struct {
 	referenceable
 	Call ModuleCallInstance
 	Name string
@@ -82,21 +82,21 @@ type AbsModuleCallOutput struct {
 
 // ModuleCallOutput returns the referenceable ModuleCallOutput for this
 // particular instance.
-func (co AbsModuleCallOutput) ModuleCallOutput() ModuleCallOutput {
+func (co ModuleCallInstanceOutput) ModuleCallOutput() ModuleCallOutput {
 	return ModuleCallOutput{
 		Call: co.Call.Call,
 		Name: co.Name,
 	}
 }
 
-func (co AbsModuleCallOutput) String() string {
+func (co ModuleCallInstanceOutput) String() string {
 	return fmt.Sprintf("%s.%s", co.Call.String(), co.Name)
 }
 
 // AbsOutputValue returns the absolute output value address that corresponds
 // to the receving module call output address, once resolved in the given
 // calling module.
-func (co AbsModuleCallOutput) AbsOutputValue(caller ModuleInstance) AbsOutputValue {
+func (co ModuleCallInstanceOutput) AbsOutputValue(caller ModuleInstance) AbsOutputValue {
 	moduleAddr := co.Call.ModuleInstance(caller)
 	return moduleAddr.OutputValue(co.Name)
 }

--- a/internal/addrs/module_call.go
+++ b/internal/addrs/module_call.go
@@ -42,6 +42,14 @@ type AbsModuleCall struct {
 	Call   ModuleCall
 }
 
+func (c AbsModuleCall) absMoveableSigil() {
+	// AbsModuleCall is "moveable".
+}
+
+func (c AbsModuleCall) String() string {
+	return fmt.Sprintf("%s.%s", c.Module, c.Call.Name)
+}
+
 func (c AbsModuleCall) Instance(key InstanceKey) ModuleInstance {
 	ret := make(ModuleInstance, len(c.Module), len(c.Module)+1)
 	copy(ret, c.Module)

--- a/internal/addrs/module_instance.go
+++ b/internal/addrs/module_instance.go
@@ -492,6 +492,10 @@ func (m ModuleInstance) targetableSigil() {
 	// ModuleInstance is targetable
 }
 
+func (m ModuleInstance) absMoveableSigil() {
+	// ModuleInstance is moveable
+}
+
 func (s ModuleInstanceStep) String() string {
 	if s.InstanceKey != NoKey {
 		return s.Name + s.InstanceKey.String()

--- a/internal/addrs/move_endpoint.go
+++ b/internal/addrs/move_endpoint.go
@@ -1,0 +1,260 @@
+package addrs
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// MoveEndpoint is to AbsMoveable and ConfigMoveable what Target is to
+// Targetable: a wrapping struct that captures the result of decoding an HCL
+// traversal representing a relative path from the current module to
+// a moveable object.
+//
+// Its name reflects that its primary purpose is for the "from" and "to"
+// addresses in a "moved" statement in the configuration, but it's also
+// valid to use MoveEndpoint for other similar mechanisms that give
+// Terraform hints about historical configuration changes that might
+// prompt creating a different plan than Terraform would by default.
+//
+// To obtain a full address from a MoveEndpoint you must use
+// either the package function UnifyMoveEndpoints (to get an AbsMovable) or
+// the method ConfigMoveable (to get a ConfigMoveable).
+type MoveEndpoint struct {
+	// SourceRange is the location of the physical endpoint address
+	// in configuration, if this MoveEndpoint was decoded from a
+	// configuration expresson.
+	SourceRange tfdiags.SourceRange
+
+	// Internally we (ab)use AbsMovable as the representation of our
+	// relative address, even though everywhere else in Terraform
+	// AbsMovable always represents a fully-absolute address.
+	// In practice, due to the implementation of ParseMoveEndpoint,
+	// this is always either a ModuleInstance or an AbsResourceInstance,
+	// and we only consider the possibility of interpreting it as
+	// a AbsModuleCall or an AbsResource in UnifyMoveEndpoints.
+	// This is intentionally unexported to encapsulate this unusual
+	// meaning of AbsMovable.
+	relSubject AbsMoveable
+}
+
+func (e *MoveEndpoint) String() string {
+	// Our internal pseudo-AbsMovable representing the relative
+	// address (either ModuleInstance or AbsResourceInstance) is
+	// a good enough proxy for the relative move endpoint address
+	// serialization.
+	return e.relSubject.String()
+}
+
+// ConfigMovable transforms the reciever into a ConfigMovable by resolving it
+// relative to the given base module, which should be the module where
+// the MoveEndpoint expression was found.
+//
+// The result is useful for finding the target object in the configuration,
+// but it's not sufficient for fully interpreting a move statement because
+// it lacks the specific module and resource instance keys.
+func (e *MoveEndpoint) ConfigMoveable(baseModule Module) ConfigMoveable {
+	addr := e.relSubject
+	switch addr := addr.(type) {
+	case ModuleInstance:
+		ret := make(Module, 0, len(baseModule)+len(addr))
+		ret = append(ret, baseModule...)
+		ret = append(ret, addr.Module()...)
+		return ret
+	case AbsResourceInstance:
+		moduleAddr := make(Module, 0, len(baseModule)+len(addr.Module))
+		moduleAddr = append(moduleAddr, baseModule...)
+		moduleAddr = append(moduleAddr, addr.Module.Module()...)
+		return ConfigResource{
+			Module:   moduleAddr,
+			Resource: addr.Resource.Resource,
+		}
+	default:
+		// The above should be exhaustive for all of the types
+		// that ParseMoveEndpoint produces as our intermediate
+		// address representation.
+		panic(fmt.Sprintf("unsupported address type %T", addr))
+	}
+
+}
+
+// ParseMoveEndpoint attempts to interpret the given traversal as a
+// "move endpoint" address, which is a relative path from the module containing
+// the traversal to a movable object in either the same module or in some
+// child module.
+//
+// This deals only with the syntactic element of a move endpoint expression
+// in configuration. Before the result will be useful you'll need to combine
+// it with the address of the module where it was declared in order to get
+// an absolute address relative to the root module.
+func ParseMoveEndpoint(traversal hcl.Traversal) (*MoveEndpoint, tfdiags.Diagnostics) {
+	path, remain, diags := parseModuleInstancePrefix(traversal)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	rng := tfdiags.SourceRangeFromHCL(traversal.SourceRange())
+
+	if len(remain) == 0 {
+		return &MoveEndpoint{
+			relSubject:  path,
+			SourceRange: rng,
+		}, diags
+	}
+
+	riAddr, moreDiags := parseResourceInstanceUnderModule(path, remain)
+	diags = diags.Append(moreDiags)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &MoveEndpoint{
+		relSubject:  riAddr,
+		SourceRange: rng,
+	}, diags
+}
+
+// UnifyMoveEndpoints takes a pair of MoveEndpoint objects representing the
+// "from" and "to" addresses in a moved block, and returns a pair of
+// AbsMoveable addresses guaranteed to be of the same dynamic type
+// that represent what the two MoveEndpoint addresses refer to.
+//
+// moduleAddr must be the address of the module instance where the move
+// was declared.
+//
+// This function deals both with the conversion from relative to absolute
+// addresses and with resolving the ambiguity between no-key instance
+// addresses and whole-object addresses, returning the least specific
+// address type possible.
+//
+// Not all combinations of addresses are unifyable: the two addresses must
+// either both include resources or both just be modules. If the two
+// given addresses are incompatible then UnifyMoveEndpoints returns (nil, nil),
+// in which case the caller should typically report an error to the user
+// stating the unification constraints.
+func UnifyMoveEndpoints(moduleAddr ModuleInstance, relFrom, relTo *MoveEndpoint) (absFrom, absTo AbsMoveable) {
+
+	// First we'll make a decision about which address type we're
+	// ultimately trying to unify to. For our internal purposes
+	// here we're going to borrow TargetableAddrType just as a
+	// convenient way to talk about our address types, even though
+	// targetable address types are not 100% aligned with moveable
+	// address types.
+	fromType := relFrom.internalAddrType()
+	toType := relTo.internalAddrType()
+	var wantType TargetableAddrType
+
+	// Our goal here is to choose the whole-resource or whole-module-call
+	// addresses if both agree on it, but to use specific instance addresses
+	// otherwise. This is a somewhat-arbitrary way to resolve syntactic
+	// ambiguity between the two situations which allows both for renaming
+	// whole resources and for switching from a single-instance object to
+	// a multi-instance object.
+	switch {
+	case fromType == AbsResourceInstanceAddrType || toType == AbsResourceInstanceAddrType:
+		wantType = AbsResourceInstanceAddrType
+	case fromType == AbsResourceAddrType || toType == AbsResourceAddrType:
+		wantType = AbsResourceAddrType
+	case fromType == ModuleInstanceAddrType || toType == ModuleInstanceAddrType:
+		wantType = ModuleInstanceAddrType
+	case fromType == ModuleAddrType || toType == ModuleAddrType:
+		// NOTE: We're fudging a little here and using
+		// ModuleAddrType to represent AbsModuleCall rather
+		// than Module.
+		wantType = ModuleAddrType
+	default:
+		panic("unhandled move address types")
+	}
+
+	absFrom = relFrom.prepareAbsMoveable(moduleAddr, wantType)
+	absTo = relTo.prepareAbsMoveable(moduleAddr, wantType)
+	if absFrom == nil || absTo == nil {
+		// if either of them failed then they both failed, to make the
+		// caller's life a little easier.
+		return nil, nil
+	}
+	return absFrom, absTo
+}
+
+func (e *MoveEndpoint) prepareAbsMoveable(moduleAddr ModuleInstance, wantType TargetableAddrType) AbsMoveable {
+	// relAddr can only be either AbsResourceInstance or ModuleInstance, the
+	// internal intermediate representation produced by ParseMoveEndpoint.
+	relAddr := e.relSubject
+
+	switch relAddr := relAddr.(type) {
+	case ModuleInstance:
+		switch wantType {
+		case ModuleInstanceAddrType:
+			ret := make(ModuleInstance, 0, len(moduleAddr)+len(relAddr))
+			ret = append(ret, moduleAddr...)
+			ret = append(ret, relAddr...)
+			return ret
+		case ModuleAddrType:
+			// NOTE: We're fudging a little here and using
+			// ModuleAddrType to represent AbsModuleCall rather
+			// than Module.
+			callerAddr := make(ModuleInstance, 0, len(moduleAddr)+len(relAddr)-1)
+			callerAddr = append(callerAddr, moduleAddr...)
+			callerAddr = append(callerAddr, relAddr[:len(relAddr)-1]...)
+			return AbsModuleCall{
+				Module: callerAddr,
+				Call: ModuleCall{
+					Name: relAddr[len(relAddr)-1].Name,
+				},
+			}
+		default:
+			return nil // can't make any other types from a ModuleInstance
+		}
+	case AbsResourceInstance:
+		callerAddr := make(ModuleInstance, 0, len(moduleAddr)+len(relAddr.Module))
+		callerAddr = append(callerAddr, moduleAddr...)
+		callerAddr = append(callerAddr, relAddr.Module...)
+		switch wantType {
+		case AbsResourceInstanceAddrType:
+			return AbsResourceInstance{
+				Module:   callerAddr,
+				Resource: relAddr.Resource,
+			}
+		case AbsResourceAddrType:
+			return AbsResource{
+				Module:   callerAddr,
+				Resource: relAddr.Resource.Resource,
+			}
+		default:
+			return nil // can't make any other types from an AbsResourceInstance
+		}
+	default:
+		panic(fmt.Sprintf("unhandled address type %T", relAddr))
+	}
+}
+
+// internalAddrType helps facilitate our slight abuse of TargetableAddrType
+// as a way to talk about our different possible result address types in
+// UnifyMoveEndpoints.
+//
+// It's not really correct to use TargetableAddrType in this way, because
+// it's for Targetable rather than for AbsMoveable, but as long as the two
+// remain aligned enough it saves introducing yet another enumeration with
+// similar members that would be for internal use only anyway.
+func (e *MoveEndpoint) internalAddrType() TargetableAddrType {
+	switch addr := e.relSubject.(type) {
+	case ModuleInstance:
+		if !addr.IsRoot() && addr[len(addr)-1].InstanceKey == NoKey {
+			// NOTE: We're fudging a little here and using
+			// ModuleAddrType to represent AbsModuleCall rather
+			// than Module.
+			return ModuleAddrType
+		}
+		return ModuleInstanceAddrType
+	case AbsResourceInstance:
+		if addr.Resource.Key == NoKey {
+			return AbsResourceAddrType
+		}
+		return AbsResourceInstanceAddrType
+	default:
+		// The above should cover all of the address types produced
+		// by ParseMoveEndpoint.
+		panic(fmt.Sprintf("unsupported address type %T", addr))
+	}
+}

--- a/internal/addrs/move_endpoint.go
+++ b/internal/addrs/move_endpoint.go
@@ -47,6 +47,36 @@ func (e *MoveEndpoint) String() string {
 	return e.relSubject.String()
 }
 
+func (e *MoveEndpoint) Equal(other *MoveEndpoint) bool {
+	switch {
+	case (e == nil) != (other == nil):
+		return false
+	case e == nil:
+		return true
+	default:
+		// Since we only use ModuleInstance and AbsResourceInstance in our
+		// string representation, we have no ambiguity between address types
+		// and can safely just compare the string representations to
+		// compare the relSubject values.
+		return e.String() == other.String() && e.SourceRange == other.SourceRange
+	}
+}
+
+// MightUnifyWith returns true if it is possible that a later call to
+// UnifyMoveEndpoints might succeed if given the reciever and the other
+// given endpoint.
+//
+// This is intended for early static validation of obviously-wrong situations,
+// although there are still various semantic errors that this cannot catch.
+func (e *MoveEndpoint) MightUnifyWith(other *MoveEndpoint) bool {
+	// For our purposes here we'll just do a unify without a base module
+	// address, because the rules for whether unify can succeed depend
+	// only on the relative part of the addresses, not on which module
+	// they were declared in.
+	from, to := UnifyMoveEndpoints(RootModuleInstance, e, other)
+	return from != nil && to != nil
+}
+
 // ConfigMovable transforms the reciever into a ConfigMovable by resolving it
 // relative to the given base module, which should be the module where
 // the MoveEndpoint expression was found.

--- a/internal/addrs/move_endpoint_test.go
+++ b/internal/addrs/move_endpoint_test.go
@@ -1,0 +1,752 @@
+package addrs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestParseMoveEndpoint(t *testing.T) {
+	tests := []struct {
+		Input   string
+		WantRel AbsMoveable // funny intermediate subset of AbsMovable
+		WantErr string
+	}{
+		{
+			`foo.bar`,
+			AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: NoKey,
+				},
+			},
+			``,
+		},
+		{
+			`foo.bar[0]`,
+			AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: IntKey(0),
+				},
+			},
+			``,
+		},
+		{
+			`foo.bar["a"]`,
+			AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: StringKey("a"),
+				},
+			},
+			``,
+		},
+		{
+			`module.boop.foo.bar`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					ModuleInstanceStep{Name: "boop"},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: NoKey,
+				},
+			},
+			``,
+		},
+		{
+			`module.boop.foo.bar[0]`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					ModuleInstanceStep{Name: "boop"},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: IntKey(0),
+				},
+			},
+			``,
+		},
+		{
+			`module.boop.foo.bar["a"]`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					ModuleInstanceStep{Name: "boop"},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: StringKey("a"),
+				},
+			},
+			``,
+		},
+		{
+			`data.foo.bar`,
+			AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: DataResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: NoKey,
+				},
+			},
+			``,
+		},
+		{
+			`data.foo.bar[0]`,
+			AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: DataResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: IntKey(0),
+				},
+			},
+			``,
+		},
+		{
+			`data.foo.bar["a"]`,
+			AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: DataResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: StringKey("a"),
+				},
+			},
+			``,
+		},
+		{
+			`module.boop.data.foo.bar`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					ModuleInstanceStep{Name: "boop"},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: DataResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: NoKey,
+				},
+			},
+			``,
+		},
+		{
+			`module.boop.data.foo.bar[0]`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					ModuleInstanceStep{Name: "boop"},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: DataResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: IntKey(0),
+				},
+			},
+			``,
+		},
+		{
+			`module.boop.data.foo.bar["a"]`,
+			AbsResourceInstance{
+				Module: ModuleInstance{
+					ModuleInstanceStep{Name: "boop"},
+				},
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: DataResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: StringKey("a"),
+				},
+			},
+			``,
+		},
+		{
+			`module.foo`,
+			ModuleInstance{
+				ModuleInstanceStep{Name: "foo"},
+			},
+			``,
+		},
+		{
+			`module.foo[0]`,
+			ModuleInstance{
+				ModuleInstanceStep{Name: "foo", InstanceKey: IntKey(0)},
+			},
+			``,
+		},
+		{
+			`module.foo["a"]`,
+			ModuleInstance{
+				ModuleInstanceStep{Name: "foo", InstanceKey: StringKey("a")},
+			},
+			``,
+		},
+		{
+			`module.foo.module.bar`,
+			ModuleInstance{
+				ModuleInstanceStep{Name: "foo"},
+				ModuleInstanceStep{Name: "bar"},
+			},
+			``,
+		},
+		{
+			`module.foo[1].module.bar`,
+			ModuleInstance{
+				ModuleInstanceStep{Name: "foo", InstanceKey: IntKey(1)},
+				ModuleInstanceStep{Name: "bar"},
+			},
+			``,
+		},
+		{
+			`module.foo.module.bar[1]`,
+			ModuleInstance{
+				ModuleInstanceStep{Name: "foo"},
+				ModuleInstanceStep{Name: "bar", InstanceKey: IntKey(1)},
+			},
+			``,
+		},
+		{
+			`module.foo[0].module.bar[1]`,
+			ModuleInstance{
+				ModuleInstanceStep{Name: "foo", InstanceKey: IntKey(0)},
+				ModuleInstanceStep{Name: "bar", InstanceKey: IntKey(1)},
+			},
+			``,
+		},
+		{
+			`module`,
+			nil,
+			`Invalid address operator: Prefix "module." must be followed by a module name.`,
+		},
+		{
+			`module[0]`,
+			nil,
+			`Invalid address operator: Prefix "module." must be followed by a module name.`,
+		},
+		{
+			`module.foo.data`,
+			nil,
+			`Invalid address: Resource specification must include a resource type and name.`,
+		},
+		{
+			`module.foo.data.bar`,
+			nil,
+			`Invalid address: Resource specification must include a resource type and name.`,
+		},
+		{
+			`module.foo.data[0]`,
+			nil,
+			`Invalid address: Resource specification must include a resource type and name.`,
+		},
+		{
+			`module.foo.data.bar[0]`,
+			nil,
+			`Invalid address: A resource name is required.`,
+		},
+		{
+			`module.foo.bar`,
+			nil,
+			`Invalid address: Resource specification must include a resource type and name.`,
+		},
+		{
+			`module.foo.bar[0]`,
+			nil,
+			`Invalid address: A resource name is required.`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			traversal, hclDiags := hclsyntax.ParseTraversalAbs([]byte(test.Input), "", hcl.InitialPos)
+			if hclDiags.HasErrors() {
+				// We're not trying to test the HCL parser here, so any
+				// failures at this point are likely to be bugs in the
+				// test case itself.
+				t.Fatalf("syntax error: %s", hclDiags.Error())
+			}
+
+			moveEp, diags := ParseMoveEndpoint(traversal)
+
+			switch {
+			case test.WantErr != "":
+				if !diags.HasErrors() {
+					t.Fatalf("unexpected success\nwant error: %s", test.WantErr)
+				}
+				gotErr := diags.Err().Error()
+				if gotErr != test.WantErr {
+					t.Fatalf("wrong error\ngot:  %s\nwant: %s", gotErr, test.WantErr)
+				}
+			default:
+				if diags.HasErrors() {
+					t.Fatalf("unexpected error: %s", diags.Err().Error())
+				}
+				if diff := cmp.Diff(test.WantRel, moveEp.relSubject); diff != "" {
+					t.Errorf("wrong result\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestUnifyMoveEndpoints(t *testing.T) {
+	tests := []struct {
+		InputFrom, InputTo string
+		Module             ModuleInstance
+		WantFrom, WantTo   AbsMoveable
+	}{
+		{
+			InputFrom: `foo.bar`,
+			InputTo:   `foo.baz`,
+			Module:    RootModuleInstance,
+			WantFrom: AbsResource{
+				Module: RootModuleInstance,
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "foo",
+					Name: "bar",
+				},
+			},
+			WantTo: AbsResource{
+				Module: RootModuleInstance,
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "foo",
+					Name: "baz",
+				},
+			},
+		},
+		{
+			InputFrom: `foo.bar`,
+			InputTo:   `foo.baz`,
+			Module:    RootModuleInstance.Child("a", NoKey),
+			WantFrom: AbsResource{
+				Module: RootModuleInstance.Child("a", NoKey),
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "foo",
+					Name: "bar",
+				},
+			},
+			WantTo: AbsResource{
+				Module: RootModuleInstance.Child("a", NoKey),
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "foo",
+					Name: "baz",
+				},
+			},
+		},
+		{
+			InputFrom: `foo.bar`,
+			InputTo:   `module.b[0].foo.baz`,
+			Module:    RootModuleInstance.Child("a", NoKey),
+			WantFrom: AbsResource{
+				Module: RootModuleInstance.Child("a", NoKey),
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "foo",
+					Name: "bar",
+				},
+			},
+			WantTo: AbsResource{
+				Module: RootModuleInstance.Child("a", NoKey).Child("b", IntKey(0)),
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "foo",
+					Name: "baz",
+				},
+			},
+		},
+		{
+			InputFrom: `foo.bar`,
+			InputTo:   `foo.bar["thing"]`,
+			Module:    RootModuleInstance,
+			WantFrom: AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+				},
+			},
+			WantTo: AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: StringKey("thing"),
+				},
+			},
+		},
+		{
+			InputFrom: `foo.bar["thing"]`,
+			InputTo:   `foo.bar`,
+			Module:    RootModuleInstance,
+			WantFrom: AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: StringKey("thing"),
+				},
+			},
+			WantTo: AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+				},
+			},
+		},
+		{
+			InputFrom: `foo.bar["a"]`,
+			InputTo:   `foo.bar["b"]`,
+			Module:    RootModuleInstance,
+			WantFrom: AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: StringKey("a"),
+				},
+			},
+			WantTo: AbsResourceInstance{
+				Module: RootModuleInstance,
+				Resource: ResourceInstance{
+					Resource: Resource{
+						Mode: ManagedResourceMode,
+						Type: "foo",
+						Name: "bar",
+					},
+					Key: StringKey("b"),
+				},
+			},
+		},
+		{
+			InputFrom: `module.foo`,
+			InputTo:   `module.bar`,
+			Module:    RootModuleInstance,
+			WantFrom: AbsModuleCall{
+				Module: RootModuleInstance,
+				Call:   ModuleCall{Name: "foo"},
+			},
+			WantTo: AbsModuleCall{
+				Module: RootModuleInstance,
+				Call:   ModuleCall{Name: "bar"},
+			},
+		},
+		{
+			InputFrom: `module.foo`,
+			InputTo:   `module.bar.module.baz`,
+			Module:    RootModuleInstance,
+			WantFrom: AbsModuleCall{
+				Module: RootModuleInstance,
+				Call:   ModuleCall{Name: "foo"},
+			},
+			WantTo: AbsModuleCall{
+				Module: RootModuleInstance.Child("bar", NoKey),
+				Call:   ModuleCall{Name: "baz"},
+			},
+		},
+		{
+			InputFrom: `module.foo`,
+			InputTo:   `module.bar.module.baz`,
+			Module:    RootModuleInstance.Child("bloop", StringKey("hi")),
+			WantFrom: AbsModuleCall{
+				Module: RootModuleInstance.Child("bloop", StringKey("hi")),
+				Call:   ModuleCall{Name: "foo"},
+			},
+			WantTo: AbsModuleCall{
+				Module: RootModuleInstance.Child("bloop", StringKey("hi")).Child("bar", NoKey),
+				Call:   ModuleCall{Name: "baz"},
+			},
+		},
+		{
+			InputFrom: `module.foo[0]`,
+			InputTo:   `module.foo["a"]`,
+			Module:    RootModuleInstance,
+			WantFrom:  RootModuleInstance.Child("foo", IntKey(0)),
+			WantTo:    RootModuleInstance.Child("foo", StringKey("a")),
+		},
+		{
+			InputFrom: `module.foo`,
+			InputTo:   `module.foo["a"]`,
+			Module:    RootModuleInstance,
+			WantFrom:  RootModuleInstance.Child("foo", NoKey),
+			WantTo:    RootModuleInstance.Child("foo", StringKey("a")),
+		},
+		{
+			InputFrom: `module.foo[0]`,
+			InputTo:   `module.foo`,
+			Module:    RootModuleInstance,
+			WantFrom:  RootModuleInstance.Child("foo", IntKey(0)),
+			WantTo:    RootModuleInstance.Child("foo", NoKey),
+		},
+		{
+			InputFrom: `module.foo[0]`,
+			InputTo:   `module.foo`,
+			Module:    RootModuleInstance.Child("bloop", NoKey),
+			WantFrom:  RootModuleInstance.Child("bloop", NoKey).Child("foo", IntKey(0)),
+			WantTo:    RootModuleInstance.Child("bloop", NoKey).Child("foo", NoKey),
+		},
+		{
+			InputFrom: `module.foo`,
+			InputTo:   `foo.bar`,
+			Module:    RootModuleInstance,
+			WantFrom:  nil, // Can't unify module call with resource
+			WantTo:    nil,
+		},
+		{
+			InputFrom: `module.foo[0]`,
+			InputTo:   `foo.bar`,
+			Module:    RootModuleInstance,
+			WantFrom:  nil, // Can't unify module instance with resource
+			WantTo:    nil,
+		},
+		{
+			InputFrom: `module.foo`,
+			InputTo:   `foo.bar[0]`,
+			Module:    RootModuleInstance,
+			WantFrom:  nil, // Can't unify module call with resource instance
+			WantTo:    nil,
+		},
+		{
+			InputFrom: `module.foo[0]`,
+			InputTo:   `foo.bar[0]`,
+			Module:    RootModuleInstance,
+			WantFrom:  nil, // Can't unify module instance with resource instance
+			WantTo:    nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s to %s in %s", test.InputFrom, test.InputTo, test.Module), func(t *testing.T) {
+			parseInput := func(input string) *MoveEndpoint {
+				t.Helper()
+
+				traversal, hclDiags := hclsyntax.ParseTraversalAbs([]byte(input), "", hcl.InitialPos)
+				if hclDiags.HasErrors() {
+					// We're not trying to test the HCL parser here, so any
+					// failures at this point are likely to be bugs in the
+					// test case itself.
+					t.Fatalf("syntax error: %s", hclDiags.Error())
+				}
+
+				moveEp, diags := ParseMoveEndpoint(traversal)
+				if diags.HasErrors() {
+					t.Fatalf("unexpected error: %s", diags.Err().Error())
+				}
+				return moveEp
+			}
+
+			fromEp := parseInput(test.InputFrom)
+			toEp := parseInput(test.InputTo)
+
+			diffOpts := cmpopts.IgnoreUnexported(ModuleCall{})
+			gotFrom, gotTo := UnifyMoveEndpoints(test.Module, fromEp, toEp)
+			if diff := cmp.Diff(test.WantFrom, gotFrom, diffOpts); diff != "" {
+				t.Errorf("wrong 'from' address\n%s", diff)
+			}
+			if diff := cmp.Diff(test.WantTo, gotTo, diffOpts); diff != "" {
+				t.Errorf("wrong 'to' address\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMoveEndpointConfigMoveable(t *testing.T) {
+	tests := []struct {
+		Input  string
+		Module Module
+		Want   ConfigMoveable
+	}{
+		{
+			`foo.bar`,
+			RootModule,
+			ConfigResource{
+				Module: RootModule,
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "foo",
+					Name: "bar",
+				},
+			},
+		},
+		{
+			`foo.bar[0]`,
+			RootModule,
+			ConfigResource{
+				Module: RootModule,
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "foo",
+					Name: "bar",
+				},
+			},
+		},
+		{
+			`module.foo.bar.baz`,
+			RootModule,
+			ConfigResource{
+				Module: Module{"foo"},
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "bar",
+					Name: "baz",
+				},
+			},
+		},
+		{
+			`module.foo[0].bar.baz`,
+			RootModule,
+			ConfigResource{
+				Module: Module{"foo"},
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "bar",
+					Name: "baz",
+				},
+			},
+		},
+		{
+			`foo.bar`,
+			Module{"boop"},
+			ConfigResource{
+				Module: Module{"boop"},
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "foo",
+					Name: "bar",
+				},
+			},
+		},
+		{
+			`module.bloop.foo.bar`,
+			Module{"bleep"},
+			ConfigResource{
+				Module: Module{"bleep", "bloop"},
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "foo",
+					Name: "bar",
+				},
+			},
+		},
+		{
+			`module.foo.bar.baz`,
+			RootModule,
+			ConfigResource{
+				Module: Module{"foo"},
+				Resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "bar",
+					Name: "baz",
+				},
+			},
+		},
+		{
+			`module.foo`,
+			RootModule,
+			Module{"foo"},
+		},
+		{
+			`module.foo[0]`,
+			RootModule,
+			Module{"foo"},
+		},
+		{
+			`module.bloop`,
+			Module{"bleep"},
+			Module{"bleep", "bloop"},
+		},
+		{
+			`module.bloop[0]`,
+			Module{"bleep"},
+			Module{"bleep", "bloop"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s in %s", test.Input, test.Module), func(t *testing.T) {
+			traversal, hclDiags := hclsyntax.ParseTraversalAbs([]byte(test.Input), "", hcl.InitialPos)
+			if hclDiags.HasErrors() {
+				// We're not trying to test the HCL parser here, so any
+				// failures at this point are likely to be bugs in the
+				// test case itself.
+				t.Fatalf("syntax error: %s", hclDiags.Error())
+			}
+
+			moveEp, diags := ParseMoveEndpoint(traversal)
+			if diags.HasErrors() {
+				t.Fatalf("unexpected error: %s", diags.Err().Error())
+			}
+
+			got := moveEp.ConfigMoveable(test.Module)
+			if diff := cmp.Diff(test.Want, got); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/addrs/moveable.go
+++ b/internal/addrs/moveable.go
@@ -1,0 +1,44 @@
+package addrs
+
+// AbsMoveable is an interface implemented by address types that can be either
+// the source or destination of a "moved" statement in configuration, along
+// with any other similar cross-module state refactoring statements we might
+// allow.
+//
+// Note that AbsMovable represents an absolute address relative to the root
+// of the configuration, which is different than the direct representation
+// of these in configuration where the author gives an address relative to
+// the current module where the address is defined. The type MoveEndpoint
+
+type AbsMoveable interface {
+	absMoveableSigil()
+
+	String() string
+}
+
+// The following are all of the possible AbsMovable address types:
+var (
+	_ AbsMoveable = AbsResource{}
+	_ AbsMoveable = AbsResourceInstance{}
+	_ AbsMoveable = ModuleInstance(nil)
+	_ AbsMoveable = AbsModuleCall{}
+)
+
+// ConfigMoveable is similar to AbsMoveable but represents a static object in
+// the configuration, rather than an instance of that object created by
+// module expansion.
+//
+// Note that ConfigMovable represents an absolute address relative to the root
+// of the configuration, which is different than the direct representation
+// of these in configuration where the author gives an address relative to
+// the current module where the address is defined. The type MoveEndpoint
+// represents the relative form given directly in configuration.
+type ConfigMoveable interface {
+	configMoveableSigil()
+}
+
+// The following are all of the possible ConfigMovable address types:
+var (
+	_ ConfigMoveable = ConfigResource{}
+	_ ConfigMoveable = Module(nil)
+)

--- a/internal/addrs/output_value.go
+++ b/internal/addrs/output_value.go
@@ -66,13 +66,13 @@ func (v AbsOutputValue) Equal(o AbsOutputValue) bool {
 //
 // The root module does not have a call, and so this method cannot be used
 // with outputs in the root module, and will panic in that case.
-func (v AbsOutputValue) ModuleCallOutput() (ModuleInstance, AbsModuleCallOutput) {
+func (v AbsOutputValue) ModuleCallOutput() (ModuleInstance, ModuleCallInstanceOutput) {
 	if v.Module.IsRoot() {
 		panic("ReferenceFromCall used with root module output")
 	}
 
 	caller, call := v.Module.CallInstance()
-	return caller, AbsModuleCallOutput{
+	return caller, ModuleCallInstanceOutput{
 		Call: call,
 		Name: v.OutputValue.Name,
 	}

--- a/internal/addrs/parse_ref.go
+++ b/internal/addrs/parse_ref.go
@@ -191,7 +191,7 @@ func parseRef(traversal hcl.Traversal) (*Reference, tfdiags.Diagnostics) {
 		if attrTrav, ok := remain[0].(hcl.TraverseAttr); ok {
 			remain = remain[1:]
 			return &Reference{
-				Subject: AbsModuleCallOutput{
+				Subject: ModuleCallInstanceOutput{
 					Name: attrTrav.Name,
 					Call: callInstance,
 				},

--- a/internal/addrs/parse_ref_test.go
+++ b/internal/addrs/parse_ref_test.go
@@ -294,7 +294,7 @@ func TestParseRef(t *testing.T) {
 		{
 			`module.foo.bar`,
 			&Reference{
-				Subject: AbsModuleCallOutput{
+				Subject: ModuleCallInstanceOutput{
 					Call: ModuleCallInstance{
 						Call: ModuleCall{
 							Name: "foo",
@@ -312,7 +312,7 @@ func TestParseRef(t *testing.T) {
 		{
 			`module.foo.bar.baz`,
 			&Reference{
-				Subject: AbsModuleCallOutput{
+				Subject: ModuleCallInstanceOutput{
 					Call: ModuleCallInstance{
 						Call: ModuleCall{
 							Name: "foo",
@@ -355,7 +355,7 @@ func TestParseRef(t *testing.T) {
 		{
 			`module.foo["baz"].bar`,
 			&Reference{
-				Subject: AbsModuleCallOutput{
+				Subject: ModuleCallInstanceOutput{
 					Call: ModuleCallInstance{
 						Call: ModuleCall{
 							Name: "foo",
@@ -374,7 +374,7 @@ func TestParseRef(t *testing.T) {
 		{
 			`module.foo["baz"].bar.boop`,
 			&Reference{
-				Subject: AbsModuleCallOutput{
+				Subject: ModuleCallInstanceOutput{
 					Call: ModuleCallInstance{
 						Call: ModuleCall{
 							Name: "foo",

--- a/internal/addrs/resource.go
+++ b/internal/addrs/resource.go
@@ -178,6 +178,10 @@ func (r AbsResource) Equal(o AbsResource) bool {
 	return r.Module.Equal(o.Module) && r.Resource.Equal(o.Resource)
 }
 
+func (r AbsResource) absMoveableSigil() {
+	// AbsResource is moveable
+}
+
 // AbsResourceInstance is an absolute address for a resource instance under a
 // given module path.
 type AbsResourceInstance struct {
@@ -276,6 +280,10 @@ func (r AbsResourceInstance) Less(o AbsResourceInstance) bool {
 	}
 }
 
+func (r AbsResourceInstance) absMoveableSigil() {
+	// AbsResourceInstance is moveable
+}
+
 // ConfigResource is an address for a resource within a configuration.
 type ConfigResource struct {
 	targetable
@@ -333,6 +341,10 @@ func (r ConfigResource) String() string {
 
 func (r ConfigResource) Equal(o ConfigResource) bool {
 	return r.Module.Equal(o.Module) && r.Resource.Equal(o.Resource)
+}
+
+func (r ConfigResource) configMoveableSigil() {
+	// AbsResource is moveable
 }
 
 // ResourceMode defines which lifecycle applies to a given resource. Each

--- a/internal/command/jsonconfig/expression.go
+++ b/internal/command/jsonconfig/expression.go
@@ -68,9 +68,9 @@ func marshalExpression(ex hcl.Expression) expression {
 					// Include the resource, without the key
 					varString = append(varString, ref.Subject.(addrs.ResourceInstance).Resource.String())
 				}
-			case addrs.AbsModuleCallOutput:
+			case addrs.ModuleCallInstanceOutput:
 				// Include the module name, without the output name
-				varString = append(varString, ref.Subject.(addrs.AbsModuleCallOutput).Call.String())
+				varString = append(varString, ref.Subject.(addrs.ModuleCallInstanceOutput).Call.String())
 			}
 		}
 		ret.References = varString

--- a/internal/configs/experiments.go
+++ b/internal/configs/experiments.go
@@ -197,6 +197,17 @@ func checkModuleExperiments(m *Module) hcl.Diagnostics {
 		}
 	}
 
+	if !m.ActiveExperiments.Has(experiments.ConfigDrivenMove) {
+		for _, mc := range m.Moved {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Config-driven move is experimental",
+				Detail:   "This feature is currently under development and is not yet fully-functional.\n\nIf you'd like to try the partial implementation that exists so far, add config_driven_move to the set of active experiments for this module.",
+				Subject:  mc.DeclRange.Ptr(),
+			})
+		}
+	}
+
 	return diags
 }
 

--- a/internal/configs/moved_test.go
+++ b/internal/configs/moved_test.go
@@ -48,8 +48,8 @@ func TestDecodeMovedBlock(t *testing.T) {
 				DefRange: blockRange,
 			},
 			&Moved{
-				From:      mustTargetFromExpr(foo_expr),
-				To:        mustTargetFromExpr(bar_expr),
+				From:      mustMoveEndpointFromExpr(foo_expr),
+				To:        mustMoveEndpointFromExpr(bar_expr),
 				DeclRange: blockRange,
 			},
 			``,
@@ -72,8 +72,8 @@ func TestDecodeMovedBlock(t *testing.T) {
 				DefRange: blockRange,
 			},
 			&Moved{
-				From:      mustTargetFromExpr(foo_index_expr),
-				To:        mustTargetFromExpr(bar_index_expr),
+				From:      mustMoveEndpointFromExpr(foo_index_expr),
+				To:        mustMoveEndpointFromExpr(bar_index_expr),
 				DeclRange: blockRange,
 			},
 			``,
@@ -96,8 +96,8 @@ func TestDecodeMovedBlock(t *testing.T) {
 				DefRange: blockRange,
 			},
 			&Moved{
-				From:      mustTargetFromExpr(mod_foo_expr),
-				To:        mustTargetFromExpr(mod_bar_expr),
+				From:      mustMoveEndpointFromExpr(mod_foo_expr),
+				To:        mustMoveEndpointFromExpr(mod_bar_expr),
 				DeclRange: blockRange,
 			},
 			``,
@@ -116,7 +116,7 @@ func TestDecodeMovedBlock(t *testing.T) {
 				DefRange: blockRange,
 			},
 			&Moved{
-				From:      mustTargetFromExpr(foo_expr),
+				From:      mustMoveEndpointFromExpr(foo_expr),
 				DeclRange: blockRange,
 			},
 			"Missing required argument",
@@ -139,11 +139,11 @@ func TestDecodeMovedBlock(t *testing.T) {
 				DefRange: blockRange,
 			},
 			&Moved{
-				To:        mustTargetFromExpr(foo_expr),
-				From:      mustTargetFromExpr(mod_foo_expr),
+				To:        mustMoveEndpointFromExpr(foo_expr),
+				From:      mustMoveEndpointFromExpr(mod_foo_expr),
 				DeclRange: blockRange,
 			},
-			"Invalid \"moved\" targets",
+			"Invalid \"moved\" addresses",
 		},
 	}
 
@@ -162,23 +162,23 @@ func TestDecodeMovedBlock(t *testing.T) {
 				t.Fatal("expected error")
 			}
 
-			if !cmp.Equal(got, test.want) {
+			if !cmp.Equal(got, test.want, cmp.AllowUnexported(addrs.MoveEndpoint{})) {
 				t.Fatalf("wrong result: %s", cmp.Diff(got, test.want))
 			}
 		})
 	}
 }
 
-func mustTargetFromExpr(expr hcl.Expression) *addrs.Target {
+func mustMoveEndpointFromExpr(expr hcl.Expression) *addrs.MoveEndpoint {
 	traversal, hcldiags := hcl.AbsTraversalForExpr(expr)
 	if hcldiags.HasErrors() {
 		panic(hcldiags.Errs())
 	}
 
-	target, diags := addrs.ParseTarget(traversal)
+	ep, diags := addrs.ParseMoveEndpoint(traversal)
 	if diags.HasErrors() {
 		panic(diags.Err())
 	}
 
-	return target
+	return ep
 }

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -2,7 +2,6 @@ package configs
 
 import (
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/terraform/internal/experiments"
 )
 
 // LoadConfigFile reads the file at the given path and parses it as a config
@@ -150,16 +149,10 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 			}
 
 		case "moved":
-			// This is not quite the usual usage of the experiments package.
-			// EverythingIsAPlan is not registered as an active experiment, so
-			// this block will not be decoded until either the experiment is
-			// registered, or this check is dropped altogether.
-			if file.ActiveExperiments.Has(experiments.EverythingIsAPlan) {
-				cfg, cfgDiags := decodeMovedBlock(block)
-				diags = append(diags, cfgDiags...)
-				if cfg != nil {
-					file.Moved = append(file.Moved, cfg)
-				}
+			cfg, cfgDiags := decodeMovedBlock(block)
+			diags = append(diags, cfgDiags...)
+			if cfg != nil {
+				file.Moved = append(file.Moved, cfg)
 			}
 
 		default:

--- a/internal/configs/testdata/invalid-modules/config-driven-move-experiment/config-driven-move-experiment.tf
+++ b/internal/configs/testdata/invalid-modules/config-driven-move-experiment/config-driven-move-experiment.tf
@@ -1,0 +1,7 @@
+# This is currently invalid alone because config-driven move requires the
+# "config_driven_move" experiment. We can remove this test case altogther
+# if moved blocks of this sort graduate to being stable.
+moved {
+  from = a.b
+  to   = c.d
+}

--- a/internal/configs/testdata/valid-modules/moved-blocks/moved-blocks-1.tf
+++ b/internal/configs/testdata/valid-modules/moved-blocks/moved-blocks-1.tf
@@ -1,0 +1,29 @@
+terraform {
+  # For the moment this is experimental
+  experiments = [config_driven_move]
+}
+
+moved {
+  from = test.foo
+  to   = test.bar
+}
+
+moved {
+  from = test.foo
+  to   = test.bar["bloop"]
+}
+
+moved {
+  from = module.a
+  to   = module.b
+}
+
+moved {
+  from = module.a
+  to   = module.a["foo"]
+}
+
+moved {
+  from = test.foo
+  to   = module.a.test.foo
+}

--- a/internal/configs/testdata/valid-modules/moved-blocks/moved-blocks-2.tf
+++ b/internal/configs/testdata/valid-modules/moved-blocks/moved-blocks-2.tf
@@ -1,0 +1,6 @@
+# One more moved block in a separate file just to make sure the
+# appending of multiple files works properly.
+moved {
+  from = data.test.foo
+  to   = data.test.bar
+}

--- a/internal/experiments/experiment.go
+++ b/internal/experiments/experiment.go
@@ -16,7 +16,7 @@ const (
 	VariableValidation             = Experiment("variable_validation")
 	ModuleVariableOptionalAttrs    = Experiment("module_variable_optional_attrs")
 	SuppressProviderSensitiveAttrs = Experiment("provider_sensitive_attrs")
-	EverythingIsAPlan              = Experiment("everything_is_a_plan")
+	ConfigDrivenMove               = Experiment("config_driven_move")
 )
 
 func init() {
@@ -25,6 +25,7 @@ func init() {
 	registerConcludedExperiment(VariableValidation, "Custom variable validation can now be used by default, without enabling an experiment.")
 	registerConcludedExperiment(SuppressProviderSensitiveAttrs, "Provider-defined sensitive attributes are now redacted by default, without enabling an experiment.")
 	registerCurrentExperiment(ModuleVariableOptionalAttrs)
+	registerCurrentExperiment(ConfigDrivenMove)
 }
 
 // GetCurrent takes an experiment name and returns the experiment value

--- a/internal/lang/data_test.go
+++ b/internal/lang/data_test.go
@@ -47,7 +47,7 @@ func (d *dataForTests) GetModule(addr addrs.ModuleCall, rng tfdiags.SourceRange)
 	return d.Modules[addr.String()], nil
 }
 
-func (d *dataForTests) GetModuleInstanceOutput(addr addrs.AbsModuleCallOutput, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetModuleInstanceOutput(addr addrs.ModuleCallInstanceOutput, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	// This will panic if the module object does not have the requested attribute
 	obj := d.Modules[addr.Call.String()]
 	return obj.GetAttr(addr.Name), nil

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -341,7 +341,7 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 			rawSubj = addr.ContainingResource()
 		case addrs.ModuleCallInstance:
 			rawSubj = addr.Call
-		case addrs.AbsModuleCallOutput:
+		case addrs.ModuleCallInstanceOutput:
 			rawSubj = addr.Call.Call
 		}
 

--- a/internal/terraform/evaluate_valid.go
+++ b/internal/terraform/evaluate_valid.go
@@ -91,7 +91,7 @@ func (d *evaluationStateData) staticValidateReference(ref *addrs.Reference, self
 		return d.staticValidateModuleCallReference(modCfg, addr, ref.Remaining, ref.SourceRange)
 	case addrs.ModuleCallInstance:
 		return d.staticValidateModuleCallReference(modCfg, addr.Call, ref.Remaining, ref.SourceRange)
-	case addrs.AbsModuleCallOutput:
+	case addrs.ModuleCallInstanceOutput:
 		// This one is a funny one because we will take the output name referenced
 		// and use it to fake up a "remaining" that would make sense for the
 		// module call itself, rather than for the specific output, and then

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -296,7 +296,7 @@ func (m ReferenceMap) References(v dag.Vertex) []dag.Vertex {
 				subject = ri.ContainingResource()
 			case addrs.ResourceInstancePhase:
 				subject = ri.ContainingResource()
-			case addrs.AbsModuleCallOutput:
+			case addrs.ModuleCallInstanceOutput:
 				subject = ri.ModuleCallOutput()
 			case addrs.ModuleCallInstance:
 				subject = ri.Call


### PR DESCRIPTION
I had originally set out here to implement the more dynamic validation rules for config-driven move, but in the process of doing so I kept running into confusing situations where it wasn't clear whether a particular `addrs.AbsResourceInstance` or `addrs.ModuleInstance` was representing an absolute address as usual, or instead serving as our new kind of "relative address" that appears in the `moved` blocks.

After getting that messed up a few times I concluded that this was the sort of thing we'd intended the `addrs` package to encapsulate, so that the compiler can help us use addresses only in a consistent way. Therefore I've implemented some new types in the `addrs` package specifically for representing that sort of address, which I've called `MoveEndpoint`, `AbsMoveable`, and `ConfigMoveable` under the assumption that "move" is going to be the most significant of our config-driven refactoring situations, even if later on we might end up using these address types for some other similar mechanisms too:

* `MoveEndpoint` represents the relative address as written in the configuration. This address type intentionally encapsulates the actual address the user wrote and forces callers to transform into one of the other address types before making real use of the address, which means that most of our code (outside of the `addrs` package and configuration) can continue working with absolute addresses as before.
* `AbsMoveable` represents an absolute address (from the root) of one of the four object types that can be moved: whole module calls, instances of module calls, whole resources, and instances of resources.
* `ConfigMoveable` represents a not-yet-expanded absolute address, echoing the `ConfigResource` address type, which we'll be able to use to look up objects in the configuration when we implement the static (config-only) portion of our validation rules in later commits.

(I considered "Refactorable" and similar sorts of names but that seemed like an unnecessary amount of letters to spend; if these names grow confusing in light of later developments then we'll be free to rename them at that point when we know what problem we're trying to solve.)

While pulling on this thread I also worked on some other prerequisites I needed for implementing and testing the validation rules:
* The new `moved` blocks are now behind an experiment gate that is actually activate-able, though the experiment currently achieves very little because nothing is actually making use of the blocks.
* The moved blocks get aggregated together in the `configs.Module` from all of the individual `configs.File` objects.

Because of this, it may be easiest to review this on a commit-by-commit basis to see the individual steps.
