### PR TITLE
Update cidrnetmask documentation for IPv6

### DIFF
--- a/website/docs/language/functions/cidrnetmask.mdx
+++ b/website/docs/language/functions/cidrnetmask.mdx
@@ -1,27 +1,24 @@
 ---
 page_title: cidrnetmask - Functions - Configuration Language
 description: |-
-  The cidrnetmask function converts an IPv4 address prefix given in CIDR
-  notation into a subnet mask address.
+  The cidrnetmask function converts an IPv4 or IPv6 address prefix given in
+  CIDR notation into a subnet mask address.
 ---
 
 # `cidrnetmask` Function
 
-`cidrnetmask` converts an IPv4 address prefix given in CIDR notation into
-a subnet mask address.
+`cidrnetmask` converts an IPv4 or IPv6 address prefix given in CIDR notation\
+into a subnet mask address.
 
 ```hcl
 cidrnetmask(prefix)
 ```
 
-`prefix` must be given in IPv4 CIDR notation, as defined in
+`prefix` must be given in IPv4 or IPv6 CIDR notation, as defined in
 [RFC 4632 section 3.1](https://tools.ietf.org/html/rfc4632#section-3.1).
 
 The result is a subnet address formatted in the conventional dotted-decimal
-IPv4 address syntax, as expected by some software.
-
-CIDR notation is the only valid notation for IPv6 addresses, so `cidrnetmask`
-produces an error if given an IPv6 address.
+IPv4 or IPv6 address syntax, as expected by some software.
 
 -> **Note:** As a historical accident, this function interprets IPv4 address
 octets that have leading zeros as decimal numbers, which is contrary to some
@@ -33,4 +30,7 @@ for backward compatibility, but recommend against relying on this behavior.
 ```
 > cidrnetmask("172.16.0.0/12")
 255.240.0.0
+
+> cidrnetmask("2a01:111:f403:f000::/64")
+ffff:ffff:ffff:ffff::
 ```


### PR DESCRIPTION
There is probably a better way to update this, but I noticed recently that the documentation suggested `cidrnetmask()` only works with IPv4. I tried using it with `can(cidrnetmask())` and found out that it doesn't actually error with IPv6. For either IPv4 or IPv6, it returns a netmask. The documentation should be updated to reflect that.

This is using Terraform v1.1.7. Also, credit to `mjdouble` here: https://discuss.hashicorp.com/t/how-to-filter-out-ip4-and-ip6-subnets/22556/2 for finding this (and helping me realize it wasn't working as documented).

As stated, there might need to be more changes to the documentation, but wanted to open this to at least try and update what is there to be accurate to how it functions currently. Thanks!