### PR TITLE
fix temp directory handling in some tests

### DIFF
--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -132,7 +132,7 @@ func TestLocalRun_stalePlan(t *testing.T) {
 	stateFile := statefile.New(plan.PriorState, "boop", 2)
 
 	// Roundtrip through serialization as expected by the operation
-	outDir := testTempDir(t)
+	outDir := t.TempDir()
 	defer os.RemoveAll(outDir)
 	planPath := filepath.Join(outDir, "plan.tfplan")
 	if err := planfile.Create(planPath, configload.NewEmptySnapshot(), prevStateFile, stateFile, plan); err != nil {

--- a/internal/backend/local/backend_plan_test.go
+++ b/internal/backend/local/backend_plan_test.go
@@ -174,7 +174,7 @@ func TestLocal_planOutputsChanged(t *testing.T) {
 		// unknown" situation because that's already common for printing out
 		// resource changes and we already have many tests for that.
 	}))
-	outDir := testTempDir(t)
+	outDir := t.TempDir()
 	defer os.RemoveAll(outDir)
 	planPath := filepath.Join(outDir, "plan.tfplan")
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-outputs-changed")
@@ -232,7 +232,7 @@ func TestLocal_planModuleOutputsChanged(t *testing.T) {
 			OutputValue: addrs.OutputValue{Name: "changed"},
 		}, cty.StringVal("before"), false)
 	}))
-	outDir := testTempDir(t)
+	outDir := t.TempDir()
 	defer os.RemoveAll(outDir)
 	planPath := filepath.Join(outDir, "plan.tfplan")
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-module-outputs-changed")
@@ -275,8 +275,7 @@ func TestLocal_planTainted(t *testing.T) {
 	defer cleanup()
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState_tainted())
-	outDir := testTempDir(t)
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
 	defer configCleanup()
@@ -356,8 +355,7 @@ func TestLocal_planDeposedOnly(t *testing.T) {
 			},
 		)
 	}))
-	outDir := testTempDir(t)
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
 	defer configCleanup()
@@ -448,8 +446,7 @@ func TestLocal_planTainted_createBeforeDestroy(t *testing.T) {
 	defer cleanup()
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState_tainted())
-	outDir := testTempDir(t)
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-cbd")
 	defer configCleanup()
@@ -540,8 +537,7 @@ func TestLocal_planDestroy(t *testing.T) {
 	TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState())
 
-	outDir := testTempDir(t)
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
 
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
@@ -594,8 +590,7 @@ func TestLocal_planDestroy_withDataSources(t *testing.T) {
 	TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState_withDataSource())
 
-	outDir := testTempDir(t)
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
 
 	op, configCleanup, done := testOperationPlan(t, "./testdata/destroy-with-ds")
@@ -670,8 +665,7 @@ func TestLocal_planOutPathNoChange(t *testing.T) {
 	TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState())
 
-	outDir := testTempDir(t)
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
 
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -1,7 +1,6 @@
 package local
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,7 +23,7 @@ import (
 // public fields without any locks.
 func TestLocal(t *testing.T) (*Local, func()) {
 	t.Helper()
-	tempDir := testTempDir(t)
+	tempDir := t.TempDir()
 
 	local := New()
 	local.StatePath = filepath.Join(tempDir, "state.tfstate")
@@ -187,15 +186,6 @@ func (b *TestLocalNoDefaultState) StateMgr(name string) (statemgr.Full, error) {
 		return nil, backend.ErrDefaultWorkspaceNotSupported
 	}
 	return b.Local.StateMgr(name)
-}
-
-func testTempDir(t *testing.T) string {
-	d, err := ioutil.TempDir("", "tf")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	return d
 }
 
 func testStateFile(t *testing.T, path string, s *states.State) {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -147,16 +147,10 @@ func tempWorkingDir(t *testing.T) (*workdir.Dir, func() error) {
 // the testWorkingDir commentary for an example of how to use this function
 // along with testChdir to meet the expectations of command.Meta legacy
 // functionality.
-func tempWorkingDirFixture(t *testing.T, fixtureName string) (*workdir.Dir, func() error) {
+func tempWorkingDirFixture(t *testing.T, fixtureName string) *workdir.Dir {
 	t.Helper()
 
-	dirPath, err := os.MkdirTemp("", "tf-command-test-"+fixtureName)
-	if err != nil {
-		t.Fatal(err)
-	}
-	done := func() error {
-		return os.RemoveAll(dirPath)
-	}
+	dirPath := testTempDir(t)
 	t.Logf("temporary directory %s with fixture %q", dirPath, fixtureName)
 
 	fixturePath := testFixturePath(fixtureName)
@@ -165,7 +159,7 @@ func tempWorkingDirFixture(t *testing.T, fixtureName string) (*workdir.Dir, func
 	// on failure, a failure to copy will prevent us from cleaning up the
 	// temporary directory. Oh well. :(
 
-	return workdir.NewDir(dirPath), done
+	return workdir.NewDir(dirPath)
 }
 
 func testFixturePath(name string) string {
@@ -550,13 +544,8 @@ func testTempFile(t *testing.T) string {
 
 func testTempDir(t *testing.T) string {
 	t.Helper()
-
-	d, err := ioutil.TempDir(testingDir, "tf")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	d, err = filepath.EvalSymlinks(d)
+	d := t.TempDir()
+	d, err := filepath.EvalSymlinks(d)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/get_test.go
+++ b/internal/command/get_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestGet(t *testing.T) {
-	wd, cleanup := tempWorkingDirFixture(t, "get")
-	defer cleanup()
+	wd := tempWorkingDirFixture(t, "get")
 	defer testChdir(t, wd.RootModuleDir())()
 
 	ui := cli.NewMockUi()
@@ -56,8 +55,7 @@ func TestGet_multipleArgs(t *testing.T) {
 }
 
 func TestGet_update(t *testing.T) {
-	wd, cleanup := tempWorkingDirFixture(t, "get")
-	defer cleanup()
+	wd := tempWorkingDirFixture(t, "get")
 	defer testChdir(t, wd.RootModuleDir())()
 
 	ui := cli.NewMockUi()

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -1855,8 +1855,7 @@ func TestMetaBackend_configToExtra(t *testing.T) {
 
 // no config; return inmem backend stored in state
 func TestBackendFromState(t *testing.T) {
-	wd, cleanup := tempWorkingDirFixture(t, "backend-from-state")
-	defer cleanup()
+	wd := tempWorkingDirFixture(t, "backend-from-state")
 	defer testChdir(t, wd.RootModuleDir())()
 
 	// Setup the meta


### PR DESCRIPTION
Use `EvalSymlinks` with temp dir paths to help with MacOS errors from various terraform components. Same fixes as used in other PRs like #27005 and #23596. Update impacted test fixtures to use `t.TempDir` for more consistent handling.

This is not a comprehensive cleanup, just enough to get tests working again on darwin.
