### PR TITLE
Gather the data needed to implement refactoring.ValidateMoves

### DIFF
--- a/internal/addrs/module_instance.go
+++ b/internal/addrs/module_instance.go
@@ -237,6 +237,15 @@ func (m ModuleInstance) Child(name string, key InstanceKey) ModuleInstance {
 	})
 }
 
+// ChildCall returns the address of a module call within the receiver,
+// identified by the given name.
+func (m ModuleInstance) ChildCall(name string) AbsModuleCall {
+	return AbsModuleCall{
+		Module: m,
+		Call:   ModuleCall{Name: name},
+	}
+}
+
 // Parent returns the address of the parent module instance of the receiver, or
 // the receiver itself if there is no parent (if it's the root module address).
 func (m ModuleInstance) Parent() ModuleInstance {

--- a/internal/instances/set.go
+++ b/internal/instances/set.go
@@ -1,0 +1,41 @@
+package instances
+
+import (
+	"github.com/hashicorp/terraform/internal/addrs"
+)
+
+// Set is a set of instances, intended mainly for the return value of
+// Expander.AllInstances, where it therefore represents all of the module
+// and resource instances known to the expander.
+type Set struct {
+	// Set currently really just wraps Expander with a reduced API that
+	// only supports lookups, to make it clear that a holder of a Set should
+	// not be modifying the expander any further.
+	exp *Expander
+}
+
+// HasModuleInstance returns true if and only if the set contains the module
+// instance with the given address.
+func (s Set) HasModuleInstance(want addrs.ModuleInstance) bool {
+	return s.exp.knowsModuleInstance(want)
+}
+
+// HasModuleCall returns true if and only if the set contains the module
+// call with the given address, even if that module call has no instances.
+func (s Set) HasModuleCall(want addrs.AbsModuleCall) bool {
+	return s.exp.knowsModuleCall(want)
+}
+
+// HasResourceInstance returns true if and only if the set contains the resource
+// instance with the given address.
+// TODO:
+func (s Set) HasResourceInstance(want addrs.AbsResourceInstance) bool {
+	return s.exp.knowsResourceInstance(want)
+}
+
+// HasResource returns true if and only if the set contains the resource with
+// the given address, even if that resource has no instances.
+// TODO:
+func (s Set) HasResource(want addrs.AbsResource) bool {
+	return s.exp.knowsResource(want)
+}

--- a/internal/instances/set_test.go
+++ b/internal/instances/set_test.go
@@ -1,0 +1,207 @@
+package instances
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestSet(t *testing.T) {
+	exp := NewExpander()
+
+	// The following constructs the following imaginary module/resource tree:
+	// - root module
+	//   - test_thing.single: no repetition
+	//   - test_thing.count: count = 1
+	//   - test_thing.for_each: for_each = { c = "C" }
+	//   - module.single: no repetition
+	//     - test_thing.single: no repetition
+	//     - module.nested_single: no repetition
+	//       - module.zero_count: count = 0
+	//   - module.count: count = 2
+	//     - module.nested_for_each: [0] for_each = {}, [1] for_each = { e = "E" }
+	//   - module.for_each: for_each = { a = "A", b = "B" }
+	//     - test_thing.count: ["a"] count = 0, ["b"] count = 1
+	exp.SetModuleSingle(addrs.RootModuleInstance, addrs.ModuleCall{Name: "single"})
+	exp.SetModuleCount(addrs.RootModuleInstance, addrs.ModuleCall{Name: "count"}, 2)
+	exp.SetModuleForEach(addrs.RootModuleInstance, addrs.ModuleCall{Name: "for_each"}, map[string]cty.Value{
+		"a": cty.StringVal("A"),
+		"b": cty.StringVal("B"),
+	})
+	exp.SetModuleSingle(addrs.RootModuleInstance.Child("single", addrs.NoKey), addrs.ModuleCall{Name: "nested_single"})
+	exp.SetModuleForEach(addrs.RootModuleInstance.Child("count", addrs.IntKey(0)), addrs.ModuleCall{Name: "nested_for_each"}, nil)
+	exp.SetModuleForEach(addrs.RootModuleInstance.Child("count", addrs.IntKey(1)), addrs.ModuleCall{Name: "nested_for_each"}, map[string]cty.Value{
+		"e": cty.StringVal("E"),
+	})
+	exp.SetModuleCount(
+		addrs.RootModuleInstance.Child("single", addrs.NoKey).Child("nested_single", addrs.NoKey),
+		addrs.ModuleCall{Name: "zero_count"},
+		0,
+	)
+
+	rAddr := func(name string) addrs.Resource {
+		return addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "test_thing",
+			Name: name,
+		}
+	}
+	exp.SetResourceSingle(addrs.RootModuleInstance, rAddr("single"))
+	exp.SetResourceCount(addrs.RootModuleInstance, rAddr("count"), 1)
+	exp.SetResourceForEach(addrs.RootModuleInstance, rAddr("for_each"), map[string]cty.Value{
+		"c": cty.StringVal("C"),
+	})
+	exp.SetResourceSingle(addrs.RootModuleInstance.Child("single", addrs.NoKey), rAddr("single"))
+	exp.SetResourceCount(addrs.RootModuleInstance.Child("for_each", addrs.StringKey("a")), rAddr("count"), 0)
+	exp.SetResourceCount(addrs.RootModuleInstance.Child("for_each", addrs.StringKey("b")), rAddr("count"), 1)
+
+	set := exp.AllInstances()
+
+	// HasModuleInstance tests
+	if input := addrs.RootModuleInstance; !set.HasModuleInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("single", addrs.NoKey); !set.HasModuleInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("single", addrs.NoKey).Child("nested_single", addrs.NoKey); !set.HasModuleInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("count", addrs.IntKey(0)); !set.HasModuleInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("count", addrs.IntKey(1)); !set.HasModuleInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("count", addrs.IntKey(1)).Child("nested_for_each", addrs.StringKey("e")); !set.HasModuleInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("for_each", addrs.StringKey("a")); !set.HasModuleInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("for_each", addrs.StringKey("b")); !set.HasModuleInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("single", addrs.IntKey(0)); set.HasModuleInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("single", addrs.StringKey("a")); set.HasModuleInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("single", addrs.NoKey).Child("nonexist", addrs.NoKey); set.HasModuleInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("count", addrs.NoKey); set.HasModuleInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("count", addrs.IntKey(2)); set.HasModuleInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("count", addrs.StringKey("a")); set.HasModuleInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("count", addrs.IntKey(0)).Child("nested_for_each", addrs.StringKey("e")); set.HasModuleInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("single", addrs.NoKey).Child("nested_single", addrs.NoKey).Child("zero_count", addrs.NoKey); set.HasModuleInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("single", addrs.NoKey).Child("nested_single", addrs.NoKey).Child("zero_count", addrs.IntKey(0)); set.HasModuleInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+
+	// HasModuleCall tests
+	if input := addrs.RootModuleInstance.ChildCall("single"); !set.HasModuleCall(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("single", addrs.NoKey).ChildCall("nested_single"); !set.HasModuleCall(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.ChildCall("count"); !set.HasModuleCall(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("count", addrs.IntKey(0)).ChildCall("nested_for_each"); !set.HasModuleCall(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("count", addrs.IntKey(1)).ChildCall("nested_for_each"); !set.HasModuleCall(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.ChildCall("for_each"); !set.HasModuleCall(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("single", addrs.NoKey).Child("nested_single", addrs.NoKey).ChildCall("zero_count"); !set.HasModuleCall(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.ChildCall("nonexist"); set.HasModuleCall(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := addrs.RootModuleInstance.Child("single", addrs.NoKey).ChildCall("nonexist"); set.HasModuleCall(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+
+	// HasResourceInstance tests
+	if input := rAddr("single").Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance); !set.HasResourceInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := rAddr("count").Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance); !set.HasResourceInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := rAddr("for_each").Instance(addrs.StringKey("c")).Absolute(addrs.RootModuleInstance); !set.HasResourceInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := rAddr("single").Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance.Child("single", addrs.NoKey)); !set.HasResourceInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := rAddr("count").Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance.Child("for_each", addrs.StringKey("b"))); !set.HasResourceInstance(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := rAddr("single").Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance); set.HasResourceInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := rAddr("single").Instance(addrs.StringKey("")).Absolute(addrs.RootModuleInstance); set.HasResourceInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := rAddr("count").Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance); set.HasResourceInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := rAddr("count").Instance(addrs.StringKey("")).Absolute(addrs.RootModuleInstance); set.HasResourceInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := rAddr("count").Instance(addrs.IntKey(1)).Absolute(addrs.RootModuleInstance); set.HasResourceInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := rAddr("single").Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance.Child("single", addrs.IntKey(0))); set.HasResourceInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := rAddr("count").Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance.Child("for_each", addrs.StringKey("a"))); set.HasResourceInstance(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+
+	// HasResource tests
+	if input := rAddr("single").Absolute(addrs.RootModuleInstance); !set.HasResource(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := rAddr("count").Absolute(addrs.RootModuleInstance); !set.HasResource(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := rAddr("for_each").Absolute(addrs.RootModuleInstance); !set.HasResource(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := rAddr("single").Absolute(addrs.RootModuleInstance.Child("single", addrs.NoKey)); !set.HasResource(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := rAddr("count").Absolute(addrs.RootModuleInstance.Child("for_each", addrs.StringKey("a"))); !set.HasResource(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := rAddr("count").Absolute(addrs.RootModuleInstance.Child("for_each", addrs.StringKey("b"))); !set.HasResource(input) {
+		t.Errorf("missing %T %s", input, input.String())
+	}
+	if input := rAddr("nonexist").Absolute(addrs.RootModuleInstance); set.HasResource(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+	if input := rAddr("count").Absolute(addrs.RootModuleInstance.Child("for_each", addrs.StringKey("nonexist"))); set.HasResource(input) {
+		t.Errorf("unexpected %T %s", input, input.String())
+	}
+
+}

--- a/internal/refactoring/move_validate.go
+++ b/internal/refactoring/move_validate.go
@@ -24,7 +24,7 @@ import (
 // construct in incorrect plan (because it'll be starting from the wrong
 // prior state) but ValidateMoves will block actually showing that invalid
 // plan to the user.
-func ValidateMoves(stmts []MoveStatement, rootCfg *configs.Config, expander *instances.Expander) tfdiags.Diagnostics {
+func ValidateMoves(stmts []MoveStatement, rootCfg *configs.Config, declaredInsts instances.Set) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	g := buildMoveStatementGraph(stmts)


### PR DESCRIPTION
This PR aims to resolve a TODO we previously left in `Context.Plan` to somehow gather the set of all declared module and resource instances to pass into the `refactoring.ValidateMoves` function.

I got there by creating a small wrapper around `instances.Expander` that provides an API more tailored to what move validation needs, and then passing that through to `refactoring.ValidateMoves` once we've finished creating the plan.

Since the instance expander only exists inside the graph walker this took a small amount of refactoring compared to what we originally stubbed in `Context.Plan`, where now the finding, applying, and validating of `moved` blocks happens in each of the separate plan mode methods rather than in the overall `Plan` method that dispatches to them. That's a little unfortunate but seemed like the best compromise to avoid more significant refactoring, and I was able to minimize the duplication by factoring out the common steps into separate methods.

There are no tests for the core package part of this yet because `refactoring.ValidateMoves` doesn't actually do anything so far -- it just always returns `nil`. A subsequent PR will fill out the `refactoring.ValidateMoves` function, along with its own unit tests, and then at that point we should finally also have enough of the machinery in place to write some integration tests in the core package to exercise the full process.
