### PR TITLE
terraform init: add suggested fix for when a checksum is missing from the lock file

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -761,7 +761,7 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 				// but rather just emit a single general message about it at
 				// the end, by checking ctx.Err().
 
-			case providercache.ErrChecksumMiss:
+			case providercache.ErrProviderChecksumMiss:
 				// This is a special kind of error that can often be fixed using
 				// the `terraform providers lock` command. We're just going to
 				// amend the actual error message with some extra information
@@ -770,8 +770,8 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Failed to install provider",
-					fmt.Sprintf("Error while installing %s v%s: %s\n\nUse the `terraform providers lock` command to include all necessary platforms in the dependency lock file. Ensure the current platform, %s, is included.",
-						provider.ForDisplay(), version, err.Msg, err.Meta.TargetPlatform.String(),
+					fmt.Sprintf("Error while installing %s v%s: %s\n\nYou can ensure the current platform, %s, is included in the dependency lock file by running: `terraform providers lock -provider=%s`.\n\nIf this does not fix the problem you may need to reset any provider caching present in your setup or make sure you are connecting to valid provider distributions.",
+						provider.ForDisplay(), version, err.Msg, err.Meta.TargetPlatform.String(), err.Meta.TargetPlatform.String(),
 					),
 				))
 

--- a/internal/getproviders/errors.go
+++ b/internal/getproviders/errors.go
@@ -210,7 +210,7 @@ func (err ErrQueryFailed) Unwrap() error {
 	return err.Wrapped
 }
 
-// ErrRequestCancelled is an error type used to indicate that an operation
+// ErrRequestCanceled is an error type used to indicate that an operation
 // failed due to being cancelled via the given context.Context object.
 //
 // This error type doesn't include information about what was cancelled,

--- a/internal/providercache/errors.go
+++ b/internal/providercache/errors.go
@@ -2,11 +2,13 @@ package providercache
 
 import "github.com/hashicorp/terraform/internal/getproviders"
 
-type ErrChecksumMiss struct {
+// ErrProviderChecksumMiss is an error type used to indicate a provider
+// installation failed due to a mismatch in the terraform provider lock file.
+type ErrProviderChecksumMiss struct {
 	Meta getproviders.PackageMeta
 	Msg  string
 }
 
-func (err ErrChecksumMiss) Error() string {
+func (err ErrProviderChecksumMiss) Error() string {
 	return err.Msg
 }

--- a/internal/providercache/errors.go
+++ b/internal/providercache/errors.go
@@ -1,0 +1,12 @@
+package providercache
+
+import "github.com/hashicorp/terraform/internal/getproviders"
+
+type ErrChecksumMiss struct {
+	Meta getproviders.PackageMeta
+	Msg  string
+}
+
+func (err ErrChecksumMiss) Error() string {
+	return err.Msg
+}

--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -116,7 +116,7 @@ func installFromLocalArchive(ctx context.Context, meta getproviders.PackageMeta,
 				meta.Provider, meta.Version, meta.Location, err,
 			)
 		} else if !matches {
-			return authResult, ErrChecksumMiss{
+			return authResult, ErrProviderChecksumMiss{
 				Meta: meta,
 				Msg: fmt.Sprintf(
 					"the current package for %s %s doesn't match any of the checksums previously recorded in the dependency lock file",
@@ -201,7 +201,7 @@ func installFromLocalDir(ctx context.Context, meta getproviders.PackageMeta, tar
 				meta.Provider, meta.Version, meta.Location, err,
 			)
 		} else if !matches {
-			return authResult, ErrChecksumMiss{
+			return authResult, ErrProviderChecksumMiss{
 				Meta: meta,
 				Msg: fmt.Sprintf(
 					"the local package for %s %s doesn't match any of the checksums previously recorded in the dependency lock file (this might be because the available checksums are for packages targeting different platforms)",

--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -116,10 +116,13 @@ func installFromLocalArchive(ctx context.Context, meta getproviders.PackageMeta,
 				meta.Provider, meta.Version, meta.Location, err,
 			)
 		} else if !matches {
-			return authResult, fmt.Errorf(
-				"the current package for %s %s doesn't match any of the checksums previously recorded in the dependency lock file",
-				meta.Provider, meta.Version,
-			)
+			return authResult, ErrChecksumMiss{
+				Meta: meta,
+				Msg: fmt.Sprintf(
+					"the current package for %s %s doesn't match any of the checksums previously recorded in the dependency lock file",
+					meta.Provider, meta.Version,
+				),
+			}
 		}
 	}
 
@@ -198,10 +201,13 @@ func installFromLocalDir(ctx context.Context, meta getproviders.PackageMeta, tar
 				meta.Provider, meta.Version, meta.Location, err,
 			)
 		} else if !matches {
-			return authResult, fmt.Errorf(
-				"the local package for %s %s doesn't match any of the checksums previously recorded in the dependency lock file (this might be because the available checksums are for packages targeting different platforms)",
-				meta.Provider, meta.Version,
-			)
+			return authResult, ErrChecksumMiss{
+				Meta: meta,
+				Msg: fmt.Sprintf(
+					"the local package for %s %s doesn't match any of the checksums previously recorded in the dependency lock file (this might be because the available checksums are for packages targeting different platforms)",
+					meta.Provider, meta.Version,
+				),
+			}
 		}
 	}
 


### PR DESCRIPTION
`terraform init` will now tell users to try `terraform providers lock` whenever it cannot download a provider due to a checksum mismatch.

The original request suggested we only do this when we check the existing hashes and verify there are only `h1` schema hashes present. This would only be a heuristic for the actual problem though (which is that the original `terraform init` attempt did not record checksums for other platforms). Instead of making that check, I've just amended the output to always suggest this as a fix as this problem will continue to be a concern after the `zh` schema has been completely removed at which point we'd have to change to this solution anyway.