### PR TITLE
Fix link to index function

### DIFF
--- a/website/docs/language/functions/element.html.md
+++ b/website/docs/language/functions/element.html.md
@@ -46,5 +46,5 @@ c
 
 ## Related Functions
 
-* [`index`](./index.html) finds the index for a particular element value.
+* [`index`](./index_function.html) finds the index for a particular element value.
 * [`lookup`](./lookup.html) retrieves a value from a _map_ given its _key_.


### PR DESCRIPTION
The element function page previously linked to the index page for all functions where it meant to link to the index function page.