### PR TITLE
Added link to "hostname" argument

### DIFF
--- a/website/docs/language/settings/terraform-cloud.mdx
+++ b/website/docs/language/settings/terraform-cloud.mdx
@@ -29,7 +29,7 @@ terraform {
 }
 ```
 
-If you do not specify the `hostname`, it defaults to `app.terraform.io` for Terraform Cloud. For Terraform Enterprise installations, include the `hostname` configuration argument.  
+If you do not specify the `hostname`, it defaults to `app.terraform.io` for Terraform Cloud. For Terraform Enterprise installations, include the [hostname](/cli/cloud/settings#hostname) configuration argument.  
 
 You cannot use the CLI integration and a [state backend](/language/settings/backends) in the same configuration; they are mutually exclusive. A configuration can only provide one `cloud` block and the `cloud` block cannot refer to named values like input variables, locals, or data source attributes.
 


### PR DESCRIPTION
There should be a link to the argument being referenced for clarity and completeness.