### PR TITLE
backend/oss: Supports the new attribute sts_endpoint

### DIFF
--- a/internal/backend/remote-state/oss/backend.go
+++ b/internal/backend/remote-state/oss/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -120,6 +121,12 @@ func New() backend.Backend {
 				Optional:    true,
 				Description: "The region of the OSS bucket.",
 				DefaultFunc: schema.EnvDefaultFunc("ALICLOUD_REGION", os.Getenv("ALICLOUD_DEFAULT_REGION")),
+			},
+			"sts_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A custom endpoint for the STS API",
+				DefaultFunc: schema.EnvDefaultFunc("ALICLOUD_STS_ENDPOINT", ""),
 			},
 			"tablestore_endpoint": {
 				Type:        schema.TypeString,
@@ -304,6 +311,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	securityToken := getBackendConfig(d.Get("security_token").(string), "sts_token")
 	region := getBackendConfig(d.Get("region").(string), "region_id")
 
+	stsEndpoint := d.Get("sts_endpoint").(string)
 	endpoint := d.Get("endpoint").(string)
 	schma := "https"
 
@@ -360,7 +368,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	}
 
 	if roleArn != "" {
-		subAccessKeyId, subAccessKeySecret, subSecurityToken, err := getAssumeRoleAK(accessKey, secretKey, securityToken, region, roleArn, sessionName, policy, sessionExpiration)
+		subAccessKeyId, subAccessKeySecret, subSecurityToken, err := getAssumeRoleAK(accessKey, secretKey, securityToken, region, roleArn, sessionName, policy, stsEndpoint, sessionExpiration)
 		if err != nil {
 			return err
 		}
@@ -432,7 +440,7 @@ func (b *Backend) getOSSEndpointByRegion(access_key, secret_key, security_token,
 	return endpointsResponse, nil
 }
 
-func getAssumeRoleAK(accessKey, secretKey, stsToken, region, roleArn, sessionName, policy string, sessionExpiration int) (string, string, string, error) {
+func getAssumeRoleAK(accessKey, secretKey, stsToken, region, roleArn, sessionName, policy, stsEndpoint string, sessionExpiration int) (string, string, string, error) {
 	request := sts.CreateAssumeRoleRequest()
 	request.RoleArn = roleArn
 	request.RoleSessionName = sessionName
@@ -449,6 +457,9 @@ func getAssumeRoleAK(accessKey, secretKey, stsToken, region, roleArn, sessionNam
 	}
 	if err != nil {
 		return "", "", "", err
+	}
+	if stsEndpoint != "" {
+		endpoints.AddEndpointMapping(region, "STS", stsEndpoint)
 	}
 	response, err := client.AssumeRole(request)
 	if err != nil {

--- a/website/docs/language/settings/backends/oss.html.md
+++ b/website/docs/language/settings/backends/oss.html.md
@@ -88,6 +88,7 @@ The following configuration options or environment variables are supported:
 * `key` - (Optional) The name of the state file. Defaults to `terraform.tfstate`.
 * `tablestore_endpoint` / `ALICLOUD_TABLESTORE_ENDPOINT` - (Optional) A custom endpoint for the TableStore API.
 * `tablestore_table` - (Optional) A TableStore table for state locking and consistency. The table must have a primary key named `LockID` of type `String`.
+* `sts_endpoint` - (Optional, Available in 1.0.11+) Custom endpoint for the AliCloud Security Token Service (STS) API. It supports environment variable `ALICLOUD_STS_ENDPOINT`.
 * `encrypt` - (Optional) Whether to enable server side
   encryption of the state file. If it is true, OSS will use 'AES256' encryption algorithm to encrypt state file.
 * `acl` - (Optional) [Object


### PR DESCRIPTION
This PR aims to add new attribute `sts_endpoint` to support setting custom Security Token Service endpoint.