### PR TITLE
Fix error handling in "workspace list" command

### DIFF
--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -46,6 +46,9 @@ func (b *Backend) Workspaces() ([]string, error) {
 	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == s3.ErrCodeNoSuchBucket {
 		return nil, fmt.Errorf(errS3NoSuchBucket, err)
 	}
+	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "AccessDenied" {
+		return nil, fmt.Errorf(errS3ListBucketPermissionDenied, err)
+	}
 
 	sort.Strings(wss[1:])
 	return wss, nil

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -420,3 +420,10 @@ again.
 
 Error: %s
 `
+
+const errS3ListBucketPermissionDenied = `Permission denied to list s3 bucket.
+
+Make sure you have access permission to the backend bucket.
+
+Error: %s
+`


### PR DESCRIPTION
resolve https://github.com/hashicorp/terraform/issues/26414

Errors other than "s3.ErrCodeNoSuchBucket" were ignored.
Added implementation to handle them correctly.

before
```
$ terraform workspace list
* default
```

Fixed as follows.
```
$ terraform workspace list
Permission denied to access s3 bucket.

Make sure you have access permission to the backend bucket.

Error: AccessDenied: Access Denied
        status code: 403, request id: AZJDVZC6E5SFNRNG, host id: 48Rq/uBVhKQWLH0prpWvS0tTpRG4pRu/yuD8i7Ea0Sv+BhOXiEm9GvVY5//gzlEY8bCHa56R+lc=
```