### PR TITLE
create installer event for tracking provider lock hashes

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -815,10 +815,12 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 			// If local hashes and prior hashes are exactly the same then
 			// it means we didn't record any signed hashes previously, and
 			// we know we're not adding any extra in now (because we already
-			// checked the signedHashes), so that's a problem. We check here
-			// if they are not equal and return early. If they are equal then
-			// this is handled by amending incompleteProviders below.
-			if !reflect.DeepEqual(localHashes, priorHashes) {
+			// checked the signedHashes), so that's a problem.
+			//
+			// In the actual check here, if we have any priorHashes and those
+			// hashes are not the same as the local hashes then we're going to
+			// accept that this provider has been configured correctly.
+			if len(priorHashes) > 0 && !reflect.DeepEqual(localHashes, priorHashes) {
 				return
 			}
 

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -385,14 +385,14 @@ NeedProvider:
 				// calculated from the package we just linked, which allows
 				// the lock file to gradually transition to recording newer hash
 				// schemes when they become available.
-				var newHashes []getproviders.Hash
+				var cachedHashes []getproviders.Hash
 				if lock != nil && lock.Version() == version {
 					// If the version we're installing is identical to the
 					// one we previously locked then we'll keep all of the
 					// hashes we saved previously and add to it. Otherwise
 					// we'll be starting fresh, because each version has its
 					// own set of packages and thus its own hashes.
-					newHashes = append(newHashes, preferredHashes...)
+					cachedHashes = append(cachedHashes, preferredHashes...)
 
 					// NOTE: The behavior here is unfortunate when a particular
 					// provider version was already cached on the first time
@@ -423,8 +423,13 @@ NeedProvider:
 				// The hashes slice gets deduplicated in the lock file
 				// implementation, so we don't worry about potentially
 				// creating a duplicate here.
+				var newHashes []getproviders.Hash
+				newHashes = append(newHashes, cachedHashes...)
 				newHashes = append(newHashes, newHash)
 				locks.SetProvider(provider, version, reqs[provider], newHashes)
+				if cb := evts.ProvidersLockUpdated; cb != nil {
+					cb(provider, version, newHash, nil, cachedHashes)
+				}
 
 				if cb := evts.LinkFromCacheSuccess; cb != nil {
 					cb(provider, version, new.PackageDir)
@@ -524,14 +529,14 @@ NeedProvider:
 		// The hashes slice gets deduplicated in the lock file
 		// implementation, so we don't worry about potentially
 		// creating duplicates here.
-		var newHashes []getproviders.Hash
+		var cachedHashes []getproviders.Hash
 		if lock != nil && lock.Version() == version {
 			// If the version we're installing is identical to the
 			// one we previously locked then we'll keep all of the
 			// hashes we saved previously and add to it. Otherwise
 			// we'll be starting fresh, because each version has its
 			// own set of packages and thus its own hashes.
-			newHashes = append(newHashes, preferredHashes...)
+			cachedHashes = append(cachedHashes, preferredHashes...)
 		}
 		newHash, err := new.Hash()
 		if err != nil {
@@ -542,15 +547,25 @@ NeedProvider:
 			}
 			continue
 		}
-		newHashes = append(newHashes, newHash)
+
+		var remoteHashes []getproviders.Hash
 		if authResult.SignedByAnyParty() {
 			// We'll trust new hashes from upstream only if they were verified
 			// as signed by a suitable key. Otherwise, we'd record only
 			// a new hash we just calculated ourselves from the bytes on disk,
 			// and so the hashes would cover only the current platform.
-			newHashes = append(newHashes, meta.AcceptableHashes()...)
+			remoteHashes = append(remoteHashes, meta.AcceptableHashes()...)
 		}
+
+		var newHashes []getproviders.Hash
+		newHashes = append(newHashes, newHash)
+		newHashes = append(newHashes, cachedHashes...)
+		newHashes = append(newHashes, remoteHashes...)
+
 		locks.SetProvider(provider, version, reqs[provider], newHashes)
+		if cb := evts.ProvidersLockUpdated; cb != nil {
+			cb(provider, version, newHash, remoteHashes, cachedHashes)
+		}
 
 		if cb := evts.FetchPackageSuccess; cb != nil {
 			cb(provider, version, new.PackageDir, authResult)

--- a/internal/providercache/installer_events.go
+++ b/internal/providercache/installer_events.go
@@ -106,15 +106,21 @@ type InstallerEvents struct {
 	FetchPackageSuccess func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult)
 	FetchPackageFailure func(provider addrs.Provider, version getproviders.Version, err error)
 
+	// The ProvidersLockUpdated event is called whenever the lock file will be
+	// updated. It provides information around which hashes were already
+	// present, which hashes were fetched from the remote cache, and which hash
+	// was computed locally.
+	//
+	// The final lock file will be updated with all the supplied hashes.
+	//
+	// It not just likely, but expected that there will be duplicates shared
+	// between all three collections of hashes i.e. the local hash and remote
+	// hashes could already be in the cached hashes.
+	ProvidersLockUpdated func(provider addrs.Provider, version getproviders.Version, local getproviders.Hash, remote []getproviders.Hash, cached []getproviders.Hash)
+
 	// The ProvidersFetched event is called after all fetch operations if at
 	// least one provider was fetched successfully.
 	ProvidersFetched func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult)
-
-	// HashPackageFailure is called if the installer is unable to determine
-	// the hash of the contents of an installed package after installation.
-	// In that case, the selection will not be recorded in the target cache
-	// directory's lock file.
-	HashPackageFailure func(provider addrs.Provider, version getproviders.Version, err error)
 }
 
 // OnContext produces a context with all of the same behaviors as the given

--- a/internal/providercache/installer_events.go
+++ b/internal/providercache/installer_events.go
@@ -107,16 +107,23 @@ type InstallerEvents struct {
 	FetchPackageFailure func(provider addrs.Provider, version getproviders.Version, err error)
 
 	// The ProvidersLockUpdated event is called whenever the lock file will be
-	// updated. It provides information around which hashes were already
-	// present, which hashes were fetched from the remote cache, and which hash
-	// was computed locally.
+	// updated. It provides the following information:
 	//
-	// The final lock file will be updated with all the supplied hashes.
+	//   - `localHashes`: Hashes computed on the local system by analyzing
+	//                    files on disk.
+	//   - `signedHashes`: Hashes signed by the private key that the origin
+	//                     registry claims is the owner of this provider.
+	//   - `priorHashes`: Hashes already present in the lock file before we
+	//                    made any changes.
 	//
-	// It not just likely, but expected that there will be duplicates shared
-	// between all three collections of hashes i.e. the local hash and remote
-	// hashes could already be in the cached hashes.
-	ProvidersLockUpdated func(provider addrs.Provider, version getproviders.Version, local getproviders.Hash, remote []getproviders.Hash, cached []getproviders.Hash)
+	// The final lock file will be updated with a union of all the provided
+	// hashes. It not just likely, but expected that there will be duplicates
+	// shared between all three collections of hashes i.e. the local hash and
+	// remote hashes could already be in the cached hashes.
+	//
+	// In addition, we place a guarantee that the hash slices will be ordered
+	// in the same manner enforced by the lock file within NewProviderLock.
+	ProvidersLockUpdated func(provider addrs.Provider, version getproviders.Version, localHashes []getproviders.Hash, signedHashes []getproviders.Hash, priorHashes []getproviders.Hash)
 
 	// The ProvidersFetched event is called after all fetch operations if at
 	// least one provider was fetched successfully.

--- a/internal/providercache/installer_events_test.go
+++ b/internal/providercache/installer_events_test.go
@@ -164,16 +164,16 @@ func installerLogEventsForTests(into chan<- *testInstallerEventLogItem) *Install
 				}{version.String(), err.Error()},
 			}
 		},
-		ProvidersLockUpdated: func(provider addrs.Provider, version getproviders.Version, local getproviders.Hash, remote []getproviders.Hash, cached []getproviders.Hash) {
+		ProvidersLockUpdated: func(provider addrs.Provider, version getproviders.Version, localHashes []getproviders.Hash, signedHashes []getproviders.Hash, priorHashes []getproviders.Hash) {
 			into <- &testInstallerEventLogItem{
 				Event:    "ProvidersLockUpdated",
 				Provider: provider,
 				Args: struct {
 					Version string
-					Local   getproviders.Hash
-					Remote  []getproviders.Hash
-					Cached  []getproviders.Hash
-				}{version.String(), local, remote, cached},
+					Local   []getproviders.Hash
+					Signed  []getproviders.Hash
+					Prior   []getproviders.Hash
+				}{version.String(), localHashes, signedHashes, priorHashes},
 			}
 		},
 		ProvidersFetched: func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {

--- a/internal/providercache/installer_events_test.go
+++ b/internal/providercache/installer_events_test.go
@@ -164,20 +164,22 @@ func installerLogEventsForTests(into chan<- *testInstallerEventLogItem) *Install
 				}{version.String(), err.Error()},
 			}
 		},
+		ProvidersLockUpdated: func(provider addrs.Provider, version getproviders.Version, local getproviders.Hash, remote []getproviders.Hash, cached []getproviders.Hash) {
+			into <- &testInstallerEventLogItem{
+				Event:    "ProvidersLockUpdated",
+				Provider: provider,
+				Args: struct {
+					Version string
+					Local   getproviders.Hash
+					Remote  []getproviders.Hash
+					Cached  []getproviders.Hash
+				}{version.String(), local, remote, cached},
+			}
+		},
 		ProvidersFetched: func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
 			into <- &testInstallerEventLogItem{
 				Event: "ProvidersFetched",
 				Args:  authResults,
-			}
-		},
-		HashPackageFailure: func(provider addrs.Provider, version getproviders.Version, err error) {
-			into <- &testInstallerEventLogItem{
-				Event:    "HashPackageFailure",
-				Provider: provider,
-				Args: struct {
-					Version string
-					Error   string
-				}{version.String(), err.Error()},
 			}
 		},
 	}

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -176,12 +176,12 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Provider: beepProvider,
 							Args: struct {
 								Version string
-								Local   getproviders.Hash
-								Remote  []getproviders.Hash
-								Cached  []getproviders.Hash
+								Local   []getproviders.Hash
+								Signed  []getproviders.Hash
+								Prior   []getproviders.Hash
 							}{
 								"2.1.0",
-								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								[]getproviders.Hash{"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84="},
 								nil,
 								nil,
 							},
@@ -307,12 +307,12 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Provider: beepProvider,
 							Args: struct {
 								Version string
-								Local   getproviders.Hash
-								Remote  []getproviders.Hash
-								Cached  []getproviders.Hash
+								Local   []getproviders.Hash
+								Signed  []getproviders.Hash
+								Prior   []getproviders.Hash
 							}{
 								"2.1.0",
-								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								[]getproviders.Hash{"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84="},
 								nil,
 								nil,
 							},
@@ -446,12 +446,12 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Provider: beepProvider,
 							Args: struct {
 								Version string
-								Local   getproviders.Hash
-								Remote  []getproviders.Hash
-								Cached  []getproviders.Hash
+								Local   []getproviders.Hash
+								Signed  []getproviders.Hash
+								Prior   []getproviders.Hash
 							}{
 								"2.1.0",
-								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								[]getproviders.Hash{"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84="},
 								nil,
 								nil,
 							},
@@ -585,12 +585,12 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Provider: beepProvider,
 							Args: struct {
 								Version string
-								Local   getproviders.Hash
-								Remote  []getproviders.Hash
-								Cached  []getproviders.Hash
+								Local   []getproviders.Hash
+								Signed  []getproviders.Hash
+								Prior   []getproviders.Hash
 							}{
 								"2.0.0",
-								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								[]getproviders.Hash{"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84="},
 								nil,
 								[]getproviders.Hash{"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84="},
 							},
@@ -828,12 +828,12 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Provider: beepProvider,
 							Args: struct {
 								Version string
-								Local   getproviders.Hash
-								Remote  []getproviders.Hash
-								Cached  []getproviders.Hash
+								Local   []getproviders.Hash
+								Signed  []getproviders.Hash
+								Prior   []getproviders.Hash
 							}{
 								"2.1.0",
-								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								[]getproviders.Hash{"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84="},
 								nil,
 								nil,
 							},
@@ -1009,12 +1009,12 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Provider: beepProvider,
 							Args: struct {
 								Version string
-								Local   getproviders.Hash
-								Remote  []getproviders.Hash
-								Cached  []getproviders.Hash
+								Local   []getproviders.Hash
+								Signed  []getproviders.Hash
+								Prior   []getproviders.Hash
 							}{
 								"1.0.0",
-								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								[]getproviders.Hash{"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84="},
 								nil,
 								[]getproviders.Hash{"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84="},
 							},

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -172,6 +172,21 @@ func TestEnsureProviderVersions(t *testing.T) {
 							}{"2.1.0", beepProviderDir},
 						},
 						{
+							Event:    "ProvidersLockUpdated",
+							Provider: beepProvider,
+							Args: struct {
+								Version string
+								Local   getproviders.Hash
+								Remote  []getproviders.Hash
+								Cached  []getproviders.Hash
+							}{
+								"2.1.0",
+								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								nil,
+								nil,
+							},
+						},
+						{
 							Event:    "FetchPackageSuccess",
 							Provider: beepProvider,
 							Args: struct {
@@ -286,6 +301,21 @@ func TestEnsureProviderVersions(t *testing.T) {
 								Version  string
 								Location getproviders.PackageLocation
 							}{"2.1.0", beepProviderDir},
+						},
+						{
+							Event:    "ProvidersLockUpdated",
+							Provider: beepProvider,
+							Args: struct {
+								Version string
+								Local   getproviders.Hash
+								Remote  []getproviders.Hash
+								Cached  []getproviders.Hash
+							}{
+								"2.1.0",
+								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								nil,
+								nil,
+							},
 						},
 						{
 							Event:    "FetchPackageSuccess",
@@ -412,6 +442,21 @@ func TestEnsureProviderVersions(t *testing.T) {
 							},
 						},
 						{
+							Event:    "ProvidersLockUpdated",
+							Provider: beepProvider,
+							Args: struct {
+								Version string
+								Local   getproviders.Hash
+								Remote  []getproviders.Hash
+								Cached  []getproviders.Hash
+							}{
+								"2.1.0",
+								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								nil,
+								nil,
+							},
+						},
+						{
 							Event:    "LinkFromCacheSuccess",
 							Provider: beepProvider,
 							Args: struct {
@@ -534,6 +579,21 @@ func TestEnsureProviderVersions(t *testing.T) {
 								Version  string
 								Location getproviders.PackageLocation
 							}{"2.0.0", beepProviderDir},
+						},
+						{
+							Event:    "ProvidersLockUpdated",
+							Provider: beepProvider,
+							Args: struct {
+								Version string
+								Local   getproviders.Hash
+								Remote  []getproviders.Hash
+								Cached  []getproviders.Hash
+							}{
+								"2.0.0",
+								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								nil,
+								[]getproviders.Hash{"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84="},
+							},
 						},
 						{
 							Event:    "FetchPackageSuccess",
@@ -764,6 +824,21 @@ func TestEnsureProviderVersions(t *testing.T) {
 							}{"2.1.0", beepProviderDir},
 						},
 						{
+							Event:    "ProvidersLockUpdated",
+							Provider: beepProvider,
+							Args: struct {
+								Version string
+								Local   getproviders.Hash
+								Remote  []getproviders.Hash
+								Cached  []getproviders.Hash
+							}{
+								"2.1.0",
+								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								nil,
+								nil,
+							},
+						},
+						{
 							Event:    "FetchPackageSuccess",
 							Provider: beepProvider,
 							Args: struct {
@@ -928,6 +1003,21 @@ func TestEnsureProviderVersions(t *testing.T) {
 								Version  string
 								Location getproviders.PackageLocation
 							}{"1.0.0", beepProviderDir},
+						},
+						{
+							Event:    "ProvidersLockUpdated",
+							Provider: beepProvider,
+							Args: struct {
+								Version string
+								Local   getproviders.Hash
+								Remote  []getproviders.Hash
+								Cached  []getproviders.Hash
+							}{
+								"1.0.0",
+								"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+								nil,
+								[]getproviders.Hash{"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84="},
+							},
 						},
 						{
 							Event:    "FetchPackageSuccess",


### PR DESCRIPTION
This is an attempt to implement @apparentlymart's suggestion in https://github.com/hashicorp/terraform/pull/31399.

I can merge this back into the original PR if we like it.

I also noticed `HashPackageFailure` was not in use so removed it.