### PR TITLE
Update docs to use `assume_role` block

### DIFF
--- a/website/docs/language/settings/backends/s3.html.md
+++ b/website/docs/language/settings/backends/s3.html.md
@@ -313,7 +313,9 @@ provider "aws" {
   # No credentials explicitly set here because they come from either the
   # environment or the global credentials file.
 
-  assume_role = "${var.workspace_iam_roles[terraform.workspace]}"
+  assume_role = {
+    role_arn = "${var.workspace_iam_roles[terraform.workspace]}"
+  }
 }
 ```
 


### PR DESCRIPTION
I'm guessing this document is just out of date, but I got an error when configuring `assume_role` as an argument and had to add an `assume_role` block