### PR TITLE
Fix CLI help text for output. 

### DIFF
--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -107,7 +107,8 @@ Usage: terraform [global options] output [options] [NAME]
 Options:
 
   -state=path      Path to the state file to read. Defaults to
-                   "terraform.tfstate".
+                   "terraform.tfstate". Ignored when remote 
+                   state is used.
 
   -no-color        If specified, output won't contain any color.
 


### PR DESCRIPTION
The official docs [suggest](https://www.terraform.io/docs/cli/commands/output.html#usage) the `-state` flag  for `terraform output` is ignored, when using remote state. This information is not present in the CLI help text. From my experience, it does seem the official docs are correct.