### PR TITLE
backend/azurerm: exclusively using Microsoft Graph/MSAL and removing Azure Active Directory Graph/ADAL

### DIFF
--- a/internal/backend/remote-state/azure/arm_client.go
+++ b/internal/backend/remote-state/azure/arm_client.go
@@ -7,11 +7,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/manicminer/hamilton/environments"
-
-	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
-	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/containers"
-
 	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
 	armStorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-01-01/storage"
 	"github.com/Azure/go-autorest/autorest"
@@ -19,6 +14,10 @@ import (
 	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/go-azure-helpers/sender"
 	"github.com/hashicorp/terraform/internal/httpclient"
+	"github.com/hashicorp/terraform/version"
+	"github.com/manicminer/hamilton/environments"
+	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
+	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/containers"
 )
 
 type ArmClient struct {
@@ -91,7 +90,7 @@ func buildArmClient(ctx context.Context, config BackendConfig) (*ArmClient, erro
 		SupportsClientSecretAuth:       true,
 		SupportsManagedServiceIdentity: config.UseMsi,
 		SupportsOIDCAuth:               config.UseOIDC,
-		UseMicrosoftGraph:              config.UseMicrosoftGraph,
+		UseMicrosoftGraph:              true,
 	}
 	armConfig, err := builder.Build()
 	if err != nil {
@@ -109,37 +108,19 @@ func buildArmClient(ctx context.Context, config BackendConfig) (*ArmClient, erro
 	}
 
 	sender := sender.BuildSender("backend/remote-state/azure")
-	var auth autorest.Authorizer
-	if builder.UseMicrosoftGraph {
-		log.Printf("[DEBUG] Obtaining an MSAL / Microsoft Graph token for Resource Manager..")
-		auth, err = armConfig.GetMSALToken(ctx, hamiltonEnv.ResourceManager, sender, oauthConfig, env.TokenAudience)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		log.Printf("[DEBUG] Obtaining an ADAL / Azure Active Directory Graph token for Resource Manager..")
-		auth, err = armConfig.GetADALToken(ctx, sender, oauthConfig, env.TokenAudience)
-		if err != nil {
-			return nil, err
-		}
+	log.Printf("[DEBUG] Obtaining an MSAL / Microsoft Graph token for Resource Manager..")
+	auth, err := armConfig.GetMSALToken(ctx, hamiltonEnv.ResourceManager, sender, oauthConfig, env.TokenAudience)
+	if err != nil {
+		return nil, err
 	}
 
 	if config.UseAzureADAuthentication {
-		if builder.UseMicrosoftGraph {
-			log.Printf("[DEBUG] Obtaining an MSAL / Microsoft Graph token for Storage..")
-			storageAuth, err := armConfig.GetMSALToken(ctx, hamiltonEnv.Storage, sender, oauthConfig, env.ResourceIdentifiers.Storage)
-			if err != nil {
-				return nil, err
-			}
-			client.azureAdStorageAuth = &storageAuth
-		} else {
-			log.Printf("[DEBUG] Obtaining an ADAL / Azure Active Directory Graph token for Storage..")
-			storageAuth, err := armConfig.GetADALToken(ctx, sender, oauthConfig, env.ResourceIdentifiers.Storage)
-			if err != nil {
-				return nil, err
-			}
-			client.azureAdStorageAuth = &storageAuth
+		log.Printf("[DEBUG] Obtaining an MSAL / Microsoft Graph token for Storage..")
+		storageAuth, err := armConfig.GetMSALToken(ctx, hamiltonEnv.Storage, sender, oauthConfig, env.ResourceIdentifiers.Storage)
+		if err != nil {
+			return nil, err
 		}
+		client.azureAdStorageAuth = &storageAuth
 	}
 
 	accountsClient := armStorage.NewAccountsClientWithBaseURI(env.ResourceManagerEndpoint, armConfig.SubscriptionID)
@@ -252,7 +233,7 @@ func (c *ArmClient) configureClient(client *autorest.Client, auth autorest.Autho
 }
 
 func buildUserAgent() string {
-	userAgent := httpclient.UserAgentString()
+	userAgent := httpclient.TerraformUserAgent(version.Version)
 
 	// append the CloudShell version to the user agent if it exists
 	if azureAgent := os.Getenv("AZURE_HTTP_USER_AGENT"); azureAgent != "" {

--- a/internal/backend/remote-state/azure/backend.go
+++ b/internal/backend/remote-state/azure/backend.go
@@ -164,13 +164,6 @@ func New() backend.Backend {
 				Description: "Should Terraform use AzureAD Authentication to access the Blob?",
 				DefaultFunc: schema.EnvDefaultFunc("ARM_USE_AZUREAD", false),
 			},
-			"use_microsoft_graph": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Deprecated:  "This field now defaults to `true` and will be removed in v1.3 of Terraform Core due to the deprecation of ADAL by Microsoft.",
-				Description: "Should Terraform obtain an MSAL auth token and use Microsoft Graph rather than Azure Active Directory?",
-				DefaultFunc: schema.EnvDefaultFunc("ARM_USE_MSGRAPH", true),
-			},
 		},
 	}
 
@@ -213,7 +206,6 @@ type BackendConfig struct {
 	UseMsi                        bool
 	UseOIDC                       bool
 	UseAzureADAuthentication      bool
-	UseMicrosoftGraph             bool
 }
 
 func (b *Backend) configure(ctx context.Context) error {
@@ -248,7 +240,6 @@ func (b *Backend) configure(ctx context.Context) error {
 		UseMsi:                        data.Get("use_msi").(bool),
 		UseOIDC:                       data.Get("use_oidc").(bool),
 		UseAzureADAuthentication:      data.Get("use_azuread_auth").(bool),
-		UseMicrosoftGraph:             data.Get("use_microsoft_graph").(bool),
 	}
 
 	armClient, err := buildArmClient(context.TODO(), config)

--- a/internal/backend/remote-state/azure/backend_test.go
+++ b/internal/backend/remote-state/azure/backend_test.go
@@ -123,7 +123,7 @@ func TestAccBackendOIDCBasic(t *testing.T) {
 	backend.TestBackendStates(t, b)
 }
 
-func TestAccBackendADALAzureADAuthBasic(t *testing.T) {
+func TestAccBackendAzureADAuthBasic(t *testing.T) {
 	testAccAzureBackend(t)
 	rs := acctest.RandString(4)
 	res := testResourceNames(rs, "testState")
@@ -151,7 +151,7 @@ func TestAccBackendADALAzureADAuthBasic(t *testing.T) {
 	backend.TestBackendStates(t, b)
 }
 
-func TestAccBackendADALManagedServiceIdentityBasic(t *testing.T) {
+func TestAccBackendManagedServiceIdentityBasic(t *testing.T) {
 	testAccAzureBackendRunningInAzure(t)
 	rs := acctest.RandString(4)
 	res := testResourceNames(rs, "testState")
@@ -179,7 +179,7 @@ func TestAccBackendADALManagedServiceIdentityBasic(t *testing.T) {
 	backend.TestBackendStates(t, b)
 }
 
-func TestAccBackendADALServicePrincipalClientCertificateBasic(t *testing.T) {
+func TestAccBackendServicePrincipalClientCertificateBasic(t *testing.T) {
 	testAccAzureBackend(t)
 
 	clientCertPassword := os.Getenv("ARM_CLIENT_CERTIFICATE_PASSWORD")
@@ -216,7 +216,7 @@ func TestAccBackendADALServicePrincipalClientCertificateBasic(t *testing.T) {
 	backend.TestBackendStates(t, b)
 }
 
-func TestAccBackendADALServicePrincipalClientSecretBasic(t *testing.T) {
+func TestAccBackendServicePrincipalClientSecretBasic(t *testing.T) {
 	testAccAzureBackend(t)
 	rs := acctest.RandString(4)
 	res := testResourceNames(rs, "testState")
@@ -245,7 +245,7 @@ func TestAccBackendADALServicePrincipalClientSecretBasic(t *testing.T) {
 	backend.TestBackendStates(t, b)
 }
 
-func TestAccBackendADALServicePrincipalClientSecretCustomEndpoint(t *testing.T) {
+func TestAccBackendServicePrincipalClientSecretCustomEndpoint(t *testing.T) {
 	testAccAzureBackend(t)
 
 	// this is only applicable for Azure Stack.
@@ -256,169 +256,6 @@ func TestAccBackendADALServicePrincipalClientSecretCustomEndpoint(t *testing.T) 
 
 	rs := acctest.RandString(4)
 	res := testResourceNames(rs, "testState")
-	armClient := buildTestClient(t, res)
-
-	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
-	if err != nil {
-		t.Fatalf("Error creating Test Resources: %q", err)
-	}
-
-	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"storage_account_name": res.storageAccountName,
-		"container_name":       res.storageContainerName,
-		"key":                  res.storageKeyName,
-		"resource_group_name":  res.resourceGroup,
-		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
-		"tenant_id":            os.Getenv("ARM_TENANT_ID"),
-		"client_id":            os.Getenv("ARM_CLIENT_ID"),
-		"client_secret":        os.Getenv("ARM_CLIENT_SECRET"),
-		"environment":          os.Getenv("ARM_ENVIRONMENT"),
-		"endpoint":             endpoint,
-	})).(*Backend)
-
-	backend.TestBackendStates(t, b)
-}
-
-func TestAccBackendMSALAzureADAuthBasic(t *testing.T) {
-	testAccAzureBackend(t)
-	rs := acctest.RandString(4)
-	res := testResourceNames(rs, "testState")
-	res.useAzureADAuth = true
-	res.useMicrosoftGraph = true
-	armClient := buildTestClient(t, res)
-
-	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
-	if err != nil {
-		armClient.destroyTestResources(ctx, res)
-		t.Fatalf("Error creating Test Resources: %q", err)
-	}
-
-	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"storage_account_name": res.storageAccountName,
-		"container_name":       res.storageContainerName,
-		"key":                  res.storageKeyName,
-		"access_key":           res.storageAccountAccessKey,
-		"environment":          os.Getenv("ARM_ENVIRONMENT"),
-		"endpoint":             os.Getenv("ARM_ENDPOINT"),
-		"use_azuread_auth":     true,
-	})).(*Backend)
-
-	backend.TestBackendStates(t, b)
-}
-
-func TestAccBackendMSALManagedServiceIdentityBasic(t *testing.T) {
-	testAccAzureBackendRunningInAzure(t)
-	rs := acctest.RandString(4)
-	res := testResourceNames(rs, "testState")
-	res.useMicrosoftGraph = true
-	armClient := buildTestClient(t, res)
-
-	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
-	if err != nil {
-		t.Fatalf("Error creating Test Resources: %q", err)
-	}
-
-	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"storage_account_name": res.storageAccountName,
-		"container_name":       res.storageContainerName,
-		"key":                  res.storageKeyName,
-		"resource_group_name":  res.resourceGroup,
-		"use_msi":              true,
-		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
-		"tenant_id":            os.Getenv("ARM_TENANT_ID"),
-		"environment":          os.Getenv("ARM_ENVIRONMENT"),
-		"endpoint":             os.Getenv("ARM_ENDPOINT"),
-	})).(*Backend)
-
-	backend.TestBackendStates(t, b)
-}
-
-func TestAccBackendMSALServicePrincipalClientCertificateBasic(t *testing.T) {
-	testAccAzureBackend(t)
-
-	clientCertPassword := os.Getenv("ARM_CLIENT_CERTIFICATE_PASSWORD")
-	clientCertPath := os.Getenv("ARM_CLIENT_CERTIFICATE_PATH")
-	if clientCertPath == "" {
-		t.Skip("Skipping since `ARM_CLIENT_CERTIFICATE_PATH` is not specified!")
-	}
-
-	rs := acctest.RandString(4)
-	res := testResourceNames(rs, "testState")
-	res.useMicrosoftGraph = true
-	armClient := buildTestClient(t, res)
-
-	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
-	if err != nil {
-		t.Fatalf("Error creating Test Resources: %q", err)
-	}
-
-	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"storage_account_name":        res.storageAccountName,
-		"container_name":              res.storageContainerName,
-		"key":                         res.storageKeyName,
-		"resource_group_name":         res.resourceGroup,
-		"subscription_id":             os.Getenv("ARM_SUBSCRIPTION_ID"),
-		"tenant_id":                   os.Getenv("ARM_TENANT_ID"),
-		"client_id":                   os.Getenv("ARM_CLIENT_ID"),
-		"client_certificate_password": clientCertPassword,
-		"client_certificate_path":     clientCertPath,
-		"environment":                 os.Getenv("ARM_ENVIRONMENT"),
-		"endpoint":                    os.Getenv("ARM_ENDPOINT"),
-	})).(*Backend)
-
-	backend.TestBackendStates(t, b)
-}
-
-func TestAccBackendMSALServicePrincipalClientSecretBasic(t *testing.T) {
-	testAccAzureBackend(t)
-	rs := acctest.RandString(4)
-	res := testResourceNames(rs, "testState")
-	res.useMicrosoftGraph = true
-	armClient := buildTestClient(t, res)
-
-	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
-	if err != nil {
-		t.Fatalf("Error creating Test Resources: %q", err)
-	}
-
-	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
-		"storage_account_name": res.storageAccountName,
-		"container_name":       res.storageContainerName,
-		"key":                  res.storageKeyName,
-		"resource_group_name":  res.resourceGroup,
-		"subscription_id":      os.Getenv("ARM_SUBSCRIPTION_ID"),
-		"tenant_id":            os.Getenv("ARM_TENANT_ID"),
-		"client_id":            os.Getenv("ARM_CLIENT_ID"),
-		"client_secret":        os.Getenv("ARM_CLIENT_SECRET"),
-		"environment":          os.Getenv("ARM_ENVIRONMENT"),
-		"endpoint":             os.Getenv("ARM_ENDPOINT"),
-	})).(*Backend)
-
-	backend.TestBackendStates(t, b)
-}
-
-func TestAccBackendMSALServicePrincipalClientSecretCustomEndpoint(t *testing.T) {
-	testAccAzureBackend(t)
-
-	// this is only applicable for Azure Stack.
-	endpoint := os.Getenv("ARM_ENDPOINT")
-	if endpoint == "" {
-		t.Skip("Skipping as ARM_ENDPOINT isn't configured")
-	}
-
-	rs := acctest.RandString(4)
-	res := testResourceNames(rs, "testState")
-	res.useMicrosoftGraph = true
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()

--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -10,10 +10,9 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
-	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
-
 	"github.com/hashicorp/terraform/internal/states/remote"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
+	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
 )
 
 const (

--- a/internal/backend/remote-state/azure/helpers_test.go
+++ b/internal/backend/remote-state/azure/helpers_test.go
@@ -93,7 +93,6 @@ func buildTestClient(t *testing.T, res resourceNames) *ArmClient {
 		StorageAccountName:            res.storageAccountName,
 		UseMsi:                        msiEnabled,
 		UseAzureADAuthentication:      res.useAzureADAuth,
-		UseMicrosoftGraph:             res.useMicrosoftGraph,
 	})
 	if err != nil {
 		t.Fatalf("Failed to build ArmClient: %+v", err)
@@ -137,7 +136,6 @@ type resourceNames struct {
 	storageKeyName          string
 	storageAccountAccessKey string
 	useAzureADAuth          bool
-	useMicrosoftGraph       bool
 }
 
 func testResourceNames(rString string, keyName string) resourceNames {

--- a/internal/httpclient/useragent.go
+++ b/internal/httpclient/useragent.go
@@ -13,7 +13,7 @@ import (
 const userAgentFormat = "Terraform/%s"
 const uaEnvVar = "TF_APPEND_USER_AGENT"
 
-// Deprecated: Use UserAgent(version) instead
+// Deprecated: Use TerraformUserAgent(version) instead
 func UserAgentString() string {
 	ua := fmt.Sprintf(userAgentFormat, version.Version)
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -9,7 +9,7 @@ Stores the state as a Blob with the given Key within the Blob Container within [
 
 This backend supports state locking and consistency checking with Azure Blob Storage native capabilities.
 
--> **Note:** In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph) rather than ADAL (and Azure Active Directory Graph) for authentication by default - you can disable this by setting `use_microsoft_graph` to `false`. **This setting will be removed in Terraform 1.3, due to Microsoft's deprecation of ADAL**.
+~> **Terraform 1.1 and 1.2 supported a feature-flag to allow enabling/disabling the use of Microsoft Graph (and MSAL) rather than Azure Active Directory Graph (and ADAL) - however this flag has since been removed in Terraform 1.3. Microsoft Graph (and MSAL) are now enabled by default and Azure Active Directory Graph (and ADAL) can no longer be used.
 
 ## Example Configuration
 
@@ -260,10 +260,6 @@ When authenticating using the Managed Service Identity (MSI) - the following fie
 
 * `tenant_id` - (Optional) The Tenant ID in which the Subscription exists. This can also be sourced from the `ARM_TENANT_ID` environment variable.
 
-* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `true`.
-
--> **Note:** In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph) rather than ADAL (and Azure Active Directory Graph) for authentication by default - you can disable this by setting `use_microsoft_graph` to `false`. **This setting will be removed in Terraform 1.3, due to Microsoft's deprecation of ADAL**.
-
 * `use_msi` - (Optional) Should Managed Service Identity authentication be used? This can also be sourced from the `ARM_USE_MSI` environment variable.
 
 ***
@@ -275,8 +271,6 @@ When authenticating using a Service Principal with OpenID Connect (OIDC) - the f
 * `oidc_request_token` - (Optional) The bearer token for the request to the OIDC provider. This can also be sourced from the `ARM_OIDC_REQUEST_TOKEN` or `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variables.
 
 * `use_oidc` - (Optional) Should OIDC authentication be used? This can also be sourced from the `ARM_USE_OIDC` environment variable.
-
-~> **Note:** When using OIDC for authentication, `use_microsoft_graph` must be set to `true` (which is the default).
 
 ***
 
@@ -298,10 +292,6 @@ When authenticating using AzureAD Authentication - the following fields are also
 
 -> **Note:** When using AzureAD for Authentication to Storage you also need to ensure the `Storage Blob Data Owner` role is assigned.
 
-* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `true`.
-
--> **Note:** In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph) rather than ADAL (and Azure Active Directory Graph) for authentication by default - you can disable this by setting `use_microsoft_graph` to `false`. **This setting will be removed in Terraform 1.3, due to Microsoft's deprecation of ADAL**.
-
 ***
 
 When authenticating using a Service Principal with a Client Certificate - the following fields are also supported:
@@ -318,10 +308,6 @@ When authenticating using a Service Principal with a Client Certificate - the fo
 
 * `tenant_id` - (Optional) The Tenant ID in which the Subscription exists. This can also be sourced from the `ARM_TENANT_ID` environment variable.
 
-* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `true`.
-
--> **Note:** In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph) rather than ADAL (and Azure Active Directory Graph) for authentication by default - you can disable this by setting `use_microsoft_graph` to `false`. **This setting will be removed in Terraform 1.3, due to Microsoft's deprecation of ADAL**.
-
 ***
 
 When authenticating using a Service Principal with a Client Secret - the following fields are also supported:
@@ -335,7 +321,3 @@ When authenticating using a Service Principal with a Client Secret - the followi
 * `subscription_id` - (Optional) The Subscription ID in which the Storage Account exists. This can also be sourced from the `ARM_SUBSCRIPTION_ID` environment variable.
 
 * `tenant_id` - (Optional) The Tenant ID in which the Subscription exists. This can also be sourced from the `ARM_TENANT_ID` environment variable.
-
-* `use_microsoft_graph` - (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? Defaults to `true`.
-
--> **Note:** In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph) rather than ADAL (and Azure Active Directory Graph) for authentication by default - you can disable this by setting `use_microsoft_graph` to `false`. **This setting will be removed in Terraform 1.3, due to Microsoft's deprecation of ADAL**.


### PR DESCRIPTION
This PR finishes the migration from ADAL to MSAL for the AzureRM Backend - meaning that Microsoft Graph (and MSAL) are now used by default and Azure Active Directory Graph (and ADAL) are no longer available.

Whilst this is _technically_ a breaking change to the config, this has been called out in the v1.1 and v1.2 releases (and is marked as deprecated in v1.2) - we believe that this shouldn't be impactful to users - and ADAL is scheduled for removal in the near future: https://docs.microsoft.com/graph/migrate-azure-ad-graph-faq

```
$ TF_ACC=1 go test -v ./internal/backend/remote-state/azure/ -timeout=60m
=== RUN   TestBackend_impl
--- PASS: TestBackend_impl (0.00s)
=== RUN   TestBackendConfig
--- PASS: TestBackendConfig (0.00s)
=== RUN   TestAccBackendAccessKeyBasic
--- PASS: TestAccBackendAccessKeyBasic (103.50s)
=== RUN   TestAccBackendSASTokenBasic
--- PASS: TestAccBackendSASTokenBasic (102.84s)
=== RUN   TestAccBackendOIDCBasic
--- PASS: TestAccBackendOIDCBasic (110.92s)
=== RUN   TestAccBackendMSALAzureADAuthBasic
--- PASS: TestAccBackendMSALAzureADAuthBasic (105.68s)
=== RUN   TestAccBackendMSALManagedServiceIdentityBasic
   helpers_test.go:38: Skipping test since not running in Azure
--- SKIP: TestAccBackendMSALManagedServiceIdentityBasic (0.00s)
=== RUN   TestAccBackendMSALServicePrincipalClientCertificateBasic
   backend_test.go:188: Skipping since `ARM_CLIENT_CERTIFICATE_PATH` is not specified!
--- SKIP: TestAccBackendMSALServicePrincipalClientCertificateBasic (0.00s)
=== RUN   TestAccBackendMSALServicePrincipalClientSecretBasic
--- PASS: TestAccBackendMSALServicePrincipalClientSecretBasic (111.77s)
=== RUN   TestAccBackendMSALServicePrincipalClientSecretCustomEndpoint
   backend_test.go:254: Skipping as ARM_ENDPOINT isn't configured
--- SKIP: TestAccBackendMSALServicePrincipalClientSecretCustomEndpoint (0.00s)
=== RUN   TestAccBackendAccessKeyLocked
--- PASS: TestAccBackendAccessKeyLocked (104.27s)
=== RUN   TestAccBackendServicePrincipalLocked
--- PASS: TestAccBackendServicePrincipalLocked (104.48s)
=== RUN   TestRemoteClient_impl
--- PASS: TestRemoteClient_impl (0.00s)
=== RUN   TestRemoteClientAccessKeyBasic
--- PASS: TestRemoteClientAccessKeyBasic (97.54s)
=== RUN   TestRemoteClientManagedServiceIdentityBasic
   helpers_test.go:38: Skipping test since not running in Azure
--- SKIP: TestRemoteClientManagedServiceIdentityBasic (0.00s)
=== RUN   TestRemoteClientSasTokenBasic
--- PASS: TestRemoteClientSasTokenBasic (112.18s)
=== RUN   TestRemoteClientServicePrincipalBasic
--- PASS: TestRemoteClientServicePrincipalBasic (102.07s)
=== RUN   TestRemoteClientAccessKeyLocks
--- PASS: TestRemoteClientAccessKeyLocks (100.13s)
=== RUN   TestRemoteClientServicePrincipalLocks
--- PASS: TestRemoteClientServicePrincipalLocks (103.39s)
=== RUN   TestPutMaintainsMetaData
--- PASS: TestPutMaintainsMetaData (100.11s)
PASS
ok  	github.com/hashicorp/terraform/internal/backend/remote-state/azure	1359.403s
```