### PR TITLE
internal/backend/remote-state/oss: fix dropped error

### DIFF
--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -85,6 +85,9 @@ func (b *Backend) Workspaces() ([]string, error) {
 				options = append(options, oss.Marker(lastObj))
 			}
 			resp, err = bucket.ListObjects(options...)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			break
 		}


### PR DESCRIPTION
This fixes a dropped `err` variable in `internal/backend/remote-state/oss`.