### PR TITLE
cli: Fix diff for nested set unchanged elements

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -569,6 +569,8 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 
 		p.buf.WriteString(" = [")
 
+		var unchanged int
+
 		for it := all.ElementIterator(); it.Next(); {
 			_, val := it.Element()
 			var action plans.Action
@@ -598,12 +600,17 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 				newValue = val
 			}
 
+			if action == plans.NoOp {
+				unchanged++
+				continue
+			}
+
 			p.buf.WriteString("\n")
 			p.buf.WriteString(strings.Repeat(" ", indent+4))
 			p.writeActionSymbol(action)
 			p.buf.WriteString("{")
 
-			if action != plans.NoOp && (p.pathForcesNewResource(path) || p.pathForcesNewResource(path[:len(path)-1])) {
+			if p.pathForcesNewResource(path) || p.pathForcesNewResource(path[:len(path)-1]) {
 				p.buf.WriteString(p.color.Color(forcesNewResourceCaption))
 			}
 
@@ -615,6 +622,7 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 			p.buf.WriteString("},")
 		}
 		p.buf.WriteString("\n")
+		p.writeSkippedElems(unchanged, indent+4)
 		p.buf.WriteString(strings.Repeat(" ", indent+2))
 		p.buf.WriteString("]")
 

--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -615,14 +615,14 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 			}
 
 			path := append(path, cty.IndexStep{Key: val})
-			p.writeAttrsDiff(objS.Attributes, oldValue, newValue, indent+6, path, result)
+			p.writeAttrsDiff(objS.Attributes, oldValue, newValue, indent+8, path, result)
 
 			p.buf.WriteString("\n")
-			p.buf.WriteString(strings.Repeat(" ", indent+4))
+			p.buf.WriteString(strings.Repeat(" ", indent+6))
 			p.buf.WriteString("},")
 		}
 		p.buf.WriteString("\n")
-		p.writeSkippedElems(unchanged, indent+4)
+		p.writeSkippedElems(unchanged, indent+6)
 		p.buf.WriteString(strings.Repeat(" ", indent+2))
 		p.buf.WriteString("]")
 

--- a/internal/command/format/diff_test.go
+++ b/internal/command/format/diff_test.go
@@ -2800,8 +2800,8 @@ func TestResourceChange_nestedSet(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
           + {
-            + mount_point = "/var/diska"
-          },
+              + mount_point = "/var/diska"
+            },
         ]
         id    = "i-02ae66f368e8518a9"
 
@@ -2861,13 +2861,13 @@ func TestResourceChange_nestedSet(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
           + {
-            + mount_point = "/var/diska"
-            + size        = "50GB"
-          },
+              + mount_point = "/var/diska"
+              + size        = "50GB"
+            },
           - {
-            - mount_point = "/var/diska" -> null
-          },
-          # (1 unchanged element hidden)
+              - mount_point = "/var/diska" -> null
+            },
+            # (1 unchanged element hidden)
         ]
         id    = "i-02ae66f368e8518a9"
 
@@ -2925,13 +2925,13 @@ func TestResourceChange_nestedSet(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
           - { # forces replacement
-            - mount_point = "/var/diska" -> null
-            - size        = "50GB" -> null
-          },
+              - mount_point = "/var/diska" -> null
+              - size        = "50GB" -> null
+            },
           + { # forces replacement
-            + mount_point = "/var/diskb"
-            + size        = "50GB"
-          },
+              + mount_point = "/var/diskb"
+              + size        = "50GB"
+            },
         ]
         id    = "i-02ae66f368e8518a9"
 
@@ -2982,9 +2982,9 @@ func TestResourceChange_nestedSet(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
           - {
-            - mount_point = "/var/diska" -> null
-            - size        = "50GB" -> null
-          },
+              - mount_point = "/var/diska" -> null
+              - size        = "50GB" -> null
+            },
         ]
         id    = "i-02ae66f368e8518a9"
 
@@ -3071,9 +3071,9 @@ func TestResourceChange_nestedSet(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       + disks = [
           + {
-            + mount_point = "/var/diska"
-            + size        = "50GB"
-          },
+              + mount_point = "/var/diska"
+              + size        = "50GB"
+            },
         ]
         id    = "i-02ae66f368e8518a9"
 
@@ -3127,9 +3127,9 @@ func TestResourceChange_nestedSet(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = [
           - {
-            - mount_point = "/var/diska" -> null
-            - size        = "50GB" -> null
-          },
+              - mount_point = "/var/diska" -> null
+              - size        = "50GB" -> null
+            },
         ] -> (known after apply)
         id    = "i-02ae66f368e8518a9"
 

--- a/internal/command/format/diff_test.go
+++ b/internal/command/format/diff_test.go
@@ -2822,6 +2822,10 @@ func TestResourceChange_nestedSet(t *testing.T) {
 						"mount_point": cty.StringVal("/var/diska"),
 						"size":        cty.NullVal(cty.String),
 					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diskb"),
+						"size":        cty.StringVal("100GB"),
+					}),
 				}),
 				"root_block_device": cty.SetVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
@@ -2837,6 +2841,10 @@ func TestResourceChange_nestedSet(t *testing.T) {
 					cty.ObjectVal(map[string]cty.Value{
 						"mount_point": cty.StringVal("/var/diska"),
 						"size":        cty.StringVal("50GB"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diskb"),
+						"size":        cty.StringVal("100GB"),
 					}),
 				}),
 				"root_block_device": cty.SetVal([]cty.Value{
@@ -2859,6 +2867,7 @@ func TestResourceChange_nestedSet(t *testing.T) {
           - {
             - mount_point = "/var/diska" -> null
           },
+          # (1 unchanged element hidden)
         ]
         id    = "i-02ae66f368e8518a9"
 


### PR DESCRIPTION
Unchanged elements in nested attributes backed by sets were previously misrendered as empty objects. This PR removes the additional brackets and adds a count of unchanged elements, and secondarily fixes the indentation for these diffs.

Targeting 1.1 backport.

### Screenshots

Before:

<img width="452" alt="after" src="https://user-images.githubusercontent.com/68917/142661721-18dba468-0b70-41a7-8e84-2388995bd60d.png">

After:

<img width="454" alt="Screen Shot 2021-11-19 at 1 04 25 PM" src="https://user-images.githubusercontent.com/68917/142670833-64427660-45a3-4954-a13d-a2ce42707ce0.png">
