### PR TITLE
refactoring: ApplyMoves new return type and more accurate results

### DIFF
--- a/internal/addrs/resource.go
+++ b/internal/addrs/resource.go
@@ -194,8 +194,12 @@ func (r AbsResource) absMoveableSigil() {
 	// AbsResource is moveable
 }
 
+type absResourceKey string
+
+func (r absResourceKey) uniqueKeySigil() {}
+
 func (r AbsResource) UniqueKey() UniqueKey {
-	return absResourceInstanceKey(r.String())
+	return absResourceKey(r.String())
 }
 
 // AbsResourceInstance is an absolute address for a resource instance under a

--- a/internal/refactoring/move_execute_test.go
+++ b/internal/refactoring/move_execute_test.go
@@ -115,13 +115,16 @@ func TestApplyMoves(t *testing.T) {
 		}.Instance(addrs.IntKey(0)).Absolute(moduleBarKey),
 	}
 
-	emptyResults := map[addrs.UniqueKey]MoveResult{}
+	emptyResults := MoveResults{
+		Changes: map[addrs.UniqueKey]MoveSuccess{},
+		Blocked: map[addrs.UniqueKey]MoveBlocked{},
+	}
 
 	tests := map[string]struct {
 		Stmts []MoveStatement
 		State *states.State
 
-		WantResults       map[addrs.UniqueKey]MoveResult
+		WantResults       MoveResults
 		WantInstanceAddrs []string
 	}{
 		"no moves and empty state": {
@@ -161,15 +164,14 @@ func TestApplyMoves(t *testing.T) {
 					providerAddr,
 				)
 			}),
-			map[addrs.UniqueKey]MoveResult{
-				instAddrs["foo.from"].UniqueKey(): {
-					From: instAddrs["foo.from"],
-					To:   instAddrs["foo.to"],
+			MoveResults{
+				Changes: map[addrs.UniqueKey]MoveSuccess{
+					instAddrs["foo.to"].UniqueKey(): {
+						From: instAddrs["foo.from"],
+						To:   instAddrs["foo.to"],
+					},
 				},
-				instAddrs["foo.to"].UniqueKey(): {
-					From: instAddrs["foo.from"],
-					To:   instAddrs["foo.to"],
-				},
+				Blocked: map[addrs.UniqueKey]MoveBlocked{},
 			},
 			[]string{
 				`foo.to`,
@@ -189,15 +191,14 @@ func TestApplyMoves(t *testing.T) {
 					providerAddr,
 				)
 			}),
-			map[addrs.UniqueKey]MoveResult{
-				instAddrs["foo.from[0]"].UniqueKey(): {
-					From: instAddrs["foo.from[0]"],
-					To:   instAddrs["foo.to[0]"],
+			MoveResults{
+				Changes: map[addrs.UniqueKey]MoveSuccess{
+					instAddrs["foo.to[0]"].UniqueKey(): {
+						From: instAddrs["foo.from[0]"],
+						To:   instAddrs["foo.to[0]"],
+					},
 				},
-				instAddrs["foo.to[0]"].UniqueKey(): {
-					From: instAddrs["foo.from[0]"],
-					To:   instAddrs["foo.to[0]"],
-				},
+				Blocked: map[addrs.UniqueKey]MoveBlocked{},
 			},
 			[]string{
 				`foo.to[0]`,
@@ -218,19 +219,14 @@ func TestApplyMoves(t *testing.T) {
 					providerAddr,
 				)
 			}),
-			map[addrs.UniqueKey]MoveResult{
-				instAddrs["foo.from"].UniqueKey(): {
-					From: instAddrs["foo.from"],
-					To:   instAddrs["foo.mid"],
+			MoveResults{
+				Changes: map[addrs.UniqueKey]MoveSuccess{
+					instAddrs["foo.to"].UniqueKey(): {
+						From: instAddrs["foo.from"],
+						To:   instAddrs["foo.to"],
+					},
 				},
-				instAddrs["foo.mid"].UniqueKey(): {
-					From: instAddrs["foo.mid"],
-					To:   instAddrs["foo.to"],
-				},
-				instAddrs["foo.to"].UniqueKey(): {
-					From: instAddrs["foo.mid"],
-					To:   instAddrs["foo.to"],
-				},
+				Blocked: map[addrs.UniqueKey]MoveBlocked{},
 			},
 			[]string{
 				`foo.to`,
@@ -251,15 +247,14 @@ func TestApplyMoves(t *testing.T) {
 					providerAddr,
 				)
 			}),
-			map[addrs.UniqueKey]MoveResult{
-				instAddrs["foo.from[0]"].UniqueKey(): {
-					From: instAddrs["foo.from[0]"],
-					To:   instAddrs["module.boo.foo.to[0]"],
+			MoveResults{
+				Changes: map[addrs.UniqueKey]MoveSuccess{
+					instAddrs["module.boo.foo.to[0]"].UniqueKey(): {
+						From: instAddrs["foo.from[0]"],
+						To:   instAddrs["module.boo.foo.to[0]"],
+					},
 				},
-				instAddrs["module.boo.foo.to[0]"].UniqueKey(): {
-					From: instAddrs["foo.from[0]"],
-					To:   instAddrs["module.boo.foo.to[0]"],
-				},
+				Blocked: map[addrs.UniqueKey]MoveBlocked{},
 			},
 			[]string{
 				`module.boo.foo.to[0]`,
@@ -280,15 +275,14 @@ func TestApplyMoves(t *testing.T) {
 					providerAddr,
 				)
 			}),
-			map[addrs.UniqueKey]MoveResult{
-				instAddrs["module.boo.foo.from[0]"].UniqueKey(): {
-					From: instAddrs["module.boo.foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.to[0]"],
+			MoveResults{
+				Changes: map[addrs.UniqueKey]MoveSuccess{
+					instAddrs["module.bar[0].foo.to[0]"].UniqueKey(): {
+						From: instAddrs["module.boo.foo.from[0]"],
+						To:   instAddrs["module.bar[0].foo.to[0]"],
+					},
 				},
-				instAddrs["module.bar[0].foo.to[0]"].UniqueKey(): {
-					From: instAddrs["module.boo.foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.to[0]"],
-				},
+				Blocked: map[addrs.UniqueKey]MoveBlocked{},
 			},
 			[]string{
 				`module.bar[0].foo.to[0]`,
@@ -309,15 +303,14 @@ func TestApplyMoves(t *testing.T) {
 					providerAddr,
 				)
 			}),
-			map[addrs.UniqueKey]MoveResult{
-				instAddrs["module.boo.foo.from[0]"].UniqueKey(): {
-					From: instAddrs["module.boo.foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.from[0]"],
+			MoveResults{
+				Changes: map[addrs.UniqueKey]MoveSuccess{
+					instAddrs["module.bar[0].foo.from[0]"].UniqueKey(): {
+						From: instAddrs["module.boo.foo.from[0]"],
+						To:   instAddrs["module.bar[0].foo.from[0]"],
+					},
 				},
-				instAddrs["module.bar[0].foo.from[0]"].UniqueKey(): {
-					From: instAddrs["module.boo.foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.from[0]"],
-				},
+				Blocked: map[addrs.UniqueKey]MoveBlocked{},
 			},
 			[]string{
 				`module.bar[0].foo.from[0]`,
@@ -339,19 +332,14 @@ func TestApplyMoves(t *testing.T) {
 					providerAddr,
 				)
 			}),
-			map[addrs.UniqueKey]MoveResult{
-				instAddrs["module.boo.foo.from[0]"].UniqueKey(): {
-					From: instAddrs["module.boo.foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.from[0]"],
+			MoveResults{
+				Changes: map[addrs.UniqueKey]MoveSuccess{
+					instAddrs["module.bar[0].foo.to[0]"].UniqueKey(): {
+						From: instAddrs["module.boo.foo.from[0]"],
+						To:   instAddrs["module.bar[0].foo.to[0]"],
+					},
 				},
-				instAddrs["module.bar[0].foo.from[0]"].UniqueKey(): {
-					From: instAddrs["module.bar[0].foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.to[0]"],
-				},
-				instAddrs["module.bar[0].foo.to[0]"].UniqueKey(): {
-					From: instAddrs["module.bar[0].foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.to[0]"],
-				},
+				Blocked: map[addrs.UniqueKey]MoveBlocked{},
 			},
 			[]string{
 				`module.bar[0].foo.to[0]`,
@@ -373,19 +361,14 @@ func TestApplyMoves(t *testing.T) {
 					providerAddr,
 				)
 			}),
-			map[addrs.UniqueKey]MoveResult{
-				instAddrs["module.boo.foo.from[0]"].UniqueKey(): {
-					From: instAddrs["module.boo.foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.from[0]"],
+			MoveResults{
+				Changes: map[addrs.UniqueKey]MoveSuccess{
+					instAddrs["module.bar[0].foo.to[0]"].UniqueKey(): {
+						From: instAddrs["module.boo.foo.from[0]"],
+						To:   instAddrs["module.bar[0].foo.to[0]"],
+					},
 				},
-				instAddrs["module.bar[0].foo.from[0]"].UniqueKey(): {
-					From: instAddrs["module.bar[0].foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.to[0]"],
-				},
-				instAddrs["module.bar[0].foo.to[0]"].UniqueKey(): {
-					From: instAddrs["module.bar[0].foo.from[0]"],
-					To:   instAddrs["module.bar[0].foo.to[0]"],
-				},
+				Blocked: map[addrs.UniqueKey]MoveBlocked{},
 			},
 			[]string{
 				`module.bar[0].foo.to[0]`,
@@ -414,9 +397,16 @@ func TestApplyMoves(t *testing.T) {
 					providerAddr,
 				)
 			}),
-			map[addrs.UniqueKey]MoveResult{
+			MoveResults{
 				// Nothing moved, because the module.b address is already
 				// occupied by another module.
+				Changes: map[addrs.UniqueKey]MoveSuccess{},
+				Blocked: map[addrs.UniqueKey]MoveBlocked{
+					instAddrs["module.bar[0].foo.from"].Module.UniqueKey(): {
+						Wanted: instAddrs["module.boo.foo.to[0]"].Module,
+						Actual: instAddrs["module.bar[0].foo.from"].Module,
+					},
+				},
 			},
 			[]string{
 				`module.bar[0].foo.from`,
@@ -446,9 +436,16 @@ func TestApplyMoves(t *testing.T) {
 					providerAddr,
 				)
 			}),
-			map[addrs.UniqueKey]MoveResult{
-				// Nothing moved, because the module.b address is already
-				// occupied by another module.
+			MoveResults{
+				// Nothing moved, because the from.to address is already
+				// occupied by another resource.
+				Changes: map[addrs.UniqueKey]MoveSuccess{},
+				Blocked: map[addrs.UniqueKey]MoveBlocked{
+					instAddrs["foo.from"].ContainingResource().UniqueKey(): {
+						Wanted: instAddrs["foo.to"].ContainingResource(),
+						Actual: instAddrs["foo.from"].ContainingResource(),
+					},
+				},
 			},
 			[]string{
 				`foo.from`,
@@ -478,22 +475,141 @@ func TestApplyMoves(t *testing.T) {
 					providerAddr,
 				)
 			}),
-			map[addrs.UniqueKey]MoveResult{
-				// Nothing moved, because the module.b address is already
-				// occupied by another module.
+			MoveResults{
+				// Nothing moved, because the from.to[0] address is already
+				// occupied by another resource instance.
+				Changes: map[addrs.UniqueKey]MoveSuccess{},
+				Blocked: map[addrs.UniqueKey]MoveBlocked{
+					instAddrs["foo.from"].UniqueKey(): {
+						Wanted: instAddrs["foo.to[0]"],
+						Actual: instAddrs["foo.from"],
+					},
+				},
 			},
 			[]string{
 				`foo.from`,
 				`foo.to[0]`,
 			},
 		},
+
+		// FIXME: This test seems to flap between the result the test case
+		// currently records and the "more intuitive" results included inline,
+		// which suggests we have a missing edge in our move dependency graph.
+		// (The MoveResults commented out below predates some changes to that
+		// struct, so will need updating once we uncomment this test.)
+		/*
+			"move module and then move resource into it": {
+				[]MoveStatement{
+					testMoveStatement(t, "", "module.bar[0]", "module.boo"),
+					testMoveStatement(t, "", "foo.from", "module.boo.foo.from"),
+				},
+				states.BuildState(func(s *states.SyncState) {
+					s.SetResourceInstanceCurrent(
+						instAddrs["module.bar[0].foo.to"],
+						&states.ResourceInstanceObjectSrc{
+							Status:    states.ObjectReady,
+							AttrsJSON: []byte(`{}`),
+						},
+						providerAddr,
+					)
+					s.SetResourceInstanceCurrent(
+						instAddrs["foo.from"],
+						&states.ResourceInstanceObjectSrc{
+							Status:    states.ObjectReady,
+							AttrsJSON: []byte(`{}`),
+						},
+						providerAddr,
+					)
+				}),
+				MoveResults{
+					// FIXME: This result is counter-intuitive, because ApplyMoves
+					// handled the resource move first and then the module move
+					// collided with it. It would be arguably more intuitive to
+					// complete the module move first and then let the "smaller"
+					// resource move merge into it.
+					// (The arguably-more-intuitive results are commented out
+					// in the maps below.)
+
+					Changes: map[addrs.UniqueKey]MoveSuccess{
+						//instAddrs["module.boo.foo.to"].UniqueKey():   instAddrs["module.bar[0].foo.to"],
+						//instAddrs["module.boo.foo.from"].UniqueKey(): instAddrs["foo.from"],
+						instAddrs["module.boo.foo.from"].UniqueKey(): instAddrs["foo.from"],
+					},
+					Blocked: map[addrs.UniqueKey]MoveBlocked{
+						// intuitive result: nothing blocked
+						instAddrs["module.bar[0].foo.to"].Module.UniqueKey(): instAddrs["module.boo.foo.from"].Module,
+					},
+				},
+				[]string{
+					//`foo.from`,
+					//`module.boo.foo.from`,
+					`module.bar[0].foo.to`,
+					`module.boo.foo.from`,
+				},
+			},
+		*/
+
+		// FIXME: This test seems to flap between the result the test case
+		// currently records and the "more intuitive" results included inline,
+		// which suggests we have a missing edge in our move dependency graph.
+		// (The MoveResults commented out below predates some changes to that
+		// struct, so will need updating once we uncomment this test.)
+		/*
+			"module move collides with resource move": {
+				[]MoveStatement{
+					testMoveStatement(t, "", "module.bar[0]", "module.boo"),
+					testMoveStatement(t, "", "foo.from", "module.boo.foo.from"),
+				},
+				states.BuildState(func(s *states.SyncState) {
+					s.SetResourceInstanceCurrent(
+						instAddrs["module.bar[0].foo.from"],
+						&states.ResourceInstanceObjectSrc{
+							Status:    states.ObjectReady,
+							AttrsJSON: []byte(`{}`),
+						},
+						providerAddr,
+					)
+					s.SetResourceInstanceCurrent(
+						instAddrs["foo.from"],
+						&states.ResourceInstanceObjectSrc{
+							Status:    states.ObjectReady,
+							AttrsJSON: []byte(`{}`),
+						},
+						providerAddr,
+					)
+				}),
+				MoveResults{
+					// FIXME: This result is counter-intuitive, because ApplyMoves
+					// handled the resource move first and then it was the
+					// module move that collided, whereas it would arguably have
+					// been better to let the module take priority and have only
+					// the one resource move be ignored due to the collision.
+					// (The arguably-more-intuitive results are commented out
+					// in the maps below.)
+					Changes: map[addrs.UniqueKey]MoveSuccess{
+						//instAddrs["module.boo.foo.from"].UniqueKey(): instAddrs["module.bar[0].foo.from"],
+						instAddrs["module.boo.foo.from"].UniqueKey(): instAddrs["foo.from"],
+					},
+					Blocked: map[addrs.UniqueKey]MoveBlocked{
+						//instAddrs["foo.from"].UniqueKey(): instAddrs["module.bar[0].foo.from"],
+						instAddrs["module.bar[0].foo.from"].Module.UniqueKey(): instAddrs["module.boo.foo.from"].Module,
+					},
+				},
+				[]string{
+					//`foo.from`,
+					//`module.boo.foo.from`,
+					`module.bar[0].foo.from`,
+					`module.boo.foo.from`,
+				},
+			},
+		*/
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			var stmtsBuf strings.Builder
 			for _, stmt := range test.Stmts {
-				fmt.Fprintf(&stmtsBuf, "- from: %s\n  to:   %s\n", stmt.From, stmt.To)
+				fmt.Fprintf(&stmtsBuf, "• from: %s\n  to:   %s\n", stmt.From, stmt.To)
 			}
 			t.Logf("move statements:\n%s", stmtsBuf.String())
 

--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -325,29 +325,6 @@ Each resource can have moved from only one source resource.`,
 
 Each resource can have moved from only one source resource.`,
 		},
-		/*
-					// FIXME: This rule requires a deeper analysis to understand that
-					// module.single already contains a test.single and thus moving
-					// it to module.foo implicitly also moves module.single.test.single
-					// module.foo.test.single.
-					"two different moves to nested test.single by different paths": {
-						Statements: []MoveStatement{
-							makeTestMoveStmt(t,
-								``,
-								`test.beep`,
-								`module.foo.test.single`,
-							),
-							makeTestMoveStmt(t,
-								``,
-								`module.single`,
-								`module.foo`,
-							),
-						},
-						WantError: `Ambiguous move statements: A statement at test:1,1 declared that test.beep moved to module.foo.test.single, but this statement instead declares that module.single.test.single moved there.
-
-			Each resource can have moved from only one source resource.`,
-					},
-		*/
 		"move from resource in another module package": {
 			Statements: []MoveStatement{
 				makeTestMoveStmt(t,

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -3,7 +3,6 @@ package terraform
 import (
 	"log"
 
-	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/plans"
@@ -25,7 +24,7 @@ type graphWalkOpts struct {
 	Config     *configs.Config
 
 	RootVariableValues InputValues
-	MoveResults        map[addrs.UniqueKey]refactoring.MoveResult
+	MoveResults        refactoring.MoveResults
 }
 
 func (c *Context) walk(graph *Graph, operation walkOperation, opts *graphWalkOpts) (*ContextGraphWalker, tfdiags.Diagnostics) {

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -174,7 +174,7 @@ type EvalContext interface {
 	// This data structure is created prior to the graph walk and read-only
 	// thereafter, so callers must not modify the returned map or any other
 	// objects accessible through it.
-	MoveResults() map[addrs.UniqueKey]refactoring.MoveResult
+	MoveResults() refactoring.MoveResults
 
 	// WithPath returns a copy of the context with the internal path set to the
 	// path argument.

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -69,7 +69,7 @@ type BuiltinEvalContext struct {
 	RefreshStateValue     *states.SyncState
 	PrevRunStateValue     *states.SyncState
 	InstanceExpanderValue *instances.Expander
-	MoveResultsValue      map[addrs.UniqueKey]refactoring.MoveResult
+	MoveResultsValue      refactoring.MoveResults
 }
 
 // BuiltinEvalContext implements EvalContext
@@ -368,6 +368,6 @@ func (ctx *BuiltinEvalContext) InstanceExpander() *instances.Expander {
 	return ctx.InstanceExpanderValue
 }
 
-func (ctx *BuiltinEvalContext) MoveResults() map[addrs.UniqueKey]refactoring.MoveResult {
+func (ctx *BuiltinEvalContext) MoveResults() refactoring.MoveResults {
 	return ctx.MoveResultsValue
 }

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -132,7 +132,7 @@ type MockEvalContext struct {
 	PrevRunStateState  *states.SyncState
 
 	MoveResultsCalled  bool
-	MoveResultsResults map[addrs.UniqueKey]refactoring.MoveResult
+	MoveResultsResults refactoring.MoveResults
 
 	InstanceExpanderCalled   bool
 	InstanceExpanderExpander *instances.Expander
@@ -353,7 +353,7 @@ func (c *MockEvalContext) PrevRunState() *states.SyncState {
 	return c.PrevRunStateState
 }
 
-func (c *MockEvalContext) MoveResults() map[addrs.UniqueKey]refactoring.MoveResult {
+func (c *MockEvalContext) MoveResults() refactoring.MoveResults {
 	c.MoveResultsCalled = true
 	return c.MoveResultsResults
 }

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -25,12 +25,12 @@ type ContextGraphWalker struct {
 
 	// Configurable values
 	Context            *Context
-	State              *states.SyncState                          // Used for safe concurrent access to state
-	RefreshState       *states.SyncState                          // Used for safe concurrent access to state
-	PrevRunState       *states.SyncState                          // Used for safe concurrent access to state
-	Changes            *plans.ChangesSync                         // Used for safe concurrent writes to changes
-	InstanceExpander   *instances.Expander                        // Tracks our gradual expansion of module and resource instances
-	MoveResults        map[addrs.UniqueKey]refactoring.MoveResult // Read-only record of earlier processing of move statements
+	State              *states.SyncState       // Used for safe concurrent access to state
+	RefreshState       *states.SyncState       // Used for safe concurrent access to state
+	PrevRunState       *states.SyncState       // Used for safe concurrent access to state
+	Changes            *plans.ChangesSync      // Used for safe concurrent writes to changes
+	InstanceExpander   *instances.Expander     // Tracks our gradual expansion of module and resource instances
+	MoveResults        refactoring.MoveResults // Read-only record of earlier processing of move statements
 	Operation          walkOperation
 	StopContext        context.Context
 	RootVariableValues InputValues

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -2282,13 +2282,5 @@ func (n *NodeAbstractResourceInstance) prevRunAddr(ctx EvalContext) addrs.AbsRes
 
 func resourceInstancePrevRunAddr(ctx EvalContext, currentAddr addrs.AbsResourceInstance) addrs.AbsResourceInstance {
 	table := ctx.MoveResults()
-
-	result, ok := table[currentAddr.UniqueKey()]
-	if !ok {
-		// If there's no entry in the table then we'll assume it didn't move
-		// at all, and so its previous address is the same as the current one.
-		return currentAddr
-	}
-
-	return result.From
+	return table.OldAddr(currentAddr)
 }


### PR DESCRIPTION
When we originally stubbed `ApplyMoves` we didn't know yet how exactly we'd be using the result, so we made it a double-indexed map allowing looking up moves in both directions.

However, in practice we only actually need to look up old addresses by new addresses, and so this commit first removes the double indexing so that each move is only represented by one element in the map.

We also need to describe situations where a move was blocked, because in a future commit we'll generate some warnings in those cases. Therefore `ApplyMoves` now returns a `MoveResults` object which contains both a map of changes and a map of blocks. The map of blocks isn't used yet as of this commit, but we'll use it in a later commit to produce warnings within the "terraform" package.

---

While working on this, I also found and fixed a bug in `addrs.AbsResource.UniqueKey`, where it was incorrectly returning a resource _instance_ `UniqueKey`, rather than a distinct address type for whole resources.
