### PR TITLE
states/remote: Check for LockError error type

### DIFF
--- a/internal/states/remote/testing.go
+++ b/internal/states/remote/testing.go
@@ -77,6 +77,9 @@ func TestRemoteLocks(t *testing.T, a, b Client) {
 		lockerA.Unlock(lockIDA)
 		t.Fatal("client B obtained lock while held by client A")
 	}
+	if _, ok := err.(*statemgr.LockError); !ok {
+		t.Errorf("expected a LockError, but was %t: %s", err, err)
+	}
 
 	if err := lockerA.Unlock(lockIDA); err != nil {
 		t.Fatal("error unlocking client A", err)


### PR DESCRIPTION
When attempting to lock a remote state backend, failure due to an existing lock should return an instance of `LockError`. This allows the wrapping code to retry until the specified timeout, instead of immediately exiting.

This commit adds a test for this in the `TestRemoteLocks` test helper, which is used in many of the remote state backend test suites.

This would have caught the bug fixed by #31256, for example, and the http backend tests fail without the commit in that PR.