### PR TITLE
Use plan graph builder for destroy

### DIFF
--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -923,7 +923,7 @@ variable "in" {
   type = map(string)
   default = {
     "a" = "first"
-	"b" = "second"
+    "b" = "second"
   }
 }
 

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -574,7 +574,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 		}).Build(addrs.RootModuleInstance)
 		return graph, walkPlan, diags
 	case plans.DestroyMode:
-		graph, diags := (&DestroyPlanGraphBuilder{
+		graph, diags := DestroyPlanGraphBuilder(&PlanGraphBuilder{
 			Config:             config,
 			State:              prevRunState,
 			RootVariableValues: opts.SetVariables,

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -136,10 +136,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&ForcedCBDTransformer{},
 
 		// Destruction ordering
-		&DestroyEdgeTransformer{
-			Config: b.Config,
-			State:  b.State,
-		},
+		&DestroyEdgeTransformer{},
 		&CBDEdgeTransformer{
 			Config: b.Config,
 			State:  b.State,

--- a/internal/terraform/graph_builder_destroy_plan.go
+++ b/internal/terraform/graph_builder_destroy_plan.go
@@ -1,115 +1,17 @@
 package terraform
 
 import (
-	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
-	"github.com/hashicorp/terraform/internal/states"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// DestroyPlanGraphBuilder implements GraphBuilder and is responsible for
-// planning a pure-destroy.
-//
-// Planning a pure destroy operation is simple because we can ignore most
-// ordering configuration and simply reverse the state. This graph mainly
-// exists for targeting, because we need to walk the destroy dependencies to
-// ensure we plan the required resources. Without the requirement for
-// targeting, the plan could theoretically be created directly from the state.
-type DestroyPlanGraphBuilder struct {
-	// Config is the configuration tree to build the plan from.
-	Config *configs.Config
-
-	// State is the current state
-	State *states.State
-
-	// RootVariableValues are the raw input values for root input variables
-	// given by the caller, which we'll resolve into final values as part
-	// of the plan walk.
-	RootVariableValues InputValues
-
-	// Plugins is a library of plug-in components (providers and
-	// provisioners) available for use.
-	Plugins *contextPlugins
-
-	// Targets are resources to target
-	Targets []addrs.Targetable
-
-	// If set, skipRefresh will cause us stop skip refreshing any existing
-	// resource instances as part of our planning. This will cause us to fail
-	// to detect if an object has already been deleted outside of Terraform.
-	skipRefresh bool
-}
-
-// See GraphBuilder
-func (b *DestroyPlanGraphBuilder) Build(path addrs.ModuleInstance) (*Graph, tfdiags.Diagnostics) {
-	return (&BasicGraphBuilder{
-		Steps: b.Steps(),
-		Name:  "DestroyPlanGraphBuilder",
-	}).Build(path)
-}
-
-// See GraphBuilder
-func (b *DestroyPlanGraphBuilder) Steps() []GraphTransformer {
-	concreteResourceInstance := func(a *NodeAbstractResourceInstance) dag.Vertex {
+func DestroyPlanGraphBuilder(p *PlanGraphBuilder) GraphBuilder {
+	p.ConcreteResourceInstance = func(a *NodeAbstractResourceInstance) dag.Vertex {
 		return &NodePlanDestroyableResourceInstance{
 			NodeAbstractResourceInstance: a,
-			skipRefresh:                  b.skipRefresh,
+			skipRefresh:                  p.skipRefresh,
 		}
 	}
-	concreteResourceInstanceDeposed := func(a *NodeAbstractResourceInstance, key states.DeposedKey) dag.Vertex {
-		return &NodePlanDeposedResourceInstanceObject{
-			NodeAbstractResourceInstance: a,
-			DeposedKey:                   key,
-			skipRefresh:                  b.skipRefresh,
-		}
-	}
+	p.destroy = true
 
-	concreteProvider := func(a *NodeAbstractProvider) dag.Vertex {
-		return &NodeApplyableProvider{
-			NodeAbstractProvider: a,
-		}
-	}
-
-	steps := []GraphTransformer{
-		// Creates nodes for the resource instances tracked in the state.
-		&StateTransformer{
-			ConcreteCurrent: concreteResourceInstance,
-			ConcreteDeposed: concreteResourceInstanceDeposed,
-			State:           b.State,
-		},
-
-		// Create the delete changes for root module outputs.
-		&OutputTransformer{
-			Config:  b.Config,
-			Destroy: true,
-		},
-
-		// Attach the state
-		&AttachStateTransformer{State: b.State},
-
-		// Attach the configuration to any resources
-		&AttachResourceConfigTransformer{Config: b.Config},
-
-		transformProviders(concreteProvider, b.Config),
-
-		// Destruction ordering. We require this only so that
-		// targeting below will prune the correct things.
-		&DestroyEdgeTransformer{
-			Config: b.Config,
-			State:  b.State,
-		},
-
-		&TargetsTransformer{Targets: b.Targets},
-
-		// Close opened plugin connections
-		&CloseProviderTransformer{},
-
-		// Close the root module
-		&CloseRootModuleTransformer{},
-
-		&TransitiveReductionTransformer{},
-	}
-
-	return steps
+	return p
 }

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -82,9 +82,9 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 	steps := []GraphTransformer{
 		// Creates all the resources represented in the config
 		&ConfigTransformer{
-			Concrete:    b.ConcreteResource,
-			Config:      b.Config,
-			destroyPlan: b.destroy,
+			Concrete: b.ConcreteResource,
+			Config:   b.Config,
+			skip:     b.destroy,
 		},
 
 		// Add dynamic values
@@ -92,17 +92,17 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&ModuleVariableTransformer{Config: b.Config},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
-			Config:      b.Config,
-			RefreshOnly: b.skipPlanChanges,
-			destroyPlan: b.destroy,
+			Config:            b.Config,
+			RefreshOnly:       b.skipPlanChanges,
+			removeRootOutputs: b.destroy,
 		},
 
 		// Add orphan resources
 		&OrphanResourceInstanceTransformer{
-			Concrete:    b.ConcreteResourceOrphan,
-			State:       b.State,
-			Config:      b.Config,
-			destroyPlan: b.destroy,
+			Concrete: b.ConcreteResourceOrphan,
+			State:    b.State,
+			Config:   b.Config,
+			skip:     b.destroy,
 		},
 
 		// We also need nodes for any deposed instance objects present in the

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -29,18 +29,17 @@ type ConfigTransformer struct {
 	ModeFilter bool
 	Mode       addrs.ResourceMode
 
-	// destroyPlan indicated this is being called from a destroy plan.
-	destroyPlan bool
+	// Do not apply this transformer.
+	skip bool
 }
 
 func (t *ConfigTransformer) Transform(g *Graph) error {
-	// If no configuration is available, we don't do anything
-	if t.Config == nil {
+	if t.skip {
 		return nil
 	}
 
-	// Configured resource are not added for a destroy plan
-	if t.destroyPlan {
+	// If no configuration is available, we don't do anything
+	if t.Config == nil {
 		return nil
 	}
 

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -28,11 +28,19 @@ type ConfigTransformer struct {
 	// Mode will only add resources that match the given mode
 	ModeFilter bool
 	Mode       addrs.ResourceMode
+
+	// destroyPlan indicated this is being called from a destroy plan.
+	destroyPlan bool
 }
 
 func (t *ConfigTransformer) Transform(g *Graph) error {
 	// If no configuration is available, we don't do anything
 	if t.Config == nil {
+		return nil
+	}
+
+	// Configured resource are not added for a destroy plan
+	if t.destroyPlan {
 		return nil
 	}
 

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -4,7 +4,6 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-
 	"github.com/hashicorp/terraform/internal/dag"
 )
 

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -4,9 +4,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/states"
 
-	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
 )
 
@@ -40,12 +38,7 @@ type GraphNodeCreator interface {
 // dependent resources will block parent resources from deleting. Concrete
 // example: VPC with subnets, the VPC can't be deleted while there are
 // still subnets.
-type DestroyEdgeTransformer struct {
-	// These are needed to properly build the graph of dependencies
-	// to determine what a destroy node depends on. Any of these can be nil.
-	Config *configs.Config
-	State  *states.State
-}
+type DestroyEdgeTransformer struct{}
 
 func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 	// Build a map of what is being destroyed (by address string) to
@@ -89,7 +82,7 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 		return nil
 	}
 
-	// Connect destroy despendencies as stored in the state
+	// Connect destroy dependencies as stored in the state
 	for _, ds := range destroyers {
 		for _, des := range ds {
 			ri, ok := des.(GraphNodeResourceInstance)

--- a/internal/terraform/transform_destroy_edge_test.go
+++ b/internal/terraform/transform_destroy_edge_test.go
@@ -37,9 +37,7 @@ func TestDestroyEdgeTransformer_basic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tf := &DestroyEdgeTransformer{
-		Config: testModule(t, "transform-destroy-edge-basic"),
-	}
+	tf := &DestroyEdgeTransformer{}
 	if err := tf.Transform(&g); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -93,9 +91,7 @@ func TestDestroyEdgeTransformer_multi(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tf := &DestroyEdgeTransformer{
-		Config: testModule(t, "transform-destroy-edge-multi"),
-	}
+	tf := &DestroyEdgeTransformer{}
 	if err := tf.Transform(&g); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -110,9 +106,7 @@ func TestDestroyEdgeTransformer_multi(t *testing.T) {
 func TestDestroyEdgeTransformer_selfRef(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	g.Add(testDestroyNode("test_object.A"))
-	tf := &DestroyEdgeTransformer{
-		Config: testModule(t, "transform-destroy-edge-self-ref"),
-	}
+	tf := &DestroyEdgeTransformer{}
 	if err := tf.Transform(&g); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -153,9 +147,7 @@ func TestDestroyEdgeTransformer_module(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tf := &DestroyEdgeTransformer{
-		Config: testModule(t, "transform-destroy-edge-module"),
-	}
+	tf := &DestroyEdgeTransformer{}
 	if err := tf.Transform(&g); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -214,9 +206,7 @@ func TestDestroyEdgeTransformer_moduleOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tf := &DestroyEdgeTransformer{
-		Config: testModule(t, "transform-destroy-edge-module-only"),
-	}
+	tf := &DestroyEdgeTransformer{}
 	if err := tf.Transform(&g); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -284,16 +274,7 @@ func TestDestroyEdgeTransformer_destroyThenUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := testModuleInline(t, map[string]string{
-		"main.tf": `
-resource "test_instance" "a" {
-	test_string = "udpated"
-}
-`,
-	})
-	tf := &DestroyEdgeTransformer{
-		Config: m,
-	}
+	tf := &DestroyEdgeTransformer{}
 	if err := tf.Transform(&g); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/internal/terraform/transform_orphan_resource.go
+++ b/internal/terraform/transform_orphan_resource.go
@@ -26,9 +26,17 @@ type OrphanResourceInstanceTransformer struct {
 	// Config is the root node in the configuration tree. We'll look up
 	// the appropriate note in this tree using the path in each node.
 	Config *configs.Config
+
+	// There are no orphans when doing a full destroy
+	destroyPlan bool
 }
 
 func (t *OrphanResourceInstanceTransformer) Transform(g *Graph) error {
+	if t.destroyPlan {
+		// everything is being destroyed, so don't worry about orphaned instances
+		return nil
+	}
+
 	if t.State == nil {
 		// If the entire state is nil, there can't be any orphans
 		return nil

--- a/internal/terraform/transform_orphan_resource.go
+++ b/internal/terraform/transform_orphan_resource.go
@@ -27,13 +27,12 @@ type OrphanResourceInstanceTransformer struct {
 	// the appropriate note in this tree using the path in each node.
 	Config *configs.Config
 
-	// There are no orphans when doing a full destroy
-	destroyPlan bool
+	// Do not apply this transformer
+	skip bool
 }
 
 func (t *OrphanResourceInstanceTransformer) Transform(g *Graph) error {
-	if t.destroyPlan {
-		// everything is being destroyed, so don't worry about orphaned instances
+	if t.skip {
 		return nil
 	}
 

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -21,7 +21,7 @@ type OutputTransformer struct {
 
 	// If this is a planned destroy, root outputs are still in the configuration
 	// so we need to record that we wish to remove them
-	destroyPlan bool
+	removeRootOutputs bool
 
 	// Refresh-only mode means that any failing output preconditions are
 	// reported as warnings rather than errors
@@ -66,7 +66,7 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			}
 		}
 
-		destroy := t.destroyPlan
+		destroy := t.removeRootOutputs
 		if rootChange != nil {
 			destroy = rootChange.Action == plans.Delete
 		}
@@ -95,7 +95,7 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 				Addr:        addr,
 				Module:      c.Path,
 				Config:      o,
-				Destroy:     t.destroyPlan,
+				Destroy:     t.removeRootOutputs,
 				RefreshOnly: t.RefreshOnly,
 			}
 		}

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -21,7 +21,7 @@ type OutputTransformer struct {
 
 	// If this is a planned destroy, root outputs are still in the configuration
 	// so we need to record that we wish to remove them
-	Destroy bool
+	destroyPlan bool
 
 	// Refresh-only mode means that any failing output preconditions are
 	// reported as warnings rather than errors
@@ -66,7 +66,7 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			}
 		}
 
-		destroy := t.Destroy
+		destroy := t.destroyPlan
 		if rootChange != nil {
 			destroy = rootChange.Action == plans.Delete
 		}
@@ -95,7 +95,7 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 				Addr:        addr,
 				Module:      c.Path,
 				Config:      o,
-				Destroy:     t.Destroy,
+				Destroy:     t.destroyPlan,
 				RefreshOnly: t.RefreshOnly,
 			}
 		}

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -114,6 +114,7 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 			// use their own state.
 			continue
 		}
+
 		parents := m.References(v)
 		parentsDbg := make([]string, len(parents))
 		for i, v := range parents {
@@ -124,6 +125,14 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 			dag.VertexName(v), parentsDbg)
 
 		for _, parent := range parents {
+			// A destroy plan relies solely on the state, so we only need to
+			// ensure that temporary values are connected to get the evaluation
+			// order correct. Any references to destroy nodes will cause
+			// cycles, because they are connected in reverse order.
+			if _, ok := parent.(GraphNodeDestroyer); ok {
+				continue
+			}
+
 			if !graphNodesAreResourceInstancesInDifferentInstancesOfSameModule(v, parent) {
 				g.Connect(dag.BasicEdge(v, parent))
 			} else {


### PR DESCRIPTION
This PR aims to allow the same components used in `PlanGraphBuilder` to create the full destroy plan, and eliminate the special case of the `DestroyPlanGraph`.

The destroy plan was originally envisioned to be completely "offline", where we could generate a simple `Delete` action for every resource in the state. It turns out that this is not possible, since in order to read each resource from the state, we must call `UpgradeResourceState` to ensure the schema matches the encoded state, requiring interaction with the provider aside from fetching the schema. Provider developers have also expressed the desire to be able to plan or validate destroy actions, which would also require providers to be correctly configured. 

Because the simplistic `DestroyPlanGraphBuilder` was only intended to create `Delete` actions, it was not sufficient to ensure we had all the data required to configure a provider before calling `UpgradeResourceState`. The complete plan graph is where all the setup to properly evaluate the entire config is already done, and since a destroy plan is still a form of planning, we can extend the existing `PlanGraphBuilder` to accommodate a complete destroy operation rather than duplicating all the logic in the `DestroyPlanGraphBuilder`. A secondary reason for extending the `PlanGraphBuilder` (rather than duplicating the logic) is that the destroy graph is often forgotten when changing how plans work, which has led to numerous bugs we can avoid with a single plan codepath.

This does not yet fix the un-configured `UpgradeResourceState` calls reported in #30460, but does lay the foundation for being able to make that call. This also provides the necessary infrastructure to be able to address #30140, since that also requires a fully configured provider.

Aside from the above mentioned issues, another possibility from this point is to combine the separate refresh step into the destroy plan, removing the special case where we need 2 individual plans to complete a destroy operation. That was purposely left out of consideration for this PR to prevent it from growing too large, and it's not yet clear whether there are any blockers to that being possible.