### PR TITLE
Add deploy instructions to readme

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -28,3 +28,19 @@ You should preview all of your changes locally before creating a pull request. T
 1. Navigate into your local `terraform` top-level directory and run `make website`.
 2. Open `http://localhost:4567` in your web browser. While the preview is running, you can edit pages and Middleman will automatically rebuild them.
 3. When you're done with the preview, press `ctrl-C` in your terminal to stop the server.
+
+## Deploying Changes
+
+Merge the PR to main. The changes will appear in the next major Terraform release.
+
+If you need your changes to be deployed sooner, cherry-pick them to:
+- the current release branch (e.g. `v1.0`) and push. They will be deployed in the next minor version release (once every two weeks).
+- the `stable-website` branch and push. They will be included in the next site deploy (see below). Note that the release process resets `stable-website` to match the release tag, removing any additional commits. So, we recommend always cherry-picking to the version branch first and then to `stable-website` when needed.
+
+### Deployment
+The [terraform.io][] site gets deployed by a CI job, currently managed by CircleCI. This job can be run manually by many people within HashiCorp, and also runs automatically whenever a user in the HashiCorp GitHub org merges changes to master in the `terraform-website` repository.
+
+New commits in this repository don't automatically deploy the [terraform.io][] site, but an unrelated site deploy will usually happen within a day. If you can't wait that long, you can do a manual CircleCI build or ask someone in the #proj-terraform-docs channel to do so:
+- Log in to circleci.com, and  make sure you're viewing the HashiCorp organization.
+- Go to the terraform-website project's list of workflows.
+- Find the most recent "website-deploy" workflow, and click the "Rerun workflow from start" button (which looks like a refresh button with a numeral "1" inside).

--- a/website/docs/language/data-sources/index.html.md
+++ b/website/docs/language/data-sources/index.html.md
@@ -3,13 +3,13 @@ layout: "language"
 page_title: "Data Sources - Configuration Language"
 sidebar_current: "docs-config-data-sources"
 description: |-
-  Data sources allow data to be fetched or computed for use elsewhere in Terraform configuration.
+  Using Data sources to give Terraform access to data from APIs or other Terraform configurations.
 ---
 
 # Data Sources
 
 _Data sources_ allow Terraform use information defined outside of Terraform,
-defined by another separate Terraform configuration, or modified by functions. 
+defined by another separate Terraform configuration, or modified by functions.
 
 > **Hands-on:** Try the [Query Data Sources](https://learn.hashicorp.com/tutorials/terraform/data-sources) tutorial on HashiCorp Learn.
 

--- a/website/docs/language/dependency-lock.html.md
+++ b/website/docs/language/dependency-lock.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "Dependency Lock File (.terraform.lock.hcl) - Configuration Language"
+description: |-
+  Details about the dependency lock file `.teraform.lock.hcl` that Terraform uses to track and select provider versions. 
 ---
 
 # Dependency Lock File

--- a/website/docs/language/files/index.html.md
+++ b/website/docs/language/files/index.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "Files and Directories - Configuration Language"
+description: |-
+  An overview of how Terraform configuration files are named, organized, and stored as well as how Terraform modules are created and evaluated.
 ---
 
 # Files and Directories

--- a/website/docs/language/files/override.html.md
+++ b/website/docs/language/files/override.html.md
@@ -3,8 +3,7 @@ layout: "language"
 page_title: "Override Files - Configuration Language"
 sidebar_current: "docs-config-override"
 description: |-
-  Override files allow additional settings to be merged into existing
-  configuration objects.
+  How Terraform override files merge additional settings into existing configuration objects.
 ---
 
 # Override Files

--- a/website/docs/language/index.html.md
+++ b/website/docs/language/index.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "Overview - Configuration Language"
+description: |-
+  An introduction to the Terraform Configuration Language that is used to declare resources in infrastructure as code.
 ---
 
 # Terraform Language Documentation

--- a/website/docs/language/meta-arguments/count.html.md
+++ b/website/docs/language/meta-arguments/count.html.md
@@ -2,7 +2,7 @@
 layout: "language"
 page_title: "The count Meta-Argument - Configuration Language"
 description: |-
-  Use the Terraform language `count` meta-argument to efficiently manage nearly identical resources without writing a separate block for each one.
+  Using the Terraform language `count` meta-argument to efficiently manage nearly identical resources without writing a separate block for each one.
 ---
 
 # The `count` Meta-Argument

--- a/website/docs/language/meta-arguments/count.html.md
+++ b/website/docs/language/meta-arguments/count.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "The count Meta-Argument - Configuration Language"
+description: |-
+  Use the Terraform language `count` meta-argument to efficiently manage nearly identical resources without writing a separate block for each one.
 ---
 
 # The `count` Meta-Argument

--- a/website/docs/language/meta-arguments/depends_on.html.md
+++ b/website/docs/language/meta-arguments/depends_on.html.md
@@ -2,7 +2,7 @@
 layout: "language"
 page_title: "The depends_on Meta-Argument - Configuration Language"
 description: |-
-  The Terraform language `depends_on` meta-argument is used to handle hidden resource or module dependencies.
+  Use the Terraform language `depends_on` meta-argument to handle hidden resource or module dependencies.
 ---
 
 # The `depends_on` Meta-Argument

--- a/website/docs/language/meta-arguments/depends_on.html.md
+++ b/website/docs/language/meta-arguments/depends_on.html.md
@@ -2,7 +2,7 @@
 layout: "language"
 page_title: "The depends_on Meta-Argument - Configuration Language"
 description: |-
-  Use the Terraform language `depends_on` meta-argument to handle hidden resource or module dependencies.
+  Using the Terraform language `depends_on` meta-argument to handle hidden resource or module dependencies.
 ---
 
 # The `depends_on` Meta-Argument

--- a/website/docs/language/meta-arguments/depends_on.html.md
+++ b/website/docs/language/meta-arguments/depends_on.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "The depends_on Meta-Argument - Configuration Language"
+description: |-
+  The Terraform language `depends_on` meta-argument is used to handle hidden resource or module dependencies.
 ---
 
 # The `depends_on` Meta-Argument

--- a/website/docs/language/meta-arguments/for_each.html.md
+++ b/website/docs/language/meta-arguments/for_each.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "The for_each Meta-Argument - Configuration Language"
+description: |-
+  Use the Terraform language `for_each` meta-argument to efficiently manage similar resources without writing a separate block for each one.
 ---
 
 # The `for_each` Meta-Argument

--- a/website/docs/language/meta-arguments/for_each.html.md
+++ b/website/docs/language/meta-arguments/for_each.html.md
@@ -2,7 +2,7 @@
 layout: "language"
 page_title: "The for_each Meta-Argument - Configuration Language"
 description: |-
-  Use the Terraform language `for_each` meta-argument to efficiently manage similar resources without writing a separate block for each one.
+  Using the Terraform language `for_each` meta-argument to efficiently manage similar resources without writing a separate block for each one.
 ---
 
 # The `for_each` Meta-Argument

--- a/website/docs/language/meta-arguments/lifecycle.html.md
+++ b/website/docs/language/meta-arguments/lifecycle.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "The lifecycle Meta-Argument - Configuration Language"
+description: |-
+  Use the Terraform language `lifecycle` meta-argument to customize resource behavior. 
 ---
 
 # The `lifecycle` Meta-Argument

--- a/website/docs/language/meta-arguments/lifecycle.html.md
+++ b/website/docs/language/meta-arguments/lifecycle.html.md
@@ -2,7 +2,7 @@
 layout: "language"
 page_title: "The lifecycle Meta-Argument - Configuration Language"
 description: |-
-  Use the Terraform language `lifecycle` meta-argument to customize resource behavior. 
+  Using the Terraform language `lifecycle` meta-argument to customize resource behavior. 
 ---
 
 # The `lifecycle` Meta-Argument

--- a/website/docs/language/meta-arguments/resource-provider.html.md
+++ b/website/docs/language/meta-arguments/resource-provider.html.md
@@ -2,7 +2,7 @@
 layout: "language"
 page_title: "The Resource provider Meta-Argument - Configuration Language"
 description: |-
-  Use the Terraform language `provider` meta-argument to specify which provider configuration to use for a resource.
+  Using the Terraform language `provider` meta-argument to specify which provider configuration to use for a resource.
 ---
 
 # The Resource `provider` Meta-Argument

--- a/website/docs/language/meta-arguments/resource-provider.html.md
+++ b/website/docs/language/meta-arguments/resource-provider.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "The Resource provider Meta-Argument - Configuration Language"
+description: |-
+  Use the Terraform language `provider` meta-argument to specify which provider configuration to use for a resource.
 ---
 
 # The Resource `provider` Meta-Argument

--- a/website/docs/language/modules/develop/index.html.md
+++ b/website/docs/language/modules/develop/index.html.md
@@ -3,7 +3,7 @@ layout: "language"
 page_title: "Creating Modules"
 sidebar_current: "docs-modules"
 description: |-
-  A module is a container for multiple resources that are used together.
+  An introduction to creating modules, containers for multiple resources that are used together in a Terraform configuration.
 ---
 
 # Creating Modules

--- a/website/docs/language/modules/index.html.md
+++ b/website/docs/language/modules/index.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "Modules Overview - Configuration Language"
+description: |-
+  An overview of Terraform modules, containers for multiple resources that are used together in a configuration.
 ---
 
 # Modules

--- a/website/docs/language/modules/sources.html.md
+++ b/website/docs/language/modules/sources.html.md
@@ -2,7 +2,7 @@
 layout: "language"
 page_title: "Module Sources"
 sidebar_current: "docs-modules-sources"
-description: The source argument within a module block specifies the location of the source code of a child module.
+description: Using `source` in Terraform modules to specify child modules in locations like GitHub, the Terraform Registry, Bitbucket, Git, Mercurial, S3, and GCS.
 ---
 
 # Module Sources
@@ -36,7 +36,7 @@ types, as listed below.
   * [S3 buckets](#s3-bucket)
 
   * [GCS buckets](#gcs-bucket)
-  
+
   * [Modules in Package Sub-directories](#modules-in-package-sub-directories)
 
 Each of these is described in the following sections. Module source addresses

--- a/website/docs/language/providers/configuration.html.md
+++ b/website/docs/language/providers/configuration.html.md
@@ -3,8 +3,7 @@ layout: "language"
 page_title: "Provider Configuration - Configuration Language"
 sidebar_current: "docs-config-providers"
 description: |-
-  Learn how to configure provider settings and alias providers to use multiple
-  different provider configurations in the same Terraform project.
+  Configuring Terraform providers, including how to use the `alias` meta-argument to specify multiple configurations for a single provider.
 ---
 
 # Provider Configuration

--- a/website/docs/language/providers/index.html.md
+++ b/website/docs/language/providers/index.html.md
@@ -2,9 +2,7 @@
 layout: "language"
 page_title: "Providers - Configuration Language"
 description: |-
-  Terraform providers are plugins that allow Terraform to create resources and
-  use data sources from services, cloud providers, and other APIs. Read about
-  how to discover, install, and use providers.
+  An overview of how to install and use providers, Terraform plugins that interact with services, cloud providers, and other APIs. 
 ---
 
 # Providers
@@ -12,7 +10,7 @@ description: |-
 > **Hands-on:** Try the [Perform CRUD Operations with Providers](https://learn.hashicorp.com/tutorials/terraform/provider-use?in=terraform/configuration-language&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform relies on plugins called "providers" to interact with cloud providers,
-SaaS providers, and other APIs. 
+SaaS providers, and other APIs.
 
 Terraform configurations must declare which providers they require so that
 Terraform can install and use them. Additionally, some providers require

--- a/website/docs/language/providers/requirements.html.md
+++ b/website/docs/language/providers/requirements.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "Provider Requirements - Configuration Language"
+description: |-
+  Declaring providers in your module configuration so that Terraform can install them.
 ---
 
 # Provider Requirements

--- a/website/docs/language/resources/behavior.html.md
+++ b/website/docs/language/resources/behavior.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "Resource Behavior - Configuration Language"
+description: |-
+  How Terraform uses resource blocks to create infrastructure objects as well as details about resource attributes and dependencies.
 ---
 
 # Resource Behavior

--- a/website/docs/language/resources/index.html.md
+++ b/website/docs/language/resources/index.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "Resources Overview - Configuration Language"
+description: |-
+  An introduction to the Terraform language resources element that is used to describe infrastructure objects.
 ---
 
 # Resources

--- a/website/docs/language/resources/provisioners/connection.html.md
+++ b/website/docs/language/resources/provisioners/connection.html.md
@@ -3,7 +3,7 @@ layout: "language"
 page_title: "Provisioner Connection Settings"
 sidebar_current: "docs-provisioners-connection"
 description: |-
-  Managing connection defaults for SSH and WinRM using the `connection` block.
+  Managing provisioner connection defaults for SSH and WinRM using the `connection` block in Terraform language.
 ---
 
 # Provisioner Connection Settings

--- a/website/docs/language/resources/provisioners/connection.html.md
+++ b/website/docs/language/resources/provisioners/connection.html.md
@@ -133,7 +133,7 @@ block would create a dependency cycle.
 
 * `insecure` - Set to `true` to not validate the HTTPS certificate chain.
 
-* `use_ntlm` - Set to `true` to use NTLM authentication, rather than default (basic authentication), removing the requirement for basic authentication to be enabled within the target guest. Further reading for remote connection authentication can be found [here](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx).
+* `use_ntlm` - Set to `true` to use NTLM authentication, rather than default (basic authentication), removing the requirement for basic authentication to be enabled within the target guest. Further reading for remote connection authentication can be found [here](https://docs.microsoft.com/en-us/windows/win32/winrm/authentication-for-remote-connections?redirectedfrom=MSDN).
 
 * `cacert` - The CA certificate to validate against.
 

--- a/website/docs/language/resources/provisioners/index.html.md
+++ b/website/docs/language/resources/provisioners/index.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "Provisioners Overview - Configuration Language"
+description: |-
+  An introduction to Terraform provisioners that prepare infrastructure objects for service.
 ---
 
 # Provisioners

--- a/website/docs/language/resources/provisioners/null_resource.html.md
+++ b/website/docs/language/resources/provisioners/null_resource.html.md
@@ -3,8 +3,7 @@ layout: "language"
 page_title: "Provisioners Without a Resource"
 sidebar_current: "docs-provisioners-null-resource"
 description: |-
-  The `null_resource` is a resource allows you to configure provisioners that
-  are not directly associated with a single existing resource.
+  Using 'null_resource' to configure Terraform provisioners that are not directly associated with a single existing resource.
 ---
 
 # Provisioners Without a Resource

--- a/website/docs/language/resources/provisioners/syntax.html.md
+++ b/website/docs/language/resources/provisioners/syntax.html.md
@@ -102,7 +102,7 @@ for launching specific configuration management products.
 
 We strongly recommend not using these, and instead running system configuration
 steps during a custom image build process. For example,
-[HashiCorp Packer](https://packer.io/) offers a similar complement of
+[HashiCorp Packer](https://www.packer.io/) offers a similar complement of
 configuration management provisioners and can run their installation steps
 during a separate build process, before creating a system disk image that you
 can deploy many times.

--- a/website/docs/language/resources/provisioners/syntax.html.md
+++ b/website/docs/language/resources/provisioners/syntax.html.md
@@ -3,7 +3,7 @@ layout: "language"
 page_title: "Provisioners"
 sidebar_current: "docs-provisioners"
 description: |-
-  How to use provisioners in Terraform to execute scripts on a local or remote machine as part of resource creation or destruction.
+  Using provisioners in Terraform to execute scripts on a local or remote machine as part of resource creation or destruction.
 ---
 
 # Provisioners

--- a/website/docs/language/resources/provisioners/syntax.html.md
+++ b/website/docs/language/resources/provisioners/syntax.html.md
@@ -3,7 +3,7 @@ layout: "language"
 page_title: "Provisioners"
 sidebar_current: "docs-provisioners"
 description: |-
-  Provisioners are used to execute scripts on a local or remote machine as part of resource creation or destruction.
+  How to use provisioners in Terraform to execute scripts on a local or remote machine as part of resource creation or destruction.
 ---
 
 # Provisioners

--- a/website/docs/language/resources/syntax.html.md
+++ b/website/docs/language/resources/syntax.html.md
@@ -3,9 +3,7 @@ layout: "language"
 page_title: "Resources - Configuration Language"
 sidebar_current: "docs-config-resources"
 description: |-
-  Resources are the most important element in a Terraform configuration.
-  Each resource corresponds to an infrastructure object, such as a virtual
-  network or compute instance.
+  Details about Terraform resources, which correspond to infrastructure objects like virtual networks or compute instances.
 ---
 
 # Resource Blocks

--- a/website/docs/language/syntax/configuration.html.md
+++ b/website/docs/language/syntax/configuration.html.md
@@ -3,9 +3,7 @@ layout: "language"
 page_title: "Syntax - Configuration Language"
 sidebar_current: "docs-config-syntax"
 description: |-
-  The Terraform language has its own syntax, intended to combine declarative
-  structure with expressions in a way that is easy for humans to read and
-  understand.
+  Key constructs of the native Terraform language syntax, including identifiers, arguments, blocks, and comments.
 ---
 
 # Configuration Syntax

--- a/website/docs/language/syntax/index.html.md
+++ b/website/docs/language/syntax/index.html.md
@@ -2,7 +2,7 @@
 layout: "language"
 page_title: "Syntax Overview - Configuration Language"
 description: |-
-  An introduction to Terraform Configuration Language syntax for both the native and JSON variants as well as formatting conventions.
+  An introduction to Terraform language syntax for both the native and JSON variants as well as formatting conventions.
 ---
 
 # Syntax

--- a/website/docs/language/syntax/index.html.md
+++ b/website/docs/language/syntax/index.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "Syntax Overview - Configuration Language"
+description: |-
+  An introduction to Terraform Configuration Language syntax for both the native and JSON variants as well as formatting conventions.
 ---
 
 # Syntax

--- a/website/docs/language/syntax/json.html.md
+++ b/website/docs/language/syntax/json.html.md
@@ -3,8 +3,7 @@ layout: "language"
 page_title: "JSON Configuration Syntax - Configuration Language"
 sidebar_current: "docs-config-syntax-json"
 description: |-
-  In addition to the native syntax that is most commonly used with Terraform,
-  the Terraform language can also be expressed in a JSON-compatible syntax.
+  Details about the JSON-compatible Terraform language syntax, including file structure, expression mapping, and blocks.
 ---
 
 # JSON Configuration Syntax

--- a/website/docs/language/syntax/style.html.md
+++ b/website/docs/language/syntax/style.html.md
@@ -3,9 +3,7 @@ layout: "language"
 page_title: "Style Conventions - Configuration Language"
 sidebar_current: "docs-config-style"
 description: |-
-  The Terraform language has some idiomatic style conventions, which we
-  recommend users always follow for consistency between files and modules
-  written by different teams.
+  Recommended formatting conventions for the Terraform language.
 ---
 
 # Style Conventions

--- a/website/docs/language/values/index.html.md
+++ b/website/docs/language/values/index.html.md
@@ -1,6 +1,8 @@
 ---
 layout: "language"
 page_title: "Variables and Outputs"
+description: |-
+  An overview of input variables, output values, and local values in Terraform language. 
 ---
 
 # Variables and Outputs

--- a/website/docs/language/values/locals.html.md
+++ b/website/docs/language/values/locals.html.md
@@ -3,8 +3,7 @@ layout: "language"
 page_title: "Local Values - Configuration Language"
 sidebar_current: "docs-config-locals"
 description: |-
-  Local values assign a name to an expression that can then be used multiple times
-  within a module.
+  Local values assign a name to an expression that can be used multiple times within a Terraform module.
 ---
 
 # Local Values

--- a/website/docs/language/values/variables.html.md
+++ b/website/docs/language/values/variables.html.md
@@ -3,9 +3,7 @@ layout: "language"
 page_title: "Input Variables - Configuration Language"
 sidebar_current: "docs-config-variables"
 description: |-
-  Input variables allow you to customize Terraform configuration according to 
-  set parameters. Learn about input variable syntax, including how to declare,
-  define, and reference variables in root and child modules.
+  Using input variables to customize Terraform configurations, including how to declare, define, and reference variables in root and child modules.
 ---
 
 # Input Variables

--- a/website/docs/providers/index.html.markdown
+++ b/website/docs/providers/index.html.markdown
@@ -3,8 +3,7 @@ layout: "language"
 page_title: "Provider Documentation"
 sidebar_current: "docs-providers"
 description: |-
-  Terraform's resources are implemented by provider plugins. The Terraform
-  Registry is the main directory of publicly available Terraform providers.
+  Pointers to documentation for Terraform provider plugins, including the Terraform Registry.
 ---
 
 # Provider Documentation


### PR DESCRIPTION
Adding this because there are some gotchas associated with deploying changes to docs that live in the terraform repo.

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)