### PR TITLE
command: Render "moved" annotations in plan UI

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -72,13 +72,27 @@ func ResourceChange(
 			// Some extra context about this unusual situation.
 			buf.WriteString(color.Color("\n  # (left over from a partially-failed replacement of this instance)"))
 		}
+	case plans.NoOp:
+		if change.Moved() {
+			buf.WriteString(color.Color(fmt.Sprintf("[bold]  # %s[reset] has moved to [bold]%s[reset]", change.PrevRunAddr.String(), dispAddr)))
+			break
+		}
+		fallthrough
 	default:
 		// should never happen, since the above is exhaustive
 		buf.WriteString(fmt.Sprintf("%s has an action the plan renderer doesn't support (this is a bug)", dispAddr))
 	}
 	buf.WriteString(color.Color("[reset]\n"))
 
-	buf.WriteString(color.Color(DiffActionSymbol(change.Action)) + " ")
+	if change.Moved() && change.Action != plans.NoOp {
+		buf.WriteString(color.Color(fmt.Sprintf("[bold]  # [reset]([bold]%s[reset] has moved to [bold]%s[reset])\n", change.PrevRunAddr.String(), dispAddr)))
+	}
+
+	if change.Moved() && change.Action == plans.NoOp {
+		buf.WriteString("    ")
+	} else {
+		buf.WriteString(color.Color(DiffActionSymbol(change.Action)) + " ")
+	}
 
 	switch addr.Resource.Resource.Mode {
 	case addrs.ManagedResourceMode:

--- a/internal/command/views/plan_test.go
+++ b/internal/command/views/plan_test.go
@@ -63,12 +63,15 @@ func testPlan(t *testing.T) *plans.Plan {
 	}
 
 	changes := plans.NewChanges()
+	addr := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "test_resource",
+		Name: "foo",
+	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
+
 	changes.SyncWrapper().AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
-		Addr: addrs.Resource{
-			Mode: addrs.ManagedResourceMode,
-			Type: "test_resource",
-			Name: "foo",
-		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+		Addr:        addr,
+		PrevRunAddr: addr,
 		ProviderAddr: addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -33,7 +33,7 @@ func NewChanges() *Changes {
 
 func (c *Changes) Empty() bool {
 	for _, res := range c.Resources {
-		if res.Action != NoOp {
+		if res.Action != NoOp || res.Moved() {
 			return false
 		}
 	}

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -125,6 +125,10 @@ func (rcs *ResourceInstanceChangeSrc) DeepCopy() *ResourceInstanceChangeSrc {
 	return &ret
 }
 
+func (rcs *ResourceInstanceChangeSrc) Moved() bool {
+	return !rcs.Addr.Equal(rcs.PrevRunAddr)
+}
+
 // OutputChangeSrc describes a change to an output value.
 type OutputChangeSrc struct {
 	// Addr is the absolute address of the output value that the change

--- a/internal/plans/changes_test.go
+++ b/internal/plans/changes_test.go
@@ -4,9 +4,126 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 )
+
+func TestChangesEmpty(t *testing.T) {
+	testCases := map[string]struct {
+		changes *Changes
+		want    bool
+	}{
+		"no changes": {
+			&Changes{},
+			true,
+		},
+		"resource change": {
+			&Changes{
+				Resources: []*ResourceInstanceChangeSrc{
+					{
+						Addr: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "test_thing",
+							Name: "woot",
+						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+						PrevRunAddr: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "test_thing",
+							Name: "woot",
+						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+						ChangeSrc: ChangeSrc{
+							Action: Update,
+						},
+					},
+				},
+			},
+			false,
+		},
+		"resource change with no-op action": {
+			&Changes{
+				Resources: []*ResourceInstanceChangeSrc{
+					{
+						Addr: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "test_thing",
+							Name: "woot",
+						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+						PrevRunAddr: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "test_thing",
+							Name: "woot",
+						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+						ChangeSrc: ChangeSrc{
+							Action: NoOp,
+						},
+					},
+				},
+			},
+			true,
+		},
+		"resource moved with no-op change": {
+			&Changes{
+				Resources: []*ResourceInstanceChangeSrc{
+					{
+						Addr: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "test_thing",
+							Name: "woot",
+						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+						PrevRunAddr: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "test_thing",
+							Name: "toot",
+						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+						ChangeSrc: ChangeSrc{
+							Action: NoOp,
+						},
+					},
+				},
+			},
+			false,
+		},
+		"output change": {
+			&Changes{
+				Outputs: []*OutputChangeSrc{
+					{
+						Addr: addrs.OutputValue{
+							Name: "result",
+						}.Absolute(addrs.RootModuleInstance),
+						ChangeSrc: ChangeSrc{
+							Action: Update,
+						},
+					},
+				},
+			},
+			false,
+		},
+		"output change no-op": {
+			&Changes{
+				Outputs: []*OutputChangeSrc{
+					{
+						Addr: addrs.OutputValue{
+							Name: "result",
+						}.Absolute(addrs.RootModuleInstance),
+						ChangeSrc: ChangeSrc{
+							Action: NoOp,
+						},
+					},
+				},
+			},
+			true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if got, want := tc.changes.Empty(), tc.want; got != want {
+				t.Fatalf("unexpected result: got %v, want %v", got, want)
+			}
+		})
+	}
+}
 
 func TestChangeEncodeSensitive(t *testing.T) {
 	testVals := []cty.Value{


### PR DESCRIPTION
For resources which are planned to move, render the previous run address as additional information in the plan UI. For the case of a move-only resource (which otherwise is unchanged), we also render that as a planned change, but without any corresponding action symbol.

If all changes in the plan are moves without changes, the plan is no longer considered "empty". In this case, we skip rendering the action symbols in the UI.

### Screenshots

Plan consisting of one move, without changes:
<img width="902" alt="noop-move" src="https://user-images.githubusercontent.com/68917/132067733-ab9c2972-2b45-44b5-b8c4-c70034917de0.png">

Adding another move, this time with changes which cause the resource to be replaced:
<img width="902" alt="moves" src="https://user-images.githubusercontent.com/68917/132067726-9494aeac-966b-4af5-a9bb-90a98e53d829.png">
