### PR TITLE
refactoring: Implied move statements can be cross-package

### DIFF
--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -366,6 +366,50 @@ Each resource can have moved from only one source resource.`,
 			},
 			WantError: `Cross-package move statement: This statement declares a move to an object declared in external module package "fake-external:///". Move statements can be only within a single module package.`,
 		},
+		"implied move from resource in another module package": {
+			Statements: []MoveStatement{
+				makeTestImpliedMoveStmt(t,
+					``,
+					`module.fake_external.test.thing`,
+					`test.thing`,
+				),
+			},
+			// Implied move statements are not subject to the cross-package restriction
+			WantError: ``,
+		},
+		"implied move to resource in another module package": {
+			Statements: []MoveStatement{
+				makeTestImpliedMoveStmt(t,
+					``,
+					`test.thing`,
+					`module.fake_external.test.thing`,
+				),
+			},
+			// Implied move statements are not subject to the cross-package restriction
+			WantError: ``,
+		},
+		"implied move from module call in another module package": {
+			Statements: []MoveStatement{
+				makeTestImpliedMoveStmt(t,
+					``,
+					`module.fake_external.module.a`,
+					`module.b`,
+				),
+			},
+			// Implied move statements are not subject to the cross-package restriction
+			WantError: ``,
+		},
+		"implied move to module call in another module package": {
+			Statements: []MoveStatement{
+				makeTestImpliedMoveStmt(t,
+					``,
+					`module.a`,
+					`module.fake_external.module.b`,
+				),
+			},
+			// Implied move statements are not subject to the cross-package restriction
+			WantError: ``,
+		},
 		"move to a call that refers to another module package": {
 			Statements: []MoveStatement{
 				makeTestMoveStmt(t,
@@ -648,6 +692,13 @@ func makeTestMoveStmt(t *testing.T, moduleStr, fromStr, toStr string) MoveStatem
 			End:      tfdiags.SourcePos{Line: 1, Column: 1},
 		},
 	}
+}
+
+func makeTestImpliedMoveStmt(t *testing.T, moduleStr, fromStr, toStr string) MoveStatement {
+	t.Helper()
+	ret := makeTestMoveStmt(t, moduleStr, fromStr, toStr)
+	ret.Implied = true
+	return ret
 }
 
 var fakeExternalModuleSource = addrs.ModuleSourceRemote{


### PR DESCRIPTION
Terraform uses "implied" move statements to represent the situation where it automatically handles a switch from `count` to no-`count` on a resource. Because that situation requires targeting only a specific resource instance inside a specific module instance, implied move statements are always presented as if they had been declared in the root module and then traversed through the exact module instance path to reach the target resource.

However, that means they can potentially cross a module package boundary, if the changed resource belongs to an external module. Normally we prohibit that to avoid the root module depending on implementation details of the called module, but Terraform generates these implied statements based only on information in the called module and so there's no need to apply that same restriction to implied move statements, which will always have source and destination addresses belonging to the same module instance.

This change therefore fixes a misbehavior where Terraform would reject an attempt to switch from no-`count` to `count` in a called module, where previously the author of the calling configuration had no recourse to fix it because the change has actually happened upstream.

This fixes #30326. The function which generates the implied move statements already checks that they get generated with `Implied: true` set, and so the new test here just forces that to be true in order to see how the validation function reacts to it.
