### PR TITLE
Sort dependencies when encoding `ResourceInstanceObject`

### DIFF
--- a/internal/states/instance_object_test.go
+++ b/internal/states/instance_object_test.go
@@ -12,26 +12,39 @@ func TestResourceInstanceObject_encode(t *testing.T) {
 	value := cty.ObjectVal(map[string]cty.Value{
 		"foo": cty.True,
 	})
-	deps := []addrs.ConfigResource{
+	// The in-memory order of resource dependencies is random, since they're an
+	// unordered set.
+	depsOne := []addrs.ConfigResource{
 		addrs.RootModule.Resource(addrs.ManagedResourceMode, "test", "honk"),
 		addrs.RootModule.Child("child").Resource(addrs.ManagedResourceMode, "test", "flub"),
 		addrs.RootModule.Resource(addrs.ManagedResourceMode, "test", "boop"),
 	}
-	wantDeps := []addrs.ConfigResource{
+	depsTwo := []addrs.ConfigResource{
 		addrs.RootModule.Child("child").Resource(addrs.ManagedResourceMode, "test", "flub"),
 		addrs.RootModule.Resource(addrs.ManagedResourceMode, "test", "boop"),
 		addrs.RootModule.Resource(addrs.ManagedResourceMode, "test", "honk"),
 	}
-	rio := &ResourceInstanceObject{
+	rioOne := &ResourceInstanceObject{
 		Value:        value,
 		Status:       ObjectPlanned,
-		Dependencies: deps,
+		Dependencies: depsOne,
 	}
-	rios, err := rio.Encode(value.Type(), 0)
+	rioTwo := &ResourceInstanceObject{
+		Value:        value,
+		Status:       ObjectPlanned,
+		Dependencies: depsTwo,
+	}
+	riosOne, err := rioOne.Encode(value.Type(), 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if diff := cmp.Diff(wantDeps, rios.Dependencies); diff != "" {
-		t.Errorf("wrong result for deps\n%s", diff)
+	riosTwo, err := rioTwo.Encode(value.Type(), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	// However, identical sets of dependencies should always be written to state
+	// in an identical order, so we don't do meaningless state updates on refresh.
+	if diff := cmp.Diff(riosOne.Dependencies, riosTwo.Dependencies); diff != "" {
+		t.Errorf("identical dependencies got encoded in different orders:\n%s", diff)
 	}
 }

--- a/internal/states/instance_object_test.go
+++ b/internal/states/instance_object_test.go
@@ -1,0 +1,37 @@
+package states
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestResourceInstanceObject_encode(t *testing.T) {
+	value := cty.ObjectVal(map[string]cty.Value{
+		"foo": cty.True,
+	})
+	deps := []addrs.ConfigResource{
+		addrs.RootModule.Resource(addrs.ManagedResourceMode, "test", "honk"),
+		addrs.RootModule.Child("child").Resource(addrs.ManagedResourceMode, "test", "flub"),
+		addrs.RootModule.Resource(addrs.ManagedResourceMode, "test", "boop"),
+	}
+	wantDeps := []addrs.ConfigResource{
+		addrs.RootModule.Child("child").Resource(addrs.ManagedResourceMode, "test", "flub"),
+		addrs.RootModule.Resource(addrs.ManagedResourceMode, "test", "boop"),
+		addrs.RootModule.Resource(addrs.ManagedResourceMode, "test", "honk"),
+	}
+	rio := &ResourceInstanceObject{
+		Value:        value,
+		Status:       ObjectPlanned,
+		Dependencies: deps,
+	}
+	rios, err := rio.Encode(value.Type(), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if diff := cmp.Diff(wantDeps, rios.Dependencies); diff != "" {
+		t.Errorf("wrong result for deps\n%s", diff)
+	}
+}


### PR DESCRIPTION
Resource dependencies are by nature an unordered collection, but they're
persisted to state as a JSON array (in random order). This makes a mess for
`terraform apply -refresh-only`, which sees the new random order as a change
that requires the user to approve a state update.

(As an additional problem on top of that, the user interface for refresh-only
runs doesn't expect to see that as a type of change, so it says "no changes!
would you like to update to reflect these detected changes?")

This commit changes `ResourceInstanceObject.Encode()` to sort the in-memory
slice of dependencies (lexically, by address) before passing it on to be
compared and persisted. This appears to fix the observed UI issues with a
minimum of logic changes.

### Potential issues

- ~This change _does_ fix the UI issue, but oddly, it will _silently_ write a new state file (with an appropriately bumped serial) when it encounters out-of-order dependencies written by an older version of Terraform. That wasn't what I expected to have happen, and I'm mildly concerned by it! I _think_ it's okay; clearly thrashing the ordering of that list wasn't a huge problem previously, other than the UI annoyance. But if anyone knows what's going on there and whether there's a practical way to do something different, I'm all ears. Saying no updates were needed and then doing an update without asking is strange.~
    - @apparentlymart and I talked through this one a while back -- on further consideration, this doesn't seem like a big deal at all.
- ~I'm not sure where to add a test for this, and could use some advice!~