### PR TITLE
[backport] Add support for protocol 6 providers during init. (#29153)

### DIFF
--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -55,7 +55,7 @@ func init() {
 	configureRequestTimeout()
 }
 
-var SupportedPluginProtocols = MustParseVersionConstraints("~> 5")
+var SupportedPluginProtocols = MustParseVersionConstraints(">= 5, <7")
 
 // registryClient is a client for the provider registry protocol that is
 // specialized only for the needs of this package. It's not intended as a

--- a/internal/getproviders/registry_client_test.go
+++ b/internal/getproviders/registry_client_test.go
@@ -218,6 +218,10 @@ func fakeRegistryHandler(resp http.ResponseWriter, req *http.Request) {
 			resp.Header().Set("Content-Type", "application/json")
 			resp.WriteHeader(200)
 			resp.Write([]byte(`{"versions":[{"version":"1.0.0","protocols":["0.1"]}]}`))
+		case "weaksauce/protocol-six":
+			resp.Header().Set("Content-Type", "application/json")
+			resp.WriteHeader(200)
+			resp.Write([]byte(`{"versions":[{"version":"1.0.0","protocols":["6.0"]}]}`))
 		case "weaksauce/no-versions":
 			resp.Header().Set("Content-Type", "application/json")
 			resp.WriteHeader(200)
@@ -410,6 +414,12 @@ func TestFindClosestProtocolCompatibleVersion(t *testing.T) {
 			addrs.MustParseProviderSourceString("example.com/weaksauce/unsupported-protocol"),
 			MustParseVersion("1.0.0"),
 			versions.Unspecified,
+			``,
+		},
+		"provider protocol six": {
+			addrs.MustParseProviderSourceString("example.com/weaksauce/protocol-six"),
+			MustParseVersion("1.0.0"),
+			MustParseVersion("1.0.0"),
 			``,
 		},
 	}


### PR DESCRIPTION
Update the version constraints for what providers will be downloaded
from the registry, allowing protocol 6 providers to be downloaded from
the registry.

(backport)