### PR TITLE
temp path clean for some backend tests

### DIFF
--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func TestLocal_applyBasic(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", applyFixtureSchema())
 	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{
@@ -73,8 +72,7 @@ test_instance.foo:
 }
 
 func TestLocal_applyEmptyDir(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", &terraform.ProviderSchema{})
 	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("yes")})}
@@ -108,8 +106,7 @@ func TestLocal_applyEmptyDir(t *testing.T) {
 }
 
 func TestLocal_applyEmptyDirDestroy(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", &terraform.ProviderSchema{})
 	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{}
@@ -139,8 +136,7 @@ func TestLocal_applyEmptyDirDestroy(t *testing.T) {
 }
 
 func TestLocal_applyError(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	schema := &terraform.ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
@@ -208,8 +204,7 @@ test_instance.foo:
 }
 
 func TestLocal_applyBackendFail(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", applyFixtureSchema())
 
@@ -272,8 +267,7 @@ test_instance.foo: (tainted)
 }
 
 func TestLocal_applyRefreshFalse(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState())

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -25,8 +25,7 @@ import (
 
 func TestLocalRun(t *testing.T) {
 	configDir := "./testdata/empty"
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir)
 	defer configCleanup()
@@ -53,8 +52,7 @@ func TestLocalRun(t *testing.T) {
 
 func TestLocalRun_error(t *testing.T) {
 	configDir := "./testdata/invalid"
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	// This backend will return an error when asked to RefreshState, which
 	// should then cause LocalRun to return with the state unlocked.
@@ -85,8 +83,7 @@ func TestLocalRun_error(t *testing.T) {
 
 func TestLocalRun_stalePlan(t *testing.T) {
 	configDir := "./testdata/apply"
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir)
 	defer configCleanup()

--- a/internal/backend/local/backend_plan_test.go
+++ b/internal/backend/local/backend_plan_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func TestLocal_planBasic(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
@@ -53,8 +52,7 @@ func TestLocal_planBasic(t *testing.T) {
 }
 
 func TestLocal_planInAutomation(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 	TestLocalProvider(t, b, "test", planFixtureSchema())
 
 	const msg = `You didn't use the -out option`
@@ -85,8 +83,7 @@ func TestLocal_planInAutomation(t *testing.T) {
 }
 
 func TestLocal_planNoConfig(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 	TestLocalProvider(t, b, "test", &terraform.ProviderSchema{})
 
 	op, configCleanup, done := testOperationPlan(t, "./testdata/empty")
@@ -116,8 +113,7 @@ func TestLocal_planNoConfig(t *testing.T) {
 // This test validates the state lacking behavior when the inner call to
 // Context() fails
 func TestLocal_plan_context_error(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	// This is an intentionally-invalid value to make terraform.NewContext fail
 	// when b.Operation calls it.
@@ -157,8 +153,7 @@ func TestLocal_plan_context_error(t *testing.T) {
 }
 
 func TestLocal_planOutputsChanged(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 	testStateFile(t, b.StatePath, states.BuildState(func(ss *states.SyncState) {
 		ss.SetOutputValue(addrs.AbsOutputValue{
 			Module:      addrs.RootModuleInstance,
@@ -239,8 +234,7 @@ state, without changing any real infrastructure.
 
 // Module outputs should not cause the plan to be rendered
 func TestLocal_planModuleOutputsChanged(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 	testStateFile(t, b.StatePath, states.BuildState(func(ss *states.SyncState) {
 		ss.SetOutputValue(addrs.AbsOutputValue{
 			Module:      addrs.RootModuleInstance.Child("mod", addrs.NoKey),
@@ -286,8 +280,7 @@ No changes. Your infrastructure matches the configuration.
 }
 
 func TestLocal_planTainted(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState_tainted())
 	outDir := t.TempDir()
@@ -343,8 +336,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.`
 }
 
 func TestLocal_planDeposedOnly(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, states.BuildState(func(ss *states.SyncState) {
 		ss.SetResourceInstanceDeposed(
@@ -457,8 +449,8 @@ Plan: 1 to add, 0 to change, 1 to destroy.`
 }
 
 func TestLocal_planTainted_createBeforeDestroy(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
+
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState_tainted())
 	outDir := t.TempDir()
@@ -514,8 +506,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.`
 }
 
 func TestLocal_planRefreshFalse(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState())
@@ -546,8 +537,7 @@ func TestLocal_planRefreshFalse(t *testing.T) {
 }
 
 func TestLocal_planDestroy(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState())
@@ -599,8 +589,7 @@ func TestLocal_planDestroy(t *testing.T) {
 }
 
 func TestLocal_planDestroy_withDataSources(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState_withDataSource())
@@ -675,8 +664,7 @@ func getAddrs(resources []*plans.ResourceInstanceChangeSrc) []string {
 }
 
 func TestLocal_planOutPathNoChange(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 	TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState())
 

--- a/internal/backend/local/backend_refresh_test.go
+++ b/internal/backend/local/backend_refresh_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 func TestLocal_refresh(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
 	testStateFile(t, b.StatePath, testRefreshState())
@@ -58,8 +57,7 @@ test_instance.foo:
 }
 
 func TestLocal_refreshInput(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	schema := &terraform.ProviderSchema{
 		Provider: &configschema.Block{
@@ -121,8 +119,7 @@ test_instance.foo:
 }
 
 func TestLocal_refreshValidate(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
 	testStateFile(t, b.StatePath, testRefreshState())
 	p.ReadResourceFn = nil
@@ -151,8 +148,7 @@ test_instance.foo:
 }
 
 func TestLocal_refreshValidateProviderConfigured(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	schema := &terraform.ProviderSchema{
 		Provider: &configschema.Block{
@@ -204,8 +200,7 @@ test_instance.foo:
 // This test validates the state lacking behavior when the inner call to
 // Context() fails
 func TestLocal_refresh_context_error(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 	testStateFile(t, b.StatePath, testRefreshState())
 	op, configCleanup, done := testOperationRefresh(t, "./testdata/apply")
 	defer configCleanup()
@@ -225,8 +220,7 @@ func TestLocal_refresh_context_error(t *testing.T) {
 }
 
 func TestLocal_refreshEmptyState(t *testing.T) {
-	b, cleanup := TestLocal(t)
-	defer cleanup()
+	b := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
 	testStateFile(t, b.StatePath, states.NewState())

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -1,7 +1,6 @@
 package local
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,9 +20,12 @@ import (
 //
 // No operations will be called on the returned value, so you can still set
 // public fields without any locks.
-func TestLocal(t *testing.T) (*Local, func()) {
+func TestLocal(t *testing.T) *Local {
 	t.Helper()
-	tempDir := t.TempDir()
+	tempDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	local := New()
 	local.StatePath = filepath.Join(tempDir, "state.tfstate")
@@ -32,13 +34,7 @@ func TestLocal(t *testing.T) (*Local, func()) {
 	local.StateWorkspaceDir = filepath.Join(tempDir, "state.tfstate.d")
 	local.ContextOpts = &terraform.ContextOpts{}
 
-	cleanup := func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatal("error cleanup up test:", err)
-		}
-	}
-
-	return local, cleanup
+	return local
 }
 
 // TestLocalProvider modifies the ContextOpts of the *Local parameter to


### PR DESCRIPTION
Clean up some temp directory handling in tests. No functional changes here, only saving the commit from a PR which went unused.