### PR TITLE
Update linux packaging action path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,7 @@ jobs:
           (cd dist && unzip "../terraform_${{ env.version }}_${{ env.os }}_${{ env.arch }}.zip")
           mkdir -p out
       - name: Build Linux distribution packages
-        uses: hashicorp/package@v1
+        uses: hashicorp/actions-packaging-linux@v1
         with:
           name: "terraform"
           description: "Terraform enables you to safely and predictably create, change, and improve infrastructure. It is an open source tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned."


### PR DESCRIPTION
Hey all 👋  We need to update the github action linux packaging path instead of relying on the old redirect, which is no longer working. More info in this slack thread: https://hashicorp.slack.com/archives/C024ZDP4YGY/p1642701024072100