### PR TITLE
Fix reference to child module in outputs docs

### DIFF
--- a/website/docs/language/values/outputs.mdx
+++ b/website/docs/language/values/outputs.mdx
@@ -115,7 +115,7 @@ module "foo" {
 }
 
 resource "test_instance" "x" {
-  some_attribute = module.mod.a # resource attribute references a sensitive output
+  some_attribute = module.foo.a # resource attribute references a sensitive output
 }
 
 output "out" {


### PR DESCRIPTION
References to child modules should use the resource name, not their path