### PR TITLE
[Docs] Added github.com commit reference example

### DIFF
--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -472,6 +472,7 @@ the version control sources, the sub-directory portion must be _before_ those
 arguments:
 
 - `git::https://example.com/network.git//modules/vpc?ref=v1.2.0`
+- `github.com/hashicorp/example//modules/vpc?ref=v1.2.0`
 
 Terraform will still extract the entire package to local disk, but will read
 the module from the subdirectory. As a result, it is safe for a module in


### PR DESCRIPTION
Adding another example to make clear how to mix github.com inference as well as commit reference.

I came across this because I initially was using the github.com auto-magic reference AND it was inferring modules from subdirectories without the double slash. When it came time to pin my reference to a commit, I had trouble finding the proper format because I had to now add back in the double slash as well as the reference.

This example would have helped show me exactly what I needed in this instance.