### PR TITLE
addrs: Format string instance keys in an HCL-compatible way

### DIFF
--- a/internal/addrs/instance_key_test.go
+++ b/internal/addrs/instance_key_test.go
@@ -1,0 +1,75 @@
+package addrs
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestInstanceKeyString(t *testing.T) {
+	tests := []struct {
+		Key  InstanceKey
+		Want string
+	}{
+		{
+			IntKey(0),
+			`[0]`,
+		},
+		{
+			IntKey(5),
+			`[5]`,
+		},
+		{
+			StringKey(""),
+			`[""]`,
+		},
+		{
+			StringKey("hi"),
+			`["hi"]`,
+		},
+		{
+			StringKey("0"),
+			`["0"]`, // intentionally distinct from IntKey(0)
+		},
+		{
+			// Quotes must be escaped
+			StringKey(`"`),
+			`["\""]`,
+		},
+		{
+			// Escape sequences must themselves be escaped
+			StringKey(`\r\n`),
+			`["\\r\\n"]`,
+		},
+		{
+			// Template interpolation sequences "${" must be escaped.
+			StringKey(`${hello}`),
+			`["$${hello}"]`,
+		},
+		{
+			// Template control sequences "%{" must be escaped.
+			StringKey(`%{ for something in something }%{ endfor }`),
+			`["%%{ for something in something }%%{ endfor }"]`,
+		},
+		{
+			// Dollar signs that aren't followed by { are not interpolation sequences
+			StringKey(`$hello`),
+			`["$hello"]`,
+		},
+		{
+			// Percent signs that aren't followed by { are not control sequences
+			StringKey(`%hello`),
+			`["%hello"]`,
+		},
+	}
+
+	for _, test := range tests {
+		testName := fmt.Sprintf("%#v", test.Key)
+		t.Run(testName, func(t *testing.T) {
+			got := test.Key.String()
+			want := test.Want
+			if got != want {
+				t.Errorf("wrong result\nreciever: %s\ngot:      %s\nwant:     %s", testName, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
So far we've only ever needed to re-parse address strings that happen not to contain instance keys and so we've gotten away with our serialization of these not being quite right, but given how liberally we've expected to be able to use address strings from this package for wire format interchange it seems likely that this is going to surprise us eventually.

Now we'll use an escaping scheme compatible with HCL's parser rather than Go's parser, and so we can safely rely on hclsyntax.ParseTraversal as part of reversing this operation to transform an address string back into an address equivalent to the value it was created from.

This will cause string keys containing certain control characters to appear a little differently in the UI, but the difference is consistent with our usual preference to show the addresses in the same way a user would write them in configuration.

---

I'm extracting a few prerequisite commits I ended up doing in other branches into separate PRs in order to reduce the amount of ancillary noise in those other branches and hopefully make final review a little easier. This one came from #31268, where I started using module instance addresses in a way that required parsing them back later and so needed `.String` to produce something parseable. However, I think this is of general utility for any time we need to use an address string as part of a wire format, so I'm submitting it separately.
