### PR TITLE
dags: fix BasicEdge pointer issue

### DIFF
--- a/internal/dag/edge.go
+++ b/internal/dag/edge.go
@@ -1,9 +1,5 @@
 package dag
 
-import (
-	"fmt"
-)
-
 // Edge represents an edge in the graph, with a source and target vertex.
 type Edge interface {
 	Source() Vertex
@@ -25,7 +21,7 @@ type basicEdge struct {
 }
 
 func (e *basicEdge) Hashcode() interface{} {
-	return fmt.Sprintf("%p-%p", e.S, e.T)
+	return [...]interface{}{e.S, e.T}
 }
 
 func (e *basicEdge) Source() Vertex {


### PR DESCRIPTION
When creating a `Set` of `BasicEdge`s, the `Hashcode()` function is used to determine map keys for the underlying set data structure.

The string hex representation of the two vertices' pointers is unsafe to use as a map key, since these addresses may change between the time they are added to the set and the time the set is operated on.

Instead we modify the `Hashcode()` function to maintain the references to the underlying vertices so they cannot be garbage collected during the lifetime of the `Set`.

N.B. Testing of this PR is discussed elsewhere. I'm not sure if it is possible to create a unit test to demonstrate the undesirable behaviour.