### PR TITLE
Consider credentias from env vars for S3 backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ BUG FIXES:
 
 * Made `terraform output` CLI help documentation consistent with web-based documentation. ([#29354](https://github.com/hashicorp/terraform/issues/29354))
 * `terraform show -json`: Fixed missing unknown markers in the encoding of partially unknown tuples and sets. [GH-31236]
+* Consider `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables in S3 backend.
 
 EXPERIMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ BUG FIXES:
 
 * Made `terraform output` CLI help documentation consistent with web-based documentation. ([#29354](https://github.com/hashicorp/terraform/issues/29354))
 * `terraform show -json`: Fixed missing unknown markers in the encoding of partially unknown tuples and sets. [GH-31236]
-* Consider `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables in S3 backend.
+* Consider `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` environment variables 
+  in S3 backend. ([#31300](https://github.com/hashicorp/terraform/pull/31300))
 
 EXPERIMENTS:
 

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -139,7 +139,7 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "MFA token",
-				Default:     "",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_SESSION_TOKEN", ""),
 			},
 
 			"skip_credentials_validation": {

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -97,14 +97,14 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "AWS access key",
-				Default:     "",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_ACCESS_KEY_ID", ""),
 			},
 
 			"secret_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "AWS secret key",
-				Default:     "",
+				DefaultFunc: schema.EnvDefaultFunc("AWS_SECRET_ACCESS_KEY", ""),
 			},
 
 			"kms_key_id": {


### PR DESCRIPTION
## Synopsis

Documentation for S3 backend states that [`access_key` and `secret_key` can be read from `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively](https://www.terraform.io/language/settings/backends/s3#access_key):   
<img width="662" alt="Screenshot 2022-06-22 at 21 17 18" src="https://user-images.githubusercontent.com/7114909/175118639-a62f4fef-0bef-4c8c-9d26-4ca0194bfc84.png">

But in fact, [it doesn't](https://github.com/hashicorp/terraform/blob/v1.2.3/internal/backend/remote-state/s3/backend.go#L96-L108), while `sse_customer_key`, for example, [does](https://github.com/hashicorp/terraform/blob/v1.2.3/internal/backend/remote-state/s3/backend.go#L170).


## Solution

Default to `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env vars for `access_key` and `secret_key` options.

Additionally, the same goes for [`token` option](https://www.terraform.io/language/settings/backends/s3#token).

