### PR TITLE
lang/funcs: fileexists slightly better "not a file" error message

### DIFF
--- a/internal/lang/funcs/filesystem_test.go
+++ b/internal/lang/funcs/filesystem_test.go
@@ -228,12 +228,12 @@ func TestFileExists(t *testing.T) {
 		{
 			cty.StringVal(""),
 			cty.BoolVal(false),
-			`"." is not a regular file, but "drwxr-xr-x"`,
+			`"." is a directory, not a file`,
 		},
 		{
 			cty.StringVal("testdata").Mark(marks.Sensitive),
 			cty.BoolVal(false),
-			`(sensitive value) is not a regular file, but "drwxr-xr-x"`,
+			`(sensitive value) is a directory, not a file`,
 		},
 		{
 			cty.StringVal("testdata/missing"),


### PR DESCRIPTION
Previously we were just returning a string representation of the file mode, which spends more characters on the irrelevant permission bits that it does on the directory entry type, and is presented in a Unix-centric format that likely won't be familiar to the user of a Windows system.

Instead, we'll recognize a few specific directory entry types that seem worth mentioning by name, and then use a generic message for the rest.

The original motivation here was actually to deal with the fact that our tests for this function were previously not portable due to the error message leaking system-specific permission detail that are not relevant to the test. Rather than just directly addressing that portability problem, I took the opportunity to improve the error messages at the same time.

However, because of that initial focus there are only actually tests here for the directory case. A test that tries to test any of these other file modes would not be portable and in some cases would require superuser access, so we'll just leave those cases untested for the moment since they weren't tested before anyway, and so we've not _lost_ any test coverage here.

---

I've marked this for backport just because it'll fix some unreliable test cases in the v1.1 branch. It isn't super urgent otherwise, but subtly improving the error messages won't hurt.
