### PR TITLE
Fix a result in examples for urlencode.html.md

### DIFF
--- a/website/docs/language/functions/urlencode.html.md
+++ b/website/docs/language/functions/urlencode.html.md
@@ -30,5 +30,5 @@ Hello%20World
 > urlencode("☃")
 %E2%98%83
 > "http://example.com/search?q=${urlencode("terraform urlencode")}"
-http://example.com/search?q=terraform%20urlencode
+http://example.com/search?q=terraform+urlencode
 ```


### PR DESCRIPTION
Found typo in the examples of `urlencode`. This behavior is originated from the Go's function `url.QueryEscape`.

Confirmed by executing `echo '"http://example.com/search?q=${urlencode("terraform urlencode")}"' | terraform console` in the latest version.