### PR TITLE
Fix for issue 15264 - Disable colors if output is redirected or piped

### DIFF
--- a/internal/command/arguments/view.go
+++ b/internal/command/arguments/view.go
@@ -1,5 +1,7 @@
 package arguments
 
+import "os"
+
 // View represents the global command-line arguments which configure the view.
 type View struct {
 	// NoColor is used to disable the use of terminal color codes in all
@@ -17,6 +19,12 @@ type View struct {
 // found, they will be removed from the slice.
 func ParseView(args []string) (*View, []string) {
 	common := &View{}
+
+	// Disable colors if output is redirected or piped.
+	o, _ := os.Stdout.Stat()
+	if (o.Mode() & os.ModeCharDevice) != os.ModeCharDevice {
+		common.NoColor = true
+	}
 
 	// Keep track of the length of the returned slice. When we find an
 	// argument we support, i will not be incremented.


### PR DESCRIPTION
Hello,

This patch fixes issue https://github.com/hashicorp/terraform/issues/15264. I.e. colors are automatically disabled if output is redirected or piped.

Screenshot of Terraform v1.2.2 (above) and Terraform with patch applied (below):
<img width="682" alt="Terraform" src="https://user-images.githubusercontent.com/595501/174060168-10056ebc-1c19-4d0c-883e-9dbf8516d35d.png">

Ended up with this solution after reading: https://rderik.com/blog/identify-if-output-goes-to-the-terminal-or-is-being-redirected-in-golang/

Disclaimer: I have zero prior experience with the Terraform code base so someone else better verify that this is done in the right place and so on.

Best regards,
Göran Gustafsson
