### PR TITLE
Allow remote service creds to be configured using env

### DIFF
--- a/internal/command/cliconfig/credentials_test.go
+++ b/internal/command/cliconfig/credentials_test.go
@@ -130,6 +130,31 @@ func TestCredentialsForHost(t *testing.T) {
 			t.Errorf("wrong result\ngot: %s\nwant: %s", got, expectedToken)
 		}
 	})
+
+	t.Run("hyphens can be encoded as double underscores", func(t *testing.T) {
+		envName := "TF_TOKEN_env_xn____caf__dma_fr"
+		expectedToken := "configured-by-fallback"
+		t.Cleanup(func() {
+			os.Unsetenv(envName)
+		})
+
+		os.Setenv(envName, expectedToken)
+
+		hostname, _ := svchost.ForComparison("env.café.fr")
+		creds, err := credSrc.ForHost(hostname)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if creds == nil {
+			t.Fatal("no credentials found")
+		}
+
+		if got := creds.Token(); got != expectedToken {
+			t.Errorf("wrong result\ngot: %s\nwant: %s", got, expectedToken)
+		}
+	})
 }
 
 func TestCredentialsStoreForget(t *testing.T) {

--- a/internal/command/cliconfig/credentials_test.go
+++ b/internal/command/cliconfig/credentials_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/hashicorp/terraform-svchost"
+	svchost "github.com/hashicorp/terraform-svchost"
 	svcauth "github.com/hashicorp/terraform-svchost/auth"
 )
 
@@ -81,6 +81,53 @@ func TestCredentialsForHost(t *testing.T) {
 		}
 		if got, want := testReqAuthHeader(t, creds), ""; got != want {
 			t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+	t.Run("set in environment", func(t *testing.T) {
+		envName := "TF_TOKEN_configured_example_com"
+		t.Cleanup(func() {
+			os.Unsetenv(envName)
+		})
+
+		expectedToken := "configured-by-env"
+		os.Setenv(envName, expectedToken)
+
+		creds, err := credSrc.ForHost(svchost.Hostname("configured.example.com"))
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if creds == nil {
+			t.Fatal("no credentials found")
+		}
+
+		if got := creds.Token(); got != expectedToken {
+			t.Errorf("wrong result\ngot: %s\nwant: %s", got, expectedToken)
+		}
+	})
+
+	t.Run("punycode name set in environment", func(t *testing.T) {
+		envName := "TF_TOKEN_env_xn--eckwd4c7cu47r2wf_com"
+		t.Cleanup(func() {
+			os.Unsetenv(envName)
+		})
+
+		expectedToken := "configured-by-env"
+		os.Setenv(envName, expectedToken)
+
+		hostname, _ := svchost.ForComparison("env.ドメイン名例.com")
+		creds, err := credSrc.ForHost(hostname)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if creds == nil {
+			t.Fatal("no credentials found")
+		}
+
+		if got := creds.Token(); got != expectedToken {
+			t.Errorf("wrong result\ngot: %s\nwant: %s", got, expectedToken)
 		}
 	})
 }

--- a/internal/command/cliconfig/credentials_test.go
+++ b/internal/command/cliconfig/credentials_test.go
@@ -2,6 +2,7 @@ package cliconfig
 
 import (
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 

--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -115,12 +115,22 @@ is available at multiple hostnames, use only one of them consistently.
 Terraform Cloud responds to API calls at both its current hostname
 `app.terraform.io`, and its historical hostname `atlas.hashicorp.com`.
 
-### Credentials Helpers
+### Environment Variable Credentials
 
 If you would prefer not to store your API tokens directly in the CLI
-configuration as described in the previous section, you can optionally instruct
-Terraform to use a different credentials storage mechanism by configuring a
-special kind of plugin program called a _credentials helper_.
+configuration, you may use a host-specific environment variable. For example,
+the value of a variable named `TF_TOKEN_app_terraform_io` will be used as an
+Authorization: Bearer token whenever making service requests to the hostname
+"app.terraform.io".
+
+Internationalized domain names should be converted to their [punycode equivalent](https://www.charset.org/punycode)
+with an ACE prefix when used as a variable name. For example, token credentials
+for 例えば.com should be set in a variable called `TF_TOKEN_xn--r8j3dr99h_com`.
+
+### Credentials Helpers
+
+Finally, you may instruct Terraform to use a different credentials storage mechanism
+by configuring a special kind of plugin program called a _credentials helper_.
 
 ```hcl
 credentials_helper "example" {

--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -118,12 +118,22 @@ Terraform Cloud responds to API calls at both its current hostname
 ### Environment Variable Credentials
 
 If you would prefer not to store your API tokens directly in the CLI
-configuration, you may use a host-specific environment variable. Environment variable names should be the prefix `TF_TOKEN_` added to the domain name. For example,
-the value of a variable named `TF_TOKEN_app_terraform_io` will be used as a bearer authorization token when the CLI makes service requests to the hostname "app.terraform.io".
+configuration, you may use a host-specific environment variable. Environment variable names should
+have the prefix `TF_TOKEN_` added to the domain name, with periods encoded as underscores.
+For example, the value of a variable named `TF_TOKEN_app_terraform_io` will be used as a
+bearer authorization token when the CLI makes service requests to the hostname "app.terraform.io".
 
-Internationalized domain names should be converted to their [punycode equivalent](https://www.charset.org/punycode)
+Domain names containing non-ASCII characters should be converted to
+their [punycode equivalent](https://www.charset.org/punycode)
 with an ACE prefix when used as a variable name. For example, token credentials
-for 例えば.com should be set in a variable called `TF_TOKEN_xn--r8j3dr99h_com`.
+for 例えば.com must be set in a variable called `TF_TOKEN_xn--r8j3dr99h_com`.
+
+Hyphens are allowed within variable names by certain tools, such as the `env` utility,
+but are not valid POSIX variable names. Therefore, it can be tricky to
+set them with interactive tools such as bash or zsh so you may encode
+hyphens as double underscores. For example, a token for the domain name "café.fr" can
+be set by either `TF_TOKEN_xn--caf-dma_fr` or `TF_TOKEN_xn____caf__dma_fr` if that is more
+convenient. If both are defined, the variable containing hyphens is preferred.
 
 ### Credentials Helpers
 
@@ -152,6 +162,16 @@ Terraform does not include any credentials helpers in the main distribution.
 To learn how to write and install your own credentials helpers to integrate
 with existing in-house credentials management systems, see
 [the guide to Credentials Helper internals](/internals/credentials-helpers).
+
+### Credentials Source Priority Order
+
+Credentials found in an environment variable for a particular service host
+as described above will be preferred over those in CLI config as set by `terraform login`.
+If neither are set, any configured credentials helper will be consulted.
+
+~> **Note:** For users of [terraform-credentials-helper](https://github.com/apparentlymart/terraform-credentials-env), this priority has been effectively reversed following the
+release of Terraform 1.2. Previously, credentials found within CLI config or set by
+`terraform login` were preferred to `TF_TOKEN_*` variables.
 
 ## Provider Installation
 

--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -122,18 +122,12 @@ configuration, you may use a host-specific environment variable. Environment var
 have the prefix `TF_TOKEN_` added to the domain name, with periods encoded as underscores.
 For example, the value of a variable named `TF_TOKEN_app_terraform_io` will be used as a
 bearer authorization token when the CLI makes service requests to the hostname "app.terraform.io".
+If multiple variables evaluate to the same hostname, Terraform will use the one defined later in the
+operating system's variable table.
 
-Domain names containing non-ASCII characters should be converted to
-their [punycode equivalent](https://www.charset.org/punycode)
-with an ACE prefix when used as a variable name. For example, token credentials
-for 例えば.com must be set in a variable called `TF_TOKEN_xn--r8j3dr99h_com`.
+When using domain names as a variable name, you must convert domain names containing non-ASCII characters to their [punycode equivalent](https://www.charset.org/punycode) with an ACE prefix. For example, token credentials for 例えば.com must be set in a variable called `TF_TOKEN_xn--r8j3dr99h_com`.
 
-Hyphens are allowed within variable names by certain tools, such as the `env` utility,
-but are not valid POSIX variable names. Therefore, it can be tricky to
-set them with interactive tools such as bash or zsh so you may encode
-hyphens as double underscores. For example, a token for the domain name "café.fr" can
-be set by either `TF_TOKEN_xn--caf-dma_fr` or `TF_TOKEN_xn____caf__dma_fr` if that is more
-convenient. If both are defined, the variable containing hyphens is preferred.
+Some tools like the `env` utility allow hyphens in variable names, but hyphens create invalid POSIX variable names. Therefore, you can encode hyphens as double underscores when you set variables with interactive tools like Bash or Zsh. For example, you can set a token for the domain name "café.fr" as either `TF_TOKEN_xn--caf-dma_fr` or `TF_TOKEN_xn____caf__dma_fr`. If both are defined, Terraform will use the version containing hyphens.
 
 ### Credentials Helpers
 

--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -118,10 +118,8 @@ Terraform Cloud responds to API calls at both its current hostname
 ### Environment Variable Credentials
 
 If you would prefer not to store your API tokens directly in the CLI
-configuration, you may use a host-specific environment variable. For example,
-the value of a variable named `TF_TOKEN_app_terraform_io` will be used as an
-Authorization: Bearer token whenever making service requests to the hostname
-"app.terraform.io".
+configuration, you may use a host-specific environment variable. Environment variable names should be the prefix `TF_TOKEN_` added to the domain name. For example,
+the value of a variable named `TF_TOKEN_app_terraform_io` will be used as a bearer authorization token when the CLI makes service requests to the hostname "app.terraform.io".
 
 Internationalized domain names should be converted to their [punycode equivalent](https://www.charset.org/punycode)
 with an ACE prefix when used as a variable name. For example, token credentials
@@ -129,8 +127,7 @@ for 例えば.com should be set in a variable called `TF_TOKEN_xn--r8j3dr99h_com
 
 ### Credentials Helpers
 
-Finally, you may instruct Terraform to use a different credentials storage mechanism
-by configuring a special kind of plugin program called a _credentials helper_.
+You can configure a `credentials_helper` to instruct Terraform to use a different credentials storage mechanism.
 
 ```hcl
 credentials_helper "example" {

--- a/website/docs/internals/remote-service-discovery.mdx
+++ b/website/docs/internals/remote-service-discovery.mdx
@@ -90,8 +90,8 @@ At present, the following service identifiers are in use:
 ## Authentication
 
 If credentials for the given hostname are available in
-[the CLI config](/cli/config/config-file) then they will be included
-in the request for the discovery document.
+[the CLI config, by a credential helper, or using a host-specific environment variable](/cli/config/config-file#Credentials)
+then they will be included in the request for the discovery document.
 
 The credentials may also be provided to endpoints declared in the discovery
 document, depending on the requirements of the service in question.

--- a/website/docs/internals/remote-service-discovery.mdx
+++ b/website/docs/internals/remote-service-discovery.mdx
@@ -90,8 +90,7 @@ At present, the following service identifiers are in use:
 ## Authentication
 
 If credentials for the given hostname are available in
-[the CLI config, by a credential helper, or using a host-specific environment variable](/cli/config/config-file#Credentials)
-then they will be included in the request for the discovery document.
+[the CLI config](/cli/config/config-file#Credentials) through a `credentials_helper` or a host-specific environment variable, then they will be included in the request for the discovery document.
 
 The credentials may also be provided to endpoints declared in the discovery
 document, depending on the requirements of the service in question.


### PR DESCRIPTION
# Description

Introduces a new method of configuring token service credentials using a host-specific environment variable. This configuration was previously possible using the [terraform-credentials-env](https://github.com/apparentlymart/terraform-credentials-env) credentials helper.

This new method is now consulted first, as it is seen to be the most proximate source of credentials before CLI configuration. The configured credential helpers are consulted as a last resort.

The same naming methodology found in the helper is used for domains: periods (.) must be replaced by underscores, which is preferred because underscores are not allowed in DNS names and because periods are not allowed (or tricky to set) in variable names. The only gotcha I uncovered was that dashes are not valid characters in bash identifiers, while they are used in both DNS and the ACE prefix for internationalized names. Go will happily fetch a variable named "TF_TOKEN_xa--r8j3dr99h_com" but it's not possible to set this variable name using Bash without help from the "env" utility (see below)

# Testing Steps

0. Build the app: `go build -o terraform-dev`
1. Ensure you DON'T have proper credentials for your chosen test environment hostname specified in your CLI config by temporarily changing them. Make sure you keep a copy of the correct token `~/.terraform.d/credentials.tfrc.json`
2. Try to init any config with a terraform cloud block. You should receive an error because the credentials are not correct. See Sample Config below
3. Use the correct token to configure the same init: `env 'TF_TOKEN_app_terraform_io="CORRECT_TOKEN"' ./terraform-dev init`
4. If it works, this proves that the env value was used and took precedence over the credentials block.

<details>
<summary>Sample config</summary>

```
terraform {
  cloud {
    hostname = "app.terraform.io"
    organization = "YOUR_ORG"

    workspaces {
      name = "terraform-minimal-FOO"
    }
  }
}

resource "null_resource" "null" {
  triggers = {
    hello: "world"
  }
}
```
</details>