### PR TITLE
Add shell explanation to remote-exec `inline` argument documentation.

### DIFF
--- a/website/docs/language/resources/provisioners/remote-exec.mdx
+++ b/website/docs/language/resources/provisioners/remote-exec.mdx
@@ -48,8 +48,10 @@ resource "aws_instance" "web" {
 
 The following arguments are supported:
 
-* `inline` - This is a list of command strings. They are executed in the order
-  they are provided. This cannot be provided with `script` or `scripts`.
+* `inline` - This is a list of command strings. Strings are collected in order as
+  a single `.sh` script which is executed on the remote host. A default shell `#!` 
+  is used unless a `#!` string is the first command, such as `#!/bin/bash`. 
+  This cannot be provided with `script` or `scripts`.
 
 * `script` - This is a path (relative or absolute) to a local script that will
   be copied to the remote resource and then executed. This cannot be provided


### PR DESCRIPTION
The current implementation does not use the default shell for
the ssh user to execute inline commands, which can be somewhat
confusing to debug. Provide explicit documentation to explain this,
and documentation can be removed if ssh user default shell is supported.

Required some time digging through terraform repo to see how shell
was being determined, currently it defaults to `/bin/sh`.