### PR TITLE
cli: Fix nested single and map diff rendering

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -461,10 +461,10 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 		if action != plans.NoOp && (p.pathForcesNewResource(path) || p.pathForcesNewResource(path[:len(path)-1])) {
 			p.buf.WriteString(p.color.Color(forcesNewResourceCaption))
 		}
-		p.writeAttrsDiff(objS.Attributes, old, new, indent+2, path, result)
-		p.writeSkippedAttr(result.skippedAttributes, indent+4)
+		p.writeAttrsDiff(objS.Attributes, old, new, indent+4, path, result)
+		p.writeSkippedAttr(result.skippedAttributes, indent+6)
 		p.buf.WriteString("\n")
-		p.buf.WriteString(strings.Repeat(" ", indent))
+		p.buf.WriteString(strings.Repeat(" ", indent+2))
 		p.buf.WriteString("}")
 
 	case configschema.NestingList:
@@ -690,15 +690,15 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 				}
 
 				path := append(path, cty.IndexStep{Key: cty.StringVal(k)})
-				p.writeAttrsDiff(objS.Attributes, oldValue, newValue, indent+6, path, result)
-				p.writeSkippedAttr(result.skippedAttributes, indent+8)
+				p.writeAttrsDiff(objS.Attributes, oldValue, newValue, indent+8, path, result)
+				p.writeSkippedAttr(result.skippedAttributes, indent+10)
 				p.buf.WriteString("\n")
-				p.buf.WriteString(strings.Repeat(" ", indent+4))
+				p.buf.WriteString(strings.Repeat(" ", indent+6))
 				p.buf.WriteString("},\n")
 			}
 		}
 
-		p.writeSkippedElems(unchanged, indent+4)
+		p.writeSkippedElems(unchanged, indent+6)
 		p.buf.WriteString(strings.Repeat(" ", indent+2))
 		p.buf.WriteString("}")
 		if !new.IsKnown() {

--- a/internal/command/format/diff_test.go
+++ b/internal/command/format/diff_test.go
@@ -354,9 +354,9 @@ new line
 			ExpectedOutput: `  # test_instance.example will be created
   + resource "test_instance" "example" {
       + conn_info = {
-        + password = (sensitive value)
-        + user     = "not-secret"
-      }
+          + password = (sensitive value)
+          + user     = "not-secret"
+        }
       + id        = (known after apply)
       + password  = (sensitive value)
     }
@@ -3179,8 +3179,8 @@ func TestResourceChange_nestedMap(t *testing.T) {
       + ami   = "ami-AFTER"
       + disks = {
           + "disk_a" = {
-            + mount_point = "/var/diska"
-          },
+              + mount_point = "/var/diska"
+            },
         }
       + id    = "i-02ae66f368e8518a9"
 
@@ -3226,8 +3226,8 @@ func TestResourceChange_nestedMap(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = {
           + "disk_a" = {
-            + mount_point = "/var/diska"
-          },
+              + mount_point = "/var/diska"
+            },
         }
         id    = "i-02ae66f368e8518a9"
 
@@ -3279,9 +3279,9 @@ func TestResourceChange_nestedMap(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = {
           ~ "disk_a" = {
-            + size        = "50GB"
-              # (1 unchanged attribute hidden)
-          },
+              + size        = "50GB"
+                # (1 unchanged attribute hidden)
+            },
         }
         id    = "i-02ae66f368e8518a9"
 
@@ -3342,10 +3342,10 @@ func TestResourceChange_nestedMap(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = {
           + "disk_2" = {
-            + mount_point = "/var/disk2"
-            + size        = "50GB"
-          },
-          # (1 unchanged element hidden)
+              + mount_point = "/var/disk2"
+              + size        = "50GB"
+            },
+            # (1 unchanged element hidden)
         }
         id    = "i-02ae66f368e8518a9"
 
@@ -3409,9 +3409,9 @@ func TestResourceChange_nestedMap(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = {
           ~ "disk_a" = { # forces replacement
-            ~ size        = "50GB" -> "100GB"
-              # (1 unchanged attribute hidden)
-          },
+              ~ size        = "50GB" -> "100GB"
+                # (1 unchanged attribute hidden)
+            },
         }
         id    = "i-02ae66f368e8518a9"
 
@@ -3460,9 +3460,9 @@ func TestResourceChange_nestedMap(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = {
           - "disk_a" = {
-            - mount_point = "/var/diska" -> null
-            - size        = "50GB" -> null
-          },
+              - mount_point = "/var/diska" -> null
+              - size        = "50GB" -> null
+            },
         }
         id    = "i-02ae66f368e8518a9"
 
@@ -3513,9 +3513,9 @@ func TestResourceChange_nestedMap(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = {
           - "disk_a" = {
-            - mount_point = "/var/diska" -> null
-            - size        = "50GB" -> null
-          },
+              - mount_point = "/var/diska" -> null
+              - size        = "50GB" -> null
+            },
         } -> (known after apply)
         id    = "i-02ae66f368e8518a9"
 
@@ -3572,9 +3572,9 @@ func TestResourceChange_nestedMap(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = {
           + "disk_a" = {
-            + mount_point = (sensitive)
-            + size        = "50GB"
-          },
+              + mount_point = (sensitive)
+              + size        = "50GB"
+            },
         }
         id    = "i-02ae66f368e8518a9"
 
@@ -4742,9 +4742,9 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example must be replaced
 -/+ resource "test_instance" "example" {
       ~ conn_info = { # forces replacement
-        ~ password = (sensitive value)
-          # (1 unchanged attribute hidden)
-      }
+          ~ password = (sensitive value)
+            # (1 unchanged attribute hidden)
+        }
         id        = "i-02ae66f368e8518a9"
     }
 `,


### PR DESCRIPTION
[As noted in this comment](https://github.com/hashicorp/terraform/pull/29983#issuecomment-974383383), the indentation for nested map rendering was out by two spaces. The same was true for a nested single object. As of this commit, these are now consistent with the other displays of object/map values.

Backporting to 1.1.

## Screenshot

Before:

<img width="753" alt="before" src="https://user-images.githubusercontent.com/68917/142687415-d1fdb53d-c80c-4655-9510-b6d9806160bc.png">

After:

<img width="769" alt="after" src="https://user-images.githubusercontent.com/68917/142689926-3d219046-121c-4fec-8a0c-f76689a074d9.png">

