### PR TITLE
core: Use DynamicExpand even for root module outputs

### DIFF
--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -1,9 +1,10 @@
 package plans
 
 import (
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Changes describes various actions that Terraform will attempt to take if
@@ -114,6 +115,23 @@ func (c *Changes) OutputValue(addr addrs.AbsOutputValue) *OutputChangeSrc {
 	}
 
 	return nil
+}
+
+// RootOutputValues returns planned changes for all outputs of the root module.
+func (c *Changes) RootOutputValues() []*OutputChangeSrc {
+	var res []*OutputChangeSrc
+
+	for _, oc := range c.Outputs {
+		// we can't evaluate root module outputs
+		if !oc.Addr.Module.Equal(addrs.RootModuleInstance) {
+			continue
+		}
+
+		res = append(res, oc)
+
+	}
+
+	return res
 }
 
 // OutputValues returns planned changes for all outputs for all module

--- a/internal/plans/changes_sync.go
+++ b/internal/plans/changes_sync.go
@@ -185,6 +185,22 @@ func (cs *ChangesSync) GetOutputChange(addr addrs.AbsOutputValue) *OutputChangeS
 	return cs.changes.OutputValue(addr)
 }
 
+// GetRootOutputChanges searches the set of output changes for any that reside
+// the root module. If no such changes exist, nil is returned.
+//
+// The returned objects are a deep copy of the change recorded in the plan, so
+// callers may mutate them although it's generally better (less confusing) to
+// treat planned changes as immutable after they've been initially constructed.
+func (cs *ChangesSync) GetRootOutputChanges() []*OutputChangeSrc {
+	if cs == nil {
+		panic("GetRootOutputChanges on nil ChangesSync")
+	}
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
+
+	return cs.changes.RootOutputValues()
+}
+
 // GetOutputChanges searches the set of output changes for any that reside in
 // module instances beneath the given module. If no changes exist, nil
 // is returned.

--- a/internal/terraform/context_apply_test.go
+++ b/internal/terraform/context_apply_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-test/deep"
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
@@ -28,8 +31,6 @@ import (
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/gocty"
 )
 
 func TestContext2Apply_basic(t *testing.T) {
@@ -7024,6 +7025,12 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 	// (which depends on the targeted resource) from state. That version of this
 	// test did not match actual terraform behavior: the output remains in
 	// state.
+	//
+	// The reason it remains in the state is that we prune out the root module
+	// output values from the destroy graph as part of pruning out the "update"
+	// nodes for the resources, because otherwise the root module output values
+	// force the resources to stay in the graph and can therefore cause
+	// unwanted dependency cycles.
 	//
 	// TODO: Future refactoring may enable us to remove the output from state in
 	// this case, and that would be Just Fine - this test can be modified to

--- a/internal/terraform/graph_builder_plan_test.go
+++ b/internal/terraform/graph_builder_plan_test.go
@@ -233,7 +233,7 @@ local.instance_id (expand)
   aws_instance.web (expand)
 openstack_floating_ip.random (expand)
   provider["registry.terraform.io/hashicorp/openstack"]
-output.instance_id
+output.instance_id (expand)
   local.instance_id (expand)
 provider["registry.terraform.io/hashicorp/aws"]
   openstack_floating_ip.random (expand)
@@ -243,7 +243,7 @@ provider["registry.terraform.io/hashicorp/openstack"]
 provider["registry.terraform.io/hashicorp/openstack"] (close)
   openstack_floating_ip.random (expand)
 root
-  output.instance_id
+  output.instance_id (expand)
   provider["registry.terraform.io/hashicorp/aws"] (close)
   provider["registry.terraform.io/hashicorp/openstack"] (close)
 var.foo

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -212,6 +212,16 @@ func (t *pruneUnusedNodesTransformer) Transform(g *Graph) error {
 					for _, v := range g.UpEdges(n) {
 						switch v.(type) {
 						case graphNodeExpandsInstances:
+							// Root module output values (which the following
+							// condition matches) are exempt because we know
+							// there is only ever exactly one instance of the
+							// root module, and so it's not actually important
+							// to expand it and so this lets us do a bit more
+							// pruning than we'd be able to do otherwise.
+							if tmp, ok := v.(graphNodeTemporaryValue); ok && !tmp.temporaryValue() {
+								continue
+							}
+
 							// expanders can always depend on module expansion
 							// themselves
 							return

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -71,8 +71,8 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			destroy = rootChange.Action == plans.Delete
 		}
 
-		// If this is a root output, we add the apply or destroy node directly,
-		// as the root modules does not expand.
+		// If this is a root output and we're destroying, we add the destroy
+		// node directly, as there is no need to expand.
 
 		var node dag.Vertex
 		switch {
@@ -80,14 +80,6 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			node = &NodeDestroyableOutput{
 				Addr:   addr.Absolute(addrs.RootModuleInstance),
 				Config: o,
-			}
-
-		case c.Path.IsRoot():
-			node = &NodeApplyableOutput{
-				Addr:        addr.Absolute(addrs.RootModuleInstance),
-				Config:      o,
-				Change:      rootChange,
-				RefreshOnly: t.RefreshOnly,
 			}
 
 		default:

--- a/internal/terraform/transform_targets_test.go
+++ b/internal/terraform/transform_targets_test.go
@@ -122,7 +122,7 @@ module.child.module.grandchild.output.id (expand)
   module.child.module.grandchild.aws_instance.foo
 module.child.output.grandchild_id (expand)
   module.child.module.grandchild.output.id (expand)
-output.grandchild_id
+output.grandchild_id (expand)
   module.child.output.grandchild_id (expand)
 	`)
 	if actual != expected {
@@ -193,7 +193,7 @@ module.child.module.grandchild.output.id (expand)
   module.child.module.grandchild.aws_instance.foo
 module.child.output.grandchild_id (expand)
   module.child.module.grandchild.output.id (expand)
-output.grandchild_id
+output.grandchild_id (expand)
   module.child.output.grandchild_id (expand)
 	`)
 	if actual != expected {


### PR DESCRIPTION
We previously had a special case in the graph transformer for output values where it would directly create an individual output value node instead of an "expand" node as we would do for output values in nested modules.

While it's true that we do always know that expanding a root module output value will always produce exactly one instance, treating this case as special creates the risk of those two codepaths diverging in other ways.

Instead, we'll let the expand node also deal with root modules and minimize the special case only to how we look up any changes for the output values, since the design of plans.Changes is a bit awkward and requires us to ask the question differently for root module output values. Otherwise, the behavior will now be consistent across all output values regardless of module.

The "expander" abstraction already understands that it should generate exactly one instance of the root module in all cases, so we don't need to do any special work here to make the module expand graph nodes handle that case.

---

This change ended up causing us to add another [ad-hoc hypothesis](https://en.wikipedia.org/wiki/Ad_hoc_hypothesis) to our destroy-graph-cycle-avoidance strategy. I've left all of my raw debugging notes below in case it's useful supporting material to understand how we got there, but alternatively you might want to [skip to the end](https://github.com/hashicorp/terraform/pull/31395#issuecomment-1191828504) to see what we landed on and why.

---

I'm currently hoisting some isolated commits out of some other longer-lived branches I've been working on just to separate the prerequisites from the real goal to hopefully make it easier to review as smaller commits. This particular one came from #31268, which also provides a specific motivation for changing this other than the general consistency argument I made above:

The checks mechanism I proposed over there requires Terraform Core to register the expanded addresses for any checkable object as part of the transient check state, so that we can still report the associated checks as "skipped"/"unknown" if we get blocked from evaluating the checks by an error elsewhere. However, because we currently skip expansion for root module outputs, there was nothing registering the single instance of each root module output value in the check state. Rather than introduce another funny special case somewhere else, I decided to resolve this by _removing_ a special case, so that we will always expand all output values in the same way across both the plan and apply phases and regardless of which module they belong to.
