### PR TITLE
functions: Fix sum() of all strings

### DIFF
--- a/internal/lang/funcs/collection.go
+++ b/internal/lang/funcs/collection.go
@@ -527,6 +527,10 @@ var SumFunc = function.New(&function.Spec{
 		if s.IsNull() {
 			return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple of number values")
 		}
+		s, err = convert.Convert(s, cty.Number)
+		if err != nil {
+			return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple of number values")
+		}
 		for _, v := range arg[1:] {
 			if v.IsNull() {
 				return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple of number values")

--- a/internal/lang/funcs/collection_test.go
+++ b/internal/lang/funcs/collection_test.go
@@ -1629,6 +1629,15 @@ func TestSum(t *testing.T) {
 			cty.NilVal,
 			"can't compute sum of opposing infinities",
 		},
+		{
+			cty.ListVal([]cty.Value{
+				cty.StringVal("1"),
+				cty.StringVal("2"),
+				cty.StringVal("3"),
+			}),
+			cty.NumberIntVal(6),
+			"",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The `sum()` function accepts a collection of values which must all convert to numbers. It is valid for this to be a collection of string values representing numbers.

Previously the function would panic if the first element of a collection was a non-number type, as we didn't attempt to convert it to a number before calling the cty `Add` method.