### PR TITLE
Add warning about spaces in variable value assignment

### DIFF
--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -167,6 +167,8 @@ we recommend using the `-var-file` option instead, and write your actual values
 in a separate file so that Terraform can parse them directly, rather than
 interpreting the result of your shell's parsing.
 
+~> **Warning:** Terraform will error if you include a space before or after the equals sign (e.g., `-var "length = 2"`).
+
 To use `-var` on a Unix-style shell on a system like Linux or macOS we
 recommend writing the option argument in single quotes `'` to ensure the
 shell will interpret the value literally:


### PR DESCRIPTION
Related to: https://github.com/hashicorp/terraform/issues/30600

This PR warns users that Terraform will error if they include spaces before or after variable declarations when using the `-var` flag. For example, users should not use `-var "length = 2". Instead, they should use `-var "length=2". 


<img width="950" alt="Screen Shot 2022-04-29 at 5 01 37 PM" src="https://user-images.githubusercontent.com/83350965/166068640-d6e8fe1a-07a4-4175-b741-9b4e94ea30b3.png">

