### PR TITLE
chore: update lock message

### DIFF
--- a/internal/command/clistate/state.go
+++ b/internal/command/clistate/state.go
@@ -23,7 +23,11 @@ const (
 Terraform acquires a state lock to protect the state from being written
 by multiple users at the same time. Please resolve the issue above and try
 again. For most commands, you can disable locking with the "-lock=false"
-flag, but this is not recommended.`
+flag, but this is not recommended.
+
+If the lock didn't release properly, Terraform may not be able to run future commands since it'll appear as if
+the lock is held. In that case please call:
+terraform force-unlock LOCK_ID`
 
 	UnlockErrorMessage = `Error message: %s
 

--- a/internal/command/clistate/state.go
+++ b/internal/command/clistate/state.go
@@ -27,7 +27,7 @@ flag, but this is not recommended.
 
 If the lock didn't release properly, Terraform may not be able to run future commands since it'll appear as if
 the lock is held. In that case please call:
-terraform force-unlock LOCK_ID`
+terraform force-unlock`
 
 	UnlockErrorMessage = `Error message: %s
 


### PR DESCRIPTION
I have encountered an issue today with a connectivity lost that happened to let the lock in a bad state.
The message was helpful enough to make me understand this but not how to unlock, 
and I figured because you mention `"-lock=false"` there was no other command available.
But actually there is another command. Maybe it was intentional to not mention it, but as you are already mentioning a way to bypass the lock it's even better to displays to correct solution. 

Not putting the -force intentionally so that people still get the confirmation by copy/pasting.

I also think it could be highlighted in white and maybe with the LOCK_ID prefilled for convenience, but my skills in go stop there :D 
