### PR TITLE
configs: Show tailored message for optional attrs experiment

### DIFF
--- a/internal/configs/experiments.go
+++ b/internal/configs/experiments.go
@@ -84,6 +84,25 @@ func sniffActiveExperiments(body hcl.Body, allowed bool) (experiments.Set, hcl.D
 		}
 
 		exps, expDiags := decodeExperimentsAttr(attr)
+
+		// Because we concluded this particular experiment in the same
+		// release as we made experiments alpha-releases-only, we need to
+		// treat it as special to avoid masking the "experiment has concluded"
+		// error with the more general "experiments are not available at all"
+		// error. Note that this experiment is marked as concluded so this
+		// only "allows" showing the different error message that it is
+		// concluded, and does not allow actually using the experiment outside
+		// of an alpha.
+		// NOTE: We should be able to remove this special exception a release
+		// or two after v1.3 when folks have had a chance to notice that the
+		// experiment has concluded and update their modules accordingly.
+		// When we do so, we might also consider changing decodeExperimentsAttr
+		// to _not_ include concluded experiments in the returned set, since
+		// we're doing that right now only to make this condition work.
+		if exps.Has(experiments.ModuleVariableOptionalAttrs) && len(exps) == 1 {
+			allowed = true
+		}
+
 		if allowed {
 			diags = append(diags, expDiags...)
 			if !expDiags.HasErrors() {
@@ -134,6 +153,15 @@ func decodeExperimentsAttr(attr *hcl.Attribute) (experiments.Set, hcl.Diagnostic
 				Subject:  expr.Range().Ptr(),
 			})
 		case experiments.ConcludedError:
+			// As a special case we still include the optional attributes
+			// experiment if it's present, because our caller treats that
+			// as special. See the comment in sniffActiveExperiments for
+			// more information, and remove this special case here one the
+			// special case up there is also removed.
+			if kw == "module_variable_optional_attrs" {
+				ret.Add(experiments.ModuleVariableOptionalAttrs)
+			}
+
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Experiment has concluded",

--- a/internal/experiments/experiment.go
+++ b/internal/experiments/experiment.go
@@ -27,7 +27,7 @@ func init() {
 	registerConcludedExperiment(SuppressProviderSensitiveAttrs, "Provider-defined sensitive attributes are now redacted by default, without enabling an experiment.")
 	registerConcludedExperiment(ConfigDrivenMove, "Declarations of moved resource instances using \"moved\" blocks can now be used by default, without enabling an experiment.")
 	registerConcludedExperiment(PreconditionsPostconditions, "Condition blocks can now be used by default, without enabling an experiment.")
-	registerConcludedExperiment(ModuleVariableOptionalAttrs, "Optional object attributes in module variable type constraints can now be used by default, without enabling an experiment.")
+	registerConcludedExperiment(ModuleVariableOptionalAttrs, "The final feature corresponding to this experiment differs from the experimental form and is available in the Terraform language from Terraform v1.3.0 onwards.")
 }
 
 // GetCurrent takes an experiment name and returns the experiment value


### PR DESCRIPTION
Since we've both concluded the `module_variables_optional_attrs` experiment and made experiments available only in alpha releases in the same minor release, we accidentally made the more general message about experiments not being available mask the specific message about the experiment being concluded.

In order to give better feedback to those who were participating in the experiment in earlier Terraform releases, we'll retain a minimal exception to our checks to allow the "experiment has concluded" error message to shine through if and only if that is the only selected experiment.

---

Before:

```
╷
│ Error: Module uses experimental features
│ 
│   on optional-attributes.tf line 2, in terraform:
│    2:   experiments = [module_variable_optional_attrs]
│ 
│ Experimental features are intended only for gathering early
│ feedback on new language designs, and so are available
│ only in alpha releases of Terraform.
╵
```

After:

```
╷
│ Error: Experiment has concluded
│ 
│   on optional-attributes.tf line 2, in terraform:
│    2:   experiments = [module_variable_optional_attrs]
│ 
│ Experiment "module_variable_optional_attrs" is no longer
│ available. The final feature corresponding to this experiment
│ differs from the experimental form and is available in the
│ Terraform language from Terraform v1.3.0 onwards.
╵
```

This exception is only for when the set of declared experiments is _exactly `[module_variable_optional_attrs]`. For any other combination the more general message will appear, which in particular means that we are still masking the concluded messages for all previous experiments up until this point, but it's been long enough since those concluded that I don't expect that to cause a significant problem.

I anticipate us removing this exception during the v1.4 development period so that Terraform v1.4.0 onwards will revert to the previous behavior of just announcing that experiments are not available in alpha releases, after we've given folks a chance to notice that the experiment has concluded and update their modules to declare `required_version = ">= 1.3.0"` instead of enabling the experiment.


