### PR TITLE
Docs Update: Show example of state lock table access control

### DIFF
--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -410,12 +410,35 @@ to only a single state object within an S3 bucket is shown below:
 }
 ```
 
-It is not possible to apply such fine-grained access control to the DynamoDB
-table used for locking, so it is possible for any user with Terraform access
-to lock any workspace state, even if they do not have access to read or write
-that state. If a malicious user has such access they could block attempts to
-use Terraform against some or all of your workspaces as long as locking is
-enabled in the backend configuration.
+It is also possible to apply fine-grained access control to the DynamoDB
+table used for locking. An example policy statement is shown below:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "dynamodb:DeleteItem",
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:Query",
+          "dynamodb:UpdateItem"
+        ],
+        "Resource" : ["arn:aws:dynamodb:*:*:table/myorg-state-lock-table"],
+        "Condition" : {
+          "ForAllValues:StringEquals" : {
+            "dynamodb:LeadingKeys" : [
+              "myorg-terraform-states/myapp/production/tfstate",
+              "myorg-terraform-states/myapp/production/tfstate-md5"
+            ]
+          }
+        }
+      }
+  ]
+}
+```
 
 ### Configuring Custom User-Agent Information
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -411,13 +411,9 @@ to only a single state object within an S3 bucket is shown below:
 ```
 
 It is also possible to apply fine-grained access control to the DynamoDB
-table used for locking. During a `terraform plan`, when the state lock is put in place,
-Terraform stores the full statefile as a document with its partition key set 
-as the s3 object key. After the state lock is released, a digest of the updated
-statefile is placed in DynamoDB with a key similar to that of the original 
-statefile but suffixed with `-md5`. A simple IAM policy that would allow the 
-role assumed for backend operations to perform the aforementioned operations is 
-shown below:
+table used for locking. When Terraform puts the state lock in place during `terraform plan`, it stores the full state file as a document and sets the s3 object key as the partition key for the document. After the state lock is released, Terraform places a digest of the updated state file in DynamoDB. The key is similar to the one for the original state file, but is suffixed with `-md5`. 
+
+The example below shows a simple IAM policy that allows the backend operations role to perform these operations:
 
 ```json
 {

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -411,7 +411,13 @@ to only a single state object within an S3 bucket is shown below:
 ```
 
 It is also possible to apply fine-grained access control to the DynamoDB
-table used for locking. An example policy statement is shown below:
+table used for locking. During a `terraform plan`, when the state lock is put in place,
+Terraform stores the full statefile as a document with its partition key set 
+as the s3 object key. After the state lock is released, a digest of the updated
+statefile is placed in DynamoDB with a key similar to that of the original 
+statefile but suffixed with `-md5`. A simple IAM policy that would allow the 
+role assumed for backend operations to perform the aforementioned operations is 
+shown below:
 
 ```json
 {

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -415,8 +415,9 @@ table used for locking. During a `terraform plan`, when the state lock is put in
 Terraform stores the full statefile as a document with its partition key set 
 as the s3 object key. After the state lock is released, a digest of the updated
 statefile is placed in DynamoDB with a key similar to that of the original 
-statefile but suffixed with `-md5`. The example below shows an IAM policy that would allow the 
-role assumed for backend operations to perform these operations. 
+statefile but suffixed with `-md5`. A simple IAM policy that would allow the 
+role assumed for backend operations to perform the aforementioned operations is 
+shown below:
 
 ```json
 {
@@ -435,8 +436,8 @@ role assumed for backend operations to perform these operations.
         "Condition" : {
           "ForAllValues:StringEquals" : {
             "dynamodb:LeadingKeys" : [
-              "myorg-terraform-states/myapp/production/tfstate",
-              "myorg-terraform-states/myapp/production/tfstate-md5"
+              "myorg-terraform-states/myapp/production/tfstate", // during a state lock the full state file is stored with this key
+              "myorg-terraform-states/myapp/production/tfstate-md5" // after the lock is released a hash of the statefile's contents are stored with this key
             ]
           }
         }
@@ -444,6 +445,8 @@ role assumed for backend operations to perform these operations.
   ]
 }
 ```
+
+Refer to the [AWS documentation on DynamoDB fine-grained locking](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/specifying-conditions.html) for more details.
 
 ### Configuring Custom User-Agent Information
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -415,9 +415,8 @@ table used for locking. During a `terraform plan`, when the state lock is put in
 Terraform stores the full statefile as a document with its partition key set 
 as the s3 object key. After the state lock is released, a digest of the updated
 statefile is placed in DynamoDB with a key similar to that of the original 
-statefile but suffixed with `-md5`. A simple IAM policy that would allow the 
-role assumed for backend operations to perform the aforementioned operations is 
-shown below:
+statefile but suffixed with `-md5`. The example below shows an IAM policy that would allow the 
+role assumed for backend operations to perform these operations. 
 
 ```json
 {


### PR DESCRIPTION
This PR contains a small update to the docs to show an example of fine-grained access control to the dynamo state lock table.