### PR TITLE
skip provider resolution when there are errors

### DIFF
--- a/internal/configs/config_build.go
+++ b/internal/configs/config_build.go
@@ -23,9 +23,13 @@ func BuildConfig(root *Module, walker ModuleWalker) (*Config, hcl.Diagnostics) {
 	cfg.Root = cfg // Root module is self-referential.
 	cfg.Children, diags = buildChildModules(cfg, walker)
 
-	// Now that the config is built, we can connect the provider names to all
-	// the known types for validation.
-	cfg.resolveProviderTypes()
+	// Skip provider resolution if there are any errors, since the provider
+	// configurations themselves may not be valid.
+	if !diags.HasErrors() {
+		// Now that the config is built, we can connect the provider names to all
+		// the known types for validation.
+		cfg.resolveProviderTypes()
+	}
 
 	diags = append(diags, validateProviderConfigs(nil, cfg, false)...)
 

--- a/internal/configs/testdata/config-diagnostics/invalid-provider/errors
+++ b/internal/configs/testdata/config-diagnostics/invalid-provider/errors
@@ -1,0 +1,1 @@
+main.tf:1,1-20: Invalid provider local name; crash_es is an invalid provider local name

--- a/internal/configs/testdata/config-diagnostics/invalid-provider/main.tf
+++ b/internal/configs/testdata/config-diagnostics/invalid-provider/main.tf
@@ -1,0 +1,3 @@
+module "mod" {
+  source = "./mod"
+}

--- a/internal/configs/testdata/config-diagnostics/invalid-provider/mod/main.tf
+++ b/internal/configs/testdata/config-diagnostics/invalid-provider/mod/main.tf
@@ -1,0 +1,2 @@
+provider "crash_es" {
+}

--- a/internal/configs/testdata/config-diagnostics/invalid-provider/warnings
+++ b/internal/configs/testdata/config-diagnostics/invalid-provider/warnings
@@ -1,0 +1,1 @@
+Empty provider configuration blocks are not required


### PR DESCRIPTION
If there are errors loading the configuration, don't try to resolve the
provider names, as those names may not even be valid.

Fixes #30078