### PR TITLE
Handle move blocks within a module which is changing the index

### DIFF
--- a/internal/addrs/module_instance_test.go
+++ b/internal/addrs/module_instance_test.go
@@ -162,9 +162,9 @@ func TestModuleInstance_IsDeclaredByCall(t *testing.T) {
 }
 
 func mustParseModuleInstanceStr(str string) ModuleInstance {
-	mi, err := ParseModuleInstanceStr(str)
-	if err != nil {
-		panic(err)
+	mi, diags := ParseModuleInstanceStr(str)
+	if diags.HasErrors() {
+		panic(diags.ErrWithWarnings())
 	}
 	return mi
 }

--- a/internal/addrs/move_endpoint_module_test.go
+++ b/internal/addrs/move_endpoint_module_test.go
@@ -1686,6 +1686,25 @@ func TestIsModuleMoveReIndex(t *testing.T) {
 			},
 			expect: false,
 		},
+
+		{
+			from: AbsModuleCall{
+				Module: mustParseModuleInstanceStr(`module.bar[0]`),
+				Call:   ModuleCall{Name: "baz"},
+			},
+			to:     mustParseModuleInstanceStr(`module.bar.module.baz[0]`),
+			expect: true,
+		},
+
+		{
+			from: mustParseModuleInstanceStr(`module.bar.module.baz[0]`),
+			to: AbsModuleCall{
+				Module: mustParseModuleInstanceStr(`module.bar[0]`),
+				Call:   ModuleCall{Name: "baz"},
+			},
+			expect: true,
+		},
+
 		{
 			from:   mustParseModuleInstanceStr(`module.baz`),
 			to:     mustParseModuleInstanceStr(`module.bar.module.baz[0]`),
@@ -1709,7 +1728,7 @@ func TestIsModuleMoveReIndex(t *testing.T) {
 					relSubject: test.to,
 				}
 
-				if got := IsModuleMoveReIndex(from, to); got != test.expect {
+				if got := from.IsModuleReIndex(to); got != test.expect {
 					t.Errorf("expected %t, got %t", test.expect, got)
 				}
 			},

--- a/internal/refactoring/move_statement.go
+++ b/internal/refactoring/move_statement.go
@@ -149,7 +149,7 @@ func impliedMoveStatements(cfg *configs.Config, prevRunState *states.State, expl
 	}
 
 	for _, childCfg := range cfg.Children {
-		into = findMoveStatements(childCfg, into)
+		into = impliedMoveStatements(childCfg, prevRunState, explicitStmts, into)
 	}
 
 	return into

--- a/internal/refactoring/move_statement_test.go
+++ b/internal/refactoring/move_statement_test.go
@@ -18,6 +18,15 @@ func TestImpliedMoveStatements(t *testing.T) {
 			Name: name,
 		}.Absolute(addrs.RootModuleInstance)
 	}
+
+	nestedResourceAddr := func(mod, name string) addrs.AbsResource {
+		return addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "foo",
+			Name: name,
+		}.Absolute(addrs.RootModuleInstance.Child(mod, addrs.NoKey))
+	}
+
 	instObjState := func() *states.ResourceInstanceObjectSrc {
 		return &states.ResourceInstanceObjectSrc{}
 	}
@@ -86,6 +95,19 @@ func TestImpliedMoveStatements(t *testing.T) {
 			instObjState(),
 			providerAddr,
 		)
+
+		// Add two resource nested in a module to ensure we find these
+		// recursively.
+		s.SetResourceInstanceCurrent(
+			nestedResourceAddr("child", "formerly_count").Instance(addrs.IntKey(0)),
+			instObjState(),
+			providerAddr,
+		)
+		s.SetResourceInstanceCurrent(
+			nestedResourceAddr("child", "now_count").Instance(addrs.NoKey),
+			instObjState(),
+			providerAddr,
+		)
 	})
 
 	explicitStmts := FindMoveStatements(rootCfg)
@@ -101,12 +123,37 @@ func TestImpliedMoveStatements(t *testing.T) {
 				End:      tfdiags.SourcePos{Line: 5, Column: 32, Byte: 211},
 			},
 		},
+
+		// Found implied moves in a nested module, ignoring the explicit moves
+		{
+			From:    addrs.ImpliedMoveStatementEndpoint(nestedResourceAddr("child", "formerly_count").Instance(addrs.IntKey(0)), tfdiags.SourceRange{}),
+			To:      addrs.ImpliedMoveStatementEndpoint(nestedResourceAddr("child", "formerly_count").Instance(addrs.NoKey), tfdiags.SourceRange{}),
+			Implied: true,
+			DeclRange: tfdiags.SourceRange{
+				Filename: "testdata/move-statement-implied/child/move-statement-implied.tf",
+				Start:    tfdiags.SourcePos{Line: 5, Column: 1, Byte: 180},
+				End:      tfdiags.SourcePos{Line: 5, Column: 32, Byte: 211},
+			},
+		},
+
 		{
 			From:    addrs.ImpliedMoveStatementEndpoint(resourceAddr("now_count").Instance(addrs.NoKey), tfdiags.SourceRange{}),
 			To:      addrs.ImpliedMoveStatementEndpoint(resourceAddr("now_count").Instance(addrs.IntKey(0)), tfdiags.SourceRange{}),
 			Implied: true,
 			DeclRange: tfdiags.SourceRange{
 				Filename: "testdata/move-statement-implied/move-statement-implied.tf",
+				Start:    tfdiags.SourcePos{Line: 10, Column: 11, Byte: 282},
+				End:      tfdiags.SourcePos{Line: 10, Column: 12, Byte: 283},
+			},
+		},
+
+		// Found implied moves in a nested module, ignoring the explicit moves
+		{
+			From:    addrs.ImpliedMoveStatementEndpoint(nestedResourceAddr("child", "now_count").Instance(addrs.NoKey), tfdiags.SourceRange{}),
+			To:      addrs.ImpliedMoveStatementEndpoint(nestedResourceAddr("child", "now_count").Instance(addrs.IntKey(0)), tfdiags.SourceRange{}),
+			Implied: true,
+			DeclRange: tfdiags.SourceRange{
+				Filename: "testdata/move-statement-implied/child/move-statement-implied.tf",
 				Start:    tfdiags.SourcePos{Line: 10, Column: 11, Byte: 282},
 				End:      tfdiags.SourcePos{Line: 10, Column: 12, Byte: 283},
 			},

--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -404,6 +404,58 @@ Each resource can have moved from only one source resource.`,
 			},
 			WantError: `Resource type mismatch: This statement declares a move from test.nonexist1[0] to other.single, which is a resource instance of a different type.`,
 		},
+		"crossing nested statements": {
+			// overlapping nested moves will result in a cycle.
+			Statements: []MoveStatement{
+				makeTestMoveStmt(t, ``,
+					`module.nonexist.test.single`,
+					`module.count[0].test.count[0]`,
+				),
+				makeTestMoveStmt(t, ``,
+					`module.nonexist`,
+					`module.count[0]`,
+				),
+			},
+			WantError: `Cyclic dependency in move statements: The following chained move statements form a cycle, and so there is no final location to move objects to:
+  - test:1,1: module.nonexist → module.count[0]
+  - test:1,1: module.nonexist.test.single → module.count[0].test.count[0]
+
+A chain of move statements must end with an address that doesn't appear in any other statements, and which typically also refers to an object still declared in the configuration.`,
+		},
+		"fully contained nested statements": {
+			// we have to avoid a cycle because the nested moves appear in both
+			// the from and to address of the parent when only the module index
+			// is changing.
+			Statements: []MoveStatement{
+				makeTestMoveStmt(t, `count`,
+					`test.count`,
+					`test.count[0]`,
+				),
+				makeTestMoveStmt(t, ``,
+					`module.count`,
+					`module.count[0]`,
+				),
+			},
+		},
+		"double fully contained nested statements": {
+			// we have to avoid a cycle because the nested moves appear in both
+			// the from and to address of the parent when only the module index
+			// is changing.
+			Statements: []MoveStatement{
+				makeTestMoveStmt(t, `count`,
+					`module.count`,
+					`module.count[0]`,
+				),
+				makeTestMoveStmt(t, `count.count`,
+					`test.count`,
+					`test.count[0]`,
+				),
+				makeTestMoveStmt(t, ``,
+					`module.count`,
+					`module.count[0]`,
+				),
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/refactoring/testdata/move-statement-implied/child/move-statement-implied.tf
+++ b/internal/refactoring/testdata/move-statement-implied/child/move-statement-implied.tf
@@ -1,0 +1,16 @@
+# This fixture is useful only in conjunction with a previous run state that
+# conforms to the statements encoded in the resource names. It's for
+# TestImpliedMoveStatements only.
+
+resource "foo" "formerly_count" {
+  # but not count anymore
+}
+
+resource "foo" "now_count" {
+  count = 1
+}
+
+moved {
+  from = foo.no_longer_present[1]
+  to   = foo.no_longer_present
+}

--- a/internal/refactoring/testdata/move-statement-implied/move-statement-implied.tf
+++ b/internal/refactoring/testdata/move-statement-implied/move-statement-implied.tf
@@ -48,3 +48,7 @@ resource "foo" "ambiguous" {
   # set it up to have both no-key and zero-key instances in the
   # state.
 }
+
+module "child" {
+  source = "./child"
+}


### PR DESCRIPTION
When a move statement is only changing the index of a module, any moves within that module would result in cycles, because both the absolute `From` and `To` addresses would match both of the parent module's `From` and `To` address.

For example, changing the index of a module named `count` results in a a `from->to` of:
```
module.count->module.count[0]
```

And changing the count of a resource nested within `module.count` results in:
```
module.count[*].test.count->module.count[*].test.count[0]
```

Because `module.count[*]` matches both the `From` and `To` addresses of the parent, the edges would be added in both directions resulting in a cycle.

The graph we actually want in this case looks like 
```
module.count->module.count[0]
module.count[*].test.count->module.count[*].test.count[0]
  module.count->module.count[0]
```
with a connection only from the inner move to the outer move, which matches the same order of operations when the outer module is changing the name entirely. We achieve this by checking if the dependent move statement is only changing the module index with a new `from.MoveModuleReIndex(to)` method, and skip adding the graph edge.

Fixes #30208

While not contributing to the cycle, it was noticed in #30208 that `impliedMoveStatements` was not correctly calling itself recursively, which is also fixed and tested by this PR.