### PR TITLE
Update taint command page to make alternative clearer

### DIFF
--- a/website/docs/cli/commands/taint.mdx
+++ b/website/docs/cli/commands/taint.mdx
@@ -22,7 +22,7 @@ For Terraform v0.15.2 and later, we recommend using the [`-replace` option](/cli
 $ terraform apply -replace="aws_instance.example[0]"
 ```
 
-The `-replace` option is superior because it lets you understand the full effect of replacing the object before you take any externally-visible action. When you use `terraform taint`, other users could create a new plan against your tainted object before you can review the consequences of that change.
+We recommend the `-replace` option because the change will be reflected in the Terraform plan, letting you understand how it will affect your infrastructure before you take any externally-visible action. When you use `terraform taint`, other users could create a new plan against your tainted object before you can review the effects.
 
 ## Usage
 

--- a/website/docs/cli/commands/taint.mdx
+++ b/website/docs/cli/commands/taint.mdx
@@ -9,36 +9,26 @@ description: |-
 
 The `terraform taint` command informs Terraform that a particular object has
 become degraded or damaged. Terraform represents this by marking the
-object as "tainted" in the Terraform state, in which case Terraform will
+object as "tainted" in the Terraform state, and Terraform will
 propose to replace it in the next plan you create.
 
-~> _Warning:_ This command is deprecated, because there are better alternatives
-available in Terraform v0.15.2 and later. See below for more details.
+~> **Warning:** This command is deprecated. For Terraform v0.15.2 and later, we recommend using the `-replace` option with `terraform apply` instead (details below).
 
-If your intent is to force replacement of a particular object even though
-there are no configuration changes that would require it, we recommend instead
-to use the `-replace` option with [`terraform apply`](/cli/commands/apply).
-For example:
+## Recommended Alternative
+
+For Terraform v0.15.2 and later, we recommend using the [`-replace` option](/cli/commands/plan#replace-address) with `terraform apply` to force Terraform to replace an object even though there are no configuration changes that would require it.
 
 ```
-terraform apply -replace="aws_instance.example[0]"
+$ terraform apply -replace="aws_instance.example[0]"
 ```
 
-Creating a plan with the "replace" option is superior to using `terraform taint`
-because it will allow you to see the full effect of that change before you take
-any externally-visible action. When you use `terraform taint` to get a similar
-effect, you risk someone else on your team creating a new plan against your
-tainted object before you've had a chance to review the consequences of that
-change yourself.
-
-The `-replace=...` option to `terraform apply` is only available from
-Terraform v0.15.2 onwards, so if you are using an earlier version you will need
-to use `terraform taint` to force object replacement, while considering the
-caveats described above.
+The `-replace` option is superior because it lets you understand the full effect of replacing the object before you take any externally-visible action. When you use `terraform taint`, other users could create a new plan against your tainted object before you can review the consequences of that change.
 
 ## Usage
 
-Usage: `terraform taint [options] address`
+```
+$ terraform taint [options] <address>
+```
 
 The `address` argument is the address of the resource to mark as tainted.
 The address is in


### PR DESCRIPTION
A user recently submitted [this issue](https://github.com/hashicorp/terraform/issues/30194) where they were confused by the fact that the `-replace` flag is available on apply, but is not actually documented on the `apply` page or in the CLI output. It is documented in the `plan` page and CLI output, though and is indeed a valid flag for `apply`.

An investigation revealed that we do mention several times on the apply page that `apply` accepts all of the planning options and modes available on the `plan` page. Here's an example:

<img width="1047" alt="Screen Shot 2021-12-20 at 3 47 43 PM" src="https://user-images.githubusercontent.com/83350965/146830735-4f8378e7-1123-4525-aa03-787da6caa5dd.png">

We also have a note in the CLI output for `apply -help` that says:
```
If you don't provide a saved plan file then this command will also accept
  all of the plan-customization options accepted by the terraform plan command.
  For more information on those options, run:
      terraform plan -help
```

We do not want to provide the full list of flags in multiple places because this duplicated content would likely result in the lists getting out of sync (and further confusing users). So the decision is to leave the content on the `apply` page and CLI output as is. However, the user specifically mentions the `taint` page where the `-replace` flag is listed as the preferred alternative to `taint` for more recent Terraform versions. 

This PR updates the content on the `taint` page to make it clearer that `-replace` is the recommended alternative. It also links directly to where the flag is documented on the `plan` page, rather than linking to the apply page where the user would search for and not find it. 