### PR TITLE
communicator/ssh: Add support SSH over HTTP Proxy

### DIFF
--- a/internal/communicator/shared/shared.go
+++ b/internal/communicator/shared/shared.go
@@ -81,7 +81,7 @@ var ConnectionBlockSupersetSchema = &configschema.Block{
 			Optional: true,
 		},
 		"proxy_port": {
-			Type:     cty.String,
+			Type:     cty.Number,
 			Optional: true,
 		},
 		"proxy_user_name": {

--- a/internal/communicator/shared/shared.go
+++ b/internal/communicator/shared/shared.go
@@ -72,6 +72,26 @@ var ConnectionBlockSupersetSchema = &configschema.Block{
 			Type:     cty.String,
 			Optional: true,
 		},
+		"proxy_scheme": {
+			Type:     cty.String,
+			Optional: true,
+		},
+		"proxy_host": {
+			Type:     cty.String,
+			Optional: true,
+		},
+		"proxy_port": {
+			Type:     cty.String,
+			Optional: true,
+		},
+		"proxy_user_name": {
+			Type:     cty.String,
+			Optional: true,
+		},
+		"proxy_user_password": {
+			Type:     cty.String,
+			Optional: true,
+		},
 		"bastion_host": {
 			Type:     cty.String,
 			Optional: true,

--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -172,6 +172,20 @@ func (c *Communicator) Connect(o provisioners.UIOutput) (err error) {
 		}
 	}
 
+	if c.connInfo.ProxyHost != "" {
+		o.Output(fmt.Sprintf(
+			"Using configured proxy host...\n"+
+				"  ProxyHost: %s\n"+
+				"  ProxyPort: %d\n"+
+				"  ProxyUserName: %s\n"+
+				"  ProxyUserPassword: %t",
+			c.connInfo.ProxyHost,
+			c.connInfo.ProxyPort,
+			c.connInfo.ProxyUserName,
+			c.connInfo.ProxyUserPassword != "",
+		))
+	}
+
 	hostAndPort := fmt.Sprintf("%s:%d", c.connInfo.Host, c.connInfo.Port)
 	log.Printf("[DEBUG] Connecting to %s for SSH", hostAndPort)
 	c.conn, err = c.config.connection()
@@ -770,9 +784,19 @@ func scpUploadDir(root string, fs []os.FileInfo, w io.Writer, r *bufio.Reader) e
 // ConnectFunc is a convenience method for returning a function
 // that just uses net.Dial to communicate with the remote end that
 // is suitable for use with the SSH communicator configuration.
-func ConnectFunc(network, addr string) func() (net.Conn, error) {
+func ConnectFunc(network, addr string, p *proxyInfo) func() (net.Conn, error) {
 	return func() (net.Conn, error) {
-		c, err := net.DialTimeout(network, addr, 15*time.Second)
+		var c net.Conn
+		var err error
+
+		// Wrap connection to host if proxy server is configured
+		if p != nil {
+			RegisterDialerType()
+			c, err = NewHttpProxyConn(p, addr)
+		} else {
+			c, err = net.DialTimeout(network, addr, 15*time.Second)
+		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -792,10 +816,38 @@ func BastionConnectFunc(
 	bAddr string,
 	bConf *ssh.ClientConfig,
 	proto string,
-	addr string) func() (net.Conn, error) {
+	addr string,
+	p *proxyInfo) func() (net.Conn, error) {
 	return func() (net.Conn, error) {
 		log.Printf("[DEBUG] Connecting to bastion: %s", bAddr)
-		bastion, err := ssh.Dial(bProto, bAddr, bConf)
+		var bastion *ssh.Client
+		var err error
+
+		// Wrap connection to bastion server if proxy server is configured
+		if p != nil {
+			var pConn net.Conn
+			var bConn ssh.Conn
+			var bChans <-chan ssh.NewChannel
+			var bReq <-chan *ssh.Request
+
+			RegisterDialerType()
+			pConn, err = NewHttpProxyConn(p, bAddr)
+
+			if err != nil {
+				return nil, fmt.Errorf("Error connecting to proxy: %s", err)
+			}
+
+			bConn, bChans, bReq, err = ssh.NewClientConn(pConn, bAddr, bConf)
+
+			if err != nil {
+				return nil, fmt.Errorf("Error creating new client connection via proxy: %s", err)
+			}
+
+			bastion = ssh.NewClient(bConn, bChans, bReq)
+		} else {
+			bastion, err = ssh.Dial(bProto, bAddr, bConf)
+		}
+
 		if err != nil {
 			return nil, fmt.Errorf("Error connecting to bastion: %s", err)
 		}

--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -792,7 +792,7 @@ func ConnectFunc(network, addr string, p *proxyInfo) func() (net.Conn, error) {
 		// Wrap connection to host if proxy server is configured
 		if p != nil {
 			RegisterDialerType()
-			c, err = NewHttpProxyConn(p, addr)
+			c, err = newHttpProxyConn(p, addr)
 		} else {
 			c, err = net.DialTimeout(network, addr, 15*time.Second)
 		}
@@ -831,7 +831,7 @@ func BastionConnectFunc(
 			var bReq <-chan *ssh.Request
 
 			RegisterDialerType()
-			pConn, err = NewHttpProxyConn(p, bAddr)
+			pConn, err = newHttpProxyConn(p, bAddr)
 
 			if err != nil {
 				return nil, fmt.Errorf("Error connecting to proxy: %s", err)

--- a/internal/communicator/ssh/http_proxy.go
+++ b/internal/communicator/ssh/http_proxy.go
@@ -2,7 +2,6 @@ package ssh
 
 import (
 	"bufio"
-	"encoding/base64"
 	"fmt"
 	"net"
 	"net/http"
@@ -13,7 +12,7 @@ import (
 )
 
 // Dialer implements for SSH over HTTP Proxy.
-type Dialer struct {
+type proxyDialer struct {
 	proxy proxyInfo
 	// forwarding Dialer
 	forward proxy.Dialer
@@ -24,12 +23,8 @@ type proxyInfo struct {
 	host string
 	// HTTP Proxy scheme
 	scheme string
-	// User name if http proxy needs authentication
-	username string
-	// User password if http proxy needs authentication
-	password string
-	// Whether the HTTP Proxy requires authentication
-	auth bool
+	// An immutable encapsulation of username and password details for a URL
+	userInfo *url.Userinfo
 }
 
 func newProxyInfo(host, scheme, username, password string) *proxyInfo {
@@ -38,11 +33,7 @@ func newProxyInfo(host, scheme, username, password string) *proxyInfo {
 		scheme: scheme,
 	}
 
-	if username != "" && password != "" {
-		p.auth = true
-		p.username = username
-		p.password = password
-	}
+	p.userInfo = url.UserPassword(username, password)
 
 	if p.scheme == "" {
 		p.scheme = "http"
@@ -51,17 +42,15 @@ func newProxyInfo(host, scheme, username, password string) *proxyInfo {
 	return p
 }
 
-func (p *proxyInfo) url() (*url.URL, error) {
-	base := p.scheme + "://"
-
-	if p.auth {
-		base = base + p.username + ":" + p.password + "@"
+func (p *proxyInfo) url() *url.URL {
+	return &url.URL{
+		Scheme: p.scheme,
+		User:   p.userInfo,
+		Host:   p.host,
 	}
-
-	return url.Parse(base + p.host)
 }
 
-func (p *Dialer) Dial(network, addr string) (net.Conn, error) {
+func (p *proxyDialer) Dial(network, addr string) (net.Conn, error) {
 	// Dial the proxy host
 	c, err := p.forward.Dial(network, p.proxy.host)
 
@@ -75,12 +64,10 @@ func (p *Dialer) Dial(network, addr string) (net.Conn, error) {
 	}
 
 	// Generate request URL to host accessed through the proxy
-	reqUrl, err := url.Parse("http://" + addr)
-	if err != nil {
-		c.Close()
-		return nil, err
+	reqUrl := &url.URL{
+		Scheme: "",
+		Host:   addr,
 	}
-	reqUrl.Scheme = ""
 
 	// Create a request object using the CONNECT method to instruct the proxy server to tunnel a protocol other than HTTP.
 	req, err := http.NewRequest("CONNECT", reqUrl.String(), nil)
@@ -90,9 +77,11 @@ func (p *Dialer) Dial(network, addr string) (net.Conn, error) {
 	}
 
 	// If http proxy requires authentication, configure settings for basic authentication.
-	if p.proxy.auth {
-		req.SetBasicAuth(p.proxy.username, p.proxy.password)
-		req.Header.Add("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(p.proxy.username+":"+p.proxy.password)))
+	if p.proxy.userInfo.String() != "" {
+		username := p.proxy.userInfo.Username()
+		password, _ := p.proxy.userInfo.Password()
+		req.SetBasicAuth(username, password)
+		req.Header.Add("Proxy-Authorization", req.Header.Get("Authorization"))
 	}
 
 	// Do not close the connection after sending this request and reading its response.
@@ -124,14 +113,14 @@ func (p *Dialer) Dial(network, addr string) (net.Conn, error) {
 }
 
 // NewHttpProxyDialer generate Http Proxy Dialer
-func NewHttpProxyDialer(u *url.URL, forward proxy.Dialer) (proxy.Dialer, error) {
+func newHttpProxyDialer(u *url.URL, forward proxy.Dialer) (proxy.Dialer, error) {
 	var proxyUserName, proxyPassword string
 	if u.User != nil {
 		proxyUserName = u.User.Username()
 		proxyPassword, _ = u.User.Password()
 	}
 
-	pd := &Dialer{
+	pd := &proxyDialer{
 		proxy:   *newProxyInfo(u.Host, u.Scheme, proxyUserName, proxyPassword),
 		forward: forward,
 	}
@@ -141,24 +130,19 @@ func NewHttpProxyDialer(u *url.URL, forward proxy.Dialer) (proxy.Dialer, error) 
 
 // RegisterDialerType register schemes used by `proxy.FromURL`
 func RegisterDialerType() {
-	proxy.RegisterDialerType("http", NewHttpProxyDialer)
-	proxy.RegisterDialerType("https", NewHttpProxyDialer)
+	proxy.RegisterDialerType("http", newHttpProxyDialer)
+	proxy.RegisterDialerType("https", newHttpProxyDialer)
 }
 
 // NewHttpProxyConn create a connection to connect through the proxy server.
-func NewHttpProxyConn(p *proxyInfo, targetAddr string) (net.Conn, error) {
-	proxyURL, err := p.url()
-	if err != nil {
-		return nil, err
-	}
-
-	proxyDialer, err := proxy.FromURL(proxyURL, proxy.Direct)
+func newHttpProxyConn(p *proxyInfo, targetAddr string) (net.Conn, error) {
+	pd, err := proxy.FromURL(p.url(), proxy.Direct)
 
 	if err != nil {
 		return nil, err
 	}
 
-	proxyConn, err := proxyDialer.Dial("tcp", targetAddr)
+	proxyConn, err := pd.Dial("tcp", targetAddr)
 
 	if err != nil {
 		return nil, err

--- a/internal/communicator/ssh/http_proxy.go
+++ b/internal/communicator/ssh/http_proxy.go
@@ -1,0 +1,168 @@
+package ssh
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+// Dialer implements for SSH over HTTP Proxy.
+type Dialer struct {
+	proxy proxyInfo
+	// forwarding Dialer
+	forward proxy.Dialer
+}
+
+type proxyInfo struct {
+	// HTTP Proxy host or host:port
+	host string
+	// HTTP Proxy scheme
+	scheme string
+	// User name if http proxy needs authentication
+	username string
+	// User password if http proxy needs authentication
+	password string
+	// Whether the HTTP Proxy requires authentication
+	auth bool
+}
+
+func newProxyInfo(host, scheme, username, password string) *proxyInfo {
+	p := &proxyInfo{
+		host:   host,
+		scheme: scheme,
+	}
+
+	if username != "" && password != "" {
+		p.auth = true
+		p.username = username
+		p.password = password
+	}
+
+	if p.scheme == "" {
+		p.scheme = "http"
+	}
+
+	return p
+}
+
+func (p *proxyInfo) url() (*url.URL, error) {
+	base := p.scheme + "://"
+
+	if p.auth {
+		base = base + p.username + ":" + p.password + "@"
+	}
+
+	return url.Parse(base + p.host)
+}
+
+func (p *Dialer) Dial(network, addr string) (net.Conn, error) {
+	// Dial the proxy host
+	c, err := p.forward.Dial(network, p.proxy.host)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.SetDeadline(time.Now().Add(15 * time.Second))
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate request URL to host accessed through the proxy
+	reqUrl, err := url.Parse("http://" + addr)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+	reqUrl.Scheme = ""
+
+	// Create a request object using the CONNECT method to instruct the proxy server to tunnel a protocol other than HTTP.
+	req, err := http.NewRequest("CONNECT", reqUrl.String(), nil)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	// If http proxy requires authentication, configure settings for basic authentication.
+	if p.proxy.auth {
+		req.SetBasicAuth(p.proxy.username, p.proxy.password)
+		req.Header.Add("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(p.proxy.username+":"+p.proxy.password)))
+	}
+
+	// Do not close the connection after sending this request and reading its response.
+	req.Close = false
+
+	// Writes the request in the form expected by an HTTP proxy.
+	err = req.Write(c)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	res, err := http.ReadResponse(bufio.NewReader(c), req)
+
+	if err != nil {
+		res.Body.Close()
+		c.Close()
+		return nil, err
+	}
+
+	res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		c.Close()
+		return nil, fmt.Errorf("Connection Error: StatusCode: %d", res.StatusCode)
+	}
+
+	return c, nil
+}
+
+// NewHttpProxyDialer generate Http Proxy Dialer
+func NewHttpProxyDialer(u *url.URL, forward proxy.Dialer) (proxy.Dialer, error) {
+	var proxyUserName, proxyPassword string
+	if u.User != nil {
+		proxyUserName = u.User.Username()
+		proxyPassword, _ = u.User.Password()
+	}
+
+	pd := &Dialer{
+		proxy:   *newProxyInfo(u.Host, u.Scheme, proxyUserName, proxyPassword),
+		forward: forward,
+	}
+
+	return pd, nil
+}
+
+// RegisterDialerType register schemes used by `proxy.FromURL`
+func RegisterDialerType() {
+	proxy.RegisterDialerType("http", NewHttpProxyDialer)
+	proxy.RegisterDialerType("https", NewHttpProxyDialer)
+}
+
+// NewHttpProxyConn create a connection to connect through the proxy server.
+func NewHttpProxyConn(p *proxyInfo, targetAddr string) (net.Conn, error) {
+	proxyURL, err := p.url()
+	if err != nil {
+		return nil, err
+	}
+
+	proxyDialer, err := proxy.FromURL(proxyURL, proxy.Direct)
+
+	if err != nil {
+		return nil, err
+	}
+
+	proxyConn, err := proxyDialer.Dial("tcp", targetAddr)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return proxyConn, err
+}

--- a/internal/communicator/ssh/provisioner.go
+++ b/internal/communicator/ssh/provisioner.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -62,6 +63,12 @@ type connectionInfo struct {
 	Timeout        string
 	TimeoutVal     time.Duration
 
+	ProxyScheme       string
+	ProxyHost         string
+	ProxyPort         uint16
+	ProxyUserName     string
+	ProxyUserPassword string
+
 	BastionUser        string
 	BastionPassword    string
 	BastionPrivateKey  string
@@ -112,6 +119,20 @@ func decodeConnInfo(v cty.Value) (*connectionInfo, error) {
 			connInfo.TargetPlatform = v.AsString()
 		case "timeout":
 			connInfo.Timeout = v.AsString()
+		case "proxy_scheme":
+			connInfo.ProxyScheme = v.AsString()
+		case "proxy_host":
+			connInfo.ProxyHost = v.AsString()
+		case "proxy_port":
+			p, err := strconv.ParseUint(v.AsString(), 10, 16)
+			if err != nil {
+				return nil, err
+			}
+			connInfo.ProxyPort = uint16(p)
+		case "proxy_user_name":
+			connInfo.ProxyUserName = v.AsString()
+		case "proxy_user_password":
+			connInfo.ProxyUserPassword = v.AsString()
 		case "bastion_user":
 			connInfo.BastionUser = v.AsString()
 		case "bastion_password":
@@ -254,7 +275,18 @@ func prepareSSHConfig(connInfo *connectionInfo) (*sshConfig, error) {
 		return nil, err
 	}
 
-	connectFunc := ConnectFunc("tcp", host)
+	var p *proxyInfo
+
+	if connInfo.ProxyHost != "" {
+		p = newProxyInfo(
+			connInfo.ProxyHost+":"+strconv.FormatUint(uint64(connInfo.ProxyPort), 10),
+			connInfo.ProxyScheme,
+			connInfo.ProxyUserName,
+			connInfo.ProxyUserPassword,
+		)
+	}
+
+	connectFunc := ConnectFunc("tcp", host, p)
 
 	var bastionConf *ssh.ClientConfig
 	if connInfo.BastionHost != "" {
@@ -273,7 +305,7 @@ func prepareSSHConfig(connInfo *connectionInfo) (*sshConfig, error) {
 			return nil, err
 		}
 
-		connectFunc = BastionConnectFunc("tcp", bastionHost, bastionConf, "tcp", host)
+		connectFunc = BastionConnectFunc("tcp", bastionHost, bastionConf, "tcp", host, p)
 	}
 
 	config := &sshConfig{

--- a/internal/communicator/ssh/provisioner.go
+++ b/internal/communicator/ssh/provisioner.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -124,11 +123,9 @@ func decodeConnInfo(v cty.Value) (*connectionInfo, error) {
 		case "proxy_host":
 			connInfo.ProxyHost = v.AsString()
 		case "proxy_port":
-			p, err := strconv.ParseUint(v.AsString(), 10, 16)
-			if err != nil {
+			if err := gocty.FromCtyValue(v, &connInfo.ProxyPort); err != nil {
 				return nil, err
 			}
-			connInfo.ProxyPort = uint16(p)
 		case "proxy_user_name":
 			connInfo.ProxyUserName = v.AsString()
 		case "proxy_user_password":
@@ -279,7 +276,7 @@ func prepareSSHConfig(connInfo *connectionInfo) (*sshConfig, error) {
 
 	if connInfo.ProxyHost != "" {
 		p = newProxyInfo(
-			connInfo.ProxyHost+":"+strconv.FormatUint(uint64(connInfo.ProxyPort), 10),
+			fmt.Sprintf("%s:%d", connInfo.ProxyHost, connInfo.ProxyPort),
 			connInfo.ProxyScheme,
 			connInfo.ProxyUserName,
 			connInfo.ProxyUserPassword,

--- a/internal/communicator/ssh/provisioner_test.go
+++ b/internal/communicator/ssh/provisioner_test.go
@@ -137,6 +137,52 @@ func TestProvisioner_connInfoEmptyHostname(t *testing.T) {
 	}
 }
 
+func TestProvisioner_connInfoProxy(t *testing.T) {
+	v := cty.ObjectVal(map[string]cty.Value{
+		"type":                cty.StringVal("ssh"),
+		"user":                cty.StringVal("root"),
+		"password":            cty.StringVal("supersecret"),
+		"private_key":         cty.StringVal("someprivatekeycontents"),
+		"host":                cty.StringVal("example.com"),
+		"port":                cty.StringVal("22"),
+		"timeout":             cty.StringVal("30s"),
+		"proxy_scheme":        cty.StringVal("http"),
+		"proxy_host":          cty.StringVal("proxy.example.com"),
+		"proxy_port":          cty.StringVal("80"),
+		"proxy_user_name":     cty.StringVal("proxyuser"),
+		"proxy_user_password": cty.StringVal("proxyuser_password"),
+	})
+
+	conf, err := parseConnectionInfo(v)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if conf.Host != "example.com" {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	if conf.ProxyScheme != "http" {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	if conf.ProxyHost != "proxy.example.com" {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	if conf.ProxyPort != 80 {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	if conf.ProxyUserName != "proxyuser" {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	if conf.ProxyUserPassword != "proxyuser_password" {
+		t.Fatalf("bad: %v", conf)
+	}
+}
+
 func TestProvisioner_stringBastionPort(t *testing.T) {
 	v := cty.ObjectVal(map[string]cty.Value{
 		"type":         cty.StringVal("ssh"),

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -191,6 +191,26 @@ var connectionBlockSupersetSchema = &configschema.Block{
 			Type:     cty.String,
 			Optional: true,
 		},
+		"proxy_scheme": {
+			Type:     cty.String,
+			Optional: true,
+		},
+		"proxy_host": {
+			Type:     cty.String,
+			Optional: true,
+		},
+		"proxy_port": {
+			Type:     cty.String,
+			Optional: true,
+		},
+		"proxy_user_name": {
+			Type:     cty.String,
+			Optional: true,
+		},
+		"proxy_user_password": {
+			Type:     cty.String,
+			Optional: true,
+		},
 		"bastion_host": {
 			Type:     cty.String,
 			Optional: true,

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -200,7 +200,7 @@ var connectionBlockSupersetSchema = &configschema.Block{
 			Optional: true,
 		},
 		"proxy_port": {
-			Type:     cty.String,
+			Type:     cty.Number,
 			Optional: true,
 		},
 		"proxy_user_name": {

--- a/website/docs/language/resources/provisioners/connection.mdx
+++ b/website/docs/language/resources/provisioners/connection.mdx
@@ -113,6 +113,21 @@ indirectly with a [bastion host](https://en.wikipedia.org/wiki/Bastion_host).
 | `bastion_private_key` | The contents of an SSH key file to use for the bastion host. These can be loaded from a file on disk using [the `file` function](/language/functions/file). | The value of the `private_key` field. |
 | `bastion_certificate` |  The contents of a signed CA Certificate. The certificate argument must be used in conjunction with a `bastion_private_key`. These can be loaded from a file on disk using the [the `file` function](/language/functions/file). |
 
+## Connection through a HTTP Proxy with SSH
+
+The `ssh` connection also supports the following fields to facilitate connections by SSH over HTTP proxy.
+
+* `proxy_scheme` - http or https
+
+* `proxy_host` - Setting this enables the SSH over HTTP connection. This host
+  will be connected to first, and then the `host` or `bastion_host` connection will be made from there.
+
+* `proxy_port` - The port to use connect to the proxy host.
+
+* `proxy_user_name` - The username to use connect to the private proxy host.
+
+* `proxy_user_password` - The password to use connect to the private proxy host.
+
 ## How Provisioners Execute Remote Scripts
 
 Provisioners which execute commands on a remote system via a protocol such as

--- a/website/docs/language/resources/provisioners/connection.mdx
+++ b/website/docs/language/resources/provisioners/connection.mdx
@@ -117,16 +117,13 @@ indirectly with a [bastion host](https://en.wikipedia.org/wiki/Bastion_host).
 
 The `ssh` connection also supports the following fields to facilitate connections by SSH over HTTP proxy.
 
-* `proxy_scheme` - http or https
-
-* `proxy_host` - Setting this enables the SSH over HTTP connection. This host
-  will be connected to first, and then the `host` or `bastion_host` connection will be made from there.
-
-* `proxy_port` - The port to use connect to the proxy host.
-
-* `proxy_user_name` - The username to use connect to the private proxy host.
-
-* `proxy_user_password` - The password to use connect to the private proxy host.
+| Argument | Description | Default |
+|---------------|-------------|---------|
+| `proxy_scheme` | http or https | |
+| `proxy_host` | Setting this enables the SSH over HTTP connection. This host will be connected to first, and then the `host` or `bastion_host` connection will be made from there. | |
+| `proxy_port` | The port to use connect to the proxy host. | |
+| `proxy_user_name` | The username to use connect to the private proxy host. This argument should be specified only if authentication is required for the HTTP Proxy server. | |
+| `proxy_user_password` | The password to use connect to the private proxy host. This argument should be specified only if authentication is required for the HTTP Proxy server. | |
 
 ## How Provisioners Execute Remote Scripts
 


### PR DESCRIPTION
## Description
These commits support SSH over HTTP Proxy in the SSH provisioner without significantly changing the existing Pure Go SSH implementation.
I found that in #4523 #1709, the lack of support for SSH on HTTP Proxy has inconvenienced many people. I myself have to switch networks whenever I use terraform in a company network.
Therefore, I proposed this implementation.

## Changes
- add `proxy_*` fields to `connection` which add configuration for a proxy host
   - `proxy_host`: Setting this enables the SSH over HTTP connection. This host
  will be connected to first, and then the `host` or `bastion_host` connection will be made from there.
   - `proxy_port` - The port to use connect to the proxy host.
   - `proxy_scheme` - http or https
   - `proxy_user_name` - The username to use connect to the private proxy host.
   - `proxy_user_password` - The password to use connect to the private proxy host.

## Others
You can create a test environment that connects to the test node via SSH through HTTP PROXY in the following repository.

https://github.com/htamakos/terraform-communicator-ssh-test-env

### Result Example
```sh
$ ~/ghq/github.com/htamakos/terraform/terraform apply -auto-approve
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion: Refreshing state... [id=8719430125056995160]
null_resource.remote_exec_via_ssh: Refreshing state... [id=1156678337337142727]
null_resource.remote_exec_via_ssh_over_http_proxy: Refreshing state... [id=2456805027942864311]
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion: Refreshing state... [id=2488039607822794741]
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth: Refreshing state... [id=4092500202928979050]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # null_resource.remote_exec_via_ssh must be replaced
-/+ resource "null_resource" "remote_exec_via_ssh" {
      ~ id       = "1156678337337142727" -> (known after apply)
      ~ triggers = {
          - "build_number" = "2021-12-30T03:16:55Z"
        } -> (known after apply) # forces replacement
    }

  # null_resource.remote_exec_via_ssh_over_http_proxy must be replaced
-/+ resource "null_resource" "remote_exec_via_ssh_over_http_proxy" {
      ~ id       = "2456805027942864311" -> (known after apply)
      ~ triggers = {
          - "build_number" = "2021-12-30T03:16:56Z"
        } -> (known after apply) # forces replacement
    }

  # null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion must be replaced
-/+ resource "null_resource" "remote_exec_via_ssh_over_http_proxy_through_bastion" {
      ~ id       = "2488039607822794741" -> (known after apply)
      ~ triggers = {
          - "build_number" = "2021-12-30T03:16:56Z"
        } -> (known after apply) # forces replacement
    }

  # null_resource.remote_exec_via_ssh_over_http_proxy_with_auth must be replaced
-/+ resource "null_resource" "remote_exec_via_ssh_over_http_proxy_with_auth" {
      ~ id       = "4092500202928979050" -> (known after apply)
      ~ triggers = {
          - "build_number" = "2021-12-30T03:16:56Z"
        } -> (known after apply) # forces replacement
    }

  # null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion must be replaced
-/+ resource "null_resource" "remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion" {
      ~ id       = "8719430125056995160" -> (known after apply)
      ~ triggers = {
          - "build_number" = "2021-12-30T03:16:56Z"
        } -> (known after apply) # forces replacement
    }
Plan: 5 to add, 0 to change, 5 to destroy.
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth: Destroying... [id=4834391650718277819]
null_resource.remote_exec_via_ssh: Destroying... [id=4727489635703643485]
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion: Destroying... [id=154493005404606358]
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion: Destroying... [id=5750345333101675414]
null_resource.remote_exec_via_ssh_over_http_proxy: Destroying... [id=2912693274146434159]
null_resource.remote_exec_via_ssh: Destruction complete after 0s
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth: Destruction complete after 0s
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion: Destruction complete after 0s
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion: Destruction complete after 0s
null_resource.remote_exec_via_ssh_over_http_proxy: Destruction complete after 0s
null_resource.remote_exec_via_ssh: Creating...
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth: Creating...
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion: Creating...
null_resource.remote_exec_via_ssh: Provisioning with 'remote-exec'...
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth: Provisioning with 'remote-exec'...
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec): Connecting to remote host via SSH...
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   Host: bas
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   User: root
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   Password: true
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   Private key: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   Certificate: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   SSH Agent: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   Checking Host Key: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   Target Platform: unix
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec): Using configured proxy host...
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   ProxyHost: localhost
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   ProxyPort: 23129
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   ProxyUserName: root
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec):   ProxyUserPassword: true
null_resource.remote_exec_via_ssh (remote-exec): Connecting to remote host via SSH...
null_resource.remote_exec_via_ssh (remote-exec):   Host: 0.0.0.0
null_resource.remote_exec_via_ssh (remote-exec):   User: root
null_resource.remote_exec_via_ssh (remote-exec):   Password: true
null_resource.remote_exec_via_ssh (remote-exec):   Private key: false
null_resource.remote_exec_via_ssh (remote-exec):   Certificate: false
null_resource.remote_exec_via_ssh (remote-exec):   SSH Agent: false
null_resource.remote_exec_via_ssh (remote-exec):   Checking Host Key: false
null_resource.remote_exec_via_ssh (remote-exec):   Target Platform: unix
null_resource.remote_exec_via_ssh_over_http_proxy: Creating...
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion: Creating...
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion: Provisioning with 'remote-exec'...
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec): Connecting to remote host via SSH...
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   Host: app
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   User: root
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   Password: true
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   Private key: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   Certificate: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   SSH Agent: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   Checking Host Key: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   Target Platform: unix
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec): Using configured bastion host...
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   Host: bas
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   User: root
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   Password: true
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   Private key: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   Certificate: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   SSH Agent: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   Checking Host Key: false
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec): Using configured proxy host...
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   ProxyHost: localhost
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   ProxyPort: 23129
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   ProxyUserName: root
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec):   ProxyUserPassword: true
null_resource.remote_exec_via_ssh_over_http_proxy: Provisioning with 'remote-exec'...
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion: Provisioning with 'remote-exec'...
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec): Connecting to remote host via SSH...
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   Host: bas
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   User: root
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   Password: true
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   Private key: false
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   Certificate: false
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   SSH Agent: false
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   Checking Host Key: false
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   Target Platform: unix
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec): Connecting to remote host via SSH...
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   Host: app
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   User: root
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   Password: true
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   Private key: false
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   Certificate: false
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   SSH Agent: false
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   Checking Host Key: false
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   Target Platform: unix
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec): Using configured proxy host...
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   ProxyHost: localhost
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   ProxyPort: 23128
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   ProxyUserName:
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec):   ProxyUserPassword: false
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec): Using configured bastion host...
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   Host: bas
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   User: root
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   Password: true
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   Private key: false
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   Certificate: false
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   SSH Agent: false
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   Checking Host Key: false
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec): Using configured proxy host...
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   ProxyHost: localhost
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   ProxyPort: 23128
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   ProxyUserName:
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec):   ProxyUserPassword: false
null_resource.remote_exec_via_ssh (remote-exec): Connected!
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec): Connected!
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec): Connected!
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec): Connected!
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec): Connected!
null_resource.remote_exec_via_ssh (remote-exec): Success: remote_exec_via_ssh
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth (remote-exec): Success: remote_exec_via_ssh_over_http_proxy_with_auth
null_resource.remote_exec_via_ssh_over_http_proxy (remote-exec): Success: remote_exec_via_ssh_over_http_proxy
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion (remote-exec): Success: remote_exec_via_ssh_over_http_proxy_through_bastio
n
null_resource.remote_exec_via_ssh: Creation complete after 0s [id=1156678337337142727]
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion (remote-exec): Success: remote_exec_via_ssh_over_http_proxy_with
_auth_through_bastion
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth: Creation complete after 0s [id=4092500202928979050]
null_resource.remote_exec_via_ssh_over_http_proxy_through_bastion: Creation complete after 0s [id=2488039607822794741]
null_resource.remote_exec_via_ssh_over_http_proxy: Creation complete after 0s [id=2456805027942864311]
null_resource.remote_exec_via_ssh_over_http_proxy_with_auth_through_bastion: Creation complete after 0s [id=8719430125056995160]
```
