### PR TITLE
configs: Disable experiment warnings at link time

### DIFF
--- a/internal/configs/experiments.go
+++ b/internal/configs/experiments.go
@@ -9,6 +9,16 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// When developing UI for experimental features, you can temporarily disable
+// the experiment warning by setting this package-level variable to a non-empty
+// value using a link-time flag:
+//
+// go install -ldflags="-X 'github.com/hashicorp/terraform/internal/configs.disableExperimentWarnings=yes'"
+//
+// This functionality is for development purposes only and is not a feature we
+// are committing to supporting for end users.
+var disableExperimentWarnings = ""
+
 // sniffActiveExperiments does minimal parsing of the given body for
 // "terraform" blocks with "experiments" attributes, returning the
 // experiments found.
@@ -126,17 +136,19 @@ func decodeExperimentsAttr(attr *hcl.Attribute) (experiments.Set, hcl.Diagnostic
 			// No error at all means it's valid and current.
 			ret.Add(exp)
 
-			// However, experimental features are subject to breaking changes
-			// in future releases, so we'll warn about them to help make sure
-			// folks aren't inadvertently using them in places where that'd be
-			// inappropriate, particularly if the experiment is active in a
-			// shared module they depend on.
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagWarning,
-				Summary:  fmt.Sprintf("Experimental feature %q is active", exp.Keyword()),
-				Detail:   "Experimental features are subject to breaking changes in future minor or patch releases, based on feedback.\n\nIf you have feedback on the design of this feature, please open a GitHub issue to discuss it.",
-				Subject:  expr.Range().Ptr(),
-			})
+			if disableExperimentWarnings == "" {
+				// However, experimental features are subject to breaking changes
+				// in future releases, so we'll warn about them to help make sure
+				// folks aren't inadvertently using them in places where that'd be
+				// inappropriate, particularly if the experiment is active in a
+				// shared module they depend on.
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  fmt.Sprintf("Experimental feature %q is active", exp.Keyword()),
+					Detail:   "Experimental features are subject to breaking changes in future minor or patch releases, based on feedback.\n\nIf you have feedback on the design of this feature, please open a GitHub issue to discuss it.",
+					Subject:  expr.Range().Ptr(),
+				})
+			}
 
 		default:
 			// This should never happen, because GetCurrent is not documented


### PR DESCRIPTION
This package level variable can be overridden at link time to allow temporarily disabling the UI warning when experimental features are enabled. This makes it easier to understand how UI will render when the feature is no longer experimental.

This change is only for those developing Terraform.