### PR TITLE
command: Suppress prompt for init -force-copy

### DIFF
--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -146,19 +146,23 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 func (m *Meta) backendMigrateState_S_S(opts *backendMigrateOpts) error {
 	log.Print("[TRACE] backendMigrateState: migrating all named workspaces")
 
-	// Ask the user if they want to migrate their existing remote state
-	migrate, err := m.confirm(&terraform.InputOpts{
-		Id: "backend-migrate-multistate-to-multistate",
-		Query: fmt.Sprintf(
-			"Do you want to migrate all workspaces to %q?",
-			opts.TwoType),
-		Description: fmt.Sprintf(
-			strings.TrimSpace(inputBackendMigrateMultiToMulti),
-			opts.OneType, opts.TwoType),
-	})
-	if err != nil {
-		return fmt.Errorf(
-			"Error asking for state migration action: %s", err)
+	migrate := opts.force
+	if !migrate {
+		var err error
+		// Ask the user if they want to migrate their existing remote state
+		migrate, err = m.confirm(&terraform.InputOpts{
+			Id: "backend-migrate-multistate-to-multistate",
+			Query: fmt.Sprintf(
+				"Do you want to migrate all workspaces to %q?",
+				opts.TwoType),
+			Description: fmt.Sprintf(
+				strings.TrimSpace(inputBackendMigrateMultiToMulti),
+				opts.OneType, opts.TwoType),
+		})
+		if err != nil {
+			return fmt.Errorf(
+				"Error asking for state migration action: %s", err)
+		}
 	}
 	if !migrate {
 		return fmt.Errorf("Migration aborted by user.")


### PR DESCRIPTION
The `-force-copy` flag to init should automatically migrate state. Previously this was not applied to one case: when migrating from a backend with multiple workspaces to another backend supporting multiple workspaces. I believe this was an oversight so this commit fixes that.

Fixes #29239