### PR TITLE
addrs: Address rewriting logic for moves of resources and resource instances

### DIFF
--- a/internal/addrs/move_endpoint_module_test.go
+++ b/internal/addrs/move_endpoint_module_test.go
@@ -314,6 +314,121 @@ func TestAbsResourceInstanceMoveDestination(t *testing.T) {
 	}{
 		{
 			``,
+			`test_object.beep`,
+			`test_object.boop`,
+			`test_object.beep`,
+			true,
+			`test_object.boop`,
+		},
+		{
+			``,
+			`test_object.beep`,
+			`test_object.beep[2]`,
+			`test_object.beep`,
+			true,
+			`test_object.beep[2]`,
+		},
+		{
+			``,
+			`test_object.beep`,
+			`module.foo.test_object.beep`,
+			`test_object.beep`,
+			true,
+			`module.foo.test_object.beep`,
+		},
+		{
+			``,
+			`test_object.beep[2]`,
+			`module.foo.test_object.beep["a"]`,
+			`test_object.beep[2]`,
+			true,
+			`module.foo.test_object.beep["a"]`,
+		},
+		{
+			``,
+			`test_object.beep`,
+			`module.foo[0].test_object.beep`,
+			`test_object.beep`,
+			true,
+			`module.foo[0].test_object.beep`,
+		},
+		{
+			``,
+			`module.foo.test_object.beep`,
+			`test_object.beep`,
+			`module.foo.test_object.beep`,
+			true,
+			`test_object.beep`,
+		},
+		{
+			``,
+			`module.foo[0].test_object.beep`,
+			`test_object.beep`,
+			`module.foo[0].test_object.beep`,
+			true,
+			`test_object.beep`,
+		},
+		{
+			`foo`,
+			`test_object.beep`,
+			`test_object.boop`,
+			`module.foo[0].test_object.beep`,
+			true,
+			`module.foo[0].test_object.boop`,
+		},
+		{
+			`foo`,
+			`test_object.beep`,
+			`test_object.beep[1]`,
+			`module.foo[0].test_object.beep`,
+			true,
+			`module.foo[0].test_object.beep[1]`,
+		},
+		{
+			``,
+			`test_object.beep`,
+			`test_object.boop`,
+			`test_object.boop`,
+			false, // the reciever is already the "to" address
+			``,
+		},
+		{
+			``,
+			`test_object.beep[1]`,
+			`test_object.beep[2]`,
+			`test_object.beep[5]`,
+			false, // the receiver has a non-matching instance key
+			``,
+		},
+		{
+			`foo`,
+			`test_object.beep`,
+			`test_object.boop`,
+			`test_object.beep`,
+			false, // the receiver is not inside an instance of module "foo"
+			``,
+		},
+		{
+			`foo.bar`,
+			`test_object.beep`,
+			`test_object.boop`,
+			`test_object.beep`,
+			false, // the receiver is not inside an instance of module "foo.bar"
+			``,
+		},
+		{
+			``,
+			`module.foo[0].test_object.beep`,
+			`test_object.beep`,
+			`module.foo[1].test_object.beep`,
+			false, // receiver is in a different instance of module.foo
+			``,
+		},
+
+		// Moving a module also moves all of the resources declared within it.
+		// The following tests all cover variations of that rule.
+		{
+			``,
 			`module.foo`,
 			`module.bar`,
 			`module.foo.test_object.beep`,
@@ -618,7 +733,6 @@ func TestAbsResourceMoveDestination(t *testing.T) {
 			true,
 			`module.foo[0].test_object.beep`,
 		},
-
 		{
 			``,
 			`module.foo.test_object.beep`,
@@ -643,7 +757,6 @@ func TestAbsResourceMoveDestination(t *testing.T) {
 			true,
 			`module.foo[0].test_object.boop`,
 		},
-
 		{
 			``,
 			`test_object.beep`,


### PR DESCRIPTION
This is a continuation of #29247 which finishes up the rules for resolving `moved` blocks, now handling the situation where a `moved` block contains either resource or resource instance addresses.

The two resource cases are somewhat simpler because resources can only contain resource instances and resource instances can't contain anything, so we don't need to deal with the case of only a prefix match on the address like we did with module instances in the previous PR.

The two sets of logic here end up looking textually very similar to a human reader, but that's just because `addrs.AbsResource` and `addrs.AbsResourceInstance` both have some method names in common. The Go compiler still sees the two as distinct, and so it's not straightforward to reuse the same codepath for both situations. I did try a few things to achieve that but the results all ended up being significantly harder to read (in my opinion) and so I concluded that it was better to keep the cases as readable as possible given that this logic is already pretty fiddly and also it's unlikely to change significantly once released, due to being constrained by compatibility promises.
