### PR TITLE
cli: Fix state mv exit code for missing resource (#29839)

### DIFF
--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -176,6 +176,8 @@ func (c *StateMvCommand) Run(args []string) int {
 			msgInvalidSource,
 			fmt.Sprintf("Cannot move %s: does not match anything in the current state.", sourceAddr),
 		))
+		c.showDiagnostics(diags)
+		return 1
 	}
 	for _, rawAddrFrom := range sourceAddrs {
 		switch addrFrom := rawAddrFrom.(type) {

--- a/internal/command/state_mv_test.go
+++ b/internal/command/state_mv_test.go
@@ -1685,6 +1685,34 @@ func TestStateMvHelp(t *testing.T) {
 	}
 }
 
+func TestStateMvInvalidSourceAddress(t *testing.T) {
+	state := states.BuildState(func(s *states.SyncState) {})
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	view, _ := testView(t)
+	c := &StateMvCommand{
+		StateMeta{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				Ui:               ui,
+				View:             view,
+			},
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"foo.bar1",
+		"foo.bar2",
+	}
+	code := c.Run(args)
+	if code != 1 {
+		t.Fatalf("expected error code 1, got:\n%d", code)
+	}
+}
+
 const testStateMvOutputOriginal = `
 test_instance.baz:
   ID = foo


### PR DESCRIPTION
Manual backport of #29839 targeting v1.1. Fix `terraform state mv` to exit with code `1` when the specified resources are not found. Previously an error diagnostic would be displayed, but Terraform would exit successfully.