### PR TITLE
Performance - Allow a single terraform import command to process multiple resources.

### DIFF
--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -52,38 +52,14 @@ func (c *ImportCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	if len(args) != 2 {
-		c.Ui.Error("The import command expects two arguments.")
+	if len(args)%2 != 0 {
+		c.Ui.Error("The import command expects even amount of arguments.")
 		cmdFlags.Usage()
 		return 1
 	}
 
+	targets := make([]*terraform.ImportTarget, len(args)/2)
 	var diags tfdiags.Diagnostics
-
-	// Parse the provided resource address.
-	traversalSrc := []byte(args[0])
-	traversal, travDiags := hclsyntax.ParseTraversalAbs(traversalSrc, "<import-address>", hcl.Pos{Line: 1, Column: 1})
-	diags = diags.Append(travDiags)
-	if travDiags.HasErrors() {
-		c.registerSynthConfigSource("<import-address>", traversalSrc) // so we can include a source snippet
-		c.showDiagnostics(diags)
-		c.Ui.Info(importCommandInvalidAddressReference)
-		return 1
-	}
-	addr, addrDiags := addrs.ParseAbsResourceInstance(traversal)
-	diags = diags.Append(addrDiags)
-	if addrDiags.HasErrors() {
-		c.registerSynthConfigSource("<import-address>", traversalSrc) // so we can include a source snippet
-		c.showDiagnostics(diags)
-		c.Ui.Info(importCommandInvalidAddressReference)
-		return 1
-	}
-
-	if addr.Resource.Resource.Mode != addrs.ManagedResourceMode {
-		diags = diags.Append(errors.New("A managed resource address is required. Importing into a data resource is not allowed."))
-		c.showDiagnostics(diags)
-		return 1
-	}
 
 	if !c.dirIsConfigPath(configPath) {
 		diags = diags.Append(&hcl.Diagnostic{
@@ -107,52 +83,84 @@ func (c *ImportCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Verify that the given address points to something that exists in config.
-	// This is to reduce the risk that a typo in the resource address will
-	// import something that Terraform will want to immediately destroy on
-	// the next plan, and generally acts as a reassurance of user intent.
-	targetConfig := config.DescendentForInstance(addr.Module)
-	if targetConfig == nil {
-		modulePath := addr.Module.String()
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Import to non-existent module",
-			Detail: fmt.Sprintf(
-				"%s is not defined in the configuration. Please add configuration for this module before importing into it.",
-				modulePath,
-			),
-		})
-		c.showDiagnostics(diags)
-		return 1
-	}
-	targetMod := targetConfig.Module
-	rcs := targetMod.ManagedResources
 	var rc *configs.Resource
-	resourceRelAddr := addr.Resource.Resource
-	for _, thisRc := range rcs {
-		if resourceRelAddr.Type == thisRc.Type && resourceRelAddr.Name == thisRc.Name {
-			rc = thisRc
-			break
+
+	for i := 0; i < len(args); i += 2 {
+		// Parse the provided resource address.
+		traversalSrc := []byte(args[i])
+		traversal, travDiags := hclsyntax.ParseTraversalAbs(traversalSrc, "<import-address>", hcl.Pos{Line: 1, Column: 1})
+		diags = diags.Append(travDiags)
+		if travDiags.HasErrors() {
+			c.registerSynthConfigSource("<import-address>", traversalSrc) // so we can include a source snippet
+			c.showDiagnostics(diags)
+			c.Ui.Info(importCommandInvalidAddressReference)
+			return 1
 		}
-	}
-	if !c.Meta.allowMissingConfig && rc == nil {
-		modulePath := addr.Module.String()
-		if modulePath == "" {
-			modulePath = "the root module"
+		addr, addrDiags := addrs.ParseAbsResourceInstance(traversal)
+		diags = diags.Append(addrDiags)
+		if addrDiags.HasErrors() {
+			c.registerSynthConfigSource("<import-address>", traversalSrc) // so we can include a source snippet
+			c.showDiagnostics(diags)
+			c.Ui.Info(importCommandInvalidAddressReference)
+			return 1
 		}
 
-		c.showDiagnostics(diags)
+		if addr.Resource.Resource.Mode != addrs.ManagedResourceMode {
+			diags = diags.Append(errors.New("A managed resource address is required. Importing into a data resource is not allowed."))
+			c.showDiagnostics(diags)
+			return 1
+		}
 
-		// This is not a diagnostic because currently our diagnostics printer
-		// doesn't support having a code example in the detail, and there's
-		// a code example in this message.
-		// TODO: Improve the diagnostics printer so we can use it for this
-		// message.
-		c.Ui.Error(fmt.Sprintf(
-			importCommandMissingResourceFmt,
-			addr, modulePath, resourceRelAddr.Type, resourceRelAddr.Name,
-		))
-		return 1
+		// Verify that the given address points to something that exists in config.
+		// This is to reduce the risk that a typo in the resource address will
+		// import something that Terraform will want to immediately destroy on
+		// the next plan, and generally acts as a reassurance of user intent.
+		targetConfig := config.DescendentForInstance(addr.Module)
+		if targetConfig == nil {
+			modulePath := addr.Module.String()
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Import to non-existent module",
+				Detail: fmt.Sprintf(
+					"%s is not defined in the configuration. Please add configuration for this module before importing into it.",
+					modulePath,
+				),
+			})
+			c.showDiagnostics(diags)
+			return 1
+		}
+		targetMod := targetConfig.Module
+		rcs := targetMod.ManagedResources
+		resourceRelAddr := addr.Resource.Resource
+		for _, thisRc := range rcs {
+			if resourceRelAddr.Type == thisRc.Type && resourceRelAddr.Name == thisRc.Name {
+				rc = thisRc
+				break
+			}
+		}
+		if !c.Meta.allowMissingConfig && rc == nil {
+			modulePath := addr.Module.String()
+			if modulePath == "" {
+				modulePath = "the root module"
+			}
+
+			c.showDiagnostics(diags)
+
+			// This is not a diagnostic because currently our diagnostics printer
+			// doesn't support having a code example in the detail, and there's
+			// a code example in this message.
+			// TODO: Improve the diagnostics printer so we can use it for this
+			// message.
+			c.Ui.Error(fmt.Sprintf(
+				importCommandMissingResourceFmt,
+				addr, modulePath, resourceRelAddr.Type, resourceRelAddr.Name,
+			))
+			return 1
+		}
+		targets[i/2] = &terraform.ImportTarget{
+			Addr: addr,
+			ID:   args[i+1],
+		}
 	}
 
 	// Check for user-supplied plugin path
@@ -227,16 +235,9 @@ func (c *ImportCommand) Run(args []string) int {
 		}
 	}()
 
-	// Perform the import. Note that as you can see it is possible for this
-	// API to import more than one resource at once. For now, we only allow
-	// one while we stabilize this feature.
+	// Perform the import.
 	newState, importDiags := lr.Core.Import(lr.Config, lr.InputState, &terraform.ImportOpts{
-		Targets: []*terraform.ImportTarget{
-			{
-				Addr: addr,
-				ID:   args[1],
-			},
-		},
+		Targets: targets,
 
 		// The LocalRun idea is designed around our primary operations, so
 		// the input variables end up represented as plan options even though

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -277,11 +277,11 @@ func (c *ImportCommand) Run(args []string) int {
 
 func (c *ImportCommand) Help() string {
 	helpText := `
-Usage: terraform [global options] import [options] ADDR ID
+Usage: terraform [global options] import [options] ADDR ID [additional pairs of ADDR and ID]
 
   Import existing infrastructure into your Terraform state.
 
-  This will find and import the specified resource into your Terraform
+  This will find and import the specified resource(s) into your Terraform
   state, allowing existing infrastructure to come under Terraform
   management without having to be initially created by Terraform.
 

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -52,7 +52,7 @@ func (c *ImportCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	if len(args)%2 != 0 {
+	if len(args) == 0 || len(args)%2 != 0 {
 		c.Ui.Error("The import command expects even amount of arguments.")
 		cmdFlags.Usage()
 		return 1


### PR DESCRIPTION
Currently, each terraform import command reads and parses all *.tf files.
The change allows reading and parsing all *.tf files once.
And then, process all imports using the default amount of parallel threads.

Current code imported 152 resources using 152 import commands in 150 seconds.
Modified code imported same 152 resources using 1 import command in 7.5 seconds.