### PR TITLE
data schema changes may prevent state decoding

### DIFF
--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -389,15 +389,19 @@ func (n *NodeAbstractResource) readResourceInstanceState(ctx EvalContext, addr a
 	}
 	diags = diags.Append(upgradeDiags)
 	if diags.HasErrors() {
-		// Note that we don't have any channel to return warnings here. We'll
-		// accept that for now since warnings during a schema upgrade would
-		// be pretty weird anyway, since this operation is supposed to seem
-		// invisible to the user.
 		return nil, diags
 	}
 
 	obj, err := src.Decode(schema.ImpliedType())
 	if err != nil {
+		// In the case of a data source which contains incompatible state
+		// migrations, we can just ignore decoding errors and skip comparing
+		// the prior state.
+		if addr.Resource.Resource.Mode == addrs.DataResourceMode {
+			log.Printf("[DEBUG] readResourceInstanceState: data source schema change for %s prevents decoding: %s", addr, err)
+			return nil, diags
+		}
+
 		diags = diags.Append(err)
 	}
 

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -84,7 +84,8 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 	// However, note that we don't have any explicit mechanism for upgrading
 	// data resource results as we do for managed resources, and so the
 	// prevRunState might not conform to the current schema if the
-	// previous run was with a different provider version.
+	// previous run was with a different provider version. In that case the
+	// snapshot will be null if we could not decode it at all.
 	diags = diags.Append(n.writeResourceInstanceState(ctx, state, prevRunState))
 	if diags.HasErrors() {
 		return diags

--- a/internal/terraform/upgrade_resource_state.go
+++ b/internal/terraform/upgrade_resource_state.go
@@ -127,7 +127,7 @@ func stripRemovedStateAttributes(state []byte, ty cty.Type) []byte {
 	if err != nil {
 		// we just log any errors here, and let the normal decode process catch
 		// invalid JSON.
-		log.Printf("[ERROR] UpgradeResourceState: %s", err)
+		log.Printf("[ERROR] UpgradeResourceState: stripRemovedStateAttributes: %s", err)
 		return state
 	}
 


### PR DESCRIPTION
Data sources do not have state migrations, so there may be no way to
decode the prior state when faced with incompatible type changes.

Because prior state is only informational to the plan, and its existence
should not effect the planning process, we can skip decoding when faced
with errors.

This PR intended for backporting avoids the error, however we probably don't need to deal with the prior state at all. I can follow-up with a more invasive PR to remove the extra state handling entirely for v1.2.

Fixes #30823