### PR TITLE
`terraform add`: `-out` option append to existing config & optionally check resource existance

### DIFF
--- a/internal/command/views/add.go
+++ b/internal/command/views/add.go
@@ -74,7 +74,14 @@ func (v *addHuman) Resource(addr addrs.AbsResourceInstance, schema *configschema
 	} else {
 		// The Println call above adds this final newline automatically; we add it manually here.
 		formatted = append(formatted, '\n')
-		return os.WriteFile(v.outPath, formatted, 0600)
+
+		f, err := os.OpenFile(v.outPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = f.Write(formatted)
+		return err
 	}
 }
 


### PR DESCRIPTION
This PR fixes #29220 about `terraform add` command used with `-out` option:

1. As the help message of this command indicated, the `-out` should append to the existing file. While current implementation truncated it. In reallity, since users are likely to repeatedly call the `terraform add` on different resources, and output to the same file. So this PR changes the implementation to make it align with indicated as the help message.
2. When users didn't specify `-out`, or the `-out` directs to some non-module-like directory, the in-module check on the target resource should be skipped.