### PR TITLE
Fix autocomplete for workspace subcommands

### DIFF
--- a/internal/command/autocomplete.go
+++ b/internal/command/autocomplete.go
@@ -19,11 +19,7 @@ var completePredictModuleSource = complete.PredictAnything
 type completePredictSequence []complete.Predictor
 
 func (s completePredictSequence) Predict(a complete.Args) []string {
-	// Only one level of command is stripped off the prefix of a.Completed
-	// here, so nested subcommands like "workspace new" will need to provide
-	// dummy entries (e.g. complete.PredictNothing) as placeholders for
-	// all but the first subcommand. For example, "workspace new" needs
-	// one placeholder for the argument "new".
+	// Nested subcommands do not require any placeholder entry for their subcommand name.
 	idx := len(a.Completed)
 	if idx >= len(s) {
 		return nil

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -190,7 +190,6 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 
 func (c *WorkspaceDeleteCommand) AutocompleteArgs() complete.Predictor {
 	return completePredictSequence{
-		complete.PredictNothing, // the "select" subcommand itself (already matched)
 		c.completePredictWorkspaceName(),
 		complete.PredictDirs(""),
 	}

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -167,7 +167,6 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 
 func (c *WorkspaceNewCommand) AutocompleteArgs() complete.Predictor {
 	return completePredictSequence{
-		complete.PredictNothing, // the "new" subcommand itself (already matched)
 		complete.PredictAnything,
 		complete.PredictDirs(""),
 	}

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -117,7 +117,6 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 
 func (c *WorkspaceSelectCommand) AutocompleteArgs() complete.Predictor {
 	return completePredictSequence{
-		complete.PredictNothing, // the "select" subcommand itself (already matched)
 		c.completePredictWorkspaceName(),
 		complete.PredictDirs(""),
 	}


### PR DESCRIPTION
Fixes #30193 crash caused by nil pointer exception. It seems the autocomplete entry for the subcommand name itself was unnecessary and was crashing terraform. It has been removed.