### PR TITLE
Fix broken links for language syntax doc

### DIFF
--- a/website/docs/language/syntax/index.mdx
+++ b/website/docs/language/syntax/index.mdx
@@ -11,13 +11,13 @@ The majority of the Terraform language documentation focuses on the practical
 uses of the language and the specific constructs it uses. The pages in this
 section offer a more abstract view of the Terraform language.
 
-- [Configuration Syntax](/language/syntax/configuration) describes the native
+- [Configuration Syntax](/website/docs/language/syntax/configuration.mdx) describes the native
   grammar of the Terraform language.
-- [JSON Configuration Syntax](/language/syntax/json) documents
+- [JSON Configuration Syntax](/website/docs/language/syntax/json.mdx) documents
   how to represent Terraform language constructs in the pure JSON variant of the
   Terraform language. Terraform's JSON syntax is unfriendly to humans, but can
   be very useful when generating infrastructure as code with other systems that
   don't have a readily available HCL library.
-- [Style Conventions](/language/syntax/style) documents some commonly
+- [Style Conventions](/website/docs/language/syntax/style.mdx) documents some commonly
   accepted formatting guidelines for Terraform code. These conventions can be
   enforced automatically with [`terraform fmt`](/cli/commands/fmt).


### PR DESCRIPTION
I am reading the docs for first time and I realised that link were broken to use on  Github web. Not sure if these docs are used somewhere else where these type of links make sense. I see this is broken on other pages as well but I am not putting efforts to fix this for 3 reasons:

1) I don't understand if this website repo is expected to be consumed on GItHub web. 
2) This change can break other things which I am not aware. I never navigated through this repo before.
3) I need to understand repo to figure out what all is broken so that I can write some script to create PR instead of checking links manually 