### PR TITLE
Document config in plan file for http backend

### DIFF
--- a/website/docs/language/settings/backends/http.mdx
+++ b/website/docs/language/settings/backends/http.mdx
@@ -15,6 +15,9 @@ endpoint should return a 423: Locked or 409: Conflict with the holding lock info
 taken, 200: OK for success. Any other status will be considered an error. The ID of the holding lock
 info will be added as a query parameter to state updates requests.
 
+~> **Warning!** It is highly recommended that you supply sensitive or dynamic configuration to the HTTP backend via environment variables.
+Supplying values to the backend using either `-backend-config` or in HCL directly will result in these [values being stored in plain-text in plan files.](#configuration-cached-in-plan-files)
+
 ## Example Usage
 
 ```hcl
@@ -65,3 +68,11 @@ The following configuration options / environment variables are supported:
   seconds to wait between HTTP request attempts. Defaults to `1`.
 - `retry_wait_max` / `TF_HTTP_RETRY_WAIT_MAX` – (Optional) The maximum time in
   seconds to wait between HTTP request attempts. Defaults to `30`.
+
+## Configuration cached in plan files
+
+Configuration passed to a backend via either `-backend-config`, or directly defined in HCL in the `backend` block, are
+stored plain-text in plan files when produced with `terraform plan -out my_plan`. This can leak sensitive credentials if
+plans are not stored securely. In addition, configuration stored in a plan file will take precedence over other
+configuration, and may cause authentication issues if credentials change between creating and applying plans (eg, in
+automated environments where credentials are scoped to the duration of a job).


### PR DESCRIPTION
This attempts to document the storage of backend configuration in plan files when the config was provided with either `-backend-config` or directly written in HCL. This only changes the docs for the HTTP backend which is where [I discovered this when using gitlab managed Terraform state](https://gitlab.com/gitlab-org/gitlab/-/issues/338482), but a more global location may be better suited such as the backend overview page or a page on the plan command?

This also partially resolves https://github.com/hashicorp/terraform/issues/29195