### PR TITLE
add url to run task summary

### DIFF
--- a/internal/cloud/backend_runTasks.go
+++ b/internal/cloud/backend_runTasks.go
@@ -106,7 +106,12 @@ func (b *Cloud) runTasksWithTaskResults(context *IntegrationContext, output Inte
 			title := fmt.Sprintf(`%s ⸺   %s`, t.TaskName, status)
 			output.SubOutput(title)
 
-			output.SubOutput(fmt.Sprintf("[dim]%s", t.Message))
+			if len(t.Message) > 0 {
+				output.SubOutput(fmt.Sprintf("[dim]%s", t.Message))
+			}
+			if len(t.URL) > 0 {
+				output.SubOutput(fmt.Sprintf("[dim]Details: %s", t.URL))
+			}
 			output.SubOutput("")
 		}
 


### PR DESCRIPTION
Ryan Hall noticed that one important aspect of the run task result is not present in the run task result summary displayed by the CLI: The URL

In the platform, the run task result offers a link "details" which directs the user to the URL from the third party integration where the user can see more information about why a task failed or succeeded.

The URL was never part of the original implementation for how we display results in the CLI. So this is not a bug. However, by looking at some of the design images shared by Brian, there was clearly a desired to include the url in the output. We may have not noticed the url was there and that is why we skipped that implementation at the time.

Result after adding the URL:

<img width="1677" alt="Screen Shot 2022-05-10 at 7 31 47 AM" src="https://user-images.githubusercontent.com/21225410/167657766-f2f36091-e8a4-42f0-b222-5adf55c63dc6.png">


When I squeeze my terminal, I have noticed that vertical line gets pushed. Improving the looks of the output is outside of the scope of these changes, but I thought I should mention it, in case later we want to take a second look at design implementations and improve over them:

<img width="1162" alt="Screen Shot 2022-05-10 at 7 47 19 AM" src="https://user-images.githubusercontent.com/21225410/167658206-f2270b4a-4430-4565-b1c5-25b2aad89bfe.png">
