### PR TITLE
pre-commit: add example pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,5 +5,4 @@ repos:
       - id: go-fmt
       - id: go-vet
       - id: go-imports
-      - id: go-lint
       - id: go-mod-tidy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.0
+    hooks:
+      - id: go-fmt
+      - id: go-vet
+      - id: go-imports
+      - id: go-lint
+      - id: go-mod-tidy


### PR DESCRIPTION
This is a very simple pre-commit config that will validate go format, imports, and style. It can be extended to run tests, validate other languages, pretty much anything as it can run custom scripts in the local repository.

This allows developer machines and CI/CD pipelines to run the exact same checks.

pre-commit already has github actions configured: https://github.com/marketplace/actions/pre-commit
There's also a different CI/CD pipeline available that will push commits into branches (fixing things automatically): https://pre-commit.ci/

Example:

https://user-images.githubusercontent.com/56838463/178232595-77d70b2a-ec99-423f-8c5b-b3c3c73ecb8c.mp4

