### PR TITLE
website: Correct navbar link to the "Refactoring" page

### DIFF
--- a/website/docs/language/settings/backends/remote.html.md
+++ b/website/docs/language/settings/backends/remote.html.md
@@ -68,7 +68,7 @@ the Terraform CLI workspace `prod` within the current configuration. Remote
 Terraform operations such as `plan` and `apply` executed against that Terraform
 CLI workspace will be executed in the Terraform Cloud workspace `networking-prod`.
 
-Additionally, the [`terraform.workspace`](/docs/language/state/workspaces.html#referencing-the-current-workspace-name)
+Additionally, the [`terraform.workspace`](/docs/language/state/workspaces.html#current-workspace-interpolation)
 expression shouldn't be used in Terraform configurations that use Terraform 1.0.x or earlier and run
 remote operations against Terraform Cloud workspaces. The reason for this is that
 prior to Terraform 1.1.0, Terraform Cloud workspaces only used the single `default` Terraform

--- a/website/docs/language/values/variables.html.md
+++ b/website/docs/language/values/variables.html.md
@@ -304,7 +304,7 @@ random_pet.animal: Creating...
 random_pet.animal: Creation complete after 0s [id=jae-known-mongoose]
 ```
 
-### Disallowing null Module Input Values
+### Disallowing Null Input Values
 
 [inpage-nullable]: #disallowing-null-input-values
 

--- a/website/layouts/language.erb
+++ b/website/layouts/language.erb
@@ -251,7 +251,7 @@
               </li>
 
               <li>
-                <a href="/docs/language/modules/refactoring.html">Refactoring</a>
+                <a href="/docs/language/modules/develop/refactoring.html">Refactoring</a>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
We late-reorganized this into the "Module Development" subsection, but forgot to update the actual link in the navbar, so it was still linking to its old location.