### PR TITLE
command/format: improve list nested attribute rendering

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -505,10 +505,8 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 			oldItem := oldItems[i]
 			newItem := newItems[i]
 			if oldItem.RawEquals(newItem) {
-				action = plans.NoOp
 				unchanged++
-			}
-			if action != plans.NoOp {
+			} else if action != plans.NoOp {
 				p.writeAttrsDiff(objS.Attributes, oldItem, newItem, indent+6, path, result)
 				p.writeSkippedAttr(result.skippedAttributes, indent+8)
 				p.buf.WriteString("\n")

--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -473,9 +473,6 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 			p.buf.WriteString(p.color.Color(forcesNewResourceCaption))
 		}
 		p.buf.WriteString("\n")
-		p.buf.WriteString(strings.Repeat(" ", indent+4))
-		p.writeActionSymbol(action)
-		p.buf.WriteString("{")
 
 		oldItems := ctyCollectionValues(old)
 		newItems := ctyCollectionValues(new)
@@ -489,46 +486,62 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 		// commonLen is number of elements that exist in both lists, which
 		// will be presented as updates (~). Any additional items in one
 		// of the lists will be presented as either creates (+) or deletes (-)
-		// depending on which list they belong to.
+		// depending on which list they belong to. maxLen is the number of
+		// elements in that longer list.
 		var commonLen int
+		var maxLen int
 		// unchanged is the number of unchanged elements
 		var unchanged int
 
 		switch {
 		case len(oldItems) < len(newItems):
 			commonLen = len(oldItems)
+			maxLen = len(newItems)
 		default:
 			commonLen = len(newItems)
+			maxLen = len(oldItems)
 		}
-		for i := 0; i < commonLen; i++ {
+		for i := 0; i < maxLen; i++ {
 			path := append(path, cty.IndexStep{Key: cty.NumberIntVal(int64(i))})
-			oldItem := oldItems[i]
-			newItem := newItems[i]
-			if oldItem.RawEquals(newItem) {
-				unchanged++
-			} else if action != plans.NoOp {
-				p.writeAttrsDiff(objS.Attributes, oldItem, newItem, indent+6, path, result)
-				p.writeSkippedAttr(result.skippedAttributes, indent+8)
+
+			var action plans.Action
+			var oldItem, newItem cty.Value
+			switch {
+			case i < commonLen:
+				oldItem = oldItems[i]
+				newItem = newItems[i]
+				if oldItem.RawEquals(newItem) {
+					action = plans.NoOp
+					unchanged++
+				} else {
+					action = plans.Update
+				}
+			case i < len(oldItems):
+				oldItem = oldItems[i]
+				newItem = cty.NullVal(oldItem.Type())
+				action = plans.Delete
+			case i < len(newItems):
+				newItem = newItems[i]
+				oldItem = cty.NullVal(newItem.Type())
+				action = plans.Create
+			default:
+				action = plans.NoOp
+			}
+
+			if action != plans.NoOp {
+				p.buf.WriteString(strings.Repeat(" ", indent+4))
+				p.writeActionSymbol(action)
+				p.buf.WriteString("{")
+				p.writeAttrsDiff(objS.Attributes, oldItem, newItem, indent+8, path, result)
+				if action == plans.Update {
+					p.writeSkippedAttr(result.skippedAttributes, indent+10)
+				}
 				p.buf.WriteString("\n")
+				p.buf.WriteString(strings.Repeat(" ", indent+6))
+				p.buf.WriteString("},\n")
 			}
 		}
-		for i := commonLen; i < len(oldItems); i++ {
-			path := append(path, cty.IndexStep{Key: cty.NumberIntVal(int64(i))})
-			oldItem := oldItems[i]
-			newItem := cty.NullVal(oldItem.Type())
-			p.writeAttrsDiff(objS.Attributes, oldItem, newItem, indent+6, path, result)
-			p.buf.WriteString("\n")
-		}
-		for i := commonLen; i < len(newItems); i++ {
-			path := append(path, cty.IndexStep{Key: cty.NumberIntVal(int64(i))})
-			newItem := newItems[i]
-			oldItem := cty.NullVal(newItem.Type())
-			p.writeAttrsDiff(objS.Attributes, oldItem, newItem, indent+6, path, result)
-			p.buf.WriteString("\n")
-		}
-		p.buf.WriteString(strings.Repeat(" ", indent+4))
-		p.buf.WriteString("},\n")
-		p.writeSkippedElems(unchanged, indent+4)
+		p.writeSkippedElems(unchanged, indent+6)
 		p.buf.WriteString(strings.Repeat(" ", indent+2))
 		p.buf.WriteString("]")
 

--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -532,11 +532,14 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 				p.buf.WriteString(strings.Repeat(" ", indent+4))
 				p.writeActionSymbol(action)
 				p.buf.WriteString("{")
+
+				result := &blockBodyDiffResult{}
 				p.writeAttrsDiff(objS.Attributes, oldItem, newItem, indent+8, path, result)
 				if action == plans.Update {
 					p.writeSkippedAttr(result.skippedAttributes, indent+10)
 				}
 				p.buf.WriteString("\n")
+
 				p.buf.WriteString(strings.Repeat(" ", indent+6))
 				p.buf.WriteString("},\n")
 			}

--- a/internal/command/format/diff_test.go
+++ b/internal/command/format/diff_test.go
@@ -2263,10 +2263,10 @@ func TestResourceChange_nestedList(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
-          ~ {
-            + mount_point = "/var/diska"
-            + size        = "50GB"
-          },
+          + {
+              + mount_point = "/var/diska"
+              + size        = "50GB"
+            },
         ]
         id    = "i-02ae66f368e8518a9"
 
@@ -2309,9 +2309,9 @@ func TestResourceChange_nestedList(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
-          ~ {
-            + mount_point = "/var/diska"
-          },
+          + {
+              + mount_point = "/var/diska"
+            },
         ]
         id    = "i-02ae66f368e8518a9"
 
@@ -2371,10 +2371,10 @@ func TestResourceChange_nestedList(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
           ~ {
-            + size        = "50GB"
-              # (1 unchanged attribute hidden)
-          },
-          # (1 unchanged element hidden)
+              + size        = "50GB"
+                # (1 unchanged attribute hidden)
+            },
+            # (1 unchanged element hidden)
         ]
         id    = "i-02ae66f368e8518a9"
 
@@ -2437,9 +2437,9 @@ func TestResourceChange_nestedList(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
           ~ {
-            ~ mount_point = "/var/diska" -> "/var/diskb" # forces replacement
-              # (1 unchanged attribute hidden)
-          },
+              ~ mount_point = "/var/diska" -> "/var/diskb" # forces replacement
+                # (1 unchanged attribute hidden)
+            },
         ]
         id    = "i-02ae66f368e8518a9"
 
@@ -2493,9 +2493,9 @@ func TestResourceChange_nestedList(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [ # forces replacement
           ~ {
-            ~ mount_point = "/var/diska" -> "/var/diskb"
-              # (1 unchanged attribute hidden)
-          },
+              ~ mount_point = "/var/diska" -> "/var/diskb"
+                # (1 unchanged attribute hidden)
+            },
         ]
         id    = "i-02ae66f368e8518a9"
 
@@ -2540,10 +2540,10 @@ func TestResourceChange_nestedList(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
-          ~ {
-            - mount_point = "/var/diska" -> null
-            - size        = "50GB" -> null
-          },
+          - {
+              - mount_point = "/var/diska" -> null
+              - size        = "50GB" -> null
+            },
         ]
         id    = "i-02ae66f368e8518a9"
 
@@ -2674,10 +2674,10 @@ func TestResourceChange_nestedList(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
-          ~ {
-            - mount_point = "/var/diska" -> null
-            - size        = "50GB" -> null
-          },
+          - {
+              - mount_point = "/var/diska" -> null
+              - size        = "50GB" -> null
+            },
         ] -> (known after apply)
         id    = "i-02ae66f368e8518a9"
 
@@ -2735,10 +2735,10 @@ func TestResourceChange_nestedList(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
           ~ {
-            ~ size        = "50GB" -> "75GB"
-              # (1 unchanged attribute hidden)
-          },
-          # (1 unchanged element hidden)
+              ~ size        = "50GB" -> "75GB"
+                # (1 unchanged attribute hidden)
+            },
+            # (1 unchanged element hidden)
         ]
         id    = "i-02ae66f368e8518a9"
 

--- a/internal/command/format/diff_test.go
+++ b/internal/command/format/diff_test.go
@@ -2700,6 +2700,10 @@ func TestResourceChange_nestedList(t *testing.T) {
 						"mount_point": cty.StringVal("/var/diskb"),
 						"size":        cty.StringVal("50GB"),
 					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diskc"),
+						"size":        cty.StringVal("50GB"),
+					}),
 				}),
 				"root_block_device": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
@@ -2720,6 +2724,10 @@ func TestResourceChange_nestedList(t *testing.T) {
 						"mount_point": cty.StringVal("/var/diskb"),
 						"size":        cty.StringVal("75GB"),
 					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diskc"),
+						"size":        cty.StringVal("25GB"),
+					}),
 				}),
 				"root_block_device": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
@@ -2736,6 +2744,10 @@ func TestResourceChange_nestedList(t *testing.T) {
       ~ disks = [
           ~ {
               ~ size        = "50GB" -> "75GB"
+                # (1 unchanged attribute hidden)
+            },
+          ~ {
+              ~ size        = "50GB" -> "25GB"
                 # (1 unchanged attribute hidden)
             },
             # (1 unchanged element hidden)


### PR DESCRIPTION
This change contains two commits, the first addressing a bug and the second improving general rendering in the same area. I'm submitting them together, but would be happy to split them up or only submit the bug fix.

### Bug: Lists that mix changed and unchanged elements did not render

Diffs only rendered correctly if all changed elements appeared before all unchanged elements. Once an unchanged element was found, all remaining elements were skipped. This usually led to the output being an empty list with a weird amount of space between the brackets.

**Before:**

```
  # nested_fields.example will be updated in-place
  ~ resource "nested_fields" "example" {
        name   = "example"
      ~ values = [
          ~ {          },
          # (3 unchanged elements hidden)
        ]
    }
```

**After:**

```
  # nested_fields.example will be updated in-place
  ~ resource "nested_fields" "example" {
        name   = "example"
      ~ values = [
          ~ {
              name  = "b"
            ~ value = "2" -> "3"
          },
          # (3 unchanged elements hidden)
        ]
    }
```

### Formatting Improvements

I made several changes to make list diffs clearer and more consistent:

* Separate items with brackets instead of only new lines. This better matches the input syntax and avoids confusion from the first and last brackets implying there is a single item.
* Render an action symbol for each element of the list
* Use the correct action symbol for new and deleted items
* Fix the alignment of opening and closing brackets

**Before:**

```
  # nested_fields.example will be updated in-place
  ~ resource "nested_fields" "example" {
        name   = "example"
      ~ values = [
          ~ {
              name  = "c"
            ~ value = "3" -> "c"

            + name  = "e"
            + value = "5"
          },
          # (3 unchanged elements hidden)
        ]
    }
```

**After:**

```
  # nested_fields.example will be updated in-place
  ~ resource "nested_fields" "example" {
        name   = "example"
      ~ values = [
          ~ {
                name  = "c"
              ~ value = "3" -> "c"
            },
          + {
              + name  = "e"
              + value = "5"
            },
            # (3 unchanged elements hidden)
        ]
    }
```


### Context

I'm writing a provider using the new `terraform-plugin-framework` that uses the [`ListNestedAttributes`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework@v0.4.2/tfsdk#ListNestedAttributes) type in several places. I extracted the relevant logic into a [sample provider](https://gist.github.com/bluekeyes/44d54f191a1628ed2e732ef0f2324f55) to experiment more after I observed strange plan output.
