### PR TITLE
Fix known races and enable race detector in tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,6 +64,40 @@ jobs:
         run: |
           go test ./...
 
+  race-tests:
+    name: "Race Tests"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Fetch source code"
+        uses: actions/checkout@v2
+
+      - name: Determine Go version
+        id: go
+        uses: ./.github/actions/go-version
+
+      - name: Install Go toolchain
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ steps.go.outputs.version }}
+
+      # NOTE: This cache is shared so the following step must always be
+      # identical across the unit-tests, e2e-tests, and consistency-checks
+      # jobs, or else weird things could happen.
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: "~/go/pkg"
+          key: go-mod-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-
+
+      # The race detector add significant time to the unit tests, so only run
+      # it for select packages.
+      - name: "Race detector"
+        run: |
+          go test -race ./internal/terraform ./internal/command
+
   e2e-tests:
     # This is an intentionally-limited form of our E2E test run which only
     # covers Terraform running on Linux. The build.yml workflow runs these

--- a/internal/plans/changes_sync.go
+++ b/internal/plans/changes_sync.go
@@ -191,6 +191,7 @@ func (cs *ChangesSync) RemoveOutputChange(addr addrs.AbsOutputValue) {
 	defer cs.lock.Unlock()
 
 	addrStr := addr.String()
+
 	for i, o := range cs.changes.Outputs {
 		if o.Addr.String() != addrStr {
 			continue

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -22,7 +22,6 @@ type nodeExpandOutput struct {
 	Addr        addrs.OutputValue
 	Module      addrs.Module
 	Config      *configs.Output
-	Changes     []*plans.OutputChangeSrc
 	Destroy     bool
 	RefreshOnly bool
 }
@@ -52,6 +51,7 @@ func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	}
 
 	expander := ctx.InstanceExpander()
+	changes := ctx.Changes()
 
 	var g Graph
 	for _, module := range expander.ExpandModule(n.Module) {
@@ -59,7 +59,8 @@ func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
 
 		// Find any recorded change for this output
 		var change *plans.OutputChangeSrc
-		for _, c := range n.Changes {
+		parent, call := module.Call()
+		for _, c := range changes.GetOutputChanges(parent, call) {
 			if c.Addr.String() == absAddr.String() {
 				change = c
 				break

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -95,7 +95,6 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 				Addr:        addr,
 				Module:      c.Path,
 				Config:      o,
-				Changes:     changes,
 				Destroy:     t.Destroy,
 				RefreshOnly: t.RefreshOnly,
 			}


### PR DESCRIPTION
The only non-test issue covered here was the use of stored changes from the plan in the output nodes, which instead should have been pulling the synchronized set directly from the context.

The additional race-enabled tests cover the bulk of terraform code via the `./internal/terraform` and `./internal/command` packages. They are much more time consuming to run however, and we can revisit the necessity of having the command package included in these if the race tests end up delaying results too much.