### PR TITLE
Variables shouldn't need to be set when using destroy

### DIFF
--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -8,6 +8,7 @@ import (
 	remoteBackend "github.com/hashicorp/terraform/internal/backend/remote"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/plans/planfile"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -269,6 +270,10 @@ func (c *ApplyCommand) OperationRequest(
 	opReq.ForceReplace = args.ForceReplace
 	opReq.Type = backend.OperationTypeApply
 	opReq.View = view.Operation()
+
+	if opReq.PlanMode == plans.DestroyMode {
+		opReq.AllowUnsetVariables = true
+	}
 
 	var err error
 	opReq.ConfigLoader, err = c.initConfigLoader()

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -152,6 +153,10 @@ func (c *PlanCommand) OperationRequest(
 	opReq.ForceReplace = args.ForceReplace
 	opReq.Type = backend.OperationTypePlan
 	opReq.View = view.Operation()
+
+	if opReq.PlanMode == plans.DestroyMode {
+		opReq.AllowUnsetVariables = true
+	}
 
 	var err error
 	opReq.ConfigLoader, err = c.initConfigLoader()


### PR DESCRIPTION
As explained in #23552, it seems inconvenient having to set values for the variables when the whole point of the destroy argument/command is to delete the existing resources.

This commit fixes this by making a change to the `apply` and `plan` command.
By checking if the command is executed in `DestroyMode` we can set the `AllowUnsetVariables` bool to true which skips the whole variable setting part during the destroy operations:

- `terraform plan -destroy`
- `terraform apply -destroy`
- `terraform destroy`

See https://github.com/I3urny/terraform/blob/0d3d05f0ab8d8ffb97a20ce60037eb5b8707776c/internal/backend/local/backend_local.go#L155-L160

and https://github.com/I3urny/terraform/blob/0d3d05f0ab8d8ffb97a20ce60037eb5b8707776c/internal/backend/remote/backend_context.go#L98-L103

Closes #23552