### PR TITLE
Remove statefile after migrating to TFC

### DIFF
--- a/internal/states/statemgr/filesystem.go
+++ b/internal/states/statemgr/filesystem.go
@@ -108,6 +108,10 @@ func (s *Filesystem) BackupPath() string {
 	return s.backupPath
 }
 
+func (s *Filesystem) Path() string {
+	return s.path
+}
+
 // State is an implementation of Reader.
 func (s *Filesystem) State() *states.State {
 	defer s.mutex()()


### PR DESCRIPTION
Anytime you migrate states to Terraform Cloud, if you are using the
default workspace (that is, it has state, and can be used either by
itself or along with any number of named workspaces), the old state file
in the current working directory (./terraform.tfstate) is left behind
after the migration. This is problematic because remote runs in TFC
require that file to not be present in the slug. It means that when
a user migrates their default workspace, their first experience doing
a terraform apply is a runtime error in the worker telling them they did
something wrong.

This commit ensures the original state file has been emptied and the
backup state file exists and is not empty. Then it deletes the empty
original state file.