### PR TITLE
allow json output to marshal ConfigModeAttr blocks

### DIFF
--- a/internal/command/jsonconfig/expression.go
+++ b/internal/command/jsonconfig/expression.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/blocktoattr"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
@@ -95,6 +96,9 @@ func marshalExpressions(body hcl.Body, schema *configschema.Block) expressions {
 	lowSchema := hcldec.ImpliedSchema(schema.DecoderSpec())
 	// (lowSchema is an hcl.BodySchema:
 	// https://godoc.org/github.com/hashicorp/hcl/v2/hcl#BodySchema )
+
+	// fix any ConfigModeAttr blocks present from legacy providers
+	body = blocktoattr.FixUpBlockAttrs(body, schema)
 
 	// Use the low-level schema with the body to decode one level We'll just
 	// ignore any additional content that's not covered by the schema, which

--- a/internal/command/jsonconfig/expression_test.go
+++ b/internal/command/jsonconfig/expression_test.go
@@ -80,6 +80,29 @@ func TestMarshalExpressions(t *testing.T) {
 				},
 			},
 		},
+		{
+			hcltest.MockBody(&hcl.BodyContent{
+				Blocks: hcl.Blocks{
+					{
+						Type: "block_to_attr",
+						Body: hcltest.MockBody(&hcl.BodyContent{
+
+							Attributes: hcl.Attributes{
+								"foo": {
+									Name: "foo",
+									Expr: hcltest.MockExprTraversalSrc(`module.foo.bar`),
+								},
+							},
+						}),
+					},
+				},
+			}),
+			expressions{
+				"block_to_attr": expression{
+					References: []string{"module.foo.bar", "module.foo"},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -88,6 +111,11 @@ func TestMarshalExpressions(t *testing.T) {
 				"foo": {
 					Type:     cty.String,
 					Optional: true,
+				},
+				"block_to_attr": {
+					Type: cty.List(cty.Object(map[string]cty.Type{
+						"foo": cty.String,
+					})),
 				},
 			},
 		}


### PR DESCRIPTION
In order to marshal config blocks using ConfigModeAttr, we need to insert the fixup body to map hcl blocks to the attribute in the schema.

Serializing the configuration of `dynamic` blocks is something that will need to be handled separately, if at all, as they require more context than is available at the time of serialization.

Fixes #29022

