### PR TITLE
cli: Fix console crash when using type function

### DIFF
--- a/internal/repl/format_test.go
+++ b/internal/repl/format_test.go
@@ -174,6 +174,33 @@ EOT_`,
 			cty.StringVal("sensitive value").Mark(marks.Sensitive),
 			"(sensitive)",
 		},
+		{
+			cty.StringVal("map(string)").Mark(marks.Raw),
+			"map(string)",
+		},
+		{
+			// Strings marked with marks.Raw are returned from the console-only
+			// type() function and should be printed without quoting
+			cty.StringVal("map(string)").Mark(marks.Raw),
+			"map(string)",
+		},
+		{
+			// Other values marked with marks.Raw should drop the mark and be
+			// formatted as usual
+			cty.MapVal(map[string]cty.Value{
+				"boop": cty.StringVal("honk"),
+			}).Mark(marks.Raw),
+			`tomap({
+  "boop" = "honk"
+})`,
+		},
+		{
+			// Values marked with multiple marks should drop only the Raw mark
+			cty.MapVal(map[string]cty.Value{
+				"boop": cty.StringVal("honk"),
+			}).WithMarks(cty.NewValueMarks(marks.Raw, marks.Sensitive)),
+			"(sensitive)",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The console-only `type` function allows interrogation of any value's type. An implementation quirk is that we use a `cty.Mark` to allow the console to display this type information without the usual HCL quoting. For example:

```
> type("boop")
string
```

instead of:

```
> type("boop")
"string"
```

Because these marks can propagate when used in complex expressions, using the `type` function as part of constructing a non-string value could result in this "print as raw" mark being attached to a collection. When this happened, it would result in a crash when we tried to iterate over a marked value.

This commit fixes this by stripping the raw mark from any non-string types before attempting to format the output. We are careful not to strip other marks, to ensure we don't accidentally reveal sensitive information by doing so.

Fixes #30470.