### PR TITLE
Add Machine-Readable UI to sidebar

### DIFF
--- a/website/docs/internals/machine-readable-ui.html.md
+++ b/website/docs/internals/machine-readable-ui.html.md
@@ -1,12 +1,12 @@
 ---
 layout: "docs"
-page_title: "Internals: Machine Readable UI"
+page_title: "Internals: Machine-Readable UI"
 sidebar_current: "docs-internals-machine-readable-ui"
 description: |-
   Terraform provides a machine-readable streaming JSON UI output for plan, apply, and refresh operations.
 ---
 
-# Machine Readable UI
+# Machine-Readable UI
 
 -> **Note:** This format is available in Terraform 0.15.3 and later.
 

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -571,15 +571,15 @@
           </li>
 
           <li>
+            <a href="/docs/internals/remote-service-discovery.html">Remote Service Discovery</a>
+          </li>
+          
+          <li>
             <a href="/docs/internals/graph.html">Resource Graph</a>
           </li>
 
           <li>
             <a href="/docs/internals/lifecycle.html">Resource Lifecycle</a>
-          </li>
-
-          <li>
-            <a href="/docs/internals/remote-service-discovery.html">Remote Service Discovery</a>
           </li>
 
         </ul>

--- a/website/layouts/docs.erb
+++ b/website/layouts/docs.erb
@@ -543,7 +543,23 @@
           </li>
 
           <li>
+            <a href="/docs/internals/json-format.html">JSON Output Format</a>
+          </li>
+
+          <li>
+            <a href="/docs/internals/login-protocol.html">Login Protocol</a>
+          </li>
+
+          <li>
+            <a href="/docs/internals/machine-readable-ui.html">Machine-Readable UI</a>
+          </li>
+
+          <li>
             <a href="/docs/internals/module-registry-protocol.html">Module Registry Protocol</a>
+          </li>
+
+          <li>
+            <a href="/docs/internals/provider-meta.html">Provider Metadata</a>
           </li>
 
           <li>
@@ -563,20 +579,9 @@
           </li>
 
           <li>
-            <a href="/docs/internals/login-protocol.html">Login Protocol</a>
-          </li>
-
-          <li>
-            <a href="/docs/internals/json-format.html">JSON Output Format</a>
-          </li>
-
-          <li>
             <a href="/docs/internals/remote-service-discovery.html">Remote Service Discovery</a>
           </li>
 
-          <li>
-            <a href="/docs/internals/provider-meta.html">Provider Metadata</a>
-          </li>
         </ul>
       </li>
 


### PR DESCRIPTION
This PR adds the Machine-Readable UI page to the documentation sidebar, adds a hyphen (because machine-readable is modifying UI in this case, so it gets a hyphen), and reorganizes the internals sidebar so that topics appear in alphabetical order. 

I have:
- [x] Verified that this previews successfully on my local machine. 
- [x] Added at least one tag.
- [x] Requested at least one reviewer.
