### PR TITLE
Minor typo in apt.html.md

### DIFF
--- a/website/docs/cli/install/apt.html.md
+++ b/website/docs/cli/install/apt.html.md
@@ -52,7 +52,7 @@ The above command line uses the following sub-shell commands:
 
 `apt-add-repository` usually automatically runs `apt update` as part of its
 work in order to fetch the new package indices, but if it does not then you
-will need to so manually before the packages will be available.
+will need to do so manually before the packages will be available.
 
 To install Terraform from the new repository:
 


### PR DESCRIPTION
As part of this PR, just wanted to have this typo fixed to have a better sense of the sentence.

> `apt-add-repository` usually automatically runs `apt update` as part of its work in order to fetch the new package indices, but if it does not, then you will need to do so manually before the packages will be available.


Also, I wanted to rephrase the sentence as below(less wording and more readable- let me know if this is okay and I can raise a new pull request):


> `apt-add-repository` usually automatically runs `apt update` as part of its work to fetch the new package indices, but if it does not, you will need to manually do so before the packages will be available.

Thanks,
susenj