### PR TITLE
configs: Fix module loader nil pointer panic

### DIFF
--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -60,8 +60,11 @@ func (l *Loader) moduleWalkerLoad(req *configs.ModuleRequest) (*configs.Module, 
 
 	var diags hcl.Diagnostics
 
-	// Check for inconsistencies between manifest and config
-	if req.SourceAddr.String() != record.SourceAddr {
+	// Check for inconsistencies between manifest and config.
+
+	// We ignore a nil SourceAddr here, which represents a failure during
+	// configuration parsing, and will be reported in a diagnostic elsewhere.
+	if req.SourceAddr != nil && req.SourceAddr.String() != record.SourceAddr {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Module source has changed",

--- a/internal/configs/configload/loader_snapshot_test.go
+++ b/internal/configs/configload/loader_snapshot_test.go
@@ -1,6 +1,7 @@
 package configload
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -69,6 +70,26 @@ module "child_b" {
 		t.Errorf("wrong root module snapshot\ngot: %swant: %s", spew.Sdump(gotRoot), spew.Sdump(wantRoot))
 	}
 
+}
+
+func TestLoadConfigWithSnapshot_invalidSource(t *testing.T) {
+	fixtureDir := filepath.Clean("testdata/already-installed-now-invalid")
+
+	old, _ := os.Getwd()
+	os.Chdir(fixtureDir)
+	defer os.Chdir(old)
+
+	loader, err := NewLoader(&Config{
+		ModulesDir: ".terraform/modules",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from NewLoader: %s", err)
+	}
+
+	_, _, diags := loader.LoadConfigWithSnapshot(".")
+	if !diags.HasErrors() {
+		t.Error("LoadConfigWithSnapshot succeeded; want errors")
+	}
 }
 
 func TestSnapshotRoundtrip(t *testing.T) {

--- a/internal/configs/configload/loader_test.go
+++ b/internal/configs/configload/loader_test.go
@@ -14,7 +14,7 @@ func assertNoDiagnostics(t *testing.T, diags hcl.Diagnostics) bool {
 
 func assertDiagnosticCount(t *testing.T, diags hcl.Diagnostics, want int) bool {
 	t.Helper()
-	if len(diags) != 0 {
+	if len(diags) != want {
 		t.Errorf("wrong number of diagnostics %d; want %d", len(diags), want)
 		for _, diag := range diags {
 			t.Logf("- %s", diag)

--- a/internal/configs/configload/testdata/already-installed-now-invalid/.terraform/modules/modules.json
+++ b/internal/configs/configload/testdata/already-installed-now-invalid/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"foo","Source":"./foo","Dir":"foo"},{"Key":"foo.bar","Source":"./bar","Dir":"foo/bar"}]}

--- a/internal/configs/configload/testdata/already-installed-now-invalid/foo/bar/main.tf
+++ b/internal/configs/configload/testdata/already-installed-now-invalid/foo/bar/main.tf
@@ -1,0 +1,3 @@
+output "hello" {
+  value = "Hello from foo/bar"
+}

--- a/internal/configs/configload/testdata/already-installed-now-invalid/foo/main.tf
+++ b/internal/configs/configload/testdata/already-installed-now-invalid/foo/main.tf
@@ -1,0 +1,3 @@
+module "bar" {
+  source = "${path.module}/bar"
+}

--- a/internal/configs/configload/testdata/already-installed-now-invalid/root.tf
+++ b/internal/configs/configload/testdata/already-installed-now-invalid/root.tf
@@ -1,0 +1,3 @@
+module "foo" {
+  source  = "./foo"
+}


### PR DESCRIPTION
In configurations which have already been initialized, updating the source of a non-root module call to an invalid value could cause a nil pointer panic. This commit fixes the bug and adds test coverage.

Fixes #31056.