### PR TITLE
Improve error message when S3 state checksums don't line up

### DIFF
--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -109,7 +109,7 @@ func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 				continue
 			}
 
-			return nil, fmt.Errorf(errBadChecksumFmt, digest)
+			return nil, fmt.Errorf(errBadChecksumFmt, c.bucketName, c.path, expected, digest, digest)
 		}
 
 		break
@@ -501,8 +501,12 @@ func (c *RemoteClient) logger(operation string) hclog.Logger {
 
 const errBadChecksumFmt = `state data in S3 does not have the expected content.
 
+I tried to get the state data in bucket: %s at path: %s, but its MD5 checksum
+didn't line up with what I have stored in DynamoDB. The checksum I have stored
+is %x, but I calculated a checksum of %x for the state currently stored in S3.
+
 This may be caused by unusually long delays in S3 processing a previous state
-update.  Please wait for a minute or two and try again. If this problem
+update. Please wait for a minute or two and try again. If this problem
 persists, and neither S3 nor DynamoDB are experiencing an outage, you may need
 to manually verify the remote state and update the Digest value stored in the
 DynamoDB table to the following value: %x

--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -300,8 +299,10 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 
 	// fetching an empty state through client1 should now error out due to a
 	// mismatched checksum.
-	if _, err := client1.Get(); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
+	if _, err := client1.Get(); !IsA[badChecksumError](err) {
 		t.Fatalf("expected state checksum error: got %s", err)
+	} else if bse, ok := As[badChecksumError](err); ok && len(bse.digest) != 0 {
+		t.Fatalf("expected empty checksum, got %x", bse.digest)
 	}
 
 	// put the old state in place of the new, without updating the checksum
@@ -311,7 +312,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 
 	// fetching the wrong state through client1 should now error out due to a
 	// mismatched checksum.
-	if _, err := client1.Get(); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
+	if _, err := client1.Get(); !IsA[badChecksumError](err) {
 		t.Fatalf("expected state checksum error: got %s", err)
 	}
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/28496

**The Problem:** Currently, if S3 checksums don't match up with what terraform expects when running a plan/apply, it prints out only what it calculated the digest to be for the state in question. This can lead to difficulty debugging as in the issue linked above. In my case, one remote state call of many failed with this error, and it was really difficult to figure out which state was actually failing, or even that it was a remote state (rather than the state for my project) that was failing.

**Solution:** This PR adds more detail to the error message emitted when S3 states don't have the expected checksum, letting the user know exactly which state failed, and what it was expected to be. As a (slightly redacted) example:
```
│ Error: state data in S3 does not have the expected content.
│ 
│ I tried to get the state data in bucket: <redacted>-terraform-state at path: development-sandbox/terraform.tfstate, but its MD5 checksum
│ didn't line up with what I have stored in DynamoDB. The checksum I have stored 
│ is 015e457bffb<snip>, but I calculated a checksum of 90b8c0cbef08<snip> for the state currently stored in S3.
│ 
│ This may be caused by unusually long delays in S3 processing a previous state
│ update. Please wait for a minute or two and try again. If this problem
│ persists, and neither S3 nor DynamoDB are experiencing an outage, you may need
│ to manually verify the remote state and update the Digest value stored in the
│ DynamoDB table to the following value: 90b8c0cbef0<snip>