### PR TITLE
command/meta_backend: fix for cloud integration panic

### DIFF
--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -320,6 +320,9 @@ func (m *Meta) BackendForPlan(settings plans.Backend) (backend.Enhanced, tfdiags
 
 	configureDiags := b.Configure(newVal)
 	diags = diags.Append(configureDiags)
+	if configureDiags.HasErrors() {
+		return nil, diags
+	}
 
 	// If the backend supports CLI initialization, do it.
 	if cli, ok := b.(backend.CLI); ok {


### PR DESCRIPTION
### Description
Currently if an error occurs during client configuration, `b.Configure` it gets swallowed. This PR returns the error after it gets added to error diagnostics.

### Problem
Errors occurring during client configuration gets swallowed.

### Fix
Fixes [issue #30760](https://github.com/hashicorp/terraform/issues/30760)

### Tests
Unit tests already exists

### Notes
Paired with @uturunku1 