### PR TITLE
backend/oss: Changes the DescribeEndpoint to DescribeEndpoints to fixes the unsupported sts bug

### DIFF
--- a/internal/backend/remote-state/oss/backend_test.go
+++ b/internal/backend/remote-state/oss/backend_test.go
@@ -2,6 +2,7 @@ package oss
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -69,9 +70,10 @@ func TestBackendConfig(t *testing.T) {
 
 func TestBackendConfigWorkSpace(t *testing.T) {
 	testACC(t)
+	bucketName := fmt.Sprintf("terraform-backend-oss-test-%d", rand.Intn(1000))
 	config := map[string]interface{}{
 		"region":              "cn-beijing",
-		"bucket":              "terraform-backend-oss-test",
+		"bucket":              bucketName,
 		"prefix":              "mystate",
 		"key":                 "first.tfstate",
 		"tablestore_endpoint": "https://terraformstate.cn-beijing.ots.aliyuncs.com",
@@ -79,15 +81,15 @@ func TestBackendConfigWorkSpace(t *testing.T) {
 	}
 
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
-	createOSSBucket(t, b.ossClient, "terraform-backend-oss-test")
-	defer deleteOSSBucket(t, b.ossClient, "terraform-backend-oss-test")
+	createOSSBucket(t, b.ossClient, bucketName)
+	defer deleteOSSBucket(t, b.ossClient, bucketName)
 	if _, err := b.Workspaces(); err != nil {
 		t.Fatal(err.Error())
 	}
 	if !strings.HasPrefix(b.ossClient.Config.Endpoint, "https://oss-cn-beijing") {
 		t.Fatalf("Incorrect region was provided")
 	}
-	if b.bucketName != "terraform-backend-oss-test" {
+	if b.bucketName != bucketName {
 		t.Fatalf("Incorrect bucketName was provided")
 	}
 	if b.statePrefix != "mystate" {


### PR DESCRIPTION
The API DescribeEndpoint does not support STS authorizing and using the DescribeEndpoints instead.

```
TF_ACC=1 go test -v ./internal/backend/remote-state/oss/ -run=TestBackend -timeout 120m
=== RUN   TestBackend_impl
--- PASS: TestBackend_impl (0.00s)
=== RUN   TestBackendConfig
    backend_test.go:48: TestBackendConfig on *oss.Backend with configs.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"bucket":cty.StringVal("terraform-backend-oss-test"), "key":cty.StringVal("first.tfstate"), "prefix":cty.StringVal("mystate"), "region":cty.StringVal("cn-beijing"), "tablestore_endpoint":cty.StringVal("https://terraformstate.cn-beijing.ots.aliyuncs.com"), "tablestore_table":cty.StringVal("TableStore")}}
--- PASS: TestBackendConfig (0.58s)
=== RUN   TestBackendConfigWorkSpace
    backend_test.go:83: TestBackendConfig on *oss.Backend with configs.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"bucket":cty.StringVal("terraform-backend-oss-test-81"), "key":cty.StringVal("first.tfstate"), "prefix":cty.StringVal("mystate"), "region":cty.StringVal("cn-beijing"), "tablestore_endpoint":cty.StringVal("https://terraformstate.cn-beijing.ots.aliyuncs.com"), "tablestore_table":cty.StringVal("TableStore")}}
--- PASS: TestBackendConfigWorkSpace (1.48s)
=== RUN   TestBackendConfigProfile
    backend_test.go:122: TestBackendConfig on *oss.Backend with configs.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"bucket":cty.StringVal("terraform-backend-oss-test"), "key":cty.StringVal("first.tfstate"), "prefix":cty.StringVal("mystate"), "profile":cty.StringVal("default"), "region":cty.StringVal("cn-beijing"), "tablestore_endpoint":cty.StringVal("https://terraformstate.cn-beijing.ots.aliyuncs.com"), "tablestore_table":cty.StringVal("TableStore")}}
--- PASS: TestBackendConfigProfile (0.56s)
=== RUN   TestBackendConfig_invalidKey
--- PASS: TestBackendConfig_invalidKey (0.00s)
=== RUN   TestBackend
    backend_test.go:168: TestBackendConfig on *oss.Backend with configs.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"bucket":cty.StringVal("terraform-remote-oss-test-60efea39"), "prefix":cty.StringVal("multi/level/path/")}}
    backend_test.go:173: TestBackendConfig on *oss.Backend with configs.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"bucket":cty.StringVal("terraform-remote-oss-test-60efea39"), "prefix":cty.StringVal("multi/level/path/")}}
    testing.go:299: TestBackend: testing state locking for *oss.Backend
    testing.go:299: TestBackend: *oss.Backend: empty string returned for lock, assuming disabled
    testing.go:299: TestBackend: testing state locking for *oss.Backend
    testing.go:299: TestBackend: *oss.Backend: empty string returned for lock, assuming disabled
--- PASS: TestBackend (3.96s)
PASS
ok      github.com/hashicorp/terraform/internal/backend/remote-state/oss        7.852s

```