### PR TITLE
Add TF_ORGANIZATION env var support

### DIFF
--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -157,7 +157,7 @@ func (b *Cloud) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		// organization is specified in the config but is invalid, so
 		// we'll fallback on TF_ORGANIZATION
 		if val := os.Getenv("TF_ORGANIZATION"); val == "" {
-			diags = diags.Append(invalidOrganizationConfigMissingValue)
+			diags = diags.Append(missingConfigAttributeAndEnvVar("organization", "TF_ORGANIZATION"))
 		}
 	}
 

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -86,7 +86,7 @@ func TestCloud_PrepareConfig(t *testing.T) {
 					"tags": cty.NullVal(cty.Set(cty.String)),
 				}),
 			}),
-			expectedErr: `Invalid organization value: The "organization" attribute value must not be empty.`,
+			expectedErr: `Invalid or missing required argument: "organization" must be set in the cloud configuration or as an environment variable: TF_ORGANIZATION.`,
 		},
 		"null workspace": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -173,7 +173,7 @@ func TestCloud_PrepareConfigWithEnvVars(t *testing.T) {
 				}),
 			}),
 			vars:        map[string]string{},
-			expectedErr: `Invalid organization value: The "organization" attribute value must not be empty.`,
+			expectedErr: `Invalid or missing required argument: "organization" must be set in the cloud configuration or as an environment variable: TF_ORGANIZATION.`,
 		},
 	}
 

--- a/internal/cloud/errors.go
+++ b/internal/cloud/errors.go
@@ -9,13 +9,6 @@ import (
 )
 
 var (
-	invalidOrganizationConfigMissingValue = tfdiags.AttributeValue(
-		tfdiags.Error,
-		"Invalid organization value",
-		`The "organization" attribute value must not be empty.\n\n%s`,
-		cty.Path{cty.GetAttrStep{Name: "organization"}},
-	)
-
 	invalidWorkspaceConfigMissingValues = tfdiags.AttributeValue(
 		tfdiags.Error,
 		"Invalid workspaces configuration",
@@ -32,6 +25,15 @@ var (
 )
 
 const ignoreRemoteVersionHelp = "If you're sure you want to upgrade the state, you can force Terraform to continue using the -ignore-remote-version flag. This may result in an unusable workspace."
+
+func missingConfigAttributeAndEnvVar(attribute string, envVar string) tfdiags.Diagnostic {
+	detail := strings.TrimSpace(fmt.Sprintf("\"%s\" must be set in the cloud configuration or as an environment variable: %s.\n", attribute, envVar))
+	return tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Invalid or missing required argument",
+		detail,
+		cty.Path{cty.GetAttrStep{Name: attribute}})
+}
 
 func incompatibleWorkspaceTerraformVersion(message string, ignoreVersionConflict bool) tfdiags.Diagnostic {
 	severity := tfdiags.Error

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -82,6 +82,13 @@ The `cloud` block supports the following configuration arguments:
   `credentials` in the
   [CLI config file](/cli/config/config-file#credentials).
 
+### Environment Variables
+
+Alternatively, the `cloud` block can be configured with the following environment variables:
+
+- `TF_ORGANIZATION` - The name of the organization. Serves as a fallback for `organization`
+    in the cloud configuration. If both are specified, the configuration takes precedence. 
+
 ## Excluding Files from Upload with .terraformignore
 
 When executing a remote `plan` or `apply` in a [CLI-driven run](/cloud-docs/run/cli),


### PR DESCRIPTION
`TF_ORGANIZATION` will serve as a fallback for configuring an organization in the `cloud`
block. This is the first step to make it easier for users wanting to configure Terraform
programmatically.

## Testing this feature
1. Pull this branch locally and run `go install .` which will install the binary in `$GOPATH/bin/terraform` 
1. Export `TF_ORGANIZATION` so Terraform can consume the var: 
```sh
export TF_ORGANIZATION="my-awesome-org"
```
3. Create a simple Terraform configuration, omitting `organization` from the `cloud` block. We'll use the `tfe` provider in this example. 
```hcl
terraform {
  cloud {
    hostname = "my-tfe.host.com"
    workspaces {
      name = "test"
    }
  }
}

provider "tfe" {
  hostname = "my-tfe.host.com"
  token = "my-tfe-token"
}

resource "tfe_workspace" "test" {
  name = "my-awesome-workspace"
  organization = "my-awesome-organization"
}
```
4. Run `$GOPATH/bin/terraform init` and then `$GOPATH/bin/terraform apply` ! 

### What if both values are set?

An organization specified in the cloud block should always take precedence over `TF_ORGANIZATION`. Try setting an organization in your configuration while `TF_ORGANIZATION` is set in your environment to test this. 

### Run Unit Tests
```sh
go test ./internal/cloud/ -run TestCloud_PrepareConfigWithEnvVars
go test ./internal/cloud/ -run TestCloud_configWithEnvVars
```