### PR TITLE
Empty nested attribute handling in diffs

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -646,11 +646,11 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 			case !val.IsKnown():
 				action = plans.Update
 				newValue = val
-			case !old.HasElement(val).True():
+			case old.IsNull() || !old.HasElement(val).True():
 				action = plans.Create
 				oldValue = cty.NullVal(val.Type())
 				newValue = val
-			case !new.HasElement(val).True():
+			case new.IsNull() || !new.HasElement(val).True():
 				action = plans.Delete
 				oldValue = val
 				newValue = cty.NullVal(val.Type())

--- a/internal/command/format/diff_test.go
+++ b/internal/command/format/diff_test.go
@@ -2863,6 +2863,41 @@ func TestResourceChange_nestedSet(t *testing.T) {
     }
 `,
 		},
+		"in-place update - empty nested sets": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+				"disks": cty.NullVal(cty.Set(cty.Object(map[string]cty.Type{
+					"mount_point": cty.String,
+					"size":        cty.String,
+				}))),
+				"root_block_device": cty.SetValEmpty(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+				})),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.SetValEmpty(cty.Object(map[string]cty.Type{
+					"mount_point": cty.String,
+					"size":        cty.String,
+				})),
+				"root_block_device": cty.SetValEmpty(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+				})),
+			}),
+			RequiredReplace: cty.NewPathSet(),
+			Schema:          testSchema(configschema.NestingSet),
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+      + disks = []
+        id    = "i-02ae66f368e8518a9"
+    }
+`,
+		},
 	}
 	runTestCases(t, testCases)
 }


### PR DESCRIPTION
Better handling of null and empty containers when rendering a diff of nested attribute object types.
Empty containers can be rendered as single attributes to avoid the need to differentiate between empty and null in the element handling. Null containers were not handled at all, because the old block formatting would never nee null values.

Fixes #29382
Fixes #29385
