### PR TITLE
configs/configschema: extend block.AttributeByPath to descend into Objects

### DIFF
--- a/internal/configs/configschema/path.go
+++ b/internal/configs/configschema/path.go
@@ -1,8 +1,6 @@
 package configschema
 
 import (
-	"fmt"
-
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -18,7 +16,7 @@ func (b *Block) AttributeByPath(path cty.Path) *Attribute {
 				// If the Attribute is defined with a NestedType and there's
 				// more to the path, descend into the NestedType
 				if attr.NestedType != nil && i < len(path)-1 {
-					return attr.NestedType.AttributeByPath(path)
+					return attr.NestedType.AttributeByPath(path[i+1:])
 				} else if i < len(path)-1 { // There's more to the path, but not more to this Attribute.
 					return nil
 				}
@@ -43,7 +41,6 @@ func (o *Object) AttributeByPath(path cty.Path) *Attribute {
 	for i, step := range path {
 		switch step := step.(type) {
 		case cty.GetAttrStep:
-			fmt.Println(step.Name)
 			if attr := o.Attributes[step.Name]; attr != nil {
 				if attr.NestedType != nil && i < len(path)-1 {
 					return attr.NestedType.AttributeByPath(path[i+1:])

--- a/internal/configs/configschema/path.go
+++ b/internal/configs/configschema/path.go
@@ -1,19 +1,27 @@
 package configschema
 
 import (
+	"fmt"
+
 	"github.com/zclconf/go-cty/cty"
 )
 
 // AttributeByPath looks up the Attribute schema which corresponds to the given
 // cty.Path. A nil value is returned if the given path does not correspond to a
 // specific attribute.
-// TODO: this will need to be updated for nested attributes
 func (b *Block) AttributeByPath(path cty.Path) *Attribute {
 	block := b
-	for _, step := range path {
+	for i, step := range path {
 		switch step := step.(type) {
 		case cty.GetAttrStep:
 			if attr := block.Attributes[step.Name]; attr != nil {
+				// If the Attribute is defined with a NestedType and there's
+				// more to the path, descend into the NestedType
+				if attr.NestedType != nil && i < len(path)-1 {
+					return attr.NestedType.AttributeByPath(path)
+				} else if i < len(path)-1 { // There's more to the path, but not more to this Attribute.
+					return nil
+				}
 				return attr
 			}
 
@@ -23,6 +31,27 @@ func (b *Block) AttributeByPath(path cty.Path) *Attribute {
 			}
 
 			return nil
+		}
+	}
+	return nil
+}
+
+// AttributeByPath recurses through a NestedType to look up the Attribute scheme
+// which corresponds to the given cty.Path. A nil value is returned if the given
+// path does not correspond to a specific attribute.
+func (o *Object) AttributeByPath(path cty.Path) *Attribute {
+	for i, step := range path {
+		switch step := step.(type) {
+		case cty.GetAttrStep:
+			fmt.Println(step.Name)
+			if attr := o.Attributes[step.Name]; attr != nil {
+				if attr.NestedType != nil && i < len(path)-1 {
+					return attr.NestedType.AttributeByPath(path[i+1:])
+				} else if i < len(path)-1 { // There's more to the path, but not more to this Attribute.
+					return nil
+				}
+				return attr
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
This commit adds a recursive Object.AttributeByPath function which will step through Attributes with NestedTypes. If an Attribute without a NestedType is encountered while there is still more to the path, it will return nil.

