### PR TITLE
cloud: Fix prerelease version constraint checks

### DIFF
--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -701,6 +701,7 @@ func TestCloud_VerifyWorkspaceTerraformVersion(t *testing.T) {
 		// pre-release versions are comparable within their pre-release stage (dev,
 		// alpha, beta), but not comparable to different stages and not comparable
 		// to final releases.
+		{"1.1.0-beta1", "1.1.0-beta1", true, false},
 		{"1.1.0-beta1", "~> 1.1.0-beta", true, false},
 		{"1.1.0", "~> 1.1.0-beta", true, true},
 		{"1.1.0-beta1", "~> 1.1.0-dev", true, true},


### PR DESCRIPTION
When a remote workspace specifies an exact version constraint against a prerelease version, we need to skip the looser version constraint checks. This is because a prerelease version cannot satisfy a constraint which uses any operator other than `=`.

Also modify the diagnostics to include the constraint which is not met, rather than the specific version. This ensures that if our logic expands the workspace's given constraint, we are clear that it is this that fails.