### PR TITLE
core: Fix refresh-only interaction with orphans

### DIFF
--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -132,6 +132,8 @@ func (n *nodeExpandPlannableResource) DynamicExpand(ctx EvalContext) (*Graph, er
 
 		return &NodePlannableResourceInstanceOrphan{
 			NodeAbstractResourceInstance: a,
+			skipRefresh:                  n.skipRefresh,
+			skipPlanChanges:              n.skipPlanChanges,
 		}
 	}
 
@@ -351,6 +353,7 @@ func (n *NodePlannableResource) DynamicExpand(ctx EvalContext) (*Graph, error) {
 		return &NodePlannableResourceInstanceOrphan{
 			NodeAbstractResourceInstance: a,
 			skipRefresh:                  n.skipRefresh,
+			skipPlanChanges:              n.skipPlanChanges,
 		}
 	}
 


### PR DESCRIPTION
When planning in refresh-only mode, we must not remove orphaned resources due to changed `count` or `for_each` values from the planned state. This was previously happening because we failed to pass through the plan's skip-plan-changes flag to the instance orphan node.

This bug is present in the 1.0 series, and while not reported by anyone else as far as I can tell, it seems reasonable to me to backport it.

Fixes #29638