### PR TITLE
Handle marks on ignore_changes values

### DIFF
--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -510,7 +510,8 @@ output "out" {
 }
 
 func TestContext2Apply_ignoreImpureFunctionChanges(t *testing.T) {
-	// Ensure we're not trying to double-mark values decoded from state
+	// The impure function call should not cause a planned change with
+	// ignore_changes
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "pw" {
@@ -524,6 +525,15 @@ resource "test_object" "x" {
   }
   lifecycle {
     ignore_changes = [ test_map["string"] ]
+  }
+}
+
+resource "test_object" "y" {
+  test_map = {
+	string = "X${bcrypt(var.pw)}"
+  }
+  lifecycle {
+    ignore_changes = [ test_map ]
   }
 }
 

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -508,3 +508,59 @@ output "out" {
 		}
 	}
 }
+
+func TestContext2Apply_ignoreImpureFunctionChanges(t *testing.T) {
+	// Ensure we're not trying to double-mark values decoded from state
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+variable "pw" {
+  sensitive = true
+  default = "foo"
+}
+
+resource "test_object" "x" {
+  test_map = {
+	string = "X${bcrypt(var.pw)}"
+  }
+  lifecycle {
+    ignore_changes = [ test_map["string"] ]
+  }
+}
+
+`,
+	})
+
+	p := simpleMockProvider()
+
+	ctx := testContext2(t, &ContextOpts{
+		Config: m,
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan()
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+
+	_, diags = ctx.Apply()
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+
+	// FINAL PLAN:
+	plan, diags := ctx.Plan()
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+
+	// make sure the same marks are compared in the next plan as well
+	for _, c := range plan.Changes.Resources {
+		if c.Action != plans.NoOp {
+			t.Logf("marks before: %#v", c.BeforeValMarks)
+			t.Logf("marks after:  %#v", c.AfterValMarks)
+			t.Errorf("Unexpcetd %s change for %s", c.Action, c.Addr)
+		}
+	}
+}

--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -4794,7 +4794,7 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 
 	checkVals(t, objectVal(t, schema, map[string]cty.Value{
 		"id":   cty.StringVal("bar"),
-		"ami":  cty.StringVal("ami-abcd1234").Mark(marks.Sensitive),
+		"ami":  cty.StringVal("ami-abcd1234"),
 		"type": cty.StringVal("aws_instance"),
 	}), ric.After)
 }

--- a/internal/terraform/reduce_plan_test.go
+++ b/internal/terraform/reduce_plan_test.go
@@ -382,7 +382,7 @@ func TestProcessIgnoreChangesIndividual(t *testing.T) {
 				ignore[i] = trav
 			}
 
-			ret, diags := processIgnoreChangesIndividual(test.Old, test.New, ignore)
+			ret, diags := processIgnoreChangesIndividual(test.Old, test.New, traversalsToPaths(ignore))
 			if diags.HasErrors() {
 				t.Fatal(diags.Err())
 			}


### PR DESCRIPTION
Up until now marks were not considered by `ignore_changes`, that however
means changes to sensitivity within a configuration cannot be ignored, even
though they are planned as changes.

Rather than separating the marks and tracking their paths, we can easily
update the processIgnoreChanges routine to handle the marked values
directly. Moving the `processIgnoreChanges` call also cleans up some of
the variable naming, making it more consistent through the body of the
function.

Fixes #29173 in conjunction with https://github.com/hashicorp/hcl/pull/478