### PR TITLE
core: Remove unused PlanOpts.Validate

### DIFF
--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -462,7 +462,7 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 		return nil, diags
 	}
 
-	graph, walkOp, moreDiags := c.planGraph(config, prevRunState, opts, true)
+	graph, walkOp, moreDiags := c.planGraph(config, prevRunState, opts)
 	diags = diags.Append(moreDiags)
 	if diags.HasErrors() {
 		return nil, diags
@@ -517,7 +517,7 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 	return plan, diags
 }
 
-func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, opts *PlanOpts, validate bool) (*Graph, walkOperation, tfdiags.Diagnostics) {
+func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*Graph, walkOperation, tfdiags.Diagnostics) {
 	switch mode := opts.Mode; mode {
 	case plans.NormalMode:
 		graph, diags := (&PlanGraphBuilder{
@@ -527,7 +527,6 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			Plugins:            c.plugins,
 			Targets:            opts.Targets,
 			ForceReplace:       opts.ForceReplace,
-			Validate:           validate,
 			skipRefresh:        opts.SkipRefresh,
 		}).Build(addrs.RootModuleInstance)
 		return graph, walkPlan, diags
@@ -538,7 +537,6 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			RootVariableValues: opts.SetVariables,
 			Plugins:            c.plugins,
 			Targets:            opts.Targets,
-			Validate:           validate,
 			skipRefresh:        opts.SkipRefresh,
 			skipPlanChanges:    true, // this activates "refresh only" mode.
 		}).Build(addrs.RootModuleInstance)
@@ -550,7 +548,6 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			RootVariableValues: opts.SetVariables,
 			Plugins:            c.plugins,
 			Targets:            opts.Targets,
-			Validate:           validate,
 			skipRefresh:        opts.SkipRefresh,
 		}).Build(addrs.RootModuleInstance)
 		return graph, walkPlanDestroy, diags
@@ -714,7 +711,7 @@ func (c *Context) PlanGraphForUI(config *configs.Config, prevRunState *states.St
 
 	opts := &PlanOpts{Mode: mode}
 
-	graph, _, moreDiags := c.planGraph(config, prevRunState, opts, false)
+	graph, _, moreDiags := c.planGraph(config, prevRunState, opts)
 	diags = diags.Append(moreDiags)
 	return graph, diags
 }

--- a/internal/terraform/context_validate.go
+++ b/internal/terraform/context_validate.go
@@ -58,7 +58,6 @@ func (c *Context) Validate(config *configs.Config) tfdiags.Diagnostics {
 	graph, moreDiags := ValidateGraphBuilder(&PlanGraphBuilder{
 		Config:             config,
 		Plugins:            c.plugins,
-		Validate:           true,
 		State:              states.NewState(),
 		RootVariableValues: varValues,
 	}).Build(addrs.RootModuleInstance)

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -45,9 +45,6 @@ type PlanGraphBuilder struct {
 	// action instead. Create and Delete actions are not affected.
 	ForceReplace []addrs.AbsResourceInstance
 
-	// Validate will do structural validation of the graph.
-	Validate bool
-
 	// skipRefresh indicates that we should skip refreshing managed resources
 	skipRefresh bool
 
@@ -72,9 +69,8 @@ type PlanGraphBuilder struct {
 // See GraphBuilder
 func (b *PlanGraphBuilder) Build(path addrs.ModuleInstance) (*Graph, tfdiags.Diagnostics) {
 	return (&BasicGraphBuilder{
-		Steps:    b.Steps(),
-		Validate: b.Validate,
-		Name:     "PlanGraphBuilder",
+		Steps: b.Steps(),
+		Name:  "PlanGraphBuilder",
 	}).Build(path)
 }
 


### PR DESCRIPTION
This vestigial field was written to but never read. I can't find when it was last used, but it appears to be useless now.