### PR TITLE
command/show: Disable plan state lineage checks

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -275,6 +275,13 @@ type Operation struct {
 	// the variables set in the plan are used instead, and they must be valid.
 	AllowUnsetVariables bool
 
+	// When loading a plan file for a read-only operation, we may want to
+	// disable the state lineage checks which are only relevant for operations
+	// which can modify state. An example where this is important is showing
+	// a plan which was prepared against a non-default state file, because the
+	// lineage checks are always against the default state.
+	DisablePlanFileStateLineageChecks bool
+
 	// View implements the logic for all UI interactions.
 	View views.Operation
 

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -284,7 +284,7 @@ func (b *Local) localRunForPlanFile(op *backend.Operation, pf *planfile.Reader, 
 		))
 		return nil, snap, diags
 	}
-	if currentStateMeta != nil {
+	if !op.DisablePlanFileStateLineageChecks && currentStateMeta != nil {
 		// If the caller sets this, we require that the stored prior state
 		// has the same metadata, which is an extra safety check that nothing
 		// has changed since the plan was created. (All of the "real-world"

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -94,6 +94,7 @@ func (c *ShowCommand) Run(args []string) int {
 	opReq.PlanFile = planFile
 	opReq.ConfigLoader, err = c.initConfigLoader()
 	opReq.AllowUnsetVariables = true
+	opReq.DisablePlanFileStateLineageChecks = true
 	if err != nil {
 		diags = diags.Append(err)
 		c.showDiagnostics(diags)


### PR DESCRIPTION
When showing a saved plan, we do not need to check the state lineage against current state, because the plan cannot be applied. This is relevant when plan and apply specify a `-state` argument to choose a non-default state file. In this case, the stored prior state in the plan will not match the default state file, so a lineage check will always error.

Fixes #30195