### PR TITLE
Issues with Backend config command

### DIFF
--- a/website/docs/language/settings/backends/remote.html.md
+++ b/website/docs/language/settings/backends/remote.html.md
@@ -148,7 +148,7 @@ organization = "company"
 Running `terraform init` with the backend file:
 
 ```sh
-terraform init -backend-config=config.remote.tfbackend
+terraform init --backend-config=config.remote.tfbackend
 ```
 
 ### Data Source Configuration


### PR DESCRIPTION
The command terraform init -backend-config=backend.hcl should be updated to terraform init --backend-config=backend.hcl

single '-' before backend throws the below error
Too many command line arguments. Did you mean to use -chdir?