### PR TITLE
json-output: Fix unknowns for tuples and sets

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -566,8 +566,9 @@ func omitUnknowns(val cty.Value) cty.Value {
 			newVal := omitUnknowns(v)
 			if newVal != cty.NilVal {
 				vals = append(vals, newVal)
-			} else if newVal == cty.NilVal && ty.IsListType() {
-				// list length may be significant, so we will turn unknowns into nulls
+			} else if newVal == cty.NilVal {
+				// element order is how we correlate unknownness, so we must
+				// replace unknowns with nulls
 				vals = append(vals, cty.NullVal(v.Type()))
 			}
 		}

--- a/internal/command/jsonplan/plan_test.go
+++ b/internal/command/jsonplan/plan_test.go
@@ -66,6 +66,18 @@ func TestOmitUnknowns(t *testing.T) {
 			}),
 		},
 		{
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("alpha"),
+				cty.UnknownVal(cty.String),
+				cty.StringVal("charlie"),
+			}),
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("alpha"),
+				cty.NullVal(cty.String),
+				cty.StringVal("charlie"),
+			}),
+		},
+		{
 			cty.SetVal([]cty.Value{
 				cty.StringVal("dev"),
 				cty.StringVal("foo"),
@@ -76,6 +88,7 @@ func TestOmitUnknowns(t *testing.T) {
 				cty.StringVal("dev"),
 				cty.StringVal("foo"),
 				cty.StringVal("stg"),
+				cty.NullVal(cty.String),
 			}),
 		},
 		{


### PR DESCRIPTION
The JSON output for sequences previously omitted unknown values for tuples and sets, which made it impossible to interpret the corresponding unknown marks. For example, consider this resource:

```hcl
resource "example_resource" "example" {
  tags = toset(["alpha", timestamp(), "charlie"])
}
```

This would previously be encoded in JSON as:

```json
"after": {
    "tags": ["alpha", "charlie"]
},
"after_unknown": {
    "id": true,
    "tags": [false, true, false]
},
```

That is, the timestamp value would be omitted from the output altogether, while the corresponding unknown marks would include a value for each of the set members.

This commit changes the behaviour to:

```json
"after": {
    "tags": ["alpha", null, "charlie"]
},
"after_unknown": {
    "id": true,
    "tags": [false, true, false]
},
```

This aligns tuples and sets with the prior behaviour for lists, and makes it clear which elements are known and which are unknown.

I consider this a bug fix, as the prior output was not usable, and I believe this behaviour is correct.