### PR TITLE
backend/http: supply logging.LogOutput() to retryable client

### DIFF
--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/legacy/helper/schema"
+	"github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/states/remote"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 )
@@ -161,6 +163,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	rClient.RetryMax = data.Get("retry_max").(int)
 	rClient.RetryWaitMin = time.Duration(data.Get("retry_wait_min").(int)) * time.Second
 	rClient.RetryWaitMax = time.Duration(data.Get("retry_wait_max").(int)) * time.Second
+	rClient.Logger = log.New(logging.LogOutput(), "", log.Flags())
 
 	b.client = &httpClient{
 		URL:          updateURL,


### PR DESCRIPTION
Fixes #29978.

This retryablehttp client was missed when we introduced the `internal/logging` hclog logger.