### PR TITLE
cli: Refactor show command & migrate to command arguments and views

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -275,13 +275,6 @@ type Operation struct {
 	// the variables set in the plan are used instead, and they must be valid.
 	AllowUnsetVariables bool
 
-	// When loading a plan file for a read-only operation, we may want to
-	// disable the state lineage checks which are only relevant for operations
-	// which can modify state. An example where this is important is showing
-	// a plan which was prepared against a non-default state file, because the
-	// lineage checks are always against the default state.
-	DisablePlanFileStateLineageChecks bool
-
 	// View implements the logic for all UI interactions.
 	View views.Operation
 

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -284,7 +284,7 @@ func (b *Local) localRunForPlanFile(op *backend.Operation, pf *planfile.Reader, 
 		))
 		return nil, snap, diags
 	}
-	if !op.DisablePlanFileStateLineageChecks && currentStateMeta != nil {
+	if currentStateMeta != nil {
 		// If the caller sets this, we require that the stored prior state
 		// has the same metadata, which is an extra safety check that nothing
 		// has changed since the plan was created. (All of the "real-world"

--- a/internal/command/arguments/show.go
+++ b/internal/command/arguments/show.go
@@ -1,0 +1,59 @@
+package arguments
+
+import (
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// Show represents the command-line arguments for the show command.
+type Show struct {
+	// Path is the path to the state file or plan file to be displayed. If
+	// unspecified, show will display the latest state snapshot.
+	Path string
+
+	// ViewType specifies which output format to use: human, JSON, or "raw".
+	ViewType ViewType
+}
+
+// ParseShow processes CLI arguments, returning a Show value and errors.
+// If errors are encountered, a Show value is still returned representing
+// the best effort interpretation of the arguments.
+func ParseShow(args []string) (*Show, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	show := &Show{
+		Path: "",
+	}
+
+	var jsonOutput bool
+	cmdFlags := defaultFlagSet("show")
+	cmdFlags.BoolVar(&jsonOutput, "json", false, "json")
+
+	if err := cmdFlags.Parse(args); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line flags",
+			err.Error(),
+		))
+	}
+
+	args = cmdFlags.Args()
+	if len(args) > 1 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Too many command line arguments",
+			"Expected at most one positional argument.",
+		))
+	}
+
+	if len(args) > 0 {
+		show.Path = args[0]
+	}
+
+	switch {
+	case jsonOutput:
+		show.ViewType = ViewJSON
+	default:
+		show.ViewType = ViewHuman
+	}
+
+	return show, diags
+}

--- a/internal/command/arguments/show_test.go
+++ b/internal/command/arguments/show_test.go
@@ -1,0 +1,99 @@
+package arguments
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestParseShow_valid(t *testing.T) {
+	testCases := map[string]struct {
+		args []string
+		want *Show
+	}{
+		"defaults": {
+			nil,
+			&Show{
+				Path:     "",
+				ViewType: ViewHuman,
+			},
+		},
+		"json": {
+			[]string{"-json"},
+			&Show{
+				Path:     "",
+				ViewType: ViewJSON,
+			},
+		},
+		"path": {
+			[]string{"-json", "foo"},
+			&Show{
+				Path:     "foo",
+				ViewType: ViewJSON,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, diags := ParseShow(tc.args)
+			if len(diags) > 0 {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+			if *got != *tc.want {
+				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseShow_invalid(t *testing.T) {
+	testCases := map[string]struct {
+		args      []string
+		want      *Show
+		wantDiags tfdiags.Diagnostics
+	}{
+		"unknown flag": {
+			[]string{"-boop"},
+			&Show{
+				Path:     "",
+				ViewType: ViewHuman,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Failed to parse command-line flags",
+					"flag provided but not defined: -boop",
+				),
+			},
+		},
+		"too many arguments": {
+			[]string{"-json", "bar", "baz"},
+			&Show{
+				Path:     "bar",
+				ViewType: ViewJSON,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Too many command line arguments",
+					"Expected at most one positional argument.",
+				),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, gotDiags := ParseShow(tc.args)
+			if *got != *tc.want {
+				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			}
+			if !reflect.DeepEqual(gotDiags, tc.wantDiags) {
+				t.Errorf("wrong result\ngot: %s\nwant: %s", spew.Sdump(gotDiags), spew.Sdump(tc.wantDiags))
+			}
+		})
+	}
+}

--- a/internal/command/testdata/show-json-state/no-state/output.json
+++ b/internal/command/testdata/show-json-state/no-state/output.json
@@ -1,0 +1,3 @@
+{
+    "format_version": "1.0"
+}

--- a/internal/command/views/show.go
+++ b/internal/command/views/show.go
@@ -2,37 +2,95 @@ package views
 
 import (
 	"fmt"
-
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/format"
+	"github.com/hashicorp/terraform/internal/command/jsonplan"
+	"github.com/hashicorp/terraform/internal/command/jsonstate"
+	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/terraform"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// FIXME: this is a temporary partial definition of the view for the show
-// command, in place to allow access to the plan renderer which is now in the
-// views package.
 type Show interface {
-	Plan(plan *plans.Plan, schemas *terraform.Schemas)
+	// Display renders the plan, if it is available. If plan is nil, it renders the statefile.
+	Display(config *configs.Config, plan *plans.Plan, stateFile *statefile.File, schemas *terraform.Schemas) int
+
+	// Diagnostics renders early diagnostics, resulting from argument parsing.
+	Diagnostics(diags tfdiags.Diagnostics)
 }
 
-// FIXME: the show view should support both human and JSON types. This code is
-// currently only used to render the plan in human-readable UI, so does not yet
-// support JSON.
 func NewShow(vt arguments.ViewType, view *View) Show {
 	switch vt {
+	case arguments.ViewJSON:
+		return &ShowJSON{view: view}
 	case arguments.ViewHuman:
-		return &ShowHuman{View: *view}
+		return &ShowHuman{view: view}
 	default:
 		panic(fmt.Sprintf("unknown view type %v", vt))
 	}
 }
 
 type ShowHuman struct {
-	View
+	view *View
 }
 
 var _ Show = (*ShowHuman)(nil)
 
-func (v *ShowHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
-	renderPlan(plan, schemas, &v.View)
+func (v *ShowHuman) Display(config *configs.Config, plan *plans.Plan, stateFile *statefile.File, schemas *terraform.Schemas) int {
+	if plan != nil {
+		renderPlan(plan, schemas, v.view)
+	} else {
+		if stateFile == nil {
+			v.view.streams.Println("No state.")
+			return 0
+		}
+
+		v.view.streams.Println(format.State(&format.StateOpts{
+			State:   stateFile.State,
+			Color:   v.view.colorize,
+			Schemas: schemas,
+		}))
+	}
+	return 0
+}
+
+func (v *ShowHuman) Diagnostics(diags tfdiags.Diagnostics) {
+	v.view.Diagnostics(diags)
+}
+
+type ShowJSON struct {
+	view *View
+}
+
+var _ Show = (*ShowJSON)(nil)
+
+func (v *ShowJSON) Display(config *configs.Config, plan *plans.Plan, stateFile *statefile.File, schemas *terraform.Schemas) int {
+	if plan != nil {
+		jsonPlan, err := jsonplan.Marshal(config, plan, stateFile, schemas)
+
+		if err != nil {
+			v.view.streams.Eprintf("Failed to marshal plan to json: %s", err)
+			return 1
+		}
+		v.view.streams.Println(string(jsonPlan))
+	} else {
+		// It is possible that there is neither state nor a plan.
+		// That's ok, we'll just return an empty object.
+		jsonState, err := jsonstate.Marshal(stateFile, schemas)
+		if err != nil {
+			v.view.streams.Eprintf("Failed to marshal state to json: %s", err)
+			return 1
+		}
+		v.view.streams.Println(string(jsonState))
+	}
+	return 0
+}
+
+// Diagnostics should only be called if show cannot be executed.
+// In this case, we choose to render human-readable diagnostic output,
+// primarily for backwards compatibility.
+func (v *ShowJSON) Diagnostics(diags tfdiags.Diagnostics) {
+	v.view.Diagnostics(diags)
 }

--- a/internal/command/views/show_test.go
+++ b/internal/command/views/show_test.go
@@ -1,0 +1,184 @@
+package views
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/initwd"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/states/statefile"
+	"github.com/hashicorp/terraform/internal/terminal"
+	"github.com/hashicorp/terraform/internal/terraform"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestShowHuman(t *testing.T) {
+	testCases := map[string]struct {
+		plan       *plans.Plan
+		stateFile  *statefile.File
+		schemas    *terraform.Schemas
+		wantExact  bool
+		wantString string
+	}{
+		"plan file": {
+			testPlan(t),
+			nil,
+			testSchemas(),
+			false,
+			"# test_resource.foo will be created",
+		},
+		"statefile": {
+			nil,
+			&statefile.File{
+				Serial:  0,
+				Lineage: "fake-for-testing",
+				State:   testState(),
+			},
+			testSchemas(),
+			false,
+			"# test_resource.foo:",
+		},
+		"empty statefile": {
+			nil,
+			&statefile.File{
+				Serial:  0,
+				Lineage: "fake-for-testing",
+				State:   states.NewState(),
+			},
+			testSchemas(),
+			true,
+			"\n",
+		},
+		"nothing": {
+			nil,
+			nil,
+			nil,
+			true,
+			"No state.\n",
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			view := NewView(streams)
+			view.Configure(&arguments.View{NoColor: true})
+			v := NewShow(arguments.ViewHuman, view)
+
+			code := v.Display(nil, testCase.plan, testCase.stateFile, testCase.schemas)
+			if code != 0 {
+				t.Errorf("expected 0 return code, got %d", code)
+			}
+
+			output := done(t)
+			got := output.Stdout()
+			want := testCase.wantString
+			if (testCase.wantExact && got != want) || (!testCase.wantExact && !strings.Contains(got, want)) {
+				t.Fatalf("unexpected output\ngot: %s\nwant: %s", got, want)
+			}
+		})
+	}
+}
+
+func TestShowJSON(t *testing.T) {
+	testCases := map[string]struct {
+		plan      *plans.Plan
+		stateFile *statefile.File
+	}{
+		"plan file": {
+			testPlan(t),
+			nil,
+		},
+		"statefile": {
+			nil,
+			&statefile.File{
+				Serial:  0,
+				Lineage: "fake-for-testing",
+				State:   testState(),
+			},
+		},
+		"empty statefile": {
+			nil,
+			&statefile.File{
+				Serial:  0,
+				Lineage: "fake-for-testing",
+				State:   states.NewState(),
+			},
+		},
+		"nothing": {
+			nil,
+			nil,
+		},
+	}
+
+	config, _, configCleanup := initwd.MustLoadConfigForTests(t, "./testdata/show")
+	defer configCleanup()
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			view := NewView(streams)
+			view.Configure(&arguments.View{NoColor: true})
+			v := NewShow(arguments.ViewJSON, view)
+
+			schemas := &terraform.Schemas{
+				Providers: map[addrs.Provider]*terraform.ProviderSchema{
+					addrs.NewDefaultProvider("test"): {
+						ResourceTypes: map[string]*configschema.Block{
+							"test_resource": {
+								Attributes: map[string]*configschema.Attribute{
+									"id":  {Type: cty.String, Optional: true, Computed: true},
+									"foo": {Type: cty.String, Optional: true},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			code := v.Display(config, testCase.plan, testCase.stateFile, schemas)
+
+			if code != 0 {
+				t.Errorf("expected 0 return code, got %d", code)
+			}
+
+			// Make sure the result looks like JSON; we comprehensively test
+			// the structure of this output in the command package tests.
+			var result map[string]interface{}
+			got := done(t).All()
+			t.Logf("output: %s", got)
+			if err := json.Unmarshal([]byte(got), &result); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+// testState returns a test State structure.
+func testState() *states.State {
+	return states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_resource",
+				Name: "foo",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"id":"bar","foo":"value"}`),
+				Status:    states.ObjectReady,
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			},
+		)
+		// DeepCopy is used here to ensure our synthetic state matches exactly
+		// with a state that will have been copied during the command
+		// operation, and all fields have been copied correctly.
+	}).DeepCopy()
+}

--- a/internal/command/views/testdata/show/main.tf
+++ b/internal/command/views/testdata/show/main.tf
@@ -1,0 +1,3 @@
+resource "test_resource" "foo" {
+    foo = "value"
+}


### PR DESCRIPTION
## Description 

This PR refactors the `show` command by:
1. Removing its dependence on a local backend and local run to load necessary data
1. Only loading the backend when we need it
1. Migrating it to use the command arguments and views packages
1. Removing the now unnecessary `DisablePlanFileStateLineageChecks` flag added in #30205  to fix #30195 

The goal of this PR is to make the show command significantly simpler and easier to understand, without changing existing functionality. 

See https://github.com/hashicorp/terraform/pull/30205#issuecomment-997113175 for more context

## Testing plan
main.tf used for relevant scenarios below
```
resource "null_resource" "test" {
  count = 1
}
```

Build this branch locally and compare the following basic scenarios to the most recent version of Terraform to make sure the command still functions the same:
1. Bad args (too many arguments, unsupported flags): 
   - `terraform show too many arguments`
      <details>
         <summary>Output</summary>
      
      ```
      # 15:56:53 # : ~/new-test $ terraform show too many arguments
      The show command expects at most two arguments.
       The path to a Terraform state or plan file, and optionally -json for json output.

      Usage: terraform [global options] show [options] [path]

        Reads and outputs a Terraform state or plan file in a human-readable
        form. If no path is specified, the current state will be shown.

      Options:

        -no-color           If specified, output won't contain any color.
        -json               If specified, output the Terraform plan or state in
                            a machine-readable form.
      # 16:00:51 # : ~/new-test $ $GOBIN/terraform show too many arguments
      ╷
      │ Error: Too many command line arguments
      │ 
      │ Expected at most one positional argument.
      ╵

      For more help on using this command, run:
        terraform show -help
      ```
      </details>
   - `terraform show -json too many arguments`
      <details>
         <summary>Output</summary>
      
      ```
      # 15:56:53 # : ~/new-test $ terraform show -json too many arguments
      The show command expects at most two arguments.
       The path to a Terraform state or plan file, and optionally -json for json output.

      Usage: terraform [global options] show [options] [path]

        Reads and outputs a Terraform state or plan file in a human-readable
        form. If no path is specified, the current state will be shown.

      Options:

        -no-color           If specified, output won't contain any color.
        -json               If specified, output the Terraform plan or state in
                            a machine-readable form.
      # 16:00:51 # : ~/new-test $ $GOBIN/terraform show -json too many arguments
      ╷
      │ Error: Too many command line arguments
      │ 
      │ Expected at most one positional argument.
      ╵

      For more help on using this command, run:
        terraform show -help
      ```
      </details>
1. No args, empty directory: 
   - `terraform show` in an empty directory
      <details>
         <summary>Output</summary>
      
      ```
      # 15:47:20 # : ~/new-test $ terraform show
      No state.
      # 15:47:30 # : ~/new-test $ $GOBIN/terraform show
      No state.
      ```
      </details>
   - `terraform show -json` in an empty directory
      <details>
         <summary>Output</summary>
      
      ```
      # 15:47:26 # : ~/new-test $ terraform show -json
      {"format_version":"1.0"}
      # 15:47:34 # : ~/new-test $ $GOBIN/terraform show -json
      {"format_version":"1.0"}
      ```
      </details>
1. No args, no statefile: 
   - `terraform show` in an directory where `terraform init` has been run
      <details>
         <summary>Output</summary>
      
      ```
      # 15:47:20 # : ~/new-test $ terraform show
      No state.
      # 15:47:30 # : ~/new-test $ $GOBIN/terraform show
      No state.
      ```
      </details>
   - `terraform show -json` in an directory where `terraform init` has been run
      <details>
         <summary>Output</summary>
      
      ```
      # 15:47:26 # : ~/new-test $ terraform show -json
      {"format_version":"1.0"}
      # 15:47:34 # : ~/new-test $ $GOBIN/terraform show -json
      {"format_version":"1.0"}
      ```
      </details>
1. No args, statefile exists: 
   - `terraform show` in a directory where you have a default `terraform.tfstate` statefile
      <details>
         <summary>Output</summary>
      
      ```
      # 16:02:44 # : ~/new-test $ terraform show
      # null_resource.test[0]:
      resource "null_resource" "test" {
          id = "5392993047991207106"
      }
      # 16:03:16 # : ~/new-test $ $GOBIN/terraform show
      # null_resource.test[0]:
      resource "null_resource" "test" {
          id = "5392993047991207106"
      }
      ```
      </details>
   - `terraform show -json` in a directory where you have a default `terraform.tfstate` statefile
      <details>
         <summary>Output</summary>
      
      ```
      # 16:04:08 # : ~/new-test $ terraform show -json | jq '.'
      {
        "format_version": "1.0",
        "terraform_version": "1.1.1",
        "values": {
          "root_module": {
            "resources": [
              {
                "address": "null_resource.test[0]",
                "mode": "managed",
                "type": "null_resource",
                "name": "test",
                "index": 0,
                "provider_name": "registry.terraform.io/hashicorp/null",
                "schema_version": 0,
                "values": {
                  "id": "5392993047991207106",
                  "triggers": null
                },
                "sensitive_values": {}
              }
            ]
          }
        }
      }
      # 16:04:28 # : ~/new-test $ $GOBIN/terraform show -json | jq '.'
      {
        "format_version": "1.0",
        "terraform_version": "1.1.1",
        "values": {
          "root_module": {
            "resources": [
              {
                "address": "null_resource.test[0]",
                "mode": "managed",
                "type": "null_resource",
                "name": "test",
                "index": 0,
                "provider_name": "registry.terraform.io/hashicorp/null",
                "schema_version": 0,
                "values": {
                  "id": "5392993047991207106",
                  "triggers": null
                },
                "sensitive_values": {}
              }
            ]
          }
        }
      }
      ```
      </details>
1. Statefile passed in as arg, statefile exists: 
   - `terraform show state.tfstate` & `terraform show -json state.tfstate` in a directory where you have a non-default `state.tfstate` statefile
      ```
      Output should look essentially like the previous scenario
      ```
1. Statefile passed in as arg, statefile does not exist: 
   - `terraform show state.tfstate` in a directory where you do not have a non-default `state.tfstate` statefile
      <details>
         <summary>Output</summary>
      
      ```
      # 16:06:49 # : ~/new-test $ terraform show state.tfstate
      Terraform couldn't read the given file as a state or plan file.
      The errors while attempting to read the file as each format are
      shown below.

      State read error: Error loading statefile: open state.tfstate: no such file or directory

      Plan read error: open state.tfstate: no such file or directory
      # 16:07:00 # : ~/new-test $ $GOBIN/terraform show state.tfstate
      ╷
      │ Error: Terraform couldn't read the given file as a state or plan file.
      │ The errors while attempting to read the file as each format are
      │ shown below.
      │ 
      │ State read error: Error loading statefile: open state.tfstate: no such file or directory
      │ 
      │ Plan read error: open state.tfstate: no such file or directory
      │ 
      │ 
      ╵
      ```
      </details>
   - `terraform show -json state.tfstate` in a directory where you do not have a non-default `state.tfstate` statefile
      <details>
         <summary>Output</summary>
      
      ```
      # 16:06:49 # : ~/new-test $ terraform show -json state.tfstate
      Terraform couldn't read the given file as a state or plan file.
      The errors while attempting to read the file as each format are
      shown below.

      State read error: Error loading statefile: open state.tfstate: no such file or directory

      Plan read error: open state.tfstate: no such file or directory
      # 16:07:00 # : ~/new-test $ $GOBIN/terraform show -json state.tfstate
      ╷
      │ Error: Terraform couldn't read the given file as a state or plan file.
      │ The errors while attempting to read the file as each format are
      │ shown below.
      │ 
      │ State read error: Error loading statefile: open state.tfstate: no such file or directory
      │ 
      │ Plan read error: open state.tfstate: no such file or directory
      │ 
      │ 
      ╵
      ```
      </details>
1. Plan file passed in as arg, plan file exists: 
   - `terraform show plan.tfplan` in a directory where you have a saved plan file `plan.tfplan`
      <details>
         <summary>Output</summary>
      
      ```
      # 16:13:50 # : ~/new-test $ terraform show plan.tfplan

      Terraform used the selected providers to generate the following execution plan.
      Resource actions are indicated with the following symbols:
        + create

      Terraform will perform the following actions:

        # null_resource.test[1] will be created
        + resource "null_resource" "test" {
            + id = (known after apply)
          }

      Plan: 1 to add, 0 to change, 0 to destroy.
      # 16:15:25 # : ~/new-test $ $GOBIN/terraform show plan.tfplan

      Terraform used the selected providers to generate the following execution plan.
      Resource actions are indicated with the following symbols:
        + create

      Terraform will perform the following actions:

        # null_resource.test[1] will be created
        + resource "null_resource" "test" {
            + id = (known after apply)
          }

      Plan: 1 to add, 0 to change, 0 to destroy.
      ```
      </details>
   - `terraform show -json plan.tfplan` in a directory where you have a saved plan file `plan.tfplan`
1. Plan file passed in as arg, plan file does not exist: 
   - `terraform show plan.tfplan` & `terraform show -json plan.tfplan` in a directory where you do not have a saved plan file `plan.tfplan`
      ```
      Output should look similar to the output in scenario #6
      ```
1. Plan file passed in as arg, plan file exists and has non-default state lineage:
   - Create a plan with non-default state lineage by running the following:
      `terraform init`
      `terraform apply -state test.tfstate -auto-approve`
      `terraform plan -state test.tfstate -out saved.tfplan`
   - Then run `terraform show saved.tfplan` & `terraform show -json saved.tfplan`
      ```
      Output should look similar to the output in scenario #7
      ```

Feel free to test any other scenarios you can think of. These are just some basic scenarios that have had bugs fixed recently or didn't previously have tests. 