### PR TITLE
cloud: Allow cloud tests to be run in parallel

### DIFF
--- a/internal/cloud/e2e/apply_auto_approve_test.go
+++ b/internal/cloud/e2e/apply_auto_approve_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func Test_terraform_apply_autoApprove(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	ctx := context.Background()

--- a/internal/cloud/e2e/backend_apply_before_init_test.go
+++ b/internal/cloud/e2e/backend_apply_before_init_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func Test_backend_apply_before_init(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	cases := map[string]struct {

--- a/internal/cloud/e2e/init_with_empty_tags_test.go
+++ b/internal/cloud/e2e/init_with_empty_tags_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func Test_init_with_empty_tags(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	cases := map[string]struct {

--- a/internal/cloud/e2e/migrate_state_multi_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_multi_to_tfc_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func Test_migrate_multi_to_tfc_cloud_name_strategy(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	ctx := context.Background()
@@ -244,6 +245,7 @@ func Test_migrate_multi_to_tfc_cloud_name_strategy(t *testing.T) {
 }
 
 func Test_migrate_multi_to_tfc_cloud_tags_strategy(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	ctx := context.Background()

--- a/internal/cloud/e2e/migrate_state_remote_backend_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_remote_backend_to_tfc_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func Test_migrate_remote_backend_name_to_tfc_name(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	ctx := context.Background()
@@ -199,6 +200,7 @@ func Test_migrate_remote_backend_name_to_tfc_name(t *testing.T) {
 }
 
 func Test_migrate_remote_backend_name_to_tfc_name_different_org(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	ctx := context.Background()
@@ -338,6 +340,7 @@ func Test_migrate_remote_backend_name_to_tfc_name_different_org(t *testing.T) {
 }
 
 func Test_migrate_remote_backend_name_to_tfc_tags(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	ctx := context.Background()
@@ -483,6 +486,7 @@ func Test_migrate_remote_backend_name_to_tfc_tags(t *testing.T) {
 }
 
 func Test_migrate_remote_backend_prefix_to_tfc_name(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	ctx := context.Background()
@@ -703,6 +707,7 @@ func Test_migrate_remote_backend_prefix_to_tfc_name(t *testing.T) {
 }
 
 func Test_migrate_remote_backend_prefix_to_tfc_tags(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	ctx := context.Background()

--- a/internal/cloud/e2e/migrate_state_single_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_single_to_tfc_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func Test_migrate_single_to_tfc(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	ctx := context.Background()

--- a/internal/cloud/e2e/migrate_state_tfc_to_other_test.go
+++ b/internal/cloud/e2e/migrate_state_tfc_to_other_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func Test_migrate_tfc_to_other(t *testing.T) {
+	t.Parallel()
 	cases := map[string]struct {
 		operations []operationSets
 	}{

--- a/internal/cloud/e2e/migrate_state_tfc_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_tfc_to_tfc_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func Test_migrate_tfc_to_tfc_single_workspace(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 	ctx := context.Background()
 
@@ -301,6 +302,7 @@ func Test_migrate_tfc_to_tfc_single_workspace(t *testing.T) {
 }
 
 func Test_migrate_tfc_to_tfc_multiple_workspace(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	ctx := context.Background()

--- a/internal/cloud/e2e/run_variables_test.go
+++ b/internal/cloud/e2e/run_variables_test.go
@@ -46,6 +46,7 @@ output "test_env" {
 }
 
 func Test_cloud_run_variables(t *testing.T) {
+	t.Parallel()
 	skipWithoutRemoteTerraformVersion(t)
 
 	cases := testCases{


### PR DESCRIPTION
Add the `-parallel N` switch to tell the tests to run in N processes:

```
TFE_TOKEN=$TFE_TOKEN TFE_HOSTNAME=$TFE_HOSTNAME TF_ACC=1 go test -v \
  -tags=e2e ./internal/cloud/e2e/... -parallel 4
```