### PR TITLE
core: Eval pre/postconditions in refresh-only mode

### DIFF
--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -99,7 +99,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&RootVariableTransformer{Config: b.Config, RawValues: b.RootVariableValues},
 		&ModuleVariableTransformer{Config: b.Config},
 		&LocalTransformer{Config: b.Config},
-		&OutputTransformer{Config: b.Config},
+		&OutputTransformer{Config: b.Config, RefreshOnly: b.skipPlanChanges},
 
 		// Add orphan resources
 		&OrphanResourceInstanceTransformer{

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -655,6 +655,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		checkResourcePrecondition,
 		n.Config.Preconditions,
 		ctx, nil, keyData,
+		tfdiags.Error,
 	)
 	diags = diags.Append(checkDiags)
 	if diags.HasErrors() {
@@ -1476,7 +1477,7 @@ func (n *NodeAbstractResourceInstance) providerMetas(ctx EvalContext) (cty.Value
 // value, but it still matches the previous state, then we can record a NoNop
 // change. If the states don't match then we record a Read change so that the
 // new value is applied to the state.
-func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, currentState *states.ResourceInstanceObject) (*plans.ResourceInstanceChange, *states.ResourceInstanceObject, instances.RepetitionData, tfdiags.Diagnostics) {
+func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, currentState *states.ResourceInstanceObject, checkRuleSeverity tfdiags.Severity) (*plans.ResourceInstanceChange, *states.ResourceInstanceObject, instances.RepetitionData, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	var keyData instances.RepetitionData
 	var configVal cty.Value
@@ -1510,6 +1511,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, currentSt
 		checkResourcePrecondition,
 		n.Config.Preconditions,
 		ctx, nil, keyData,
+		checkRuleSeverity,
 	)
 	diags = diags.Append(checkDiags)
 	if diags.HasErrors() {
@@ -1689,6 +1691,7 @@ func (n *NodeAbstractResourceInstance) applyDataSource(ctx EvalContext, planned 
 		checkResourcePrecondition,
 		n.Config.Preconditions,
 		ctx, nil, keyData,
+		tfdiags.Error,
 	)
 	diags = diags.Append(checkDiags)
 	if diags.HasErrors() {

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -184,6 +184,7 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 		n.Config.Postconditions,
 		ctx, n.ResourceInstanceAddr().Resource,
 		repeatData,
+		tfdiags.Error,
 	)
 	diags = diags.Append(checkDiags)
 
@@ -361,6 +362,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		checkResourcePostcondition,
 		n.Config.Postconditions,
 		ctx, addr, repeatData,
+		tfdiags.Error,
 	)
 	diags = diags.Append(checkDiags)
 

--- a/internal/tfdiags/diagnostic.go
+++ b/internal/tfdiags/diagnostic.go
@@ -1,6 +1,8 @@
 package tfdiags
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
 )
 
@@ -23,6 +25,20 @@ const (
 	Error   Severity = 'E'
 	Warning Severity = 'W'
 )
+
+// ToHCL converts a Severity to the equivalent HCL diagnostic severity.
+func (s Severity) ToHCL() hcl.DiagnosticSeverity {
+	switch s {
+	case Warning:
+		return hcl.DiagWarning
+	case Error:
+		return hcl.DiagError
+	default:
+		// The above should always be exhaustive for all of the valid
+		// Severity values in this package.
+		panic(fmt.Sprintf("unknown diagnostic severity %s", s))
+	}
+}
 
 type Description struct {
 	Address string

--- a/internal/tfdiags/hcl.go
+++ b/internal/tfdiags/hcl.go
@@ -1,8 +1,6 @@
 package tfdiags
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/hcl/v2"
 )
 
@@ -110,19 +108,9 @@ func (diags Diagnostics) ToHCL() hcl.Diagnostics {
 		fromExpr := diag.FromExpr()
 
 		hclDiag := &hcl.Diagnostic{
-			Summary: desc.Summary,
-			Detail:  desc.Detail,
-		}
-
-		switch severity {
-		case Warning:
-			hclDiag.Severity = hcl.DiagWarning
-		case Error:
-			hclDiag.Severity = hcl.DiagError
-		default:
-			// The above should always be exhaustive for all of the valid
-			// Severity values in this package.
-			panic(fmt.Sprintf("unknown diagnostic severity %s", severity))
+			Summary:  desc.Summary,
+			Detail:   desc.Detail,
+			Severity: severity.ToHCL(),
 		}
 		if source.Subject != nil {
 			hclDiag.Subject = source.Subject.ToHCL().Ptr()


### PR DESCRIPTION
Evaluate precondition and postcondition blocks in refresh-only mode, but report any failures as warnings instead of errors. This ensures that any deviation from the contract defined by condition blocks is reported as early as possible, without preventing the completion of a state refresh operation.

Prior to this commit, Terraform evaluated output preconditions and data source pre/postconditions as normal in refresh-only mode, while managed resource pre/postconditions were not evaluated at all. This omission could lead to confusing partial condition errors, or failure to detect undesired changes which would otherwise cause resources to become invalid.

Reporting the failures as errors also meant that changes retrieved during refresh could cause the refresh operation to fail. This is also undesirable, as the primary purpose of the operation is to update local state. Precondition/postcondition checks are still valuable here, but should be informative rather than blocking.