### PR TITLE
Fix broken logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Terraform
 - Tutorials: [HashiCorp's Learn Platform](https://learn.hashicorp.com/terraform)
 - Certification Exam: [HashiCorp Certified: Terraform Associate](https://www.hashicorp.com/certification/#hashicorp-certified-terraform-associate)
 
-<img alt="Terraform" src="https://www.terraform.io/assets/images/logo-hashicorp-3f10732f.svg" width="600px">
+<img alt="Terraform" src="https://www.datocms-assets.com/2885/1629941242-logo-terraform-main.svg" width="600px">
 
 Terraform is a tool for building, changing, and versioning infrastructure safely and efficiently. Terraform can manage existing and popular service providers as well as custom in-house solutions.
 


### PR DESCRIPTION
A change to an image path on the terraform website inadvertently caused the hotlinked logo image from the readme to break - this replaces it with a functional and more stable image path!