### PR TITLE
Clarify how the ~> version constraint operator works

### DIFF
--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -248,7 +248,8 @@ directory where you'd run `terraform apply` — should also specify the
 _maximum_ provider version it is intended to work with, to avoid accidental
 upgrades to incompatible new versions. The `~>` operator is a convenient
 shorthand for allowing the rightmost component of a version to increment. In
-the example below it permits patch releases within a specific minor release:
+the example below, the operator permits patch releases within a specific minor
+release:
 
 ```hcl
 terraform {

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -247,9 +247,7 @@ A module intended to be used as the root of a configuration — that is, as the
 directory where you'd run `terraform apply` — should also specify the
 _maximum_ provider version it is intended to work with, to avoid accidental
 upgrades to incompatible new versions. The `~>` operator is a convenient
-shorthand for allowing the rightmost component of a version to increment. In
-the example below, the operator will permit patch releases within a specific
-minor release:
+shorthand for allowing the rightmost component of a version to increment. The following example uses the operator to allow only patch releases within a specific minor release:
 
 ```hcl
 terraform {

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -247,7 +247,9 @@ A module intended to be used as the root of a configuration — that is, as the
 directory where you'd run `terraform apply` — should also specify the
 _maximum_ provider version it is intended to work with, to avoid accidental
 upgrades to incompatible new versions. The `~>` operator is a convenient
-shorthand for allowing the rightmost component of a version to increment. The following example uses the operator to allow only patch releases within a specific minor release:
+shorthand for allowing the rightmost component of a version to increment. The
+following example uses the operator to allow only patch releases within a 
+specific minor release:
 
 ```hcl
 terraform {

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -248,8 +248,8 @@ directory where you'd run `terraform apply` — should also specify the
 _maximum_ provider version it is intended to work with, to avoid accidental
 upgrades to incompatible new versions. The `~>` operator is a convenient
 shorthand for allowing the rightmost component of a version to increment. In
-the example below, the operator permits patch releases within a specific minor
-release:
+the example below, the operator will permit patch releases within a specific
+minor release:
 
 ```hcl
 terraform {

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -247,7 +247,8 @@ A module intended to be used as the root of a configuration — that is, as the
 directory where you'd run `terraform apply` — should also specify the
 _maximum_ provider version it is intended to work with, to avoid accidental
 upgrades to incompatible new versions. The `~>` operator is a convenient
-shorthand for allowing only patch releases within a specific minor release:
+shorthand for allowing the rightmost component of a version to increment. In
+the example below it permits patch releases within a specific minor release:
 
 ```hcl
 terraform {


### PR DESCRIPTION
The [Best Practices](https://www.terraform.io/language/providers/requirements#best-practices-for-provider-versions) section of the Provider Requirements page incorrectly describes how a provider version operator works. Specifically this sentence:

> The ~> operator is a convenient shorthand for allowing only patch releases within a specific minor release:

It suggests the operator is only concerned with the patch portion of a version, but that's not correct. According to the [Version Constraint docs](https://www.terraform.io/language/expressions/version-constraints) it:

> Allows only the rightmost version component to increment. For example, to allow new patch releases within a specific minor release, use the full version number: ~> 1.0.4 will allow installation of 1.0.5 and 1.0.10 but not 1.1.0. This is usually called the pessimistic constraint operator.

Asana ticket: https://app.asana.com/0/1128567758154570/1202400166737159/f