### PR TITLE
Fix typo on "moose" variable

### DIFF
--- a/website/docs/language/values/variables.html.md
+++ b/website/docs/language/values/variables.html.md
@@ -477,7 +477,7 @@ variable "moose" {
 And the following `.tfvars` file:
 
 ```hcl
-mosse = "Moose"
+moose = "Moose"
 ```
 
 Will cause Terraform to warn you that there is no variable declared `"mosse"`, which can help


### PR DESCRIPTION
There is a typo on "moose" variable that doesn't match the name in both examples.