### PR TITLE
refactoring: complete CanChainFrom and NestedWithin

### DIFF
--- a/internal/refactoring/move_execute_test.go
+++ b/internal/refactoring/move_execute_test.go
@@ -324,10 +324,10 @@ func TestApplyMoves(t *testing.T) {
 			},
 		},
 
-		"move whole module to within indexed module and instance chained": {
+		"move whole module to indexed module and move instance chained": {
 			[]MoveStatement{
 				testMoveStatement(t, "", "module.boo", "module.bar[0]"),
-				testMoveStatement(t, "module.bar[0]", "foo.from[0]", "foo.too[0]"),
+				testMoveStatement(t, "bar", "foo.from[0]", "foo.to[0]"),
 			},
 			states.BuildState(func(s *states.SyncState) {
 				s.SetResourceInstanceCurrent(
@@ -345,19 +345,23 @@ func TestApplyMoves(t *testing.T) {
 					To:   instAddrs["module.bar[0].foo.from[0]"],
 				},
 				instAddrs["module.bar[0].foo.from[0]"].UniqueKey(): {
-					From: instAddrs["module.boo.foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.from[0]"],
+					From: instAddrs["module.bar[0].foo.from[0]"],
+					To:   instAddrs["module.bar[0].foo.to[0]"],
+				},
+				instAddrs["module.bar[0].foo.to[0]"].UniqueKey(): {
+					From: instAddrs["module.bar[0].foo.from[0]"],
+					To:   instAddrs["module.bar[0].foo.to[0]"],
 				},
 			},
 			[]string{
-				`module.bar[0].foo.from[0]`,
+				`module.bar[0].foo.to[0]`,
 			},
 		},
 
 		"move instance to indexed module and instance chained": {
 			[]MoveStatement{
 				testMoveStatement(t, "", "module.boo.foo.from[0]", "module.bar[0].foo.from[0]"),
-				testMoveStatement(t, "module.bar[0]", "foo.from[0]", "foo.too[0]"),
+				testMoveStatement(t, "bar", "foo.from[0]", "foo.to[0]"),
 			},
 			states.BuildState(func(s *states.SyncState) {
 				s.SetResourceInstanceCurrent(
@@ -375,12 +379,16 @@ func TestApplyMoves(t *testing.T) {
 					To:   instAddrs["module.bar[0].foo.from[0]"],
 				},
 				instAddrs["module.bar[0].foo.from[0]"].UniqueKey(): {
-					From: instAddrs["module.boo.foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.from[0]"],
+					From: instAddrs["module.bar[0].foo.from[0]"],
+					To:   instAddrs["module.bar[0].foo.to[0]"],
+				},
+				instAddrs["module.bar[0].foo.to[0]"].UniqueKey(): {
+					From: instAddrs["module.bar[0].foo.from[0]"],
+					To:   instAddrs["module.bar[0].foo.to[0]"],
 				},
 			},
 			[]string{
-				`module.bar[0].foo.from[0]`,
+				`module.bar[0].foo.to[0]`,
 			},
 		},
 	}


### PR DESCRIPTION
Add the `anyKey` `InstanceKey` value to the addrs package to simplify module path comparison. This allows all combinations of module path representation to be normalized into a `ModuleInstance` which can be compared directly, rather than dealing with multiple levels of different prefix types.

The new `anyKey` value and `anyKeyImpl` type are not exported, and only used within the package for comparing combinations of configuration, relative and absolute instance addresses. This value and type should not be used outside of the `addrs` package, and does not show up as an `InstanceKeyType`.

We can use this new type to reimplement `CanChainFrom` and `NestedWithin` using the new `ModuleInstance` path representation, simplifying the code significantly.

