### PR TITLE
main: Report version information for "interesting" dependencies

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,6 +79,9 @@ func realMain() int {
 	log.Printf(
 		"[INFO] Terraform version: %s %s",
 		Version, VersionPrerelease)
+	for _, depMod := range version.InterestingDependencies() {
+		log.Printf("[DEBUG] using %s %s", depMod.Path, depMod.Version)
+	}
 	log.Printf("[INFO] Go runtime version: %s", runtime.Version())
 	log.Printf("[INFO] CLI args: %#v", os.Args)
 

--- a/version/dependencies.go
+++ b/version/dependencies.go
@@ -1,0 +1,44 @@
+package version
+
+import "runtime/debug"
+
+// See the docs for InterestingDependencyVersions to understand what
+// "interesting" is intended to mean here. We should keep this set relatively
+// small to avoid bloating the logs too much.
+var interestingDependencies = map[string]struct{}{
+	"github.com/hashicorp/hcl/v2":                   {},
+	"github.com/zclconf/go-cty":                     {},
+	"github.com/hashicorp/go-tfe":                   {},
+	"github.com/hashicorp/terraform-config-inspect": {},
+	"github.com/hashicorp/terraform-svchost":        {},
+}
+
+// InterestingDependencies returns the compiled-in module version info for
+// a small number of dependencies that Terraform uses broadly and which we
+// tend to upgrade relatively often as part of improvements to Terraform.
+//
+// The set of dependencies this reports might change over time if our
+// opinions change about what's "interesting". This is here only to create
+// a small number of extra annotations in a debug log to help us more easily
+// cross-reference bug reports with dependency changelogs.
+func InterestingDependencies() []*debug.Module {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		// Weird to not be built in module mode, but not a big deal.
+		return nil
+	}
+
+	ret := make([]*debug.Module, 0, len(interestingDependencies))
+
+	for _, mod := range info.Deps {
+		if _, ok := interestingDependencies[mod.Path]; !ok {
+			continue
+		}
+		if mod.Replace != nil {
+			mod = mod.Replace
+		}
+		ret = append(ret, mod)
+	}
+
+	return ret
+}


### PR DESCRIPTION
We have a few dependencies that are such a significant part of Terraform's behavior that they will often be the root cause of or the solution to a bug reported against Terraform.

As a small quality-of-life improvement to help with diagnosing those, we'll now report the selected versions for each of these so-called "interesting" dependencies as part of our initial trace log output during Terraform startup.

The goal here is that when someone opens a bug report, and includes the trace log as our bug report template requests, we'll be able to see at a glance which versions of these dependencies were involved, instead of having to manually cross-reference in the go.mod file of the reported main Terraform CLI version.

This does slightly grow the general overhead of the logs, but as long as we keep this set of interesting dependencies relatively small it shouldn't present any significant problem in typical usage.

```
2021-11-04T16:15:58.761-0700 [INFO]  Terraform version: 1.1.0 dev
2021-11-04T16:15:58.762-0700 [DEBUG] using github.com/hashicorp/go-tfe v0.19.1-0.20211020175229-e52963e079d0
2021-11-04T16:15:58.762-0700 [DEBUG] using github.com/hashicorp/hcl/v2 v2.10.1
2021-11-04T16:15:58.762-0700 [DEBUG] using github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2
2021-11-04T16:15:58.762-0700 [DEBUG] using github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
2021-11-04T16:15:58.762-0700 [DEBUG] using github.com/zclconf/go-cty v1.10.0
2021-11-04T16:15:58.762-0700 [INFO]  Go runtime version: go1.17.2
```

My criteria for this initial set of "interesting" dependencies was: dependencies that are an integral part of the Terraform language, and dependencies that are an integral part of our use of [Terraform-native services](https://www.terraform.io/docs/internals/remote-service-discovery.html), in both cases focusing on dependencies that we (the Terraform team) either directly maintain or typically contribute to directly as part of work on Terraform.

---

It's interesting to note that once Go 1.18 is released and we've upgraded to it we should also be able to use a similar technique to extract Terraform's _own_ main version number automatically from the executable, using the result of golang/go#37475, which wouldn't make any practical difference for official release binaries (since we write their information in a different way at packaging time anyway) but would help give us exact commit information for reports people make for unofficial builds they made themselves. That'll be for another day though, since Go 1.18 isn't out yet. :grinning: 

