### PR TITLE
command: mention plan options in refresh help text

### DIFF
--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -215,6 +215,11 @@ Options:
 
   -state, state-out, and -backup are legacy options supported for the local
   backend only. For more information, see the local backend's documentation.
+
+  This command also accepts all of the plan-customization options accepted by
+  the terraform plan command, except as mentioned above.
+  For more information on those options, run:
+      terraform plan -help
 `
 	return strings.TrimSpace(helpText)
 }


### PR DESCRIPTION
Fixes #30880

There are some compromises to be made here between completeness, helpfulness, and uniqueness. 
We could remove all duplicated options from the `refresh` help text, but then there would be nothing there. It's most helpful to include the most popular `refresh` options in its help text so the user doesn't have to run another command most of the time.
Initially started trying to make this more systematic using `internal/command/arguments` but I think hand-written help text is the best way to maximise helpfulness for now.