### PR TITLE
Adds documentation to `substr` function to cover when `length` exceeds input length

### DIFF
--- a/website/docs/language/functions/substr.mdx
+++ b/website/docs/language/functions/substr.mdx
@@ -37,7 +37,7 @@ string after the given offset will be returned.
 world
 ```
 
-The length may be greater than the length of the string, in which case the substring
+If the length is greater than the length of the string, the substring
 will be the length of all remaining characters.
 
 ```

--- a/website/docs/language/functions/substr.mdx
+++ b/website/docs/language/functions/substr.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # `substr` Function
 
-`substr` extracts a substring from a given string by offset and length.
+`substr` extracts a substring from a given string by offset and (maximum) length.
 
 ```hcl
 substr(string, offset, length)
@@ -34,5 +34,13 @@ string after the given offset will be returned.
 
 ```
 > substr("hello world", -5, -1)
+world
+```
+
+The length may be greater than the length of the string, in which case the substring
+will be the length of all remaining characters.
+
+```
+> substr("hello world", 6, 10)
 world
 ```


### PR DESCRIPTION
The `substr` function allows the `length` parameter to be longer than the remaining characters in the input after the offset. This is useful for when you want to truncate a string to a maximum number of characters. However, the documentation isn't clear on this so I had to do a test deployment to confirm the behaviour after finding the behaviour in an old issue https://github.com/hashicorp/terraform/issues/15751