### PR TITLE
fix(references.mdx): typo

### DIFF
--- a/website/docs/language/expressions/references.mdx
+++ b/website/docs/language/expressions/references.mdx
@@ -86,7 +86,7 @@ block, as long as you don't introduce circular dependencies.
 
 ### Child Module Outputs
 
-`module.<MODULE NAME>` is an value representing the results of
+`module.<MODULE NAME>` is a value representing the results of
 [a `module` block](/language/modules/syntax).
 
 If the corresponding `module` block does not have either `count` nor `for_each`


### PR DESCRIPTION
# Description

This fixes a typo, and backports changes to older release branches