### PR TITLE
backport cloud integration panic fix

### DIFF
--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -320,6 +320,9 @@ func (m *Meta) BackendForPlan(settings plans.Backend) (backend.Enhanced, tfdiags
 
 	configureDiags := b.Configure(newVal)
 	diags = diags.Append(configureDiags)
+	if configureDiags.HasErrors() {
+		return nil, diags
+	}
 
 	// If the backend supports CLI initialization, do it.
 	if cli, ok := b.(backend.CLI); ok {


### PR DESCRIPTION

Backport of [https://github.com/hashicorp/terraform/pull/30773](https://github.com/hashicorp/terraform/pull/30773)

Closes [https://github.com/hashicorp/terraform/issues/30646](https://github.com/hashicorp/terraform/issues/30646) and [https://github.com/hashicorp/terraform/issues/30760](https://github.com/hashicorp/terraform/issues/30760)