### PR TITLE
website: Try function documentation "provably" vs "probably" typo

### DIFF
--- a/website/docs/language/functions/try.mdx
+++ b/website/docs/language/functions/try.mdx
@@ -94,7 +94,7 @@ fallback
 ```
 
 The `try` function will _not_ catch errors relating to constructs that are
-probably invalid even before dynamic expression evaluation, such as a malformed
+provably invalid even before dynamic expression evaluation, such as a malformed
 reference or a reference to a top-level object that has not been declared:
 
 ```


### PR DESCRIPTION
This paragraph is trying to say that try only works for dynamic errors and not for errors that are _not_ based on dynamic decision-making in expressions.

I'm not sure if this typo was always here or if it was mistakenly "corrected" at some point, but either way the word "probably" changes the meaning of this sentence entirely, making it seem like Terraform is hedging the likelihood of a problem rather than checking exactly for one.

(The text on this page could probably do with some more general editing and review too, but my goal here is only to correct this specific bug so that the paragraph is not misleading, and so I'd rather save more elaborate editing for a separate PR another day.)
