### PR TITLE
Address a few inconsistencies in how we process root module input variables vs. called module input variables

### DIFF
--- a/internal/backend/unparsed_value_test.go
+++ b/internal/backend/unparsed_value_test.go
@@ -204,7 +204,7 @@ func TestUnparsedValue(t *testing.T) {
 				},
 			},
 			"missing2": {
-				Value:      cty.StringVal("default for missing2"),
+				Value:      cty.NilVal, // Terraform Core handles substituting the default
 				SourceType: terraform.ValueFromConfig,
 				SourceRange: tfdiags.SourceRange{
 					Filename: "fake.tf",

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -426,7 +426,7 @@ resource "test_resource" "b" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -530,14 +530,14 @@ resource "test_object" "y" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
 	assertNoErrors(t, diags)
 
 	// FINAL PLAN:
-	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags = ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	// make sure the same marks are compared in the next plan as well

--- a/internal/terraform/context_apply_test.go
+++ b/internal/terraform/context_apply_test.go
@@ -517,7 +517,7 @@ func TestContext2Apply_mapVarBetweenModules(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -2262,7 +2262,7 @@ func TestContext2Apply_countVariable(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -2288,7 +2288,7 @@ func TestContext2Apply_countVariableRef(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -2327,7 +2327,7 @@ func TestContext2Apply_provisionerInterpCount(t *testing.T) {
 		Provisioners: provisioners,
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	// We'll marshal and unmarshal the plan here, to ensure that we have
@@ -3682,7 +3682,7 @@ func TestContext2Apply_multiVarOrder(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -3713,7 +3713,7 @@ func TestContext2Apply_multiVarOrderInterp(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -4704,9 +4704,7 @@ func TestContext2Apply_provisionerDestroy(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
-		Mode: plans.DestroyMode,
-	})
+	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -4753,9 +4751,7 @@ func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
-		Mode: plans.DestroyMode,
-	})
+	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -5908,7 +5904,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 		assertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m)
@@ -5929,9 +5925,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
-			Mode: plans.DestroyMode,
-		})
+		plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
 		if diags.HasErrors() {
 			t.Fatalf("destroy plan err: %s", diags.Err())
 		}
@@ -7561,6 +7555,12 @@ func TestContext2Apply_vars(t *testing.T) {
 			Value:      cty.StringVal("us-east-1"),
 			SourceType: ValueFromCaller,
 		},
+		"bar": &InputValue{
+			// This one is not explicitly set but that's okay because it
+			// has a declared default, which Terraform Core will use instead.
+			Value:      cty.NilVal,
+			SourceType: ValueFromCaller,
+		},
 		"test_list": &InputValue{
 			Value: cty.ListVal([]cty.Value{
 				cty.StringVal("Hello"),
@@ -7876,7 +7876,7 @@ func TestContext2Apply_issue7824(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -7932,7 +7932,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -7951,7 +7951,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags = ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8845,7 +8845,7 @@ func TestContext2Apply_plannedInterpolatedCount(t *testing.T) {
 		Providers: Providers,
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("plan failed: %s", diags.Err())
 	}
@@ -8904,9 +8904,7 @@ func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
 		Providers: providers,
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
-		Mode: plans.DestroyMode,
-	})
+	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("plan failed: %s", diags.Err())
 	}
@@ -9674,7 +9672,7 @@ func TestContext2Apply_plannedConnectionRefs(t *testing.T) {
 		Hooks:        []Hook{hook},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	diags.HasErrors()
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -11687,7 +11685,7 @@ resource "test_resource" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -11702,7 +11700,7 @@ resource "test_resource" "foo" {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags = ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -11720,6 +11718,7 @@ resource "test_resource" "foo" {
 	plan, diags = ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
+			"sensitive_id": &InputValue{Value: cty.NilVal},
 			"sensitive_var": &InputValue{
 				Value: cty.StringVal("bar"),
 			},
@@ -11759,7 +11758,7 @@ resource "test_resource" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("plan errors: %s", diags.Err())
 	}
@@ -11904,7 +11903,7 @@ resource "test_resource" "foo" {
 		)
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	addr := mustResourceInstanceAddr("test_resource.foo")
@@ -11954,7 +11953,7 @@ resource "test_resource" "foo" {
 	// but this seems rather suspicious and we should ideally figure out what
 	// this test was originally intending to do and make it do that.
 	oldPlan := plan
-	_, diags = ctx2.Plan(m2, state, DefaultPlanOpts)
+	_, diags = ctx2.Plan(m2, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 	stateWithoutSensitive, diags := ctx.Apply(oldPlan, m)
 	assertNoErrors(t, diags)
@@ -12206,7 +12205,7 @@ func TestContext2Apply_dataSensitive(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {

--- a/internal/terraform/context_eval.go
+++ b/internal/terraform/context_eval.go
@@ -60,9 +60,10 @@ func (c *Context) Eval(config *configs.Config, state *states.State, moduleAddr a
 	log.Printf("[DEBUG] Building and walking 'eval' graph")
 
 	graph, moreDiags := (&EvalGraphBuilder{
-		Config:  config,
-		State:   state,
-		Plugins: c.plugins,
+		Config:             config,
+		State:              state,
+		RootVariableValues: variables,
+		Plugins:            c.plugins,
 	}).Build(addrs.RootModuleInstance)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
@@ -70,9 +71,8 @@ func (c *Context) Eval(config *configs.Config, state *states.State, moduleAddr a
 	}
 
 	walkOpts := &graphWalkOpts{
-		InputState:         state,
-		Config:             config,
-		RootVariableValues: variables,
+		InputState: state,
+		Config:     config,
 	}
 
 	walker, moreDiags = c.walk(graph, walkEval, walkOpts)

--- a/internal/terraform/context_eval.go
+++ b/internal/terraform/context_eval.go
@@ -45,7 +45,7 @@ func (c *Context) Eval(config *configs.Config, state *states.State, moduleAddr a
 	state = state.DeepCopy()
 	var walker *ContextGraphWalker
 
-	variables := mergeDefaultInputVariableValues(opts.SetVariables, config.Module.Variables)
+	variables := opts.SetVariables
 
 	// By the time we get here, we should have values defined for all of
 	// the root module variables, even if some of them are "unknown". It's the

--- a/internal/terraform/context_eval_test.go
+++ b/internal/terraform/context_eval_test.go
@@ -54,7 +54,9 @@ func TestContextEval(t *testing.T) {
 		},
 	})
 
-	scope, diags := ctx.Eval(m, states.NewState(), addrs.RootModuleInstance, &EvalOpts{})
+	scope, diags := ctx.Eval(m, states.NewState(), addrs.RootModuleInstance, &EvalOpts{
+		SetVariables: testInputValuesUnset(m.Module.Variables),
+	})
 	if diags.HasErrors() {
 		t.Fatalf("Eval errors: %s", diags.Err())
 	}

--- a/internal/terraform/context_import.go
+++ b/internal/terraform/context_import.go
@@ -53,11 +53,14 @@ func (c *Context) Import(config *configs.Config, prevRunState *states.State, opt
 
 	log.Printf("[DEBUG] Building and walking import graph")
 
+	variables := mergeDefaultInputVariableValues(opts.SetVariables, config.Module.Variables)
+
 	// Initialize our graph builder
 	builder := &ImportGraphBuilder{
-		ImportTargets: opts.Targets,
-		Config:        config,
-		Plugins:       c.plugins,
+		ImportTargets:      opts.Targets,
+		Config:             config,
+		RootVariableValues: variables,
+		Plugins:            c.plugins,
 	}
 
 	// Build the graph
@@ -67,13 +70,10 @@ func (c *Context) Import(config *configs.Config, prevRunState *states.State, opt
 		return state, diags
 	}
 
-	variables := mergeDefaultInputVariableValues(opts.SetVariables, config.Module.Variables)
-
 	// Walk it
 	walker, walkDiags := c.walk(graph, walkImport, &graphWalkOpts{
-		Config:             config,
-		InputState:         state,
-		RootVariableValues: variables,
+		Config:     config,
+		InputState: state,
 	})
 	diags = diags.Append(walkDiags)
 	if walkDiags.HasErrors() {

--- a/internal/terraform/context_import.go
+++ b/internal/terraform/context_import.go
@@ -53,7 +53,7 @@ func (c *Context) Import(config *configs.Config, prevRunState *states.State, opt
 
 	log.Printf("[DEBUG] Building and walking import graph")
 
-	variables := mergeDefaultInputVariableValues(opts.SetVariables, config.Module.Variables)
+	variables := opts.SetVariables
 
 	// Initialize our graph builder
 	builder := &ImportGraphBuilder{

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -205,7 +205,7 @@ data "test_data_source" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	for _, res := range plan.Changes.Resources {

--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -405,7 +405,7 @@ func TestContext2Plan_moduleExpand(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1175,7 +1175,7 @@ func TestContext2Plan_moduleProviderVar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2242,7 +2242,7 @@ func TestContext2Plan_countModuleStatic(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2295,7 +2295,7 @@ func TestContext2Plan_countModuleStaticGrandchild(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3938,7 +3938,7 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state.DeepCopy(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(m, state.DeepCopy(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 		if diags.HasErrors() {
 			t.Fatalf("unexpected errors: %s", diags.Err())
 		}
@@ -5481,7 +5481,7 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -5544,6 +5544,7 @@ func TestContext2Plan_variableSensitivityModule(t *testing.T) {
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
+			"sensitive_var": {Value: cty.NilVal},
 			"another_var": &InputValue{
 				Value:      cty.StringVal("boop"),
 				SourceType: ValueFromCaller,
@@ -6657,7 +6658,7 @@ resource "test_resource" "foo" {
 			},
 		)
 	})
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}

--- a/internal/terraform/context_validate_test.go
+++ b/internal/terraform/context_validate_test.go
@@ -1187,32 +1187,6 @@ resource "aws_instance" "foo" {
 	}
 }
 
-// Manually validate using the new PlanGraphBuilder
-func TestContext2Validate_PlanGraphBuilder(t *testing.T) {
-	fixture := contextFixtureApplyVars(t)
-	opts := fixture.ContextOpts()
-	c := testContext2(t, opts)
-
-	graph, diags := ValidateGraphBuilder(&PlanGraphBuilder{
-		Config:  fixture.Config,
-		State:   states.NewState(),
-		Plugins: c.plugins,
-	}).Build(addrs.RootModuleInstance)
-	if diags.HasErrors() {
-		t.Fatalf("errors from PlanGraphBuilder: %s", diags.Err())
-	}
-	defer c.acquireRun("validate-test")()
-	walker, diags := c.walk(graph, walkValidate, &graphWalkOpts{
-		Config: fixture.Config,
-	})
-	if diags.HasErrors() {
-		t.Fatal(diags.Err())
-	}
-	if len(walker.NonFatalDiagnostics) > 0 {
-		t.Fatal(walker.NonFatalDiagnostics.Err())
-	}
-}
-
 func TestContext2Validate_invalidOutput(t *testing.T) {
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -23,8 +23,7 @@ type graphWalkOpts struct {
 	Changes    *plans.Changes
 	Config     *configs.Config
 
-	RootVariableValues InputValues
-	MoveResults        refactoring.MoveResults
+	MoveResults refactoring.MoveResults
 }
 
 func (c *Context) walk(graph *Graph, operation walkOperation, opts *graphWalkOpts) (*ContextGraphWalker, tfdiags.Diagnostics) {
@@ -98,16 +97,15 @@ func (c *Context) graphWalker(operation walkOperation, opts *graphWalkOpts) *Con
 	}
 
 	return &ContextGraphWalker{
-		Context:            c,
-		State:              state,
-		Config:             opts.Config,
-		RefreshState:       refreshState,
-		PrevRunState:       prevRunState,
-		Changes:            changes.SyncWrapper(),
-		InstanceExpander:   instances.NewExpander(),
-		MoveResults:        opts.MoveResults,
-		Operation:          operation,
-		StopContext:        c.runContext,
-		RootVariableValues: opts.RootVariableValues,
+		Context:          c,
+		State:            state,
+		Config:           opts.Config,
+		RefreshState:     refreshState,
+		PrevRunState:     prevRunState,
+		Changes:          changes.SyncWrapper(),
+		InstanceExpander: instances.NewExpander(),
+		MoveResults:      opts.MoveResults,
+		Operation:        operation,
+		StopContext:      c.runContext,
 	}
 }

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -121,12 +121,24 @@ type EvalContext interface {
 	// addresses in this context.
 	EvaluationScope(self addrs.Referenceable, keyData InstanceKeyEvalData) *lang.Scope
 
-	// SetModuleCallArguments defines values for the variables of a particular
-	// child module call.
+	// SetRootModuleArgument defines the value for one variable of the root
+	// module. The caller must ensure that given value is a suitable
+	// "final value" for the variable, which means that it's already converted
+	// and validated to match any configured constraints and validation rules.
 	//
-	// Calling this function multiple times has merging behavior, keeping any
-	// previously-set keys that are not present in the new map.
-	SetModuleCallArguments(addrs.ModuleCallInstance, map[string]cty.Value)
+	// Calling this function multiple times with the same variable address
+	// will silently overwrite the value provided by a previous call.
+	SetRootModuleArgument(addrs.InputVariable, cty.Value)
+
+	// SetModuleCallArgument defines the value for one input variable of a
+	// particular child module call. The caller must ensure that the given
+	// value is a suitable "final value" for the variable, which means that
+	// it's already converted and validated to match any configured
+	// constraints and validation rules.
+	//
+	// Calling this function multiple times with the same variable address
+	// will silently overwrite the value provided by a previous call.
+	SetModuleCallArgument(addrs.ModuleCallInstance, addrs.InputVariable, cty.Value)
 
 	// GetVariableValue returns the value provided for the input variable with
 	// the given address, or cty.DynamicVal if the variable hasn't been assigned

--- a/internal/terraform/eval_variable.go
+++ b/internal/terraform/eval_variable.go
@@ -12,6 +12,102 @@ import (
 	"github.com/zclconf/go-cty/cty/convert"
 )
 
+func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, given cty.Value, valRange tfdiags.SourceRange, cfg *configs.Variable) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	convertTy := cfg.ConstraintType
+	log.Printf("[TRACE] prepareFinalInputVariableValue: preparing %s", addr)
+
+	var defaultVal cty.Value
+	if cfg.Default != cty.NilVal {
+		log.Printf("[TRACE] prepareFinalInputVariableValue: %s has a default value", addr)
+		var err error
+		defaultVal, err = convert.Convert(cfg.Default, convertTy)
+		if err != nil {
+			// Validation of the declaration should typically catch this,
+			// but we'll check it here too to be robust.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid default value for module argument",
+				Detail: fmt.Sprintf(
+					"The default value for variable %q is incompatible with its type constraint: %s.",
+					cfg.Name, err,
+				),
+				Subject: &cfg.DeclRange,
+			})
+			// We'll return a placeholder unknown value to avoid producing
+			// redundant downstream errors.
+			return cty.UnknownVal(cfg.Type), diags
+		}
+	}
+
+	if given == cty.NilVal { // The variable wasn't set at all (even to null)
+		log.Printf("[TRACE] prepareFinalInputVariableValue: %s has no defined value", addr)
+		if cfg.Required() {
+			// NOTE: The CLI layer typically checks for itself whether all of
+			// the required _root_ module variables are not set, which would
+			// mask this error. We can get here for child module variables,
+			// though.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  `Required variable not set`,
+				Detail:   fmt.Sprintf(`The variable %q is required, but is not set.`, addr.Variable.Name),
+				Subject:  valRange.ToHCL().Ptr(),
+			})
+			// We'll return a placeholder unknown value to avoid producing
+			// redundant downstream errors.
+			return cty.UnknownVal(cfg.Type), diags
+		}
+
+		given = defaultVal // must be set, because we checked above that the variable isn't required
+	}
+
+	val, err := convert.Convert(given, convertTy)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid value for module argument",
+			Detail: fmt.Sprintf(
+				"The given value is not suitable for child module variable %q defined at %s: %s.",
+				cfg.Name, cfg.DeclRange.String(), err,
+			),
+			Subject: valRange.ToHCL().Ptr(),
+		})
+		// We'll return a placeholder unknown value to avoid producing
+		// redundant downstream errors.
+		return cty.UnknownVal(cfg.Type), diags
+	}
+
+	// By the time we get here, we know:
+	// - val matches the variable's type constraint
+	// - val is definitely not cty.NilVal, but might be a null value if the given was already null.
+	//
+	// That means we just need to handle the case where the value is null,
+	// which might mean we need to use the default value, or produce an error.
+	//
+	// For historical reasons we do this only for a "non-nullable" variable.
+	// Nullable variables just appear as null if they were set to null,
+	// regardless of any default value.
+	if val.IsNull() && !cfg.Nullable {
+		log.Printf("[TRACE] prepareFinalInputVariableValue: %s is defined as null", addr)
+		if defaultVal != cty.NilVal {
+			val = defaultVal
+		} else {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  `Required variable not set`,
+				Detail:   fmt.Sprintf(`The variable %q is required, but the given value is null.`, addr.Variable.Name),
+				Subject:  valRange.ToHCL().Ptr(),
+			})
+			// Stub out our return value so that the semantic checker doesn't
+			// produce redundant downstream errors.
+			val = cty.UnknownVal(cfg.Type)
+		}
+	}
+
+	return val, diags
+}
+
 // evalVariableValidations ensures that all of the configured custom validations
 // for a variable are passing.
 //
@@ -20,9 +116,10 @@ import (
 // EvalModuleCallArgument for variables in descendent modules.
 func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *configs.Variable, expr hcl.Expression, ctx EvalContext) (diags tfdiags.Diagnostics) {
 	if config == nil || len(config.Validations) == 0 {
-		log.Printf("[TRACE] evalVariableValidations: not active for %s, so skipping", addr)
+		log.Printf("[TRACE] evalVariableValidations: no validation rules declared for %s, so skipping", addr)
 		return nil
 	}
+	log.Printf("[TRACE] evalVariableValidations: validating %s", addr)
 
 	// Variable nodes evaluate in the parent module to where they were declared
 	// because the value expression (n.Expr, if set) comes from the calling
@@ -34,6 +131,14 @@ func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *config
 	// evaluation context containing just the required value, and thus avoid
 	// the problem that ctx's evaluation functions refer to the wrong module.
 	val := ctx.GetVariableValue(addr)
+	if val == cty.NilVal {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "No final value for variable",
+			Detail:   fmt.Sprintf("Terraform doesn't have a final value for %s during validation. This is a bug in Terraform; please report it!", addr),
+		})
+		return diags
+	}
 	hclCtx := &hcl.EvalContext{
 		Variables: map[string]cty.Value{
 			"var": cty.ObjectVal(map[string]cty.Value{

--- a/internal/terraform/eval_variable.go
+++ b/internal/terraform/eval_variable.go
@@ -45,9 +45,11 @@ func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, given c
 		log.Printf("[TRACE] prepareFinalInputVariableValue: %s has no defined value", addr)
 		if cfg.Required() {
 			// NOTE: The CLI layer typically checks for itself whether all of
-			// the required _root_ module variables are not set, which would
-			// mask this error. We can get here for child module variables,
-			// though.
+			// the required _root_ module variables are set, which would
+			// mask this error with a more specific one that refers to the
+			// CLI features for setting such variables. We can get here for
+			// child module variables, though.
+			log.Printf("[ERROR] prepareFinalInputVariableValue: %s is required but is not set", addr)
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  `Required variable not set`,
@@ -64,6 +66,7 @@ func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, given c
 
 	val, err := convert.Convert(given, convertTy)
 	if err != nil {
+		log.Printf("[ERROR] prepareFinalInputVariableValue: %s has unsuitable type\n  got:  %s\n  want: %s", addr, given.Type(), convertTy)
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid value for module argument",
@@ -93,6 +96,7 @@ func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, given c
 		if defaultVal != cty.NilVal {
 			val = defaultVal
 		} else {
+			log.Printf("[ERROR] prepareFinalInputVariableValue: %s is non-nullable but set to null, and is required", addr)
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  `Required variable not set`,

--- a/internal/terraform/eval_variable_test.go
+++ b/internal/terraform/eval_variable_test.go
@@ -1,0 +1,426 @@
+package terraform
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestPrepareFinalInputVariableValue(t *testing.T) {
+	// This is just a concise way to define a bunch of *configs.Variable
+	// objects to use in our tests below. We're only going to decode this
+	// config, not fully evaluate it.
+	cfgSrc := `
+		variable "nullable_required" {
+		}
+		variable "nullable_optional_default_string" {
+			default = "hello"
+		}
+		variable "nullable_optional_default_null" {
+			default = null
+		}
+		variable "constrained_string_nullable_required" {
+			type = string
+		}
+		variable "constrained_string_nullable_optional_default_string" {
+			type    = string
+			default = "hello"
+		}
+		variable "constrained_string_nullable_optional_default_bool" {
+			type    = string
+			default = true
+		}
+		variable "constrained_string_nullable_optional_default_null" {
+			type    = string
+			default = null
+		}
+		variable "required" {
+			nullable = false
+		}
+		variable "optional_default_string" {
+			nullable = false
+			default  = "hello"
+		}
+		variable "constrained_string_required" {
+			nullable = false
+			type     = string
+		}
+		variable "constrained_string_optional_default_string" {
+			nullable = false
+			type     = string
+			default  = "hello"
+		}
+		variable "constrained_string_optional_default_bool" {
+			nullable = false
+			type     = string
+			default  = true
+		}
+	`
+	cfg := testModuleInline(t, map[string]string{
+		"main.tf": cfgSrc,
+	})
+	variableConfigs := cfg.Module.Variables
+
+	tests := []struct {
+		varName string
+		given   cty.Value
+		want    cty.Value
+		wantErr string
+	}{
+		// nullable_required
+		{
+			"nullable_required",
+			cty.NilVal,
+			cty.UnknownVal(cty.DynamicPseudoType),
+			`Required variable not set: The variable "nullable_required" is required, but is not set.`,
+		},
+		{
+			"nullable_required",
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.NullVal(cty.DynamicPseudoType),
+			``, // "required" for a nullable variable means only that it must be set, even if it's set to null
+		},
+		{
+			"nullable_required",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"nullable_required",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+
+		// nullable_optional_default_string
+		{
+			"nullable_optional_default_string",
+			cty.NilVal,
+			cty.StringVal("hello"), // the declared default value
+			``,
+		},
+		{
+			"nullable_optional_default_string",
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.NullVal(cty.DynamicPseudoType), // nullable variables can be really set to null, masking the default
+			``,
+		},
+		{
+			"nullable_optional_default_string",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"nullable_optional_default_string",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+
+		// nullable_optional_default_null
+		{
+			"nullable_optional_default_null",
+			cty.NilVal,
+			cty.NullVal(cty.DynamicPseudoType), // the declared default value
+			``,
+		},
+		{
+			"nullable_optional_default_null",
+			cty.NullVal(cty.String),
+			cty.NullVal(cty.String), // nullable variables can be really set to null, masking the default
+			``,
+		},
+		{
+			"nullable_optional_default_null",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"nullable_optional_default_null",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+
+		// constrained_string_nullable_required
+		{
+			"constrained_string_nullable_required",
+			cty.NilVal,
+			cty.UnknownVal(cty.String),
+			`Required variable not set: The variable "constrained_string_nullable_required" is required, but is not set.`,
+		},
+		{
+			"constrained_string_nullable_required",
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.NullVal(cty.String), // the null value still gets converted to match the type constraint
+			``,                      // "required" for a nullable variable means only that it must be set, even if it's set to null
+		},
+		{
+			"constrained_string_nullable_required",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"constrained_string_nullable_required",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+
+		// constrained_string_nullable_optional_default_string
+		{
+			"constrained_string_nullable_optional_default_string",
+			cty.NilVal,
+			cty.StringVal("hello"), // the declared default value
+			``,
+		},
+		{
+			"constrained_string_nullable_optional_default_string",
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.NullVal(cty.String), // nullable variables can be really set to null, masking the default
+			``,
+		},
+		{
+			"constrained_string_nullable_optional_default_string",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"constrained_string_nullable_optional_default_string",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+
+		// constrained_string_nullable_optional_default_bool
+		{
+			"constrained_string_nullable_optional_default_bool",
+			cty.NilVal,
+			cty.StringVal("true"), // the declared default value, automatically converted to match type constraint
+			``,
+		},
+		{
+			"constrained_string_nullable_optional_default_bool",
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.NullVal(cty.String), // nullable variables can be really set to null, masking the default
+			``,
+		},
+		{
+			"constrained_string_nullable_optional_default_bool",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"constrained_string_nullable_optional_default_bool",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+
+		// constrained_string_nullable_optional_default_null
+		{
+			"constrained_string_nullable_optional_default_null",
+			cty.NilVal,
+			cty.NullVal(cty.String),
+			``,
+		},
+		{
+			"constrained_string_nullable_optional_default_null",
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.NullVal(cty.String),
+			``,
+		},
+		{
+			"constrained_string_nullable_optional_default_null",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"constrained_string_nullable_optional_default_null",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+
+		// required
+		{
+			"required",
+			cty.NilVal,
+			cty.UnknownVal(cty.DynamicPseudoType),
+			`Required variable not set: The variable "required" is required, but is not set.`,
+		},
+		{
+			"required",
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.UnknownVal(cty.DynamicPseudoType),
+			`Required variable not set: The variable "required" is required, but the given value is null.`,
+		},
+		{
+			"required",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"required",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+
+		// optional_default_string
+		{
+			"optional_default_string",
+			cty.NilVal,
+			cty.StringVal("hello"), // the declared default value
+			``,
+		},
+		{
+			"optional_default_string",
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.StringVal("hello"), // the declared default value
+			``,
+		},
+		{
+			"optional_default_string",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"optional_default_string",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+
+		// constrained_string_required
+		{
+			"constrained_string_required",
+			cty.NilVal,
+			cty.UnknownVal(cty.String),
+			`Required variable not set: The variable "constrained_string_required" is required, but is not set.`,
+		},
+		{
+			"constrained_string_required",
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.UnknownVal(cty.String),
+			`Required variable not set: The variable "constrained_string_required" is required, but the given value is null.`,
+		},
+		{
+			"constrained_string_required",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"constrained_string_required",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+
+		// constrained_string_optional_default_string
+		{
+			"constrained_string_optional_default_string",
+			cty.NilVal,
+			cty.StringVal("hello"), // the declared default value
+			``,
+		},
+		{
+			"constrained_string_optional_default_string",
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.StringVal("hello"), // the declared default value
+			``,
+		},
+		{
+			"constrained_string_optional_default_string",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"constrained_string_optional_default_string",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+
+		// constrained_string_optional_default_bool
+		{
+			"constrained_string_optional_default_bool",
+			cty.NilVal,
+			cty.StringVal("true"), // the declared default value, automatically converted to match type constraint
+			``,
+		},
+		{
+			"constrained_string_optional_default_bool",
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.StringVal("true"), // the declared default value, automatically converted to match type constraint
+			``,
+		},
+		{
+			"constrained_string_optional_default_bool",
+			cty.StringVal("ahoy"),
+			cty.StringVal("ahoy"),
+			``,
+		},
+		{
+			"constrained_string_optional_default_bool",
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.String),
+			``,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s %#v", test.varName, test.given), func(t *testing.T) {
+			varAddr := addrs.InputVariable{Name: test.varName}.Absolute(addrs.RootModuleInstance)
+			varCfg := variableConfigs[test.varName]
+			if varCfg == nil {
+				t.Fatalf("invalid variable name %q", test.varName)
+			}
+
+			t.Logf(
+				"test case\nvariable:    %s\nconstraint:  %#v\ndefault:     %#v\nnullable:    %#v\ngiven value: %#v",
+				varAddr,
+				varCfg.Type,
+				varCfg.Default,
+				varCfg.Nullable,
+				test.given,
+			)
+
+			got, diags := prepareFinalInputVariableValue(
+				varAddr, test.given, tfdiags.SourceRangeFromHCL(varCfg.DeclRange), varCfg,
+			)
+
+			if test.wantErr != "" {
+				if !diags.HasErrors() {
+					t.Errorf("unexpected success\nwant error: %s", test.wantErr)
+				} else if got, want := diags.Err().Error(), test.wantErr; got != want {
+					t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+				}
+			} else {
+				if diags.HasErrors() {
+					t.Errorf("unexpected error\ngot: %s", diags.Err().Error())
+				}
+			}
+
+			// NOTE: should still have returned some reasonable value even if there was an error
+			if !test.want.RawEquals(got) {
+				t.Fatalf("wrong result\ngot:  %#v\nwant: %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -26,6 +26,11 @@ type ApplyGraphBuilder struct {
 	// State is the current state
 	State *states.State
 
+	// RootVariableValues are the root module input variables captured as
+	// part of the plan object, which we must reproduce in the apply step
+	// to get a consistent result.
+	RootVariableValues InputValues
+
 	// Plugins is a library of the plug-in components (providers and
 	// provisioners) available for use.
 	Plugins *contextPlugins
@@ -88,7 +93,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		},
 
 		// Add dynamic values
-		&RootVariableTransformer{Config: b.Config},
+		&RootVariableTransformer{Config: b.Config, RawValues: b.RootVariableValues},
 		&ModuleVariableTransformer{Config: b.Config},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{Config: b.Config, Changes: b.Changes},

--- a/internal/terraform/graph_builder_destroy_plan.go
+++ b/internal/terraform/graph_builder_destroy_plan.go
@@ -23,6 +23,11 @@ type DestroyPlanGraphBuilder struct {
 	// State is the current state
 	State *states.State
 
+	// RootVariableValues are the raw input values for root input variables
+	// given by the caller, which we'll resolve into final values as part
+	// of the plan walk.
+	RootVariableValues InputValues
+
 	// Plugins is a library of plug-in components (providers and
 	// provisioners) available for use.
 	Plugins *contextPlugins

--- a/internal/terraform/graph_builder_eval.go
+++ b/internal/terraform/graph_builder_eval.go
@@ -30,6 +30,11 @@ type EvalGraphBuilder struct {
 	// State is the current state
 	State *states.State
 
+	// RootVariableValues are the raw input values for root input variables
+	// given by the caller, which we'll resolve into final values as part
+	// of the plan walk.
+	RootVariableValues InputValues
+
 	// Plugins is a library of plug-in components (providers and
 	// provisioners) available for use.
 	Plugins *contextPlugins
@@ -60,7 +65,7 @@ func (b *EvalGraphBuilder) Steps() []GraphTransformer {
 		},
 
 		// Add dynamic values
-		&RootVariableTransformer{Config: b.Config},
+		&RootVariableTransformer{Config: b.Config, RawValues: b.RootVariableValues},
 		&ModuleVariableTransformer{Config: b.Config},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{Config: b.Config},

--- a/internal/terraform/graph_builder_import.go
+++ b/internal/terraform/graph_builder_import.go
@@ -17,6 +17,11 @@ type ImportGraphBuilder struct {
 	// Module is a configuration to build the graph from. See ImportOpts.Config.
 	Config *configs.Config
 
+	// RootVariableValues are the raw input values for root input variables
+	// given by the caller, which we'll resolve into final values as part
+	// of the plan walk.
+	RootVariableValues InputValues
+
 	// Plugins is a library of plug-in components (providers and
 	// provisioners) available for use.
 	Plugins *contextPlugins
@@ -53,7 +58,7 @@ func (b *ImportGraphBuilder) Steps() []GraphTransformer {
 		&ConfigTransformer{Config: config},
 
 		// Add dynamic values
-		&RootVariableTransformer{Config: b.Config},
+		&RootVariableTransformer{Config: b.Config, RawValues: b.RootVariableValues},
 		&ModuleVariableTransformer{Config: b.Config},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{Config: b.Config},

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -28,6 +28,11 @@ type PlanGraphBuilder struct {
 	// State is the current state
 	State *states.State
 
+	// RootVariableValues are the raw input values for root input variables
+	// given by the caller, which we'll resolve into final values as part
+	// of the plan walk.
+	RootVariableValues InputValues
+
 	// Plugins is a library of plug-in components (providers and
 	// provisioners) available for use.
 	Plugins *contextPlugins
@@ -95,7 +100,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		},
 
 		// Add dynamic values
-		&RootVariableTransformer{Config: b.Config},
+		&RootVariableTransformer{Config: b.Config, RawValues: b.RootVariableValues},
 		&ModuleVariableTransformer{Config: b.Config},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{Config: b.Config},

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -227,7 +227,16 @@ func (n *nodeModuleVariable) evalModuleCallArgument(ctx EvalContext, validateOnl
 		errSourceRange = tfdiags.SourceRangeFromHCL(n.Config.DeclRange) // we use the declaration range as a fallback for an undefined variable
 	}
 
-	finalVal, moreDiags := prepareFinalInputVariableValue(n.Addr, givenVal, errSourceRange, n.Config)
+	// We construct a synthetic InputValue here to pretend as if this were
+	// a root module variable set from outside, just as a convenience so we
+	// can reuse the InputValue type for this.
+	rawVal := &InputValue{
+		Value:       givenVal,
+		SourceType:  ValueFromConfig,
+		SourceRange: errSourceRange,
+	}
+
+	finalVal, moreDiags := prepareFinalInputVariableValue(n.Addr, rawVal, n.Config)
 	diags = diags.Append(moreDiags)
 
 	return finalVal, diags.ErrWithWarnings()

--- a/internal/terraform/node_root_variable.go
+++ b/internal/terraform/node_root_variable.go
@@ -1,16 +1,26 @@
 package terraform
 
 import (
+	"log"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // NodeRootVariable represents a root variable input.
 type NodeRootVariable struct {
 	Addr   addrs.InputVariable
 	Config *configs.Variable
+
+	// RawValue is the value for the variable set from outside Terraform
+	// Core, such as on the command line, or from an environment variable,
+	// or similar. This is the raw value that was provided, not yet
+	// converted or validated, and can be nil for a variable that isn't
+	// set at all.
+	RawValue *InputValue
 }
 
 var (
@@ -38,21 +48,56 @@ func (n *NodeRootVariable) ReferenceableAddrs() []addrs.Referenceable {
 
 // GraphNodeExecutable
 func (n *NodeRootVariable) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
-	// We don't actually need to _evaluate_ a root module variable, because
-	// its value is always constant and already stashed away in our EvalContext.
-	// However, we might need to run some user-defined validation rules against
-	// the value.
+	// Root module variables are special in that they are provided directly
+	// by the caller (usually, the CLI layer) and so we don't really need to
+	// evaluate them in the usual sense, but we do need to process the raw
+	// values given by the caller to match what the module is expecting, and
+	// make sure the values are valid.
+	var diags tfdiags.Diagnostics
 
-	if n.Config == nil || len(n.Config.Validations) == 0 {
-		return nil // nothing to do
+	addr := addrs.RootModuleInstance.InputVariable(n.Addr.Name)
+	log.Printf("[TRACE] NodeRootVariable: evaluating %s", addr)
+
+	if n.Config == nil {
+		// Because we build NodeRootVariable from configuration in the normal
+		// case it's strange to get here, but we tolerate it to allow for
+		// tests that might not populate the inputs fully.
+		return nil
 	}
 
-	return evalVariableValidations(
+	var givenVal cty.Value
+	if n.RawValue != nil {
+		givenVal = n.RawValue.Value
+	} else {
+		// We'll use cty.NilVal to represent the variable not being set at
+		// all, which for historical reasons is unfortunately different than
+		// explicitly setting it to null in some cases.
+		givenVal = cty.NilVal
+	}
+
+	finalVal, moreDiags := prepareFinalInputVariableValue(
+		addr,
+		givenVal,
+		tfdiags.SourceRangeFromHCL(n.Config.DeclRange),
+		n.Config,
+	)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		// No point in proceeding to validations then, because they'll
+		// probably fail trying to work with a value of the wrong type.
+		return diags
+	}
+
+	ctx.SetRootModuleArgument(addr.Variable, finalVal)
+
+	moreDiags = evalVariableValidations(
 		addrs.RootModuleInstance.InputVariable(n.Addr.Name),
 		n.Config,
 		nil, // not set for root module variables
 		ctx,
 	)
+	diags = diags.Append(moreDiags)
+	return diags
 }
 
 // dag.GraphNodeDotter impl.

--- a/internal/terraform/node_root_variable_test.go
+++ b/internal/terraform/node_root_variable_test.go
@@ -3,26 +3,164 @@ package terraform
 import (
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
-	"github.com/zclconf/go-cty/cty"
+	"github.com/hashicorp/terraform/internal/lang"
 )
 
 func TestNodeRootVariableExecute(t *testing.T) {
-	ctx := new(MockEvalContext)
+	t.Run("type conversion", func(t *testing.T) {
+		ctx := new(MockEvalContext)
 
-	n := &NodeRootVariable{
-		Addr: addrs.InputVariable{Name: "foo"},
-		Config: &configs.Variable{
-			Name:           "foo",
-			Type:           cty.String,
-			ConstraintType: cty.String,
-		},
+		n := &NodeRootVariable{
+			Addr: addrs.InputVariable{Name: "foo"},
+			Config: &configs.Variable{
+				Name:           "foo",
+				Type:           cty.String,
+				ConstraintType: cty.String,
+			},
+			RawValue: &InputValue{
+				Value:      cty.True,
+				SourceType: ValueFromUnknown,
+			},
+		}
+
+		diags := n.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
+		}
+
+		if !ctx.SetRootModuleArgumentCalled {
+			t.Fatalf("ctx.SetRootModuleArgument wasn't called")
+		}
+		if got, want := ctx.SetRootModuleArgumentAddr.String(), "var.foo"; got != want {
+			t.Errorf("wrong address for ctx.SetRootModuleArgument\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := ctx.SetRootModuleArgumentValue, cty.StringVal("true"); !want.RawEquals(got) {
+			// NOTE: The given value was cty.Bool but the type constraint was
+			// cty.String, so it was NodeRootVariable's responsibility to convert
+			// as part of preparing the "final value".
+			t.Errorf("wrong value for ctx.SetRootModuleArgument\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+	t.Run("validation", func(t *testing.T) {
+		ctx := new(MockEvalContext)
+
+		// The variable validation function gets called with Terraform's
+		// built-in functions available, so we need a minimal scope just for
+		// it to get the functions from.
+		ctx.EvaluationScopeScope = &lang.Scope{}
+
+		// We need to reimplement a _little_ bit of EvalContextBuiltin logic
+		// here to get a similar effect with EvalContextMock just to get the
+		// value to flow through here in a realistic way that'll make this test
+		// useful.
+		var finalVal cty.Value
+		ctx.SetRootModuleArgumentFunc = func(addr addrs.InputVariable, v cty.Value) {
+			if addr.Name == "foo" {
+				t.Logf("set %s to %#v", addr.String(), v)
+				finalVal = v
+			}
+		}
+		ctx.GetVariableValueFunc = func(addr addrs.AbsInputVariableInstance) cty.Value {
+			if addr.String() != "var.foo" {
+				return cty.NilVal
+			}
+			t.Logf("reading final val for %s (%#v)", addr.String(), finalVal)
+			return finalVal
+		}
+
+		n := &NodeRootVariable{
+			Addr: addrs.InputVariable{Name: "foo"},
+			Config: &configs.Variable{
+				Name:           "foo",
+				Type:           cty.Number,
+				ConstraintType: cty.Number,
+				Validations: []*configs.VariableValidation{
+					{
+						Condition: fakeHCLExpressionFunc(func(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+							// This returns true only if the given variable value
+							// is exactly cty.Number, which allows us to verify
+							// that we were given the value _after_ type
+							// conversion.
+							// This had previously not been handled correctly,
+							// as reported in:
+							//     https://github.com/hashicorp/terraform/issues/29899
+							vars := ctx.Variables["var"]
+							if vars == cty.NilVal || !vars.Type().IsObjectType() || !vars.Type().HasAttribute("foo") {
+								t.Logf("var.foo isn't available")
+								return cty.False, nil
+							}
+							val := vars.GetAttr("foo")
+							if val == cty.NilVal || val.Type() != cty.Number {
+								t.Logf("var.foo is %#v; want a number", val)
+								return cty.False, nil
+							}
+							return cty.True, nil
+						}),
+						ErrorMessage: "Must be a number.",
+					},
+				},
+			},
+			RawValue: &InputValue{
+				// Note: This is a string, but the variable's type constraint
+				// is number so it should be converted before use.
+				Value:      cty.StringVal("5"),
+				SourceType: ValueFromUnknown,
+			},
+		}
+
+		diags := n.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
+		}
+
+		if !ctx.SetRootModuleArgumentCalled {
+			t.Fatalf("ctx.SetRootModuleArgument wasn't called")
+		}
+		if got, want := ctx.SetRootModuleArgumentAddr.String(), "var.foo"; got != want {
+			t.Errorf("wrong address for ctx.SetRootModuleArgument\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := ctx.SetRootModuleArgumentValue, cty.NumberIntVal(5); !want.RawEquals(got) {
+			// NOTE: The given value was cty.Bool but the type constraint was
+			// cty.String, so it was NodeRootVariable's responsibility to convert
+			// as part of preparing the "final value".
+			t.Errorf("wrong value for ctx.SetRootModuleArgument\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+}
+
+// fakeHCLExpressionFunc is a fake implementation of hcl.Expression that just
+// directly produces a value with direct Go code.
+//
+// An expression of this type has no references and so it cannot access any
+// variables from the EvalContext unless something else arranges for them
+// to be guaranteed available. For example, custom variable validations just
+// unconditionally have access to the variable they are validating regardless
+// of references.
+type fakeHCLExpressionFunc func(*hcl.EvalContext) (cty.Value, hcl.Diagnostics)
+
+var _ hcl.Expression = fakeHCLExpressionFunc(nil)
+
+func (f fakeHCLExpressionFunc) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+	return f(ctx)
+}
+
+func (f fakeHCLExpressionFunc) Variables() []hcl.Traversal {
+	return nil
+}
+
+func (f fakeHCLExpressionFunc) Range() hcl.Range {
+	return hcl.Range{
+		Filename: "fake",
+		Start:    hcl.InitialPos,
+		End:      hcl.InitialPos,
 	}
+}
 
-	diags := n.Execute(ctx, walkApply)
-	if diags.HasErrors() {
-		t.Fatalf("unexpected error: %s", diags.Err())
-	}
-
+func (f fakeHCLExpressionFunc) StartRange() hcl.Range {
+	return f.Range()
 }

--- a/internal/terraform/transform_variable.go
+++ b/internal/terraform/transform_variable.go
@@ -13,6 +13,8 @@ import (
 // reach them.
 type RootVariableTransformer struct {
 	Config *configs.Config
+
+	RawValues InputValues
 }
 
 func (t *RootVariableTransformer) Transform(g *Graph) error {
@@ -31,7 +33,8 @@ func (t *RootVariableTransformer) Transform(g *Graph) error {
 			Addr: addrs.InputVariable{
 				Name: v.Name,
 			},
-			Config: v,
+			Config:   v,
+			RawValue: t.RawValues[v.Name],
 		}
 		g.Add(node)
 	}


### PR DESCRIPTION
This should close #29899 along with just generally creating some better consistency in how we handle root module input variables as compared to called module input variables, to make sure we're following an equivalent workflow in each case.

The starting idea here is to make the user-provided value (prior to type conversion and validation) be attached to the graph node representing a root module variable, which corresponds with our strategy of including in a called module variable node the expression that will define that variable. We can then follow the same steps during evaluation aside from skipping the expression evaluation in the root module scenario, because root module variables always arrive as concrete values.

Another level of consistency which builds on the above is that the set of variables kept inside the `terraform.EvalContext` is _always_ the so-called "final" values, after type conversion and validation. Previously that was true for called module variables but not for root module variables, which I believe was the inconsistency that led to the bug described in #29899.

This diff is noisier than I'd like because of how much it takes to wire a new argument (the raw variable values) through to the graph builders, and the need to collect the variable values a little earlier so they're ready to pass to the graph builders, but those changes are pretty mechanical and the interesting logic lives inside the plan graph builder itself, in `NodeRootVariable`, and the shared helper functions in `eval_variable.go`. My main goal is for both `NodeRootVariable` and `NodeModuleVariable` to have the same structure where the "source value" lives inside the node itself, and the graph node uses that to prepare the "final value" to save in the `EvalContext`. `NodeRootVariable` has a constant `cty.Value` (wrapped inside `terraform.InputValue`) whereas `NodeModuleVariable` has a dynamic `hcl.Expression`, but the same general principle applies.

While here I also took the opportunity to fix a historical API wart in `EvalContext`, where `SetModuleCallArguments` was built to take a set of variable values all at once but our current caller always calls with only one at a time. That is now just 
`SetModuleCallArgument` singular, to match with the new `SetRootModuleArgument` to deal with root module variables.