### PR TITLE
command: Early error message for missing cache entries of locked providers

### DIFF
--- a/internal/command/e2etest/providers_tamper_test.go
+++ b/internal/command/e2etest/providers_tamper_test.go
@@ -1,0 +1,221 @@
+package e2etest
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/e2e"
+	"github.com/hashicorp/terraform/internal/getproviders"
+)
+
+// TestProviderTampering tests various ways that the provider plugins in the
+// local cache directory might be modified after an initial "terraform init",
+// which other Terraform commands which use those plugins should catch and
+// report early.
+func TestProviderTampering(t *testing.T) {
+	// General setup: we'll do a one-off init of a test directory as our
+	// starting point, and then we'll clone that result for each test so
+	// that we can save the cost of a repeated re-init with the same
+	// provider.
+	t.Parallel()
+
+	// This test reaches out to releases.hashicorp.com to download the
+	// null provider, so it can only run if network access is allowed.
+	skipIfCannotAccessNetwork(t)
+
+	fixturePath := filepath.Join("testdata", "provider-tampering-base")
+	tf := e2e.NewBinary(terraformBin, fixturePath)
+	defer tf.Close()
+
+	stdout, stderr, err := tf.Run("init")
+	if err != nil {
+		t.Fatalf("unexpected init error: %s\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "Installing hashicorp/null v") {
+		t.Errorf("null provider download message is missing from init output:\n%s", stdout)
+		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
+	}
+
+	seedDir := tf.WorkDir()
+	const providerVersion = "3.1.0" // must match the version in the fixture config
+	pluginDir := ".terraform/providers/registry.terraform.io/hashicorp/null/" + providerVersion + "/" + getproviders.CurrentPlatform.String()
+	pluginExe := pluginDir + "/terraform-provider-null_v" + providerVersion + "_x5"
+	if getproviders.CurrentPlatform.OS == "windows" {
+		pluginExe += ".exe" // ugh
+	}
+
+	t.Run("cache dir totally gone", func(t *testing.T) {
+		tf := e2e.NewBinary(terraformBin, seedDir)
+		defer tf.Close()
+		workDir := tf.WorkDir()
+
+		err := os.RemoveAll(filepath.Join(workDir, ".terraform"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, stderr, err := tf.Run("plan")
+		if err == nil {
+			t.Fatalf("unexpected plan success\nstdout:\n%s", stdout)
+		}
+		if want := `registry.terraform.io/hashicorp/null: there is no package for registry.terraform.io/hashicorp/null 3.1.0 cached in .terraform/providers`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+		if want := `terraform init`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+	})
+	t.Run("null plugin package modified before plan", func(t *testing.T) {
+		tf := e2e.NewBinary(terraformBin, seedDir)
+		defer tf.Close()
+		workDir := tf.WorkDir()
+
+		err := ioutil.WriteFile(filepath.Join(workDir, pluginExe), []byte("tamper"), 0600)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stdout, stderr, err := tf.Run("plan")
+		if err == nil {
+			t.Fatalf("unexpected plan success\nstdout:\n%s", stdout)
+		}
+		if want := `registry.terraform.io/hashicorp/null: the cached package for registry.terraform.io/hashicorp/null 3.1.0 (in .terraform/providers) does not match any of the checksums recorded in the dependency lock file`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+		if want := `terraform init`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+	})
+	t.Run("version constraint changed in config before plan", func(t *testing.T) {
+		tf := e2e.NewBinary(terraformBin, seedDir)
+		defer tf.Close()
+		workDir := tf.WorkDir()
+
+		err := ioutil.WriteFile(filepath.Join(workDir, "provider-tampering-base.tf"), []byte(`
+			terraform {
+				required_providers {
+					null = {
+						source  = "hashicorp/null"
+						version = "1.0.0"
+					}
+				}
+			}
+		`), 0600)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stdout, stderr, err := tf.Run("plan")
+		if err == nil {
+			t.Fatalf("unexpected plan success\nstdout:\n%s", stdout)
+		}
+		if want := `provider registry.terraform.io/hashicorp/null: locked version selection 3.1.0 doesn't match the updated version constraints "1.0.0"`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+		if want := `terraform init -upgrade`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+	})
+	t.Run("lock file modified before plan", func(t *testing.T) {
+		tf := e2e.NewBinary(terraformBin, seedDir)
+		defer tf.Close()
+		workDir := tf.WorkDir()
+
+		// NOTE: We're just emptying out the lock file here because that's
+		// good enough for what we're trying to assert. The leaf codepath
+		// that generates this family of errors has some different variations
+		// of this error message for otehr sorts of inconsistency, but those
+		// are tested more thoroughly over in the "configs" package, which is
+		// ultimately responsible for that logic.
+		err := ioutil.WriteFile(filepath.Join(workDir, ".terraform.lock.hcl"), []byte(``), 0600)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stdout, stderr, err := tf.Run("plan")
+		if err == nil {
+			t.Fatalf("unexpected plan success\nstdout:\n%s", stdout)
+		}
+		if want := `provider registry.terraform.io/hashicorp/null: required by this configuration but no version is selected`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+		if want := `terraform init`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+	})
+	t.Run("lock file modified after plan", func(t *testing.T) {
+		tf := e2e.NewBinary(terraformBin, seedDir)
+		defer tf.Close()
+		workDir := tf.WorkDir()
+
+		_, stderr, err := tf.Run("plan", "-out", "tfplan")
+		if err != nil {
+			t.Fatalf("unexpected plan failure\nstderr:\n%s", stderr)
+		}
+
+		err = os.Remove(filepath.Join(workDir, ".terraform.lock.hcl"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stdout, stderr, err := tf.Run("apply", "tfplan")
+		if err == nil {
+			t.Fatalf("unexpected apply success\nstdout:\n%s", stdout)
+		}
+		if want := `provider registry.terraform.io/hashicorp/null: required by this configuration but no version is selected`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+		if want := `Create a new plan from the updated configuration.`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+	})
+	t.Run("plugin cache dir entirely removed after plan", func(t *testing.T) {
+		tf := e2e.NewBinary(terraformBin, seedDir)
+		defer tf.Close()
+		workDir := tf.WorkDir()
+
+		_, stderr, err := tf.Run("plan", "-out", "tfplan")
+		if err != nil {
+			t.Fatalf("unexpected plan failure\nstderr:\n%s", stderr)
+		}
+
+		err = os.RemoveAll(filepath.Join(workDir, ".terraform"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stdout, stderr, err := tf.Run("apply", "tfplan")
+		if err == nil {
+			t.Fatalf("unexpected apply success\nstdout:\n%s", stdout)
+		}
+		if want := `registry.terraform.io/hashicorp/null: there is no package for registry.terraform.io/hashicorp/null 3.1.0 cached in .terraform/providers`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+	})
+	t.Run("null plugin package modified after plan", func(t *testing.T) {
+		tf := e2e.NewBinary(terraformBin, seedDir)
+		defer tf.Close()
+		workDir := tf.WorkDir()
+
+		_, stderr, err := tf.Run("plan", "-out", "tfplan")
+		if err != nil {
+			t.Fatalf("unexpected plan failure\nstderr:\n%s", stderr)
+		}
+
+		err = ioutil.WriteFile(filepath.Join(workDir, pluginExe), []byte("tamper"), 0600)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stdout, stderr, err := tf.Run("apply", "tfplan")
+		if err == nil {
+			t.Fatalf("unexpected apply success\nstdout:\n%s", stdout)
+		}
+		if want := `registry.terraform.io/hashicorp/null: the cached package for registry.terraform.io/hashicorp/null 3.1.0 (in .terraform/providers) does not match any of the checksums recorded in the dependency lock file`; !strings.Contains(stderr, want) {
+			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
+		}
+	})
+}

--- a/internal/command/e2etest/testdata/provider-tampering-base/provider-tampering-base.tf
+++ b/internal/command/e2etest/testdata/provider-tampering-base/provider-tampering-base.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    null = {
+      # Our version is intentionally fixed so that we have a fixed
+      # test case here, though we might have to update this in future
+      # if e.g. Terraform stops supporting plugin protocol 5, or if
+      # the null provider is yanked from the registry for some reason.
+      source  = "hashicorp/null"
+      version = "3.1.0"
+    }
+  }
+}

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -461,20 +461,7 @@ func (m *Meta) contextOpts() (*terraform.ContextOpts, error) {
 	} else {
 		providerFactories, err := m.providerFactories()
 		if err != nil {
-			// providerFactories can fail if the plugin selections file is
-			// invalid in some way, but we don't have any way to report that
-			// from here so we'll just behave as if no providers are available
-			// in that case. However, we will produce a warning in case this
-			// shows up unexpectedly and prompts a bug report.
-			// This situation shouldn't arise commonly in practice because
-			// the selections file is generated programmatically.
-			log.Printf("[WARN] Failed to determine selected providers: %s", err)
-
-			// variable providerFactories may now be incomplete, which could
-			// lead to errors reported downstream from here. providerFactories
-			// tries to populate as many providers as possible even in an
-			// error case, so that operations not using problematic providers
-			// can still succeed.
+			return nil, err
 		}
 		opts.Providers = providerFactories
 		opts.Provisioners = m.provisionerFactories()

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"log"
@@ -8,7 +9,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
 	plugin "github.com/hashicorp/go-plugin"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -236,7 +236,7 @@ func (m *Meta) providerFactories() (map[addrs.Provider]providers.Factory, error)
 	// where appropriate and so that callers can potentially make use of the
 	// partial result we return if e.g. they want to enumerate which providers
 	// are available, or call into one of the providers that didn't fail.
-	var err error
+	errs := make(map[addrs.Provider]error)
 
 	// For the providers from the lock file, we expect them to be already
 	// available in the provider cache because "terraform init" should already
@@ -274,7 +274,7 @@ func (m *Meta) providerFactories() (map[addrs.Provider]providers.Factory, error)
 	}
 	for provider, lock := range providerLocks {
 		reportError := func(thisErr error) {
-			err = multierror.Append(err, thisErr)
+			errs[provider] = thisErr
 			// We'll populate a provider factory that just echoes our error
 			// again if called, which allows us to still report a helpful
 			// error even if it gets detected downstream somewhere from the
@@ -323,6 +323,11 @@ func (m *Meta) providerFactories() (map[addrs.Provider]providers.Factory, error)
 	}
 	for provider, reattach := range unmanagedProviders {
 		factories[provider] = unmanagedProviderFactory(provider, reattach)
+	}
+
+	var err error
+	if len(errs) > 0 {
+		err = providerPluginErrors(errs)
 	}
 	return factories, err
 }
@@ -474,4 +479,26 @@ func providerFactoryError(err error) providers.Factory {
 	return func() (providers.Interface, error) {
 		return nil, err
 	}
+}
+
+// providerPluginErrors is an error implementation we can return from
+// Meta.providerFactories to capture potentially multiple errors about the
+// locally-cached plugins (or lack thereof) for particular external providers.
+//
+// Some functions closer to the UI layer can sniff for this error type in order
+// to return a more helpful error message.
+type providerPluginErrors map[addrs.Provider]error
+
+func (errs providerPluginErrors) Error() string {
+	if len(errs) == 1 {
+		for addr, err := range errs {
+			return fmt.Sprintf("%s: %s", addr, err)
+		}
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "missing or corrupted provider plugins:")
+	for addr, err := range errs {
+		fmt.Fprintf(&buf, "\n  - %s: %s", addr, err)
+	}
+	return buf.String()
 }


### PR DESCRIPTION
In the original incarnation of `Meta.providerFactories` we were returning into a `Meta.contextOpts` whose signature didn't allow it to return an error directly, and so we had compromised by making the provider factory functions themselves return errors once called.

Subsequent work made `Meta.contextOpts` need to return an error anyway, but at the time we neglected to update our handling of the `providerFactories` result, having it still defer the error handling until we finally instantiate a provider.

Although that did ultimately return these error messages anyway, the error ended up being reported from deep in the guts of a Terraform Core graph walk, in whichever concurrently-visited graph node happened to try to instantiate the plugin first. This meant that the exact phrasing of the error message would vary between runs and the reporting codepath didn't have enough context to given an actionable suggestion on how to proceed.

In this commit we make `Meta.contextOpts` pass through directly any error that `Meta.providerFactories` produces, and then make `Meta.providerFactories` produce a special error type so that `Meta.Backend` can ultimately return a user-friendly diagnostic message containing a specific suggestion to run `terraform init`, along with a short explanation of what a provider
plugin is.

The reliance here on an implied contract between two functions that are not directly connected in the call stack is non-ideal, and so hopefully we'll revisit this further in future work on the overall architecture of the CLI layer. To try to make this a _little_ robust in the meantime though, I wrote it to use the `errors.As` function to potentially unwrap a wrapped version of our special error type, in case one of the intervening layers is changed at some point to wrap the downstream error before returning it.

---

This is hopefully _for real this time_ the last PR in this series of work to consolidate where and how we handle provider plugin package inconsistencies. The previous changeset in this chain was #29683.
