### PR TITLE
Clean up ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 *.dll
 *.exe
 .DS_Store
-example.tf
-terraform.tfplan
-terraform.tfstate
 bin/
 modules-dev/
 /pkg/
@@ -13,9 +10,6 @@ website/build
 website/node_modules
 .vagrant/
 *.backup
-./*.tfstate
-.terraform/
-*.log
 *.bak
 *~
 .*.swp
@@ -26,10 +20,6 @@ website/node_modules
 
 website/vendor
 vendor/
-
-# Test exclusions
-!command/testdata/**/*.tfstate
-!command/testdata/**/.terraform/
 
 # Coverage
 coverage.txt


### PR DESCRIPTION
The main purpose of this change is to avoid a problem where new golden files added to certain directories for test purposes (like .log) shouldn't be ignored.

Cleaning up a bit more and broadening the definition, this removes ignore rules for artifacts of Terraform itself (state files, plans). It's generally not recommended to be using this codebase as your Terraform working directory anyway; build here, test elsewhere.