### PR TITLE
Clearify which type of id is used in the documentation

### DIFF
--- a/website/docs/cli/commands/import.mdx
+++ b/website/docs/cli/commands/import.mdx
@@ -22,7 +22,7 @@ ADDRESS must be a valid [resource address](/cli/state/resource-addressing).
 Because any resource address is valid, the import command can import resources
 into modules as well as directly into the root of your state.
 
-ID is dependent on the resource type being imported. For example, for AWS
+ID is dependent on the resource type being imported. For example, for AWS EC2
 instances it is the instance ID (`i-abcd1234`) but for AWS Route53 zones
 it is the zone ID (`Z12ABC4UGMOZ2N`). Please reference the provider documentation for details
 on the ID format. If you're unsure, feel free to just try an ID. If the ID

--- a/website/docs/cli/import/usage.mdx
+++ b/website/docs/cli/import/usage.mdx
@@ -46,7 +46,7 @@ resource configuration:
 $ terraform import aws_instance.example i-abcd1234
 ```
 
-This command locates the AWS instance with ID `i-abcd1234`. Then it attaches
+This command locates the AWS EC2 instance with ID `i-abcd1234`. Then it attaches
 the existing settings of the instance, as described by the EC2 API, to the
 name `aws_instance.example` of a module. In this example the module path
 implies that the root module is used. Finally, the mapping is saved in the


### PR DESCRIPTION
If any non(-regular) AWS user reads over the documentation for the import command, they might be confused when it just says 'AWS instance' as it could also refer to an account or datacenter.
So I added the resource type name to make it clear _which type of instance_ is meant.