### PR TITLE
Constants analogous to locals

### DIFF
--- a/website/docs/language/values/locals.mdx
+++ b/website/docs/language/values/locals.mdx
@@ -20,7 +20,7 @@ compare Terraform modules to function definitions:
 
 - [Input variables](/language/values/variables) are like function arguments.
 - [Output values](/language/values/outputs) are like function return values.
-- Local values are like a function's temporary local variables.
+- Local values are like constants. When a value is going to be repeated multiple times, you put a descriptive name for it.
 
 -> **Note:** For brevity, local values are often referred to as just "locals"
 when the meaning is clear from context.


### PR DESCRIPTION
I think "constant" would be a more suitable analogy for locals. In programming languages constants are fixed during compile time and runtime. The purpose of constants are to name a fixed value, which is going to be used multiple times, with a more descriptive label.
C++: const int PI=3.1415;
Java: public static final long PI=3.1415;