### PR TITLE
Add flag to exclude specific resources from plan

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -258,11 +258,12 @@ type Operation struct {
 
 	// The options below are more self-explanatory and affect the runtime
 	// behavior of the operation.
-	PlanMode     plans.Mode
-	AutoApprove  bool
-	Targets      []addrs.Targetable
-	ForceReplace []addrs.AbsResourceInstance
-	Variables    map[string]UnparsedVariableValue
+	PlanMode       plans.Mode
+	AutoApprove    bool
+	Targets        []addrs.Targetable
+	ExcludeTargets []addrs.Targetable
+	ForceReplace   []addrs.AbsResourceInstance
+	Variables      map[string]UnparsedVariableValue
 
 	// Some operations use root module variables only opportunistically or
 	// don't need them at all. If this flag is set, the backend must treat

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -187,11 +187,12 @@ func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, cor
 	}
 
 	planOpts := &terraform.PlanOpts{
-		Mode:         op.PlanMode,
-		Targets:      op.Targets,
-		ForceReplace: op.ForceReplace,
-		SetVariables: variables,
-		SkipRefresh:  op.Type != backend.OperationTypeRefresh && !op.PlanRefresh,
+		Mode:           op.PlanMode,
+		Targets:        op.Targets,
+		ExcludeTargets: op.ExcludeTargets,
+		ForceReplace:   op.ForceReplace,
+		SetVariables:   variables,
+		SkipRefresh:    op.Type != backend.OperationTypeRefresh && !op.PlanRefresh,
 	}
 	run.PlanOpts = planOpts
 

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -265,6 +265,7 @@ func (c *ApplyCommand) OperationRequest(
 	opReq.PlanFile = planFile
 	opReq.PlanRefresh = args.Refresh
 	opReq.Targets = args.Targets
+	opReq.ExcludeTargets = args.ExcludeTargets
 	opReq.ForceReplace = args.ForceReplace
 	opReq.Type = backend.OperationTypeApply
 	opReq.View = view.Operation()

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -160,8 +160,9 @@ type Meta struct {
 	input        bool
 
 	// Targets for this context (private)
-	targets     []addrs.Targetable
-	targetFlags []string
+	targets        []addrs.Targetable
+	excludeTargets []addrs.Targetable
+	targetFlags    []string
 
 	// Internal fields
 	color bool

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -430,6 +430,7 @@ func (m *Meta) Operation(b backend.Backend) *backend.Operation {
 	return &backend.Operation{
 		PlanOutBackend:  planOutBackend,
 		Targets:         m.targets,
+		ExcludeTargets:  m.excludeTargets,
 		UIIn:            m.UIInput(),
 		UIOut:           m.Ui,
 		Workspace:       workspace,

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -150,6 +150,7 @@ func (c *PlanCommand) OperationRequest(
 	opReq.PlanRefresh = args.Refresh
 	opReq.PlanOutPath = planOutPath
 	opReq.Targets = args.Targets
+	opReq.ExcludeTargets = args.ExcludeTargets
 	opReq.ForceReplace = args.ForceReplace
 	opReq.Type = backend.OperationTypePlan
 	opReq.View = view.Operation()

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -140,6 +140,7 @@ func (c *RefreshCommand) OperationRequest(be backend.Enhanced, view views.Refres
 	opReq.ConfigDir = "."
 	opReq.Hooks = view.Hooks()
 	opReq.Targets = args.Targets
+	opReq.ExcludeTargets = args.ExcludeTargets
 	opReq.Type = backend.OperationTypeRefresh
 	opReq.View = view.Operation()
 

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -29,12 +29,13 @@ type Plan struct {
 	// the Changes field, regardless of how the plan was created.
 	UIMode Mode
 
-	VariableValues    map[string]DynamicValue
-	Changes           *Changes
-	DriftedResources  []*ResourceInstanceChangeSrc
-	TargetAddrs       []addrs.Targetable
-	ForceReplaceAddrs []addrs.AbsResourceInstance
-	Backend           Backend
+	VariableValues      map[string]DynamicValue
+	Changes             *Changes
+	DriftedResources    []*ResourceInstanceChangeSrc
+	TargetAddrs         []addrs.Targetable
+	ExcludeTargetsAddrs []addrs.Targetable
+	ForceReplaceAddrs   []addrs.AbsResourceInstance
+	Backend             Backend
 
 	// PrevRunState and PriorState both describe the situation that the plan
 	// was derived from:

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -34,7 +34,8 @@ type ApplyGraphBuilder struct {
 	// unnecessary outputs aren't included in the apply graph. The plan
 	// builder successfully handles targeting resources. In the future,
 	// outputs should go into the diff so that this is unnecessary.
-	Targets []addrs.Targetable
+	Targets        []addrs.Targetable
+	ExcludeTargets []addrs.Targetable
 
 	// ForceReplace are the resource instance addresses that the user
 	// requested to force replacement for when creating the plan, if any.
@@ -150,7 +151,10 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&pruneUnusedNodesTransformer{},
 
 		// Target
-		&TargetsTransformer{Targets: b.Targets},
+		&TargetsTransformer{
+			Targets:        b.Targets,
+			ExcludeTargets: b.ExcludeTargets,
+		},
 
 		// Close opened plugin connections
 		&CloseProviderTransformer{},

--- a/internal/terraform/graph_builder_destroy_plan.go
+++ b/internal/terraform/graph_builder_destroy_plan.go
@@ -28,7 +28,8 @@ type DestroyPlanGraphBuilder struct {
 	Plugins *contextPlugins
 
 	// Targets are resources to target
-	Targets []addrs.Targetable
+	Targets        []addrs.Targetable
+	ExcludeTargets []addrs.Targetable
 
 	// Validate will do structural validation of the graph.
 	Validate bool
@@ -99,7 +100,10 @@ func (b *DestroyPlanGraphBuilder) Steps() []GraphTransformer {
 			State:  b.State,
 		},
 
-		&TargetsTransformer{Targets: b.Targets},
+		&TargetsTransformer{
+			Targets:        b.Targets,
+			ExcludeTargets: b.ExcludeTargets,
+		},
 
 		// Close opened plugin connections
 		&CloseProviderTransformer{},

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -33,7 +33,8 @@ type PlanGraphBuilder struct {
 	Plugins *contextPlugins
 
 	// Targets are resources to target
-	Targets []addrs.Targetable
+	Targets        []addrs.Targetable
+	ExcludeTargets []addrs.Targetable
 
 	// ForceReplace are resource instances where if we would normally have
 	// generated a NoOp or Update action then we'll force generating a replace
@@ -150,7 +151,10 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&attachDataResourceDependsOnTransformer{},
 
 		// Target
-		&TargetsTransformer{Targets: b.Targets},
+		&TargetsTransformer{
+			Targets:        b.Targets,
+			ExcludeTargets: b.ExcludeTargets,
+		},
 
 		// Detect when create_before_destroy must be forced on for a particular
 		// node due to dependency edges, to avoid graph cycles during apply.

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -60,7 +60,8 @@ type NodeAbstractResource struct {
 	ProvisionerSchemas map[string]*configschema.Block
 
 	// Set from GraphNodeTargetable
-	Targets []addrs.Targetable
+	Targets        []addrs.Targetable
+	ExcludeTargets []addrs.Targetable
 
 	// Set from AttachDataResourceDependsOn
 	dependsOn      []addrs.ConfigResource
@@ -262,6 +263,7 @@ func (n *NodeAbstractResource) ResourceAddr() addrs.ConfigResource {
 // GraphNodeTargetable
 func (n *NodeAbstractResource) SetTargets(targets []addrs.Targetable) {
 	n.Targets = targets
+	n.ExcludeTargets = []addrs.Targetable{}
 }
 
 // graphNodeAttachDataResourceDependsOn

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -379,7 +379,10 @@ func (n *NodePlannableResource) DynamicExpand(ctx EvalContext) (*Graph, error) {
 		&AttachStateTransformer{State: state},
 
 		// Targeting
-		&TargetsTransformer{Targets: n.Targets},
+		&TargetsTransformer{
+			Targets:        n.Targets,
+			ExcludeTargets: n.ExcludeTargets,
+		},
 
 		// Connect references so ordering is correct
 		&ReferenceTransformer{},

--- a/internal/terraform/testdata/transform-targets-conflict/child/child.tf
+++ b/internal/terraform/testdata/transform-targets-conflict/child/child.tf
@@ -1,0 +1,5 @@
+resource "aws_vpc" "foo" {
+}
+
+resource "aws_instance" "foo" {
+}

--- a/internal/terraform/testdata/transform-targets-conflict/main.tf
+++ b/internal/terraform/testdata/transform-targets-conflict/main.tf
@@ -1,0 +1,5 @@
+resource "aws_vpc" "me" {}
+
+module "child" {
+  source = "./child"
+}

--- a/internal/terraform/transform_import_state.go
+++ b/internal/terraform/transform_import_state.go
@@ -14,8 +14,9 @@ import (
 // ImportStateTransformer is a GraphTransformer that adds nodes to the
 // graph to represent the imports we want to do for resources.
 type ImportStateTransformer struct {
-	Targets []*ImportTarget
-	Config  *configs.Config
+	Targets        []*ImportTarget
+	ExcludeTargets []*ImportTarget
+	Config         *configs.Config
 }
 
 func (t *ImportStateTransformer) Transform(g *Graph) error {

--- a/internal/terraform/transform_targets_test.go
+++ b/internal/terraform/transform_targets_test.go
@@ -58,6 +58,54 @@ aws_vpc.me
 	}
 }
 
+func TestExcludeTargetsTransformer(t *testing.T) {
+	mod := testModule(t, "transform-targets-basic")
+
+	g := Graph{Path: addrs.RootModuleInstance}
+	{
+		tf := &ConfigTransformer{Config: mod}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		transform := &AttachResourceConfigTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		transform := &ReferenceTransformer{}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		transform := &TargetsTransformer{
+			ExcludeTargets: []addrs.Targetable{
+				addrs.RootModuleInstance.Resource(
+					addrs.ManagedResourceMode, "aws_subnet", "me",
+				),
+			},
+		}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(`
+aws_instance.notme
+aws_subnet.notme
+aws_vpc.me
+aws_vpc.notme
+	`)
+	if actual != expected {
+		t.Fatalf("bad:\n\nexpected:\n%s\n\ngot:\n%s\n", expected, actual)
+	}
+}
 func TestTargetsTransformer_downstream(t *testing.T) {
 	mod := testModule(t, "transform-targets-downstream")
 
@@ -113,6 +161,22 @@ func TestTargetsTransformer_downstream(t *testing.T) {
 		}
 	}
 
+	{
+		transform := &TargetsTransformer{
+			Targets: []addrs.Targetable{
+				addrs.RootModuleInstance.
+					Child("child", addrs.NoKey).
+					Child("grandchild", addrs.NoKey).
+					Resource(
+						addrs.ManagedResourceMode, "aws_instance", "foo",
+					),
+			},
+		}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
 	actual := strings.TrimSpace(g.String())
 	// Even though we only asked to target the grandchild resource, all of the
 	// outputs that descend from it are also targeted.
@@ -124,6 +188,79 @@ module.child.output.grandchild_id (expand)
   module.child.module.grandchild.output.id (expand)
 output.grandchild_id
   module.child.output.grandchild_id (expand)
+	`)
+	if actual != expected {
+		t.Fatalf("bad:\n\nexpected:\n%s\n\ngot:\n%s\n", expected, actual)
+	}
+}
+
+func TestExcludeTargetsTransformer_downstream(t *testing.T) {
+	mod := testModule(t, "transform-targets-downstream")
+
+	g := Graph{Path: addrs.RootModuleInstance}
+	{
+		transform := &ConfigTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &AttachResourceConfigTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &AttachResourceConfigTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &OutputTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &ReferenceTransformer{}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		transform := &TargetsTransformer{
+			ExcludeTargets: []addrs.Targetable{
+				addrs.RootModuleInstance.
+					Child("child", addrs.NoKey).
+					Child("grandchild", addrs.NoKey).
+					Resource(
+						addrs.ManagedResourceMode, "aws_instance", "foo",
+					),
+			},
+		}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	actual := strings.TrimSpace(g.String())
+	// Even though we only asked to target the grandchild resource, all of the
+	// outputs that descend from it are also targeted.
+	expected := strings.TrimSpace(`
+aws_instance.foo
+module.child.aws_instance.foo
+module.child.output.id (expand)
+  module.child.aws_instance.foo
+output.child_id
+  module.child.output.id (expand)
+output.root_id
+  aws_instance.foo
 	`)
 	if actual != expected {
 		t.Fatalf("bad:\n\nexpected:\n%s\n\ngot:\n%s\n", expected, actual)
@@ -195,6 +332,143 @@ module.child.output.grandchild_id (expand)
   module.child.module.grandchild.output.id (expand)
 output.grandchild_id
   module.child.output.grandchild_id (expand)
+	`)
+	if actual != expected {
+		t.Fatalf("bad:\n\nexpected:\n%s\n\ngot:\n%s\n", expected, actual)
+	}
+}
+
+// This tests the ExcludeTargetsTransformer targeting a whole module,
+// rather than a resource within a module instance.
+func TestExcludeTargetsTransformer_wholeModule(t *testing.T) {
+	mod := testModule(t, "transform-targets-downstream")
+
+	g := Graph{Path: addrs.RootModuleInstance}
+	{
+		transform := &ConfigTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &AttachResourceConfigTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &AttachResourceConfigTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &OutputTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &ReferenceTransformer{}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		transform := &TargetsTransformer{
+			ExcludeTargets: []addrs.Targetable{
+				addrs.RootModule.
+					Child("child").
+					Child("grandchild"),
+			},
+		}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	actual := strings.TrimSpace(g.String())
+	// Even though we only asked to exclude the grandchild module, all of the
+	// outputs that descend from it are also targeted.
+	expected := strings.TrimSpace(`
+aws_instance.foo
+module.child.aws_instance.foo
+module.child.output.id (expand)
+  module.child.aws_instance.foo
+output.child_id
+  module.child.output.id (expand)
+output.root_id
+  aws_instance.foo
+	`)
+	if actual != expected {
+		t.Fatalf("bad:\n\nexpected:\n%s\n\ngot:\n%s\n", expected, actual)
+	}
+}
+
+// This tests whether exclude and target work together without conflicting
+func TestBothTargetTransformer(t *testing.T) {
+	mod := testModule(t, "transform-targets-conflict")
+
+	g := Graph{Path: addrs.RootModuleInstance}
+	{
+		transform := &ConfigTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &AttachResourceConfigTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &AttachResourceConfigTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &OutputTransformer{Config: mod}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	{
+		transform := &ReferenceTransformer{}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		transform := &TargetsTransformer{
+			Targets: []addrs.Targetable{
+				addrs.RootModuleInstance.Module().Child("child"),
+			},
+			ExcludeTargets: []addrs.Targetable{
+				addrs.RootModuleInstance.Module().Child("child").Resource(addrs.ManagedResourceMode, "aws_vpc", "foo"),
+			},
+		}
+		if err := transform.Transform(&g); err != nil {
+			t.Fatalf("%T failed: %s", transform, err)
+		}
+	}
+
+	actual := strings.TrimSpace(g.String())
+	// Even though we only asked to target the grandchild module, all of the
+	// outputs that descend from it are also targeted.
+	expected := strings.TrimSpace(`
+	module.child.aws_instance.foo
 	`)
 	if actual != expected {
 		t.Fatalf("bad:\n\nexpected:\n%s\n\ngot:\n%s\n", expected, actual)

--- a/website/docs/cli/commands/plan.html.md
+++ b/website/docs/cli/commands/plan.html.md
@@ -174,6 +174,14 @@ the previous section, are also available with the same meanings on
     [Resource Targeting](#resource-targeting)
     below for more information.
 
+* `-exclude=ADDRESS` - Instructs Terraform to focus its planning efforts
+   on resource instances that don't match the given address and on any objects
+   that those instances depend on
+
+    This command is for exceptional use only. See
+    [Resource Targeting](#resource-targeting)
+    below for more information.
+
 * `-var 'NAME=VALUE'` - Sets a value for a single
   [input variable](/docs/language/values/variables.html) declared in the
   root module of the configuration. Use this option multiple times to set
@@ -187,10 +195,10 @@ the previous section, are also available with the same meanings on
   ["tfvars" file](/docs/language/values/variables.html#variable-definitions-tfvars-files).
   Use this option multiple times to include values from more than one file.
 
-There are several other ways to set values for input variables in the root
-module, aside from the `-var` and `-var-file` options. For more information,
-see
-[Assigning Values to Root Module Variables](/docs/language/values/variables.html#assigning-values-to-root-module-variables).
+There are several other ways to set values for input variables in the
+root module, aside from the `-var` and `-var-file` options. For more
+information, see [Assigning Values to Root Module
+Variables](/docs/language/values/variables.html#assigning-values-to-root-module-variables).
 
 ### Input Variables on the Command Line
 
@@ -270,9 +278,8 @@ input variables, see
 > **Hands-on:** Try the [Target resources](https://learn.hashicorp.com/tutorials/terraform/resource-targeting?in=terraform/state&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 You can use the `-target` option to focus Terraform's attention on only a
-subset of resources.
-You can use [resource address syntax](/docs/cli/state/resource-addressing.html)
-to specify the constraint. Terraform interprets the resource address as follows:
+subset of resources. You can use the `-exclude` option to target all resources
+besides the specified resources. You can use [resource address syntax](/docs/cli/state/resource-addressing.html) to specify the constraint. Terraform interprets the resource address as follows:
 
 * If the given address identifies one specific resource instance, Terraform
   will select that instance alone. For resources with either `count` or
@@ -296,11 +303,11 @@ that those selections depend on either directly or indirectly.
 
 This targeting capability is provided for exceptional circumstances, such
 as recovering from mistakes or working around Terraform limitations. It
-is *not recommended* to use `-target` for routine operations, since this can
+is *not recommended* to use `-target` and `-exclude` for routine operations, since this can
 lead to undetected configuration drift and confusion about how the true state
 of resources relates to configuration.
 
-Instead of using `-target` as a means to operate on isolated portions of very
+Instead of using `-target` or `-exclude` as a means to operate on isolated portions of very
 large configurations, prefer instead to break large configurations into
 several smaller configurations that can each be independently applied.
 [Data sources](/docs/language/data-sources/index.html) can be used to access


### PR DESCRIPTION
This pull request implements the feature requested in https://github.com/hashicorp/terraform/issues/2253.

# Summary
Implements -exclude flag which allows a user to select resource/s to avoid modifying/targeting 

## Implementation
Adds a new flag -exclude into extended.go, then passes it along the chain through a new excludeTarget field, into TargetsTransformer. Then TargetsTransformer is looked at to see if there are any excluded resources which then modifies the graph accordingly using selectExcludedNodes, which performs the same purpose as selectTargetedNodes but for excluded resources.  

Two new functions are written inside of context_plan.go that extend upon the original warning system to include -exclude and a special case (explained below). This decision was made with readability in mind.

All other changes are either adding the excludeTarget field, made for testing purposes inside of test data, or documentation including a brief explanation of -exclude at ./website/docs/cli/commands/plan.html.md as it is not a commonly used feature.

## Edge cases
The -exclude and -target flags can be used at the same time. 

If the user excludes and targets different resources, a warning will be printed to the user stating that they are using both -exclude and -target at the same time. Behavior will commence as normal for each flag. The main use case for combining -target and -exclude is to -target a module, and then -exclude a specific sub-resource within that module. Such a combination will result in all resources within the module except the -excluded one being selected.

If the user excludes and targets exactly the same resource then a warning will be printed stating that they are excluding and targeting the same resource, in addition to the regular warning above. Due to the conflicting flags, nothing will happen in the resulting plan or apply.

## Tests
Three new tests were written for the addition of the exclude flag:
* TestExcludeTargetsTransformer tests if everything works
* TestExcludeTargetsTransformer_downstream tests ExcludeTargetsTransformer targeting a whole module, rather than a resource within a module instance
* TestExcludeTargetsTransformer_wholeModule tests if exclude and target work together without conflict


## Previous implementations
While browsing the issue tracker, we saw an older PR (https://github.com/hashicorp/terraform/pull/3366), seemingly with the same goal that this PR had in mind. The older PR has a significantly simpler implementation, where the syntax for specifying targets is changed to allow prefixing them with an exclamation point (!) to exclude them. Although the older pull request’s code is simpler, the code assumes that all instances of the addrs.Targetable interface are strings, which might not hold in general. Another disadvantage of using the character ! specifically is that it may be interpreted by the shell as part of history expansion, and would therefore need to be quoted, which isn't very ergonomic.

## Example usage

<details>
<summary>Terminal session</summary>

```
% cat main.tf

terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 3.27"
    }
  }

  required_version = ">= 0.14.9"
}

provider "aws" {
  profile = "default"
  region  = "us-west-2"
}

resource "aws_instance" "app_server" {
  ami           = "ami-830c94e3"
  instance_type = "t2.micro"

  tags = {
    Name = "ExampleAppServerInstance"
  }
}

resource "aws_instance" "web" {
  ami           = "ami-830c94e3"
  instance_type = "t2.micro"
}

% terraform apply -exclude aws_instance.app_server

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_instance.web will be created
  + resource "aws_instance" "web" {
      + ami                                  = "ami-830c94e3"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = (known after apply)
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = (known after apply)
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + subnet_id                            = (known after apply)
      + tags_all                             = (known after apply)
      + tenancy                              = (known after apply)
      + user_data                            = (known after apply)
      + user_data_base64                     = (known after apply)
      + vpc_security_group_ids               = (known after apply)

      + capacity_reservation_specification {
          + capacity_reservation_preference = (known after apply)

          + capacity_reservation_target {
              + capacity_reservation_id = (known after apply)
            }
        }

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + enclave_options {
          + enabled = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_interface_id  = (known after apply)
        }

      + root_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

╷
│ Warning: Resource targeting is in effect
│
│ You are creating a plan with the -exclude option, which means that the result of this plan may not represent all of the changes requested by
│ the current configuration.
│
│ The -exclude option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or
│ when Terraform specifically suggests to use it as part of an error message.
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_instance.web: Creating...
aws_instance.web: Still creating... [10s elapsed]
aws_instance.web: Still creating... [20s elapsed]
aws_instance.web: Still creating... [30s elapsed]
aws_instance.web: Still creating... [40s elapsed]
aws_instance.web: Creation complete after 47s [id=i-01691c95f213eeab2]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```

</details>


