### PR TITLE
command: Adjust skipping of resource counts for any remote implementation

### DIFF
--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/backend"
-	remoteBackend "github.com/hashicorp/terraform/internal/backend/remote"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/plans/planfile"
@@ -130,9 +129,9 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 		return op.Result.ExitStatus()
 	}
 
-	// Render the resource count and outputs, unless we're using the remote
-	// backend locally, in which case these are rendered remotely
-	if rb, isRemoteBackend := be.(*remoteBackend.Remote); !isRemoteBackend || rb.IsLocalOperations() {
+	// Render the resource count and outputs, unless those counts are being
+	// rendered already in a remote Terraform process.
+	if rb, isRemoteBackend := be.(BackendWithRemoteTerraformVersion); !isRemoteBackend || rb.IsLocalOperations() {
 		view.ResourceCount(args.State.StateOutPath)
 		if !c.Destroy && op.State != nil {
 			view.Outputs(op.State.RootModule().OutputValues)

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -60,6 +60,7 @@ type BackendOpts struct {
 type BackendWithRemoteTerraformVersion interface {
 	IgnoreVersionConflict()
 	VerifyWorkspaceTerraformVersion(workspace string) tfdiags.Diagnostics
+	IsLocalOperations() bool
 }
 
 // Backend initializes and returns the backend for this CLI session.


### PR DESCRIPTION
When using the Terraform Cloud integration - like the 'remote' backend - the resource count output should be suppressed if those counts are already being rendered remotely. This generalizes this to the shared interface, so the following duplicated output doesn't happen:

![image](https://user-images.githubusercontent.com/2430490/139517445-d98acc14-5193-4f15-bcb6-e082694f307b.png)