### PR TITLE
Fix typo `aws.dst`

### DIFF
--- a/website/docs/language/modules/develop/providers.html.md
+++ b/website/docs/language/modules/develop/providers.html.md
@@ -222,7 +222,7 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 2.7.0"
-      configuration_aliases = [ aws.src, aws.dest ]
+      configuration_aliases = [ aws.src, aws.dst ]
     }
   }
 }


### PR DESCRIPTION
Example contained `aws.dst` and one `aws.dest` that should have been a `aws.dst`.