### PR TITLE
website: CLI state manipulation section de-emphasize old features

### DIFF
--- a/website/docs/cli/state/index.mdx
+++ b/website/docs/cli/state/index.mdx
@@ -22,7 +22,7 @@ infrastructure.
 Terraform CLI supports several workflows for interacting with state:
 
 - [Inspecting State](/cli/state/inspect)
-- [Forcing Re-creation (Tainting)](/cli/state/taint)
+- [Forcing Re-creation](/cli/state/taint)
 - [Moving Resources](/cli/state/move)
 - Importing Pre-existing Resources (documented in the
   [Importing Infrastructure](/cli/import) section)

--- a/website/docs/cli/state/move.mdx
+++ b/website/docs/cli/state/move.mdx
@@ -21,12 +21,21 @@ In cases where it's important to preserve an existing infrastructure object, you
 can explicitly tell Terraform to associate it with a different configured
 resource.
 
+For most cases we recommend using
+[the Terraform language's refactoring features](/language/modules/develop/refactoring)
+to document in your module exactly how the resource names have changed over
+time. Terraform will react to this information automatically during planning,
+and thus users of your module will not need to take any unusual extra steps.
+
+> **Hands On:** Try the [Use Configuration to Move Resources](https://learn.hashicorp.com/tutorials/terraform/move-config) on HashiCorp Learn.
+
+There are some other situations which require explicit state modifications,
+though. For those, consider the following Terraform commands:
+
 - [The `terraform state mv` command](/cli/commands/state/mv) changes
   which resource address in your configuration is associated with a particular
   real-world object. Use this to preserve an object when renaming a resource, or
   when moving a resource into or out of a child module.
-
-  > **Hands On:** Try the [Use Configuration to Move Resources](https://learn.hashicorp.com/tutorials/terraform/move-config) on HashiCorp Learn.
 
 - [The `terraform state rm` command](/cli/commands/state/rm) tells
   Terraform to stop managing a resource as part of the current working directory

--- a/website/docs/cli/state/taint.mdx
+++ b/website/docs/cli/state/taint.mdx
@@ -1,25 +1,63 @@
 ---
-page_title: Forcing Re-creation of Resources (Tainting) - Terraform CLI
+page_title: Forcing Re-creation of Resources - Terraform CLI
 description: Commands that allow you to destroy and re-create resources manually.
 ---
 
-# Forcing Re-creation of Resources (Tainting)
+# Forcing Re-creation of Resources
 
-When a resource declaration is modified, Terraform usually attempts to update
-the existing resource in place (although some changes can require destruction
-and re-creation, usually due to upstream API limitations).
+During planning, by default Terraform retrieves the latest state of each
+existing object and compares it with the current configuration, planning
+actions only against objects whose current state does not match the
+configuration.
 
-In some cases, you might want a resource to be destroyed and re-created even
-when Terraform doesn't think it's necessary. This is usually for objects that
-aren't fully described by their resource arguments due to side-effects that
-happen during creation; for example, a virtual machine that configures itself
-with `cloud-init` on startup might no longer meet your needs if the cloud-init
-configuration changes.
+However, in some cases a remote object may become damaged or degraded in a
+way that Terraform cannot automatically detect. For example, if software
+running inside a virtual machine crashes but the virtual machine itself is
+still running then Terraform will typically have no way to detect and respond
+to the problem, because Terraform only directly manages the machine as a whole.
 
-- [The `terraform taint` command](/cli/commands/taint) tells Terraform to
-  destroy and re-create a particular resource during the next apply, regardless
-  of whether its resource arguments would normally require that.
+If you know that an object is damaged, or if you want to force Terraform to
+replace it for any other reason, you can override Terraform's default behavior
+using [the `-replace=...` planning option](/cli/commands/plan#replace-address)
+when you run either `terraform plan` or `terraform apply`:
 
-- [The `terraform untaint` command](/cli/commands/untaint) undoes a
-  previous taint, or can preserve a resource that was automatically tainted due
-  to failed [provisioners](/language/resources/provisioners/syntax).
+```shellsession
+$ terraform apply -replace=aws_instance.example
+# ...
+
+  # aws_instance.example will be replaced, as requested
+-/+ resource "aws_instance" "example" {
+      # ...
+    }
+```
+
+## The "tainted" status
+
+Sometimes Terraform is able to infer automatically that an object is in an
+incomplete or degraded state. For example, if creation of a complex object
+fails in such a way that parts of it already exist in the remote system, or
+if object creation succeeded but a provisioner step subsequently failed,
+Terraform must remember that the object exists but may not be fully-functional.
+
+Terraform represents this situation by marking an object in the state as
+"tainted". When an object is marked with this status, the next plan will force
+replacing that object in a similar way to if you had specified that object's
+address using `-replace=...` as described above.
+
+```
+  # aws_instance.example is tainted, so must be replaced
+-/+ resource "aws_instance" "example" {
+      # ...
+    }
+```
+
+If Terraform has marked an object as tainted but you consider it to be working
+correctly and do not want to replace it, you can override Terraform's
+determination using [the `terraform untaint` command](/cli/commands/untaint),
+after which Terraform will consider the object to be ready for use by any
+downstream resource declarations.
+
+You can also _force_ Terraform to mark a particular object as tainted using
+[the `terraform taint` command](/cli/commands/taint), but that approach is
+deprecated in favor of the `-replace=...` option, which avoids the need to
+create an interim state snapshot with a tainted object.


### PR DESCRIPTION
Previously the `terraform state ...` subcommands were the only way to perform various manipulations of the state, but in recent Terraform versions we have replaced these with better options.

Since these pages about `terraform state ...` seem to already have pretty good search engine optimization for the use-cases they are describing, we'll prioritize mentioning the new approaches and only mention the now-deprecated or de-emphasized features as a secondary approach.

Specifically:
- Describe the `-replace=...` planning option in preference to `terraform taint`, and present taint as primarily a mechanism for Terraform to use itself, as opposed to something end-users should typically use directly.
- Introduce the config-based refactoring features before describing `terraform state mv`.

The older features here are still applicable in some situations and are required for those still using older versions of Terraform, so we will retain the information about them for now while aiming to be clearer in each case about which is our preferred, modern approach.
