### PR TITLE
funcs: defer close file in filesha256

### DIFF
--- a/internal/lang/funcs/crypto.go
+++ b/internal/lang/funcs/crypto.go
@@ -248,6 +248,7 @@ func makeFileHashFunction(baseDir string, hf func() hash.Hash, enc func([]byte) 
 			if err != nil {
 				return cty.UnknownVal(cty.String), err
 			}
+			defer f.Close()
 
 			h := hf()
 			_, err = io.Copy(h, f)

--- a/internal/lang/funcs/filesystem.go
+++ b/internal/lang/funcs/filesystem.go
@@ -377,6 +377,7 @@ func readFileBytes(baseDir, path string) ([]byte, error) {
 		}
 		return nil, err
 	}
+	defer f.Close()
 
 	src, err := ioutil.ReadAll(f)
 	if err != nil {


### PR DESCRIPTION
Files opened by the filesha256 function were not being closed,
leaking file descriptors. Close files that were opened when the
function exist.

Even though I'm fairly certain that this is a fix, I'm asking for your review and opinion on this as I'm not that familiar with the codebase.