### PR TITLE
Add TF_HOSTNAME env var support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ ENHANCEMENTS:
 * Error messages for preconditions, postconditions, and custom variable validations are now evaluated as expressions, allowing interpolation of relevant values into the output. ([#30613](https://github.com/hashicorp/terraform/issues/30613))
 * There are some small improvements to the error and warning messages Terraform will emit in the case of invalid provider configuration passing between modules. There are no changes to which situations will produce errors and warnings, but the messages now include additional information intended to clarify what problem Terraform is describing and how to address it. ([#30639](https://github.com/hashicorp/terraform/issues/30639))
 * When running `terraform plan`, only show external changes which may have contributed to the current plan ([#30486](https://github.com/hashicorp/terraform/issues/30486))
+* Add `TF_ORGANIZATION` environment variable fallback for `organization` in the cloud configuration
+* Add `TF_HOSTNAME` environment variable fallback for `hostname` in the cloud configuration 
 
 BUG FIXES:
 

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -341,9 +341,10 @@ func (b *Cloud) setConfigurationFields(obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	// Get the hostname.
+	b.hostname = os.Getenv("TF_HOSTNAME")
 	if val := obj.GetAttr("hostname"); !val.IsNull() && val.AsString() != "" {
 		b.hostname = val.AsString()
-	} else {
+	} else if b.hostname == "" {
 		b.hostname = defaultHostname
 	}
 

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -201,6 +201,7 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 		config               cty.Value
 		vars                 map[string]string
 		expectedOrganization string
+		expectedHostname     string
 	}{
 		"with no organization specified": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -232,6 +233,36 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 			},
 			expectedOrganization: "hashicorp",
 		},
+		"with no hostname specified": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"organization": cty.StringVal("hashicorp"),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("prod"),
+					"tags": cty.NullVal(cty.Set(cty.String)),
+				}),
+			}),
+			vars: map[string]string{
+				"TF_HOSTNAME": "app.terraform.io",
+			},
+			expectedHostname: "app.terraform.io",
+		},
+		"with hostname and env var specified": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"hostname":     cty.StringVal("app.terraform.io"),
+				"token":        cty.NullVal(cty.String),
+				"organization": cty.StringVal("hashicorp"),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("prod"),
+					"tags": cty.NullVal(cty.Set(cty.String)),
+				}),
+			}),
+			vars: map[string]string{
+				"TF_HOSTNAME": "mycool.tfe-host.io",
+			},
+			expectedHostname: "app.terraform.io",
+		},
 	}
 
 	for name, tc := range cases {
@@ -255,6 +286,10 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 
 		if tc.expectedOrganization != "" && tc.expectedOrganization != b.organization {
 			t.Fatalf("%s: organization not valid: %s, expected: %s", name, b.organization, tc.expectedOrganization)
+		}
+
+		if tc.expectedHostname != "" && tc.expectedHostname != b.hostname {
+			t.Fatalf("%s: hostname not valid: %s, expected: %s", name, b.hostname, tc.expectedHostname)
 		}
 	}
 }

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -89,6 +89,8 @@ Alternatively, the `cloud` block can be configured with the following environmen
 - `TF_ORGANIZATION` - The name of the organization. Serves as a fallback for `organization`
     in the cloud configuration. If both are specified, the configuration takes precedence. 
 
+- `TF_HOSTNAME` - The hostname of a Terraform Enterprise installation. Serves as a fallback if `hostname` is not specified in the cloud configuration. If both are specified, the configuration takes precendence. 
+
 ## Excluding Files from Upload with .terraformignore
 
 When executing a remote `plan` or `apply` in a [CLI-driven run](/cloud-docs/run/cli),


### PR DESCRIPTION
This PR introduces the ability to configure `hostname` in the cloud configuration using the `TF_HOSTNAME` environment variable. `TF_HOSTNAME` is of course optional, as the cloud configuration will default to `app.terraform.io` if neither the env variable nor the hostname in the configuration are set. If both the `TF_HOSTNAME` and `hostname` in the configuration are set, Terraform will use `hostname`. 

## Testing this feature
1. Pull this branch locally and run `go install .` which will install the binary in `$GOPATH/bin/terraform` 
1. Export `TF_HOSTNAME` so Terraform can consume the var: 
```sh
export TF_HOSTNAME="my-awesome.tfe-host.io"
```
3. Create a simple Terraform configuration, omitting `hostname` from the `cloud` block. We'll use the `tfe` provider in this example. 
```hcl
terraform {
  cloud {
    organization = "my-awesome-org"
    workspaces {
      name = "test"
    }
  }
}

provider "tfe" {
  hostname = "my-awesome.tfe-host.io"
  token = "my-tfe-token"
}

resource "tfe_workspace" "test" {
  name = "my-awesome-workspace"
  organization = "my-awesome-org"
}
```
4. Run `$GOPATH/bin/terraform init` and then `$GOPATH/bin/terraform apply` ! 

### Using the `TF_ORGANIZATION` variable

Building off #30719 , you can also remove `organization` from your `cloud` configuration. Ensure the variable is set:

```sh
export TF_ORGANIZATION="my-awesome-org"
```
and repeat step 4! 

### Notes for reviewer
Setting `TF_HOSTNAME` should behave exactly as if it had been set in the configuration. If you provide an invalid host for `TF_HOSTNAME` you should receive an error denoting an invalid host. Or perhaps you specify a host _without_ a corresponding token in `~/.terraform.d/credentials.tfrc.json`? 


### Run Unit Tests
```sh
go test ./internal/cloud/ -run TestCloud_PrepareConfigWithEnvVars
go test ./internal/cloud/ -run TestCloud_configWithEnvVars
```