### PR TITLE
Cloud: Update Workspace during Tags strategy

### DIFF
--- a/internal/cloud/tfe_client_mock.go
+++ b/internal/cloud/tfe_client_mock.go
@@ -1391,7 +1391,7 @@ func (m *MockWorkspaces) Tags(ctx context.Context, workspaceID string, options t
 }
 
 func (m *MockWorkspaces) AddTags(ctx context.Context, workspaceID string, options tfe.WorkspaceAddTagsOptions) error {
-	panic("not implemented")
+	return nil
 }
 
 func (m *MockWorkspaces) RemoveTags(ctx context.Context, workspaceID string, options tfe.WorkspaceRemoveTagsOptions) error {


### PR DESCRIPTION
### Description

Currently, when using the Tags strategy for the `cloud` integration, a workspace passed to the `StateMgr` doesn't handle new tags. This is evident during a migration, where new workspaces are created or existing ones retrieved. The workspaces in question should have the tags declared in the configuration. This change enables that. 