### PR TITLE
Support HTTP based cloud backends

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
 	github.com/hashicorp/hcl/v2 v2.12.0
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2
-	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
+	github.com/hashicorp/terraform-svchost v0.0.0-20220506210715-ad350411ef4e
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/joyent/triton-go v0.0.0-20180313100802-d8f9c0314926
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/go.sum
+++ b/go.sum
@@ -453,8 +453,6 @@ github.com/hashicorp/terraform-exec v0.14.0/go.mod h1:qrAASDq28KZiMPDnQ02sFS9udc
 github.com/hashicorp/terraform-json v0.12.0/go.mod h1:pmbq9o4EuL43db5+0ogX10Yofv1nozM+wskr/bGFJpI=
 github.com/hashicorp/terraform-plugin-go v0.4.0/go.mod h1:7u/6nt6vaiwcWE2GuJKbJwNlDFnf5n95xKw4hqIVr58=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.8.0/go.mod h1:6KbP09YzlB++S6XSUKYl83WyoHVN4MgeoCbPRsdfCtA=
-github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
-github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/terraform-svchost v0.0.0-20220506210715-ad350411ef4e h1:gGWeXp4j1qFCheGQ6UtGeYxFaVvKn/rTDXJnfIrpnx4=
 github.com/hashicorp/terraform-svchost v0.0.0-20220506210715-ad350411ef4e/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/go.sum
+++ b/go.sum
@@ -455,6 +455,8 @@ github.com/hashicorp/terraform-plugin-go v0.4.0/go.mod h1:7u/6nt6vaiwcWE2GuJKbJw
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.8.0/go.mod h1:6KbP09YzlB++S6XSUKYl83WyoHVN4MgeoCbPRsdfCtA=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
+github.com/hashicorp/terraform-svchost v0.0.0-20220506210715-ad350411ef4e h1:gGWeXp4j1qFCheGQ6UtGeYxFaVvKn/rTDXJnfIrpnx4=
+github.com/hashicorp/terraform-svchost v0.0.0-20220506210715-ad350411ef4e/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -428,8 +428,15 @@ func (b *Cloud) discover() (*url.URL, error) {
 		return nil, err
 	}
 
-	fmt.Printf("Going to fail right after this line: %#v\n", hostname)
-	host, err := b.services.Discover(hostname)
+	var host *disco.Host
+	switch b.scheme {
+	case "https":
+		host, err = b.services.Discover(hostname)
+	case "http":
+		host, err = b.services.DiscoverHTTP(hostname)
+	default:
+		err = fmt.Errorf("unsupported scheme %q provided", b.scheme)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cloud/backend_common.go
+++ b/internal/cloud/backend_common.go
@@ -368,7 +368,7 @@ func (b *Cloud) checkPolicy(stopCtx, cancelCtx context.Context, op *backend.Oper
 		case tfe.PolicyHardFailed:
 			return fmt.Errorf(msgPrefix + " hard failed.")
 		case tfe.PolicySoftFailed:
-			runUrl := fmt.Sprintf(runHeader, b.hostname, b.organization, op.Workspace, r.ID)
+			runUrl := fmt.Sprintf(runHeader, b.scheme, b.hostname, b.organization, op.Workspace, r.ID)
 
 			if op.Type == backend.OperationTypePlan || op.UIOut == nil || op.UIIn == nil ||
 				!pc.Actions.IsOverridable || !pc.Permissions.CanOverride {

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -288,7 +288,7 @@ in order to capture the filesystem context the remote workspace expects:
 
 	if b.CLI != nil {
 		b.CLI.Output(b.Colorize().Color(strings.TrimSpace(fmt.Sprintf(
-			runHeader, b.hostname, b.organization, op.Workspace, r.ID)) + "\n"))
+			runHeader, b.scheme, b.hostname, b.organization, op.Workspace, r.ID)) + "\n"))
 	}
 
 	r, err = b.waitForRun(stopCtx, cancelCtx, op, "plan", r, w)
@@ -403,7 +403,7 @@ Preparing the remote plan...
 
 const runHeader = `
 [reset][yellow]To view this run in a browser, visit:
-https://%s/app/%s/%s/runs/%s[reset]
+%s://%s/app/%s/%s/runs/%s[reset]
 `
 
 // The newline in this error is to make it look good in the CLI!

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -228,12 +228,14 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 		vars                  map[string]string
 		expectedOrganization  string
 		expectedHostname      string
+		expectedScheme        string
 		expectedWorkspaceName string
 		expectedErr           string
 	}{
 		"with no organization specified": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"token":        cty.NullVal(cty.String),
 				"organization": cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -249,6 +251,7 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 		"with both organization and env var specified": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"token":        cty.NullVal(cty.String),
 				"organization": cty.StringVal("hashicorp"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -264,6 +267,7 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 		"with no hostname specified": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"token":        cty.NullVal(cty.String),
 				"organization": cty.StringVal("hashicorp"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -279,6 +283,7 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 		"with hostname and env var specified": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.StringVal("private.hashicorp.engineering"),
+				"scheme":       cty.NullVal(cty.String),
 				"token":        cty.NullVal(cty.String),
 				"organization": cty.StringVal("hashicorp"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -291,9 +296,26 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 			},
 			expectedHostname: "private.hashicorp.engineering",
 		},
+		"with scheme and env var specified": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.StringVal("http"),
+				"token":        cty.NullVal(cty.String),
+				"organization": cty.StringVal("hashicorp"),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("prod"),
+					"tags": cty.NullVal(cty.Set(cty.String)),
+				}),
+			}),
+			vars: map[string]string{
+				"TF_CLOUD_SCHEME": "https",
+			},
+			expectedScheme: "http",
+		},
 		"an invalid workspace env var": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"token":        cty.NullVal(cty.String),
 				"organization": cty.StringVal("hashicorp"),
 				"workspaces": cty.NullVal(cty.Object(map[string]cty.Type{
@@ -309,6 +331,7 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 		"workspaces and env var specified": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"token":        cty.NullVal(cty.String),
 				"organization": cty.StringVal("mordor"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -333,6 +356,7 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 			},
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"token":        cty.NullVal(cty.String),
 				"organization": cty.StringVal("mordor"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -364,6 +388,7 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 			},
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"token":        cty.NullVal(cty.String),
 				"organization": cty.StringVal("mordor"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -381,6 +406,7 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 		"with everything set as env vars": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"token":        cty.NullVal(cty.String),
 				"organization": cty.NullVal(cty.String),
 				"workspaces":   cty.NullVal(cty.String),
@@ -389,10 +415,12 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 				"TF_CLOUD_ORGANIZATION": "mordor",
 				"TF_WORKSPACE":          "mt-doom",
 				"TF_CLOUD_HOSTNAME":     "mycool.tfe-host.io",
+				"TF_CLOUD_SCHEME":       "http",
 			},
 			expectedOrganization:  "mordor",
 			expectedWorkspaceName: "mt-doom",
 			expectedHostname:      "mycool.tfe-host.io",
+			expectedScheme:        "http",
 		},
 	}
 
@@ -434,6 +462,10 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 				t.Fatalf("%s: hostname not valid: %s, expected: %s", name, b.hostname, tc.expectedHostname)
 			}
 
+			if tc.expectedScheme != "" && tc.expectedScheme != b.scheme {
+				t.Fatalf("%s: scheme not valid: %s, expected: %s", name, b.scheme, tc.expectedScheme)
+			}
+
 			if tc.expectedWorkspaceName != "" && tc.expectedWorkspaceName != b.WorkspaceMapping.Name {
 				t.Fatalf("%s: workspace name not valid: %s, expected: %s", name, b.WorkspaceMapping.Name, tc.expectedWorkspaceName)
 			}
@@ -450,6 +482,7 @@ func TestCloud_config(t *testing.T) {
 		"with_an_unknown_host": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.StringVal("nonexisting.local"),
+				"scheme":       cty.NullVal(cty.String),
 				"organization": cty.StringVal("hashicorp"),
 				"token":        cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -463,6 +496,7 @@ func TestCloud_config(t *testing.T) {
 		"without_a_token": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.StringVal("localhost"),
+				"scheme":       cty.StringVal("http"),
 				"organization": cty.StringVal("hashicorp"),
 				"token":        cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -475,6 +509,7 @@ func TestCloud_config(t *testing.T) {
 		"with_tags": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"organization": cty.StringVal("hashicorp"),
 				"token":        cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -490,6 +525,7 @@ func TestCloud_config(t *testing.T) {
 		"with_a_name": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"organization": cty.StringVal("hashicorp"),
 				"token":        cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -501,6 +537,7 @@ func TestCloud_config(t *testing.T) {
 		"without_a_name_tags": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"organization": cty.StringVal("hashicorp"),
 				"token":        cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -513,6 +550,7 @@ func TestCloud_config(t *testing.T) {
 		"with_both_a_name_and_tags": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"organization": cty.StringVal("hashicorp"),
 				"token":        cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -554,6 +592,7 @@ func TestCloud_config(t *testing.T) {
 func TestCloud_configVerifyMinimumTFEVersion(t *testing.T) {
 	config := cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.NullVal(cty.String),
+		"scheme":       cty.NullVal(cty.String),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -590,6 +629,7 @@ func TestCloud_configVerifyMinimumTFEVersion(t *testing.T) {
 func TestCloud_configVerifyMinimumTFEVersionInAutomation(t *testing.T) {
 	config := cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.NullVal(cty.String),
+		"scheme":       cty.NullVal(cty.String),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -633,6 +673,7 @@ func TestCloud_setUnavailableTerraformVersion(t *testing.T) {
 
 	config := cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.NullVal(cty.String),
+		"scheme":       cty.NullVal(cty.String),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -683,6 +724,7 @@ func TestCloud_setConfigurationFields(t *testing.T) {
 	cases := map[string]struct {
 		obj                   cty.Value
 		expectedHostname      string
+		expectedScheme        string
 		expectedOrganziation  string
 		expectedWorkspaceName string
 		expectedWorkspaceTags []string
@@ -695,36 +737,42 @@ func TestCloud_setConfigurationFields(t *testing.T) {
 			obj: cty.ObjectVal(map[string]cty.Value{
 				"organization": cty.StringVal("hashicorp"),
 				"hostname":     cty.StringVal("hashicorp.com"),
+				"scheme":       cty.StringVal("https"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
 					"name": cty.StringVal("prod"),
 					"tags": cty.NullVal(cty.Set(cty.String)),
 				}),
 			}),
 			expectedHostname:     "hashicorp.com",
+			expectedScheme:       "https",
 			expectedOrganziation: "hashicorp",
 		},
-		"with hostname not set, set to default hostname": {
+		"with hostname and scheme not set, set to default hostname and scheme": {
 			obj: cty.ObjectVal(map[string]cty.Value{
 				"organization": cty.StringVal("hashicorp"),
 				"hostname":     cty.NullVal(cty.String),
+				"scheme":       cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
 					"name": cty.StringVal("prod"),
 					"tags": cty.NullVal(cty.Set(cty.String)),
 				}),
 			}),
 			expectedHostname:     defaultHostname,
+			expectedScheme:       defaultScheme,
 			expectedOrganziation: "hashicorp",
 		},
 		"with workspace name set": {
 			obj: cty.ObjectVal(map[string]cty.Value{
 				"organization": cty.StringVal("hashicorp"),
 				"hostname":     cty.StringVal("hashicorp.com"),
+				"scheme":       cty.StringVal("https"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
 					"name": cty.StringVal("prod"),
 					"tags": cty.NullVal(cty.Set(cty.String)),
 				}),
 			}),
 			expectedHostname:      "hashicorp.com",
+			expectedScheme:        "hashicorp.com",
 			expectedOrganziation:  "hashicorp",
 			expectedWorkspaceName: "prod",
 		},
@@ -732,6 +780,7 @@ func TestCloud_setConfigurationFields(t *testing.T) {
 			obj: cty.ObjectVal(map[string]cty.Value{
 				"organization": cty.StringVal("hashicorp"),
 				"hostname":     cty.StringVal("hashicorp.com"),
+				"scheme":       cty.StringVal("https"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
 					"name": cty.NullVal(cty.String),
 					"tags": cty.SetVal(
@@ -742,6 +791,7 @@ func TestCloud_setConfigurationFields(t *testing.T) {
 				}),
 			}),
 			expectedHostname:      "hashicorp.com",
+			expectedScheme:        "https",
 			expectedOrganziation:  "hashicorp",
 			expectedWorkspaceTags: []string{"billing"},
 		},
@@ -749,12 +799,14 @@ func TestCloud_setConfigurationFields(t *testing.T) {
 			obj: cty.ObjectVal(map[string]cty.Value{
 				"organization": cty.StringVal("hashicorp"),
 				"hostname":     cty.StringVal("hashicorp.com"),
+				"scheme":       cty.StringVal("https"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
 					"name": cty.NullVal(cty.String),
 					"tags": cty.NullVal(cty.Set(cty.String)),
 				}),
 			}),
 			expectedHostname:     "hashicorp.com",
+			expectedScheme:       "https",
 			expectedOrganziation: "hashicorp",
 			setEnv: func() {
 				os.Setenv("TF_FORCE_LOCAL_BACKEND", "1")
@@ -785,6 +837,9 @@ func TestCloud_setConfigurationFields(t *testing.T) {
 
 		if tc.expectedHostname != "" && b.hostname != tc.expectedHostname {
 			t.Fatalf("%s: expected hostname %s to match configured hostname %s", name, b.hostname, tc.expectedHostname)
+		}
+		if tc.expectedScheme != "" && b.scheme != tc.expectedScheme {
+			t.Fatalf("%s: expected scheme %s to match configured scheme %s", name, b.scheme, tc.expectedScheme)
 		}
 		if tc.expectedOrganziation != "" && b.organization != tc.expectedOrganziation {
 			t.Fatalf("%s: expected organization (%s) to match configured organization (%s)", name, b.organization, tc.expectedOrganziation)

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -68,6 +68,7 @@ func testInput(t *testing.T, answers map[string]string) *mockInput {
 func testBackendWithName(t *testing.T) (*Cloud, func()) {
 	obj := cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.NullVal(cty.String),
+		"scheme":       cty.NullVal(cty.String),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -81,6 +82,7 @@ func testBackendWithName(t *testing.T) (*Cloud, func()) {
 func testBackendWithTags(t *testing.T) (*Cloud, func()) {
 	obj := cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.NullVal(cty.String),
+		"scheme":       cty.NullVal(cty.String),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -98,6 +100,7 @@ func testBackendWithTags(t *testing.T) (*Cloud, func()) {
 func testBackendNoOperations(t *testing.T) (*Cloud, func()) {
 	obj := cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.NullVal(cty.String),
+		"scheme":       cty.NullVal(cty.String),
 		"organization": cty.StringVal("no-operations"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{


### PR DESCRIPTION
## What

Adding support for specifying the schema when using the new `cloud` backend type. This is primarily an internal-facing change allowing developers and CI pipelines in Terraform Cloud to host the app without needing to provision an internet-facing HTTPS URL or juggle self-signed certificates.

## TODO

- [ ] I had to update terraform-svchost to support HTTP as well. This PR is dependent upon https://github.com/hashicorp/terraform-svchost/pull/7 being accepted.