### PR TITLE
Add instructions to preview docs site locally to /website readme

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -18,9 +18,9 @@ You should preview all of your changes locally before creating a pull request. T
 2. Create a ~/go directory manually or by [installing Go](https://golang.org/doc/install).
 3. Set GOPATH as an environment variable:
 
- Bash: `export $GOPATH=~/go`(bash)
+    Bash: `export $GOPATH=~/go`(bash)
 
- Zsh: `echo -n 'export GOPATH=~/go' >> ~/.zshrc`
+    Zsh: `echo -n 'export GOPATH=~/go' >> ~/.zshrc`
 4. Restart your terminal or command line session.
 
 **Launch Site Locally**

--- a/website/README.md
+++ b/website/README.md
@@ -15,13 +15,13 @@ You should preview all of your changes locally before creating a pull request. T
 **Set Up Local Environment**
 
 1. [Install Docker](https://docs.docker.com/get-docker/).
-2. Create a ~/go directory manually or by [installing Go](https://golang.org/doc/install).
-3. Open terminal and set GOPATH as an environment variable:
+1. Create a `~/go` directory manually or by [installing Go](https://golang.org/doc/install).
+1. Open terminal and set `GOPATH` as an environment variable:
 
     Bash: `export $GOPATH=~/go`(bash)
 
     Zsh: `echo -n 'export GOPATH=~/go' >> ~/.zshrc`
-4. Restart your terminal or command line session.
+1. Restart your terminal or command line session.
 
 **Launch Site Locally**
 

--- a/website/README.md
+++ b/website/README.md
@@ -16,7 +16,7 @@ You should preview all of your changes locally before creating a pull request. T
 
 1. [Install Docker](https://docs.docker.com/get-docker/).
 2. Create a ~/go directory manually or by [installing Go](https://golang.org/doc/install).
-3. Set GOPATH as an environment variable:
+3. Open terminal and set GOPATH as an environment variable:
 
     Bash: `export $GOPATH=~/go`(bash)
 
@@ -25,8 +25,6 @@ You should preview all of your changes locally before creating a pull request. T
 
 **Launch Site Locally**
 
-1. From terminal, navigate into your local `terraform` top-level directory and run `make website`.
-3. Open `http://localhost:4567` in your web browser.
+1. Navigate into your local `terraform` top-level directory and run `make website`.
+3. Open `http://localhost:4567` in your web browser. While the preview is running, you can edit pages and Middleman will automatically rebuild them.
 4. When you're done with the preview, press ctrl-C in your terminal to stop the server.
-
-While the preview is running, you can edit pages and Middleman will automatically rebuild them.

--- a/website/README.md
+++ b/website/README.md
@@ -16,9 +16,11 @@ You should preview all of your changes locally before creating a pull request. T
 
 1. [Install Docker](https://docs.docker.com/get-docker/).
 2. Create a ~/go directory manually or by [installing Go](https://golang.org/doc/install).
-3. Set GOPATH as an environment variable: 
-  - bash: `export $GOPATH=~/go`
-  - zsh: `echo -n 'export GOPATH=~/go' >> ~/.zshrc`
+3. Set GOPATH as an environment variable:
+
+ Bash: `export $GOPATH=~/go`(bash)
+
+ Zsh: `echo -n 'export GOPATH=~/go' >> ~/.zshrc`
 4. Restart your terminal or command line session.
 
 **Launch Site Locally**

--- a/website/README.md
+++ b/website/README.md
@@ -15,13 +15,13 @@ You should preview all of your changes locally before creating a pull request. T
 **Set Up Local Environment**
 
 1. [Install Docker](https://docs.docker.com/get-docker/).
-1. Create a `~/go` directory manually or by [installing Go](https://golang.org/doc/install).
-1. Open terminal and set `GOPATH` as an environment variable:
+2. Create a `~/go` directory manually or by [installing Go](https://golang.org/doc/install).
+3. Open terminal and set `GOPATH` as an environment variable:
 
     Bash: `export $GOPATH=~/go`(bash)
 
     Zsh: `echo -n 'export GOPATH=~/go' >> ~/.zshrc`
-1. Restart your terminal or command line session.
+4. Restart your terminal or command line session.
 
 **Launch Site Locally**
 

--- a/website/README.md
+++ b/website/README.md
@@ -26,5 +26,5 @@ You should preview all of your changes locally before creating a pull request. T
 **Launch Site Locally**
 
 1. Navigate into your local `terraform` top-level directory and run `make website`.
-3. Open `http://localhost:4567` in your web browser. While the preview is running, you can edit pages and Middleman will automatically rebuild them.
-4. When you're done with the preview, press `ctrl-C` in your terminal to stop the server.
+2. Open `http://localhost:4567` in your web browser. While the preview is running, you can edit pages and Middleman will automatically rebuild them.
+3. When you're done with the preview, press `ctrl-C` in your terminal to stop the server.

--- a/website/README.md
+++ b/website/README.md
@@ -7,3 +7,20 @@ The files in this directory are intended to be used in conjunction with
 [the `terraform-website` repository](https://github.com/hashicorp/terraform-website), which brings all of the
 different documentation sources together and contains the scripts for testing and building the site as
 a whole.
+
+## Previewing Changes
+
+You should preview all of your changes locally before creating a pull request. The build includes content from this repository and the `terraform-website` repository, allowing you to preview the entire Terraform documentation site.
+
+**Set Up Local Environment**
+
+1. [Install Docker](https://docs.docker.com/get-docker/).
+2. Create a ~/go directory manually or by [installing Go](https://golang.org/doc/install).
+3. Set GOPATH as an environment variable: 
+  - bash: `export $GOPATH=~/go`
+  - zsh: `echo -n 'export GOPATH=~/go' >> ~/.zshrc`
+4. Restart your terminal or command line session.
+
+**Launch Site Locally**
+
+Navigate into your local `terraform` top-level directory and run `make website`. Preview the site at http://localhost:4567.

--- a/website/README.md
+++ b/website/README.md
@@ -27,4 +27,4 @@ You should preview all of your changes locally before creating a pull request. T
 
 1. Navigate into your local `terraform` top-level directory and run `make website`.
 3. Open `http://localhost:4567` in your web browser. While the preview is running, you can edit pages and Middleman will automatically rebuild them.
-4. When you're done with the preview, press ctrl-C in your terminal to stop the server.
+4. When you're done with the preview, press `ctrl-C` in your terminal to stop the server.

--- a/website/README.md
+++ b/website/README.md
@@ -25,4 +25,8 @@ You should preview all of your changes locally before creating a pull request. T
 
 **Launch Site Locally**
 
-Navigate into your local `terraform` top-level directory and run `make website`. Preview the site at http://localhost:4567.
+1. From terminal, navigate into your local `terraform` top-level directory and run `make website`.
+3. Open `http://localhost:4567` in your web browser.
+4. When you're done with the preview, press ctrl-C in your terminal to stop the server.
+
+While the preview is running, you can edit pages and Middleman will automatically rebuild them.

--- a/website/README.md
+++ b/website/README.md
@@ -10,7 +10,7 @@ a whole.
 
 ## Previewing Changes
 
-You should preview all of your changes locally before creating a pull request. The build includes content from this repository and the `terraform-website` repository, allowing you to preview the entire Terraform documentation site.
+You should preview all of your changes locally before creating a pull request. The build includes content from this repository and the [`terraform-website`](https://github.com/hashicorp/terraform-website/) repository, allowing you to preview the entire Terraform documentation site. If `terraform-website` isn't in your `GOPATH`, the preview command will clone it to your machine.
 
 **Set Up Local Environment**
 


### PR DESCRIPTION
**Description**
Adding instructions describing how to preview documentation changes locally to the /website readme. Please note that CircleCI link check is failing, but it's just for the localhost address we give for previewing the website on the user's local machine. We can ignore this.

Requested review scope:
- [x] Content touched by the PR only (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)


Review urgency:
- [ ] ASAP (bug fixes, broken content, imminent releases)
- [ ] 3 days (small changes, easy reviews)
- [x] 1 week (default)
- [ ] Best effort (very non-urgent)

I have:
- [x] Verified that all status checks have passed
- [x] Verified that preview environment has successfully deployed.
- [x] Assigned an appropriate label (either Platform or a product name)
- [x] Requested at least one review