### PR TITLE
cidrnetmask() produce an error with IPv6

### DIFF
--- a/internal/lang/funcs/cidr.go
+++ b/internal/lang/funcs/cidr.go
@@ -60,6 +60,10 @@ var CidrNetmaskFunc = function.New(&function.Spec{
 			return cty.UnknownVal(cty.String), fmt.Errorf("invalid CIDR expression: %s", err)
 		}
 
+		if network.IP.To4() == nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("IPv6 is invalid")
+		}
+
 		return cty.StringVal(ipaddr.IP(network.Mask).String()), nil
 	},
 })

--- a/internal/lang/funcs/cidr_test.go
+++ b/internal/lang/funcs/cidr_test.go
@@ -119,11 +119,6 @@ func TestCidrNetmask(t *testing.T) {
 			false,
 		},
 		{
-			cty.StringVal("1::/64"),
-			cty.StringVal("ffff:ffff:ffff:ffff::"),
-			false,
-		},
-		{
 			// We inadvertently inherited a pre-Go1.17 standard library quirk
 			// if parsing zero-prefix parts as decimal rather than octal.
 			// Go 1.17 resolved that quirk by making zero-prefix invalid, but
@@ -143,6 +138,11 @@ func TestCidrNetmask(t *testing.T) {
 			cty.StringVal("110.256.0.0/8"),
 			cty.UnknownVal(cty.String),
 			true, // can't have an octet >255
+		},
+		{
+			cty.StringVal("1::/64"),
+			cty.UnknownVal(cty.String),
+			true, // IPv6 is invalid
 		},
 	}
 


### PR DESCRIPTION
- Closes #30680 

Make `cidrnetmask()` produce an error when trying to create a netmask for IPv6.

- ref: <https://pkg.go.dev/net#IP.To4>
