### PR TITLE
addrs: Expose the registry address parser's error messages

### DIFF
--- a/internal/configs/testdata/error-files/module-invalid-registry-source-with-module.tf
+++ b/internal/configs/testdata/error-files/module-invalid-registry-source-with-module.tf
@@ -1,0 +1,5 @@
+
+module "test" {
+  source  = "---.com/HashiCorp/Consul/aws" # ERROR: Invalid registry module source address
+  version = "1.0.0" # Makes Terraform assume "source" is a module address
+}

--- a/internal/configs/testdata/error-files/module-local-source-with-version.tf
+++ b/internal/configs/testdata/error-files/module-local-source-with-version.tf
@@ -1,0 +1,5 @@
+
+module "test" {
+  source  = "../boop" # ERROR: Invalid registry module source address
+  version = "1.0.0" # Makes Terraform assume "source" is a module address
+}

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -547,7 +547,7 @@ func (i *ModuleInstaller) installGoGetterModule(ctx context.Context, req *earlyc
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Invalid version constraint",
-			fmt.Sprintf("Cannot apply a version constraint to module %q (at %s:%d) because it has a non Registry URL.", req.Name, req.CallPos.Filename, req.CallPos.Line),
+			fmt.Sprintf("Cannot apply a version constraint to module %q (at %s:%d) because it doesn't come from a module registry.", req.Name, req.CallPos.Filename, req.CallPos.Line),
 		))
 		return nil, diags
 	}

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -192,7 +192,12 @@ func TestModuleInstaller_invalid_version_constraint_error(t *testing.T) {
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
 	} else {
-		assertDiagnosticSummary(t, diags, "Invalid version constraint")
+		// We use the presence of the "version" argument as a heuristic for
+		// user intent to use a registry module, and so we intentionally catch
+		// this as an invalid registry module address rather than an invalid
+		// version constraint, so we can surface the specific address parsing
+		// error instead of a generic version constraint error.
+		assertDiagnosticSummary(t, diags, "Invalid registry module source address")
 	}
 }
 
@@ -210,7 +215,12 @@ func TestModuleInstaller_invalidVersionConstraintGetter(t *testing.T) {
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
 	} else {
-		assertDiagnosticSummary(t, diags, "Invalid version constraint")
+		// We use the presence of the "version" argument as a heuristic for
+		// user intent to use a registry module, and so we intentionally catch
+		// this as an invalid registry module address rather than an invalid
+		// version constraint, so we can surface the specific address parsing
+		// error instead of a generic version constraint error.
+		assertDiagnosticSummary(t, diags, "Invalid registry module source address")
 	}
 }
 
@@ -228,7 +238,12 @@ func TestModuleInstaller_invalidVersionConstraintLocal(t *testing.T) {
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
 	} else {
-		assertDiagnosticSummary(t, diags, "Invalid version constraint")
+		// We use the presence of the "version" argument as a heuristic for
+		// user intent to use a registry module, and so we intentionally catch
+		// this as an invalid registry module address rather than an invalid
+		// version constraint, so we can surface the specific address parsing
+		// error instead of a generic version constraint error.
+		assertDiagnosticSummary(t, diags, "Invalid registry module source address")
 	}
 }
 


### PR DESCRIPTION
Previously we ended up losing all of the error message detail produced by the registry address parser, because we treated any registry address failure as cause to parse the address as a go-getter-style remote address instead.

That led to terrible feedback in the situation where the user _was_ trying to write a module address but it was invalid in some way.

Although we can't really tighten this up in the default case due to our compatibility promises, it's never been valid to use the `version` argument with anything other than a registry address and so as a compromise here we'll use the presence of `version` as a heuristic for user intent to parse the source address as a registry address, and thus we can return a registry-address-specific error message in that case and thus give more direct feedback about what was wrong.

This unfortunately won't help someone trying to install from the registry _without_ a version constraint, but I didn't want to let perfect be the enemy of the good here, particularly since we recommend using version constraints with registry modules anyway; indeed, that's one of the main benefits of using a registry rather than a remote source directly.

---

This is a compromise intended to close #29532 as best we can within our compatibility constraints. In that other issue we can see an example situation that led to the confusing error messages I alluded to above:

```hcl
module "test" {
	source = "terraform-google-modules/gcloud/gcp-beta"
	version = "0.1.0"
}
```

The above address is invalid because, for historical reasons somewhat lost to history, we don't allow dashes in the "target system" portion of the address, which is `gcp-beta` in the above example.

Previously Terraform would produce a confusing error message about the version constraint in this case, which I'm quoting here directly from the original issue report:

```
╷
│ Error: Invalid version constraint
│
│ Cannot apply a version constraint to module "test" (at main.tf:1) because it has a non Registry URL.
╵
```

It is true that this is a "non-Registry URL" in the sense that it doesn't meet the syntax, this particular presentation is pretty confusing since the user _intended_ this to be a registry URL and doesn't get any information about _why_ Terraform isn't considering it to be one.

With this changeset, we get a new error message in this case, because this example includes `version` and thus gives us the heuristic for user intent:

```
╷
│ Error: Invalid registry module source address
│ 
│ Module "foo" (declared at module-source-registry-addrs.tf line 2) has invalid
│ source address "terraform-google-modules/gcloud/gcp-beta": invalid target system
│ "gcp-beta": must be between one and 64 ASCII letters or digits.
│ 
│ Terraform assumed that you intended a module registry source address because you
│ also set the argument "version", which applies only to registry modules.
╵
```

Due to how we get here this does have an unfortunate Go-error-style "so many: colons when: will we actually: end the sentence" structure, but aside from that cosmetic wart it now gives direct feedback that it was the `gcp-beta` portion that was invalid, and specifies the validation constraints for that segment.

---

As usual with module-installation-related stuff, this has to be implemented in both the "earlyconfig"/"initwd" packages (which `terraform init` uses for its early analyses) and in the `configs` package. The above messages are from the earlyconfig case because `terraform init` is typically the first place to encounter this sort of problem, though it _is_ possible to reach the other form of the message if you run the commands out of order, such as adding the invalid source address only after you already successfully ran `terraform init` before and then running a non-init command:

```
╷
│ Error: Invalid registry module source address
│ 
│   on module-source-registry-addrs.tf line 3, in module "foo":
│    3:   source = "terraform-google-modules/gcloud/gcp-beta"
│ 
│ Failed to parse module registry address: invalid target system "gcp-beta": must be
│ between one and 64 ASCII letters or digits.
│ 
│ Terraform assumed that you intended a module registry source address because you
│ also set the argument "version", which applies only to registry modules.
╵
```

The `configs`-package messages are, as usual, slightly higher quality than the earlyconfig ones because we're parsing directly with HCL v2 rather than with the `terraform-config-inspect` indirection (which abstracts over both HCL v1 and v2 so we can give better feedback to folks trying to use new Terraform with old-style syntax). We will hopefully eventually simplify this so that everything is using `configs` again, since we're now far after the v0.12 upgrade process that originally motivated this approach of using two different parser/decoders, but that sort of refactoring is beyond the scope I have time for today.
