### PR TITLE
Warn when ignore_changes includes a Computed attribute

### DIFF
--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1146,28 +1146,33 @@ func (n *NodeAbstractResource) processIgnoreChanges(prior, config cty.Value) (ct
 func traversalsToPaths(traversals []hcl.Traversal) []cty.Path {
 	paths := make([]cty.Path, len(traversals))
 	for i, traversal := range traversals {
-		path := make(cty.Path, len(traversal))
-		for si, step := range traversal {
-			switch ts := step.(type) {
-			case hcl.TraverseRoot:
-				path[si] = cty.GetAttrStep{
-					Name: ts.Name,
-				}
-			case hcl.TraverseAttr:
-				path[si] = cty.GetAttrStep{
-					Name: ts.Name,
-				}
-			case hcl.TraverseIndex:
-				path[si] = cty.IndexStep{
-					Key: ts.Key,
-				}
-			default:
-				panic(fmt.Sprintf("unsupported traversal step %#v", step))
-			}
-		}
+		path := traversalToPath(traversal)
 		paths[i] = path
 	}
 	return paths
+}
+
+func traversalToPath(traversal hcl.Traversal) cty.Path {
+	path := make(cty.Path, len(traversal))
+	for si, step := range traversal {
+		switch ts := step.(type) {
+		case hcl.TraverseRoot:
+			path[si] = cty.GetAttrStep{
+				Name: ts.Name,
+			}
+		case hcl.TraverseAttr:
+			path[si] = cty.GetAttrStep{
+				Name: ts.Name,
+			}
+		case hcl.TraverseIndex:
+			path[si] = cty.IndexStep{
+				Key: ts.Key,
+			}
+		default:
+			panic(fmt.Sprintf("unsupported traversal step %#v", step))
+		}
+	}
+	return path
 }
 
 func processIgnoreChangesIndividual(prior, config cty.Value, ignoreChangesPath []cty.Path) (cty.Value, tfdiags.Diagnostics) {

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -402,10 +402,9 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 
 						diags = diags.Append(&hcl.Diagnostic{
 							Severity: hcl.DiagWarning,
-							Summary:  "Invalid ignore_changes",
-							Detail:   fmt.Sprintf("ignore_changes cannot be used with non-Optional Computed attributes. Please remove \"%s\" from ignore_changes.", attrDisplayPath),
-
-							Subject: &n.Config.TypeRange,
+							Summary:  "Redundant ignore_changes element",
+							Detail:   fmt.Sprintf("Adding an attribute name to ignore_changes tells Terraform to ignore future changes to the argument in configuration after the object has been created, retaining the value originally configured.\n\nThe attribute %s is decided by the provider alone and therefore there can be no configured value to compare with. Including this attribute in ignore_changes has no effect. Remove the attribute from ignore_changes to quiet this warning.", attrDisplayPath),
+							Subject:  &n.Config.TypeRange,
 						})
 					}
 				}

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -390,21 +390,7 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 				// use that to check whether the Attribute is Computed and
 				// non-Optional.
 				if !diags.HasErrors() {
-					path := make(cty.Path, len(traversal))
-					for si, step := range traversal {
-						switch ts := step.(type) {
-						case hcl.TraverseAttr:
-							path[si] = cty.GetAttrStep{
-								Name: ts.Name,
-							}
-						case hcl.TraverseIndex:
-							path[si] = cty.IndexStep{
-								Key: ts.Key,
-							}
-						default:
-							panic(fmt.Sprintf("unsupported traversal step %#v", step))
-						}
-					}
+					path := traversalToPath(traversal)
 
 					attrSchema := schema.AttributeByPath(path)
 

--- a/internal/terraform/node_resource_validate_test.go
+++ b/internal/terraform/node_resource_validate_test.go
@@ -627,7 +627,9 @@ func TestNodeValidatableResource_ValidateResource_invalidIgnoreChangesComputed(t
 	if diags.HasErrors() {
 		t.Fatalf("got unexpected error: %s", diags.ErrWithWarnings())
 	}
-	if got, want := diags.ErrWithWarnings().Error(), "Invalid ignore_changes: ignore_changes cannot be used with non-Optional Computed attributes. Please remove \"computed_string\" from ignore_changes."; !strings.Contains(got, want) {
+	if got, want := diags.ErrWithWarnings().Error(), `Redundant ignore_changes element: Adding an attribute name to ignore_changes tells Terraform to ignore future changes to the argument in configuration after the object has been created, retaining the value originally configured.
+
+The attribute computed_string is decided by the provider alone and therefore there can be no configured value to compare with. Including this attribute in ignore_changes has no effect. Remove the attribute from ignore_changes to quiet this warning.`; !strings.Contains(got, want) {
 		t.Fatalf("wrong error\ngot:  %s\nwant: Message containing %q", got, want)
 	}
 }

--- a/internal/terraform/node_resource_validate_test.go
+++ b/internal/terraform/node_resource_validate_test.go
@@ -489,7 +489,7 @@ func TestNodeValidatableResource_ValidateResource_invalidDependsOn(t *testing.T)
 	}
 }
 
-func TestNodeValidatableResource_ValidateResource_invalidIgnoreChanges(t *testing.T) {
+func TestNodeValidatableResource_ValidateResource_invalidIgnoreChangesNonexistent(t *testing.T) {
 	mp := simpleMockProvider()
 	mp.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 		return providers.ValidateResourceConfigResponse{}
@@ -545,6 +545,89 @@ func TestNodeValidatableResource_ValidateResource_invalidIgnoreChanges(t *testin
 		t.Fatal("no error for invalid ignore_changes")
 	}
 	if got, want := diags.Err().Error(), "Unsupported attribute: This object has no argument, nested block, or exported attribute named \"nonexistent\""; !strings.Contains(got, want) {
+		t.Fatalf("wrong error\ngot:  %s\nwant: Message containing %q", got, want)
+	}
+}
+
+func TestNodeValidatableResource_ValidateResource_invalidIgnoreChangesComputed(t *testing.T) {
+	// construct a schema with a computed attribute
+	ms := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"test_string": {
+				Type:     cty.String,
+				Optional: true,
+			},
+			"computed_string": {
+				Type:     cty.String,
+				Computed: true,
+				Optional: false,
+			},
+		},
+	}
+
+	mp := &MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{Block: ms},
+			ResourceTypes: map[string]providers.Schema{
+				"test_object": providers.Schema{Block: ms},
+			},
+		},
+	}
+
+	mp.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+		return providers.ValidateResourceConfigResponse{}
+	}
+
+	// We'll check a _valid_ config first, to make sure we're not failing
+	// for some other reason, and then make it invalid.
+	p := providers.Interface(mp)
+	rc := &configs.Resource{
+		Mode:   addrs.ManagedResourceMode,
+		Type:   "test_object",
+		Name:   "foo",
+		Config: configs.SynthBody("", map[string]cty.Value{}),
+		Managed: &configs.ManagedResource{
+			IgnoreChanges: []hcl.Traversal{
+				{
+					hcl.TraverseAttr{
+						Name: "test_string",
+					},
+				},
+			},
+		},
+	}
+	node := NodeValidatableResource{
+		NodeAbstractResource: &NodeAbstractResource{
+			Addr:             mustConfigResourceAddr("test_foo.bar"),
+			Config:           rc,
+			ResolvedProvider: mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
+		},
+	}
+
+	ctx := &MockEvalContext{}
+	ctx.installSimpleEval()
+
+	ctx.ProviderSchemaSchema = mp.ProviderSchema()
+	ctx.ProviderProvider = p
+
+	diags := node.validateResource(ctx)
+	if diags.HasErrors() {
+		t.Fatalf("error for supposedly-valid config: %s", diags.ErrWithWarnings())
+	}
+
+	// Now we'll make it invalid by attempting to ignore a computed
+	// attribute.
+	rc.Managed.IgnoreChanges = append(rc.Managed.IgnoreChanges, hcl.Traversal{
+		hcl.TraverseAttr{
+			Name: "computed_string",
+		},
+	})
+
+	diags = node.validateResource(ctx)
+	if diags.HasErrors() {
+		t.Fatalf("got unexpected error: %s", diags.ErrWithWarnings())
+	}
+	if got, want := diags.ErrWithWarnings().Error(), "Invalid ignore_changes: ignore_changes cannot be used with non-Optional Computed attributes. Please remove \"computed_string\" from ignore_changes."; !strings.Contains(got, want) {
 		t.Fatalf("wrong error\ngot:  %s\nwant: Message containing %q", got, want)
 	}
 }

--- a/internal/terraform/node_resource_validate_test.go
+++ b/internal/terraform/node_resource_validate_test.go
@@ -488,3 +488,63 @@ func TestNodeValidatableResource_ValidateResource_invalidDependsOn(t *testing.T)
 		t.Fatalf("wrong error\ngot:  %s\nwant: Message containing %q", got, want)
 	}
 }
+
+func TestNodeValidatableResource_ValidateResource_invalidIgnoreChanges(t *testing.T) {
+	mp := simpleMockProvider()
+	mp.ValidateResourceConfigFn = func(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+		return providers.ValidateResourceConfigResponse{}
+	}
+
+	// We'll check a _valid_ config first, to make sure we're not failing
+	// for some other reason, and then make it invalid.
+	p := providers.Interface(mp)
+	rc := &configs.Resource{
+		Mode:   addrs.ManagedResourceMode,
+		Type:   "test_object",
+		Name:   "foo",
+		Config: configs.SynthBody("", map[string]cty.Value{}),
+		Managed: &configs.ManagedResource{
+			IgnoreChanges: []hcl.Traversal{
+				{
+					hcl.TraverseAttr{
+						Name: "test_string",
+					},
+				},
+			},
+		},
+	}
+	node := NodeValidatableResource{
+		NodeAbstractResource: &NodeAbstractResource{
+			Addr:             mustConfigResourceAddr("test_foo.bar"),
+			Config:           rc,
+			ResolvedProvider: mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
+		},
+	}
+
+	ctx := &MockEvalContext{}
+	ctx.installSimpleEval()
+
+	ctx.ProviderSchemaSchema = mp.ProviderSchema()
+	ctx.ProviderProvider = p
+
+	diags := node.validateResource(ctx)
+	if diags.HasErrors() {
+		t.Fatalf("error for supposedly-valid config: %s", diags.ErrWithWarnings())
+	}
+
+	// Now we'll make it invalid by attempting to ignore a nonexistent
+	// attribute.
+	rc.Managed.IgnoreChanges = append(rc.Managed.IgnoreChanges, hcl.Traversal{
+		hcl.TraverseAttr{
+			Name: "nonexistent",
+		},
+	})
+
+	diags = node.validateResource(ctx)
+	if !diags.HasErrors() {
+		t.Fatal("no error for invalid ignore_changes")
+	}
+	if got, want := diags.Err().Error(), "Unsupported attribute: This object has no argument, nested block, or exported attribute named \"nonexistent\""; !strings.Contains(got, want) {
+		t.Fatalf("wrong error\ngot:  %s\nwant: Message containing %q", got, want)
+	}
+}


### PR DESCRIPTION
Adding a (non-Optional) Computed attribute to `ignore_changes` is a no-op, so we should warn users when they do this, as it is likely they intended something else.

Throwing an error here would be a breaking change.

Also adds test for the `StaticValidateTraversal()` check that verifies `ignore_changes` paths are present in the schema.