### PR TITLE
Command state mv: Error when backup or backup-out options are used without the state option on non-local backends

### DIFF
--- a/internal/command/state_mv_test.go
+++ b/internal/command/state_mv_test.go
@@ -150,6 +150,257 @@ func TestStateMv(t *testing.T) {
 
 }
 
+func TestStateMv_backupAndBackupOutOptionsWithNonLocalBackend(t *testing.T) {
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_instance",
+				Name: "foo",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"id":"bar","foo":"value","bar":"value"}`),
+				Status:    states.ObjectReady,
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			},
+		)
+	})
+
+	t.Run("backup option specified", func(t *testing.T) {
+		td := tempDir(t)
+		testCopyDir(t, testFixturePath("init-backend-http"), td)
+		defer os.RemoveAll(td)
+		defer testChdir(t, td)()
+
+		backupPath := filepath.Join(td, "backup")
+
+		// Set up our backend state using mock state
+		dataState, srv := testBackendState(t, state, 200)
+		defer srv.Close()
+		testStateFileRemote(t, dataState)
+
+		p := testProvider()
+		ui := new(cli.MockUi)
+		view, _ := testView(t)
+		c := &StateMvCommand{
+			StateMeta{
+				Meta: Meta{
+					testingOverrides: metaOverridesForProvider(p),
+					Ui:               ui,
+					View:             view,
+				},
+			},
+		}
+
+		args := []string{
+			"-backup", backupPath,
+			"test_instance.foo",
+			"test_instance.bar",
+		}
+		if code := c.Run(args); code == 0 {
+			t.Fatalf("expected error output, got:\n%s", ui.OutputWriter.String())
+		}
+
+		gotErr := ui.ErrorWriter.String()
+		wantErr := `
+Error: Invalid command line options: -backup
+
+Command line options -backup and -backup-out are legacy options that operate
+on a local state file only. You must specify a local state file with the
+-state option or switch to the local backend.
+
+`
+		if gotErr != wantErr {
+			t.Fatalf("expected error\ngot:%s\n\nwant:%s", gotErr, wantErr)
+		}
+	})
+
+	t.Run("backup-out option specified", func(t *testing.T) {
+		td := tempDir(t)
+		testCopyDir(t, testFixturePath("init-backend-http"), td)
+		defer os.RemoveAll(td)
+		defer testChdir(t, td)()
+
+		backupOutPath := filepath.Join(td, "backup-out")
+
+		// Set up our backend state using mock state
+		dataState, srv := testBackendState(t, state, 200)
+		defer srv.Close()
+		testStateFileRemote(t, dataState)
+
+		p := testProvider()
+		ui := new(cli.MockUi)
+		view, _ := testView(t)
+		c := &StateMvCommand{
+			StateMeta{
+				Meta: Meta{
+					testingOverrides: metaOverridesForProvider(p),
+					Ui:               ui,
+					View:             view,
+				},
+			},
+		}
+
+		args := []string{
+			"-backup-out", backupOutPath,
+			"test_instance.foo",
+			"test_instance.bar",
+		}
+		if code := c.Run(args); code == 0 {
+			t.Fatalf("expected error output, got:\n%s", ui.OutputWriter.String())
+		}
+
+		gotErr := ui.ErrorWriter.String()
+		wantErr := `
+Error: Invalid command line options: -backup-out
+
+Command line options -backup and -backup-out are legacy options that operate
+on a local state file only. You must specify a local state file with the
+-state option or switch to the local backend.
+
+`
+		if gotErr != wantErr {
+			t.Fatalf("expected error\ngot:%s\n\nwant:%s", gotErr, wantErr)
+		}
+	})
+
+	t.Run("backup and backup-out options specified", func(t *testing.T) {
+		td := tempDir(t)
+		testCopyDir(t, testFixturePath("init-backend-http"), td)
+		defer os.RemoveAll(td)
+		defer testChdir(t, td)()
+
+		backupPath := filepath.Join(td, "backup")
+		backupOutPath := filepath.Join(td, "backup-out")
+
+		// Set up our backend state using mock state
+		dataState, srv := testBackendState(t, state, 200)
+		defer srv.Close()
+		testStateFileRemote(t, dataState)
+
+		p := testProvider()
+		ui := new(cli.MockUi)
+		view, _ := testView(t)
+		c := &StateMvCommand{
+			StateMeta{
+				Meta: Meta{
+					testingOverrides: metaOverridesForProvider(p),
+					Ui:               ui,
+					View:             view,
+				},
+			},
+		}
+
+		args := []string{
+			"-backup", backupPath,
+			"-backup-out", backupOutPath,
+			"test_instance.foo",
+			"test_instance.bar",
+		}
+		if code := c.Run(args); code == 0 {
+			t.Fatalf("expected error output, got:\n%s", ui.OutputWriter.String())
+		}
+
+		gotErr := ui.ErrorWriter.String()
+		wantErr := `
+Error: Invalid command line options: -backup, -backup-out
+
+Command line options -backup and -backup-out are legacy options that operate
+on a local state file only. You must specify a local state file with the
+-state option or switch to the local backend.
+
+`
+		if gotErr != wantErr {
+			t.Fatalf("expected error\ngot:%s\n\nwant:%s", gotErr, wantErr)
+		}
+	})
+
+	t.Run("backup option specified with state option", func(t *testing.T) {
+		td := tempDir(t)
+		testCopyDir(t, testFixturePath("init-backend-http"), td)
+		defer os.RemoveAll(td)
+		defer testChdir(t, td)()
+
+		statePath := testStateFile(t, state)
+		backupPath := filepath.Join(td, "backup")
+
+		// Set up our backend state using mock state
+		dataState, srv := testBackendState(t, state, 200)
+		defer srv.Close()
+		testStateFileRemote(t, dataState)
+
+		p := testProvider()
+		ui := new(cli.MockUi)
+		view, _ := testView(t)
+		c := &StateMvCommand{
+			StateMeta{
+				Meta: Meta{
+					testingOverrides: metaOverridesForProvider(p),
+					Ui:               ui,
+					View:             view,
+				},
+			},
+		}
+
+		args := []string{
+			"-state", statePath,
+			"-backup", backupPath,
+			"test_instance.foo",
+			"test_instance.bar",
+		}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+		}
+
+		// Test it is correct
+		testStateOutput(t, statePath, testStateMvBackupAndBackupOutOptionsWithNonLocalBackendOutput)
+	})
+
+	t.Run("backup-out option specified with state option", func(t *testing.T) {
+		td := tempDir(t)
+		testCopyDir(t, testFixturePath("init-backend-http"), td)
+		defer os.RemoveAll(td)
+		defer testChdir(t, td)()
+
+		statePath := testStateFile(t, state)
+		backupOutPath := filepath.Join(td, "backup-out")
+
+		// Set up our backend state using mock state
+		dataState, srv := testBackendState(t, state, 200)
+		defer srv.Close()
+		testStateFileRemote(t, dataState)
+
+		p := testProvider()
+		ui := new(cli.MockUi)
+		view, _ := testView(t)
+		c := &StateMvCommand{
+			StateMeta{
+				Meta: Meta{
+					testingOverrides: metaOverridesForProvider(p),
+					Ui:               ui,
+					View:             view,
+				},
+			},
+		}
+
+		args := []string{
+			"-state", statePath,
+			"-backup-out", backupOutPath,
+			"test_instance.foo",
+			"test_instance.bar",
+		}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+		}
+
+		// Test it is correct
+		testStateOutput(t, statePath, testStateMvBackupAndBackupOutOptionsWithNonLocalBackendOutput)
+	})
+}
+
 func TestStateMv_resourceToInstance(t *testing.T) {
 	// A single resource (no count defined)
 	state := states.BuildState(func(s *states.SyncState) {
@@ -1458,6 +1709,14 @@ test_instance.bar:
   foo = value
 test_instance.baz:
   ID = foo
+  provider = provider["registry.terraform.io/hashicorp/test"]
+  bar = value
+  foo = value
+`
+
+const testStateMvBackupAndBackupOutOptionsWithNonLocalBackendOutput = `
+test_instance.bar:
+  ID = bar
   provider = provider["registry.terraform.io/hashicorp/test"]
   bar = value
   foo = value

--- a/internal/command/testdata/init-backend-http/main.tf
+++ b/internal/command/testdata/init-backend-http/main.tf
@@ -1,0 +1,4 @@
+terraform {
+  backend "http" {
+  }
+}

--- a/website/docs/cli/commands/state/mv.html.md
+++ b/website/docs/cli/commands/state/mv.html.md
@@ -73,10 +73,18 @@ only, `terraform state mv`
 also accepts the option
 [`-ignore-remote-version`](/docs/language/settings/backends/remote.html#command-line-arguments).
 
+The legacy options [`-backup` and `-backup-out`](/docs/language/settings/backends/local.html#command-line-arguments)
+operate on a local state file only. Configurations using
+[the `remote` backend](/docs/language/settings/backends/remote.html) 
+must specify a local state file with the [`-state`](/docs/language/settings/backends/local.html#command-line-arguments)
+option in order to use the [`-backup` and `-backup-out`](/docs/language/settings/backends/local.html#command-line-arguments)
+options.
+
+
 For configurations using
 [the `local` state mv](/docs/language/settings/backends/local.html) only,
-`terraform taint` also accepts the legacy options
-[`-state`, `-state-out`, and `-backup`](/docs/language/settings/backends/local.html#command-line-arguments).
+`terraform state mv` also accepts the legacy options
+[`-state`, `-state-out`, `-backup`, and `-backup-out`](/docs/language/settings/backends/local.html#command-line-arguments).
 
 ## Example: Rename a Resource
 


### PR DESCRIPTION
## Description

While [the documentation for the `state mv` command says](https://www.terraform.io/docs/cli/commands/state/mv.html#usage) that `-state`, `-state-out`, `-backup`, and `-backup-out` are only supported on the local backend, Terraform will accept these options and ignore the backup options silently when used with a non-local backend. This can put users into a state where they think they have backed up their state when modifying it but they actually haven't. This PR changes the `state mv` command to error when the `-backup` or `-backup-out` options are used without the `-state` option on non-local backends. 
Closes #27908

There were a few different options I explored while trying to figure out what behavior made the most sense here:
1. Don't allow the use of the options `-state`, `-state-out`, `-backup`, and `-backup-out` with configurations using a non-local backend.
   - This is simple, straightforward, and matches exactly what is currently in the documentation.
   - However, it is possible that there are workflows where users might pull remote state down locally to make modifications, some that may involve supported Terraform commands and some that might be manual. To do this, they would use the `-state` option to point to their local copy of state. You could argue that they could do the `state mv` work before pulling the state down for other modifications but this seems like an arbitrary and inconvenient ordering to me.
1. Don't allow the use of the options `-backup` and `-backup-out` with configurations using a non-local backend.
   - This is straightforward but like the previous solution doesn't address the use case of modifying remote state locally. 
1. Don't allow the use of the options `-backup` and `-backup-out` with configurations using a non-local backend unless the `-state` option has been specified
   - This is definitely not as simple and straightforward as previous solutions but it supports modifying remote state locally while also still erroring when users use the backup options incorrectly. 
   - This also means eventually updating the documentation to reflect the fact that you can actually use the state options with a configuration that uses a non-local backend (doing so essentially overrides your backend and uses the local state file). The documentation will also need to be updated to explain that backup options can be used with configurations using a non-local backend but only if you use the state options to override your backend. 

There are other commands that are likely to have the same problem. They will be addressed in later PRs, likely in a similar manner:
1. `apply`
2. `import`
3. `refresh`
4. `taint`
5. `untaint`
6. `state replace-provider`
7. `state rm`

## Testing plan

You can use whatever configs you like for testing the `state mv` command against local and non-local backends. I've provided the simple configs I used below.
#### Example configs to use for testing:
1. Local backend
   ```terraform
   resource "random_id" "random_local" {
     keepers = {
       uuid = uuid()
     }
     byte_length = 11
   }

   output "random" {
     value = random_id.random_local.hex
   }
   ```
1. Non-local backend: Consul (feel free to use whatever non-local backend you like)
   ```terraform
   terraform {
     backend "consul" {
       path    = "state-mv-test"
     }
   }

   resource "random_id" "random_remote" {
     keepers = {
       uuid = uuid()
     }
     byte_length = 11
   }

   output "random" {
     value = random_id.random_remote.hex
   }
   ```

#### Local backend:
The basic idea for this section is that everything should continue to work the way it always has in previous Terraform versions, regardless of which option combinations you use or if you use an implicit or explicit local backend. 
1. Run `terraform state mv -backup=fancy-local.backup random_id.random_local random_id.random_local1`. 
   This should behave the same way as in previous Terraform versions, resulting in an error that looks like this:
   ```
   │ Error: Backend initialization required, please run "terraform init"
   │ 
   │ Reason: Initial configuration of the requested backend "local"
   │ 
   │ The "backend" is the interface that Terraform uses to store state,
   ...
   │ hasn't changed and try again. At this point, no changes to your existing
   │ configuration or state have been made.
   ```
1. Run `terraform init` 
   and then `terraform state mv -backup=fancy-local.backup random_id.random_local random_id.random_local1`. 
   This should behave the same way as in previous Terraform versions, resulting in an error that looks like this:
   ```
   No state file was found!

   State management commands require a state file. Run this command
   in a directory where Terraform has been run or use the -state flag
   to point the command to a specific state location.
   ```
1. Run `terraform apply` 
   and then `terraform state mv -backup=fancy-local.backup random_id.random_local random_id.random_local1`. 
   This should behave the same way as in previous Terraform versions, succeeding and resulting in a backup file called `fancy-local.backup` being created and the resource being renamed in your `terraform.tfstate` file
1. Try various combinations of `-state`, `-state-out`, `-backup`, and `-backup-out`. These should all behave the same way they have in previous versions of Terraform. 

#### Non-local backend:
1. Run `terraform state mv -backup=fancy-remote.backup random_id.random_remote random_id.random_remote1`. 
   This should behave the same way as in previous Terraform versions, resulting in an error that looks like this:
   ```
   │ Error: Backend initialization required, please run "terraform init"
   │ 
   │ Reason: Initial configuration of the requested backend "consul"
   │ 
   │ The "backend" is the interface that Terraform uses to store state,
   ...
   │ hasn't changed and try again. At this point, no changes to your existing
   │ configuration or state have been made.
   ```
1. Run `terraform init` 
   and then `terraform state mv -backup=fancy-remote.backup random_id.random_remote random_id.random_remote1`. 
   This should throw the new error that looks like this:
   ```
   │ Error: Invalid command line options: -backup
   │ 
   │ Command line options -backup and -backup-out are legacy options that operate on a local state file only. You must specify a local state file with the
   │ -state option or switch to the local backend.
   ```
1. Try running the same command with the `-backup-out` option and with the `-backup` and `-backup-out` options together. You should see the same error, with the first line changing to indicate which options you've used. 
1. Run `terraform apply` 
   and then `terraform state mv -backup=fancy-remote.backup random_id.random_remote random_id.random_remote1`. 
   You should see the same error as before and nothing should change in your remote state.
   ```
   │ Error: Invalid command line option: -backup
   │ 
   │ Command line options -backup and -backup-out are legacy options that operate on a local state file only. You must specify a local state file with the
   │ -state option or switch to the local backend.
   ```
1. Try running the same command with the `-backup-out` option and with the `-backup` and `-backup-out` options together. You should see the same error, with the first line changing to indicate which options you've used. 
1. Create a local copy of your remote state by running `terraform state pull > terraform-local-copy.tfstate`
1. Run the same command as before but with with the state option specified this time
   `terraform state mv -state=terraform-local-copy.tfstate -backup=fancy-remote.backup random_id.random_remote random_id.random_remote1`. 
   This should succeed and you should see a `fancy-remote.backup` file created and you should see your resource name updated in `terraform-local-copy.tfstate`. Nothing should change in your remote state. 
1. Try various combinations of `-state`, `-state-out`, `-backup`, and `-backup-out`. These should all work as expected as long as the state option has been specified.

## Screenshots

#### Local build of section of updated docs:
<img width="970" alt="Screen Shot 2021-11-05 at 3 38 04 PM" src="https://user-images.githubusercontent.com/12189856/140575525-54627e6a-9f67-4b51-967f-950d21343fb6.png">
