### PR TITLE
Add assume role with web identity support for the S3 backend

### DIFF
--- a/internal/backend/remote-state/s3/validate.go
+++ b/internal/backend/remote-state/s3/validate.go
@@ -318,7 +318,8 @@ func validateAttributesConflict(paths ...cty.Path) objectValidator {
 					"Invalid Path for Schema",
 					"The S3 Backend unexpectedly provided a path that does not match the schema. "+
 						"Please report this to the developers.\n\n"+
-						"Path: "+pathString(path),
+						"Path: "+pathString(path)+"\n\n"+
+						"Error:"+err.Error(),
 					objPath,
 				))
 				continue
@@ -329,17 +330,67 @@ func validateAttributesConflict(paths ...cty.Path) objectValidator {
 					for i, path := range paths {
 						pathStrs[i] = pathString(path)
 					}
-					*diags = diags.Append(attributeErrDiag(
-						"Invalid Attribute Combination",
-						fmt.Sprintf(`Only one of %s can be set.`, strings.Join(pathStrs, ", ")),
-						objPath,
-					))
+					*diags = diags.Append(invalidAttributeCombinationDiag(objPath, paths))
 				} else {
 					found = true
 				}
 			}
 		}
 	}
+}
+
+func validateExactlyOneOfAttributes(paths ...cty.Path) objectValidator {
+	return func(obj cty.Value, objPath cty.Path, diags *tfdiags.Diagnostics) {
+		var localDiags tfdiags.Diagnostics
+		found := make(map[string]cty.Path, len(paths))
+		for _, path := range paths {
+			val, err := path.Apply(obj)
+			if err != nil {
+				localDiags = localDiags.Append(attributeErrDiag(
+					"Invalid Path for Schema",
+					"The S3 Backend unexpectedly provided a path that does not match the schema. "+
+						"Please report this to the developers.\n\n"+
+						"Path: "+pathString(path)+"\n\n"+
+						"Error:"+err.Error(),
+					objPath,
+				))
+				continue
+			}
+			if !val.IsNull() {
+				found[pathString(path)] = path
+			}
+		}
+		*diags = diags.Append(localDiags)
+
+		if len(found) > 1 {
+			*diags = diags.Append(invalidAttributeCombinationDiag(objPath, paths))
+			return
+		}
+
+		if len(found) == 0 && !localDiags.HasErrors() {
+			pathStrs := make([]string, len(paths))
+			for i, path := range paths {
+				pathStrs[i] = pathString(path)
+			}
+			*diags = diags.Append(attributeErrDiag(
+				"Missing Required Value",
+				fmt.Sprintf(`Exactly one of %s must be set.`, strings.Join(pathStrs, ", ")),
+				objPath,
+			))
+		}
+	}
+}
+
+func invalidAttributeCombinationDiag(objPath cty.Path, paths []cty.Path) tfdiags.Diagnostic {
+	pathStrs := make([]string, len(paths))
+	for i, path := range paths {
+		pathStrs[i] = pathString(path)
+	}
+	return attributeErrDiag(
+		"Invalid Attribute Combination",
+		fmt.Sprintf(`Only one of %s can be set.`, strings.Join(pathStrs, ", ")),
+		objPath,
+	)
 }
 
 func attributeErrDiag(summary, detail string, attrPath cty.Path) tfdiags.Diagnostic {

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -206,6 +206,54 @@ The following arguments on the top level are deprecated:
 * `session_name` - (Optional) Session name to use when assuming the role.
   Use `assume_role.session_name` instead.
 
+```terraform
+terraform {
+  backend "s3" {
+    bucket = "terraform-state-prod"
+    key    = "network/terraform.tfstate"
+    region = "us-east-1"
+    assume_role {
+      role_arn = "arn:aws:iam::PRODUCTION-ACCOUNT-ID:role/Terraform"
+    }
+  }
+}
+```
+
+#### Assume Role With Web Identity Configuration
+
+The following `assume_role_with_web_identity` configuration block is optional:
+
+* `role_arn` - (Required) Amazon Resource Name (ARN) of the IAM Role to assume.
+  Can also be set with the `AWS_ROLE_ARN` environment variable.
+* `duration` - (Optional) The duration individual credentials will be valid.
+  Credentials are automatically renewed up to the maximum defined by the AWS account.
+  Specified using the format `<hours>h<minutes>m<seconds>s` with any unit being optional.
+  For example, an hour and a half can be specified as `1h30m` or `90m`. 
+  Must be between 15 minutes (15m) and 12 hours (12h).
+* `policy` - (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+* `policy_arns` - (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+* `session_name` - (Optional) Session name to use when assuming the role.
+  Can also be set with the `AWS_ROLE_SESSION_NAME` environment variable.
+* `web_identity_token` - (Optional) The value of a web identity token from an OpenID Connect (OIDC) or OAuth provider.
+  One of `web_identity_token` or `web_identity_token_file` is required.
+* `web_identity_token_file` - (Optional) File containing a web identity token from an OpenID Connect (OIDC) or OAuth provider.
+  One of `web_identity_token_file` or `web_identity_token` is required.
+  Can also be set with the `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable.
+
+```terraform
+terraform {
+  backend "s3" {
+    bucket = "terraform-state-prod"
+    key    = "network/terraform.tfstate"
+    region = "us-east-1"
+    assume_role_with_web_identity {
+      role_arn           = "arn:aws:iam::PRODUCTION-ACCOUNT-ID:role/Terraform"
+      web_identity_token = "<token value>"
+    }
+  }
+}
+```
+
 ### S3 State Storage
 
 The following configuration is required:


### PR DESCRIPTION
This pull request implements the feature requested in https://github.com/hashicorp/terraform/issues/31244.

# Summary
Currently the [S3 Backend](https://www.terraform.io/language/settings/backends/s3) does not support assuming a role with web identity. As we already support assuming a different role as part of the S3 backend this seems like a valid request.

Next to that I think that it's also right to have feature parity with the [Terraform AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#assume_role_with_web_identity-configuration-block) as they added the OpenID Connect (OIDC) support too recently.

OIDC allows GitHub Actions and other CI/CD pipelines to access resources in Amazon Web Services (AWS), without needing to store the AWS credentials as long-lived GitHub secrets. Security wise this seems like a huge win for those that assume a different role for the S3 backend.

# A little heads-up

There seems to be no support yet for `AssumeRoleWithWebIdentity` in the [awsbase go package](https://pkg.go.dev/github.com/hashicorp/aws-sdk-go-base@v0.7.1) we're using. As support for AssumeRoleWithWebIdentity through awsbase is only added to the  [awsbase/v2](https://pkg.go.dev/github.com/hashicorp/aws-sdk-go-base/v2) package. 

I've refactored a part of the S3 backend code to be compatible with the [awsbase/v2](https://pkg.go.dev/github.com/hashicorp/aws-sdk-go-base/v2) package.

Next to that, to separate the assume role and assume role through web identity configurations I've offloaded the existing attributes to 2 different configuration blocks. `assume_role` and `assume_role_with_web_identity`. For both a cleaner and simpler interface as well as to be inline with the existing configuration blocks coming from the [Terraform AWS provder](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#assume_role_with_web_identity-configuration-block).

For example the below existing Terraform configuration
```hcl
terraform {
  backend "s3" {
    region     = "us-west-2"
    bucket     = "example-bucket"
    key        = "example/state.tfstate"
    role_arn = "arn:aws:iam::837424938642:role/example-role"
    assume_role_duration_seconds = 600
  }
}
```

Becomes as following:
```hcl
terraform {
  backend "s3" {
    region     = "us-west-2"
    bucket     = "example-bucket"
    key        = "example/state.tfstate"
    
    assume_role {
      role_arn = "arn:aws:iam::837424938642:role/example-role"
      duration_seconds = 600
    }
  }
}
```

Similar to the new `assume_role` block, a `assume_role_with_web_identity` block has been added to support the feature request.

```hcl
terraform {
  backend "s3" {
    region     = "us-west-2"
    bucket     = "example-bucket"
    key        = "example/state.tfstate"
    
    assume_role_with_web_identity {
      role_arn = "arn:aws:iam::837424938642:role/example-role"
      web_identity_token_file = "/example/tokenfile"
      duration_seconds = 600
    }
  }
}
```

### (Optional) backwards compatible - if we want no breaking changes
 
This doesn't have to be a breaking change, even though existing assume role related attributes are moved to a nested attribute and renamed. We could make the change backwards compatible, the old attributes can still be provided and override the `assume_role` block and a deprecation warning is shown to the user.

# Implementation

Due to the S3 backend code being fairly outdated, I was forced to refactor a portion of the code to be compatible with the [awsbase/v2](https://pkg.go.dev/github.com/hashicorp/aws-sdk-go-base/v2). Which isn't a bad thing as this helped to stay inline with the Terraform AWS provider, most of the code was years old and up for a refactor nevertheless. 

I've created 2 new configuration blocks, `assume_role` and `assume_role_with_web_identity_provider`. I've also added a new parameter `duration` to the `assume_role` block to be inline with the `assume_role_with_web_identity_provider` block.

# To be done

Here some points that I'm still working on:

-  [awsbase/v2](https://pkg.go.dev/github.com/hashicorp/aws-sdk-go-base/v2) does not suppport `SkipMetadataApiCheck` as it's been replaced infavor of [new tri-state EC2MetadataServiceEnableState](https://github.com/hashicorp/aws-sdk-go-base/pull/240) -- I have to sort this out to avoid a breaking change... 
- Fix tests
- ~~Update [S3 backend](https://www.terraform.io/language/settings/backends/s3) documentation~~

(if we plan on having backwards compatible)
- Add support for backwards compatibility
- Deprecation warning if _old_ attributes are set

# Tests

To be added..

# Example usage

To be added..

```hcl
terraform {
  backend "s3" {
    key            = "25335/test.tfstate"
    bucket         = "tf-state-837424938642-eu-central-1"
    region         = "eu-central-1"
    encrypt        = true
    dynamodb_table = "tf-state-837424938642-eu-central-1"

    assume_role_with_web_identity {
      role_arn = "arn:aws:iam::837424938642:role/example-role"
      web_identity_token_file = "/example/tokenfile"
    }
  }
}
```