### PR TITLE
use `cty.DynamicVal` for expanded resources during validation

### DIFF
--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -5308,7 +5308,6 @@ func TestContext2Plan_selfRefMultiAll(t *testing.T) {
 		ResourceTypes: map[string]*configschema.Block{
 			"aws_instance": {
 				Attributes: map[string]*configschema.Attribute{
-					"id":  {Type: cty.String, Computed: true},
 					"foo": {Type: cty.List(cty.String), Optional: true},
 				},
 			},

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -696,21 +696,12 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 				log.Printf("[ERROR] unknown instance %q referenced during %s", addr.Absolute(d.ModulePath), d.Operation)
 				return cty.DynamicVal, diags
 			}
-		default:
-			if d.Operation != walkValidate {
-				log.Printf("[ERROR] missing state for %q while in %s\n", addr.Absolute(d.ModulePath), d.Operation)
-			}
 
-			// Validation is done with only the configuration, so generate
-			// unknown values of the correct shape for evaluation.
-			switch {
-			case config.Count != nil:
-				return cty.UnknownVal(cty.List(ty)), diags
-			case config.ForEach != nil:
-				return cty.UnknownVal(cty.Map(ty)), diags
-			default:
-				return cty.UnknownVal(ty), diags
-			}
+		default:
+			// We should only end up here during the validate walk,
+			// since later walks should have at least partial states populated
+			// for all resources in the configuration.
+			return cty.DynamicVal, diags
 		}
 	}
 

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -794,7 +794,7 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 		instances[key] = val
 	}
 
-	var ret cty.Value
+	ret := cty.DynamicVal
 
 	switch {
 	case config.Count != nil:

--- a/internal/terraform/testdata/plan-self-ref-multi-all/main.tf
+++ b/internal/terraform/testdata/plan-self-ref-multi-all/main.tf
@@ -1,4 +1,4 @@
 resource "aws_instance" "web" {
-    foo = aws_instance.web[*].id
+    foo = "${aws_instance.web.*.foo}"
     count = 4
 }


### PR DESCRIPTION
Revert the evaluation change from #29862.

While returning a dynamic value for all expanded resources during validation is not optimal, trying to work around this using unknown maps and lists is causing other undesirable behaviors during evaluation.

Fixes #30127