### PR TITLE
build: Further polishing of the prototype build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,15 +77,11 @@ jobs:
           # Split off the build metadata part, if any
           # (we won't actually include it in our final version, and handle it only for
           # compleness against semver syntax.)
-          IFS='+' read -ra BUILD_METADATA_PARTS <<< "$VERSION"
-          VERSION="${BUILD_METADATA_PARTS[0]}"
-          BUILD_META="${BUILD_METADATA_PARTS[1]}"
+          IFS='+' read -ra VERSION BUILD_META <<< "$VERSION"
 
           # Separate out the prerelease part, if any
           # (version.go expects it to be in a separate variable)
-          IFS='-' read -ra PRERELEASE_PARTS <<< "$VERSION"
-          BASE_VERSION="${PRERELEASE_PARTS[0]}"
-          PRERELEASE="${PRERELEASE_PARTS[1]}"
+          IFS='-' read -r BASE_VERSION PRERELEASE <<< "$VERSION"
 
           EXPERIMENTS_ENABLED=0
           if [[ "$PRERELEASE" == alpha* ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,13 +44,17 @@ jobs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # Need all commits and tags to find a reasonable version number
+      - uses: actions/checkout@v3
       - name: Git Describe
         id: git-describe
         run: |
-          git describe --first-parent
+          # The actions/checkout action tries hard to fetch as little as
+          # possible, to the extent that even with "depth: 0" it fails to
+          # produce enough tag metadata for us to "describe" successfully.
+          # We'll therefore re-fetch the tags here to make sure we will
+          # select the most accurate version number.
+          git fetch origin --force --tags
+          git tag
           echo "::set-output name=raw-version::$(git describe --first-parent)"
       - name: Decide version number
         id: get-product-version
@@ -58,6 +62,7 @@ jobs:
         env:
           RAW_VERSION: ${{ steps.git-describe.outputs.raw-version }}
         run: |
+          echo "Version number is ${RAW_VERSION}"
           echo "::set-output name=product-version::${RAW_VERSION#v}"
       - name: Report chosen version number
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
+      product-version-base: ${{ steps.get-product-version.outputs.product-version-base }}
+      product-version-pre: ${{ steps.get-product-version.outputs.product-version-pre }}
+      experiments: ${{ steps.get-product-version.outputs.experiments }}
+      go-ldflags: ${{ steps.get-product-version.outputs.go-ldflags }}
 
     steps:
       - uses: actions/checkout@v3
@@ -53,17 +57,60 @@ jobs:
           # produce enough tag metadata for us to "describe" successfully.
           # We'll therefore re-fetch the tags here to make sure we will
           # select the most accurate version number.
-          git fetch origin --force --tags
-          git tag
-          echo "::set-output name=raw-version::$(git describe --first-parent)"
+          git fetch origin --force --tags --quiet --unshallow
+          git log --tags --simplify-by-decoration --decorate-refs='refs/tags/v*' --pretty=format:'%h %<|(35)%S %ci' --max-count 15 --topo-order
+          set -e
+          RAW_VERSION=$(git describe --tags --match='v*' ${GITHUB_SHA})
+          echo "
+          
+          Raw version is ${RAW_VERSION}"
+          echo "::set-output name=raw-version::${RAW_VERSION}"
       - name: Decide version number
         id: get-product-version
         shell: bash
         env:
           RAW_VERSION: ${{ steps.git-describe.outputs.raw-version }}
         run: |
-          echo "Version number is ${RAW_VERSION}"
-          echo "::set-output name=product-version::${RAW_VERSION#v}"
+          # Trim the "v" prefix, if any.
+          VERSION="${RAW_VERSION#v}"
+
+          # Split off the build metadata part, if any
+          # (we won't actually include it in our final version, and handle it only for
+          # compleness against semver syntax.)
+          IFS='+' read -ra BUILD_METADATA_PARTS <<< "$VERSION"
+          VERSION="${BUILD_METADATA_PARTS[0]}"
+          BUILD_META="${BUILD_METADATA_PARTS[1]}"
+
+          # Separate out the prerelease part, if any
+          # (version.go expects it to be in a separate variable)
+          IFS='-' read -ra PRERELEASE_PARTS <<< "$VERSION"
+          BASE_VERSION="${PRERELEASE_PARTS[0]}"
+          PRERELEASE="${PRERELEASE_PARTS[1]}"
+
+          EXPERIMENTS_ENABLED=0
+          if [[ "$PRERELEASE" == alpha* ]]; then
+            EXPERIMENTS_ENABLED=1
+          fi
+          if [[ "$PRERELEASE" == dev* ]]; then
+            EXPERIMENTS_ENABLED=1
+          fi
+
+          LDFLAGS="-w -s"
+          if [[ "$EXPERIMENTS_ENABLED" == 1 ]]; then
+            LDFLAGS="${LDFLAGS} -X 'main.experimentsAllowed=yes'"
+          fi
+          LDFLAGS="${LDFLAGS} -X 'github.com/hashicorp/terraform/version.Version=${BASE_VERSION}'"
+          LDFLAGS="${LDFLAGS} -X 'github.com/hashicorp/terraform/version.Prerelease=${PRERELEASE}'"
+
+          echo "Building Terraform CLI ${VERSION}"
+          if [[ "$EXPERIMENTS_ENABLED" == 1 ]]; then
+            echo "This build allows use of experimental features"
+          fi
+          echo "::set-output name=product-version::${VERSION}"
+          echo "::set-output name=product-version-base::${BASE_VERSION}"
+          echo "::set-output name=product-version-pre::${PRERELEASE}"
+          echo "::set-output name=experiments::${EXPERIMENTS_ENABLED}"
+          echo "::set-output name=go-ldflags::${LDFLAGS}"
       - name: Report chosen version number
         run: |
           [ -n "${{steps.get-product-version.outputs.product-version}}" ]
@@ -127,6 +174,13 @@ jobs:
           - {goos: "darwin", goarch: "arm64", runson: "macos-latest"}
       fail-fast: false
 
+    env:
+      FULL_VERSION: ${{ needs.get-product-version.outputs.product-version }}
+      BASE_VERSION: ${{ needs.get-product-version.outputs.product-version-base }}
+      VERSION_PRERELEASE: ${{ needs.get-product-version.outputs.product-version-pre }}
+      EXPERIMENTS_ENABLED: ${{ needs.get-product-version.outputs.experiments }}
+      GO_LDFLAGS: ${{ needs.get-product-version.outputs.go-ldflags }}
+
     steps:
       - uses: actions/checkout@v2
 
@@ -159,13 +213,14 @@ jobs:
             # cross-build for darwin_arm64.)
             export CGO_ENABLED=1
           fi
-          go build -ldflags "-w -s" -o dist/ .
-          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+          set -x
+          go build -ldflags "${GO_LDFLAGS}" -o dist/ .
+          zip -r -j out/${{ env.PKG_NAME }}_${FULL_VERSION}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
 
       - uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          name: ${{ env.PKG_NAME }}_${{ env.FULL_VERSION }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: out/${{ env.PKG_NAME }}_${{ env.FULL_VERSION }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
   package-linux:
     name: "Build Linux distro packages for ${{ matrix.arch }}"
@@ -252,7 +307,7 @@ jobs:
       fail-fast: false
 
     env:
-      repo: ${{github.event.repository.name}}
+      repo: "terraform"
       version: ${{needs.get-product-version.outputs.product-version}}
 
     steps:
@@ -260,7 +315,9 @@ jobs:
       - name: Build Docker images
         uses: hashicorp/actions-docker-build@v1
         with:
+          pkg_name: "terraform_${{env.version}}"
           version: ${{env.version}}
+          bin_name: terraform
           target: default
           arch: ${{matrix.arch}}
           dockerfile: .github/workflows/build-Dockerfile
@@ -271,7 +328,9 @@ jobs:
   e2etest-build:
     name: Build e2etest for ${{ matrix.goos }}_${{ matrix.goarch }}
     runs-on: ubuntu-latest
-    needs: ["get-go-version"]
+    needs:
+      - get-product-version
+      - get-go-version
     strategy:
       matrix:
         # We build test harnesses only for the v1.0 Compatibility Promises
@@ -306,7 +365,12 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          GO_LDFLAGS: ${{ needs.get-product-version.outputs.go-ldflags }}
         run: |
+          # NOTE: This script reacts to the GOOS, GOARCH, and GO_LDFLAGS
+          # environment variables defined above. The e2e test harness
+          # needs to know the version we're building for so it can verify
+          # that "terraform version" is returning that version number.
           bash ./internal/command/e2etest/make-archive.sh
 
       - uses: actions/upload-artifact@v2

--- a/internal/command/e2etest/make-archive.sh
+++ b/internal/command/e2etest/make-archive.sh
@@ -31,13 +31,20 @@ GOEXE="$(go env GOEXE)"
 OUTDIR="build/${GOOS}_${GOARCH}"
 OUTFILE="terraform-e2etest_${GOOS}_${GOARCH}.zip"
 
+LDFLAGS="-X github.com/hashicorp/terraform/internal/command/e2etest.terraformBin=./terraform$GOEXE"
+# Caller may pass in the environment variable GO_LDFLAGS with additional
+# flags we'll use when building.
+if [ -n "${GO_LDFLAGS+set}" ]; then
+    LDFLAGS="${GO_LDFLAGS} ${LDFLAGS}"
+fi
+
 mkdir -p "$OUTDIR"
 
 # We need the test fixtures available when we run the tests.
 cp -r testdata "$OUTDIR/testdata"
 
 # Build the test program
-go test -o "$OUTDIR/e2etest$GOEXE" -c -ldflags "-X github.com/hashicorp/terraform/internal/command/e2etest.terraformBin=./terraform$GOEXE" github.com/hashicorp/terraform/internal/command/e2etest
+go test -o "$OUTDIR/e2etest$GOEXE" -c -ldflags "$LDFLAGS" github.com/hashicorp/terraform/internal/command/e2etest
 
 # Now bundle it all together for easy shipping!
 cd "$OUTDIR"


### PR DESCRIPTION
Back in #30283 we introduced a prototype new build process that for now just signals whether we were able to build working executables for various platforms, but is hopefully destined to one day become the first step in our routine release process, producing the artifacts that we'll ultimately publish.

We merged that PR early in order to get some experience with its behavior over several different kinds of releases, since this sort of thing is notoriously hard to test realistically in an artificial environment. Since then, we've learned about a couple of quirks that this PR aims to now address:
* #30864: Due to how the standard "checkout" GitHub Action tries to fetch as little as possible, it was not producing a fully-fledged-enough repository for us to analyze tags to automatically determine a version number. Consequently, it ended up inconsistently misclassifying real releases as being tagged ones.

    That's fixed here by retroactively "unshallowing" the repository and explicitly fetching all of the tags. That then gives us sufficient data for `git describe` to return a correct result. If the commit being built exactly matches a tag then the version number will be derived from that tag, and if not it will derive a "close enough" modified version number by suffixing a number of commits since the tag and an abbeviated commit ID of the selected commit.
* In #30283 I'd intentionally skipped having the build process write the detected version number into the built executables because I was anticipating that golang/go#37475 would cause the Go toolchain to make that information available in a different way after Go 1.18. However, in subsequent testing I learned that it currently stamps only the commit ID and not any module version information for the main package. golang/go#50603 is an open request tracking the behavior I had hoped for, but it remains unimplemented at the time I'm writing this and there are some doubts about what exactly it would do if it _were_ implemented.

    In light of that, I've instead adopted the typical old strategy of using linker arguments to write dynamically-selected strings into the executable at build time. This achieves the desired effect of making `go version` return the intended version number.

---

In addition to these two quirks, I've also been continuing to think about what I proposed in #30948 and as part of that I wanted to explore what it might look like for the build process to be responsible for annotating builds as allowing experiments. At the moment that doesn't actually have any effect, since #30948 is not merged. Continuing with the previous goal of using this as an experimental vehicle to see how this build process treats different releases we'll run in the coming months, I'd like to include that here only so I can inspect the real builds that will follow and make sure this workflow makes the correct selections for which builds _ought to have_ experiment support.

---

I'm proposing also to backport this to the `v1.2` branch so that we can observe its behavior with the v1.2.x patch releases, since it is likely to be at least several months before we're running any non-prerelease releases from the `main` branch and I want to observe how it treats both real releases and alpha releases.

Because this PR is from a branch that has the prefix `build-workflow-dev/`, you can see the results of running this workflow as checks on this PR. (In the normal case we only run this workflow _after_ merge, in the context of a real release branch, in order to keep the PR check turnaround time reasonable and to keep resource usage reasonable.)

Since this workflow currently doesn't feed into anything downstream, the risk of changing this is pretty low: in the worst case, we might see some failing runs of this workflow after a PR is merged or after a release tag is created by our current process. Such errors will not block any other processes and so I will attend to them asynchronously as needed.


