### PR TITLE
add XTerraformGetLimit to prevent redirect loops

### DIFF
--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -94,8 +94,9 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 	// generality of go-getter but it's still handy to use the HTTP getter
 	// as an easy way to download over HTTP into a file on disk.
 	httpGetter := getter.HttpGetter{
-		Client: httpclient.New(),
-		Netrc:  true,
+		Client:             httpclient.New(),
+		Netrc:              true,
+		XTerraformGetLimit: 10,
 	}
 
 	// The following logic is similar to that used by the provider installer

--- a/internal/getmodules/getter.go
+++ b/internal/getmodules/getter.go
@@ -83,8 +83,9 @@ var goGetterGetters = map[string]getter.Getter{
 var getterHTTPClient = cleanhttp.DefaultClient()
 
 var getterHTTPGetter = &getter.HttpGetter{
-	Client: getterHTTPClient,
-	Netrc:  true,
+	Client:             getterHTTPClient,
+	Netrc:              true,
+	XTerraformGetLimit: 10,
 }
 
 // A reusingGetter is a helper for the module installer that remembers


### PR DESCRIPTION
A number of new [security options](https://github.com/hashicorp/go-getter#security-options) were added to the recent update of `go-getter`. The most important option for the Terraform CLI is going to be `XTerraformGetLimit` to prevent possible endless redirect loops.

Set a default limit of 10 redirects that can be forced via the `XTerraformGetLimit` header.