### PR TITLE
Fix consul backend limit check

### DIFF
--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -96,6 +96,9 @@ func (c *RemoteClient) Get() (*remote.Payload, error) {
 			}
 			payload = append(payload, pair.Value[:]...)
 		}
+		if err = json.Unmarshal(payload, &payload); err != nil {
+			return nil, err
+		}
 	} else {
 		payload = pair.Value
 	}
@@ -203,6 +206,10 @@ func (c *RemoteClient) Put(data []byte) error {
 	// one but there is really no reason for them to do so, if they changed it
 	// it is certainly to set a larger value.
 	limit := 524288
+	// decode this to base64 as this will get us the correct size that will be sent.
+	if payload, err = json.Marshal(payload); err != nil {
+		return err
+	}
 	if len(payload) > limit {
 		md5 := md5.Sum(data)
 		chunks := split(payload, limit)


### PR DESCRIPTION
Same issue as #28838 but fixed in another way.
The data gets base64 encoded so the size of the payload is off when it gets calculated, this PR also does the json marshalling to get the correct size.