### PR TITLE
change action to pull v1 instead of main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Generate package metadata
         id: generate-metadata-file
-        uses: hashicorp/actions-generate-metadata@main
+        uses: hashicorp/actions-generate-metadata@v1
         with:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}


### PR DESCRIPTION
The `generate-metadata` action needs to be pulling from tags for better release management. We run the risk of disruption if we pushed changes to the `main` branch of the generate-metadata action thus disrupting release workflows for Terraform. 

Read more on [Using tags for release management](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management)

Feel free to add any labels (unsure if backporting is supported) -- LMK if I need to make this change for Terraform Enterprise. 