### PR TITLE
Cloud e2e tests for configuring `cloud` with env vars

### DIFF
--- a/internal/cloud/e2e/env_variables_test.go
+++ b/internal/cloud/e2e/env_variables_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+)
+
+func Test_cloud_organization_env_var(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	org, cleanup := createOrganization(t)
+	t.Cleanup(cleanup)
+
+	cases := testCases{
+		"with TF_ORGANIZATION set": {
+			operations: []operationSets{
+				{
+					prep: func(t *testing.T, orgName, dir string) {
+						remoteWorkspace := "cloud-workspace"
+						tfBlock := terraformConfigCloudBackendOmitOrg(remoteWorkspace)
+						writeMainTF(t, tfBlock, dir)
+					},
+					commands: []tfCommand{
+						{
+							command:           []string{"init"},
+							expectedCmdOutput: `Terraform Cloud has been successfully initialized!`,
+						},
+						{
+							command:         []string{"apply", "-auto-approve"},
+							postInputOutput: []string{`Apply complete!`},
+						},
+					},
+				},
+			},
+			validations: func(t *testing.T, orgName string) {
+				expectedName := "cloud-workspace"
+				ws, err := tfeClient.Workspaces.Read(ctx, org.Name, expectedName)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if ws == nil {
+					t.Fatalf("Expected workspace %s to be present, but is not.", expectedName)
+				}
+			},
+		},
+	}
+
+	testRunner(t, cases, 0, fmt.Sprintf("TF_ORGANIZATION=%s", org.Name))
+}
+
+func Test_cloud_workspace_name_env_var(t *testing.T) {
+	t.Parallel()
+
+	org, orgCleanup := createOrganization(t)
+	t.Cleanup(orgCleanup)
+
+	wk := createWorkspace(t, org.Name, tfe.WorkspaceCreateOptions{
+		Name: tfe.String("cloud-workspace"),
+	})
+
+	validCases := testCases{
+		"a workspace that exists": {
+			operations: []operationSets{
+				{
+					prep: func(t *testing.T, orgName, dir string) {
+						tfBlock := terraformConfigCloudBackendOmitWorkspaces(org.Name)
+						writeMainTF(t, tfBlock, dir)
+					},
+					commands: []tfCommand{
+						{
+							command:           []string{"init"},
+							expectedCmdOutput: `Terraform Cloud has been successfully initialized!`,
+						},
+						{
+							command:         []string{"apply", "-auto-approve"},
+							postInputOutput: []string{`Apply complete!`},
+						},
+					},
+				},
+				{
+					prep: func(t *testing.T, orgName, dir string) {
+						tfBlock := terraformConfigCloudBackendOmitWorkspaces(org.Name)
+						writeMainTF(t, tfBlock, dir)
+					},
+					commands: []tfCommand{
+						{
+							command:           []string{"init"},
+							expectedCmdOutput: `Terraform Cloud has been successfully initialized!`,
+						},
+						{
+							command:           []string{"workspace", "show"},
+							expectedCmdOutput: wk.Name,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errCases := testCases{
+		"a workspace that doesn't exist": {
+			operations: []operationSets{
+				{
+					prep: func(t *testing.T, orgName, dir string) {
+						tfBlock := terraformConfigCloudBackendOmitWorkspaces(org.Name)
+						writeMainTF(t, tfBlock, dir)
+					},
+					commands: []tfCommand{
+						{
+							command:     []string{"init"},
+							expectError: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testRunner(t, validCases, 0, fmt.Sprintf(`TF_WORKSPACE=%s`, wk.Name))
+	testRunner(t, errCases, 0, fmt.Sprintf(`TF_WORKSPACE=%s`, "the-fires-of-mt-doom"))
+}
+
+func Test_cloud_workspace_tags_env_var(t *testing.T) {
+	t.Parallel()
+
+	org, orgCleanup := createOrganization(t)
+	t.Cleanup(orgCleanup)
+
+	wkValid := createWorkspace(t, org.Name, tfe.WorkspaceCreateOptions{
+		Name: tfe.String("cloud-workspace"),
+		Tags: []*tfe.Tag{
+			{Name: "cloud"},
+		},
+	})
+
+	// this will be a workspace that won't have a tag listed in our test configuration
+	wkInvalid := createWorkspace(t, org.Name, tfe.WorkspaceCreateOptions{
+		Name: tfe.String("cloud-workspace-2"),
+	})
+
+	validCases := testCases{
+		"a workspace with valid tag": {
+			operations: []operationSets{
+				{
+					prep: func(t *testing.T, orgName, dir string) {
+						tfBlock := terraformConfigCloudBackendTags(org.Name, wkValid.TagNames[0])
+						writeMainTF(t, tfBlock, dir)
+					},
+					commands: []tfCommand{
+						{
+							command:           []string{"init"},
+							expectedCmdOutput: `Terraform Cloud has been successfully initialized!`,
+						},
+						{
+							command:         []string{"apply", "-auto-approve"},
+							postInputOutput: []string{`Apply complete!`},
+						},
+					},
+				},
+				{
+					prep: func(t *testing.T, orgName, dir string) {
+						tfBlock := terraformConfigCloudBackendTags(org.Name, wkValid.TagNames[0])
+						writeMainTF(t, tfBlock, dir)
+					},
+					commands: []tfCommand{
+						{
+							command:           []string{"init"},
+							expectedCmdOutput: `Terraform Cloud has been successfully initialized!`,
+						},
+						{
+							command:           []string{"workspace", "show"},
+							expectedCmdOutput: wkValid.Name,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errCases := testCases{
+		"a workspace not specified by tags": {
+			operations: []operationSets{
+				{
+					prep: func(t *testing.T, orgName, dir string) {
+						tfBlock := terraformConfigCloudBackendTags(org.Name, wkValid.TagNames[0])
+						writeMainTF(t, tfBlock, dir)
+					},
+					commands: []tfCommand{
+						{
+							command:     []string{"init"},
+							expectError: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testRunner(t, validCases, 0, fmt.Sprintf(`TF_WORKSPACE=%s`, wkValid.Name))
+	testRunner(t, errCases, 0, fmt.Sprintf(`TF_WORKSPACE=%s`, wkInvalid.Name))
+}
+
+func Test_cloud_null_config(t *testing.T) {
+	t.Parallel()
+
+	org, cleanup := createOrganization(t)
+	t.Cleanup(cleanup)
+
+	wk := createWorkspace(t, org.Name, tfe.WorkspaceCreateOptions{
+		Name: tfe.String("cloud-workspace"),
+	})
+
+	cases := testCases{
+		"with all env vars set": {
+			operations: []operationSets{
+				{
+					prep: func(t *testing.T, orgName, dir string) {
+						tfBlock := terraformConfigCloudBackendOmitConfig()
+						writeMainTF(t, tfBlock, dir)
+					},
+					commands: []tfCommand{
+						{
+							command:           []string{"init"},
+							expectedCmdOutput: `Terraform Cloud has been successfully initialized!`,
+						},
+						{
+							command:         []string{"apply", "-auto-approve"},
+							postInputOutput: []string{`Apply complete!`},
+						},
+					},
+				},
+				{
+					prep: func(t *testing.T, orgName, dir string) {
+						tfBlock := terraformConfigCloudBackendOmitConfig()
+						writeMainTF(t, tfBlock, dir)
+					},
+					commands: []tfCommand{
+						{
+							command:           []string{"init"},
+							expectedCmdOutput: `Terraform Cloud has been successfully initialized!`,
+						},
+						{
+							command:           []string{"workspace", "show"},
+							expectedCmdOutput: wk.Name,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testRunner(t, cases, 1,
+		fmt.Sprintf(`TF_ORGANIZATION=%s`, org.Name),
+		fmt.Sprintf(`TF_HOSTNAME=%s`, tfeHostname),
+		fmt.Sprintf(`TF_WORKSPACE=%s`, wk.Name))
+}

--- a/internal/cloud/e2e/env_variables_test.go
+++ b/internal/cloud/e2e/env_variables_test.go
@@ -10,6 +10,7 @@ import (
 
 func Test_cloud_organization_env_var(t *testing.T) {
 	t.Parallel()
+	skipIfMissingEnvVar(t)
 
 	ctx := context.Background()
 	org, cleanup := createOrganization(t)
@@ -54,6 +55,7 @@ func Test_cloud_organization_env_var(t *testing.T) {
 
 func Test_cloud_workspace_name_env_var(t *testing.T) {
 	t.Parallel()
+	skipIfMissingEnvVar(t)
 
 	org, orgCleanup := createOrganization(t)
 	t.Cleanup(orgCleanup)
@@ -126,6 +128,7 @@ func Test_cloud_workspace_name_env_var(t *testing.T) {
 
 func Test_cloud_workspace_tags_env_var(t *testing.T) {
 	t.Parallel()
+	skipIfMissingEnvVar(t)
 
 	org, orgCleanup := createOrganization(t)
 	t.Cleanup(orgCleanup)
@@ -206,6 +209,7 @@ func Test_cloud_workspace_tags_env_var(t *testing.T) {
 
 func Test_cloud_null_config(t *testing.T) {
 	t.Parallel()
+	skipIfMissingEnvVar(t)
 
 	org, cleanup := createOrganization(t)
 	t.Cleanup(cleanup)

--- a/internal/cloud/e2e/helper_test.go
+++ b/internal/cloud/e2e/helper_test.go
@@ -191,6 +191,51 @@ output "val" {
 `, tfeHostname, org, name)
 }
 
+func terraformConfigCloudBackendOmitOrg(workspaceName string) string {
+	return fmt.Sprintf(`
+terraform {
+  cloud {
+    hostname = "%s"
+
+	workspaces {
+	  name = "%s"
+	}
+  }
+}
+
+output "val" {
+  value = "${terraform.workspace}"
+}
+`, tfeHostname, workspaceName)
+}
+
+func terraformConfigCloudBackendOmitWorkspaces(orgName string) string {
+	return fmt.Sprintf(`
+terraform {
+  cloud {
+    hostname = "%s"
+	organization = "%s"
+  }
+}
+
+output "val" {
+  value = "${terraform.workspace}"
+}
+`, tfeHostname, orgName)
+}
+
+func terraformConfigCloudBackendOmitConfig() string {
+	return `
+terraform {
+  cloud {}
+}
+
+output "val" {
+  value = "${terraform.workspace}"
+}
+`
+}
+
 func writeMainTF(t *testing.T, block string, dir string) {
 	f, err := os.Create(fmt.Sprintf("%s/main.tf", dir))
 	if err != nil {

--- a/internal/cloud/e2e/main_test.go
+++ b/internal/cloud/e2e/main_test.go
@@ -98,11 +98,15 @@ func testRunner(t *testing.T, cases testCases, orgCount int, tfEnvFlags ...strin
 
 			var orgName string
 			for index, op := range tc.operations {
-				if orgCount == 1 {
+				switch orgCount {
+				case 0:
+					orgName = ""
+				case 1:
 					orgName = orgNames[0]
-				} else {
+				default:
 					orgName = orgNames[index]
 				}
+
 				op.prep(t, orgName, tf.WorkDir())
 				for _, tfCmd := range op.commands {
 					cmd := tf.Cmd(tfCmd.command...)


### PR DESCRIPTION
Cloud e2e tests for using environment variables: `TF_ORGANIZATION`, `TF_HOSTNAME`, `TF_WORKSPACE` to configure the `cloud` block. 

To run the tests:
```sh
# TF_ORGANIZATION
go test ./internal/cloud/e2e -run Test_cloud_organization_env_var

# TF_WORKSPACE (both strategies) 
go test ./internal/cloud/e2e -run Test_cloud_workspace_name_env_var
go test ./internal/cloud/e2e -run Test_cloud_workspace_tags_env_var

# TF_ORGANIZATION, TF_HOSTNAME, TF_WORKSPACE
go test ./internal/cloud/e2e -run Test_cloud_null_config
```