### PR TITLE
json-output: Add resource drift to machine readable UI

### DIFF
--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -9,6 +9,7 @@ const (
 	MessageDiagnostic MessageType = "diagnostic"
 
 	// Operation results
+	MessageResourceDrift MessageType = "resource_drift"
 	MessagePlannedChange MessageType = "planned_change"
 	MessageChangeSummary MessageType = "change_summary"
 	MessageOutputs       MessageType = "outputs"

--- a/internal/command/views/json_view.go
+++ b/internal/command/views/json_view.go
@@ -95,6 +95,14 @@ func (v *JSONView) PlannedChange(c *json.ResourceInstanceChange) {
 	)
 }
 
+func (v *JSONView) ResourceDrift(c *json.ResourceInstanceChange) {
+	v.log.Info(
+		fmt.Sprintf("%s: Drift detected (%s)", c.Resource.Addr, c.Action),
+		"type", json.MessageResourceDrift,
+		"change", c,
+	)
+}
+
 func (v *JSONView) ChangeSummary(cs *json.ChangeSummary) {
 	v.log.Info(
 		cs.String(),

--- a/internal/command/views/operation.go
+++ b/internal/command/views/operation.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform/internal/command/format"
 	"github.com/hashicorp/terraform/internal/command/views/json"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type Operation interface {
@@ -160,6 +162,12 @@ func (v *OperationJSON) EmergencyDumpState(stateFile *statefile.File) error {
 // Log a change summary and a series of "planned" messages for the changes in
 // the plan.
 func (v *OperationJSON) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
+	if err := v.resourceDrift(plan.PrevRunState, plan.PriorState, schemas); err != nil {
+		var diags tfdiags.Diagnostics
+		diags = diags.Append(err)
+		v.Diagnostics(diags)
+	}
+
 	cs := &json.ChangeSummary{
 		Operation: json.OperationPlanned,
 	}
@@ -186,6 +194,83 @@ func (v *OperationJSON) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
 	}
 
 	v.view.ChangeSummary(cs)
+}
+
+func (v *OperationJSON) resourceDrift(oldState, newState *states.State, schemas *terraform.Schemas) error {
+	if newState.ManagedResourcesEqual(oldState) {
+		// Nothing to do, because we only detect and report drift for managed
+		// resource instances.
+		return nil
+	}
+	for _, ms := range oldState.Modules {
+		for _, rs := range ms.Resources {
+			if rs.Addr.Resource.Mode != addrs.ManagedResourceMode {
+				// Drift reporting is only for managed resources
+				continue
+			}
+
+			provider := rs.ProviderConfig.Provider
+			for key, oldIS := range rs.Instances {
+				if oldIS.Current == nil {
+					// Not interested in instances that only have deposed objects
+					continue
+				}
+				addr := rs.Addr.Instance(key)
+				newIS := newState.ResourceInstance(addr)
+
+				schema, _ := schemas.ResourceTypeConfig(
+					provider,
+					addr.Resource.Resource.Mode,
+					addr.Resource.Resource.Type,
+				)
+				if schema == nil {
+					return fmt.Errorf("no schema found for %s (in provider %s)", addr, provider)
+				}
+				ty := schema.ImpliedType()
+
+				oldObj, err := oldIS.Current.Decode(ty)
+				if err != nil {
+					return fmt.Errorf("failed to decode previous run data for %s: %s", addr, err)
+				}
+
+				var newObj *states.ResourceInstanceObject
+				if newIS != nil && newIS.Current != nil {
+					newObj, err = newIS.Current.Decode(ty)
+					if err != nil {
+						return fmt.Errorf("failed to decode refreshed data for %s: %s", addr, err)
+					}
+				}
+
+				var oldVal, newVal cty.Value
+				oldVal = oldObj.Value
+				if newObj != nil {
+					newVal = newObj.Value
+				} else {
+					newVal = cty.NullVal(ty)
+				}
+
+				if oldVal.RawEquals(newVal) {
+					// No drift if the two values are semantically equivalent
+					continue
+				}
+
+				// We can only detect updates and deletes as drift.
+				action := plans.Update
+				if newVal.IsNull() {
+					action = plans.Delete
+				}
+
+				change := &plans.ResourceInstanceChangeSrc{
+					Addr: addr,
+					ChangeSrc: plans.ChangeSrc{
+						Action: action,
+					},
+				}
+				v.view.ResourceDrift(json.NewResourceInstanceChange(change))
+			}
+		}
+	}
+	return nil
 }
 
 func (v *OperationJSON) PlannedChange(change *plans.ResourceInstanceChangeSrc) {

--- a/website/docs/internals/machine-readable-ui.html.md
+++ b/website/docs/internals/machine-readable-ui.html.md
@@ -54,6 +54,7 @@ The following message types are supported:
 
 ### Operation Results
 
+- `resource_drift`: describes a detected change to a single resource made outside of Terraform
 - `planned_change`: describes a planned change to a single resource
 - `change_summary`: summary of all planned or applied changes
 - `outputs`: list of all root module outputs
@@ -82,6 +83,39 @@ A machine-readable UI command output will always begin with a `version` message.
   "terraform": "0.15.4",
   "type": "version",
   "ui": "0.1.0"
+}
+```
+
+## Resource Drift
+
+If drift is detected during planning, Terraform will emit a `resource_drift` message for each resource which has changed outside of Terraform. This message has an embedded `change` object with the following keys:
+
+- `resource`: object describing the address of the resource to be changed; see [resource object](#resource-object) below for details
+- `action`: the action planned to be taken for the resource. Values: `update`, `delete`.
+
+This message does not include details about the exact changes which caused the change to be planned. That information is available in [the JSON plan output](./json-format.html).
+
+### Example
+
+```json
+{
+  "@level": "info",
+  "@message": "random_pet.animal: Drift detected (update)",
+  "@module": "terraform.ui",
+  "@timestamp": "2021-05-25T13:32:41.705503-04:00",
+  "change": {
+    "resource": {
+      "addr": "random_pet.animal",
+      "module": "",
+      "resource": "random_pet.animal",
+      "implied_provider": "random",
+      "resource_type": "random_pet",
+      "resource_name": "animal",
+      "resource_key": null
+    },
+    "action": "update"
+  },
+  "type": "resource_drift"
 }
 ```
 


### PR DESCRIPTION
The new `resource_drift` message allows consumers of the `terraform plan -json` output to determine which resources Terraform found to have changed externally after the refresh phase.

Note to reviewers: this implementation is a _third_ copy of the logic for determining resource drift for a plan. I'm not happy about this, but I'm struggling to see a way to extract the logic to a single place, given the intertwingled dependencies. Any suggestions?