### PR TITLE
Revert "Docs: Change misspelling of variable in documentation"

### DIFF
--- a/website/docs/language/values/variables.mdx
+++ b/website/docs/language/values/variables.mdx
@@ -478,7 +478,7 @@ variable "moose" {
 And the following `.tfvars` file:
 
 ```hcl
-moose = "Moose"
+mosse = "Moose"
 ```
 
 Will cause Terraform to warn you that there is no variable declared `"mosse"`, which can help


### PR DESCRIPTION
manual backport of #31121

This reverts commit 7756023564f006658a9bdef2a21a0005c4702b2b.