### PR TITLE
communicator/ssh: Fix crash using SSH+HTTP proxy

### DIFF
--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -170,20 +170,20 @@ func (c *Communicator) Connect(o provisioners.UIOutput) (err error) {
 				c.connInfo.BastionHostKey != "",
 			))
 		}
-	}
 
-	if c.connInfo.ProxyHost != "" {
-		o.Output(fmt.Sprintf(
-			"Using configured proxy host...\n"+
-				"  ProxyHost: %s\n"+
-				"  ProxyPort: %d\n"+
-				"  ProxyUserName: %s\n"+
-				"  ProxyUserPassword: %t",
-			c.connInfo.ProxyHost,
-			c.connInfo.ProxyPort,
-			c.connInfo.ProxyUserName,
-			c.connInfo.ProxyUserPassword != "",
-		))
+		if c.connInfo.ProxyHost != "" {
+			o.Output(fmt.Sprintf(
+				"Using configured proxy host...\n"+
+					"  ProxyHost: %s\n"+
+					"  ProxyPort: %d\n"+
+					"  ProxyUserName: %s\n"+
+					"  ProxyUserPassword: %t",
+				c.connInfo.ProxyHost,
+				c.connInfo.ProxyPort,
+				c.connInfo.ProxyUserName,
+				c.connInfo.ProxyUserPassword != "",
+			))
+		}
 	}
 
 	hostAndPort := fmt.Sprintf("%s:%d", c.connInfo.Host, c.connInfo.Port)


### PR DESCRIPTION
A mistake in the nested conditional logic led to us calling `o.Output` when `o` was `nil`, which is the case for the `file` provisioner's connection process.

Fixes #30982. Tested manually:

```
aws_instance.test: Creating...
aws_instance.test: Still creating... [10s elapsed]
aws_instance.test: Still creating... [20s elapsed]
aws_instance.test: Still creating... [30s elapsed]
aws_instance.test: Still creating... [40s elapsed]
aws_instance.test: Provisioning with 'file'...
aws_instance.test: Still creating... [50s elapsed]
aws_instance.test: Provisioning with 'remote-exec'...
aws_instance.test (remote-exec): Connecting to remote host via SSH...
aws_instance.test (remote-exec):   Host: 34.227.59.196
aws_instance.test (remote-exec):   User: ec2-user
aws_instance.test (remote-exec):   Password: false
aws_instance.test (remote-exec):   Private key: true
aws_instance.test (remote-exec):   Certificate: false
aws_instance.test (remote-exec):   SSH Agent: true
aws_instance.test (remote-exec):   Checking Host Key: false
aws_instance.test (remote-exec):   Target Platform: unix
aws_instance.test (remote-exec): Using configured proxy host...
aws_instance.test (remote-exec):   ProxyHost: localhost
aws_instance.test (remote-exec):   ProxyPort: 23128
aws_instance.test (remote-exec):   ProxyUserName:
aws_instance.test (remote-exec):   ProxyUserPassword: false
aws_instance.test (remote-exec): Connected!
aws_instance.test (remote-exec): test script
aws_instance.test: Creation complete after 52s [id=i-048654effcc1005ae]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```