### PR TITLE
Bug fix: Terraform workspace command returns zero exit code when given an invalid argument.

### DIFF
--- a/internal/command/workspace_command.go
+++ b/internal/command/workspace_command.go
@@ -15,6 +15,12 @@ type WorkspaceCommand struct {
 }
 
 func (c *WorkspaceCommand) Run(args []string) int {
+	c.Meta.process(args)
+	envCommandShowWarning(c.Ui, c.LegacyName)
+
+	cmdFlags := c.Meta.extendedFlagSet("workspace")
+	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
+
 	return cli.RunResultHelp
 }
 

--- a/internal/command/workspace_command.go
+++ b/internal/command/workspace_command.go
@@ -15,14 +15,7 @@ type WorkspaceCommand struct {
 }
 
 func (c *WorkspaceCommand) Run(args []string) int {
-	c.Meta.process(args)
-	envCommandShowWarning(c.Ui, c.LegacyName)
-
-	cmdFlags := c.Meta.extendedFlagSet("workspace")
-	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
-
-	c.Ui.Output(c.Help())
-	return 0
+	return cli.RunResultHelp
 }
 
 func (c *WorkspaceCommand) Help() string {


### PR DESCRIPTION
The Terraform workspace command will return a 0 return code even when invalid arguments are passed to the command.
For example, `terraform workspace seleect` will return a 0 (non-error) return code even though it's an invalid command. This PR updates the Run method to fall in line with other terraform commands and returns a proper non-zero return code when an invalid argument is passed to `terraform workspace`.
```bash
➜  linux_amd64 git:(twittyc/terraformWorkspaceInvalidArgsReturnsNon0) terraform workspace seleect
Usage: terraform [global options] workspace

  new, list, show, select and delete Terraform workspaces.
➜  linux_amd64 git:(twittyc/terraformWorkspaceInvalidArgsReturnsNon0) echo $?
0
```
This fix updates the return code to properly give an error
``` bash
➜  linux_amd64 git:(twittyc/terraformWorkspaceInvalidArgsReturnsNon0) terraform workspace seleect
Usage: terraform [global options] workspace

  new, list, show, select and delete Terraform workspaces.
➜  linux_amd64 git:(twittyc/terraformWorkspaceInvalidArgsReturnsNon0) echo $?
1
```

`go tests` pass. Let me know if I need to do anything else or if you have any feedback :) 