### PR TITLE
fix sensitive_values internal format documentation

### DIFF
--- a/website/docs/internals/json-format.html.md
+++ b/website/docs/internals/json-format.html.md
@@ -272,7 +272,7 @@ The following example illustrates the structure of a `<values-representation>`:
         // "sensitive_values" is the JSON representation of the sensitivity of
         // the resource's attribute values. Only attributes which are sensitive
         // are included in this structure.
-        "values": {
+        "sensitive_values": {
           "id": true,
         }
       }


### PR DESCRIPTION
The `sensitive_values` field is described but the example copies the `values` field from the previous example.

Presumably, the `id` field is being marked sensitive with a true/false value with the actual sensitive value stored in the `values` map appearing before `sensitive_values`.  Side note, if this is accurate it was not clear from the existing documentation.