### PR TITLE
Configure providers during a destroy plan

### DIFF
--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -1042,11 +1042,38 @@ output "out" {
 	state, diags := ctx.Apply(plan, m)
 	assertNoErrors(t, diags)
 
-	// TODO: extend this to ensure the otherProvider is always properly
-	// configured during the destroy plan
+	otherProvider.ConfigureProviderCalled = false
+	otherProvider.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
+		// check that our config is complete, even during a destroy plan
+		expected := cty.ObjectVal(map[string]cty.Value{
+			"local":  cty.ListVal([]cty.Value{cty.StringVal("first-ok"), cty.StringVal("second-ok")}),
+			"output": cty.ListVal([]cty.Value{cty.StringVal("first-ok"), cty.StringVal("second-ok")}),
+			"var": cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("first"),
+				"b": cty.StringVal("second"),
+			}),
+		})
+
+		if !req.Config.RawEquals(expected) {
+			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf(
+				`incorrect provider config:
+expected: %#v
+got:      %#v`,
+				expected, req.Config))
+		}
+
+		return resp
+	}
 
 	opts.Mode = plans.DestroyMode
+	// skip refresh so that we don't configure the provider before the destroy plan
+	opts.SkipRefresh = true
+
 	// destroy only a single instance not included in the moved statements
 	_, diags = ctx.Plan(m, state, opts)
 	assertNoErrors(t, diags)
+
+	if !otherProvider.ConfigureProviderCalled {
+		t.Fatal("failed to configure provider during destroy plan")
+	}
 }

--- a/internal/terraform/node_provider.go
+++ b/internal/terraform/node_provider.go
@@ -37,10 +37,7 @@ func (n *NodeApplyableProvider) Execute(ctx EvalContext, op walkOperation) (diag
 	case walkValidate:
 		log.Printf("[TRACE] NodeApplyableProvider: validating configuration for %s", n.Addr)
 		return diags.Append(n.ValidateProvider(ctx, provider))
-	case walkPlan, walkApply, walkDestroy:
-		// walkPlanDestroy is purposely skipped here, since the config is not
-		// evaluated, and the provider is not needed to create delete actions
-		// for all instances.
+	case walkPlan, walkPlanDestroy, walkApply, walkDestroy:
 		log.Printf("[TRACE] NodeApplyableProvider: configuring %s", n.Addr)
 		return diags.Append(n.ConfigureProvider(ctx, provider, false))
 	case walkImport:

--- a/internal/terraform/node_resource_abstract_test.go
+++ b/internal/terraform/node_resource_abstract_test.go
@@ -121,6 +121,9 @@ func TestNodeAbstractResource_ReadResourceInstanceState(t *testing.T) {
 			},
 		},
 	})
+	// This test does not configure the provider, but the mock provider will
+	// check that this was called and report errors.
+	mockProvider.ConfigureProviderCalled = true
 
 	tests := map[string]struct {
 		State              *states.State
@@ -158,6 +161,7 @@ func TestNodeAbstractResource_ReadResourceInstanceState(t *testing.T) {
 			ctx.StateState = test.State.SyncWrapper()
 			ctx.PathPath = addrs.RootModuleInstance
 			ctx.ProviderSchemaSchema = mockProvider.ProviderSchema()
+
 			ctx.ProviderProvider = providers.Interface(mockProvider)
 
 			got, readDiags := test.Node.readResourceInstanceState(ctx, test.Node.Addr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance))
@@ -183,6 +187,9 @@ func TestNodeAbstractResource_ReadResourceInstanceStateDeposed(t *testing.T) {
 			},
 		},
 	})
+	// This test does not configure the provider, but the mock provider will
+	// check that this was called and report errors.
+	mockProvider.ConfigureProviderCalled = true
 
 	tests := map[string]struct {
 		State              *states.State

--- a/internal/terraform/provider_mock.go
+++ b/internal/terraform/provider_mock.go
@@ -218,6 +218,11 @@ func (p *MockProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequ
 	p.Lock()
 	defer p.Unlock()
 
+	if !p.ConfigureProviderCalled {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("Configure not called before UpgradeResourceState %q", r.TypeName))
+		return resp
+	}
+
 	schema, ok := p.getProviderSchema().ResourceTypes[r.TypeName]
 	if !ok {
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no schema found for %q", r.TypeName))


### PR DESCRIPTION
In order to correctly call `UpgradeResourceState` during a destroy plan, the provider provider must be configured. Now that the destroy plan can completely evaluate the provider configuration, enable the call to `ConfigureProvider` during that plan.

Fixes #30460