### PR TITLE
configs: fix module for_each call bug

### DIFF
--- a/internal/configs/provider_validation.go
+++ b/internal/configs/provider_validation.go
@@ -30,28 +30,24 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 
 	for name, child := range cfg.Children {
 		mc := mod.ModuleCalls[name]
-
+		childNoProviderConfigRange := noProviderConfigRange
 		// if the module call has any of count, for_each or depends_on,
 		// providers are prohibited from being configured in this module, or
 		// any module beneath this module.
-		// NOTE: If noProviderConfigRange was already set but we encounter
-		// a nested conflicting argument then we'll overwrite the caller's
-		// range, which allows us to report the problem as close to its
-		// cause as possible.
 		switch {
 		case mc.Count != nil:
-			noProviderConfigRange = mc.Count.Range().Ptr()
+			childNoProviderConfigRange = mc.Count.Range().Ptr()
 		case mc.ForEach != nil:
-			noProviderConfigRange = mc.ForEach.Range().Ptr()
+			childNoProviderConfigRange = mc.ForEach.Range().Ptr()
 		case mc.DependsOn != nil:
 			if len(mc.DependsOn) > 0 {
-				noProviderConfigRange = mc.DependsOn[0].SourceRange().Ptr()
+				childNoProviderConfigRange = mc.DependsOn[0].SourceRange().Ptr()
 			} else {
 				// Weird! We'll just use the call itself, then.
-				noProviderConfigRange = mc.DeclRange.Ptr()
+				childNoProviderConfigRange = mc.DeclRange.Ptr()
 			}
 		}
-		diags = append(diags, validateProviderConfigs(mc, child, noProviderConfigRange)...)
+		diags = append(diags, validateProviderConfigs(mc, child, childNoProviderConfigRange)...)
 	}
 
 	// the set of provider configuration names passed into the module, with the


### PR DESCRIPTION
This fixes a bug introduced in #30639 in which initialising a module will fail if that module contains both a provider block and a module call using `for_each`.

This bug was introduced in https://github.com/hashicorp/terraform/pull/30639/files#diff-95e614048e1ba4ba7621e22ba67cfe5c8acd386e5540b8c92c267d2fd1b3d31eR31-R55 by removing a variable scoped to a `for` loop (`var nope`) and instead overwriting `noProviderConfigRange`. This meant that the error at https://github.com/hashicorp/terraform/pull/30639/files#diff-95e614048e1ba4ba7621e22ba67cfe5c8acd386e5540b8c92c267d2fd1b3d31eR181 would be triggered if the _parent_ module contained a provider block, not the child.

Fixes #31081

## Test case

There are no tests in code for this behaviour. Highly recommend adding them as follow up. I manually tested this using the example below, kindly provided by @knbnnate.

```
.
├── barren_child
│   └── main.tf
├── grandchild
│   └── main.tf
└── main.tf
```

#### `main.tf`
```hcl
provider "azurerm" {
  features {
  }
}
terraform {
  backend "local" {
  }
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.99"
    }
  }
}


module "child" {
  source = "./barren_child"
}
```

#### `barren_child/main.tf`
```hcl
provider "azurerm" {
  alias           = "other"
  subscription_id = var.some_other_sub
  features {
  }
}

module "grandchild" {
  for_each = toset(["bar","baz"])
  source = "../grandchild"
}
```

#### `grandchild/main.tf`

```hcl
variable "text" {
  type = string
  default = "foo"
  description = "stuff"
}
resource "local_file" "foo" {
  filename = "/dev/null"
  content = jsonencode(var.text)
}
```

