### PR TITLE
[v1.0 RelAPI Onboarding] Add release API metadata file

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,0 +1,5 @@
+url_docker_registry_dockerhub = "https://hub.docker.com/r/hashicorp/terraform"
+url_docker_registry_ecr = "https://gallery.ecr.aws/hashicorp/terraform"
+url_license = "https://github.com/hashicorp/terraform/blob/main/LICENSE"
+url_project_website = "https://www.terraform.io"
+url_source_repository = "https://github.com/hashicorp/terraform"


### PR DESCRIPTION
This is a manual backport of https://github.com/hashicorp/terraform/pull/30717 for `v1.0`. 

👋  This PR adds a `.release/release-metadata.hcl` file to the repo. This contains static metadata that will be processed and sent as part of the payload in RelAPI POST requests, which will be sent when staging and production releases are triggered.  

This can be merged now, but will not have any effect until after the RelAPI launch. Similar additions are being added across all projects that publish to releases.hashicorp.com.