### PR TITLE
Ignore unexpanded paths when validating move statements.

### DIFF
--- a/internal/instances/set.go
+++ b/internal/instances/set.go
@@ -47,5 +47,5 @@ func (s Set) HasResource(want addrs.AbsResource) bool {
 // then the result is the full expansion of all combinations of all of their
 // declared instance keys.
 func (s Set) InstancesForModule(modAddr addrs.Module) []addrs.ModuleInstance {
-	return s.exp.ExpandModule(modAddr)
+	return s.exp.expandModule(modAddr, true)
 }

--- a/internal/instances/set_test.go
+++ b/internal/instances/set_test.go
@@ -204,4 +204,8 @@ func TestSet(t *testing.T) {
 		t.Errorf("unexpected %T %s", input, input.String())
 	}
 
+	// ensure we can lookup non-existent addrs in a set without panic
+	if set.InstancesForModule(addrs.RootModule.Child("missing")) != nil {
+		t.Error("unexpected instances from missing module")
+	}
 }

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -631,8 +631,6 @@ func TestContext2Apply_nullableVariables(t *testing.T) {
 }
 
 func TestContext2Apply_targetedDestroyWithMoved(t *testing.T) {
-	// The impure function call should not cause a planned change with
-	// ignore_changes
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "modb" {

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -629,3 +629,54 @@ func TestContext2Apply_nullableVariables(t *testing.T) {
 		t.Fatalf("incorrect 'non_nullable_no_default' output value: %#v\n", v)
 	}
 }
+
+func TestContext2Apply_targetedDestroyWithMoved(t *testing.T) {
+	// The impure function call should not cause a planned change with
+	// ignore_changes
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "modb" {
+  source = "./mod"
+  for_each = toset(["a", "b"])
+}
+`,
+		"./mod/main.tf": `
+resource "test_object" "a" {
+}
+
+module "sub" {
+  for_each = toset(["a", "b"])
+  source = "./sub"
+}
+
+moved {
+  from = module.old
+  to = module.sub
+}
+`,
+		"./mod/sub/main.tf": `
+resource "test_object" "s" {
+}
+`})
+
+	p := simpleMockProvider()
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	assertNoErrors(t, diags)
+
+	state, diags := ctx.Apply(plan, m)
+	assertNoErrors(t, diags)
+
+	// destroy only a single instance not included in the moved statements
+	_, diags = ctx.Plan(m, state, &PlanOpts{
+		Mode:    plans.DestroyMode,
+		Targets: []addrs.Targetable{mustResourceInstanceAddr(`module.modb["a"].test_object.a`)},
+	})
+	assertNoErrors(t, diags)
+}


### PR DESCRIPTION
After each plan, the entire set of known move blocks must be validated. Sometimes the individual addresses may lie outside of paths which are expanded during the plan, either through the use of `-target`, or later changes to the configuration that make the `moved` obsolete.

Since `instances.Set` is only used after all instances have been processed, it should only handle known instances and not panic when given an address that traverses an unexpanded module. This will allow for validation of `moved` block which no longer apply to the current set of address to skip over addresses which cannot be expanded.

Fixes #30196
Fixes #30184