### PR TITLE
Improve the help.go docs: typo and a more explicit comment.

### DIFF
--- a/help.go
+++ b/help.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-// helpFunc is a cli.HelpFunc that can is used to output the help for Terraform.
+// helpFunc is a cli.HelpFunc that can be used to output the help CLI instructions for Terraform.
 func helpFunc(commands map[string]cli.CommandFactory) string {
 	// Determine the maximum key length, and classify based on type
 	var otherCommands []string


### PR DESCRIPTION
Improve the help.go docs: typo and a more explicit comment.