### PR TITLE
remove the use of data source prior state from planning

### DIFF
--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -394,14 +394,6 @@ func (n *NodeAbstractResource) readResourceInstanceState(ctx EvalContext, addr a
 
 	obj, err := src.Decode(schema.ImpliedType())
 	if err != nil {
-		// In the case of a data source which contains incompatible state
-		// migrations, we can just ignore decoding errors and skip comparing
-		// the prior state.
-		if addr.Resource.Resource.Mode == addrs.DataResourceMode {
-			log.Printf("[DEBUG] readResourceInstanceState: data source schema change for %s prevents decoding: %s", addr, err)
-			return nil, diags
-		}
-
 		diags = diags.Append(err)
 	}
 

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -264,12 +264,6 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		return diags
 	}
 
-	state, readDiags = n.readResourceInstanceState(ctx, n.ResourceInstanceAddr())
-	diags = diags.Append(readDiags)
-	if diags.HasErrors() {
-		return diags
-	}
-
 	diffApply = reducePlan(addr, diffApply, false)
 	// reducePlan may have simplified our planned change
 	// into a NoOp if it only requires destroying, since destroying

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -71,26 +71,6 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 		return diags
 	}
 
-	state, readDiags := n.readResourceInstanceState(ctx, addr)
-	diags = diags.Append(readDiags)
-	if diags.HasErrors() {
-		return diags
-	}
-
-	// We'll save a snapshot of what we just read from the state into the
-	// prevRunState which will capture the result read in the previous
-	// run, possibly tweaked by any upgrade steps that
-	// readResourceInstanceState might've made.
-	// However, note that we don't have any explicit mechanism for upgrading
-	// data resource results as we do for managed resources, and so the
-	// prevRunState might not conform to the current schema if the
-	// previous run was with a different provider version. In that case the
-	// snapshot will be null if we could not decode it at all.
-	diags = diags.Append(n.writeResourceInstanceState(ctx, state, prevRunState))
-	if diags.HasErrors() {
-		return diags
-	}
-
 	diags = diags.Append(validateSelfRef(addr.Resource, config.Config, providerSchema))
 	if diags.HasErrors() {
 		return diags
@@ -101,7 +81,7 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 		checkRuleSeverity = tfdiags.Warning
 	}
 
-	change, state, repeatData, planDiags := n.planDataSource(ctx, state, checkRuleSeverity)
+	change, state, repeatData, planDiags := n.planDataSource(ctx, checkRuleSeverity)
 	diags = diags.Append(planDiags)
 	if diags.HasErrors() {
 		return diags

--- a/internal/terraform/upgrade_resource_state.go
+++ b/internal/terraform/upgrade_resource_state.go
@@ -21,6 +21,14 @@ import (
 // If any errors occur during upgrade, error diagnostics are returned. In that
 // case it is not safe to proceed with using the original state object.
 func upgradeResourceState(addr addrs.AbsResourceInstance, provider providers.Interface, src *states.ResourceInstanceObjectSrc, currentSchema *configschema.Block, currentVersion uint64) (*states.ResourceInstanceObjectSrc, tfdiags.Diagnostics) {
+	if addr.Resource.Resource.Mode != addrs.ManagedResourceMode {
+		// We only do state upgrading for managed resources.
+		// This was a part of the normal workflow in older versions and
+		// returned early, so we are only going to log the error for now.
+		log.Printf("[ERROR] data resource %s should not require state upgrade", addr)
+		return src, nil
+	}
+
 	// Remove any attributes from state that are not present in the schema.
 	// This was previously taken care of by the provider, but data sources do
 	// not go through the UpgradeResourceState process.
@@ -30,11 +38,6 @@ func upgradeResourceState(addr addrs.AbsResourceInstance, provider providers.Int
 	// removed attributes.
 	if len(src.AttrsJSON) > 0 && src.SchemaVersion == currentVersion {
 		src.AttrsJSON = stripRemovedStateAttributes(src.AttrsJSON, currentSchema.ImpliedType())
-	}
-
-	if addr.Resource.Resource.Mode != addrs.ManagedResourceMode {
-		// We only do state upgrading for managed resources.
-		return src, nil
 	}
 
 	stateIsFlatmap := len(src.AttrsJSON) == 0


### PR DESCRIPTION
After data source handling was moved from a separate refresh phase into the planning phase, reading the existing state was only used for informational purposes. This had been reduced to reporting warnings when the provider returned an unexpected value to try and help locate legacy provider bugs, but any actual issues located from those warnings were very few and far between.

Because the prior state cannot be reliably decoded when faced with incompatible provider schema upgrades, and there is no longer any significant reason to try and get the prior state at all, we can skip the process entirely.

The only place where the prior state was functionally used was in the destroy path to create the change entry. Because a data source destroy is only for cleanup purposes to clean out the state using the same code paths as a managed resource, we can substitute the prior state in the change with a null value to maintain the same behavior.

This is a more complete followup to #30830, not intended for backport.