### PR TITLE
Terraform may be misled, not provider

### DIFF
--- a/website/docs/cli/commands/refresh.mdx
+++ b/website/docs/cli/commands/refresh.mdx
@@ -47,7 +47,7 @@ and `-auto-approve` is always enabled.
 Automatically applying the effect of a refresh is risky. If you have
 misconfigured credentials for one or more providers then Terraform may
 be misled into thinking that all of the managed objects have been deleted,
-and thus removes all of the tracked objects without any confirmation prompt.
+causing it to remove all of the tracked objects without any confirmation prompt.
 
 Instead, we recommend using the following command in order to get the same
 effect but with the opportunity to review the changes that Terraform has

--- a/website/docs/cli/commands/refresh.mdx
+++ b/website/docs/cli/commands/refresh.mdx
@@ -44,7 +44,7 @@ Consequently, it supports all of the same options as
 plan file, it doesn't allow selecting a planning mode other than "refresh only",
 and `-auto-approve` is always enabled.
 
-Automatically applying the effect of a refresh is risky, because if you have
+Automatically applying the effect of a refresh is risky. If you have
 misconfigured credentials for one or more providers then Terraform may
 be misled into thinking that all of the managed objects have been deleted,
 and thus removes all of the tracked objects without any confirmation prompt.

--- a/website/docs/cli/commands/refresh.mdx
+++ b/website/docs/cli/commands/refresh.mdx
@@ -45,7 +45,7 @@ plan file, it doesn't allow selecting a planning mode other than "refresh only",
 and `-auto-approve` is always enabled.
 
 Automatically applying the effect of a refresh is risky. If you have
-misconfigured credentials for one or more providers then Terraform may
+misconfigured credentials for one or more providers, Terraform may
 be misled into thinking that all of the managed objects have been deleted,
 causing it to remove all of the tracked objects without any confirmation prompt.
 

--- a/website/docs/cli/commands/refresh.mdx
+++ b/website/docs/cli/commands/refresh.mdx
@@ -45,9 +45,9 @@ plan file, it doesn't allow selecting a planning mode other than "refresh only",
 and `-auto-approve` is always enabled.
 
 Automatically applying the effect of a refresh is risky, because if you have
-misconfigured credentials for one or more providers then the provider may
+misconfigured credentials for one or more providers then Terraform may
 be misled into thinking that all of the managed objects have been deleted,
-and thus remove all of the tracked objects without any confirmation prompt.
+and thus removes all of the tracked objects without any confirmation prompt.
 
 Instead, we recommend using the following command in order to get the same
 effect but with the opportunity to review the changes that Terraform has


### PR DESCRIPTION
Provider is not misled into thinking. Terraform may be misled into thinking that all of the managed objects have been deleted . So, Terraform removes all of the tracked objects from the state file.