### PR TITLE
Fix a wrong usage of sudo in debian install doc

### DIFF
--- a/website/docs/cli/install/apt.mdx
+++ b/website/docs/cli/install/apt.mdx
@@ -39,7 +39,7 @@ After registering the key, you can add the official HashiCorp repository to
 your system:
 
 ```bash
-sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/terraform-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/terraform.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/terraform-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/terraform.list
 ```
 
 The above command line uses the following sub-shell commands:


### PR DESCRIPTION
Currently `sudo` is applied to `echo` resulting in:
`/etc/apt/sources.list.d/terraform.list: Permission denied`

Using `echo "..." | sudo tee /etc/apt/sources.list.d/terraform.list` fix the problem