### PR TITLE
handle NestedTypes in configschema CoerceValue

### DIFF
--- a/internal/configs/configschema/coerce_value_test.go
+++ b/internal/configs/configschema/coerce_value_test.go
@@ -538,6 +538,67 @@ func TestCoerceValue(t *testing.T) {
 			}),
 			``,
 		},
+		"nested types": {
+			// handle NestedTypes
+			&Block{
+				Attributes: map[string]*Attribute{
+					"foo": {
+						NestedType: &Object{
+							Nesting: NestingList,
+							Attributes: map[string]*Attribute{
+								"bar": {
+									Type:     cty.String,
+									Required: true,
+								},
+								"baz": {
+									Type:     cty.Map(cty.String),
+									Optional: true,
+								},
+							},
+						},
+						Optional: true,
+					},
+					"fob": {
+						NestedType: &Object{
+							Nesting: NestingSet,
+							Attributes: map[string]*Attribute{
+								"bar": {
+									Type:     cty.String,
+									Optional: true,
+								},
+							},
+						},
+						Optional: true,
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("beep"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("beep"),
+						"baz": cty.NullVal(cty.Map(cty.String)),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"bar": cty.StringVal("boop"),
+						"baz": cty.NullVal(cty.Map(cty.String)),
+					}),
+				}),
+				"fob": cty.NullVal(cty.Set(cty.Object(map[string]cty.Type{
+					"bar": cty.String,
+				}))),
+			}),
+			``,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
The CoerceValue code was not updated to handle NestedTypes, and while none of the newer codepaths make use of this method, there are still some internal uses.

Here we continue to leverage the go-cty `Convert` function to transform the attribute values, but instead read the attribute type from the `configschema.Block` spec type rather than recursing into the `NestedType` values.