### PR TITLE
Add PowerShell note to file provisioner page

### DIFF
--- a/website/docs/language/resources/provisioners/file.mdx
+++ b/website/docs/language/resources/provisioners/file.mdx
@@ -8,8 +8,8 @@ description: >-
 
 # File Provisioner
 
-The `file` provisioner is used to copy files or directories from the machine
-executing Terraform to the newly created resource. The `file` provisioner
+The `file` provisioner copies files or directories from the machine
+running Terraform to the newly created resource. The `file` provisioner
 supports both `ssh` and `winrm` type [connections](/language/resources/provisioners/connection).
 
 ~> **Important:** Use provisioners as a last resort. There are better alternatives for most situations. Refer to
@@ -46,6 +46,8 @@ resource "aws_instance" "web" {
   }
 }
 ```
+
+-> **Note:** When the `file` provisioner is talking to a Windows system over SSH, you must configure OpenSSH to run the commands with `cmd.exe` and not by PowerShell. 
 
 ## Argument Reference
 

--- a/website/docs/language/resources/provisioners/file.mdx
+++ b/website/docs/language/resources/provisioners/file.mdx
@@ -47,7 +47,7 @@ resource "aws_instance" "web" {
 }
 ```
 
--> **Note:** When the `file` provisioner is talking to a Windows system over SSH, you must configure OpenSSH to run the commands with `cmd.exe` and not by PowerShell. 
+-> **Note:** When the `file` provisioner communicates with a Windows system over SSH, you must configure OpenSSH to run the commands with `cmd.exe` and not PowerShell. PowerShell causes file parsing errors because it is incompatible with both Unix shells and the Windows command interpreter.
 
 ## Argument Reference
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/issues/30661#issuecomment-1067082006

This PR adds a note that when using `file` provisioner over SSH to a Windows system, you need to make sure that `cmd.exe` runs the commands and not PowerShell. Using PowerShell causes parsing errors that prevent the file from uploading properly. It also fixes the opening sentence to use active voice and also to avoid unnecessarily violent language, per our style guide.