### PR TITLE
json-output: Add output changes to plan logs

### DIFF
--- a/internal/command/views/json/output_test.go
+++ b/internal/command/views/json/output_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -61,6 +63,95 @@ func TestOutputsFromMap(t *testing.T) {
 			Sensitive: false,
 			Type:      json.RawMessage(`["map","bool"]`),
 			Value:     json.RawMessage(`null`),
+		},
+	}
+
+	if !cmp.Equal(want, got) {
+		t.Fatalf("unexpected result\n%s", cmp.Diff(want, got))
+	}
+}
+
+func TestOutputsFromChanges(t *testing.T) {
+	root := addrs.RootModuleInstance
+	num, err := plans.NewDynamicValue(cty.NumberIntVal(1234), cty.Number)
+	str, err := plans.NewDynamicValue(cty.StringVal("1234"), cty.String)
+	if err != nil {
+		t.Fatalf("unexpected error creating dynamic value: %v", err)
+	}
+
+	got := OutputsFromChanges([]*plans.OutputChangeSrc{
+		// Unchanged output "boop", value 1234
+		{
+			Addr: root.OutputValue("boop"),
+			ChangeSrc: plans.ChangeSrc{
+				Action: plans.NoOp,
+				Before: num,
+				After:  num,
+			},
+			Sensitive: false,
+		},
+		// New output "beep", value 1234
+		{
+			Addr: root.OutputValue("beep"),
+			ChangeSrc: plans.ChangeSrc{
+				Action: plans.Create,
+				Before: nil,
+				After:  num,
+			},
+			Sensitive: false,
+		},
+		// Deleted output "blorp", prior value 1234
+		{
+			Addr: root.OutputValue("blorp"),
+			ChangeSrc: plans.ChangeSrc{
+				Action: plans.Delete,
+				Before: num,
+				After:  nil,
+			},
+			Sensitive: false,
+		},
+		// Updated output "honk", prior value 1234, new value "1234"
+		{
+			Addr: root.OutputValue("honk"),
+			ChangeSrc: plans.ChangeSrc{
+				Action: plans.Update,
+				Before: num,
+				After:  str,
+			},
+			Sensitive: false,
+		},
+		// New sensitive output "secret", value "1234"
+		{
+			Addr: root.OutputValue("secret"),
+			ChangeSrc: plans.ChangeSrc{
+				Action: plans.Create,
+				Before: nil,
+				After:  str,
+			},
+			Sensitive: true,
+		},
+	})
+
+	want := Outputs{
+		"boop": {
+			Action:    "noop",
+			Sensitive: false,
+		},
+		"beep": {
+			Action:    "create",
+			Sensitive: false,
+		},
+		"blorp": {
+			Action:    "delete",
+			Sensitive: false,
+		},
+		"honk": {
+			Action:    "update",
+			Sensitive: false,
+		},
+		"secret": {
+			Action:    "create",
+			Sensitive: true,
 		},
 	}
 

--- a/internal/command/views/operation.go
+++ b/internal/command/views/operation.go
@@ -195,6 +195,17 @@ func (v *OperationJSON) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
 	}
 
 	v.view.ChangeSummary(cs)
+
+	var rootModuleOutputs []*plans.OutputChangeSrc
+	for _, output := range plan.Changes.Outputs {
+		if !output.Addr.Module.IsRoot() {
+			continue
+		}
+		rootModuleOutputs = append(rootModuleOutputs, output)
+	}
+	if len(rootModuleOutputs) > 0 {
+		v.view.Outputs(json.OutputsFromChanges(rootModuleOutputs))
+	}
 }
 
 func (v *OperationJSON) resourceDrift(oldState, newState *states.State, schemas *terraform.Schemas) error {

--- a/website/docs/internals/machine-readable-ui.html.md
+++ b/website/docs/internals/machine-readable-ui.html.md
@@ -185,10 +185,11 @@ Terraform outputs a change summary when a plan or apply operation completes. Bot
 
 ## Outputs
 
-After a successful apply, a message with type `outputs` contains the values of all root module output values. This message contains an `outputs` object, the keys of which are the output names. The outputs values are objects with the following keys:
+After a successful plan or apply, a message with type `outputs` contains the values of all root module output values. This message contains an `outputs` object, the keys of which are the output names. The outputs values are objects with the following keys:
 
-- `value:` the value of the output, encoded in JSON
-- `type`: the detected HCL type of the output value
+- `action`: for planned outputs, the action which will be taken for the output. Values: `noop`, `create`, `update`, `delete`
+- `value`: for applied outputs, the value of the output, encoded in JSON
+- `type`: for applied outputs, the detected HCL type of the output value
 - `sensitive`: boolean value, `true` if the output is sensitive and should be hidden from UI by default
 
 Note that `sensitive` outputs still include the `value` field, and integrating software should respect the sensitivity value as appropriate for the given use case.


### PR DESCRIPTION
Extend the outputs JSON log message to support an `action` field (and make the `type` and `value` fields optional). This allows us to emit a useful output change summary as part of the plan, bringing the JSON log output into parity with the text output.

While we do have access to the before/after values in the output changes, attempting to wedge those into a structured log message is not appropriate. That level of detail can be extracted from the JSON plan output from `terraform show -json`.

Proposed for backport to 1.0.x, as I consider this to be a bug of omission (this message should have been omitted for plans) and it has narrow scope.