### PR TITLE
add example `moved` block to "Renaming a Module Call"

### DIFF
--- a/website/docs/language/modules/develop/refactoring.html.md
+++ b/website/docs/language/modules/develop/refactoring.html.md
@@ -231,6 +231,11 @@ module "b" {
 
   # (module arguments)
 }
+
+moved {
+  from = module.a
+  to   = module.b
+}
 ```
 
 When creating the next plan for each configuration using this module, Terraform


### PR DESCRIPTION
There are `moved` examples in all other sections, so I suppose this one missing was a mistake.