### PR TITLE
Added example with function argument expansion

### DIFF
--- a/website/docs/language/functions/merge.mdx
+++ b/website/docs/language/functions/merge.mdx
@@ -28,6 +28,15 @@ type structure of the attributes after the merging rules have been applied.
 ```
 
 ```
+> merge([{a="b", c="d"}, {}, {e="f", c="z"}]...)
+{
+  "a" = "b"
+  "c" = "z"
+  "e" = "f"
+}
+```
+
+```
 > merge({a="b"}, {a=[1,2], c="z"}, {d=3})
 {
   "a" = [

--- a/website/docs/language/functions/merge.mdx
+++ b/website/docs/language/functions/merge.mdx
@@ -27,8 +27,6 @@ type structure of the attributes after the merging rules have been applied.
 }
 ```
 
-The following example uses the expansion symbol (...) to transform the value into separate arguments. Refer to [Expanding Function Argument](/language/expressions/function-calls#expanding-function-arguments) for details.
-
 ```
 > merge({a="b"}, {a=[1,2], c="z"}, {d=3})
 {
@@ -38,5 +36,16 @@ The following example uses the expansion symbol (...) to transform the value int
   ]
   "c" = "z"
   "d" = 3
+}
+```
+
+The following example uses the expansion symbol (...) to transform the value into separate arguments. Refer to [Expanding Function Argument](/language/expressions/function-calls#expanding-function-arguments) for details.
+
+```
+> merge([{a="b", c="d"}, {}, {e="f", c="z"}]...)
+{
+  "a" = "b"
+  "c" = "z"
+  "e" = "f"
 }
 ```

--- a/website/docs/language/functions/merge.mdx
+++ b/website/docs/language/functions/merge.mdx
@@ -27,14 +27,7 @@ type structure of the attributes after the merging rules have been applied.
 }
 ```
 
-```
-> merge([{a="b", c="d"}, {}, {e="f", c="z"}]...)
-{
-  "a" = "b"
-  "c" = "z"
-  "e" = "f"
-}
-```
+The following example uses the expansion symbol (...) to transform the value into separate arguments. Refer to [Expanding Function Argument](/language/expressions/function-calls#expanding-function-arguments) for details.
 
 ```
 > merge({a="b"}, {a=[1,2], c="z"}, {d=3})


### PR DESCRIPTION
Even if the expansion with three dots is explicity mentioned in https://www.terraform.io/language/expressions/function-calls#expanding-function-arguments the additional example would have helped me a lot as it is a common use case to "flatten" a list of maps.