### PR TITLE
jsonplan: Improve performance for deep objects

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -597,7 +597,7 @@ func unknownAsBool(val cty.Value) cty.Value {
 			// Omit all of the "false"s for known values for more compact
 			// serialization
 			if !vAsBool.RawEquals(cty.False) {
-				vals[k.AsString()] = unknownAsBool(v)
+				vals[k.AsString()] = vAsBool
 			}
 		}
 		// The above transform may have changed the types of some of the

--- a/internal/command/jsonplan/plan_test.go
+++ b/internal/command/jsonplan/plan_test.go
@@ -304,3 +304,59 @@ func TestEncodePaths(t *testing.T) {
 		})
 	}
 }
+
+func deepObjectValue(depth int) cty.Value {
+	v := cty.ObjectVal(map[string]cty.Value{
+		"a": cty.StringVal("a"),
+		"b": cty.NumberIntVal(2),
+		"c": cty.True,
+		"d": cty.UnknownVal(cty.String),
+	})
+
+	result := v
+
+	for i := 0; i < depth; i++ {
+		result = cty.ObjectVal(map[string]cty.Value{
+			"a": result,
+			"b": result,
+			"c": result,
+		})
+	}
+
+	return result
+}
+
+func BenchmarkUnknownAsBool_2(b *testing.B) {
+	value := deepObjectValue(2)
+	for n := 0; n < b.N; n++ {
+		unknownAsBool(value)
+	}
+}
+
+func BenchmarkUnknownAsBool_3(b *testing.B) {
+	value := deepObjectValue(3)
+	for n := 0; n < b.N; n++ {
+		unknownAsBool(value)
+	}
+}
+
+func BenchmarkUnknownAsBool_5(b *testing.B) {
+	value := deepObjectValue(5)
+	for n := 0; n < b.N; n++ {
+		unknownAsBool(value)
+	}
+}
+
+func BenchmarkUnknownAsBool_7(b *testing.B) {
+	value := deepObjectValue(7)
+	for n := 0; n < b.N; n++ {
+		unknownAsBool(value)
+	}
+}
+
+func BenchmarkUnknownAsBool_9(b *testing.B) {
+	value := deepObjectValue(9)
+	for n := 0; n < b.N; n++ {
+		unknownAsBool(value)
+	}
+}


### PR DESCRIPTION
When calculating the unknown values for JSON plan output, we would previously recursively call the `unknownAsBool` function on the current sub-tree twice, if any values were unknown. This was wasteful, but not noticeable for normal Terraform resource shapes.

However for deeper nested object values, such as Kubernetes manifests, this was a severe performance problem, causing `terraform show -json` to take several hours to render a plan.

This commit reuses the already calculated unknown value for the subtree, and adds benchmark coverage to demonstrate the improvement.

Fixes #30548.

### Benchmark results

For these benchmarks, we construct a fairly narrow object value of variable depth, then compute its unknown value. The execution time difference for this change is:

| Object Depth | Speedup |
|---|---|
| 2 | 4x |
| 3 | 7x |
| 5 | 28x |
| 7 | 116x |
| 9 | 422x |

Before:

```
$ go test -bench=. ./internal/command/jsonplan/
goos: darwin
goarch: amd64
pkg: github.com/hashicorp/terraform/internal/command/jsonplan
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkUnknownAsBool_2-16    	   10000	    101835 ns/op
BenchmarkUnknownAsBool_3-16    	    1947	    610288 ns/op
BenchmarkUnknownAsBool_5-16    	      48	  22955366 ns/op
BenchmarkUnknownAsBool_7-16    	       2	 836706698 ns/op
BenchmarkUnknownAsBool_9-16    	       1	27352356756 ns/op
PASS
ok  	github.com/hashicorp/terraform/internal/command/jsonplan	33.781s
```

After:

```
$ go test -bench=. ./internal/command/jsonplan/
goos: darwin
goarch: amd64
pkg: github.com/hashicorp/terraform/internal/command/jsonplan
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkUnknownAsBool_2-16    	   33733	     30257 ns/op
BenchmarkUnknownAsBool_3-16    	   13136	     90776 ns/op
BenchmarkUnknownAsBool_5-16    	    1458	    815009 ns/op
BenchmarkUnknownAsBool_7-16    	     162	   7209663 ns/op
BenchmarkUnknownAsBool_9-16    	      19	  64790729 ns/op
PASS
ok  	github.com/hashicorp/terraform/internal/command/jsonplan	9.800s
```