### PR TITLE
Add note about powershell formatting

### DIFF
--- a/website/docs/cli/commands/state/pull.mdx
+++ b/website/docs/cli/commands/state/pull.mdx
@@ -27,4 +27,4 @@ You cannot use this command to inspect the Terraform version of
 the remote state, as it will always be converted to the current Terraform
 version before output.
 
--> **Note:** Terraform state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `terraform state pull | sc terraform.tfstate`
+-> **Note:** Terraform state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `terraform state pull | sc terraform.tfstate`.

--- a/website/docs/cli/commands/state/pull.mdx
+++ b/website/docs/cli/commands/state/pull.mdx
@@ -15,14 +15,16 @@ works with local state.
 
 Usage: `terraform state pull`
 
-This command will download the state from its current location, upgrade the
+This command downloads the state from its current location, upgrades the
 local copy to the latest state file version that is compatible with
-locally-installed Terraform, and output the raw format to stdout.
+locally-installed Terraform, and outputs the raw format to stdout.
 
 This is useful for reading values out of state (potentially pairing this
 command with something like [jq](https://stedolan.github.io/jq/)). It is
 also useful if you need to make manual modifications to state.
 
-~> Note: This command cannot be used to inspect the Terraform version of
+You cannot use this command to inspect the Terraform version of
 the remote state, as it will always be converted to the current Terraform
 version before output.
+
+-> **Note:** Terraform state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `terraform state pull | sc terraform.tfstate`

--- a/website/docs/cli/commands/state/push.mdx
+++ b/website/docs/cli/commands/state/push.mdx
@@ -16,12 +16,14 @@ manual intervention is necessary with the remote state.
 
 Usage: `terraform state push [options] PATH`
 
-This command will push the state specified by PATH to the currently
+This command pushes the state specified by PATH to the currently
 configured [backend](/language/settings/backends).
 
 If PATH is "-" then the state data to push is read from stdin. This data
 is loaded completely into memory and verified prior to being written to
 the destination state.
+
+-> **Note:** Terraform state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `terraform state push | sc terraform.tfstate`.
 
 Terraform will perform a number of safety checks to prevent you from
 making changes that appear to be unsafe:


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/issues/24986.

Users requested that we update the documentation to specify that terraform state files must be in UTF-8 format without a byte order mark. We also provide a solution to ensure that the state file is formatted properly using `Set-Content`.