### PR TITLE
Description of '-' symbol as used in format()

### DIFF
--- a/website/docs/language/functions/format.mdx
+++ b/website/docs/language/functions/format.mdx
@@ -98,7 +98,7 @@ to set additional flags:
 | ------ | -------------------------------------------------------------- |
 | space  | Leave a space where the sign would be if a number is positive. |
 | `+`    | Show the sign of a number even if it is positive.              |
-| `-`    | Pad the width with spaces on the left rather than the right.   |
+| `-`    | Pad the width with spaces on the right rather than the left.   |
 | `0`    | Pad the width with leading zeros rather than spaces.           |
 
 By default, `%` sequences consume successive arguments starting with the first.


### PR DESCRIPTION
The existing description for the '-' symbol as use in format() stated that the result would padded spaces to the left.  When tested in via 'terraform console' using `format("%-10.1f", 3)` the result was `"3.0       "`

Terraform v1.1.7