### PR TITLE
fix to simplify range expression

### DIFF
--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -42,7 +42,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 
 	result := make([]string, 1, len(envs)+1)
 	result[0] = backend.DefaultStateName
-	for k, _ := range envs {
+	for k := range envs {
 		result = append(result, k)
 	}
 

--- a/internal/legacy/terraform/diff.go
+++ b/internal/legacy/terraform/diff.go
@@ -313,7 +313,7 @@ func (d *ModuleDiff) String() string {
 	var buf bytes.Buffer
 
 	names := make([]string, 0, len(d.Resources))
-	for name, _ := range d.Resources {
+	for name := range d.Resources {
 		names = append(names, name)
 	}
 	sort.Strings(names)
@@ -345,7 +345,7 @@ func (d *ModuleDiff) String() string {
 		keyLen := 0
 		rdiffAttrs := rdiff.CopyAttributes()
 		keys := make([]string, 0, len(rdiffAttrs))
-		for key, _ := range rdiffAttrs {
+		for key := range rdiffAttrs {
 			if key == "id" {
 				continue
 			}
@@ -1252,7 +1252,7 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 			// Found it! Ignore all of these. The prefix here is stripping
 			// off the "%" so it is just "k."
 			prefix := k[:len(k)-1]
-			for k2, _ := range d.Attributes {
+			for k2 := range d.Attributes {
 				if strings.HasPrefix(k2, prefix) {
 					ignoreAttrs[k2] = struct{}{}
 				}
@@ -1292,17 +1292,17 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 	// same attributes. To start, build up the check map to be all the keys.
 	checkOld := make(map[string]struct{})
 	checkNew := make(map[string]struct{})
-	for k, _ := range d.Attributes {
+	for k := range d.Attributes {
 		checkOld[k] = struct{}{}
 	}
-	for k, _ := range d2.CopyAttributes() {
+	for k := range d2.CopyAttributes() {
 		checkNew[k] = struct{}{}
 	}
 
 	// Make an ordered list so we are sure the approximated hashes are left
 	// to process at the end of the loop
 	keys := make([]string, 0, len(d.Attributes))
-	for k, _ := range d.Attributes {
+	for k := range d.Attributes {
 		keys = append(keys, k)
 	}
 	sort.StringSlice(keys).Sort()
@@ -1360,7 +1360,7 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 					return false, fmt.Sprintf("regexp failed to compile; err: %#v", err)
 				}
 
-				for k2, _ := range checkNew {
+				for k2 := range checkNew {
 					if re.MatchString(k2) {
 						delete(checkNew, k2)
 					}
@@ -1397,12 +1397,12 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 			// This is a computed list, set, or map, so remove any keys with
 			// this prefix from the check list.
 			kprefix := k[:len(k)-matchLen]
-			for k2, _ := range checkOld {
+			for k2 := range checkOld {
 				if strings.HasPrefix(k2, kprefix) {
 					delete(checkOld, k2)
 				}
 			}
-			for k2, _ := range checkNew {
+			for k2 := range checkNew {
 				if strings.HasPrefix(k2, kprefix) {
 					delete(checkNew, k2)
 				}
@@ -1422,7 +1422,7 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 	// Check for leftover attributes
 	if len(checkNew) > 0 {
 		extras := make([]string, 0, len(checkNew))
-		for attr, _ := range checkNew {
+		for attr := range checkNew {
 			extras = append(extras, attr)
 		}
 		return false,

--- a/internal/legacy/terraform/state.go
+++ b/internal/legacy/terraform/state.go
@@ -1137,7 +1137,7 @@ func (m *ModuleState) View(id string) *ModuleState {
 	}
 
 	r := m.deepcopy()
-	for k, _ := range r.Resources {
+	for k := range r.Resources {
 		if id == k || strings.HasPrefix(k, id+".") {
 			continue
 		}
@@ -1224,7 +1224,7 @@ func (m *ModuleState) String() string {
 	}
 
 	names := make([]string, 0, len(m.Resources))
-	for name, _ := range m.Resources {
+	for name := range m.Resources {
 		names = append(names, name)
 	}
 


### PR DESCRIPTION
I've fixed to simplify range expression.

e.g.

### Before
```go
for k, _ := range envs {
    result = append(result, k)
}
```

### After
```go
for k := range envs {
    result = append(result, k)
}
```