### PR TITLE
fix typo for task.Status

### DIFF
--- a/internal/cloud/backend_runTasks.go
+++ b/internal/cloud/backend_runTasks.go
@@ -25,7 +25,7 @@ func summarizeTaskResults(taskResults []*tfe.TaskResult) *taskResultSummary {
 			return &taskResultSummary{
 				unreachable: true,
 			}
-		} else if task.Status == "running" || task.Status == "pendingCountnding" {
+		} else if task.Status == "running" || task.Status == "pending" {
 			pendingCount++
 		} else if task.Status == "passed" {
 			passedCount++


### PR DESCRIPTION
Whoops! I have no idea how this was working before, but by looking at Go-TFE statuses for Run Tasks, I believe this string should be reading "pending".

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202212658537836