### PR TITLE
Cloud: For TFC init must be interactive

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -378,6 +378,15 @@ func (c *InitCommand) initCloud(root *configs.Module, extraConfig rawFlags) (be 
 		return nil, true, diags
 	}
 
+	if c.Meta.input == false {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid command-line option",
+			"The Terraform Cloud integration requires user interactivity.",
+		))
+		return nil, true, diags
+	}
+
 	backendConfig := root.CloudConfig.ToBackendConfig()
 
 	opts := &BackendOpts{


### PR DESCRIPTION
The Cloud integration requires user interactivity and cannot always
programmatically migrate workspaces without prompts.