### PR TITLE
Allow remote state encryption (using azurerm backend)

### DIFF
--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -91,6 +91,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		keyName:            b.path(name),
 		accountName:        b.accountName,
 		snapshot:           b.snapshot,
+		encryptionKey:      b.encryptionKey,
 	}
 
 	stateMgr := &remote.State{Client: client}

--- a/internal/backend/remote-state/azure/crypto.go
+++ b/internal/backend/remote-state/azure/crypto.go
@@ -1,0 +1,56 @@
+package azure
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+const nonceSize int = 12
+
+func encrypt(key []byte, plain []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, nonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	dst := make([]byte, 0, nonceSize+((len(plain)+len(key)-1)/len(key))*len(key))
+	dst = append(dst, nonce...)
+	encoded := aesgcm.Seal(dst, nonce, plain, nil)
+	return encoded, nil
+}
+
+func decrypt(key []byte, encoded []byte) ([]byte, error) {
+	if len(encoded) < nonceSize {
+		return nil, fmt.Errorf("not enough data to read nonce")
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	plain, err := aesgcm.Open(nil, encoded[:nonceSize], encoded[nonceSize:], nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return plain, nil
+}

--- a/internal/backend/remote-state/azure/crypto_test.go
+++ b/internal/backend/remote-state/azure/crypto_test.go
@@ -1,0 +1,49 @@
+package azure
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestEncryptionShort(t *testing.T) {
+	key, _ := hex.DecodeString("0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF")
+	plaintext := []byte("Hello world")
+	ciphertext, err := encrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("Error encrypting plaintext: %q", err)
+	}
+
+	decrypted, err := decrypt(key, ciphertext)
+	if err != nil {
+		t.Fatalf("Error decrypting ciphertext: %q", err)
+	}
+
+	if string(decrypted) != string(plaintext) {
+		t.Fatalf("Expected cipher: %s, got: %s", plaintext, decrypted)
+	}
+}
+
+func TestEncryptionLarge(t *testing.T) {
+	key, _ := hex.DecodeString("0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF")
+	plaintext := make([]byte, 10000)
+	if _, err := io.ReadFull(rand.Reader, plaintext); err != nil {
+		t.Fatalf("Error getting random data: %q", err)
+	}
+
+	ciphertext, err := encrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("Error encrypting plaintext: %q", err)
+	}
+
+	decrypted, err := decrypt(key, ciphertext)
+	if err != nil {
+		t.Fatalf("Error decrypting ciphertext: %q", err)
+	}
+
+	if !reflect.DeepEqual(decrypted, plaintext) {
+		t.Fatal("Decrypted data isn't equal to the original data")
+	}
+}

--- a/website/docs/language/settings/backends/azurerm.html.md
+++ b/website/docs/language/settings/backends/azurerm.html.md
@@ -211,6 +211,8 @@ The following configuration options are supported:
 
 * `snapshot` - (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use? Defaults to `false`. This value can also be sourced from the `ARM_SNAPSHOT` environment variable.
 
+* `encryption_phrase` - (Optional) Encryption phrase that is used to encrypt the state (using AES-256 GCM). Defaults to an empty string, that disables encryption. This value can also be sourced from the `ARM_ENCRYPTION_PHRASE` environment variable.
+
 ---
 
 When authenticating using the Managed Service Identity (MSI) - the following fields are also supported:


### PR DESCRIPTION
I created an implementation to allow encrypted state as suggested in https://github.com/hashicorp/terraform/issues/29272#issuecomment-891649877.

# Motivation
Sometimes it's hard to prevent access to the Terraform state files. Because these state files often contain sensitive data, such as client secrets, passwords, certificates, ... it is a good idea to have these state files encrypted.

# Implementation details
As you can see from the commit, it is very straightforward and this approach could be used for other backend providers too. I think it's better to implement it at the provider level, because:

1. Some back-ends might have even stronger encryptions (i.e. keys can be sourced from external vaults).
2. Some back-ends don't really need encryption.
3. Implementation is pretty straightforward (especially if the cyrpto functions are moved up to a more generic level).

The implementation uses AES-256 GCM encryption with a 12-byte secure random IV, so the encryption should be secure for most environments. The actual 256-bit key is derived by creating a SHA256 of the encryption phrase, so the length and randomness of the encryption phrase actually determines the actual security.