### PR TITLE
Additional note on usage of single quotes for for_each resources

### DIFF
--- a/website/docs/cli/commands/state/show.mdx
+++ b/website/docs/cli/commands/state/show.mdx
@@ -68,7 +68,7 @@ $ terraform state show 'packet_device.worker[0]'
 
 ## Example: Show a Resource configured with for_each
 
-The following example shows the `"example"` instance of a packet_device resource named worker configured with [`for_each`](/language/meta-arguments/for_each). You must place the resource name in single quotes when it contains special characters (e.g., double quotes).
+The following example shows the `"example"` instance of a `packet_device` resource named `worker` configured with the [`for_each`](/language/meta-arguments/for_each) meta-argument. You must place the resource name in single quotes when it contains special characters like double quotes.
 
 Linux, Mac OS, and UNIX:
 

--- a/website/docs/cli/commands/state/show.mdx
+++ b/website/docs/cli/commands/state/show.mdx
@@ -68,8 +68,7 @@ $ terraform state show 'packet_device.worker[0]'
 
 ## Example: Show a Resource configured with for_each
 
-The example below shows the `"example"` instance of a `packet_device` resource named `worker` configured with
-[`for_each`](/language/meta-arguments/for_each). Please note that single quotes ``` surrounding a resource name are required when referencing a resource that contains special characters, such as double quotes, in its identifier:
+The following example shows the "example" instance of a packet_device resource named worker configured with for_each. You must place the resource name in single quotes when it contains special characters (e.g., double quotes).:
 
 Linux, Mac OS, and UNIX:
 

--- a/website/docs/cli/commands/state/show.mdx
+++ b/website/docs/cli/commands/state/show.mdx
@@ -69,7 +69,7 @@ $ terraform state show 'packet_device.worker[0]'
 ## Example: Show a Resource configured with for_each
 
 The example below shows the `"example"` instance of a `packet_device` resource named `worker` configured with
-[`for_each`](/language/meta-arguments/for_each):
+[`for_each`](/language/meta-arguments/for_each). Please note that single quotes ``` surrounding a resource name are required when referencing a resource that contains special characters, such as double quotes, in its identifier:
 
 Linux, Mac OS, and UNIX:
 

--- a/website/docs/cli/commands/state/show.mdx
+++ b/website/docs/cli/commands/state/show.mdx
@@ -68,7 +68,7 @@ $ terraform state show 'packet_device.worker[0]'
 
 ## Example: Show a Resource configured with for_each
 
-The following example shows the "example" instance of a packet_device resource named worker configured with for_each. You must place the resource name in single quotes when it contains special characters (e.g., double quotes).:
+The following example shows the `"example"` instance of a packet_device resource named worker configured with [`for_each`](/language/meta-arguments/for_each). You must place the resource name in single quotes when it contains special characters (e.g., double quotes).
 
 Linux, Mac OS, and UNIX:
 


### PR DESCRIPTION
The `terraform state show` command doesn't normally need quotes around the resource name to return information. But when querying resources that have been created by the use of `for_each` - which creates resource identifiers such as ` module.thing[\"item\"]` - the command fails to find the the resource. The documentation does show the use of single quotes but this can be easily missed when reading the documentation. 

I would be nice to have this highlighted a bit more as this is very subtle and can be missed when you are used to the command working without wrapping single quotes. 

Also, I haven't found a way to show these resources with the `terraform console` yet either.