### PR TITLE
Update Console Command Documentation

### DIFF
--- a/website/docs/cli/commands/console.mdx
+++ b/website/docs/cli/commands/console.mdx
@@ -16,15 +16,12 @@ Usage: `terraform console [options]`
 
 This command provides an interactive command-line console for evaluating and
 experimenting with [expressions](/language/expressions).
-This is useful for testing interpolations before using them in configurations,
-and for interacting with any values currently saved in
-[state](/language/state).
+You can use it to test interpolations before using them in configurations
+and to interact with any values currently saved in
+[state](/language/state). If the current state is empty or has not yet been created, you can use the console to experiment with the expression syntax and
+[built-in functions](/language/functions). You cannot use the console during a run because Terraform prevents read actions while it is writing new state.
 
-If the current state is empty or has not yet been created, the console can be
-used to experiment with the expression syntax and
-[built-in functions](/language/functions).
-
-You can close the console with the `exit` command or by pressing Control-C
+To close the console, enter the `exit` command or press Control-C
 or Control-D.
 
 For configurations using

--- a/website/docs/cli/commands/console.mdx
+++ b/website/docs/cli/commands/console.mdx
@@ -19,7 +19,7 @@ experimenting with [expressions](/language/expressions).
 You can use it to test interpolations before using them in configurations
 and to interact with any values currently saved in
 [state](/language/state). If the current state is empty or has not yet been created, you can use the console to experiment with the expression syntax and
-[built-in functions](/language/functions). You cannot use the console during a run because Terraform prevents read actions while it is writing new state.
+[built-in functions](/language/functions). The console holds a [lock on the state](/language/state/locking), and you will not be able to use the console while performing other actions that modify state.
 
 To close the console, enter the `exit` command or press Control-C
 or Control-D.


### PR DESCRIPTION
This PR adds a line to the console command documentation that explains to users why they can't use the console during a run. This came from an internal conversation where users were surprised that they couldn't do this, as the console only performs read actions. But this is the intended behavior - we prevent any processes that read state while the state is actively being written. 