### PR TITLE
cli: Fix missing identifying attributes in diff

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -1620,7 +1620,10 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 					action = plans.Update
 				}
 
-				if action == plans.NoOp && !p.verbose {
+				// TODO: If in future we have a schema associated with this
+				// object, we should pass the attribute's schema to
+				// identifyingAttribute here.
+				if action == plans.NoOp && !p.verbose && !identifyingAttribute(k, nil) {
 					suppressedElements++
 					continue
 				}


### PR DESCRIPTION
When rendering a diff for an object value within a resource, Terraform should always display the value of attributes which may be identifying. At present, this is a simple rule: render attributes named "id", "name", or "tags".

Prior to this commit, Terraform would only apply this rule to top-level resource attributes and those inside nested blocks. Here we extend the implementation to include object values in other contexts as well.

Fixes #30641