### PR TITLE
unmark object ID or Name for formatting

### DIFF
--- a/internal/command/format/object_id_test.go
+++ b/internal/command/format/object_id_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -56,6 +57,14 @@ func TestObjectValueIDOrName(t *testing.T) {
 			[...]string{"name", "awesome-foo"},
 			[...]string{"name", "awesome-foo"},
 			[...]string{"name", "awesome-foo"},
+		},
+		{
+			cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("awesome-foo").Mark(marks.Sensitive),
+			}),
+			[...]string{"", ""},
+			[...]string{"", ""},
+			[...]string{"", ""},
 		},
 		{
 			cty.ObjectVal(map[string]cty.Value{
@@ -155,6 +164,16 @@ func TestObjectValueIDOrName(t *testing.T) {
 			cty.ObjectVal(map[string]cty.Value{
 				"tags": cty.MapVal(map[string]cty.Value{
 					"Name": cty.UnknownVal(cty.String),
+				}),
+			}),
+			[...]string{"", ""},
+			[...]string{"", ""},
+			[...]string{"", ""},
+		},
+		{
+			cty.ObjectVal(map[string]cty.Value{
+				"tags": cty.MapVal(map[string]cty.Value{
+					"Name": cty.UnknownVal(cty.String).Mark(marks.Sensitive),
 				}),
 			}),
 			[...]string{"", ""},


### PR DESCRIPTION
It's possible that an "identifying" attribute could have marks. Make sure we don't return sensitive values as identifying attributes, and unmark the entire value when converting to a string.

Fixes #29374