### PR TITLE
Fixes #29532: fix provider name validation in module URL to download from a registry

### DIFF
--- a/internal/registry/regsrc/module.go
+++ b/internal/registry/regsrc/module.go
@@ -27,7 +27,7 @@ var (
 	// does not anchor the start or end so it can be composed into more complex
 	// RegExps below. Only lowercase chars and digits are supported in practice.
 	// Max length 64 chars.
-	providerSubRe = "[0-9a-z]{1,64}"
+	providerSubRe = "[0-9a-z](?:[0-9a-z-]{0,62}[0-9a-z])?"
 
 	// moduleSourceRe is a regular expression that matches the basic
 	// namespace/name/provider[//...] format for registry sources. It assumes

--- a/internal/registry/regsrc/module_test.go
+++ b/internal/registry/regsrc/module_test.go
@@ -77,6 +77,14 @@ func TestModule(t *testing.T) {
 			wantErr:     false,
 		},
 		{
+			name:        "valid host, valid provider format with hyphen",
+			source:      "foo.com/var/baz/prov-ider",
+			wantString:  "foo.com/var/baz/prov-ider",
+			wantDisplay: "foo.com/var/baz/prov-ider",
+			wantNorm:    "foo.com/var/baz/prov-ider",
+			wantErr:     false,
+		},
+		{
 			name:    "invalid host",
 			source:  "---.com/HashiCorp/Consul/aws",
 			wantErr: true,
@@ -104,6 +112,16 @@ func TestModule(t *testing.T) {
 		{
 			name:    "disallow bitbucket",
 			source:  "bitbucket.org/HashiCorp/Consul/aws",
+			wantErr: true,
+		},
+		{
+			name:    "valid host, invalid provider suffix",
+			source:  "foo.com/var/baz/provider-",
+			wantErr: true,
+		},
+		{
+			name:    "valid host, invalid provider prefix",
+			source:  "foo.com/var/baz/-provider",
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
a hyphen can be present in provider name (except first and last character) in module URL to download from registry (cf #29532)