### PR TITLE
Fix for newer go version (go get => go install)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,7 +29,7 @@ fi
 
 if ! which gox > /dev/null; then
     echo "==> Installing gox..."
-    go get github.com/mitchellh/gox
+    go install github.com/mitchellh/gox
 fi
 
 # Instruct gox to build statically linked binaries


### PR DESCRIPTION
go get for compiling and installing is deprecated. Updating it to the new "go install"