### PR TITLE
Fix broken link on provisioners connection page

### DIFF
--- a/website/docs/language/resources/provisioners/connection.mdx
+++ b/website/docs/language/resources/provisioners/connection.mdx
@@ -110,7 +110,7 @@ indirectly with a [bastion host](https://en.wikipedia.org/wiki/Bastion_host).
 | `bastion_port` | The port to use connect to the bastion host. | The value of the `port` field.|
 | `bastion_user`| The user for the connection to the bastion host. | The value of the `user` field. |
 | `bastion_password` | The password to use for the bastion host. | The value of the `password` field. |
-| `bastion_private_key` | The contents of an SSH key file to use for the bastion host. These can be loaded from a file on disk using [the `file` function](language/functions/file). | The value of the `private_key` field. |
+| `bastion_private_key` | The contents of an SSH key file to use for the bastion host. These can be loaded from a file on disk using [the `file` function](/language/functions/file). | The value of the `private_key` field. |
 | `bastion_certificate` |  The contents of a signed CA Certificate. The certificate argument must be used in conjunction with a `bastion_private_key`. These can be loaded from a file on disk using the [the `file` function](/language/functions/file). |
 
 ## How Provisioners Execute Remote Scripts


### PR DESCRIPTION
One of the links was missing a slash before the path :-) 