### PR TITLE
Add *sh auto-completion support for resource addresses

### DIFF
--- a/internal/command/autocomplete_test.go
+++ b/internal/command/autocomplete_test.go
@@ -1,6 +1,9 @@
 package command
 
 import (
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/states/statefile"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -32,6 +35,57 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 		Last: "",
 	})
 	want := []string{"default"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestMetaCompletePredictResourceName(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	os.MkdirAll(td, 0755)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	// Create a new state file
+	state := states.NewState()
+	rootModule := state.RootModule()
+	if rootModule == nil {
+		t.Errorf("root module is nil; want valid object")
+	}
+	rootModule.SetResourceInstanceCurrent(
+		addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "test_thing",
+			Name: "baz",
+		}.Instance(addrs.IntKey(0)),
+		&states.ResourceInstanceObjectSrc{
+			Status:        states.ObjectReady,
+			SchemaVersion: 1,
+			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
+		},
+		addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   addrs.RootModule,
+		},
+	)
+	stateFile := statefile.New(state, "", 0)
+	f, err := os.Create(DefaultStateFilename)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := statefile.Write(stateFile, f); err != nil {
+		t.Error(err)
+	}
+
+	// Test the complete predictor
+	ui := new(cli.MockUi)
+	meta := &Meta{Ui: ui}
+	predictor := meta.completePredictResourceName()
+	got := predictor.Predict(complete.Args{
+		Last: "",
+	})
+	want := []string{"test_thing.baz[0]"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
 	}

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -11,11 +11,29 @@ import (
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
 )
 
 // StateMvCommand is a Command implementation that shows a single resource.
 type StateMvCommand struct {
 	StateMeta
+}
+
+func (c *StateMvCommand) AutocompleteArgs() complete.Predictor {
+	return c.completePredictResourceName()
+}
+
+func (c *StateMvCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-ignore-remote-version": completePredictBoolean,
+		"-dry-run":               completePredictBoolean,
+		"-backup":                complete.PredictAnything,
+		"-backup-out":            complete.PredictAnything,
+		"-lock":                  completePredictBoolean,
+		"-lock-timeout":          complete.PredictAnything,
+		"-state":                 complete.PredictAnything,
+		"-state-out":             complete.PredictAnything,
+	}
 }
 
 func (c *StateMvCommand) Run(args []string) int {

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/posener/complete"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -15,6 +16,21 @@ import (
 // StateRmCommand is a Command implementation that shows a single resource.
 type StateRmCommand struct {
 	StateMeta
+}
+
+func (c *StateRmCommand) AutocompleteArgs() complete.Predictor {
+	return c.completePredictResourceName()
+}
+
+func (c *StateRmCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-ignore-remote-version": completePredictBoolean,
+		"-dry-run":               completePredictBoolean,
+		"-backup":                complete.PredictAnything,
+		"-lock":                  completePredictBoolean,
+		"-lock-timeout":          complete.PredictAnything,
+		"-state":                 complete.PredictAnything,
+	}
 }
 
 func (c *StateRmCommand) Run(args []string) int {

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -25,7 +25,7 @@ func (c *StateShowCommand) AutocompleteArgs() complete.Predictor {
 
 func (c *StateShowCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-state":                 complete.PredictAnything,
+		"-state": complete.PredictAnything,
 	}
 }
 

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/posener/complete"
 	"os"
 	"strings"
 
@@ -16,6 +17,16 @@ import (
 type StateShowCommand struct {
 	Meta
 	StateMeta
+}
+
+func (c *StateShowCommand) AutocompleteArgs() complete.Predictor {
+	return c.completePredictResourceName()
+}
+
+func (c *StateShowCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-state":                 complete.PredictAnything,
+	}
 }
 
 func (c *StateShowCommand) Run(args []string) int {

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/posener/complete"
 	"os"
 	"strings"
 
@@ -18,6 +19,22 @@ import (
 // a resource, marking it for recreation.
 type TaintCommand struct {
 	Meta
+}
+
+func (c *TaintCommand) AutocompleteArgs() complete.Predictor {
+	return c.completePredictResourceName()
+}
+
+func (c *TaintCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-ignore-remote-version": completePredictBoolean,
+		"-allow-missing":         completePredictBoolean,
+		"-backup":                complete.PredictAnything,
+		"-lock":                  completePredictBoolean,
+		"-lock-timeout":          complete.PredictAnything,
+		"-state":                 complete.PredictAnything,
+		"-state-out":             complete.PredictAnything,
+	}
 }
 
 func (c *TaintCommand) Run(args []string) int {

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/posener/complete"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -16,6 +17,22 @@ import (
 // a resource, marking it as primary and ready for service.
 type UntaintCommand struct {
 	Meta
+}
+
+func (c *UntaintCommand) AutocompleteArgs() complete.Predictor {
+	return c.completePredictResourceName()
+}
+
+func (c *UntaintCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-ignore-remote-version": completePredictBoolean,
+		"-allow-missing":         completePredictBoolean,
+		"-backup":                complete.PredictAnything,
+		"-lock":                  completePredictBoolean,
+		"-lock-timeout":          complete.PredictAnything,
+		"-state":                 complete.PredictAnything,
+		"-state-out":             complete.PredictAnything,
+	}
 }
 
 func (c *UntaintCommand) Run(args []string) int {


### PR DESCRIPTION
Add supports for the *sh auto-completion on options and arguments (the resource address) for below sub-commands:

- terraform state mv
- terraform state rm
- terraform state show
- terraform taint
- terraform untaint

Fixes #28788

## Test

```bash
💤 go test ./internal/command/ -run="TestMetaCompletePredictResourceName"
ok      github.com/hashicorp/terraform/internal/command 0.027s
```