### PR TITLE
Add internals to the sidebar

### DIFF
--- a/website/data/cli-nav-data.json
+++ b/website/data/cli-nav-data.json
@@ -429,59 +429,6 @@
     ]
   },
   {
-    "title": "Internals",
-    "routes": [
-      {
-        "title": "Overview",
-        "href": "/internals"
-      },
-      {
-        "title": "Credentials Helpers",
-        "href": "/internals/credentials-helpers"
-      },
-      {
-        "title": "Debugging Terraform",
-        "href": "/internals/debugging"
-      },
-      {
-        "title": "Module Registry Protocol",
-        "href": "/internals/module-registry-protocol"
-      },
-      {
-        "title": "Provider Network Mirror Protocol",
-        "href": "/internals/provider-network-mirror-protocol"
-      },
-      {
-        "title": "Provider Registry Protocol",
-        "href": "/internals/provider-registry-protocol"
-      },
-      {
-        "title": "Resource Graph",
-        "href": "/internals/graph"
-      },
-      {
-        "title": "Resource Lifecycle",
-        "href": "/internals/lifecycle"
-      },
-      {
-        "title": "Login Protocol",
-        "href": "/internals/login-protocol"
-      },
-      {
-        "title": "JSON Output Format",
-        "href": "/internals/json-format"
-      },
-      {
-        "title": "Remote Service Discovery",
-        "href": "/internals/remote-service-discovery"
-      },
-      {
-        "title": "Provider Metadata",
-        "href": "/internals/provider-meta"
-      }
-    ]
-  },
-  {
     "title": "Installation",
     "hidden": true,
     "routes": [
@@ -494,5 +441,8 @@
         "path": "install/yum"
       }
     ]
-  }
+  },
+  { "divider": true },
+  { "title": "Terraform Internals", "href": "/internals" },
+  { "divider": true }
 ]

--- a/website/data/internals-nav-data.json
+++ b/website/data/internals-nav-data.json
@@ -1,4 +1,5 @@
 [
+  { "heading": "Terraform Internals" },
   {
     "title": "Credentials Helpers",
     "path": "credentials-helpers"
@@ -52,5 +53,10 @@
     "title": "Archiving",
     "path": "archiving",
     "hidden": true
-  }
+  },
+  { "divider": true },
+  { "title": "Terraform CLI", "href": "/cli" },
+  { "divider": true },
+  { "title": "Configuration Language", "href": "/language" },
+  { "divider": true }
 ]

--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -1214,5 +1214,8 @@
         "path": "configuration-0-11/environment-variables"
       }
     ]
-  }
+  },
+  { "divider": true },
+  { "title": "Terraform Internals", "href": "/internals" },
+  { "divider": true }
 ]


### PR DESCRIPTION
Previously, the "Internals" section of our docs took you to a page that did not have a standard sidebar. This is a disorienting experience for users. It is also disorienting because currently, the Internals section appears to be a part of the CLI sidebar, but when users actually click a page, they are suddenly taken to a new sidebar.

This PR adds a header to the Internals sidebar to make it feel more standard and also provides links to and from the CLI and Language documentation so users can navigate back and forth. It uses a convention that we have leveraged in the Terraform Cloud Agents documentation to signify to users that they are about to be taken to a new sidebar. 

**Links in TFC Docs:** 
<img width="1041" alt="Screen Shot 2022-06-13 at 5 36 12 PM" src="https://user-images.githubusercontent.com/83350965/173449462-6f1172f1-322f-47fc-9cc4-dfffaeb69376.png">

## Before
<img width="1182" alt="Screen Shot 2022-06-13 at 5 34 53 PM" src="https://user-images.githubusercontent.com/83350965/173449305-3c15cf62-4440-48e3-9769-a9fe6473463c.png">

<img width="1304" alt="Screen Shot 2022-06-13 at 5 35 08 PM" src="https://user-images.githubusercontent.com/83350965/173449330-893da826-d80c-4243-9a16-4157e79303ca.png">


## After

<img width="1354" alt="Screen Shot 2022-06-13 at 5 37 03 PM" src="https://user-images.githubusercontent.com/83350965/173449579-44cd7836-c5fd-40d7-9677-2a4bc9050fa5.png">

<img width="1388" alt="Screen Shot 2022-06-13 at 5 37 23 PM" src="https://user-images.githubusercontent.com/83350965/173449619-d02fec4f-24c0-4050-b6dd-992a8a0584e6.png">

