### PR TITLE
Add deploy information to website folder readme

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -38,7 +38,7 @@ If you need your changes to be deployed sooner, cherry-pick them to:
 - the `stable-website` branch and push. They will be included in the next site deploy (see below). Note that the release process resets `stable-website` to match the release tag, removing any additional commits. So, we recommend always cherry-picking to the version branch first and then to `stable-website` when needed.
 
 ### Deployment
-The [terraform.io][] site gets deployed by a CI job, currently managed by CircleCI. This job can be run manually by many people within HashiCorp, and also runs automatically whenever a user in the HashiCorp GitHub org merges changes to master in the `terraform-website` repository.
+Currently, HashiCorp uses a CircleCI job to deploy the [terraform.io](terraform.io) site. This job can be run manually by many people within HashiCorp, and also runs automatically whenever a user in the HashiCorp GitHub org merges changes to master in the `terraform-website` repository.
 
 New commits in this repository don't automatically deploy the [terraform.io][] site, but an unrelated site deploy will usually happen within a day. If you can't wait that long, you can do a manual CircleCI build or ask someone in the #proj-terraform-docs channel to do so:
 - Log in to circleci.com, and  make sure you're viewing the HashiCorp organization.

--- a/website/README.md
+++ b/website/README.md
@@ -28,3 +28,19 @@ You should preview all of your changes locally before creating a pull request. T
 1. Navigate into your local `terraform` top-level directory and run `make website`.
 2. Open `http://localhost:4567` in your web browser. While the preview is running, you can edit pages and Middleman will automatically rebuild them.
 3. When you're done with the preview, press `ctrl-C` in your terminal to stop the server.
+
+## Deploying Changes
+
+Merge the PR to main. The changes will appear in the next major Terraform release.
+
+If you need your changes to be deployed sooner, cherry-pick them to:
+- the current release branch (e.g. `v1.0`) and push. They will be deployed in the next minor version release (once every two weeks).
+- the `stable-website` branch and push. They will be included in the next site deploy (see below). Note that the release process resets `stable-website` to match the release tag, removing any additional commits. So, we recommend always cherry-picking to the version branch first and then to `stable-website` when needed.
+
+### Deployment
+The [terraform.io][] site gets deployed by a CI job, currently managed by CircleCI. This job can be run manually by many people within HashiCorp, and also runs automatically whenever a user in the HashiCorp GitHub org merges changes to master in the `terraform-website` repository.
+
+New commits in this repository don't automatically deploy the [terraform.io][] site, but an unrelated site deploy will usually happen within a day. If you can't wait that long, you can do a manual CircleCI build or ask someone in the #proj-terraform-docs channel to do so:
+- Log in to circleci.com, and  make sure you're viewing the HashiCorp organization.
+- Go to the terraform-website project's list of workflows.
+- Find the most recent "website-deploy" workflow, and click the "Rerun workflow from start" button (which looks like a refresh button with a numeral "1" inside).


### PR DESCRIPTION
Adding this because there are some gotchas associated with deploying changes to docs that live in the terraform repo.

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)