### PR TITLE
Update apt.mdx

### DIFF
--- a/website/docs/cli/install/apt.mdx
+++ b/website/docs/cli/install/apt.mdx
@@ -32,14 +32,14 @@ so in most situations the first step would be to configure your system to trust
 that HashiCorp key for package authentication. For example:
 
 ```bash
-curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+wget -qO - terraform.gpg https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/terraform-archive-keyring.gpg
 ```
 
 After registering the key, you can add the official HashiCorp repository to
 your system:
 
 ```bash
-sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/terraform-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/terraform.list
 ```
 
 The above command line uses the following sub-shell commands:


### PR DESCRIPTION
- Removed usage of `apt-key` which is deprecated and replaced by `gpg` command
- Removed usage of `curl` command which is not present by default on Debian systems