### PR TITLE
Fix example for values-representation in docs for JSON Format internals

### DIFF
--- a/website/docs/internals/json-format.html.md
+++ b/website/docs/internals/json-format.html.md
@@ -272,7 +272,7 @@ The following example illustrates the structure of a `<values-representation>`:
         // "sensitive_values" is the JSON representation of the sensitivity of
         // the resource's attribute values. Only attributes which are sensitive
         // are included in this structure.
-        "values": {
+        "sensitive_values": {
           "id": true,
         }
       }


### PR DESCRIPTION
The `root_module.resources[].sensitive_values` key in the example output was incorrectly named and clashed with the regular `root_module.resources[].values` key.