### PR TITLE
backend/local: Restore original intent of TestLocal_plan_context_error test case

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -249,7 +249,6 @@ type Operation struct {
 	// behavior of the operation.
 	PlanMode     plans.Mode
 	AutoApprove  bool
-	Parallelism  int
 	Targets      []addrs.Targetable
 	ForceReplace []addrs.AbsResourceInstance
 	Variables    map[string]UnparsedVariableValue

--- a/internal/backend/remote/backend_apply.go
+++ b/internal/backend/remote/backend_apply.go
@@ -42,7 +42,7 @@ func (b *Remote) opApply(stopCtx, cancelCtx context.Context, op *backend.Operati
 		return nil, diags.Err()
 	}
 
-	if op.Parallelism != defaultParallelism {
+	if b.ContextOpts != nil && b.ContextOpts.Parallelism != defaultParallelism {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Custom parallelism values are currently not supported",

--- a/internal/backend/remote/backend_apply_test.go
+++ b/internal/backend/remote/backend_apply_test.go
@@ -46,7 +46,6 @@ func testOperationApplyWithTimeout(t *testing.T, configDir string, timeout time.
 	return &backend.Operation{
 		ConfigDir:    configDir,
 		ConfigLoader: configLoader,
-		Parallelism:  defaultParallelism,
 		PlanRefresh:  true,
 		StateLocker:  clistate.NewLocker(timeout, stateLockerView),
 		Type:         backend.OperationTypeApply,
@@ -223,7 +222,10 @@ func TestRemote_applyWithParallelism(t *testing.T) {
 	op, configCleanup, done := testOperationApply(t, "./testdata/apply")
 	defer configCleanup()
 
-	op.Parallelism = 3
+	if b.ContextOpts == nil {
+		b.ContextOpts = &terraform.ContextOpts{}
+	}
+	b.ContextOpts.Parallelism = 3
 	op.Workspace = backend.DefaultStateName
 
 	run, err := b.Operation(context.Background(), op)

--- a/internal/backend/remote/backend_plan.go
+++ b/internal/backend/remote/backend_plan.go
@@ -38,7 +38,7 @@ func (b *Remote) opPlan(stopCtx, cancelCtx context.Context, op *backend.Operatio
 		return nil, diags.Err()
 	}
 
-	if op.Parallelism != defaultParallelism {
+	if b.ContextOpts != nil && b.ContextOpts.Parallelism != defaultParallelism {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Custom parallelism values are currently not supported",

--- a/internal/backend/remote/backend_plan_test.go
+++ b/internal/backend/remote/backend_plan_test.go
@@ -44,7 +44,6 @@ func testOperationPlanWithTimeout(t *testing.T, configDir string, timeout time.D
 	return &backend.Operation{
 		ConfigDir:    configDir,
 		ConfigLoader: configLoader,
-		Parallelism:  defaultParallelism,
 		PlanRefresh:  true,
 		StateLocker:  clistate.NewLocker(timeout, stateLockerView),
 		Type:         backend.OperationTypePlan,
@@ -198,7 +197,10 @@ func TestRemote_planWithParallelism(t *testing.T) {
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
 	defer configCleanup()
 
-	op.Parallelism = 3
+	if b.ContextOpts == nil {
+		b.ContextOpts = &terraform.ContextOpts{}
+	}
+	b.ContextOpts.Parallelism = 3
 	op.Workspace = backend.DefaultStateName
 
 	run, err := b.Operation(context.Background(), op)

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -349,7 +349,6 @@ func (m *Meta) Operation(b backend.Backend) *backend.Operation {
 
 	return &backend.Operation{
 		PlanOutBackend: planOutBackend,
-		Parallelism:    m.parallelism,
 		Targets:        m.targets,
 		UIIn:           m.UIInput(),
 		UIOut:          m.Ui,


### PR DESCRIPTION
The original intent of this test was to verify that we properly release the state lock if `terraform.NewContext` fails. This was in response to a bug in an earlier version of Terraform where that wasn't always true. (see #25454)

In the recent refactoring that made terraform.NewContext no longer responsible for provider constraint/checksum verification, this test began testing a failed plan operation instead, which left the error return path from `terraform.NewContext` untested.

An invalid parallelism value is the one remaining case where `terraform.NewContext` can return an error, so as a localized fix for this test I've switched it to just intentionally set an invalid parallelism value. This is still not ideal because it's still testing an
implementation detail, but I've at least left a comment inline to try to be clearer about what the goal is here so that we can respond in a more appropriate way if future changes cause this test to fail again.

In the long run I'd like to move this last remaining check out to be the responsibility of the CLI layer, with `terraform.NewContext` either just assuming the value correct or panicking when it isn't, but the handling of this CLI option is currently rather awkwardly spread across the command and backend packages so we'll save that refactoring for a later date.

---

While working on this I got derailed by the fact that we had a field `backend.Operation.Parallelism` which the local backend wasn't using at all, and the remote backend was using only to return an error if the user tries to set parallelism in remote mode. (Terraform Cloud can't currently support that.)

To try to reduce the confusion here a little, my additional first commit here removes `backend.Operation.Parallelism` altogether and standardizes on using `ContextOpts.Parallelism` in all cases.

The `ContextOpts.Parallelism` field is populated by the `command` package as part of the partially-built `terraform.ContextOpts` it passes into the backend, so this new situation isn't really ideal _either_ (it'd be nicer, in my opinion, to put the responsibility for constructing `ContextOpts` entirely in one place) but it at least avoids the question over whether `terraform.ContextOpts.Parallelism` or `backend.Operation.Parallelism` is the source of truth for this value.
