### PR TITLE
Generate a working ps1 command from remote-exec ssh

### DIFF
--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -433,7 +433,7 @@ func (c *Communicator) Upload(path string, input io.Reader) error {
 		return scpUploadFile(targetFile, input, w, stdoutR, size)
 	}
 
-	cmd, err := quoteShell([]string{"scp", "-vt", targetDir}, c.connInfo.TargetPlatform)
+	cmd, err := quoteShell([]string{"scp", "-vt", targetDir}, c.connInfo.TargetPlatform, c.connInfo.ScriptPath)
 	if err != nil {
 		return err
 	}
@@ -506,7 +506,7 @@ func (c *Communicator) UploadDir(dst string, src string) error {
 		return uploadEntries()
 	}
 
-	cmd, err := quoteShell([]string{"scp", "-rvt", dst}, c.connInfo.TargetPlatform)
+	cmd, err := quoteShell([]string{"scp", "-rvt", dst}, c.connInfo.TargetPlatform, c.connInfo.ScriptPath)
 	if err != nil {
 		return err
 	}
@@ -877,14 +877,17 @@ func (c *bastionConn) Close() error {
 	return c.Bastion.Close()
 }
 
-func quoteShell(args []string, targetPlatform string) (string, error) {
+func quoteShell(args []string, targetPlatform string, scriptPath string) (string, error) {
 	if targetPlatform == TargetPlatformUnix {
 		return shquot.POSIXShell(args), nil
 	}
 	if targetPlatform == TargetPlatformWindows {
-		return shquot.WindowsArgv(args), nil
+		cmd := shquot.WindowsArgv(args)
+		if (strings.HasPrefix(cmd, `"`) && strings.HasSuffix(scriptPath, ".ps1")) {
+			cmd = "&" + cmd
+		}
+		return cmd, nil
 	}
 
 	return "", fmt.Errorf("Cannot quote shell command, target platform unknown: %s", targetPlatform)
-
 }


### PR DESCRIPTION
Terraform's remote-exec with `type=ssh` won't connect to remote Windows boxes due to quoted escaping on the scp command passed to the ssh layer.

The Windows command `"scp" -vt c:/windows/temp` is passed to the remote which works fine where the shell is `cmd.exe` but fails when the shell is `powershell.exe`.

Raised as issue #31423.