### PR TITLE
command/init: Add -cloud alias to -backend, adjust `init` help output

### DIFF
--- a/internal/command/arguments/flags.go
+++ b/internal/command/arguments/flags.go
@@ -84,3 +84,14 @@ type FlagNameValue struct {
 func (f FlagNameValue) String() string {
 	return fmt.Sprintf("%s=%q", f.Name, f.Value)
 }
+
+// FlagIsSet returns whether a flag is explicitly set in a set of flags
+func FlagIsSet(flags *flag.FlagSet, name string) bool {
+	isSet := false
+	flags.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			isSet = true
+		}
+	})
+	return isSet
+}

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -1048,14 +1048,16 @@ Options:
 
                           aliases: -cloud=false
 
-  -backend-config=path    This can be either a path to an HCL file with key/value
+  -backend-config=path    Configuration to be merged with what is in the
+                          configuration file's 'backend' block. This can be
+                          either a path to an HCL file with key/value
                           assignments (same format as terraform.tfvars) or a
-                          'key=value' format. This is merged with what is in the
-                          configuration file. This can be specified multiple
+                          'key=value' format, and can be specified multiple
                           times. The backend type must be in the configuration
                           itself.
 
-  -force-copy             Suppress prompts about copying state data. This is
+  -force-copy             Suppress prompts about copying state data when
+                          initializating a new state backend. This is
                           equivalent to providing a "yes" to all confirmation
                           prompts.
 
@@ -1064,9 +1066,9 @@ Options:
 
   -get=false              Disable downloading modules for this configuration.
 
-  -input=false            Disable prompting for missing backend configuration
-                          values. This will result in an error if the backend
-                          configuration is not fully specified.
+  -input=false            Disable interactive prompts. Note that some actions may
+                          require interactive prompts and will error if input is
+                          disabled.
 
   -lock=false             Don't hold a state lock during backend migration.
                           This is dangerous if others might concurrently run
@@ -1081,10 +1083,10 @@ Options:
                           automatic installation of plugins. This flag can be used
                           multiple times.
 
-  -reconfigure            Reconfigure the backend, ignoring any saved
+  -reconfigure            Reconfigure a backend, ignoring any saved
                           configuration.
 
-  -migrate-state          Reconfigure the backend, and attempt to migrate any
+  -migrate-state          Reconfigure a backend, and attempt to migrate any
                           existing state.
 
   -upgrade                Install the latest module and provider versions
@@ -1095,8 +1097,12 @@ Options:
   -lockfile=MODE          Set a dependency lockfile mode.
                           Currently only "readonly" is valid.
 
-  -ignore-remote-version  A rare option used for the remote backend only. See
-                          the remote backend documentation for more information.
+  -ignore-remote-version  A rare option used for Terraform Cloud and the remote backend
+                          only. Set this to ignore checking that the local and remote
+                          Terraform versions use compatible state representations, making
+                          an operation proceed even when there is a potential mismatch.
+                          See the documentation on configuring Terraform with
+                          Terraform Cloud for more information.
 
 `
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
This fixes an issue where a user could not disable initialization of the `cloud` configuration block (As is possible with `-backend=false` for state backends), as well as add some syntactic sugar around `-backend` by adding a mutually
exclusive `-cloud` alias.

It also adjusts some help text in `init` to account for a backend to not necessarily be a constant in a _usage_ sense (e.g. you've configured TFC, etc).

![image](https://user-images.githubusercontent.com/2430490/142690103-cba80f98-1c30-4745-a144-ee620a461073.png)
