### PR TITLE
Handle null variable input with nullable=false

### DIFF
--- a/internal/terraform/context_validate_test.go
+++ b/internal/terraform/context_validate_test.go
@@ -2088,3 +2088,36 @@ output "out" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 }
+
+func TestContext2Validate_nonNullableVariableDefaultValidation(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+ module "first" {
+   source = "./mod"
+   input = null
+ }
+ `,
+
+		"mod/main.tf": `
+ variable "input" {
+   type        = string
+   default     = "default"
+   nullable    = false
+
+   // Validation expressions should receive the default with nullable=false and
+   // a null input.
+   validation {
+     condition     = var.input != null
+     error_message = "Input cannot be null!"
+   }
+ }
+ `,
+	})
+
+	ctx := testContext2(t, &ContextOpts{})
+
+	diags := ctx.Validate(m)
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+}


### PR DESCRIPTION
v1.1 targeted fix for #30307. The variable handling has been overhauled in v1.2 already, but we want to head off any possible incorrect use of null variables slipping into validation when `nullable=false` in the variable configuration. The given test is already fixed in v1.2 by #29959.

Default values are currently being handled in two places, the graph
transformation where a synthetic default expression is created if there
was no input expression, and in the evaluator when a reference to the
variable is evaluated. Unfortunately neither of these covers the case
where a non-nullable variable default needs to be checked within a
validation statement

Rather than try and fix the overall variable handling here, which runs
the risk of encountering more unexpected behavior, we are going to fixup
this one case to ensure a null value doesn't continue to slip into
validation. A more extensive refactoring of variable handling has been
completed in v1.2, and this code will only be relevant for the v1.1
branch.

Fixes #30307