### PR TITLE
Document logical operators not short-circuiting

### DIFF
--- a/website/docs/language/expressions/operators.mdx
+++ b/website/docs/language/expressions/operators.mdx
@@ -103,3 +103,5 @@ The logical operators all expect bool values and produce bool values as results.
 Terraform does not have an operator for the "exclusive OR" operation. If you
 know that both operators are boolean values then exclusive OR is equivalent
 to the `!=` ("not equal") operator.
+
+The logical operators in Terraform do not short-circuit, meaning `var.foo || var.foo.bar` will produce an error message if `var.foo` is `null` because both `var.foo` and `var.foo.bar` are evaluated.


### PR DESCRIPTION
Including a note about logical operators not short-circuiting will make the documentation clearer and more useful. https://github.com/hashicorp/terraform/issues/24128 includes examples of people being caught out by this lack of clarity.