### PR TITLE
docs: Add note about multiple variable `validation` blocks

### DIFF
--- a/website/docs/language/values/variables.html.md
+++ b/website/docs/language/values/variables.html.md
@@ -201,6 +201,9 @@ that includes the sentences given in `error_message`. The error message string
 should be at least one full sentence explaining the constraint that failed,
 using a sentence structure similar to the above examples.
 
+Multiple `validation` blocks can be declared in which case error messages
+will be returned for _all_ failed conditions.
+
 ### Suppressing Values in CLI Output
 
 [inpage-sensitive]: #suppressing-values-in-cli-output


### PR DESCRIPTION
Previously the docs never mentioned that it's possible to declare multiple `validation` blocks.

The wording mostly reflects the implementation https://github.com/hashicorp/terraform/blob/d35bc0531255b496beb5d932f185cbcdb2d61a99/internal/terraform/eval_variable.go#L46-L111