### PR TITLE
copy dependency values when sorting

### DIFF
--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -38,6 +38,9 @@ type nodeExpandPlannableResource struct {
 
 	// We attach dependencies to the Resource during refresh, since the
 	// instances are instantiated during DynamicExpand.
+	// FIXME: These would be better off converted to a generic Set data
+	// structure in the future, as we need to compare for equality and take the
+	// union of multiple groups of dependencies.
 	dependencies []addrs.ConfigResource
 }
 

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -391,6 +391,14 @@ func depsEqual(a, b []addrs.ConfigResource) bool {
 		return false
 	}
 
+	// Because we need to sort the deps to compare equality, make shallow
+	// copies to prevent concurrently modifying the array values on
+	// dependencies shared between expanded instances.
+	copyA, copyB := make([]addrs.ConfigResource, len(a)), make([]addrs.ConfigResource, len(b))
+	copy(copyA, a)
+	copy(copyB, b)
+	a, b = copyA, copyB
+
 	less := func(s []addrs.ConfigResource) func(i, j int) bool {
 		return func(i, j int) bool {
 			return s[i].String() < s[j].String()


### PR DESCRIPTION
Expanded resource instances can initially share the same dependency
slice, so we must take care to not modify the array values when
checking the dependencies.

In the future we can convert these to a generic Set data type, as we
often need to compare for equality and take the union of multiple groups
of dependencies.

Fixes #31243