### PR TITLE
Apply graph failure handling

### DIFF
--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -168,6 +168,14 @@ func (b *Local) opApply(
 	}
 	diags = diags.Append(applyDiags)
 
+	// Even on error with an empty state, the state value should not be nil.
+	// Return early here to prevent corrupting any existing state.
+	if diags.HasErrors() && applyState == nil {
+		log.Printf("[ERROR] backend/local: apply returned nil state")
+		op.ReportResult(runningOp, diags)
+		return
+	}
+
 	// Store the final state
 	runningOp.State = applyState
 	err := statemgr.WriteAndPersist(opState, applyState)

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -22,12 +22,11 @@ import (
 // resulting state which is likely to have been partially-updated.
 func (c *Context) Apply(plan *plans.Plan, config *configs.Config) (*states.State, tfdiags.Diagnostics) {
 	defer c.acquireRun("apply")()
-	var diags tfdiags.Diagnostics
 
 	log.Printf("[DEBUG] Building and walking apply graph for %s plan", plan.UIMode)
 
-	graph, operation, moreDiags := c.applyGraph(plan, config, true)
-	if moreDiags.HasErrors() {
+	graph, operation, diags := c.applyGraph(plan, config, true)
+	if diags.HasErrors() {
 		return nil, diags
 	}
 


### PR DESCRIPTION
This PR resolves 2 issues around failures during the core Apply step. 
 - The first is that the graph building diagnostics were lost, and no error was being returned upon failure, allowing terraform to continue. 
 - The second issue is that while an apply error normally means that there could be a partial state to store, in the event of an error before any apply operations have started we have no state, and should not overwrite the existing state. 

Fixes #30178