### PR TITLE
Fix an example for urlencode.mdx

### DIFF
--- a/website/docs/language/functions/urlencode.mdx
+++ b/website/docs/language/functions/urlencode.mdx
@@ -23,7 +23,7 @@ UTF-8 and then percent encoding is applied separately to each UTF-8 byte.
 
 ```
 > urlencode("Hello World")
-Hello%20World
+Hello+World
 > urlencode("☃")
 %E2%98%83
 > "http://example.com/search?q=${urlencode("terraform urlencode")}"

--- a/website/docs/language/functions/urlencode.mdx
+++ b/website/docs/language/functions/urlencode.mdx
@@ -22,8 +22,8 @@ UTF-8 and then percent encoding is applied separately to each UTF-8 byte.
 ## Examples
 
 ```
-> urlencode("Hello World")
-Hello+World
+> urlencode("Hello World!")
+Hello+World%21
 > urlencode("☃")
 %E2%98%83
 > "http://example.com/search?q=${urlencode("terraform urlencode")}"


### PR DESCRIPTION
## What
This PR fixes the result of `urlencode()`.
Also, I added a special character `!` into its example in order to the example show how urlencode works for ASCII special characters which should become percent-encoded.

## Why
The `urlencode()` is implemented by `url.QueryEncode()`.
https://github.com/hashicorp/terraform/blob/983e40bf4a27ce4a0c89a62a152bc8fec5476fa3/internal/lang/funcs/encoding.go#L183
 `url.QueryEncode()` does not escapes ` ` to `%20` but `+`.
https://pkg.go.dev/net/url#QueryEscape

## Ref
https://github.com/hashicorp/terraform/pull/29359