### PR TITLE
note that output of jsonencode is minified

### DIFF
--- a/website/docs/language/functions/jsonencode.html.md
+++ b/website/docs/language/functions/jsonencode.html.md
@@ -38,7 +38,7 @@ Unicode escape sequences: replacing `<`, `>`, `&`, `U+2028`, and `U+2029` with
 `\u003c`, `\u003e`, `\u0026`, `\u2028`, and `\u2029`. This is to preserve
 compatibility with Terraform 0.11 behavior.
 
-The output of `jsonencode` is a minified representation of the input.
+`jsonencode` outputs a minified representation of the input.
 
 ## Examples
 

--- a/website/docs/language/functions/jsonencode.html.md
+++ b/website/docs/language/functions/jsonencode.html.md
@@ -38,6 +38,8 @@ Unicode escape sequences: replacing `<`, `>`, `&`, `U+2028`, and `U+2029` with
 `\u003c`, `\u003e`, `\u0026`, `\u2028`, and `\u2029`. This is to preserve
 compatibility with Terraform 0.11 behavior.
 
+The output of `jsonencode` is a minified representation of the input.
+
 ## Examples
 
 ```


### PR DESCRIPTION
The use of `jsonencode` to minify JSON values is useful, so note that in the docs explicitly. A data source or resource may produce a JSON string as an attribute that is not minified, and if needs to be used elsewhere minified, an expression like `jsonencode(jsondecode(data.some_data_source.json))` will do this.