### PR TITLE
remove Crash section of issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -53,11 +53,6 @@ Full debug output can be obtained by running Terraform with the environment vari
 Debug output may contain sensitive information. Please review it before posting publicly, and if you are concerned feel free to encrypt the files using the HashiCorp security public key.
 -->
 
-### Crash Output
-<!--
-If the console output indicates that Terraform crashed, please share a link to a GitHub Gist containing the output of the `crash.log` file.
--->
-
 ### Expected Behavior
 <!--
 What should have happened?


### PR DESCRIPTION
Terraform is no longer going to silently capture all logs for a possible
crash report, and therefor won't create a crash.log file when a panic is
encountered.

The prompt to create a log file with TF_LOG from the Debug Output
section should suffice to get users to submit the logs when possible. In
the case of a crash specifically, the crash output also requests that
the stack trace be added to the issue for users who may not be aware of
what is necessary.