### PR TITLE
Performance: string builder speedup for Module.String()

### DIFF
--- a/internal/addrs/module.go
+++ b/internal/addrs/module.go
@@ -33,11 +33,21 @@ func (m Module) String() string {
 	if len(m) == 0 {
 		return ""
 	}
-	var steps []string
+	size := 0
 	for _, s := range m {
-		steps = append(steps, "module", s)
+		size += len(s)
 	}
-	return strings.Join(steps, ".")
+	var sb strings.Builder
+	// 8 is len("module.") + len(".")
+	sb.Grow(8*len(m) + size)
+	for i, s := range m {
+		sb.WriteString("module.")
+		sb.WriteString(s)
+		if i != len(m)-1 {
+			sb.WriteString(".")
+		}
+	}
+	return sb.String()
 }
 
 func (m Module) Equal(other Module) bool {

--- a/internal/addrs/module.go
+++ b/internal/addrs/module.go
@@ -33,21 +33,22 @@ func (m Module) String() string {
 	if len(m) == 0 {
 		return ""
 	}
-	size := 0
-	for _, s := range m {
-		size += len(s)
+	// Calculate necessary space.
+	l := 0
+	for _, step := range m {
+		l += len(step)
 	}
-	var sb strings.Builder
-	// 8 is len("module.") + len(".")
-	sb.Grow(8*len(m) + size)
-	for i, s := range m {
-		sb.WriteString("module.")
-		sb.WriteString(s)
-		if i != len(m)-1 {
-			sb.WriteString(".")
-		}
+	buf := strings.Builder{}
+	// 8 is len(".module.") which separates entries.
+	buf.Grow(l + len(m)*8)
+	sep := ""
+	for _, step := range m {
+		buf.WriteString(sep)
+		buf.WriteString("module.")
+		buf.WriteString(step)
+		sep = "."
 	}
-	return sb.String()
+	return buf.String()
 }
 
 func (m Module) Equal(other Module) bool {

--- a/internal/addrs/module_test.go
+++ b/internal/addrs/module_test.go
@@ -56,6 +56,31 @@ func TestModuleEqual_false(t *testing.T) {
 	}
 }
 
+func TestModuleString(t *testing.T) {
+	testCases := map[string]Module{
+		"": {},
+		"module.alpha": {
+			"alpha",
+		},
+		"module.alpha.module.beta": {
+			"alpha",
+			"beta",
+		},
+		"module.alpha.module.beta.module.charlie": {
+			"alpha",
+			"beta",
+			"charlie",
+		},
+	}
+	for str, module := range testCases {
+		t.Run(str, func(t *testing.T) {
+			if got, want := module.String(), str; got != want {
+				t.Errorf("wrong result: got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func BenchmarkModuleStringShort(b *testing.B) {
 	module := Module{"a", "b"}
 	for n := 0; n < b.N; n++ {

--- a/internal/addrs/module_test.go
+++ b/internal/addrs/module_test.go
@@ -55,3 +55,17 @@ func TestModuleEqual_false(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkModuleStringShort(b *testing.B) {
+	module := Module{"a", "b"}
+	for n := 0; n < b.N; n++ {
+		module.String()
+	}
+}
+
+func BenchmarkModuleStringLong(b *testing.B) {
+	module := Module{"southamerica-brazil-region", "user-regional-desktop", "user-name"}
+	for n := 0; n < b.N; n++ {
+		module.String()
+	}
+}


### PR DESCRIPTION
After the change:

```
terraform/internal/addrs$ go test -bench=Module . -benchmem
BenchmarkModuleStringShort-12           15489140                77.80 ns/op           24 B/op          1 allocs/op          
BenchmarkModuleStringLong-12            10807070               111.8 ns/op            80 B/op          1 allocs/op   
```

before the change:
```
BenchmarkModuleStringShort-12            3290968               384.2 ns/op           120 B/op          3 allocs/op          
BenchmarkModuleStringLong-12             1859038               668.4 ns/op           304 B/op          4 allocs/op  
```

About 5x speedup for time, and only single allocation.

Inspiration for this change is perf profiling on a particularly large config which points to memory churn:
```
  29.34%  terraform  terraform         [.] runtime.scanobject                                                               
  12.31%  terraform  terraform         [.] runtime.findObject                                                               
  11.94%  terraform  terraform         [.] runtime.greyobject                                                               
   8.35%  terraform  terraform         [.] runtime.heapBitsSetType                                                          
   7.25%  terraform  terraform         [.] runtime.mallocgc                                                                 
   5.10%  terraform  terraform         [.] strings.Join                                                                     
   3.12%  terraform  terraform         [.] runtime.memmove                                                                  
   3.02%  terraform  terraform         [.] runtime.gcDrain                                                                  
   2.85%  terraform  terraform         [.] google3/third_party/golang/hashicorp/terraform/addrs/addrs.Module.String         
   2.13%  terraform  terraform         [.] runtime.growslice                                                                
   1.65%  terraform  terraform         [.] google3/third_party/golang/hashicorp/terraform/terraform/terraform.(*nodeExpandMo
   1.02%  terraform  terraform         [.] runtime.sweepone                                                                 
   0.99%  terraform  terraform         [.] runtime.(*sweepLocked).sweep                                                     
   0.77%  terraform  terraform         [.] runtime.(*spanSet).pop                                                           
   0.68%  terraform  terraform         [.] runtime.memclrNoHeapPointers     
```