### PR TITLE
Bump compatibility version to 1.3.0 for terraform core release

### DIFF
--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -939,9 +939,9 @@ func (b *Remote) VerifyWorkspaceTerraformVersion(workspaceName string) tfdiags.D
 		// are aware of are:
 		//
 		// - 0.14.0 is guaranteed to be compatible with versions up to but not
-		//   including 1.2.0
-		v120 := version.Must(version.NewSemver("1.2.0"))
-		if tfversion.SemVer.LessThan(v120) && remoteVersion.LessThan(v120) {
+		//   including 1.3.0
+		v130 := version.Must(version.NewSemver("1.3.0"))
+		if tfversion.SemVer.LessThan(v130) && remoteVersion.LessThan(v130) {
 			return diags
 		}
 		// - Any new Terraform state version will require at least minor patch

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -567,7 +567,7 @@ func TestRemote_VerifyWorkspaceTerraformVersion(t *testing.T) {
 		{"0.14.0", "0.14.1", "remote", false},
 		{"0.14.0", "1.0.99", "remote", false},
 		{"0.14.0", "1.1.0", "remote", false},
-		{"0.14.0", "1.2.0", "remote", true},
+		{"0.14.0", "1.3.0", "remote", true},
 		{"1.2.0", "1.2.99", "remote", false},
 		{"1.2.0", "1.3.0", "remote", true},
 		{"0.15.0", "latest", "remote", false},

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -865,12 +865,12 @@ func (b *Cloud) VerifyWorkspaceTerraformVersion(workspaceName string) tfdiags.Di
 	// operator other than simple equality.
 	if remoteVersion != nil && remoteVersion.Prerelease() == "" {
 		v014 := version.Must(version.NewSemver("0.14.0"))
-		v120 := version.Must(version.NewSemver("1.2.0"))
+		v130 := version.Must(version.NewSemver("1.3.0"))
 
 		// Versions from 0.14 through the early 1.x series should be compatible
-		// (though we don't know about 1.2 yet).
-		if remoteVersion.GreaterThanOrEqual(v014) && remoteVersion.LessThan(v120) {
-			early1xCompatible, err := version.NewConstraint(fmt.Sprintf(">= 0.14.0, < %s", v120.String()))
+		// (though we don't know about 1.3 yet).
+		if remoteVersion.GreaterThanOrEqual(v014) && remoteVersion.LessThan(v130) {
+			early1xCompatible, err := version.NewConstraint(fmt.Sprintf(">= 0.14.0, < %s", v130.String()))
 			if err != nil {
 				panic(err)
 			}
@@ -879,7 +879,7 @@ func (b *Cloud) VerifyWorkspaceTerraformVersion(workspaceName string) tfdiags.Di
 
 		// Any future new state format will require at least a minor version
 		// increment, so x.y.* will always be compatible with each other.
-		if remoteVersion.GreaterThanOrEqual(v120) {
+		if remoteVersion.GreaterThanOrEqual(v130) {
 			rwvs := remoteVersion.Segments64()
 			if len(rwvs) >= 3 {
 				// ~> x.y.0

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -974,7 +974,7 @@ func TestCloud_VerifyWorkspaceTerraformVersion(t *testing.T) {
 		{"0.14.0", "0.14.1", "remote", false},
 		{"0.14.0", "1.0.99", "remote", false},
 		{"0.14.0", "1.1.0", "remote", false},
-		{"0.14.0", "1.2.0", "remote", true},
+		{"0.14.0", "1.3.0", "remote", true},
 		{"1.2.0", "1.2.99", "remote", false},
 		{"1.2.0", "1.3.0", "remote", true},
 		{"0.15.0", "latest", "remote", false},


### PR DESCRIPTION
Bump compatibility version from 1.2.0 to 1.3.0 for upcoming terraform core release.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202218836281989