### PR TITLE
Add -simple flag to version command for scripting friendly output.

### DIFF
--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -91,6 +91,62 @@ func TestVersion_flags(t *testing.T) {
 	}
 }
 
+func TestVersion_simple(t *testing.T) {
+	ui := new(cli.MockUi)
+	m := Meta{
+		Ui: ui,
+	}
+
+	// `terraform version`
+	c := &VersionCommand{
+		Meta:              m,
+		Version:           "4.5.6",
+		VersionPrerelease: "foo",
+		Platform:          getproviders.Platform{OS: "aros", Arch: "riscv64"},
+	}
+
+	if code := c.Run([]string{"-v", "-simple"}); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+
+	actual := strings.TrimSpace(ui.OutputWriter.String())
+	expected := "4.5.6-foo"
+	if actual != expected {
+		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actual, expected)
+	}
+}
+
+func TestVersion_simple_json_error(t *testing.T) {
+	ui := new(cli.MockUi)
+	m := Meta{
+		Ui: ui,
+	}
+
+	// `terraform version`
+	c := &VersionCommand{
+		Meta:              m,
+		Version:           "4.5.6",
+		VersionPrerelease: "foo",
+		Platform:          getproviders.Platform{OS: "aros", Arch: "riscv64"},
+	}
+
+	if code := c.Run([]string{"-v", "-simple", "-json"}); code == 0 {
+		t.Fatalf("-simple and -json are incompatible flags, but no error was raised")
+	}
+
+	actual := strings.TrimSpace(ui.OutputWriter.String())
+	expected := ""
+	if actual != expected {
+		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actual, expected)
+	}
+
+	actualError := strings.TrimSpace(ui.ErrorWriter.String())
+	expectedError := "-simple and -json flags are not compatible together"
+	if actual != expected {
+		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actualError, expectedError)
+	}
+}
+
 func TestVersion_outdated(t *testing.T) {
 	ui := new(cli.MockUi)
 	m := Meta{


### PR DESCRIPTION
Sometimes it is useful during scripting to get simple version number of the program. There is already `terraform version` and `terraform version -json`, but those are oriented to user interaction or (in the second case) needs to be parsed as a JSON (using tools like `jq` during scripting).

I have added new flag `-simple` to `version` command to print out just version with no more info (excluding also outdated notification) useful for scripting. It is incompatible with `json` flag and it raises an error if used together.

### example

```bash
$ ~/go/bin/terraform version -simple
1.1.0-dev

$~/go/bin/terraform version -simple -json
-simple and -json flags are not compatible together
```

---

### little background

Another CLI tools do have the same version output. I'm attaching few examples.

```bash
$ gem -v
3.2.22
$ npm -v
6.14.15
$ yarn -v
1.22.10
```

I would expect this kind of simple output as a default one, but changing this in terraform would be backward incompatible action and I believe there is good reason for this default output. That is the reason for adding new `-simple` flag instead of changing the default output.

---

:information_source: _I'm not Go programmer and this is my first Go contribution. I tried to respect the code styling around._