### PR TITLE
lang/funcs: add direxists function

### DIFF
--- a/internal/lang/funcs/filesystem_test.go
+++ b/internal/lang/funcs/filesystem_test.go
@@ -236,6 +236,49 @@ func TestFileExists(t *testing.T) {
 	}
 }
 
+func TestDirExists(t *testing.T) {
+	tests := []struct {
+		Path cty.Value
+		Want cty.Value
+		Err  bool
+	}{
+		{
+			cty.StringVal("testdata/subdirectory"),
+			cty.BoolVal(true),
+			false,
+		},
+		{
+			cty.StringVal("testdata/missing"),
+			cty.BoolVal(false),
+			false, // no directory exists
+		},
+		{
+			cty.StringVal("testdata/hello.txt"),
+			cty.BoolVal(false),
+			true, // is a file
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("DirExists(\".\", %#v)", test.Path), func(t *testing.T) {
+			got, err := DirExists(".", test.Path)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
 func TestFileSet(t *testing.T) {
 	tests := []struct {
 		Path    cty.Value

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -57,6 +57,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"contains":         stdlib.ContainsFunc,
 			"csvdecode":        stdlib.CSVDecodeFunc,
 			"defaults":         s.experimentalFunction(experiments.ModuleVariableOptionalAttrs, funcs.DefaultsFunc),
+			"direxists":        funcs.MakeDirExistsFunc(s.BaseDir),
 			"dirname":          funcs.DirnameFunc,
 			"distinct":         stdlib.DistinctFunc,
 			"element":          stdlib.ElementFunc,

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -303,6 +303,13 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"direxists": {
+			{
+				`direxists("subdirectory")`,
+				cty.BoolVal(true),
+			},
+		},
+
 		"dirname": {
 			{
 				`dirname("testdata/hello.txt")`,

--- a/website/docs/language/functions/direxists.html.md
+++ b/website/docs/language/functions/direxists.html.md
@@ -1,0 +1,35 @@
+---
+layout: "language"
+page_title: "direxists - Functions - Configuration Language"
+sidebar_current: "docs-funcs-file-directory-exists"
+description: |-
+The direxists function determines whether a directory exists at a given path.
+---
+
+# `direxists` Function
+
+`direxists` determines whether a directory exists at a given path.
+
+```hcl
+direxists(path)
+```
+
+Functions are evaluated during configuration parsing rather than at apply time,
+so this function can only be used with directories that are already present on disk
+before Terraform takes any actions.
+
+If the path is empty then the result is ".", representing the current working directory.
+
+This function works only with directories. If used with a file, FIFO,
+or another file with a special mode, it will return an error.
+
+## Examples
+
+```
+> direxists("${path.module}/files")
+true
+```
+
+## Related Functions
+
+* [`fileexists`](./fileexists.html) determines whether a file exists at a given path.

--- a/website/docs/language/functions/fileexists.html.md
+++ b/website/docs/language/functions/fileexists.html.md
@@ -35,3 +35,4 @@ fileexists("custom-section.sh") ? file("custom-section.sh") : local.default_cont
 ## Related Functions
 
 * [`file`](./file.html) reads the contents of a file at a given path
+* [`direxists`](./direxists.html) determines whether a directory exists at a given path

--- a/website/layouts/language.erb
+++ b/website/layouts/language.erb
@@ -657,6 +657,10 @@
               </li>
 
               <li>
+                <a href="/docs/language/functions/direxists.html">direxists</a>
+              </li>
+
+              <li>
                 <a href="/docs/language/functions/fileset.html">fileset</a>
               </li>
 


### PR DESCRIPTION
This commit creates a new `direxists` function to Terraform configuration. The function reuses an abstraction of `fileexists` function to obtain file path Information.

This might help with this issue: [#25316](https://github.com/hashicorp/terraform/issues/25316) 