### PR TITLE
core: Fix schema loading for deleted resources

### DIFF
--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -136,6 +136,9 @@ func (n *NodeAbstractResourceInstance) Provider() addrs.Provider {
 	if n.Config != nil {
 		return n.Config.Provider
 	}
+	if n.storedProviderConfig.Provider.Type != "" {
+		return n.storedProviderConfig.Provider
+	}
 	return addrs.ImpliedProviderForUnqualifiedType(n.Addr.Resource.ContainingResource().ImpliedProvider())
 }
 

--- a/internal/terraform/node_resource_abstract_instance_test.go
+++ b/internal/terraform/node_resource_abstract_instance_test.go
@@ -13,9 +13,10 @@ import (
 
 func TestNodeAbstractResourceInstanceProvider(t *testing.T) {
 	tests := []struct {
-		Addr   addrs.AbsResourceInstance
-		Config *configs.Resource
-		Want   addrs.Provider
+		Addr                 addrs.AbsResourceInstance
+		Config               *configs.Resource
+		StoredProviderConfig addrs.AbsProviderConfig
+		Want                 addrs.Provider
 	}{
 		{
 			Addr: addrs.Resource{
@@ -87,6 +88,28 @@ func TestNodeAbstractResourceInstanceProvider(t *testing.T) {
 				Type:      "happycloud",
 			},
 		},
+		{
+			Addr: addrs.Resource{
+				Mode: addrs.DataResourceMode,
+				Type: "null_resource",
+				Name: "baz",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			Config: nil,
+			StoredProviderConfig: addrs.AbsProviderConfig{
+				Module: addrs.RootModule,
+				Provider: addrs.Provider{
+					Hostname:  addrs.DefaultProviderRegistryHost,
+					Namespace: "awesomecorp",
+					Type:      "null",
+				},
+			},
+			// The stored provider config overrides the default behavior.
+			Want: addrs.Provider{
+				Hostname:  addrs.DefaultProviderRegistryHost,
+				Namespace: "awesomecorp",
+				Type:      "null",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -104,6 +127,7 @@ func TestNodeAbstractResourceInstanceProvider(t *testing.T) {
 				NodeAbstractResource: NodeAbstractResource{
 					Config: test.Config,
 				},
+				storedProviderConfig: test.StoredProviderConfig,
 			}
 			got := node.Provider()
 			if got != test.Want {


### PR DESCRIPTION
Resource instances removed from the configuration would previously use the implied provider address. This is correct for default providers, but incorrect for those from other namespaces or hosts. The fix here is to use the stored provider config if it is present.

Fixes #30018