### PR TITLE
test(cloud): ensure mocks are used for backend configure tests

### DIFF
--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -253,30 +253,32 @@ func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
 		return diags
 	}
 
-	cfg := &tfe.Config{
-		Address:      service.String(),
-		BasePath:     service.Path,
-		Token:        token,
-		Headers:      make(http.Header),
-		RetryLogHook: b.retryLogHook,
-	}
+	if b.client == nil {
+		cfg := &tfe.Config{
+			Address:      service.String(),
+			BasePath:     service.Path,
+			Token:        token,
+			Headers:      make(http.Header),
+			RetryLogHook: b.retryLogHook,
+		}
 
-	// Set the version header to the current version.
-	cfg.Headers.Set(tfversion.Header, tfversion.Version)
-	cfg.Headers.Set(headerSourceKey, headerSourceValue)
+		// Set the version header to the current version.
+		cfg.Headers.Set(tfversion.Header, tfversion.Version)
+		cfg.Headers.Set(headerSourceKey, headerSourceValue)
 
-	// Create the TFC/E API client.
-	b.client, err = tfe.NewClient(cfg)
-	if err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to create the Terraform Cloud/Enterprise client",
-			fmt.Sprintf(
-				`Encountered an unexpected error while creating the `+
-					`Terraform Cloud/Enterprise client: %s.`, err,
-			),
-		))
-		return diags
+		// Create the TFC/E API client.
+		b.client, err = tfe.NewClient(cfg)
+		if err != nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Failed to create the Terraform Cloud/Enterprise client",
+				fmt.Sprintf(
+					`Encountered an unexpected error while creating the `+
+						`Terraform Cloud/Enterprise client: %s.`, err,
+				),
+			))
+			return diags
+		}
 	}
 
 	// Check if the organization exists by reading its entitlements.
@@ -383,7 +385,7 @@ func (b *Cloud) setConfigurationFields(obj cty.Value) tfdiags.Diagnostics {
 			var tags []string
 			err := gocty.FromCtyValue(val, &tags)
 			if err != nil {
-				log.Panicf("An unxpected error occurred: %s", err)
+				log.Panicf("An unexpected error occurred: %s", err)
 			}
 
 			b.WorkspaceMapping.Tags = tags

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -223,6 +223,7 @@ func TestCloud_PrepareConfigWithEnvVars(t *testing.T) {
 
 func TestCloud_configWithEnvVars(t *testing.T) {
 	cases := map[string]struct {
+		setup                 func(b *Cloud)
 		config                cty.Value
 		vars                  map[string]string
 		expectedOrganization  string
@@ -271,13 +272,13 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 				}),
 			}),
 			vars: map[string]string{
-				"TF_HOSTNAME": "app.terraform.io",
+				"TF_HOSTNAME": "private.hashicorp.engineering",
 			},
-			expectedHostname: "app.terraform.io",
+			expectedHostname: "private.hashicorp.engineering",
 		},
 		"with hostname and env var specified": {
 			config: cty.ObjectVal(map[string]cty.Value{
-				"hostname":     cty.StringVal("app.terraform.io"),
+				"hostname":     cty.StringVal("private.hashicorp.engineering"),
 				"token":        cty.NullVal(cty.String),
 				"organization": cty.StringVal("hashicorp"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -288,11 +289,11 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 			vars: map[string]string{
 				"TF_HOSTNAME": "mycool.tfe-host.io",
 			},
-			expectedHostname: "app.terraform.io",
+			expectedHostname: "private.hashicorp.engineering",
 		},
 		"an invalid workspace env var": {
 			config: cty.ObjectVal(map[string]cty.Value{
-				"hostname":     cty.StringVal("app.terraform.io"),
+				"hostname":     cty.NullVal(cty.String),
 				"token":        cty.NullVal(cty.String),
 				"organization": cty.StringVal("hashicorp"),
 				"workspaces": cty.NullVal(cty.Object(map[string]cty.Type{
@@ -307,25 +308,98 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 		},
 		"workspaces and env var specified": {
 			config: cty.ObjectVal(map[string]cty.Value{
-				"hostname":     cty.StringVal("app.terraform.io"),
+				"hostname":     cty.NullVal(cty.String),
 				"token":        cty.NullVal(cty.String),
-				"organization": cty.StringVal("hashicorp"),
+				"organization": cty.StringVal("mordor"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name": cty.StringVal("prod"),
+					"name": cty.StringVal("mt-doom"),
 					"tags": cty.NullVal(cty.Set(cty.String)),
 				}),
 			}),
 			vars: map[string]string{
-				"TF_WORKSPACE": "mt-doom",
+				"TF_WORKSPACE": "shire",
 			},
-			expectedWorkspaceName: "prod",
+			expectedWorkspaceName: "mt-doom",
+		},
+		"env var workspace does not have specified tag": {
+			setup: func(b *Cloud) {
+				b.client.Organizations.Create(context.Background(), tfe.OrganizationCreateOptions{
+					Name: tfe.String("mordor"),
+				})
+
+				b.client.Workspaces.Create(context.Background(), "mordor", tfe.WorkspaceCreateOptions{
+					Name: tfe.String("shire"),
+				})
+			},
+			config: cty.ObjectVal(map[string]cty.Value{
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"organization": cty.StringVal("mordor"),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name": cty.NullVal(cty.String),
+					"tags": cty.SetVal([]cty.Value{
+						cty.StringVal("cloud"),
+					}),
+				}),
+			}),
+			vars: map[string]string{
+				"TF_WORKSPACE": "shire",
+			},
+			expectedErr: "Terraform failed to find workspace \"shire\" with the tags specified in your configuration:\n[cloud]",
+		},
+		"env var workspace has specified tag": {
+			setup: func(b *Cloud) {
+				b.client.Organizations.Create(context.Background(), tfe.OrganizationCreateOptions{
+					Name: tfe.String("mordor"),
+				})
+
+				b.client.Workspaces.Create(context.Background(), "mordor", tfe.WorkspaceCreateOptions{
+					Name: tfe.String("shire"),
+					Tags: []*tfe.Tag{
+						{
+							Name: "hobbity",
+						},
+					},
+				})
+			},
+			config: cty.ObjectVal(map[string]cty.Value{
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"organization": cty.StringVal("mordor"),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name": cty.NullVal(cty.String),
+					"tags": cty.SetVal([]cty.Value{
+						cty.StringVal("hobbity"),
+					}),
+				}),
+			}),
+			vars: map[string]string{
+				"TF_WORKSPACE": "shire",
+			},
+			expectedWorkspaceName: "", // No error is raised, but workspace is not set
+		},
+		"with everything set as env vars": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"organization": cty.NullVal(cty.String),
+				"workspaces":   cty.NullVal(cty.String),
+			}),
+			vars: map[string]string{
+				"TF_ORGANIZATION": "mordor",
+				"TF_WORKSPACE":    "mt-doom",
+				"TF_HOSTNAME":     "mycool.tfe-host.io",
+			},
+			expectedOrganization:  "mordor",
+			expectedWorkspaceName: "mt-doom",
+			expectedHostname:      "mycool.tfe-host.io",
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			s := testServer(t)
-			b := New(testDisco(s))
+			b, cleanup := testUnconfiguredBackend(t)
+			t.Cleanup(cleanup)
 
 			for k, v := range tc.vars {
 				os.Setenv(k, v)
@@ -340,6 +414,10 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 			_, valDiags := b.PrepareConfig(tc.config)
 			if valDiags.Err() != nil {
 				t.Fatalf("%s: unexpected validation result: %v", name, valDiags.Err())
+			}
+
+			if tc.setup != nil {
+				tc.setup(b)
 			}
 
 			diags := b.Configure(tc.config)
@@ -466,8 +544,8 @@ func TestCloud_config(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		s := testServer(t)
-		b := New(testDisco(s))
+		b, cleanup := testUnconfiguredBackend(t)
+		t.Cleanup(cleanup)
 
 		// Validate
 		_, valDiags := b.PrepareConfig(tc.config)

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -447,18 +447,6 @@ func TestCloud_config(t *testing.T) {
 		confErr string
 		valErr  string
 	}{
-		"with_a_nonexisting_organization": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"hostname":     cty.NullVal(cty.String),
-				"organization": cty.StringVal("nonexisting"),
-				"token":        cty.NullVal(cty.String),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name": cty.StringVal("prod"),
-					"tags": cty.NullVal(cty.Set(cty.String)),
-				}),
-			}),
-			confErr: "organization \"nonexisting\" at host app.terraform.io not found",
-		},
 		"with_an_unknown_host": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.StringVal("nonexisting.local"),


### PR DESCRIPTION
Ensure mocks are used for cloud backend configure tests and adds a few new tests for cloud configuration using environment variables.

# Notes

Mocks were previously not used in these tests because Configure creates the tfe client but also makes several API calls using it. One minor functional change to highlight is that the cloud Backend Configure method only sets the client field if it's not already set. This prevents overwriting the mock client when the Configure method itself is under test.