### PR TITLE
cli: Fix double-quoted map keys in diff UI

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -1473,24 +1473,21 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 			p.buf.WriteString("\n")
 
 			var allKeys []string
-			displayKeys := make(map[string]string)
 			keyLen := 0
 			for it := old.ElementIterator(); it.Next(); {
 				k, _ := it.Element()
 				keyStr := k.AsString()
 				allKeys = append(allKeys, keyStr)
-				displayKeys[keyStr] = displayAttributeName(keyStr)
-				if len(displayKeys[keyStr]) > keyLen {
-					keyLen = len(displayKeys[keyStr])
+				if len(keyStr) > keyLen {
+					keyLen = len(keyStr)
 				}
 			}
 			for it := new.ElementIterator(); it.Next(); {
 				k, _ := it.Element()
 				keyStr := k.AsString()
 				allKeys = append(allKeys, keyStr)
-				displayKeys[keyStr] = displayAttributeName(keyStr)
-				if len(displayKeys[keyStr]) > keyLen {
-					keyLen = len(displayKeys[keyStr])
+				if len(keyStr) > keyLen {
+					keyLen = len(keyStr)
 				}
 			}
 
@@ -1533,8 +1530,8 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 
 				p.buf.WriteString(strings.Repeat(" ", indent+2))
 				p.writeActionSymbol(action)
-				p.writeValue(cty.StringVal(displayKeys[k]), action, indent+4)
-				p.buf.WriteString(strings.Repeat(" ", keyLen-len(displayKeys[k])))
+				p.writeValue(cty.StringVal(k), action, indent+4)
+				p.buf.WriteString(strings.Repeat(" ", keyLen-len(k)))
 				p.buf.WriteString(" = ")
 				switch action {
 				case plans.Create, plans.NoOp:

--- a/internal/command/format/diff_test.go
+++ b/internal/command/format/diff_test.go
@@ -2115,6 +2115,7 @@ func TestResourceChange_map(t *testing.T) {
 				"ami": cty.StringVal("ami-STATIC"),
 				"map_field": cty.MapVal(map[string]cty.Value{
 					"new-key": cty.StringVal("new-element"),
+					"be:ep":   cty.StringVal("boop"),
 				}),
 			}),
 			Schema: &configschema.Block{
@@ -2129,6 +2130,7 @@ func TestResourceChange_map(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       + map_field = {
+          + "be:ep"   = "boop"
           + "new-key" = "new-element"
         }
         # (1 unchanged attribute hidden)
@@ -2148,6 +2150,7 @@ func TestResourceChange_map(t *testing.T) {
 				"ami": cty.StringVal("ami-STATIC"),
 				"map_field": cty.MapVal(map[string]cty.Value{
 					"new-key": cty.StringVal("new-element"),
+					"be:ep":   cty.StringVal("boop"),
 				}),
 			}),
 			Schema: &configschema.Block{
@@ -2162,6 +2165,7 @@ func TestResourceChange_map(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       ~ map_field = {
+          + "be:ep"   = "boop"
           + "new-key" = "new-element"
         }
         # (1 unchanged attribute hidden)
@@ -2183,9 +2187,10 @@ func TestResourceChange_map(t *testing.T) {
 				"id":  cty.UnknownVal(cty.String),
 				"ami": cty.StringVal("ami-STATIC"),
 				"map_field": cty.MapVal(map[string]cty.Value{
-					"a": cty.StringVal("aaaa"),
-					"b": cty.StringVal("bbbb"),
-					"c": cty.StringVal("cccc"),
+					"a":   cty.StringVal("aaaa"),
+					"b":   cty.StringVal("bbbb"),
+					"b:b": cty.StringVal("bbbb"),
+					"c":   cty.StringVal("cccc"),
 				}),
 			}),
 			Schema: &configschema.Block{
@@ -2200,7 +2205,8 @@ func TestResourceChange_map(t *testing.T) {
   ~ resource "test_instance" "example" {
       ~ id        = "i-02ae66f368e8518a9" -> (known after apply)
       ~ map_field = {
-          + "b" = "bbbb"
+          + "b"   = "bbbb"
+          + "b:b" = "bbbb"
             # (2 unchanged elements hidden)
         }
         # (1 unchanged attribute hidden)


### PR DESCRIPTION
[A previous change](https://github.com/hashicorp/terraform/pull/30766) added missing quoting around object keys which do not parse as barewords. At the same time we introduced a bug where map keys could be double-quoted, due to calling the `displayAttributeName` helper function (to quote non-bareword keys) then using the `writeValue` method (which quotes all strings).

This commit fixes this and adds test coverage for map keys which require quoting.

Fixes #30854