### PR TITLE
Add goimports as a check to the Github commit actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -178,9 +178,13 @@ jobs:
           restore-keys: |
             protobuf-tools-
 
+      - name: Install CI tooling
+        run: |
+          go install golang.org/x/tools/cmd/goimports@v0.1.11
+
       - name: "Code consistency checks"
         run: |
-          make fmtcheck generate staticcheck exhaustive protobuf
+          make fmtcheck importscheck generate staticcheck exhaustive protobuf
           if [[ -n "$(git status --porcelain)" ]]; then
             echo >&2 "ERROR: Generated files are inconsistent. Run 'make generate' and 'make protobuf' locally and then commit the updated files."
             git >&2 status --porcelain

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -141,6 +141,8 @@ jobs:
     steps:
       - name: "Fetch source code"
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # We need to do comparisons against the main branch.
 
       - name: Determine Go version
         id: go

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ protobuf:
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
+importscheck:
+	@sh -c "'$(CURDIR)/scripts/goimportscheck.sh'"
+
 staticcheck:
 	@sh -c "'$(CURDIR)/scripts/staticcheck.sh'"
 
@@ -63,4 +66,4 @@ website/build-local:
 # under parallel conditions.
 .NOTPARALLEL:
 
-.PHONY: fmtcheck generate protobuf website website-test staticcheck website/local website/build-local
+.PHONY: fmtcheck importscheck generate protobuf website website-test staticcheck website/local website/build-local

--- a/scripts/goimportscheck.sh
+++ b/scripts/goimportscheck.sh
@@ -2,7 +2,7 @@
 
 # Check goimports
 echo "==> Checking the code complies with goimports requirements..."
-target_files=$(git diff --name-only main | grep "\.go")
+target_files=$(git diff --name-only origin/main | grep "\.go")
 
 if [[ -z ${target_files}  ]]; then
   exit 0

--- a/scripts/goimportscheck.sh
+++ b/scripts/goimportscheck.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Check goimports
+echo "==> Checking the code complies with goimports requirements..."
+target_files=$(git diff --name-only HEAD HEAD~1 | grep .go)
+
+if [[ -n ${target_files}  ]]; then
+  exit 0
+fi
+
+goimports_files=$(goimports -l -local github.com/hashicorp/terraform/ ${target_files})
+if [[ -n ${goimports_files} ]]; then
+  echo 'goimports needs running on the following files:'
+  echo "${goimports_files}"
+  echo "You can use the command and flags \`goimports -w -l -local github.com/hashicorp/terraform/\` to reformat the code"
+  exit 1
+fi
+
+exit 0

--- a/scripts/goimportscheck.sh
+++ b/scripts/goimportscheck.sh
@@ -2,7 +2,7 @@
 
 # Check goimports
 echo "==> Checking the code complies with goimports requirements..."
-target_files=$(git diff --name-only origin/main | grep "\.go")
+target_files=$(git diff --name-only main | grep "\.go")
 
 if [[ -z ${target_files}  ]]; then
   exit 0

--- a/scripts/goimportscheck.sh
+++ b/scripts/goimportscheck.sh
@@ -2,9 +2,9 @@
 
 # Check goimports
 echo "==> Checking the code complies with goimports requirements..."
-target_files=$(git diff --name-only main | grep .go)
+target_files=$(git diff --name-only main | grep "\.go")
 
-if [[ -n ${target_files}  ]]; then
+if [[ -z ${target_files}  ]]; then
   exit 0
 fi
 

--- a/scripts/goimportscheck.sh
+++ b/scripts/goimportscheck.sh
@@ -8,7 +8,7 @@ if [[ -n ${target_files}  ]]; then
   exit 0
 fi
 
-goimports_files=$(goimports -l -local github.com/hashicorp/terraform/ ${target_files})
+goimports_files=$(goimports -w -l -local github.com/hashicorp/terraform/ ${target_files})
 if [[ -n ${goimports_files} ]]; then
   echo 'goimports needs running on the following files:'
   echo "${goimports_files}"

--- a/scripts/goimportscheck.sh
+++ b/scripts/goimportscheck.sh
@@ -2,7 +2,7 @@
 
 # Check goimports
 echo "==> Checking the code complies with goimports requirements..."
-target_files=$(git diff --name-only HEAD HEAD~1 | grep .go)
+target_files=$(git diff --name-only main | grep .go)
 
 if [[ -n ${target_files}  ]]; then
   exit 0


### PR DESCRIPTION
A couple of assumptions made here:

- `goimports` is actually the right tool to be using for this.
- We only check the files that were modified in the last commit, this is because a lot of the files in this repository are not valid with our imports schema (they only sometimes separate out github.com/hashicorp/terraform from other third party imports).
  - Instead, we could run against against all the files that have diffed from `main`: `git diff --name-only main` (this would mean this check would never work when against the main branch as it will always report no difference).
  - Or, we could run against all the files in the repo, and do a single merge that fixes all the current broken files.
 
Thoughts?

