### PR TITLE
internal/registry: Add URL to error message for clarity

### DIFF
--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -478,7 +478,7 @@ func maxRetryErrorHandler(resp *http.Response, err error, numTries int) (*http.R
 	// both response and error.
 	var errMsg string
 	if resp != nil {
-		errMsg = fmt.Sprintf(": %d", resp.StatusCode)
+		errMsg = fmt.Sprintf(": %s returned from %s", resp.Status, resp.Request.URL)
 	} else if err != nil {
 		errMsg = fmt.Sprintf(": %s", err)
 	}

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -295,7 +295,7 @@ func maxRetryErrorHandler(resp *http.Response, err error, numTries int) (*http.R
 	// both response and error.
 	var errMsg string
 	if resp != nil {
-		errMsg = fmt.Sprintf(": %d", resp.StatusCode)
+		errMsg = fmt.Sprintf(": %s returned from %s", resp.Status, resp.Request.URL)
 	} else if err != nil {
 		errMsg = fmt.Sprintf(": %s", err)
 	}


### PR DESCRIPTION
Prior to this patch the user could receive a message like this from `init`:

```
Error: Failed to install provider
Error while installing 1password/onepassword v1.1.2: could not query provider
registry for registry.terraform.io/1password/onepassword: failed to retrieve
authentication checksums for provider: the request failed after 2 attempts,
please try again later: 500
```

While the status code is helpful, it would be far more helpful if the user knew what URL/hostname returned that error.

I mistakenly thought this would come from the Registry API, but @bethanyr helpfully pointed out to me that the checksums are in fact pulled from GitHub.

The new (proposed) error message would therefore indicate this:

```
Error: Failed to install provider
Error while installing 1password/onepassword v1.1.2: could not query provider
registry for registry.terraform.io/1password/onepassword: failed to retrieve
authentication checksums for provider: the request failed after 2 attempts,
please try again later: 500 Internal Server Error (https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.1.2/terraform-provider-onepassword_1.1.2_SHA256SUMS)
```

I am also open to shortening this to just the hostname (`github.com` in this case) instead of full URL if we deem that whole URL makes the message too long.