### PR TITLE
`ignore_changes` converting null maps to empty maps, and applying marks.

### DIFF
--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1289,10 +1289,15 @@ func processIgnoreChangesIndividual(prior, config cty.Value, ignoreChangesPath [
 		}
 
 		var newVal cty.Value
-		if len(configMap) == 0 {
-			newVal = cty.MapValEmpty(v.Type().ElementType())
-		} else {
+		switch {
+		case len(configMap) > 0:
 			newVal = cty.MapVal(configMap)
+		case v.IsNull():
+			// if the config value was null, and no values remain in the map,
+			// reset the value to null.
+			newVal = v
+		default:
+			newVal = cty.MapValEmpty(v.Type().ElementType())
 		}
 
 		if len(vMarks) > 0 {

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1301,7 +1301,7 @@ func processIgnoreChangesIndividual(prior, config cty.Value, ignoreChangesPath [
 		}
 
 		if len(vMarks) > 0 {
-			newVal = v.WithMarks(vMarks)
+			newVal = newVal.WithMarks(vMarks)
 		}
 
 		return newVal, nil

--- a/internal/terraform/reduce_plan_test.go
+++ b/internal/terraform/reduce_plan_test.go
@@ -369,6 +369,54 @@ func TestProcessIgnoreChangesIndividual(t *testing.T) {
 				"b": cty.StringVal("new b value"),
 			}),
 		},
+		"null_map": {
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("ok"),
+				"list": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"s":   cty.StringVal("ok"),
+						"map": cty.NullVal(cty.Map(cty.String)),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NullVal(cty.String),
+				"list": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"s":   cty.StringVal("ok"),
+						"map": cty.NullVal(cty.Map(cty.String)),
+					}),
+				}),
+			}),
+			[]string{"a"},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("ok"),
+				"list": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"s":   cty.StringVal("ok"),
+						"map": cty.NullVal(cty.Map(cty.String)),
+					}),
+				}),
+			}),
+		},
+		"marked_map": {
+			cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"key": cty.StringVal("val"),
+				}).Mark("marked"),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"key": cty.StringVal("new val"),
+				}).Mark("marked"),
+			}),
+			[]string{`map["key"]`},
+			cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"key": cty.StringVal("val"),
+				}).Mark("marked"),
+			}),
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
When processing nested data structures for `ignore_changes`, a null map was sometimes converted to an empty map. 

When processing individual changes within a map, those changes could be lost when re-applying any marks set on the outer map.

Fixes #29921