### PR TITLE
Fix broken links to external docs

### DIFF
--- a/website/docs/language/resources/provisioners/salt-masterless.mdx
+++ b/website/docs/language/resources/provisioners/salt-masterless.mdx
@@ -47,28 +47,26 @@ Optional:
   Docker builder, you will likely want to pass `true` since `sudo` is often not pre-installed.
 
 - `remote_pillar_roots` (string) - The path to your remote [pillar
-  roots](http://docs.saltstack.com/ref/configuration/master.html#pillar-configuration).
+  roots](https://docs.saltproject.io/en/latest/ref/configuration/master.html#pillar-configuration).
   default: `/srv/pillar`. This option cannot be used with `minion_config`.
 
 - `remote_state_tree` (string) - The path to your remote [state
-  tree](http://docs.saltstack.com/ref/states/highstate.html#the-salt-state-tree).
+  tree](https://docs.saltproject.io/en/latest/ref/states/highstate.html#the-salt-state-tree).
   default: `/srv/salt`. This option cannot be used with `minion_config`.
 
 - `local_pillar_roots` (string) - The path to your local [pillar
-  roots](http://docs.saltstack.com/ref/configuration/master.html#pillar-configuration).
+  roots](https://docs.saltproject.io/en/latest/ref/configuration/master.html#pillar-configuration).
   This will be uploaded to the `remote_pillar_roots` on the remote.
 
 - `local_state_tree` (string) - The path to your local [state
-  tree](http://docs.saltstack.com/ref/states/highstate.html#the-salt-state-tree).
+  tree](https://docs.saltproject.io/en/latest/ref/states/highstate.html#the-salt-state-tree).
   This will be uploaded to the `remote_state_tree` on the remote.
 
 - `custom_state` (string) - A state to be run instead of `state.highstate`.
   Defaults to `state.highstate` if unspecified.
 
 - `minion_config_file` (string) - The path to your local [minion config
-  file](http://docs.saltstack.com/ref/configuration/minion.html). This will be
-  uploaded to the `/etc/salt` on the remote. This option overrides the
-  `remote_state_tree` or `remote_pillar_roots` options.
+  file](https://docs.saltproject.io/en/latest/ref/configuration/minion.html). This will be uploaded to the `/etc/salt` on the remote. This option overrides the `remote_state_tree` or `remote_pillar_roots` options.
 
 - `skip_bootstrap` (boolean) - By default the salt provisioner runs [salt
   bootstrap](https://github.com/saltstack/salt-bootstrap) to install salt. Set
@@ -83,7 +81,7 @@ Optional:
 - `log_level` (string) - Set the logging level for the `salt-call` run.
 
 - `salt_call_args` (string) - Additional arguments to pass directly to `salt-call`. See
-  [salt-call](https://docs.saltstack.com/ref/cli/salt-call.html) documentation for more
+  [salt-call](https://docs.saltproject.io/en/latest/ref/cli/salt-call.html) documentation for more
   information. By default no additional arguments (besides the ones Terraform generates)
   are passed to `salt-call`.
 


### PR DESCRIPTION
This PR fixes broken links that were found from a manual link check of the entire terraform.io site. Apparently SaltStack documentation has been relocated to a new URL. This PR fixes the broken links to point to the new URL paths. 