### PR TITLE
internal/getproviders: Add URL to error message for clarity

### DIFF
--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -437,7 +437,7 @@ func (c *registryClient) getFile(url *url.URL) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s returned from %s", resp.Status, resp.Request.URL)
+		return nil, fmt.Errorf("%s returned from %s", resp.Status, resp.Request.Host)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -478,7 +478,7 @@ func maxRetryErrorHandler(resp *http.Response, err error, numTries int) (*http.R
 	// both response and error.
 	var errMsg string
 	if resp != nil {
-		errMsg = fmt.Sprintf(": %s returned from %s", resp.Status, resp.Request.URL)
+		errMsg = fmt.Sprintf(": %s returned from %s", resp.Status, resp.Request.Host)
 	} else if err != nil {
 		errMsg = fmt.Sprintf(": %s", err)
 	}

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -437,7 +437,7 @@ func (c *registryClient) getFile(url *url.URL) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", resp.Status)
+		return nil, fmt.Errorf("%s returned from %s", resp.Status, resp.Request.URL)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Occasionally `terraform init` on some providers may return the following error message:

```
Error while installing citrix/citrixadc v1.13.0: could not query provider
registry for registry.terraform.io/citrix/citrixadc: failed to retrieve
authentication checksums for provider: 403 Forbidden
```

That 403 is most often returned from GitHub (rather than Registry API) and this change makes it more obvious.

Similar to https://github.com/hashicorp/terraform/pull/29298