### PR TITLE
Implement migration away from TFC; unify migration code paths a bit more

### DIFF
--- a/internal/cloud/e2e/helper_test.go
+++ b/internal/cloud/e2e/helper_test.go
@@ -16,6 +16,9 @@ import (
 
 const (
 	expectConsoleTimeout = 15 * time.Second
+	// Remote runs can be very slow in local dockerized TFC, so tests that do
+	// plans and applies might need to opt into a longer timeout:
+	expectRemoteOperationsTimeout = 60 * time.Second
 )
 
 type tfCommand struct {
@@ -39,6 +42,17 @@ type testCases map[string]struct {
 func defaultOpts() []expect.ConsoleOpt {
 	opts := []expect.ConsoleOpt{
 		expect.WithDefaultTimeout(expectConsoleTimeout),
+	}
+	if verboseMode {
+		opts = append(opts, expect.WithStdout(os.Stdout))
+	}
+	return opts
+}
+
+// Like defaultOpts, but with a longer timeout.
+func remoteOperationsOpts() []expect.ConsoleOpt {
+	opts := []expect.ConsoleOpt{
+		expect.WithDefaultTimeout(expectRemoteOperationsTimeout),
 	}
 	if verboseMode {
 		opts = append(opts, expect.WithStdout(os.Stdout))

--- a/internal/cloud/e2e/migrate_state_tfc_to_other_test.go
+++ b/internal/cloud/e2e/migrate_state_tfc_to_other_test.go
@@ -14,7 +14,7 @@ func Test_migrate_tfc_to_other(t *testing.T) {
 	cases := map[string]struct {
 		operations []operationSets
 	}{
-		"migrate from cloud to local backend": {
+		"migrate from cloud (name) to local backend": {
 			operations: []operationSets{
 				{
 					prep: func(t *testing.T, orgName, dir string) {
@@ -27,6 +27,10 @@ func Test_migrate_tfc_to_other(t *testing.T) {
 							command:           []string{"init"},
 							expectedCmdOutput: `Terraform Cloud has been successfully initialized!`,
 						},
+						{
+							command:           []string{"apply", "-auto-approve"},
+							expectedCmdOutput: `Apply complete!`,
+						},
 					},
 				},
 				{
@@ -37,8 +41,13 @@ func Test_migrate_tfc_to_other(t *testing.T) {
 					commands: []tfCommand{
 						{
 							command:           []string{"init", "-migrate-state"},
-							expectedCmdOutput: `Migrating state from Terraform Cloud to another backend is not yet implemented.`,
-							expectError:       true,
+							expectedCmdOutput: `Do you want to copy existing state to the new backend?`,
+							userInput:         []string{"yes"},
+							postInputOutput:   []string{`Terraform has been successfully initialized!`},
+						},
+						{
+							command:           []string{"apply", "-auto-approve"},
+							expectedCmdOutput: `Your infrastructure matches the configuration.`,
 						},
 					},
 				},
@@ -52,7 +61,7 @@ func Test_migrate_tfc_to_other(t *testing.T) {
 			t.Parallel()
 			organization, cleanup := createOrganization(t)
 			defer cleanup()
-			exp, err := expect.NewConsole(defaultOpts()...)
+			exp, err := expect.NewConsole(remoteOperationsOpts()...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -857,9 +857,11 @@ func (m *Meta) backend_c_r_S(c *configs.Backend, cHash int, sMgr *clistate.Local
 	}
 
 	if output {
-		m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-			"[reset][green]\n\n"+
-				strings.TrimSpace(successBackendUnset), backendType)))
+		successMessage := fmt.Sprintf(strings.TrimSpace(successBackendUnset), backendType)
+		if backendType == "cloud" {
+			successMessage = strings.TrimSpace(successCloudUnset)
+		}
+		m.Ui.Output(m.Colorize().Color("[reset][green]\n\n" + successMessage))
 	}
 
 	// Return no backend
@@ -1431,6 +1433,10 @@ name to create a new Terraform Cloud workspace.
 
 const successBackendUnset = `
 Successfully unset the backend %q. Terraform will now operate locally.
+`
+
+const successCloudUnset = `
+Successfully unconfigured Terraform Cloud. Terraform will now operate locally.
 `
 
 const successBackendSet = `

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -1021,7 +1021,9 @@ func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr *clista
 	if s.Backend.Type != c.Type {
 		output := fmt.Sprintf(outputBackendMigrateChange, s.Backend.Type, c.Type)
 		if c.Type == "cloud" {
-			output = fmt.Sprintf(outputBackendMigrateChangeCloud, s.Backend.Type)
+			output = fmt.Sprintf(outputBackendMigrateChangeToCloud, s.Backend.Type)
+		} else if s.Backend.Type == "cloud" {
+			output = fmt.Sprintf(outputBackendMigrateChangeFromCloud, c.Type)
 		}
 		m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
 			"[reset]%s\n",
@@ -1404,8 +1406,12 @@ const outputBackendMigrateChange = `
 Terraform detected that the backend type changed from %q to %q.
 `
 
-const outputBackendMigrateChangeCloud = `
+const outputBackendMigrateChangeToCloud = `
 Terraform detected that the backend type changed from %q to Terraform Cloud.
+`
+
+const outputBackendMigrateChangeFromCloud = `
+Terraform detected that the backend type changed from Terraform Cloud to %q.
 `
 
 const outputBackendMigrateLocal = `

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -643,6 +643,9 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 
 			log.Printf("[INFO] backendMigrateTFC: multi-to-single migration from source %s to destination %q", opts.sourceWorkspace, opts.destinationWorkspace)
 
+			// now switch back to the default workspace so we can acccess the new backend
+			m.SetWorkspace(backend.DefaultStateName)
+
 			return m.backendMigrateState_s_s(opts)
 
 		// Multi via tags, migrate everything.

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -120,12 +120,12 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 		return m.backendMigrateTFC(opts)
 
 	// Single-state to single-state. This is the easiest case: we just
-	// copy the default state directly.
+	// copy the one existing state directly.
 	case sourceSingleState && destinationSingleState:
 		return m.backendMigrateState_s_s(opts)
 
 	// Single-state to multi-state. This is easy since we just copy
-	// the default state and ignore the rest in the destination.
+	// the one existing state and ignore the rest in the destination.
 	case sourceSingleState && !destinationSingleState:
 		return m.backendMigrateState_s_s(opts)
 

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -83,13 +83,12 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 		opts.destinationWorkspace = destinationAsCloud.WorkspaceMapping.Name
 	}
 
-	// Regardless of source type: If the source only *has* one state, we can treat
-	// it as if it doesn't support multi-state.
+	// If a multi-workspace source only *has* one state, we can act like it's single-state.
 	if len(sourceWorkspaces) == 1 {
 		sourceSingleState = true
-		// In most backends that one state would be "default"; in TFC, it'd have
-		// a unique name. In either case, if the destination allows us to choose a
-		// name, we should use whatever name the source uses.
+		// That one state is "default" in most backends, but would have some other
+		// name in TFC. Either way, if the destination allows us to choose a name,
+		// we should use whatever name the source uses.
 		if !destinationSingleState {
 			opts.destinationWorkspace = opts.sourceWorkspace
 		}

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -653,6 +653,7 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 			// New branch:
 			// Migrate all workspaces, yey. Resembles S_S but we need new prompts.
 			// can. we just replace the prompts w/ conditionals?
+			return m.backendMigrateState_S_S(opts)
 		}
 	}
 	// TODO: modify this failure return once things start working

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -62,9 +62,13 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 	if err != nil {
 		return err
 	}
+	currentWorkspace, err := m.Workspace()
+	if err != nil {
+		return err
+	}
 
 	// Set up defaults
-	opts.sourceWorkspace = backend.DefaultStateName
+	opts.sourceWorkspace = currentWorkspace
 	opts.destinationWorkspace = backend.DefaultStateName
 	opts.force = m.forceInitCopy
 
@@ -566,7 +570,6 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 	if err != nil {
 		return err
 	}
-	currentWorkspace, err := m.Workspace()
 	if err != nil {
 		return err
 	}
@@ -578,9 +581,6 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 		destinationNameStrategy = cloudBackendDestination.WorkspaceMapping.Strategy() == cloud.WorkspaceNameStrategy
 	}
 
-	// In almost every case, source workspace should be the current workspace; in the one exception
-	// (multi-to-multi), there's no harm in setting it now.
-	opts.sourceWorkspace = currentWorkspace
 	// Set the name early if we happen to know it already.
 	if destinationNameStrategy {
 		opts.destinationWorkspace = cloudBackendDestination.WorkspaceMapping.Name
@@ -627,7 +627,7 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 
 		// Single to single, keeping existing name. Mutate opts, return s_s.
 		case sourceSingle && !destinationSingleState:
-			opts.destinationWorkspace = currentWorkspace
+			opts.destinationWorkspace = opts.sourceWorkspace
 			log.Printf("[INFO] backendMigrateTFC: single-to-single migration from source %s to destination %q", opts.sourceWorkspace, opts.destinationWorkspace)
 			return m.backendMigrateState_s_s(opts)
 

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -223,14 +223,10 @@ func (m *Meta) backendMigrateState_S_S(opts *backendMigrateOpts) error {
 	return nil
 }
 
-// Multi-state to single state.
+// Multi-state to single state. Make sure to set opts.sourceWorkspace to an appropriate value before calling
+// this function.
 func (m *Meta) backendMigrateState_S_s(opts *backendMigrateOpts) error {
 	log.Printf("[INFO] backendMigrateState: destination backend type %q does not support named workspaces", opts.DestinationType)
-
-	currentWorkspace, err := m.Workspace()
-	if err != nil {
-		return err
-	}
 
 	migrate := opts.force
 	if !migrate {
@@ -250,7 +246,7 @@ func (m *Meta) backendMigrateState_S_s(opts *backendMigrateOpts) error {
 		} else {
 			description = fmt.Sprintf(
 				strings.TrimSpace(inputBackendMigrateMultiToSingle),
-				opts.SourceType, opts.DestinationType, currentWorkspace)
+				opts.SourceType, opts.DestinationType, opts.sourceWorkspace)
 		}
 
 		// Ask the user if they want to migrate their existing remote state
@@ -269,10 +265,7 @@ func (m *Meta) backendMigrateState_S_s(opts *backendMigrateOpts) error {
 		return fmt.Errorf("Migration aborted by user.")
 	}
 
-	// Copy the default state
-	opts.sourceWorkspace = currentWorkspace
-
-	// now switch back to the default env so we can acccess the new backend
+	// now switch back to the default workspace so we can acccess the new backend.
 	m.SetWorkspace(backend.DefaultStateName)
 
 	return m.backendMigrateState_s_s(opts)

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -451,7 +451,13 @@ func (m *Meta) backendMigrateEmptyConfirm(source, destination statemgr.Full, opt
 		inputOpts = &terraform.InputOpts{
 			Id:          "backend-migrate-copy-to-empty-cloud",
 			Query:       "Do you want to copy existing state to Terraform Cloud?",
-			Description: fmt.Sprintf(strings.TrimSpace(inputBackendMigrateEmptyCloud), opts.SourceType),
+			Description: fmt.Sprintf(strings.TrimSpace(inputBackendMigrateToEmptyCloud), opts.SourceType),
+		}
+	} else if opts.SourceType == "cloud" {
+		inputOpts = &terraform.InputOpts{
+			Id:          "backend-migrate-copy-cloud-to-empty",
+			Query:       "Do you want to copy existing state to the new backend?",
+			Description: fmt.Sprintf(strings.TrimSpace(inputBackendMigrateCloudToEmpty), opts.DestinationType),
 		}
 	} else {
 		inputOpts = &terraform.InputOpts{
@@ -1008,16 +1014,23 @@ Enter "yes" to proceed or "no" to cancel.
 `
 
 const inputBackendMigrateEmpty = `
-Pre-existing state was found while migrating the previous %q backend to the
-newly configured %q backend. No existing state was found in the newly
-configured %[2]q backend. Do you want to copy this state to the new %[2]q
-backend? Enter "yes" to copy and "no" to start with an empty state.
+Terraform found pre-existing state in the previous %q backend, and did not
+find any state in the newly configured %q backend. Do you want to copy
+this state to the new %[2]q backend? Enter "yes" to copy and "no" to start
+with an empty state.
 `
 
-const inputBackendMigrateEmptyCloud = `
-Pre-existing state was found while migrating the previous %q backend to Terraform Cloud.
-No existing state was found in Terraform Cloud. Do you want to copy this state to Terraform Cloud?
-Enter "yes" to copy and "no" to start with an empty state.
+const inputBackendMigrateToEmptyCloud = `
+Terraform found pre-existing state in the previous %q backend, and did not
+find any existing state in Terraform Cloud. Do you want to copy this state to
+Terraform Cloud? Enter "yes" to copy and "no" to start with an empty state.
+`
+
+const inputBackendMigrateCloudToEmpty = `
+Terraform found pre-existing state in Terraform Cloud, and did not find any
+existing state in the newly configured %q backend. Do you want to copy this
+state to the new %[1]q backend? Enter "yes" to copy and "no" to start
+with an empty state.
 `
 
 const inputBackendMigrateNonEmpty = `

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -650,14 +650,12 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 
 		// Multi via tags, migrate everything.
 		case !sourceSingle && !destinationSingleState:
-			// New branch:
-			// Migrate all workspaces, yey. Resembles S_S but we need new prompts.
-			// can. we just replace the prompts w/ conditionals?
+			// Normal S_S works fine.
 			return m.backendMigrateState_S_S(opts)
 		}
 	}
-	// TODO: modify this failure return once things start working
-	return fmt.Errorf(strings.TrimSpace(errTFCMigrateNotYetImplemented))
+
+	return fmt.Errorf("Hit an unaccounted-for case when migrating away from Terraform Cloud; this should never happen.")
 }
 
 // migrates a multi-state backend to Terraform Cloud
@@ -952,12 +950,6 @@ Error copying state from the previous %q backend to the newly configured
 
 The state in the previous backend remains intact and unmodified. Please resolve
 the error above and try again.
-`
-
-const errTFCMigrateNotYetImplemented = `
-Migrating state from Terraform Cloud to another backend is not yet implemented.
-
-Please use the API to do this: https://www.terraform.io/docs/cloud/api/state-versions.html
 `
 
 const tfcInputBackendMigrateMultiToMultiPattern = `

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -86,12 +86,6 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 	// If a multi-workspace source only *has* one state, we can act like it's single-state.
 	if len(sourceWorkspaces) == 1 {
 		sourceSingleState = true
-		// That one state is "default" in most backends, but would have some other
-		// name in TFC. Either way, if the destination allows us to choose a name,
-		// we should use whatever name the source uses.
-		if !destinationSingleState {
-			opts.destinationWorkspace = opts.sourceWorkspace
-		}
 	}
 
 	// Disregard remote Terraform version for the state source backend. If it's a
@@ -132,9 +126,12 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 	case sourceSingleState && destinationSingleState:
 		return m.backendMigrateState_s_s(opts)
 
-	// Single-state to multi-state. This is easy since we just copy
-	// the one existing state and ignore the rest in the destination.
+	// Single-state to multi-state. We copy the one existing state and ignore the
+	// rest in the destination.
 	case sourceSingleState && !destinationSingleState:
+		// The destination lets us choose a name, so match the source. (TFC allows a
+		// named workspace as the only state, so this might not be "default".)
+		opts.destinationWorkspace = opts.sourceWorkspace
 		return m.backendMigrateState_s_s(opts)
 
 	// Multi-state to single-state. If the source has more than the default


### PR DESCRIPTION
Previously, we didn't support migrating away from the new TFC integration to an old-school state backend via a normal `terraform init -migrate-state`. This PR adds that capability.

Well, really all it _adds_ is some alternate message text for various stages of the process; most of the heavy lifting happens by _removing_ the TFC-specific reimplementation of the `backendMigrateState` wrapper function. 

When migrating onto or off of TFC, we need to take some slightly different signals into account to determine which path we're taking. But the ultimate decisions about which path to take end up being almost exactly the same (with the notable exception of multi-to-multi-with-renames); it's just that we need to check different values. 

So instead of running through the logic twice, this PR adds a couple of conditionals to the beginning of `backendMigrateState` to translate the TFC-specific signals about what's going on into the format that the rest of the function expects. Once that's done, the normal four-way switch statement works almost unmodified. 

## How to test this

The newly supported behaviors all involve:

1. Setting up + initting the cloud block, then performing a run to create some state.
2. Removing the cloud block, replacing it with either a `backend` block or nothing (implicit local backend), and re-running init with `-migrate-state`. 

In all cases, `terraform workspace list` should show you at least the workspaces you intended to migrate (sometimes with the addition of `default`), and you should be able to see the state data if you dig into the appropriate storage. The state should also remain in the TFC workspaces unmodified, since migration only copies; the user is in charge of deletion. 

Some cases worth looking at: 

- `cloud` with `name`, migrating to (nothing, consul, etc.): any existing workspaces in the new backend still exist (including `default`, even if it's empty), and it should add a named workspace with the original name. The new workspace is selected. 
    - If a workspace with the target name already existed in the new backend, it should ask you which state to use. 
- `cloud` with `tags` and multiple workspaces migrating to (nothing, consul, etc.): existing workspaces in backend still exist, new workspaces are added for each workspace from TFC. 
    - For any workspace names that already exist, it should ask which state to use. 
- `cloud` with `tags` and only one matching workspace migrating to (nothing, consul, etc.): Should behave like migrating with `name`.
- `cloud` with `name` migrating to a backend that only supports one state at a time: Should migrate the TFC state to the `default` workspace in the new backend.
- `cloud` with `tags` and multiple workspaces migrating to a single-state backend: Should confirm that you're okay with migrating only the current selected workspace to `default`, and then do it. 
- `cloud` with `tags` and only one workspace matching, migrating to single-state: Should behave like `name` -> single-state. (Doesn't need to confirm that only the current workspace will ride along, since there's only one.)