### PR TITLE
command: Update backend hash value only after a successful migration

### DIFF
--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -616,6 +616,41 @@ func TestInit_backendMigrateWhileLocked(t *testing.T) {
 	}
 }
 
+func TestInit_backendConfigFileChangeWithExistingState(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	testCopyDir(t, testFixturePath("init-backend-config-file-change-migrate-existing"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	ui := new(cli.MockUi)
+	c := &InitCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			Ui:               ui,
+		},
+	}
+
+	oldState := testDataStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
+
+	// we deliberately do not provide the answer for backend-migrate-copy-to-empty to trigger error
+	args := []string{"-migrate-state", "-backend-config", "input.config", "-input=true"}
+	if code := c.Run(args); code == 0 {
+		t.Fatal("expected error")
+	}
+
+	// Read our backend config and verify new settings are not saved
+	state := testDataStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
+	if got, want := normalizeJSON(t, state.Backend.ConfigRaw), `{"path":"local-state.tfstate"}`; got != want {
+		t.Errorf("wrong config\ngot:  %s\nwant: %s", got, want)
+	}
+
+	// without changing config, hash should not change
+	if oldState.Backend.Hash != state.Backend.Hash {
+		t.Errorf("backend hash should not have changed\ngot:  %d\nwant: %d", state.Backend.Hash, oldState.Backend.Hash)
+	}
+}
+
 func TestInit_backendConfigKV(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := tempDir(t)

--- a/internal/command/testdata/init-backend-config-file-change-migrate-existing/.terraform/terraform.tfstate
+++ b/internal/command/testdata/init-backend-config-file-change-migrate-existing/.terraform/terraform.tfstate
@@ -1,0 +1,22 @@
+{
+    "version": 3,
+    "serial": 0,
+    "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
+    "backend": {
+        "type": "local",
+        "config": {
+            "path": "local-state.tfstate"
+        },
+        "hash": 9073424445967744180
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/internal/command/testdata/init-backend-config-file-change-migrate-existing/input.config
+++ b/internal/command/testdata/init-backend-config-file-change-migrate-existing/input.config
@@ -1,0 +1,1 @@
+path = "hello"

--- a/internal/command/testdata/init-backend-config-file-change-migrate-existing/local-state.tfstate
+++ b/internal/command/testdata/init-backend-config-file-change-migrate-existing/local-state.tfstate
@@ -1,0 +1,21 @@
+{
+    "version": 3,
+    "terraform_version": "0.8.2",
+    "serial": 8,
+    "lineage": "local",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {
+                "foo": {
+                    "type": "string",
+                    "value": "bar"
+                }
+            },
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/internal/command/testdata/init-backend-config-file-change-migrate-existing/main.tf
+++ b/internal/command/testdata/init-backend-config-file-change-migrate-existing/main.tf
@@ -1,0 +1,5 @@
+terraform {
+    backend "local" {
+        path = "local-state.tfstate"
+    }
+}


### PR DESCRIPTION
Replaces #29856
Closes #26259
Closes #26260

The `Meta.backend_C_r_S_unchanged()` method was sadly pulling too many duties.

It seems to have originally been used as a method to be called when the backend is not changing, with an extra assumption that if the configured backend's hash doesn't match the one in state, surely the hash should just be updated as an option might have been moved to command line flags.

However, this function was used throughout this file as 'the method to load the initialized (but not necessarily configured) backend', regardless of whether or not it is the same (unchanged). This is in addition to `Meta.backendFromState()`, which is used to load the same thing except in the main codepath of 'init -backend=false'.

These changes separate the concerns of backend_C_r_S_unchanged() by

1) Fetching the saved backend (`savedBackend()`)
2) Updating the hash value in the backend cache when appropriate (either by leaving it to the caller to do themselves or by calling `updateSavedBackendHash()`)

This allows migration codepaths to *not* update the hash value until after a migration has successfully taken place.

Although it would make sense to incoporate `Meta.backendFromState()` in to this shared API, I've left that alone as it's not consequential to the specific bug we're after here.