### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/planning-behaviors.md
+++ b/docs/planning-behaviors.md
@@ -9,7 +9,7 @@ There are also some historical exceptions to this rule, which we hope to
 supplement with plan-and-apply-based equivalents over time.
 
 This document describes the default planning behavior of Terraform in the
-absense of any special instructions, and also describes the three main
+absence of any special instructions, and also describes the three main
 design approaches we can choose from when modelling non-default behaviors that
 require additional information from outside of Terraform Core.
 
@@ -148,7 +148,7 @@ main sub-categories:
   top-level block which refers to other resources using the typical address
   syntax.
 
-The following is a non-exhastive list of existing examples of
+The following is a non-exhaustive list of existing examples of
 configuration-driven behaviors, selected to illustrate some different variations
 that might be useful inspiration for new designs:
 
@@ -210,7 +210,7 @@ protocol does not talk about the action types explicitly, and instead only
 implies them via other content of the request and response, with Terraform Core
 making the final decision about how to react to that information.
 
-The following is a non-exhastive list of existing examples of
+The following is a non-exhaustive list of existing examples of
 provider-driven behaviors, selected to illustrate some different variations
 that might be useful inspiration for new designs:
 
@@ -258,7 +258,7 @@ most appropriate way to handle a particular use-case, because the need for the
 behavior originates in some process happening outside of the scope of any
 particular Terraform module or provider.
 
-The following is a non-exhastive list of existing examples of
+The following is a non-exhaustive list of existing examples of
 single-run behaviors, selected to illustrate some different variations
 that might be useful inspiration for new designs:
 

--- a/docs/resource-instance-change-lifecycle.md
+++ b/docs/resource-instance-change-lifecycle.md
@@ -322,7 +322,7 @@ to bring them under Terraform's management without needing to recreate them
 first.
 
 When using this facility, the user provides the address of the resource
-instance they wish to bind the existing object to, and a string repesentation
+instance they wish to bind the existing object to, and a string representation
 of the identifier of the existing object to be imported in a syntax defined
 by the provider on a per-resource-type basis, which we'll call the
 **Import ID**.

--- a/website/README.md
+++ b/website/README.md
@@ -15,7 +15,7 @@ Click **Edit this page** at the bottom of any Terraform website page to go direc
 
 ## Modifying Sidebar Navigation
 
-Updates to the sidebar navigation of Terraform docs need to be made in the [`terraform-website`](https://github.com/hashicorp/terraform-website/) repository (preferrably in a PR also updating the submodule commit). You can read more about how to make modifications to the navigation in the [README for `terraform-website`](https://github.com/hashicorp/terraform-website#editing-navigation-sidebars).
+Updates to the sidebar navigation of Terraform docs need to be made in the [`terraform-website`](https://github.com/hashicorp/terraform-website/) repository (preferably in a PR also updating the submodule commit). You can read more about how to make modifications to the navigation in the [README for `terraform-website`](https://github.com/hashicorp/terraform-website#editing-navigation-sidebars).
 
 ## Previewing Changes
 


### PR DESCRIPTION
There are small typos in:
- docs/planning-behaviors.md
- docs/resource-instance-change-lifecycle.md
- website/README.md

Fixes:
- Should read `exhaustive` rather than `exhastive`.
- Should read `representation` rather than `repesentation`.
- Should read `preferably` rather than `preferrably`.
- Should read `absence` rather than `absense`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md