### PR TITLE
backend/remote-state/azure: defaulting the Azure Backend to use MSAL

### DIFF
--- a/internal/backend/remote-state/azure/backend.go
+++ b/internal/backend/remote-state/azure/backend.go
@@ -145,6 +145,7 @@ func New() backend.Backend {
 			"use_microsoft_graph": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Deprecated:  "This field now defaults to `true` and will be removed in v1.3 of Terraform Core due to the deprecation of ADAL by Microsoft.",
 				Description: "Should Terraform obtain an MSAL auth token and use Microsoft Graph rather than Azure Active Directory?",
 				DefaultFunc: schema.EnvDefaultFunc("ARM_USE_MSGRAPH", true),
 			},

--- a/internal/backend/remote-state/azure/backend.go
+++ b/internal/backend/remote-state/azure/backend.go
@@ -146,7 +146,7 @@ func New() backend.Backend {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Should Terraform obtain an MSAL auth token and use Microsoft Graph rather than Azure Active Directory?",
-				DefaultFunc: schema.EnvDefaultFunc("ARM_USE_MSGRAPH", false),
+				DefaultFunc: schema.EnvDefaultFunc("ARM_USE_MSGRAPH", true),
 			},
 		},
 	}

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -41,7 +41,8 @@ func TestBackendConfig(t *testing.T, b Backend, c hcl.Body) Backend {
 	newObj, valDiags := b.PrepareConfig(obj)
 	diags = diags.Append(valDiags.InConfigBody(c, ""))
 
-	if len(diags) != 0 {
+	// it's valid for a Backend to have warnings (e.g. a Deprecation) as such we should only raise on errors
+	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -9,7 +9,7 @@ Stores the state as a Blob with the given Key within the Blob Container within [
 
 This backend supports state locking and consistency checking with Azure Blob Storage native capabilities.
 
--> **Note:** By default the Azure Backend uses ADAL for authentication which is deprecated in favour of MSAL - MSAL can be used by setting `use_microsoft_graph` to `true`. **The default for this will change in Terraform 1.2**, so that MSAL authentication is used by default.
+-> **Note:** In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph) rather than ADAL (and Azure Active Directory Graph) for authentication by default - you can disable this by setting `use_microsoft_graph` to `false`. **This setting will be removed in Terraform 1.3, due to Microsoft's deprecation of ADAL**.
 
 ## Example Configuration
 
@@ -219,15 +219,13 @@ When authenticating using the Managed Service Identity (MSI) - the following fie
 
 * `msi_endpoint` - (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified. This can also be sourced from the `ARM_MSI_ENDPOINT` environment variable.
 
-*
-
 * `subscription_id` - (Optional) The Subscription ID in which the Storage Account exists. This can also be sourced from the `ARM_SUBSCRIPTION_ID` environment variable.
 
 * `tenant_id` - (Optional) The Tenant ID in which the Subscription exists. This can also be sourced from the `ARM_TENANT_ID` environment variable.
 
-* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `false`.
+* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `true`.
 
--> **Note:** By default the Azure Backend uses ADAL for authentication which is deprecated in favour of MSAL - MSAL can be used by setting `use_microsoft_graph` to `true`. **The default for this will change in Terraform 1.2**, so that MSAL authentication is used by default.
+-> **Note:** In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph) rather than ADAL (and Azure Active Directory Graph) for authentication by default - you can disable this by setting `use_microsoft_graph` to `false`. **This setting will be removed in Terraform 1.3, due to Microsoft's deprecation of ADAL**.
 
 * `use_msi` - (Optional) Should Managed Service Identity authentication be used? This can also be sourced from the `ARM_USE_MSI` environment variable.
 
@@ -251,9 +249,9 @@ When authenticating using AzureAD Authentication - the following fields are also
 
 -> **Note:** When using AzureAD for Authentication to Storage you also need to ensure the `Storage Blob Data Owner` role is assigned.
 
-* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `false`.
+* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `true`.
 
--> **Note:** By default the Azure Backend uses ADAL for authentication which is deprecated in favour of MSAL - MSAL can be used by setting `use_microsoft_graph` to `true`. **The default for this will change in Terraform 1.2**, so that MSAL authentication is used by default.
+-> **Note:** In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph) rather than ADAL (and Azure Active Directory Graph) for authentication by default - you can disable this by setting `use_microsoft_graph` to `false`. **This setting will be removed in Terraform 1.3, due to Microsoft's deprecation of ADAL**.
 
 ***
 
@@ -271,9 +269,9 @@ When authenticating using a Service Principal with a Client Certificate - the fo
 
 * `tenant_id` - (Optional) The Tenant ID in which the Subscription exists. This can also be sourced from the `ARM_TENANT_ID` environment variable.
 
-* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `false`.
+* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `true`.
 
--> **Note:** By default the Azure Backend uses ADAL for authentication which is deprecated in favour of MSAL - MSAL can be used by setting `use_microsoft_graph` to `true`. **The default for this will change in Terraform 1.2**, so that MSAL authentication is used by default.
+-> **Note:** In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph) rather than ADAL (and Azure Active Directory Graph) for authentication by default - you can disable this by setting `use_microsoft_graph` to `false`. **This setting will be removed in Terraform 1.3, due to Microsoft's deprecation of ADAL**.
 
 ***
 
@@ -289,6 +287,6 @@ When authenticating using a Service Principal with a Client Secret - the followi
 
 * `tenant_id` - (Optional) The Tenant ID in which the Subscription exists. This can also be sourced from the `ARM_TENANT_ID` environment variable.
 
-* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `false`.
+* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `true`.
 
--> **Note:** By default the Azure Backend uses ADAL for authentication which is deprecated in favour of MSAL - MSAL can be used by setting `use_microsoft_graph` to `true`. **The default for this will change in Terraform 1.2**, so that MSAL authentication is used by default.
+-> **Note:** In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph) rather than ADAL (and Azure Active Directory Graph) for authentication by default - you can disable this by setting `use_microsoft_graph` to `false`. **This setting will be removed in Terraform 1.3, due to Microsoft's deprecation of ADAL**.


### PR DESCRIPTION
This PR changes the default value of `use_microsoft_graph` within the Azure Backend from `false` to `true` - [which was announced when this field was introduced in Terraform 1.1](https://www.terraform.io/language/settings/backends/azurerm#azurerm).

For end-users there should be no difference in obtaining a MSAL Token rather than an ADAL Token (although permissions changes may be needed for Microsoft Graph, rather than Azure Active Directory)

Fixes #30881

```
$ TF_ACC=1 envchain azurerm go test -v -timeout 900m ./internal/backend/remote-state/azure/...
=== RUN   TestBackend_impl
--- PASS: TestBackend_impl (0.00s)
=== RUN   TestBackendConfig
--- PASS: TestBackendConfig (0.00s)
=== RUN   TestBackendAccessKeyBasic
--- PASS: TestBackendAccessKeyBasic (109.04s)
=== RUN   TestBackendSASTokenBasic
--- PASS: TestBackendSASTokenBasic (103.46s)
=== RUN   TestBackendADALAzureADAuthBasic
--- PASS: TestBackendADALAzureADAuthBasic (119.88s)
=== RUN   TestBackendADALManagedServiceIdentityBasic
--- SKIP: TestBackendADALManagedServiceIdentityBasic (0.00s)
=== RUN   TestBackendADALServicePrincipalClientCertificateBasic
--- SKIP: TestBackendADALServicePrincipalClientCertificateBasic (0.00s)
=== RUN   TestBackendADALServicePrincipalClientSecretBasic
--- PASS: TestBackendADALServicePrincipalClientSecretBasic (170.48s)
=== RUN   TestBackendADALServicePrincipalClientSecretCustomEndpoint
--- SKIP: TestBackendADALServicePrincipalClientSecretCustomEndpoint (0.00s)
=== RUN   TestBackendMSALAzureADAuthBasic
--- PASS: TestBackendMSALAzureADAuthBasic (104.74s)
=== RUN   TestBackendMSALManagedServiceIdentityBasic
--- SKIP: TestBackendMSALManagedServiceIdentityBasic (0.00s)
=== RUN   TestBackendMSALServicePrincipalClientCertificateBasic
--- SKIP: TestBackendMSALServicePrincipalClientCertificateBasic (0.00s)
=== RUN   TestBackendMSALServicePrincipalClientSecretBasic
--- PASS: TestBackendMSALServicePrincipalClientSecretBasic (110.37s)
=== RUN   TestBackendMSALServicePrincipalClientSecretCustomEndpoint
--- SKIP: TestBackendMSALServicePrincipalClientSecretCustomEndpoint (0.00s)
=== RUN   TestBackendAccessKeyLocked
--- PASS: TestBackendAccessKeyLocked (104.40s)
=== RUN   TestBackendServicePrincipalLocked
--- PASS: TestBackendServicePrincipalLocked (105.28s)
=== RUN   TestRemoteClient_impl
--- PASS: TestRemoteClient_impl (0.00s)
=== RUN   TestRemoteClientAccessKeyBasic
--- PASS: TestRemoteClientAccessKeyBasic (100.07s)
=== RUN   TestRemoteClientManagedServiceIdentityBasic
--- SKIP: TestRemoteClientManagedServiceIdentityBasic (0.00s)
=== RUN   TestRemoteClientSasTokenBasic
--- PASS: TestRemoteClientSasTokenBasic (100.29s)
=== RUN   TestRemoteClientServicePrincipalBasic
--- PASS: TestRemoteClientServicePrincipalBasic (101.36s)
=== RUN   TestRemoteClientAccessKeyLocks
--- PASS: TestRemoteClientAccessKeyLocks (100.93s)
=== RUN   TestRemoteClientServicePrincipalLocks
--- PASS: TestRemoteClientServicePrincipalLocks (105.00s)
=== RUN   TestPutMaintainsMetaData
--- PASS: TestPutMaintainsMetaData (99.97s)
PASS
ok  	github.com/hashicorp/terraform/internal/backend/remote-state/azure	1535.389s