### PR TITLE
build: CGO_ENABLED when building for macOS in our experimental new build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,8 +147,17 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          ACTIONSOS: ${{ matrix.runson }}
         run: |
           mkdir dist out
+          if [ "$ACTIONSOS" == "macos-latest" ] && [ "$GOOS" == "darwin" ]; then
+            # When building for macOS _on_ macOS we must force CGo to get
+            # correct hostname resolution behavior. (This must be conditional
+            # because other cross-compiles won't have suitable headers
+            # available to use CGo; darwin_amd64 has suitable headers to
+            # cross-build for darwin_arm64.)
+            export CGO_ENABLED=1
+          fi
           go build -ldflags "-w -s" -o dist/ .
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
 


### PR DESCRIPTION
Normally when we cross-compile we do so without CGo (the Go toolchain's default), because we don't have suitable C headers available for systems other than the host.

However, building for macOS on macOS is special because there are sufficient headers available on darwin_amd64 to build for both darwin_amd64 _and_ darwin_arm64. Also, we _must_ use CGo on macOS because the system resolver is only available via darwin's libc, and so building without CGo produces executables that don't resolve hostnames correctly. (golang/go#12524)

This is a conditional in bash to avoid having to duplicate the entire step. Perhaps later we'll find a more general version of this which can avoid the special case, but this is sufficient for the moment.

(Please note that this workflow is currently only used for development feedback and is not yet part of the official release pipeline that produces the packages available from our main download page. Therefore this won't have any material impact on the official release packages, which currently have incorrect hostname resolution behavior on `darwin_arm64` due to there not being equivalent logic to this in the active release process. That'll need fixing elsewhere, if we don't adopt these packages as input into the real release process in the near future, but that's out of scope for this change.)
