### PR TITLE
Cloud: Respect State Version Outputs Permission

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-retryablehttp v0.7.0
-	github.com/hashicorp/go-tfe v0.21.0
+	github.com/hashicorp/go-tfe v0.24.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ github.com/hashicorp/go-slug v0.7.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
-github.com/hashicorp/go-tfe v0.21.0 h1:P1QoeLkigDi4BXGQ//42kyXwfcHUqbh5jJemml6iQJs=
-github.com/hashicorp/go-tfe v0.21.0/go.mod h1:gyXLXbpBVxA2F/6opah8XBsOkZJxHYQmghl0OWi8keI=
+github.com/hashicorp/go-tfe v0.24.0 h1:7RyYTafFXGN6I6ayASJOpw6pARtKKSPdA9KRiovKQRM=
+github.com/hashicorp/go-tfe v0.24.0/go.mod h1:gyXLXbpBVxA2F/6opah8XBsOkZJxHYQmghl0OWi8keI=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -437,6 +437,14 @@ func (b *Cloud) retryLogHook(attemptNum int, resp *http.Response) {
 	}
 }
 
+func (b *Cloud) Workspace(name string) (*tfe.Workspace, error) {
+	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, name)
+	if err != nil {
+		return nil, err
+	}
+	return workspace, nil
+}
+
 // Workspaces implements backend.Enhanced, returning a filtered list of workspace names according to
 // the workspace mapping strategy configured.
 func (b *Cloud) Workspaces() ([]string, error) {
@@ -517,7 +525,7 @@ func (b *Cloud) StateMgr(name string) (statemgr.Full, error) {
 		return nil, backend.ErrWorkspacesNotSupported
 	}
 
-	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, name)
+	workspace, err := b.Workspace(name)
 	if err != nil && err != tfe.ErrResourceNotFound {
 		return nil, fmt.Errorf("Failed to retrieve workspace %s: %v", name, err)
 	}
@@ -604,7 +612,7 @@ func (b *Cloud) Operation(ctx context.Context, op *backend.Operation) (*backend.
 	name := op.Workspace
 
 	// Retrieve the workspace for this operation.
-	w, err := b.client.Workspaces.Read(ctx, b.organization, name)
+	w, err := b.Workspace(name)
 	if err != nil {
 		switch err {
 		case context.Canceled:

--- a/internal/cloud/backend_apply_test.go
+++ b/internal/cloud/backend_apply_test.go
@@ -966,7 +966,7 @@ func TestCloud_applyLockTimeout(t *testing.T) {
 	ctx := context.Background()
 
 	// Retrieve the workspace used to run this operation in.
-	w, err := b.client.Workspaces.Read(ctx, b.organization, b.WorkspaceMapping.Name)
+	w, err := b.Workspace(b.WorkspaceMapping.Name)
 	if err != nil {
 		t.Fatalf("error retrieving workspace: %v", err)
 	}

--- a/internal/cloud/backend_common.go
+++ b/internal/cloud/backend_common.go
@@ -87,7 +87,7 @@ func (b *Cloud) waitForRun(stopCtx, cancelCtx context.Context, op *backend.Opera
 			}
 
 			// Retrieve the workspace used to run this operation in.
-			w, err = b.client.Workspaces.Read(stopCtx, b.organization, w.Name)
+			w, err = b.Workspace(w.Name)
 			if err != nil {
 				return nil, generalError("Failed to retrieve workspace", err)
 			}

--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -150,7 +150,7 @@ func (b *Cloud) getRemoteWorkspace(ctx context.Context, localWorkspaceName strin
 	remoteWorkspaceName := b.getRemoteWorkspaceName(localWorkspaceName)
 
 	log.Printf("[TRACE] cloud: looking up workspace for %s/%s", b.organization, remoteWorkspaceName)
-	remoteWorkspace, err := b.client.Workspaces.Read(ctx, b.organization, remoteWorkspaceName)
+	remoteWorkspace, err := b.Workspace(remoteWorkspaceName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cloud/backend_plan_test.go
+++ b/internal/cloud/backend_plan_test.go
@@ -695,7 +695,7 @@ func TestCloud_planLockTimeout(t *testing.T) {
 	ctx := context.Background()
 
 	// Retrieve the workspace used to run this operation in.
-	w, err := b.client.Workspaces.Read(ctx, b.organization, b.WorkspaceMapping.Name)
+	w, err := b.Workspace(b.WorkspaceMapping.Name)
 	if err != nil {
 		t.Fatalf("error retrieving workspace: %v", err)
 	}

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -369,7 +369,7 @@ func TestCloud_setUnavailableTerraformVersion(t *testing.T) {
 	// happens when a workspace gets created. This is why we can't use "name" in
 	// the backend config above, btw: if you do, testBackend() creates the default
 	// workspace before we get a chance to do anything.
-	_, err := b.client.Workspaces.Read(context.Background(), b.organization, workspaceName)
+	_, err := b.Workspace(workspaceName)
 	if err != tfe.ErrResourceNotFound {
 		t.Fatalf("the workspace we were about to try and create (%s/%s) already exists in the mocks somehow, so this test isn't trustworthy anymore", b.organization, workspaceName)
 	}
@@ -379,7 +379,7 @@ func TestCloud_setUnavailableTerraformVersion(t *testing.T) {
 		t.Fatalf("expected no error from StateMgr, despite not being able to set remote Terraform version: %#v", err)
 	}
 	// Make sure the workspace was created:
-	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, workspaceName)
+	workspace, err := b.Workspace(workspaceName)
 	if err != nil {
 		t.Fatalf("b.StateMgr() didn't actually create the desired workspace")
 	}

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform/internal/cloud"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/states"
@@ -73,6 +74,32 @@ func (c *OutputCommand) Outputs(statePath string) (map[string]*states.OutputValu
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Error selecting workspace: %s", err))
 		return nil, diags
+	}
+
+	// See if we are using the Cloud backend
+	cloud, cloudOk := b.(*cloud.Cloud)
+	if cloudOk {
+		workspace, err := cloud.Workspace(env)
+		if err != nil {
+			diags = diags.Append(fmt.Errorf("Failed to load workspace: %s", err))
+			return nil, diags
+		}
+		stateVersionOutputs, err := cloud.StateVersionOutputs(workspace.CurrentStateVersion.ID)
+		if err != nil {
+			diags = diags.Append(fmt.Errorf("Failed to load state version outputs: %s", err))
+			return nil, diags
+		}
+
+		// Convert the state version outputs to map[string]OutputValue
+		rootModule := states.NewState().RootModule()
+		for name, output := range stateVersionOutputs.Outputs {
+			rootModule.SetOutputValue(
+				name,
+				output.Value,
+				output.Sensitive,
+			)
+		}
+		return rootModule.OutputValues, diags
 	}
 
 	// Get the state


### PR DESCRIPTION
This fixes an issue for users using the cloud backend when running `terraform output`. When a user/team has the *read outputs only* permission for state versions they were not able to read the outputs. This recognizes that you're using the cloud backend and then calls the TFC Workspace API with `include=outputs` to get the state version outputs.

I created some helper methods to call the workspace API so that logic can live in the cloud backend. That necessitated small changes in a handful of files to use the new helper method.