### PR TITLE
fix(creds): allow periods in TF_TOKEN_... credentials vars

### DIFF
--- a/internal/command/cliconfig/credentials_test.go
+++ b/internal/command/cliconfig/credentials_test.go
@@ -156,6 +156,56 @@ func TestCredentialsForHost(t *testing.T) {
 			t.Errorf("wrong result\ngot: %s\nwant: %s", got, expectedToken)
 		}
 	})
+
+	t.Run("periods are ok", func(t *testing.T) {
+		envName := "TF_TOKEN_configured.example.com"
+		expectedToken := "configured-by-env"
+		t.Cleanup(func() {
+			os.Unsetenv(envName)
+		})
+
+		os.Setenv(envName, expectedToken)
+
+		hostname, _ := svchost.ForComparison("configured.example.com")
+		creds, err := credSrc.ForHost(hostname)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if creds == nil {
+			t.Fatal("no credentials found")
+		}
+
+		if got := creds.Token(); got != expectedToken {
+			t.Errorf("wrong result\ngot: %s\nwant: %s", got, expectedToken)
+		}
+	})
+
+	t.Run("casing is insensitive", func(t *testing.T) {
+		envName := "TF_TOKEN_CONFIGUREDUPPERCASE_EXAMPLE_COM"
+		expectedToken := "configured-by-env"
+
+		os.Setenv(envName, expectedToken)
+		t.Cleanup(func() {
+			os.Unsetenv(envName)
+		})
+
+		hostname, _ := svchost.ForComparison("configureduppercase.example.com")
+		creds, err := credSrc.ForHost(hostname)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if creds == nil {
+			t.Fatal("no credentials found")
+		}
+
+		if got := creds.Token(); got != expectedToken {
+			t.Errorf("wrong result\ngot: %s\nwant: %s", got, expectedToken)
+		}
+	})
 }
 
 func TestCredentialsStoreForget(t *testing.T) {

--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -117,17 +117,21 @@ Terraform Cloud responds to API calls at both its current hostname
 
 ### Environment Variable Credentials
 
-If you would prefer not to store your API tokens directly in the CLI
-configuration, you may use a host-specific environment variable. Environment variable names should
-have the prefix `TF_TOKEN_` added to the domain name, with periods encoded as underscores.
-For example, the value of a variable named `TF_TOKEN_app_terraform_io` will be used as a
-bearer authorization token when the CLI makes service requests to the hostname "app.terraform.io".
-If multiple variables evaluate to the same hostname, Terraform will use the one defined later in the
-operating system's variable table.
+If you would prefer not to store your API tokens directly in the CLI configuration, you may use
+a host-specific environment variable. Environment variable names should have the prefix
+`TF_TOKEN_` added to the domain name, with periods encoded as underscores. For example, the
+value of a variable named `TF_TOKEN_app_terraform_io` will be used as a bearer authorization
+token when the CLI makes service requests to the hostname `app.terraform.io`.
 
-When using domain names as a variable name, you must convert domain names containing non-ASCII characters to their [punycode equivalent](https://www.charset.org/punycode) with an ACE prefix. For example, token credentials for 例えば.com must be set in a variable called `TF_TOKEN_xn--r8j3dr99h_com`.
+You must convert domain names containing non-ASCII characters to their [punycode equivalent](https://www.charset.org/punycode)
+with an ACE prefix. For example, token credentials for 例えば.com must be set in a variable
+called `TF_TOKEN_xn--r8j3dr99h_com`.
 
-Some tools like the `env` utility allow hyphens in variable names, but hyphens create invalid POSIX variable names. Therefore, you can encode hyphens as double underscores when you set variables with interactive tools like Bash or Zsh. For example, you can set a token for the domain name "café.fr" as either `TF_TOKEN_xn--caf-dma_fr` or `TF_TOKEN_xn____caf__dma_fr`. If both are defined, Terraform will use the version containing hyphens.
+Hyphens are also valid within host names but usually invalid as variable names and
+may be encoded as double underscores. For example, you can set a token for the domain name
+`café.fr` as `TF_TOKEN_xn--caf-dma.fr`, `TF_TOKEN_xn--caf-dma_fr`,  or `TF_TOKEN_xn____caf__dma_fr`.
+If multiple variables evaluate to the same hostname, Terraform will choose the one defined last
+in the operating system's variable table.
 
 ### Credentials Helpers
 


### PR DESCRIPTION
After re-reviewing terraform-credentials-env, I made a mistake in not allowing period characters in `TF_TOKEN_...` variable names, nor allowing case-insensitive variable names. I now see that being liberal with variable names by using svchost.ForComparison on the variable name itself can allow for all these variations without a bunch of guessing code. I should have just lifted @apparentlymart 's code to begin with!

The only addition I made was to encode hyphens as double underscores. My reasoning about why this is OK is captured in the comment:

> We accept double underscores in place of hyphens because hyphens are not valid identifiers in most shells and are therefore hard to set. This is unambiguous with replacing single underscores below because hyphens are not allowed at the beginning or end of a label and therefore odd numbers of underscores will not appear together in a valid variable name.

Can you double check my logic there?

I also revised the docs accordingly @laurapacilio 