### PR TITLE
command: Don't update backend hash unless backend is changing

### DIFF
--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -1083,7 +1083,7 @@ func (m *Meta) backend_C_r_S_unchanged(c *configs.Backend, cHash int, sMgr *clis
 	// it's possible for a backend to be unchanged, and the config itself to
 	// have changed by moving a parameter from the config to `-backend-config`
 	// In this case we only need to update the Hash.
-	if c != nil && s.Backend.Hash != uint64(cHash) {
+	if c != nil && c.Type == s.Backend.Type && s.Backend.Hash != uint64(cHash) {
 		s.Backend.Hash = uint64(cHash)
 		if err := sMgr.WriteState(s); err != nil {
 			diags = diags.Append(err)


### PR DESCRIPTION
The `Meta.backend_C_r_S_unchanged()` method is sadly a bit of a mess.

It seems to have originally been used as a method to be called when the backend is not changing, with an extra assumption that if the configured backend's hash doesn't match the one in state, surely the hash should just be updated as an option might have been moved to command line flags.

However, this function is used throughout this file as 'the method to load the initialized (but not necessarily configured) backend', regardless of whether or not it is the same (unchanged). This is in addition to `Meta.backendFromState()`, which is used to load the same thing except in the main codepath of 'init -backend=false'.

A more proper way to handle this situation would be to consolidate this method (and `backendFromState()`) in to a shared API that pulls these responsibilities apart. One for loading the backend from state, one for updating the hash, etc etc. In the interests of stability and deferring larger refactoring, however, we'll cheat here to maintain the same odd API responsibilities of this method and just not update the hash if the backends don't match, which they frequently don't.

This is awkward, as the API here really assumes the caller wouldn't be calling this method unless that was already the case (it is literally named 'unchanged') but is a reasonable workaround to avoid changing this entire interface to separate that out.

### Testing plan

Basically, any error in the middle of a state migration should _not_ cause the hash value in the legacy state file to change. That is, any error should abort the migration process and you should be able to restart the process by re-running `init`. Previously, re-running `init` would result in a successful init of the old backend with a new configuration, because the hash value would reflect the new one while the backend name remains unchanged.

An easy way to test this is to attempt a state migration (using `tags`) with Terraform Cloud, and give an intentionally bad value for one of the prompts. Re-running init should restart the process, not succeed with the local backend.