### PR TITLE
Add guidance about using the format function

### DIFF
--- a/website/docs/language/expressions/custom-conditions.mdx
+++ b/website/docs/language/expressions/custom-conditions.mdx
@@ -341,7 +341,7 @@ The selected AMI must be tagged with the Component value "nomad-server".
 ```
 
 The `error_message` argument can be any expression that evaluates to a string.
-This includes literal strings, heredocs, and template expressions. Multi-line
+This includes literal strings, heredocs, and template expressions. You can use the [`format` function](/language/functions/format) to convert `null` and items from a `list` or `map` into a formatted string. Multi-line
 error messages are supported, and lines with leading whitespace will not be
 word wrapped.
 

--- a/website/docs/language/expressions/custom-conditions.mdx
+++ b/website/docs/language/expressions/custom-conditions.mdx
@@ -341,7 +341,7 @@ The selected AMI must be tagged with the Component value "nomad-server".
 ```
 
 The `error_message` argument can be any expression that evaluates to a string.
-This includes literal strings, heredocs, and template expressions. You can use the [`format` function](/language/functions/format) to convert `null` and items from a `list` or `map` into a formatted string. Multi-line
+This includes literal strings, heredocs, and template expressions. You can use the [`format` function](/language/functions/format) to convert items of `null`, `list`, or `map` types into a formatted string. Multi-line
 error messages are supported, and lines with leading whitespace will not be
 word wrapped.
 


### PR DESCRIPTION
Clarify for users how they can use the `format` function to translate `null` values and items from `list` and `map` into a formatted string. This lets them include these values in the error messages :) 

Closes https://github.com/hashicorp/terraform/issues/31165