### PR TITLE
Add note about lockfile's relationship to state 

### DIFF
--- a/website/docs/language/files/dependency-lock.mdx
+++ b/website/docs/language/files/dependency-lock.mdx
@@ -366,9 +366,11 @@ this command.
 
 ### Providers that are no longer required
 
-If you remove the last dependency on a particular provider from your
-configuration, then `terraform init` will remove any existing lock file entry
-for that provider.
+To determine whether there still exists a dependency on a given provider,
+Terraform uses two sources of truth: the configuration itself, and the state.
+If you remove the last dependency on a particular provider from both your
+configuration and state, then `terraform init` will remove any existing lock
+file entry for that provider.
 
 ```diff
 --- .terraform.lock.hcl	2020-10-07 16:12:07.539570634 -0700


### PR DESCRIPTION
I was recently confused by the continued presence in the lock file of a provider on which I had (so I thought!) removed all dependencies from my config. With @alisdair's help, I determined that the provider was still being included in the lock file because there was still a data source from that provider in my state.

Adding a note about state to the lock file documentation to help others.