### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -7,7 +7,6 @@ package backend
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -411,7 +410,7 @@ func ReadPathOrContents(poc string) (string, error) {
 	}
 
 	if _, err := os.Stat(path); err == nil {
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			return string(contents), err
 		}

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"strings"
@@ -118,7 +117,7 @@ func testTempFile(t *testing.T, baseDir ...string) (*os.File, func()) {
 	if len(baseDir) == 1 {
 		base = baseDir[0]
 	}
-	f, err := ioutil.TempFile(base, "tf")
+	f, err := os.CreateTemp(base, "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -189,7 +188,7 @@ func (b *Local) Workspaces() ([]string, error) {
 	// the listing always start with "default"
 	envs := []string{backend.DefaultStateName}
 
-	entries, err := ioutil.ReadDir(b.stateWorkspaceDir())
+	entries, err := os.ReadDir(b.stateWorkspaceDir())
 	// no error if there's no envs configured
 	if os.IsNotExist(err) {
 		return envs, nil

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -228,7 +227,7 @@ func TestLocal_multiStateBackend(t *testing.T) {
 
 // change into a tmp dir and return a deferable func to change back and cleanup
 func testTmpDir(t *testing.T) func() {
-	tmp, err := ioutil.TempDir("", "tf")
+	tmp, err := os.MkdirTemp("", "tf")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/consul/backend_test.go
+++ b/internal/backend/remote-state/consul/backend_test.go
@@ -3,7 +3,7 @@ package consul
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -29,8 +29,8 @@ func newConsulTestServer(t *testing.T) *testutil.TestServer {
 		}
 
 		if !testing.Verbose() {
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
 		}
 	})
 

--- a/internal/backend/remote-state/cos/client.go
+++ b/internal/backend/remote-state/cos/client.go
@@ -6,7 +6,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -193,7 +193,7 @@ func (c *remoteClient) getObject(cosFile string) (exists bool, data []byte, chec
 	}
 
 	exists = true
-	data, err = ioutil.ReadAll(rsp.Body)
+	data, err = io.ReadAll(rsp.Body)
 	log.Printf("[DEBUG] getObject %s: data length: %d", cosFile, len(data))
 	if err != nil {
 		err = fmt.Errorf("failed to open file at %v: %v", cosFile, err)

--- a/internal/backend/remote-state/gcs/client.go
+++ b/internal/backend/remote-state/gcs/client.go
@@ -3,7 +3,7 @@ package gcs
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strconv"
 
 	"cloud.google.com/go/storage"
@@ -36,7 +36,7 @@ func (c *remoteClient) Get() (payload *remote.Payload, err error) {
 	}
 	defer stateFileReader.Close()
 
-	stateFileContents, err := ioutil.ReadAll(stateFileReader)
+	stateFileContents, err := io.ReadAll(stateFileReader)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read state file from %v: %v", c.stateFileURL(), err)
 	}
@@ -143,7 +143,7 @@ func (c *remoteClient) lockInfo() (*statemgr.LockInfo, error) {
 	}
 	defer r.Close()
 
-	rawData, err := ioutil.ReadAll(r)
+	rawData, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -98,7 +97,7 @@ func (c *httpClient) Lock(info *statemgr.LockInfo) (string, error) {
 		return "", fmt.Errorf("HTTP remote state endpoint invalid auth")
 	case http.StatusConflict, http.StatusLocked:
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", fmt.Errorf("HTTP remote state already locked, failed to read body")
 		}

--- a/internal/backend/remote-state/manta/backend.go
+++ b/internal/backend/remote-state/manta/backend.go
@@ -5,7 +5,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/hashicorp/errwrap"
@@ -155,7 +154,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	} else {
 		var keyBytes []byte
 		if _, err = os.Stat(config.KeyMaterial); err == nil {
-			keyBytes, err = ioutil.ReadFile(config.KeyMaterial)
+			keyBytes, err = os.ReadFile(config.KeyMaterial)
 			if err != nil {
 				return fmt.Errorf("Error reading key material from %s: %s",
 					config.KeyMaterial, err)

--- a/internal/backend/remote-state/oss/backend.go
+++ b/internal/backend/remote-state/oss/backend.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -18,6 +16,7 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/location"
@@ -562,7 +561,7 @@ func getConfigFromProfile(d *schema.ResourceData, ProfileKey string) (interface{
 		providerConfig = make(map[string]interface{})
 		_, err = os.Stat(profilePath)
 		if !os.IsNotExist(err) {
-			data, err := ioutil.ReadFile(profilePath)
+			data, err := os.ReadFile(profilePath)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/backend/remote/backend_plan.go
+++ b/internal/backend/remote/backend_plan.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -231,7 +230,7 @@ in order to capture the filesystem context the remote workspace expects:
 		// We did a check earlier to make sure we either have a config dir,
 		// or the plan is run with -destroy. So this else clause will only
 		// be executed when we are destroying and doesn't need the config.
-		configDir, err = ioutil.TempDir("", "tf")
+		configDir, err = os.MkdirTemp("", "tf")
 		if err != nil {
 			return nil, generalError("Failed to create temporary directory", err)
 		}

--- a/internal/builtin/provisioners/file/resource_provisioner.go
+++ b/internal/builtin/provisioners/file/resource_provisioner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/hashicorp/terraform/internal/communicator"
@@ -129,7 +128,7 @@ func getSrc(v cty.Value) (string, bool, error) {
 
 	switch {
 	case !content.IsNull():
-		file, err := ioutil.TempFile("", "tf-file-content")
+		file, err := os.CreateTemp("", "tf-file-content")
 		if err != nil {
 			return "", true, err
 		}

--- a/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -2,7 +2,6 @@ package localexec
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -35,7 +34,7 @@ func TestResourceProvider_Apply(t *testing.T) {
 	}
 
 	// Check the file
-	raw, err := ioutil.ReadFile("test_out")
+	raw, err := os.ReadFile("test_out")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/internal/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -179,7 +178,7 @@ func collectScripts(v cty.Value) ([]io.ReadCloser, error) {
 
 		var r []io.ReadCloser
 		for _, script := range scripts {
-			r = append(r, ioutil.NopCloser(bytes.NewReader([]byte(script))))
+			r = append(r, io.NopCloser(bytes.NewReader([]byte(script))))
 		}
 
 		return r, nil

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -144,7 +143,7 @@ in order to capture the filesystem context the remote workspace expects:
 		// We did a check earlier to make sure we either have a config dir,
 		// or the plan is run with -destroy. So this else clause will only
 		// be executed when we are destroying and doesn't need the config.
-		configDir, err = ioutil.TempDir("", "tf")
+		configDir, err = os.MkdirTemp("", "tf")
 		if err != nil {
 			return nil, generalError("Failed to create temporary directory", err)
 		}

--- a/internal/cloud/e2e/apply_auto_approve_test.go
+++ b/internal/cloud/e2e/apply_auto_approve_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -191,7 +190,7 @@ func Test_terraform_apply_autoApprove(t *testing.T) {
 			}
 			defer exp.Close()
 
-			tmpDir, err := ioutil.TempDir("", "terraform-test")
+			tmpDir, err := os.MkdirTemp("", "terraform-test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/cloud/e2e/backend_apply_before_init_test.go
+++ b/internal/cloud/e2e/backend_apply_before_init_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -83,7 +82,7 @@ func Test_backend_apply_before_init(t *testing.T) {
 			}
 			defer exp.Close()
 
-			tmpDir, err := ioutil.TempDir("", "terraform-test")
+			tmpDir, err := os.MkdirTemp("", "terraform-test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/cloud/e2e/init_with_empty_tags_test.go
+++ b/internal/cloud/e2e/init_with_empty_tags_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -50,7 +49,7 @@ func Test_init_with_empty_tags(t *testing.T) {
 			}
 			defer exp.Close()
 
-			tmpDir, err := ioutil.TempDir("", "terraform-test")
+			tmpDir, err := os.MkdirTemp("", "terraform-test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/cloud/e2e/main_test.go
+++ b/internal/cloud/e2e/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -89,7 +88,7 @@ func setTfeClient() {
 
 func setupBinary() func() {
 	log.Println("Setting up terraform binary")
-	tmpTerraformBinaryDir, err := ioutil.TempDir("", "terraform-test")
+	tmpTerraformBinaryDir, err := os.MkdirTemp("", "terraform-test")
 	if err != nil {
 		fmt.Printf("Could not create temp directory: %v\n", err)
 		os.Exit(1)

--- a/internal/cloud/e2e/migrate_state_multi_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_multi_to_tfc_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -236,7 +235,7 @@ func Test_migrate_multi_to_tfc_cloud_name_strategy(t *testing.T) {
 			}
 			defer exp.Close()
 
-			tmpDir, err := ioutil.TempDir("", "terraform-test")
+			tmpDir, err := os.MkdirTemp("", "terraform-test")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -524,7 +523,7 @@ func Test_migrate_multi_to_tfc_cloud_tags_strategy(t *testing.T) {
 			}
 			defer exp.Close()
 
-			tmpDir, err := ioutil.TempDir("", "terraform-test")
+			tmpDir, err := os.MkdirTemp("", "terraform-test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/cloud/e2e/migrate_state_remote_backend_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_remote_backend_to_tfc_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -73,7 +72,7 @@ func Test_migrate_remote_backend_name_to_tfc_name(t *testing.T) {
 	}
 	defer exp.Close()
 
-	tmpDir, err := ioutil.TempDir("", "terraform-test")
+	tmpDir, err := os.MkdirTemp("", "terraform-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +195,7 @@ func Test_migrate_remote_backend_name_to_tfc_same_name(t *testing.T) {
 	}
 	defer exp.Close()
 
-	tmpDir, err := ioutil.TempDir("", "terraform-test")
+	tmpDir, err := os.MkdirTemp("", "terraform-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +319,7 @@ func Test_migrate_remote_backend_name_to_tfc_name_different_org(t *testing.T) {
 	}
 	defer exp.Close()
 
-	tmpDir, err := ioutil.TempDir("", "terraform-test")
+	tmpDir, err := os.MkdirTemp("", "terraform-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -459,7 +458,7 @@ func Test_migrate_remote_backend_name_to_tfc_tags(t *testing.T) {
 	}
 	defer exp.Close()
 
-	tmpDir, err := ioutil.TempDir("", "terraform-test")
+	tmpDir, err := os.MkdirTemp("", "terraform-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -584,7 +583,7 @@ func Test_migrate_remote_backend_prefix_to_tfc_name_strategy_single_workspace(t 
 	}
 	defer exp.Close()
 
-	tmpDir, err := ioutil.TempDir("", "terraform-test")
+	tmpDir, err := os.MkdirTemp("", "terraform-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -738,7 +737,7 @@ func Test_migrate_remote_backend_prefix_to_tfc_name_strategy_multi_workspace(t *
 	}
 	defer exp.Close()
 
-	tmpDir, err := ioutil.TempDir("", "terraform-test")
+	tmpDir, err := os.MkdirTemp("", "terraform-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -864,7 +863,7 @@ func Test_migrate_remote_backend_prefix_to_tfc_tags_strategy_single_workspace(t 
 	}
 	defer exp.Close()
 
-	tmpDir, err := ioutil.TempDir("", "terraform-test")
+	tmpDir, err := os.MkdirTemp("", "terraform-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1020,7 +1019,7 @@ func Test_migrate_remote_backend_prefix_to_tfc_tags_strategy_multi_workspace(t *
 	}
 	defer exp.Close()
 
-	tmpDir, err := ioutil.TempDir("", "terraform-test")
+	tmpDir, err := os.MkdirTemp("", "terraform-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cloud/e2e/migrate_state_single_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_single_to_tfc_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -140,7 +139,7 @@ func Test_migrate_single_to_tfc(t *testing.T) {
 			}
 			defer exp.Close()
 
-			tmpDir, err := ioutil.TempDir("", "terraform-test")
+			tmpDir, err := os.MkdirTemp("", "terraform-test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/cloud/e2e/migrate_state_tfc_to_other_test.go
+++ b/internal/cloud/e2e/migrate_state_tfc_to_other_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -58,7 +57,7 @@ func Test_migrate_tfc_to_other(t *testing.T) {
 			}
 			defer exp.Close()
 
-			tmpDir, err := ioutil.TempDir("", "terraform-test")
+			tmpDir, err := os.MkdirTemp("", "terraform-test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/cloud/e2e/migrate_state_tfc_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_tfc_to_tfc_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -226,7 +225,7 @@ func Test_migrate_tfc_to_tfc_single_workspace(t *testing.T) {
 			}
 			defer exp.Close()
 
-			tmpDir, err := ioutil.TempDir("", "terraform-test")
+			tmpDir, err := os.MkdirTemp("", "terraform-test")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -471,7 +470,7 @@ func Test_migrate_tfc_to_tfc_multiple_workspace(t *testing.T) {
 			}
 			defer exp.Close()
 
-			tmpDir, err := ioutil.TempDir("", "terraform-test")
+			tmpDir, err := os.MkdirTemp("", "terraform-test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/cloud/e2e/run_variables_test.go
+++ b/internal/cloud/e2e/run_variables_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -90,7 +89,7 @@ func Test_cloud_run_variables(t *testing.T) {
 			}
 			defer exp.Close()
 
-			tmpDir, err := ioutil.TempDir("", "terraform-test")
+			tmpDir, err := os.MkdirTemp("", "terraform-test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/cloud/tfe_client_mock.go
+++ b/internal/cloud/tfe_client_mock.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -129,7 +128,7 @@ func (m *MockApplies) Logs(ctx context.Context, applyID string) (io.Reader, erro
 		return bytes.NewBufferString("logfile does not exist"), nil
 	}
 
-	logs, err := ioutil.ReadFile(logfile)
+	logs, err := os.ReadFile(logfile)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +297,7 @@ func (m *MockCostEstimates) Logs(ctx context.Context, costEstimateID string) (io
 		return bytes.NewBufferString("logfile does not exist"), nil
 	}
 
-	logs, err := ioutil.ReadFile(logfile)
+	logs, err := os.ReadFile(logfile)
 	if err != nil {
 		return nil, err
 	}
@@ -503,7 +502,7 @@ func (m *MockPlans) Logs(ctx context.Context, planID string) (io.Reader, error) 
 		return bytes.NewBufferString("logfile does not exist"), nil
 	}
 
-	logs, err := ioutil.ReadFile(logfile)
+	logs, err := os.ReadFile(logfile)
 	if err != nil {
 		return nil, err
 	}
@@ -619,7 +618,7 @@ func (m *MockPolicyChecks) Read(ctx context.Context, policyCheckID string) (*tfe
 		return nil, fmt.Errorf("logfile does not exist")
 	}
 
-	logs, err := ioutil.ReadFile(logfile)
+	logs, err := os.ReadFile(logfile)
 	if err != nil {
 		return nil, err
 	}
@@ -668,7 +667,7 @@ func (m *MockPolicyChecks) Logs(ctx context.Context, policyCheckID string) (io.R
 		return bytes.NewBufferString("logfile does not exist"), nil
 	}
 
-	logs, err := ioutil.ReadFile(logfile)
+	logs, err := os.ReadFile(logfile)
 	if err != nil {
 		return nil, err
 	}
@@ -847,7 +846,7 @@ func (m *MockRuns) ReadWithOptions(ctx context.Context, runID string, _ *tfe.Run
 		r.Plan.Status = tfe.PlanRunning
 	}
 
-	logs, _ := ioutil.ReadFile(m.client.Plans.logs[r.Plan.LogReadURL])
+	logs, _ := os.ReadFile(m.client.Plans.logs[r.Plan.LogReadURL])
 	if r.Status == tfe.RunPlanning && r.Plan.Status == tfe.PlanFinished {
 		if r.IsDestroy || bytes.Contains(logs, []byte("1 to add, 0 to change, 0 to destroy")) {
 			r.Actions.IsCancelable = false

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -853,12 +853,12 @@ func TestApply_plan_remoteState(t *testing.T) {
 
 	// State file should be not be installed
 	if _, err := os.Stat(filepath.Join(tmp, DefaultStateFilename)); err == nil {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 		t.Fatalf("State path should not exist: %s", string(data))
 	}
 
 	// Check that there is no remote state config
-	if src, err := ioutil.ReadFile(remoteStatePath); err == nil {
+	if src, err := os.ReadFile(remoteStatePath); err == nil {
 		t.Fatalf("has %s file; should not\n%s", remoteStatePath, src)
 	}
 }
@@ -866,7 +866,7 @@ func TestApply_plan_remoteState(t *testing.T) {
 func TestApply_planWithVarFile(t *testing.T) {
 	varFileDir := testTempDir(t)
 	varFilePath := filepath.Join(varFileDir, "terraform.tfvars")
-	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1393,7 +1393,7 @@ func TestApply_varFile(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := testTempFile(t)
-	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1456,7 +1456,7 @@ func TestApply_varFileDefault(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := filepath.Join(td, "terraform.tfvars")
-	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1518,7 +1518,7 @@ func TestApply_varFileDefaultJSON(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := filepath.Join(td, "terraform.tfvars.json")
-	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFileJSON), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(applyVarFileJSON), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -2093,7 +2093,7 @@ func TestApply_jsonGoldenReference(t *testing.T) {
 		t.Fatalf("failed to open output file: %s", err)
 	}
 	defer wantFile.Close()
-	wantBytes, err := ioutil.ReadAll(wantFile)
+	wantBytes, err := io.ReadAll(wantFile)
 	if err != nil {
 		t.Fatalf("failed to read output file: %s", err)
 	}

--- a/internal/command/arguments/default.go
+++ b/internal/command/arguments/default.go
@@ -2,14 +2,14 @@ package arguments
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 )
 
 // defaultFlagSet creates a FlagSet with the common settings to override
 // the flag package's noisy defaults.
 func defaultFlagSet(name string) *flag.FlagSet {
 	f := flag.NewFlagSet(name, flag.ContinueOnError)
-	f.SetOutput(ioutil.Discard)
+	f.SetOutput(io.Discard)
 	f.Usage = func() {}
 
 	return f

--- a/internal/command/arguments/test.go
+++ b/internal/command/arguments/test.go
@@ -2,7 +2,7 @@ package arguments
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -36,7 +36,7 @@ func ParseTest(args []string) (Test, tfdiags.Diagnostics) {
 	// command to report error diagnostics in a suitable way.
 
 	f := flag.NewFlagSet("test", flag.ContinueOnError)
-	f.SetOutput(ioutil.Discard)
+	f.SetOutput(io.Discard)
 	f.Usage = func() {}
 	f.StringVar(&ret.Output.JUnitXMLFile, "junit-xml", "", "Write a JUnit XML file describing the results")
 

--- a/internal/command/autocomplete_test.go
+++ b/internal/command/autocomplete_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -18,7 +17,7 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 	defer testChdir(t, td)()
 
 	// make sure a vars file doesn't interfere
-	err := ioutil.WriteFile(DefaultVarsFilename, nil, 0644)
+	err := os.WriteFile(DefaultVarsFilename, nil, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/cliconfig/cliconfig.go
+++ b/internal/command/cliconfig/cliconfig.go
@@ -10,7 +10,6 @@ package cliconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -134,7 +133,7 @@ func loadConfigFile(path string) (*Config, tfdiags.Diagnostics) {
 	log.Printf("Loading CLI configuration from %s", path)
 
 	// Read the HCL file and prepare for parsing
-	d, err := ioutil.ReadFile(path)
+	d, err := os.ReadFile(path)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Error reading %s: %s", path, err))
 		return result, diags
@@ -179,7 +178,7 @@ func loadConfigDir(path string) (*Config, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	result := &Config{}
 
-	entries, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Error reading %s: %s", path, err))
 		return result, diags

--- a/internal/command/cliconfig/credentials.go
+++ b/internal/command/cliconfig/credentials.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -244,7 +243,7 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 		return fmt.Errorf("unable to determine credentials file path: %s", err)
 	}
 
-	oldSrc, err := ioutil.ReadFile(filename)
+	oldSrc, err := os.ReadFile(filename)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("cannot read %s: %s", filename, err)
 	}
@@ -311,7 +310,7 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 	// the underlying OS/filesystem will allow.
 	{
 		dir, file := filepath.Split(filename)
-		f, err := ioutil.TempFile(dir, file)
+		f, err := os.CreateTemp(dir, file)
 		if err != nil {
 			return fmt.Errorf("cannot create temporary file to update credentials: %s", err)
 		}
@@ -369,7 +368,7 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 // this returns an empty set, reflecting that effectively no credentials are
 // stored there.
 func readHostsInCredentialsFile(filename string) map[svchost.Hostname]struct{} {
-	src, err := ioutil.ReadFile(filename)
+	src, err := os.ReadFile(filename)
 	if err != nil {
 		return nil
 	}

--- a/internal/command/cliconfig/credentials_test.go
+++ b/internal/command/cliconfig/credentials_test.go
@@ -1,7 +1,6 @@
 package cliconfig
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -88,7 +87,7 @@ func TestCredentialsForHost(t *testing.T) {
 }
 
 func TestCredentialsStoreForget(t *testing.T) {
-	d, err := ioutil.TempDir("", "terraform-cliconfig-test")
+	d, err := os.MkdirTemp("", "terraform-cliconfig-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/clistate/local_state.go
+++ b/internal/command/clistate/local_state.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -287,7 +286,7 @@ func (s *LocalState) lockInfoPath() string {
 // lockInfo returns the data in a lock info file
 func (s *LocalState) lockInfo() (*statemgr.LockInfo, error) {
 	path := s.lockInfoPath()
-	infoData, err := ioutil.ReadFile(path)
+	infoData, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +305,7 @@ func (s *LocalState) writeLockInfo(info *statemgr.LockInfo) error {
 	info.Path = s.Path
 	info.Created = time.Now().UTC()
 
-	err := ioutil.WriteFile(path, info.Marshal(), 0600)
+	err := os.WriteFile(path, info.Marshal(), 0600)
 	if err != nil {
 		return fmt.Errorf("could not write lock info for %q: %s", s.Path, err)
 	}

--- a/internal/command/console_test.go
+++ b/internal/command/console_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,7 +60,7 @@ func TestConsole_tfvars(t *testing.T) {
 
 	// Write a terraform.tvars
 	varFilePath := filepath.Join(td, "terraform.tfvars")
-	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/command/e2etest/provider_dev_test.go
+++ b/internal/command/e2etest/provider_dev_test.go
@@ -2,7 +2,6 @@ package e2etest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +35,7 @@ func TestProviderDevOverrides(t *testing.T) {
 	providerExe := e2e.GoBuild("github.com/hashicorp/terraform/internal/provider-simple/main", providerExePrefix)
 	t.Logf("temporary provider executable is %s", providerExe)
 
-	err := ioutil.WriteFile(filepath.Join(tf.WorkDir(), "dev.tfrc"), []byte(fmt.Sprintf(`
+	err := os.WriteFile(filepath.Join(tf.WorkDir(), "dev.tfrc"), []byte(fmt.Sprintf(`
 		provider_installation {
 			dev_overrides {
 				"example.com/test/test" = %q

--- a/internal/command/e2etest/providers_mirror_test.go
+++ b/internal/command/e2etest/providers_mirror_test.go
@@ -1,7 +1,6 @@
 package e2etest
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -23,7 +22,7 @@ func TestTerraformProvidersMirror(t *testing.T) {
 	// allowed.
 	skipIfCannotAccessNetwork(t)
 
-	outputDir, err := ioutil.TempDir("", "terraform-e2etest-providers-mirror")
+	outputDir, err := os.MkdirTemp("", "terraform-e2etest-providers-mirror")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/e2etest/providers_tamper_test.go
+++ b/internal/command/e2etest/providers_tamper_test.go
@@ -1,7 +1,6 @@
 package e2etest
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,7 +82,7 @@ func TestProviderTampering(t *testing.T) {
 		defer tf.Close()
 		workDir := tf.WorkDir()
 
-		err := ioutil.WriteFile(filepath.Join(workDir, "backend.tf"), []byte(localBackendConfig), 0600)
+		err := os.WriteFile(filepath.Join(workDir, "backend.tf"), []byte(localBackendConfig), 0600)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -119,7 +118,7 @@ func TestProviderTampering(t *testing.T) {
 		defer tf.Close()
 		workDir := tf.WorkDir()
 
-		err := ioutil.WriteFile(filepath.Join(workDir, pluginExe), []byte("tamper"), 0600)
+		err := os.WriteFile(filepath.Join(workDir, pluginExe), []byte("tamper"), 0600)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -140,7 +139,7 @@ func TestProviderTampering(t *testing.T) {
 		defer tf.Close()
 		workDir := tf.WorkDir()
 
-		err := ioutil.WriteFile(filepath.Join(workDir, "provider-tampering-base.tf"), []byte(`
+		err := os.WriteFile(filepath.Join(workDir, "provider-tampering-base.tf"), []byte(`
 			terraform {
 				required_providers {
 					null = {
@@ -176,7 +175,7 @@ func TestProviderTampering(t *testing.T) {
 		// of this error message for otehr sorts of inconsistency, but those
 		// are tested more thoroughly over in the "configs" package, which is
 		// ultimately responsible for that logic.
-		err := ioutil.WriteFile(filepath.Join(workDir, ".terraform.lock.hcl"), []byte(``), 0600)
+		err := os.WriteFile(filepath.Join(workDir, ".terraform.lock.hcl"), []byte(``), 0600)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -251,7 +250,7 @@ func TestProviderTampering(t *testing.T) {
 			t.Fatalf("unexpected plan failure\nstderr:\n%s", stderr)
 		}
 
-		err = ioutil.WriteFile(filepath.Join(workDir, pluginExe), []byte("tamper"), 0600)
+		err = os.WriteFile(filepath.Join(workDir, pluginExe), []byte("tamper"), 0600)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/command/e2etest/unmanaged_test.go
+++ b/internal/command/e2etest/unmanaged_test.go
@@ -3,7 +3,7 @@ package e2etest
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -160,7 +160,7 @@ func TestUnmanagedSeparatePlan(t *testing.T) {
 		Logger: hclog.New(&hclog.LoggerOptions{
 			Name:   "plugintest",
 			Level:  hclog.Trace,
-			Output: ioutil.Discard,
+			Output: io.Discard,
 		}),
 		Test: &plugin.ServeTestConfig{
 			Context:          ctx,
@@ -266,7 +266,7 @@ func TestUnmanagedSeparatePlan_proto5(t *testing.T) {
 		Logger: hclog.New(&hclog.LoggerOptions{
 			Name:   "plugintest",
 			Level:  hclog.Trace,
-			Output: ioutil.Discard,
+			Output: io.Discard,
 		}),
 		Test: &plugin.ServeTestConfig{
 			Context:          ctx,

--- a/internal/command/fmt.go
+++ b/internal/command/fmt.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -157,7 +156,7 @@ func (c *FmtCommand) processFile(path string, r io.Reader, w io.Writer, isStdout
 
 	log.Printf("[TRACE] terraform fmt: Formatting %s", path)
 
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to read %s", path))
 		return diags
@@ -184,7 +183,7 @@ func (c *FmtCommand) processFile(path string, r io.Reader, w io.Writer, isStdout
 			fmt.Fprintln(w, path)
 		}
 		if c.write {
-			err := ioutil.WriteFile(path, result, 0644)
+			err := os.WriteFile(path, result, 0644)
 			if err != nil {
 				diags = diags.Append(fmt.Errorf("Failed to write %s", path))
 				return diags
@@ -215,7 +214,7 @@ func (c *FmtCommand) processDir(path string, stdout io.Writer) tfdiags.Diagnosti
 
 	log.Printf("[TRACE] terraform fmt: looking for files in %s", path)
 
-	entries, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		switch {
 		case os.IsNotExist(err):
@@ -564,14 +563,14 @@ func (c *FmtCommand) Synopsis() string {
 }
 
 func bytesDiff(b1, b2 []byte, path string) (data []byte, err error) {
-	f1, err := ioutil.TempFile("", "")
+	f1, err := os.CreateTemp("", "")
 	if err != nil {
 		return
 	}
 	defer os.Remove(f1.Name())
 	defer f1.Close()
 
-	f2, err := ioutil.TempFile("", "")
+	f2, err := os.CreateTemp("", "")
 	if err != nil {
 		return
 	}

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,12 +16,12 @@ func TestFmt(t *testing.T) {
 	const inSuffix = "_in.tf"
 	const outSuffix = "_out.tf"
 	const gotSuffix = "_got.tf"
-	entries, err := ioutil.ReadDir("testdata/fmt")
+	entries, err := os.ReadDir("testdata/fmt")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	td, err := ioutil.TempDir("", "terraform-fmt-test")
+	td, err := os.MkdirTemp("", "terraform-fmt-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,15 +44,15 @@ func TestFmt(t *testing.T) {
 			inFile := filepath.Join("testdata", "fmt", testName+inSuffix)
 			wantFile := filepath.Join("testdata", "fmt", testName+outSuffix)
 			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
-			input, err := ioutil.ReadFile(inFile)
+			input, err := os.ReadFile(inFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want, err := ioutil.ReadFile(wantFile)
+			want, err := os.ReadFile(wantFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ioutil.WriteFile(gotFile, input, 0700)
+			err = os.WriteFile(gotFile, input, 0700)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -70,7 +69,7 @@ func TestFmt(t *testing.T) {
 				t.Fatalf("fmt command was unsuccessful:\n%s", ui.ErrorWriter.String())
 			}
 
-			got, err := ioutil.ReadFile(gotFile)
+			got, err := os.ReadFile(gotFile)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -112,7 +111,7 @@ func TestFmt_syntaxError(t *testing.T) {
 a = 1 +
 `
 
-	err := ioutil.WriteFile(filepath.Join(tempDir, "invalid.tf"), []byte(invalidSrc), 0644)
+	err := os.WriteFile(filepath.Join(tempDir, "invalid.tf"), []byte(invalidSrc), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +140,7 @@ func TestFmt_snippetInError(t *testing.T) {
 
 	backendSrc := `terraform {backend "s3" {}}`
 
-	err := ioutil.WriteFile(filepath.Join(tempDir, "backend.tf"), []byte(backendSrc), 0644)
+	err := os.WriteFile(filepath.Join(tempDir, "backend.tf"), []byte(backendSrc), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,7 +398,7 @@ var fmtFixture = struct {
 func fmtFixtureWriteDir(t *testing.T) string {
 	dir := testTempDir(t)
 
-	err := ioutil.WriteFile(filepath.Join(dir, fmtFixture.filename), fmtFixture.input, 0644)
+	err := os.WriteFile(filepath.Join(dir, fmtFixture.filename), fmtFixture.input, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -285,7 +284,7 @@ func TestInit_backendUnset(t *testing.T) {
 		log.Printf("[TRACE] TestInit_backendUnset: beginning second init")
 
 		// Unset
-		if err := ioutil.WriteFile("main.tf", []byte(""), 0644); err != nil {
+		if err := os.WriteFile("main.tf", []byte(""), 0644); err != nil {
 			t.Fatalf("err: %s", err)
 		}
 
@@ -911,7 +910,7 @@ func TestInit_backendReinitConfigToExtra(t *testing.T) {
 
 	// init again but remove the path option from the config
 	cfg := "terraform {\n  backend \"local\" {}\n}\n"
-	if err := ioutil.WriteFile("main.tf", []byte(cfg), 0644); err != nil {
+	if err := os.WriteFile("main.tf", []byte(cfg), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2131,7 +2130,7 @@ func TestInit_providerLockFile(t *testing.T) {
 	}
 
 	lockFile := ".terraform.lock.hcl"
-	buf, err := ioutil.ReadFile(lockFile)
+	buf, err := os.ReadFile(lockFile)
 	if err != nil {
 		t.Fatalf("failed to read dependency lock file %s: %s", lockFile, err)
 	}
@@ -2311,7 +2310,7 @@ provider "registry.terraform.io/hashicorp/test" {
 
 			// write input lockfile
 			lockFile := ".terraform.lock.hcl"
-			if err := ioutil.WriteFile(lockFile, []byte(tc.input), 0644); err != nil {
+			if err := os.WriteFile(lockFile, []byte(tc.input), 0644); err != nil {
 				t.Fatalf("failed to write input lockfile: %s", err)
 			}
 
@@ -2323,7 +2322,7 @@ provider "registry.terraform.io/hashicorp/test" {
 				t.Fatalf("expected error, got output: \n%s", ui.OutputWriter.String())
 			}
 
-			buf, err := ioutil.ReadFile(lockFile)
+			buf, err := os.ReadFile(lockFile)
 			if err != nil {
 				t.Fatalf("failed to read dependency lock file %s: %s", lockFile, err)
 			}

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net"
@@ -259,7 +259,7 @@ func (c *LoginCommand) Run(args []string) int {
 			return 0
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			c.logMOTDError(err)
 			c.outputDefaultTFCLoginSuccess()

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -36,7 +35,7 @@ func TestLogin(t *testing.T) {
 	loginTestCase := func(test func(t *testing.T, c *LoginCommand, ui *cli.MockUi)) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
-			workDir, err := ioutil.TempDir("", "terraform-test-command-login")
+			workDir, err := os.MkdirTemp("", "terraform-test-command-login")
 			if err != nil {
 				t.Fatalf("cannot create temporary directory: %s", err)
 			}

--- a/internal/command/logout_test.go
+++ b/internal/command/logout_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestLogout(t *testing.T) {
-	workDir, err := ioutil.TempDir("", "terraform-test-command-logout")
+	workDir, err := os.MkdirTemp("", "terraform-test-command-logout")
 	if err != nil {
 		t.Fatalf("cannot create temporary directory: %s", err)
 	}

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -477,7 +477,7 @@ func (m *Meta) contextOpts() (*terraform.ContextOpts, error) {
 // See also command/arguments/default.go
 func (m *Meta) defaultFlagSet(n string) *flag.FlagSet {
 	f := flag.NewFlagSet(n, flag.ContinueOnError)
-	f.SetOutput(ioutil.Discard)
+	f.SetOutput(io.Discard)
 
 	// Set the default Usage to empty
 	f.Usage = func() {}
@@ -687,7 +687,7 @@ func (m *Meta) WorkspaceOverridden() (string, bool) {
 		return envVar, true
 	}
 
-	envData, err := ioutil.ReadFile(filepath.Join(m.DataDir(), local.DefaultWorkspaceFile))
+	envData, err := os.ReadFile(filepath.Join(m.DataDir(), local.DefaultWorkspaceFile))
 	current := string(bytes.TrimSpace(envData))
 	if current == "" {
 		current = backend.DefaultStateName
@@ -709,7 +709,7 @@ func (m *Meta) SetWorkspace(name string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(m.DataDir(), local.DefaultWorkspaceFile), []byte(name), 0644)
+	err = os.WriteFile(filepath.Join(m.DataDir(), local.DefaultWorkspaceFile), []byte(name), 0644)
 	if err != nil {
 		return err
 	}

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -475,7 +474,7 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 	destination := destinationState.State()
 
 	// Save both to a temporary
-	td, err := ioutil.TempDir("", "terraform")
+	td, err := os.MkdirTemp("", "terraform")
 	if err != nil {
 		return false, fmt.Errorf("Error creating temporary directory: %s", err)
 	}

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -367,7 +366,7 @@ func TestMetaBackend_configureNewWithState(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
@@ -418,7 +417,7 @@ func TestMetaBackend_configureNewWithoutCopy(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
@@ -464,7 +463,7 @@ func TestMetaBackend_configureNewWithStateNoMigrate(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
@@ -536,7 +535,7 @@ func TestMetaBackend_configureNewWithStateExisting(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
@@ -608,7 +607,7 @@ func TestMetaBackend_configureNewWithStateExistingNoMigrate(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
@@ -1461,13 +1460,13 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
 
 	// Verify a backup doesn't exist
 	if !isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename + DefaultBackupExtension)
+		data, _ := os.ReadFile(DefaultStateFilename + DefaultBackupExtension)
 		t.Fatal("backup should not exist, but contains:\n", string(data))
 	}
 
@@ -1484,7 +1483,7 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 
 	// Verify no backup since it was empty to start
 	if !isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename + DefaultBackupExtension)
+		data, _ := os.ReadFile(DefaultStateFilename + DefaultBackupExtension)
 		t.Fatal("backup state should be empty, but contains:\n", string(data))
 	}
 }
@@ -1930,7 +1929,7 @@ func TestMetaBackend_configToExtra(t *testing.T) {
 
 	// init again but remove the path option from the config
 	cfg := "terraform {\n  backend \"local\" {}\n}\n"
-	if err := ioutil.WriteFile("main.tf", []byte(cfg), 0644); err != nil {
+	if err := os.WriteFile("main.tf", []byte(cfg), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -272,7 +271,7 @@ func TestMeta_Workspace_invalidSelected(t *testing.T) {
 	if err := os.MkdirAll(DefaultDataDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(DefaultDataDir, local.DefaultWorkspaceFile), []byte(workspace), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(DefaultDataDir, local.DefaultWorkspaceFile), []byte(workspace), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -305,7 +304,7 @@ func TestMeta_process(t *testing.T) {
 	// they _aren't_ being interpreted by process, since that could otherwise
 	// cause them to be added more than once and mess up the precedence order.
 	defaultVarsfile := "terraform.tfvars"
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		filepath.Join(d, defaultVarsfile),
 		[]byte(""),
 		0644)
@@ -313,7 +312,7 @@ func TestMeta_process(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	fileFirstAlphabetical := "a-file.auto.tfvars"
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, fileFirstAlphabetical),
 		[]byte(""),
 		0644)
@@ -321,7 +320,7 @@ func TestMeta_process(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	fileLastAlphabetical := "z-file.auto.tfvars"
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, fileLastAlphabetical),
 		[]byte(""),
 		0644)
@@ -330,7 +329,7 @@ func TestMeta_process(t *testing.T) {
 	}
 	// Regular tfvars files will not be autoloaded
 	fileIgnored := "ignored.tfvars"
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, fileIgnored),
 		[]byte(""),
 		0644)

--- a/internal/command/meta_vars.go
+++ b/internal/command/meta_vars.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -70,7 +69,7 @@ func (m *Meta) collectVariableValues() (map[string]backend.UnparsedVariableValue
 		moreDiags := m.addVarsFromFile(defaultVarsFilenameJSON, terraform.ValueFromAutoFile, ret)
 		diags = diags.Append(moreDiags)
 	}
-	if infos, err := ioutil.ReadDir("."); err == nil {
+	if infos, err := os.ReadDir("."); err == nil {
 		// "infos" is already sorted by name, so we just need to filter it here.
 		for _, info := range infos {
 			name := info.Name()
@@ -125,7 +124,7 @@ func (m *Meta) collectVariableValues() (map[string]backend.UnparsedVariableValue
 func (m *Meta) addVarsFromFile(filename string, sourceType terraform.ValueSourceType, to map[string]backend.UnparsedVariableValue) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	src, err := ioutil.ReadFile(filename)
+	src, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			diags = diags.Append(tfdiags.Sourceless(

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -787,7 +786,7 @@ func TestPlan_varFile(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := testTempFile(t)
-	if err := ioutil.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -829,7 +828,7 @@ func TestPlan_varFileDefault(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := filepath.Join(td, "terraform.tfvars")
-	if err := ioutil.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -869,7 +868,7 @@ func TestPlan_varFileWithDecls(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := testTempFile(t)
-	if err := ioutil.WriteFile(varFilePath, []byte(planVarFileWithDecl), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(planVarFileWithDecl), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/command/plugins_lock.go
+++ b/internal/command/plugins_lock.go
@@ -3,8 +3,8 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 )
 
 type pluginSHA256LockFile struct {
@@ -25,7 +25,7 @@ func (pf *pluginSHA256LockFile) Read() map[string][]byte {
 	// constraint verification fails during context creation.
 	digests := make(map[string][]byte)
 
-	buf, err := ioutil.ReadFile(pf.Filename)
+	buf, err := os.ReadFile(pf.Filename)
 	if err != nil {
 		// This is expected if the user runs any context-using command before
 		// running "terraform init".

--- a/internal/command/plugins_lock_test.go
+++ b/internal/command/plugins_lock_test.go
@@ -1,14 +1,13 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 )
 
 func TestPluginSHA256LockFile_Read(t *testing.T) {
-	f, err := ioutil.TempFile(testingDir, "tf-pluginsha1lockfile-test-")
+	f, err := os.CreateTemp(testingDir, "tf-pluginsha1lockfile-test-")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 
@@ -177,7 +176,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 	ctx, cancel := c.InterruptibleContext()
 	defer cancel()
 	for _, platform := range platforms {
-		tempDir, err := ioutil.TempDir("", "terraform-providers-lock")
+		tempDir, err := os.MkdirTemp("", "terraform-providers-lock")
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -3,7 +3,6 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -291,7 +290,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 		// when running on Windows as of Go 1.13. We should revisit this once
 		// we're supporting network mirrors, to avoid having them briefly
 		// become corrupted during updates.
-		err = ioutil.WriteFile(filepath.Join(indexDir, "index.json"), mainIndexJSON, 0644)
+		err = os.WriteFile(filepath.Join(indexDir, "index.json"), mainIndexJSON, 0644)
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
@@ -309,7 +308,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 				// our control.
 				panic(fmt.Sprintf("failed to encode version index: %s", err))
 			}
-			err = ioutil.WriteFile(filepath.Join(indexDir, version.String()+".json"), versionIndexJSON, 0644)
+			err = os.WriteFile(filepath.Join(indexDir, version.String()+".json"), versionIndexJSON, 0644)
 			if err != nil {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,

--- a/internal/command/providers_schema_test.go
+++ b/internal/command/providers_schema_test.go
@@ -3,7 +3,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +33,7 @@ func TestProvidersSchema_error(t *testing.T) {
 
 func TestProvidersSchema_output(t *testing.T) {
 	fixtureDir := "testdata/providers-schema"
-	testDirs, err := ioutil.ReadDir(fixtureDir)
+	testDirs, err := os.ReadDir(fixtureDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestProvidersSchema_output(t *testing.T) {
 				t.Fatalf("err: %s", err)
 			}
 			defer wantFile.Close()
-			byteValue, err := ioutil.ReadAll(wantFile)
+			byteValue, err := io.ReadAll(wantFile)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}

--- a/internal/command/refresh_test.go
+++ b/internal/command/refresh_test.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -324,7 +323,7 @@ func TestRefresh_outPath(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	// Output path
-	outf, err := ioutil.TempFile(testingDir, "tf")
+	outf, err := os.CreateTemp(testingDir, "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -442,7 +441,7 @@ func TestRefresh_varFile(t *testing.T) {
 	p.GetProviderSchemaResponse = refreshVarFixtureSchema()
 
 	varFilePath := testTempFile(t)
-	if err := ioutil.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -485,7 +484,7 @@ func TestRefresh_varFileDefault(t *testing.T) {
 	p.GetProviderSchemaResponse = refreshVarFixtureSchema()
 
 	varFilePath := filepath.Join(td, "terraform.tfvars")
-	if err := ioutil.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -566,7 +565,7 @@ func TestRefresh_backup(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	// Output path
-	outf, err := ioutil.TempFile(testingDir, "tf")
+	outf, err := os.CreateTemp(testingDir, "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -581,7 +580,7 @@ func TestRefresh_backup(t *testing.T) {
 	}
 
 	// Backup path
-	backupf, err := ioutil.TempFile(testingDir, "tf")
+	backupf, err := os.CreateTemp(testingDir, "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -652,7 +651,7 @@ func TestRefresh_disableBackup(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	// Output path
-	outf, err := ioutil.TempFile(testingDir, "tf")
+	outf, err := os.CreateTemp(testingDir, "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -3,7 +3,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -312,7 +312,7 @@ func TestShow_state(t *testing.T) {
 
 func TestShow_json_output(t *testing.T) {
 	fixtureDir := "testdata/show-json"
-	testDirs, err := ioutil.ReadDir(fixtureDir)
+	testDirs, err := os.ReadDir(fixtureDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -397,7 +397,7 @@ func TestShow_json_output(t *testing.T) {
 				t.Fatalf("err: %s", err)
 			}
 			defer wantFile.Close()
-			byteValue, err := ioutil.ReadAll(wantFile)
+			byteValue, err := io.ReadAll(wantFile)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}
@@ -481,7 +481,7 @@ func TestShow_json_output_sensitive(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	defer wantFile.Close()
-	byteValue, err := ioutil.ReadAll(wantFile)
+	byteValue, err := io.ReadAll(wantFile)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -495,7 +495,7 @@ func TestShow_json_output_sensitive(t *testing.T) {
 // similar test as above, without the plan
 func TestShow_json_output_state(t *testing.T) {
 	fixtureDir := "testdata/show-json-state"
-	testDirs, err := ioutil.ReadDir(fixtureDir)
+	testDirs, err := os.ReadDir(fixtureDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -562,7 +562,7 @@ func TestShow_json_output_state(t *testing.T) {
 				t.Fatalf("err: %s", err)
 			}
 			defer wantFile.Close()
-			byteValue, err := ioutil.ReadAll(wantFile)
+			byteValue, err := io.ReadAll(wantFile)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}

--- a/internal/command/state_pull_test.go
+++ b/internal/command/state_pull_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ func TestStatePull(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
-	expected, err := ioutil.ReadFile("local-state.tfstate")
+	expected, err := os.ReadFile("local-state.tfstate")
 	if err != nil {
 		t.Fatalf("error reading state: %v", err)
 	}

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -609,7 +608,7 @@ func (c *TestCommand) testSuiteDestroy(ctx context.Context, state *states.State,
 }
 
 func (c *TestCommand) collectSuiteNames() ([]string, error) {
-	items, err := ioutil.ReadDir("tests")
+	items, err := os.ReadDir("tests")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -57,7 +56,7 @@ Success! All of the test assertions passed.
 			t.Errorf("wrong stderr\n%s", diff)
 		}
 
-		gotXMLSrc, err := ioutil.ReadFile("junit.xml")
+		gotXMLSrc, err := os.ReadFile("junit.xml")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -132,7 +131,7 @@ wrong value
 			t.Errorf("wrong stderr\n%s", diff)
 		}
 
-		gotXMLSrc, err := ioutil.ReadFile("junit.xml")
+		gotXMLSrc, err := os.ReadFile("junit.xml")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -231,7 +231,7 @@ func TestValidate_json(t *testing.T) {
 				t.Fatalf("failed to open output file: %s", err)
 			}
 			defer wantFile.Close()
-			wantBytes, err := ioutil.ReadAll(wantFile)
+			wantBytes, err := io.ReadAll(wantFile)
 			if err != nil {
 				t.Fatalf("failed to read output file: %s", err)
 			}

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -18,7 +17,7 @@ func TestVersionCommand_implements(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	td, err := ioutil.TempDir("", "terraform-test-version")
+	td, err := os.MkdirTemp("", "terraform-test-version")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +115,7 @@ func TestVersion_outdated(t *testing.T) {
 }
 
 func TestVersion_json(t *testing.T) {
-	td, err := ioutil.TempDir("", "terraform-test-version")
+	td, err := os.MkdirTemp("", "terraform-test-version")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/views/json/diagnostic_test.go
+++ b/internal/command/views/json/diagnostic_test.go
@@ -3,7 +3,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -793,7 +793,7 @@ func TestNewDiagnostic(t *testing.T) {
 				t.Fatalf("failed to open golden file: %s", err)
 			}
 			defer wantFile.Close()
-			wantBytes, err := ioutil.ReadAll(wantFile)
+			wantBytes, err := io.ReadAll(wantFile)
 			if err != nil {
 				t.Fatalf("failed to read output file: %s", err)
 			}

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -3,7 +3,7 @@ package views
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -324,7 +324,7 @@ func (v *testHuman) junitXMLResults(results map[string]*moduletest.Suite, filena
 		panic(fmt.Sprintf("invalid values to marshal as JUnit XML: %s", err))
 	}
 
-	err = ioutil.WriteFile(filename, xmlOut, 0644)
+	err = os.WriteFile(filename, xmlOut, 0644)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/workdir/plugin_dirs.go
+++ b/internal/command/workdir/plugin_dirs.go
@@ -2,7 +2,6 @@ package workdir
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -33,7 +32,7 @@ func (d *Dir) ProviderLocalCacheDir() string {
 // non-empty list with no errors then the result totally replaces the default
 // search directories.
 func (d *Dir) ForcedPluginDirs() ([]string, error) {
-	raw, err := ioutil.ReadFile(filepath.Join(d.dataDir, PluginPathFilename))
+	raw, err := os.ReadFile(filepath.Join(d.dataDir, PluginPathFilename))
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
@@ -78,6 +77,6 @@ func (d *Dir) SetForcedPluginDirs(dirs []string) error {
 			return err
 		}
 
-		return ioutil.WriteFile(filePath, raw, 0644)
+		return os.WriteFile(filePath, raw, 0644)
 	}
 }

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,7 +69,7 @@ func TestWorkspace_createAndList(t *testing.T) {
 	defer testChdir(t, td)()
 
 	// make sure a vars file doesn't interfere
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		DefaultVarsFilename,
 		[]byte(`foo = "bar"`),
 		0644,
@@ -119,7 +118,7 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	defer testChdir(t, td)()
 
 	// make sure a vars file doesn't interfere
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		DefaultVarsFilename,
 		[]byte(`foo = "bar"`),
 		0644,
@@ -305,7 +304,7 @@ func TestWorkspace_delete(t *testing.T) {
 	if err := os.MkdirAll(DefaultDataDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(DefaultDataDir, local.DefaultWorkspaceFile), []byte("test"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(DefaultDataDir, local.DefaultWorkspaceFile), []byte("test"), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/communicator/remote/command.go
+++ b/internal/communicator/remote/command.go
@@ -20,7 +20,7 @@ type Cmd struct {
 	// Stdout and Stderr represent the process's standard output and
 	// error.
 	//
-	// If either is nil, it will be set to ioutil.Discard.
+	// If either is nil, it will be set to io.Discard.
 	Stdout io.Writer
 	Stderr io.Writer
 

--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -631,7 +630,7 @@ func scpUploadFile(dst string, src io.Reader, w io.Writer, r *bufio.Reader, size
 	if size == 0 {
 		// Create a temporary file where we can copy the contents of the src
 		// so that we can determine the length, since SCP is length-prefixed.
-		tf, err := ioutil.TempFile("", "terraform-upload")
+		tf, err := os.CreateTemp("", "terraform-upload")
 		if err != nil {
 			return fmt.Errorf("Error creating temporary file for upload: %s", err)
 		}

--- a/internal/communicator/ssh/communicator_test.go
+++ b/internal/communicator/ssh/communicator_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -576,7 +575,7 @@ func TestAccUploadFile(t *testing.T) {
 		t.Fatalf("error creating communicator: %s", err)
 	}
 
-	tmpDir, err := ioutil.TempDir("", "communicator")
+	tmpDir, err := os.MkdirTemp("", "communicator")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -590,7 +589,7 @@ func TestAccUploadFile(t *testing.T) {
 		t.Fatalf("error uploading file: %s", err)
 	}
 
-	data, err := ioutil.ReadFile(tmpFile)
+	data, err := os.ReadFile(tmpFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -624,7 +623,7 @@ func TestAccHugeUploadFile(t *testing.T) {
 	size := int64(1 << 32)
 	source := io.LimitReader(rand.New(rand.NewSource(0)), size)
 
-	dest, err := ioutil.TempFile("", "communicator")
+	dest, err := os.CreateTemp("", "communicator")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/communicator/ssh/provisioner.go
+++ b/internal/communicator/ssh/provisioner.go
@@ -5,7 +5,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -302,7 +301,7 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 		// generally wants to handle config data in-memory. Rather than making
 		// the known_hosts file an exception, write out the data to a temporary
 		// file to create the HostKeyCallback.
-		tf, err := ioutil.TempFile("", "tf-known_hosts")
+		tf, err := os.CreateTemp("", "tf-known_hosts")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temp known_hosts file: %s", err)
 		}
@@ -493,7 +492,7 @@ func idKeyData(id string) [][]byte {
 	}
 
 	for _, p := range paths {
-		d, err := ioutil.ReadFile(p)
+		d, err := os.ReadFile(p)
 		if err != nil {
 			log.Printf("[DEBUG] error reading %q: %s", p, err)
 			continue

--- a/internal/communicator/ssh/ssh_test.go
+++ b/internal/communicator/ssh/ssh_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,7 +16,7 @@ import (
 // verify that we can locate public key data
 func TestFindKeyData(t *testing.T) {
 	// set up a test directory
-	td, err := ioutil.TempDir("", "ssh")
+	td, err := os.MkdirTemp("", "ssh")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +40,7 @@ func TestFindKeyData(t *testing.T) {
 	if err := os.Rename(id+".pub", "saved.pub"); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(id+".pub", []byte("not a public key"), 0600); err != nil {
+	if err := os.WriteFile(id+".pub", []byte("not a public key"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,7 +55,7 @@ func TestFindKeyData(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(id, []byte("encrypted private key"), 0600); err != nil {
+	if err := os.WriteFile(id, []byte("encrypted private key"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -96,7 +95,7 @@ func generateSSHKey(t *testing.T, idFile string) ssh.PublicKey {
 		t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(idFile+".pub", ssh.MarshalAuthorizedKey(pub), 0600)
+	err = os.WriteFile(idFile+".pub", ssh.MarshalAuthorizedKey(pub), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/configs/config_build_test.go
+++ b/internal/configs/config_build_test.go
@@ -2,7 +2,7 @@ package configs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -158,7 +158,7 @@ func TestBuildConfigChildModuleBackend(t *testing.T) {
 
 func TestBuildConfigInvalidModules(t *testing.T) {
 	testDir := "testdata/config-diagnostics"
-	dirs, err := ioutil.ReadDir(testDir)
+	dirs, err := os.ReadDir(testDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,8 +199,8 @@ func TestBuildConfigInvalidModules(t *testing.T) {
 			// expected location in the source, but is not required.
 			// The literal characters `\n` are replaced with newlines, but
 			// otherwise the string is unchanged.
-			expectedErrs := readDiags(ioutil.ReadFile(filepath.Join(testDir, name, "errors")))
-			expectedWarnings := readDiags(ioutil.ReadFile(filepath.Join(testDir, name, "warnings")))
+			expectedErrs := readDiags(os.ReadFile(filepath.Join(testDir, name, "errors")))
+			expectedWarnings := readDiags(os.ReadFile(filepath.Join(testDir, name, "warnings")))
 
 			_, buildDiags := BuildConfig(mod, ModuleWalkerFunc(
 				func(req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {

--- a/internal/configs/configload/copy_dir_test.go
+++ b/internal/configs/configload/copy_dir_test.go
@@ -1,7 +1,6 @@
 package configload
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,7 +20,7 @@ import (
 //         └── main.tf
 
 func TestCopyDir_symlinks(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "copy-dir-test")
+	tmpdir, err := os.MkdirTemp("", "copy-dir-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +38,7 @@ func TestCopyDir_symlinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(subModuleDir, "main.tf"), []byte("hello"), 0644)
+	err = os.WriteFile(filepath.Join(subModuleDir, "main.tf"), []byte("hello"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +66,7 @@ func TestCopyDir_symlinks(t *testing.T) {
 }
 
 func TestCopyDir_symlink_file(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "copy-file-test")
+	tmpdir, err := os.MkdirTemp("", "copy-file-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +78,7 @@ func TestCopyDir_symlink_file(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("hello"), 0644)
+	err = os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("hello"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/configs/configload/testing.go
+++ b/internal/configs/configload/testing.go
@@ -1,7 +1,6 @@
 package configload
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -20,7 +19,7 @@ import (
 func NewLoaderForTests(t *testing.T) (*Loader, func()) {
 	t.Helper()
 
-	modulesDir, err := ioutil.TempDir("", "tf-configs")
+	modulesDir, err := os.MkdirTemp("", "tf-configs")
 	if err != nil {
 		t.Fatalf("failed to create temporary modules dir: %s", err)
 		return nil, func() {}

--- a/internal/configs/module_call_test.go
+++ b/internal/configs/module_call_test.go
@@ -1,7 +1,7 @@
 package configs
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLoadModuleCall(t *testing.T) {
-	src, err := ioutil.ReadFile("testdata/invalid-files/module-calls.tf")
+	src, err := os.ReadFile("testdata/invalid-files/module-calls.tf")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/configs/parser_config_dir_test.go
+++ b/internal/configs/parser_config_dir_test.go
@@ -2,7 +2,7 @@ package configs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,7 +21,7 @@ import (
 // module element contents. More detailed assertions may be made on some subset
 // of these configuration files in other tests.
 func TestParserLoadConfigDirSuccess(t *testing.T) {
-	dirs, err := ioutil.ReadDir("testdata/valid-modules")
+	dirs, err := os.ReadDir("testdata/valid-modules")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestParserLoadConfigDirSuccess(t *testing.T) {
 
 	// The individual files in testdata/valid-files should also work
 	// when loaded as modules.
-	files, err := ioutil.ReadDir("testdata/valid-files")
+	files, err := os.ReadDir("testdata/valid-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestParserLoadConfigDirSuccess(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(fmt.Sprintf("%s as module", name), func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/valid-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/valid-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -116,7 +116,7 @@ func TestParserLoadConfigDirSuccess(t *testing.T) {
 // diagnostics in particular. More detailed assertions may be made on some subset
 // of these configuration files in other tests.
 func TestParserLoadConfigDirFailure(t *testing.T) {
-	dirs, err := ioutil.ReadDir("testdata/invalid-modules")
+	dirs, err := os.ReadDir("testdata/invalid-modules")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +139,7 @@ func TestParserLoadConfigDirFailure(t *testing.T) {
 
 	// The individual files in testdata/valid-files should also work
 	// when loaded as modules.
-	files, err := ioutil.ReadDir("testdata/invalid-files")
+	files, err := os.ReadDir("testdata/invalid-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +147,7 @@ func TestParserLoadConfigDirFailure(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(fmt.Sprintf("%s as module", name), func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/invalid-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/invalid-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/configs/parser_config_test.go
+++ b/internal/configs/parser_config_test.go
@@ -3,7 +3,7 @@ package configs
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,7 +21,7 @@ import (
 // file element contents. More detailed assertions may be made on some subset
 // of these configuration files in other tests.
 func TestParserLoadConfigFileSuccess(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata/valid-files")
+	files, err := os.ReadDir("testdata/valid-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +29,7 @@ func TestParserLoadConfigFileSuccess(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(name, func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/valid-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/valid-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -57,7 +57,7 @@ func TestParserLoadConfigFileSuccess(t *testing.T) {
 // assertions should be made on some subset of these configuration files in
 // other tests.
 func TestParserLoadConfigFileFailure(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata/invalid-files")
+	files, err := os.ReadDir("testdata/invalid-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestParserLoadConfigFileFailure(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(name, func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/invalid-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/invalid-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -133,7 +133,7 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Filename, func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata", test.Filename))
+			src, err := os.ReadFile(filepath.Join("testdata", test.Filename))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -167,7 +167,7 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 // file element contents in spite of those warnings. More detailed assertions
 // may be made on some subset of these configuration files in other tests.
 func TestParserLoadConfigFileWarning(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata/warning-files")
+	files, err := os.ReadDir("testdata/warning-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestParserLoadConfigFileWarning(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(name, func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/warning-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/warning-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -232,7 +232,7 @@ func TestParserLoadConfigFileWarning(t *testing.T) {
 // file element contents in spite of those errors. More detailed assertions
 // may be made on some subset of these configuration files in other tests.
 func TestParserLoadConfigFileError(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata/error-files")
+	files, err := os.ReadDir("testdata/error-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestParserLoadConfigFileError(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(name, func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/error-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/error-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/configs/provider_test.go
+++ b/internal/configs/provider_test.go
@@ -1,7 +1,7 @@
 package configs
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -11,7 +11,7 @@ import (
 )
 
 func TestProviderReservedNames(t *testing.T) {
-	src, err := ioutil.ReadFile("testdata/invalid-files/provider-reserved.tf")
+	src, err := os.ReadFile("testdata/invalid-files/provider-reserved.tf")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/copy/copy_dir_test.go
+++ b/internal/copy/copy_dir_test.go
@@ -1,7 +1,6 @@
 package copy
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,7 +20,7 @@ import (
 //         └── main.tf
 
 func TestCopyDir_symlinks(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "copy-dir-test")
+	tmpdir, err := os.MkdirTemp("", "copy-dir-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +38,7 @@ func TestCopyDir_symlinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(subModuleDir, "main.tf"), []byte("hello"), 0644)
+	err = os.WriteFile(filepath.Join(subModuleDir, "main.tf"), []byte("hello"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +66,7 @@ func TestCopyDir_symlinks(t *testing.T) {
 }
 
 func TestCopyDir_symlink_file(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "copy-file-test")
+	tmpdir, err := os.MkdirTemp("", "copy-file-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +78,7 @@ func TestCopyDir_symlink_file(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("hello"), 0644)
+	err = os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("hello"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/depsfile/locks_file_test.go
+++ b/internal/depsfile/locks_file_test.go
@@ -2,7 +2,6 @@ package depsfile
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,7 +24,7 @@ func TestLoadLocksFromFile(t *testing.T) {
 	// Some of the files also have additional assertions that
 	// are encoded in the test code below. These must pass
 	// in addition to the standard diagnostics tests, if present.
-	files, err := ioutil.ReadDir("testdata/locks-files")
+	files, err := os.ReadDir("testdata/locks-files")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -220,7 +219,7 @@ func TestSaveLocksToFile(t *testing.T) {
 	locks.SetProvider(bazProvider, oneDotTwo, nil, nil)
 	locks.SetProvider(booProvider, oneDotTwo, abbreviatedOneDotTwo, nil)
 
-	dir, err := ioutil.TempDir("", "terraform-internal-depsfile-savelockstofile")
+	dir, err := os.MkdirTemp("", "terraform-internal-depsfile-savelockstofile")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -240,7 +239,7 @@ func TestSaveLocksToFile(t *testing.T) {
 		t.Fatalf("Expected lock file to be non-executable: %o", mode)
 	}
 
-	gotContentBytes, err := ioutil.ReadFile(filename)
+	gotContentBytes, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,7 +31,7 @@ type binary struct {
 // this function will panic. Tests should be written to assume that this
 // function always succeeds.
 func NewBinary(binaryPath, workingDir string) *binary {
-	tmpDir, err := ioutil.TempDir("", "binary-e2etest")
+	tmpDir, err := os.MkdirTemp("", "binary-e2etest")
 	if err != nil {
 		panic(err)
 	}
@@ -171,7 +170,7 @@ func (b *binary) OpenFile(path ...string) (*os.File, error) {
 // directory.
 func (b *binary) ReadFile(path ...string) ([]byte, error) {
 	flatPath := b.Path(path...)
-	return ioutil.ReadFile(flatPath)
+	return os.ReadFile(flatPath)
 }
 
 // FileExists is a helper for easily testing whether a particular file
@@ -255,7 +254,7 @@ func (b *binary) Close() {
 
 func GoBuild(pkgPath, tmpPrefix string) string {
 	dir, prefix := filepath.Split(tmpPrefix)
-	tmpFile, err := ioutil.TempFile(dir, prefix)
+	tmpFile, err := os.CreateTemp(dir, prefix)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/getmodules/git_getter.go
+++ b/internal/getmodules/git_getter.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -114,7 +113,7 @@ func (g *gitGetter) Get(dst string, u *url.URL) error {
 		}
 
 		// Create a temp file for the key and ensure it is removed.
-		fh, err := ioutil.TempFile("", "go-getter")
+		fh, err := os.CreateTemp("", "go-getter")
 		if err != nil {
 			return err
 		}

--- a/internal/getmodules/git_getter_test.go
+++ b/internal/getmodules/git_getter_test.go
@@ -3,7 +3,6 @@ package getmodules
 import (
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -416,14 +415,14 @@ func TestGitGetter_gitVersion(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows since the test requires sh")
 	}
-	dir, err := ioutil.TempDir("", "go-getter")
+	dir, err := os.MkdirTemp("", "go-getter")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
 
 	script := filepath.Join(dir, "git")
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		script,
 		[]byte("#!/bin/sh\necho \"git version 2.0 (Some Metadata Here)\n\""),
 		0700)
@@ -705,7 +704,7 @@ type gitRepo struct {
 // testGitRepo creates a new test git repository.
 func testGitRepo(t *testing.T, name string) *gitRepo {
 	t.Helper()
-	dir, err := ioutil.TempDir("", "go-getter")
+	dir, err := os.MkdirTemp("", "go-getter")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -747,7 +746,7 @@ func (r *gitRepo) git(args ...string) {
 // commitFile writes and commits a text file to the repo.
 func (r *gitRepo) commitFile(file, content string) {
 	path := filepath.Join(r.dir, file)
-	if err := ioutil.WriteFile(path, []byte(content), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		r.t.Fatal(err)
 	}
 	r.git("add", file)
@@ -799,7 +798,7 @@ Bw/uEHUCgYAFs+JPOR25oRyBs7ujrMo/OY1z/eXTVVgZxY+tYGe1FJqDeFyR7ytK
 -----END RSA PRIVATE KEY-----`
 
 func assertContents(t *testing.T, path string, contents string) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -810,7 +809,7 @@ func assertContents(t *testing.T, path string, contents string) {
 }
 
 func tempDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "tf")
+	dir, err := os.MkdirTemp("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/internal/getproviders/mock_source.go
+++ b/internal/getproviders/mock_source.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -153,7 +152,7 @@ func FakePackageMeta(provider addrs.Provider, version Version, protocols Version
 // should call the callback even if this function returns an error, because
 // some error conditions leave a partially-created file on disk.
 func FakeInstallablePackageMeta(provider addrs.Provider, version Version, protocols VersionList, target Platform, execFilename string) (PackageMeta, func(), error) {
-	f, err := ioutil.TempFile("", "terraform-getproviders-fake-package-")
+	f, err := os.CreateTemp("", "terraform-getproviders-fake-package-")
 	if err != nil {
 		return PackageMeta{}, func() {}, err
 	}

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -440,7 +440,7 @@ func (c *registryClient) getFile(url *url.URL) ([]byte, error) {
 		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return data, err
 	}

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -3,7 +3,6 @@ package initwd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -52,7 +51,7 @@ func DirFromModule(ctx context.Context, rootDir, modulesDir, sourceAddr string, 
 
 	// The target directory must exist but be empty.
 	{
-		entries, err := ioutil.ReadDir(rootDir)
+		entries, err := os.ReadDir(rootDir)
 		if err != nil {
 			if os.IsNotExist(err) {
 				diags = diags.Append(tfdiags.Sourceless(

--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -2,7 +2,6 @@ package initwd
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -214,7 +213,7 @@ func TestDirFromModule_rel_submodules(t *testing.T) {
 	// - tmpdir/local-modules (with contents of testdata/local-modules)
 	// - tmpdir/empty: the workDir we CD into for the test
 	// - tmpdir/empty/target (target, the destination for init -from-module)
-	tmpDir, err := ioutil.TempDir("", "terraform-configload")
+	tmpDir, err := os.MkdirTemp("", "terraform-configload")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,12 +120,12 @@ func TestModuleInstaller_packageEscapeError(t *testing.T) {
 	// %%BASE%% with the temporary directory path.
 	{
 		rootFilename := filepath.Join(dir, "package-escape.tf")
-		template, err := ioutil.ReadFile(rootFilename)
+		template, err := os.ReadFile(rootFilename)
 		if err != nil {
 			t.Fatal(err)
 		}
 		final := bytes.ReplaceAll(template, []byte("%%BASE%%"), []byte(filepath.ToSlash(dir)))
-		err = ioutil.WriteFile(rootFilename, final, 0644)
+		err = os.WriteFile(rootFilename, final, 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -156,12 +155,12 @@ func TestModuleInstaller_explicitPackageBoundary(t *testing.T) {
 	// %%BASE%% with the temporary directory path.
 	{
 		rootFilename := filepath.Join(dir, "package-prefix.tf")
-		template, err := ioutil.ReadFile(rootFilename)
+		template, err := os.ReadFile(rootFilename)
 		if err != nil {
 			t.Fatal(err)
 		}
 		final := bytes.ReplaceAll(template, []byte("%%BASE%%"), []byte(filepath.ToSlash(dir)))
-		err = ioutil.WriteFile(rootFilename, final, 0644)
+		err = os.WriteFile(rootFilename, final, 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -636,7 +635,7 @@ func (h *testInstallHooks) Install(moduleAddr string, version *version.Version, 
 func tempChdir(t *testing.T, sourceDir string) (string, func()) {
 	t.Helper()
 
-	tmpDir, err := ioutil.TempDir("", "terraform-configload")
+	tmpDir, err := os.MkdirTemp("", "terraform-configload")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s", err)
 		return "", nil

--- a/internal/lang/funcs/filesystem.go
+++ b/internal/lang/funcs/filesystem.go
@@ -3,7 +3,7 @@ package funcs
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"unicode/utf8"
@@ -379,7 +379,7 @@ func readFileBytes(baseDir, path string) ([]byte, error) {
 	}
 	defer f.Close()
 
-	src, err := ioutil.ReadAll(f)
+	src, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s", path)
 	}

--- a/internal/legacy/terraform/state.go
+++ b/internal/legacy/terraform/state.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -1956,7 +1955,7 @@ func ReadState(src io.Reader) (*State, error) {
 
 	// If we are JSON we buffer the whole thing in memory so we can read it twice.
 	// This is suboptimal, but will work for now.
-	jsonBytes, err := ioutil.ReadAll(buf)
+	jsonBytes, err := io.ReadAll(buf)
 	if err != nil {
 		return nil, fmt.Errorf("Reading state file failed: %v", err)
 	}

--- a/internal/modsdir/manifest.go
+++ b/internal/modsdir/manifest.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -67,7 +66,7 @@ type manifestSnapshotFile struct {
 }
 
 func ReadManifestSnapshot(r io.Reader) (Manifest, error) {
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plans/planfile/config_snapshot.go
+++ b/internal/plans/planfile/config_snapshot.go
@@ -4,7 +4,7 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path"
 	"sort"
 	"strings"
@@ -52,7 +52,7 @@ func readConfigSnapshot(z *zip.Reader) (*configload.Snapshot, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to open module manifest: %s", r)
 			}
-			manifestSrc, err = ioutil.ReadAll(r)
+			manifestSrc, err = io.ReadAll(r)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read module manifest: %s", r)
 			}
@@ -74,7 +74,7 @@ func readConfigSnapshot(z *zip.Reader) (*configload.Snapshot, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to open snapshot of %s from module %q: %s", fileName, moduleKey, err)
 			}
-			fileSrc, err := ioutil.ReadAll(r)
+			fileSrc, err := io.ReadAll(r)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read snapshot of %s from module %q: %s", fileName, moduleKey, err)
 			}

--- a/internal/plans/planfile/planfile_test.go
+++ b/internal/plans/planfile/planfile_test.go
@@ -1,7 +1,7 @@
 package planfile
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -84,7 +84,7 @@ func TestRoundtrip(t *testing.T) {
 		},
 	)
 
-	workDir, err := ioutil.TempDir("", "tf-planfile")
+	workDir, err := os.MkdirTemp("", "tf-planfile")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/plans/planfile/reader.go
+++ b/internal/plans/planfile/reader.go
@@ -4,7 +4,8 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
@@ -35,7 +36,7 @@ func Open(filename string) (*Reader, error) {
 	if err != nil {
 		// To give a better error message, we'll sniff to see if this looks
 		// like our old plan format from versions prior to 0.12.
-		if b, sErr := ioutil.ReadFile(filename); sErr == nil {
+		if b, sErr := os.ReadFile(filename); sErr == nil {
 			if bytes.HasPrefix(b, []byte("tfplan")) {
 				return nil, fmt.Errorf("the given plan file was created by an earlier version of Terraform; plan files cannot be shared between different Terraform versions")
 			}
@@ -212,7 +213,7 @@ func (r *Reader) ReadDependencyLocks() (*depsfile.Locks, tfdiags.Diagnostics) {
 				))
 				return nil, diags
 			}
-			src, err := ioutil.ReadAll(r)
+			src, err := io.ReadAll(r)
 			if err != nil {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -3,7 +3,6 @@ package planfile
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"google.golang.org/protobuf/proto"
 
@@ -31,7 +30,7 @@ const tfplanFilename = "tfplan"
 // a plan file, which is stored in a special file in the archive called
 // "tfplan".
 func readTfplan(r io.Reader) (*plans.Plan, error) {
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugin/discovery/find.go
+++ b/internal/plugin/discovery/find.go
@@ -1,7 +1,6 @@
 package discovery
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -48,7 +47,7 @@ func findPluginPaths(kind string, dirs []string) []string {
 	ret := make([]string, 0, len(dirs))
 
 	for _, dir := range dirs {
-		items, err := ioutil.ReadDir(dir)
+		items, err := os.ReadDir(dir)
 		if err != nil {
 			// Ignore missing dirs, non-dirs, etc
 			continue

--- a/internal/providercache/cached_provider.go
+++ b/internal/providercache/cached_provider.go
@@ -2,7 +2,7 @@ package providercache
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -101,7 +101,7 @@ func (cp *CachedProvider) HashV1() (getproviders.Hash, error) {
 // slashes and backslashes as long as the separators are consistent within a
 // particular path string.
 func (cp *CachedProvider) ExecutableFile() (string, error) {
-	infos, err := ioutil.ReadDir(cp.PackageDir)
+	infos, err := os.ReadDir(cp.PackageDir)
 	if err != nil {
 		// If the directory itself doesn't exist or isn't readable then we
 		// can't access an executable in it.

--- a/internal/providercache/dir_modify_test.go
+++ b/internal/providercache/dir_modify_test.go
@@ -2,7 +2,6 @@ package providercache
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestInstallPackage(t *testing.T) {
-	tmpDirPath, err := ioutil.TempDir("", "terraform-test-providercache")
+	tmpDirPath, err := os.MkdirTemp("", "terraform-test-providercache")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +73,7 @@ func TestInstallPackage(t *testing.T) {
 
 func TestLinkFromOtherCache(t *testing.T) {
 	srcDirPath := "testdata/cachedir"
-	tmpDirPath, err := ioutil.TempDir("", "terraform-test-providercache")
+	tmpDirPath, err := os.MkdirTemp("", "terraform-test-providercache")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -3,7 +3,6 @@ package providercache
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -1443,7 +1442,7 @@ func TestEnsureProviderVersions_local_source(t *testing.T) {
 	source := getproviders.NewFilesystemMirrorSource("testdata/cachedir")
 
 	// create a temporary workdir
-	tmpDirPath, err := ioutil.TempDir("", "terraform-test-providercache")
+	tmpDirPath, err := os.MkdirTemp("", "terraform-test-providercache")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1545,7 +1544,7 @@ func TestEnsureProviderVersions_protocol_errors(t *testing.T) {
 	defer close()
 
 	// create a temporary workdir
-	tmpDirPath, err := ioutil.TempDir("", "terraform-test-providercache")
+	tmpDirPath, err := os.MkdirTemp("", "terraform-test-providercache")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -3,7 +3,6 @@ package providercache
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -53,7 +52,7 @@ func installFromHTTPURL(ctx context.Context, meta getproviders.PackageMeta, targ
 		return nil, fmt.Errorf("unsuccessful request to %s: %s", url, resp.Status)
 	}
 
-	f, err := ioutil.TempFile("", "terraform-provider")
+	f, err := os.CreateTemp("", "terraform-provider")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open temporary file to download from %s", url)
 	}

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -225,7 +225,7 @@ func (c *Client) ModuleLocation(ctx context.Context, module *regsrc.Module, vers
 	defer resp.Body.Close()
 
 	// there should be no body, but save it for logging
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading response body from registry: %s", err)
 	}

--- a/internal/replacefile/writefile.go
+++ b/internal/replacefile/writefile.go
@@ -2,13 +2,12 @@ package replacefile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
 
 // AtomicWriteFile uses a temporary file along with this package's AtomicRename
-// function in order to provide a replacement for ioutil.WriteFile that
+// function in order to provide a replacement for os.WriteFile that
 // writes the given file into place as atomically as the underlying operating
 // system can support.
 //
@@ -33,7 +32,7 @@ func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
 		// treats an empty dir as meaning "use the TMPDIR environment variable".
 		dir = "."
 	}
-	f, err := ioutil.TempFile(dir, file) // alongside target file and with a similar name
+	f, err := os.CreateTemp(dir, file) // alongside target file and with a similar name
 	if err != nil {
 		return fmt.Errorf("cannot create temporary file to update %s: %s", filename, err)
 	}

--- a/internal/states/statefile/read.go
+++ b/internal/states/statefile/read.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	version "github.com/hashicorp/go-version"
@@ -38,7 +37,7 @@ func Read(r io.Reader) (*File, error) {
 	// We actually just buffer the whole thing in memory, because states are
 	// generally not huge and we need to do be able to sniff for a version
 	// number before full parsing.
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/states/statefile/roundtrip_test.go
+++ b/internal/states/statefile/roundtrip_test.go
@@ -2,7 +2,6 @@ package statefile
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -14,7 +13,7 @@ import (
 
 func TestRoundtrip(t *testing.T) {
 	const dir = "testdata/roundtrip"
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +33,7 @@ func TestRoundtrip(t *testing.T) {
 		outName := name + outSuffix
 
 		t.Run(name, func(t *testing.T) {
-			oSrcWant, err := ioutil.ReadFile(filepath.Join(dir, outName))
+			oSrcWant, err := os.ReadFile(filepath.Join(dir, outName))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/states/statemgr/filesystem.go
+++ b/internal/states/statemgr/filesystem.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -483,7 +482,7 @@ func (s *Filesystem) lockInfoPath() string {
 // lockInfo returns the data in a lock info file
 func (s *Filesystem) lockInfo() (*LockInfo, error) {
 	path := s.lockInfoPath()
-	infoData, err := ioutil.ReadFile(path)
+	infoData, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -503,7 +502,7 @@ func (s *Filesystem) writeLockInfo(info *LockInfo) error {
 	info.Created = time.Now().UTC()
 
 	log.Printf("[TRACE] statemgr.Filesystem: writing lock metadata to %s", path)
-	err := ioutil.WriteFile(path, info.Marshal(), 0600)
+	err := os.WriteFile(path, info.Marshal(), 0600)
 	if err != nil {
 		return fmt.Errorf("could not write lock info for %q: %s", s.readPath, err)
 	}

--- a/internal/states/statemgr/filesystem_test.go
+++ b/internal/states/statemgr/filesystem_test.go
@@ -1,7 +1,6 @@
 package statemgr
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -130,7 +129,7 @@ func TestFilesystem_writeWhileLocked(t *testing.T) {
 
 func TestFilesystem_pathOut(t *testing.T) {
 	defer testOverrideVersion(t, "1.2.3")()
-	f, err := ioutil.TempFile("", "tf")
+	f, err := os.CreateTemp("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -146,7 +145,7 @@ func TestFilesystem_pathOut(t *testing.T) {
 
 func TestFilesystem_backup(t *testing.T) {
 	defer testOverrideVersion(t, "1.2.3")()
-	f, err := ioutil.TempFile("", "tf")
+	f, err := os.CreateTemp("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -185,7 +184,7 @@ func TestFilesystem_backup(t *testing.T) {
 func TestFilesystem_backupAndReadPath(t *testing.T) {
 	defer testOverrideVersion(t, "1.2.3")()
 
-	workDir, err := ioutil.TempDir("", "tf")
+	workDir, err := os.MkdirTemp("", "tf")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s", err)
 	}
@@ -344,7 +343,7 @@ func TestFilesystem_impl(t *testing.T) {
 }
 
 func testFilesystem(t *testing.T) *Filesystem {
-	f, err := ioutil.TempFile("", "tf")
+	f, err := os.CreateTemp("", "tf")
 	if err != nil {
 		t.Fatalf("failed to create temporary file %s", err)
 	}
@@ -372,7 +371,7 @@ func testFilesystem(t *testing.T) *Filesystem {
 // Make sure we can refresh while the state is locked
 func TestFilesystem_refreshWhileLocked(t *testing.T) {
 	defer testOverrideVersion(t, "1.2.3")()
-	f, err := ioutil.TempFile("", "tf")
+	f, err := os.CreateTemp("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/internal/terraform/context_test.go
+++ b/internal/terraform/context_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -624,7 +623,7 @@ func testProviderSchema(name string) *providers.GetProviderSchemaResponse {
 // round-trip things through on-disk files is often an important part of
 // fully representing an old bug in a regression test.
 func contextOptsForPlanViaFile(configSnap *configload.Snapshot, plan *plans.Plan) (*ContextOpts, *configs.Config, *plans.Plan, error) {
-	dir, err := ioutil.TempDir("", "terraform-contextForPlanViaFile")
+	dir, err := os.MkdirTemp("", "terraform-contextForPlanViaFile")
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,7 +85,7 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 func testModuleInline(t *testing.T, sources map[string]string) *configs.Config {
 	t.Helper()
 
-	cfgPath, err := ioutil.TempDir("", "tf-test")
+	cfgPath, err := os.MkdirTemp("", "tf-test")
 	if err != nil {
 		t.Errorf("Error creating temporary directory for config: %s", err)
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since this project has been upgraded to Go 1.17 in 383bbdeebc8426bc58e346e6d22438fcb72ccddd, this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.