### PR TITLE
cli: Improved plan UI for move-only changes

### DIFF
--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -471,7 +471,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 func (c *Context) driftedResources(config *configs.Config, oldState, newState *states.State, moves map[addrs.UniqueKey]refactoring.MoveResult) ([]*plans.ResourceInstanceChangeSrc, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	if newState.ManagedResourcesEqual(oldState) {
+	if newState.ManagedResourcesEqual(oldState) && len(moves) == 0 {
 		// Nothing to do, because we only detect and report drift for managed
 		// resource instances.
 		return nil, diags


### PR DESCRIPTION
This PR fixes some edge cases with plans which include unexecuted config-driven moves on resources which are otherwise unchanged.

- Add move-only changes to the set of "drifted" resources in a plan. This allows us to show pending moves in refresh-only plans, which then more completely represents what will happen if they are applied.
- Correspondingly, ensure that for normal plans we do not double-render move-only changes

This PR is based on #29589, to be merged after it.

### Screenshots

Refresh-only plan with a single unexecuted move operation:
<img width="1019" alt="simple-move-plan-refresh-only" src="https://user-images.githubusercontent.com/68917/133681931-8e2f0e27-ea56-42e9-93ec-3161e5d03bc9.png">

Normal plan with the same situation:
<img width="1019" alt="simple-move-plan" src="https://user-images.githubusercontent.com/68917/133681934-7b7bca4d-aab4-4dff-bdfb-d5782dc13732.png">

Refresh-only plan including unexecuted move operation and detected drift:
<img width="1127" alt="move-plan-refresh-only" src="https://user-images.githubusercontent.com/68917/133681771-0a4a8d7e-f7a3-478b-ab4a-3e9bcd01263f.png">

Normal plan with the same situation:
<img width="907" alt="move-plan" src="https://user-images.githubusercontent.com/68917/133681833-d534379e-0c92-41ff-bf21-94f8e5b5b311.png">


