### PR TITLE
Fix data source mixed with data resource in docs

### DIFF
--- a/website/docs/language/data-sources/index.mdx
+++ b/website/docs/language/data-sources/index.mdx
@@ -51,7 +51,7 @@ When distinguishing from data resources, the primary kind of resource (as declar
 by a `resource` block) is known as a _managed resource_. Both kinds of resources
 take arguments and export attributes for use in configuration, but while
 managed resources cause Terraform to create, update, and delete infrastructure
-objects, data resources cause Terraform only to _read_ objects. For brevity,
+objects, data sources cause Terraform only to _read_ objects. For brevity,
 managed resources are often referred to just as "resources" when the meaning
 is clear from context.
 


### PR DESCRIPTION
It seems that in data source docs the _data source_ is accidentally called _data resource_, when data source is compared to data resources/managed resources.