### PR TITLE
Pull changes from go-tfe 1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-retryablehttp v0.7.0
-	github.com/hashicorp/go-tfe v0.26.0
+	github.com/hashicorp/go-tfe v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f

--- a/go.sum
+++ b/go.sum
@@ -410,14 +410,13 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
-github.com/hashicorp/go-slug v0.7.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
 github.com/hashicorp/go-slug v0.8.0 h1:h7AGtXVAI/cJ/Wwa/JQQaftQnWQmZbAzkzgZeZVVmLw=
 github.com/hashicorp/go-slug v0.8.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
-github.com/hashicorp/go-tfe v0.26.0 h1:6vQshg2NW5CkN4fkM64qhX+Z5Ua7ip74n8nAJRlhKKg=
-github.com/hashicorp/go-tfe v0.26.0/go.mod h1:gyXLXbpBVxA2F/6opah8XBsOkZJxHYQmghl0OWi8keI=
+github.com/hashicorp/go-tfe v1.0.0 h1:CmwoHrOs7WJfD/yEmVjJ65+dyKeVRrgvRHBLVSQQ6Ks=
+github.com/hashicorp/go-tfe v1.0.0/go.mod h1:tJF/OlAXzVbmjiimAPLplSLgwg6kZDUOy0MzHuMwvF4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -321,7 +321,7 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	}
 
 	// Check if the organization exists by reading its entitlements.
-	entitlements, err := b.client.Organizations.Entitlements(context.Background(), b.organization)
+	entitlements, err := b.client.Organizations.ReadEntitlements(context.Background(), b.organization)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			err = fmt.Errorf("organization %q at host %s not found.\n\n"+
@@ -527,12 +527,12 @@ func (b *Remote) Workspaces() ([]string, error) {
 
 // workspaces returns a filtered list of remote workspace names.
 func (b *Remote) workspaces() ([]string, error) {
-	options := tfe.WorkspaceListOptions{}
+	options := &tfe.WorkspaceListOptions{}
 	switch {
 	case b.workspace != "":
-		options.Search = tfe.String(b.workspace)
+		options.Search = b.workspace
 	case b.prefix != "":
-		options.Search = tfe.String(b.prefix)
+		options.Search = b.prefix
 	}
 
 	// Create a slice to contain all the names.

--- a/internal/backend/remote/backend_apply_test.go
+++ b/internal/backend/remote/backend_apply_test.go
@@ -777,7 +777,7 @@ func TestRemote_applyApprovedExternally(t *testing.T) {
 	wl, err := b.client.Workspaces.List(
 		ctx,
 		b.organization,
-		tfe.WorkspaceListOptions{},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error listing workspaces: %v", err)
@@ -786,7 +786,7 @@ func TestRemote_applyApprovedExternally(t *testing.T) {
 		t.Fatalf("expected 1 workspace, got %d workspaces", len(wl.Items))
 	}
 
-	rl, err := b.client.Runs.List(ctx, wl.Items[0].ID, tfe.RunListOptions{})
+	rl, err := b.client.Runs.List(ctx, wl.Items[0].ID, nil)
 	if err != nil {
 		t.Fatalf("unexpected error listing runs: %v", err)
 	}
@@ -851,7 +851,7 @@ func TestRemote_applyDiscardedExternally(t *testing.T) {
 	wl, err := b.client.Workspaces.List(
 		ctx,
 		b.organization,
-		tfe.WorkspaceListOptions{},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error listing workspaces: %v", err)
@@ -860,7 +860,7 @@ func TestRemote_applyDiscardedExternally(t *testing.T) {
 		t.Fatalf("expected 1 workspace, got %d workspaces", len(wl.Items))
 	}
 
-	rl, err := b.client.Runs.List(ctx, wl.Items[0].ID, tfe.RunListOptions{})
+	rl, err := b.client.Runs.List(ctx, wl.Items[0].ID, nil)
 	if err != nil {
 		t.Fatalf("unexpected error listing runs: %v", err)
 	}

--- a/internal/backend/remote/backend_common.go
+++ b/internal/backend/remote/backend_common.go
@@ -110,7 +110,7 @@ func (b *Remote) waitForRun(stopCtx, cancelCtx context.Context, op *backend.Oper
 			// Skip checking the workspace queue when we are the current run.
 			if w.CurrentRun == nil || w.CurrentRun.ID != r.ID {
 				found := false
-				options := tfe.RunListOptions{}
+				options := &tfe.RunListOptions{}
 			runlist:
 				for {
 					rl, err := b.client.Runs.List(stopCtx, w.ID, options)
@@ -165,10 +165,10 @@ func (b *Remote) waitForRun(stopCtx, cancelCtx context.Context, op *backend.Oper
 				}
 			}
 
-			options := tfe.RunQueueOptions{}
+			options := tfe.ReadRunQueueOptions{}
 		search:
 			for {
-				rq, err := b.client.Organizations.RunQueue(stopCtx, b.organization, options)
+				rq, err := b.client.Organizations.ReadRunQueue(stopCtx, b.organization, options)
 				if err != nil {
 					return r, generalError("Failed to retrieve queue", err)
 				}
@@ -191,7 +191,7 @@ func (b *Remote) waitForRun(stopCtx, cancelCtx context.Context, op *backend.Oper
 			}
 
 			if position > 0 {
-				c, err := b.client.Organizations.Capacity(stopCtx, b.organization)
+				c, err := b.client.Organizations.ReadCapacity(stopCtx, b.organization)
 				if err != nil {
 					return r, generalError("Failed to retrieve capacity", err)
 				}

--- a/internal/backend/remote/backend_context.go
+++ b/internal/backend/remote/backend_context.go
@@ -108,7 +108,7 @@ func (b *Remote) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Fu
 			log.Printf("[TRACE] skipping retrieving variables from workspace %s/%s (%s), workspace is in Local Execution mode", remoteWorkspaceName, b.organization, remoteWorkspaceID)
 		} else {
 			log.Printf("[TRACE] backend/remote: retrieving variables from workspace %s/%s (%s)", remoteWorkspaceName, b.organization, remoteWorkspaceID)
-			tfeVariables, err := b.client.Variables.List(context.Background(), remoteWorkspaceID, tfe.VariableListOptions{})
+			tfeVariables, err := b.client.Variables.List(context.Background(), remoteWorkspaceID, nil)
 			if err != nil && err != tfe.ErrResourceNotFound {
 				diags = diags.Append(fmt.Errorf("error loading variables: %w", err))
 				return nil, nil, diags

--- a/internal/backend/remote/backend_state.go
+++ b/internal/backend/remote/backend_state.go
@@ -27,7 +27,7 @@ type remoteClient struct {
 func (r *remoteClient) Get() (*remote.Payload, error) {
 	ctx := context.Background()
 
-	sv, err := r.client.StateVersions.Current(ctx, r.workspace.ID)
+	sv, err := r.client.StateVersions.ReadCurrent(ctx, r.workspace.ID)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			// If no state exists, then return nil.

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -273,7 +273,7 @@ func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
 	}
 
 	// Check if the organization exists by reading its entitlements.
-	entitlements, err := b.client.Organizations.Entitlements(context.Background(), b.organization)
+	entitlements, err := b.client.Organizations.ReadEntitlements(context.Background(), b.organization)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			err = fmt.Errorf("organization %q at host %s not found.\n\n"+
@@ -452,10 +452,10 @@ func (b *Cloud) Workspaces() ([]string, error) {
 
 	// Otherwise, multiple workspaces are being mapped. Query Terraform Cloud for all the remote
 	// workspaces by the provided mapping strategy.
-	options := tfe.WorkspaceListOptions{}
+	options := &tfe.WorkspaceListOptions{}
 	if b.WorkspaceMapping.Strategy() == WorkspaceTagsStrategy {
 		taglist := strings.Join(b.WorkspaceMapping.Tags, ",")
-		options.Tags = &taglist
+		options.Tags = taglist
 	}
 
 	for {

--- a/internal/cloud/backend_apply_test.go
+++ b/internal/cloud/backend_apply_test.go
@@ -655,7 +655,7 @@ func TestCloud_applyApprovedExternally(t *testing.T) {
 	wl, err := b.client.Workspaces.List(
 		ctx,
 		b.organization,
-		tfe.WorkspaceListOptions{},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error listing workspaces: %v", err)
@@ -664,7 +664,7 @@ func TestCloud_applyApprovedExternally(t *testing.T) {
 		t.Fatalf("expected 1 workspace, got %d workspaces", len(wl.Items))
 	}
 
-	rl, err := b.client.Runs.List(ctx, wl.Items[0].ID, tfe.RunListOptions{})
+	rl, err := b.client.Runs.List(ctx, wl.Items[0].ID, nil)
 	if err != nil {
 		t.Fatalf("unexpected error listing runs: %v", err)
 	}
@@ -729,7 +729,7 @@ func TestCloud_applyDiscardedExternally(t *testing.T) {
 	wl, err := b.client.Workspaces.List(
 		ctx,
 		b.organization,
-		tfe.WorkspaceListOptions{},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error listing workspaces: %v", err)
@@ -738,7 +738,7 @@ func TestCloud_applyDiscardedExternally(t *testing.T) {
 		t.Fatalf("expected 1 workspace, got %d workspaces", len(wl.Items))
 	}
 
-	rl, err := b.client.Runs.List(ctx, wl.Items[0].ID, tfe.RunListOptions{})
+	rl, err := b.client.Runs.List(ctx, wl.Items[0].ID, nil)
 	if err != nil {
 		t.Fatalf("unexpected error listing runs: %v", err)
 	}

--- a/internal/cloud/backend_common.go
+++ b/internal/cloud/backend_common.go
@@ -109,7 +109,7 @@ func (b *Cloud) waitForRun(stopCtx, cancelCtx context.Context, op *backend.Opera
 			// Skip checking the workspace queue when we are the current run.
 			if w.CurrentRun == nil || w.CurrentRun.ID != r.ID {
 				found := false
-				options := tfe.RunListOptions{}
+				options := &tfe.RunListOptions{}
 			runlist:
 				for {
 					rl, err := b.client.Runs.List(stopCtx, w.ID, options)
@@ -164,10 +164,10 @@ func (b *Cloud) waitForRun(stopCtx, cancelCtx context.Context, op *backend.Opera
 				}
 			}
 
-			options := tfe.RunQueueOptions{}
+			options := tfe.ReadRunQueueOptions{}
 		search:
 			for {
-				rq, err := b.client.Organizations.RunQueue(stopCtx, b.organization, options)
+				rq, err := b.client.Organizations.ReadRunQueue(stopCtx, b.organization, options)
 				if err != nil {
 					return r, generalError("Failed to retrieve queue", err)
 				}
@@ -190,7 +190,7 @@ func (b *Cloud) waitForRun(stopCtx, cancelCtx context.Context, op *backend.Opera
 			}
 
 			if position > 0 {
-				c, err := b.client.Organizations.Capacity(stopCtx, b.organization)
+				c, err := b.client.Organizations.ReadCapacity(stopCtx, b.organization)
 				if err != nil {
 					return r, generalError("Failed to retrieve capacity", err)
 				}

--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -97,18 +97,17 @@ func (b *Cloud) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Ful
 			diags = diags.Append(fmt.Errorf("error finding remote workspace: %w", err))
 			return nil, nil, diags
 		}
-
-		// Retrieve the workspace for this operation.
 		w, err := b.fetchWorkspace(context.Background(), b.organization, op.Workspace)
 		if err != nil {
 			diags = diags.Append(fmt.Errorf("error loading workspace: %w", err))
 			return nil, nil, diags
 		}
+
 		if isLocalExecutionMode(w.ExecutionMode) {
 			log.Printf("[TRACE] skipping retrieving variables from workspace %s/%s (%s), workspace is in Local Execution mode", remoteWorkspaceName, b.organization, remoteWorkspaceID)
 		} else {
 			log.Printf("[TRACE] cloud: retrieving variables from workspace %s/%s (%s)", remoteWorkspaceName, b.organization, remoteWorkspaceID)
-			tfeVariables, err := b.client.Variables.List(context.Background(), remoteWorkspaceID, tfe.VariableListOptions{})
+			tfeVariables, err := b.client.Variables.List(context.Background(), remoteWorkspaceID, nil)
 			if err != nil && err != tfe.ErrResourceNotFound {
 				diags = diags.Append(fmt.Errorf("error loading variables: %w", err))
 				return nil, nil, diags

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -326,7 +326,7 @@ in order to capture the filesystem context the remote workspace expects:
 	// Retrieve the run to get its current status.
 	runID := r.ID
 	r, err = b.client.Runs.ReadWithOptions(stopCtx, runID, &tfe.RunReadOptions{
-		Include: "task_stages",
+		Include: []tfe.RunIncludeOpt{tfe.RunTaskStages},
 	})
 	if err != nil {
 		// This error would be expected for older versions of TFE that do not allow

--- a/internal/cloud/backend_runTasks.go
+++ b/internal/cloud/backend_runTasks.go
@@ -136,7 +136,7 @@ func (b *Cloud) runTasksWithTaskResults(context *IntegrationContext, output Inte
 func (b *Cloud) runTasks(ctx *IntegrationContext, output IntegrationOutputWriter, stageID string) error {
 	return b.runTasksWithTaskResults(ctx, output, func(b *Cloud, stopCtx context.Context) (*tfe.TaskStage, error) {
 		options := tfe.TaskStageReadOptions{
-			Include: []tfe.TaskStageIncludeOps{tfe.TaskStageTaskResults},
+			Include: []tfe.TaskStageIncludeOpt{tfe.TaskStageTaskResults},
 		}
 
 		return b.client.TaskStages.Read(ctx.StopContext, stageID, &options)

--- a/internal/cloud/backend_state.go
+++ b/internal/cloud/backend_state.go
@@ -27,7 +27,7 @@ type remoteClient struct {
 func (r *remoteClient) Get() (*remote.Payload, error) {
 	ctx := context.Background()
 
-	sv, err := r.client.StateVersions.Current(ctx, r.workspace.ID)
+	sv, err := r.client.StateVersions.ReadCurrent(ctx, r.workspace.ID)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			// If no state exists, then return nil.

--- a/internal/cloud/e2e/apply_auto_approve_test.go
+++ b/internal/cloud/e2e/apply_auto_approve_test.go
@@ -44,7 +44,7 @@ func Test_terraform_apply_autoApprove(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				workspace, err := tfeClient.Workspaces.ReadWithOptions(ctx, orgName, "app", &tfe.WorkspaceReadOptions{Include: "current_run"})
+				workspace, err := tfeClient.Workspaces.ReadWithOptions(ctx, orgName, "app", &tfe.WorkspaceReadOptions{Include: []tfe.WSIncludeOpt{tfe.WSCurrentRun}})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -84,7 +84,7 @@ func Test_terraform_apply_autoApprove(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				workspace, err := tfeClient.Workspaces.ReadWithOptions(ctx, orgName, "app", &tfe.WorkspaceReadOptions{Include: "current_run"})
+				workspace, err := tfeClient.Workspaces.ReadWithOptions(ctx, orgName, "app", &tfe.WorkspaceReadOptions{Include: []tfe.WSIncludeOpt{tfe.WSCurrentRun}})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -122,7 +122,7 @@ func Test_terraform_apply_autoApprove(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				workspace, err := tfeClient.Workspaces.ReadWithOptions(ctx, orgName, "app", &tfe.WorkspaceReadOptions{Include: "current_run"})
+				workspace, err := tfeClient.Workspaces.ReadWithOptions(ctx, orgName, "app", &tfe.WorkspaceReadOptions{Include: []tfe.WSIncludeOpt{tfe.WSCurrentRun}})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -160,7 +160,7 @@ func Test_terraform_apply_autoApprove(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				workspace, err := tfeClient.Workspaces.ReadWithOptions(ctx, orgName, "app", &tfe.WorkspaceReadOptions{Include: "current_run"})
+				workspace, err := tfeClient.Workspaces.ReadWithOptions(ctx, orgName, "app", &tfe.WorkspaceReadOptions{Include: []tfe.WSIncludeOpt{tfe.WSCurrentRun}})
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/internal/cloud/e2e/helper_test.go
+++ b/internal/cloud/e2e/helper_test.go
@@ -213,7 +213,7 @@ func skipWithoutRemoteTerraformVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("Error instantiating go-version for %s", version))
 	}
-	opts := tfe.AdminTerraformVersionsListOptions{
+	opts := &tfe.AdminTerraformVersionsListOptions{
 		ListOptions: tfe.ListOptions{
 			PageNumber: 1,
 			PageSize:   100,

--- a/internal/cloud/e2e/migrate_state_multi_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_multi_to_tfc_test.go
@@ -71,7 +71,7 @@ func Test_migrate_multi_to_tfc_cloud_name_strategy(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{})
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, nil)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -136,7 +136,7 @@ func Test_migrate_multi_to_tfc_cloud_name_strategy(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{})
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, nil)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -202,7 +202,7 @@ func Test_migrate_multi_to_tfc_cloud_name_strategy(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{})
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, nil)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -310,8 +310,8 @@ func Test_migrate_multi_to_tfc_cloud_tags_strategy(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{
-					Tags: tfe.String("app"),
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, &tfe.WorkspaceListOptions{
+					Tags: "app",
 				})
 				if err != nil {
 					t.Fatal(err)
@@ -411,8 +411,8 @@ func Test_migrate_multi_to_tfc_cloud_tags_strategy(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{
-					Tags: tfe.String("app"),
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, &tfe.WorkspaceListOptions{
+					Tags: "app",
 				})
 				if err != nil {
 					t.Fatal(err)

--- a/internal/cloud/e2e/migrate_state_remote_backend_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_remote_backend_to_tfc_test.go
@@ -165,8 +165,8 @@ func Test_migrate_remote_backend_single_org(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{
-					Tags: tfe.String("app"),
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, &tfe.WorkspaceListOptions{
+					Tags: "app",
 				})
 				if err != nil {
 					t.Fatal(err)
@@ -294,7 +294,7 @@ func Test_migrate_remote_backend_single_org(t *testing.T) {
 				if ws == nil {
 					t.Fatalf("Expected workspace %s to be present, but is not.", expectedName)
 				}
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{})
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, nil)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -428,8 +428,8 @@ func Test_migrate_remote_backend_single_org(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{
-					Tags: tfe.String("app"),
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, &tfe.WorkspaceListOptions{
+					Tags: "app",
 				})
 				if err != nil {
 					t.Fatal(err)

--- a/internal/cloud/e2e/migrate_state_single_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_single_to_tfc_test.go
@@ -56,7 +56,7 @@ func Test_migrate_single_to_tfc(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{})
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, nil)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -108,8 +108,8 @@ func Test_migrate_single_to_tfc(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{
-					Tags: tfe.String("app"),
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, &tfe.WorkspaceListOptions{
+					Tags: "app",
 				})
 				if err != nil {
 					t.Fatal(err)

--- a/internal/cloud/e2e/migrate_state_tfc_to_tfc_test.go
+++ b/internal/cloud/e2e/migrate_state_tfc_to_tfc_test.go
@@ -70,7 +70,7 @@ func Test_migrate_tfc_to_tfc_single_workspace(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{})
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, nil)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -126,8 +126,8 @@ func Test_migrate_tfc_to_tfc_single_workspace(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{
-					Tags: tfe.String("app"),
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, &tfe.WorkspaceListOptions{
+					Tags: "app",
 				})
 				if err != nil {
 					t.Fatal(err)
@@ -189,7 +189,7 @@ func Test_migrate_tfc_to_tfc_single_workspace(t *testing.T) {
 			validations: func(t *testing.T, orgName string) {
 				// We created the workspace, so it will be there. We could not complete the state migration,
 				// though, so the workspace should be empty.
-				ws, err := tfeClient.Workspaces.ReadWithOptions(ctx, orgName, "new-workspace", &tfe.WorkspaceReadOptions{Include: "current_run"})
+				ws, err := tfeClient.Workspaces.ReadWithOptions(ctx, orgName, "new-workspace", &tfe.WorkspaceReadOptions{Include: []tfe.WSIncludeOpt{tfe.WSCurrentRun}})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -348,8 +348,8 @@ func Test_migrate_tfc_to_tfc_multiple_workspace(t *testing.T) {
 				},
 			},
 			validations: func(t *testing.T, orgName string) {
-				wsList, err := tfeClient.Workspaces.List(ctx, orgName, tfe.WorkspaceListOptions{
-					Tags: tfe.String("billing"),
+				wsList, err := tfeClient.Workspaces.List(ctx, orgName, &tfe.WorkspaceListOptions{
+					Tags: "billing",
 				})
 				if err != nil {
 					t.Fatal(err)

--- a/internal/cloud/tfe_client_mock.go
+++ b/internal/cloud/tfe_client_mock.go
@@ -167,7 +167,7 @@ func newMockConfigurationVersions(client *MockClient) *MockConfigurationVersions
 	}
 }
 
-func (m *MockConfigurationVersions) List(ctx context.Context, workspaceID string, options tfe.ConfigurationVersionListOptions) (*tfe.ConfigurationVersionList, error) {
+func (m *MockConfigurationVersions) List(ctx context.Context, workspaceID string, options *tfe.ConfigurationVersionListOptions) (*tfe.ConfigurationVersionList, error) {
 	cvl := &tfe.ConfigurationVersionList{}
 	for _, cv := range m.configVersions {
 		cvl.Items = append(cvl.Items, cv)
@@ -224,6 +224,14 @@ func (m *MockConfigurationVersions) Upload(ctx context.Context, url, path string
 	m.uploadPaths[cv.ID] = path
 	cv.Status = tfe.ConfigurationUploaded
 	return nil
+}
+
+func (m *MockConfigurationVersions) Archive(ctx context.Context, cvID string) error {
+	panic("not implemented")
+}
+
+func (m *MockConfigurationVersions) Download(ctx context.Context, cvID string) ([]byte, error) {
+	panic("not implemented")
 }
 
 type MockCostEstimates struct {
@@ -320,7 +328,7 @@ func newMockOrganizations(client *MockClient) *MockOrganizations {
 	}
 }
 
-func (m *MockOrganizations) List(ctx context.Context, options tfe.OrganizationListOptions) (*tfe.OrganizationList, error) {
+func (m *MockOrganizations) List(ctx context.Context, options *tfe.OrganizationListOptions) (*tfe.OrganizationList, error) {
 	orgl := &tfe.OrganizationList{}
 	for _, org := range m.organizations {
 		orgl.Items = append(orgl.Items, org)
@@ -392,7 +400,7 @@ func (m *MockOrganizations) Delete(ctx context.Context, name string) error {
 	return nil
 }
 
-func (m *MockOrganizations) Capacity(ctx context.Context, name string) (*tfe.Capacity, error) {
+func (m *MockOrganizations) ReadCapacity(ctx context.Context, name string) (*tfe.Capacity, error) {
 	var pending, running int
 	for _, r := range m.client.Runs.Runs {
 		if r.Status == tfe.RunPending {
@@ -404,7 +412,7 @@ func (m *MockOrganizations) Capacity(ctx context.Context, name string) (*tfe.Cap
 	return &tfe.Capacity{Pending: pending, Running: running}, nil
 }
 
-func (m *MockOrganizations) Entitlements(ctx context.Context, name string) (*tfe.Entitlements, error) {
+func (m *MockOrganizations) ReadEntitlements(ctx context.Context, name string) (*tfe.Entitlements, error) {
 	return &tfe.Entitlements{
 		Operations:            true,
 		PrivateModuleRegistry: true,
@@ -415,7 +423,7 @@ func (m *MockOrganizations) Entitlements(ctx context.Context, name string) (*tfe
 	}, nil
 }
 
-func (m *MockOrganizations) RunQueue(ctx context.Context, name string, options tfe.RunQueueOptions) (*tfe.RunQueue, error) {
+func (m *MockOrganizations) ReadRunQueue(ctx context.Context, name string, options tfe.ReadRunQueueOptions) (*tfe.RunQueue, error) {
 	rq := &tfe.RunQueue{}
 
 	for _, r := range m.client.Runs.Runs {
@@ -525,7 +533,7 @@ func (m *MockPlans) Logs(ctx context.Context, planID string) (io.Reader, error) 
 	}, nil
 }
 
-func (m *MockPlans) JSONOutput(ctx context.Context, planID string) ([]byte, error) {
+func (m *MockPlans) ReadJSONOutput(ctx context.Context, planID string) ([]byte, error) {
 	planOutput, ok := m.planOutputs[planID]
 	if !ok {
 		return nil, tfe.ErrResourceNotFound
@@ -582,7 +590,7 @@ func (m *MockPolicyChecks) create(cvID, workspaceID string) (*tfe.PolicyCheck, e
 	return pc, nil
 }
 
-func (m *MockPolicyChecks) List(ctx context.Context, runID string, options tfe.PolicyCheckListOptions) (*tfe.PolicyCheckList, error) {
+func (m *MockPolicyChecks) List(ctx context.Context, runID string, options *tfe.PolicyCheckListOptions) (*tfe.PolicyCheckList, error) {
 	_, ok := m.client.Runs.Runs[runID]
 	if !ok {
 		return nil, tfe.ErrResourceNotFound
@@ -714,7 +722,7 @@ func newMockRuns(client *MockClient) *MockRuns {
 	}
 }
 
-func (m *MockRuns) List(ctx context.Context, workspaceID string, options tfe.RunListOptions) (*tfe.RunList, error) {
+func (m *MockRuns) List(ctx context.Context, workspaceID string, options *tfe.RunListOptions) (*tfe.RunList, error) {
 	m.Lock()
 	defer m.Unlock()
 
@@ -926,7 +934,7 @@ func newMockStateVersions(client *MockClient) *MockStateVersions {
 	}
 }
 
-func (m *MockStateVersions) List(ctx context.Context, options tfe.StateVersionListOptions) (*tfe.StateVersionList, error) {
+func (m *MockStateVersions) List(ctx context.Context, options *tfe.StateVersionListOptions) (*tfe.StateVersionList, error) {
 	svl := &tfe.StateVersionList{}
 	for _, sv := range m.stateVersions {
 		svl.Items = append(svl.Items, sv)
@@ -982,11 +990,11 @@ func (m *MockStateVersions) ReadWithOptions(ctx context.Context, svID string, op
 	return sv, nil
 }
 
-func (m *MockStateVersions) Current(ctx context.Context, workspaceID string) (*tfe.StateVersion, error) {
-	return m.CurrentWithOptions(ctx, workspaceID, nil)
+func (m *MockStateVersions) ReadCurrent(ctx context.Context, workspaceID string) (*tfe.StateVersion, error) {
+	return m.ReadCurrentWithOptions(ctx, workspaceID, nil)
 }
 
-func (m *MockStateVersions) CurrentWithOptions(ctx context.Context, workspaceID string, options *tfe.StateVersionCurrentOptions) (*tfe.StateVersion, error) {
+func (m *MockStateVersions) ReadCurrentWithOptions(ctx context.Context, workspaceID string, options *tfe.StateVersionCurrentOptions) (*tfe.StateVersion, error) {
 	w, ok := m.client.Workspaces.workspaceIDs[workspaceID]
 	if !ok {
 		return nil, tfe.ErrResourceNotFound
@@ -1013,7 +1021,7 @@ func (m *MockStateVersions) Download(ctx context.Context, url string) ([]byte, e
 	return state, nil
 }
 
-func (m *MockStateVersions) Outputs(ctx context.Context, svID string, options tfe.StateVersionOutputsListOptions) ([]*tfe.StateVersionOutput, error) {
+func (m *MockStateVersions) ListOutputs(ctx context.Context, svID string, options *tfe.StateVersionOutputsListOptions) (*tfe.StateVersionOutputsList, error) {
 	panic("not implemented")
 }
 
@@ -1031,7 +1039,7 @@ func newMockVariables(client *MockClient) *MockVariables {
 	}
 }
 
-func (m *MockVariables) List(ctx context.Context, workspaceID string, options tfe.VariableListOptions) (*tfe.VariableList, error) {
+func (m *MockVariables) List(ctx context.Context, workspaceID string, options *tfe.VariableListOptions) (*tfe.VariableList, error) {
 	vl := m.workspaces[workspaceID]
 	return vl, nil
 }
@@ -1090,21 +1098,22 @@ func newMockWorkspaces(client *MockClient) *MockWorkspaces {
 	}
 }
 
-func (m *MockWorkspaces) List(ctx context.Context, organization string, options tfe.WorkspaceListOptions) (*tfe.WorkspaceList, error) {
+func (m *MockWorkspaces) List(ctx context.Context, organization string, options *tfe.WorkspaceListOptions) (*tfe.WorkspaceList, error) {
 	wl := &tfe.WorkspaceList{}
-
 	// Get all the workspaces that match the Search value
 	searchValue := ""
-	if options.Search != nil {
-		searchValue = *options.Search
-	}
-
 	var ws []*tfe.Workspace
 	var tags []string
 
-	if options.Tags != nil {
-		tags = strings.Split(*options.Tags, ",")
+	if options != nil {
+		if len(options.Search) > 0 {
+			searchValue = options.Search
+		}
+		if len(options.Tags) > 0 {
+			tags = strings.Split(options.Tags, ",")
+		}
 	}
+
 	for _, w := range m.workspaceIDs {
 		wTags := make(map[string]struct{})
 		for _, wTag := range w.Tags {
@@ -1134,8 +1143,10 @@ func (m *MockWorkspaces) List(ctx context.Context, organization string, options 
 
 	numPages := (len(ws) / 20) + 1
 	currentPage := 1
-	if options.PageNumber != 0 {
-		currentPage = options.PageNumber
+	if options != nil {
+		if options.PageNumber != 0 {
+			currentPage = options.PageNumber
+		}
 	}
 	previousPage := currentPage - 1
 	nextPage := currentPage + 1
@@ -1372,7 +1383,7 @@ func (m *MockWorkspaces) UnassignSSHKey(ctx context.Context, workspaceID string)
 	panic("not implemented")
 }
 
-func (m *MockWorkspaces) RemoteStateConsumers(ctx context.Context, workspaceID string, options *tfe.RemoteStateConsumersListOptions) (*tfe.WorkspaceList, error) {
+func (m *MockWorkspaces) ListRemoteStateConsumers(ctx context.Context, workspaceID string, options *tfe.RemoteStateConsumersListOptions) (*tfe.WorkspaceList, error) {
 	panic("not implemented")
 }
 
@@ -1392,7 +1403,7 @@ func (m *MockWorkspaces) Readme(ctx context.Context, workspaceID string) (io.Rea
 	panic("not implemented")
 }
 
-func (m *MockWorkspaces) Tags(ctx context.Context, workspaceID string, options tfe.WorkspaceTagListOptions) (*tfe.TagList, error) {
+func (m *MockWorkspaces) ListTags(ctx context.Context, workspaceID string, options *tfe.WorkspaceTagListOptions) (*tfe.TagList, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
This PR is updating terraform to use the latest major version for go-tfe.
1.0 version is not introducing new major features or functionality into the client, but mainly bringing consistency of practices into its codebase, like adding pointer type to optional fields and renaming interface methods. Because of this, the upgrade contains breaking changes.
More details about about 1.0 release: https://github.com/hashicorp/go-tfe/releases/tag/v1.0.0