### PR TITLE
core: Potential optimization of ModuleExpansionTransformer

### DIFF
--- a/internal/addrs/module.go
+++ b/internal/addrs/module.go
@@ -165,3 +165,11 @@ func (m Module) Ancestors() []Module {
 func (m Module) configMoveableSigil() {
 	// ModuleInstance is moveable
 }
+
+func (m Module) UniqueKey() UniqueKey {
+	return moduleUniqueKey(m.String())
+}
+
+type moduleUniqueKey string
+
+func (k moduleUniqueKey) uniqueKeySigil() {}

--- a/internal/configs/configload/testing.go
+++ b/internal/configs/configload/testing.go
@@ -17,7 +17,7 @@ import (
 // In the case of any errors, t.Fatal (or similar) will be called to halt
 // execution of the test, so the calling test does not need to handle errors
 // itself.
-func NewLoaderForTests(t *testing.T) (*Loader, func()) {
+func NewLoaderForTests(t testing.TB) (*Loader, func()) {
 	t.Helper()
 
 	modulesDir, err := ioutil.TempDir("", "tf-configs")

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -42,13 +42,13 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func testModule(t *testing.T, name string) *configs.Config {
+func testModule(t testing.TB, name string) *configs.Config {
 	t.Helper()
 	c, _ := testModuleWithSnapshot(t, name)
 	return c
 }
 
-func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *configload.Snapshot) {
+func testModuleWithSnapshot(t testing.TB, name string) (*configs.Config, *configload.Snapshot) {
 	t.Helper()
 
 	dir := filepath.Join(fixtureDir, name)
@@ -85,7 +85,7 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 
 // testModuleInline takes a map of path -> config strings and yields a config
 // structure with those files loaded from disk
-func testModuleInline(t *testing.T, sources map[string]string) *configs.Config {
+func testModuleInline(t testing.TB, sources map[string]string) *configs.Config {
 	t.Helper()
 
 	cfgPath := t.TempDir()

--- a/internal/terraform/testdata/module-expansion-nesting/a/a/module-expansion-nesting-aa.tf
+++ b/internal/terraform/testdata/module-expansion-nesting/a/a/module-expansion-nesting-aa.tf
@@ -1,0 +1,2 @@
+
+resource "foo" "bar" {}

--- a/internal/terraform/testdata/module-expansion-nesting/a/b/module-expansion-nesting-ab.tf
+++ b/internal/terraform/testdata/module-expansion-nesting/a/b/module-expansion-nesting-ab.tf
@@ -1,0 +1,2 @@
+
+resource "foo" "bar" {}

--- a/internal/terraform/testdata/module-expansion-nesting/a/module-expansion-nesting-a.tf
+++ b/internal/terraform/testdata/module-expansion-nesting/a/module-expansion-nesting-a.tf
@@ -1,0 +1,12 @@
+
+module "a" {
+  count  = 1
+  source = "./a"
+}
+
+module "b" {
+  count  = 1
+  source = "./b"
+}
+
+resource "foo" "bar" {}

--- a/internal/terraform/testdata/module-expansion-nesting/b/a/module-expansion-nesting-ba.tf
+++ b/internal/terraform/testdata/module-expansion-nesting/b/a/module-expansion-nesting-ba.tf
@@ -1,0 +1,2 @@
+
+resource "foo" "bar" {}

--- a/internal/terraform/testdata/module-expansion-nesting/b/b/module-expansion-nesting-bb.tf
+++ b/internal/terraform/testdata/module-expansion-nesting/b/b/module-expansion-nesting-bb.tf
@@ -1,0 +1,2 @@
+
+resource "foo" "bar" {}

--- a/internal/terraform/testdata/module-expansion-nesting/b/module-expansion-nesting-b.tf
+++ b/internal/terraform/testdata/module-expansion-nesting/b/module-expansion-nesting-b.tf
@@ -1,0 +1,12 @@
+
+module "a" {
+  count  = 1
+  source = "./a"
+}
+
+module "b" {
+  count  = 1
+  source = "./b"
+}
+
+resource "foo" "bar" {}

--- a/internal/terraform/testdata/module-expansion-nesting/module-expansion-nesting.tf
+++ b/internal/terraform/testdata/module-expansion-nesting/module-expansion-nesting.tf
@@ -1,0 +1,24 @@
+
+# This configuration includes a bunch of module nesting in support of
+# benchmarking ModuleExpansionTransformer in BenchmarkModuleExpansionTransformer.
+#
+# The transformer recursively visits all modules in the tree, and so the shape
+# of this tree is intended to allow the benchmark to be sensitive to
+# differences between performance costs that:
+# - scale by total number of distinct modules, regardless of tree shape
+# - scale by the depth of nesting of the module tree
+# - are fixed, regardless of number of modules or tree shape
+
+module "a" {
+  count = 1
+
+  source = "./a"
+}
+
+module "b" {
+  count = 1
+
+  source = "./b"
+}
+
+resource "foo" "bar" {}

--- a/internal/terraform/transform_module_expansion_test.go
+++ b/internal/terraform/transform_module_expansion_test.go
@@ -1,0 +1,47 @@
+package terraform
+
+import (
+	"testing"
+)
+
+var benchmarkModuleExpansionTransformerGraph *Graph
+
+func BenchmarkModuleExpansionTransformer(b *testing.B) {
+	// We need to construct quite an elaborate set of inputs in order to
+	// make for a "realistic" run of the transformer that will generate
+	// useful benchmark results. In particular, we need to have a
+	// configuration with a relatively large number of non-root modules
+	// so that the benchmark can be sensitive to the difference between
+	// costs that scale per module or per level of nesting and costs
+	// that are fixed regardless of the configuration tree complexity.
+
+	cfg := testModule(b, "module-expansion-nesting")
+
+	for i := 0; i < b.N; i++ {
+		// We'll make sure that the graph "escapes" so that the Go compiler
+		// can't optimize it away with local optimizations.
+		benchmarkModuleExpansionTransformerGraph = func() *Graph {
+			graph := &Graph{}
+
+			// The module expansion transformer expects there to already be
+			// graph nodes representing objects within the modules in the graph,
+			// and so we'll borrow the ConfigTransformer to get an approximation
+			// of that.
+			cfgTransformer := &ConfigTransformer{
+				Config: cfg,
+			}
+			cfgTransformer.Transform(graph)
+
+			// Now we can run the module expansion transformer to add all of the
+			// expand/close nodes for the modules and the edges from the expand
+			// nodes to the resources inside.
+			modExpTransformer := &ModuleExpansionTransformer{
+				Config: cfg,
+			}
+			modExpTransformer.Transform(graph)
+
+			return graph
+		}()
+	}
+
+}


### PR DESCRIPTION
This aims to amortize the cost of unique-keying and comparing module addresses by doing a single up-front transform of all of them into `UniqueKey` values. This was motivated by noticing some potential low-hanging fruit in the report over in #30968.

Internally these `UniqueKey` values are really just string addresses and so comparing these boils down to just a string comparison in practice.

I only wrote this up to see if it would be possible to do it, and so I've not actually measured if it's any faster this way. I'll need to develop a realistic benchmark to measure this with first before we can decide if this is a productive optimization. This didn't fit so neatly into my remaining work day as I'd hoped and so I've run out of time for now but might poke at this some more later.

