### PR TITLE
configs: Validate pre/postcondition self-refs

### DIFF
--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -245,6 +245,10 @@ func decodeResourceBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagno
 				case "precondition", "postcondition":
 					cr, moreDiags := decodeCheckRuleBlock(block, override)
 					diags = append(diags, moreDiags...)
+
+					moreDiags = cr.validateSelfReferences(block.Type, r.Addr())
+					diags = append(diags, moreDiags...)
+
 					switch block.Type {
 					case "precondition":
 						r.Preconditions = append(r.Preconditions, cr)
@@ -445,6 +449,10 @@ func decodeDataBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagnostic
 				case "precondition", "postcondition":
 					cr, moreDiags := decodeCheckRuleBlock(block, override)
 					diags = append(diags, moreDiags...)
+
+					moreDiags = cr.validateSelfReferences(block.Type, r.Addr())
+					diags = append(diags, moreDiags...)
+
 					switch block.Type {
 					case "precondition":
 						r.Preconditions = append(r.Preconditions, cr)

--- a/internal/configs/testdata/error-files/precondition-postcondition-selfref.tf
+++ b/internal/configs/testdata/error-files/precondition-postcondition-selfref.tf
@@ -1,0 +1,55 @@
+resource "test" "test" {
+  lifecycle {
+    precondition {
+      condition     = test.test.foo # ERROR: Invalid reference in precondition
+      error_message = "Cannot refer to self."
+    }
+    postcondition {
+      condition     = test.test.foo # ERROR: Invalid reference in postcondition
+      error_message = "Cannot refer to self."
+    }
+  }
+}
+
+data "test" "test" {
+  lifecycle {
+    precondition {
+      condition     = data.test.test.foo # ERROR: Invalid reference in precondition
+      error_message = "Cannot refer to self."
+    }
+    postcondition {
+      condition     = data.test.test.foo # ERROR: Invalid reference in postcondition
+      error_message = "Cannot refer to self."
+    }
+  }
+}
+
+resource "test" "test_counted" {
+  count = 1
+
+  lifecycle {
+    precondition {
+      condition     = test.test_counted[0].foo # ERROR: Invalid reference in precondition
+      error_message = "Cannot refer to self."
+    }
+    postcondition {
+      condition     = test.test_counted[0].foo # ERROR: Invalid reference in postcondition
+      error_message = "Cannot refer to self."
+    }
+  }
+}
+
+data "test" "test_counted" {
+  count = 1
+
+  lifecycle {
+    precondition {
+      condition     = data.test.test_counted[0].foo # ERROR: Invalid reference in precondition
+      error_message = "Cannot refer to self."
+    }
+    postcondition {
+      condition     = data.test.test_counted[0].foo # ERROR: Invalid reference in postcondition
+      error_message = "Cannot refer to self."
+    }
+  }
+}


### PR DESCRIPTION
Preconditions and postconditions for resources and data sources may not refer to the address of the containing resource or data source. This commit adds a parse-time validation for this rule.

### Example

Config:

```terraform
terraform {
  experiments = [preconditions_postconditions]
}

variable "length" {
  type    = number
  default = 2
}

resource "random_pet" "example" {
  length  = var.length
  keepers = {
    uuid = uuid()
  }
  
  lifecycle {
    precondition {
      condition = random_pet.example.length > random_pet.example.length
      error_message = "Pets cannot have single word names."
    }
    postcondition {
      condition = length(regexall("[aeiou]", random_pet.example.id)) > 3
      error_message = "Pet names must have at least three vowels."
    }
  }
}
```

Before:

<img width="902" alt="plan-before" src="https://user-images.githubusercontent.com/68917/152237497-117e7580-cddc-40e6-a938-b0c99365f2b7.png">

After:

<img width="902" alt="plan-after" src="https://user-images.githubusercontent.com/68917/152237651-6c351ac8-9133-4856-a7aa-6c3806314789.png">
