### PR TITLE
Update cidrnetmask for IPv6

### DIFF
--- a/website/docs/language/functions/cidrnetmask.mdx
+++ b/website/docs/language/functions/cidrnetmask.mdx
@@ -20,8 +20,7 @@ cidrnetmask(prefix)
 The result is a subnet address formatted in the conventional dotted-decimal
 IPv4 address syntax, as expected by some software.
 
-CIDR notation is the only valid notation for IPv6 addresses, so `cidrnetmask`
-produces an error if given an IPv6 address.
+CIDR notation is the only valid notation for IPv6 addresses, so we do not recommend providing an IPv6 address to `cidrnetmask`.
 
 -> **Note:** As a historical accident, this function interprets IPv4 address
 octets that have leading zeros as decimal numbers, which is contrary to some


### PR DESCRIPTION
Fix to prevent docs users from being confused until this issue is completed: https://github.com/hashicorp/terraform/issues/30680

This function does not actually produce an error if you use IPv6, even though it should. Rather than inaccurately saying it produces an error, we should make a statement to discourage users from using the function with IPv6.