### PR TITLE
Fix custom conditions example

### DIFF
--- a/website/docs/language/expressions/custom-conditions.mdx
+++ b/website/docs/language/expressions/custom-conditions.mdx
@@ -312,12 +312,12 @@ data "aws_vpc" "example" {
 }
 
 resource "aws_internet_gateway" "example" {
-  for_each = aws_vpc.example
+  for_each = data.aws_vpc.example
   vpc_id = each.value.id
 
   lifecycle {
     precondition {
-      condition     = aws_vpc.example[each.key].state == "available"
+      condition     = data.aws_vpc.example[each.key].state == "available"
       error_message = "VPC ${each.key} must be available."
     }
   }


### PR DESCRIPTION
Original code block erroneously references `aws_vpc.example` but appears to actually mean `data.aws_vpc.example`.