### PR TITLE
Fix flapping JSON output test properly

### DIFF
--- a/internal/command/views/operation_test.go
+++ b/internal/command/views/operation_test.go
@@ -707,25 +707,6 @@ func TestOperationJSON_planDrift(t *testing.T) {
 	v.Plan(plan, testSchemas())
 
 	want := []map[string]interface{}{
-		// Drift detected: update
-		{
-			"@level":   "info",
-			"@message": "test_resource.boop: Drift detected (update)",
-			"@module":  "terraform.ui",
-			"type":     "resource_drift",
-			"change": map[string]interface{}{
-				"action": "update",
-				"resource": map[string]interface{}{
-					"addr":             "test_resource.boop",
-					"implied_provider": "test",
-					"module":           "",
-					"resource":         "test_resource.boop",
-					"resource_key":     nil,
-					"resource_name":    "boop",
-					"resource_type":    "test_resource",
-				},
-			},
-		},
 		// Drift detected: delete
 		{
 			"@level":   "info",
@@ -741,6 +722,25 @@ func TestOperationJSON_planDrift(t *testing.T) {
 					"resource":         "test_resource.beep",
 					"resource_key":     nil,
 					"resource_name":    "beep",
+					"resource_type":    "test_resource",
+				},
+			},
+		},
+		// Drift detected: update
+		{
+			"@level":   "info",
+			"@message": "test_resource.boop: Drift detected (update)",
+			"@module":  "terraform.ui",
+			"type":     "resource_drift",
+			"change": map[string]interface{}{
+				"action": "update",
+				"resource": map[string]interface{}{
+					"addr":             "test_resource.boop",
+					"implied_provider": "test",
+					"module":           "",
+					"resource":         "test_resource.boop",
+					"resource_key":     nil,
+					"resource_name":    "boop",
 					"resource_type":    "test_resource",
 				},
 			},


### PR DESCRIPTION
#29175 didn't work. This commit makes the output order of the resource drift messages stable, by building a slice of changes and sorting it by address.

I've run these tests locally 30 times in a row with no failures, which surely ought to be enough to be certain that it's stable…? 🤞 