### PR TITLE
Fix side effect on nil map due to ignore change processing

### DIFF
--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1290,7 +1290,11 @@ func processIgnoreChangesIndividual(prior, config cty.Value, ignoreChangesPath [
 
 		var newVal cty.Value
 		if len(configMap) == 0 {
-			newVal = cty.MapValEmpty(v.Type().ElementType())
+			if v.IsNull() {
+				newVal = v
+			} else {
+				newVal = cty.MapValEmpty(v.Type().ElementType())
+			}
 		} else {
 			newVal = cty.MapVal(configMap)
 		}


### PR DESCRIPTION
I'm newbie to the core code, but with some debugging, it seems that the ignore change processing might introduce a side effect on the nil maps in the config, that will turn these nil map into empty map. This PR fixes differentiate the nil map and empty map using an not ideal way (since I'm not sure how to create a cty.Map with nil value).

Fixes: #29921