### PR TITLE
Update apt install instructions

### DIFF
--- a/website/docs/cli/install/apt.mdx
+++ b/website/docs/cli/install/apt.mdx
@@ -39,7 +39,7 @@ After registering the key, you can add the official HashiCorp repository to
 your system:
 
 ```bash
-sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/terraform-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/terraform.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/terraform-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/terraform.list
 ```
 
 The above command line uses the following sub-shell commands:

--- a/website/docs/cli/install/apt.mdx
+++ b/website/docs/cli/install/apt.mdx
@@ -81,6 +81,7 @@ following distribution releases:
 * Ubuntu 20.10 (`groovy`)
 * Ubuntu 21.04 (`hirsute`)
 * Ubuntu 21.10 (`impish`)
+* Ubuntu 22.04 (`jammy`)
 
 No repositories are available for other Debian or Ubuntu versions or
 any other APT-based Linux distributions. If you add the repository using


### PR DESCRIPTION
Running `sudo echo ...` resulted in an error:

```
❯ sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/terraform-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/terraform.list 
zsh: permission denied: /etc/apt/sources.list.d/terraform.list
```

Changed to using `tee`, just like [kubernetes](https://github.com/kubernetes/website/blob/06e3808ae1283880a894ff737456c213924b1a32/content/en/docs/tasks/tools/install-kubectl-linux.md) does it.

Additionally added Ubuntu 22.04 to supported versions as it worked just fine for me.