### PR TITLE
Docs: Change misspelling of variable in documentation

### DIFF
--- a/website/docs/language/values/variables.html.md
+++ b/website/docs/language/values/variables.html.md
@@ -509,7 +509,7 @@ variable "moose" {
 And the following `.tfvars` file:
 
 ```hcl
-mosse = "Moose"
+moose = "Moose"
 ```
 
 Will cause Terraform to warn you that there is no variable declared `"mosse"`, which can help


### PR DESCRIPTION
The variable example for `.tfvars` includes a spelling error making the `terraform` and `hcl` examples mismatch. (`moose` vs. `mosse`).

Live documentation with the typo: https://www.terraform.io/docs/language/values/variables.html#values-for-undeclared-variables