### PR TITLE
fix to error strings be lower case.

### DIFF
--- a/internal/legacy/terraform/resource_address.go
+++ b/internal/legacy/terraform/resource_address.go
@@ -179,7 +179,7 @@ func parseResourceAddressInternal(s string) (*ResourceAddress, error) {
 	// elements (type and name).
 	parts := strings.Split(s, ".")
 	if len(parts) < 2 || len(parts) > 4 {
-		return nil, fmt.Errorf("Invalid internal resource address format: %s", s)
+		return nil, fmt.Errorf("invalid internal resource address format: %s", s)
 	}
 
 	// Data resource if we have at least 3 parts and the first one is data
@@ -191,7 +191,7 @@ func parseResourceAddressInternal(s string) (*ResourceAddress, error) {
 
 	// If we're not a data resource and we have more than 3, then it is an error
 	if len(parts) > 3 && mode != DataResourceMode {
-		return nil, fmt.Errorf("Invalid internal resource address format: %s", s)
+		return nil, fmt.Errorf("invalid internal resource address format: %s", s)
 	}
 
 	// Build the parts of the resource address that are guaranteed to exist
@@ -207,7 +207,7 @@ func parseResourceAddressInternal(s string) (*ResourceAddress, error) {
 	if len(parts) > 2 {
 		idx, err := strconv.ParseInt(parts[2], 0, 0)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing resource address %q: %s", s, err)
+			return nil, fmt.Errorf("error parsing resource address %q: %s", s, err)
 		}
 
 		addr.Index = int(idx)
@@ -583,7 +583,7 @@ func ParseInstanceType(s string) (InstanceType, error) {
 	case "tainted":
 		return TypeTainted, nil
 	default:
-		return TypeInvalid, fmt.Errorf("Unexpected value for InstanceType field: %q", s)
+		return TypeInvalid, fmt.Errorf("unexpected value for InstanceType field: %q", s)
 	}
 }
 

--- a/internal/legacy/terraform/schemas.go
+++ b/internal/legacy/terraform/schemas.go
@@ -106,7 +106,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to instantiate provider %q to obtain schema: %s", name, err),
+				fmt.Errorf("failed to instantiate provider %q to obtain schema: %s", name, err),
 			)
 			return
 		}
@@ -120,7 +120,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to retrieve schema from provider %q: %s", name, resp.Diagnostics.Err()),
+				fmt.Errorf("failed to retrieve schema from provider %q: %s", name, resp.Diagnostics.Err()),
 			)
 			return
 		}
@@ -200,7 +200,7 @@ func loadProvisionerSchemas(schemas map[string]*configschema.Block, config *conf
 			// future calls.
 			schemas[name] = &configschema.Block{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to instantiate provisioner %q to obtain schema: %s", name, err),
+				fmt.Errorf("failed to instantiate provisioner %q to obtain schema: %s", name, err),
 			)
 			return
 		}
@@ -216,7 +216,7 @@ func loadProvisionerSchemas(schemas map[string]*configschema.Block, config *conf
 			// future calls.
 			schemas[name] = &configschema.Block{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to retrieve schema from provisioner %q: %s", name, resp.Diagnostics.Err()),
+				fmt.Errorf("failed to retrieve schema from provisioner %q: %s", name, resp.Diagnostics.Err()),
 			)
 			return
 		}

--- a/internal/legacy/terraform/state.go
+++ b/internal/legacy/terraform/state.go
@@ -669,7 +669,7 @@ func (s *State) ensureHasLineage() {
 	if s.Lineage == "" {
 		lineage, err := uuid.GenerateUUID()
 		if err != nil {
-			panic(fmt.Errorf("Failed to generate lineage: %v", err))
+			panic(fmt.Errorf("failed to generate lineage: %v", err))
 		}
 		s.Lineage = lineage
 		log.Printf("[DEBUG] New state was assigned lineage %q\n", s.Lineage)
@@ -951,7 +951,7 @@ func (s *OutputState) deepcopy() *OutputState {
 
 	stateCopy, err := copystructure.Config{Lock: true}.Copy(s)
 	if err != nil {
-		panic(fmt.Errorf("Error copying output value: %s", err))
+		panic(fmt.Errorf("error copying output value: %s", err))
 	}
 
 	return stateCopy.(*OutputState)
@@ -1397,7 +1397,7 @@ func ParseResourceStateKey(k string) (*ResourceStateKey, error) {
 		parts = parts[1:]
 	}
 	if len(parts) < 2 || len(parts) > 3 {
-		return nil, fmt.Errorf("Malformed resource state key: %s", k)
+		return nil, fmt.Errorf("malformed resource state key: %s", k)
 	}
 	rsk := &ResourceStateKey{
 		Mode:  mode,
@@ -1408,7 +1408,7 @@ func ParseResourceStateKey(k string) (*ResourceStateKey, error) {
 	if len(parts) == 3 {
 		index, err := strconv.Atoi(parts[2])
 		if err != nil {
-			return nil, fmt.Errorf("Malformed resource state key index: %s", k)
+			return nil, fmt.Errorf("malformed resource state key index: %s", k)
 		}
 		rsk.Index = index
 	}
@@ -1917,13 +1917,13 @@ type jsonStateVersionIdentifier struct {
 func testForV0State(buf *bufio.Reader) error {
 	start, err := buf.Peek(len("tfstate"))
 	if err != nil {
-		return fmt.Errorf("Failed to check for magic bytes: %v", err)
+		return fmt.Errorf("failed to check for magic bytes: %v", err)
 	}
 	if string(start) == "tfstate" {
-		return fmt.Errorf("Terraform 0.7 no longer supports upgrading the binary state\n" +
+		return fmt.Errorf("terraform 0.7 no longer supports upgrading the binary state\n" +
 			"format which was used prior to Terraform 0.3. Please upgrade\n" +
 			"this state file using Terraform 0.6.16 prior to using it with\n" +
-			"Terraform 0.7.")
+			"Terraform 0.7")
 	}
 
 	return nil
@@ -1958,18 +1958,18 @@ func ReadState(src io.Reader) (*State, error) {
 	// This is suboptimal, but will work for now.
 	jsonBytes, err := ioutil.ReadAll(buf)
 	if err != nil {
-		return nil, fmt.Errorf("Reading state file failed: %v", err)
+		return nil, fmt.Errorf("reading state file failed: %v", err)
 	}
 
 	versionIdentifier := &jsonStateVersionIdentifier{}
 	if err := json.Unmarshal(jsonBytes, versionIdentifier); err != nil {
-		return nil, fmt.Errorf("Decoding state file version failed: %v", err)
+		return nil, fmt.Errorf("decoding state file version failed: %v", err)
 	}
 
 	var result *State
 	switch versionIdentifier.Version {
 	case 0:
-		return nil, fmt.Errorf("State version 0 is not supported as JSON.")
+		return nil, fmt.Errorf("state version 0 is not supported as JSON")
 	case 1:
 		v1State, err := ReadStateV1(jsonBytes)
 		if err != nil {
@@ -2009,7 +2009,7 @@ func ReadState(src io.Reader) (*State, error) {
 
 		result = v3State
 	default:
-		return nil, fmt.Errorf("Terraform %s does not support state version %d, please update.",
+		return nil, fmt.Errorf("terraform %s does not support state version %d, please update",
 			tfversion.SemVer.String(), versionIdentifier.Version)
 	}
 
@@ -2033,11 +2033,11 @@ func ReadState(src io.Reader) (*State, error) {
 func ReadStateV1(jsonBytes []byte) (*stateV1, error) {
 	v1State := &stateV1{}
 	if err := json.Unmarshal(jsonBytes, v1State); err != nil {
-		return nil, fmt.Errorf("Decoding state file failed: %v", err)
+		return nil, fmt.Errorf("decoding state file failed: %v", err)
 	}
 
 	if v1State.Version != 1 {
-		return nil, fmt.Errorf("Decoded state version did not match the decoder selection: "+
+		return nil, fmt.Errorf("decoded state version did not match the decoder selection: "+
 			"read %d, expected 1", v1State.Version)
 	}
 
@@ -2047,13 +2047,13 @@ func ReadStateV1(jsonBytes []byte) (*stateV1, error) {
 func ReadStateV2(jsonBytes []byte) (*State, error) {
 	state := &State{}
 	if err := json.Unmarshal(jsonBytes, state); err != nil {
-		return nil, fmt.Errorf("Decoding state file failed: %v", err)
+		return nil, fmt.Errorf("decoding state file failed: %v", err)
 	}
 
 	// Check the version, this to ensure we don't read a future
 	// version that we don't understand
 	if state.Version > StateVersion {
-		return nil, fmt.Errorf("Terraform %s does not support state version %d, please update.",
+		return nil, fmt.Errorf("terraform %s does not support state version %d, please update",
 			tfversion.SemVer.String(), state.Version)
 	}
 
@@ -2061,11 +2061,11 @@ func ReadStateV2(jsonBytes []byte) (*State, error) {
 	if state.TFVersion != "" {
 		if _, err := version.NewVersion(state.TFVersion); err != nil {
 			return nil, fmt.Errorf(
-				"State contains invalid version: %s\n\n"+
+				"state contains invalid version: %s\n\n"+
 					"Terraform validates the version format prior to writing it. This\n"+
 					"means that this is invalid of the state becoming corrupted through\n"+
 					"some external means. Please manually modify the Terraform version\n"+
-					"field to be a proper semantic version.",
+					"field to be a proper semantic version",
 				state.TFVersion)
 		}
 	}
@@ -2082,13 +2082,13 @@ func ReadStateV2(jsonBytes []byte) (*State, error) {
 func ReadStateV3(jsonBytes []byte) (*State, error) {
 	state := &State{}
 	if err := json.Unmarshal(jsonBytes, state); err != nil {
-		return nil, fmt.Errorf("Decoding state file failed: %v", err)
+		return nil, fmt.Errorf("decoding state file failed: %v", err)
 	}
 
 	// Check the version, this to ensure we don't read a future
 	// version that we don't understand
 	if state.Version > StateVersion {
-		return nil, fmt.Errorf("Terraform %s does not support state version %d, please update.",
+		return nil, fmt.Errorf("terraform %s does not support state version %d, please update",
 			tfversion.SemVer.String(), state.Version)
 	}
 
@@ -2096,11 +2096,11 @@ func ReadStateV3(jsonBytes []byte) (*State, error) {
 	if state.TFVersion != "" {
 		if _, err := version.NewVersion(state.TFVersion); err != nil {
 			return nil, fmt.Errorf(
-				"State contains invalid version: %s\n\n"+
+				"state contains invalid version: %s\n\n"+
 					"Terraform validates the version format prior to writing it. This\n"+
 					"means that this is invalid of the state becoming corrupted through\n"+
 					"some external means. Please manually modify the Terraform version\n"+
-					"field to be a proper semantic version.",
+					"field to be a proper semantic version",
 				state.TFVersion)
 		}
 	}
@@ -2150,9 +2150,9 @@ func WriteState(d *State, dst io.Writer) error {
 	if d.TFVersion != "" {
 		if _, err := version.NewVersion(d.TFVersion); err != nil {
 			return fmt.Errorf(
-				"Error writing state, invalid version: %s\n\n"+
+				"error writing state, invalid version: %s\n\n"+
 					"The Terraform version when writing the state must be a semantic\n"+
-					"version.",
+					"version",
 				d.TFVersion)
 		}
 	}
@@ -2160,7 +2160,7 @@ func WriteState(d *State, dst io.Writer) error {
 	// Encode the data in a human-friendly way
 	data, err := json.MarshalIndent(d, "", "    ")
 	if err != nil {
-		return fmt.Errorf("Failed to encode state: %s", err)
+		return fmt.Errorf("failed to encode state: %s", err)
 	}
 
 	// We append a newline to the data because MarshalIndent doesn't
@@ -2168,7 +2168,7 @@ func WriteState(d *State, dst io.Writer) error {
 
 	// Write the data out to the dst
 	if _, err := io.Copy(dst, bytes.NewReader(data)); err != nil {
-		return fmt.Errorf("Failed to write state: %v", err)
+		return fmt.Errorf("failed to write state: %v", err)
 	}
 
 	return nil

--- a/internal/legacy/terraform/state_filter.go
+++ b/internal/legacy/terraform/state_filter.go
@@ -28,7 +28,7 @@ func (f *StateFilter) Filter(fs ...string) ([]*StateFilterResult, error) {
 	for i, v := range fs {
 		a, err := ParseResourceAddress(v)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing address '%s': %s", v, err)
+			return nil, fmt.Errorf("error parsing address '%s': %s", v, err)
 		}
 
 		as[i] = a

--- a/internal/legacy/terraform/state_upgrade_v1_to_v2.go
+++ b/internal/legacy/terraform/state_upgrade_v1_to_v2.go
@@ -15,14 +15,14 @@ func upgradeStateV1ToV2(old *stateV1) (*State, error) {
 
 	remote, err := old.Remote.upgradeToV2()
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading State V1: %v", err)
+		return nil, fmt.Errorf("error upgrading State V1: %v", err)
 	}
 
 	modules := make([]*ModuleState, len(old.Modules))
 	for i, module := range old.Modules {
 		upgraded, err := module.upgradeToV2()
 		if err != nil {
-			return nil, fmt.Errorf("Error upgrading State V1: %v", err)
+			return nil, fmt.Errorf("error upgrading State V1: %v", err)
 		}
 		modules[i] = upgraded
 	}
@@ -50,7 +50,7 @@ func (old *remoteStateV1) upgradeToV2() (*RemoteState, error) {
 
 	config, err := copystructure.Copy(old.Config)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading RemoteState V1: %v", err)
+		return nil, fmt.Errorf("error upgrading RemoteState V1: %v", err)
 	}
 
 	return &RemoteState{
@@ -66,11 +66,11 @@ func (old *moduleStateV1) upgradeToV2() (*ModuleState, error) {
 
 	pathRaw, err := copystructure.Copy(old.Path)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading ModuleState V1: %v", err)
+		return nil, fmt.Errorf("error upgrading ModuleState V1: %v", err)
 	}
 	path, ok := pathRaw.([]string)
 	if !ok {
-		return nil, fmt.Errorf("Error upgrading ModuleState V1: path is not a list of strings")
+		return nil, fmt.Errorf("error upgrading ModuleState V1: path is not a list of strings")
 	}
 	if len(path) == 0 {
 		// We found some V1 states with a nil path. Assume root and catch
@@ -92,14 +92,14 @@ func (old *moduleStateV1) upgradeToV2() (*ModuleState, error) {
 	for key, oldResource := range old.Resources {
 		upgraded, err := oldResource.upgradeToV2()
 		if err != nil {
-			return nil, fmt.Errorf("Error upgrading ModuleState V1: %v", err)
+			return nil, fmt.Errorf("error upgrading ModuleState V1: %v", err)
 		}
 		resources[key] = upgraded
 	}
 
 	dependencies, err := copystructure.Copy(old.Dependencies)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading ModuleState V1: %v", err)
+		return nil, fmt.Errorf("error upgrading ModuleState V1: %v", err)
 	}
 
 	return &ModuleState{
@@ -117,19 +117,19 @@ func (old *resourceStateV1) upgradeToV2() (*ResourceState, error) {
 
 	dependencies, err := copystructure.Copy(old.Dependencies)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading ResourceState V1: %v", err)
+		return nil, fmt.Errorf("error upgrading ResourceState V1: %v", err)
 	}
 
 	primary, err := old.Primary.upgradeToV2()
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading ResourceState V1: %v", err)
+		return nil, fmt.Errorf("error upgrading ResourceState V1: %v", err)
 	}
 
 	deposed := make([]*InstanceState, len(old.Deposed))
 	for i, v := range old.Deposed {
 		upgraded, err := v.upgradeToV2()
 		if err != nil {
-			return nil, fmt.Errorf("Error upgrading ResourceState V1: %v", err)
+			return nil, fmt.Errorf("error upgrading ResourceState V1: %v", err)
 		}
 		deposed[i] = upgraded
 	}
@@ -153,16 +153,16 @@ func (old *instanceStateV1) upgradeToV2() (*InstanceState, error) {
 
 	attributes, err := copystructure.Copy(old.Attributes)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading InstanceState V1: %v", err)
+		return nil, fmt.Errorf("error upgrading InstanceState V1: %v", err)
 	}
 	ephemeral, err := old.Ephemeral.upgradeToV2()
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading InstanceState V1: %v", err)
+		return nil, fmt.Errorf("error upgrading InstanceState V1: %v", err)
 	}
 
 	meta, err := copystructure.Copy(old.Meta)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading InstanceState V1: %v", err)
+		return nil, fmt.Errorf("error upgrading InstanceState V1: %v", err)
 	}
 
 	newMeta := make(map[string]interface{})
@@ -181,7 +181,7 @@ func (old *instanceStateV1) upgradeToV2() (*InstanceState, error) {
 func (old *ephemeralStateV1) upgradeToV2() (*EphemeralState, error) {
 	connInfo, err := copystructure.Copy(old.ConnInfo)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading EphemeralState V1: %v", err)
+		return nil, fmt.Errorf("error upgrading EphemeralState V1: %v", err)
 	}
 	return &EphemeralState{
 		ConnInfo: connInfo.(map[string]string),

--- a/internal/legacy/terraform/state_upgrade_v2_to_v3.go
+++ b/internal/legacy/terraform/state_upgrade_v2_to_v3.go
@@ -18,8 +18,8 @@ func upgradeStateV2ToV3(old *State) (*State, error) {
 
 	// Ensure the copied version is v2 before attempting to upgrade
 	if new.Version != 2 {
-		return nil, fmt.Errorf("Cannot apply v2->v3 state upgrade to " +
-			"a state which is not version 2.")
+		return nil, fmt.Errorf("cannot apply v2->v3 state upgrade to " +
+			"a state which is not version 2")
 	}
 
 	// Set the new version number


### PR DESCRIPTION
I've fixed to some error strings as a reference below url.

https://github.com/golang/go/wiki/CodeReviewComments#error-strings

> Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context. That is, use fmt.Errorf("something bad") not fmt.Errorf("Something bad"), so that log.Printf("Reading %s: %v", filename, err) formats without a spurious capital letter mid-message. This does not apply to logging, which is implicitly line-oriented and not combined inside other messages.