### PR TITLE
new: support token http header

### DIFF
--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -67,6 +67,18 @@ func New() backend.Backend {
 				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_PASSWORD", nil),
 				Description: "The password for HTTP basic authentication",
 			},
+			"token": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_TOKEN", nil),
+				Description: "The token for token authentication",
+			},
+			"token_header": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_TOKEN_HEADER", nil),
+				Description: "The HTTP header for token authentication",
+			},
 			"skip_cert_verification": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -171,8 +183,10 @@ func (b *Backend) configure(ctx context.Context) error {
 		UnlockURL:    unlockURL,
 		UnlockMethod: unlockMethod,
 
-		Username: data.Get("username").(string),
-		Password: data.Get("password").(string),
+		Username:    data.Get("username").(string),
+		Password:    data.Get("password").(string),
+		Token:       data.Get("token").(string),
+		TokenHeader: data.Get("token_header").(string),
 
 		// accessible only for testing use
 		Client: rClient,

--- a/internal/backend/remote-state/http/backend_test.go
+++ b/internal/backend/remote-state/http/backend_test.go
@@ -53,6 +53,8 @@ func TestHTTPClientFactory(t *testing.T) {
 		"unlock_method":  cty.StringVal("BLOOP"),
 		"username":       cty.StringVal("user"),
 		"password":       cty.StringVal("pass"),
+		"token":          cty.StringVal("token"),
+		"token_header":   cty.StringVal("x-token"),
 		"retry_max":      cty.StringVal("999"),
 		"retry_wait_min": cty.StringVal("15"),
 		"retry_wait_max": cty.StringVal("150"),
@@ -79,6 +81,10 @@ func TestHTTPClientFactory(t *testing.T) {
 		t.Fatalf("Unexpected username \"%s\" vs \"%s\" or password \"%s\" vs \"%s\"", client.Username, conf["username"],
 			client.Password, conf["password"])
 	}
+	if client.Token != "token" || client.TokenHeader != "x-token" {
+		t.Fatalf("Unexpected token \"%s\" vs \"%s\" or token header \"%s\" vs \"%s\"", client.Token, conf["token"],
+			client.TokenHeader, conf["token-header"])
+	}
 	if client.Client.RetryMax != 999 {
 		t.Fatalf("Expected retry_max \"%d\", got \"%d\"", 999, client.Client.RetryMax)
 	}
@@ -101,6 +107,8 @@ func TestHTTPClientFactoryWithEnv(t *testing.T) {
 		"unlock_method":  "BLOOP",
 		"username":       "user",
 		"password":       "pass",
+		"token":          "token",
+		"token_header":   "x-token",
 		"retry_max":      "999",
 		"retry_wait_min": "15",
 		"retry_wait_max": "150",
@@ -114,6 +122,8 @@ func TestHTTPClientFactoryWithEnv(t *testing.T) {
 	defer testWithEnv(t, "TF_HTTP_UNLOCK_METHOD", conf["unlock_method"])()
 	defer testWithEnv(t, "TF_HTTP_USERNAME", conf["username"])()
 	defer testWithEnv(t, "TF_HTTP_PASSWORD", conf["password"])()
+	defer testWithEnv(t, "TF_HTTP_TOKEN", conf["token"])()
+	defer testWithEnv(t, "TF_HTTP_TOKEN_HEADER", conf["token_header"])()
 	defer testWithEnv(t, "TF_HTTP_RETRY_MAX", conf["retry_max"])()
 	defer testWithEnv(t, "TF_HTTP_RETRY_WAIT_MIN", conf["retry_wait_min"])()
 	defer testWithEnv(t, "TF_HTTP_RETRY_WAIT_MAX", conf["retry_wait_max"])()
@@ -138,6 +148,10 @@ func TestHTTPClientFactoryWithEnv(t *testing.T) {
 	if client.Username != "user" || client.Password != "pass" {
 		t.Fatalf("Unexpected username \"%s\" vs \"%s\" or password \"%s\" vs \"%s\"", client.Username, conf["username"],
 			client.Password, conf["password"])
+	}
+	if client.Token != conf["token"] || client.TokenHeader != conf["token_header"] {
+		t.Fatalf("Unexpected token \"%s\" vs \"%s\" or token header \"%s\" vs \"%s\"", client.Token, conf["token"],
+			client.TokenHeader, conf["token_header"])
 	}
 	if client.Client.RetryMax != 999 {
 		t.Fatalf("Expected retry_max \"%d\", got \"%d\"", 999, client.Client.RetryMax)

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -29,9 +29,11 @@ type httpClient struct {
 	UnlockMethod string
 
 	// HTTP
-	Client   *retryablehttp.Client
-	Username string
-	Password string
+	Client      *retryablehttp.Client
+	Username    string
+	Password    string
+	Token       string
+	TokenHeader string
 
 	lockID       string
 	jsonLockInfo []byte
@@ -52,6 +54,11 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	// Set up basic auth
 	if c.Username != "" {
 		req.SetBasicAuth(c.Username, c.Password)
+	}
+
+	// Set up token header
+	if c.TokenHeader != "" {
+		req.Header.Set(c.TokenHeader, c.Token)
 	}
 
 	// Work with data/body

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -816,6 +816,8 @@ func TestApply_plan_remoteState(t *testing.T) {
 		"unlock_method":          cty.NullVal(cty.String),
 		"username":               cty.NullVal(cty.String),
 		"password":               cty.NullVal(cty.String),
+		"token":                  cty.NullVal(cty.String),
+		"token_header":           cty.NullVal(cty.String),
 		"skip_cert_verification": cty.NullVal(cty.Bool),
 		"retry_max":              cty.NullVal(cty.String),
 		"retry_wait_min":         cty.NullVal(cty.String),

--- a/website/docs/language/settings/backends/http.html.md
+++ b/website/docs/language/settings/backends/http.html.md
@@ -60,7 +60,7 @@ The following configuration options / environment variables are supported:
    authentication
  * `password` / `TF_HTTP_PASSWORD` - (Optional) The password for HTTP basic
    authentication
- * `token` / `TF_HTTP_TOKEN` - (Optional) "The token for token authentication
+ * `token` / `TF_HTTP_TOKEN` - (Optional) The token for token authentication
  * `token_header` / `TF_HTTP_TOKEN_HEADER` - (Optional) The HTTP header for 
    token authentication
  * `skip_cert_verification` - (Optional) Whether to skip TLS verification.

--- a/website/docs/language/settings/backends/http.html.md
+++ b/website/docs/language/settings/backends/http.html.md
@@ -60,6 +60,9 @@ The following configuration options / environment variables are supported:
    authentication
  * `password` / `TF_HTTP_PASSWORD` - (Optional) The password for HTTP basic
    authentication
+ * `token` / `TF_HTTP_TOKEN` - (Optional) "The token for token authentication
+ * `token_header` / `TF_HTTP_TOKEN_HEADER` - (Optional) The HTTP header for 
+   token authentication
  * `skip_cert_verification` - (Optional) Whether to skip TLS verification.
    Defaults to `false`.
  * `retry_max` / `TF_HTTP_RETRY_MAX` – (Optional) The number of HTTP request


### PR DESCRIPTION
Hi! 👋 I would love to use HTTP state backend with JWT tokens. This PR adds support to optionally pass token http header to the http backend. (POC https://twitter.com/adam_janis/status/1452389074812260359)