### PR TITLE
Clarify that users can set TF_WORKSPACE and use tags

### DIFF
--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -90,11 +90,11 @@ Use the following environment variables to configure the `cloud` block:
 
 
 - `TF_ORGANIZATION` - The name of the organization. Serves as a fallback for `organization`
-    in the cloud configuration. If both are specified, the configuration takes precedence. 
+    in the cloud configuration. If both are specified, the configuration takes precedence.
 
-- `TF_HOSTNAME` - The hostname of a Terraform Enterprise installation. Serves as a fallback if `hostname` is not specified in the cloud configuration. If both are specified, the configuration takes precendence. 
+- `TF_HOSTNAME` - The hostname of a Terraform Enterprise installation. Serves as a fallback if `hostname` is not specified in the cloud configuration. If both are specified, the configuration takes precendence.
 
-- `TF_WORKSPACE` - The name of a single Terraform Cloud workspace.  If the `workspaces` attribute is not included in your configuration file, the `cloud` block interprets `TF_WORKSPACE` as the `name` value of the `workspaces` attribute. The workspace must exist in the organization specified in the configuration or `TF_ORGANIZATION`. If the `cloud` block uses tags, Terraform Cloud will return an error if the value of `TF_WORKSPACE` is not included in the set of tags. Refer to [TF_WORKSPACE](https://www.terraform.io/cli/config/environment-variables#tf_workspace) for more details.
+- `TF_WORKSPACE` - The name of a single Terraform Cloud workspace.  If the `workspaces` attribute is not included in your configuration file, the `cloud` block interprets `TF_WORKSPACE` as the `name` value of the `workspaces` attribute. The workspace must exist in the organization specified in the configuration or `TF_ORGANIZATION`. You can set this variable if the `cloud` block in your configuration uses tags. However, Terraform Cloud will return an error if the value of `TF_WORKSPACE` is not included in the set of tags. Refer to [TF_WORKSPACE](https://www.terraform.io/cli/config/environment-variables#tf_workspace) for more details.
 
 ## Excluding Files from Upload with .terraformignore
 


### PR DESCRIPTION
A very tiny change to make sure users know that they can use `TF_WORKSPACE` environment variable AND have tags in their `cloud` block inside the configuration file. I think it's important to explicitly say this because in the configuration file, you can't have both workspace and tags set. 