### PR TITLE
Update docs for indent() (fix #29508)

### DIFF
--- a/website/docs/language/functions/indent.html.md
+++ b/website/docs/language/functions/indent.html.md
@@ -22,7 +22,7 @@ This function is useful for inserting a multi-line string into an
 already-indented context in another string:
 
 ```
-> "  items: ${indent(2, "[\n  foo,\n  bar,\n]\n")}"
+> "  items: ${indent(2, "[\n  foo,\n  bar,\n]")}"
   items: [
     foo,
     bar,
@@ -31,3 +31,36 @@ already-indented context in another string:
 
 The first line of the string is not indented so that, as above, it can be
 placed after an introduction sequence that has already begun the line.
+
+Note that whitespaces are added even after the final newline character.
+If your mutli-line string ends with newline character (e.g.: here-doc literal),
+use [`chomp`](./chomp.html) function to avoid it:
+
+```tf
+locals {
+  is_bad_user         = <<-EOS
+    user_id IS NULL
+    OR user_id == ''
+  EOS
+  where_without_chomp = "NOT (\n  ${indent(2, local.is_bad_user)})\n"
+  where_with_chomp    = "NOT (\n  ${indent(2, chomp(local.is_bad_user))}\n)\n"
+}
+```
+
+The result will be:
+
+```txt
+NOT (
+  user_id IS NULL
+  OR user_id == ''
+  )
+```
+
+vs.
+
+```txt
+NOT (
+  user_id IS NULL
+  OR user_id == ''
+)
+```


### PR DESCRIPTION
As `indent()` function behaves weirdly on final newline character, I added document to clarify the situation.