### PR TITLE
Add cloud config support for TF_WORKSPACE

### DIFF
--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -172,6 +172,8 @@ func (b *Cloud) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 				log.Panicf("An unxpected error occurred: %s", err)
 			}
 		}
+	} else {
+		WorkspaceMapping.Name = os.Getenv("TF_WORKSPACE")
 	}
 
 	switch WorkspaceMapping.Strategy() {
@@ -376,6 +378,8 @@ func (b *Cloud) setConfigurationFields(obj cty.Value) tfdiags.Diagnostics {
 
 			b.WorkspaceMapping.Tags = tags
 		}
+	} else {
+		b.WorkspaceMapping.Name = os.Getenv("TF_WORKSPACE")
 	}
 
 	// Determine if we are forced to use the local backend.

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -298,6 +298,16 @@ func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
 		return diags
 	}
 
+	if ws, ok := os.LookupEnv("TF_WORKSPACE"); ok {
+		if ws == b.WorkspaceMapping.Name || b.WorkspaceMapping.Strategy() == WorkspaceTagsStrategy {
+			diag := b.validWorkspaceEnvVar(context.Background(), b.organization, ws)
+			if diag != nil {
+				diags = diags.Append(diag)
+				return diags
+			}
+		}
+	}
+
 	// Check for the minimum version of Terraform Enterprise required.
 	//
 	// For API versions prior to 2.3, RemoteAPIVersion will return an empty string,
@@ -992,6 +1002,72 @@ func (b *Cloud) fetchWorkspace(ctx context.Context, organization string, workspa
 	}
 
 	return w, nil
+}
+
+// validWorkspaceEnvVar ensures we have selected a valid workspace using TF_WORKSPACE:
+// First, it ensures the workspace specified by TF_WORKSPACE exists in the organization
+// Second, if tags are specified in the configuration, it ensures TF_WORKSPACE belongs to the set
+// of available workspaces with those given tags.
+func (b *Cloud) validWorkspaceEnvVar(ctx context.Context, organization, workspace string) tfdiags.Diagnostic {
+	// first ensure the workspace exists
+	_, err := b.client.Workspaces.Read(ctx, organization, workspace)
+	if err != nil && err != tfe.ErrResourceNotFound {
+		return tfdiags.Sourceless(
+			tfdiags.Error,
+			"Terraform Cloud returned an unexpected error",
+			err.Error(),
+		)
+	}
+
+	if err == tfe.ErrResourceNotFound {
+		return tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid workspace selection",
+			fmt.Sprintf(`Terraform failed to find workspace %q in organization %s.`, workspace, organization),
+		)
+	}
+
+	// if the configuration has specified tags, we need to ensure TF_WORKSPACE
+	// is a valid member
+	if b.WorkspaceMapping.Strategy() == WorkspaceTagsStrategy {
+		opts := &tfe.WorkspaceListOptions{}
+		opts.Tags = strings.Join(b.WorkspaceMapping.Tags, ",")
+
+		for {
+			wl, err := b.client.Workspaces.List(ctx, b.organization, opts)
+			if err != nil {
+				return tfdiags.Sourceless(
+					tfdiags.Error,
+					"Terraform Cloud returned an unexpected error",
+					err.Error(),
+				)
+			}
+
+			for _, ws := range wl.Items {
+				if ws.Name == workspace {
+					return nil
+				}
+			}
+
+			if wl.CurrentPage >= wl.TotalPages {
+				break
+			}
+
+			opts.PageNumber = wl.NextPage
+		}
+
+		return tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid workspace selection",
+			fmt.Sprintf(
+				"Terraform failed to find workspace %q with the tags specified in your configuration:\n[%s]",
+				workspace,
+				strings.ReplaceAll(opts.Tags, ",", ", "),
+			),
+		)
+	}
+
+	return nil
 }
 
 func (wm WorkspaceMapping) tfeTags() []*tfe.Tag {

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -303,7 +303,7 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 			vars: map[string]string{
 				"TF_WORKSPACE": "i-dont-exist-in-org",
 			},
-			expectedErr: `Invalid workspace selection: "i-dont-exist-in-org" was not found in organization hashicorp`,
+			expectedErr: `Invalid workspace selection: Terraform failed to find workspace "i-dont-exist-in-org" in organization hashicorp`,
 		},
 		"workspaces and env var specified": {
 			config: cty.ObjectVal(map[string]cty.Value{

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -94,7 +94,7 @@ Use the following environment variables to configure the `cloud` block:
 
 - `TF_HOSTNAME` - The hostname of a Terraform Enterprise installation. Serves as a fallback if `hostname` is not specified in the cloud configuration. If both are specified, the configuration takes precendence. 
 
-- `TF_WORKSPACE` - The workspace to select from the available set. The `cloud` block interprets this variable as the `name` value of the `workspaces` attribute. The `cloud` block only reads this variable if the `workspaces` block is not included in your configuration file. When you supply `TF_WORKSPACE`, Terraform also uses it to select the workspace locally. Refer to [TF_WORKSPACE](https://www.terraform.io/cli/config/environment-variables#tf_workspace) for more details.
+- `TF_WORKSPACE` - The workspace to select from. The `cloud` block interprets this variable as the `name` value of the `workspaces` attribute if the `workspaces` attrribute is not included in your configuration file. Furthermore, it validates that `TF_WORKSPACE` exists in the organization specified in your configuration or `TF_ORGANIZATION`. Alternatively, this variable can also be used to select a workspace if you specify tags in your `cloud` configuration, returning an error if `TF_WORKSPACE` is not included in the set of tags specified in your configuration. Refer to [TF_WORKSPACE](https://www.terraform.io/cli/config/environment-variables#tf_workspace) for more details.
 
 ## Excluding Files from Upload with .terraformignore
 

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -84,12 +84,17 @@ The `cloud` block supports the following configuration arguments:
 
 ### Environment Variables
 
-Alternatively, the `cloud` block can be configured with the following environment variables:
+You can use environment variables to configure one or more `cloud` block attributes. This is helpful when you want to configure Terraform as part of a Continuous Integration (CI) pipeline. Terraform only reads these variables if the corresponding attribute is omitted from your configuration file. If you choose to configure the `cloud` block entirely through environment variables, you must still add an empty `cloud` block in your configuration file.
+
+Use the following environment variables to configure the `cloud` block:
+
 
 - `TF_ORGANIZATION` - The name of the organization. Serves as a fallback for `organization`
     in the cloud configuration. If both are specified, the configuration takes precedence. 
 
 - `TF_HOSTNAME` - The hostname of a Terraform Enterprise installation. Serves as a fallback if `hostname` is not specified in the cloud configuration. If both are specified, the configuration takes precendence. 
+
+- `TF_WORKSPACE` - The workspace to select from the available set. The `cloud` block interprets this variable as the `name` value of the `workspaces` attribute. The `cloud` block only reads this variable if the `workspaces` block is not included in your configuration file. When you supply `TF_WORKSPACE`, Terraform also uses it to select the workspace locally. Refer to [TF_WORKSPACE](https://www.terraform.io/cli/config/environment-variables#tf_workspace) for more details.
 
 ## Excluding Files from Upload with .terraformignore
 

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -94,7 +94,7 @@ Use the following environment variables to configure the `cloud` block:
 
 - `TF_HOSTNAME` - The hostname of a Terraform Enterprise installation. Serves as a fallback if `hostname` is not specified in the cloud configuration. If both are specified, the configuration takes precendence. 
 
-- `TF_WORKSPACE` - The workspace to select from. The `cloud` block interprets this variable as the `name` value of the `workspaces` attribute if the `workspaces` attrribute is not included in your configuration file. Furthermore, it validates that `TF_WORKSPACE` exists in the organization specified in your configuration or `TF_ORGANIZATION`. Alternatively, this variable can also be used to select a workspace if you specify tags in your `cloud` configuration, returning an error if `TF_WORKSPACE` is not included in the set of tags specified in your configuration. Refer to [TF_WORKSPACE](https://www.terraform.io/cli/config/environment-variables#tf_workspace) for more details.
+- `TF_WORKSPACE` - The name of a single Terraform Cloud workspace.  If the `workspaces` attribute is not included in your configuration file, the `cloud` block interprets `TF_WORKSPACE` as the `name` value of the `workspaces` attribute. The workspace must exist in the organization specified in the configuration or `TF_ORGANIZATION`. If the `cloud` block uses tags, Terraform Cloud will return an error if the value of `TF_WORKSPACE` is not included in the set of tags. Refer to [TF_WORKSPACE](https://www.terraform.io/cli/config/environment-variables#tf_workspace) for more details.
 
 ## Excluding Files from Upload with .terraformignore
 


### PR DESCRIPTION
`TF_WORKSPACE` can now be used to configure your cloud block, effectively serving as an alternative to setting the `name` attribute in your workspaces configuration. In short, setting `TF_WORKSPACE="my-cool-wkspace"` is now akin to:
```hcl
terraform {
  cloud {
     workspaces {
        name = "my-cool-workspace"
      }
   }
}
```

Given we've added support for `TF_ORGANIZATION` in #30719 and `TF_HOSTNAME` in #30748, we can now non-interactively configure the cloud block, leaving it empty in our configuration:
```hcl
terraform {
  cloud {}
}
```
*^is now valid*

## Testing this feature
1. Pull this branch locally and run `go install .` which will install the binary in `$GOPATH/bin/terraform` 
1. Export `TF_WORKSPACE` so Terraform can consume the var: 
```sh
export TF_WORKSPACE="wkspace"
```
3. Create a simple Terraform configuration, omitting `workspaces` from the `cloud` block. We'll use the `tfe` provider in this example. 
```hcl
terraform {
  cloud {
    organization = "my-awesome-org"
    hostname = "my-awesome.tfe-host.io"
  }
}

provider "tfe" {
  hostname = "my-awesome.tfe-host.io"
  token = "my-tfe-token"
}

resource "tfe_workspace" "test" {
  name = "my-awesome-workspace"
  organization = "my-awesome-org"
}
```
4. Run `$GOPATH/bin/terraform init` and then `$GOPATH/bin/terraform apply` ! 