### PR TITLE
fix(run variables): support all variable types (map, list, bool, number, null, string)

### DIFF
--- a/internal/cloud/backend_plan_test.go
+++ b/internal/cloud/backend_plan_test.go
@@ -477,7 +477,7 @@ func TestCloud_planWithRequiredVariables(t *testing.T) {
 	defer configCleanup()
 	defer done(t)
 
-	op.Variables = testVariables(terraform.ValueFromCLIArg, "foo") // "bar" variable value missing
+	op.Variables = testVariables(terraform.ValueFromCLIArg, "foo") // "bar" variable defined in config is  missing
 	op.Workspace = testBackendSingleWorkspaceName
 
 	run, err := b.Operation(context.Background(), op)
@@ -487,7 +487,7 @@ func TestCloud_planWithRequiredVariables(t *testing.T) {
 
 	<-run.Done()
 	// The usual error of a required variable being missing is deferred and the operation
-	// is successful
+	// is successful.
 	if run.Result != backend.OperationSuccess {
 		t.Fatal("expected plan operation to succeed")
 	}


### PR DESCRIPTION
All run variables remain encoded as strings in the TFC/E API requests but will now be expressed as an HCL string to be evaluated by the remote terraform. Previously, only string variables were supported but now you can express all types of cloud run variable values when using -var-file

Examples:
string: \`"quoted literal"\` (strings must be quoted)
map:  \`{ foo = "bar" }\`
list: \`["foo", "bar"]\`
bool: \`true\`
null: \`null\`
number: \`0.0001\`

This requires the API to anticipate that all run variables be HCL values. 