### PR TITLE
Some small improvements to diagnostic reporting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl/v2 v2.12.0
+	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
 	github.com/jmespath/go-jmespath v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
-github.com/hashicorp/hcl/v2 v2.12.0 h1:PsYxySWpMD4KPaoJLnsHwtK5Qptvj/4Q6s0t4sUxZf4=
-github.com/hashicorp/hcl/v2 v2.12.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
+github.com/hashicorp/hcl/v2 v2.13.0 h1:0Apadu1w6M11dyGFxWnmhhcMjkbAiKCv7G1r/2QgCNc=
+github.com/hashicorp/hcl/v2 v2.13.0/go.mod h1:e4z5nxYlWNPdDSNYX+ph14EvWYMFm3eP0zIUqPc2jr0=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d h1:9ARUJJ1VVynB176G1HCwleORqCaXm/Vx0uUi0dL26I0=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
@@ -682,7 +682,6 @@ github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
-github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=

--- a/internal/command/format/diagnostic.go
+++ b/internal/command/format/diagnostic.go
@@ -278,7 +278,7 @@ func appendSourceSnippets(buf *bytes.Buffer, diag *viewsjson.Diagnostic, color *
 			)
 		}
 
-		if len(snippet.Values) > 0 {
+		if len(snippet.Values) > 0 || (snippet.FunctionCall != nil && snippet.FunctionCall.Signature != nil) {
 			// The diagnostic may also have information about the dynamic
 			// values of relevant variables at the point of evaluation.
 			// This is particularly useful for expressions that get evaluated
@@ -291,6 +291,24 @@ func appendSourceSnippets(buf *bytes.Buffer, diag *viewsjson.Diagnostic, color *
 			})
 
 			fmt.Fprint(buf, color.Color("    [dark_gray]├────────────────[reset]\n"))
+			if callInfo := snippet.FunctionCall; callInfo != nil && callInfo.Signature != nil {
+
+				fmt.Fprintf(buf, color.Color("    [dark_gray]│[reset] while calling [bold]%s[reset]("), callInfo.CalledAs)
+				for i, param := range callInfo.Signature.Params {
+					if i > 0 {
+						buf.WriteString(", ")
+					}
+					buf.WriteString(param.Name)
+				}
+				if param := callInfo.Signature.VariadicParam; param != nil {
+					if len(callInfo.Signature.Params) > 0 {
+						buf.WriteString(", ")
+					}
+					buf.WriteString(param.Name)
+					buf.WriteString("...")
+				}
+				buf.WriteString(")\n")
+			}
 			for _, value := range values {
 				fmt.Fprintf(buf, color.Color("    [dark_gray]│[reset] [bold]%s[reset] %s\n"), value.Traversal, value.Statement)
 			}

--- a/internal/command/views/json/diagnostic.go
+++ b/internal/command/views/json/diagnostic.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcled"
 	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
@@ -95,6 +96,10 @@ type DiagnosticSnippet struct {
 	// Values is a sorted slice of expression values which may be useful in
 	// understanding the source of an error in a complex expression.
 	Values []DiagnosticExpressionValue `json:"values"`
+
+	// FunctionCall is information about a function call whose failure is
+	// being reported by this diagnostic, if any.
+	FunctionCall *DiagnosticFunctionCall `json:"function_call,omitempty"`
 }
 
 // DiagnosticExpressionValue represents an HCL traversal string (e.g.
@@ -105,6 +110,20 @@ type DiagnosticSnippet struct {
 type DiagnosticExpressionValue struct {
 	Traversal string `json:"traversal"`
 	Statement string `json:"statement"`
+}
+
+// DiagnosticFunctionCall represents a function call whose information is
+// being included as part of a diagnostic snippet.
+type DiagnosticFunctionCall struct {
+	// CalledAs is the full name that was used to call this function,
+	// potentially including namespace prefixes if the function does not belong
+	// to the default function namespace.
+	CalledAs string `json:"called_as"`
+
+	// Signature is a description of the signature of the function that was
+	// called, if any. Might be omitted if we're reporting that a call failed
+	// because the given function name isn't known, for example.
+	Signature *Function `json:"signature,omitempty"`
 }
 
 // NewDiagnostic takes a tfdiags.Diagnostic and a map of configuration sources,
@@ -294,7 +313,24 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 					return values[i].Traversal < values[j].Traversal
 				})
 				diagnostic.Snippet.Values = values
+
+				if callInfo := tfdiags.ExtraInfo[hclsyntax.FunctionCallDiagExtra](diag); callInfo != nil && callInfo.CalledFunctionName() != "" {
+					calledAs := callInfo.CalledFunctionName()
+					baseName := calledAs
+					if idx := strings.LastIndex(baseName, "::"); idx >= 0 {
+						baseName = baseName[idx+2:]
+					}
+					callInfo := &DiagnosticFunctionCall{
+						CalledAs: calledAs,
+					}
+					if f, ok := ctx.Functions[calledAs]; ok {
+						callInfo.Signature = DescribeFunction(baseName, f)
+					}
+					diagnostic.Snippet.FunctionCall = callInfo
+				}
+
 			}
+
 		}
 	}
 

--- a/internal/command/views/json/function.go
+++ b/internal/command/views/json/function.go
@@ -1,0 +1,112 @@
+package json
+
+import (
+	"encoding/json"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// Function is a description of the JSON representation of the signature of
+// a function callable from the Terraform language.
+type Function struct {
+	// Name is the leaf name of the function, without any namespace prefix.
+	Name string `json:"name"`
+
+	Params        []FunctionParam `json:"params"`
+	VariadicParam *FunctionParam  `json:"variadic_param,omitempty"`
+
+	// ReturnType is type constraint which is a static approximation of the
+	// possibly-dynamic return type of the function.
+	ReturnType json.RawMessage `json:"return_type"`
+
+	Description     string `json:"description,omitempty"`
+	DescriptionKind string `json:"description_kind,omitempty"`
+}
+
+// FunctionParam represents a single parameter to a function, as represented
+// by type Function.
+type FunctionParam struct {
+	// Name is a name for the function which is used primarily for
+	// documentation purposes, because function arguments are positional
+	// and therefore don't appear directly in configuration source code.
+	Name string `json:"name"`
+
+	// Type is a type constraint which is a static approximation of the
+	// possibly-dynamic type of the parameter. Particular functions may
+	// have additional requirements that a type constraint alone cannot
+	// represent.
+	Type json.RawMessage `json:"type"`
+
+	// Maybe some of the other fields in function.Parameter would be
+	// interesting to describe here too, but we'll wait to see if there
+	// is a use-case first.
+
+	Description     string `json:"description,omitempty"`
+	DescriptionKind string `json:"description_kind,omitempty"`
+}
+
+// DescribeFunction returns a description of the signature of the given cty
+// function, as a pointer to this package's serializable type Function.
+func DescribeFunction(name string, f function.Function) *Function {
+	ret := &Function{
+		Name: name,
+	}
+
+	params := f.Params()
+	ret.Params = make([]FunctionParam, len(params))
+	typeCheckArgs := make([]cty.Type, len(params), len(params)+1)
+	for i, param := range params {
+		ret.Params[i] = describeFunctionParam(&param)
+		typeCheckArgs[i] = param.Type
+	}
+	if varParam := f.VarParam(); varParam != nil {
+		descParam := describeFunctionParam(varParam)
+		ret.VariadicParam = &descParam
+		typeCheckArgs = append(typeCheckArgs, varParam.Type)
+	}
+
+	retType, err := f.ReturnType(typeCheckArgs)
+	if err != nil {
+		// Getting an error when type-checking with exactly the type constraints
+		// the function called for is weird, so we'll just treat it as if it
+		// has a dynamic return type instead, for our purposes here.
+		// One reason this can happen is for a function which has a variadic
+		// parameter but has logic inside it which considers it invalid to
+		// specify exactly one argument for that parameter (since that's what
+		// we did in typeCheckArgs as an approximation of a valid call above.)
+		retType = cty.DynamicPseudoType
+	}
+
+	if raw, err := retType.MarshalJSON(); err != nil {
+		// Again, we'll treat any errors as if the function is dynamically
+		// typed because it would be weird to get here.
+		ret.ReturnType = json.RawMessage(`"dynamic"`)
+	} else {
+		ret.ReturnType = json.RawMessage(raw)
+	}
+
+	// We don't currently have any sense of descriptions for functions and
+	// their parameters, so we'll just leave those fields unpopulated for now.
+
+	return ret
+}
+
+func describeFunctionParam(p *function.Parameter) FunctionParam {
+	ret := FunctionParam{
+		Name: p.Name,
+	}
+
+	if raw, err := p.Type.MarshalJSON(); err != nil {
+		// We'll treat any errors as if the function is dynamically
+		// typed because it would be weird to get here.
+		ret.Type = json.RawMessage(`"dynamic"`)
+	} else {
+		ret.Type = json.RawMessage(raw)
+	}
+
+	// We don't currently have any sense of descriptions for functions and
+	// their parameters, so we'll just leave those fields unpopulated for now.
+
+	return ret
+}

--- a/internal/command/views/json/function_test.go
+++ b/internal/command/views/json/function_test.go
@@ -1,0 +1,92 @@
+package json
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+func TestDescribeFunction(t *testing.T) {
+	// NOTE: This test case is referring to some real functions in other
+	// packages. and so if those functions change signature later it will
+	// probably make some cases here fail. If that is the cause of the failure,
+	// it's fine to update the test here to match rather than to revert the
+	// change to the function signature, as long as the change to the
+	// function signature is otherwise within the bounds of our compatibility
+	// promises.
+
+	tests := map[string]struct {
+		Function function.Function
+		Want     *Function
+	}{
+		"upper": {
+			Function: stdlib.UpperFunc,
+			Want: &Function{
+				Name: "upper",
+				Params: []FunctionParam{
+					{
+						Name: "str",
+						Type: json.RawMessage(`"string"`),
+					},
+				},
+				ReturnType: json.RawMessage(`"string"`),
+			},
+		},
+		"coalesce": {
+			Function: stdlib.CoalesceFunc,
+			Want: &Function{
+				Name:   "coalesce",
+				Params: []FunctionParam{},
+				VariadicParam: &FunctionParam{
+					Name: "vals",
+					Type: json.RawMessage(`"dynamic"`),
+				},
+				ReturnType: json.RawMessage(`"dynamic"`),
+			},
+		},
+		"join": {
+			Function: stdlib.JoinFunc,
+			Want: &Function{
+				Name: "join",
+				Params: []FunctionParam{
+					{
+						Name: "separator",
+						Type: json.RawMessage(`"string"`),
+					},
+				},
+				VariadicParam: &FunctionParam{
+					Name: "lists",
+					Type: json.RawMessage(`["list","string"]`),
+				},
+				ReturnType: json.RawMessage(`"string"`),
+			},
+		},
+		"jsonencode": {
+			Function: stdlib.JSONEncodeFunc,
+			Want: &Function{
+				Name: "jsonencode",
+				Params: []FunctionParam{
+					{
+						Name: "val",
+						Type: json.RawMessage(`"dynamic"`),
+					},
+				},
+				ReturnType: json.RawMessage(`"string"`),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := DescribeFunction(name, test.Function)
+			want := test.Want
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/command/views/json/testdata/diagnostic/error-with-source-code-subject-and-expression-referring-to-sensitive-value-when-not-caused-by-sensitive-values.json
+++ b/internal/command/views/json/testdata/diagnostic/error-with-source-code-subject-and-expression-referring-to-sensitive-value-when-not-caused-by-sensitive-values.json
@@ -1,0 +1,26 @@
+{
+  "severity": "error",
+  "summary": "Wrong noises",
+  "detail": "Biological sounds are not allowed",
+  "range": {
+    "filename": "test.tf",
+    "start": {
+      "line": 2,
+      "column": 9,
+      "byte": 42
+    },
+    "end": {
+      "line": 2,
+      "column": 26,
+      "byte": 59
+    }
+  },
+  "snippet": {
+    "context": "resource \"test_resource\" \"test\"",
+    "code": "  foo = var.boop[\"hello!\"]",
+    "start_line": 2,
+    "highlight_start_offset": 8,
+    "highlight_end_offset": 25,
+    "values": []
+  }
+}

--- a/internal/command/views/json/testdata/diagnostic/error-with-source-code-subject-and-unknown-expression-of-unknown-type-when-not-caused-by-unknown-values.json
+++ b/internal/command/views/json/testdata/diagnostic/error-with-source-code-subject-and-unknown-expression-of-unknown-type-when-not-caused-by-unknown-values.json
@@ -1,0 +1,26 @@
+{
+  "severity": "error",
+  "summary": "Wrong noises",
+  "detail": "Biological sounds are not allowed",
+  "range": {
+    "filename": "test.tf",
+    "start": {
+      "line": 2,
+      "column": 9,
+      "byte": 42
+    },
+    "end": {
+      "line": 2,
+      "column": 26,
+      "byte": 59
+    }
+  },
+  "snippet": {
+    "context": "resource \"test_resource\" \"test\"",
+    "code": "  foo = var.boop[\"hello!\"]",
+    "start_line": 2,
+    "highlight_start_offset": 8,
+    "highlight_end_offset": 25,
+    "values": []
+  }
+}

--- a/internal/earlyconfig/diagnostics.go
+++ b/internal/earlyconfig/diagnostics.go
@@ -76,3 +76,7 @@ func (d wrappedDiagnostic) Source() tfdiags.Source {
 func (d wrappedDiagnostic) FromExpr() *tfdiags.FromExpr {
 	return nil
 }
+
+func (d wrappedDiagnostic) ExtraInfo() interface{} {
+	return nil
+}

--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -3093,6 +3093,15 @@ func TestContext2Plan_forEachUnknownValue(t *testing.T) {
 	if !strings.Contains(gotErrStr, wantErrStr) {
 		t.Fatalf("missing expected error\ngot: %s\n\nwant: error containing %q", gotErrStr, wantErrStr)
 	}
+
+	// We should have a diagnostic that is marked as being caused by unknown
+	// values.
+	for _, diag := range diags {
+		if tfdiags.DiagnosticCausedByUnknown(diag) {
+			return // don't fall through to the error below
+		}
+	}
+	t.Fatalf("no diagnostic is marked as being caused by unknown\n%s", diags.Err().Error())
 }
 
 func TestContext2Plan_destroy(t *testing.T) {

--- a/internal/terraform/diagnostics.go
+++ b/internal/terraform/diagnostics.go
@@ -1,0 +1,42 @@
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// This file contains some package-local helpers for working with diagnostics.
+// For the main diagnostics API, see the separate "tfdiags" package.
+
+// diagnosticCausedByUnknown is an implementation of
+// tfdiags.DiagnosticExtraBecauseUnknown which we can use in the "Extra" field
+// of a diagnostic to indicate that the problem was caused by unknown values
+// being involved in an expression evaluation.
+//
+// When using this, set the Extra to diagnosticCausedByUnknown(true) and also
+// populate the EvalContext and Expression fields of the diagnostic so that
+// the diagnostic renderer can use all of that information together to assist
+// the user in understanding what was unknown.
+type diagnosticCausedByUnknown bool
+
+var _ tfdiags.DiagnosticExtraBecauseUnknown = diagnosticCausedByUnknown(true)
+
+func (e diagnosticCausedByUnknown) DiagnosticCausedByUnknown() bool {
+	return bool(e)
+}
+
+// diagnosticCausedBySensitive is an implementation of
+// tfdiags.DiagnosticExtraBecauseSensitive which we can use in the "Extra" field
+// of a diagnostic to indicate that the problem was caused by sensitive values
+// being involved in an expression evaluation.
+//
+// When using this, set the Extra to diagnosticCausedBySensitive(true) and also
+// populate the EvalContext and Expression fields of the diagnostic so that
+// the diagnostic renderer can use all of that information together to assist
+// the user in understanding what was sensitive.
+type diagnosticCausedBySensitive bool
+
+var _ tfdiags.DiagnosticExtraBecauseSensitive = diagnosticCausedBySensitive(true)
+
+func (e diagnosticCausedBySensitive) DiagnosticCausedBySensitive() bool {
+	return bool(e)
+}

--- a/internal/terraform/eval_count.go
+++ b/internal/terraform/eval_count.go
@@ -31,6 +31,12 @@ func evaluateCountExpression(expr hcl.Expression, ctx EvalContext) (int, tfdiags
 			Summary:  "Invalid count argument",
 			Detail:   `The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first apply only the resources that the count depends on.`,
 			Subject:  expr.Range().Ptr(),
+
+			// TODO: Also populate Expression and EvalContext in here, but
+			// we can't easily do that right now because the hcl.EvalContext
+			// (which is not the same as the ctx we have in scope here) is
+			// hidden away inside evaluateCountExpressionValue.
+			Extra: diagnosticCausedByUnknown(true),
 		})
 	}
 
@@ -91,7 +97,7 @@ func evaluateCountExpressionValue(expr hcl.Expression, ctx EvalContext) (cty.Val
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid count argument",
-			Detail:   `The given "count" argument value is unsuitable: negative numbers are not supported.`,
+			Detail:   `The given "count" argument value is unsuitable: must be greater than or equal to zero.`,
 			Subject:  expr.Range().Ptr(),
 		})
 		return nullCount, diags

--- a/internal/terraform/eval_for_each.go
+++ b/internal/terraform/eval_for_each.go
@@ -70,6 +70,7 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext, allowU
 			Subject:     expr.Range().Ptr(),
 			Expression:  expr,
 			EvalContext: hclCtx,
+			Extra:       diagnosticCausedBySensitive(true),
 		})
 	}
 
@@ -109,6 +110,7 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext, allowU
 				Subject:     expr.Range().Ptr(),
 				Expression:  expr,
 				EvalContext: hclCtx,
+				Extra:       diagnosticCausedByUnknown(true),
 			})
 		}
 		// ensure that we have a map, and not a DynamicValue
@@ -144,6 +146,7 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext, allowU
 					Subject:     expr.Range().Ptr(),
 					Expression:  expr,
 					EvalContext: hclCtx,
+					Extra:       diagnosticCausedByUnknown(true),
 				})
 			}
 			return cty.UnknownVal(ty), diags

--- a/internal/tfdiags/consolidate_warnings.go
+++ b/internal/tfdiags/consolidate_warnings.go
@@ -119,6 +119,10 @@ func (wg *warningGroup) FromExpr() *FromExpr {
 	return wg.Warnings[0].FromExpr()
 }
 
+func (wg *warningGroup) ExtraInfo() interface{} {
+	return wg.Warnings[0].ExtraInfo()
+}
+
 func (wg *warningGroup) Append(diag Diagnostic) {
 	if diag.Severity() != Warning {
 		panic("can't append a non-warning diagnostic to a warningGroup")

--- a/internal/tfdiags/diagnostic.go
+++ b/internal/tfdiags/diagnostic.go
@@ -15,6 +15,13 @@ type Diagnostic interface {
 	// available. Returns nil if the diagnostic is not related to an
 	// expression evaluation.
 	FromExpr() *FromExpr
+
+	// ExtraInfo returns the raw extra information value. This is a low-level
+	// API which requires some work on the part of the caller to properly
+	// access associated information, so in most cases it'll be more convienient
+	// to use the package-level ExtraInfo function to try to unpack a particular
+	// specialized interface from this value.
+	ExtraInfo() interface{}
 }
 
 type Severity rune

--- a/internal/tfdiags/diagnostic_base.go
+++ b/internal/tfdiags/diagnostic_base.go
@@ -31,3 +31,7 @@ func (d diagnosticBase) Source() Source {
 func (d diagnosticBase) FromExpr() *FromExpr {
 	return nil
 }
+
+func (d diagnosticBase) ExtraInfo() interface{} {
+	return nil
+}

--- a/internal/tfdiags/diagnostic_extra.go
+++ b/internal/tfdiags/diagnostic_extra.go
@@ -101,3 +101,71 @@ type DiagnosticExtraUnwrapper interface {
 	// value returns a value that was also wrapping it.
 	UnwrapDiagnosticExtra() interface{}
 }
+
+// DiagnosticExtraBecauseUnknown is an interface implemented by values in
+// the Extra field of Diagnostic when the diagnostic is potentially caused by
+// the presence of unknown values in an expression evaluation.
+//
+// Just implementing this interface is not sufficient signal, though. Callers
+// must also call the DiagnosticCausedByUnknown method in order to confirm
+// the result, or use the package-level function DiagnosticCausedByUnknown
+// as a convenient wrapper.
+type DiagnosticExtraBecauseUnknown interface {
+	// DiagnosticCausedByUnknown returns true if the associated diagnostic
+	// was caused by the presence of unknown values during an expression
+	// evaluation, or false otherwise.
+	//
+	// Callers might use this to tailor what contextual information they show
+	// alongside an error report in the UI, to avoid potential confusion
+	// caused by talking about the presence of unknown values if that was
+	// immaterial to the error.
+	DiagnosticCausedByUnknown() bool
+}
+
+// DiagnosticCausedByUnknown returns true if the given diagnostic has an
+// indication that it was caused by the presence of unknown values during
+// an expression evaluation.
+//
+// This is a wrapper around checking if the diagnostic's extra info implements
+// interface DiagnosticExtraBecauseUnknown and then calling its method if so.
+func DiagnosticCausedByUnknown(diag Diagnostic) bool {
+	maybe := ExtraInfo[DiagnosticExtraBecauseUnknown](diag)
+	if maybe == nil {
+		return false
+	}
+	return maybe.DiagnosticCausedByUnknown()
+}
+
+// DiagnosticExtraBecauseSensitive is an interface implemented by values in
+// the Extra field of Diagnostic when the diagnostic is potentially caused by
+// the presence of sensitive values in an expression evaluation.
+//
+// Just implementing this interface is not sufficient signal, though. Callers
+// must also call the DiagnosticCausedBySensitive method in order to confirm
+// the result, or use the package-level function DiagnosticCausedBySensitive
+// as a convenient wrapper.
+type DiagnosticExtraBecauseSensitive interface {
+	// DiagnosticCausedBySensitive returns true if the associated diagnostic
+	// was caused by the presence of sensitive values during an expression
+	// evaluation, or false otherwise.
+	//
+	// Callers might use this to tailor what contextual information they show
+	// alongside an error report in the UI, to avoid potential confusion
+	// caused by talking about the presence of sensitive values if that was
+	// immaterial to the error.
+	DiagnosticCausedBySensitive() bool
+}
+
+// DiagnosticCausedBySensitive returns true if the given diagnostic has an
+// indication that it was caused by the presence of sensitive values during
+// an expression evaluation.
+//
+// This is a wrapper around checking if the diagnostic's extra info implements
+// interface DiagnosticExtraBecauseSensitive and then calling its method if so.
+func DiagnosticCausedBySensitive(diag Diagnostic) bool {
+	maybe := ExtraInfo[DiagnosticExtraBecauseSensitive](diag)
+	if maybe == nil {
+		return false
+	}
+	return maybe.DiagnosticCausedBySensitive()
+}

--- a/internal/tfdiags/diagnostic_extra.go
+++ b/internal/tfdiags/diagnostic_extra.go
@@ -1,0 +1,103 @@
+package tfdiags
+
+// This "Extra" idea is something we've inherited from HCL's diagnostic model,
+// and so it's primarily to expose that functionality from wrapped HCL
+// diagnostics but other diagnostic types could potentially implement this
+// protocol too, if needed.
+
+// ExtraInfo tries to retrieve extra information of interface type T from
+// the given diagnostic.
+//
+// "Extra information" is situation-specific additional contextual data which
+// might allow for some special tailored reporting of particular
+// diagnostics in the UI. Conventionally the extra information is provided
+// as a hidden type that implements one or more interfaces which a caller
+// can pass as type parameter T to retrieve a value of that type when the
+// diagnostic has such an implementation.
+//
+// If the given diagnostic's extra value has an implementation of interface T
+// then ExtraInfo returns a non-nil interface value. If there is no such
+// implementation, ExtraInfo returns a nil T.
+//
+// Although the signature of this function does not constrain T to be an
+// interface type, our convention is to only use interface types to access
+// extra info in order to allow for alternative or wrapping implementations
+// of the interface.
+func ExtraInfo[T any](diag Diagnostic) T {
+	extra := diag.ExtraInfo()
+	if ret, ok := extra.(T); ok {
+		return ret
+	}
+
+	// If "extra" doesn't implement T directly then we'll delegate to
+	// our ExtraInfoNext helper to try iteratively unwrapping it.
+	return ExtraInfoNext[T](extra)
+}
+
+// ExtraInfoNext takes a value previously returned by ExtraInfo and attempts
+// to find an implementation of interface T wrapped inside of it. The return
+// value meaning is the same as for ExtraInfo.
+//
+// This is to help with the less common situation where a particular "extra"
+// value might be wrapping another value implementing the same interface,
+// and so callers can peel away one layer at a time until there are no more
+// nested layers.
+//
+// Because this function is intended for searching for _nested_ implementations
+// of T, ExtraInfoNext does not consider whether value "previous" directly
+// implements interface T, on the assumption that the previous call to ExtraInfo
+// with the same T caused "previous" to already be that result.
+func ExtraInfoNext[T any](previous interface{}) T {
+	// As long as T is an interface type as documented, zero will always be
+	// a nil interface value for us to return in the non-matching case.
+	var zero T
+
+	unwrapper, ok := previous.(DiagnosticExtraUnwrapper)
+	// If the given value isn't unwrappable then it can't possibly have
+	// any other info nested inside of it.
+	if !ok {
+		return zero
+	}
+
+	extra := unwrapper.UnwrapDiagnosticExtra()
+
+	// We'll keep unwrapping until we either find the interface we're
+	// looking for or we run out of layers of unwrapper.
+	for {
+		if ret, ok := extra.(T); ok {
+			return ret
+		}
+
+		if unwrapper, ok := extra.(DiagnosticExtraUnwrapper); ok {
+			extra = unwrapper.UnwrapDiagnosticExtra()
+		} else {
+			return zero
+		}
+	}
+}
+
+// DiagnosticExtraUnwrapper is an interface implemented by values in the
+// Extra field of Diagnostic when they are wrapping another "Extra" value that
+// was generated downstream.
+//
+// Diagnostic recipients which want to examine "Extra" values to sniff for
+// particular types of extra data can either type-assert this interface
+// directly and repeatedly unwrap until they recieve nil, or can use the
+// helper function DiagnosticExtra.
+//
+// This interface intentionally matches hcl.DiagnosticExtraUnwrapper, so that
+// wrapping extra values implemented using HCL's API will also work with the
+// tfdiags API, but that non-HCL uses of this will not need to implement HCL
+// just to get this interface.
+type DiagnosticExtraUnwrapper interface {
+	// If the reciever is wrapping another "diagnostic extra" value, returns
+	// that value. Otherwise returns nil to indicate dynamically that nothing
+	// is wrapped.
+	//
+	// The "nothing is wrapped" condition can be signalled either by this
+	// method returning nil or by a type not implementing this interface at all.
+	//
+	// Implementers should never create unwrap "cycles" where a nested extra
+	// value returns a value that was also wrapping it.
+	UnwrapDiagnosticExtra() interface{}
+}

--- a/internal/tfdiags/error.go
+++ b/internal/tfdiags/error.go
@@ -26,3 +26,8 @@ func (e nativeError) FromExpr() *FromExpr {
 	// Native errors are not expression-related
 	return nil
 }
+
+func (e nativeError) ExtraInfo() interface{} {
+	// Native errors don't carry any "extra information".
+	return nil
+}

--- a/internal/tfdiags/hcl.go
+++ b/internal/tfdiags/hcl.go
@@ -50,6 +50,10 @@ func (d hclDiagnostic) FromExpr() *FromExpr {
 	}
 }
 
+func (d hclDiagnostic) ExtraInfo() interface{} {
+	return d.diag.Extra
+}
+
 // SourceRangeFromHCL constructs a SourceRange from the corresponding range
 // type within the HCL package.
 func SourceRangeFromHCL(hclRange hcl.Range) SourceRange {

--- a/internal/tfdiags/rpc_friendly.go
+++ b/internal/tfdiags/rpc_friendly.go
@@ -54,6 +54,11 @@ func (d rpcFriendlyDiag) FromExpr() *FromExpr {
 	return nil
 }
 
+func (d rpcFriendlyDiag) ExtraInfo() interface{} {
+	// RPC-friendly diagnostics always discard any "extra information".
+	return nil
+}
+
 func init() {
 	gob.Register((*rpcFriendlyDiag)(nil))
 }

--- a/internal/tfdiags/simple_warning.go
+++ b/internal/tfdiags/simple_warning.go
@@ -28,3 +28,8 @@ func (e simpleWarning) FromExpr() *FromExpr {
 	// Simple warnings are not expression-related
 	return nil
 }
+
+func (e simpleWarning) ExtraInfo() interface{} {
+	// Simple warnings cannot carry extra information.
+	return nil
+}


### PR DESCRIPTION
This PR upgrades to a newer version of HCL which supports annotating diagnostics with "extra information", and then uses that new mechanism as the basis for two separate improvements to our diagnostic rendering.

# Function signatures for function call errors

HCL itself is now annotating diagnostics relating to problems calling a function with extra information to allow a renderer to determine which function is being called.

We can now use that information to add additional context to error messages about incorrect function calls, so that it's easier to see which of the positional parameters a particular name mentioned in an error message belongs to:

```
╷
│ Error: Invalid function argument
│ 
│   on invalid-func-call.tf line 2, in output "result":
│    2:   value = join(["foo"], "bar")
│     ├────────────────
│     │ while calling join(separator, lists...)
│ 
│ Invalid value for "separator" parameter: string required.
╵
╷
│ Error: Invalid function argument
│ 
│   on invalid-func-call.tf line 2, in output "result":
│    2:   value = join(["foo"], "bar")
│     ├────────────────
│     │ while calling join(separator, lists...)
│ 
│ Invalid value for "lists" parameter: list of string required.
╵
```

In the above example I made the classic mistake of getting the two `join` arguments mixed up, which causes one diagnostic for each argument but both of them include the additional statement "while calling join(separator, lists...)" so a reader can see which of the parameters is "separator" and which is "lists".

This particular change also adds a new property to the JSON representation of diagnostics in order to describe the function name and signature, so any external UIs built in terms of the JSON will need a corresponding change if they want to include the same information.

# Don't mention unknown values and sensitive values when they aren't relevant

I've repeatedly noticed people asking questions in a way that betrays that they thought that Terraform saying that a value would be "known only during apply" was Terraform describing a problem they needed to fix, rather than just describing which values were in scope during evaluation. That has come up less often for sensitive values, but a similar principle applies in both cases: mentioning possibly-unfamiliar concepts that are not relevant to the error message can cause a reasonable reader to assume that they are part of the problem Terraform is describing, and it can therefore be a "red herring" leading the user off in an unproductive direction when trying to understand the problem.

To address that, I've added an ability to explicitly mark a diagnostic as being related to unknown values or related to sensitive values. The diagnostic render will then avoid using the words "known only after apply" and avoid mentioning sensitive values at all unless the diagnostic has the corresponding annotation indicating that the additional information is likely to be relevant and helpful.

I don't have a handy example to show of this one since it's a _subtractive_ change rather than an additive one -- we'll now be showing slightly less information than we were before -- but essentially the idea is to prefer to not mention a value at all if there is no way to talk about it without mentioning that it is unknown or sensitive. As a compromise, there is a special case where if we have an unknown value of a known type we will still state the value's type:

```
Error: Contrived example

  on test.tf line 1:
   1: contrived example
    ├────────────────
    │ boop.beep is a string

This is indeed a contrived example.
```

In the above example, `boop.beep` was `cty.UnknownVal(cty.String)` and so we can at least mention that it's a string, even though we'll no longer include the subsequent ", known only after apply" that we would've included before this.

In this case the filtering is done at the JSON generation stage and so anyone consuming the JSON form of diagnostics will just see fewer elements in the array of values than before, and so any alternative UI based on the JSON output will automatically follow along and skip showing the distracting information.

