### PR TITLE
Clarify multiple times usage

### DIFF
--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -220,7 +220,8 @@ Plan Customization Options:
   -replace=resource   Force replacement of a particular resource instance using
                       its resource address. If the plan would've normally
                       produced an update or no-op action for this instance,
-                      Terraform will plan to replace it instead.
+                      Terraform will plan to replace it instead. You can use
+                      this option multiple times to include more than one object.
 
   -target=resource    Limit the planning operation to only the given module,
                       resource, or resource instance and all of its


### PR DESCRIPTION
This extends the documentation of `plan -replace` option to include that the option can be used multiple times.