### PR TITLE
Typo in zipmap documentation

### DIFF
--- a/website/docs/language/functions/zipmap.mdx
+++ b/website/docs/language/functions/zipmap.mdx
@@ -27,7 +27,7 @@ is used in the resulting map.
 ```
 > zipmap(["a", "b"], [1, 2])
 {
-  "a" = 1,
-  "b" = 2,
+  "a" = 1
+  "b" = 2
 }
 ```


### PR DESCRIPTION
zipmap does not produce a map with comma in terraform cli
tested with Terraform v1.1.3