### PR TITLE
A new build process, based on GitHub Actions

### DIFF
--- a/.github/workflows/build-Dockerfile
+++ b/.github/workflows/build-Dockerfile
@@ -1,0 +1,41 @@
+# This Dockerfile is not intended for general use, but is rather used to
+# produce our "light" release packages as part of our official release
+# pipeline.
+#
+# If you want to test this locally you'll need to set the three arguments
+# to values realistic for what the hashicorp/actions-docker-build GitHub
+# action would set, and ensure that there's a suitable "terraform" executable
+# in the dist/linux/${TARGETARCH} directory.
+
+FROM docker.mirror.hashicorp.services/alpine:latest AS default
+
+# This is intended to be run from the hashicorp/actions-docker-build GitHub
+# action, which sets these appropriately based on context.
+ARG PRODUCT_VERSION=UNSPECIFIED
+ARG PRODUCT_REVISION=UNSPECIFIED
+ARG BIN_NAME=terraform
+
+# This argument is set by the Docker toolchain itself, to the name
+# of the CPU architecture we're building an image for.
+# Our caller should've extracted the corresponding "terraform" executable
+# into dist/linux/${TARGETARCH} for us to use.
+ARG TARGETARCH
+
+LABEL maintainer="HashiCorp Terraform Team <terraform@hashicorp.com>"
+
+# New standard version label.
+LABEL version=$VERSION
+
+# Historical Terraform-specific label preserved for backward compatibility.
+LABEL "com.hashicorp.terraform.version"="${VERSION}"
+
+RUN apk add --no-cache git openssh
+
+# The hashicorp/actions-docker-build GitHub Action extracts the appropriate
+# release package for our target architecture into the current working
+# directory before running "docker build", which we'll then copy into the
+# Docker image to make sure that we use an identical binary as all of the
+# other official release channels.
+COPY ["dist/linux/${TARGETARCH}/terraform", "/bin/terraform"]
+
+ENTRYPOINT ["/bin/terraform"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,20 @@ name: Build Terraform CLI Packages
 # which is a special prefix that triggers this workflow even though it's not
 # actually a release branch.
 
+# NOTE: This workflow is currently used only to verify that all commits to a
+# release branch are buildable. It's set up to generate some artifacts that
+# might in principle be consumed by a downstream release process, but currently
+# they are not used in this way and official Terraform CLI releases are instead
+# built using a separate process maintained elsewhere. We intend to adopt this
+# new process fully later, once other HashiCorp-internal tooling is ready.
+#
+# Currently this process produces what should be working packages but packages
+# NOT suitable for distribution to end-users as official releases, because it
+# doesn't include a step to ensure that "terraform version" (and similar) will
+# report the intended version number. Consequently we can safely use these
+# results for testing purposes, but not yet for release purposes. See the
+# "build" job below for a FIXME comment related to version numbers.
+
 on:
   workflow_dispatch:
   push:
@@ -28,6 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -54,6 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
+
     steps:
       - uses: actions/checkout@v2
       - name: Determine Go version
@@ -91,7 +107,6 @@ jobs:
     needs:
       - get-product-version
       - get-go-version
-
     strategy:
       matrix:
         include:
@@ -142,51 +157,90 @@ jobs:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
-      - name: Linux distribution packages
-        if: ${{ matrix.goos == 'linux' }}
+  package-linux:
+    name: "Build Linux distro packages for ${{ matrix.arch }}"
+    runs-on: ubuntu-latest
+    needs:
+      - get-product-version
+      - build
+    strategy:
+      matrix:
+        include:
+          - {arch: "386"}
+          - {arch: "amd64"}
+          - {arch: "arm"}
+          - {arch: "arm64"}
+      fail-fast: false
+
+    env:
+      os: linux
+      arch: ${{matrix.arch}}
+      version: ${{needs.get-product-version.outputs.product-version}}
+
+    steps:
+      - name: "Download Terraform CLI package"
+        uses: actions/download-artifact@v2
+        id: clipkg
+        with:
+          name: terraform_${{ env.version }}_${{ env.os }}_${{ env.arch }}.zip
+          path: .
+      - name: Extract packages
+        run: |
+          mkdir -p dist
+          (cd dist && unzip "../terraform_${{ env.version }}_${{ env.os }}_${{ env.arch }}.zip")
+          mkdir -p out
+      - name: Build Linux distribution packages
         uses: hashicorp/package@v1
         with:
           name: "terraform"
           description: "Terraform enables you to safely and predictably create, change, and improve infrastructure. It is an open source tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned."
-          arch: ${{ matrix.goarch }}
-          version: ${{ needs.get-product-version.outputs.product-version }}
+          arch: ${{ matrix.arch }}
+          version: ${{ env.version }}
           maintainer: "HashiCorp"
           homepage: "https://terraform.io/"
           license: "MPL-2.0"
-          binary: "dist/${{ env.PKG_NAME }}"
+          binary: "dist/terraform"
           deb_depends: "git"
           rpm_depends: "git"
-
       - name: Gather Linux distribution package filenames
-        if: ${{ matrix.goos == 'linux' }}
         run: |
           echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
           echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
-
-      # FIXME: Generate homebrew packages when targeting macOS.
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ matrix.goos == 'linux' }}
+      - name: "Save .rpm package"
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ env.RPM_PACKAGE }}
           path: out/${{ env.RPM_PACKAGE }}
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ matrix.goos == 'linux' }}
+      - name: "Save .deb package"
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ env.DEB_PACKAGE }}
           path: out/${{ env.DEB_PACKAGE }}
 
-  build-docker:
+  # TODO: homebrew packages for macOS
+  #package-homebrew:
+  #  name: Build Homebrew package for darwin_${{ matrix.arch }}
+  #  runs-on: macos-latest
+  #  needs:
+  #    - get-product-version
+  #    - build
+  #  strategy:
+  #    matrix:
+  #      arch: ["amd64", "arm64"]
+  #    fail-fast: false
+  # ...
+
+  package-docker:
     name: Build Docker image for linux_${{ matrix.arch }}
+    runs-on: ubuntu-latest
     needs:
       - get-product-version
       - build
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: ["amd64"]
       fail-fast: false
+
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
@@ -206,8 +260,8 @@ jobs:
 
   e2etest-build:
     name: Build e2etest for ${{ matrix.goos }}_${{ matrix.goarch }}
-    needs: ["get-go-version"]
     runs-on: ubuntu-latest
+    needs: ["get-go-version"]
     strategy:
       matrix:
         # We build test harnesses only for the v1.0 Compatibility Promises
@@ -258,7 +312,6 @@ jobs:
       - get-product-version
       - build
       - e2etest-build
-
     strategy:
       matrix:
         include:
@@ -306,7 +359,6 @@ jobs:
       - get-product-version
       - build
       - e2etest-build
-
     strategy:
       matrix:
         include:
@@ -353,7 +405,6 @@ jobs:
       - get-product-version
       - build
       - e2etest-build
-
     strategy:
       matrix:
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,22 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Need all commits and tags to find a reasonable version number
-      - name: Decide version number
-        id: get-product-version
+      - name: Git Describe
+        id: git-describe
         run: |
           git describe --first-parent
-          echo "::set-output name=product-version::$(git describe --first-parent)"
+          echo "::set-output name=raw-version::$(git describe --first-parent)"
+      - name: Decide version number
+        id: get-product-version
+        shell: bash
+        env:
+          RAW_VERSION: ${{ steps.git-describe.outputs.raw-version }}
+        run: |
+          echo "::set-output name=product-version::${RAW_VERSION#v}"
+      - name: Report chosen version number
+        run: |
+          [ -n "${{steps.get-product-version.outputs.product-version}}" ]
+          echo "::notice title=Terraform CLI Version::${{ steps.get-product-version.outputs.product-version }}"
 
   get-go-version:
     name: "Determine Go toolchain version"
@@ -207,3 +218,195 @@ jobs:
           tags: |
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
             986891699432.dkr.ecr.us-east-1.amazonaws.com/hashicorp/${{env.repo}}:${{env.version}}
+
+  e2etest-build:
+    name: Build e2etest for ${{ matrix.goos }}_${{ matrix.goarch }}
+    needs: ["get-go-version"]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # We build test harnesses only for the v1.0 Compatibility Promises
+        # supported platforms. Even within that set, we can only run on
+        # architectures for which we have GitHub Actions runners available,
+        # which is currently only amd64 (x64).
+        # TODO: GitHub Actions does support _self-hosted_ arm and arm64
+        # runners, so we could potentially run some ourselves to run our
+        # tests there, but at the time of writing there is no documented
+        # support for darwin_arm64 (macOS on Apple Silicon).
+        include:
+          - {goos: "darwin", goarch: "amd64"}
+          #- {goos: "darwin", goarch: "arm64"}
+          - {goos: "windows", goarch: "amd64"}
+          - {goos: "linux", goarch: "amd64"}
+          #- {goos: "linux", goarch: "arm"}
+          #- {goos: "linux", goarch: "arm64"}
+      fail-fast: false
+
+    env:
+      build_script: ./internal/command/e2etest/make-archive.sh
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Go toolchain
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+
+      - name: Build test harness package
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          bash ./internal/command/e2etest/make-archive.sh
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: terraform-e2etest_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: internal/command/e2etest/build/terraform-e2etest_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          if-no-files-found: error
+
+  e2etest-linux:
+    name: e2etest for linux_${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    needs:
+      - get-product-version
+      - build
+      - e2etest-build
+
+    strategy:
+      matrix:
+        include:
+          - {goarch: "amd64"}
+          #- {goarch: "arm64"}
+          #- {goarch: "arm"}
+      fail-fast: false
+
+    env:
+      os: linux
+      arch: ${{ matrix.goarch }}
+      version: ${{needs.get-product-version.outputs.product-version}}
+
+    steps:
+      # NOTE: This intentionally _does not_ check out the source code
+      # for the commit/tag we're building, because by now we should
+      # have everything we need in the combination of CLI release package
+      # and e2etest package for this platform. (This helps ensure that we're
+      # really testing the release package and not inadvertently testing a
+      # fresh build from source.)
+      - name: "Download e2etest package"
+        uses: actions/download-artifact@v2
+        id: e2etestpkg
+        with:
+          name: terraform-e2etest_${{ env.os }}_${{ env.arch }}.zip
+          path: .
+      - name: "Download Terraform CLI package"
+        uses: actions/download-artifact@v2
+        id: clipkg
+        with:
+          name: terraform_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip
+          path: .
+      - name: Extract packages
+        run: |
+          unzip "./terraform-e2etest_${{ env.os }}_${{ env.arch }}.zip"
+          unzip "./terraform_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip"
+      - name: Run E2E Tests
+        run: |
+          TF_ACC=1 ./e2etest -test.v
+
+  e2etest-darwin:
+    name: e2etest for darwin_${{ matrix.goarch }}
+    runs-on: macos-latest
+    needs:
+      - get-product-version
+      - build-darwin
+      - e2etest-build
+
+    strategy:
+      matrix:
+        include:
+          - {goarch: "amd64"}
+          #- {goarch: "arm64"}
+      fail-fast: false
+
+    env:
+      os: darwin
+      arch: ${{ matrix.goarch }}
+      version: ${{needs.get-product-version.outputs.product-version}}
+
+    steps:
+      # NOTE: This intentionally _does not_ check out the source code
+      # for the commit/tag we're building, because by now we should
+      # have everything we need in the combination of CLI release package
+      # and e2etest package for this platform. (This helps ensure that we're
+      # really testing the release package and not inadvertently testing a
+      # fresh build from source.)
+      - name: "Download e2etest package"
+        uses: actions/download-artifact@v2
+        id: e2etestpkg
+        with:
+          name: terraform-e2etest_${{ env.os }}_${{ env.arch }}.zip
+          path: .
+      - name: "Download Terraform CLI package"
+        uses: actions/download-artifact@v2
+        id: clipkg
+        with:
+          name: terraform_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip
+          path: .
+      - name: Extract packages
+        run: |
+          unzip "./terraform-e2etest_${{ env.os }}_${{ env.arch }}.zip"
+          unzip "./terraform_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip"
+      - name: Run E2E Tests
+        run: |
+          TF_ACC=1 ./e2etest -test.v
+
+  e2etest-windows:
+    name: e2etest for windows_${{ matrix.goarch }}
+    runs-on: windows-latest
+    needs:
+      - get-product-version
+      - build
+      - e2etest-build
+
+    strategy:
+      matrix:
+        include:
+          - {goarch: "amd64"}
+      fail-fast: false
+
+    env:
+      os: windows
+      arch: ${{ matrix.goarch }}
+      version: ${{needs.get-product-version.outputs.product-version}}
+
+    steps:
+      # NOTE: This intentionally _does not_ check out the source code
+      # for the commit/tag we're building, because by now we should
+      # have everything we need in the combination of CLI release package
+      # and e2etest package for this platform. (This helps ensure that we're
+      # really testing the release package and not inadvertently testing a
+      # fresh build from source.)
+      - name: "Download e2etest package"
+        uses: actions/download-artifact@v2
+        id: e2etestpkg
+        with:
+          name: terraform-e2etest_${{ env.os }}_${{ env.arch }}.zip
+          path: .
+      - name: "Download Terraform CLI package"
+        uses: actions/download-artifact@v2
+        id: clipkg
+        with:
+          name: terraform_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip
+          path: .
+      - name: Extract packages
+        shell: pwsh
+        run: |
+          Expand-Archive -LiteralPath 'terraform-e2etest_${{ env.os }}_${{ env.arch }}.zip' -DestinationPath '.'
+          Expand-Archive -LiteralPath 'terraform_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip' -DestinationPath '.'
+      - name: Run E2E Tests
+        env:
+          TF_ACC: 1
+        shell: cmd
+        run: |
+          e2etest.exe -test.v

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -410,3 +410,26 @@ jobs:
         shell: cmd
         run: |
           e2etest.exe -test.v
+
+  docs-source-package:
+    name: "Build documentation bundle"
+    runs-on: ubuntu-latest
+    needs:
+      - get-product-version
+
+    env:
+      version: ${{needs.get-product-version.outputs.product-version}}
+
+    steps:
+      - uses: actions/checkout@v2
+      # FIXME: We should include some sort of pre-validation step here, to
+      # confirm that the doc content is mechanically valid so that the
+      # publishing pipeline will be able to render all content without errors.
+      - name: "Create documentation source bundle"
+        run: |
+          (cd website && zip -9 -r ../terraform-cli-docs-source_${{ env.version }}.zip .)
+      - uses: actions/upload-artifact@v2
+        with:
+          name: terraform-cli-docs-source_${{ env.version }}.zip
+          path: terraform-cli-docs-source_${{ env.version }}.zip
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ on:
 env:
   PKG_NAME: "terraform"
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   get-product-version:
     name: "Determine intended Terraform version"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,10 +62,11 @@ jobs:
 
   generate-metadata-file:
     name: "Generate release metadata"
-    needs: get-product-version
     runs-on: ubuntu-latest
+    needs: get-product-version
     outputs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
+
     steps:
       - uses: actions/checkout@v2
       - name: Generate package metadata
@@ -81,26 +82,30 @@ jobs:
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
 
   build:
-    needs: ["get-product-version", "get-go-version"]
-    runs-on: ubuntu-latest
+    name: Build for ${{ matrix.goos }}_${{ matrix.goarch }}
+    runs-on: ${{ matrix.runson }}
+    needs:
+      - get-product-version
+      - get-go-version
+
     strategy:
       matrix:
         include:
-          - {goos: "freebsd", goarch: "386"}
-          - {goos: "freebsd", goarch: "amd64"}
-          - {goos: "freebsd", goarch: "arm"}
-          - {goos: "linux", goarch: "386"}
-          - {goos: "linux", goarch: "amd64"}
-          - {goos: "linux", goarch: "arm"}
-          - {goos: "linux", goarch: "arm64"}
-          - {goos: "openbsd", goarch: "386"}
-          - {goos: "openbsd", goarch: "amd64"}
-          - {goos: "solaris", goarch: "amd64"}
-          - {goos: "windows", goarch: "386"}
-          - {goos: "windows", goarch: "amd64"}
+          - {goos: "freebsd", goarch: "386", runson: "ubuntu-latest"}
+          - {goos: "freebsd", goarch: "amd64", runson: "ubuntu-latest"}
+          - {goos: "freebsd", goarch: "arm", runson: "ubuntu-latest"}
+          - {goos: "linux", goarch: "386", runson: "ubuntu-latest"}
+          - {goos: "linux", goarch: "amd64", runson: "ubuntu-latest"}
+          - {goos: "linux", goarch: "arm", runson: "ubuntu-latest"}
+          - {goos: "linux", goarch: "arm64", runson: "ubuntu-latest"}
+          - {goos: "openbsd", goarch: "386", runson: "ubuntu-latest"}
+          - {goos: "openbsd", goarch: "amd64", runson: "ubuntu-latest"}
+          - {goos: "solaris", goarch: "amd64", runson: "ubuntu-latest"}
+          - {goos: "windows", goarch: "386", runson: "ubuntu-latest"}
+          - {goos: "windows", goarch: "amd64", runson: "ubuntu-latest"}
+          - {goos: "darwin", goarch: "amd64", runson: "macos-latest"}
+          - {goos: "darwin", goarch: "arm64", runson: "macos-latest"}
       fail-fast: false
-
-    name: Build for ${{ matrix.goos }}_${{ matrix.goarch }}
 
     steps:
       - uses: actions/checkout@v2
@@ -110,13 +115,22 @@ jobs:
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
 
+      # FIXME: We're not currently setting the hard-coded version string in
+      # version/version.go at any point here, which means that the packages
+      # this process builds are not suitable for release. Once we're using
+      # Go 1.18 we may begin using the version information automatically
+      # embedded by the Go toolchain, at which point we won't need any
+      # special steps during build, but failing that we'll need to rework
+      # the version/version.go package so we can more readily update it
+      # using linker flags rather than direct code modification.
+
       - name: Build
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
           mkdir dist out
-          go build -o dist/ .
+          go build -ldflags "-w -s" -o dist/ .
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
 
       - uses: actions/upload-artifact@v2
@@ -145,6 +159,8 @@ jobs:
           echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
           echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
 
+      # FIXME: Generate homebrew packages when targeting macOS.
+
       - uses: actions/upload-artifact@v2
         if: ${{ matrix.goos == 'linux' }}
         with:
@@ -156,41 +172,6 @@ jobs:
         with:
           name: ${{ env.DEB_PACKAGE }}
           path: out/${{ env.DEB_PACKAGE }}
-
-  build-darwin:
-    needs: ["get-product-version", "get-go-version"]
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        include:
-          - {goos: "darwin", goarch: "amd64"}
-          - {goos: "darwin", goarch: "arm64"}
-      fail-fast: false
-
-    name: Build for ${{ matrix.goos }}_${{ matrix.goarch }}
-
-    env:
-      GOOS: ${{ matrix.goos }}
-      GOARCH: ${{ matrix.goarch }}
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install Go toolchain
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ needs.get-go-version.outputs.go-version }}
-
-      - name: Build
-        run: |
-          mkdir dist out
-          go build -o dist/
-          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
   build-docker:
     name: Build Docker image for linux_${{ matrix.arch }}
@@ -319,7 +300,7 @@ jobs:
     runs-on: macos-latest
     needs:
       - get-product-version
-      - build-darwin
+      - build
       - e2etest-build
 
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,209 @@
+name: Build Terraform CLI Packages
+
+# If you want to test changes to this file before merging to a main branch,
+# push them up to a branch whose name has the prefix "build-workflow-dev/",
+# which is a special prefix that triggers this workflow even though it's not
+# actually a release branch.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - 'v[0-9]+.[0-9]+'
+      - build-workflow-dev/*
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+env:
+  PKG_NAME: "terraform"
+
+jobs:
+  get-product-version:
+    name: "Determine intended Terraform version"
+    runs-on: ubuntu-latest
+    outputs:
+      product-version: ${{ steps.get-product-version.outputs.product-version }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Need all commits and tags to find a reasonable version number
+      - name: Decide version number
+        id: get-product-version
+        run: |
+          git describe --first-parent
+          echo "::set-output name=product-version::$(git describe --first-parent)"
+
+  get-go-version:
+    name: "Determine Go toolchain version"
+    runs-on: ubuntu-latest
+    outputs:
+      go-version: ${{ steps.get-go-version.outputs.go-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Determine Go version
+        id: get-go-version
+        # We use .go-version as our source of truth for current Go
+        # version, because "goenv" can react to it automatically.
+        run: |
+          echo "Building with Go $(cat .go-version)"
+          echo "::set-output name=go-version::$(cat .go-version)"
+
+  generate-metadata-file:
+    name: "Generate release metadata"
+    needs: get-product-version
+    runs-on: ubuntu-latest
+    outputs:
+      filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate package metadata
+        id: generate-metadata-file
+        uses: hashicorp/actions-generate-metadata@main
+        with:
+          version: ${{ needs.get-product-version.outputs.product-version }}
+          product: ${{ env.PKG_NAME }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: metadata.json
+          path: ${{ steps.generate-metadata-file.outputs.filepath }}
+
+  build:
+    needs: ["get-product-version", "get-go-version"]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - {goos: "freebsd", goarch: "386"}
+          - {goos: "freebsd", goarch: "amd64"}
+          - {goos: "freebsd", goarch: "arm"}
+          - {goos: "linux", goarch: "386"}
+          - {goos: "linux", goarch: "amd64"}
+          - {goos: "linux", goarch: "arm"}
+          - {goos: "linux", goarch: "arm64"}
+          - {goos: "openbsd", goarch: "386"}
+          - {goos: "openbsd", goarch: "amd64"}
+          - {goos: "solaris", goarch: "amd64"}
+          - {goos: "windows", goarch: "386"}
+          - {goos: "windows", goarch: "amd64"}
+      fail-fast: false
+
+    name: Build for ${{ matrix.goos }}_${{ matrix.goarch }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Go toolchain
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          mkdir dist out
+          go build -o dist/ .
+          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+
+      - name: Linux distribution packages
+        if: ${{ matrix.goos == 'linux' }}
+        uses: hashicorp/package@v1
+        with:
+          name: "terraform"
+          description: "Terraform enables you to safely and predictably create, change, and improve infrastructure. It is an open source tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned."
+          arch: ${{ matrix.goarch }}
+          version: ${{ needs.get-product-version.outputs.product-version }}
+          maintainer: "HashiCorp"
+          homepage: "https://terraform.io/"
+          license: "MPL-2.0"
+          binary: "dist/${{ env.PKG_NAME }}"
+          deb_depends: "git"
+          rpm_depends: "git"
+
+      - name: Gather Linux distribution package filenames
+        if: ${{ matrix.goos == 'linux' }}
+        run: |
+          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
+          echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ env.RPM_PACKAGE }}
+          path: out/${{ env.RPM_PACKAGE }}
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ env.DEB_PACKAGE }}
+          path: out/${{ env.DEB_PACKAGE }}
+
+  build-darwin:
+    needs: ["get-product-version", "get-go-version"]
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - {goos: "darwin", goarch: "amd64"}
+          - {goos: "darwin", goarch: "arm64"}
+      fail-fast: false
+
+    name: Build for ${{ matrix.goos }}_${{ matrix.goarch }}
+
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Go toolchain
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+
+      - name: Build
+        run: |
+          mkdir dist out
+          go build -o dist/
+          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+
+  build-docker:
+    name: Build Docker image for linux_${{ matrix.arch }}
+    needs:
+      - get-product-version
+      - build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["amd64"]
+      fail-fast: false
+    env:
+      repo: ${{github.event.repository.name}}
+      version: ${{needs.get-product-version.outputs.product-version}}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Docker images
+        uses: hashicorp/actions-docker-build@v1
+        with:
+          version: ${{env.version}}
+          target: default
+          arch: ${{matrix.arch}}
+          dockerfile: .github/workflows/build-Dockerfile
+          tags: |
+            docker.io/hashicorp/${{env.repo}}:${{env.version}}
+            986891699432.dkr.ecr.us-east-1.amazonaws.com/hashicorp/${{env.repo}}:${{env.version}}

--- a/internal/command/e2etest/main_test.go
+++ b/internal/command/e2etest/main_test.go
@@ -11,6 +11,18 @@ import (
 
 var terraformBin string
 
+// canRunGoBuild is a short-term compromise to account for the fact that we
+// have a small number of tests that work by building helper programs using
+// "go build" at runtime, but we can't do that in our isolated test mode
+// driven by the make-archive.sh script.
+//
+// FIXME: Rework this a bit so that we build the necessary helper programs
+// (test plugins, etc) as part of the initial suite setup, and in the
+// make-archive.sh script, so that we can run all of the tests in both
+// situations with the tests just using the executable already built for
+// them, as we do for terraformBin.
+var canRunGoBuild bool
+
 func TestMain(m *testing.M) {
 	teardown := setup()
 	code := m.Run()
@@ -21,10 +33,10 @@ func TestMain(m *testing.M) {
 func setup() func() {
 	if terraformBin != "" {
 		// this is pre-set when we're running in a binary produced from
-		// the make-archive.sh script, since that builds a ready-to-go
-		// binary into the archive. However, we do need to turn it into
-		// an absolute path so that we can find it when we change the
-		// working directory during tests.
+		// the make-archive.sh script, since that is for testing an
+		// executable obtained from a real release package. However, we do
+		// need to turn it into an absolute path so that we can find it
+		// when we change the working directory during tests.
 		var err error
 		terraformBin, err = filepath.Abs(terraformBin)
 		if err != nil {
@@ -37,6 +49,11 @@ func setup() func() {
 
 	// Make the executable available for use in tests
 	terraformBin = tmpFilename
+
+	// Tests running in the ad-hoc testing mode are allowed to use "go build"
+	// and similar to produce other test executables.
+	// (See the comment on this variable's declaration for more information.)
+	canRunGoBuild = true
 
 	return func() {
 		os.Remove(tmpFilename)

--- a/internal/command/e2etest/make-archive.sh
+++ b/internal/command/e2etest/make-archive.sh
@@ -13,9 +13,12 @@
 # and then executed as follows:
 #    set TF_ACC=1
 #    ./e2etest.exe
-# Since the test archive includes both the test fixtures and the compiled
-# terraform executable along with this test program, the result is
-# self-contained and does not require a local Go compiler on the target system.
+#
+# Because separated e2etest harnesses are intended for testing against "real"
+# release executables, the generated archives don't include a copy of
+# the Terraform executable. Instead, the caller of the tests must retrieve
+# and extract a release package into the working directory before running
+# the e2etest executable, so that "e2etest" can find and execute it.
 
 set +euo pipefail
 
@@ -32,10 +35,6 @@ mkdir -p "$OUTDIR"
 
 # We need the test fixtures available when we run the tests.
 cp -r testdata "$OUTDIR/testdata"
-
-# Bundle a copy of our binary so the target system doesn't need the go
-# compiler installed.
-go build -o "$OUTDIR/terraform$GOEXE" github.com/hashicorp/terraform
 
 # Build the test program
 go test -o "$OUTDIR/e2etest$GOEXE" -c -ldflags "-X github.com/hashicorp/terraform/internal/command/e2etest.terraformBin=./terraform$GOEXE" github.com/hashicorp/terraform/internal/command/e2etest

--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -204,13 +204,13 @@ func TestPrimaryChdirOption(t *testing.T) {
 	}
 
 	gotOutput := state.RootModule().OutputValues["cwd"]
-	wantOutputValue := cty.StringVal(tf.Path()) // path.cwd returns the original path, because path.root is how we get the overridden path
+	wantOutputValue := cty.StringVal(filepath.ToSlash(tf.Path())) // path.cwd returns the original path, because path.root is how we get the overridden path
 	if gotOutput == nil || !wantOutputValue.RawEquals(gotOutput.Value) {
 		t.Errorf("incorrect value for cwd output\ngot: %#v\nwant Value: %#v", gotOutput, wantOutputValue)
 	}
 
 	gotOutput = state.RootModule().OutputValues["root"]
-	wantOutputValue = cty.StringVal(tf.Path("subdir")) // path.root is a relative path, but the text fixture uses abspath on it.
+	wantOutputValue = cty.StringVal(filepath.ToSlash(tf.Path("subdir"))) // path.root is a relative path, but the text fixture uses abspath on it.
 	if gotOutput == nil || !wantOutputValue.RawEquals(gotOutput.Value) {
 		t.Errorf("incorrect value for root output\ngot: %#v\nwant Value: %#v", gotOutput, wantOutputValue)
 	}

--- a/internal/command/e2etest/provider_dev_test.go
+++ b/internal/command/e2etest/provider_dev_test.go
@@ -18,6 +18,14 @@ import (
 // we normally do, so they can just overwrite the same local executable
 // in-place to iterate faster.
 func TestProviderDevOverrides(t *testing.T) {
+	if !canRunGoBuild {
+		// We're running in a separate-build-then-run context, so we can't
+		// currently execute this test which depends on being able to build
+		// new executable at runtime.
+		//
+		// (See the comment on canRunGoBuild's declaration for more information.)
+		t.Skip("can't run without building a new provider executable")
+	}
 	t.Parallel()
 
 	tf := e2e.NewBinary(terraformBin, "testdata/provider-dev-override")

--- a/internal/command/e2etest/provider_plugin_test.go
+++ b/internal/command/e2etest/provider_plugin_test.go
@@ -13,6 +13,14 @@ import (
 // TestProviderProtocols verifies that Terraform can execute provider plugins
 // with both supported protocol versions.
 func TestProviderProtocols(t *testing.T) {
+	if !canRunGoBuild {
+		// We're running in a separate-build-then-run context, so we can't
+		// currently execute this test which depends on being able to build
+		// new executable at runtime.
+		//
+		// (See the comment on canRunGoBuild's declaration for more information.)
+		t.Skip("can't run without building a new provider executable")
+	}
 	t.Parallel()
 
 	tf := e2e.NewBinary(terraformBin, "testdata/provider-plugin")

--- a/internal/command/e2etest/providers_tamper_test.go
+++ b/internal/command/e2etest/providers_tamper_test.go
@@ -41,11 +41,15 @@ func TestProviderTampering(t *testing.T) {
 
 	seedDir := tf.WorkDir()
 	const providerVersion = "3.1.0" // must match the version in the fixture config
-	pluginDir := ".terraform/providers/registry.terraform.io/hashicorp/null/" + providerVersion + "/" + getproviders.CurrentPlatform.String()
-	pluginExe := pluginDir + "/terraform-provider-null_v" + providerVersion + "_x5"
+	pluginDir := filepath.Join(".terraform", "providers", "registry.terraform.io", "hashicorp", "null", providerVersion, getproviders.CurrentPlatform.String())
+	pluginExe := filepath.Join(pluginDir, "terraform-provider-null_v"+providerVersion+"_x5")
 	if getproviders.CurrentPlatform.OS == "windows" {
 		pluginExe += ".exe" // ugh
 	}
+
+	// filepath.Join here to make sure we get the right path separator
+	// for whatever OS we're running these tests on.
+	providerCacheDir := filepath.Join(".terraform", "providers")
 
 	t.Run("cache dir totally gone", func(t *testing.T) {
 		tf := e2e.NewBinary(terraformBin, seedDir)
@@ -61,7 +65,7 @@ func TestProviderTampering(t *testing.T) {
 		if err == nil {
 			t.Fatalf("unexpected plan success\nstdout:\n%s", stdout)
 		}
-		if want := `registry.terraform.io/hashicorp/null: there is no package for registry.terraform.io/hashicorp/null 3.1.0 cached in .terraform/providers`; !strings.Contains(stderr, want) {
+		if want := `registry.terraform.io/hashicorp/null: there is no package for registry.terraform.io/hashicorp/null 3.1.0 cached in ` + providerCacheDir; !strings.Contains(stderr, want) {
 			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
 		}
 		if want := `terraform init`; !strings.Contains(stderr, want) {
@@ -128,7 +132,7 @@ func TestProviderTampering(t *testing.T) {
 		if err == nil {
 			t.Fatalf("unexpected plan success\nstdout:\n%s", stdout)
 		}
-		if want := `registry.terraform.io/hashicorp/null: the cached package for registry.terraform.io/hashicorp/null 3.1.0 (in .terraform/providers) does not match any of the checksums recorded in the dependency lock file`; !strings.Contains(stderr, want) {
+		if want := `registry.terraform.io/hashicorp/null: the cached package for registry.terraform.io/hashicorp/null 3.1.0 (in ` + providerCacheDir + `) does not match any of the checksums recorded in the dependency lock file`; !strings.Contains(stderr, want) {
 			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
 		}
 		if want := `terraform init`; !strings.Contains(stderr, want) {
@@ -237,7 +241,7 @@ func TestProviderTampering(t *testing.T) {
 		if err == nil {
 			t.Fatalf("unexpected apply success\nstdout:\n%s", stdout)
 		}
-		if want := `registry.terraform.io/hashicorp/null: there is no package for registry.terraform.io/hashicorp/null 3.1.0 cached in .terraform/providers`; !strings.Contains(stderr, want) {
+		if want := `registry.terraform.io/hashicorp/null: there is no package for registry.terraform.io/hashicorp/null 3.1.0 cached in ` + providerCacheDir; !strings.Contains(stderr, want) {
 			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
 		}
 	})
@@ -260,7 +264,7 @@ func TestProviderTampering(t *testing.T) {
 		if err == nil {
 			t.Fatalf("unexpected apply success\nstdout:\n%s", stdout)
 		}
-		if want := `registry.terraform.io/hashicorp/null: the cached package for registry.terraform.io/hashicorp/null 3.1.0 (in .terraform/providers) does not match any of the checksums recorded in the dependency lock file`; !strings.Contains(stderr, want) {
+		if want := `registry.terraform.io/hashicorp/null: the cached package for registry.terraform.io/hashicorp/null 3.1.0 (in ` + providerCacheDir + `) does not match any of the checksums recorded in the dependency lock file`; !strings.Contains(stderr, want) {
 			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
 		}
 	})

--- a/internal/command/e2etest/provisioner_plugin_test.go
+++ b/internal/command/e2etest/provisioner_plugin_test.go
@@ -12,6 +12,14 @@ import (
 // TestProvisionerPlugin is a test that terraform can execute a 3rd party
 // provisioner plugin.
 func TestProvisionerPlugin(t *testing.T) {
+	if !canRunGoBuild {
+		// We're running in a separate-build-then-run context, so we can't
+		// currently execute this test which depends on being able to build
+		// new executable at runtime.
+		//
+		// (See the comment on canRunGoBuild's declaration for more information.)
+		t.Skip("can't run without building a new provisioner executable")
+	}
 	t.Parallel()
 
 	// This test reaches out to releases.hashicorp.com to download the


### PR DESCRIPTION
This introduces a new process, based on GitHub Actions, for producing the various release artifacts for Terraform CLI.

The _ultimate_ goal here is for this workflow to build all of the artifacts needed to drive the Terraform CLI release process, so that the actual release process (maintained elsewhere) could consume these artifacts directly and no longer need to access the actual repository content, which in turn means that we can verify all of the artifacts before optionally launching the separate release process. The intended workflow then would be to first have this workflow build on the release branch, then once it's succeeded create a tag from the same commit to produce a releasable build. The branch build will have a synthetic version number including the commit ID, while the _tag_ build would reflect the version number indicated in the tag.

However, **for now my goals here are more modest**: just to get a new process in place which will give us earlier warning if anything merged to a release branch or included in a tagged version has any build problems. No automated process is actually consuming the results of this for now, and I expect we'll iterate more on this workflow once we're ready to integrate this with a new release process. Which is to say: _there are some known and documented limitations here_, which we'll hopefully address in later commits, but which are not in scope for this PR.

The effect of merging this will be that any future merges to a release branch or to the `main` branch will trigger a full build for all of our target platforms, including the construction of the various "wrapper package" types our official process produces (Deb packages, RPM packages, Docker Images). It will then run the end-to-end tests against the `linux_amd64`, `darwin_amd64`, and `windows_amd64` packages, which should increase our confidence that we built generally-working packages across those three platforms.

Given that, I'd like to merge this to get that relatively-minor benefit for now and also to get some experience with the behavior of this workflow in advance of us integrating it with the rest of the release process. In particular, we'll be able to see how it behaves in our _real_ workflow with release branches and tagging, whereas so far I've only been able to test it on this development branch.

---

Because for the moment we will not actually be releasing the packages built by this process (we'll continue to release the artifacts produced by the non-public release workflow as part of releasing), this doesn't technically assure us that the _released_ packages would also pass the e2etests once built, but in practice the build process here is similar enough to the one the real release process uses that it should still serve as a good early warning signal.

The later work to integrate this with a new release process that actually _consumes_ all of these artifacts will be in closer collaboration with the release engineering team and I expect it will result in at least some small changes to the details of how this works, so we can make sure this is producing artifacts in a suitable shape for the standard release process. However, for my part I did derive this from the build process templates provided from the release engineering team, and referred to the corresponding internal documentation, and so I believe it should already be broadly compatible with those assumptions and only require minor tweaks later.

---

Although this PR doesn't modify any "real" Terraform code, it does include some adjustments to the `internal/command/e2etest` package to make it ready to support the separate build run approach used by this workflow. This separation between building the test harness and running it was an original intention of the e2etest design, to allow us to be sure that we're really testing the actual release executable and not a fresh build from source, but we previously didn't end up actually using it in that mode and so that capability has "bitrotted" a bit over the last few years.

In particular, we introduced a few new tests that expect to be able to build new executables from source _during the test run_, which is counter to the original idea of a test suite we can run against pre-built executables. As a compromise for now I've just made the test harness skip over those tests when running in this mode, since we'll still get those run _on Linux_ during the normal pull request check process. In a later commit I'd like to adjust this slightly so that the `make_archive.sh` script _also_ includes the needed supporting executables and thus we'll be able to make the separate test harness run the full test suite as originally intended.

---

You can preview the effect of this workflow by viewing [the Actions runs generated from this workflow on this development branch](https://github.com/hashicorp/terraform/actions/workflows/build.yml?query=branch%3Abuild-workflow-dev%2Fmatkins-initial), though I believe you'll need to be a maintainer in this repository in order to be able to actually download the built artifacts.

Note that there's a quirk in the GitHub Actions UI whereby any artifact you download is always wrapped in a `.zip` archive container, _even if the artifact itself is a `.zip` file_. That's kinda annoying for the various `.zip` packages we produce here, but is an expected part of how GitHub Actions works and doesn't really hurt for our final intended use because the GitHub Actions steps for consuming these artifacts downstream automatically unpacks the outer wrapping archive to reveal the _real_ `.zip` file inside. This extra level of wrapping is actually important because GitHub Actions's _own_ packaging cannot preserve file permissions, and so the extra inner `.zip` file we produced ourselves can preserve the executable permission on the `terraform` executable.

