### PR TITLE
Add test case for usage of S3 Object Lock in remote state backend

### DIFF
--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -30,7 +30,29 @@ func TestRemoteClient(t *testing.T) {
 		"encrypt": true,
 	})).(*Backend)
 
-	createS3Bucket(t, b.s3Client, bucketName)
+	createS3Bucket(t, b.s3Client, bucketName, false)
+	defer deleteS3Bucket(t, b.s3Client, bucketName)
+
+	state, err := b.StateMgr(backend.DefaultStateName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remote.TestClient(t, state.(*remote.State).Client)
+}
+
+func TestRemoteClientObjectLocks(t *testing.T) {
+	testACC(t)
+	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
+	keyName := "testState"
+
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
+		"bucket":  bucketName,
+		"key":     keyName,
+		"encrypt": true,
+	})).(*Backend)
+
+	createS3Bucket(t, b.s3Client, bucketName, true)
 	defer deleteS3Bucket(t, b.s3Client, bucketName)
 
 	state, err := b.StateMgr(backend.DefaultStateName)
@@ -60,7 +82,7 @@ func TestRemoteClientLocks(t *testing.T) {
 		"dynamodb_table": bucketName,
 	})).(*Backend)
 
-	createS3Bucket(t, b1.s3Client, bucketName)
+	createS3Bucket(t, b1.s3Client, bucketName, false)
 	defer deleteS3Bucket(t, b1.s3Client, bucketName)
 	createDynamoDBTable(t, b1.dynClient, bucketName)
 	defer deleteDynamoDBTable(t, b1.dynClient, bucketName)
@@ -98,7 +120,7 @@ func TestForceUnlock(t *testing.T) {
 		"dynamodb_table": bucketName,
 	})).(*Backend)
 
-	createS3Bucket(t, b1.s3Client, bucketName)
+	createS3Bucket(t, b1.s3Client, bucketName, false)
 	defer deleteS3Bucket(t, b1.s3Client, bucketName)
 	createDynamoDBTable(t, b1.dynClient, bucketName)
 	defer deleteDynamoDBTable(t, b1.dynClient, bucketName)
@@ -167,7 +189,7 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 		"dynamodb_table": bucketName,
 	})).(*Backend)
 
-	createS3Bucket(t, b.s3Client, bucketName)
+	createS3Bucket(t, b.s3Client, bucketName, false)
 	defer deleteS3Bucket(t, b.s3Client, bucketName)
 	createDynamoDBTable(t, b.dynClient, bucketName)
 	defer deleteDynamoDBTable(t, b.dynClient, bucketName)
@@ -215,7 +237,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 		"dynamodb_table": bucketName,
 	})).(*Backend)
 
-	createS3Bucket(t, b1.s3Client, bucketName)
+	createS3Bucket(t, b1.s3Client, bucketName, false)
 	defer deleteS3Bucket(t, b1.s3Client, bucketName)
 	createDynamoDBTable(t, b1.dynClient, bucketName)
 	defer deleteDynamoDBTable(t, b1.dynClient, bucketName)


### PR DESCRIPTION
This PR adds a test case for verifying the compatibility of S3 Object Lock with S3 remote state backend,
as #23127 reported it was not working properly.

Test results:

```sh
# TF_S3_TEST=1 go test -v ./internal/backend/remote-state/s3/ -run TestRemoteClientObjectLocks
=== RUN   TestRemoteClientObjectLocks
    client_test.go:49: TestBackendConfig on *s3.Backend with configs.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"bucket":cty.StringVal("terraform-remote-s3-test-61893862"), "encrypt":cty.True, "key":cty.StringVal("testState")}}
    backend_test.go:694: creating S3 bucket terraform-remote-s3-test-61893862 in us-west-2
    backend_test.go:739: WARNING: Failed to delete the test S3 bucket. It may have been left in your AWS account and may incur storage charges. (error was BucketNotEmpty: The bucket you tried to delete is not empty. You must delete all versions in the bucket.
                status code: 409, request id: QYT049JZMWK158C7, host id: 7FhDcdSMlLQi8Z/YSn0QrXteJVbwwTnZ5pECZH/2kQYRS5Dkk9yr1TJE/K8w6Y/Aoo86gDtToB8=)
--- PASS: TestRemoteClientObjectLocks (7.63s)
PASS
ok      github.com/hashicorp/terraform/internal/backend/remote-state/s3 7.640s
```

```
# aws s3api get-object-lock-configuration --bucket terraform-remote-s3-test-61893862
{
    "ObjectLockConfiguration": {
        "ObjectLockEnabled": "Enabled",
        "Rule": {
            "DefaultRetention": {
                "Mode": "COMPLIANCE",
                "Days": 1
            }
        }
    }
}
```

Note: this creates S3 buckets and objects that cannot be destroyed before the expiration of the retention delay (hard-coded to 1 day in the testing code).

![image](https://user-images.githubusercontent.com/318490/140764195-78ddd7af-6369-4f0a-8729-7acaa166f6aa.png)

![image](https://user-images.githubusercontent.com/318490/140764354-c52cc478-dc37-4db0-9ebd-499c3e0f55bd.png)

![image](https://user-images.githubusercontent.com/318490/140764478-7dcd57aa-de3d-4262-a5a6-ff2bd5c0f361.png)

![image](https://user-images.githubusercontent.com/318490/140764538-3a61973e-402c-4ae5-9589-079a5990edb3.png)


