### PR TITLE
Fixed cidrhost() example 1 and 2 with correct function parameter

### DIFF
--- a/website/docs/language/functions/cidrhost.html.md
+++ b/website/docs/language/functions/cidrhost.html.md
@@ -37,9 +37,9 @@ the same addressing scheme as the given prefix.
 ## Examples
 
 ```
-> cidrhost("10.12.127.0/20", 16)
+> cidrhost("10.12.112.0/20", 16)
 10.12.112.16
-> cidrhost("10.12.127.0/20", 268)
+> cidrhost("10.12.112.0/20", 268)
 10.12.113.12
 > cidrhost("fd00:fd12:3456:7890:00a2::/72", 34)
 fd00:fd12:3456:7890::22


### PR DESCRIPTION
The return value of the cidrhost() function in the documentation examples does not match the logic described by the description and the way it actually works, due to a typo. The first two examples have "10.12.127.0/20" as the input CIDR to get an IP from, but they should really be "10.12.112.0/20".

Thanks!