### PR TITLE
cloud: Add streamlined 'remote' backend state migration path

### DIFF
--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -569,6 +569,17 @@ func (b *Remote) workspaces() ([]string, error) {
 	return names, nil
 }
 
+// WorkspaceNamePattern provides an appropriate workspace renaming pattern for backend migration
+// purposes (handled outside of this package), based on previous usage of this backend with the
+// 'prefix' workspace functionality. As of this writing, see meta_backend.migrate.go
+func (b *Remote) WorkspaceNamePattern() string {
+	if b.prefix != "" {
+		return b.prefix + "*"
+	}
+
+	return ""
+}
+
 // DeleteWorkspace implements backend.Enhanced.
 func (b *Remote) DeleteWorkspace(name string) error {
 	if b.workspace == "" && name == backend.DefaultStateName {

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -1002,7 +1002,7 @@ func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr *clista
 	if output {
 		// Notify the user
 		m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-			"[reset]%s\n\n",
+			"[reset]%s\n",
 			strings.TrimSpace(outputBackendReconfigure))))
 	}
 
@@ -1021,7 +1021,9 @@ func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr *clista
 		if c.Type == "cloud" {
 			output = fmt.Sprintf(outputBackendMigrateChangeCloud, s.Backend.Type)
 		}
-		m.Ui.Output(strings.TrimSpace(output))
+		m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
+			"[reset]%s\n",
+			strings.TrimSpace(output))))
 	}
 
 	// Grab the existing backend


### PR DESCRIPTION
For Terraform Cloud users using the `remote` backend, the existing 'pattern' prompt should work just fine - but because their workspaces are already present in TFC, the 'migration' here is really just realigning their local workspaces with Terraform Cloud. Instead of forcing users to do the mental gymnastics of what it means to migrate from 'prefix' - and because their remote workspaces probably already exist and already conform to Terraform Cloud's naming concerns - streamline the process for them and calculate the necessary pattern to migrate as-is, without any user intervention necessary.

Given the previous remote backend configuration:

```hcl
terraform {
  backend "remote" {
    organization = "foo"
    workspaces {
      prefix = "lol-"
    }
  }
}
```

To a new `cloud` configuration:

```hcl
terraform {
  cloud {
    organization = "foo"
    workspaces {
      tags = ["lol"]
    }
  }
}
```

Migrating from the `remote` backend using `prefix` now looks like this:

![image](https://user-images.githubusercontent.com/2430490/140185055-5c976aa8-5877-4cd6-8944-129c02e05d47.png)

The workspace name reflects that of the TFC workspace name; the tag specified by the `cloud` block is automatically added.
