### PR TITLE
Making this error message more helpful

### DIFF
--- a/internal/command/format/diagnostic_test.go
+++ b/internal/command/format/diagnostic_test.go
@@ -169,7 +169,7 @@ func TestDiagnostic(t *testing.T) {
 [red]│[reset]   on test.tf line 1:
 [red]│[reset]    1: test [underline]source[reset] code
 [red]│[reset]     [dark_gray]├────────────────[reset]
-[red]│[reset]     [dark_gray]│[reset] [bold]boop.beep[reset] is a string, known only after apply
+[red]│[reset]     [dark_gray]│[reset] [bold]boop.beep[reset] contains an unknown string expression
 [red]│[reset]
 [red]│[reset] Whatever shall we do?
 [red]╵[reset]


### PR DESCRIPTION
I ran into this when I defined a string variable and then populated it with a map.  It would have been easier for me to just know I'd created an unknown string expression.
It was "is a string, known only after apply."  Now it is "contains an unknown string expression."