### PR TITLE
Add warning about drift to cloud block environment variables

### DIFF
--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -88,7 +88,7 @@ The `cloud` block supports the following configuration arguments:
 
 You can use environment variables to configure one or more `cloud` block attributes. This is helpful when you want to configure Terraform as part of a Continuous Integration (CI) pipeline. Terraform only reads these variables if the corresponding attribute is omitted from your configuration file. If you choose to configure the `cloud` block entirely through environment variables, you must still add an empty `cloud` block in your configuration file.
 
-~> **Warning:** Remote execution with non-interactive workflows may introduce drift. Drift occurs when there are changes to your infrastructure outside of Terraform. Refer to [Non-Interactive Workflows](/cloud-docs/run/cli#non-interactive-workflows) for details.
+~> **Warning:** Remote execution with non-interactive workflows requires auto-approved deployments. Minimize risk of unpredictable infrastructure changes and configuration drift by making sure that no one can change your infrastructure outside of your automated build pipeline.  Refer to [Non-Interactive Workflows](/cloud-docs/run/cli#non-interactive-workflows) for details.
 
 Use the following environment variables to configure the `cloud` block:
 

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -88,6 +88,8 @@ The `cloud` block supports the following configuration arguments:
 
 You can use environment variables to configure one or more `cloud` block attributes. This is helpful when you want to configure Terraform as part of a Continuous Integration (CI) pipeline. Terraform only reads these variables if the corresponding attribute is omitted from your configuration file. If you choose to configure the `cloud` block entirely through environment variables, you must still add an empty `cloud` block in your configuration file.
 
+~> **Warning:** Remote execution with non-interactive workflows may introduce drift. Drift occurs when there are changes to your infrastructure outside of Terraform. Refer to [Non-Interactive Workflows](/cloud-docs/run/cli#non-interactive-workflows) for details.
+
 Use the following environment variables to configure the `cloud` block:
 
 - `TF_CLOUD_ORGANIZATION` - The name of the organization. Terraform reads this variable when `organization` omitted from the `cloud` block`. If both are specified, the configuration takes precedence.


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-website/pull/2310

Add a warning about the potential of drift to the new section about non-interactive `cloud` block environment variables. Remote execution with the non-interactive component would require users to auto-approve plans. We provide more details about why this happens and suggest an alternative in the linked PR.