### PR TITLE
fix typo in struct tag

### DIFF
--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -539,7 +539,7 @@ type instanceObjectStateV4 struct {
 	SchemaVersion           uint64            `json:"schema_version"`
 	AttributesRaw           json.RawMessage   `json:"attributes,omitempty"`
 	AttributesFlat          map[string]string `json:"attributes_flat,omitempty"`
-	AttributeSensitivePaths json.RawMessage   `json:"sensitive_attributes,omitempty,"`
+	AttributeSensitivePaths json.RawMessage   `json:"sensitive_attributes,omitempty"`
 
 	PrivateRaw []byte `json:"private,omitempty"`
 


### PR DESCRIPTION
typo found by [`revive`](https://github.com/mgechev/revive)