### PR TITLE
configs: fix ignore_changes config override bug

### DIFF
--- a/internal/configs/configschema/validate_traversal.go
+++ b/internal/configs/configschema/validate_traversal.go
@@ -17,7 +17,7 @@ import (
 // diagnostics if any problems are found.
 //
 // This method is "optimistic" in that it will not return errors for possible
-// problems that cannot be detected statically. It is possible that an
+// problems that cannot be detected statically. It is possible that a
 // traversal which passed static validation will still fail when evaluated.
 func (b *Block) StaticValidateTraversal(traversal hcl.Traversal) tfdiags.Diagnostics {
 	if !traversal.IsRelative() {

--- a/internal/configs/module_merge.go
+++ b/internal/configs/module_merge.go
@@ -242,6 +242,9 @@ func (r *Resource) merge(or *Resource, rps map[string]*RequiredProvider) hcl.Dia
 		if len(or.Managed.IgnoreChanges) != 0 {
 			r.Managed.IgnoreChanges = or.Managed.IgnoreChanges
 		}
+		if or.Managed.IgnoreAllChanges {
+			r.Managed.IgnoreAllChanges = true
+		}
 		if or.Managed.PreventDestroySet {
 			r.Managed.PreventDestroy = or.Managed.PreventDestroy
 			r.Managed.PreventDestroySet = or.Managed.PreventDestroySet

--- a/internal/configs/module_merge_test.go
+++ b/internal/configs/module_merge_test.go
@@ -320,3 +320,13 @@ func TestModuleOverrideResourceFQNs(t *testing.T) {
 		t.Fatalf("wrong result: found provider config ref %s, expected nil", got.ProviderConfigRef)
 	}
 }
+
+func TestModuleOverrideIgnoreAllChanges(t *testing.T) {
+	mod, diags := testModuleFromDir("testdata/valid-modules/override-ignore-changes")
+	assertNoDiagnostics(t, diags)
+
+	r := mod.ManagedResources["test_instance.foo"]
+	if !r.Managed.IgnoreAllChanges {
+		t.Fatalf("wrong result: expected r.Managed.IgnoreAllChanges to be true")
+	}
+}

--- a/internal/configs/testdata/valid-modules/override-ignore-changes/main.tf
+++ b/internal/configs/testdata/valid-modules/override-ignore-changes/main.tf
@@ -1,0 +1,3 @@
+resource "test_instance" "foo" {
+  foo = "bar"
+}

--- a/internal/configs/testdata/valid-modules/override-ignore-changes/main_override.tf
+++ b/internal/configs/testdata/valid-modules/override-ignore-changes/main_override.tf
@@ -1,0 +1,6 @@
+resource "test_instance" "foo" {
+  foo = "bar"
+  lifecycle {
+    ignore_changes = all
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/21474, in which `ignore_changes = all` does not survive a module merge.