### PR TITLE
Standardise how blank lines are added to plan for unchanged blocks

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -310,7 +310,7 @@ func (p *blockBodyDiffPrinter) writeBlockBodyDiff(schema *configschema.Block, ol
 			if result.skippedBlocks == 1 {
 				noun = "block"
 			}
-			p.buf.WriteString("\n")
+			p.buf.WriteString("\n\n")
 			p.buf.WriteString(strings.Repeat(" ", indent+2))
 			p.buf.WriteString(fmt.Sprintf(p.color.Color("[dark_gray]# (%d unchanged %s hidden)[reset]"), result.skippedBlocks, noun))
 		}
@@ -325,8 +325,6 @@ func (p *blockBodyDiffPrinter) writeAttrsDiff(
 	indent int,
 	path cty.Path,
 	result *blockBodyDiffResult) bool {
-
-	blankBeforeBlocks := false
 
 	attrNames := make([]string, 0, len(attrsS))
 	displayAttrNames := make(map[string]string, len(attrsS))
@@ -349,8 +347,8 @@ func (p *blockBodyDiffPrinter) writeAttrsDiff(
 		}
 	}
 	sort.Strings(attrNames)
-	if len(attrNames) > 0 {
-		blankBeforeBlocks = true
+	if len(attrNames) == 0 {
+		return false
 	}
 
 	for _, name := range attrNames {
@@ -365,7 +363,7 @@ func (p *blockBodyDiffPrinter) writeAttrsDiff(
 		}
 	}
 
-	return blankBeforeBlocks
+	return true
 }
 
 // getPlanActionAndShow returns the action value
@@ -754,10 +752,7 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 			action = plans.Update
 		}
 
-		if blankBefore {
-			p.buf.WriteRune('\n')
-		}
-		skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, action, old, new, indent, path)
+		skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, action, old, new, indent, blankBefore, path)
 		if skipped {
 			return 1
 		}
@@ -790,10 +785,7 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 			commonLen = len(newItems)
 		}
 
-		if blankBefore && (len(oldItems) > 0 || len(newItems) > 0) {
-			p.buf.WriteRune('\n')
-		}
-
+		blankBeforeInner := blankBefore
 		for i := 0; i < commonLen; i++ {
 			path := append(path, cty.IndexStep{Key: cty.NumberIntVal(int64(i))})
 			oldItem := oldItems[i]
@@ -802,27 +794,29 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 			if oldItem.RawEquals(newItem) {
 				action = plans.NoOp
 			}
-			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, action, oldItem, newItem, indent, path)
+			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, action, oldItem, newItem, indent, blankBeforeInner, path)
 			if skipped {
 				skippedBlocks++
+			} else {
+				blankBeforeInner = false
 			}
 		}
 		for i := commonLen; i < len(oldItems); i++ {
 			path := append(path, cty.IndexStep{Key: cty.NumberIntVal(int64(i))})
 			oldItem := oldItems[i]
 			newItem := cty.NullVal(oldItem.Type())
-			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, plans.Delete, oldItem, newItem, indent, path)
+			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, plans.Delete, oldItem, newItem, indent, blankBeforeInner, path)
 			if skipped {
-				skippedBlocks++
+				blankBeforeInner = false
 			}
 		}
 		for i := commonLen; i < len(newItems); i++ {
 			path := append(path, cty.IndexStep{Key: cty.NumberIntVal(int64(i))})
 			newItem := newItems[i]
 			oldItem := cty.NullVal(newItem.Type())
-			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, plans.Create, oldItem, newItem, indent, path)
+			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, plans.Create, oldItem, newItem, indent, blankBeforeInner, path)
 			if skipped {
-				skippedBlocks++
+				blankBeforeInner = false
 			}
 		}
 	case configschema.NestingSet:
@@ -845,10 +839,7 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 		allItems = append(allItems, newItems...)
 		all := cty.SetVal(allItems)
 
-		if blankBefore {
-			p.buf.WriteRune('\n')
-		}
-
+		blankBeforeInner := blankBefore
 		for it := all.ElementIterator(); it.Next(); {
 			_, val := it.Element()
 			var action plans.Action
@@ -871,9 +862,11 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 				newValue = val
 			}
 			path := append(path, cty.IndexStep{Key: val})
-			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, action, oldValue, newValue, indent, path)
+			skipped := p.writeNestedBlockDiff(name, nil, &blockS.Block, action, oldValue, newValue, indent, blankBeforeInner, path)
 			if skipped {
 				skippedBlocks++
+			} else {
+				blankBeforeInner = false
 			}
 		}
 
@@ -904,10 +897,7 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 		}
 		sort.Strings(allKeysOrder)
 
-		if blankBefore {
-			p.buf.WriteRune('\n')
-		}
-
+		blankBeforeInner := blankBefore
 		for _, k := range allKeysOrder {
 			var action plans.Action
 			oldValue := oldItems[k]
@@ -926,9 +916,11 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 			}
 
 			path := append(path, cty.IndexStep{Key: cty.StringVal(k)})
-			skipped := p.writeNestedBlockDiff(name, &k, &blockS.Block, action, oldValue, newValue, indent, path)
+			skipped := p.writeNestedBlockDiff(name, &k, &blockS.Block, action, oldValue, newValue, indent, blankBeforeInner, path)
 			if skipped {
 				skippedBlocks++
+			} else {
+				blankBeforeInner = false
 			}
 		}
 	}
@@ -974,9 +966,13 @@ func (p *blockBodyDiffPrinter) writeSensitiveNestedBlockDiff(name string, old, n
 	p.buf.WriteString("}")
 }
 
-func (p *blockBodyDiffPrinter) writeNestedBlockDiff(name string, label *string, blockS *configschema.Block, action plans.Action, old, new cty.Value, indent int, path cty.Path) bool {
+func (p *blockBodyDiffPrinter) writeNestedBlockDiff(name string, label *string, blockS *configschema.Block, action plans.Action, old, new cty.Value, indent int, blankBefore bool, path cty.Path) bool {
 	if action == plans.NoOp && !p.verbose {
 		return true
+	}
+
+	if blankBefore {
+		p.buf.WriteRune('\n')
 	}
 
 	p.buf.WriteString("\n")


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/issues/28217

Fix the issue where multiple blank lines were inserted into the plan for every unchanged block type.

There are two cases for unchanged blocks, either the previous block is of the same type or it's of a different type. Previously, if they were the same type there would be no blank line and if they were different there would be a blank line. However, this was confusing because the unchanged blocks are grouped regardless of type so whether a blank line appears or not doesn't always actually mean anything.

So now, this is standardised and there is always a blank line before any `unchanged block` statement. New unit tests have been added to verify this, and some existing tests have been modified to reflect the new standard.