### PR TITLE
experiments: config_driven_move has concluded

### DIFF
--- a/internal/command/testdata/show-json/moved-drift/main.tf
+++ b/internal/command/testdata/show-json/moved-drift/main.tf
@@ -12,10 +12,6 @@ resource "test_instance" "should_refresh_with_move" {
   ami = "baz"
 }
 
-terraform {
-  experiments = [ config_driven_move ]
-}
-
 moved {
   from = test_instance.should_refresh
   to   = test_instance.should_refresh_with_move

--- a/internal/command/testdata/show-json/moved/main.tf
+++ b/internal/command/testdata/show-json/moved/main.tf
@@ -2,10 +2,6 @@ resource "test_instance" "baz" {
   ami = "baz"
 }
 
-terraform {
-  experiments = [ config_driven_move ]
-}
-
 moved {
   from = test_instance.foo
   to   = test_instance.baz

--- a/internal/configs/experiments.go
+++ b/internal/configs/experiments.go
@@ -209,17 +209,6 @@ func checkModuleExperiments(m *Module) hcl.Diagnostics {
 		}
 	}
 
-	if !m.ActiveExperiments.Has(experiments.ConfigDrivenMove) {
-		for _, mc := range m.Moved {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Config-driven move is experimental",
-				Detail:   "This feature is currently under development and is not yet fully-functional.\n\nIf you'd like to try the partial implementation that exists so far, add config_driven_move to the set of active experiments for this module.",
-				Subject:  mc.DeclRange.Ptr(),
-			})
-		}
-	}
-
 	return diags
 }
 

--- a/internal/configs/testdata/invalid-modules/config-driven-move-experiment/config-driven-move-experiment.tf
+++ b/internal/configs/testdata/invalid-modules/config-driven-move-experiment/config-driven-move-experiment.tf
@@ -1,7 +1,0 @@
-# This is currently invalid alone because config-driven move requires the
-# "config_driven_move" experiment. We can remove this test case altogther
-# if moved blocks of this sort graduate to being stable.
-moved {
-  from = a.b
-  to   = c.d
-}

--- a/internal/configs/testdata/valid-modules/moved-blocks/moved-blocks-1.tf
+++ b/internal/configs/testdata/valid-modules/moved-blocks/moved-blocks-1.tf
@@ -1,8 +1,3 @@
-terraform {
-  # For the moment this is experimental
-  experiments = [config_driven_move]
-}
-
 moved {
   from = test.foo
   to   = test.bar

--- a/internal/experiments/experiment.go
+++ b/internal/experiments/experiment.go
@@ -24,8 +24,8 @@ func init() {
 	// a current or a concluded experiment.
 	registerConcludedExperiment(VariableValidation, "Custom variable validation can now be used by default, without enabling an experiment.")
 	registerConcludedExperiment(SuppressProviderSensitiveAttrs, "Provider-defined sensitive attributes are now redacted by default, without enabling an experiment.")
+	registerConcludedExperiment(ConfigDrivenMove, "Declarations of moved resource instances using \"moved\" blocks can now be used by default, without enabling an experiment.")
 	registerCurrentExperiment(ModuleVariableOptionalAttrs)
-	registerCurrentExperiment(ConfigDrivenMove)
 }
 
 // GetCurrent takes an experiment name and returns the experiment value

--- a/internal/refactoring/move_statement_test.go
+++ b/internal/refactoring/move_statement_test.go
@@ -97,8 +97,8 @@ func TestImpliedMoveStatements(t *testing.T) {
 			Implied: true,
 			DeclRange: tfdiags.SourceRange{
 				Filename: "testdata/move-statement-implied/move-statement-implied.tf",
-				Start:    tfdiags.SourcePos{Line: 9, Column: 1, Byte: 232},
-				End:      tfdiags.SourcePos{Line: 9, Column: 32, Byte: 263},
+				Start:    tfdiags.SourcePos{Line: 5, Column: 1, Byte: 180},
+				End:      tfdiags.SourcePos{Line: 5, Column: 32, Byte: 211},
 			},
 		},
 		{
@@ -107,8 +107,8 @@ func TestImpliedMoveStatements(t *testing.T) {
 			Implied: true,
 			DeclRange: tfdiags.SourceRange{
 				Filename: "testdata/move-statement-implied/move-statement-implied.tf",
-				Start:    tfdiags.SourcePos{Line: 14, Column: 11, Byte: 334},
-				End:      tfdiags.SourcePos{Line: 14, Column: 12, Byte: 335},
+				Start:    tfdiags.SourcePos{Line: 10, Column: 11, Byte: 282},
+				End:      tfdiags.SourcePos{Line: 10, Column: 12, Byte: 283},
 			},
 		},
 
@@ -123,8 +123,8 @@ func TestImpliedMoveStatements(t *testing.T) {
 			Implied: true,
 			DeclRange: tfdiags.SourceRange{
 				Filename: "testdata/move-statement-implied/move-statement-implied.tf",
-				Start:    tfdiags.SourcePos{Line: 50, Column: 1, Byte: 858},
-				End:      tfdiags.SourcePos{Line: 50, Column: 27, Byte: 884},
+				Start:    tfdiags.SourcePos{Line: 46, Column: 1, Byte: 806},
+				End:      tfdiags.SourcePos{Line: 46, Column: 27, Byte: 832},
 			},
 		},
 	}

--- a/internal/refactoring/testdata/move-statement-implied/move-statement-implied.tf
+++ b/internal/refactoring/testdata/move-statement-implied/move-statement-implied.tf
@@ -2,10 +2,6 @@
 # conforms to the statements encoded in the resource names. It's for
 # TestImpliedMoveStatements only.
 
-terraform {
-  experiments = [config_driven_move]
-}
-
 resource "foo" "formerly_count" {
   # but not count anymore
 }

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -740,10 +740,6 @@ func TestContext2Plan_movedResourceBasic(t *testing.T) {
 				from = test_object.a
 				to   = test_object.b
 			}
-
-			terraform {
-				experiments = [config_driven_move]
-			}
 		`,
 	})
 
@@ -1026,10 +1022,6 @@ func TestContext2Plan_movedResourceUntargeted(t *testing.T) {
 				from = test_object.a
 				to   = test_object.b
 			}
-
-			terraform {
-				experiments = [config_driven_move]
-			}
 		`,
 	})
 
@@ -1221,10 +1213,6 @@ func TestContext2Plan_movedResourceRefreshOnly(t *testing.T) {
 			moved {
 				from = test_object.a
 				to   = test_object.b
-			}
-
-			terraform {
-				experiments = [config_driven_move]
 			}
 		`,
 	})


### PR DESCRIPTION
Based on feedback during earlier alpha releases, we've decided to move forward with the current design for the first phase of config-driven refactoring.

Therefore here we've marked the experiment as concluded with no changes to the most recent incarnation of the functionality. The other changes here are all just updating test fixtures to no longer declare that they are using experimental features.

Shortly after we land this I also intend to merge the docs over in #29126, and so between those two PRs we should be in a code-complete state for this feature, ready for inclusion in a release.
