### PR TITLE
Add uniqueness constraint on workspaces name for the pg backend

### DIFF
--- a/internal/backend/remote-state/pg/backend.go
+++ b/internal/backend/remote-state/pg/backend.go
@@ -111,7 +111,7 @@ func (b *Backend) configure(ctx context.Context) error {
 
 		query = `CREATE TABLE IF NOT EXISTS %s.%s (
 			id bigint NOT NULL DEFAULT nextval('public.global_states_id_seq') PRIMARY KEY,
-			name text,
+			name text UNIQUE,
 			data text
 			)`
 		if _, err := db.Exec(fmt.Sprintf(query, b.schemaName, statesTableName)); err != nil {

--- a/website/docs/language/settings/backends/pg.html.md
+++ b/website/docs/language/settings/backends/pg.html.md
@@ -73,9 +73,9 @@ The following configuration options or environment variables are supported:
 
  * `conn_str` - (Required) Postgres connection string; a `postgres://` URL
  * `schema_name` - Name of the automatically-managed Postgres schema, default `terraform_remote_state`.
- * `skip_schema_creation` - If set to `true`, the Postgres schema must already exist. Terraform won't try to create the schema. Useful when the Postgres user does not have "create schema" permission on the database.
- * `skip_table_creation` - If set to `true`, the Postgres table must already exist. Terraform won't try to create the table. Useful when the Postgres user does not have "create table" permission on the database.
- * `skip_index_creation` - If set to `true`, the Postgres index must already exist. Terraform won't try to create the index. Useful when the Postgres user does not have "create index" permission on the database.
+ * `skip_schema_creation` - If set to `true`, the Postgres schema must already exist. Terraform won't try to create the schema, this is useful when it has already been created by a database administrator.
+ * `skip_table_creation` - If set to `true`, the Postgres table must already exist. Terraform won't try to create the table, this is useful when it has already been created by a database administrator.
+ * `skip_index_creation` - If set to `true`, the Postgres index must already exist. Terraform won't try to create the index, this is useful when it has already been created by a database administrator.
 
 ## Technical Design
 


### PR DESCRIPTION
While it should not be possible to create two workspaces with the same name as the index should be created by the database administrator when `skip_index_creation` is used, this additional constraint will make it impossible to do so even if the index is missing.

I also reworded the documentation for the `skip_...` options which was inaccurate.

Discussion at https://github.com/hashicorp/terraform/issues/29034