### PR TITLE
handle variable evaluation in one location

### DIFF
--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -110,6 +110,11 @@ func (c *Context) Plan(config *configs.Config, prevRunState *states.State, opts 
 	// includes language asking the user to report a bug.
 	varDiags := checkInputVariables(config.Module.Variables, variables)
 	diags = diags.Append(varDiags)
+	if diags.HasErrors() {
+		// We can't plan anything with values missing entirely, so let the user
+		// know which variables must be set as early as possible.
+		return nil, diags
+	}
 
 	if len(opts.Targets) > 0 {
 		diags = diags.Append(tfdiags.Sourceless(

--- a/internal/terraform/context_validate_test.go
+++ b/internal/terraform/context_validate_test.go
@@ -314,6 +314,8 @@ func TestContext2Validate_countVariableNoDefault(t *testing.T) {
 	})
 	assertNoDiagnostics(t, diags)
 
+	// This is a type of validation which happens during plan, since there are
+	// no variables values during actual validation.
 	_, diags = c.Plan(m, nil, &PlanOpts{})
 	if !diags.HasErrors() {
 		// Error should be: The input variable "foo" has not been assigned a value.
@@ -2082,6 +2084,39 @@ output "out" {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
+
+	diags := ctx.Validate(m)
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+}
+
+func TestContext2Validate_nonNullableVariableDefaultValidation(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "first" {
+  source = "./mod"
+  input = null
+}
+`,
+
+		"mod/main.tf": `
+variable "input" {
+  type        = string
+  default     = "default"
+  nullable    = false
+
+  // Validation expressions should receive the default with nullable=false and
+  // a null input.
+  validation {
+    condition     = var.input != null
+    error_message = "Input cannot be null!"
+  }
+}
+`,
+	})
+
+	ctx := testContext2(t, &ContextOpts{})
 
 	diags := ctx.Validate(m)
 	if diags.HasErrors() {

--- a/internal/terraform/transform_module_variable.go
+++ b/internal/terraform/transform_module_variable.go
@@ -3,7 +3,6 @@ package terraform
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
@@ -94,13 +93,6 @@ func (t *ModuleVariableTransformer) transformSingle(g *Graph, parent, c *configs
 		var expr hcl.Expression
 		if attr := content.Attributes[v.Name]; attr != nil {
 			expr = attr.Expr
-		} else {
-			// No expression provided for this variable, so we'll make a
-			// synthetic one using the variable's default value.
-			expr = &hclsyntax.LiteralValueExpr{
-				Val:      v.Default,
-				SrcRange: v.DeclRange, // This is not exact, but close enough
-			}
 		}
 
 		// Add a plannable node, as the variable may expand


### PR DESCRIPTION
Module variable evaluation was spread out over 3 locations, which led to
a skew in what value could be seen within a module, and what value could
be seen within a variable's own validation scope.

First, the graph transformer would create a fake input expression on the
fly for variables with no input, and load it with the default value.
This caused trouble during actual evaluation where the input expression
would be mapped to the wrong source location, and made it difficult to
determine if an input value was really assigned or not.

The variables nodes would then evaluate the expression, but not be able
to handle defaults, because there always appeared to be an input
expression set for the variable. Because defaults could not be handled,
the wrong value could be passed into the validation expressions for the
variable.

GetInputVariable from the evaluator would check again for defaults, but
was usually fooled by the fake expression value. Even when it could
assign a default, as in the case of `nullable=false` with a null input,
it was already too late for the variable validation block to handle it.

We can unify all evaluation handling into the nodeModuleVaraible exec
node. This way the context is always loaded with the correct final value
of the variable, so GetInputVariable is only concerned with fetching
that value to evaluate references to it, and the graph transformer is
taken out of the picture entirely.

Due to the possibility of uncovering other bugs while refactoring variable evaluation, this won't be backported to v1.1, however a more localized fix may be possible to mitigate the incorrect validation values.

Fixes #30307