### PR TITLE
Update documentation for uuid() and timestamp() functions

### DIFF
--- a/website/docs/language/functions/timestamp.html.md
+++ b/website/docs/language/functions/timestamp.html.md
@@ -9,10 +9,10 @@ description: |-
 
 # `timestamp` Function
 
-`timestamp` returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format.
+`timestamp` returns a UTC timestamp string in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.
 
 In the Terraform language, timestamps are conventionally represented as
-strings using [RFC 3339](https://tools.ietf.org/html/rfc3339)
+strings using [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339)
 "Date and Time format" syntax, and so `timestamp` returns a string
 in this format.
 

--- a/website/docs/language/functions/timestamp.html.md
+++ b/website/docs/language/functions/timestamp.html.md
@@ -24,9 +24,7 @@ but in rare cases it can be used in conjunction with
 to take the timestamp only on initial creation of the resource. For more stable
 time handling, see the [Time Provider](https://registry.terraform.io/providers/hashicorp/time/).
 
-Due to the constantly changing return value, the result of this function cannot
-be predicted during Terraform's planning phase, and so the timestamp will be
-taken only once the plan is being applied.
+If this function produced a value during the plan step, it would cause the final configuration during the apply step not to match the actions shown in the plan (since the function is called again in the apply step, and would return a different value), which violates the Terraform execution model. For that reason, this function produces an unknown value result during the plan step, with the real result being decided only during the apply step. This means that the recorded time will be the instant when Terraform began _applying_ the change, rather than when Terraform _planned_ the change.
 
 ## Examples
 

--- a/website/docs/language/functions/uuid.html.md
+++ b/website/docs/language/functions/uuid.html.md
@@ -19,7 +19,9 @@ This function produces a new value each time it is called, and so using it
 directly in resource arguments will result in spurious diffs. We do not
 recommend using the `uuid` function in resource configurations, but it can
 be used with care in conjunction with
-[the `ignore_changes` lifecycle meta-argument](/docs/language/meta-arguments/lifecycle.html#ignore_changes).
+[the `ignore_changes` lifecycle meta-argument](/docs/language/meta-arguments/lifecycle.html#ignore_changes). 
+
+If this function produced a value during the plan step, it would cause the final configuration during the apply step not to match the actions shown in the plan (since the function is called again in the apply step, and would return a different value), which violates the Terraform execution model. For that reason, this function produces an unknown value result during the plan step, with the real result being decided only during the apply step.
 
 In most cases we recommend using [the `random` provider](https://registry.terraform.io/providers/hashicorp/random/latest/docs)
 instead, since it allows the one-time generation of random values that are

--- a/website/docs/language/functions/uuid.html.md
+++ b/website/docs/language/functions/uuid.html.md
@@ -11,7 +11,7 @@ description: |-
 `uuid` generates a unique identifier string.
 
 The id is a generated and formatted as required by
-[RFC 4122 section 4.4](https://tools.ietf.org/html/rfc4122#section-4.4),
+[RFC 4122 section 4.4](https://datatracker.ietf.org/doc/html/rfc4122#section-4.4),
 producing a Version 4 UUID. The result is a UUID generated only from
 pseudo-random numbers.
 


### PR DESCRIPTION
This PR updates documentation for the uuid() and timestamp() functions to provide greater clarity on why values are not produced during the plan step. Closes #29340.