### PR TITLE
Cloud: Update Terraform init -reconfigure prompt

### DIFF
--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -97,14 +97,6 @@ func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, tfdiags.Diagnostics
 		b, backendDiags = m.backendFromConfig(opts)
 		diags = diags.Append(backendDiags)
 
-		if opts.Init && b != nil && !diags.HasErrors() {
-			// Its possible that the currently selected workspace doesn't exist, so
-			// we call selectWorkspace to ensure an existing workspace is selected.
-			if err := m.selectWorkspace(b); err != nil {
-				diags = diags.Append(err)
-			}
-		}
-
 		if diags.HasErrors() {
 			return nil, diags
 		}
@@ -232,8 +224,11 @@ func (m *Meta) selectWorkspace(b backend.Backend) error {
 				Query:       "\n[reset][bold][yellow]No workspaces found.[reset]",
 				Description: fmt.Sprintf(inputCloudInitCreateWorkspace, strings.Join(c.WorkspaceMapping.Tags, ", ")),
 			})
+			if err != nil {
+				return fmt.Errorf("Couldn't create initial workspace: %w", err)
+			}
 			name = strings.TrimSpace(name)
-			if err != nil || name == "" {
+			if name == "" {
 				return fmt.Errorf("Couldn't create initial workspace: no name provided")
 			}
 			log.Printf("[TRACE] Meta.selectWorkspace: selecting the new TFC workspace requested by the user (%s)", name)
@@ -610,7 +605,7 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 
 		return m.backend_c_r_S(c, cHash, sMgr, true)
 
-	// Configuring a backend for the first time.
+	// Configuring a backend for the first time or -reconfigure flag was used
 	case c != nil && s.Backend.Empty():
 		log.Printf("[TRACE] Meta.Backend: moving from default local state only to %q backend", c.Type)
 		if !opts.Init {
@@ -631,9 +626,7 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 			}
 			return nil, diags
 		}
-
-		return m.backend_C_r_s(c, cHash, sMgr)
-
+		return m.backend_C_r_s(c, cHash, sMgr, opts)
 	// Potentially changing a backend configuration
 	case c != nil && !s.Backend.Empty():
 		// We are not going to migrate if...
@@ -643,7 +636,15 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 		// AND we're not providing any overrides. An override can mean a change overriding an unchanged backend block (indicated by the hash value).
 		if (uint64(cHash) == s.Backend.Hash) && (!opts.Init || opts.ConfigOverride == nil) {
 			log.Printf("[TRACE] Meta.Backend: using already-initialized, unchanged %q backend configuration", c.Type)
-			return m.savedBackend(sMgr)
+			savedBackend, diags := m.savedBackend(sMgr)
+			// Verify that selected workspace exist. Otherwise prompt user to create one
+			if opts.Init && savedBackend != nil {
+				if err := m.selectWorkspace(savedBackend); err != nil {
+					diags = diags.Append(err)
+					return nil, diags
+				}
+			}
+			return savedBackend, diags
 		}
 
 		// If our configuration (the result of both the literal configuration and given
@@ -665,6 +666,13 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 			if moreDiags.HasErrors() {
 				return nil, diags
 			}
+			// Verify that selected workspace exist. Otherwise prompt user to create one
+			if opts.Init && savedBackend != nil {
+				if err := m.selectWorkspace(savedBackend); err != nil {
+					diags = diags.Append(err)
+					return nil, diags
+				}
+			}
 
 			return savedBackend, diags
 		}
@@ -685,7 +693,7 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 		}
 
 		log.Printf("[WARN] backend config has changed since last init")
-		return m.backend_C_r_S_changed(c, cHash, sMgr, true)
+		return m.backend_C_r_S_changed(c, cHash, sMgr, true, opts)
 
 	default:
 		diags = diags.Append(fmt.Errorf(
@@ -897,7 +905,7 @@ func (m *Meta) backend_c_r_S(c *configs.Backend, cHash int, sMgr *clistate.Local
 }
 
 // Configuring a backend for the first time.
-func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.LocalState) (backend.Backend, tfdiags.Diagnostics) {
+func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.LocalState, opts *BackendOpts) (backend.Backend, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// Grab a purely local backend to get the local state if it exists
@@ -1017,6 +1025,14 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 		Hash:      uint64(cHash),
 	}
 
+	// Verify that selected workspace exist. Otherwise prompt user to create one
+	if opts.Init && b != nil {
+		if err := m.selectWorkspace(b); err != nil {
+			diags = diags.Append(err)
+			return nil, diags
+		}
+	}
+
 	if err := sMgr.WriteState(s); err != nil {
 		diags = diags.Append(fmt.Errorf(errBackendWriteSaved, err))
 		return nil, diags
@@ -1037,7 +1053,7 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 }
 
 // Changing a previously saved backend.
-func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr *clistate.LocalState, output bool) (backend.Backend, tfdiags.Diagnostics) {
+func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr *clistate.LocalState, output bool, opts *BackendOpts) (backend.Backend, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// Get the old state
@@ -1131,6 +1147,14 @@ func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr *clista
 		Type:      c.Type,
 		ConfigRaw: json.RawMessage(configJSON),
 		Hash:      uint64(cHash),
+	}
+
+	// Verify that selected workspace exist. Otherwise prompt user to create one
+	if opts.Init && b != nil {
+		if err := m.selectWorkspace(b); err != nil {
+			diags = diags.Append(err)
+			return b, diags
+		}
 	}
 
 	if err := sMgr.WriteState(s); err != nil {


### PR DESCRIPTION
## Description of the issue

We recently added a prompt where, if no workspaces match the mapping in the configuration, we ask the user to create a new workspace instead of erroring with 'No workspaces found, so create a new workspace.', which is great.

<img width="684" alt="image" src="https://user-images.githubusercontent.com/21225410/142041706-c0808638-ab8e-4e2f-99f9-1211be7383fd.png">

The issue is, if that prompt is ignored and exited, the user is left in a very awkward state:

1. The saved backend config file (terraform.tfstate) shows now diff for the JSON attributes "serial", "tags" and "hash"
2. workspace list is completely empty if they run `terraform workspace list`
3.` terraform apply` still runs successfully and it's using the previous workspace, from the previous config and not the one from the current saved backend config
4. The cloud config is not reflective of how the working directory is set up at all


## Reproduction steps:

1. Change the workspace tag value inside of a cloud block that already had a pre-existing association with a workspace in TFC and it had a local `.terraform` directory. 
2. Run `terraform init -reconfigure` 
3. You will get the prompt that we see in the screenshot that says "No workspaces found ...Enter a value.."
4. Instead of providing a name after the "Enter a value" prompt, press control + c
5. Get the error from the screenshot: "Couldn't create initial workspace: no name provided" 
6. terraform.tfstate file will show diff for the attributes "serial", "tags" and "hash"
7. Run terraform workspace list and see an empty result
8. Run `terraform apply`. It will run successfully and when you visit the cloud platform, you will notice it used the previous config.

## My general approach on how to solve it:

If an error occurs here or the user exits the prompt, the saved backend config should not be updated because we did not select a workspace. That way the user is back to where they started and they have to Terraform reinitialize again before proceeding with new changes.

## Implementation details:

Currently the "select workspace" prompt is happening after this relevant step has already happened:

```
        if err := sMgr.WriteState(s); err != nil {
		diags = diags.Append(fmt.Errorf(errBackendWriteSaved, err))
		return nil, diags
	}
	if err := sMgr.PersistState(); err != nil {
		diags = diags.Append(fmt.Errorf(errBackendWriteSaved, err))
		return nil, diags
	}
```

This means that either you choose to pass a new workspace or exit the prompt with no name, it doesn't matter, terraform already wrote the changes to local state file before even knowing what your decision is.

In my opinion, we need to move the prompt to a point before the permanent local changes occur.

Because all this prompt logic for workspace is nicely restrain within the method `func (m *Meta) selectWorkspace(b backend.Backend) error`, then we can  move it around to a place before the permanent local changes.

Right now we call this `selectWorkspace` method right after `func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Diagnostics) ` has returned a backend.Backend. And we used that backend.Backend instance as a parameter in selectWorkspace:

```
                 b, backendDiags = m.backendFromConfig(opts)
		diags = diags.Append(backendDiags)

		if opts.Init && b != nil && !diags.HasErrors() {
			// Its possible that the currently selected workspace doesn't exist, so
			// we call selectWorkspace to ensure an existing workspace is selected.
			if err := m.selectWorkspace(b); err != nil {
				diags = diags.Append(err)
			}
		}
```

So, I thought, as long as I can move the calling of `selectWorkspace` to a point where we have access to that backend.Backend instance AND we still have not yet run `sMgr.WriteState(s)`,  then these changes should stay faithful to what the current expected behavior is, except that this time terraform wrote the changes after making sure the user passed a value into the prompt.


## How to test changes

First you'll have to build the go binary using this branch. You'll use this binary for testing the new behavior.

Now follow the same steps outlined in the section "Reproduction steps", except that for step 6, 7 and 8 you will see the following behavior:

6. terraform.tfstate file will not show any diffs
7. Run `terraform workspace list` and you'll get the error `Error: Terraform Cloud initialization required, please run "terraform init"`
8. Run `terraform apply` and you'll get the error `Error: Terraform Cloud initialization required, please run "terraform init"`

## Pending
Write some unit tests
