### PR TITLE
Make -replace flag clearer

### DIFF
--- a/website/docs/cli/commands/apply.mdx
+++ b/website/docs/cli/commands/apply.mdx
@@ -39,10 +39,8 @@ Terraform will propose the plan to you and prompt you to approve it before
 taking the described actions, unless you waive that prompt by using the
 `-auto-approve` option.
 
--> **Tip:** When performing its own plan, `terraform apply` supports all of the same
-[planning modes](/cli/commands/plan#planning-modes) and
-[planning options](/cli/commands/plan#planning-options) that `terraform plan` would
-accept, so you can customize how Terraform will create the plan.
+-> **Tip:** When you run `terraform apply` without a saved plan file, you can use all of the [planning modes](/cli/commands/plan#planning-modes) and
+[planning options](/cli/commands/plan#planning-options) available for `terraform plan`. This lets you customize how Terraform will create the plan.
 
 ### Saved Plan Mode
 
@@ -111,8 +109,9 @@ apply command executes and reports on the apply operation.
   [walks the graph](/internals/graph#walking-the-graph). Defaults to
   10\.
 
-- Planning modes and options available for
-[`terraform plan`](/cli/commands/plan#planning-options) - Only available when you run `terraform apply` without a saved plan file.
+- All [planning modes](/cli/commands/plan#planning-modes) and
+[planning options](/cli/commands/plan#planning-options) for
+`terraform plan` - Customize how Terraform will create the plan. Only available when you run `terraform apply` without a saved plan file.
 
 For configurations using
 [the `local` backend](/language/settings/backends/local) only,

--- a/website/docs/cli/commands/apply.mdx
+++ b/website/docs/cli/commands/apply.mdx
@@ -39,7 +39,7 @@ Terraform will propose the plan to you and prompt you to approve it before
 taking the described actions, unless you waive that prompt by using the
 `-auto-approve` option.
 
-When performing its own plan, `terraform apply` supports all of the same
+-> **Tip:** When performing its own plan, `terraform apply` supports all of the same
 [planning modes](/cli/commands/plan#planning-modes) and
 [planning options](/cli/commands/plan#planning-options) that `terraform plan` would
 accept, so you can customize how Terraform will create the plan.
@@ -67,10 +67,7 @@ plan`'s planning modes and planning options. For details, see:
 ### Apply Options
 
 The following options allow you to change various details about how the
-apply command executes and reports on the apply operation. If you are running
-`terraform apply` _without_ a previously-saved plan file, these options are
-_in addition to_ the planning modes and planning options described for
-[`terraform plan`](/cli/commands/plan).
+apply command executes and reports on the apply operation.
 
 * `-auto-approve` - Skips interactive approval of plan before applying. This
   option is ignored when you pass a previously-saved plan file, because
@@ -113,6 +110,9 @@ _in addition to_ the planning modes and planning options described for
 * `-parallelism=n` - Limit the number of concurrent operation as Terraform
   [walks the graph](/internals/graph#walking-the-graph). Defaults to
   10\.
+
+- Planning modes and options available for
+[`terraform plan`](/cli/commands/plan#planning-options) - Only available when you run `terraform apply` without a previously-saved plan file.
 
 For configurations using
 [the `local` backend](/language/settings/backends/local) only,

--- a/website/docs/cli/commands/apply.mdx
+++ b/website/docs/cli/commands/apply.mdx
@@ -112,7 +112,7 @@ apply command executes and reports on the apply operation.
   10\.
 
 - Planning modes and options available for
-[`terraform plan`](/cli/commands/plan#planning-options) - Only available when you run `terraform apply` without a previously-saved plan file.
+[`terraform plan`](/cli/commands/plan#planning-options) - Only available when you run `terraform apply` without a saved plan file.
 
 For configurations using
 [the `local` backend](/language/settings/backends/local) only,

--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -137,7 +137,7 @@ options in this section, along with the planning mode selection options in
 the previous section, are also available with the same meanings on
 `terraform apply`.
 
-* `-refresh=false` - Disables the default behavior of synchronizing the
+- `-refresh=false` - Disables the default behavior of synchronizing the
   Terraform state with remote objects before checking for configuration changes.
 
   This option can potentially make the planning operation faster by reducing
@@ -149,7 +149,7 @@ the previous section, are also available with the same meanings on
   it would effectively disable the entirety of the planning operation in that
   case.
 
-* `-replace=ADDRESS` - Instructs Terraform to plan to replace the single
+- `-replace=ADDRESS` - Instructs Terraform to plan to replace the single
   resource instance with the given address. If the given instance would
   normally have caused only an "update" action, or no action at all, then
   Terraform will choose a "replace" action instead.
@@ -157,7 +157,7 @@ the previous section, are also available with the same meanings on
   You can use this option if you have learned that a particular remote object
   has become degraded in some way. If you are using immutable infrastructure
   patterns then you may wish to respond to that by replacing the
-  malfunctioning object with a new object that has the same configuration.
+  malfunctioning object with a new object that has the same configuration. You can also replace multiple objects at once by adding multiple flags to the command. 
 
   This option is allowed only in the normal planning mode, so this option
   is incompatible with the `-destroy` option.
@@ -166,7 +166,7 @@ the previous section, are also available with the same meanings on
   For earlier versions, you can achieve a similar effect (with some caveats)
   using [`terraform taint`](/cli/commands/taint).
 
-* `-target=ADDRESS` - Instructs Terraform to focus its planning efforts only
+- `-target=ADDRESS` - Instructs Terraform to focus its planning efforts only
   on resource instances which match the given address and on any objects that
   those instances depend on.
 
@@ -174,14 +174,14 @@ the previous section, are also available with the same meanings on
   [Resource Targeting](#resource-targeting)
   below for more information.
 
-* `-var 'NAME=VALUE'` - Sets a value for a single
+- `-var 'NAME=VALUE'` - Sets a value for a single
   [input variable](/language/values/variables) declared in the
   root module of the configuration. Use this option multiple times to set
   more than one variable. For more information see
   [Input Variables on the Command Line](#input-variables-on-the-command-line),
   below.
 
-* `-var-file=FILENAME` - Sets values for potentially many
+- `-var-file=FILENAME` - Sets values for potentially many
   [input variables](/language/values/variables) declared in the
   root module of the configuration, using definitions from a
   ["tfvars" file](/language/values/variables#variable-definitions-tfvars-files).

--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -154,10 +154,9 @@ the previous section, are also available with the same meanings on
   normally have caused only an "update" action, or no action at all, then
   Terraform will choose a "replace" action instead.
 
-  You can use this option if you have learned that a particular remote object
-  has become degraded in some way. If you are using immutable infrastructure
-  patterns then you may wish to respond to that by replacing the
-  malfunctioning object with a new object that has the same configuration. You can also replace multiple objects at once by adding multiple flags to the command. 
+  You can use this option if you have learned that one or more remote objects
+  has become degraded in some way. Add multiple `-replace` flags to the command to replace several objects at once. If you are using immutable infrastructure
+  patterns, you may wish to replace the malfunctioning objects with new objects that have the same configuration.
 
   This option is allowed only in the normal planning mode, so this option
   is incompatible with the `-destroy` option.

--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -82,12 +82,9 @@ The remaining sections on this page describe the various options:
 
 ## Planning Modes
 
-The section above described Terraform's default planning behavior, which is
-intended for changing the remote system to match with changes you've made to
-your configuration.
-
-Terraform has two alternative planning modes, each of which creates a plan with
-a different intended outcome:
+The previous section describes Terraform's default planning behavior, which
+changes the remote system to match the changes you make to
+your configuration. Terraform has two alternative planning modes, each of which creates a plan with a different intended outcome. These options are available for  both `terraform plan` and [`terraform apply`](/cli/commands/apply).
 
 * **Destroy mode:** creates a plan whose goal is to destroy all remote objects
   that currently exist, leaving an empty Terraform state. This can be useful
@@ -127,18 +124,10 @@ and later.
 
 ## Planning Options
 
-In addition to the planning _modes_ described above, there are also several
-additional options that can modify details of the behavior of the planning
-step.
-
-When you use `terraform apply` without passing it a saved plan file, it
-incorporates the `terraform plan` command functionality and so the planning
-options in this section, along with the planning mode selection options in
-the previous section, are also available with the same meanings on
-`terraform apply`.
+In addition to alternate [planning modes](#planning-modes), there are several options that can modify planning behavior. These options are available for  both `terraform plan` and [`terraform apply`](/cli/commands/apply).
 
 - `-refresh=false` - Disables the default behavior of synchronizing the
-  Terraform state with remote objects before checking for configuration changes. This can make the planning operation faster by reducing the number of remote API requests. However, setting `refresh=false` causes Terraform to ignore external changes, which could result in an incomplete or incorrect plan. You cannot use `refresh=false` in "refresh only" planning mode because it would effectively disable the entirety of the planning operation.
+  Terraform state with remote objects before checking for configuration changes. This can make the planning operation faster by reducing the number of remote API requests. However, setting `refresh=false` causes Terraform to ignore external changes, which could result in an incomplete or incorrect plan. You cannot use `refresh=false` in refresh-only planning mode because it would effectively disable the entirety of the planning operation.
 
 - `-replace=ADDRESS` - Instructs Terraform to plan to replace the
   resource instance with the given address. This is helpful when one or more remote objects have become degraded, and you can use replacement objects with the same configuratation to align with immutable infrastructure patterns. Terraform will use a "replace" action if the specified resource would normally cause an "update" action or no action at all. Include this option multiple times to replace several objects at once. You cannot use `-replace` with the `-destroy` option, and it is only available from Terraform v0.15.2 onwards. For earlier versions, use [`terraform taint`](/cli/commands/taint) to achieve a similar result.

--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -138,46 +138,25 @@ the previous section, are also available with the same meanings on
 `terraform apply`.
 
 - `-refresh=false` - Disables the default behavior of synchronizing the
-  Terraform state with remote objects before checking for configuration changes.
+  Terraform state with remote objects before checking for configuration changes. This can make the planning operation faster by reducing the number of remote API requests. However, setting `refresh=false` causes Terraform to ignore external changes, which could result in an incomplete or incorrect plan.
 
-  This option can potentially make the planning operation faster by reducing
-  the number of remote API requests, but it comes at the expense of having
-  Terraform not take into account any changes that might've happened outside
-  of Terraform, and thus the resulting plan may not be complete or correct.
+  -> **Note:** You cannot use `refresh=false` in "refresh only" planning mode, because it would effectively disable the entirety of the planning operation.
 
-  This option is not available in the "refresh only" planning mode, because
-  it would effectively disable the entirety of the planning operation in that
-  case.
+- `-replace=ADDRESS` - Instructs Terraform to plan to replace the
+  resource instance with the given address. This is helpful when one or more remote objects have become degraded, and you can use replacement objects with the same configuratation to align with immutable infrastructure patterns. Terraform will use a "replace" action if the specified resource would normally cause an "update" action or no action at all. Use this option multiple times to replace several objects at once.
 
-- `-replace=ADDRESS` - Instructs Terraform to plan to replace the single
-  resource instance with the given address. If the given instance would
-  normally have caused only an "update" action, or no action at all, then
-  Terraform will choose a "replace" action instead.
-
-  You can use this option if you have learned that one or more remote objects
-  have become degraded in some way. Add multiple `-replace` flags to replace several objects at once. If you are using immutable infrastructure patterns, you may wish to replace the malfunctioning objects with new objects that have the same configuration.
-
-  This option is allowed only in the normal planning mode, so this option
-  is incompatible with the `-destroy` option.
-
-  The `-replace=...` option is available only from Terraform v0.15.2 onwards.
-  For earlier versions, you can achieve a similar effect (with some caveats)
-  using [`terraform taint`](/cli/commands/taint).
+  -> **Note:** You cannot use `-replace` with the `-destroy` option, and it is only available from Terraform v0.15.2 onwards. For earlier versions, use [`terraform taint`](/cli/commands/taint) to achieve a similar result.
 
 - `-target=ADDRESS` - Instructs Terraform to focus its planning efforts only
   on resource instances which match the given address and on any objects that
-  those instances depend on.
-
-  This command is for exceptional use only. See
-  [Resource Targeting](#resource-targeting)
-  below for more information.
+  those instances depend on. This command is for exceptional use only. Refer to
+  [Resource Targeting](#resource-targeting) for more information.
 
 - `-var 'NAME=VALUE'` - Sets a value for a single
   [input variable](/language/values/variables) declared in the
   root module of the configuration. Use this option multiple times to set
-  more than one variable. For more information see
-  [Input Variables on the Command Line](#input-variables-on-the-command-line),
-  below.
+  more than one variable. Refer to
+  [Input Variables on the Command Line](#input-variables-on-the-command-line) for more information.
 
 - `-var-file=FILENAME` - Sets values for potentially many
   [input variables](/language/values/variables) declared in the
@@ -186,9 +165,8 @@ the previous section, are also available with the same meanings on
   Use this option multiple times to include values from more than one file.
 
 There are several other ways to set values for input variables in the root
-module, aside from the `-var` and `-var-file` options. For more information,
-see
-[Assigning Values to Root Module Variables](/language/values/variables#assigning-values-to-root-module-variables).
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assigning Values to Root Module Variables](/language/values/variables#assigning-values-to-root-module-variables) for more information.
 
 ### Input Variables on the Command Line
 

--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -155,8 +155,7 @@ the previous section, are also available with the same meanings on
   Terraform will choose a "replace" action instead.
 
   You can use this option if you have learned that one or more remote objects
-  has become degraded in some way. Add multiple `-replace` flags to the command to replace several objects at once. If you are using immutable infrastructure
-  patterns, you may wish to replace the malfunctioning objects with new objects that have the same configuration.
+  have become degraded in some way. Add multiple `-replace` flags to replace several objects at once. If you are using immutable infrastructure patterns, you may wish to replace the malfunctioning objects with new objects that have the same configuration.
 
   This option is allowed only in the normal planning mode, so this option
   is incompatible with the `-destroy` option.

--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -138,19 +138,16 @@ the previous section, are also available with the same meanings on
 `terraform apply`.
 
 - `-refresh=false` - Disables the default behavior of synchronizing the
-  Terraform state with remote objects before checking for configuration changes. This can make the planning operation faster by reducing the number of remote API requests. However, setting `refresh=false` causes Terraform to ignore external changes, which could result in an incomplete or incorrect plan.
-
-  -> **Note:** You cannot use `refresh=false` in "refresh only" planning mode, because it would effectively disable the entirety of the planning operation.
+  Terraform state with remote objects before checking for configuration changes. This can make the planning operation faster by reducing the number of remote API requests. However, setting `refresh=false` causes Terraform to ignore external changes, which could result in an incomplete or incorrect plan. You cannot use `refresh=false` in "refresh only" planning mode because it would effectively disable the entirety of the planning operation.
 
 - `-replace=ADDRESS` - Instructs Terraform to plan to replace the
-  resource instance with the given address. This is helpful when one or more remote objects have become degraded, and you can use replacement objects with the same configuratation to align with immutable infrastructure patterns. Terraform will use a "replace" action if the specified resource would normally cause an "update" action or no action at all. Use this option multiple times to replace several objects at once.
-
-  -> **Note:** You cannot use `-replace` with the `-destroy` option, and it is only available from Terraform v0.15.2 onwards. For earlier versions, use [`terraform taint`](/cli/commands/taint) to achieve a similar result.
+  resource instance with the given address. This is helpful when one or more remote objects have become degraded, and you can use replacement objects with the same configuratation to align with immutable infrastructure patterns. Terraform will use a "replace" action if the specified resource would normally cause an "update" action or no action at all. Include this option multiple times to replace several objects at once. You cannot use `-replace` with the `-destroy` option, and it is only available from Terraform v0.15.2 onwards. For earlier versions, use [`terraform taint`](/cli/commands/taint) to achieve a similar result.
 
 - `-target=ADDRESS` - Instructs Terraform to focus its planning efforts only
   on resource instances which match the given address and on any objects that
-  those instances depend on. This command is for exceptional use only. Refer to
-  [Resource Targeting](#resource-targeting) for more information.
+  those instances depend on.
+
+  -> **Note:** Use `-target=ADDRESS` in exceptional circumstances only, such as recovering from mistakes or working around Terraform limitations. Refer to [Resource Targeting](#resource-targeting) for more details.
 
 - `-var 'NAME=VALUE'` - Sets a value for a single
   [input variable](/language/values/variables) declared in the

--- a/website/docs/cli/commands/taint.mdx
+++ b/website/docs/cli/commands/taint.mdx
@@ -16,7 +16,7 @@ propose to replace it in the next plan you create.
 
 ## Recommended Alternative
 
-For Terraform v0.15.2 and later, we recommend using the [`-replace` option](/cli/commands/plan#replace-address) with `terraform apply` to force Terraform to replace an object even though there are no configuration changes that would require it. 
+For Terraform v0.15.2 and later, we recommend using the [`-replace` option](/cli/commands/plan#replace-address) with `terraform apply` to force Terraform to replace an object even though there are no configuration changes that would require it.
 
 ```
 $ terraform apply -replace="aws_instance.example[0]"

--- a/website/docs/cli/commands/taint.mdx
+++ b/website/docs/cli/commands/taint.mdx
@@ -16,7 +16,7 @@ propose to replace it in the next plan you create.
 
 ## Recommended Alternative
 
-For Terraform v0.15.2 and later, we recommend using the [`-replace` option](/cli/commands/plan#replace-address) with `terraform apply` to force Terraform to replace an object even though there are no configuration changes that would require it.
+For Terraform v0.15.2 and later, we recommend using the [`-replace` option](/cli/commands/plan#replace-address) with `terraform apply` to force Terraform to replace an object even though there are no configuration changes that would require it. 
 
 ```
 $ terraform apply -replace="aws_instance.example[0]"


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/issues/30194

---------

This PR:
- Clarifies that you can replace multiple resources and once.
- Updates two of the callouts on the `apply` page so that they are more obvious. The callouts let users know they can also use all of the planning modes and options available to `terraform plan` when they run `terraform apply` without supplying a plan file. 