### PR TITLE
command: Ensure all answers were used in command.testInputResponseMap

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -716,6 +716,10 @@ func testInputMap(t *testing.T, answers map[string]string) func() {
 
 	// Return the cleanup
 	return func() {
+		if len(testInputResponseMap) > 0 {
+			t.Fatalf("expected no unused answers provided to command.testInputMap, got: %v", testInputResponseMap)
+		}
+
 		test = true
 		testInputResponseMap = nil
 	}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -540,11 +540,6 @@ func TestInit_backendConfigFileChange(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
-	// Ask input
-	defer testInputMap(t, map[string]string{
-		"backend-migrate-to-new": "no",
-	})()
-
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
 	c := &InitCommand{

--- a/internal/command/ui_input.go
+++ b/internal/command/ui_input.go
@@ -90,6 +90,7 @@ func (i *UIInput) Input(ctx context.Context, opts *terraform.InputOpts) (string,
 			return "", fmt.Errorf("unexpected input request in test: %s", opts.Id)
 		}
 
+		delete(testInputResponseMap, opts.Id)
 		return v, nil
 	}
 


### PR DESCRIPTION
Remove answers from testInputResponse as they are given, and raise an error during cleanup if any answers remain unused.

This enables tests to ensure that the expected mock answers are actually used in a test; previously, an entire branch of code including an input sequence could be omitted and the test(s) would not fail.

The only test that had unused answers in this map is one leftover from legacy state migrations; this particular prompt was removed in 7c93b2e5e637bdee37c5e505d13121d9bfee223d