### PR TITLE
Fail global required_version check if it contains any prerelease fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/go-tfe v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
-	github.com/hashicorp/go-version v1.3.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2

--- a/go.sum
+++ b/go.sum
@@ -404,6 +404,8 @@ github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/go.sum
+++ b/go.sum
@@ -402,7 +402,6 @@ github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/internal/terraform/context_test.go
+++ b/internal/terraform/context_test.go
@@ -68,6 +68,22 @@ func TestNewContextRequiredVersion(t *testing.T) {
 		},
 
 		{
+			"prerelease doesn't match with inequality",
+			"",
+			"0.8.0",
+			"> 0.7.0-beta",
+			true,
+		},
+
+		{
+			"prerelease doesn't match with equality",
+			"",
+			"0.7.0",
+			"0.7.0-beta",
+			true,
+		},
+
+		{
 			"module matches",
 			"context-required-version-module",
 			"0.5.0",

--- a/internal/terraform/version_required.go
+++ b/internal/terraform/version_required.go
@@ -34,8 +34,10 @@ func CheckCoreVersionRequirements(config *configs.Config) tfdiags.Diagnostics {
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid required_version constraint",
-					Detail:   fmt.Sprintf("Prerelease version constraints are not supported: %s.", required.String()),
-					Subject:  constraint.DeclRange.Ptr(),
+					Detail: fmt.Sprintf(
+						"Prerelease version constraints are not supported: %s. Remove the prerelease information from the constraint. Prerelease versions of terraform will match constraints using their version core only.",
+						required.String()),
+					Subject: constraint.DeclRange.Ptr(),
 				})
 			}
 		}

--- a/internal/terraform/version_required.go
+++ b/internal/terraform/version_required.go
@@ -29,9 +29,10 @@ func CheckCoreVersionRequirements(config *configs.Config) tfdiags.Diagnostics {
 	for _, constraint := range module.CoreVersionConstraints {
 		// Before checking if the constraints are met, check that we are not using any prerelease fields as these
 		// are not currently supported.
+		var prereleaseDiags tfdiags.Diagnostics
 		for _, required := range constraint.Required {
 			if required.Prerelease() {
-				diags = diags.Append(&hcl.Diagnostic{
+				prereleaseDiags = prereleaseDiags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid required_version constraint",
 					Detail: fmt.Sprintf(
@@ -42,9 +43,10 @@ func CheckCoreVersionRequirements(config *configs.Config) tfdiags.Diagnostics {
 			}
 		}
 
-		if len(diags) > 0 {
+		if len(prereleaseDiags) > 0 {
 			// There were some prerelease fields in the constraints. Don't check the constraints as they will
-			// fail, and the diagnostics are already populated.
+			// fail, and populate the diagnostics for these constraints with the prerelease diagnostics.
+			diags = diags.Append(prereleaseDiags)
 			continue
 		}
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/issues/28148

Any `required_version` that contains a prerelease field will fail the later constraint check anyway. This change ensures the reported error message makes clear that prerelease versions are not supported in the `required_version` constraint.