### PR TITLE
json-output: Release format version 1.0

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -22,7 +22,7 @@ import (
 // FormatVersion represents the version of the json format and will be
 // incremented for any change to this format that requires changes to a
 // consuming parser.
-const FormatVersion = "0.2"
+const FormatVersion = "1.0"
 
 // Plan is the top-level representation of the json format of a plan. It includes
 // the complete config and current state.

--- a/internal/command/jsonprovider/provider.go
+++ b/internal/command/jsonprovider/provider.go
@@ -9,7 +9,7 @@ import (
 // FormatVersion represents the version of the json format and will be
 // incremented for any change to this format that requires changes to a
 // consuming parser.
-const FormatVersion = "0.2"
+const FormatVersion = "1.0"
 
 // providers is the top-level object returned when exporting provider schemas
 type providers struct {

--- a/internal/command/jsonstate/state.go
+++ b/internal/command/jsonstate/state.go
@@ -18,7 +18,7 @@ import (
 // FormatVersion represents the version of the json format and will be
 // incremented for any change to this format that requires changes to a
 // consuming parser.
-const FormatVersion = "0.2"
+const FormatVersion = "1.0"
 
 // state is the top-level representation of the json format of a terraform
 // state.

--- a/internal/command/testdata/providers-schema/basic/output.json
+++ b/internal/command/testdata/providers-schema/basic/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "provider_schemas": {
         "registry.terraform.io/hashicorp/test": {
             "provider": {

--- a/internal/command/testdata/providers-schema/empty/output.json
+++ b/internal/command/testdata/providers-schema/empty/output.json
@@ -1,3 +1,3 @@
 {
-    "format_version": "0.2"
+    "format_version": "1.0"
 }

--- a/internal/command/testdata/providers-schema/required/output.json
+++ b/internal/command/testdata/providers-schema/required/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "provider_schemas": {
         "registry.terraform.io/hashicorp/test": {
             "provider": {

--- a/internal/command/testdata/show-json-sensitive/output.json
+++ b/internal/command/testdata/show-json-sensitive/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "variables": {
         "test_var": {
             "value": "bar"
@@ -66,7 +66,7 @@
         }
     },
     "prior_state": {
-        "format_version": "0.2",
+        "format_version": "1.0",
         "values": {
             "outputs": {
                 "test": {

--- a/internal/command/testdata/show-json-state/basic/output.json
+++ b/internal/command/testdata/show-json-state/basic/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "terraform_version": "0.12.0",
     "values": {
         "root_module": {

--- a/internal/command/testdata/show-json-state/empty/output.json
+++ b/internal/command/testdata/show-json-state/empty/output.json
@@ -1,3 +1,3 @@
 {
-    "format_version": "0.2"
+    "format_version": "1.0"
 }

--- a/internal/command/testdata/show-json-state/modules/output.json
+++ b/internal/command/testdata/show-json-state/modules/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "terraform_version": "0.12.0",
     "values": {
         "outputs": {

--- a/internal/command/testdata/show-json-state/sensitive-variables/output.json
+++ b/internal/command/testdata/show-json-state/sensitive-variables/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "terraform_version": "0.14.0",
     "values": {
         "root_module": {

--- a/internal/command/testdata/show-json/basic-create/output.json
+++ b/internal/command/testdata/show-json/basic-create/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "variables": {
         "test_var": {
             "value": "bar"
@@ -57,7 +57,7 @@
         }
     },
     "prior_state": {
-        "format_version": "0.2",
+        "format_version": "1.0",
         "values": {
             "outputs": {
                 "test": {

--- a/internal/command/testdata/show-json/basic-delete/output.json
+++ b/internal/command/testdata/show-json/basic-delete/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "variables": {
         "test_var": {
             "value": "bar"
@@ -88,7 +88,7 @@
         }
     },
     "prior_state": {
-        "format_version": "0.2",
+        "format_version": "1.0",
         "values": {
             "outputs": {
                 "test": {

--- a/internal/command/testdata/show-json/basic-update/output.json
+++ b/internal/command/testdata/show-json/basic-update/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "variables": {
         "test_var": {
             "value": "bar"
@@ -68,7 +68,7 @@
         }
     },
     "prior_state": {
-        "format_version": "0.2",
+        "format_version": "1.0",
         "values": {
             "outputs": {
                 "test": {

--- a/internal/command/testdata/show-json/drift/output.json
+++ b/internal/command/testdata/show-json/drift/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "planned_values": {
         "root_module": {
             "resources": [
@@ -105,7 +105,7 @@
         }
     ],
     "prior_state": {
-        "format_version": "0.2",
+        "format_version": "1.0",
         "values": {
             "root_module": {
                 "resources": [

--- a/internal/command/testdata/show-json/module-depends-on/output.json
+++ b/internal/command/testdata/show-json/module-depends-on/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "terraform_version": "0.13.1-dev",
     "planned_values": {
         "root_module": {

--- a/internal/command/testdata/show-json/modules/output.json
+++ b/internal/command/testdata/show-json/modules/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "planned_values": {
         "outputs": {
             "test": {
@@ -74,7 +74,7 @@
         }
     },
     "prior_state": {
-        "format_version": "0.2",
+        "format_version": "1.0",
         "values": {
             "outputs": {
                 "test": {

--- a/internal/command/testdata/show-json/multi-resource-update/output.json
+++ b/internal/command/testdata/show-json/multi-resource-update/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "terraform_version": "0.13.0",
     "variables": {
         "test_var": {
@@ -127,7 +127,7 @@
         }
     },
     "prior_state": {
-        "format_version": "0.2",
+        "format_version": "1.0",
         "terraform_version": "0.13.0",
         "values": {
             "outputs": {

--- a/internal/command/testdata/show-json/nested-modules/output.json
+++ b/internal/command/testdata/show-json/nested-modules/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.2",
+  "format_version": "1.0",
   "planned_values": {
     "root_module": {
       "child_modules": [

--- a/internal/command/testdata/show-json/provider-version-no-config/output.json
+++ b/internal/command/testdata/show-json/provider-version-no-config/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "variables": {
         "test_var": {
             "value": "bar"
@@ -57,7 +57,7 @@
         }
     },
     "prior_state": {
-        "format_version": "0.2",
+        "format_version": "1.0",
         "values": {
             "outputs": {
                 "test": {

--- a/internal/command/testdata/show-json/provider-version/output.json
+++ b/internal/command/testdata/show-json/provider-version/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "variables": {
         "test_var": {
             "value": "bar"
@@ -57,7 +57,7 @@
         }
     },
     "prior_state": {
-        "format_version": "0.2",
+        "format_version": "1.0",
         "values": {
             "outputs": {
                 "test": {

--- a/internal/command/testdata/show-json/requires-replace/output.json
+++ b/internal/command/testdata/show-json/requires-replace/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "planned_values": {
         "root_module": {
             "resources": [
@@ -48,7 +48,7 @@
         }
     ],
     "prior_state": {
-        "format_version": "0.2",
+        "format_version": "1.0",
         "values": {
             "root_module": {
                 "resources": [

--- a/internal/command/testdata/show-json/sensitive-values/output.json
+++ b/internal/command/testdata/show-json/sensitive-values/output.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "0.2",
+    "format_version": "1.0",
     "variables": {
         "test_var": {
             "value": "boop"
@@ -69,7 +69,7 @@
         }
     },
     "prior_state": {
-        "format_version": "0.2",
+        "format_version": "1.0",
         "values": {
             "outputs": {
                 "test": {

--- a/internal/command/testdata/validate-invalid/incorrectmodulename/output.json
+++ b/internal/command/testdata/validate-invalid/incorrectmodulename/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
   "valid": false,
   "error_count": 4,
   "warning_count": 0,

--- a/internal/command/testdata/validate-invalid/interpolation/output.json
+++ b/internal/command/testdata/validate-invalid/interpolation/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
   "valid": false,
   "error_count": 2,
   "warning_count": 0,

--- a/internal/command/testdata/validate-invalid/missing_defined_var/output.json
+++ b/internal/command/testdata/validate-invalid/missing_defined_var/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
   "valid": true,
   "error_count": 0,
   "warning_count": 0,

--- a/internal/command/testdata/validate-invalid/missing_quote/output.json
+++ b/internal/command/testdata/validate-invalid/missing_quote/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
   "valid": false,
   "error_count": 1,
   "warning_count": 0,

--- a/internal/command/testdata/validate-invalid/missing_var/output.json
+++ b/internal/command/testdata/validate-invalid/missing_var/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
   "valid": false,
   "error_count": 1,
   "warning_count": 0,

--- a/internal/command/testdata/validate-invalid/multiple_modules/output.json
+++ b/internal/command/testdata/validate-invalid/multiple_modules/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
   "valid": false,
   "error_count": 1,
   "warning_count": 0,

--- a/internal/command/testdata/validate-invalid/multiple_providers/output.json
+++ b/internal/command/testdata/validate-invalid/multiple_providers/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
   "valid": false,
   "error_count": 1,
   "warning_count": 0,

--- a/internal/command/testdata/validate-invalid/multiple_resources/output.json
+++ b/internal/command/testdata/validate-invalid/multiple_resources/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
   "valid": false,
   "error_count": 1,
   "warning_count": 0,

--- a/internal/command/testdata/validate-invalid/output.json
+++ b/internal/command/testdata/validate-invalid/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
   "valid": false,
   "error_count": 1,
   "warning_count": 0,

--- a/internal/command/testdata/validate-invalid/outputs/output.json
+++ b/internal/command/testdata/validate-invalid/outputs/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
   "valid": false,
   "error_count": 2,
   "warning_count": 0,

--- a/internal/command/testdata/validate-valid/output.json
+++ b/internal/command/testdata/validate-valid/output.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
   "valid": true,
   "error_count": 0,
   "warning_count": 0,

--- a/internal/command/views/validate.go
+++ b/internal/command/views/validate.go
@@ -81,7 +81,7 @@ func (v *ValidateJSON) Results(diags tfdiags.Diagnostics) int {
 	// FormatVersion represents the version of the json format and will be
 	// incremented for any change to this format that requires changes to a
 	// consuming parser.
-	const FormatVersion = "0.1"
+	const FormatVersion = "1.0"
 
 	type Output struct {
 		FormatVersion string `json:"format_version"`

--- a/website/docs/cli/commands/providers/schema.html.md
+++ b/website/docs/cli/commands/providers/schema.html.md
@@ -23,7 +23,18 @@ The list of available flags are:
 
 Please note that, at this time, the `-json` flag is a _required_ option. In future releases, this command will be extended to allow for additional options.
 
--> **Note:** The output includes a `format_version` key, which currently has major version zero to indicate that the format is experimental and subject to change. A future version will assign a non-zero major version and make stronger promises about compatibility. We do not anticipate any significant breaking changes to the format before its first major version, however.
+The output includes a `format_version` key, which as of Terraform 1.1.0 has
+value `"1.0"`. The semantics of this version are:
+
+- We will increment the minor version, e.g. `"1.1"`, for backward-compatible
+  changes or additions. Ignore any object properties with unrecognized names to
+  remain forward-compatible with future minor versions.
+- We will increment the major version, e.g. `"2.0"`, for changes that are not
+  backward-compatible. Reject any input which reports an unsupported major
+  version.
+
+We will introduce new major versions only within the bounds of
+[the Terraform 1.0 Compatibility Promises](https://www.terraform.io/docs/language/v1-compatibility-promises.html).
 
 ## Format Summary
 
@@ -41,7 +52,7 @@ The JSON output format consists of the following objects and sub-objects:
 
 ```javascript
 {
-  "format_version": "0.1",
+  "format_version": "1.0",
 
   // "provider_schemas" describes the provider schemas for all
   // providers throughout the configuration tree.

--- a/website/docs/cli/commands/validate.html.md
+++ b/website/docs/cli/commands/validate.html.md
@@ -57,11 +57,18 @@ to the JSON output setting. For that reason, external software consuming
 Terraform's output should be prepared to find data on stdout that _isn't_ valid
 JSON, which it should then treat as a generic error case.
 
-**Note:** The output includes a `format_version` key, which currently has major
-version zero to indicate that the format is experimental and subject to change.
-A future version will assign a non-zero major version and make stronger
-promises about compatibility. We do not anticipate any significant breaking
-changes to the format before its first major version, however.
+The output includes a `format_version` key, which as of Terraform 1.1.0 has
+value `"1.0"`. The semantics of this version are:
+
+- We will increment the minor version, e.g. `"1.1"`, for backward-compatible
+  changes or additions. Ignore any object properties with unrecognized names to
+  remain forward-compatible with future minor versions.
+- We will increment the major version, e.g. `"2.0"`, for changes that are not
+  backward-compatible. Reject any input which reports an unsupported major
+  version.
+
+We will introduce new major versions only within the bounds of
+[the Terraform 1.0 Compatibility Promises](https://www.terraform.io/docs/language/v1-compatibility-promises.html).
 
 In the normal case, Terraform will print a JSON object to the standard output
 stream. The top-level JSON object will have the following properties:

--- a/website/docs/internals/json-format.html.md
+++ b/website/docs/internals/json-format.html.md
@@ -16,7 +16,18 @@ Since the format of plan files isn't suited for use with external tools (and lik
 
 Use `terraform show -json <FILE>` to generate a JSON representation of a plan or state file. See [the `terraform show` documentation](/docs/cli/commands/show.html) for more details.
 
--> **Note:** The output includes a `format_version` key, which currently has major version zero to indicate that the format is experimental and subject to change. A future version will assign a non-zero major version and make stronger promises about compatibility. We do not anticipate any significant breaking changes to the format before its first major version, however.
+The output includes a `format_version` key, which as of Terraform 1.1.0 has
+value `"1.0"`. The semantics of this version are:
+
+- We will increment the minor version, e.g. `"1.1"`, for backward-compatible
+  changes or additions. Ignore any object properties with unrecognized names to
+  remain forward-compatible with future minor versions.
+- We will increment the major version, e.g. `"2.0"`, for changes that are not
+  backward-compatible. Reject any input which reports an unsupported major
+  version.
+
+We will introduce new major versions only within the bounds of
+[the Terraform 1.0 Compatibility Promises](https://www.terraform.io/docs/language/v1-compatibility-promises.html).
 
 ## Format Summary
 
@@ -60,7 +71,7 @@ For ease of consumption by callers, the plan representation includes a partial r
 
 ```javascript
 {
-  "format_version": "0.2",
+  "format_version": "1.0",
 
   // "prior_state" is a representation of the state that the configuration is
   // being applied to, using the state representation described above.


### PR DESCRIPTION
Update all stable JSON format version numbers to "1.0", and explain what this means going forward in the public documentation. There are no other changes to the JSON format in this PR. This change is targeting a 1.1.0 release.