### PR TITLE
Validate duplicate provider local names in `required_providers`

### DIFF
--- a/internal/configs/config_test.go
+++ b/internal/configs/config_test.go
@@ -158,6 +158,12 @@ func TestConfigProviderRequirements(t *testing.T) {
 	}
 }
 
+func TestConfigProviderRequirementsDuplicate(t *testing.T) {
+	_, diags := testNestedModuleConfigFromDir(t, "testdata/duplicate-local-name")
+	assertDiagnosticCount(t, diags, 2)
+	assertDiagnosticSummary(t, diags, "Duplicate required provider")
+}
+
 func TestConfigProviderRequirementsShallow(t *testing.T) {
 	cfg, diags := testNestedModuleConfigFromDir(t, "testdata/provider-reqs")
 	// TODO: Version Constraint Deprecation.

--- a/internal/configs/config_test.go
+++ b/internal/configs/config_test.go
@@ -160,7 +160,7 @@ func TestConfigProviderRequirements(t *testing.T) {
 
 func TestConfigProviderRequirementsDuplicate(t *testing.T) {
 	_, diags := testNestedModuleConfigFromDir(t, "testdata/duplicate-local-name")
-	assertDiagnosticCount(t, diags, 2)
+	assertDiagnosticCount(t, diags, 3)
 	assertDiagnosticSummary(t, diags, "Duplicate required provider")
 }
 

--- a/internal/configs/testdata/duplicate-local-name/main.tf
+++ b/internal/configs/testdata/duplicate-local-name/main.tf
@@ -9,8 +9,15 @@ terraform {
     other = {
       source = "hashicorp/default"
     }
+
+    wrong-name = {
+      source = "hashicorp/foo"
+    }
   }
 }
 
 provider "default" {
+}
+
+resource "foo_resource" {
 }

--- a/internal/configs/testdata/duplicate-local-name/main.tf
+++ b/internal/configs/testdata/duplicate-local-name/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+    dupe = {
+      source = "hashicorp/test"
+    }
+    other = {
+      source = "hashicorp/default"
+    }
+  }
+}
+
+provider "default" {
+}

--- a/internal/terraform/transform_provider.go
+++ b/internal/terraform/transform_provider.go
@@ -543,6 +543,13 @@ func (t *ProviderConfigTransformer) transformSingle(g *Graph, c *configs.Config)
 				Module:   path,
 			}
 
+			if _, ok := t.providers[addr.String()]; ok {
+				// The config validation warns about this too, but we can't
+				// completely prevent it in v1.
+				log.Printf("[WARN] ProviderConfigTransformer: duplicate required_providers entry for %s", addr)
+				continue
+			}
+
 			abstract := &NodeAbstractProvider{
 				Addr: addr,
 			}
@@ -566,6 +573,13 @@ func (t *ProviderConfigTransformer) transformSingle(g *Graph, c *configs.Config)
 			Provider: fqn,
 			Alias:    p.Alias,
 			Module:   path,
+		}
+
+		if _, ok := t.providers[addr.String()]; ok {
+			// The abstract provider node may already have been added from the
+			// provider requirements.
+			log.Printf("[WARN] ProviderConfigTransformer: provider node %s already added", addr)
+			continue
 		}
 
 		abstract := &NodeAbstractProvider{


### PR DESCRIPTION
Adding multiple local names for the same provider type in `required_providers` was not prevented, which can lead to ambiguous behavior in Terraform. Providers are always located via the provider's fully qualified name (even using the full name as a map key in many places), so duplicate local names cannot be differentiated. This can lead terraform to non-deterministically configure the incorrect provider in some cases.

Because it is currently possible that a configuration with providers which themselves do not need explicit configuration may have been working with duplicates, we cannot turn these into errors. Adding multiple entries for the same provider now results in a warning like so:

```
│ Warning: Duplicate required provider
...
│
│ Provider hashicorp/null with the local name "dupe" was previously required as "null". A provider
│ can only be required once within required_providers.
```

We can also check for the situation where a user required a provider by a name different from the default, but attempted to configure that provider via the default local name. This can help prevent the case where a provider configuration may apparently not always be taking effect within a module. The warning here is worded slightly differently:

```
│ Warning: Duplicate required provider
...
│
│ Provider hashicorp/null with the local name "dupe" was implicitly required via a configuration
│ block as "null". Make sure the provider configuration block name matches the name used in
│ required_providers.
```

fixes #31196