### PR TITLE
Pull changes made to mocks in go-tfe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-retryablehttp v0.7.0
-	github.com/hashicorp/go-tfe v0.19.1-0.20211020175229-e52963e079d0
+	github.com/hashicorp/go-tfe v0.20.1-0.20211101140842-a4cb47d035cf
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-retryablehttp v0.7.0
-	github.com/hashicorp/go-tfe v0.20.1-0.20211101140842-a4cb47d035cf
+	github.com/hashicorp/go-tfe v0.20.1-0.20211110172530-c43c6b574caa
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
@@ -176,7 +176,7 @@ require (
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.10.0 // indirect
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
-	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/hashicorp/go-slug v0.7.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
-github.com/hashicorp/go-tfe v0.19.1-0.20211020175229-e52963e079d0 h1:64o1fy8p4a9J/5Gooy1S9iuEJQqXTVGYk5ZrXwFDZ8w=
-github.com/hashicorp/go-tfe v0.19.1-0.20211020175229-e52963e079d0/go.mod h1:gyXLXbpBVxA2F/6opah8XBsOkZJxHYQmghl0OWi8keI=
+github.com/hashicorp/go-tfe v0.20.1-0.20211101140842-a4cb47d035cf h1:VItt+uNOHWOAvWyHqhmGRJpec4yRmL24+gccz8b7bHw=
+github.com/hashicorp/go-tfe v0.20.1-0.20211101140842-a4cb47d035cf/go.mod h1:gyXLXbpBVxA2F/6opah8XBsOkZJxHYQmghl0OWi8keI=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/hashicorp/go-slug v0.7.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
-github.com/hashicorp/go-tfe v0.20.1-0.20211101140842-a4cb47d035cf h1:VItt+uNOHWOAvWyHqhmGRJpec4yRmL24+gccz8b7bHw=
-github.com/hashicorp/go-tfe v0.20.1-0.20211101140842-a4cb47d035cf/go.mod h1:gyXLXbpBVxA2F/6opah8XBsOkZJxHYQmghl0OWi8keI=
+github.com/hashicorp/go-tfe v0.20.1-0.20211110172530-c43c6b574caa h1:6LHPSBzcYJwMO+iBSOCTY1ZvMc3EeIuD4okEM7p7G7c=
+github.com/hashicorp/go-tfe v0.20.1-0.20211110172530-c43c6b574caa/go.mod h1:gyXLXbpBVxA2F/6opah8XBsOkZJxHYQmghl0OWi8keI=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
@@ -884,8 +884,9 @@ golang.org/x/time v0.0.0-20161028155119-f51c12702a4d/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/cloud/backend_apply_test.go
+++ b/internal/cloud/backend_apply_test.go
@@ -13,6 +13,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	tfe "github.com/hashicorp/go-tfe"
+	mocks "github.com/hashicorp/go-tfe/mocks"
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
@@ -576,7 +577,7 @@ func TestCloud_applyAutoApprove(t *testing.T) {
 	defer bCleanup()
 	ctrl := gomock.NewController(t)
 
-	applyMock := tfe.NewMockApplies(ctrl)
+	applyMock := mocks.NewMockApplies(ctrl)
 	// This needs three new lines because we check for a minimum of three lines
 	// in the parsing of logs in `opApply` function.
 	logs := strings.NewReader(applySuccessOneResourceAdded)
@@ -778,7 +779,7 @@ func TestCloud_applyWithAutoApprove(t *testing.T) {
 	defer bCleanup()
 	ctrl := gomock.NewController(t)
 
-	applyMock := tfe.NewMockApplies(ctrl)
+	applyMock := mocks.NewMockApplies(ctrl)
 	// This needs three new lines because we check for a minimum of three lines
 	// in the parsing of logs in `opApply` function.
 	logs := strings.NewReader(applySuccessOneResourceAdded)
@@ -1269,7 +1270,7 @@ func TestCloud_applyPolicySoftFailAutoApproveSuccess(t *testing.T) {
 	defer bCleanup()
 	ctrl := gomock.NewController(t)
 
-	policyCheckMock := tfe.NewMockPolicyChecks(ctrl)
+	policyCheckMock := mocks.NewMockPolicyChecks(ctrl)
 	// This needs three new lines because we check for a minimum of three lines
 	// in the parsing of logs in `opApply` function.
 	logs := strings.NewReader(fmt.Sprintf("%s\n%s", sentinelSoftFail, applySuccessOneResourceAdded))
@@ -1289,7 +1290,7 @@ func TestCloud_applyPolicySoftFailAutoApproveSuccess(t *testing.T) {
 	policyCheckMock.EXPECT().Logs(gomock.Any(), gomock.Any()).Return(logs, nil)
 	policyCheckMock.EXPECT().Override(gomock.Any(), gomock.Any()).Return(nil, nil)
 	b.client.PolicyChecks = policyCheckMock
-	applyMock := tfe.NewMockApplies(ctrl)
+	applyMock := mocks.NewMockApplies(ctrl)
 	// This needs three new lines because we check for a minimum of three lines
 	// in the parsing of logs in `opApply` function.
 	logs = strings.NewReader("\n\n\n1 added, 0 changed, 0 destroyed")
@@ -1348,7 +1349,7 @@ func TestCloud_applyPolicySoftFailAutoApprove(t *testing.T) {
 	defer bCleanup()
 	ctrl := gomock.NewController(t)
 
-	applyMock := tfe.NewMockApplies(ctrl)
+	applyMock := mocks.NewMockApplies(ctrl)
 	// This needs three new lines because we check for a minimum of three lines
 	// in the parsing of logs in `opApply` function.
 	logs := strings.NewReader(applySuccessOneResourceAdded)


### PR DESCRIPTION
The current version of main branch for `go-tfe` has go mocks placed in a different directory:
https://github.com/hashicorp/go-tfe/pull/280

Terraform is using some of those mocks in `terraform/internal/cloud/backend_apply_test.go`

To avoid this kind of errors:

```
terraform/internal/cloud/backend_apply_test.go:579:15: undefined: tfe.NewMockApplies
terraform/internal/cloud/backend_apply_test.go:781:15: undefined: tfe.NewMockApplies
terraform/internal/cloud/backend_apply_test.go:1272:21: undefined: tfe.NewMockPolicyChecks
```

We need this test file to import the mocks from its new path.

At this point, this PR is failing due to a different compile error not address in this PR:

`terraform/internal/cloud/backend_plan.go:238: undefined: tfe.RunVariable`

This is because this type `RunVariable` does not exist in the main go-tfe branch which is the one that includes the mock changes. Right now this terraform repo is using a specific branch version of go-tfe that includes the `RunVariable` type. 
Because the mock changes have conflicts with this branch, we can't merge these changes now. So In the meantime, I am just opening this PR draft so the team is aware that these are the changes needed once this repo wants to use the main branch for go-tfe.