### PR TITLE
cli: Improved error for invalid -var "foo = bar"

### DIFF
--- a/internal/command/meta_vars.go
+++ b/internal/command/meta_vars.go
@@ -102,6 +102,14 @@ func (m *Meta) collectVariableValues() (map[string]backend.UnparsedVariableValue
 			}
 			name := raw[:eq]
 			rawVal := raw[eq+1:]
+			if strings.HasSuffix(name, " ") {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid -var option",
+					fmt.Sprintf("Variable name %q is invalid due to trailing space. Did you mean -var=\"%s=%s\"?", name, strings.TrimSuffix(name, " "), strings.TrimPrefix(rawVal, " ")),
+				))
+				continue
+			}
 			ret[name] = unparsedVariableValueString{
 				str:        rawVal,
 				name:       name,


### PR DESCRIPTION
When specifying variable values on the command line, name-value pairs must be joined with an equals sign, without surrounding spaces. Previously Terraform would interpret `-var "foo = bar"` as assigning the value `" bar"` to the variable named `foo `. This is never valid, as variable names may not include whitespace.

This commit looks for this specific error and returns a diagnostic with a suggestion for correcting it. We cannot simply trim whitespace, because it is valid to write `-var "foo= bar"` to assign the value `" bar"` to the variable `foo`, as unlikely as it seems.

Fixes #30600, see also documentation in #30969.

### Screenshots

Before:

<img width="857" alt="before" src="https://user-images.githubusercontent.com/68917/166460301-48c2ec90-0ac5-41ad-9ed6-3d2cb042f4ba.png">

After:

<img width="857" alt="after" src="https://user-images.githubusercontent.com/68917/166460473-22732449-c52f-4661-86ca-7de07bfa898b.png">

