### PR TITLE
Add version notes 1.2

### DIFF
--- a/website/docs/cli/cloud/index.mdx
+++ b/website/docs/cli/cloud/index.mdx
@@ -4,7 +4,7 @@ page_title: Using Terraform Cloud - Terraform CLI
 
 # Using Terraform Cloud with Terraform CLI
 
-The Terraform CLI's integration with Terraform Cloud lets you to use Terraform Cloud and Terraform Enterprise on the command line. In the documentation Terraform Cloud instructions also apply to Terraform Enterprise, except where explicitly stated.
+The Terraform CLI integration with Terraform Cloud lets you use Terraform Cloud and Terraform Enterprise on the command line. In the documentation Terraform Cloud instructions also apply to Terraform Enterprise, except where explicitly stated.
 
 Using Terraform Cloud through the command line is called the [CLI-driven run workflow](/cloud-docs/run/cli). When you use the CLI workflow, operations like `terraform plan` or `terraform apply` are remotely executed in Terraform Cloud's run environment by default, with log output streaming to the local terminal. This lets you use Terraform Cloud features within the familiar Terraform CLI workflow, including variables encrypted at rest in a Terraform Cloud workspace, cost estimates, and policy checking.
 

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -85,6 +85,7 @@ The `cloud` block supports the following configuration arguments:
   [CLI config file](/cli/config/config-file#credentials).
 
 ### Environment Variables
+
 -> **Note:** CLI integration environment variables are supported in Terraform v1.2.0 and later.
 
 You can use environment variables to configure one or more `cloud` block attributes. This is helpful when you want to configure Terraform as part of a Continuous Integration (CI) pipeline. Terraform only reads these variables if the corresponding attribute is omitted from your configuration file. If you choose to configure the `cloud` block entirely through environment variables, you must still add an empty `cloud` block in your configuration file.

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -85,6 +85,7 @@ The `cloud` block supports the following configuration arguments:
   [CLI config file](/cli/config/config-file#credentials).
 
 ### Environment Variables
+-> **Note:** CLI integration environment variables are supported in Terraform v1.2.0 and later.
 
 You can use environment variables to configure one or more `cloud` block attributes. This is helpful when you want to configure Terraform as part of a Continuous Integration (CI) pipeline. Terraform only reads these variables if the corresponding attribute is omitted from your configuration file. If you choose to configure the `cloud` block entirely through environment variables, you must still add an empty `cloud` block in your configuration file.
 

--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -117,6 +117,8 @@ Terraform Cloud responds to API calls at both its current hostname
 
 ### Environment Variable Credentials
 
+-> **Note:** Environment variable credentials are supported in Terraform v1.2.0 and later.
+
 If you would prefer not to store your API tokens directly in the CLI configuration, you may use
 a host-specific environment variable. Environment variable names should have the prefix
 `TF_TOKEN_` added to the domain name, with periods encoded as underscores. For example, the

--- a/website/docs/cli/config/environment-variables.mdx
+++ b/website/docs/cli/config/environment-variables.mdx
@@ -160,3 +160,9 @@ export TF_IGNORE=trace
 ```
 
 For more details on `.terraformignore`, please see [Excluding Files from Upload with .terraformignore](/language/settings/backends/remote#excluding-files-from-upload-with-terraformignore).
+
+## Terraform Cloud CLI Integration
+
+The CLI integration with Terraform Cloud lets you use Terraform Cloud and Terraform Enterprise on the command line. The integration requires including a `cloud` block in your Terraform configuration. You can define its arguments directly in your configuration file or supply them through environment variables, which can be useful for non-interactive workflows like Continuous Integration (CI).
+
+Refer to [Terraform Cloud Settings](/cli/cloud/settings#environment-variables) for a full list of `cloud` block environment variables.

--- a/website/docs/language/expressions/custom-conditions.mdx
+++ b/website/docs/language/expressions/custom-conditions.mdx
@@ -6,6 +6,8 @@ description: >-
 
 # Custom Condition Checks
 
+-> **Note:** Custom condition checks are supported in Terraform v1.2 and later.
+
 You can create conditions that produce custom error messages for several types of objects in a configuration. For example, you can add a condition to an input variable that checks whether incoming image IDs are formatted properly. Custom conditions can capture assumptions, helping future maintainers understand the configuration design and intent. They also return useful information about errors earlier and in context, helping consumers more easily diagnose issues in their configurations.
 
 > **Hands On:** Try the [Validate Modules with Custom Conditions](https://learn.hashicorp.com/tutorials/terraform/custom-conditions?in=terraform/configuration-language) tutorial on HashiCorp Learn.


### PR DESCRIPTION
We forgot to add version notes for the CLI updates in v1.2. Specifically, we need to add a versioning note for `cloud` block environment variables and for environment variable credentials. 

This PR also fixes a few typos and adds a section to the CLI environment variables page that contains information about the new `cloud` block environment variables and points back to the Cloud Settings page (with those environment variables on it) for more information.