### PR TITLE
Change aws.dest to aws.dst

### DIFF
--- a/website/docs/language/modules/develop/providers.mdx
+++ b/website/docs/language/modules/develop/providers.mdx
@@ -221,7 +221,7 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 2.7.0"
-      configuration_aliases = [ aws.src, aws.dest ]
+      configuration_aliases = [ aws.src, aws.dst ]
     }
   }
 }


### PR DESCRIPTION
Documentation is wrong the `configuration_aliases` should be `[ aws.src, aws.dst ]` not `[ aws.src, aws.dest ]`.